### PR TITLE
[mypyc] Avoid crash when importing unknown module with from import

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -46,7 +46,7 @@ from mypyc.primitives.list_ops import to_list, list_pop_last, list_get_item_unsa
 from mypyc.primitives.dict_ops import dict_get_item_op, dict_set_item_op
 from mypyc.primitives.generic_ops import py_setattr_op, iter_op, next_op
 from mypyc.primitives.misc_ops import (
-    import_op, check_unpack_count_op, get_module_dict_op, import_extra_args_op, get_locals
+    import_op, check_unpack_count_op, get_module_dict_op, import_extra_args_op
 )
 from mypyc.crash import catch_errors
 from mypyc.options import CompilerOptions
@@ -292,13 +292,13 @@ class IRBuilder:
         self.imports[id] = None
 
         globals_dict = self.load_globals_dict()
-        locals_dict = self.call_c(get_locals, [], line)
+        null = Integer(0, dict_rprimitive, line)
         names_to_import = self.new_list_op([self.load_str(name) for name in imported], line)
 
         level = Integer(0, c_int_rprimitive, line)
         value = self.call_c(
             import_extra_args_op,
-            [self.load_str(id), globals_dict, locals_dict, names_to_import, level],
+            [self.load_str(id), globals_dict, null, names_to_import, level],
             line,
         )
         self.add(InitStatic(value, id, namespace=NAMESPACE_MODULE))

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -291,10 +291,6 @@ class IRBuilder:
     def gen_import_from(self, id: str, line: int, imported: List[str]) -> None:
         self.imports[id] = None
 
-        needs_import, out = BasicBlock(), BasicBlock()
-        self.check_if_module_loaded(id, line, needs_import, out)
-
-        self.activate_block(needs_import)
         globals_dict = self.load_globals_dict()
         locals_dict = self.call_c(get_locals, [], line)
         names_to_import = self.new_list_op([self.load_str(name) for name in imported], line)
@@ -306,7 +302,6 @@ class IRBuilder:
             line,
         )
         self.add(InitStatic(value, id, namespace=NAMESPACE_MODULE))
-        self.goto_and_activate(out)
 
     def gen_import(self, id: str, line: int) -> None:
         self.imports[id] = None

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -180,12 +180,6 @@ def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:
     # This probably doesn't matter much and the code runs basically right.
     globals = builder.load_globals_dict()
     for name, maybe_as_name in node.names:
-        # If one of the things we are importing is a module,
-        # import it as a module also.
-        fullname = id + '.' + name
-        if fullname in builder.graph or fullname in module_state.suppressed:
-            builder.gen_import(fullname, node.line)
-
         as_name = maybe_as_name or name
         obj = builder.py_get_attr(module, name, node.line)
         builder.gen_method_call(

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -170,7 +170,8 @@ def transform_import_from(builder: IRBuilder, node: ImportFrom) -> None:
 
     id = importlib.util.resolve_name('.' * node.relative + node.id, module_package)
 
-    builder.gen_import(id, node.line)
+    imported = [name for name, _ in node.names]
+    builder.gen_import_from(id, node.line, imported)
     module = builder.load_module(id)
 
     # Copy everything into our module's dict.

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -125,16 +125,6 @@ get_module_dict_op = custom_op(
     error_kind=ERR_NEVER,
     is_borrowed=True)
 
-# locals()
-get_locals = custom_op(
-    arg_types=[],
-    return_type=dict_rprimitive,
-    c_function_name='PyEval_GetLocals',
-    # documentation doesn't mention setting an exception on failure, but it might return NULL
-    error_kind=ERR_MAGIC,
-    is_borrowed=True
-)
-
 # isinstance(obj, cls)
 function_op(
     name='builtins.isinstance',

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -3,7 +3,8 @@
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_FALSE
 from mypyc.ir.rtypes import (
     bool_rprimitive, object_rprimitive, str_rprimitive, object_pointer_rprimitive,
-    int_rprimitive, dict_rprimitive, c_int_rprimitive, bit_rprimitive, c_pyssize_t_rprimitive
+    int_rprimitive, dict_rprimitive, c_int_rprimitive, bit_rprimitive, c_pyssize_t_rprimitive,
+    list_rprimitive,
 )
 from mypyc.primitives.registry import (
     function_op, custom_op, load_address_op, ERR_NEG_INT
@@ -107,6 +108,15 @@ import_op = custom_op(
     c_function_name='PyImport_Import',
     error_kind=ERR_MAGIC)
 
+# Import with extra arguments (used in from import handling)
+import_extra_args_op = custom_op(
+    arg_types=[str_rprimitive, dict_rprimitive, dict_rprimitive,
+               list_rprimitive, c_int_rprimitive],
+    return_type=object_rprimitive,
+    c_function_name='PyImport_ImportModuleLevelObject',
+    error_kind=ERR_MAGIC
+)
+
 # Get the sys.modules dictionary
 get_module_dict_op = custom_op(
     arg_types=[],
@@ -114,6 +124,16 @@ get_module_dict_op = custom_op(
     c_function_name='PyImport_GetModuleDict',
     error_kind=ERR_NEVER,
     is_borrowed=True)
+
+# locals()
+get_locals = custom_op(
+    arg_types=[],
+    return_type=dict_rprimitive,
+    c_function_name='PyEval_GetLocals',
+    # documentation doesn't mention setting an exception on failure, but it might return NULL
+    error_kind=ERR_MAGIC,
+    is_borrowed=True
+)
 
 # isinstance(obj, cls)
 function_op(

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2491,84 +2491,83 @@ def __top_level__():
     r0, r1 :: object
     r2 :: bit
     r3 :: str
-    r4, r5, r6 :: object
-    r7 :: bit
-    r8, r9 :: dict
-    r10, r11, r12 :: str
-    r13 :: list
-    r14, r15, r16, r17 :: ptr
-    r18 :: str
-    r19, r20 :: object
-    r21 :: dict
-    r22 :: str
-    r23 :: object
+    r4 :: object
+    r5, r6 :: dict
+    r7, r8, r9 :: str
+    r10 :: list
+    r11, r12, r13, r14 :: ptr
+    r15 :: str
+    r16, r17 :: object
+    r18 :: dict
+    r19 :: str
+    r20 :: object
+    r21 :: str
+    r22 :: int32
+    r23 :: bit
     r24 :: str
-    r25 :: int32
-    r26 :: bit
-    r27 :: str
-    r28 :: object
+    r25 :: object
+    r26 :: str
+    r27 :: int32
+    r28 :: bit
     r29 :: str
-    r30 :: int32
-    r31 :: bit
-    r32 :: str
-    r33 :: object
-    r34 :: str
-    r35 :: int32
-    r36 :: bit
-    r37, r38 :: str
-    r39 :: object
-    r40 :: tuple[str, object]
-    r41 :: object
-    r42 :: str
-    r43 :: object
-    r44 :: tuple[str, object]
-    r45 :: object
-    r46 :: tuple[object, object]
-    r47 :: object
-    r48 :: dict
-    r49 :: str
-    r50, r51 :: object
-    r52 :: dict
+    r30 :: object
+    r31 :: str
+    r32 :: int32
+    r33 :: bit
+    r34, r35 :: str
+    r36 :: object
+    r37 :: tuple[str, object]
+    r38 :: object
+    r39 :: str
+    r40 :: object
+    r41 :: tuple[str, object]
+    r42 :: object
+    r43 :: tuple[object, object]
+    r44 :: object
+    r45 :: dict
+    r46 :: str
+    r47, r48 :: object
+    r49 :: dict
+    r50 :: str
+    r51 :: int32
+    r52 :: bit
     r53 :: str
-    r54 :: int32
-    r55 :: bit
-    r56 :: str
-    r57 :: dict
-    r58 :: str
-    r59, r60, r61 :: object
-    r62 :: tuple
-    r63 :: dict
-    r64 :: str
-    r65 :: int32
-    r66 :: bit
-    r67 :: dict
-    r68 :: str
-    r69, r70, r71 :: object
-    r72 :: dict
+    r54 :: dict
+    r55 :: str
+    r56, r57, r58 :: object
+    r59 :: tuple
+    r60 :: dict
+    r61 :: str
+    r62 :: int32
+    r63 :: bit
+    r64 :: dict
+    r65 :: str
+    r66, r67, r68 :: object
+    r69 :: dict
+    r70 :: str
+    r71 :: int32
+    r72 :: bit
     r73 :: str
-    r74 :: int32
-    r75 :: bit
-    r76 :: str
+    r74 :: dict
+    r75 :: str
+    r76 :: object
     r77 :: dict
     r78 :: str
-    r79 :: object
-    r80 :: dict
-    r81 :: str
-    r82, r83 :: object
-    r84 :: dict
-    r85 :: str
-    r86 :: int32
-    r87 :: bit
-    r88 :: list
-    r89, r90, r91 :: object
-    r92, r93, r94, r95 :: ptr
-    r96 :: dict
-    r97 :: str
-    r98, r99 :: object
-    r100 :: dict
-    r101 :: str
-    r102 :: int32
-    r103 :: bit
+    r79, r80 :: object
+    r81 :: dict
+    r82 :: str
+    r83 :: int32
+    r84 :: bit
+    r85 :: list
+    r86, r87, r88 :: object
+    r89, r90, r91, r92 :: ptr
+    r93 :: dict
+    r94 :: str
+    r95, r96 :: object
+    r97 :: dict
+    r98 :: str
+    r99 :: int32
+    r100 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -2579,117 +2578,111 @@ L1:
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
-    r5 = typing :: module
-    r6 = load_address _Py_NoneStruct
-    r7 = r5 != r6
-    if r7 goto L4 else goto L3 :: bool
-L3:
-    r8 = __main__.globals :: static
-    r9 = PyEval_GetLocals()
-    r10 = 'List'
-    r11 = 'NewType'
-    r12 = 'NamedTuple'
-    r13 = PyList_New(3)
-    r14 = get_element_ptr r13 ob_item :: PyListObject
-    r15 = load_mem r14 :: ptr*
-    set_mem r15, r10 :: builtins.object*
-    r16 = r15 + WORD_SIZE*1
-    set_mem r16, r11 :: builtins.object*
-    r17 = r15 + WORD_SIZE*2
-    set_mem r17, r12 :: builtins.object*
-    keep_alive r13
-    r18 = 'typing'
-    r19 = PyImport_ImportModuleLevelObject(r18, r8, r9, r13, 0)
-    typing = r19 :: module
-L4:
-    r20 = typing :: module
-    r21 = __main__.globals :: static
-    r22 = 'List'
-    r23 = CPyObject_GetAttr(r20, r22)
-    r24 = 'List'
-    r25 = CPyDict_SetItem(r21, r24, r23)
-    r26 = r25 >= 0 :: signed
-    r27 = 'NewType'
-    r28 = CPyObject_GetAttr(r20, r27)
-    r29 = 'NewType'
-    r30 = CPyDict_SetItem(r21, r29, r28)
-    r31 = r30 >= 0 :: signed
-    r32 = 'NamedTuple'
-    r33 = CPyObject_GetAttr(r20, r32)
-    r34 = 'NamedTuple'
-    r35 = CPyDict_SetItem(r21, r34, r33)
-    r36 = r35 >= 0 :: signed
-    r37 = 'Lol'
-    r38 = 'a'
-    r39 = load_address PyLong_Type
-    r40 = (r38, r39)
-    r41 = box(tuple[str, object], r40)
-    r42 = 'b'
-    r43 = load_address PyUnicode_Type
-    r44 = (r42, r43)
-    r45 = box(tuple[str, object], r44)
-    r46 = (r41, r45)
-    r47 = box(tuple[object, object], r46)
-    r48 = __main__.globals :: static
-    r49 = 'NamedTuple'
-    r50 = CPyDict_GetItem(r48, r49)
-    r51 = PyObject_CallFunctionObjArgs(r50, r37, r47, 0)
-    r52 = __main__.globals :: static
-    r53 = 'Lol'
-    r54 = CPyDict_SetItem(r52, r53, r51)
-    r55 = r54 >= 0 :: signed
-    r56 = ''
-    r57 = __main__.globals :: static
-    r58 = 'Lol'
-    r59 = CPyDict_GetItem(r57, r58)
-    r60 = box(short_int, 2)
-    r61 = PyObject_CallFunctionObjArgs(r59, r60, r56, 0)
-    r62 = cast(tuple, r61)
-    r63 = __main__.globals :: static
-    r64 = 'x'
-    r65 = CPyDict_SetItem(r63, r64, r62)
-    r66 = r65 >= 0 :: signed
-    r67 = __main__.globals :: static
-    r68 = 'List'
-    r69 = CPyDict_GetItem(r67, r68)
-    r70 = load_address PyLong_Type
-    r71 = PyObject_GetItem(r69, r70)
-    r72 = __main__.globals :: static
-    r73 = 'Foo'
-    r74 = CPyDict_SetItem(r72, r73, r71)
-    r75 = r74 >= 0 :: signed
-    r76 = 'Bar'
+    r5 = __main__.globals :: static
+    r6 = PyEval_GetLocals()
+    r7 = 'List'
+    r8 = 'NewType'
+    r9 = 'NamedTuple'
+    r10 = PyList_New(3)
+    r11 = get_element_ptr r10 ob_item :: PyListObject
+    r12 = load_mem r11 :: ptr*
+    set_mem r12, r7 :: builtins.object*
+    r13 = r12 + 8
+    set_mem r13, r8 :: builtins.object*
+    r14 = r12 + 16
+    set_mem r14, r9 :: builtins.object*
+    keep_alive r10
+    r15 = 'typing'
+    r16 = PyImport_ImportModuleLevelObject(r15, r5, r6, r10, 0)
+    typing = r16 :: module
+    r17 = typing :: module
+    r18 = __main__.globals :: static
+    r19 = 'List'
+    r20 = CPyObject_GetAttr(r17, r19)
+    r21 = 'List'
+    r22 = CPyDict_SetItem(r18, r21, r20)
+    r23 = r22 >= 0 :: signed
+    r24 = 'NewType'
+    r25 = CPyObject_GetAttr(r17, r24)
+    r26 = 'NewType'
+    r27 = CPyDict_SetItem(r18, r26, r25)
+    r28 = r27 >= 0 :: signed
+    r29 = 'NamedTuple'
+    r30 = CPyObject_GetAttr(r17, r29)
+    r31 = 'NamedTuple'
+    r32 = CPyDict_SetItem(r18, r31, r30)
+    r33 = r32 >= 0 :: signed
+    r34 = 'Lol'
+    r35 = 'a'
+    r36 = load_address PyLong_Type
+    r37 = (r35, r36)
+    r38 = box(tuple[str, object], r37)
+    r39 = 'b'
+    r40 = load_address PyUnicode_Type
+    r41 = (r39, r40)
+    r42 = box(tuple[str, object], r41)
+    r43 = (r38, r42)
+    r44 = box(tuple[object, object], r43)
+    r45 = __main__.globals :: static
+    r46 = 'NamedTuple'
+    r47 = CPyDict_GetItem(r45, r46)
+    r48 = PyObject_CallFunctionObjArgs(r47, r34, r44, 0)
+    r49 = __main__.globals :: static
+    r50 = 'Lol'
+    r51 = CPyDict_SetItem(r49, r50, r48)
+    r52 = r51 >= 0 :: signed
+    r53 = ''
+    r54 = __main__.globals :: static
+    r55 = 'Lol'
+    r56 = CPyDict_GetItem(r54, r55)
+    r57 = box(short_int, 2)
+    r58 = PyObject_CallFunctionObjArgs(r56, r57, r53, 0)
+    r59 = cast(tuple, r58)
+    r60 = __main__.globals :: static
+    r61 = 'x'
+    r62 = CPyDict_SetItem(r60, r61, r59)
+    r63 = r62 >= 0 :: signed
+    r64 = __main__.globals :: static
+    r65 = 'List'
+    r66 = CPyDict_GetItem(r64, r65)
+    r67 = load_address PyLong_Type
+    r68 = PyObject_GetItem(r66, r67)
+    r69 = __main__.globals :: static
+    r70 = 'Foo'
+    r71 = CPyDict_SetItem(r69, r70, r68)
+    r72 = r71 >= 0 :: signed
+    r73 = 'Bar'
+    r74 = __main__.globals :: static
+    r75 = 'Foo'
+    r76 = CPyDict_GetItem(r74, r75)
     r77 = __main__.globals :: static
-    r78 = 'Foo'
+    r78 = 'NewType'
     r79 = CPyDict_GetItem(r77, r78)
-    r80 = __main__.globals :: static
-    r81 = 'NewType'
-    r82 = CPyDict_GetItem(r80, r81)
-    r83 = PyObject_CallFunctionObjArgs(r82, r76, r79, 0)
-    r84 = __main__.globals :: static
-    r85 = 'Bar'
-    r86 = CPyDict_SetItem(r84, r85, r83)
-    r87 = r86 >= 0 :: signed
-    r88 = PyList_New(3)
-    r89 = box(short_int, 2)
-    r90 = box(short_int, 4)
-    r91 = box(short_int, 6)
-    r92 = get_element_ptr r88 ob_item :: PyListObject
-    r93 = load_mem r92 :: ptr*
-    set_mem r93, r89 :: builtins.object*
-    r94 = r93 + WORD_SIZE*1
-    set_mem r94, r90 :: builtins.object*
-    r95 = r93 + WORD_SIZE*2
-    set_mem r95, r91 :: builtins.object*
-    keep_alive r88
-    r96 = __main__.globals :: static
-    r97 = 'Bar'
-    r98 = CPyDict_GetItem(r96, r97)
-    r99 = PyObject_CallFunctionObjArgs(r98, r88, 0)
-    r100 = __main__.globals :: static
-    r101 = 'y'
-    r102 = CPyDict_SetItem(r100, r101, r99)
-    r103 = r102 >= 0 :: signed
+    r80 = PyObject_CallFunctionObjArgs(r79, r73, r76, 0)
+    r81 = __main__.globals :: static
+    r82 = 'Bar'
+    r83 = CPyDict_SetItem(r81, r82, r80)
+    r84 = r83 >= 0 :: signed
+    r85 = PyList_New(3)
+    r86 = box(short_int, 2)
+    r87 = box(short_int, 4)
+    r88 = box(short_int, 6)
+    r89 = get_element_ptr r85 ob_item :: PyListObject
+    r90 = load_mem r89 :: ptr*
+    set_mem r90, r86 :: builtins.object*
+    r91 = r90 + 8
+    set_mem r91, r87 :: builtins.object*
+    r92 = r90 + 16
+    set_mem r92, r88 :: builtins.object*
+    keep_alive r85
+    r93 = __main__.globals :: static
+    r94 = 'Bar'
+    r95 = CPyDict_GetItem(r93, r94)
+    r96 = PyObject_CallFunctionObjArgs(r95, r85, 0)
+    r97 = __main__.globals :: static
+    r98 = 'y'
+    r99 = CPyDict_SetItem(r97, r98, r96)
+    r100 = r99 >= 0 :: signed
     return 1
 
 [case testChainedConditional]
@@ -3005,33 +2998,32 @@ def __top_level__():
     r0, r1 :: object
     r2 :: bit
     r3 :: str
-    r4, r5, r6 :: object
-    r7 :: bit
-    r8, r9 :: dict
-    r10 :: str
-    r11 :: list
-    r12, r13 :: ptr
-    r14 :: str
-    r15, r16 :: object
-    r17 :: dict
-    r18 :: str
-    r19 :: object
-    r20 :: str
-    r21 :: int32
-    r22 :: bit
+    r4 :: object
+    r5, r6 :: dict
+    r7 :: str
+    r8 :: list
+    r9, r10 :: ptr
+    r11 :: str
+    r12, r13 :: object
+    r14 :: dict
+    r15 :: str
+    r16 :: object
+    r17 :: str
+    r18 :: int32
+    r19 :: bit
+    r20 :: dict
+    r21 :: str
+    r22 :: object
     r23 :: dict
     r24 :: str
-    r25 :: object
-    r26 :: dict
-    r27 :: str
-    r28, r29 :: object
-    r30 :: dict
-    r31 :: str
-    r32, r33 :: object
-    r34 :: dict
-    r35 :: str
-    r36 :: int32
-    r37 :: bit
+    r25, r26 :: object
+    r27 :: dict
+    r28 :: str
+    r29, r30 :: object
+    r31 :: dict
+    r32 :: str
+    r33 :: int32
+    r34 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -3042,45 +3034,39 @@ L1:
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
-    r5 = typing :: module
-    r6 = load_address _Py_NoneStruct
-    r7 = r5 != r6
-    if r7 goto L4 else goto L3 :: bool
-L3:
-    r8 = __main__.globals :: static
-    r9 = PyEval_GetLocals()
-    r10 = 'Callable'
-    r11 = PyList_New(1)
-    r12 = get_element_ptr r11 ob_item :: PyListObject
-    r13 = load_mem r12 :: ptr*
-    set_mem r13, r10 :: builtins.object*
-    keep_alive r11
-    r14 = 'typing'
-    r15 = PyImport_ImportModuleLevelObject(r14, r8, r9, r11, 0)
-    typing = r15 :: module
-L4:
-    r16 = typing :: module
-    r17 = __main__.globals :: static
-    r18 = 'Callable'
-    r19 = CPyObject_GetAttr(r16, r18)
-    r20 = 'Callable'
-    r21 = CPyDict_SetItem(r17, r20, r19)
-    r22 = r21 >= 0 :: signed
+    r5 = __main__.globals :: static
+    r6 = PyEval_GetLocals()
+    r7 = 'Callable'
+    r8 = PyList_New(1)
+    r9 = get_element_ptr r8 ob_item :: PyListObject
+    r10 = load_mem r9 :: ptr*
+    set_mem r10, r7 :: builtins.object*
+    keep_alive r8
+    r11 = 'typing'
+    r12 = PyImport_ImportModuleLevelObject(r11, r5, r6, r8, 0)
+    typing = r12 :: module
+    r13 = typing :: module
+    r14 = __main__.globals :: static
+    r15 = 'Callable'
+    r16 = CPyObject_GetAttr(r13, r15)
+    r17 = 'Callable'
+    r18 = CPyDict_SetItem(r14, r17, r16)
+    r19 = r18 >= 0 :: signed
+    r20 = __main__.globals :: static
+    r21 = '__mypyc_c_decorator_helper__'
+    r22 = CPyDict_GetItem(r20, r21)
     r23 = __main__.globals :: static
-    r24 = '__mypyc_c_decorator_helper__'
+    r24 = 'b'
     r25 = CPyDict_GetItem(r23, r24)
-    r26 = __main__.globals :: static
-    r27 = 'b'
-    r28 = CPyDict_GetItem(r26, r27)
-    r29 = PyObject_CallFunctionObjArgs(r28, r25, 0)
-    r30 = __main__.globals :: static
-    r31 = 'a'
-    r32 = CPyDict_GetItem(r30, r31)
-    r33 = PyObject_CallFunctionObjArgs(r32, r29, 0)
-    r34 = __main__.globals :: static
-    r35 = 'c'
-    r36 = CPyDict_SetItem(r34, r35, r33)
-    r37 = r36 >= 0 :: signed
+    r26 = PyObject_CallFunctionObjArgs(r25, r22, 0)
+    r27 = __main__.globals :: static
+    r28 = 'a'
+    r29 = CPyDict_GetItem(r27, r28)
+    r30 = PyObject_CallFunctionObjArgs(r29, r26, 0)
+    r31 = __main__.globals :: static
+    r32 = 'c'
+    r33 = CPyDict_SetItem(r31, r32, r30)
+    r34 = r33 >= 0 :: signed
     return 1
 
 [case testDecoratorsSimple_toplevel]
@@ -3155,20 +3141,19 @@ def __top_level__():
     r0, r1 :: object
     r2 :: bit
     r3 :: str
-    r4, r5, r6 :: object
-    r7 :: bit
-    r8, r9 :: dict
-    r10 :: str
-    r11 :: list
-    r12, r13 :: ptr
-    r14 :: str
-    r15, r16 :: object
-    r17 :: dict
-    r18 :: str
-    r19 :: object
-    r20 :: str
-    r21 :: int32
-    r22 :: bit
+    r4 :: object
+    r5, r6 :: dict
+    r7 :: str
+    r8 :: list
+    r9, r10 :: ptr
+    r11 :: str
+    r12, r13 :: object
+    r14 :: dict
+    r15 :: str
+    r16 :: object
+    r17 :: str
+    r18 :: int32
+    r19 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -3179,30 +3164,24 @@ L1:
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
-    r5 = typing :: module
-    r6 = load_address _Py_NoneStruct
-    r7 = r5 != r6
-    if r7 goto L4 else goto L3 :: bool
-L3:
-    r8 = __main__.globals :: static
-    r9 = PyEval_GetLocals()
-    r10 = 'Callable'
-    r11 = PyList_New(1)
-    r12 = get_element_ptr r11 ob_item :: PyListObject
-    r13 = load_mem r12 :: ptr*
-    set_mem r13, r10 :: builtins.object*
-    keep_alive r11
-    r14 = 'typing'
-    r15 = PyImport_ImportModuleLevelObject(r14, r8, r9, r11, 0)
-    typing = r15 :: module
-L4:
-    r16 = typing :: module
-    r17 = __main__.globals :: static
-    r18 = 'Callable'
-    r19 = CPyObject_GetAttr(r16, r18)
-    r20 = 'Callable'
-    r21 = CPyDict_SetItem(r17, r20, r19)
-    r22 = r21 >= 0 :: signed
+    r5 = __main__.globals :: static
+    r6 = PyEval_GetLocals()
+    r7 = 'Callable'
+    r8 = PyList_New(1)
+    r9 = get_element_ptr r8 ob_item :: PyListObject
+    r10 = load_mem r9 :: ptr*
+    set_mem r10, r7 :: builtins.object*
+    keep_alive r8
+    r11 = 'typing'
+    r12 = PyImport_ImportModuleLevelObject(r11, r5, r6, r8, 0)
+    typing = r12 :: module
+    r13 = typing :: module
+    r14 = __main__.globals :: static
+    r15 = 'Callable'
+    r16 = CPyObject_GetAttr(r13, r15)
+    r17 = 'Callable'
+    r18 = CPyDict_SetItem(r14, r17, r16)
+    r19 = r18 >= 0 :: signed
     return 1
 
 [case testAnyAllG]

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2593,9 +2593,9 @@ L3:
     r14 = get_element_ptr r13 ob_item :: PyListObject
     r15 = load_mem r14 :: ptr*
     set_mem r15, r10 :: builtins.object*
-    r16 = r15 + 8
+    r16 = r15 + WORD_SIZE*1
     set_mem r16, r11 :: builtins.object*
-    r17 = r15 + 16
+    r17 = r15 + WORD_SIZE*2
     set_mem r17, r12 :: builtins.object*
     keep_alive r13
     r18 = 'typing'
@@ -2677,9 +2677,9 @@ L4:
     r92 = get_element_ptr r88 ob_item :: PyListObject
     r93 = load_mem r92 :: ptr*
     set_mem r93, r89 :: builtins.object*
-    r94 = r93 + 8
+    r94 = r93 + WORD_SIZE*1
     set_mem r94, r90 :: builtins.object*
-    r95 = r93 + 16
+    r95 = r93 + WORD_SIZE*2
     set_mem r95, r91 :: builtins.object*
     keep_alive r88
     r96 = __main__.globals :: static

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2587,9 +2587,9 @@ L2:
     r11 = get_element_ptr r10 ob_item :: PyListObject
     r12 = load_mem r11 :: ptr*
     set_mem r12, r7 :: builtins.object*
-    r13 = r12 + 8
+    r13 = r12 + WORD_SIZE*1
     set_mem r13, r8 :: builtins.object*
-    r14 = r12 + 16
+    r14 = r12 + WORD_SIZE*2
     set_mem r14, r9 :: builtins.object*
     keep_alive r10
     r15 = 'typing'
@@ -2670,9 +2670,9 @@ L2:
     r89 = get_element_ptr r85 ob_item :: PyListObject
     r90 = load_mem r89 :: ptr*
     set_mem r90, r86 :: builtins.object*
-    r91 = r90 + 8
+    r91 = r90 + WORD_SIZE*1
     set_mem r91, r87 :: builtins.object*
-    r92 = r90 + 16
+    r92 = r90 + WORD_SIZE*2
     set_mem r92, r88 :: builtins.object*
     keep_alive r85
     r93 = __main__.globals :: static

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2493,78 +2493,82 @@ def __top_level__():
     r3 :: str
     r4, r5, r6 :: object
     r7 :: bit
-    r8 :: str
-    r9, r10 :: object
-    r11 :: dict
-    r12 :: str
-    r13 :: object
-    r14 :: str
-    r15 :: int32
-    r16 :: bit
-    r17 :: str
-    r18 :: object
-    r19 :: str
-    r20 :: int32
-    r21 :: bit
+    r8, r9 :: dict
+    r10, r11, r12 :: str
+    r13 :: list
+    r14, r15, r16, r17 :: ptr
+    r18 :: str
+    r19, r20 :: object
+    r21 :: dict
     r22 :: str
     r23 :: object
     r24 :: str
     r25 :: int32
     r26 :: bit
-    r27, r28 :: str
-    r29 :: object
-    r30 :: tuple[str, object]
-    r31 :: object
+    r27 :: str
+    r28 :: object
+    r29 :: str
+    r30 :: int32
+    r31 :: bit
     r32 :: str
     r33 :: object
-    r34 :: tuple[str, object]
-    r35 :: object
-    r36 :: tuple[object, object]
-    r37 :: object
-    r38 :: dict
-    r39 :: str
-    r40, r41 :: object
-    r42 :: dict
-    r43 :: str
-    r44 :: int32
-    r45 :: bit
-    r46 :: str
-    r47 :: dict
-    r48 :: str
-    r49, r50, r51 :: object
-    r52 :: tuple
-    r53 :: dict
-    r54 :: str
-    r55 :: int32
-    r56 :: bit
+    r34 :: str
+    r35 :: int32
+    r36 :: bit
+    r37, r38 :: str
+    r39 :: object
+    r40 :: tuple[str, object]
+    r41 :: object
+    r42 :: str
+    r43 :: object
+    r44 :: tuple[str, object]
+    r45 :: object
+    r46 :: tuple[object, object]
+    r47 :: object
+    r48 :: dict
+    r49 :: str
+    r50, r51 :: object
+    r52 :: dict
+    r53 :: str
+    r54 :: int32
+    r55 :: bit
+    r56 :: str
     r57 :: dict
     r58 :: str
     r59, r60, r61 :: object
-    r62 :: dict
-    r63 :: str
-    r64 :: int32
-    r65 :: bit
-    r66 :: str
+    r62 :: tuple
+    r63 :: dict
+    r64 :: str
+    r65 :: int32
+    r66 :: bit
     r67 :: dict
     r68 :: str
-    r69 :: object
-    r70 :: dict
-    r71 :: str
-    r72, r73 :: object
-    r74 :: dict
-    r75 :: str
-    r76 :: int32
-    r77 :: bit
-    r78 :: list
-    r79, r80, r81 :: object
-    r82, r83, r84, r85 :: ptr
-    r86 :: dict
-    r87 :: str
-    r88, r89 :: object
-    r90 :: dict
-    r91 :: str
-    r92 :: int32
-    r93 :: bit
+    r69, r70, r71 :: object
+    r72 :: dict
+    r73 :: str
+    r74 :: int32
+    r75 :: bit
+    r76 :: str
+    r77 :: dict
+    r78 :: str
+    r79 :: object
+    r80 :: dict
+    r81 :: str
+    r82, r83 :: object
+    r84 :: dict
+    r85 :: str
+    r86 :: int32
+    r87 :: bit
+    r88 :: list
+    r89, r90, r91 :: object
+    r92, r93, r94, r95 :: ptr
+    r96 :: dict
+    r97 :: str
+    r98, r99 :: object
+    r100 :: dict
+    r101 :: str
+    r102 :: int32
+    r103 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -2580,98 +2584,112 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = 'typing'
-    r9 = PyImport_Import(r8)
-    typing = r9 :: module
+    r8 = __main__.globals :: static
+    r9 = PyEval_GetLocals()
+    r10 = 'List'
+    r11 = 'NewType'
+    r12 = 'NamedTuple'
+    r13 = PyList_New(3)
+    r14 = get_element_ptr r13 ob_item :: PyListObject
+    r15 = load_mem r14 :: ptr*
+    set_mem r15, r10 :: builtins.object*
+    r16 = r15 + 8
+    set_mem r16, r11 :: builtins.object*
+    r17 = r15 + 16
+    set_mem r17, r12 :: builtins.object*
+    keep_alive r13
+    r18 = 'typing'
+    r19 = PyImport_ImportModuleLevelObject(r18, r8, r9, r13, 0)
+    typing = r19 :: module
 L4:
-    r10 = typing :: module
-    r11 = __main__.globals :: static
-    r12 = 'List'
-    r13 = CPyObject_GetAttr(r10, r12)
-    r14 = 'List'
-    r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = r15 >= 0 :: signed
-    r17 = 'NewType'
-    r18 = CPyObject_GetAttr(r10, r17)
-    r19 = 'NewType'
-    r20 = CPyDict_SetItem(r11, r19, r18)
-    r21 = r20 >= 0 :: signed
-    r22 = 'NamedTuple'
-    r23 = CPyObject_GetAttr(r10, r22)
-    r24 = 'NamedTuple'
-    r25 = CPyDict_SetItem(r11, r24, r23)
+    r20 = typing :: module
+    r21 = __main__.globals :: static
+    r22 = 'List'
+    r23 = CPyObject_GetAttr(r20, r22)
+    r24 = 'List'
+    r25 = CPyDict_SetItem(r21, r24, r23)
     r26 = r25 >= 0 :: signed
-    r27 = 'Lol'
-    r28 = 'a'
-    r29 = load_address PyLong_Type
-    r30 = (r28, r29)
-    r31 = box(tuple[str, object], r30)
-    r32 = 'b'
-    r33 = load_address PyUnicode_Type
-    r34 = (r32, r33)
-    r35 = box(tuple[str, object], r34)
-    r36 = (r31, r35)
-    r37 = box(tuple[object, object], r36)
-    r38 = __main__.globals :: static
-    r39 = 'NamedTuple'
-    r40 = CPyDict_GetItem(r38, r39)
-    r41 = PyObject_CallFunctionObjArgs(r40, r27, r37, 0)
-    r42 = __main__.globals :: static
-    r43 = 'Lol'
-    r44 = CPyDict_SetItem(r42, r43, r41)
-    r45 = r44 >= 0 :: signed
-    r46 = ''
-    r47 = __main__.globals :: static
-    r48 = 'Lol'
-    r49 = CPyDict_GetItem(r47, r48)
-    r50 = box(short_int, 2)
-    r51 = PyObject_CallFunctionObjArgs(r49, r50, r46, 0)
-    r52 = cast(tuple, r51)
-    r53 = __main__.globals :: static
-    r54 = 'x'
-    r55 = CPyDict_SetItem(r53, r54, r52)
-    r56 = r55 >= 0 :: signed
+    r27 = 'NewType'
+    r28 = CPyObject_GetAttr(r20, r27)
+    r29 = 'NewType'
+    r30 = CPyDict_SetItem(r21, r29, r28)
+    r31 = r30 >= 0 :: signed
+    r32 = 'NamedTuple'
+    r33 = CPyObject_GetAttr(r20, r32)
+    r34 = 'NamedTuple'
+    r35 = CPyDict_SetItem(r21, r34, r33)
+    r36 = r35 >= 0 :: signed
+    r37 = 'Lol'
+    r38 = 'a'
+    r39 = load_address PyLong_Type
+    r40 = (r38, r39)
+    r41 = box(tuple[str, object], r40)
+    r42 = 'b'
+    r43 = load_address PyUnicode_Type
+    r44 = (r42, r43)
+    r45 = box(tuple[str, object], r44)
+    r46 = (r41, r45)
+    r47 = box(tuple[object, object], r46)
+    r48 = __main__.globals :: static
+    r49 = 'NamedTuple'
+    r50 = CPyDict_GetItem(r48, r49)
+    r51 = PyObject_CallFunctionObjArgs(r50, r37, r47, 0)
+    r52 = __main__.globals :: static
+    r53 = 'Lol'
+    r54 = CPyDict_SetItem(r52, r53, r51)
+    r55 = r54 >= 0 :: signed
+    r56 = ''
     r57 = __main__.globals :: static
-    r58 = 'List'
+    r58 = 'Lol'
     r59 = CPyDict_GetItem(r57, r58)
-    r60 = load_address PyLong_Type
-    r61 = PyObject_GetItem(r59, r60)
-    r62 = __main__.globals :: static
-    r63 = 'Foo'
-    r64 = CPyDict_SetItem(r62, r63, r61)
-    r65 = r64 >= 0 :: signed
-    r66 = 'Bar'
+    r60 = box(short_int, 2)
+    r61 = PyObject_CallFunctionObjArgs(r59, r60, r56, 0)
+    r62 = cast(tuple, r61)
+    r63 = __main__.globals :: static
+    r64 = 'x'
+    r65 = CPyDict_SetItem(r63, r64, r62)
+    r66 = r65 >= 0 :: signed
     r67 = __main__.globals :: static
-    r68 = 'Foo'
+    r68 = 'List'
     r69 = CPyDict_GetItem(r67, r68)
-    r70 = __main__.globals :: static
-    r71 = 'NewType'
-    r72 = CPyDict_GetItem(r70, r71)
-    r73 = PyObject_CallFunctionObjArgs(r72, r66, r69, 0)
-    r74 = __main__.globals :: static
-    r75 = 'Bar'
-    r76 = CPyDict_SetItem(r74, r75, r73)
-    r77 = r76 >= 0 :: signed
-    r78 = PyList_New(3)
-    r79 = box(short_int, 2)
-    r80 = box(short_int, 4)
-    r81 = box(short_int, 6)
-    r82 = get_element_ptr r78 ob_item :: PyListObject
-    r83 = load_mem r82 :: ptr*
-    set_mem r83, r79 :: builtins.object*
-    r84 = r83 + WORD_SIZE*1
-    set_mem r84, r80 :: builtins.object*
-    r85 = r83 + WORD_SIZE*2
-    set_mem r85, r81 :: builtins.object*
-    keep_alive r78
-    r86 = __main__.globals :: static
-    r87 = 'Bar'
-    r88 = CPyDict_GetItem(r86, r87)
-    r89 = PyObject_CallFunctionObjArgs(r88, r78, 0)
-    r90 = __main__.globals :: static
-    r91 = 'y'
-    r92 = CPyDict_SetItem(r90, r91, r89)
-    r93 = r92 >= 0 :: signed
+    r70 = load_address PyLong_Type
+    r71 = PyObject_GetItem(r69, r70)
+    r72 = __main__.globals :: static
+    r73 = 'Foo'
+    r74 = CPyDict_SetItem(r72, r73, r71)
+    r75 = r74 >= 0 :: signed
+    r76 = 'Bar'
+    r77 = __main__.globals :: static
+    r78 = 'Foo'
+    r79 = CPyDict_GetItem(r77, r78)
+    r80 = __main__.globals :: static
+    r81 = 'NewType'
+    r82 = CPyDict_GetItem(r80, r81)
+    r83 = PyObject_CallFunctionObjArgs(r82, r76, r79, 0)
+    r84 = __main__.globals :: static
+    r85 = 'Bar'
+    r86 = CPyDict_SetItem(r84, r85, r83)
+    r87 = r86 >= 0 :: signed
+    r88 = PyList_New(3)
+    r89 = box(short_int, 2)
+    r90 = box(short_int, 4)
+    r91 = box(short_int, 6)
+    r92 = get_element_ptr r88 ob_item :: PyListObject
+    r93 = load_mem r92 :: ptr*
+    set_mem r93, r89 :: builtins.object*
+    r94 = r93 + 8
+    set_mem r94, r90 :: builtins.object*
+    r95 = r93 + 16
+    set_mem r95, r91 :: builtins.object*
+    keep_alive r88
+    r96 = __main__.globals :: static
+    r97 = 'Bar'
+    r98 = CPyDict_GetItem(r96, r97)
+    r99 = PyObject_CallFunctionObjArgs(r98, r88, 0)
+    r100 = __main__.globals :: static
+    r101 = 'y'
+    r102 = CPyDict_SetItem(r100, r101, r99)
+    r103 = r102 >= 0 :: signed
     return 1
 
 [case testChainedConditional]
@@ -2989,27 +3007,31 @@ def __top_level__():
     r3 :: str
     r4, r5, r6 :: object
     r7 :: bit
-    r8 :: str
-    r9, r10 :: object
-    r11 :: dict
-    r12 :: str
-    r13 :: object
+    r8, r9 :: dict
+    r10 :: str
+    r11 :: list
+    r12, r13 :: ptr
     r14 :: str
-    r15 :: int32
-    r16 :: bit
+    r15, r16 :: object
     r17 :: dict
     r18 :: str
     r19 :: object
-    r20 :: dict
-    r21 :: str
-    r22, r23 :: object
-    r24 :: dict
-    r25 :: str
-    r26, r27 :: object
-    r28 :: dict
-    r29 :: str
-    r30 :: int32
-    r31 :: bit
+    r20 :: str
+    r21 :: int32
+    r22 :: bit
+    r23 :: dict
+    r24 :: str
+    r25 :: object
+    r26 :: dict
+    r27 :: str
+    r28, r29 :: object
+    r30 :: dict
+    r31 :: str
+    r32, r33 :: object
+    r34 :: dict
+    r35 :: str
+    r36 :: int32
+    r37 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -3025,32 +3047,40 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = 'typing'
-    r9 = PyImport_Import(r8)
-    typing = r9 :: module
+    r8 = __main__.globals :: static
+    r9 = PyEval_GetLocals()
+    r10 = 'Callable'
+    r11 = PyList_New(1)
+    r12 = get_element_ptr r11 ob_item :: PyListObject
+    r13 = load_mem r12 :: ptr*
+    set_mem r13, r10 :: builtins.object*
+    keep_alive r11
+    r14 = 'typing'
+    r15 = PyImport_ImportModuleLevelObject(r14, r8, r9, r11, 0)
+    typing = r15 :: module
 L4:
-    r10 = typing :: module
-    r11 = __main__.globals :: static
-    r12 = 'Callable'
-    r13 = CPyObject_GetAttr(r10, r12)
-    r14 = 'Callable'
-    r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = r15 >= 0 :: signed
+    r16 = typing :: module
     r17 = __main__.globals :: static
-    r18 = '__mypyc_c_decorator_helper__'
-    r19 = CPyDict_GetItem(r17, r18)
-    r20 = __main__.globals :: static
-    r21 = 'b'
-    r22 = CPyDict_GetItem(r20, r21)
-    r23 = PyObject_CallFunctionObjArgs(r22, r19, 0)
-    r24 = __main__.globals :: static
-    r25 = 'a'
-    r26 = CPyDict_GetItem(r24, r25)
-    r27 = PyObject_CallFunctionObjArgs(r26, r23, 0)
-    r28 = __main__.globals :: static
-    r29 = 'c'
-    r30 = CPyDict_SetItem(r28, r29, r27)
-    r31 = r30 >= 0 :: signed
+    r18 = 'Callable'
+    r19 = CPyObject_GetAttr(r16, r18)
+    r20 = 'Callable'
+    r21 = CPyDict_SetItem(r17, r20, r19)
+    r22 = r21 >= 0 :: signed
+    r23 = __main__.globals :: static
+    r24 = '__mypyc_c_decorator_helper__'
+    r25 = CPyDict_GetItem(r23, r24)
+    r26 = __main__.globals :: static
+    r27 = 'b'
+    r28 = CPyDict_GetItem(r26, r27)
+    r29 = PyObject_CallFunctionObjArgs(r28, r25, 0)
+    r30 = __main__.globals :: static
+    r31 = 'a'
+    r32 = CPyDict_GetItem(r30, r31)
+    r33 = PyObject_CallFunctionObjArgs(r32, r29, 0)
+    r34 = __main__.globals :: static
+    r35 = 'c'
+    r36 = CPyDict_SetItem(r34, r35, r33)
+    r37 = r36 >= 0 :: signed
     return 1
 
 [case testDecoratorsSimple_toplevel]
@@ -3127,14 +3157,18 @@ def __top_level__():
     r3 :: str
     r4, r5, r6 :: object
     r7 :: bit
-    r8 :: str
-    r9, r10 :: object
-    r11 :: dict
-    r12 :: str
-    r13 :: object
+    r8, r9 :: dict
+    r10 :: str
+    r11 :: list
+    r12, r13 :: ptr
     r14 :: str
-    r15 :: int32
-    r16 :: bit
+    r15, r16 :: object
+    r17 :: dict
+    r18 :: str
+    r19 :: object
+    r20 :: str
+    r21 :: int32
+    r22 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -3150,17 +3184,25 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = 'typing'
-    r9 = PyImport_Import(r8)
-    typing = r9 :: module
+    r8 = __main__.globals :: static
+    r9 = PyEval_GetLocals()
+    r10 = 'Callable'
+    r11 = PyList_New(1)
+    r12 = get_element_ptr r11 ob_item :: PyListObject
+    r13 = load_mem r12 :: ptr*
+    set_mem r13, r10 :: builtins.object*
+    keep_alive r11
+    r14 = 'typing'
+    r15 = PyImport_ImportModuleLevelObject(r14, r8, r9, r11, 0)
+    typing = r15 :: module
 L4:
-    r10 = typing :: module
-    r11 = __main__.globals :: static
-    r12 = 'Callable'
-    r13 = CPyObject_GetAttr(r10, r12)
-    r14 = 'Callable'
-    r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = r15 >= 0 :: signed
+    r16 = typing :: module
+    r17 = __main__.globals :: static
+    r18 = 'Callable'
+    r19 = CPyObject_GetAttr(r16, r18)
+    r20 = 'Callable'
+    r21 = CPyDict_SetItem(r17, r20, r19)
+    r22 = r21 >= 0 :: signed
     return 1
 
 [case testAnyAllG]

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2492,82 +2492,82 @@ def __top_level__():
     r2 :: bit
     r3 :: str
     r4 :: object
-    r5, r6 :: dict
-    r7, r8, r9 :: str
-    r10 :: list
-    r11, r12, r13, r14 :: ptr
-    r15 :: str
-    r16, r17 :: object
-    r18 :: dict
-    r19 :: str
-    r20 :: object
-    r21 :: str
-    r22 :: int32
-    r23 :: bit
-    r24 :: str
-    r25 :: object
-    r26 :: str
-    r27 :: int32
-    r28 :: bit
-    r29 :: str
-    r30 :: object
-    r31 :: str
-    r32 :: int32
-    r33 :: bit
-    r34, r35 :: str
-    r36 :: object
-    r37 :: tuple[str, object]
-    r38 :: object
-    r39 :: str
-    r40 :: object
-    r41 :: tuple[str, object]
-    r42 :: object
-    r43 :: tuple[object, object]
-    r44 :: object
-    r45 :: dict
-    r46 :: str
-    r47, r48 :: object
-    r49 :: dict
-    r50 :: str
-    r51 :: int32
-    r52 :: bit
-    r53 :: str
-    r54 :: dict
-    r55 :: str
-    r56, r57, r58 :: object
-    r59 :: tuple
-    r60 :: dict
-    r61 :: str
-    r62 :: int32
-    r63 :: bit
-    r64 :: dict
-    r65 :: str
-    r66, r67, r68 :: object
-    r69 :: dict
-    r70 :: str
-    r71 :: int32
-    r72 :: bit
-    r73 :: str
-    r74 :: dict
-    r75 :: str
-    r76 :: object
-    r77 :: dict
-    r78 :: str
-    r79, r80 :: object
-    r81 :: dict
-    r82 :: str
-    r83 :: int32
-    r84 :: bit
-    r85 :: list
-    r86, r87, r88 :: object
-    r89, r90, r91, r92 :: ptr
-    r93 :: dict
-    r94 :: str
-    r95, r96 :: object
-    r97 :: dict
-    r98 :: str
-    r99 :: int32
-    r100 :: bit
+    r5 :: dict
+    r6, r7, r8 :: str
+    r9 :: list
+    r10, r11, r12, r13 :: ptr
+    r14 :: str
+    r15, r16 :: object
+    r17 :: dict
+    r18 :: str
+    r19 :: object
+    r20 :: str
+    r21 :: int32
+    r22 :: bit
+    r23 :: str
+    r24 :: object
+    r25 :: str
+    r26 :: int32
+    r27 :: bit
+    r28 :: str
+    r29 :: object
+    r30 :: str
+    r31 :: int32
+    r32 :: bit
+    r33, r34 :: str
+    r35 :: object
+    r36 :: tuple[str, object]
+    r37 :: object
+    r38 :: str
+    r39 :: object
+    r40 :: tuple[str, object]
+    r41 :: object
+    r42 :: tuple[object, object]
+    r43 :: object
+    r44 :: dict
+    r45 :: str
+    r46, r47 :: object
+    r48 :: dict
+    r49 :: str
+    r50 :: int32
+    r51 :: bit
+    r52 :: str
+    r53 :: dict
+    r54 :: str
+    r55, r56, r57 :: object
+    r58 :: tuple
+    r59 :: dict
+    r60 :: str
+    r61 :: int32
+    r62 :: bit
+    r63 :: dict
+    r64 :: str
+    r65, r66, r67 :: object
+    r68 :: dict
+    r69 :: str
+    r70 :: int32
+    r71 :: bit
+    r72 :: str
+    r73 :: dict
+    r74 :: str
+    r75 :: object
+    r76 :: dict
+    r77 :: str
+    r78, r79 :: object
+    r80 :: dict
+    r81 :: str
+    r82 :: int32
+    r83 :: bit
+    r84 :: list
+    r85, r86, r87 :: object
+    r88, r89, r90, r91 :: ptr
+    r92 :: dict
+    r93 :: str
+    r94, r95 :: object
+    r96 :: dict
+    r97 :: str
+    r98 :: int32
+    r99 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -2579,110 +2579,109 @@ L1:
     builtins = r4 :: module
 L2:
     r5 = __main__.globals :: static
-    r6 = PyEval_GetLocals()
-    r7 = 'List'
-    r8 = 'NewType'
-    r9 = 'NamedTuple'
-    r10 = PyList_New(3)
-    r11 = get_element_ptr r10 ob_item :: PyListObject
-    r12 = load_mem r11 :: ptr*
+    r6 = 'List'
+    r7 = 'NewType'
+    r8 = 'NamedTuple'
+    r9 = PyList_New(3)
+    r10 = get_element_ptr r9 ob_item :: PyListObject
+    r11 = load_mem r10 :: ptr*
+    set_mem r11, r6 :: builtins.object*
+    r12 = r11 + WORD_SIZE*1
     set_mem r12, r7 :: builtins.object*
-    r13 = r12 + WORD_SIZE*1
+    r13 = r11 + WORD_SIZE*2
     set_mem r13, r8 :: builtins.object*
-    r14 = r12 + WORD_SIZE*2
-    set_mem r14, r9 :: builtins.object*
-    keep_alive r10
-    r15 = 'typing'
-    r16 = PyImport_ImportModuleLevelObject(r15, r5, r6, r10, 0)
-    typing = r16 :: module
-    r17 = typing :: module
-    r18 = __main__.globals :: static
-    r19 = 'List'
-    r20 = CPyObject_GetAttr(r17, r19)
-    r21 = 'List'
-    r22 = CPyDict_SetItem(r18, r21, r20)
-    r23 = r22 >= 0 :: signed
-    r24 = 'NewType'
-    r25 = CPyObject_GetAttr(r17, r24)
-    r26 = 'NewType'
-    r27 = CPyDict_SetItem(r18, r26, r25)
-    r28 = r27 >= 0 :: signed
-    r29 = 'NamedTuple'
-    r30 = CPyObject_GetAttr(r17, r29)
-    r31 = 'NamedTuple'
-    r32 = CPyDict_SetItem(r18, r31, r30)
-    r33 = r32 >= 0 :: signed
-    r34 = 'Lol'
-    r35 = 'a'
-    r36 = load_address PyLong_Type
-    r37 = (r35, r36)
-    r38 = box(tuple[str, object], r37)
-    r39 = 'b'
-    r40 = load_address PyUnicode_Type
-    r41 = (r39, r40)
-    r42 = box(tuple[str, object], r41)
-    r43 = (r38, r42)
-    r44 = box(tuple[object, object], r43)
-    r45 = __main__.globals :: static
-    r46 = 'NamedTuple'
-    r47 = CPyDict_GetItem(r45, r46)
-    r48 = PyObject_CallFunctionObjArgs(r47, r34, r44, 0)
-    r49 = __main__.globals :: static
-    r50 = 'Lol'
-    r51 = CPyDict_SetItem(r49, r50, r48)
-    r52 = r51 >= 0 :: signed
-    r53 = ''
-    r54 = __main__.globals :: static
-    r55 = 'Lol'
-    r56 = CPyDict_GetItem(r54, r55)
-    r57 = box(short_int, 2)
-    r58 = PyObject_CallFunctionObjArgs(r56, r57, r53, 0)
-    r59 = cast(tuple, r58)
-    r60 = __main__.globals :: static
-    r61 = 'x'
-    r62 = CPyDict_SetItem(r60, r61, r59)
-    r63 = r62 >= 0 :: signed
-    r64 = __main__.globals :: static
-    r65 = 'List'
-    r66 = CPyDict_GetItem(r64, r65)
-    r67 = load_address PyLong_Type
-    r68 = PyObject_GetItem(r66, r67)
-    r69 = __main__.globals :: static
-    r70 = 'Foo'
-    r71 = CPyDict_SetItem(r69, r70, r68)
-    r72 = r71 >= 0 :: signed
-    r73 = 'Bar'
-    r74 = __main__.globals :: static
-    r75 = 'Foo'
-    r76 = CPyDict_GetItem(r74, r75)
-    r77 = __main__.globals :: static
-    r78 = 'NewType'
-    r79 = CPyDict_GetItem(r77, r78)
-    r80 = PyObject_CallFunctionObjArgs(r79, r73, r76, 0)
-    r81 = __main__.globals :: static
-    r82 = 'Bar'
-    r83 = CPyDict_SetItem(r81, r82, r80)
-    r84 = r83 >= 0 :: signed
-    r85 = PyList_New(3)
-    r86 = box(short_int, 2)
-    r87 = box(short_int, 4)
-    r88 = box(short_int, 6)
-    r89 = get_element_ptr r85 ob_item :: PyListObject
-    r90 = load_mem r89 :: ptr*
+    keep_alive r9
+    r14 = 'typing'
+    r15 = PyImport_ImportModuleLevelObject(r14, r5, 0, r9, 0)
+    typing = r15 :: module
+    r16 = typing :: module
+    r17 = __main__.globals :: static
+    r18 = 'List'
+    r19 = CPyObject_GetAttr(r16, r18)
+    r20 = 'List'
+    r21 = CPyDict_SetItem(r17, r20, r19)
+    r22 = r21 >= 0 :: signed
+    r23 = 'NewType'
+    r24 = CPyObject_GetAttr(r16, r23)
+    r25 = 'NewType'
+    r26 = CPyDict_SetItem(r17, r25, r24)
+    r27 = r26 >= 0 :: signed
+    r28 = 'NamedTuple'
+    r29 = CPyObject_GetAttr(r16, r28)
+    r30 = 'NamedTuple'
+    r31 = CPyDict_SetItem(r17, r30, r29)
+    r32 = r31 >= 0 :: signed
+    r33 = 'Lol'
+    r34 = 'a'
+    r35 = load_address PyLong_Type
+    r36 = (r34, r35)
+    r37 = box(tuple[str, object], r36)
+    r38 = 'b'
+    r39 = load_address PyUnicode_Type
+    r40 = (r38, r39)
+    r41 = box(tuple[str, object], r40)
+    r42 = (r37, r41)
+    r43 = box(tuple[object, object], r42)
+    r44 = __main__.globals :: static
+    r45 = 'NamedTuple'
+    r46 = CPyDict_GetItem(r44, r45)
+    r47 = PyObject_CallFunctionObjArgs(r46, r33, r43, 0)
+    r48 = __main__.globals :: static
+    r49 = 'Lol'
+    r50 = CPyDict_SetItem(r48, r49, r47)
+    r51 = r50 >= 0 :: signed
+    r52 = ''
+    r53 = __main__.globals :: static
+    r54 = 'Lol'
+    r55 = CPyDict_GetItem(r53, r54)
+    r56 = box(short_int, 2)
+    r57 = PyObject_CallFunctionObjArgs(r55, r56, r52, 0)
+    r58 = cast(tuple, r57)
+    r59 = __main__.globals :: static
+    r60 = 'x'
+    r61 = CPyDict_SetItem(r59, r60, r58)
+    r62 = r61 >= 0 :: signed
+    r63 = __main__.globals :: static
+    r64 = 'List'
+    r65 = CPyDict_GetItem(r63, r64)
+    r66 = load_address PyLong_Type
+    r67 = PyObject_GetItem(r65, r66)
+    r68 = __main__.globals :: static
+    r69 = 'Foo'
+    r70 = CPyDict_SetItem(r68, r69, r67)
+    r71 = r70 >= 0 :: signed
+    r72 = 'Bar'
+    r73 = __main__.globals :: static
+    r74 = 'Foo'
+    r75 = CPyDict_GetItem(r73, r74)
+    r76 = __main__.globals :: static
+    r77 = 'NewType'
+    r78 = CPyDict_GetItem(r76, r77)
+    r79 = PyObject_CallFunctionObjArgs(r78, r72, r75, 0)
+    r80 = __main__.globals :: static
+    r81 = 'Bar'
+    r82 = CPyDict_SetItem(r80, r81, r79)
+    r83 = r82 >= 0 :: signed
+    r84 = PyList_New(3)
+    r85 = box(short_int, 2)
+    r86 = box(short_int, 4)
+    r87 = box(short_int, 6)
+    r88 = get_element_ptr r84 ob_item :: PyListObject
+    r89 = load_mem r88 :: ptr*
+    set_mem r89, r85 :: builtins.object*
+    r90 = r89 + WORD_SIZE*1
     set_mem r90, r86 :: builtins.object*
-    r91 = r90 + WORD_SIZE*1
+    r91 = r89 + WORD_SIZE*2
     set_mem r91, r87 :: builtins.object*
-    r92 = r90 + WORD_SIZE*2
-    set_mem r92, r88 :: builtins.object*
-    keep_alive r85
-    r93 = __main__.globals :: static
-    r94 = 'Bar'
-    r95 = CPyDict_GetItem(r93, r94)
-    r96 = PyObject_CallFunctionObjArgs(r95, r85, 0)
-    r97 = __main__.globals :: static
-    r98 = 'y'
-    r99 = CPyDict_SetItem(r97, r98, r96)
-    r100 = r99 >= 0 :: signed
+    keep_alive r84
+    r92 = __main__.globals :: static
+    r93 = 'Bar'
+    r94 = CPyDict_GetItem(r92, r93)
+    r95 = PyObject_CallFunctionObjArgs(r94, r84, 0)
+    r96 = __main__.globals :: static
+    r97 = 'y'
+    r98 = CPyDict_SetItem(r96, r97, r95)
+    r99 = r98 >= 0 :: signed
     return 1
 
 [case testChainedConditional]
@@ -2999,31 +2998,31 @@ def __top_level__():
     r2 :: bit
     r3 :: str
     r4 :: object
-    r5, r6 :: dict
-    r7 :: str
-    r8 :: list
-    r9, r10 :: ptr
-    r11 :: str
-    r12, r13 :: object
-    r14 :: dict
-    r15 :: str
-    r16 :: object
-    r17 :: str
-    r18 :: int32
-    r19 :: bit
-    r20 :: dict
-    r21 :: str
-    r22 :: object
-    r23 :: dict
-    r24 :: str
-    r25, r26 :: object
-    r27 :: dict
-    r28 :: str
-    r29, r30 :: object
-    r31 :: dict
-    r32 :: str
-    r33 :: int32
-    r34 :: bit
+    r5 :: dict
+    r6 :: str
+    r7 :: list
+    r8, r9 :: ptr
+    r10 :: str
+    r11, r12 :: object
+    r13 :: dict
+    r14 :: str
+    r15 :: object
+    r16 :: str
+    r17 :: int32
+    r18 :: bit
+    r19 :: dict
+    r20 :: str
+    r21 :: object
+    r22 :: dict
+    r23 :: str
+    r24, r25 :: object
+    r26 :: dict
+    r27 :: str
+    r28, r29 :: object
+    r30 :: dict
+    r31 :: str
+    r32 :: int32
+    r33 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -3035,38 +3034,37 @@ L1:
     builtins = r4 :: module
 L2:
     r5 = __main__.globals :: static
-    r6 = PyEval_GetLocals()
-    r7 = 'Callable'
-    r8 = PyList_New(1)
-    r9 = get_element_ptr r8 ob_item :: PyListObject
-    r10 = load_mem r9 :: ptr*
-    set_mem r10, r7 :: builtins.object*
-    keep_alive r8
-    r11 = 'typing'
-    r12 = PyImport_ImportModuleLevelObject(r11, r5, r6, r8, 0)
-    typing = r12 :: module
-    r13 = typing :: module
-    r14 = __main__.globals :: static
-    r15 = 'Callable'
-    r16 = CPyObject_GetAttr(r13, r15)
-    r17 = 'Callable'
-    r18 = CPyDict_SetItem(r14, r17, r16)
-    r19 = r18 >= 0 :: signed
-    r20 = __main__.globals :: static
-    r21 = '__mypyc_c_decorator_helper__'
-    r22 = CPyDict_GetItem(r20, r21)
-    r23 = __main__.globals :: static
-    r24 = 'b'
-    r25 = CPyDict_GetItem(r23, r24)
-    r26 = PyObject_CallFunctionObjArgs(r25, r22, 0)
-    r27 = __main__.globals :: static
-    r28 = 'a'
-    r29 = CPyDict_GetItem(r27, r28)
-    r30 = PyObject_CallFunctionObjArgs(r29, r26, 0)
-    r31 = __main__.globals :: static
-    r32 = 'c'
-    r33 = CPyDict_SetItem(r31, r32, r30)
-    r34 = r33 >= 0 :: signed
+    r6 = 'Callable'
+    r7 = PyList_New(1)
+    r8 = get_element_ptr r7 ob_item :: PyListObject
+    r9 = load_mem r8 :: ptr*
+    set_mem r9, r6 :: builtins.object*
+    keep_alive r7
+    r10 = 'typing'
+    r11 = PyImport_ImportModuleLevelObject(r10, r5, 0, r7, 0)
+    typing = r11 :: module
+    r12 = typing :: module
+    r13 = __main__.globals :: static
+    r14 = 'Callable'
+    r15 = CPyObject_GetAttr(r12, r14)
+    r16 = 'Callable'
+    r17 = CPyDict_SetItem(r13, r16, r15)
+    r18 = r17 >= 0 :: signed
+    r19 = __main__.globals :: static
+    r20 = '__mypyc_c_decorator_helper__'
+    r21 = CPyDict_GetItem(r19, r20)
+    r22 = __main__.globals :: static
+    r23 = 'b'
+    r24 = CPyDict_GetItem(r22, r23)
+    r25 = PyObject_CallFunctionObjArgs(r24, r21, 0)
+    r26 = __main__.globals :: static
+    r27 = 'a'
+    r28 = CPyDict_GetItem(r26, r27)
+    r29 = PyObject_CallFunctionObjArgs(r28, r25, 0)
+    r30 = __main__.globals :: static
+    r31 = 'c'
+    r32 = CPyDict_SetItem(r30, r31, r29)
+    r33 = r32 >= 0 :: signed
     return 1
 
 [case testDecoratorsSimple_toplevel]
@@ -3142,18 +3140,18 @@ def __top_level__():
     r2 :: bit
     r3 :: str
     r4 :: object
-    r5, r6 :: dict
-    r7 :: str
-    r8 :: list
-    r9, r10 :: ptr
-    r11 :: str
-    r12, r13 :: object
-    r14 :: dict
-    r15 :: str
-    r16 :: object
-    r17 :: str
-    r18 :: int32
-    r19 :: bit
+    r5 :: dict
+    r6 :: str
+    r7 :: list
+    r8, r9 :: ptr
+    r10 :: str
+    r11, r12 :: object
+    r13 :: dict
+    r14 :: str
+    r15 :: object
+    r16 :: str
+    r17 :: int32
+    r18 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -3165,23 +3163,22 @@ L1:
     builtins = r4 :: module
 L2:
     r5 = __main__.globals :: static
-    r6 = PyEval_GetLocals()
-    r7 = 'Callable'
-    r8 = PyList_New(1)
-    r9 = get_element_ptr r8 ob_item :: PyListObject
-    r10 = load_mem r9 :: ptr*
-    set_mem r10, r7 :: builtins.object*
-    keep_alive r8
-    r11 = 'typing'
-    r12 = PyImport_ImportModuleLevelObject(r11, r5, r6, r8, 0)
-    typing = r12 :: module
-    r13 = typing :: module
-    r14 = __main__.globals :: static
-    r15 = 'Callable'
-    r16 = CPyObject_GetAttr(r13, r15)
-    r17 = 'Callable'
-    r18 = CPyDict_SetItem(r14, r17, r16)
-    r19 = r18 >= 0 :: signed
+    r6 = 'Callable'
+    r7 = PyList_New(1)
+    r8 = get_element_ptr r7 ob_item :: PyListObject
+    r9 = load_mem r8 :: ptr*
+    set_mem r9, r6 :: builtins.object*
+    keep_alive r7
+    r10 = 'typing'
+    r11 = PyImport_ImportModuleLevelObject(r10, r5, 0, r7, 0)
+    typing = r11 :: module
+    r12 = typing :: module
+    r13 = __main__.globals :: static
+    r14 = 'Callable'
+    r15 = CPyObject_GetAttr(r12, r14)
+    r16 = 'Callable'
+    r17 = CPyDict_SetItem(r13, r16, r15)
+    r18 = r17 >= 0 :: signed
     return 1
 
 [case testAnyAllG]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -291,85 +291,85 @@ def __top_level__():
     r2 :: bit
     r3 :: str
     r4 :: object
-    r5, r6 :: dict
-    r7, r8 :: str
-    r9 :: list
-    r10, r11, r12 :: ptr
-    r13 :: str
-    r14, r15 :: object
-    r16 :: dict
-    r17 :: str
-    r18 :: object
-    r19 :: str
-    r20 :: int32
-    r21 :: bit
-    r22 :: str
-    r23 :: object
-    r24 :: str
-    r25 :: int32
-    r26 :: bit
-    r27, r28 :: dict
-    r29 :: str
-    r30 :: list
-    r31, r32 :: ptr
-    r33 :: str
-    r34, r35 :: object
-    r36 :: dict
+    r5 :: dict
+    r6, r7 :: str
+    r8 :: list
+    r9, r10, r11 :: ptr
+    r12 :: str
+    r13, r14 :: object
+    r15 :: dict
+    r16 :: str
+    r17 :: object
+    r18 :: str
+    r19 :: int32
+    r20 :: bit
+    r21 :: str
+    r22 :: object
+    r23 :: str
+    r24 :: int32
+    r25 :: bit
+    r26 :: dict
+    r27 :: str
+    r28 :: list
+    r29, r30 :: ptr
+    r31 :: str
+    r32, r33 :: object
+    r34 :: dict
+    r35 :: str
+    r36 :: object
     r37 :: str
-    r38 :: object
-    r39 :: str
-    r40 :: int32
-    r41 :: bit
+    r38 :: int32
+    r39 :: bit
+    r40 :: str
+    r41 :: dict
     r42 :: str
-    r43 :: dict
-    r44 :: str
-    r45, r46 :: object
-    r47 :: dict
-    r48 :: str
-    r49 :: int32
-    r50 :: bit
-    r51 :: object
-    r52 :: str
-    r53, r54 :: object
-    r55 :: bool
-    r56 :: str
-    r57 :: tuple
-    r58 :: int32
-    r59 :: bit
-    r60 :: dict
-    r61 :: str
-    r62 :: int32
-    r63 :: bit
-    r64 :: object
-    r65 :: str
-    r66, r67 :: object
-    r68 :: str
-    r69 :: tuple
-    r70 :: int32
-    r71 :: bit
-    r72 :: dict
-    r73 :: str
-    r74 :: int32
-    r75 :: bit
-    r76, r77 :: object
-    r78 :: dict
-    r79 :: str
-    r80 :: object
-    r81 :: dict
-    r82 :: str
-    r83, r84 :: object
-    r85 :: tuple
-    r86 :: str
-    r87, r88 :: object
-    r89 :: bool
-    r90, r91 :: str
-    r92 :: tuple
-    r93 :: int32
-    r94 :: bit
-    r95 :: dict
-    r96 :: str
-    r97 :: int32
-    r98 :: bit
+    r43, r44 :: object
+    r45 :: dict
+    r46 :: str
+    r47 :: int32
+    r48 :: bit
+    r49 :: object
+    r50 :: str
+    r51, r52 :: object
+    r53 :: bool
+    r54 :: str
+    r55 :: tuple
+    r56 :: int32
+    r57 :: bit
+    r58 :: dict
+    r59 :: str
+    r60 :: int32
+    r61 :: bit
+    r62 :: object
+    r63 :: str
+    r64, r65 :: object
+    r66 :: str
+    r67 :: tuple
+    r68 :: int32
+    r69 :: bit
+    r70 :: dict
+    r71 :: str
+    r72 :: int32
+    r73 :: bit
+    r74, r75 :: object
+    r76 :: dict
+    r77 :: str
+    r78 :: object
+    r79 :: dict
+    r80 :: str
+    r81, r82 :: object
+    r83 :: tuple
+    r84 :: str
+    r85, r86 :: object
+    r87 :: bool
+    r88, r89 :: str
+    r90 :: tuple
+    r91 :: int32
+    r92 :: bit
+    r93 :: dict
+    r94 :: str
+    r95 :: int32
+    r96 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -381,109 +381,107 @@ L1:
     builtins = r4 :: module
 L2:
     r5 = __main__.globals :: static
-    r6 = PyEval_GetLocals()
-    r7 = 'TypeVar'
-    r8 = 'Generic'
-    r9 = PyList_New(2)
-    r10 = get_element_ptr r9 ob_item :: PyListObject
-    r11 = load_mem r10 :: ptr*
+    r6 = 'TypeVar'
+    r7 = 'Generic'
+    r8 = PyList_New(2)
+    r9 = get_element_ptr r8 ob_item :: PyListObject
+    r10 = load_mem r9 :: ptr*
+    set_mem r10, r6 :: builtins.object*
+    r11 = r10 + WORD_SIZE*1
     set_mem r11, r7 :: builtins.object*
-    r12 = r11 + WORD_SIZE*1
-    set_mem r12, r8 :: builtins.object*
-    keep_alive r9
-    r13 = 'typing'
-    r14 = PyImport_ImportModuleLevelObject(r13, r5, r6, r9, 0)
-    typing = r14 :: module
-    r15 = typing :: module
-    r16 = __main__.globals :: static
-    r17 = 'TypeVar'
-    r18 = CPyObject_GetAttr(r15, r17)
-    r19 = 'TypeVar'
-    r20 = CPyDict_SetItem(r16, r19, r18)
-    r21 = r20 >= 0 :: signed
-    r22 = 'Generic'
-    r23 = CPyObject_GetAttr(r15, r22)
-    r24 = 'Generic'
-    r25 = CPyDict_SetItem(r16, r24, r23)
-    r26 = r25 >= 0 :: signed
-    r27 = __main__.globals :: static
-    r28 = PyEval_GetLocals()
-    r29 = 'trait'
-    r30 = PyList_New(1)
-    r31 = get_element_ptr r30 ob_item :: PyListObject
-    r32 = load_mem r31 :: ptr*
-    set_mem r32, r29 :: builtins.object*
-    keep_alive r30
-    r33 = 'mypy_extensions'
-    r34 = PyImport_ImportModuleLevelObject(r33, r27, r28, r30, 0)
-    mypy_extensions = r34 :: module
-    r35 = mypy_extensions :: module
-    r36 = __main__.globals :: static
+    keep_alive r8
+    r12 = 'typing'
+    r13 = PyImport_ImportModuleLevelObject(r12, r5, 0, r8, 0)
+    typing = r13 :: module
+    r14 = typing :: module
+    r15 = __main__.globals :: static
+    r16 = 'TypeVar'
+    r17 = CPyObject_GetAttr(r14, r16)
+    r18 = 'TypeVar'
+    r19 = CPyDict_SetItem(r15, r18, r17)
+    r20 = r19 >= 0 :: signed
+    r21 = 'Generic'
+    r22 = CPyObject_GetAttr(r14, r21)
+    r23 = 'Generic'
+    r24 = CPyDict_SetItem(r15, r23, r22)
+    r25 = r24 >= 0 :: signed
+    r26 = __main__.globals :: static
+    r27 = 'trait'
+    r28 = PyList_New(1)
+    r29 = get_element_ptr r28 ob_item :: PyListObject
+    r30 = load_mem r29 :: ptr*
+    set_mem r30, r27 :: builtins.object*
+    keep_alive r28
+    r31 = 'mypy_extensions'
+    r32 = PyImport_ImportModuleLevelObject(r31, r26, 0, r28, 0)
+    mypy_extensions = r32 :: module
+    r33 = mypy_extensions :: module
+    r34 = __main__.globals :: static
+    r35 = 'trait'
+    r36 = CPyObject_GetAttr(r33, r35)
     r37 = 'trait'
-    r38 = CPyObject_GetAttr(r35, r37)
-    r39 = 'trait'
-    r40 = CPyDict_SetItem(r36, r39, r38)
-    r41 = r40 >= 0 :: signed
-    r42 = 'T'
-    r43 = __main__.globals :: static
-    r44 = 'TypeVar'
-    r45 = CPyDict_GetItem(r43, r44)
-    r46 = PyObject_CallFunctionObjArgs(r45, r42, 0)
-    r47 = __main__.globals :: static
-    r48 = 'T'
-    r49 = CPyDict_SetItem(r47, r48, r46)
-    r50 = r49 >= 0 :: signed
-    r51 = <error> :: object
-    r52 = '__main__'
-    r53 = __main__.C_template :: type
-    r54 = CPyType_FromTemplate(r53, r51, r52)
-    r55 = C_trait_vtable_setup()
-    r56 = '__mypyc_attrs__'
-    r57 = PyTuple_Pack(0)
-    r58 = PyObject_SetAttr(r54, r56, r57)
-    r59 = r58 >= 0 :: signed
-    __main__.C = r54 :: type
-    r60 = __main__.globals :: static
-    r61 = 'C'
-    r62 = CPyDict_SetItem(r60, r61, r54)
-    r63 = r62 >= 0 :: signed
-    r64 = <error> :: object
-    r65 = '__main__'
-    r66 = __main__.S_template :: type
-    r67 = CPyType_FromTemplate(r66, r64, r65)
-    r68 = '__mypyc_attrs__'
-    r69 = PyTuple_Pack(0)
-    r70 = PyObject_SetAttr(r67, r68, r69)
-    r71 = r70 >= 0 :: signed
-    __main__.S = r67 :: type
-    r72 = __main__.globals :: static
-    r73 = 'S'
-    r74 = CPyDict_SetItem(r72, r73, r67)
-    r75 = r74 >= 0 :: signed
-    r76 = __main__.C :: type
-    r77 = __main__.S :: type
-    r78 = __main__.globals :: static
-    r79 = 'Generic'
-    r80 = CPyDict_GetItem(r78, r79)
-    r81 = __main__.globals :: static
-    r82 = 'T'
-    r83 = CPyDict_GetItem(r81, r82)
-    r84 = PyObject_GetItem(r80, r83)
-    r85 = PyTuple_Pack(3, r76, r77, r84)
-    r86 = '__main__'
-    r87 = __main__.D_template :: type
-    r88 = CPyType_FromTemplate(r87, r85, r86)
-    r89 = D_trait_vtable_setup()
-    r90 = '__mypyc_attrs__'
-    r91 = '__dict__'
-    r92 = PyTuple_Pack(1, r91)
-    r93 = PyObject_SetAttr(r88, r90, r92)
-    r94 = r93 >= 0 :: signed
-    __main__.D = r88 :: type
-    r95 = __main__.globals :: static
-    r96 = 'D'
-    r97 = CPyDict_SetItem(r95, r96, r88)
-    r98 = r97 >= 0 :: signed
+    r38 = CPyDict_SetItem(r34, r37, r36)
+    r39 = r38 >= 0 :: signed
+    r40 = 'T'
+    r41 = __main__.globals :: static
+    r42 = 'TypeVar'
+    r43 = CPyDict_GetItem(r41, r42)
+    r44 = PyObject_CallFunctionObjArgs(r43, r40, 0)
+    r45 = __main__.globals :: static
+    r46 = 'T'
+    r47 = CPyDict_SetItem(r45, r46, r44)
+    r48 = r47 >= 0 :: signed
+    r49 = <error> :: object
+    r50 = '__main__'
+    r51 = __main__.C_template :: type
+    r52 = CPyType_FromTemplate(r51, r49, r50)
+    r53 = C_trait_vtable_setup()
+    r54 = '__mypyc_attrs__'
+    r55 = PyTuple_Pack(0)
+    r56 = PyObject_SetAttr(r52, r54, r55)
+    r57 = r56 >= 0 :: signed
+    __main__.C = r52 :: type
+    r58 = __main__.globals :: static
+    r59 = 'C'
+    r60 = CPyDict_SetItem(r58, r59, r52)
+    r61 = r60 >= 0 :: signed
+    r62 = <error> :: object
+    r63 = '__main__'
+    r64 = __main__.S_template :: type
+    r65 = CPyType_FromTemplate(r64, r62, r63)
+    r66 = '__mypyc_attrs__'
+    r67 = PyTuple_Pack(0)
+    r68 = PyObject_SetAttr(r65, r66, r67)
+    r69 = r68 >= 0 :: signed
+    __main__.S = r65 :: type
+    r70 = __main__.globals :: static
+    r71 = 'S'
+    r72 = CPyDict_SetItem(r70, r71, r65)
+    r73 = r72 >= 0 :: signed
+    r74 = __main__.C :: type
+    r75 = __main__.S :: type
+    r76 = __main__.globals :: static
+    r77 = 'Generic'
+    r78 = CPyDict_GetItem(r76, r77)
+    r79 = __main__.globals :: static
+    r80 = 'T'
+    r81 = CPyDict_GetItem(r79, r80)
+    r82 = PyObject_GetItem(r78, r81)
+    r83 = PyTuple_Pack(3, r74, r75, r82)
+    r84 = '__main__'
+    r85 = __main__.D_template :: type
+    r86 = CPyType_FromTemplate(r85, r83, r84)
+    r87 = D_trait_vtable_setup()
+    r88 = '__mypyc_attrs__'
+    r89 = '__dict__'
+    r90 = PyTuple_Pack(1, r89)
+    r91 = PyObject_SetAttr(r86, r88, r90)
+    r92 = r91 >= 0 :: signed
+    __main__.D = r86 :: type
+    r93 = __main__.globals :: static
+    r94 = 'D'
+    r95 = CPyDict_SetItem(r93, r94, r86)
+    r96 = r95 >= 0 :: signed
     return 1
 
 [case testIsInstance]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -290,89 +290,86 @@ def __top_level__():
     r0, r1 :: object
     r2 :: bit
     r3 :: str
-    r4, r5, r6 :: object
-    r7 :: bit
-    r8, r9 :: dict
-    r10, r11 :: str
-    r12 :: list
-    r13, r14, r15 :: ptr
-    r16 :: str
-    r17, r18 :: object
-    r19 :: dict
-    r20 :: str
-    r21 :: object
+    r4 :: object
+    r5, r6 :: dict
+    r7, r8 :: str
+    r9 :: list
+    r10, r11, r12 :: ptr
+    r13 :: str
+    r14, r15 :: object
+    r16 :: dict
+    r17 :: str
+    r18 :: object
+    r19 :: str
+    r20 :: int32
+    r21 :: bit
     r22 :: str
-    r23 :: int32
-    r24 :: bit
-    r25 :: str
-    r26 :: object
-    r27 :: str
-    r28 :: int32
-    r29 :: bit
-    r30, r31 :: object
-    r32 :: bit
-    r33, r34 :: dict
-    r35 :: str
-    r36 :: list
-    r37, r38 :: ptr
+    r23 :: object
+    r24 :: str
+    r25 :: int32
+    r26 :: bit
+    r27, r28 :: dict
+    r29 :: str
+    r30 :: list
+    r31, r32 :: ptr
+    r33 :: str
+    r34, r35 :: object
+    r36 :: dict
+    r37 :: str
+    r38 :: object
     r39 :: str
-    r40, r41 :: object
-    r42 :: dict
-    r43 :: str
-    r44 :: object
-    r45 :: str
-    r46 :: int32
-    r47 :: bit
+    r40 :: int32
+    r41 :: bit
+    r42 :: str
+    r43 :: dict
+    r44 :: str
+    r45, r46 :: object
+    r47 :: dict
     r48 :: str
-    r49 :: dict
-    r50 :: str
-    r51, r52 :: object
-    r53 :: dict
-    r54 :: str
-    r55 :: int32
-    r56 :: bit
-    r57 :: object
-    r58 :: str
-    r59, r60 :: object
-    r61 :: bool
-    r62 :: str
-    r63 :: tuple
-    r64 :: int32
-    r65 :: bit
-    r66 :: dict
-    r67 :: str
-    r68 :: int32
-    r69 :: bit
-    r70 :: object
-    r71 :: str
-    r72, r73 :: object
-    r74 :: str
-    r75 :: tuple
-    r76 :: int32
-    r77 :: bit
+    r49 :: int32
+    r50 :: bit
+    r51 :: object
+    r52 :: str
+    r53, r54 :: object
+    r55 :: bool
+    r56 :: str
+    r57 :: tuple
+    r58 :: int32
+    r59 :: bit
+    r60 :: dict
+    r61 :: str
+    r62 :: int32
+    r63 :: bit
+    r64 :: object
+    r65 :: str
+    r66, r67 :: object
+    r68 :: str
+    r69 :: tuple
+    r70 :: int32
+    r71 :: bit
+    r72 :: dict
+    r73 :: str
+    r74 :: int32
+    r75 :: bit
+    r76, r77 :: object
     r78 :: dict
     r79 :: str
-    r80 :: int32
-    r81 :: bit
-    r82, r83 :: object
-    r84 :: dict
-    r85 :: str
-    r86 :: object
-    r87 :: dict
-    r88 :: str
-    r89, r90 :: object
-    r91 :: tuple
-    r92 :: str
-    r93, r94 :: object
-    r95 :: bool
-    r96, r97 :: str
-    r98 :: tuple
-    r99 :: int32
-    r100 :: bit
-    r101 :: dict
-    r102 :: str
-    r103 :: int32
-    r104 :: bit
+    r80 :: object
+    r81 :: dict
+    r82 :: str
+    r83, r84 :: object
+    r85 :: tuple
+    r86 :: str
+    r87, r88 :: object
+    r89 :: bool
+    r90, r91 :: str
+    r92 :: tuple
+    r93 :: int32
+    r94 :: bit
+    r95 :: dict
+    r96 :: str
+    r97 :: int32
+    r98 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -383,122 +380,110 @@ L1:
     r4 = PyImport_Import(r3)
     builtins = r4 :: module
 L2:
-    r5 = typing :: module
-    r6 = load_address _Py_NoneStruct
-    r7 = r5 != r6
-    if r7 goto L4 else goto L3 :: bool
-L3:
-    r8 = __main__.globals :: static
-    r9 = PyEval_GetLocals()
-    r10 = 'TypeVar'
-    r11 = 'Generic'
-    r12 = PyList_New(2)
-    r13 = get_element_ptr r12 ob_item :: PyListObject
-    r14 = load_mem r13 :: ptr*
-    set_mem r14, r10 :: builtins.object*
-    r15 = r14 + WORD_SIZE*1
-    set_mem r15, r11 :: builtins.object*
-    keep_alive r12
-    r16 = 'typing'
-    r17 = PyImport_ImportModuleLevelObject(r16, r8, r9, r12, 0)
-    typing = r17 :: module
-L4:
-    r18 = typing :: module
-    r19 = __main__.globals :: static
-    r20 = 'TypeVar'
-    r21 = CPyObject_GetAttr(r18, r20)
-    r22 = 'TypeVar'
-    r23 = CPyDict_SetItem(r19, r22, r21)
-    r24 = r23 >= 0 :: signed
-    r25 = 'Generic'
-    r26 = CPyObject_GetAttr(r18, r25)
-    r27 = 'Generic'
-    r28 = CPyDict_SetItem(r19, r27, r26)
-    r29 = r28 >= 0 :: signed
-    r30 = mypy_extensions :: module
-    r31 = load_address _Py_NoneStruct
-    r32 = r30 != r31
-    if r32 goto L6 else goto L5 :: bool
-L5:
-    r33 = __main__.globals :: static
-    r34 = PyEval_GetLocals()
-    r35 = 'trait'
-    r36 = PyList_New(1)
-    r37 = get_element_ptr r36 ob_item :: PyListObject
-    r38 = load_mem r37 :: ptr*
-    set_mem r38, r35 :: builtins.object*
-    keep_alive r36
-    r39 = 'mypy_extensions'
-    r40 = PyImport_ImportModuleLevelObject(r39, r33, r34, r36, 0)
-    mypy_extensions = r40 :: module
-L6:
-    r41 = mypy_extensions :: module
-    r42 = __main__.globals :: static
-    r43 = 'trait'
-    r44 = CPyObject_GetAttr(r41, r43)
-    r45 = 'trait'
-    r46 = CPyDict_SetItem(r42, r45, r44)
-    r47 = r46 >= 0 :: signed
+    r5 = __main__.globals :: static
+    r6 = PyEval_GetLocals()
+    r7 = 'TypeVar'
+    r8 = 'Generic'
+    r9 = PyList_New(2)
+    r10 = get_element_ptr r9 ob_item :: PyListObject
+    r11 = load_mem r10 :: ptr*
+    set_mem r11, r7 :: builtins.object*
+    r12 = r11 + 8
+    set_mem r12, r8 :: builtins.object*
+    keep_alive r9
+    r13 = 'typing'
+    r14 = PyImport_ImportModuleLevelObject(r13, r5, r6, r9, 0)
+    typing = r14 :: module
+    r15 = typing :: module
+    r16 = __main__.globals :: static
+    r17 = 'TypeVar'
+    r18 = CPyObject_GetAttr(r15, r17)
+    r19 = 'TypeVar'
+    r20 = CPyDict_SetItem(r16, r19, r18)
+    r21 = r20 >= 0 :: signed
+    r22 = 'Generic'
+    r23 = CPyObject_GetAttr(r15, r22)
+    r24 = 'Generic'
+    r25 = CPyDict_SetItem(r16, r24, r23)
+    r26 = r25 >= 0 :: signed
+    r27 = __main__.globals :: static
+    r28 = PyEval_GetLocals()
+    r29 = 'trait'
+    r30 = PyList_New(1)
+    r31 = get_element_ptr r30 ob_item :: PyListObject
+    r32 = load_mem r31 :: ptr*
+    set_mem r32, r29 :: builtins.object*
+    keep_alive r30
+    r33 = 'mypy_extensions'
+    r34 = PyImport_ImportModuleLevelObject(r33, r27, r28, r30, 0)
+    mypy_extensions = r34 :: module
+    r35 = mypy_extensions :: module
+    r36 = __main__.globals :: static
+    r37 = 'trait'
+    r38 = CPyObject_GetAttr(r35, r37)
+    r39 = 'trait'
+    r40 = CPyDict_SetItem(r36, r39, r38)
+    r41 = r40 >= 0 :: signed
+    r42 = 'T'
+    r43 = __main__.globals :: static
+    r44 = 'TypeVar'
+    r45 = CPyDict_GetItem(r43, r44)
+    r46 = PyObject_CallFunctionObjArgs(r45, r42, 0)
+    r47 = __main__.globals :: static
     r48 = 'T'
-    r49 = __main__.globals :: static
-    r50 = 'TypeVar'
-    r51 = CPyDict_GetItem(r49, r50)
-    r52 = PyObject_CallFunctionObjArgs(r51, r48, 0)
-    r53 = __main__.globals :: static
-    r54 = 'T'
-    r55 = CPyDict_SetItem(r53, r54, r52)
-    r56 = r55 >= 0 :: signed
-    r57 = <error> :: object
-    r58 = '__main__'
-    r59 = __main__.C_template :: type
-    r60 = CPyType_FromTemplate(r59, r57, r58)
-    r61 = C_trait_vtable_setup()
-    r62 = '__mypyc_attrs__'
-    r63 = PyTuple_Pack(0)
-    r64 = PyObject_SetAttr(r60, r62, r63)
-    r65 = r64 >= 0 :: signed
-    __main__.C = r60 :: type
-    r66 = __main__.globals :: static
-    r67 = 'C'
-    r68 = CPyDict_SetItem(r66, r67, r60)
-    r69 = r68 >= 0 :: signed
-    r70 = <error> :: object
-    r71 = '__main__'
-    r72 = __main__.S_template :: type
-    r73 = CPyType_FromTemplate(r72, r70, r71)
-    r74 = '__mypyc_attrs__'
-    r75 = PyTuple_Pack(0)
-    r76 = PyObject_SetAttr(r73, r74, r75)
-    r77 = r76 >= 0 :: signed
-    __main__.S = r73 :: type
+    r49 = CPyDict_SetItem(r47, r48, r46)
+    r50 = r49 >= 0 :: signed
+    r51 = <error> :: object
+    r52 = '__main__'
+    r53 = __main__.C_template :: type
+    r54 = CPyType_FromTemplate(r53, r51, r52)
+    r55 = C_trait_vtable_setup()
+    r56 = '__mypyc_attrs__'
+    r57 = PyTuple_Pack(0)
+    r58 = PyObject_SetAttr(r54, r56, r57)
+    r59 = r58 >= 0 :: signed
+    __main__.C = r54 :: type
+    r60 = __main__.globals :: static
+    r61 = 'C'
+    r62 = CPyDict_SetItem(r60, r61, r54)
+    r63 = r62 >= 0 :: signed
+    r64 = <error> :: object
+    r65 = '__main__'
+    r66 = __main__.S_template :: type
+    r67 = CPyType_FromTemplate(r66, r64, r65)
+    r68 = '__mypyc_attrs__'
+    r69 = PyTuple_Pack(0)
+    r70 = PyObject_SetAttr(r67, r68, r69)
+    r71 = r70 >= 0 :: signed
+    __main__.S = r67 :: type
+    r72 = __main__.globals :: static
+    r73 = 'S'
+    r74 = CPyDict_SetItem(r72, r73, r67)
+    r75 = r74 >= 0 :: signed
+    r76 = __main__.C :: type
+    r77 = __main__.S :: type
     r78 = __main__.globals :: static
-    r79 = 'S'
-    r80 = CPyDict_SetItem(r78, r79, r73)
-    r81 = r80 >= 0 :: signed
-    r82 = __main__.C :: type
-    r83 = __main__.S :: type
-    r84 = __main__.globals :: static
-    r85 = 'Generic'
-    r86 = CPyDict_GetItem(r84, r85)
-    r87 = __main__.globals :: static
-    r88 = 'T'
-    r89 = CPyDict_GetItem(r87, r88)
-    r90 = PyObject_GetItem(r86, r89)
-    r91 = PyTuple_Pack(3, r82, r83, r90)
-    r92 = '__main__'
-    r93 = __main__.D_template :: type
-    r94 = CPyType_FromTemplate(r93, r91, r92)
-    r95 = D_trait_vtable_setup()
-    r96 = '__mypyc_attrs__'
-    r97 = '__dict__'
-    r98 = PyTuple_Pack(1, r97)
-    r99 = PyObject_SetAttr(r94, r96, r98)
-    r100 = r99 >= 0 :: signed
-    __main__.D = r94 :: type
-    r101 = __main__.globals :: static
-    r102 = 'D'
-    r103 = CPyDict_SetItem(r101, r102, r94)
-    r104 = r103 >= 0 :: signed
+    r79 = 'Generic'
+    r80 = CPyDict_GetItem(r78, r79)
+    r81 = __main__.globals :: static
+    r82 = 'T'
+    r83 = CPyDict_GetItem(r81, r82)
+    r84 = PyObject_GetItem(r80, r83)
+    r85 = PyTuple_Pack(3, r76, r77, r84)
+    r86 = '__main__'
+    r87 = __main__.D_template :: type
+    r88 = CPyType_FromTemplate(r87, r85, r86)
+    r89 = D_trait_vtable_setup()
+    r90 = '__mypyc_attrs__'
+    r91 = '__dict__'
+    r92 = PyTuple_Pack(1, r91)
+    r93 = PyObject_SetAttr(r88, r90, r92)
+    r94 = r93 >= 0 :: signed
+    __main__.D = r88 :: type
+    r95 = __main__.globals :: static
+    r96 = 'D'
+    r97 = CPyDict_SetItem(r95, r96, r88)
+    r98 = r97 >= 0 :: signed
     return 1
 
 [case testIsInstance]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -388,7 +388,7 @@ L2:
     r10 = get_element_ptr r9 ob_item :: PyListObject
     r11 = load_mem r10 :: ptr*
     set_mem r11, r7 :: builtins.object*
-    r12 = r11 + 8
+    r12 = r11 + WORD_SIZE*1
     set_mem r12, r8 :: builtins.object*
     keep_alive r9
     r13 = 'typing'

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -292,79 +292,87 @@ def __top_level__():
     r3 :: str
     r4, r5, r6 :: object
     r7 :: bit
-    r8 :: str
-    r9, r10 :: object
-    r11 :: dict
-    r12 :: str
-    r13 :: object
-    r14 :: str
-    r15 :: int32
-    r16 :: bit
-    r17 :: str
-    r18 :: object
-    r19 :: str
-    r20 :: int32
-    r21 :: bit
-    r22, r23 :: object
+    r8, r9 :: dict
+    r10, r11 :: str
+    r12 :: list
+    r13, r14, r15 :: ptr
+    r16 :: str
+    r17, r18 :: object
+    r19 :: dict
+    r20 :: str
+    r21 :: object
+    r22 :: str
+    r23 :: int32
     r24 :: bit
     r25 :: str
-    r26, r27 :: object
-    r28 :: dict
-    r29 :: str
-    r30 :: object
-    r31 :: str
-    r32 :: int32
-    r33 :: bit
-    r34 :: str
-    r35 :: dict
-    r36 :: str
-    r37, r38 :: object
-    r39 :: dict
-    r40 :: str
-    r41 :: int32
-    r42 :: bit
-    r43 :: object
-    r44 :: str
-    r45, r46 :: object
-    r47 :: bool
+    r26 :: object
+    r27 :: str
+    r28 :: int32
+    r29 :: bit
+    r30, r31 :: object
+    r32 :: bit
+    r33, r34 :: dict
+    r35 :: str
+    r36 :: list
+    r37, r38 :: ptr
+    r39 :: str
+    r40, r41 :: object
+    r42 :: dict
+    r43 :: str
+    r44 :: object
+    r45 :: str
+    r46 :: int32
+    r47 :: bit
     r48 :: str
-    r49 :: tuple
-    r50 :: int32
-    r51 :: bit
-    r52 :: dict
-    r53 :: str
-    r54 :: int32
-    r55 :: bit
-    r56 :: object
-    r57 :: str
-    r58, r59 :: object
-    r60 :: str
-    r61 :: tuple
-    r62 :: int32
-    r63 :: bit
-    r64 :: dict
-    r65 :: str
-    r66 :: int32
-    r67 :: bit
-    r68, r69 :: object
-    r70 :: dict
+    r49 :: dict
+    r50 :: str
+    r51, r52 :: object
+    r53 :: dict
+    r54 :: str
+    r55 :: int32
+    r56 :: bit
+    r57 :: object
+    r58 :: str
+    r59, r60 :: object
+    r61 :: bool
+    r62 :: str
+    r63 :: tuple
+    r64 :: int32
+    r65 :: bit
+    r66 :: dict
+    r67 :: str
+    r68 :: int32
+    r69 :: bit
+    r70 :: object
     r71 :: str
-    r72 :: object
-    r73 :: dict
+    r72, r73 :: object
     r74 :: str
-    r75, r76 :: object
-    r77 :: tuple
-    r78 :: str
-    r79, r80 :: object
-    r81 :: bool
-    r82, r83 :: str
-    r84 :: tuple
-    r85 :: int32
-    r86 :: bit
+    r75 :: tuple
+    r76 :: int32
+    r77 :: bit
+    r78 :: dict
+    r79 :: str
+    r80 :: int32
+    r81 :: bit
+    r82, r83 :: object
+    r84 :: dict
+    r85 :: str
+    r86 :: object
     r87 :: dict
     r88 :: str
-    r89 :: int32
-    r90 :: bit
+    r89, r90 :: object
+    r91 :: tuple
+    r92 :: str
+    r93, r94 :: object
+    r95 :: bool
+    r96, r97 :: str
+    r98 :: tuple
+    r99 :: int32
+    r100 :: bit
+    r101 :: dict
+    r102 :: str
+    r103 :: int32
+    r104 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -380,98 +388,117 @@ L2:
     r7 = r5 != r6
     if r7 goto L4 else goto L3 :: bool
 L3:
-    r8 = 'typing'
-    r9 = PyImport_Import(r8)
-    typing = r9 :: module
+    r8 = __main__.globals :: static
+    r9 = PyEval_GetLocals()
+    r10 = 'TypeVar'
+    r11 = 'Generic'
+    r12 = PyList_New(2)
+    r13 = get_element_ptr r12 ob_item :: PyListObject
+    r14 = load_mem r13 :: ptr*
+    set_mem r14, r10 :: builtins.object*
+    r15 = r14 + 8
+    set_mem r15, r11 :: builtins.object*
+    keep_alive r12
+    r16 = 'typing'
+    r17 = PyImport_ImportModuleLevelObject(r16, r8, r9, r12, 0)
+    typing = r17 :: module
 L4:
-    r10 = typing :: module
-    r11 = __main__.globals :: static
-    r12 = 'TypeVar'
-    r13 = CPyObject_GetAttr(r10, r12)
-    r14 = 'TypeVar'
-    r15 = CPyDict_SetItem(r11, r14, r13)
-    r16 = r15 >= 0 :: signed
-    r17 = 'Generic'
-    r18 = CPyObject_GetAttr(r10, r17)
-    r19 = 'Generic'
-    r20 = CPyDict_SetItem(r11, r19, r18)
-    r21 = r20 >= 0 :: signed
-    r22 = mypy_extensions :: module
-    r23 = load_address _Py_NoneStruct
-    r24 = r22 != r23
-    if r24 goto L6 else goto L5 :: bool
+    r18 = typing :: module
+    r19 = __main__.globals :: static
+    r20 = 'TypeVar'
+    r21 = CPyObject_GetAttr(r18, r20)
+    r22 = 'TypeVar'
+    r23 = CPyDict_SetItem(r19, r22, r21)
+    r24 = r23 >= 0 :: signed
+    r25 = 'Generic'
+    r26 = CPyObject_GetAttr(r18, r25)
+    r27 = 'Generic'
+    r28 = CPyDict_SetItem(r19, r27, r26)
+    r29 = r28 >= 0 :: signed
+    r30 = mypy_extensions :: module
+    r31 = load_address _Py_NoneStruct
+    r32 = r30 != r31
+    if r32 goto L6 else goto L5 :: bool
 L5:
-    r25 = 'mypy_extensions'
-    r26 = PyImport_Import(r25)
-    mypy_extensions = r26 :: module
+    r33 = __main__.globals :: static
+    r34 = PyEval_GetLocals()
+    r35 = 'trait'
+    r36 = PyList_New(1)
+    r37 = get_element_ptr r36 ob_item :: PyListObject
+    r38 = load_mem r37 :: ptr*
+    set_mem r38, r35 :: builtins.object*
+    keep_alive r36
+    r39 = 'mypy_extensions'
+    r40 = PyImport_ImportModuleLevelObject(r39, r33, r34, r36, 0)
+    mypy_extensions = r40 :: module
 L6:
-    r27 = mypy_extensions :: module
-    r28 = __main__.globals :: static
-    r29 = 'trait'
-    r30 = CPyObject_GetAttr(r27, r29)
-    r31 = 'trait'
-    r32 = CPyDict_SetItem(r28, r31, r30)
-    r33 = r32 >= 0 :: signed
-    r34 = 'T'
-    r35 = __main__.globals :: static
-    r36 = 'TypeVar'
-    r37 = CPyDict_GetItem(r35, r36)
-    r38 = PyObject_CallFunctionObjArgs(r37, r34, 0)
-    r39 = __main__.globals :: static
-    r40 = 'T'
-    r41 = CPyDict_SetItem(r39, r40, r38)
-    r42 = r41 >= 0 :: signed
-    r43 = <error> :: object
-    r44 = '__main__'
-    r45 = __main__.C_template :: type
-    r46 = CPyType_FromTemplate(r45, r43, r44)
-    r47 = C_trait_vtable_setup()
-    r48 = '__mypyc_attrs__'
-    r49 = PyTuple_Pack(0)
-    r50 = PyObject_SetAttr(r46, r48, r49)
-    r51 = r50 >= 0 :: signed
-    __main__.C = r46 :: type
-    r52 = __main__.globals :: static
-    r53 = 'C'
-    r54 = CPyDict_SetItem(r52, r53, r46)
-    r55 = r54 >= 0 :: signed
-    r56 = <error> :: object
-    r57 = '__main__'
-    r58 = __main__.S_template :: type
-    r59 = CPyType_FromTemplate(r58, r56, r57)
-    r60 = '__mypyc_attrs__'
-    r61 = PyTuple_Pack(0)
-    r62 = PyObject_SetAttr(r59, r60, r61)
-    r63 = r62 >= 0 :: signed
-    __main__.S = r59 :: type
-    r64 = __main__.globals :: static
-    r65 = 'S'
-    r66 = CPyDict_SetItem(r64, r65, r59)
-    r67 = r66 >= 0 :: signed
-    r68 = __main__.C :: type
-    r69 = __main__.S :: type
-    r70 = __main__.globals :: static
-    r71 = 'Generic'
-    r72 = CPyDict_GetItem(r70, r71)
-    r73 = __main__.globals :: static
-    r74 = 'T'
-    r75 = CPyDict_GetItem(r73, r74)
-    r76 = PyObject_GetItem(r72, r75)
-    r77 = PyTuple_Pack(3, r68, r69, r76)
-    r78 = '__main__'
-    r79 = __main__.D_template :: type
-    r80 = CPyType_FromTemplate(r79, r77, r78)
-    r81 = D_trait_vtable_setup()
-    r82 = '__mypyc_attrs__'
-    r83 = '__dict__'
-    r84 = PyTuple_Pack(1, r83)
-    r85 = PyObject_SetAttr(r80, r82, r84)
-    r86 = r85 >= 0 :: signed
-    __main__.D = r80 :: type
+    r41 = mypy_extensions :: module
+    r42 = __main__.globals :: static
+    r43 = 'trait'
+    r44 = CPyObject_GetAttr(r41, r43)
+    r45 = 'trait'
+    r46 = CPyDict_SetItem(r42, r45, r44)
+    r47 = r46 >= 0 :: signed
+    r48 = 'T'
+    r49 = __main__.globals :: static
+    r50 = 'TypeVar'
+    r51 = CPyDict_GetItem(r49, r50)
+    r52 = PyObject_CallFunctionObjArgs(r51, r48, 0)
+    r53 = __main__.globals :: static
+    r54 = 'T'
+    r55 = CPyDict_SetItem(r53, r54, r52)
+    r56 = r55 >= 0 :: signed
+    r57 = <error> :: object
+    r58 = '__main__'
+    r59 = __main__.C_template :: type
+    r60 = CPyType_FromTemplate(r59, r57, r58)
+    r61 = C_trait_vtable_setup()
+    r62 = '__mypyc_attrs__'
+    r63 = PyTuple_Pack(0)
+    r64 = PyObject_SetAttr(r60, r62, r63)
+    r65 = r64 >= 0 :: signed
+    __main__.C = r60 :: type
+    r66 = __main__.globals :: static
+    r67 = 'C'
+    r68 = CPyDict_SetItem(r66, r67, r60)
+    r69 = r68 >= 0 :: signed
+    r70 = <error> :: object
+    r71 = '__main__'
+    r72 = __main__.S_template :: type
+    r73 = CPyType_FromTemplate(r72, r70, r71)
+    r74 = '__mypyc_attrs__'
+    r75 = PyTuple_Pack(0)
+    r76 = PyObject_SetAttr(r73, r74, r75)
+    r77 = r76 >= 0 :: signed
+    __main__.S = r73 :: type
+    r78 = __main__.globals :: static
+    r79 = 'S'
+    r80 = CPyDict_SetItem(r78, r79, r73)
+    r81 = r80 >= 0 :: signed
+    r82 = __main__.C :: type
+    r83 = __main__.S :: type
+    r84 = __main__.globals :: static
+    r85 = 'Generic'
+    r86 = CPyDict_GetItem(r84, r85)
     r87 = __main__.globals :: static
-    r88 = 'D'
-    r89 = CPyDict_SetItem(r87, r88, r80)
-    r90 = r89 >= 0 :: signed
+    r88 = 'T'
+    r89 = CPyDict_GetItem(r87, r88)
+    r90 = PyObject_GetItem(r86, r89)
+    r91 = PyTuple_Pack(3, r82, r83, r90)
+    r92 = '__main__'
+    r93 = __main__.D_template :: type
+    r94 = CPyType_FromTemplate(r93, r91, r92)
+    r95 = D_trait_vtable_setup()
+    r96 = '__mypyc_attrs__'
+    r97 = '__dict__'
+    r98 = PyTuple_Pack(1, r97)
+    r99 = PyObject_SetAttr(r94, r96, r98)
+    r100 = r99 >= 0 :: signed
+    __main__.D = r94 :: type
+    r101 = __main__.globals :: static
+    r102 = 'D'
+    r103 = CPyDict_SetItem(r101, r102, r94)
+    r104 = r103 >= 0 :: signed
     return 1
 
 [case testIsInstance]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -396,7 +396,7 @@ L3:
     r13 = get_element_ptr r12 ob_item :: PyListObject
     r14 = load_mem r13 :: ptr*
     set_mem r14, r10 :: builtins.object*
-    r15 = r14 + 8
+    r15 = r14 + WORD_SIZE*1
     set_mem r15, r11 :: builtins.object*
     keep_alive r12
     r16 = 'typing'

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -92,16 +92,12 @@ assert f(1) == 2
 # if mypy can't tell if mod isn't a module
 from pkg import mod # type: ignore
 
-def a(x: int) -> int:
-    return mod.h(x)
+def test_import():
+    assert mod.h(8) == 24
 
 [file pkg/mod.py]
 def h(x):
     return x * 3
-
-[file driver.py]
-from native import a
-assert a(8) == 24
 
 [case testFromImportWithKnownModule]
 from pkg import mod

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -86,6 +86,23 @@ def g(x: int) -> int:
 from native import f
 assert f(1) == 2
 
+[case testFromImportWithUntypedModule]
+
+# avoid including an __init__.py and use type: ignore to test what happens
+# if mypy can't tell if mod isn't a module
+from pkg import mod # type: ignore
+
+def a(x: int) -> int:
+    return mod.h(x)
+
+[file pkg/mod.py]
+def h(x):
+    return x * 3
+
+[file driver.py]
+from native import a
+assert a(8) == 24
+
 [case testReexport]
 # Test that we properly handle accessing values that have been reexported
 import a

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -92,7 +92,7 @@ assert f(1) == 2
 # if mypy can't tell if mod isn't a module
 from pkg import mod # type: ignore
 
-def test_import():
+def test_import() -> None:
     assert mod.h(8) == 24
 
 [file pkg/mod.py]
@@ -102,7 +102,7 @@ def h(x):
 [case testFromImportWithKnownModule]
 from pkg import mod
 
-def test_import():
+def test_import() -> None:
     assert mod.h(8) == 24
 
 [file pkg/__init__.py]

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -110,6 +110,25 @@ def test_import() -> None:
 def h(x: int) -> int:
     return x * 3
 
+[case testMultipleFromImportsWithSamePackageButDifferentModules]
+from pkg import a
+from pkg import b
+
+def test_import() -> None:
+    assert a.g() == 4
+    assert b.h() == 39
+
+[file pkg/__init__.py]
+[file pkg/a.py]
+
+def g() -> int:
+    return 4
+
+[file pkg/b.py]
+
+def h() -> int:
+    return 39
+
 [case testReexport]
 # Test that we properly handle accessing values that have been reexported
 import a

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -103,6 +103,17 @@ def h(x):
 from native import a
 assert a(8) == 24
 
+[case testFromImportWithKnownModule]
+from pkg import mod
+
+def test_import():
+    assert mod.h(8) == 24
+
+[file pkg/__init__.py]
+[file pkg/mod.py]
+def h(x: int) -> int:
+    return x * 3
+
 [case testReexport]
 # Test that we properly handle accessing values that have been reexported
 import a


### PR DESCRIPTION
Fixes mypyc/mypyc#851

This fixes a bug where code compiled with mypyc would crash on from imports (`from x import y`) if:
- y is a module
- mypy doesn't know that y is a module (due to an ignore_missing_imports configuration option or something else)

The bug was caused by using getattr to import modules (i.e. `y = getattr(x, 'y')`) and changing this to `import x.y as y` when it can determine that y is a module. This doesn't work when we don't know that y is a module.

I changed the from import handling to use something similar to the method shown in the [`__import__` docs](https://docs.python.org/3/library/functions.html#__import__). I also removed the special casing of from imports for modules (`from x import y` where y is a module) mentioned earlier, because these changes make that special casing unnecessary.

## Test Plan

I added 2 tests to mypyc/test-data/run-imports.test.