### PR TITLE
Fix make_simplified_union for instances with last_known_value

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -367,7 +367,8 @@ def make_simplified_union(items: Sequence[Type],
             # Keep track of the truishness info for deleted subtypes which can be relevant
             cbt = cbf = False
             for j, tj in enumerate(items):
-                if i != j and is_proper_subtype(tj, ti, keep_erased_types=keep_erased):
+                if i != j and is_proper_subtype(tj, ti, keep_erased_types=keep_erased) and \
+                        is_redundant_literal_instance(ti, tj):
                     # We found a redundant item in the union.
                     removed.add(j)
                     cbt = cbt or tj.can_be_true
@@ -804,4 +805,15 @@ def custom_special_method(typ: Type, name: str, check_all: bool = False) -> bool
         # Avoid false positives in uncertain cases.
         return True
     # TODO: support other types (see ExpressionChecker.has_member())?
+    return False
+
+
+def is_redundant_literal_instance(general: ProperType, specific: ProperType) -> bool:
+    if not isinstance(general, Instance) or general.last_known_value is None:
+        return True
+    if isinstance(specific, Instance) and specific.last_known_value == general.last_known_value:
+        return True
+    if isinstance(specific, UninhabitedType):
+        return True
+
     return False

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -268,7 +268,7 @@ def f(x: int = (c := 4)) -> int:
     f(x=(y7 := 3))
     reveal_type(y7)  # N: Revealed type is "builtins.int"
 
-    reveal_type((lambda: (y8 := 3) and y8)())  # N: Revealed type is "Literal[3]?"
+    reveal_type((lambda: (y8 := 3) and y8)())  # N: Revealed type is "builtins.int"
     y8  # E: Name "y8" is not defined
 
     y7 = 1.0  # E: Incompatible types in assignment (expression has type "float", variable has type "int")


### PR DESCRIPTION
### Description
This fixes `make_simplified_union` if multiple instances of the same type but with different `last_known_value`s are passed to it.
Previously it would falsely keep the `last_known_value` of the first occurrence:

```python
make_simplified_union([Literal[1]?, Literal[2]?])   # Results in Literal[1]?
```

I'm not sure if this can currently actually occur at runtime, but I ran into this problem while developing #10191 and decided to submit it as a separate PR, as it's not directly related to #10191.

More specifically I need it for match statements such as
```python
match m:
    case 1 | 2 as num:
        reveal_type(num)  # Union[Literal[1]?, Literal[2]?]
```
Note that I need to use instances with last known value and can't use LiteralType as that would prevent changing the value of `num`.


With this change the `last_known_value` is taken into account before a type is removed from the union.
```python
make_simplified_union([Literal[1]?, Literal[2]?])  # Union[Literal[1]?, Literal[2]?]
make_simplified_union([Literal[1]?, int])  # builtins.int
make_simplified_union([Literal[1]?, <nothing>])  # Literal[1]?
```

## Test Plan

mypy current doesn't have tests for `make_simplified_union`, but the behavior is implicitly tested by other code using it.

This change causes a minor regression in one test, however that test was only working by pure chance before, as it used the fact that `make_simplified_union([Literal[3]?, int])` returned `Literal[3]?`, which is obviously incorrect.