### PR TITLE
Fix crash with nested NamedTuple in incremental mode

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1396,7 +1396,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             #       incremental mode and we should avoid it. In general, this logic is too
             #       ad-hoc and needs to be removed/refactored.
             if '@' not in defn.info._fullname:
-                local_name = defn.info._fullname + '@' + str(defn.line)
+                local_name = defn.info.name + '@' + str(defn.line)
                 if defn.info.is_named_tuple:
                     # Module is already correctly set in _fullname for named tuples.
                     defn.info._fullname += '@' + str(defn.line)
@@ -1404,7 +1404,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                     defn.info._fullname = self.cur_mod_id + '.' + local_name
             else:
                 # Preserve name from previous fine-grained incremental run.
-                local_name = defn.info._fullname
+                local_name = defn.info.name
             defn.fullname = defn.info._fullname
             self.globals[local_name] = SymbolTableNode(GDEF, defn.info)
 
@@ -3140,7 +3140,11 @@ class SemanticAnalyzer(NodeVisitor[None],
         self.add_symbol(name, call.analyzed, s)
         return True
 
-    def basic_new_typeinfo(self, name: str, basetype_or_fallback: Instance) -> TypeInfo:
+    def basic_new_typeinfo(self, name: str,
+                           basetype_or_fallback: Instance,
+                           line: int) -> TypeInfo:
+        if self.is_func_scope() and not self.type and '@' not in name:
+            name += '@' + str(line)
         class_def = ClassDef(name, Block([]))
         if self.is_func_scope() and not self.type:
             # Full names of generated classes should always be prefixed with the module names

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -67,13 +67,13 @@ class EnumCallAnalyzer:
         items, values, ok = self.parse_enum_call_args(call, fullname.split('.')[-1])
         if not ok:
             # Error. Construct dummy return value.
-            info = self.build_enum_call_typeinfo(var_name, [], fullname)
+            info = self.build_enum_call_typeinfo(var_name, [], fullname, node.line)
         else:
             name = cast(Union[StrExpr, UnicodeExpr], call.args[0]).value
             if name != var_name or is_func_scope:
                 # Give it a unique name derived from the line number.
                 name += '@' + str(call.line)
-            info = self.build_enum_call_typeinfo(name, items, fullname)
+            info = self.build_enum_call_typeinfo(name, items, fullname, call.line)
             # Store generated TypeInfo under both names, see semanal_namedtuple for more details.
             if name != var_name or is_func_scope:
                 self.api.add_symbol_skip_local(name, info)
@@ -82,10 +82,11 @@ class EnumCallAnalyzer:
         info.line = node.line
         return info
 
-    def build_enum_call_typeinfo(self, name: str, items: List[str], fullname: str) -> TypeInfo:
+    def build_enum_call_typeinfo(self, name: str, items: List[str], fullname: str,
+                                 line: int) -> TypeInfo:
         base = self.api.named_type_or_none(fullname)
         assert base is not None
-        info = self.api.basic_new_typeinfo(name, base)
+        info = self.api.basic_new_typeinfo(name, base, line)
         info.metaclass_type = info.calculate_metaclass_type()
         info.is_enum = True
         for item in items:

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -382,7 +382,7 @@ class NamedTupleAnalyzer:
         iterable_type = self.api.named_type_or_none('typing.Iterable', [implicit_any])
         function_type = self.api.named_type('__builtins__.function')
 
-        info = self.api.basic_new_typeinfo(name, fallback)
+        info = self.api.basic_new_typeinfo(name, fallback, line)
         info.is_named_tuple = True
         tuple_base = TupleType(types, fallback)
         info.tuple_type = tuple_base

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -72,12 +72,12 @@ class NewTypeAnalyzer:
         # Create the corresponding class definition if the aliased type is subtypeable
         if isinstance(old_type, TupleType):
             newtype_class_info = self.build_newtype_typeinfo(name, old_type,
-                                                             old_type.partial_fallback)
+                                                             old_type.partial_fallback, s.line)
             newtype_class_info.tuple_type = old_type
         elif isinstance(old_type, Instance):
             if old_type.type.is_protocol:
                 self.fail("NewType cannot be used with protocol classes", s)
-            newtype_class_info = self.build_newtype_typeinfo(name, old_type, old_type)
+            newtype_class_info = self.build_newtype_typeinfo(name, old_type, old_type, s.line)
         else:
             if old_type is not None:
                 message = "Argument 2 to NewType(...) must be subclassable (got {})"
@@ -85,7 +85,7 @@ class NewTypeAnalyzer:
             # Otherwise the error was already reported.
             old_type = AnyType(TypeOfAny.from_error)
             object_type = self.api.named_type('__builtins__.object')
-            newtype_class_info = self.build_newtype_typeinfo(name, old_type, object_type)
+            newtype_class_info = self.build_newtype_typeinfo(name, old_type, object_type, s.line)
             newtype_class_info.fallback_to_any = True
 
         check_for_explicit_any(old_type, self.options, self.api.is_typeshed_stub_file, self.msg,
@@ -181,8 +181,9 @@ class NewTypeAnalyzer:
 
         return None if has_failed else old_type, should_defer
 
-    def build_newtype_typeinfo(self, name: str, old_type: Type, base_type: Instance) -> TypeInfo:
-        info = self.api.basic_new_typeinfo(name, base_type)
+    def build_newtype_typeinfo(self, name: str, old_type: Type, base_type: Instance,
+                               line: int) -> TypeInfo:
+        info = self.api.basic_new_typeinfo(name, base_type, line)
         info.is_newtype = True
 
         # Add __init__ method

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -122,7 +122,7 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
         raise NotImplementedError
 
     @abstractmethod
-    def basic_new_typeinfo(self, name: str, basetype_or_fallback: Instance) -> TypeInfo:
+    def basic_new_typeinfo(self, name: str, basetype_or_fallback: Instance, line: int) -> TypeInfo:
         raise NotImplementedError
 
     @abstractmethod

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5506,3 +5506,29 @@ class Foo:
 [delete c1.py.2]
 [file c2.py.2]
 class C: pass
+
+[case testIncrementalNestedNamedTuple]
+# flags: --python-version 3.6
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+import b # foo
+
+[file b.py]
+from typing import NamedTuple
+
+def f() -> None:
+    class NT(NamedTuple):
+        x: int
+
+    n: NT = NT(x=2)
+
+def g() -> None:
+    NT = NamedTuple('NT', [('y', str)])
+
+    n: NT = NT(y='x')
+
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
The name of the nested tuple type was inconsistent. Sometimes if was stored 
using the full name in the module symbol table.

Also improve the internal API for creating classes to be less error-prone.

Work on #7281.