### PR TITLE
Fix crash with type alias inside __init__ in incremental mode

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2796,15 +2796,18 @@ class TypeAlias(SymbolNode):
         itself an alias), while the second cannot be subscripted because of
         Python runtime limitation.
     line and column: Line an column on the original alias definition.
+    eager: If True, immediately expand alias when referred to (useful for aliases
+        within functions that can't be looked up from the symbol table)
     """
     __slots__ = ('target', '_fullname', 'alias_tvars', 'no_args', 'normalized',
-                 'line', 'column', '_is_recursive')
+                 'line', 'column', '_is_recursive', 'eager')
 
     def __init__(self, target: 'mypy.types.Type', fullname: str, line: int, column: int,
                  *,
                  alias_tvars: Optional[List[str]] = None,
                  no_args: bool = False,
-                 normalized: bool = False) -> None:
+                 normalized: bool = False,
+                 eager: bool = False) -> None:
         self._fullname = fullname
         self.target = target
         if alias_tvars is None:
@@ -2815,6 +2818,7 @@ class TypeAlias(SymbolNode):
         # This attribute is manipulated by TypeAliasType. If non-None,
         # it is the cached value.
         self._is_recursive = None  # type: Optional[bool]
+        self.eager = eager
         super().__init__(line, column)
 
     @property

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -247,6 +247,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                         python_version=self.options.python_version,
                         use_generic_error=True,
                         unexpanded_type=t)
+                if node.eager:
+                    # TODO: Generate error if recursive (once we have recursive types)
+                    res = get_proper_type(res)
                 return res
             elif isinstance(node, TypeInfo):
                 return self.analyze_type_with_type_info(node, t.args, t)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5532,3 +5532,32 @@ def g() -> None:
     n: NT = NT(y='x')
 
 [builtins fixtures/tuple.pyi]
+
+[case testIncrementalNestedTypeAlias]
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+import b
+reveal_type(b.C().x)
+reveal_type(b.D().x)
+
+[file b.py]
+from typing import List
+
+class C:
+    def __init__(self) -> None:
+        Alias = List[int]
+        self.x = []  # type: Alias
+
+class D:
+    def __init__(self) -> None:
+        Alias = List[str]
+        self.x = []  # type: Alias
+
+[builtins fixtures/list.pyi]
+[out2]
+tmp/a.py:2: note: Revealed type is "builtins.list[builtins.int]"
+tmp/a.py:3: note: Revealed type is "builtins.list[builtins.str]"


### PR DESCRIPTION
Don't create `TypeAliasType` for aliases defined within functions,
since the target can't be looked up using the full name, as we drop
function symbol tables after we've finished processing them.

Fixes #7281.