### PR TITLE
Resolves #10283; check for module level ignore_missing_imports on missing stubs

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -141,7 +141,7 @@ class Options:
         # Warn about unused '# type: ignore' comments
         self.warn_unused_ignores = False
 
-        # Warn about unused '[mypy-<pattern>]'  or '[[tool.mypy.overrides]]' config sections
+        # Warn about unused '[mypy-<pattern>]' or '[[tool.mypy.overrides]]' config sections
         self.warn_unused_configs = False
 
         # Files in which to ignore all non-fatal errors

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1,6 +1,7 @@
 -- Type checker test cases dealing with modules and imports.
 -- Towards the end there are tests for PEP 420 (namespace packages, i.e. __init__.py-less packages).
 
+
 [case testAccessImportedDefinitions]
 import m
 import typing
@@ -2982,3 +2983,43 @@ T = TypeVar("T")
 class F(M):
     x: C
     class C: ...
+
+
+-- https://github.com/python/mypy/issues/10283
+[case testIgnoreMissingImportsGlobalWithMissingStub]
+# flags: --config-file tmp/pyproject.toml
+from redis.sentinel import Sentinel
+
+[file pyproject.toml]
+\[tool.mypy]
+ignore_missing_imports = true
+
+[out]
+main:2: error: Cannot find implementation or library stub for module named "redis.sentinel"
+main:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+
+
+-- https://github.com/python/mypy/issues/10283
+[case testIgnoreMissingImportsWildcardWithMissingStub]
+# flags: --config-file tmp/pyproject.toml
+from redis.sentinel import Sentinel
+
+[file pyproject.toml]
+\[tool.mypy]
+ignore_missing_imports = false
+\[[tool.mypy.overrides]]
+module = 'redis.*'
+ignore_missing_imports = true
+
+
+-- https://github.com/python/mypy/issues/10283
+[case testIgnoreMissingImportsGlobalAndWildcardWithMissingStub]
+# flags: --config-file tmp/pyproject.toml
+from redis.sentinel import Sentinel
+
+[file pyproject.toml]
+\[tool.mypy]
+ignore_missing_imports = true
+\[[tool.mypy.overrides]]
+module = 'redis.*'
+ignore_missing_imports = true


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Fixes #10283 

For missing type stubs for legacy bundled packages, we will now look for module level overrides for ignore_missing_imports. If present, we will not issue an error like: `Cannot find implementation or library stub for module named "redis.sentinel"`

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

3 new test scenarios were added for this PR in `check-modules.test` for a missing type stub for a legacy bundled package:
Test Name | `ignore_missing_imports` global | `ignore_missing_imports` module override | Result
-|-|-|-
testIgnoreMissingImportsGlobalWithMissingStub | True | False | Error
testIgnoreMissingImportsWildcardWithMissingStub | False | True | No Error
testIgnoreMissingImportsGlobalAndWildcardWithMissingStub | True | True | No Error

The first two tests were passing before the code change and are there to help ensure no regression. The last test was the use case from #10283 to make sure the new code accomplished its mission.