### PR TITLE
Update README.md, MIT License link is not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,5 +276,5 @@ For more details, see the file [CONTRIBUTING.md](CONTRIBUTING.md).
 License
 -------
 
-Mypy is licensed under the terms of the MIT License (see the file
-LICENSE).
+Mypy is licensed under the terms of the MIT License, see the file[
+LICENSE](https://github.com/python/mypy/blob/master/LICENSE).


### PR DESCRIPTION

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

(YES)

### Description

When I was going through the README.md of mypy, I saw that a link in the README.md file is not working. This is a link about the License of the project. Although all the links are working perfectly and anyone can just click on the link and see relevant informations.

The "LICENSE" should be embedded with the link  https://github.com/python/mypy/blob/master/LICENSE


---


Before Update
![ ](https://raw.githubusercontent.com/SamirPaul1/SamirPaul1.Hacker/main/Before_Update.png)

---


After Update
![ ](https://raw.githubusercontent.com/SamirPaul1/SamirPaul1.Hacker/main/After_Update.png)