### PR TITLE
Fixed a teststubtest test failing in python 3.10

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import textwrap
 import unittest
+from pathlib import Path
 from typing import Any, Callable, Iterator, List, Optional
 
 import mypy.stubtest
@@ -83,7 +84,9 @@ def run_stubtest(
                 use_builtins_fixtures=True
             )
 
-        return output.getvalue()
+        module_path = Path(os.getcwd()) / TEST_MODULE_NAME
+        # remove cwd as it's not available from outside
+        return output.getvalue().replace(str(module_path), TEST_MODULE_NAME)
 
 
 class Case:


### PR DESCRIPTION
I couldn't track down the exact change that caused this test to fail, but python now stores the full path to the module in `test_module.bad.__code__.co_filename` instead of just the filename, despite the file being in the current working directory.

Because the working directory is unknown where the output is actually checked we just remove it from the output. This only affects tests.
