### PR TITLE
Remove invalid note in docs: setup.cfg *does* need [mypy] section

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -35,7 +35,7 @@ section names in square brackets and flag settings of the form
 `NAME = VALUE`. Comments start with ``#`` characters.
 
 - A section named ``[mypy]`` must be present.  This specifies
-  the global flags. The ``setup.cfg`` file is an exception to this.
+  the global flags.
 
 - Additional sections named ``[mypy-PATTERN1,PATTERN2,...]`` may be
   present, where ``PATTERN1``, ``PATTERN2``, etc., are comma-separated


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

As per https://github.com/python/mypy/issues/9940, a `[mypy]` section is now required in `setup.cfg` in order for config to be loaded from that file. However, the docs are out of date.

This PR removes that out of date clause.

I'm not sure if this fixes the linked issue, but I know that removing this clause would have saved me a few hours of head banging - and therefore would save others too.

## Test Plan

GitHub renders the change OK, so I'm assuming sphinx will also build it fine.
