### PR TITLE
Fixes #10083.

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -11,12 +11,14 @@ implementation simple.
 """
 
 import re
+import string
 
 from typing import (
     cast, List, Tuple, Dict, Callable, Union, Optional, Pattern, Match, Set, Any
 )
 from typing_extensions import Final, TYPE_CHECKING
 
+from mypy.traverser import TraverserVisitor
 from mypy.types import (
     Type, AnyType, TupleType, Instance, UnionType, TypeOfAny, get_proper_type, TypeVarType,
     LiteralType, get_proper_types
@@ -162,6 +164,30 @@ class ConversionSpecifier:
     def has_star(self) -> bool:
         return self.width == '*' or self.precision == '*'
 
+class LineNoChanger(TraverserVisitor):
+    def __init__(self, line: int, end_line: Optional[int], column: int) -> None:
+        self.line = line
+        self.end_line = end_line
+        self.column = column
+
+    def set_context_info(self, ctx: Context) -> None:
+        ctx.line = self.line
+        ctx.end_line = self.end_line
+        ctx.column = self.column
+
+    def visit_index_expr(self, expr: IndexExpr) -> None:
+        self.set_context_info(expr)
+        super().visit_index_expr(expr)
+
+    def visit_member_expr(self, o: MemberExpr) -> None:
+        self.set_context_info(o)
+        super().visit_member_expr(o)
+
+    def visit_int_expr(self, o: IntExpr) -> None:
+        self.set_context_info(o)
+
+    def visit_str_expr(self, o: StrExpr) -> None:
+        self.set_context_info(o)
 
 class StringFormatterChecker:
     """String interpolation/formatter type checker.
@@ -518,7 +544,21 @@ class StringFormatterChecker:
 
         # This is a bit of a dirty trick, but it looks like this is the simplest way.
         temp_errors = self.msg.clean_copy().errors
-        dummy = DUMMY_FIELD_NAME + spec.field[len(spec.key):]
+
+        try:
+            first_obj, split_fields = string._string.formatter_field_name_split(
+                spec.field[len(spec.key):])
+            split_fields_str = [
+                ("." + str(field)) if is_attr else
+                '[{}]'.format(field) if isinstance(field, int) else
+                '["{}"]'.format(field.replace('"', '\\"')) for is_attr, field in split_fields]
+        except Exception:
+            self.msg.fail('Only index and member expressions are allowed in'
+                          ' format field accessors; got "{}"'.format(spec.field),
+                          ctx, code=codes.STRING_FORMATTING)
+            return TempNode(AnyType(TypeOfAny.from_error))
+
+        dummy = DUMMY_FIELD_NAME + first_obj + ''.join(split_fields_str)
         temp_ast = parse(dummy, fnam='<format>', module=None,
                          options=self.chk.options, errors=temp_errors)  # type: Node
         if temp_errors.is_errors():
@@ -536,8 +576,7 @@ class StringFormatterChecker:
 
         # Check if there are any other errors (like missing members).
         # TODO: fix column to point to actual start of the format specifier _within_ string.
-        temp_ast.line = ctx.line
-        temp_ast.column = ctx.column
+        temp_ast.accept(LineNoChanger(ctx.line, ctx.end_line, ctx.column))
         self.exprchk.accept(temp_ast)
         return temp_ast
 
@@ -564,15 +603,13 @@ class StringFormatterChecker:
             node = temp_ast.expr
         else:
             node = temp_ast.base
-            if not isinstance(temp_ast.index, (NameExpr, IntExpr)):
+            if not isinstance(temp_ast.index, (StrExpr, IntExpr)):
                 assert spec.key, "Call this method only after auto-generating keys!"
                 assert spec.field
                 self.msg.fail('Invalid index expression in format field'
                               ' accessor "{}"'.format(spec.field[len(spec.key):]), ctx,
                               code=codes.STRING_FORMATTING)
                 return False
-            if isinstance(temp_ast.index, NameExpr):
-                temp_ast.index = StrExpr(temp_ast.index.name)
         if isinstance(node, NameExpr) and node.name == DUMMY_FIELD_NAME:
             # Replace it with the actual replacement expression.
             assert isinstance(temp_ast, (IndexExpr, MemberExpr))  # XXX: this is redundant

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1487,7 +1487,7 @@ strings: List[str]
 '{:d}, {[0].x}'.format(*strings)  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "int") \
                                   # E: "str" has no attribute "x"
 # TODO: this is a runtime error, but error message is confusing
-'{[0][:]:d}'.format(*strings)  # E: Syntax error in format specifier "0[0]["
+'{[0][:]:d}'.format(*strings)  # E: Only index and member expressions are allowed in format field accessors; got "0[0]["
 [builtins fixtures/primitives.pyi]
 
 [case testFormatCallMatchingKwArg]
@@ -1673,6 +1673,8 @@ OK: Final[str] = '...'
 from typing import Any
 x: Any
 
+"{0[k-y]}".format(x)
+"{0[@#$%^&()+[-\"']}".format(x)
 '{.x:{[0]}}'.format('yes', 42)  # E: "str" has no attribute "x" \
                                 # E: Value of type "int" is not indexable
 
@@ -1691,7 +1693,7 @@ u: User
 '{user[name]:.3f}'.format(user=u)  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float]")
 
 def f() -> str: ...
-'{[f()]}'.format(u)  # E: Invalid index expression in format field accessor "[f()]"
+'{[f()]}'.format(u)  # E: TypedDict "User" has no key "f()"
 [builtins fixtures/primitives.pyi]
 
 [case testFormatCallFlags]


### PR DESCRIPTION
### Description

Fixes #10083.

Use the same string formatting index splitting function that python uses instead of relying only on ast parsing so it would
have the same logic as python.
It also changes some errors since it catches syntax errors.

## Test Plan

I've added some positive assertion tests and changed tests where error came out with different text. I had to fix the testFormatCallAccessorsIndices test that assumed that string format can evaluate functions inside the index (it can't).

I believe the current testing + mypy primer should cover our bases.