### PR TITLE
Add support for ``functools.cached_property``

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -999,12 +999,15 @@ class SemanticAnalyzer(NodeVisitor[None],
                 dec.var.is_classmethod = True
                 self.check_decorated_function_is_method('classmethod', dec)
             elif (refers_to_fullname(d, 'builtins.property') or
-                  refers_to_fullname(d, 'abc.abstractproperty')):
+                  refers_to_fullname(d, 'abc.abstractproperty') or
+                  refers_to_fullname(d, 'functools.cached_property')):
                 removed.append(i)
                 dec.func.is_property = True
                 dec.var.is_property = True
                 if refers_to_fullname(d, 'abc.abstractproperty'):
                     dec.func.is_abstract = True
+                elif refers_to_fullname(d, 'functools.cached_property'):
+                    dec.var.is_settable_property = True
                 self.check_decorated_function_is_method('property', dec)
                 if len(dec.func.arguments) > 1:
                     self.fail('Too many arguments', dec.func)

--- a/test-data/unit/check-functools.test
+++ b/test-data/unit/check-functools.test
@@ -107,3 +107,23 @@ Ord() > 1
 Ord() >= 1  # E: Unsupported left operand type for >= ("Ord")
 [builtins fixtures/ops.pyi]
 [builtins fixtures/dict.pyi]
+
+[case testCachedProperty]
+# flags: --python-version 3.8
+from functools import cached_property
+class Parent:
+    @property
+    def f(self) -> str: pass
+class Child(Parent):
+    @cached_property
+    def f(self) -> str: pass
+    @cached_property
+    def g(self) -> int: pass
+    @cached_property
+    def h(self, arg) -> int: pass  # E: Too many arguments
+reveal_type(Parent().f)  # N: Revealed type is "builtins.str"
+reveal_type(Child().f)  # N: Revealed type is "builtins.str"
+reveal_type(Child().g)  # N: Revealed type is "builtins.int"
+Child().f = "Hello World"
+Child().g = "invalid"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/property.pyi]

--- a/test-data/unit/fixtures/property.pyi
+++ b/test-data/unit/fixtures/property.pyi
@@ -12,6 +12,7 @@ class function: pass
 
 property = object()  # Dummy definition
 
+class dict: pass
 class int: pass
 class str: pass
 class bytes: pass


### PR DESCRIPTION
### Description

Add support for `functools.cached_property` decorator. https://docs.python.org/3/library/functools.html#functools.cached_property

Closes #8913
Closes https://github.com/python/typeshed/issues/3963

## Test Plan

I added a new test case. Additionally, I used this snipped to verify mypy during development of the patch
```py
from functools import cached_property

class Parent:
    @property
    def prop(self) -> int:
        ...

class Child(Parent):
    def __init__(self):
        self._prop = 4

    @cached_property
    def prop(self) -> int:
        print("Calc value ..")
        return self._prop ** 2

c = Child()
print(c.prop)
print(c.prop)  # Returns cached value

c.prop = 24  # Overwrite cached value
print(c.prop)

c.prop = "Hello World"  # incompatiable types
print(c.prop)
```