### PR TITLE
Use double quotes errors in 'dont mix' and 'has no attributes'

### DIFF
--- a/docs/source/class_basics.rst
+++ b/docs/source/class_basics.rst
@@ -21,7 +21,7 @@ initialized within the class. Mypy infers the types of attributes:
 
    a = A(1)
    a.x = 2  # OK!
-   a.y = 3  # Error: 'A' has no attribute 'y'
+   a.y = 3  # Error: "A" has no attribute "y"
 
 This is a bit like each class having an implicitly defined
 :py:data:`__slots__ <object.__slots__>` attribute. This is only enforced during type

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -36,7 +36,7 @@ target module can be found):
 
 .. code-block:: python
 
-    # Error: Module 'os' has no attribute 'non_existent'  [attr-defined]
+    # Error: Module "os" has no attribute "non_existent"  [attr-defined]
     from os import non_existent
 
 A reference to a missing attribute is given the ``Any`` type. In the

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -212,7 +212,7 @@ def _determine_eq_order(ctx: 'mypy.plugin.ClassDefContext') -> bool:
     order = _get_decorator_optional_bool_argument(ctx, 'order')
 
     if cmp is not None and any((eq is not None, order is not None)):
-        ctx.api.fail('Don\'t mix "%s" with "%s" and "%s"' % (cmp, eq, order), ctx.reason)
+        ctx.api.fail('Don\'t mix "cmp" with "eq" and "order"', ctx.reason)
 
     # cmp takes precedence due to bw-compatibility.
     if cmp is not None:
@@ -226,7 +226,7 @@ def _determine_eq_order(ctx: 'mypy.plugin.ClassDefContext') -> bool:
         order = eq
 
     if eq is False and order is True:
-        ctx.api.fail('eq must be "True" if order is "True"', ctx.reason)
+        ctx.api.fail('eq must be True if order is True', ctx.reason)
 
     return order
 

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -212,7 +212,7 @@ def _determine_eq_order(ctx: 'mypy.plugin.ClassDefContext') -> bool:
     order = _get_decorator_optional_bool_argument(ctx, 'order')
 
     if cmp is not None and any((eq is not None, order is not None)):
-        ctx.api.fail("Don't mix `cmp` with `eq' and `order`", ctx.reason)
+        ctx.api.fail('Don\'t mix "%s" with "%s" and "%s"' % (cmp, eq, order), ctx.reason)
 
     # cmp takes precedence due to bw-compatibility.
     if cmp is not None:
@@ -226,7 +226,7 @@ def _determine_eq_order(ctx: 'mypy.plugin.ClassDefContext') -> bool:
         order = eq
 
     if eq is False and order is True:
-        ctx.api.fail("eq must be True if order is True", ctx.reason)
+        ctx.api.fail('eq must be "True" if order is "True"', ctx.reason)
 
     return order
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -137,7 +137,7 @@ class DataclassTransformer:
         # Add <, >, <=, >=, but only if the class has an eq method.
         if decorator_arguments['order']:
             if not decorator_arguments['eq']:
-                ctx.api.fail('eq must be "True" if order is "True"', ctx.cls)
+                ctx.api.fail('eq must be True if order is True', ctx.cls)
 
             for method_name in ['__lt__', '__gt__', '__le__', '__ge__']:
                 # Like for __eq__ and __ne__, we want "other" to match

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -137,7 +137,7 @@ class DataclassTransformer:
         # Add <, >, <=, >=, but only if the class has an eq method.
         if decorator_arguments['order']:
             if not decorator_arguments['eq']:
-                ctx.api.fail('eq must be True if order is True', ctx.cls)
+                ctx.api.fail('eq must be "True" if order is "True"', ctx.cls)
 
             for method_name in ['__lt__', '__gt__', '__le__', '__ge__']:
                 # Like for __eq__ and __ne__, we want "other" to match

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1856,7 +1856,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             # is incomplete. Defer the current target.
             self.mark_incomplete(imported_id, context)
             return
-        message = "Module '{}' has no attribute '{}'".format(import_id, source_id)
+        message = 'Module "{}" has no attribute "{}"'.format(import_id, source_id)
         # Suggest alternatives, if any match is found.
         module = self.modules.get(import_id)
         if module:

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -282,11 +282,11 @@ class DeprecatedTrue:
 class DeprecatedFalse:
    ...
 
-@attrs(cmp=False, eq=True)  # E: Don't mix `cmp` with `eq' and `order`
+@attrs(cmp=False, eq=True)  # E: Don't mix "False" with "True" and "None"
 class Mixed:
    ...
 
-@attrs(order=True, eq=False)  # E: eq must be True if order is True
+@attrs(order=True, eq=False)  # E: eq must be "True" if order is "True"
 class Confused:
    ...
 [builtins fixtures/attr.pyi]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -282,11 +282,11 @@ class DeprecatedTrue:
 class DeprecatedFalse:
    ...
 
-@attrs(cmp=False, eq=True)  # E: Don't mix "False" with "True" and "None"
+@attrs(cmp=False, eq=True)  # E: Don't mix "cmp" with "eq" and "order"
 class Mixed:
    ...
 
-@attrs(order=True, eq=False)  # E: eq must be "True" if order is "True"
+@attrs(order=True, eq=False)  # E: eq must be True if order is True
 class Confused:
    ...
 [builtins fixtures/attr.pyi]

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -125,7 +125,7 @@ def f(x: object, n: int, s: str) -> None:
 [case testColumnHasNoAttribute]
 import m
 if int():
-    from m import foobaz # E:5: Module 'm' has no attribute 'foobaz'; maybe "foobar"?
+    from m import foobaz # E:5: Module "m" has no attribute "foobaz"; maybe "foobar"?
 1 .x # E:1: "int" has no attribute "x"
 (m.foobaz()) # E:2: Module has no attribute "foobaz"; maybe "foobar"?
 

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -415,7 +415,7 @@ app1 >= app3
 from dataclasses import dataclass
 
 @dataclass(eq=False, order=True)
-class Application:  # E: eq must be True if order is True
+class Application:  # E: eq must be "True" if order is "True"
    ...
 
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -415,7 +415,7 @@ app1 >= app3
 from dataclasses import dataclass
 
 @dataclass(eq=False, order=True)
-class Application:  # E: eq must be "True" if order is "True"
+class Application:  # E: eq must be True if order is True
    ...
 
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -6,8 +6,8 @@
 import m
 m.x  # E: Module has no attribute "x"  [attr-defined]
 'x'.foobar  # E: "str" has no attribute "foobar"  [attr-defined]
-from m import xx  # E: Module 'm' has no attribute 'xx'  [attr-defined]
-from m import think  # E: Module 'm' has no attribute 'think'; maybe "thing"?  [attr-defined]
+from m import xx  # E: Module "m" has no attribute "xx"  [attr-defined]
+from m import think  # E: Module "m" has no attribute "think"; maybe "thing"?  [attr-defined]
 for x in 1:  # E: "int" has no attribute "__iter__" (not iterable)  [attr-defined]
     pass
 [file m.py]
@@ -504,7 +504,7 @@ from defusedxml import xyz  # E: Cannot find implementation or library stub for 
 from nonexistent import foobar  # E: Cannot find implementation or library stub for module named "nonexistent"  [import]
 import nonexistent2  # E: Cannot find implementation or library stub for module named "nonexistent2"  [import]
 from nonexistent3 import *  # E: Cannot find implementation or library stub for module named "nonexistent3"  [import]
-from pkg import bad  # E: Module 'pkg' has no attribute 'bad'  [attr-defined]
+from pkg import bad  # E: Module "pkg" has no attribute "bad"  [attr-defined]
 from pkg.bad2 import bad3  # E: Cannot find implementation or library stub for module named "pkg.bad2"  [import]
 [file pkg/__init__.py]
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1303,7 +1303,7 @@ implicit_reexport = True
 \[mypy-other_module_2]
 implicit_reexport = False
 [out]
-main:2: error: Module 'other_module_2' has no attribute 'a'
+main:2: error: Module "other_module_2" has no attribute "a"
 
 [case testImplicitAnyOKForNoArgs]
 # flags: --disallow-any-generics --show-column-numbers

--- a/test-data/unit/check-incomplete-fixture.test
+++ b/test-data/unit/check-incomplete-fixture.test
@@ -16,7 +16,7 @@ m.x # E: "object" has no attribute "x"
 from typing import List
 def f(x: List[int]) -> None: pass
 [out]
-main:1: error: Module 'typing' has no attribute 'List'
+main:1: error: Module "typing" has no attribute "List"
 main:1: note: Maybe your test fixture does not define "builtins.list"?
 main:1: note: Consider adding [builtins fixtures/list.pyi] to your test description
 
@@ -24,7 +24,7 @@ main:1: note: Consider adding [builtins fixtures/list.pyi] to your test descript
 from typing import Dict
 def f(x: Dict[int]) -> None: pass
 [out]
-main:1: error: Module 'typing' has no attribute 'Dict'
+main:1: error: Module "typing" has no attribute "Dict"
 main:1: note: Maybe your test fixture does not define "builtins.dict"?
 main:1: note: Consider adding [builtins fixtures/dict.pyi] to your test description
 
@@ -32,7 +32,7 @@ main:1: note: Consider adding [builtins fixtures/dict.pyi] to your test descript
 from typing import Set
 def f(x: Set[int]) -> None: pass
 [out]
-main:1: error: Module 'typing' has no attribute 'Set'
+main:1: error: Module "typing" has no attribute "Set"
 main:1: note: Maybe your test fixture does not define "builtins.set"?
 main:1: note: Consider adding [builtins fixtures/set.pyi] to your test description
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1821,9 +1821,9 @@ class C:
         A = NamedTuple('A', [('x', int), ('y', int)])
 [builtins fixtures/tuple.pyi]
 [out1]
-main:1: error: Module 'ntcrash' has no attribute 'nope'
+main:1: error: Module "ntcrash" has no attribute "nope"
 [out2]
-main:1: error: Module 'ntcrash' has no attribute 'nope'
+main:1: error: Module "ntcrash" has no attribute "nope"
 
 [case testIncrementalNamedTupleInMethod2]
 from ntcrash import nope
@@ -1835,9 +1835,9 @@ class C:
             A = NamedTuple('A', [('x', int), ('y', int)])
 [builtins fixtures/tuple.pyi]
 [out1]
-main:1: error: Module 'ntcrash' has no attribute 'nope'
+main:1: error: Module "ntcrash" has no attribute "nope"
 [out2]
-main:1: error: Module 'ntcrash' has no attribute 'nope'
+main:1: error: Module "ntcrash" has no attribute "nope"
 
 [case testIncrementalNamedTupleInMethod3]
 from ntcrash import nope
@@ -1850,9 +1850,9 @@ class C:
                 A = NamedTuple('A', [('x', int), ('y', int)])
 [builtins fixtures/tuple.pyi]
 [out1]
-main:1: error: Module 'ntcrash' has no attribute 'nope'
+main:1: error: Module "ntcrash" has no attribute "nope"
 [out2]
-main:1: error: Module 'ntcrash' has no attribute 'nope'
+main:1: error: Module "ntcrash" has no attribute "nope"
 
 [case testIncrementalTypedDictInMethod]
 from tdcrash import nope
@@ -1863,9 +1863,9 @@ class C:
         A = TypedDict('A', {'x': int, 'y': int})
 [builtins fixtures/dict.pyi]
 [out1]
-main:1: error: Module 'tdcrash' has no attribute 'nope'
+main:1: error: Module "tdcrash" has no attribute "nope"
 [out2]
-main:1: error: Module 'tdcrash' has no attribute 'nope'
+main:1: error: Module "tdcrash" has no attribute "nope"
 
 [case testIncrementalTypedDictInMethod2]
 from tdcrash import nope
@@ -1877,9 +1877,9 @@ class C:
             A = TypedDict('A', {'x': int, 'y': int})
 [builtins fixtures/dict.pyi]
 [out1]
-main:1: error: Module 'tdcrash' has no attribute 'nope'
+main:1: error: Module "tdcrash" has no attribute "nope"
 [out2]
-main:1: error: Module 'tdcrash' has no attribute 'nope'
+main:1: error: Module "tdcrash" has no attribute "nope"
 
 [case testIncrementalTypedDictInMethod3]
 from tdcrash import nope
@@ -1892,9 +1892,9 @@ class C:
                 A = TypedDict('A', {'x': int, 'y': int})
 [builtins fixtures/dict.pyi]
 [out1]
-main:1: error: Module 'tdcrash' has no attribute 'nope'
+main:1: error: Module "tdcrash" has no attribute "nope"
 [out2]
-main:1: error: Module 'tdcrash' has no attribute 'nope'
+main:1: error: Module "tdcrash" has no attribute "nope"
 
 [case testIncrementalNewTypeInMethod]
 from ntcrash import nope
@@ -1914,9 +1914,9 @@ def f() -> None:
 
 [builtins fixtures/dict.pyi]
 [out1]
-main:1: error: Module 'ntcrash' has no attribute 'nope'
+main:1: error: Module "ntcrash" has no attribute "nope"
 [out2]
-main:1: error: Module 'ntcrash' has no attribute 'nope'
+main:1: error: Module "ntcrash" has no attribute "nope"
 
 [case testIncrementalInnerClassAttrInMethod]
 import crash
@@ -2225,9 +2225,9 @@ from b import x
 1 + 1
 [out]
 [out2]
-tmp/b.py:1: error: Module 'c' has no attribute 'x'
+tmp/b.py:1: error: Module "c" has no attribute "x"
 [out3]
-tmp/b.py:1: error: Module 'c' has no attribute 'x'
+tmp/b.py:1: error: Module "c" has no attribute "x"
 
 [case testCacheDeletedAfterErrorsFound2]
 
@@ -2284,9 +2284,9 @@ from b import x
 1 + 1
 [out]
 [out2]
-tmp/c.py:1: error: Module 'd' has no attribute 'x'
+tmp/c.py:1: error: Module "d" has no attribute "x"
 [out3]
-tmp/c.py:1: error: Module 'd' has no attribute 'x'
+tmp/c.py:1: error: Module "d" has no attribute "x"
 
 [case testNoCrashOnDeletedWithCacheOnCmdline]
 # cmd: mypy -m nonexistent
@@ -4572,10 +4572,10 @@ B = List[A]
 
 [builtins fixtures/list.pyi]
 [out]
-tmp/lib.pyi:4: error: Module 'other' has no attribute 'B'
+tmp/lib.pyi:4: error: Module "other" has no attribute "B"
 tmp/other.pyi:3: error: Cannot resolve name "B" (possible cyclic definition)
 [out2]
-tmp/lib.pyi:4: error: Module 'other' has no attribute 'B'
+tmp/lib.pyi:4: error: Module "other" has no attribute "B"
 tmp/other.pyi:3: error: Cannot resolve name "B" (possible cyclic definition)
 tmp/a.py:3: note: Revealed type is "builtins.list[Any]"
 

--- a/test-data/unit/check-modules-case.test
+++ b/test-data/unit/check-modules-case.test
@@ -1,7 +1,7 @@
 -- Type checker test cases dealing with modules and imports on case-insensitive filesystems.
 
 [case testCaseSensitivityDir]
-from a import B  # E: Module 'a' has no attribute 'B'
+from a import B  # E: Module "a" has no attribute "B"
 
 [file a/__init__.py]
 [file a/b/__init__.py]
@@ -9,7 +9,7 @@ from a import B  # E: Module 'a' has no attribute 'B'
 [case testCaseInsensitivityDir]
 # flags: --config-file tmp/mypy.ini
 
-from a import B  # E: Module 'a' has no attribute 'B'
+from a import B  # E: Module "a" has no attribute "B"
 from other import x
 reveal_type(x)  # N: Revealed type is "builtins.int"
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1044,7 +1044,7 @@ from foo import B
 class C(B):
     pass
 [out]
-tmp/bar.py:1: error: Module 'foo' has no attribute 'B'
+tmp/bar.py:1: error: Module "foo" has no attribute "B"
 
 [case testImportSuppressedWhileAlmostSilent]
 # cmd: mypy -m main
@@ -1817,8 +1817,8 @@ m = n  # E: Cannot assign multiple modules to name 'm' without explicit 'types.M
 [builtins fixtures/module.pyi]
 
 [case testNoReExportFromStubs]
-from stub import Iterable  # E: Module 'stub' has no attribute 'Iterable'
-from stub import D  # E: Module 'stub' has no attribute 'D'
+from stub import Iterable  # E: Module "stub" has no attribute "Iterable"
+from stub import D  # E: Module "stub" has no attribute "D"
 from stub import C
 
 c = C()
@@ -1912,7 +1912,7 @@ class C:
 
 [case testNoReExportChildStubs]
 import mod
-from mod import C, D  # E: Module 'mod' has no attribute 'C'
+from mod import C, D  # E: Module "mod" has no attribute "C"
 
 reveal_type(mod.x)  # N: Revealed type is "mod.submod.C"
 mod.C  # E: Module has no attribute "C"
@@ -1930,7 +1930,7 @@ class D:
 [builtins fixtures/module.pyi]
 
 [case testNoReExportNestedStub]
-from stub import substub  # E: Module 'stub' has no attribute 'substub'
+from stub import substub  # E: Module "stub" has no attribute "substub"
 
 [file stub.pyi]
 import substub
@@ -2074,7 +2074,7 @@ def __getattr__(name: str) -> int: ...
 
 [case testModuleLevelGetattrImportFromNotStub36]
 # flags: --python-version 3.6
-from non_stub import name  # E: Module 'non_stub' has no attribute 'name'
+from non_stub import name  # E: Module "non_stub" has no attribute "name"
 reveal_type(name)  # N: Revealed type is "Any"
 
 [file non_stub.py]
@@ -2814,10 +2814,10 @@ CustomDict = TypedDict(
 [builtins fixtures/tuple.pyi]
 
 [case testNoReExportFromMissingStubs]
-from stub import a  # E: Module 'stub' has no attribute 'a'
+from stub import a  # E: Module "stub" has no attribute "a"
 from stub import b
-from stub import c  # E: Module 'stub' has no attribute 'c'
-from stub import d  # E: Module 'stub' has no attribute 'd'
+from stub import c  # E: Module "stub" has no attribute "c"
+from stub import d  # E: Module "stub" has no attribute "d"
 
 [file stub.pyi]
 from mystery import a, b as b, c as d

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -67,14 +67,14 @@ tmp/a.py:4: error: "B" not callable
 [case testNewAnalyzerTypeAnnotationCycle3]
 import b
 [file a.py]
-from b import bad # E: Module 'b' has no attribute 'bad'; maybe "bad2"?
+from b import bad # E: Module "b" has no attribute "bad"; maybe "bad2"?
 [file b.py]
-from a import bad2 # E: Module 'a' has no attribute 'bad2'; maybe "bad"?
+from a import bad2 # E: Module "a" has no attribute "bad2"; maybe "bad"?
 
 [case testNewAnalyzerTypeAnnotationCycle4]
 import b
 [file a.py]
-from b import bad # E: Module 'b' has no attribute 'bad'
+from b import bad # E: Module "b" has no attribute "bad"
 [file b.py]
 # TODO: Could we generate an error here as well?
 from a import bad

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -392,7 +392,7 @@ class A:
 main:1: error: Cannot find implementation or library stub for module named "a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
-main:1: error: Module 'a' has no attribute 'A'
+main:1: error: Module "a" has no attribute "A"
 
 [case testFixingBlockingErrorBringsInAnotherModuleWithBlocker]
 import a

--- a/test-data/unit/fine-grained-cycles.test
+++ b/test-data/unit/fine-grained-cycles.test
@@ -172,7 +172,7 @@ def h() -> None:
 
 [out]
 ==
-a.py:1: error: Module 'b' has no attribute 'C'
+a.py:1: error: Module "b" has no attribute "C"
 
 [case testReferenceToTypeThroughCycleAndReplaceWithFunction]
 

--- a/test-data/unit/fine-grained-follow-imports.test
+++ b/test-data/unit/fine-grained-follow-imports.test
@@ -501,7 +501,7 @@ from p import m
 main.py:1: error: Cannot find implementation or library stub for module named "p"
 main.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
-main.py:1: error: Module 'p' has no attribute 'm'
+main.py:1: error: Module "p" has no attribute "m"
 ==
 p/m.py:1: error: "str" not callable
 

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -402,7 +402,7 @@ from p import q
 [file p/q.py.3]
 [out]
 ==
-main:1: error: Module 'p' has no attribute 'q'
+main:1: error: Module "p" has no attribute "q"
 -- TODO: The following messages are different compared to non-incremental mode
 main:1: error: Cannot find implementation or library stub for module named "p.q"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
@@ -1474,7 +1474,7 @@ from c import *
 [file c.py.2]
 def f(x: int) -> None: pass
 [out]
-main:1: error: Module 'b' has no attribute 'f'
+main:1: error: Module "b" has no attribute "f"
 ==
 main:2: error: Missing positional argument "x" in call to "f"
 
@@ -1523,7 +1523,7 @@ from p.c import *
 [file p/c.py.2]
 def f(x: int) -> None: pass
 [out]
-main:1: error: Module 'p.b' has no attribute 'f'
+main:1: error: Module "p.b" has no attribute "f"
 ==
 main:2: error: Missing positional argument "x" in call to "f"
 
@@ -1551,7 +1551,7 @@ def f() -> None: pass
 [file c.py.2]
 [out]
 ==
-main:1: error: Module 'b' has no attribute 'f'
+main:1: error: Module "b" has no attribute "f"
 
 [case testImportStarRemoveDependency2]
 from b import *

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1645,7 +1645,7 @@ def f() -> None: pass
 [file a.py.2]
 [out]
 ==
-main:2: error: Module 'a' has no attribute 'f'
+main:2: error: Module "a" has no attribute "f"
 
 [case testTypeVarRefresh]
 from typing import TypeVar
@@ -1656,7 +1656,7 @@ def f() -> None: pass
 [file a.py.2]
 [out]
 ==
-main:2: error: Module 'a' has no attribute 'f'
+main:2: error: Module "a" has no attribute "f"
 
 [case testRefreshTyping]
 from typing import Sized
@@ -1695,7 +1695,7 @@ def f() -> None: pass
 [builtins fixtures/tuple.pyi]
 [out]
 ==
-main:2: error: Module 'a' has no attribute 'f'
+main:2: error: Module "a" has no attribute "f"
 
 [case testModuleLevelAttributeRefresh]
 from typing import Callable
@@ -1707,7 +1707,7 @@ def f() -> None: pass
 [file a.py.2]
 [out]
 ==
-main:2: error: Module 'a' has no attribute 'f'
+main:2: error: Module "a" has no attribute "f"
 
 [case testClassBodyRefresh]
 from a import f
@@ -1722,7 +1722,7 @@ f = 1
 [file a.py.2]
 [out]
 ==
-main:1: error: Module 'a' has no attribute 'f'
+main:1: error: Module "a" has no attribute "f"
 
 [case testDecoratedMethodRefresh]
 from typing import Iterator, Callable, List
@@ -2588,7 +2588,7 @@ class A: pass
 class A: pass
 [out]
 ==
-main:2: error: Module 'a' has no attribute 'A'
+main:2: error: Module "a" has no attribute "A"
 ==
 
 [case testRefreshGenericAndFailInPass3]
@@ -3400,7 +3400,7 @@ class C: pass
 [file a.py.2]
 [out]
 ==
-main:1: error: Module 'a' has no attribute 'C'
+main:1: error: Module "a" has no attribute "C"
 
 [case testRefreshSubclassNestedInFunction2]
 from a import C
@@ -7845,7 +7845,7 @@ from b import A
 [builtins fixtures/list.pyi]
 [out]
 ==
-a.py:4: error: Module 'b' has no attribute 'A'
+a.py:4: error: Module "b" has no attribute "A"
 a.py:4: error: Name 'A' already defined on line 3
 
 -- the order of errors is different with cache
@@ -9176,7 +9176,7 @@ x = 42
 def good() -> None: ...
 [out]
 ==
-a.py:1: error: Module 'b' has no attribute 'bad'
+a.py:1: error: Module "b" has no attribute "bad"
 
 [case testFileAddedAndImported2]
 # flags: --ignore-missing-imports --follow-imports=skip
@@ -9193,7 +9193,7 @@ x = 42
 def good() -> None: ...
 [out]
 ==
-a.py:1: error: Module 'b' has no attribute 'bad'
+a.py:1: error: Module "b" has no attribute "bad"
 
 [case testTypedDictCrashFallbackAfterDeletedMeet]
 # flags: --ignore-missing-imports

--- a/test-data/unit/pep561.test
+++ b/test-data/unit/pep561.test
@@ -60,7 +60,7 @@ from typedpkg import dne
 a = ex([''])
 reveal_type(a)
 [out]
-testTypedPkgStubs.py:3: error: Module 'typedpkg' has no attribute 'dne'
+testTypedPkgStubs.py:3: error: Module "typedpkg" has no attribute "dne"
 testTypedPkgStubs.py:5: note: Revealed type is "builtins.list[builtins.str]"
 
 [case testStubPrecedence]
@@ -79,7 +79,7 @@ from typedpkg import dne
 a = ex([''])
 reveal_type(a)
 [out]
-testTypedPkgStubs_python2.py:3: error: Module 'typedpkg' has no attribute 'dne'
+testTypedPkgStubs_python2.py:3: error: Module "typedpkg" has no attribute "dne"
 testTypedPkgStubs_python2.py:5: note: Revealed type is "builtins.list[builtins.str]"
 
 [case testTypedPkgSimple_python2]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -195,7 +195,7 @@ from m import y
 [file m.py]
 x = 1
 [out]
-main:2: error: Module 'm' has no attribute 'y'
+main:2: error: Module "m" has no attribute "y"
 
 [case testMissingModule]
 import typing
@@ -1273,16 +1273,16 @@ class A:
 
 [case testStubPackage]
 from m import x
-from m import y # E: Module 'm' has no attribute 'y'
+from m import y # E: Module "m" has no attribute "y"
 [file m/__init__.pyi]
 x = 1
 [out]
 
 [case testStubPackageSubModule]
 from m import x
-from m import y # E: Module 'm' has no attribute 'y'
+from m import y # E: Module "m" has no attribute "y"
 from m.m2 import y
-from m.m2 import z # E: Module 'm.m2' has no attribute 'z'
+from m.m2 import z # E: Module "m.m2" has no attribute "z"
 [file m/__init__.pyi]
 x = 1
 [file m/m2.pyi]

--- a/test-data/unit/semanal-modules.test
+++ b/test-data/unit/semanal-modules.test
@@ -771,7 +771,7 @@ import m.x
 [file m/x.py]
 from .x import nonexistent
 [out]
-tmp/m/x.py:1: error: Module 'm.x' has no attribute 'nonexistent'
+tmp/m/x.py:1: error: Module "m.x" has no attribute "nonexistent"
 
 [case testImportFromSameModule]
 import m.x
@@ -779,7 +779,7 @@ import m.x
 [file m/x.py]
 from m.x import nonexistent
 [out]
-tmp/m/x.py:1: error: Module 'm.x' has no attribute 'nonexistent'
+tmp/m/x.py:1: error: Module "m.x" has no attribute "nonexistent"
 
 [case testImportMisspellingSingleCandidate]
 import f
@@ -790,7 +790,7 @@ def some_function():
 [file f.py]
 from m.x import somefunction
 [out]
-tmp/f.py:1: error: Module 'm.x' has no attribute 'somefunction'; maybe "some_function"?
+tmp/f.py:1: error: Module "m.x" has no attribute "somefunction"; maybe "some_function"?
 
 [case testImportMisspellingMultipleCandidates]
 import f
@@ -803,7 +803,7 @@ def somef_unction():
 [file f.py]
 from m.x import somefunction
 [out]
-tmp/f.py:1: error: Module 'm.x' has no attribute 'somefunction'; maybe "somef_unction" or "some_function"?
+tmp/f.py:1: error: Module "m.x" has no attribute "somefunction"; maybe "somef_unction" or "some_function"?
 
 [case testImportMisspellingMultipleCandidatesTruncated]
 import f
@@ -820,7 +820,7 @@ def somefun_ction():
 [file f.py]
 from m.x import somefunction
 [out]
-tmp/f.py:1: error: Module 'm.x' has no attribute 'somefunction'; maybe "somefun_ction", "somefu_nction", or "somef_unction"?
+tmp/f.py:1: error: Module "m.x" has no attribute "somefunction"; maybe "somefun_ction", "somefu_nction", or "somef_unction"?
 
 [case testFromImportAsInStub]
 from m import *


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445  for `dont mix` and `has no attributes` error messages

## Test Plan
Updated test cases for the message. New test cases not added.