### PR TITLE
Double quotes in errors `Source file found twice`, `Duplicate module named`, `Setting "strict" not supported`, `bound by an outer class` and `cannot subclass`

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2799,7 +2799,7 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
             manager.errors.set_file(st.xpath, st.id)
             manager.errors.report(
                 -1, -1,
-                "Duplicate module named '%s' (also at '%s')" % (st.id, graph[st.id].xpath),
+                'Duplicate module named "%s" (also at "%s")' % (st.id, graph[st.id].xpath),
                 blocker=True,
             )
             manager.errors.report(

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2869,8 +2869,8 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
                         if newst_path in seen_files:
                             manager.errors.report(
                                 -1, 0,
-                                "Source file found twice under different module names: "
-                                "'{}' and '{}'".format(seen_files[newst_path].id, newst.id),
+                                'Source file found twice under different module names: '
+                                '"{}" and "{}"'.format(seen_files[newst_path].id, newst.id),
                                 blocker=True)
                             manager.errors.raise_error()
 

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -525,9 +525,9 @@ def parse_mypy_comments(
             errors.append((lineno, "Reports not supported in inline configuration"))
         if strict_found:
             errors.append((lineno,
-                           "Setting 'strict' not supported in inline configuration: specify it in "
-                           "a configuration file instead, or set individual inline flags "
-                           "(see 'mypy -h' for the list of flags enabled in strict mode)"))
+                           'Setting "strict" not supported in inline configuration: specify it in '
+                           'a configuration file instead, or set individual inline flags '
+                           '(see "mypy -h" for the list of flags enabled in strict mode)'))
 
         sections.update(new_sections)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1499,14 +1499,14 @@ class SemanticAnalyzer(NodeVisitor[None],
                 base_types.append(actual_base)
             elif isinstance(base, Instance):
                 if base.type.is_newtype:
-                    self.fail("Cannot subclass NewType", defn)
+                    self.fail('Cannot subclass "NewType"', defn)
                 base_types.append(base)
             elif isinstance(base, AnyType):
                 if self.options.disallow_subclassing_any:
                     if isinstance(base_expr, (NameExpr, MemberExpr)):
-                        msg = "Class cannot subclass '{}' (has type 'Any')".format(base_expr.name)
+                        msg = 'Class cannot subclass "{}" (has type "Any")'.format(base_expr.name)
                     else:
-                        msg = "Class cannot subclass value of type 'Any'"
+                        msg = 'Class cannot subclass value of type "Any"'
                     self.fail(msg, base_expr)
                 info.fallback_to_any = True
             else:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -934,7 +934,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         defs = []  # type: List[TypeVarLikeDef]
         for name, tvar in typevars:
             if not self.tvar_scope.allow_binding(tvar.fullname):
-                self.fail("Type variable '{}' is bound by an outer class".format(name), defn)
+                self.fail('Type variable "{}" is bound by an outer class'.format(name), defn)
             self.tvar_scope.bind_new(name, tvar)
             binding = self.tvar_scope.get_binding(tvar.fullname)
             assert binding is not None

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -190,7 +190,7 @@ def f() -> None: pass
 # flags: --disallow-subclassing-any
 from typing import Any
 FakeClass = None  # type: Any
-class Foo(FakeClass): pass  # E: Class cannot subclass 'FakeClass' (has type 'Any')
+class Foo(FakeClass): pass  # E: Class cannot subclass "FakeClass" (has type "Any")
 [out]
 
 [case testSubclassingAnyMultipleBaseClasses]
@@ -198,7 +198,7 @@ class Foo(FakeClass): pass  # E: Class cannot subclass 'FakeClass' (has type 'An
 from typing import Any
 FakeClass = None  # type: Any
 class ActualClass: pass
-class Foo(ActualClass, FakeClass): pass  # E: Class cannot subclass 'FakeClass' (has type 'Any')
+class Foo(ActualClass, FakeClass): pass  # E: Class cannot subclass "FakeClass" (has type "Any")
 [out]
 
 [case testSubclassingAnySilentImports]
@@ -213,7 +213,7 @@ class Foo(BaseClass): pass
 class BaseClass: pass
 
 [out]
-tmp/main.py:2: error: Class cannot subclass 'BaseClass' (has type 'Any')
+tmp/main.py:2: error: Class cannot subclass "BaseClass" (has type "Any")
 
 [case testSubclassingAnySilentImports2]
 # flags: --disallow-subclassing-any --follow-imports=skip
@@ -227,7 +227,7 @@ class Foo(ignored_module.BaseClass): pass
 class BaseClass: pass
 
 [out]
-tmp/main.py:2: error: Class cannot subclass 'BaseClass' (has type 'Any')
+tmp/main.py:2: error: Class cannot subclass "BaseClass" (has type "Any")
 
 [case testWarnNoReturnIgnoresTrivialFunctions]
 # flags: --warn-no-return
@@ -871,7 +871,7 @@ main:5: error: Argument 1 to "foo" becomes "Callable[[], Any]" due to an unfollo
 # flags: --ignore-missing-imports --disallow-any-unimported --disallow-subclassing-any
 from typing import Any
 
-class C(Any): # E: Class cannot subclass 'Any' (has type 'Any')
+class C(Any): # E: Class cannot subclass "Any" (has type "Any")
     pass
 
 [case testDisallowImplicitAnyVarDeclaration]
@@ -1797,7 +1797,7 @@ from typing import Any
 
 x = None  # type: Any
 
-class ShouldNotBeFine(x): ...  # E: Class cannot subclass 'x' (has type 'Any')
+class ShouldNotBeFine(x): ...  # E: Class cannot subclass "x" (has type "Any")
 
 [file mypy.ini]
 \[mypy]
@@ -1823,7 +1823,7 @@ from typing import Any
 
 x = None  # type: Any
 
-class ShouldNotBeFine(x): ...  # E: Class cannot subclass 'x' (has type 'Any')
+class ShouldNotBeFine(x): ...  # E: Class cannot subclass "x" (has type "Any")
 
 [file pyproject.toml]
 \[tool.mypy]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1502,7 +1502,7 @@ T = TypeVar('T')
 class Outer(Generic[T]):
     class Inner:
         x: T  # E: Invalid type "__main__.T"
-        def f(self, x: T) -> T: ...  # E: Type variable 'T' is bound by an outer class
+        def f(self, x: T) -> T: ...  # E: Type variable "T" is bound by an outer class
         def g(self) -> None:
             y: T  # E: Invalid type "__main__.T"
 

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -161,4 +161,4 @@ main:1: error: Unrecognized option: skip_file = True
 [case testInlineStrict]
 # mypy: strict
 [out]
-main:1: error: Setting 'strict' not supported in inline configuration: specify it in a configuration file instead, or set individual inline flags (see 'mypy -h' for the list of flags enabled in strict mode)
+main:1: error: Setting "strict" not supported in inline configuration: specify it in a configuration file instead, or set individual inline flags (see "mypy -h" for the list of flags enabled in strict mode)

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -338,7 +338,7 @@ a = 3  # type: UserId  # E: Incompatible types in assignment (expression has typ
 from typing import NewType
 class A: pass
 B = NewType('B', A)
-class C(B): pass  # E: Cannot subclass NewType
+class C(B): pass  # E: Cannot subclass "NewType"
 [out]
 
 [case testCannotUseNewTypeWithProtocols]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -58,7 +58,7 @@ undef
 [file dir/subdir/a.py]
 undef
 [out]
-dir/a.py: error: Duplicate module named 'a' (also at 'dir/subdir/a.py')
+dir/a.py: error: Duplicate module named "a" (also at "dir/subdir/a.py")
 dir/a.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
 == Return code: 2
 
@@ -124,7 +124,7 @@ mypy: can't decode file 'a.py': unknown encoding: uft-8
 [file two/mod/__init__.py]
 # type: ignore
 [out]
-two/mod/__init__.py: error: Duplicate module named 'mod' (also at 'one/mod/__init__.py')
+two/mod/__init__.py: error: Duplicate module named "mod" (also at "one/mod/__init__.py")
 two/mod/__init__.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
 == Return code: 2
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1140,7 +1140,7 @@ import foo.bar
 [file src/foo/bar.py]
 1+'x'
 [out]
-src/foo/bar.py: error: Source file found twice under different module names: 'src.foo.bar' and 'foo.bar'
+src/foo/bar.py: error: Source file found twice under different module names: "src.foo.bar" and "foo.bar"
 == Return code: 2
 
 [case testEnableInvalidErrorCode]


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445 for errors related to `Source file found twice`, `Duplicate module named`, `Setting "strict" not supported`, `bound by an outer class` and `cannot subclass`

## Test Plan
Updated test cases for the message. New test cases not added.