### PR TITLE
Fix faulty casts in checker

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2796,7 +2796,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         index_lvalue = None
         inferred = None
 
-        if self.is_definition(lvalue):
+        if self.is_definition(lvalue) and (
+            not isinstance(lvalue, NameExpr) or isinstance(lvalue.node, Var)
+        ):
             if isinstance(lvalue, NameExpr):
                 inferred = cast(Var, lvalue.node)
                 assert isinstance(inferred, Var)
@@ -3420,7 +3422,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                 source = ('(exception variable "{}", which we do not '
                                           'accept outside except: blocks even in '
                                           'python 2)'.format(var.name))
-                            cast(Var, var.node).type = DeletedType(source=source)
+                            if isinstance(var.node, Var):
+                                var.node.type = DeletedType(source=source)
                             self.binder.cleanse(var)
             if s.else_body:
                 self.accept(s.else_body)

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -474,3 +474,12 @@ with A() as x:
     reveal_type(x) # N: Revealed type is "builtins.int"
 with B() as x:
     x = 0 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+
+[case testRedefineModuleAsException]
+import typing
+try:
+    pass
+except Exception as typing:
+    pass
+[builtins fixtures/exception.pyi]

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1305,3 +1305,19 @@ async def f_malformed_2() -> int:
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/tuple.pyi]
+
+
+[case testConditionalTypeVarException]
+# every part of this test case was necessary to trigger the crash
+import sys
+from typing import TypeVar
+
+T = TypeVar("T", int, str)
+
+def f(t: T) -> None:
+    if sys.platform == "lol":
+        try:
+            pass
+        except BaseException as e:
+            pass
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #9615, fixes #9682

Both issue reports hit the faulty cast on L2803. This changes the logic
so that that cast is actually always true. If not, we just end up doing
whatever the fallback else clause does; this resulted in behaviour that
matched what I expected.

After that, the #9682 hit another crash in checker.py, where var.node
was None instead of a Var. It seemed reasonable to just branch instead.