### PR TITLE
Add tests for make_simplified_union

### DIFF
--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -11,8 +11,7 @@ from mypy.sametypes import is_same_type
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.types import (
     UnboundType, AnyType, CallableType, TupleType, TypeVarDef, Type, Instance, NoneType,
-    Overloaded, TypeType, UnionType, UninhabitedType, TypeVarId, TypeOfAny,
-    LiteralType, get_proper_type
+    Overloaded, TypeType, UnionType, UninhabitedType, TypeVarId, TypeOfAny, get_proper_type
 )
 from mypy.nodes import ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, CONTRAVARIANT, INVARIANT, COVARIANT
 from mypy.subtypes import is_subtype, is_more_precise, is_proper_subtype
@@ -463,7 +462,8 @@ class TypeOpsSuite(Suite):
         self.assert_simplified_union([fx.ga, fx.gsba], fx.ga)
         self.assert_simplified_union([fx.a, UnionType([fx.d])], UnionType([fx.a, fx.d]))
         self.assert_simplified_union([fx.a, UnionType([fx.a])], fx.a)
-        self.assert_simplified_union([fx.b, UnionType([fx.c, UnionType([fx.d])])], UnionType([fx.b, fx.c, fx.d]))
+        self.assert_simplified_union([fx.b, UnionType([fx.c, UnionType([fx.d])])],
+                                     UnionType([fx.b, fx.c, fx.d]))
         self.assert_simplified_union([fx.lit1, fx.lit2], UnionType([fx.lit1, fx.lit2]))
         self.assert_simplified_union([fx.lit1, fx.lit3], UnionType([fx.lit1, fx.lit3]))
         self.assert_simplified_union([fx.lit1, fx.uninhabited], fx.lit1)
@@ -971,7 +971,6 @@ class MeetSuite(Suite):
 
     def test_literal_type(self) -> None:
         a = self.fx.a
-        d = self.fx.d
         lit1 = self.fx.lit1
         lit2 = self.fx.lit2
         lit3 = self.fx.lit3

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -464,14 +464,21 @@ class TypeOpsSuite(Suite):
         self.assert_simplified_union([fx.a, UnionType([fx.a])], fx.a)
         self.assert_simplified_union([fx.b, UnionType([fx.c, UnionType([fx.d])])],
                                      UnionType([fx.b, fx.c, fx.d]))
+        self.assert_simplified_union([fx.lit1, fx.a], fx.a)
+        self.assert_simplified_union([fx.lit1, fx.lit1], fx.lit1)
         self.assert_simplified_union([fx.lit1, fx.lit2], UnionType([fx.lit1, fx.lit2]))
         self.assert_simplified_union([fx.lit1, fx.lit3], UnionType([fx.lit1, fx.lit3]))
         self.assert_simplified_union([fx.lit1, fx.uninhabited], fx.lit1)
+        self.assert_simplified_union([fx.lit1_inst, fx.a], fx.a)
+        self.assert_simplified_union([fx.lit1_inst, fx.lit1_inst], fx.lit1_inst)
         self.assert_simplified_union([fx.lit1_inst, fx.lit2_inst],
                                      UnionType([fx.lit1_inst, fx.lit2_inst]))
         self.assert_simplified_union([fx.lit1_inst, fx.lit3_inst],
                                      UnionType([fx.lit1_inst, fx.lit3_inst]))
         self.assert_simplified_union([fx.lit1_inst, fx.uninhabited], fx.lit1_inst)
+        self.assert_simplified_union([fx.lit1, fx.lit1_inst], UnionType([fx.lit1, fx.lit1_inst]))
+        self.assert_simplified_union([fx.lit1, fx.lit2_inst], UnionType([fx.lit1, fx.lit2_inst]))
+        self.assert_simplified_union([fx.lit1, fx.lit3_inst], UnionType([fx.lit1, fx.lit3_inst]))
 
     def assert_simplified_union(self, original: List[Type], union: Type) -> None:
         assert_equal(make_simplified_union(original), union)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -475,6 +475,7 @@ class TypeOpsSuite(Suite):
 
     def assert_simplified_union(self, original: List[Type], union: Type) -> None:
         assert_equal(make_simplified_union(original), union)
+        assert_equal(make_simplified_union(list(reversed(original))), union)
 
     # Helpers
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -18,7 +18,7 @@ from mypy.nodes import ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, CONTRAVARIANT, INV
 from mypy.subtypes import is_subtype, is_more_precise, is_proper_subtype
 from mypy.test.typefixture import TypeFixture, InterfaceTypeFixture
 from mypy.state import strict_optional_set
-from mypy.typeops import true_only, false_only
+from mypy.typeops import true_only, false_only, make_simplified_union
 
 
 class TypesSuite(Suite):
@@ -299,9 +299,9 @@ class TypeOpsSuite(Suite):
     def test_is_proper_subtype_and_subtype_literal_types(self) -> None:
         fx = self.fx
 
-        lit1 = LiteralType(1, fx.a)
-        lit2 = LiteralType("foo", fx.d)
-        lit3 = LiteralType("bar", fx.d)
+        lit1 = fx.lit1
+        lit2 = fx.lit2
+        lit3 = fx.lit3
 
         assert_true(is_proper_subtype(lit1, fx.a))
         assert_false(is_proper_subtype(lit1, fx.d))
@@ -450,6 +450,26 @@ class TypeOpsSuite(Suite):
             assert_false(fo.items[0].can_be_true)
             assert_true(fo.items[0].can_be_false)
             assert_true(fo.items[1] is tup_type)
+
+    def test_simplified_union(self) -> None:
+        fx = self.fx
+
+        self.assert_simplified_union([fx.a, fx.a], fx.a)
+        self.assert_simplified_union([fx.a, fx.b], fx.a)
+        self.assert_simplified_union([fx.a, fx.d], UnionType([fx.a, fx.d]))
+        self.assert_simplified_union([fx.a, fx.uninhabited], fx.a)
+        self.assert_simplified_union([fx.ga, fx.gs2a], fx.ga)
+        self.assert_simplified_union([fx.ga, fx.gsab], UnionType([fx.ga, fx.gsab]))
+        self.assert_simplified_union([fx.ga, fx.gsba], fx.ga)
+        self.assert_simplified_union([fx.a, UnionType([fx.d])], UnionType([fx.a, fx.d]))
+        self.assert_simplified_union([fx.a, UnionType([fx.a])], fx.a)
+        self.assert_simplified_union([fx.b, UnionType([fx.c, UnionType([fx.d])])], UnionType([fx.b, fx.c, fx.d]))
+        self.assert_simplified_union([fx.lit1, fx.lit2], UnionType([fx.lit1, fx.lit2]))
+        self.assert_simplified_union([fx.lit1, fx.lit3], UnionType([fx.lit1, fx.lit3]))
+        self.assert_simplified_union([fx.lit1, fx.uninhabited], fx.lit1)
+
+    def assert_simplified_union(self, original: List[Type], union: Type) -> None:
+        assert_equal(make_simplified_union(original), union)
 
     # Helpers
 
@@ -723,9 +743,9 @@ class JoinSuite(Suite):
     def test_literal_type(self) -> None:
         a = self.fx.a
         d = self.fx.d
-        lit1 = LiteralType(1, a)
-        lit2 = LiteralType(2, a)
-        lit3 = LiteralType("foo", d)
+        lit1 = self.fx.lit1
+        lit2 = self.fx.lit2
+        lit3 = self.fx.lit3
 
         self.assert_join(lit1, lit1, lit1)
         self.assert_join(lit1, a, a)
@@ -952,9 +972,9 @@ class MeetSuite(Suite):
     def test_literal_type(self) -> None:
         a = self.fx.a
         d = self.fx.d
-        lit1 = LiteralType(1, a)
-        lit2 = LiteralType(2, a)
-        lit3 = LiteralType("foo", d)
+        lit1 = self.fx.lit1
+        lit2 = self.fx.lit2
+        lit3 = self.fx.lit3
 
         self.assert_meet(lit1, lit1, lit1)
         self.assert_meet(lit1, a, lit1)
@@ -1011,11 +1031,10 @@ class SameTypeSuite(Suite):
 
     def test_literal_type(self) -> None:
         b = self.fx.b  # Reminder: b is a subclass of a
-        d = self.fx.d
 
-        lit1 = LiteralType(1, b)
-        lit2 = LiteralType(2, b)
-        lit3 = LiteralType("foo", d)
+        lit1 = self.fx.lit1
+        lit2 = self.fx.lit2
+        lit3 = self.fx.lit3
 
         self.assert_same(lit1, lit1)
         self.assert_same(UnionType([lit1, lit2]), UnionType([lit1, lit2]))

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -467,6 +467,11 @@ class TypeOpsSuite(Suite):
         self.assert_simplified_union([fx.lit1, fx.lit2], UnionType([fx.lit1, fx.lit2]))
         self.assert_simplified_union([fx.lit1, fx.lit3], UnionType([fx.lit1, fx.lit3]))
         self.assert_simplified_union([fx.lit1, fx.uninhabited], fx.lit1)
+        self.assert_simplified_union([fx.lit1_inst, fx.lit2_inst],
+                                     UnionType([fx.lit1_inst, fx.lit2_inst]))
+        self.assert_simplified_union([fx.lit1_inst, fx.lit3_inst],
+                                     UnionType([fx.lit1_inst, fx.lit3_inst]))
+        self.assert_simplified_union([fx.lit1_inst, fx.uninhabited], fx.lit1_inst)
 
     def assert_simplified_union(self, original: List[Type], union: Type) -> None:
         assert_equal(make_simplified_union(original), union)

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple
 
 from mypy.types import (
     Type, TypeVarType, AnyType, NoneType, Instance, CallableType, TypeVarDef, TypeType,
-    UninhabitedType, TypeOfAny, TypeAliasType, UnionType
+    UninhabitedType, TypeOfAny, TypeAliasType, UnionType, LiteralType
 )
 from mypy.nodes import (
     TypeInfo, ClassDef, Block, ARG_POS, ARG_OPT, ARG_STAR, SymbolTable,
@@ -148,6 +148,13 @@ class TypeFixture:
 
         self.lsta = Instance(self.std_listi, [self.a])  # List[A]
         self.lstb = Instance(self.std_listi, [self.b])  # List[B]
+
+        self.lit1 = LiteralType(1, self.a)
+        self.lit2 = LiteralType(2, self.a)
+        self.lit3 = LiteralType("foo", self.d)
+        self.lit1_inst = Instance(self.ai, [], last_known_value=self.lit1)
+        self.lit2_inst = Instance(self.ai, [], last_known_value=self.lit2)
+        self.lit3_inst = Instance(self.di, [], last_known_value=self.lit3)
 
         self.type_a = TypeType.make_normalized(self.a)
         self.type_b = TypeType.make_normalized(self.b)


### PR DESCRIPTION
This commit adds tests for `make_simplified_union`, including the new functionality added in #10373 

The only thing not tested is contracting enum literals back to the enum type, as `TypeFixture` currently doesn't support enum types. I might add that later.