### PR TITLE
Issue an error when overriding typeguard with non-typeguard in subclass

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1610,7 +1610,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if isinstance(original, FunctionLike) and isinstance(override, FunctionLike):
             if original_class_or_static and not override_class_or_static:
                 fail = True
-            if isinstance(original, CallableType) and isinstance(override, CallableType):
+            elif isinstance(original, CallableType) and isinstance(override, CallableType):
                 if original.type_guard is not None and override.type_guard is None:
                     fail = True
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1610,6 +1610,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if isinstance(original, FunctionLike) and isinstance(override, FunctionLike):
             if original_class_or_static and not override_class_or_static:
                 fail = True
+            if isinstance(original, CallableType) and isinstance(override, CallableType):
+                if original.type_guard is not None and override.type_guard is None:
+                    fail = True
 
         if is_private(name):
             fail = False

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -287,10 +287,10 @@ def main(a: object) -> None:
         reveal_type(a)  # N: Revealed type is 'builtins.float'
 [builtins fixtures/tuple.pyi]
 
-[case testTypeGuardMethodOverride-skip]
+[case testTypeGuardMethodOverride]
 from typing_extensions import TypeGuard
 class C:
     def is_float(self, a: object) -> TypeGuard[float]: pass
 class D(C):
-    def is_float(self, a: object) -> bool: pass  # E: Some error
+    def is_float(self, a: object) -> bool: pass  # E: Signature of "is_float" incompatible with supertype "C"
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
### Description

Closes #9928.

Issue an error about incompatible signature when trying to override typeguard method with non-typeguard one.