### PR TITLE
Do not allow to use Final and ClassVar at same time

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2295,6 +2295,11 @@ class SemanticAnalyzer(NodeVisitor[None],
                 self.fail("Type in Final[...] can only be omitted if there is an initializer", s)
         else:
             s.type = s.unanalyzed_type.args[0]
+
+        if s.type is not None and self.is_classvar(s.type):
+            self.fail("Variable should not be annotated with both ClassVar and Final", s)
+            return False
+
         if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], RefExpr):
             self.fail("Invalid final declaration", s)
             return False

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1082,3 +1082,10 @@ class A:
         self.x = 10  # type: Final
         undefined  # type: ignore
 [builtins fixtures/tuple.pyi]
+
+[case testFinalUsedWithClassVar]
+from typing import Final, ClassVar
+
+class A:
+    a: Final[ClassVar[int]]  # E: Variable should not be annotated with both ClassVar and Final
+[out]

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1088,4 +1088,6 @@ from typing import Final, ClassVar
 
 class A:
     a: Final[ClassVar[int]]  # E: Variable should not be annotated with both ClassVar and Final
+    b: ClassVar[Final[int]]  # E: Final can be only used as an outermost qualifier in a variable annotation
+    c: ClassVar[Final] = 1  # E: Final can be only used as an outermost qualifier in a variable annotation
 [out]


### PR DESCRIPTION
### Description

Fixes #10477

Do not allow to use Final and ClassVar at same time.

## Test Plan

Code bellow:

```python
from typing import Final, ClassVar

class A:
    a: Final[ClassVar[int]]
```

After this PR will produce an error:
```
error: Variable should not be annotated with both ClassVar and Final
```

But currently, it will not raise any error.
