### PR TITLE
Use typeddict-item error code for more errors

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -421,6 +421,10 @@ Check TypedDict items [typeddict-item]
 When constructing a ``TypedDict`` object, mypy checks that each key and value is compatible
 with the ``TypedDict`` type that is inferred from the surrounding context.
 
+When getting a ``TypedDict`` item, mypy checks that the key
+exists. When assigning to a ``TypedDict``, mypy checks that both the
+key and the value are valid.
+
 Example:
 
 .. code-block:: python

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -77,6 +77,7 @@ ArgChecker = Callable[[Type,
                        int,
                        int,
                        CallableType,
+                       Optional[Type],
                        Context,
                        Context,
                        MessageBuilder],
@@ -1011,7 +1012,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                   arg_names, formal_to_actual, context, self.msg)
 
         self.check_argument_types(arg_types, arg_kinds, args, callee, formal_to_actual, context,
-                                  messages=arg_messages)
+                                  messages=arg_messages, object_type=object_type)
 
         if (callee.is_type_obj() and (len(arg_types) == 1)
                 and is_equivalent(callee.ret_type, self.named_type('builtins.type'))):
@@ -1452,7 +1453,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                              formal_to_actual: List[List[int]],
                              context: Context,
                              messages: Optional[MessageBuilder] = None,
-                             check_arg: Optional[ArgChecker] = None) -> None:
+                             check_arg: Optional[ArgChecker] = None,
+                             object_type: Optional[Type] = None) -> None:
         """Check argument types against a callable type.
 
         Report errors if the argument types are not compatible.
@@ -1480,7 +1482,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     callee.arg_names[i], callee.arg_kinds[i])
                 check_arg(expanded_actual, actual_type, arg_kinds[actual],
                           callee.arg_types[i],
-                          actual + 1, i + 1, callee, args[actual], context, messages)
+                          actual + 1, i + 1, callee, object_type, args[actual], context, messages)
 
     def check_arg(self,
                   caller_type: Type,
@@ -1490,6 +1492,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                   n: int,
                   m: int,
                   callee: CallableType,
+                  object_type: Optional[Type],
                   context: Context,
                   outer_context: Context,
                   messages: MessageBuilder) -> None:
@@ -1515,6 +1518,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                                   callee,
                                                   original_caller_type,
                                                   caller_kind,
+                                                  object_type=object_type,
                                                   context=context,
                                                   outer_context=outer_context)
             messages.incompatible_argument_note(original_caller_type, callee_type, context,
@@ -1978,6 +1982,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                       n: int,
                       m: int,
                       callee: CallableType,
+                      object_type: Optional[Type],
                       context: Context,
                       outer_context: Context,
                       messages: MessageBuilder) -> None:
@@ -2439,7 +2444,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         return self.check_call(method_type, args, arg_kinds,
                                context, arg_messages=local_errors,
-                               callable_name=callable_name, object_type=object_type)
+                               callable_name=callable_name, object_type=base_type)
 
     def check_op_reversible(self,
                             op_name: str,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1458,6 +1458,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Check argument types against a callable type.
 
         Report errors if the argument types are not compatible.
+
+        The check_call docstring describes some of the arguments.
         """
         messages = messages or self.msg
         check_arg = check_arg or self.check_arg

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -457,7 +457,12 @@ a: D = {'x': ''}  # E: Incompatible types (expression has type "str", TypedDict 
 b: D = {'y': ''}  # E: Extra key "y" for TypedDict "D"  [typeddict-item]
 c = D(x=0) if int() else E(x=0, y=0)
 c = {}  # E: Expected TypedDict key "x" but found no keys  [typeddict-item]
+
+a['y'] = 1  # E: TypedDict "D" has no key "y"  [typeddict-item]
+a['x'] = 'x'  # E: Value of "x" has incompatible type "str"; expected "int"  [typeddict-item]
+a['y']  # E: TypedDict "D" has no key "y"  [typeddict-item]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testErrorCodeCannotDetermineType]
 y = x  # E: Cannot determine type of "x"  [has-type]
@@ -756,7 +761,7 @@ class C(TypedDict):
     x: int
 
 c: C
-c.setdefault('x', '1')  # type: ignore[arg-type]
+c.setdefault('x', '1')  # type: ignore[typeddict-item]
 
 class A:
     pass


### PR DESCRIPTION
Previously this was inconsistent, and some TypedDict operations used
the 'misc' error code, which is dangerous to ignore. TypedDict related
errors seem to be some of most commonly ignored error with the 'misc'
error code.