### PR TITLE
Fail when conditioning on implicit bool

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -665,6 +665,24 @@ consistently when using the call-based syntax. Example:
     # Error: First argument to namedtuple() should be "Point2D", not "Point"
     Point2D = NamedTuple("Point", [("x", int), ("y", int)])
 
+
+
+Implicitly converting to bool always evaluates as True [implicit-bool]
+----------------------------------------------------------------------
+
+In contexts where an expression has to be converted to a bool, an object
+which does not implement __bool__ nor __len__ will always evaluate to True.
+
+.. code-block:: python
+
+    class Foo:
+      pass
+
+    foo = Foo()
+    # Error: "{}" does not implement __bool__ or __len__ so the expression is always truthy
+    if foo:
+       ...
+
 Report syntax errors [syntax]
 -----------------------------
 

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -92,6 +92,11 @@ STR_BYTES_PY3 = ErrorCode(
     'General')  # type: Final
 EXIT_RETURN = ErrorCode(
     'exit-return', "Warn about too general return type for '__exit__'", 'General')  # type: Final
+NAME_MATCH = ErrorCode(
+    'name-match', "Check that type definition has consistent naming", 'General')  # type: Final
+IMPLICIT_BOOL = ErrorCode(
+    'implicit-bool', "Implicitly converting to bool always evaluates as True",
+    'General')  # type: Final
 
 # These error codes aren't enabled by default.
 NO_UNTYPED_DEF = ErrorCode(
@@ -117,8 +122,6 @@ REDUNDANT_EXPR = ErrorCode(
     "Warn about redundant expressions",
     'General',
     default_enabled=False)  # type: Final
-NAME_MATCH = ErrorCode(
-    'name-match', "Check that type definition has consistent naming", 'General')  # type: Final
 
 
 # Syntax errors are often blocking.

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -84,6 +84,11 @@ DUPLICATE_TYPE_SIGNATURES = 'Function has duplicate type signatures'  # type: Fi
 DESCRIPTOR_SET_NOT_CALLABLE = "{}.__set__ is not callable"  # type: Final
 DESCRIPTOR_GET_NOT_CALLABLE = "{}.__get__ is not callable"  # type: Final
 MODULE_LEVEL_GETATTRIBUTE = '__getattribute__ is not valid at the module level'  # type: Final
+TYPE_CONVERTS_TO_BOOL_IMPLICITLY = \
+    '"{}" does not implement __bool__ or __len__ so the expression is always truthy'  # type: Final
+ALL_TYPES_IN_UNION_CONVERT_TO_BOOL_IMPLICITLY = \
+    'Neither of {} implements __bool__ or __len__ '\
+    'so the expression is always truthy'  # type: Final
 
 # Generic
 GENERIC_INSTANCE_VAR_CLASS_ACCESS = \

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -718,11 +718,11 @@ class MessageBuilder:
             s = ' "{}"'.format(typ.source)
         self.fail('Assignment to variable{} outside except: block'.format(s), context)
 
-    def type_converts_to_bool_implicitly(self, typ: Type, context: Context):
+    def type_converts_to_bool_implicitly(self, typ: Type, context: Context) -> str:
         return self.fail(message_registry.TYPE_CONVERTS_TO_BOOL_IMPLICITLY
                          .format(typ), context, code=codes.IMPLICIT_BOOL)
 
-    def type_union_converts_to_bool_implicitly(self, typ: UnionType, context: Context):
+    def type_union_converts_to_bool_implicitly(self, typ: UnionType, context: Context) -> strg:
         return self.fail(message_registry.ALL_TYPES_IN_UNION_CONVERT_TO_BOOL_IMPLICITLY
                          .format(typ), context, code=codes.IMPLICIT_BOOL)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -718,6 +718,14 @@ class MessageBuilder:
             s = ' "{}"'.format(typ.source)
         self.fail('Assignment to variable{} outside except: block'.format(s), context)
 
+    def type_converts_to_bool_implicitly(self, typ: Type, context: Context):
+        return self.fail(message_registry.TYPE_CONVERTS_TO_BOOL_IMPLICITLY
+                         .format(typ), context, code=codes.IMPLICIT_BOOL)
+
+    def type_union_converts_to_bool_implicitly(self, typ: UnionType, context: Context):
+        return self.fail(message_registry.ALL_TYPES_IN_UNION_CONVERT_TO_BOOL_IMPLICITLY
+                         .format(typ), context, code=codes.IMPLICIT_BOOL)
+
     def no_variant_matches_arguments(self,
                                      plausible_targets: List[CallableType],
                                      overload: Overloaded,

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -642,6 +642,15 @@ def get_enum_values(typ: Instance) -> List[str]:
     return [name for name, sym in typ.type.names.items() if isinstance(sym.node, Var)]
 
 
+def type_has_explicit_conversion_to_bool(typ: Type) -> bool:
+    if isinstance(typ, Instance):
+        return typ.type.has_readable_member('__bool__') or typ.type.has_readable_member('__len__')
+    elif isinstance(typ, FunctionLike):
+        return False
+    else:
+        return True
+
+
 def is_singleton_type(typ: Type) -> bool:
     """Returns 'true' if this type is a "singleton type" -- if there exists
     exactly only one runtime value associated with this type.

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -807,3 +807,61 @@ from typing_extensions import TypedDict
 
 Foo = TypedDict("Bar", {})  # E: First argument "Bar" to TypedDict() does not match variable name "Foo"  [name-match]
 [builtins fixtures/dict.pyi]
+[case testImplicitBool]
+# flags: --enable-error-code implicit-bool
+from typing import List, Union
+
+class Foo:
+    pass
+
+
+foo = Foo()
+if foo:  # E: "__main__.Foo" does not implement __bool__ or __len__ so the expression is always truthy  [implicit-bool]
+    pass
+
+zero = 0
+if zero:
+    pass
+
+
+false = False
+if false:
+    pass
+
+
+null = None
+if null:
+    pass
+
+
+s = ''
+if s:
+    pass
+
+
+good_union: Union[str, int] = 5
+if good_union:
+    pass
+
+
+bad_union: Union[Foo, object] = Foo()
+if bad_union:  # E: Neither of Union[__main__.Foo, builtins.object] implements __bool__ or __len__ so the expression is always truthy  [implicit-bool]
+    pass
+
+
+def f():
+    pass
+
+
+if f:  # E: "def () -> Any" does not implement __bool__ or __len__ so the expression is always truthy  [implicit-bool]
+    pass
+
+
+lst: List[int] = []
+if lst:
+    pass
+
+
+conditional_result = 'foo' if f else 'bar'  # E: "def () -> Any" does not implement __bool__ or __len__ so the expression is always truthy  [implicit-bool]
+
+[builtins fixtures/implicit_bool.pyi]

--- a/test-data/unit/fixtures/implicit_bool.pyi
+++ b/test-data/unit/fixtures/implicit_bool.pyi
@@ -1,0 +1,16 @@
+from typing import Generic, Sequence, TypeVar
+
+_T = TypeVar('_T')
+
+
+class object:
+    def __init__(self): pass
+
+class type: pass
+class int:
+    def __bool__(self) -> bool: pass
+class bool(int): pass
+class list(Generic[_T], Sequence[_T]):
+    def __len__(self) -> int: pass
+class str:
+    def __len__(self) -> int: pass


### PR DESCRIPTION
### Description

Fails conditionals where the expression's type does not implement `__bool__` nor `__len__` since such expressions would always evaluate as truthy and likely an error (e.g. the common pitfall of conditioning on a callable rather than its result).

This feature was proposed by @pkch in https://github.com/python/mypy/issues/3195#issuecomment-295341122 as an alternative to the deprecated ``--strict-bool``.

## Test Plan

Test case was added.
