### PR TITLE
Use double quotes in errors `Duplicate argument` and `Cannot assign multiple modules`

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3225,7 +3225,7 @@ def check_arg_names(names: Sequence[Optional[str]], nodes: List[T], fail: Callab
     seen_names = set()  # type: Set[Optional[str]]
     for name, node in zip(names, nodes):
         if name is not None and name in seen_names:
-            fail("Duplicate argument '{}' in {}".format(name, description), node)
+            fail('Duplicate argument "{}" in {}'.format(name, description), node)
             break
         seen_names.add(name)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3270,8 +3270,8 @@ class SemanticAnalyzer(NodeVisitor[None],
                         if isinstance(lnode.node, MypyFile) and lnode.node is not rnode.node:
                             assert isinstance(lval, (NameExpr, MemberExpr))
                             self.fail(
-                                "Cannot assign multiple modules to name '{}' "
-                                "without explicit 'types.ModuleType' annotation".format(lval.name),
+                                'Cannot assign multiple modules to name "{}" '
+                                'without explicit "types.ModuleType" annotation'.format(lval.name),
                                 ctx)
                         # never create module alias except on initial var definition
                         elif lval.is_inferred_def:

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -395,50 +395,50 @@ def f(x: int):  # E: Function has duplicate type signatures
 def f(x, y, z):
   pass
 
-def g(x, y, x):  # E: Duplicate argument 'x' in function definition
+def g(x, y, x):  # E: Duplicate argument "x" in function definition
   pass
 
-def h(x, y, *x):  # E: Duplicate argument 'x' in function definition
+def h(x, y, *x):  # E: Duplicate argument "x" in function definition
   pass
 
-def i(x, y, *z, **z):  # E: Duplicate argument 'z' in function definition
+def i(x, y, *z, **z):  # E: Duplicate argument "z" in function definition
   pass
 
-def j(x: int, y: int, *, x: int = 3):  # E: Duplicate argument 'x' in function definition
+def j(x: int, y: int, *, x: int = 3):  # E: Duplicate argument "x" in function definition
   pass
 
-def k(*, y, z, y):  # E: Duplicate argument 'y' in function definition
+def k(*, y, z, y):  # E: Duplicate argument "y" in function definition
   pass
 
-lambda x, y, x: ...  # E: Duplicate argument 'x' in function definition
+lambda x, y, x: ...  # E: Duplicate argument "x" in function definition
 
 [case testFastParserDuplicateNames_python2]
 
 def f(x, y, z):
   pass
 
-def g(x, y, x):  # E: Duplicate argument 'x' in function definition
+def g(x, y, x):  # E: Duplicate argument "x" in function definition
   pass
 
-def h(x, y, *x):  # E: Duplicate argument 'x' in function definition
+def h(x, y, *x):  # E: Duplicate argument "x" in function definition
   pass
 
-def i(x, y, *z, **z):  # E: Duplicate argument 'z' in function definition
+def i(x, y, *z, **z):  # E: Duplicate argument "z" in function definition
   pass
 
-def j(x, (y, y), z):  # E: Duplicate argument 'y' in function definition
+def j(x, (y, y), z):  # E: Duplicate argument "y" in function definition
   pass
 
-def k(x, (y, x)):  # E: Duplicate argument 'x' in function definition
+def k(x, (y, x)):  # E: Duplicate argument "x" in function definition
   pass
 
-def l((x, y), (z, x)):  # E: Duplicate argument 'x' in function definition
+def l((x, y), (z, x)):  # E: Duplicate argument "x" in function definition
   pass
 
-def m(x, ((x, y), z)):  # E: Duplicate argument 'x' in function definition
+def m(x, ((x, y), z)):  # E: Duplicate argument "x" in function definition
   pass
 
-lambda x, (y, x): None  # E: Duplicate argument 'x' in function definition
+lambda x, (y, x): None  # E: Duplicate argument "x" in function definition
 
 [case testNoCrashOnImportFromStar]
 from pack import *

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1851,7 +1851,7 @@ def k(f: Callable[[KwArg(), NamedArg(Any, 'x')], int]): pass # E: A **kwargs arg
 from typing import Callable
 from mypy_extensions import Arg, VarArg, KwArg, DefaultArg
 
-def f(f: Callable[[Arg(int, 'x'), int, Arg(int, 'x')], int]): pass # E: Duplicate argument 'x' in Callable
+def f(f: Callable[[Arg(int, 'x'), int, Arg(int, 'x')], int]): pass # E: Duplicate argument "x" in Callable
 
 [builtins fixtures/dict.pyi]
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1746,7 +1746,7 @@ else:
 if bool():
     z = m
 else:
-    z = n  # E: Cannot assign multiple modules to name 'z' without explicit 'types.ModuleType' annotation
+    z = n  # E: Cannot assign multiple modules to name "z" without explicit "types.ModuleType" annotation
 
 [file m.py]
 a = 'foo'
@@ -1782,13 +1782,13 @@ import m, n, o
 
 x = m
 if int():
-    x = n  # E: Cannot assign multiple modules to name 'x' without explicit 'types.ModuleType' annotation
+    x = n  # E: Cannot assign multiple modules to name "x" without explicit "types.ModuleType" annotation
 if int():
-    x = o  # E: Cannot assign multiple modules to name 'x' without explicit 'types.ModuleType' annotation
+    x = o  # E: Cannot assign multiple modules to name "x" without explicit "types.ModuleType" annotation
 
 y = o
 if int():
-    y, z = m, n  # E: Cannot assign multiple modules to name 'y' without explicit 'types.ModuleType' annotation
+    y, z = m, n  # E: Cannot assign multiple modules to name "y" without explicit "types.ModuleType" annotation
 
 xx = m
 if int():
@@ -1808,7 +1808,7 @@ a = 'bar'
 
 [case testModuleAliasToOtherModule]
 import m, n
-m = n  # E: Cannot assign multiple modules to name 'm' without explicit 'types.ModuleType' annotation
+m = n  # E: Cannot assign multiple modules to name "m" without explicit "types.ModuleType" annotation
 
 [file m.py]
 
@@ -1958,7 +1958,7 @@ import othermod
 alias = mod.submod
 reveal_type(alias.whatever('/'))  # N: Revealed type is "builtins.str*"
 if int():
-    alias = othermod  # E: Cannot assign multiple modules to name 'alias' without explicit 'types.ModuleType' annotation
+    alias = othermod  # E: Cannot assign multiple modules to name "alias" without explicit "types.ModuleType" annotation
 [file mod.py]
 import submod
 [file submod.py]

--- a/test-data/unit/parse-python2.test
+++ b/test-data/unit/parse-python2.test
@@ -371,8 +371,8 @@ def f(a, (a, b)):
 def g((x, (x, y))):
     pass
 [out]
-main:1: error: Duplicate argument 'a' in function definition
-main:3: error: Duplicate argument 'x' in function definition
+main:1: error: Duplicate argument "a" in function definition
+main:3: error: Duplicate argument "x" in function definition
 
 [case testBackquotesInPython2]
 `1 + 2`


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445 for Metaclass related errors `Duplicate argument` and `Cannot assign multiple modules`

## Test Plan
Updated test cases for the message. New test cases not added.