### PR TITLE
Use double quotes in Metaclass related errors

### DIFF
--- a/docs/source/metaclasses.rst
+++ b/docs/source/metaclasses.rst
@@ -93,7 +93,7 @@ so it's better not to combine metaclasses and class hierarchies:
     class A1(metaclass=M1): pass
     class A2(metaclass=M2): pass
 
-    class B1(A1, metaclass=M2): pass  # Mypy Error: Inconsistent metaclass structure for 'B1'
+    class B1(A1, metaclass=M2): pass  # Mypy Error: Inconsistent metaclass structure for "B1"
     # At runtime the above definition raises an exception
     # TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1691,7 +1691,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 self.defer(defn)
                 return
             if not isinstance(sym.node, TypeInfo) or sym.node.tuple_type is not None:
-                self.fail("Invalid metaclass '%s'" % metaclass_name, defn.metaclass)
+                self.fail('Invalid metaclass "%s"' % metaclass_name, defn.metaclass)
                 return
             if not sym.node.is_metaclass():
                 self.fail('Metaclasses not inheriting from "type" are not supported',

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1694,7 +1694,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 self.fail("Invalid metaclass '%s'" % metaclass_name, defn.metaclass)
                 return
             if not sym.node.is_metaclass():
-                self.fail("Metaclasses not inheriting from 'type' are not supported",
+                self.fail('Metaclasses not inheriting from "type" are not supported',
                           defn.metaclass)
                 return
             inst = fill_typevars(sym.node)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1713,7 +1713,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             # Inconsistency may happen due to multiple baseclasses even in classes that
             # do not declare explicit metaclass, but it's harder to catch at this stage
             if defn.metaclass is not None:
-                self.fail("Inconsistent metaclass structure for '%s'" % defn.name, defn)
+                self.fail('Inconsistent metaclass structure for "%s"' % defn.name, defn)
         else:
             if defn.info.metaclass_type.type.has_base('enum.EnumMeta'):
                 defn.info.is_enum = True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1674,7 +1674,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             elif isinstance(defn.metaclass, MemberExpr):
                 metaclass_name = get_member_expr_fullname(defn.metaclass)
             if metaclass_name is None:
-                self.fail("Dynamic metaclass not supported for '%s'" % defn.name, defn.metaclass)
+                self.fail('Dynamic metaclass not supported for "%s"' % defn.name, defn.metaclass)
                 return
             sym = self.lookup_qualified(metaclass_name, defn.metaclass)
             if sym is None:

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -88,7 +88,7 @@ def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
         if (isinstance(expr.node, Var) and is_none_rprimitive(builder.node_type(expr))
                 and expr.node.is_inferred):
             builder.error(
-                "Local variable '{}' has inferred type None; add an annotation".format(
+                'Local variable "{}" has inferred type None; add an annotation'.format(
                     expr.node.name),
                 expr.node.line)
 

--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -180,7 +180,7 @@ d1 = {1: 2}
 
 # Make sure we can produce an error when we hit the awful None case
 def f(l: List[object]) -> None:
-    x = None  # E: Local variable 'x' has inferred type None; add an annotation
+    x = None  # E: Local variable "x" has inferred type None; add an annotation
     for i in l:
         if x is None:
             x = i

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -413,14 +413,14 @@ L5:
 L6:
     if is_error(a) goto L17 else goto L9
 L7:
-    r7 = raise UnboundLocalError("local variable 'a' referenced before assignment")
+    r7 = raise UnboundLocalError('local variable "a" referenced before assignment')
     if not r7 goto L14 (error at lol:9) else goto L8 :: bool
 L8:
     unreachable
 L9:
     if is_error(b) goto L18 else goto L12
 L10:
-    r8 = raise UnboundLocalError("local variable 'b' referenced before assignment")
+    r8 = raise UnboundLocalError('local variable "b" referenced before assignment')
     if not r8 goto L14 (error at lol:9) else goto L11 :: bool
 L11:
     unreachable
@@ -489,7 +489,7 @@ L3:
 L4:
     if is_error(v) goto L13 else goto L7
 L5:
-    r8 = raise UnboundLocalError("local variable 'v' referenced before assignment")
+    r8 = raise UnboundLocalError('local variable "v" referenced before assignment')
     if not r8 goto L9 (error at f:7) else goto L6 :: bool
 L6:
     unreachable

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -840,12 +840,12 @@ L2:
 L3:
     if is_error(y) goto L10 else goto L5
 L4:
-    r2 = raise UnboundLocalError("local variable 'y' referenced before assignment")
+    r2 = raise UnboundLocalError('local variable "y" referenced before assignment')
     unreachable
 L5:
     if is_error(z) goto L11 else goto L7
 L6:
-    r3 = raise UnboundLocalError("local variable 'z' referenced before assignment")
+    r3 = raise UnboundLocalError('local variable "z" referenced before assignment')
     unreachable
 L7:
     r4 = CPyTagged_Add(y, z)

--- a/mypyc/test-data/run-primitives.test
+++ b/mypyc/test-data/run-primitives.test
@@ -369,10 +369,10 @@ delAttribute()
 delAttributeMultiple()
 with assertRaises(AttributeError):
     native.global_var
-with assertRaises(NameError, "local variable 'dummy' referenced before assignment"):
+with assertRaises(NameError, 'local variable "dummy" referenced before assignment'):
     delLocal(True)
 assert delLocal(False) == 10
-with assertRaises(NameError, "local variable 'dummy' referenced before assignment"):
+with assertRaises(NameError, 'local variable "dummy" referenced before assignment'):
     delLocalLoop()
 [out]
 (1, 2, 3)

--- a/mypyc/transform/uninit.py
+++ b/mypyc/transform/uninit.py
@@ -72,7 +72,7 @@ def split_blocks_at_uninits(blocks: List[BasicBlock],
                                                 line=op.line))
                     raise_std = RaiseStandardError(
                         RaiseStandardError.UNBOUND_LOCAL_ERROR,
-                        "local variable '{}' referenced before assignment".format(src.name),
+                        'local variable "{}" referenced before assignment'.format(src.name),
                         op.line)
                     error_block.ops.append(raise_std)
                     error_block.ops.append(Unreachable())

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3823,11 +3823,11 @@ class B(object, A): # E: Cannot determine consistent method resolution order (MR
     __iter__ = readlines
 
 [case testDynamicMetaclass]
-class C(metaclass=int()):  # E: Dynamic metaclass not supported for 'C'
+class C(metaclass=int()):  # E: Dynamic metaclass not supported for "C"
     pass
 
 [case testDynamicMetaclassCrash]
-class C(metaclass=int().x):  # E: Dynamic metaclass not supported for 'C'
+class C(metaclass=int().x):  # E: Dynamic metaclass not supported for "C"
     pass
 
 [case testVariableSubclass]
@@ -4981,8 +4981,8 @@ class D3(A): pass
 class C4(six.with_metaclass(M), metaclass=M): pass  # E: Multiple metaclass definitions
 @six.add_metaclass(M)
 class D4(metaclass=M): pass  # E: Multiple metaclass definitions
-class C5(six.with_metaclass(f())): pass  # E: Dynamic metaclass not supported for 'C5'
-@six.add_metaclass(f())  # E: Dynamic metaclass not supported for 'D5'
+class C5(six.with_metaclass(f())): pass  # E: Dynamic metaclass not supported for "C5"
+@six.add_metaclass(f())  # E: Dynamic metaclass not supported for "D5"
 class D5: pass
 
 @six.add_metaclass(M)
@@ -5107,7 +5107,7 @@ class C1(future.utils.with_metaclass(M), object): pass  # E: Unsupported dynamic
 class C2(C1, future.utils.with_metaclass(M)): pass  # E: Unsupported dynamic base class "future.utils.with_metaclass"
 class C3(future.utils.with_metaclass(A)): pass  # E: Metaclasses not inheriting from 'type' are not supported
 class C4(future.utils.with_metaclass(M), metaclass=M): pass  # E: Multiple metaclass definitions
-class C5(future.utils.with_metaclass(f())): pass  # E: Dynamic metaclass not supported for 'C5'
+class C5(future.utils.with_metaclass(f())): pass  # E: Dynamic metaclass not supported for "C5"
 
 class M1(type): pass
 class Q1(metaclass=M1): pass

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4235,7 +4235,7 @@ reveal_type(list(Explicit))  # N: Revealed type is "builtins.list[builtins.int*]
 from typing import Tuple
 
 class M(Tuple[int]): pass
-class C(metaclass=M): pass  # E: Invalid metaclass 'M'
+class C(metaclass=M): pass  # E: Invalid metaclass "M"
 
 [builtins fixtures/tuple.pyi]
 
@@ -4309,9 +4309,9 @@ A.x # E: "Type[A]" has no attribute "x"
 from typing import Any
 M = 0  # type: int
 MM = 0
-class A(metaclass=M): # E: Invalid metaclass 'M'
+class A(metaclass=M): # E: Invalid metaclass "M"
     y = 0
-class B(metaclass=MM): # E: Invalid metaclass 'MM'
+class B(metaclass=MM): # E: Invalid metaclass "MM"
     y = 0
 reveal_type(A.y) # N: Revealed type is "builtins.int"
 A.x # E: "Type[A]" has no attribute "x"

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4170,7 +4170,7 @@ class C(B):
 class X(type): pass
 class Y(type): pass
 class A(metaclass=X): pass
-class B(A, metaclass=Y): pass  # E: Inconsistent metaclass structure for 'B'
+class B(A, metaclass=Y): pass  # E: Inconsistent metaclass structure for "B"
 
 [case testMetaclassNoTypeReveal]
 class M:
@@ -4991,8 +4991,8 @@ class CD(six.with_metaclass(M)): pass  # E: Multiple metaclass definitions
 class M1(type): pass
 class Q1(metaclass=M1): pass
 @six.add_metaclass(M)
-class CQA(Q1): pass  # E: Inconsistent metaclass structure for 'CQA'
-class CQW(six.with_metaclass(M, Q1)): pass  # E: Inconsistent metaclass structure for 'CQW'
+class CQA(Q1): pass  # E: Inconsistent metaclass structure for "CQA"
+class CQW(six.with_metaclass(M, Q1)): pass  # E: Inconsistent metaclass structure for "CQW"
 [builtins fixtures/tuple.pyi]
 
 [case testSixMetaclassErrors_python2]
@@ -5111,7 +5111,7 @@ class C5(future.utils.with_metaclass(f())): pass  # E: Dynamic metaclass not sup
 
 class M1(type): pass
 class Q1(metaclass=M1): pass
-class CQW(future.utils.with_metaclass(M, Q1)): pass  # E: Inconsistent metaclass structure for 'CQW'
+class CQW(future.utils.with_metaclass(M, Q1)): pass  # E: Inconsistent metaclass structure for "CQW"
 [builtins fixtures/tuple.pyi]
 
 [case testFutureMetaclassErrors_python2]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4176,7 +4176,7 @@ class B(A, metaclass=Y): pass  # E: Inconsistent metaclass structure for 'B'
 class M:
     x = 0  # type: int
 
-class A(metaclass=M): pass  # E: Metaclasses not inheriting from 'type' are not supported
+class A(metaclass=M): pass  # E: Metaclasses not inheriting from "type" are not supported
 
 A.x  # E: "Type[A]" has no attribute "x"
 
@@ -4973,8 +4973,8 @@ class A(object): pass
 def f() -> type: return M
 class C1(six.with_metaclass(M), object): pass  # E: Unsupported dynamic base class "six.with_metaclass"
 class C2(C1, six.with_metaclass(M)): pass  # E: Unsupported dynamic base class "six.with_metaclass"
-class C3(six.with_metaclass(A)): pass  # E: Metaclasses not inheriting from 'type' are not supported
-@six.add_metaclass(A)  # E: Metaclasses not inheriting from 'type' are not supported  \
+class C3(six.with_metaclass(A)): pass  # E: Metaclasses not inheriting from "type" are not supported
+@six.add_metaclass(A)  # E: Metaclasses not inheriting from "type" are not supported  \
     # E: Argument 1 to "add_metaclass" has incompatible type "Type[A]"; expected "Type[type]"
 
 class D3(A): pass
@@ -5105,7 +5105,7 @@ class A(object): pass
 def f() -> type: return M
 class C1(future.utils.with_metaclass(M), object): pass  # E: Unsupported dynamic base class "future.utils.with_metaclass"
 class C2(C1, future.utils.with_metaclass(M)): pass  # E: Unsupported dynamic base class "future.utils.with_metaclass"
-class C3(future.utils.with_metaclass(A)): pass  # E: Metaclasses not inheriting from 'type' are not supported
+class C3(future.utils.with_metaclass(A)): pass  # E: Metaclasses not inheriting from "type" are not supported
 class C4(future.utils.with_metaclass(M), metaclass=M): pass  # E: Multiple metaclass definitions
 class C5(future.utils.with_metaclass(f())): pass  # E: Dynamic metaclass not supported for "C5"
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1137,7 +1137,7 @@ reveal_type(A.f()) # N: Revealed type is "builtins.int"
 class A(metaclass=B):
     pass
 
-class AA(metaclass=C): # E: Metaclasses not inheriting from 'type' are not supported
+class AA(metaclass=C): # E: Metaclasses not inheriting from "type" are not supported
     pass
 
 class B(type):
@@ -1284,7 +1284,7 @@ class A:
     __metaclass__ = B
 
 class AA:
-    __metaclass__ = C  # E: Metaclasses not inheriting from 'type' are not supported
+    __metaclass__ = C  # E: Metaclasses not inheriting from "type" are not supported
 
 class B(type):
     def f(cls):

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -301,7 +301,7 @@ class M(type):
 
 [case testDynamicMetaclass]
 class C(object):
-    __metaclass__ = int()  # E: Dynamic metaclass not supported for 'C'
+    __metaclass__ = int()  # E: Dynamic metaclass not supported for "C"
 
 [case testMetaclassDefinedAsClass]
 class C(object):

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3128,7 +3128,7 @@ M = 1
 class M(type):
     pass
 [out]
-a.py:2: error: Invalid metaclass 'b.M'
+a.py:2: error: Invalid metaclass "b.M"
 ==
 
 [case testFixedAttrOnAddedMetaclass]
@@ -3241,7 +3241,7 @@ class M(type):
 M = 1
 [out]
 ==
-a.py:2: error: Invalid metaclass 'b.M'
+a.py:2: error: Invalid metaclass "b.M"
 
 [case testRefreshGenericSubclass]
 from typing import Generic, TypeVar

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3050,7 +3050,7 @@ class M(type):
     pass
 [out]
 ==
-a.py:3: error: Inconsistent metaclass structure for 'D'
+a.py:3: error: Inconsistent metaclass structure for "D"
 
 [case testFineMetaclassDeclaredUpdate]
 import a
@@ -3066,7 +3066,7 @@ class M(type): pass
 class M2(type): pass
 [out]
 ==
-a.py:3: error: Inconsistent metaclass structure for 'D'
+a.py:3: error: Inconsistent metaclass structure for "D"
 
 [case testFineMetaclassRemoveFromClass]
 import a

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -999,7 +999,7 @@ class A(metaclass=abc.Foo): pass # E: Name "abc.Foo" is not defined
 
 [case testNonClassMetaclass]
 def f(): pass
-class A(metaclass=f): pass # E: Invalid metaclass 'f'
+class A(metaclass=f): pass # E: Invalid metaclass "f"
 [out]
 
 [case testInvalidTypevarArguments]


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445 for Metaclass related errors `Inconsistent metaclass structure`, `Invalid metaclass `, and `Metaclasses not inheriting`
Also covers error `referenced before assignment`

## Test Plan
Updated test cases for the message. New test cases not added.