### PR TITLE
Remove assertion from TypeGuard serialization

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1271,8 +1271,6 @@ class CallableType(FunctionLike):
     def serialize(self) -> JsonDict:
         # TODO: As an optimization, leave out everything related to
         # generic functions for non-generic functions.
-        assert (self.type_guard is None
-                or isinstance(get_proper_type(self.type_guard), Instance)), str(self.type_guard)
         return {'.class': 'CallableType',
                 'arg_types': [t.serialize() for t in self.arg_types],
                 'arg_kinds': self.arg_kinds,


### PR DESCRIPTION
This came up in python/typeshed#5473: mypy started crashing when
I made a function return TypeGuard[Type[Any]]. I wasn't able to
reproduce this locally so far in a standalone file, but verified that removing the
assertion fixes the crash.