### PR TITLE
mypy_primer: fix comment permissions

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -13,6 +13,8 @@ jobs:
   mypy_primer:
     name: Run
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         shard-index: [0, 1, 2]
@@ -61,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: mypy_primer
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Download diffs


### PR DESCRIPTION
Port https://github.com/python/typeshed/pull/5452
We didn't have the global permission set, so maybe it wasn't broken, but
explicitly setting permissions seems like a good thing