### PR TITLE
Use double quotes errors in `already defined`, `is nonlocal and global`, `No binding for nonlocal` and `is already defined in local`

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -508,7 +508,7 @@ Example:
    class A:
        def __init__(self, x: int) -> None: ...
 
-   class A:  # Error: Name 'A' already defined on line 1  [no-redef]
+   class A:  # Error: Name "A" already defined on line 1  [no-redef]
        def __init__(self, x: str) -> None: ...
 
    # Error: Argument 1 to "A" has incompatible type "str"; expected "int"

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3463,7 +3463,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         self.statement = g
         for name in g.names:
             if name in self.nonlocal_decls[-1]:
-                self.fail("Name '{}' is nonlocal and global".format(name), g)
+                self.fail('Name "{}" is nonlocal and global'.format(name), g)
             self.global_decls[-1].add(name)
 
     def visit_nonlocal_decl(self, d: NonlocalDecl) -> None:
@@ -3476,14 +3476,14 @@ class SemanticAnalyzer(NodeVisitor[None],
                     if table is not None and name in table:
                         break
                 else:
-                    self.fail("No binding for nonlocal '{}' found".format(name), d)
+                    self.fail('No binding for nonlocal "{}" found'.format(name), d)
 
                 if self.locals[-1] is not None and name in self.locals[-1]:
-                    self.fail("Name '{}' is already defined in local "
-                              "scope before nonlocal declaration".format(name), d)
+                    self.fail('Name "{}" is already defined in local '
+                              'scope before nonlocal declaration'.format(name), d)
 
                 if name in self.global_decls[-1]:
-                    self.fail("Name '{}' is nonlocal and global".format(name), d)
+                    self.fail('Name "{}" is nonlocal and global'.format(name), d)
                 self.nonlocal_decls[-1].add(name)
 
     def visit_print_stmt(self, s: PrintStmt) -> None:
@@ -4783,7 +4783,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             extra_msg = ' on line {}'.format(node.line)
         else:
             extra_msg = ' (possibly by an import)'
-        self.fail("{} '{}' already defined{}".format(noun, unmangle(name), extra_msg), ctx,
+        self.fail('{} "{}" already defined{}'.format(noun, unmangle(name), extra_msg), ctx,
                   code=codes.NO_REDEF)
 
     def name_already_defined(self,

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -816,8 +816,8 @@ class StubtestMiscUnit(unittest.TestCase):
 
         output = run_stubtest(stub="def f(): ...\ndef f(): ...", runtime="", options=[])
         assert remove_color_code(output) == (
-            "error: failed mypy build.\n{}.pyi:2: "
-            "error: Name 'f' already defined on line 1\n".format(TEST_MODULE_NAME)
+            'error: failed mypy build.\n{}.pyi:2: '
+            'error: Name "f" already defined on line 1\n'.format(TEST_MODULE_NAME)
         )
 
     def test_missing_stubs(self) -> None:

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -976,13 +976,13 @@ reveal_type(A)  # N: Revealed type is "def (b: Any, a: Any) -> __main__.A"
 class B:
    a: int = attr.ib(default=8)
    b: int = attr.ib()
-   a: int = attr.ib()  # E: Name 'a' already defined on line 10
+   a: int = attr.ib()  # E: Name "a" already defined on line 10
 reveal_type(B)  # N: Revealed type is "def (b: builtins.int, a: builtins.int) -> __main__.B"
 @attr.s(auto_attribs=True)
 class C:
    a: int = 8
    b: int
-   a: int = attr.ib()  # E: Name 'a' already defined on line 16
+   a: int = attr.ib()  # E: Name "a" already defined on line 16
 reveal_type(C)  # N: Revealed type is "def (a: builtins.int, b: builtins.int) -> __main__.C"
 [builtins fixtures/bool.pyi]
 

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -639,16 +639,16 @@ class AnnotationsAsAMethod(NamedTuple):
 
 class ReuseNames(NamedTuple):
     x: int
-    def x(self) -> str:  # E: Name 'x' already defined on line 22
+    def x(self) -> str:  # E: Name "x" already defined on line 22
         return ''
 
     def y(self) -> int:
         return 0
-    y: str  # E: Name 'y' already defined on line 26
+    y: str  # E: Name "y" already defined on line 26
 
 class ReuseCallableNamed(NamedTuple):
     z: Callable[[ReuseNames], int]
-    def z(self) -> int:  # E: Name 'z' already defined on line 31
+    def z(self) -> int:  # E: Name "z" already defined on line 31
         return 0
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1093,7 +1093,7 @@ A()
 class A: pass
 class A: pass
 [out]
-main:4: error: Name 'A' already defined on line 3
+main:4: error: Name "A" already defined on line 3
 
 [case testDocstringInClass]
 import typing
@@ -6101,13 +6101,13 @@ def test() -> None:
 class C:
     def __init__(self) -> None:
         self.foo = 12
-        self.foo: int = 12  # E: Attribute 'foo' already defined on line 3
+        self.foo: int = 12  # E: Attribute "foo" already defined on line 3
 
 [case testMemberRedefinitionDefinedInClass]
 class C:
     foo = 12
     def __init__(self) -> None:
-        self.foo: int = 12  # E: Attribute 'foo' already defined on line 2
+        self.foo: int = 12  # E: Attribute "foo" already defined on line 2
 
 [case testAbstractInit]
 from abc import abstractmethod, ABCMeta

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1069,9 +1069,9 @@ class A2:
 from dataclasses import dataclass
 
 @dataclass
-class A:  # E: Name 'x' already defined (possibly by an import)
+class A:  # E: Name "x" already defined (possibly by an import)
     x: int = 0
-    x: int = 0  # E: Name 'x' already defined on line 7
+    x: int = 0  # E: Name "x" already defined on line 7
 
 @dataclass
 class B(A):

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -510,11 +510,11 @@ from pkg.bad2 import bad3  # E: Cannot find implementation or library stub for m
 
 [case testErrorCodeAlreadyDefined]
 x: int
-x: str  # E: Name 'x' already defined on line 1  [no-redef]
+x: str  # E: Name "x" already defined on line 1  [no-redef]
 
 def f():
     pass
-def f(): # E: Name 'f' already defined on line 4  [no-redef]
+def f(): # E: Name "f" already defined on line 4  [no-redef]
     pass
 
 [case testErrorCodeMissingReturn]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1390,7 +1390,7 @@ from typing import Any
 x = None # type: Any
 if x:
     def f(): pass
-def f(): pass # E: Name 'f' already defined on line 4
+def f(): pass # E: Name "f" already defined on line 4
 
 [case testIncompatibleConditionalFunctionDefinition]
 from typing import Any
@@ -1636,7 +1636,7 @@ x = None # type: Any
 class A:
     if x:
         def f(self): pass
-    def f(self): pass # E: Name 'f' already defined on line 5
+    def f(self): pass # E: Name "f" already defined on line 5
 
 [case testIncompatibleConditionalMethodDefinition]
 from typing import Any
@@ -2149,7 +2149,7 @@ f = g # E: Incompatible types in assignment (expression has type "Callable[[Any,
 
 [case testRedefineFunction2]
 def f() -> None: pass
-def f() -> None: pass # E: Name 'f' already defined on line 1
+def f() -> None: pass # E: Name "f" already defined on line 1
 
 
 -- Special cases

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1028,7 +1028,7 @@ import a.b
 [rechecked b]
 [stale]
 [out2]
-tmp/b.py:4: error: Name 'a' already defined on line 3
+tmp/b.py:4: error: Name "a" already defined on line 3
 
 [case testIncrementalSilentImportsAndImportsInClass]
 # flags: --ignore-missing-imports

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -326,7 +326,7 @@ main:2: error: Name "y" is not defined
 # Error messages differ with the new analyzer
 
 import xab  # E: Cannot find implementation or library stub for module named "xab"  # N: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-def xab(): pass  # E: Name 'xab' already defined (possibly by an import)
+def xab(): pass  # E: Name "xab" already defined (possibly by an import)
 
 [case testAccessingUnknownModuleFromOtherModule]
 import x
@@ -2110,7 +2110,7 @@ def __getattr__(name: str) -> Any: ...
 from has_attr import name
 from has_attr import name
 from has_attr import x
-from has_attr import y as x  # E: Name 'x' already defined (possibly by an import)
+from has_attr import y as x  # E: Name "x" already defined (possibly by an import)
 reveal_type(name)  # N: Revealed type is "builtins.int"
 
 [file has_attr.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -286,11 +286,11 @@ if MYPY:
     from b import x as y
 x = 0
 
-def y(): pass # E: Name 'y' already defined on line 4
+def y(): pass # E: Name "y" already defined on line 4
 reveal_type(y) # N: Revealed type is "builtins.int"
 
 y2 = y
-class y2: pass # E: Name 'y2' already defined on line 9
+class y2: pass # E: Name "y2" already defined on line 9
 reveal_type(y2) # N: Revealed type is "builtins.int"
 
 y3, y4 = y, y
@@ -312,11 +312,11 @@ import a
 from b import x as y
 x = 0
 
-def y(): pass # E: Name 'y' already defined on line 2
+def y(): pass # E: Name "y" already defined on line 2
 reveal_type(y) # N: Revealed type is "builtins.int"
 
 y2 = y
-class y2: pass # E: Name 'y2' already defined on line 7
+class y2: pass # E: Name "y2" already defined on line 7
 reveal_type(y2) # N: Revealed type is "builtins.int"
 
 y3, y4 = y, y
@@ -340,7 +340,7 @@ MYPY = False
 if MYPY:  # Tweak processing order
     from b import C as C2
 class C: pass
-class C2: pass # E: Name 'C2' already defined on line 4
+class C2: pass # E: Name "C2" already defined on line 4
 
 [file b.py]
 from a import C
@@ -352,7 +352,7 @@ import a
 from b import C as C2
 class C: pass
 
-class C2: pass # E: Name 'C2' already defined on line 2
+class C2: pass # E: Name "C2" already defined on line 2
 [file b.py]
 MYPY = False
 if MYPY:  # Tweak processing order
@@ -366,7 +366,7 @@ from b import f as g
 def f(): pass
 
 a, *b = g()
-class b(): pass # E: Name 'b' already defined on line 4
+class b(): pass # E: Name "b" already defined on line 4
 reveal_type(b) # N: Revealed type is "Any"
 
 [file b.py]
@@ -381,7 +381,7 @@ reveal_type(x) # N: Revealed type is "b.A"
 
 from b import *
 
-class A: pass # E: Name 'A' already defined (possibly by an import)
+class A: pass # E: Name "A" already defined (possibly by an import)
 
 [file b.py]
 class A: pass
@@ -400,7 +400,7 @@ MYPY = False
 if MYPY: # Tweak processing order
     from b import *
 
-class A: pass # E: Name 'A' already defined (possibly by an import)
+class A: pass # E: Name "A" already defined (possibly by an import)
 
 [file b.py]
 class A: pass
@@ -1911,7 +1911,7 @@ reveal_type(f) # N: Revealed type is "def (builtins.str)"
 [case testNewAnalyzerConditionallyDefineFuncOverClass]
 class C:
     1()  # E: "int" not callable
-def C() -> None:  # E: Name 'C' already defined on line 1
+def C() -> None:  # E: Name "C" already defined on line 1
     ''()  # E: "str" not callable
 
 [case testNewAnalyzerTupleIteration]
@@ -2014,7 +2014,7 @@ y = 1
 from non_existing import stuff, other_stuff
 
 stuff = 1  # OK
-other_stuff: int = 1  # E: Name 'other_stuff' already defined (possibly by an import)
+other_stuff: int = 1  # E: Name "other_stuff" already defined (possibly by an import)
 
 x: C
 class C: ...
@@ -2023,9 +2023,9 @@ class C: ...
 # flags: --ignore-missing-imports
 
 class Other: ...
-from non_existing import Other  # E: Name 'Other' already defined on line 3
+from non_existing import Other  # E: Name "Other" already defined on line 3
 from non_existing import Cls
-class Cls: ...  # E: Name 'Cls' already defined (possibly by an import)
+class Cls: ...  # E: Name "Cls" already defined (possibly by an import)
 
 x: C
 class C: ...
@@ -2056,14 +2056,14 @@ def f(x: asdf) -> None:  # E: Name "asdf" is not defined
 from enum import Enum
 
 A = Enum('A', ['x', 'y'])
-A = Enum('A', ['z', 't'])  # E: Name 'A' already defined on line 3
+A = Enum('A', ['z', 't'])  # E: Name "A" already defined on line 3
 
 [case testNewAnalyzerNewTypeRedefinition]
 from typing import NewType
 
 A = NewType('A', int)
 A = NewType('A', str)  # E: Cannot redefine 'A' as a NewType \
-                       # E: Name 'A' already defined on line 3
+                       # E: Name "A" already defined on line 3
 
 [case testNewAnalyzerNewTypeForwardClass]
 from typing import NewType, List
@@ -2432,7 +2432,7 @@ from other import C  # type: ignore
 
 y = 'bad'
 
-class C:  # E: Name 'C' already defined (possibly by an import)
+class C:  # E: Name "C" already defined (possibly by an import)
     def meth(self, other: int) -> None:
         y()  # E: "str" not callable
 
@@ -2445,7 +2445,7 @@ if int():
     def f(x: int) -> None:
         pass
 else:
-    @overload  # E: Name 'f' already defined on line 6
+    @overload  # E: Name "f" already defined on line 6
     def f(x: int) -> None: ...
     @overload
     def f(x: str) -> None: ...
@@ -2471,7 +2471,7 @@ x = y
 x = 1
 
 # We want to check that the first definition creates the variable.
-def x() -> None: ...  # E: Name 'x' already defined on line 1
+def x() -> None: ...  # E: Name "x" already defined on line 1
 y = 2
 
 [case testNewAnalyzerImportStarSpecialCase]
@@ -2955,7 +2955,7 @@ def g() -> None:
 
     def foo() -> None:
         nonlocal bar
-        bar = []  # type: typing.List[int] # E: Name 'bar' already defined on line 11
+        bar = []  # type: typing.List[int] # E: Name "bar" already defined on line 11
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerMoreInvalidTypeVarArgumentsDeferred]
@@ -3049,7 +3049,7 @@ from foo import *
 try:
     X = X
 except:
-    class X: # E: Name 'X' already defined (possibly by an import)
+    class X: # E: Name "X" already defined (possibly by an import)
         pass
 
 reveal_type(X()) # N: Revealed type is "foo.X"
@@ -3062,7 +3062,7 @@ try:
     int = int
     reveal_type(int()) # N: Revealed type is "builtins.int"
 except:
-    class int: # E: Name 'int' already defined (possibly by an import)
+    class int: # E: Name "int" already defined (possibly by an import)
         pass
 
 reveal_type(int()) # N: Revealed type is "builtins.int"
@@ -3074,7 +3074,7 @@ try:
     int = int
     reveal_type(int()) # N: Revealed type is "builtins.int"
 except:
-    class int: # E: Name 'int' already defined (possibly by an import)
+    class int: # E: Name "int" already defined (possibly by an import)
         pass
 
 reveal_type(int()) # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -19,7 +19,7 @@ a = 5  # E: Incompatible types in assignment (expression has type "int", variabl
 b: str = 5  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 zzz: int
-zzz: str  # E: Name 'zzz' already defined on line 10
+zzz: str  # E: Name "zzz" already defined on line 10
 [out]
 
 [case testNewSyntaxWithDict]

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -318,12 +318,12 @@ from typing import NewType
 a = 3
 def f(): a
 a = NewType('a', int) # E: Cannot redefine 'a' as a NewType \
-                      # E: Name 'a' already defined on line 4
+                      # E: Name "a" already defined on line 4
 
 b = NewType('b', int)
 def g(): b
 b = NewType('b', float)  # E: Cannot redefine 'b' as a NewType \
-                         # E: Name 'b' already defined on line 8
+                         # E: Name "b" already defined on line 8
 
 c = NewType('c', str)  # type: str  # E: Cannot declare the type of a NewType declaration
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -10,18 +10,18 @@ f(0)
 
 @overload  # E: Name "overload" is not defined
 def g(a:int): pass
-def g(a): pass  # E: Name 'g' already defined on line 9
+def g(a): pass  # E: Name "g" already defined on line 9
 g(0)
 
 @something  # E: Name "something" is not defined
 def r(a:int): pass
-def r(a): pass  # E: Name 'r' already defined on line 14
+def r(a): pass  # E: Name "r" already defined on line 14
 r(0)
 [out]
 main:2: error: Name "overload" is not defined
-main:4: error: Name 'f' already defined on line 2
+main:4: error: Name "f" already defined on line 2
 main:4: error: Name "overload" is not defined
-main:6: error: Name 'f' already defined on line 2
+main:6: error: Name "f" already defined on line 2
 
 [case testTypeCheckOverloadWithImplementation]
 from typing import overload, Any
@@ -144,9 +144,9 @@ def deco(fun): ...
 
 @deco
 def f(x: 'A') -> 'B': ...
-@deco  # E: Name 'f' already defined on line 5
+@deco  # E: Name "f" already defined on line 5
 def f(x: 'B') -> 'A': ...
-@deco  # E: Name 'f' already defined on line 5
+@deco  # E: Name "f" already defined on line 5
 def f(x: Any) -> Any: ...
 
 class A: pass
@@ -1459,7 +1459,7 @@ def f(a: int) -> None: pass
 @overload
 def f(a: str) -> None: pass
 [out]
-tmp/foo.pyi:3: error: Name 'f' already defined on line 2
+tmp/foo.pyi:3: error: Name "f" already defined on line 2
 tmp/foo.pyi:3: error: Single overload definition, multiple required
 
 [case testNonconsecutiveOverloads]
@@ -1473,7 +1473,7 @@ def f(a: int) -> None: pass
 def f(a: str) -> None: pass
 [out]
 tmp/foo.pyi:2: error: Single overload definition, multiple required
-tmp/foo.pyi:5: error: Name 'f' already defined on line 2
+tmp/foo.pyi:5: error: Name "f" already defined on line 2
 tmp/foo.pyi:5: error: Single overload definition, multiple required
 
 [case testNonconsecutiveOverloadsMissingFirstOverload]
@@ -1485,7 +1485,7 @@ def f(a: int) -> None: pass
 @overload
 def f(a: str) -> None: pass
 [out]
-tmp/foo.pyi:4: error: Name 'f' already defined on line 2
+tmp/foo.pyi:4: error: Name "f" already defined on line 2
 tmp/foo.pyi:4: error: Single overload definition, multiple required
 
 [case testNonconsecutiveOverloadsMissingLaterOverload]
@@ -1498,7 +1498,7 @@ def f(a: int) -> None: pass
 def f(a: str) -> None: pass
 [out]
 tmp/foo.pyi:2: error: Single overload definition, multiple required
-tmp/foo.pyi:5: error: Name 'f' already defined on line 2
+tmp/foo.pyi:5: error: Name "f" already defined on line 2
 
 [case testOverloadTuple]
 from foo import *
@@ -1543,11 +1543,11 @@ class Chain(object):
 class Test(object):
     do_chain = Chain()
 
-    @do_chain.chain  # E: Name 'do_chain' already defined on line 9
+    @do_chain.chain  # E: Name "do_chain" already defined on line 9
     def do_chain(self) -> int:
         return 2
 
-    @do_chain.chain  # E: Name 'do_chain' already defined on line 11
+    @do_chain.chain  # E: Name "do_chain" already defined on line 11
     def do_chain(self) -> int:
         return 3
 
@@ -5092,7 +5092,7 @@ def func(x):
     return x
 [out]
 tmp/lib.pyi:1: error: Name "overload" is not defined
-tmp/lib.pyi:4: error: Name 'func' already defined on line 1
+tmp/lib.pyi:4: error: Name "func" already defined on line 1
 main:2: note: Revealed type is "Any"
 
 -- Order of errors is different
@@ -5107,7 +5107,7 @@ def func(x: int) -> int: ...
 def func(x: str) -> str: ...
 [out]
 tmp/lib.pyi:1: error: Name "overload" is not defined
-tmp/lib.pyi:3: error: Name 'func' already defined on line 1
+tmp/lib.pyi:3: error: Name "func" already defined on line 1
 tmp/lib.pyi:3: error: Name "overload" is not defined
 main:3: note: Revealed type is "Any"
 

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -3,7 +3,7 @@ def d(c): ...
 @d
 
 class C: ...
-class C: ...  # E: Name 'C' already defined on line 4
+class C: ...  # E: Name "C" already defined on line 4
 
 [case testDecoratedFunctionLine]
 # flags: --disallow-untyped-defs

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -254,7 +254,7 @@ def f() -> None:
     x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "Callable[[], Any]")
     reveal_type(x) # N: Revealed type is "def () -> Any"
     y = 1
-    def y(): pass # E: Name 'y' already defined on line 6
+    def y(): pass # E: Name "y" already defined on line 6
 
 [case testCannotRedefineVarAsClass]
 # flags: --allow-redefinition
@@ -263,7 +263,7 @@ def f() -> None:
     x = 1 # E: Cannot assign to a type \
           # E: Incompatible types in assignment (expression has type "int", variable has type "Type[x]")
     y = 1
-    class y: pass # E: Name 'y' already defined on line 5
+    class y: pass # E: Name "y" already defined on line 5
 
 [case testRedefineVarAsTypeVar]
 # flags: --allow-redefinition
@@ -285,7 +285,7 @@ def f() -> None:
     import typing as m
     m = 1 # E: Incompatible types in assignment (expression has type "int", variable has type Module)
     n = 1
-    import typing as n # E: Name 'n' already defined on line 5
+    import typing as n # E: Name "n" already defined on line 5
 [builtins fixtures/module.pyi]
 
 [case testRedefineLocalWithTypeAnnotation]
@@ -305,9 +305,9 @@ def h() -> None:
     x = 1
     reveal_type(x) # N: Revealed type is "builtins.int"
     x: object
-    x: object = '' # E: Name 'x' already defined on line 16
+    x: object = '' # E: Name "x" already defined on line 16
 def farg(x: int) -> None:
-    x: str = '' # E: Name 'x' already defined on line 18
+    x: str = '' # E: Name "x" already defined on line 18
 def farg2(x: int) -> None:
     x: str = x # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -85,7 +85,7 @@ yield from x # E: 'yield from' outside function
 [case testImportFuncDup]
 
 import m
-def m() -> None: ...  # E: Name 'm' already defined (by an import)
+def m() -> None: ...  # E: Name "m" already defined (by an import)
 
 [file m.py]
 [out]
@@ -94,8 +94,8 @@ def m() -> None: ...  # E: Name 'm' already defined (by an import)
 
 import m # type: ignore
 from m import f # type: ignore
-def m() -> None: ...  # E: Name 'm' already defined (possibly by an import)
-def f() -> None: ...  # E: Name 'f' already defined (possibly by an import)
+def m() -> None: ...  # E: Name "m" already defined (possibly by an import)
+def f() -> None: ...  # E: Name "f" already defined (possibly by an import)
 
 [out]
 

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1787,7 +1787,7 @@ from typing import List
 def foo() -> None:
     global bar
     # TODO: Confusing error message
-    bar = []  # type: List[str]  # E: Name 'bar' already defined (possibly by an import)
+    bar = []  # type: List[str]  # E: Name "bar" already defined (possibly by an import)
     bar  # E: Name "bar" is not defined
 
 def foo2():

--- a/test-data/unit/check-unsupported.test
+++ b/test-data/unit/check-unsupported.test
@@ -13,5 +13,5 @@ def g(): pass
 @d # E
 def g(x): pass
 [out]
-tmp/foo.pyi:5: error: Name 'f' already defined on line 3
-tmp/foo.pyi:7: error: Name 'g' already defined on line 6
+tmp/foo.pyi:5: error: Name "f" already defined on line 3
+tmp/foo.pyi:7: error: Name "g" already defined on line 6

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7846,7 +7846,7 @@ from b import A
 [out]
 ==
 a.py:4: error: Module "b" has no attribute "A"
-a.py:4: error: Name 'A' already defined on line 3
+a.py:4: error: Name "A" already defined on line 3
 
 -- the order of errors is different with cache
 [case testImportOnTopOfAlias2]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7845,8 +7845,13 @@ from b import A
 [builtins fixtures/list.pyi]
 [out]
 ==
+<<<<<<< HEAD
 a.py:4: error: Module "b" has no attribute "A"
 a.py:4: error: Name 'A' already defined on line 3
+=======
+a.py:4: error: Module 'b' has no attribute 'A'
+a.py:4: error: Name "A" already defined on line 3
+>>>>>>> Name already defined - double quotes
 
 -- the order of errors is different with cache
 [case testImportOnTopOfAlias2]
@@ -7887,9 +7892,9 @@ def a():
 def a():
     pass
 [out]
-b.py:5: error: Name 'a' already defined on line 2
+b.py:5: error: Name "a" already defined on line 2
 ==
-b.py:5: error: Name 'a' already defined on line 2
+b.py:5: error: Name "a" already defined on line 2
 
 [case testFakeOverloadCrash2]
 
@@ -7927,7 +7932,7 @@ a.py:1: error: Name "TypeVar" is not defined
 a.py:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import TypeVar")
 a.py:7: error: Variable "a.T" is not valid as a type
 a.py:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-a.py:10: error: Name 'bar' already defined on line 6
+a.py:10: error: Name "bar" already defined on line 6
 a.py:11: error: Variable "a.T" is not valid as a type
 a.py:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 ==
@@ -7935,7 +7940,7 @@ a.py:1: error: Name "TypeVar" is not defined
 a.py:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import TypeVar")
 a.py:7: error: Variable "a.T" is not valid as a type
 a.py:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-a.py:10: error: Name 'bar' already defined on line 6
+a.py:10: error: Name "bar" already defined on line 6
 a.py:11: error: Variable "a.T" is not valid as a type
 a.py:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -145,7 +145,7 @@ class A: pass
 x = 0 # type: A
 x = 0 # type: A
 [out]
-main:4: error: Name 'x' already defined on line 3
+main:4: error: Name "x" already defined on line 3
 
 [case testLocalVarRedefinition]
 import typing
@@ -154,7 +154,7 @@ def f() -> None:
   x = 0 # type: A
   x = 0 # type: A
 [out]
-main:5: error: Name 'x' already defined on line 4
+main:5: error: Name "x" already defined on line 4
 
 [case testClassVarRedefinition]
 import typing
@@ -162,14 +162,14 @@ class A:
   x = 0 # type: object
   x = 0 # type: object
 [out]
-main:4: error: Name 'x' already defined on line 3
+main:4: error: Name "x" already defined on line 3
 
 [case testMultipleClassDefinitions]
 import typing
 class A: pass
 class A: pass
 [out]
-main:3: error: Name 'A' already defined on line 2
+main:3: error: Name "A" already defined on line 2
 
 [case testMultipleMixedDefinitions]
 import typing
@@ -177,8 +177,8 @@ x = 1
 def x(): pass
 class x: pass
 [out]
-main:3: error: Name 'x' already defined on line 2
-main:4: error: Name 'x' already defined on line 2
+main:3: error: Name "x" already defined on line 2
+main:4: error: Name "x" already defined on line 2
 
 [case testNameNotImported]
 import typing
@@ -556,7 +556,7 @@ class A:
   def g(self) -> None: pass
   def f(self, x: object) -> None: pass
 [out]
-main:5: error: Name 'f' already defined on line 3
+main:5: error: Name "f" already defined on line 3
 
 [case testInvalidGlobalDecl]
 import typing
@@ -573,7 +573,7 @@ def f():
        nonlocal x
        x = None
 [out]
-main:4: error: No binding for nonlocal 'x' found
+main:4: error: No binding for nonlocal "x" found
 main:5: error: Name "x" is not defined
 
 [case testNonlocalDeclNotMatchingGlobal]
@@ -583,7 +583,7 @@ def f() -> None:
     nonlocal x
     x = None
 [out]
-main:4: error: No binding for nonlocal 'x' found
+main:4: error: No binding for nonlocal "x" found
 main:5: error: Name "x" is not defined
 
 [case testNonlocalDeclConflictingWithParameter]
@@ -594,7 +594,7 @@ def g():
         nonlocal x
         x = None
 [out]
-main:5: error: Name 'x' is already defined in local scope before nonlocal declaration
+main:5: error: Name "x" is already defined in local scope before nonlocal declaration
 
 [case testNonlocalDeclOutsideFunction]
 x = 2
@@ -612,7 +612,7 @@ def f():
        nonlocal x
        x = None
 [out]
-main:7: error: Name 'x' is nonlocal and global
+main:7: error: Name "x" is nonlocal and global
 
 [case testNonlocalAndGlobalDecl]
 import typing
@@ -624,7 +624,7 @@ def f():
        global x
        x = None
 [out]
-main:7: error: Name 'x' is nonlocal and global
+main:7: error: Name "x" is nonlocal and global
 
 [case testNestedFunctionAndScoping]
 import typing
@@ -645,7 +645,7 @@ def f(x) -> None:
     x = 1
     def g(): pass
 [out]
-main:5: error: Name 'g' already defined on line 3
+main:5: error: Name "g" already defined on line 3
 
 [case testRedefinedOverloadedFunction]
 from typing import overload, Any
@@ -658,7 +658,7 @@ def f() -> None:
     def p(): pass # fail
 [out]
 main:3: error: An overloaded function outside a stub file must have an implementation
-main:8: error: Name 'p' already defined on line 3
+main:8: error: Name "p" already defined on line 3
 
 [case testNestedFunctionInMethod]
 import typing
@@ -1069,19 +1069,19 @@ t = 1 # E: Invalid assignment target
 [case testRedefineTypevar2]
 from typing import TypeVar
 t = TypeVar('t')
-def t(): pass # E: Name 't' already defined on line 2
+def t(): pass # E: Name "t" already defined on line 2
 [out]
 
 [case testRedefineTypevar3]
 from typing import TypeVar
 t = TypeVar('t')
-class t: pass # E: Name 't' already defined on line 2
+class t: pass # E: Name "t" already defined on line 2
 [out]
 
 [case testRedefineTypevar4]
 from typing import TypeVar
 t = TypeVar('t')
-from typing import Generic as t # E: Name 't' already defined on line 2
+from typing import Generic as t # E: Name "t" already defined on line 2
 [out]
 
 [case testInvalidStrLiteralType]
@@ -1123,7 +1123,7 @@ from typing import overload
 def dec(x): pass
 @dec
 def f(): pass
-@dec  # E: Name 'f' already defined on line 3
+@dec  # E: Name "f" already defined on line 3
 def f(): pass
 [out]
 
@@ -1220,7 +1220,7 @@ class A:
 import typing
 def f() -> None:
     import x
-    import y as x # E: Name 'x' already defined (by an import)
+    import y as x # E: Name "x" already defined (by an import)
     x.y
 [file x.py]
 y = 1
@@ -1230,7 +1230,7 @@ y = 1
 [case testImportTwoModulesWithSameNameInGlobalContext]
 import typing
 import x
-import y as x # E: Name 'x' already defined (by an import)
+import y as x # E: Name "x" already defined (by an import)
 x.y
 [file x.py]
 y = 1
@@ -1307,12 +1307,12 @@ a = ('spam', 'spam', 'eggs', 'spam')  # type: Tuple[str]
 [builtins fixtures/tuple.pyi]
 
 [out]
-main:3: error: Name 'a' already defined on line 2
-main:4: error: Name 'a' already defined on line 2
+main:3: error: Name "a" already defined on line 2
+main:4: error: Name "a" already defined on line 2
 
 [case testDuplicateDefFromImport]
 from m import A
-class A:  # E: Name 'A' already defined (possibly by an import)
+class A:  # E: Name "A" already defined (possibly by an import)
     pass
 [file m.py]
 class A:
@@ -1326,7 +1326,7 @@ def dec(x: Any) -> Any:
 @dec
 def f() -> None:
     pass
-@dec  # E: Name 'f' already defined on line 4
+@dec  # E: Name "f" already defined on line 4
 def f() -> None:
     pass
 [out]
@@ -1343,7 +1343,7 @@ if 1:
     def f(x: Any) -> None:
         pass
 else:
-    def f(x: str) -> None:  # E: Name 'f' already defined on line 3
+    def f(x: str) -> None:  # E: Name "f" already defined on line 3
         pass
 [out]
 
@@ -1352,7 +1352,7 @@ from typing import NamedTuple
 N = NamedTuple('N', [('a', int),
                      ('b', str)])
 
-class N:  # E: Name 'N' already defined on line 2
+class N:  # E: Name "N" already defined on line 2
     pass
 [builtins fixtures/tuple.pyi]
 [out]
@@ -1361,7 +1361,7 @@ class N:  # E: Name 'N' already defined on line 2
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 
-class Point:  # E: Name 'Point' already defined on line 2
+class Point:  # E: Name "Point" already defined on line 2
     pass
 [builtins fixtures/dict.pyi]
 
@@ -1370,14 +1370,14 @@ class Point:  # E: Name 'Point' already defined on line 2
 [case testTypeVarClassDup]
 from typing import TypeVar
 T = TypeVar('T')
-class T: ...  # E: Name 'T' already defined on line 2
+class T: ...  # E: Name "T" already defined on line 2
 
 [out]
 
 [case testAliasDup]
 from typing import List
 A = List[int]
-class A: ... # E: Name 'A' already defined on line 2
+class A: ... # E: Name "A" already defined on line 2
 
 [builtins fixtures/list.pyi]
 [out]


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445   for `already defined`, `is nonlocal and global`, `No binding for nonlocal` and `is already defined in local` error messages

## Test Plan
Updated test cases for the message. New test cases not added.