### PR TITLE
Use Python 3.9 for mypy self check

### DIFF
--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -18,5 +18,5 @@ show_error_codes = True
 pretty = True
 always_false = MYPYC
 plugins = misc/proper_plugin.py
-python_version = 3.5
+python_version = 3.9
 exclude = /mypy/typeshed/


### PR DESCRIPTION
Using obsolete Python 3.5 breaks typeshed's execution of mypy's self
check, as typeshed does not support Python 3.5 anymore.

Cf. python/typeshed#5242