### PR TITLE
Allow partial overlap when checking overload alternatives

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -548,6 +548,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # Is the overload alternative's arguments subtypes of the implementation's?
                 if not is_callable_compatible(impl, sig1,
                                               is_compat=is_subtype_no_promote,
+                                              allow_partial_overlap=True,
                                               ignore_return=True):
                     self.msg.overloaded_signatures_arg_specific(i + 1, defn.impl)
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5173,3 +5173,25 @@ def f2(g: G[A, Any]) -> A: ...  # E: Overloaded function signatures 1 and 2 over
 @overload
 def f2(g: G[A, B], x: int = ...) -> B: ...
 def f2(g: Any, x: int = ...) -> Any: ...
+
+[case testOverloadKeywordArgsAndKwargs]
+from typing import Optional, overload
+
+@overload
+def f(x: int = 0, **kwargs: str) -> None:
+    ...
+@overload
+def f(x: int = 0, *, y: int, **kwargs: str) -> str:
+    ...
+def f(x: int = 0, *, y: Optional[int] = None, **kwargs: str) -> Optional[str]:
+    ...
+
+reveal_type(f(0)) # N: Revealed type is "None"
+reveal_type(f(1, foo='bar')) # N: Revealed type is "None"
+reveal_type(f(1, y=2, foo='bar')) # N: Revealed type is "builtins.str"
+f(1, **{'y': 0, 'z': 'a'}) # E: No overload variant of "f" matches argument types "int", "Dict[str, object]" \
+                           # N: Possible overload variants: \
+                           # N:     def f(x: int = ..., **kwargs: str) -> None \
+                           # N:     def f(x: int = ..., *, y: int, **kwargs: str) -> str
+
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
### Description

The following case defines a function with both an explicit keyword argument and `**kwargs` but with types incompatible (`int` for the explicit one, `str` for `**kwargs`):

```python
from typing import Optional, overload

@overload
def f(x: int = 0, **kwargs: str) -> None:
    ...
@overload
def f(x: int = 0, *, y: int, **kwargs: str) -> str:
    ...
def f(x: int = 0, *, y: Optional[int] = None, **kwargs: str) -> Optional[str]:
# E: Overloaded function implementation does not accept all possible arguments of signature 1
    ...

reveal_type(f(0))
# N: Revealed type is "None"
reveal_type(f(1, foo='bar'))
# N: Revealed type is "None"
reveal_type(f(1, y=2, foo='bar'))
# N: Revealed type is "builtins.str"
```
Mypy  raises an error "Overloaded function implementation does not accept all possible arguments of signature 1" but types are correctly inferred, so the error seems to be a false-positive.

Allowing partial overlap when checking compatibility between one overload alternative and the implementation fixes the issue (the error is no longer raised). Calling `is_callable_compatible(..., allow_partial_overlap=True)` is documented to "return `True` if *there exists at least one* call to left that's also a call to right"; which seems valid for overloads.

(This appears so simple that it's quite possible that I missed something...)

## Test Plan

Example above is included as a test case. No apparent breakage in the test suite.