### PR TITLE
Resolves #10542 Add fullname of node that is still a PlaceholderNode when assertion fails

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3080,7 +3080,9 @@ class SymbolTableNode:
                         and fullname != prefix + '.' + name
                         and not (isinstance(self.node, Var)
                                  and self.node.from_module_getattr)):
-                    assert not isinstance(self.node, PlaceholderNode), 'Definition of {} is unexpectedly incomplete'.format(fullname)
+                    assert not isinstance(self.node, PlaceholderNode), (
+                        'Definition of {} is unexpectedly incomplete'.format(fullname)
+                    )
                     data['cross_ref'] = fullname
                     return data
             data['node'] = self.node.serialize()

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3080,7 +3080,7 @@ class SymbolTableNode:
                         and fullname != prefix + '.' + name
                         and not (isinstance(self.node, Var)
                                  and self.node.from_module_getattr)):
-                    assert not isinstance(self.node, PlaceholderNode), '%s' % fullname
+                    assert not isinstance(self.node, PlaceholderNode), 'Definition of {} is unexpectedly incomplete'.format(fullname)
                     data['cross_ref'] = fullname
                     return data
             data['node'] = self.node.serialize()

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3080,7 +3080,7 @@ class SymbolTableNode:
                         and fullname != prefix + '.' + name
                         and not (isinstance(self.node, Var)
                                  and self.node.from_module_getattr)):
-                    assert not isinstance(self.node, PlaceholderNode)
+                    assert not isinstance(self.node, PlaceholderNode), '%s' % fullname
                     data['cross_ref'] = fullname
                     return data
             data['node'] = self.node.serialize()


### PR DESCRIPTION
### Description

#10542 had a vague error come up due to a PlaceholderNode that did not get replaced. This PR simply adds the full name of the node so that these can be better traced back.

The error was:
```
...
    assert not isinstance(self.node, PlaceholderNode)
AssertionError
```

Will now be slightly more helpful:
```
...
    assert not isinstance(self.node, PlaceholderNode), '%s' % fullname
AssertionError: spacy.ml.models.multi_task.Doc
```

There's the possibility that something bigger needs to happen here (why is it still a PlaceholderNode?), but this was enough to help me to figure out how to move #10542 forward.

## Test Plan

Manually tested with the code provided by @ZeeD `from spacy import load` ran through mypy with `--strict`