### PR TITLE
Using length comparison to narrow types for Tuples and Literals

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5328,14 +5328,20 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 possible_types = union_items(current_type)
                 len_of_types = [len_of_type(typ) for typ in possible_types]
 
-                proposed_type = UnionType([
+                proposed_type = make_simplified_union([
                     self.narrow_type_by_length(typ, length)
                     for typ, l in zip(possible_types, len_of_types)
                     if l is None or l == length])
-                remaining_type = UnionType([
+                remaining_type = make_simplified_union([
                     typ for typ, l in zip(possible_types, len_of_types)
                     if l is None or l != length])
-                return {expr: proposed_type}, {expr: remaining_type}
+                if_map = (
+                    {} if is_same_type(proposed_type, current_type)
+                    else {expr: proposed_type})
+                else_map = (
+                    {} if is_same_type(remaining_type, current_type)
+                    else {expr: remaining_type})
+                return if_map, else_map
         else:
             return {}, {}
 

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1293,8 +1293,8 @@ else:
     reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
 [builtins fixtures/len.pyi]
 
-[case testNarrowingLenListAndStrUnaffected]
-from typing import Tuple, Union, List
+[case testNarrowingLenTypeUnaffected]
+from typing import Tuple, Union, List, Any
 
 def make() -> Union[str, List[int]]:
     return ""
@@ -1305,6 +1305,13 @@ if len(x) == 3:
     reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.list[builtins.int]]"
 else:
     reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.list[builtins.int]]"
+
+def f(self, value: Any) -> Any:
+    if isinstance(value, list) and len(value) == 0:
+        reveal_type(value) # N: Revealed type is "builtins.list[Any]"
+        return value
+    reveal_type(value) # N: Revealed type is "Any"
+    return None
 [builtins fixtures/len.pyi]
 
 [case testNarrowingLenLiteral]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1245,3 +1245,109 @@ def two_type_vars(x: Union[str, Dict[str, int], Dict[bool, object], int]) -> Non
     else:
         reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
+[case testNarrowingLenItemAndLenCompare]
+from typing import Tuple, Union, Any
+
+x: Any
+if len(x) == x:
+    reveal_type(x) # N: Revealed type is "Any"
+[builtins fixtures/len.pyi]
+
+[case testNarrowingLenTuple]
+from typing import Tuple, Union
+
+VarTuple = Union[Tuple[int, int], Tuple[int, int, int]]
+
+def make_tuple() -> VarTuple:
+    return (1, 1)
+
+x = make_tuple()
+a = b = c = 0
+if len(x) == 3:
+    a, b, c = x
+else:
+    a, b = x
+
+if len(x) != 3:
+    a, b = x
+else:
+    a, b, c = x
+[builtins fixtures/len.pyi]
+
+[case testNarrowingLenVariantLengthTuple]
+from typing import Tuple, Union
+
+def make_tuple() -> Tuple[int, ...]:
+    return (1, 1)
+
+x = make_tuple()
+
+if len(x) == 3:
+    reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
+else:
+    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int]"
+
+if len(x) != 3:
+    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int]"
+else:
+    reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
+[builtins fixtures/len.pyi]
+
+[case testNarrowingLenListAndStrUnaffected]
+from typing import Tuple, Union, List
+
+def make() -> Union[str, List[int]]:
+    return ""
+
+x = make()
+
+if len(x) == 3:
+    reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.list[builtins.int]]"
+else:
+    reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.list[builtins.int]]"
+[builtins fixtures/len.pyi]
+
+[case testNarrowingLenLiteral]
+from typing import Tuple, Union
+from typing_extensions import Literal
+
+def make() -> Literal['a', 'bb', 'cc', 'd']:
+    return "a"
+
+x = make()
+
+if len(x) == 2:
+    reveal_type(x) # N: Revealed type is "Union[Literal['bb'], Literal['cc']]"
+else:
+    reveal_type(x) # N: Revealed type is "Union[Literal['a'], Literal['d']]"
+[builtins fixtures/len.pyi]
+
+[case testNarrowingLenMultiple]
+from typing import Tuple, Union
+
+VarTuple = Union[Tuple[int, int], Tuple[int, int, int]]
+
+def make_tuple() -> VarTuple:
+    return (1, 1)
+
+x = make_tuple()
+y = make_tuple()
+if len(x) == len(y) == 3:
+    reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
+    reveal_type(y) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
+[builtins fixtures/len.pyi]
+
+[case testNarrowingLenFinal]
+from typing import Tuple, Union
+from typing_extensions import Final
+
+VarTuple = Union[Tuple[int, int], Tuple[int, int, int]]
+
+def make_tuple() -> VarTuple:
+    return (1, 1)
+
+x = make_tuple()
+fin: Final = 3
+if len(x) == fin:
+    reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
+[builtins fixtures/len.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1285,10 +1285,10 @@ x = make_tuple()
 if len(x) == 3:
     reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
 else:
-    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int]"
+    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 
 if len(x) != 3:
-    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int]"
+    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 else:
     reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
 [builtins fixtures/len.pyi]
@@ -1402,7 +1402,7 @@ def make_tuple() -> VarTuple:
 
 x = make_tuple()
 if len(x) < 3:
-    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int]"
+    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 else:
-    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int]"
+    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 [builtins fixtures/len.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1305,7 +1305,10 @@ if len(x) == 3:
     reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.list[builtins.int]]"
 else:
     reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.list[builtins.int]]"
+[builtins fixtures/len.pyi]
 
+[case testNarrowingLenAnyListElseNotAffected]
+from typing import Any
 def f(self, value: Any) -> Any:
     if isinstance(value, list) and len(value) == 0:
         reveal_type(value) # N: Revealed type is "builtins.list[Any]"
@@ -1357,4 +1360,49 @@ x = make_tuple()
 fin: Final = 3
 if len(x) == fin:
     reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
+[builtins fixtures/len.pyi]
+
+[case testNarrowingLenBiggerThan]
+from typing import Tuple, Union
+
+VarTuple = Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]]
+
+def make_tuple() -> VarTuple:
+    return (1, 1)
+
+x = make_tuple()
+if len(x) > 1:
+    reveal_type(x) # N: Revealed type is "Union[Tuple[builtins.int, builtins.int], Tuple[builtins.int, builtins.int, builtins.int]]"
+else:
+    reveal_type(x) # N: Revealed type is "Tuple[builtins.int]"
+
+if len(x) < 2:
+    reveal_type(x) # N: Revealed type is "Tuple[builtins.int]"
+else:
+    reveal_type(x) # N: Revealed type is "Union[Tuple[builtins.int, builtins.int], Tuple[builtins.int, builtins.int, builtins.int]]"
+
+if len(x) >= 2:
+    reveal_type(x) # N: Revealed type is "Union[Tuple[builtins.int, builtins.int], Tuple[builtins.int, builtins.int, builtins.int]]"
+else:
+    reveal_type(x) # N: Revealed type is "Tuple[builtins.int]"
+
+if len(x) <= 2:
+    reveal_type(x) # N: Revealed type is "Union[Tuple[builtins.int], Tuple[builtins.int, builtins.int]]"
+else:
+    reveal_type(x) # N: Revealed type is "Tuple[builtins.int, builtins.int, builtins.int]"
+[builtins fixtures/len.pyi]
+
+[case testNarrowingLenBiggerThanVariantTuple]
+from typing import Tuple
+
+VarTuple = Tuple[int, ...]
+
+def make_tuple() -> VarTuple:
+    return (1, 1)
+
+x = make_tuple()
+if len(x) < 3:
+    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int]"
+else:
+    reveal_type(x) # N: Revealed type is "builtins.tuple[builtins.int]"
 [builtins fixtures/len.pyi]

--- a/test-data/unit/fixtures/len.pyi
+++ b/test-data/unit/fixtures/len.pyi
@@ -26,6 +26,10 @@ class int:
     def __add__(self, other: 'int') -> 'int': pass
     def __eq__(self, other: 'int') -> 'bool': pass
     def __ne__(self, other: 'int') -> 'bool': pass
+    def __lt__(self, n: 'int') -> 'bool': pass
+    def __gt__(self, n: 'int') -> 'bool': pass
+    def __le__(self, n: 'int') -> 'bool': pass
+    def __ge__(self, n: 'int') -> 'bool': pass
 class float: pass
 class bool(int): pass
 class str:

--- a/test-data/unit/fixtures/len.pyi
+++ b/test-data/unit/fixtures/len.pyi
@@ -1,0 +1,34 @@
+from typing import Tuple, TypeVar, Generic, Union, Any, Type, Sequence
+from typing_extensions import Protocol
+
+T = TypeVar('T')
+
+class object:
+    def __init__(self) -> None: pass
+
+class type:
+    def __init__(self, x) -> None: pass
+
+class tuple(Generic[T]):
+    def __len__(self) -> int: pass
+
+class list(Sequence[T]): pass
+
+class function: pass
+
+class Sized(Protocol):
+    def __len__(self) -> int: pass
+
+def len(__obj: Sized) -> int: ...
+def isinstance(x: object, t: Union[Type[object], Tuple[Type[object], ...]]) -> bool: pass
+
+class int:
+    def __add__(self, other: 'int') -> 'int': pass
+    def __eq__(self, other: 'int') -> 'bool': pass
+    def __ne__(self, other: 'int') -> 'bool': pass
+class float: pass
+class bool(int): pass
+class str:
+    def __add__(self, other: 'str') -> 'str': pass
+    def __len__(self) -> int: pass
+class ellipsis: pass

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -43,6 +43,7 @@ class Generator(Iterator[T], Generic[T, U, V]):
 
 class Sequence(Iterable[T_co]):
     def __getitem__(self, n: Any) -> T_co: pass
+    def __len__(self) -> int: pass
 
 # Mapping type is oversimplified intentionally.
 class Mapping(Iterable[T], Generic[T, T_co]): pass


### PR DESCRIPTION
### Description

Fixes #1178.

This PR uses length based comparisons with Literals to narrow down types in branches. It is similar to the way mypy does it with isinstance.
There are three types of narrowing done:

1. Choosing Tuples from a union according to length
2. Reducing variant length tuples to specific sized tuples
3. Choosing Literals according to length

## Test Plan

I've added unit tests based on both the use cases and bugs mypy primer found.
