### PR TITLE
Fix argument documentation style in find_type_equals_check

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3961,9 +3961,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                ) -> Tuple[TypeMap, TypeMap]:
         """Narrow types based on any checks of the type ``type(x) == T``
 
-        :param node: The node that might contain the comparison
-
-        :param expr_indices: The list of indices of expressions in ``node`` that are being compared
+        Args:
+            node: The node that might contain the comparison
+            expr_indices: The list of indices of expressions in ``node`` that are being
+                compared
         """
         type_map = self.type_map
 


### PR DESCRIPTION
This changes the documentation style for the arguments to `find_type_equals_check` to be closer to what the rest of the code base is using, as mentioned by @JukkaL at https://github.com/python/mypy/pull/10284#discussion_r611574539.