### PR TITLE
[mypyc] Fix relative imports in `__init__.py`s

### DIFF
--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -169,7 +169,7 @@ def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:
         module_package = builder.module_name
     else:
         module_package = ''
-    
+
     id = importlib.util.resolve_name('.' * node.relative + node.id, module_package)
 
     builder.gen_import(id, node.line)

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -168,6 +168,7 @@ def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:
     else:
         module_package = ''
 
+    print(locals())
     id = importlib.util.resolve_name('.' * node.relative + node.id, module_package)
 
     builder.gen_import(id, node.line)

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -165,7 +165,7 @@ def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:
     module_state = builder.graph[builder.module_name]
     if module_state.ancestors is not None and module_state.ancestors:
         module_package = module_state.ancestors[0]
-    elif builder.module_path.endswith("__init__.py"):  # totally needed comment
+    elif builder.module_path.endswith("__init__.py"):
         module_package = builder.module_name
     else:
         module_package = ''

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -165,10 +165,11 @@ def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:
     module_state = builder.graph[builder.module_name]
     if module_state.ancestors is not None and module_state.ancestors:
         module_package = module_state.ancestors[0]
+    elif builder.module_path.endswith("__init__.py"):
+        module_package = builder.module_name
     else:
         module_package = ''
 
-    print(locals())
     id = importlib.util.resolve_name('.' * node.relative + node.id, module_package)
 
     builder.gen_import(id, node.line)

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -165,11 +165,11 @@ def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:
     module_state = builder.graph[builder.module_name]
     if module_state.ancestors is not None and module_state.ancestors:
         module_package = module_state.ancestors[0]
-    elif builder.module_path.endswith("__init__.py"):
+    elif builder.module_path.endswith("__init__.py"):  # totally needed comment
         module_package = builder.module_name
     else:
         module_package = ''
-
+    
     id = importlib.util.resolve_name('.' * node.relative + node.id, module_package)
 
     builder.gen_import(id, node.line)


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Fixes https://github.com/mypyc/mypyc/issues/842


## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

Re ran the actions and nothing failed, and it solves the issues with `importlib.util.resolve_name` failing.

Before:
```sh
(venv) James@Jamess-Air python-betterproto % mypyc src/betterproto/*.py

Traceback (most recent call last):
  File "/Users/James/PycharmProjects/python-betterproto/build/setup.py", line 5, in <module>
    ext_modules=mypycify(['src/betterproto/__init__.py', 'src/betterproto/_types.py', 'src/betterproto/_version.py', 'src/betterproto/casing.py'], opt_level="3"),
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/build.py", line 487, in mypycify
    groups, group_cfilenames = mypyc_build(
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/build.py", line 400, in mypyc_build
    group_cfiles, ops_text = generate_c(all_sources, options, groups, fscache,
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/build.py", line 200, in generate_c
    modules, ctext = emitmodule.compile_modules_to_c(
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/codegen/emitmodule.py", line 410, in compile_modules_to_c
    modules = compile_modules_to_ir(result, mapper, compiler_options, errors)
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/codegen/emitmodule.py", line 258, in compile_modules_to_ir
    scc_ir = compile_scc_to_ir(trees, result, mapper, compiler_options, errors)
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/codegen/emitmodule.py", line 209, in compile_scc_to_ir
    modules = build_ir(
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/irbuild/main.py", line 80, in build_ir
    transform_mypy_file(builder, module)
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/irbuild/main.py", line 123, in transform_mypy_file
    builder.accept(node)
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/irbuild/builder.py", line 169, in accept
    node.accept(self.visitor)
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypy/nodes.py", line 379, in accept
    return visitor.visit_import_from(self)
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/irbuild/visitor.py", line 110, in visit_import_from
    transform_import_from(self.builder, node)
  File "/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/irbuild/statement.py", line 174, in transform_import_from
    id = importlib.util.resolve_name('.' * node.relative + node.id, module_package)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/util.py", line 32, in resolve_name
    raise ImportError(f'no package specified for {repr(name)} '
src/betterproto/__init__.py:27: ImportError: no package specified for '._types' (required for relative module names)
```

After:
```
(venv) James@Jamess-Air python-betterproto % mypyc src/betterproto/*.py
running build_ext
building '999479a26e36c714bed7__mypyc' extension
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -g -I/Users/James/PycharmProjects/python-betterproto/venv/lib/python3.9/site-packages/mypyc/lib-rt -Ibuild -I/Users/James/PycharmProjects/python-betterproto/venv/include -I/Library/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c build/__native_999479a26e36c714bed7.c -o build/temp.macosx-10.9-x86_64-3.9/build/__native_999479a26e36c714bed7.o -O3 -Werror -Wno-unused-function -Wno-unused-label -Wno-unreachable-code -Wno-unused-variable -Wno-unused-command-line-argument -Wno-unknown-warning-option -Wno-unused-but-set-variable
creating build/lib.macosx-10.9-x86_64-3.9
gcc -bundle -undefined dynamic_lookup -arch x86_64 -g build/temp.macosx-10.9-x86_64-3.9/build/__native_999479a26e36c714bed7.o -o build/lib.macosx-10.9-x86_64-3.9/999479a26e36c714bed7__mypyc.cpython-39-darwin.so
building 'betterproto.__init__' extension
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -g -I/Users/James/PycharmProjects/python-betterproto/venv/include -I/Library/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c build/betterproto.c -o build/temp.macosx-10.9-x86_64-3.9/build/betterproto.o -O3 -Werror -Wno-unused-function -Wno-unused-label -Wno-unreachable-code -Wno-unused-variable -Wno-unused-command-line-argument -Wno-unknown-warning-option -Wno-unused-but-set-variable
creating build/lib.macosx-10.9-x86_64-3.9/betterproto
gcc -bundle -undefined dynamic_lookup -arch x86_64 -g build/temp.macosx-10.9-x86_64-3.9/build/betterproto.o -o build/lib.macosx-10.9-x86_64-3.9/betterproto/__init__.cpython-39-darwin.so
building 'betterproto._types' extension
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -g -I/Users/James/PycharmProjects/python-betterproto/venv/include -I/Library/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c build/betterproto/_types.c -o build/temp.macosx-10.9-x86_64-3.9/build/betterproto/_types.o -O3 -Werror -Wno-unused-function -Wno-unused-label -Wno-unreachable-code -Wno-unused-variable -Wno-unused-command-line-argument -Wno-unknown-warning-option -Wno-unused-but-set-variable
gcc -bundle -undefined dynamic_lookup -arch x86_64 -g build/temp.macosx-10.9-x86_64-3.9/build/betterproto/_types.o -o build/lib.macosx-10.9-x86_64-3.9/betterproto/_types.cpython-39-darwin.so
building 'betterproto._version' extension
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -g -I/Users/James/PycharmProjects/python-betterproto/venv/include -I/Library/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c build/betterproto/_version.c -o build/temp.macosx-10.9-x86_64-3.9/build/betterproto/_version.o -O3 -Werror -Wno-unused-function -Wno-unused-label -Wno-unreachable-code -Wno-unused-variable -Wno-unused-command-line-argument -Wno-unknown-warning-option -Wno-unused-but-set-variable
gcc -bundle -undefined dynamic_lookup -arch x86_64 -g build/temp.macosx-10.9-x86_64-3.9/build/betterproto/_version.o -o build/lib.macosx-10.9-x86_64-3.9/betterproto/_version.cpython-39-darwin.so
building 'betterproto.casing' extension
gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -arch x86_64 -g -I/Users/James/PycharmProjects/python-betterproto/venv/include -I/Library/Frameworks/Python.framework/Versions/3.9/include/python3.9 -c build/betterproto/casing.c -o build/temp.macosx-10.9-x86_64-3.9/build/betterproto/casing.o -O3 -Werror -Wno-unused-function -Wno-unused-label -Wno-unreachable-code -Wno-unused-variable -Wno-unused-command-line-argument -Wno-unknown-warning-option -Wno-unused-but-set-variable
gcc -bundle -undefined dynamic_lookup -arch x86_64 -g build/temp.macosx-10.9-x86_64-3.9/build/betterproto/casing.o -o build/lib.macosx-10.9-x86_64-3.9/betterproto/casing.cpython-39-darwin.so
copying build/lib.macosx-10.9-x86_64-3.9/999479a26e36c714bed7__mypyc.cpython-39-darwin.so -> 
copying build/lib.macosx-10.9-x86_64-3.9/betterproto/__init__.cpython-39-darwin.so -> betterproto
copying build/lib.macosx-10.9-x86_64-3.9/betterproto/_types.cpython-39-darwin.so -> betterproto
copying build/lib.macosx-10.9-x86_64-3.9/betterproto/_version.cpython-39-darwin.so -> betterproto
copying build/lib.macosx-10.9-x86_64-3.9/betterproto/casing.cpython-39-darwin.so -> betterproto
```
