### PR TITLE
Double quotes in errors "Inconsistent use of * in function", "is a type variable and only valid in type context" and "Import of x ignored"

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -348,7 +348,7 @@ accepts one of four string values:
 -   ``error`` behaves in the same way as ``skip`` but is not quite as
     silent -- it will flag the import as an error, like this::
 
-        main.py:1: note: Import of 'mycode.bar' ignored
+        main.py:1: note: Import of "mycode.bar" ignored
         main.py:1: note: (Using --follow-imports=error, module not passed on command line)
 
 If you are starting a new codebase and plan on using type hints from

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2567,7 +2567,7 @@ def skipping_module(manager: BuildManager, line: int, caller_state: Optional[Sta
     manager.errors.set_import_context(caller_state.import_context)
     manager.errors.set_file(caller_state.xpath, caller_state.id)
     manager.errors.report(line, 0,
-                          "Import of '%s' ignored" % (id,),
+                          'Import of "%s" ignored' % (id,),
                           severity='error')
     manager.errors.report(line, 0,
                           "(Using --follow-imports=error, module not passed on command line)",
@@ -2583,7 +2583,7 @@ def skipping_ancestor(manager: BuildManager, id: str, path: str, ancestor_for: '
     # so we'd need to cache the decision.
     manager.errors.set_import_context([])
     manager.errors.set_file(ancestor_for.xpath, ancestor_for.id)
-    manager.errors.report(-1, -1, "Ancestor package '%s' ignored" % (id,),
+    manager.errors.report(-1, -1, 'Ancestor package "%s" ignored' % (id,),
                           severity='error', only_once=True)
     manager.errors.report(-1, -1,
                           "(Using --follow-imports=error, submodule passed on command line)",

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3531,8 +3531,8 @@ class SemanticAnalyzer(NodeVisitor[None],
     def bind_name_expr(self, expr: NameExpr, sym: SymbolTableNode) -> None:
         """Bind name expression to a symbol table node."""
         if isinstance(sym.node, TypeVarExpr) and self.tvar_scope.get_binding(sym):
-            self.fail("'{}' is a type variable and only valid in type "
-                      "context".format(expr.name), expr)
+            self.fail('"{}" is a type variable and only valid in type '
+                      'context'.format(expr.name), expr)
         elif isinstance(sym.node, PlaceholderNode):
             self.process_placeholder(expr.name, 'name', expr)
         else:

--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -23,7 +23,7 @@ Add the test in this format anywhere in the file:
     b: str = 5  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
     zzz: int
-    zzz: str  # E: Name 'zzz' already defined
+    zzz: str  # E: Name "zzz" already defined
 
 - no code here is executed, just type checked
 - optional `# flags: ` indicates which flags to use for this unit test

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -461,7 +461,7 @@ x + ""
 [file mod.py]
 deliberate syntax error
 [out]
-main:2: error: Import of 'mod' ignored
+main:2: error: Import of "mod" ignored
 main:2: note: (Using --follow-imports=error, module not passed on command line)
 
 [case testIgnoreMissingImportsFalse]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1789,10 +1789,10 @@ import a
 [file a.py.2]
 //
 [out1]
-main:2: error: Import of 'a' ignored
+main:2: error: Import of "a" ignored
 main:2: note: (Using --follow-imports=error, module not passed on command line)
 [out2]
-main:2: error: Import of 'a' ignored
+main:2: error: Import of "a" ignored
 main:2: note: (Using --follow-imports=error, module not passed on command line)
 
 [case testIncrementalFollowImportsVariable]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1064,7 +1064,7 @@ tmp/main.py:1: note: (Using --follow-imports=error, module not passed on command
 [file foo/__init__.py]
 [builtins fixtures/module.pyi]
 [out]
-tmp/foo/bar.py: error: Ancestor package 'foo' ignored
+tmp/foo/bar.py: error: Ancestor package "foo" ignored
 tmp/foo/bar.py: note: (Using --follow-imports=error, submodule passed on command line)
 
 [case testStubImportNonStubWhileSilent]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1054,7 +1054,7 @@ import mod
 [file mod.py]
 [builtins fixtures/module.pyi]
 [out]
-tmp/main.py:1: error: Import of 'mod' ignored
+tmp/main.py:1: error: Import of "mod" ignored
 tmp/main.py:1: note: (Using --follow-imports=error, module not passed on command line)
 
 [case testAncestorSuppressedWhileAlmostSilent]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -413,7 +413,7 @@ follow_imports = error
 [file a.py]
 /  # No error reported
 [out]
-main.py:1: error: Import of 'a' ignored
+main.py:1: error: Import of "a" ignored
 main.py:1: note: (Using --follow-imports=error, module not passed on command line)
 main.py:2: note: Revealed type is "Any"
 main.py:4: note: Revealed type is "Any"
@@ -451,7 +451,7 @@ bla bla
 bla bla
 [out]
 normal.py:2: error: Unsupported operand types for + ("int" and "str")
-main.py:4: error: Import of 'error' ignored
+main.py:4: error: Import of "error" ignored
 main.py:4: note: (Using --follow-imports=error, module not passed on command line)
 main.py:5: note: Revealed type is "builtins.int"
 main.py:6: note: Revealed type is "builtins.int"
@@ -832,7 +832,7 @@ follow_imports_for_stubs = True
 import math
 math.frobnicate()
 [out]
-main.py:1: error: Import of 'math' ignored
+main.py:1: error: Import of "math" ignored
 main.py:1: note: (Using --follow-imports=error, module not passed on command line)
 
 [case testFollowImportStubs2]

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -184,7 +184,7 @@ Daemon started
 $ dmypy check foo.py bar.py
 $ dmypy recheck
 $ dmypy recheck --update foo.py --remove bar.py sir_not_appearing_in_this_film.py
-foo.py:1: error: Import of 'bar' ignored
+foo.py:1: error: Import of "bar" ignored
 foo.py:1: note: (Using --follow-imports=error, module not passed on command line)
 == Return code: 1
 $ dmypy recheck --update bar.py

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1868,7 +1868,7 @@ x = 1
 x = '2'
 [out]
 ==
-p/b.py: error: Ancestor package 'p' ignored
+p/b.py: error: Ancestor package "p" ignored
 p/b.py: note: (Using --follow-imports=error, submodule passed on command line)
 
 [case testErrorButDontIgnore4]
@@ -1886,7 +1886,7 @@ x = 1
 [delete z.py.2]
 [out]
 ==
-p/b.py: error: Ancestor package 'p' ignored
+p/b.py: error: Ancestor package "p" ignored
 p/b.py: note: (Using --follow-imports=error, submodule passed on command line)
 p/b.py:1: error: Cannot find implementation or library stub for module named "z"
 p/b.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -1828,10 +1828,10 @@ x = 1
 [file c.py.2]
 x = '2'
 [out]
-a.py:2: error: Import of 'b' ignored
+a.py:2: error: Import of "b" ignored
 a.py:2: note: (Using --follow-imports=error, module not passed on command line)
 ==
-a.py:2: error: Import of 'b' ignored
+a.py:2: error: Import of "b" ignored
 a.py:2: note: (Using --follow-imports=error, module not passed on command line)
 
 [case testErrorButDontIgnore2]
@@ -1848,7 +1848,7 @@ x = 1
 x = '2'
 [out]
 ==
-a.py:2: error: Import of 'b' ignored
+a.py:2: error: Import of "b" ignored
 a.py:2: note: (Using --follow-imports=error, module not passed on command line)
 
 -- TODO: This test fails because p.b does not depend on p (#4847)

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -258,8 +258,8 @@ def f(x): # type: (*X) -> Y
 def g(*x): # type: (X) -> Y
     pass
 [out]
-file:1: error: Inconsistent use of '*' in function signature
-file:3: error: Inconsistent use of '*' in function signature
+file:1: error: Inconsistent use of "*" in function signature
+file:3: error: Inconsistent use of "*" in function signature
 
 [case testCommentFunctionAnnotationVarArgMispatch2-skip]
 # see mypy issue #1997
@@ -268,10 +268,10 @@ def f(*x, **y): # type: (**X, *Y) -> Z
 def g(*x, **y): # type: (*X, *Y) -> Z
     pass
 [out]
-file:1: error: Inconsistent use of '*' in function signature
+file:1: error: Inconsistent use of "*" in function signature
 file:3: error: syntax error in type comment
-file:3: error: Inconsistent use of '*' in function signature
-file:3: error: Inconsistent use of '**' in function signature
+file:3: error: Inconsistent use of "*" in function signature
+file:3: error: Inconsistent use of "**" in function signature
 
 [case testPrintStatementInPython35]
 # flags: --python-version 3.5

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -277,13 +277,13 @@ file:3: error: Inconsistent use of "**" in function signature
 # flags: --python-version 3.5
 print 1
 [out]
-file:2: error: Missing parentheses in call to "print"
+file:2: error: Missing parentheses in call to 'print'
 
 [case testPrintStatementInPython37]
 # flags: --python-version 3.7
 print 1
 [out]
-file:2: error: Missing parentheses in call to "print". Did you mean print(1)?
+file:2: error: Missing parentheses in call to 'print'. Did you mean print(1)?
 
 [case testInvalidConditionInConditionalExpression]
 1 if 2, 3 else 4

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -277,13 +277,13 @@ file:3: error: Inconsistent use of '**' in function signature
 # flags: --python-version 3.5
 print 1
 [out]
-file:2: error: Missing parentheses in call to 'print'
+file:2: error: Missing parentheses in call to "print"
 
 [case testPrintStatementInPython37]
 # flags: --python-version 3.7
 print 1
 [out]
-file:2: error: Missing parentheses in call to 'print'. Did you mean print(1)?
+file:2: error: Missing parentheses in call to "print". Did you mean print(1)?
 
 [case testInvalidConditionInConditionalExpression]
 1 if 2, 3 else 4

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -533,8 +533,8 @@ class c(Generic[t]):
     def f(self) -> None: x = t
 def f(y: t): x = t
 [out]
-main:4: error: 't' is a type variable and only valid in type context
-main:5: error: 't' is a type variable and only valid in type context
+main:4: error: "t" is a type variable and only valid in type context
+main:5: error: "t" is a type variable and only valid in type context
 
 [case testMissingSelf]
 import typing


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445 for errors related to `Inconsistent use of * in function`, `is a type variable and only valid in type context`, `Import of x ignored`.

Also updated unit test data readme file(test-data/unit/README.md) for error `Name "zzz" already defined`

## Test Plan
Updated test cases for the message. New test cases not added.