### PR TITLE
rename STUBS_NOT_INSTALLED to APPROVED_STUBS_NOT_INSTALLED

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2555,7 +2555,7 @@ def module_not_found(manager: BuildManager, line: int, caller_state: State,
             if '{stub_dist}' in note:
                 note = note.format(stub_dist=legacy_bundled_packages[top_level])
             errors.report(line, 0, note, severity='note', only_once=True, code=codes.IMPORT)
-        if reason is ModuleNotFoundReason.STUBS_NOT_INSTALLED:
+        if reason is ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED:
             manager.missing_stub_packages.add(legacy_bundled_packages[top_level])
     errors.set_import_context(save_import_context)
 

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -57,7 +57,7 @@ class ModuleNotFoundReason(Enum):
     WRONG_WORKING_DIRECTORY = 2
 
     # Stub PyPI package (typically types-pkgname) known to exist but not installed.
-    STUBS_NOT_INSTALLED = 3
+    APPROVED_STUBS_NOT_INSTALLED = 3
 
     def error_message_templates(self, daemon: bool) -> Tuple[str, List[str]]:
         doc_link = "See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports"
@@ -71,7 +71,7 @@ class ModuleNotFoundReason(Enum):
         elif self is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
             msg = 'Skipping analyzing "{module}": found module but no type hints or library stubs'
             notes = [doc_link]
-        elif self is ModuleNotFoundReason.STUBS_NOT_INSTALLED:
+        elif self is ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED:
             msg = (
                 'Library stubs not installed for "{module}" (or incompatible with Python {pyver})'
             )
@@ -231,7 +231,7 @@ class FindModuleCache:
                                           or self.fscache.isfile(dir_path + ".py")):
                 plausible_match = True
         if components[0] in legacy_bundled_packages:
-            return ModuleNotFoundReason.STUBS_NOT_INSTALLED
+            return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
         elif plausible_match:
             return ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS
         else:
@@ -311,7 +311,7 @@ class FindModuleCache:
             if isinstance(non_stub_match, ModuleNotFoundReason):
                 if non_stub_match is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
                     found_possible_third_party_missing_type_hints = True
-                elif non_stub_match is ModuleNotFoundReason.STUBS_NOT_INSTALLED:
+                elif non_stub_match is ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED:
                     need_installed_stubs = True
             else:
                 third_party_inline_dirs.append(non_stub_match)
@@ -413,7 +413,7 @@ class FindModuleCache:
             return ancestor
 
         if need_installed_stubs:
-            return ModuleNotFoundReason.STUBS_NOT_INSTALLED
+            return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
         elif found_possible_third_party_missing_type_hints:
             return ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS
         else:


### PR DESCRIPTION
Since this code path involves mypy recommending installation of a stub
package, I thought I'd rename the enum to make it slightly clearer
that this should only be triggered for packages we know to be good.

Linking #10538