### PR TITLE
Removes git-submodules artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: true
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -20,9 +20,6 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: initialize submodules
-      run: git submodule update --init
-
     - name: Setup 🐍 3.8
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
### Description

I have removed some infrastructure code that checked-out non-existent `git submodules`, I have also removed empty `.gitmodules` file, because it was a bit confusing (people tend to have it when there's something inside). I was pretty sure that `mypy` still uses `typeshed` submodule and I was really confused to see that it is empty. 😕 

Now, it is plain simple again.

Related https://github.com/python/mypy/commit/ba037888eccd0f63e193d0fefd8f4e9265b8e3d3
Related https://github.com/python/mypy/pull/9973
Related https://github.com/python/mypy/issues/9971