### PR TITLE
Unreachable expressions: treat non-zero ints as truthy

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5096,7 +5096,7 @@ def gen_unique_name(base: str, table: SymbolTable) -> str:
 def is_true_literal(n: Expression) -> bool:
     """Returns true if this expression is the 'True' literal/keyword."""
     return (refers_to_fullname(n, 'builtins.True')
-            or isinstance(n, IntExpr) and n.value == 1)
+            or isinstance(n, IntExpr) and n.value != 0)
 
 
 def is_false_literal(n: Expression) -> bool:

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -908,6 +908,7 @@ def foo() -> bool: ...
 lst = [1, 2, 3, 4]
 
 a = True or foo()                        # E: Right operand of "or" is never evaluated
+b = 42 or False                          # E: Right operand of "or" is never evaluated
 d = False and foo()                      # E: Right operand of "and" is never evaluated
 e = True or (True or (True or foo()))    # E: Right operand of "or" is never evaluated
 f = (True or foo()) or (True or foo())   # E: Right operand of "or" is never evaluated


### PR DESCRIPTION
Makes `42 or False` result in `Error: Right operand of "or" is never evaluated` when invoked with [--warn-unreachable](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-warn-unreachable).