### PR TITLE
Fix re-exporting __all__ in a stub file

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1758,6 +1758,8 @@ class SemanticAnalyzer(NodeVisitor[None],
                 # precedence, but doesn't seem to be important in most use cases.
                 node = SymbolTableNode(GDEF, self.modules[fullname])
             else:
+                if id == as_id == '__all__' and module_id in self.export_map:
+                    self.all_exports[:] = self.export_map[module_id]
                 node = module.names.get(id)
 
             missing_submodule = False

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2825,3 +2825,21 @@ from mystery import a, b as b, c as d
 [out]
 tmp/stub.pyi:1: error: Cannot find implementation or library stub for module named "mystery"
 tmp/stub.pyi:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+
+[case testReExportAllInStub]
+from m1 import C
+from m1 import D  # E: Module "m1" has no attribute "D"
+C()
+C(1)  # E: Too many arguments for "C"
+[file m1.pyi]
+from m2 import *
+[file m2.pyi]
+from m3 import *
+from m3 import __all__ as __all__
+class D: pass
+[file m3.pyi]
+from m4 import C as C
+__all__ = ['C']
+[file m4.pyi]
+class C: pass
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
Propagate the value of `__all__` from the imported module.

Fixes #10381.