### PR TITLE
Fix TypedDict test case on Python 3.5

### DIFF
--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1031,6 +1031,7 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingTypedDictUsingEnumLiteral]
+# flags: --python-version 3.6
 from typing import Union
 from typing_extensions import TypedDict, Literal
 from enum import Enum


### PR DESCRIPTION
Class-based TypedDict syntax requires Python 3.6+.