### PR TITLE
Use double quotes in errors related to NewType, TypeVar, namedTuple and TypedDict

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -658,7 +658,7 @@ consistently when using the call-based syntax. Example:
 
     from typing import NamedTuple
 
-    # Error: First argument to namedtuple() should be 'Point2D', not 'Point'
+    # Error: First argument to namedtuple() should be "Point2D", not "Point"
     Point2D = NamedTuple("Point", [("x", int), ("y", int)])
 
 Report syntax errors [syntax]

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2204,7 +2204,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             self.fail("NamedTuple type as an attribute is not supported", lvalue)
             return False
         if internal_name != name:
-            self.fail("First argument to namedtuple() should be '{}', not '{}'".format(
+            self.fail('First argument to namedtuple() should be "{}", not "{}"'.format(
                 name, internal_name), s.rvalue, code=codes.NAME_MATCH)
             return True
         # Yes, it's a valid namedtuple, but defer if it is not ready.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2938,7 +2938,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                              # Also give error for another type variable with the same name.
                              (isinstance(existing.node, TypeVarExpr) and
                               existing.node is call.analyzed)):
-            self.fail("Cannot redefine '%s' as a type variable" % name, s)
+            self.fail('Cannot redefine "%s" as a type variable' % name, s)
             return False
 
         if self.options.disallow_any_unimported:
@@ -2993,7 +2993,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                       context)
             return False
         elif call.args[0].value != name:
-            msg = "String argument 1 '{}' to {}(...) does not match variable name '{}'"
+            msg = 'String argument 1 "{}" to {}(...) does not match variable name "{}"'
             self.fail(msg.format(call.args[0].value, typevarlike_type, name), context)
             return False
         return True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3068,20 +3068,20 @@ class SemanticAnalyzer(NodeVisitor[None],
                         analyzed = PlaceholderType(None, [], context.line)
                     upper_bound = get_proper_type(analyzed)
                     if isinstance(upper_bound, AnyType) and upper_bound.is_from_error:
-                        self.fail("TypeVar 'bound' must be a type", param_value)
+                        self.fail('TypeVar "bound" must be a type', param_value)
                         # Note: we do not return 'None' here -- we want to continue
                         # using the AnyType as the upper bound.
                 except TypeTranslationError:
-                    self.fail("TypeVar 'bound' must be a type", param_value)
+                    self.fail('TypeVar "bound" must be a type', param_value)
                     return None
             elif param_name == 'values':
                 # Probably using obsolete syntax with values=(...). Explain the current syntax.
-                self.fail("TypeVar 'values' argument not supported", context)
+                self.fail('TypeVar "values" argument not supported', context)
                 self.fail("Use TypeVar('T', t, ...) instead of TypeVar('T', values=(t, ...))",
                           context)
                 return None
             else:
-                self.fail("Unexpected argument to TypeVar(): {}".format(param_name), context)
+                self.fail('Unexpected argument to TypeVar(): "{}"'.format(param_name), context)
                 return None
 
         if covariant and contravariant:

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -127,7 +127,7 @@ class NewTypeAnalyzer:
             # Give a better error message than generic "Name already defined".
             if (existing and
                     not isinstance(existing.node, PlaceholderNode) and not s.rvalue.analyzed):
-                self.fail("Cannot redefine '%s' as a NewType" % name, s)
+                self.fail('Cannot redefine "%s" as a NewType' % name, s)
 
             # This dummy NewTypeExpr marks the call as sufficiently analyzed; it will be
             # overwritten later with a fully complete NewTypeExpr if there are no other
@@ -153,7 +153,7 @@ class NewTypeAnalyzer:
             self.fail("Argument 1 to NewType(...) must be a string literal", context)
             has_failed = True
         elif args[0].value != name:
-            msg = "String argument 1 '{}' to NewType(...) does not match variable name '{}'"
+            msg = 'String argument 1 "{}" to NewType(...) does not match variable name "{}"'
             self.fail(msg.format(args[0].value, name), context)
             has_failed = True
 

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -200,7 +200,7 @@ class TypedDictAnalyzer:
         else:
             if var_name is not None and name != var_name:
                 self.fail(
-                    "First argument '{}' to TypedDict() does not match variable name '{}'".format(
+                    'First argument "{}" to TypedDict() does not match variable name "{}"'.format(
                         name, var_name), node, code=codes.NAME_MATCH)
             if name != var_name or is_func_scope:
                 # Give it a unique name derived from the line number.

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4573,7 +4573,7 @@ def parse_ast(name_dict: NameDict) -> None:
 [case testNoCrashForwardRefToBrokenDoubleNewType]
 from typing import Any, Dict, List, NewType
 
-Foo = NewType('NotFoo', int) # E: String argument 1 'NotFoo' to NewType(...) does not match variable name 'Foo'
+Foo = NewType('NotFoo', int) # E: String argument 1 "NotFoo" to NewType(...) does not match variable name "Foo"
 Foos = NewType('Foos', List[Foo]) # type: ignore
 
 def frob(foos: Dict[Any, Foos]) -> None:

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -790,7 +790,7 @@ k = [x for x in lst if isinstance(x, int) or foo()]  # E: If condition in compre
 [case testNamedTupleNameMismatch]
 from typing import NamedTuple
 
-Foo = NamedTuple("Bar", [])  # E: First argument to namedtuple() should be 'Foo', not 'Bar'  [name-match]
+Foo = NamedTuple("Bar", [])  # E: First argument to namedtuple() should be "Foo", not "Bar"  [name-match]
 [builtins fixtures/tuple.pyi]
 
 [case testTypedDictNameMismatch]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -796,5 +796,5 @@ Foo = NamedTuple("Bar", [])  # E: First argument to namedtuple() should be "Foo"
 [case testTypedDictNameMismatch]
 from typing_extensions import TypedDict
 
-Foo = TypedDict("Bar", {})  # E: First argument 'Bar' to TypedDict() does not match variable name 'Foo'  [name-match]
+Foo = TypedDict("Bar", {})  # E: First argument "Bar" to TypedDict() does not match variable name "Foo"  [name-match]
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5067,9 +5067,9 @@ from typing import NamedTuple
 NT = NamedTuple('BadName', [('x', int)])
 [builtins fixtures/tuple.pyi]
 [out]
-tmp/b.py:2: error: First argument to namedtuple() should be 'NT', not 'BadName'
+tmp/b.py:2: error: First argument to namedtuple() should be "NT", not "BadName"
 [out2]
-tmp/b.py:2: error: First argument to namedtuple() should be 'NT', not 'BadName'
+tmp/b.py:2: error: First argument to namedtuple() should be "NT", not "BadName"
 tmp/a.py:3: note: Revealed type is "Tuple[builtins.int, fallback=b.NT]"
 
 [case testNewAnalyzerIncrementalBrokenNamedTupleNested]
@@ -5089,9 +5089,9 @@ def test() -> None:
     NT = namedtuple('BadName', ['x', 'y'])
 [builtins fixtures/list.pyi]
 [out]
-tmp/b.py:4: error: First argument to namedtuple() should be 'NT', not 'BadName'
+tmp/b.py:4: error: First argument to namedtuple() should be "NT", not "BadName"
 [out2]
-tmp/b.py:4: error: First argument to namedtuple() should be 'NT', not 'BadName'
+tmp/b.py:4: error: First argument to namedtuple() should be "NT", not "BadName"
 
 [case testNewAnalyzerIncrementalMethodNamedTuple]
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -967,9 +967,9 @@ Type1 = NamedTuple('Type1', [('foo', foo)])  # E: Function "b.foo" is not valid 
 from typing import NamedTuple
 from collections import namedtuple
 
-A = NamedTuple('X', [('a', int)])  # E: First argument to namedtuple() should be 'A', not 'X'
-B = namedtuple('X', ['a'])         # E: First argument to namedtuple() should be 'B', not 'X'
+A = NamedTuple('X', [('a', int)])  # E: First argument to namedtuple() should be "A", not "X"
+B = namedtuple('X', ['a'])         # E: First argument to namedtuple() should be "B", not "X"
 
-C = NamedTuple('X', [('a', 'Y')])  # E: First argument to namedtuple() should be 'C', not 'X'
+C = NamedTuple('X', [('a', 'Y')])  # E: First argument to namedtuple() should be "C", not "X"
 class Y: ...
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2062,7 +2062,7 @@ A = Enum('A', ['z', 't'])  # E: Name "A" already defined on line 3
 from typing import NewType
 
 A = NewType('A', int)
-A = NewType('A', str)  # E: Cannot redefine 'A' as a NewType \
+A = NewType('A', str)  # E: Cannot redefine "A" as a NewType \
                        # E: Name "A" already defined on line 3
 
 [case testNewAnalyzerNewTypeForwardClass]
@@ -2160,7 +2160,7 @@ from typing import TypeVar, Generic, Any
 
 T = TypeVar('T', bound=B[Any])
 # The "int" error is because of typing fixture.
-T = TypeVar('T', bound=C)  # E: Cannot redefine 'T' as a type variable \
+T = TypeVar('T', bound=C)  # E: Cannot redefine "T" as a type variable \
                            # E: Invalid assignment target \
                            # E: "int" not callable
 
@@ -2195,7 +2195,7 @@ reveal_type(y.x)
 [out]
 tmp/b.py:8: error: Type argument "builtins.int" of "B" must be a subtype of "b.B[Any]"
 tmp/b.py:10: note: Revealed type is "b.B*[Any]"
-tmp/a.py:5: error: Cannot redefine 'T' as a type variable
+tmp/a.py:5: error: Cannot redefine "T" as a type variable
 tmp/a.py:5: error: Invalid assignment target
 tmp/a.py:5: error: "int" not callable
 
@@ -2224,7 +2224,7 @@ reveal_type(y.x)
 [out]
 tmp/b.py:9: error: Type argument "builtins.int" of "B" must be a subtype of "b.B[Any]"
 tmp/b.py:11: note: Revealed type is "b.B*[Any]"
-tmp/a.py:5: error: Cannot redefine 'T' as a type variable
+tmp/a.py:5: error: Cannot redefine "T" as a type variable
 tmp/a.py:5: error: Invalid assignment target
 
 [case testNewAnalyzerTypeVarBoundInCycle]

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -269,7 +269,7 @@ tmp/m.py:14: note: Revealed type is "builtins.int"
 [case testNewTypeBadInitializationFails]
 from typing import NewType
 
-a = NewType('b', int)  # E: String argument 1 'b' to NewType(...) does not match variable name 'a'
+a = NewType('b', int)  # E: String argument 1 "b" to NewType(...) does not match variable name "a"
 b = NewType('b', 3)    # E: Argument 2 to NewType(...) must be a valid type
 c = NewType(2, int)    # E: Argument 1 to NewType(...) must be a string literal
 foo = "d"
@@ -317,12 +317,12 @@ from typing import NewType
 
 a = 3
 def f(): a
-a = NewType('a', int) # E: Cannot redefine 'a' as a NewType \
+a = NewType('a', int) # E: Cannot redefine "a" as a NewType \
                       # E: Name "a" already defined on line 4
 
 b = NewType('b', int)
 def g(): b
-b = NewType('b', float)  # E: Cannot redefine 'b' as a NewType \
+b = NewType('b', float)  # E: Cannot redefine "b" as a NewType \
                          # E: Name "b" already defined on line 8
 
 c = NewType('c', str)  # type: str  # E: Cannot declare the type of a NewType declaration

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -274,7 +274,7 @@ def f() -> None:
     reveal_type(x) # N: Revealed type is "builtins.int"
     y = 1
     # NOTE: '"int" not callable' is due to test stubs
-    y = TypeVar('y')  # E: Cannot redefine 'y' as a type variable \
+    y = TypeVar('y')  # E: Cannot redefine "y" as a type variable \
                       # E: "int" not callable
     def h(a: y) -> y: return a # E: Variable "y" is not valid as a type \
                                # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1230,7 +1230,7 @@ Point = TypedDict('Point', {'x': 1, 'y': 1})  # E: Invalid type: try using Liter
 
 [case testCannotCreateTypedDictTypeWithInvalidName]
 from mypy_extensions import TypedDict
-X = TypedDict('Y', {'x': int})  # E: First argument 'Y' to TypedDict() does not match variable name 'X'
+X = TypedDict('Y', {'x': int})  # E: First argument "Y" to TypedDict() does not match variable name "X"
 [builtins fixtures/dict.pyi]
 
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1007,7 +1007,7 @@ from typing import TypeVar
 a = TypeVar()       # E: Too few arguments for TypeVar()
 b = TypeVar(x='b')  # E: TypeVar() expects a string literal as first argument
 c = TypeVar(1)      # E: TypeVar() expects a string literal as first argument
-d = TypeVar('D')    # E: String argument 1 'D' to TypeVar(...) does not match variable name 'd'
+d = TypeVar('D')    # E: String argument 1 "D" to TypeVar(...) does not match variable name "d"
 e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to TypeVar(): x
 f = TypeVar('f', (int, str), int) # E: Type expected
 g = TypeVar('g', int)             # E: TypeVar cannot have only a single constraint
@@ -1052,7 +1052,7 @@ def g(x: T) -> None: pass # E: Name "T" is not defined
 [case testRedefineVariableAsTypevar]
 from typing import TypeVar
 x = 0
-x = TypeVar('x') # E: Cannot redefine 'x' as a type variable
+x = TypeVar('x') # E: Cannot redefine "x" as a type variable
 [out]
 
 [case testTypevarWithType]
@@ -1406,7 +1406,7 @@ def g() -> None:
 from typing_extensions import ParamSpec
 
 TParams = ParamSpec('TParams')
-TP = ParamSpec('?')  # E: String argument 1 '?' to ParamSpec(...) does not match variable name 'TP'
+TP = ParamSpec('?')  # E: String argument 1 "?" to ParamSpec(...) does not match variable name "TP"
 TP2: int = ParamSpec('TP2')  # E: Cannot declare the type of a parameter specification
 
 [out]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1008,11 +1008,11 @@ a = TypeVar()       # E: Too few arguments for TypeVar()
 b = TypeVar(x='b')  # E: TypeVar() expects a string literal as first argument
 c = TypeVar(1)      # E: TypeVar() expects a string literal as first argument
 d = TypeVar('D')    # E: String argument 1 "D" to TypeVar(...) does not match variable name "d"
-e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to TypeVar(): x
+e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to TypeVar(): "x"
 f = TypeVar('f', (int, str), int) # E: Type expected
 g = TypeVar('g', int)             # E: TypeVar cannot have only a single constraint
-h = TypeVar('h', x=(int, str))    # E: Unexpected argument to TypeVar(): x
-i = TypeVar('i', bound=1)         # E: TypeVar 'bound' must be a type
+h = TypeVar('h', x=(int, str))    # E: Unexpected argument to TypeVar(): "x"
+i = TypeVar('i', bound=1)         # E: TypeVar "bound" must be a type
 [out]
 
 [case testMoreInvalidTypevarArguments]
@@ -1032,7 +1032,7 @@ c = TypeVar('c', int, 2) # E: Invalid type: try using Literal[2] instead?
 from typing import TypeVar
 a = TypeVar('a', values=(int, str))
 [out]
-main:2: error: TypeVar 'values' argument not supported
+main:2: error: TypeVar "values" argument not supported
 main:2: error: Use TypeVar('T', t, ...) instead of TypeVar('T', values=(t, ...))
 
 [case testLocalTypevarScope]


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445 for errors related to `NewType`, `TypeVar`, `namedTuple` and `TypedDict`

## Test Plan
Updated test cases for the message. New test cases not added.