### PR TITLE
Fix a bunch of tests broken by python 3.10

### DIFF
--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -31,7 +31,11 @@ class A:
 reveal_type(1) # N: Revealed type is "Literal[1]?"
 
 [case testErrorCodeSyntaxError]
-1 '' # E: invalid syntax  [syntax]
+1 ''
+[out]
+main:1: error: invalid syntax  [syntax]
+[out version>=3.10]
+main:1: error: invalid syntax. Perhaps you forgot a comma?  [syntax]
 
 [case testErrorCodeSyntaxError2]
 def f(): # E: Type signature has too many arguments  [syntax]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -753,6 +753,9 @@ def foo(
 [out]
 a.py:1: error: unexpected EOF while parsing
 == Return code: 2
+[out version>=3.10]
+a.py:1: error: '(' was never closed
+== Return code: 2
 
 [case testParseErrorAnnots]
 # cmd: mypy a.py
@@ -1234,6 +1237,10 @@ public static void main(String[] args)
 x: str = 0
 [out]
 pkg/x.py:1: error: invalid syntax
+Found 1 error in 1 file (errors prevented further checking)
+== Return code: 2
+[out version>=3.10]
+pkg/x.py:1: error: invalid syntax. Perhaps you forgot a comma?
 Found 1 error in 1 file (errors prevented further checking)
 == Return code: 2
 

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -23,6 +23,12 @@ a.py:1: error: invalid syntax
 ==
 main:2: error: Missing positional argument "x" in call to "f"
 ==
+[out version>=3.10]
+==
+a.py:1: error: expected ':'
+==
+main:2: error: Missing positional argument "x" in call to "f"
+==
 
 [case testParseErrorShowSource]
 # flags: --pretty --show-error-codes
@@ -46,6 +52,16 @@ main:3: error: Missing positional argument "x" in call to "f"  [call-arg]
     a.f()
     ^
 ==
+[out version>=3.10]
+==
+a.py:1: error: expected ':'  [syntax]
+    def f(x: int) ->
+                   ^
+==
+main:3: error: Missing positional argument "x" in call to "f"  [call-arg]
+    a.f()
+    ^
+==
 
 [case testParseErrorMultipleTimes]
 import a
@@ -64,6 +80,13 @@ def f(x: int) -> None: pass
 a.py:1: error: invalid syntax
 ==
 a.py:2: error: invalid syntax
+==
+main:2: error: Missing positional argument "x" in call to "f"
+[out version>=3.10]
+==
+a.py:1: error: expected ':'
+==
+a.py:2: error: expected ':'
 ==
 main:2: error: Missing positional argument "x" in call to "f"
 
@@ -105,6 +128,14 @@ a.py:1: error: invalid syntax
 ==
 main:3: error: Too many arguments for "f"
 main:5: error: Too many arguments for "f"
+[out version>=3.10]
+main:3: error: Too many arguments for "f"
+main:5: error: Too many arguments for "f"
+==
+a.py:1: error: expected ':'
+==
+main:3: error: Too many arguments for "f"
+main:5: error: Too many arguments for "f"
 
 [case testUpdateClassReferenceAcrossBlockingError]
 import a
@@ -125,6 +156,11 @@ class C:
 a.py:1: error: invalid syntax
 ==
 main:5: error: Missing positional argument "x" in call to "f" of "C"
+[out version>=3.10]
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+main:5: error: Missing positional argument "x" in call to "f" of "C"
 
 [case testAddFileWithBlockingError]
 import a
@@ -138,6 +174,13 @@ main:1: error: Cannot find implementation or library stub for module named "a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
 a.py:1: error: invalid syntax
+==
+main:2: error: Too many arguments for "f"
+[out version>=3.10]
+main:1: error: Cannot find implementation or library stub for module named "a"
+main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 main:2: error: Too many arguments for "f"
 
@@ -216,6 +259,13 @@ a.py:1: error: invalid syntax
 a.py:1: error: invalid syntax
 ==
 a.py:2: error: Missing positional argument "x" in call to "f"
+[out version>=3.10]
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+a.py:2: error: Missing positional argument "x" in call to "f"
 
 [case testModifyTwoFilesIntroduceTwoBlockingErrors]
 import a
@@ -280,6 +330,13 @@ a.py:1: error: invalid syntax
 main:1: error: Cannot find implementation or library stub for module named "a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 b.py:1: error: Cannot find implementation or library stub for module named "a"
+[out version>=3.10]
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+main:1: error: Cannot find implementation or library stub for module named "a"
+main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+b.py:1: error: Cannot find implementation or library stub for module named "a"
 
 [case testDeleteFileWithBlockingError-only_when_cache]
 -- Different cache/no-cache tests because:
@@ -297,6 +354,13 @@ x x
 [out]
 ==
 a.py:1: error: invalid syntax
+==
+b.py:1: error: Cannot find implementation or library stub for module named "a"
+b.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+main:1: error: Cannot find implementation or library stub for module named "a"
+[out version>=3.10]
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 b.py:1: error: Cannot find implementation or library stub for module named "a"
 b.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
@@ -324,6 +388,14 @@ a.py:1: error: invalid syntax
 ==
 b.py:2: error: Module has no attribute "f"
 b.py:3: error: "int" not callable
+[out version>=3.10]
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+b.py:2: error: Module has no attribute "f"
+b.py:3: error: "int" not callable
 
 [case testImportBringsAnotherFileWithBlockingError1]
 import a
@@ -337,6 +409,11 @@ def f() -> None: pass
 [out]
 ==
 <ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax
+==
+a.py:1: error: "int" not callable
+[out version>=3.10]
+==
+<ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax. Perhaps you forgot a comma?
 ==
 a.py:1: error: "int" not callable
 
@@ -413,6 +490,13 @@ a.py:1: error: invalid syntax
 <ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax
 ==
 a.py:2: error: "int" not callable
+[out version>=3.10]
+==
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+<ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax. Perhaps you forgot a comma?
+==
+a.py:2: error: "int" not callable
 
 [case testInitialBlocker]
 # cmd: mypy a.py b.py
@@ -428,6 +512,11 @@ def f() -> int:
     return 0
 [out]
 a.py:1: error: invalid syntax
+==
+b.py:2: error: Incompatible return value type (got "str", expected "int")
+==
+[out version>=3.10]
+a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 b.py:2: error: Incompatible return value type (got "str", expected "int")
 ==

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -1019,6 +1019,11 @@ foo.py:4: error: unexpected EOF while parsing
 Command 'suggest' is only valid after a 'check' command (that produces no parse errors)
 ==
 foo.py:4: error: unexpected EOF while parsing
+[out version>=3.10]
+foo.py:4: error: '(' was never closed
+Command 'suggest' is only valid after a 'check' command (that produces no parse errors)
+==
+foo.py:4: error: '(' was never closed
 -- )
 
 [case testSuggestRefine]

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -932,16 +932,22 @@ MypyFile:1(
         NameExpr(z)))))
 
 [case testNotAsBinaryOp]
-x not y # E: invalid syntax
+x not y
 [out]
+main:1: error: invalid syntax
+[out version>=3.10]
+main:1: error: invalid syntax. Perhaps you forgot a comma?
 
 [case testNotIs]
 x not is y # E: invalid syntax
 [out]
 
 [case testBinaryNegAsBinaryOp]
-1 ~ 2 # E: invalid syntax
+1 ~ 2
 [out]
+main:1: error: invalid syntax
+[out version>=3.10]
+main:1: error: invalid syntax. Perhaps you forgot a comma?
 
 [case testDictionaryExpression]
 {}

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -361,11 +361,15 @@ main:2: error: 'yield' outside function
 1 = 1
 [out]
 main:1: error: can't assign to literal
+[out version>=3.10]
+main:1: error: can't assign to literal here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues2]
 (1) = 1
 [out]
 main:1: error: can't assign to literal
+[out version>=3.10]
+main:1: error: can't assign to literal here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues3]
 (1, 1) = 1
@@ -404,26 +408,36 @@ main:3: error: can't assign to literal
 x + x = 1
 [out]
 main:1: error: can't assign to operator
+[out version>=3.10]
+main:1: error: can't assign to expression here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues11]
 -x = 1
 [out]
 main:1: error: can't assign to operator
+[out version>=3.10]
+main:1: error: can't assign to expression here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues12]
 1.1 = 1
 [out]
 main:1: error: can't assign to literal
+[out version>=3.10]
+main:1: error: can't assign to literal here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues13]
 'x' = 1
 [out]
 main:1: error: can't assign to literal
+[out version>=3.10]
+main:1: error: can't assign to literal here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues14]
 x() = 1
 [out]
 main:1: error: can't assign to function call
+[out version>=3.10]
+main:1: error: can't assign to function call here. Maybe you meant '==' instead of '='?
 
 [case testTwoStarExpressions]
 a, *b, *c = 1
@@ -480,8 +494,11 @@ del x(1)  # E: can't delete function call
 
 [case testInvalidDel2]
 x = 1
-del x + 1 # E: can't delete operator
+del x + 1
 [out]
+main:2: error: cannot delete operator
+[out version>=3.10]
+main:2: error: cannot delete expression
 
 [case testInvalidDel3]
 del z     # E: Name "z" is not defined
@@ -868,6 +885,8 @@ def f(): pass
 f() = 1 # type: int
 [out]
 main:3: error: can't assign to function call
+[out version>=3.10]
+main:3: error: can't assign to function call here. Maybe you meant '==' instead of '='?
 
 [case testIndexedAssignmentWithTypeDeclaration]
 import typing
@@ -941,8 +960,11 @@ x, y = 1, 2 # type: int # E: Tuple type expected for multiple variables
 
 [case testInvalidLvalueWithExplicitType]
 a = 1
-a() = None # type: int  # E: can't assign to function call
+a() = None # type: int
 [out]
+main:2: error: cannot assign to function call
+[out version>=3.10]
+main:2: error: cannot assign to function call here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalueWithExplicitType2]
 a = 1
@@ -1263,6 +1285,8 @@ def f() -> None:
     f() = 1  # type: int
 [out]
 main:3: error: can't assign to function call
+[out version>=3.10]
+main:3: error: can't assign to function call here. Maybe you meant '==' instead of '='?
 
 [case testInvalidReferenceToAttributeOfOuterClass]
 class A:

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -551,6 +551,8 @@ def f(x, y) -> None:
     del x, y + 1
 [out]
 main:2: error: can't delete operator
+[out version>=3.10]
+main:2: error: can't delete expression
 
 [case testTry]
 class c: pass


### PR DESCRIPTION
Python 3.10 changes a bunch of parser error messages. This commit introduces the version>= argument to [out] sections of tests, which allows testing against the new messages on newer python versions.


[out] sections are overwritten by other [out] sections following them.

I also thought about supporting other comparisons such as `<`, `==` and others, while not having later out sections overwrite earlier out sections, but decided on this approach for simplicity.

This was tested on `Python 3.10.0a7+ (heads/master:0cad068, Apr 30 2021, 14:45:23)` (shortly before 3.10.0b1). Note that Travis CI nighly is still stuck on  3.10.0a5+.