### PR TITLE
stubgenc: type check for getattr changes

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -172,7 +172,7 @@ def generate_c_function_stub(module: ModuleType,
             if is_pybind11_overloaded_function_docstring(docstr, name):
                 # Remove pybind11 umbrella (*args, **kwargs) for overloaded functions
                 del inferred[-1]
-        else:
+        if not inferred:
             if class_name and name not in sigs:
                 inferred = [FunctionSig(name, args=infer_method_sig(name), ret_type=ret_type)]
             else:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -167,10 +167,12 @@ def generate_c_function_stub(module: ModuleType,
     else:
         docstr = getattr(obj, '__doc__', None)
         inferred = infer_sig_from_docstring(docstr, name)
-        if inferred and is_pybind11_overloaded_function_docstring(docstr, name):
-            # Remove pybind11 umbrella (*args, **kwargs) for overloaded functions
-            del inferred[-1]
-        if not inferred:
+        if inferred:
+            assert docstr is not None
+            if is_pybind11_overloaded_function_docstring(docstr, name):
+                # Remove pybind11 umbrella (*args, **kwargs) for overloaded functions
+                del inferred[-1]
+        else:
             if class_name and name not in sigs:
                 inferred = [FunctionSig(name, args=infer_method_sig(name), ret_type=ret_type)]
             else:


### PR DESCRIPTION
https://github.com/python/typeshed/pull/5516 makes changes to getattr
that would introduce type errors here.

`infer_sig_from_docstring` will return False if `docstr` is None, so the code itself is fine.