### PR TITLE
Infer unreachability for await no_return()

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4042,7 +4042,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return AnyType(TypeOfAny.special_form)
         else:
             generator = self.check_method_call_by_name('__await__', t, [], [], ctx)[0]
-            return self.chk.get_generator_return_type(generator, False)
+            ret_type = self.chk.get_generator_return_type(generator, False)
+            if isinstance(ret_type, UninhabitedType) and not ret_type.ambiguous:
+                self.chk.binder.unreachable()
+            return ret_type
 
     def visit_yield_from_expr(self, e: YieldFromExpr, allow_none_return: bool = False) -> Type:
         # NOTE: Whether `yield from` accepts an `async def` decorated

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4043,6 +4043,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         else:
             generator = self.check_method_call_by_name('__await__', t, [], [], ctx)[0]
             ret_type = self.chk.get_generator_return_type(generator, False)
+            ret_type = get_proper_type(ret_type)
             if isinstance(ret_type, UninhabitedType) and not ret_type.ambiguous:
                 self.chk.binder.unreachable()
             return ret_type

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -334,6 +334,20 @@ from mypy_extensions import NoReturn
 x = 0  # type: NoReturn  # E: Incompatible types in assignment (expression has type "int", variable has type "NoReturn")
 [builtins fixtures/dict.pyi]
 
+[case testNoReturnAsync]
+# flags: --warn-no-return
+from mypy_extensions import NoReturn
+
+async def f() -> NoReturn: ...
+
+async def g() -> NoReturn:
+  await f()
+
+async def h() -> NoReturn:  # E: Implicit return in function which does not return
+  f()
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-async.pyi]
+
 [case testNoReturnImportFromTyping]
 from typing import NoReturn
 


### PR DESCRIPTION
Fixes #10454

The logic here is similar to what we do in visit_call_expr_inner