### PR TITLE
Don't narrow Type[X] with a metaclass

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -74,6 +74,11 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
         return narrowed
     elif isinstance(declared, TypeType) and isinstance(narrowed, TypeType):
         return TypeType.make_normalized(narrow_declared_type(declared.item, narrowed.item))
+    elif (isinstance(declared, TypeType)
+          and isinstance(narrowed, Instance)
+          and narrowed.type.is_metaclass()):
+        # We'd need intersection types, so give up.
+        return declared
     elif isinstance(declared, (Instance, TupleType, TypeType, LiteralType)):
         return meet_types(declared, narrowed)
     elif isinstance(declared, TypedDictType) and isinstance(narrowed, Instance):

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1053,3 +1053,23 @@ def f(d: Union[Foo, Bar]) -> None:
     d['x']
     reveal_type(d)  # N: Revealed type is "TypedDict('__main__.Foo', {'tag': Literal[__main__.E.FOO], 'x': builtins.int})"
 [builtins fixtures/dict.pyi]
+
+[case testNarrowingUsingMetaclass]
+# flags: --strict-optional
+from typing import Type
+
+class M(type):
+    pass
+
+class C: pass
+
+def f(t: Type[C]) -> None:
+    if type(t) is M:
+        reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
+    else:
+        reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
+    if type(t) is not M:
+        reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
+    else:
+        reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
+    reveal_type(t)  # N: Revealed type is "Type[__main__.C]"


### PR DESCRIPTION
We could narrow `Type[T]` to `<nothing>` when tested against a
metaclass, which is not useful. Now we don't do any narrowing
in this case.

Fixes #10423.