### PR TITLE
Don't use Python 3 stdlib stubs in Python 2 mode

### DIFF
--- a/test-data/unit/python2eval.test
+++ b/test-data/unit/python2eval.test
@@ -428,3 +428,8 @@ def foo() -> None:
     reveal_type(x)
 [out]
 _testDefaultDictInference.py:5: note: Revealed type is "collections.defaultdict[builtins.str, builtins.list[builtins.int]]"
+
+[case testIgnorePython3StdlibStubs_python2]
+from collections import abc
+[out]
+_testIgnorePython3StdlibStubs_python2.py:1: error: Module "collections" has no attribute "abc"


### PR DESCRIPTION
Previously we could find stubs both in `stdlib/@python2` and
`stdlib` for the same top-level package, which could result in a
mix of Python 2 and 3 stubs being used.

Now if we find stubs for a package in the `@python2` directory, we
skip the parent directory.

Fixes #10421.