### PR TITLE
Fix inference of IntEnum value attribute type (Python 2)

### DIFF
--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -109,7 +109,11 @@ def _implements_new(info: TypeInfo) -> bool:
     subclass. In the latter case, we must infer Any as long as mypy can't infer
     the type of _value_ from assignments in __new__.
     """
-    type_with_new = _first(ti for ti in info.mro if ti.names.get('__new__'))
+    type_with_new = _first(
+        ti
+        for ti in info.mro
+        if ti.names.get('__new__') and not ti.fullname.startswith('builtins.')
+    )
     if type_with_new is None:
         return False
     return type_with_new.fullname not in ('enum.Enum', 'enum.IntEnum', 'enum.StrEnum')


### PR DESCRIPTION
The enum stubs for Python 2 are slightly different from Python 3.
The fix in #10412 didn't quite work in Python 2 mode, since `IntEnum`
doesn't define `__new__`, and the `__new__` from `builtins.int` is
found instead. Work around this by skipping any `__new__` methods
found in built-in types.

I gave up trying to write a test case for this. It's tricky because
`enum` is in Python 3 stdlib but not in Python 2 stdlib.