### PR TITLE
Use double quotes in errors

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -396,7 +396,7 @@ class Errors:
             for line in set(ignored_lines) - self.used_ignored_lines[file]:
                 # Don't use report since add_error_info will ignore the error!
                 info = ErrorInfo(self.import_context(), file, self.current_module(), None,
-                                 None, line, -1, 'error', "unused 'type: ignore' comment",
+                                 None, line, -1, 'error', 'unused "type: ignore" comment',
                                  None, False, False)
                 self._add_error_info(file, info)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2012,9 +2012,9 @@ def format_string_list(lst: List[str]) -> str:
 def format_item_name_list(s: Iterable[str]) -> str:
     lst = list(s)
     if len(lst) <= 5:
-        return '(' + ', '.join(["'%s'" % name for name in lst]) + ')'
+        return '(' + ', '.join(['"%s"' % name for name in lst]) + ')'
     else:
-        return '(' + ', '.join(["'%s'" % name for name in lst[:5]]) + ', ...)'
+        return '(' + ', '.join(['"%s"' % name for name in lst[:5]]) + ', ...)'
 
 
 def callable_name(type: FunctionLike) -> Optional[str]:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1039,7 +1039,7 @@ class SemanticAnalyzer(NodeVisitor[None],
     def check_decorated_function_is_method(self, decorator: str,
                                            context: Context) -> None:
         if not self.type or self.is_func_scope():
-            self.fail("'%s' used with a non-method" % decorator, context)
+            self.fail('"%s" used with a non-method' % decorator, context)
 
     #
     # Classes

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3326,7 +3326,7 @@ class SemanticAnalyzer(NodeVisitor[None],
     def visit_return_stmt(self, s: ReturnStmt) -> None:
         self.statement = s
         if not self.is_func_scope():
-            self.fail("'return' outside function", s)
+            self.fail('"return" outside function', s)
         if s.expr:
             s.expr.accept(self)
 
@@ -3385,12 +3385,12 @@ class SemanticAnalyzer(NodeVisitor[None],
     def visit_break_stmt(self, s: BreakStmt) -> None:
         self.statement = s
         if self.loop_depth == 0:
-            self.fail("'break' outside loop", s, serious=True, blocker=True)
+            self.fail('"break" outside loop', s, serious=True, blocker=True)
 
     def visit_continue_stmt(self, s: ContinueStmt) -> None:
         self.statement = s
         if self.loop_depth == 0:
-            self.fail("'continue' outside loop", s, serious=True, blocker=True)
+            self.fail('"continue" outside loop', s, serious=True, blocker=True)
 
     def visit_if_stmt(self, s: IfStmt) -> None:
         self.statement = s
@@ -3581,7 +3581,7 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     def visit_yield_from_expr(self, e: YieldFromExpr) -> None:
         if not self.is_func_scope():  # not sure
-            self.fail("'yield from' outside function", e, serious=True, blocker=True)
+            self.fail('"yield from" outside function', e, serious=True, blocker=True)
         else:
             if self.function_stack[-1].is_coroutine:
                 self.fail('"yield from" in async function', e, serious=True, blocker=True)
@@ -3963,7 +3963,7 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     def visit_yield_expr(self, expr: YieldExpr) -> None:
         if not self.is_func_scope():
-            self.fail("'yield' outside function", expr, serious=True, blocker=True)
+            self.fail('"yield" outside function', expr, serious=True, blocker=True)
         else:
             if self.function_stack[-1].is_coroutine:
                 if self.options.python_version < (3, 6):
@@ -3978,9 +3978,9 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     def visit_await_expr(self, expr: AwaitExpr) -> None:
         if not self.is_func_scope():
-            self.fail("'await' outside function", expr)
+            self.fail('"await" outside function', expr)
         elif not self.function_stack[-1].is_coroutine:
-            self.fail("'await' outside coroutine ('async def')", expr)
+            self.fail('"await" outside coroutine ("async def")', expr)
         expr.expr.accept(self)
 
     #

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3722,7 +3722,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                       expr)
             return False
         if expr.arg_kinds != [ARG_POS] * numargs:
-            self.fail("'%s' must be called with %s positional argument%s" %
+            self.fail('"%s" must be called with %s positional argument%s' %
                       (name, numargs, s), expr)
             return False
         return True

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1645,7 +1645,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 self.fail('Cycle in inheritance hierarchy', defn)
                 cycle = True
             if baseinfo.fullname == 'builtins.bool':
-                self.fail("'%s' is not a valid base class" %
+                self.fail('"%s" is not a valid base class' %
                           baseinfo.name, defn, blocker=True)
                 return False
         dup = find_duplicate(info.direct_base_classes())

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3718,7 +3718,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         if numargs == 1:
             s = ''
         if len(expr.args) != numargs:
-            self.fail("'%s' expects %d argument%s" % (name, numargs, s),
+            self.fail('"%s" expects %d argument%s' % (name, numargs, s),
                       expr)
             return False
         if expr.arg_kinds != [ARG_POS] * numargs:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -654,7 +654,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         assert False, "Internal error: Unexpected partial type"
 
     def visit_ellipsis_type(self, t: EllipsisType) -> Type:
-        self.fail("Unexpected '...'", t)
+        self.fail('Unexpected "..."', t)
         return AnyType(TypeOfAny.from_error)
 
     def visit_type_type(self, t: TypeType) -> Type:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -782,13 +782,13 @@ divmod(f, d)  # E: Unsupported operand types for divmod ("float" and "Decimal")
 reveal_type(divmod(d, d))  # N: Revealed type is "Tuple[__main__.Decimal, __main__.Decimal]"
 
 # Now some bad calls
-divmod()  # E: 'divmod' expects 2 arguments \
+divmod()  # E: "divmod" expects 2 arguments \
           # E: Missing positional arguments "_x", "_y" in call to "divmod"
-divmod(7)  # E: 'divmod' expects 2 arguments \
+divmod(7)  # E: "divmod" expects 2 arguments \
            # E: Missing positional argument "_y" in call to "divmod"
-divmod(7, 8, 9)  # E: 'divmod' expects 2 arguments \
+divmod(7, 8, 9)  # E: "divmod" expects 2 arguments \
                  # E: Too many arguments for "divmod"
-divmod(_x=7, _y=9)  # E: 'divmod' must be called with 2 positional arguments
+divmod(_x=7, _y=9)  # E: "divmod" must be called with 2 positional arguments
 
 divmod('foo', 'foo')  # E: Unsupported left operand type for divmod ("str")
 divmod(i, 'foo')  # E: Unsupported operand types for divmod ("int" and "str")

--- a/test-data/unit/check-generic-alias.test
+++ b/test-data/unit/check-generic-alias.test
@@ -9,7 +9,7 @@ t3: list[str]  # E: "list" is not subscriptable, use "typing.List" instead
 t4: tuple
 t5: tuple[int]  # E: "tuple" is not subscriptable, use "typing.Tuple" instead
 t6: tuple[int, str]  # E: "tuple" is not subscriptable, use "typing.Tuple" instead
-t7: tuple[int, ...]  # E: Unexpected '...' \
+t7: tuple[int, ...]  # E: Unexpected "..." \
                      # E: "tuple" is not subscriptable, use "typing.Tuple" instead
 
 t8: dict = {}

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -222,7 +222,7 @@ yield  # type: ignore  # E: 'yield' outside function
 [case testIgnoreWholeModule1]
 # flags: --warn-unused-ignores
 # type: ignore
-IGNORE # type: ignore  # E: unused 'type: ignore' comment
+IGNORE # type: ignore  # E: unused "type: ignore" comment
 
 [case testIgnoreWholeModule2]
 # type: ignore

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -217,7 +217,7 @@ def f() -> None: pass
 [out]
 
 [case testCannotIgnoreBlockingError]
-yield  # type: ignore  # E: 'yield' outside function
+yield  # type: ignore  # E: "yield" outside function
 
 [case testIgnoreWholeModule1]
 # flags: --warn-unused-ignores

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3671,7 +3671,7 @@ pass
 [out]
 [out2]
 [out3]
-tmp/a.py:2: error: unused 'type: ignore' comment
+tmp/a.py:2: error: unused "type: ignore" comment
 
 -- Test that a non cache_fine_grained run can use a fine-grained cache
 [case testRegularUsesFgCache]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -439,7 +439,7 @@ if weird_mixture["key"] is Key.B:       # E: Invalid tuple index type (actual ty
 else:
     reveal_type(weird_mixture)          # N: Revealed type is "Union[TypedDict('__main__.KeyedTypedDict', {'key': Literal[__main__.Key.B]}), Tuple[Literal[__main__.Key.C], fallback=__main__.KeyedNamedTuple]]"
 
-if weird_mixture[0] is Key.B:           # E: TypedDict key must be a string literal; expected one of ('key')
+if weird_mixture[0] is Key.B:           # E: TypedDict key must be a string literal; expected one of ("key")
     reveal_type(weird_mixture)          # N: Revealed type is "Union[TypedDict('__main__.KeyedTypedDict', {'key': Literal[__main__.Key.B]}), Tuple[Literal[__main__.Key.C], fallback=__main__.KeyedNamedTuple]]"
 else:
     reveal_type(weird_mixture)          # N: Revealed type is "Union[TypedDict('__main__.KeyedTypedDict', {'key': Literal[__main__.Key.B]}), Tuple[Literal[__main__.Key.C], fallback=__main__.KeyedNamedTuple]]"

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -18,7 +18,7 @@ def f(): ...  # E: Function is missing a return type annotation \
 def d(f): ...  # type: ignore
 @d
 # type: ignore
-def f(): ...  # type: ignore  # E: unused 'type: ignore' comment
+def f(): ...  # type: ignore  # E: unused "type: ignore" comment
 
 [case testIgnoreDecoratedFunction2]
 # flags: --disallow-untyped-defs
@@ -91,28 +91,28 @@ def g(x: int): ...
 
 [case testIgnoreScopeUnused1]
 # flags: --warn-unused-ignores
-(  # type: ignore  # E: unused 'type: ignore' comment
-    "IGNORE"  # type: ignore  # E: unused 'type: ignore' comment
-    +  # type: ignore  # E: unused 'type: ignore' comment
+(  # type: ignore  # E: unused "type: ignore" comment
+    "IGNORE"  # type: ignore  # E: unused "type: ignore" comment
+    +  # type: ignore  # E: unused "type: ignore" comment
     0  # type: ignore
-)  # type: ignore  # E: unused 'type: ignore' comment
+)  # type: ignore  # E: unused "type: ignore" comment
 [builtins fixtures/primitives.pyi]
 
 [case testIgnoreScopeUnused2]
 # flags: --warn-unused-ignores
-(  # type: ignore  # E: unused 'type: ignore' comment
+(  # type: ignore  # E: unused "type: ignore" comment
     "IGNORE"
     -  # type: ignore
-    0  # type: ignore  # E: unused 'type: ignore' comment
-)  # type: ignore  # E: unused 'type: ignore' comment
+    0  # type: ignore  # E: unused "type: ignore" comment
+)  # type: ignore  # E: unused "type: ignore" comment
 
 [case testIgnoreScopeUnused3]
 # flags: --warn-unused-ignores
-(  # type: ignore  # E: unused 'type: ignore' comment
+(  # type: ignore  # E: unused "type: ignore" comment
     "IGNORE"
     /
     0  # type: ignore
-)  # type: ignore  # E: unused 'type: ignore' comment
+)  # type: ignore  # E: unused "type: ignore" comment
 
 [case testPEP570ArgTypesMissing]
 # flags: --disallow-untyped-defs

--- a/test-data/unit/check-semanal-error.test
+++ b/test-data/unit/check-semanal-error.test
@@ -70,17 +70,17 @@ class C:  # Forgot to add type params here
 c = C(t=3)  # type: C[int]  # E: "C" expects no type arguments, but 1 given
 
 [case testBreakOutsideLoop]
-break # E: 'break' outside loop
+break # E: "break" outside loop
 
 [case testContinueOutsideLoop]
-continue # E: 'continue' outside loop
+continue # E: "continue" outside loop
 
 [case testYieldOutsideFunction]
-yield # E: 'yield' outside function
+yield # E: "yield" outside function
 
 [case testYieldFromOutsideFunction]
 x = 1
-yield from x # E: 'yield from' outside function
+yield from x # E: "yield from" outside function
 
 [case testImportFuncDup]
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -702,8 +702,8 @@ T = TypeVar('T')
 def join(x: T, y: T) -> T: return x
 ab = join(A(x='', y=1, z=''), B(x='', z=1))
 ac = join(A(x='', y=1, z=''), C(x='', y=0, z=1))
-ab['y']  # E: "y" is not a valid TypedDict key; expected one of ('x')
-ac['a']  # E: "a" is not a valid TypedDict key; expected one of ('x', 'y')
+ab['y']  # E: "y" is not a valid TypedDict key; expected one of ("x")
+ac['a']  # E: "a" is not a valid TypedDict key; expected one of ("x", "y")
 [builtins fixtures/dict.pyi]
 
 [case testCannotGetItemOfTypedDictWithNonLiteralKey]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -712,7 +712,7 @@ from typing import Union
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 def get_coordinate(p: TaggedPoint, key: str) -> Union[str, int]:
-    return p[key]  # E: TypedDict key must be a string literal; expected one of ('type', 'x', 'y')
+    return p[key]  # E: TypedDict key must be a string literal; expected one of ("type", "x", "y")
 [builtins fixtures/dict.pyi]
 
 
@@ -746,7 +746,7 @@ from typing import Union
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 def set_coordinate(p: TaggedPoint, key: str, value: int) -> None:
-    p[key] = value  # E: TypedDict key must be a string literal; expected one of ('type', 'x', 'y')
+    p[key] = value  # E: TypedDict key must be a string literal; expected one of ("type", "x", "y")
 [builtins fixtures/dict.pyi]
 
 
@@ -2095,11 +2095,11 @@ class TD(TypedDict):
     foo: int
 
 d: TD = {b'foo': 2} # E: Expected TypedDict key to be string literal
-d[b'foo'] = 3 # E: TypedDict key must be a string literal; expected one of ('foo') \
+d[b'foo'] = 3 # E: TypedDict key must be a string literal; expected one of ("foo") \
     # E: Argument 1 has incompatible type "bytes"; expected "str"
-d[b'foo'] # E: TypedDict key must be a string literal; expected one of ('foo')
-d[3] # E: TypedDict key must be a string literal; expected one of ('foo')
-d[True] # E: TypedDict key must be a string literal; expected one of ('foo')
+d[b'foo'] # E: TypedDict key must be a string literal; expected one of ("foo")
+d[3] # E: TypedDict key must be a string literal; expected one of ("foo")
+d[True] # E: TypedDict key must be a string literal; expected one of ("foo")
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -63,8 +63,8 @@ from m import * # type: ignore
 [file m.py]
 pass
 [out]
-main:3: error: unused 'type: ignore' comment
-main:4: error: unused 'type: ignore' comment
+main:3: error: unused "type: ignore" comment
+main:4: error: unused "type: ignore" comment
 
 
 -- No return

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -51,7 +51,7 @@ a = 1
 if int():
     a = 'a' # type: ignore
 if int():
-    a = 2 # type: ignore # E: unused 'type: ignore' comment
+    a = 2 # type: ignore # E: unused "type: ignore" comment
 if int():
     a = 'b' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 

--- a/test-data/unit/errorstream.test
+++ b/test-data/unit/errorstream.test
@@ -26,7 +26,7 @@ break
 ==== Errors flushed ====
 a.py:1: error: Unsupported operand types for + ("int" and "str")
 ==== Errors flushed ====
-b.py:2: error: 'break' outside loop
+b.py:2: error: "break" outside loop
 
 [case testCycles]
 import a

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -102,7 +102,7 @@ break
 def f(x: int) -> None: pass
 [out]
 ==
-a.py:2: error: 'break' outside loop
+a.py:2: error: "break" outside loop
 ==
 main:2: error: Missing positional argument "x" in call to "f"
 
@@ -427,7 +427,7 @@ import blocker2
 1()
 [out]
 ==
-<ROOT>/test-data/unit/lib-stub/blocker2.pyi:2: error: 'continue' outside loop
+<ROOT>/test-data/unit/lib-stub/blocker2.pyi:2: error: "continue" outside loop
 ==
 a.py:1: error: "int" not callable
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -829,14 +829,14 @@ cast(str[str], None) # E: "str" expects no type arguments, but 1 given
 
 [case testInvalidNumberOfArgsToCast]
 from typing import cast
-cast(str) # E: 'cast' expects 2 arguments
-cast(str, None, None) # E: 'cast' expects 2 arguments
+cast(str) # E: "cast" expects 2 arguments
+cast(str, None, None) # E: "cast" expects 2 arguments
 [out]
 
 [case testInvalidKindsOfArgsToCast]
 from typing import cast
-cast(str, *None) # E: 'cast' must be called with 2 positional arguments
-cast(str, target=None) # E: 'cast' must be called with 2 positional arguments
+cast(str, *None) # E: "cast" must be called with 2 positional arguments
+cast(str, target=None) # E: "cast" must be called with 2 positional arguments
 [out]
 
 [case testInvalidAnyCall]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -775,7 +775,7 @@ class A(Generic[t]):
 [out]
 
 [case testTestExtendPrimitives]
-class C(bool): pass # E: 'bool' is not a valid base class
+class C(bool): pass # E: "bool" is not a valid base class
 class A(int): pass # ok
 class B(float): pass # ok
 class D(str): pass # ok

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -868,7 +868,7 @@ from abc import abstractmethod
 @abstractmethod
 def foo(): pass
 [out]
-main:3: error: 'abstractmethod' used with a non-method
+main:3: error: "abstractmethod" used with a non-method
 
 [case testAbstractNestedFunction]
 import typing
@@ -877,7 +877,7 @@ def g() -> None:
   @abstractmethod
   def foo(): pass
 [out]
-main:4: error: 'abstractmethod' used with a non-method
+main:4: error: "abstractmethod" used with a non-method
 
 [case testInvalidTypeDeclaration]
 import typing
@@ -1169,8 +1169,8 @@ class A:
     def h(): pass
 [builtins fixtures/staticmethod.pyi]
 [out]
-main:2: error: 'staticmethod' used with a non-method
-main:6: error: 'staticmethod' used with a non-method
+main:2: error: "staticmethod" used with a non-method
+main:6: error: "staticmethod" used with a non-method
 
 [case testClassmethodAndNonMethod]
 import typing
@@ -1182,12 +1182,12 @@ class A:
     def h(): pass
 [builtins fixtures/classmethod.pyi]
 [out]
-main:2: error: 'classmethod' used with a non-method
-main:6: error: 'classmethod' used with a non-method
+main:2: error: "classmethod" used with a non-method
+main:6: error: "classmethod" used with a non-method
 
 [case testNonMethodProperty]
 import typing
-@property  # E: 'property' used with a non-method
+@property  # E: "property" used with a non-method
 def f() -> int: pass
 [builtins fixtures/property.pyi]
 [out]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -331,31 +331,31 @@ break
 def f():
   break
 [out]
-main:1: error: 'break' outside loop
-main:3: error: 'break' outside loop
+main:1: error: "break" outside loop
+main:3: error: "break" outside loop
 
 [case testContinueOutsideLoop]
 continue
 def f():
   continue
 [out]
-main:1: error: 'continue' outside loop
-main:3: error: 'continue' outside loop
+main:1: error: "continue" outside loop
+main:3: error: "continue" outside loop
 
 [case testReturnOutsideFunction]
 def f(): pass
 return
 return 1
 [out]
-main:2: error: 'return' outside function
-main:3: error: 'return' outside function
+main:2: error: "return" outside function
+main:3: error: "return" outside function
 
 [case testYieldOutsideFunction]
 yield 1
 yield
 [out]
-main:1: error: 'yield' outside function
-main:2: error: 'yield' outside function
+main:1: error: "yield" outside function
+main:2: error: "yield" outside function
 
 [case testInvalidLvalues1]
 1 = 1

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -703,7 +703,7 @@ MypyFile:1(
 
 [case testInvalidTupleType]
 from typing import Tuple
-t = None # type: Tuple[int, str, ...] # E: Unexpected '...'
+t = None # type: Tuple[int, str, ...] # E: Unexpected "..."
 [builtins fixtures/tuple.pyi]
 [out]
 


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445 for errors related to `TypedDict key must be a string literal`, `Unexpected "..."`, `used with a non-method`, `cast and divmod expectes 2 arguments`, `is not a valid base class`, `unused "type: ignore" comment`, `outside loop and outside function `

## Test Plan
Updated test cases for the message. New test cases not added.