### PR TITLE
First look into @python2 subdirectory of search path items

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -520,3 +520,17 @@ For example, if you have multiple projects that happen to be
 using the same set of work-in-progress stubs, it could be
 convenient to just have your ``MYPYPATH`` point to a single
 directory containing the stubs.
+
+Directories specific to Python 2 (@python2)
+*******************************************
+
+When type checking in Python 2 mode, mypy also looks for files under
+the ``@python2`` subdirectory of each ``MYPYPATH`` and ``mypy_path``
+entry, if the subdirectory exists. Files under the subdirectory take
+precedence over the parent directory. This can be used to provide
+separate Python 2 versions of stubs.
+
+.. note::
+
+    This does not need to be used (and cannot be used) with
+    :ref:`PEP 561 compliant stub packages <installed-packages>`.

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -627,6 +627,25 @@ def _make_abspath(path: str, root: str) -> str:
         return os.path.join(root, os.path.normpath(path))
 
 
+def add_py2_mypypath_entries(mypypath: List[str]) -> List[str]:
+    """Add corresponding @python2 subdirectories to mypypath.
+
+    For each path entry 'x', add 'x/@python2' before 'x' if the latter is
+    a directory.
+    """
+    result = []
+    for item in mypypath:
+        python2_dir = os.path.join(item, PYTHON2_STUB_DIR)
+        if os.path.isdir(python2_dir):
+            # @python2 takes precedence, but we also look into the parent
+            # directory.
+            result.append(python2_dir)
+            result.append(item)
+        else:
+            result.append(item)
+    return result
+
+
 def compute_search_paths(sources: List[BuildSource],
                          options: Options,
                          data_dir: str,
@@ -688,6 +707,11 @@ def compute_search_paths(sources: List[BuildSource],
     # beginning (highest priority) of the search path.
     if alt_lib_path:
         mypypath.insert(0, alt_lib_path)
+
+    # When type checking in Python 2 module, add @python2 subdirectories of
+    # path items into the search path.
+    if options.python_version[0] == 2:
+        mypypath = add_py2_mypypath_entries(mypypath)
 
     egg_dirs, site_packages = get_site_packages_dirs(options.python_executable)
     for site_dir in site_packages:

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2843,3 +2843,41 @@ __all__ = ['C']
 [file m4.pyi]
 class C: pass
 [builtins fixtures/list.pyi]
+
+[case testMypyPathAndPython2Dir_python2]
+# flags: --config-file tmp/mypy.ini
+from m import f
+from mm import g
+f(1)
+f('x')  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
+g()
+g(1)  # E: Too many arguments for "g"
+
+[file xx/@python2/m.pyi]
+def f(x: int) -> None: ...
+
+[file xx/m.pyi]
+def f(x: str) -> None: ...
+
+[file xx/mm.pyi]
+def g() -> None: ...
+
+[file mypy.ini]
+\[mypy]
+mypy_path = tmp/xx
+
+[case testMypyPathAndPython2Dir]
+# flags: --config-file tmp/mypy.ini
+from m import f
+f(1)  # E: Argument 1 to "f" has incompatible type "int"; expected "str"
+f('x')
+
+[file xx/@python2/m.pyi]
+def f(x: int) -> None: ...
+
+[file xx/m.pyi]
+def f(x: str) -> None: ...
+
+[file mypy.ini]
+\[mypy]
+mypy_path = tmp/xx


### PR DESCRIPTION
When using `mypy_path` or `MYPYPATH`, allow storing Python 2 only stubs and
source files under the `@python2` subdirectory of search path entries. This is
only used when type checking in Python 2 mode.

Closes #10391.