### PR TITLE
[mypyc] Emit native_int instead of int64/int32 in IR test output 

### DIFF
--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -276,10 +276,12 @@ c_int_rprimitive = int32_rprimitive
 
 if IS_32_BIT_PLATFORM:
     c_size_t_rprimitive = uint32_rprimitive
-    c_pyssize_t_rprimitive = int32_rprimitive
+    c_pyssize_t_rprimitive = RPrimitive('native_int', is_unboxed=True, is_refcounted=False,
+                              ctype='int32_t', size=4)  # type: Final
 else:
     c_size_t_rprimitive = uint64_rprimitive
-    c_pyssize_t_rprimitive = int64_rprimitive
+    c_pyssize_t_rprimitive = RPrimitive('native_int', is_unboxed=True, is_refcounted=False,
+                              ctype='int64_t', size=8)  # type: Final
 
 # Low level pointer, represented as integer in C backends
 pointer_rprimitive = RPrimitive('ptr', is_unboxed=True, is_refcounted=False,
@@ -338,11 +340,13 @@ def is_short_int_rprimitive(rtype: RType) -> bool:
 
 
 def is_int32_rprimitive(rtype: RType) -> bool:
-    return rtype is int32_rprimitive
+    return rtype is int32_rprimitive or
+        (rtype is c_pyssize_t_rprimitive and rtype._ctype == 'int32_t')
 
 
 def is_int64_rprimitive(rtype: RType) -> bool:
-    return rtype is int64_rprimitive
+    return rtype is int64_rprimitive or
+        (rtype is c_pyssize_t_rprimitive and rtype._ctype == 'int64_t')
 
 
 def is_uint32_rprimitive(rtype: RType) -> bool:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -277,11 +277,11 @@ c_int_rprimitive = int32_rprimitive
 if IS_32_BIT_PLATFORM:
     c_size_t_rprimitive = uint32_rprimitive
     c_pyssize_t_rprimitive = RPrimitive('native_int', is_unboxed=True, is_refcounted=False,
-                              ctype='int32_t', size=4)  # type: Final
+                              ctype='int32_t', size=4)
 else:
     c_size_t_rprimitive = uint64_rprimitive
     c_pyssize_t_rprimitive = RPrimitive('native_int', is_unboxed=True, is_refcounted=False,
-                              ctype='int64_t', size=8)  # type: Final
+                              ctype='int64_t', size=8)
 
 # Low level pointer, represented as integer in C backends
 pointer_rprimitive = RPrimitive('ptr', is_unboxed=True, is_refcounted=False,

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -340,13 +340,13 @@ def is_short_int_rprimitive(rtype: RType) -> bool:
 
 
 def is_int32_rprimitive(rtype: RType) -> bool:
-    return rtype is int32_rprimitive or
-        (rtype is c_pyssize_t_rprimitive and rtype._ctype == 'int32_t')
+    return (rtype is int32_rprimitive or
+            (rtype is c_pyssize_t_rprimitive and rtype._ctype == 'int32_t'))
 
 
 def is_int64_rprimitive(rtype: RType) -> bool:
-    return rtype is int64_rprimitive or
-        (rtype is c_pyssize_t_rprimitive and rtype._ctype == 'int64_t')
+    return (rtype is int64_rprimitive or
+            (rtype is c_pyssize_t_rprimitive and rtype._ctype == 'int64_t'))
 
 
 def is_uint32_rprimitive(rtype: RType) -> bool:

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -32,7 +32,7 @@ class TestAnalysis(MypycDataSuite):
         """Perform a data-flow analysis test case."""
 
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
-            testcase.output = replace_native_int(testcase.output)
+            # testcase.output = replace_native_int(testcase.output)
             try:
                 ir = build_ir_for_single_file(testcase.input)
             except CompileError as e:

--- a/mypyc/test/test_analysis.py
+++ b/mypyc/test/test_analysis.py
@@ -15,7 +15,7 @@ from mypyc.ir.ops import Value
 from mypyc.ir.func_ir import all_values
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, replace_native_int
+    assert_test_output
 )
 
 files = [
@@ -32,7 +32,6 @@ class TestAnalysis(MypycDataSuite):
         """Perform a data-flow analysis test case."""
 
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
-            # testcase.output = replace_native_int(testcase.output)
             try:
                 ir = build_ir_for_single_file(testcase.input)
             except CompileError as e:

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -16,7 +16,7 @@ from mypyc.transform.exceptions import insert_exception_handling
 from mypyc.transform.refcount import insert_ref_count_opcodes
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines, replace_native_int
+    assert_test_output, remove_comment_lines
 )
 
 files = [
@@ -32,7 +32,6 @@ class TestExceptionTransform(MypycDataSuite):
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            # expected_output = replace_native_int(expected_output)
             try:
                 ir = build_ir_for_single_file(testcase.input)
             except CompileError as e:

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -32,7 +32,7 @@ class TestExceptionTransform(MypycDataSuite):
         """Perform a runtime checking transformation test case."""
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            expected_output = replace_native_int(expected_output)
+            # expected_output = replace_native_int(expected_output)
             try:
                 ir = build_ir_for_single_file(testcase.input)
             except CompileError as e:

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -49,7 +49,7 @@ class TestGenOps(MypycDataSuite):
             return
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            expected_output = replace_native_int(expected_output)
+            # expected_output = replace_native_int(expected_output)
             expected_output = replace_word_size(expected_output)
             name = testcase.name
             try:

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -10,7 +10,7 @@ from mypyc.common import TOP_LEVEL_NAME
 from mypyc.ir.pprint import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines, replace_native_int, replace_word_size,
+    assert_test_output, remove_comment_lines, replace_word_size,
     infer_ir_build_options_from_test_name
 )
 
@@ -49,7 +49,6 @@ class TestGenOps(MypycDataSuite):
             return
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            # expected_output = replace_native_int(expected_output)
             expected_output = replace_word_size(expected_output)
             name = testcase.name
             try:

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -38,7 +38,7 @@ class TestRefCountTransform(MypycDataSuite):
             return
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            expected_output = replace_native_int(expected_output)
+            # expected_output = replace_native_int(expected_output)
             expected_output = replace_word_size(expected_output)
             try:
                 ir = build_ir_for_single_file(testcase.input, options)

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -16,7 +16,7 @@ from mypyc.transform.refcount import insert_ref_count_opcodes
 from mypyc.transform.uninit import insert_uninit_checks
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS, use_custom_builtins, MypycDataSuite, build_ir_for_single_file,
-    assert_test_output, remove_comment_lines, replace_native_int, replace_word_size,
+    assert_test_output, remove_comment_lines, replace_word_size,
     infer_ir_build_options_from_test_name
 )
 
@@ -38,7 +38,6 @@ class TestRefCountTransform(MypycDataSuite):
             return
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
-            # expected_output = replace_native_int(expected_output)
             expected_output = replace_word_size(expected_output)
             try:
                 ir = build_ir_for_single_file(testcase.input, options)

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -215,12 +215,6 @@ def fudge_dir_mtimes(dir: str, delta: int) -> None:
             os.utime(path, times=(new_mtime, new_mtime))
 
 
-def replace_native_int(text: List[str]) -> List[str]:
-    """Replace native_int with platform specific ints"""
-    int_format_str = 'int32' if IS_32_BIT_PLATFORM else 'int64'
-    return [s.replace('native_int', int_format_str) for s in text]
-
-
 def replace_word_size(text: List[str]) -> List[str]:
     """Replace WORDSIZE with platform specific word sizes"""
     result = []


### PR DESCRIPTION
relates https://github.com/mypyc/mypyc/issues/776

This is a super quick workaround. So far the issue mostly (if not completely) occurs in `c_pyssize_t` so making this rtype emits `native_int` would solve the issue. As a result, the `replace_native_int` pass in IR test is now removed.