### PR TITLE
Fix crash related to module-level __getattr__ in incremental mode

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -797,7 +797,7 @@ VAR_FLAGS = [
     'is_self', 'is_initialized_in_class', 'is_staticmethod',
     'is_classmethod', 'is_property', 'is_settable_property', 'is_suppressed_import',
     'is_classvar', 'is_abstract_var', 'is_final', 'final_unset_in_class', 'final_set_in_init',
-    'explicit_self_type', 'is_ready',
+    'explicit_self_type', 'is_ready', 'from_module_getattr',
 ]  # type: Final
 
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -4239,6 +4239,34 @@ tmp/c.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mi
 tmp/c.py:1: error: Cannot find implementation or library stub for module named "a.b.c"
 tmp/c.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 
+[case testModuleGetattrIncrementalSerializeVarFlag]
+import main
+
+[file main.py]
+from b import A, f
+f()
+
+[file main.py.3]
+from b import A, f  # foo
+f()
+
+[file b.py]
+from c import A
+def f() -> A: ...
+
+[file b.py.2]
+from c import A  # foo
+def f() -> A: ...
+
+[file c.py]
+from d import A
+
+[file d.pyi]
+def __getattr__(n): ...
+[out1]
+[out2]
+[out3]
+
 [case testAddedMissingStubs]
 # flags: --ignore-missing-imports
 from missing import f


### PR DESCRIPTION
The `from_module_getattr` attribute of `Var` was not serialized, so
subsequent runs didn't know about this being from `__getattr__` and
tried to create a cross-ref to the definition which doesn't actually
exist, resulting in a crash.

Fixes #10429.