### PR TITLE
Double quotes in errors messages

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -406,7 +406,7 @@ def load_plugins_from_config(
             # Plugin paths can be relative to the config file location.
             plugin_path = os.path.join(os.path.dirname(options.config_file), plugin_path)
             if not os.path.isfile(plugin_path):
-                plugin_error("Can't find plugin '{}'".format(plugin_path))
+                plugin_error('Can\'t find plugin "{}"'.format(plugin_path))
             # Use an absolute path to avoid populating the cache entry
             # for 'tmp' during tests, since it will be different in
             # different tests.
@@ -416,21 +416,21 @@ def load_plugins_from_config(
             sys.path.insert(0, plugin_dir)
         elif re.search(r'[\\/]', plugin_path):
             fnam = os.path.basename(plugin_path)
-            plugin_error("Plugin '{}' does not have a .py extension".format(fnam))
+            plugin_error('Plugin "{}" does not have a .py extension'.format(fnam))
         else:
             module_name = plugin_path
 
         try:
             module = importlib.import_module(module_name)
         except Exception as exc:
-            plugin_error("Error importing plugin '{}': {}".format(plugin_path, exc))
+            plugin_error('Error importing plugin "{}": {}'.format(plugin_path, exc))
         finally:
             if plugin_dir is not None:
                 assert sys.path[0] == plugin_dir
                 del sys.path[0]
 
         if not hasattr(module, func_name):
-            plugin_error('Plugin \'{}\' does not define entry point function "{}"'.format(
+            plugin_error('Plugin "{}" does not define entry point function "{}"'.format(
                 plugin_path, func_name))
 
         try:

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -895,17 +895,17 @@ class StringFormatterChecker:
         INT_TYPES = REQUIRE_INT_NEW if format_call else REQUIRE_INT_OLD
         if p == 'b' and not format_call:
             if self.chk.options.python_version < (3, 5):
-                self.msg.fail("Format character 'b' is only supported in Python 3.5 and later",
+                self.msg.fail('Format character "b" is only supported in Python 3.5 and later',
                               context, code=codes.STRING_FORMATTING)
                 return None
             if not isinstance(expr, BytesExpr):
-                self.msg.fail("Format character 'b' is only supported on bytes patterns", context,
+                self.msg.fail('Format character "b" is only supported on bytes patterns', context,
                               code=codes.STRING_FORMATTING)
                 return None
             return self.named_type('builtins.bytes')
         elif p == 'a':
             if self.chk.options.python_version < (3, 0):
-                self.msg.fail("Format character 'a' is only supported in Python 3", context,
+                self.msg.fail('Format character "a" is only supported in Python 3', context,
                               code=codes.STRING_FORMATTING)
                 return None
             # TODO: return type object?

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -698,7 +698,7 @@ class ASTConverter:
             elif isinstance(item.name, Name):
                 vs.append(self.set_line(NameExpr(item.name.id), item))
             else:
-                self.fail("Sorry, `except <expr>, <anything but a name>` is not supported",
+                self.fail('Sorry, "except <expr>, <anything but a name>" is not supported',
                           item.lineno, item.col_offset)
                 vs.append(None)
         types = [self.visit(h.type) for h in handlers]

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -20,7 +20,7 @@ RETURN_VALUE_EXPECTED = 'Return value expected'  # type: Final
 NO_RETURN_EXPECTED = 'Return statement in function which does not return'  # type: Final
 INVALID_EXCEPTION = 'Exception must be derived from BaseException'  # type: Final
 INVALID_EXCEPTION_TYPE = 'Exception type must be derived from BaseException'  # type: Final
-RETURN_IN_ASYNC_GENERATOR = "'return' with value in async generator is not allowed"  # type: Final
+RETURN_IN_ASYNC_GENERATOR = '"return" with value in async generator is not allowed'  # type: Final
 INVALID_RETURN_TYPE_FOR_GENERATOR = \
     'The return type of a generator function should be "Generator"' \
     ' or one of its supertypes'  # type: Final

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -910,7 +910,7 @@ class MessageBuilder:
                   context, code=codes.STRING_FORMATTING)
 
     def key_not_in_mapping(self, key: str, context: Context) -> None:
-        self.fail('Key \'%s\' not found in mapping' % key, context,
+        self.fail('Key "%s" not found in mapping' % key, context,
                   code=codes.STRING_FORMATTING)
 
     def string_interpolation_mixing_key_and_non_keys(self, context: Context) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -897,7 +897,7 @@ class MessageBuilder:
                   code=codes.STRING_FORMATTING)
 
     def unsupported_placeholder(self, placeholder: str, context: Context) -> None:
-        self.fail('Unsupported format character \'%s\'' % placeholder, context,
+        self.fail('Unsupported format character "%s"' % placeholder, context,
                   code=codes.STRING_FORMATTING)
 
     def string_interpolation_with_star_and_key(self, context: Context) -> None:

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -549,7 +549,7 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
     attr_has_factory = bool(_get_argument(rvalue, 'factory'))
 
     if attr_has_default and attr_has_factory:
-        ctx.api.fail("Can't pass both `default` and `factory`.", rvalue)
+        ctx.api.fail('Can\'t pass both "default" and "factory".', rvalue)
     elif attr_has_factory:
         attr_has_default = True
 
@@ -571,7 +571,7 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
     converter = _get_argument(rvalue, 'converter')
     convert = _get_argument(rvalue, 'convert')
     if convert and converter:
-        ctx.api.fail("Can't pass both `convert` and `converter`.", rvalue)
+        ctx.api.fail('Can\'t pass both "convert" and "converter".', rvalue)
     elif convert:
         ctx.api.fail("convert is deprecated, use converter", rvalue)
         converter = convert

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1872,8 +1872,8 @@ class SemanticAnalyzer(NodeVisitor[None],
         module = self.modules.get(import_id)
         if module:
             if not self.options.implicit_reexport and source_id in module.names.keys():
-                message = ("Module '{}' does not explicitly export attribute '{}'"
-                           "; implicit reexport disabled".format(import_id, source_id))
+                message = ('Module "{}" does not explicitly export attribute "{}"'
+                           '; implicit reexport disabled'.format(import_id, source_id))
             else:
                 alternatives = set(module.names.keys()).difference({source_id})
                 matches = best_matches(source_id, alternatives)[:3]

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -114,7 +114,7 @@ class EnumCallAnalyzer:
         valid_name = [None, 'value', 'names', 'module', 'qualname', 'type', 'start']
         for arg_name in call.arg_names:
             if arg_name not in valid_name:
-                self.fail_enum_call_arg("Unexpected keyword argument '{}'".format(arg_name), call)
+                self.fail_enum_call_arg('Unexpected keyword argument "{}"'.format(arg_name), call)
         value, names = None, None
         for arg_name, arg in zip(call.arg_names, args):
             if arg_name == 'value':

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -565,18 +565,18 @@ from typing import AsyncGenerator
 
 async def return_int() -> AsyncGenerator[int, None]:
     yield 1
-    return 42  # E: 'return' with value in async generator is not allowed
+    return 42  # E: "return" with value in async generator is not allowed
 
 async def return_none() -> AsyncGenerator[int, None]:
     yield 1
-    return None  # E: 'return' with value in async generator is not allowed
+    return None  # E: "return" with value in async generator is not allowed
 
 def f() -> None:
     return
 
 async def return_f() -> AsyncGenerator[int, None]:
     yield 1
-    return f()  # E: 'return' with value in async generator is not allowed
+    return f()  # E: "return" with value in async generator is not allowed
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -763,7 +763,7 @@ def converter(s:int) -> str:
 
 @attr.s
 class C:
-    x: str = attr.ib(converter=converter, convert=converter)  # E: Can't pass both `convert` and `converter`.
+    x: str = attr.ib(converter=converter, convert=converter)  # E: Can't pass both "convert" and "converter".
 
 [builtins fixtures/list.pyi]
 
@@ -1087,7 +1087,7 @@ A()
 import attr
 @attr.s
 class A:
-    x: int = attr.ib(factory=int, default=7)  # E: Can't pass both `default` and `factory`.
+    x: int = attr.ib(factory=int, default=7)  # E: Can't pass both "default" and "factory".
 [builtins fixtures/bool.pyi]
 
 [case testAttrsFactoryBadReturn]

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -123,7 +123,7 @@ tmp/mypy.ini:2: error: Can't find plugin "tmp/missing.py"
 \[mypy]
 plugins=missing
 [out]
-tmp/mypy.ini:2: error: Error importing plugin "missing": No module named "missing"
+tmp/mypy.ini:2: error: Error importing plugin "missing": No module named 'missing'
 
 [case testMultipleSectionsDefinePlugin]
 # flags: --config-file tmp/mypy.ini

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -114,7 +114,7 @@ plugins=['<ROOT>/test-data/unit/plugins/fnplugin.py', 'plugin2']
 \[mypy]
 plugins=missing.py
 [out]
-tmp/mypy.ini:2: error: Can't find plugin 'tmp/missing.py'
+tmp/mypy.ini:2: error: Can't find plugin "tmp/missing.py"
 --' (work around syntax highlighting)
 
 [case testMissingPlugin]
@@ -123,7 +123,7 @@ tmp/mypy.ini:2: error: Can't find plugin 'tmp/missing.py'
 \[mypy]
 plugins=missing
 [out]
-tmp/mypy.ini:2: error: Error importing plugin 'missing': No module named 'missing'
+tmp/mypy.ini:2: error: Error importing plugin "missing": No module named "missing"
 
 [case testMultipleSectionsDefinePlugin]
 # flags: --config-file tmp/mypy.ini
@@ -135,7 +135,7 @@ plugins=missing.py
 \[another]
 plugins=another_plugin
 [out]
-tmp/mypy.ini:4: error: Can't find plugin 'tmp/missing.py'
+tmp/mypy.ini:4: error: Can't find plugin "tmp/missing.py"
 --' (work around syntax highlighting)
 
 [case testInvalidPluginExtension]
@@ -145,7 +145,7 @@ tmp/mypy.ini:4: error: Can't find plugin 'tmp/missing.py'
 plugins=dir/badext.pyi
 [file dir/badext.pyi]
 [out]
-tmp/mypy.ini:2: error: Plugin 'badext.pyi' does not have a .py extension
+tmp/mypy.ini:2: error: Plugin "badext.pyi" does not have a .py extension
 
 [case testMissingPluginEntryPoint]
 # flags: --config-file tmp/mypy.ini
@@ -153,7 +153,7 @@ tmp/mypy.ini:2: error: Plugin 'badext.pyi' does not have a .py extension
 \[mypy]
  plugins = <ROOT>/test-data/unit/plugins/noentry.py
 [out]
-tmp/mypy.ini:2: error: Plugin '<ROOT>/test-data/unit/plugins/noentry.py' does not define entry point function "plugin"
+tmp/mypy.ini:2: error: Plugin "<ROOT>/test-data/unit/plugins/noentry.py" does not define entry point function "plugin"
 
 [case testCustomPluginEntryPointFile]
 # flags: --config-file tmp/mypy.ini

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -437,7 +437,7 @@ main:14: error: Enum() with tuple or list expects strings or (name, value) pairs
 main:15: error: Enum() with tuple or list expects strings or (name, value) pairs
 main:16: error: IntEnum() with tuple or list expects strings or (name, value) pairs
 main:17: error: Enum() with dict literal requires string literals
-main:18: error: Unexpected keyword argument 'keyword'
+main:18: error: Unexpected keyword argument "keyword"
 main:19: error: Unexpected arguments to Enum()
 main:20: error: Unexpected arguments to Enum()
 main:22: error: "Type[W]" has no attribute "c"

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1219,7 +1219,7 @@ a = None # type: Any
 [typing fixtures/typing-medium.pyi]
 
 [case testStringInterpolationInvalidPlaceholder]
-'%W' % 1  # E: Unsupported format character 'W'
+'%W' % 1  # E: Unsupported format character "W"
 '%b' % 1  # E: Format character 'b' is only supported on bytes patterns
 
 [case testStringInterPolationPython2]
@@ -1529,8 +1529,8 @@ x: Union[Good, Bad]
 '{:s}'.format(42)
 '{:s}'.format('yes')
 
-'{:z}'.format('what')  # E: Unsupported format character 'z'
-'{:Z}'.format('what')  # E: Unsupported format character 'Z'
+'{:z}'.format('what')  # E: Unsupported format character "z"
+'{:Z}'.format('what')  # E: Unsupported format character "Z"
 [builtins fixtures/primitives.pyi]
 
 [case testFormatCallFormatTypesChar]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1220,13 +1220,13 @@ a = None # type: Any
 
 [case testStringInterpolationInvalidPlaceholder]
 '%W' % 1  # E: Unsupported format character "W"
-'%b' % 1  # E: Format character 'b' is only supported on bytes patterns
+'%b' % 1  # E: Format character "b" is only supported on bytes patterns
 
 [case testStringInterPolationPython2]
 # flags: --python-version 2.7
-b'%b' % 1  # E: Format character 'b' is only supported in Python 3.5 and later
+b'%b' % 1  # E: Format character "b" is only supported in Python 3.5 and later
 b'%s' % 1
-b'%a' % 1  # E: Format character 'a' is only supported in Python 3
+b'%a' % 1  # E: Format character "a" is only supported in Python 3
 
 [case testBytesInterpolationBefore35]
 # flags: --python-version 3.4

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1295,7 +1295,7 @@ b'%(x)s' % {b'x': b'data'}
 [case testStringInterpolationMappingKeys]
 '%()d' % {'': 2}
 '%(a)d' % {'a': 1, 'b': 2, 'c': 3}
-'%(q)d' % {'a': 1, 'b': 2, 'c': 3}  # E: Key 'q' not found in mapping
+'%(q)d' % {'a': 1, 'b': 2, 'c': 3}  # E: Key "q" not found in mapping
 '%(a)d %%' % {'a': 1}
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-medium.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1479,7 +1479,7 @@ a = 5
 [file other_module_2.py]
 from other_module_1 import a
 [out]
-main:2: error: Module 'other_module_2' does not explicitly export attribute 'a'; implicit reexport disabled
+main:2: error: Module "other_module_2" does not explicitly export attribute "a"; implicit reexport disabled
 
 [case testNoImplicitReexportRespectsAll]
 # flags: --no-implicit-reexport
@@ -1493,7 +1493,7 @@ from other_module_1 import a, b
 __all__ = ('b',)
 [builtins fixtures/tuple.pyi]
 [out]
-main:2: error: Module 'other_module_2' does not explicitly export attribute 'a'; implicit reexport disabled
+main:2: error: Module "other_module_2" does not explicitly export attribute "a"; implicit reexport disabled
 
 [case testNoImplicitReexportStarConsideredImplicit]
 # flags: --no-implicit-reexport
@@ -1503,7 +1503,7 @@ a = 5
 [file other_module_2.py]
 from other_module_1 import *
 [out]
-main:2: error: Module 'other_module_2' does not explicitly export attribute 'a'; implicit reexport disabled
+main:2: error: Module "other_module_2" does not explicitly export attribute "a"; implicit reexport disabled
 
 [case testNoImplicitReexportStarCanBeReexportedWithAll]
 # flags: --no-implicit-reexport
@@ -1517,7 +1517,7 @@ from other_module_1 import *
 __all__ = ('b',)
 [builtins fixtures/tuple.pyi]
 [out]
-main:2: error: Module 'other_module_2' does not explicitly export attribute 'a'; implicit reexport disabled
+main:2: error: Module "other_module_2" does not explicitly export attribute "a"; implicit reexport disabled
 
 [case textNoImplicitReexportSuggestions]
 # flags: --no-implicit-reexport
@@ -1529,7 +1529,7 @@ attr_2 = 6
 [file other_module_2.py]
 from other_module_1 import attr_1, attr_2
 [out]
-main:2: error: Module 'other_module_2' does not explicitly export attribute 'attr_1'; implicit reexport disabled
+main:2: error: Module "other_module_2" does not explicitly export attribute "attr_1"; implicit reexport disabled
 
 [case testNoImplicitReexportMypyIni]
 # flags: --config-file tmp/mypy.ini

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -84,15 +84,15 @@ except BaseException, e:
 [case testTryExceptUnsupported]
 try:
     pass
-except BaseException, (e, f):  # E: Sorry, `except <expr>, <anything but a name>` is not supported
+except BaseException, (e, f):  # E: Sorry, "except <expr>, <anything but a name>" is not supported
     pass
 try:
     pass
-except BaseException, [e, f, g]:  # E: Sorry, `except <expr>, <anything but a name>` is not supported
+except BaseException, [e, f, g]:  # E: Sorry, "except <expr>, <anything but a name>" is not supported
     pass
 try:
     pass
-except BaseException, e[0]:  # E: Sorry, `except <expr>, <anything but a name>` is not supported
+except BaseException, e[0]:  # E: Sorry, "except <expr>, <anything but a name>" is not supported
     pass
 [builtins_py2 fixtures/exception.pyi]
 


### PR DESCRIPTION
### Description
This pull request fixes issue reported in #7445 for below errors:
1. does not explicitly export attribute
2. Unsupported format character
3. key not found in mapping
4. Format character support
5. Unexpected keyword argument
6. plugin related errors
7. return with value in async
8. cant pass both
9. not supported 

## Test Plan
Updated test cases for the message. New test cases not added.