### PR TITLE
Don't report error when using total_ordering in Python 2 mode

### DIFF
--- a/mypy/plugins/functools.py
+++ b/mypy/plugins/functools.py
@@ -26,7 +26,7 @@ def functools_total_ordering_maker_callback(ctx: mypy.plugin.ClassDefContext,
                                             auto_attribs_default: bool = False) -> None:
     """Add dunder methods to classes decorated with functools.total_ordering."""
     if ctx.api.options.python_version < (3,):
-        ctx.api.fail('"functools.total_ordering" is not supported in Python 2', ctx.reason)
+        # This plugin is not supported in Python 2 mode (it's a no-op).
         return
 
     comparison_methods = _analyze_class(ctx)


### PR DESCRIPTION
Even if the plugin doesn't work yet, generating an error is a
regression. The decorator used to silently do nothing in earlier
mypy versions.

Not having the plugin doesn't complelety prevent type checking code
using `total_ordering`.