### PR TITLE
stubtest: improve build error messages

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1039,11 +1039,18 @@ def build_stubs(modules: List[str], options: Options, find_submodules: bool = Fa
     try:
         res = mypy.build.build(sources=sources, options=options)
     except mypy.errors.CompileError as e:
-        output = [_style("error: ", color="red", bold=True), "failed mypy compile.\n", str(e)]
+        output = [
+            _style("error: ", color="red", bold=True),
+            "not checking stubs due to failed mypy compile:\n",
+            str(e),
+        ]
         print("".join(output))
         raise RuntimeError from e
     if res.errors:
-        output = [_style("error: ", color="red", bold=True), "failed mypy build.\n"]
+        output = [
+            _style("error: ", color="red", bold=True),
+            "not checking stubs due to mypy build errors:\n",
+        ]
         print("".join(output) + "\n".join(res.errors))
         raise RuntimeError
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -810,13 +810,13 @@ class StubtestMiscUnit(unittest.TestCase):
     def test_mypy_build(self) -> None:
         output = run_stubtest(stub="+", runtime="", options=[])
         assert remove_color_code(output) == (
-            "error: failed mypy compile.\n{}.pyi:1: "
+            "error: not checking stubs due to failed mypy compile:\n{}.pyi:1: "
             "error: invalid syntax\n".format(TEST_MODULE_NAME)
         )
 
         output = run_stubtest(stub="def f(): ...\ndef f(): ...", runtime="", options=[])
         assert remove_color_code(output) == (
-            'error: failed mypy build.\n{}.pyi:2: '
+            'error: not checking stubs due to mypy build errors:\n{}.pyi:2: '
             'error: Name "f" already defined on line 1\n'.format(TEST_MODULE_NAME)
         )
 


### PR DESCRIPTION
Make it clearer that we didn't actually run the core stubtest logic