### PR TITLE
Make classes with __getitem__ work in for context

### DIFF
--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1940,6 +1940,17 @@ reveal_type(list(c for c in C))  # N: Revealed type is "builtins.list[__main__.C
 reveal_type(list(C))  # N: Revealed type is "builtins.list[__main__.C*]"
 [builtins fixtures/list.pyi]
 
+[case testIterableGetItemOnClass]
+class A:
+    def __getitem__(self, x: int) -> int: pass
+
+class B:
+    def __getitem__(self, x: str) -> str: pass
+
+reveal_type(list(a for a in A()))  # N: Revealed type is "builtins.list[builtins.int*]"
+list(b for b in B())  # E: "B" has no attribute "__iter__" (not iterable)
+[builtins fixtures/list.pyi]
+
 [case testClassesGetattrWithProtocols]
 from typing import Protocol
 


### PR DESCRIPTION
### Description

The for analysis searches for __iter__ to decide if it is iterable. I've added a search for __getitem__ as well.
This is a step in the right direction for #2220 but it doesn't really make classes with __getitem__ be accepted as arguments marked as Iterable - I'm not sure how to solve this without being intrusive in either typeshed or mypy type inference.

Please note that I've made it work with __getitem__ that accepts int (as the docs say) so if you have **only** __getitem__ with string, this will generate an error.

## Test Plan

I've added a few tests and mypy primer seems to have fewer errors :)
