### PR TITLE
check_boolean_op: clean up semanal/type-based reachability

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2774,38 +2774,32 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         assert e.op in ('and', 'or')  # Checked by visit_op_expr
 
-        if e.op == 'and':
+        if e.right_always:
+            left_map, right_map = None, {}
+        elif e.right_unreachable:
+            left_map, right_map = {}, None
+        elif e.op == 'and':
             right_map, left_map = self.chk.find_isinstance_check(e.left)
-            restricted_left_type = false_only(left_type)
-            result_is_left = not left_type.can_be_true
         elif e.op == 'or':
             left_map, right_map = self.chk.find_isinstance_check(e.left)
-            restricted_left_type = true_only(left_type)
-            result_is_left = not left_type.can_be_false
 
         # If left_map is None then we know mypy considers the left expression
         # to be redundant.
-        #
-        # Note that we perform these checks *before* we take into account
-        # the analysis from the semanal phase below. We assume that nodes
-        # marked as unreachable during semantic analysis were done so intentionally.
-        # So, we shouldn't report an error.
-        if codes.REDUNDANT_EXPR in self.chk.options.enabled_error_codes:
-            if left_map is None:
-                self.msg.redundant_left_operand(e.op, e.left)
+        if (
+            codes.REDUNDANT_EXPR in self.chk.options.enabled_error_codes
+            and left_map is None
+            # don't report an error if it's intentional
+            and not e.right_always
+        ):
+            self.msg.redundant_left_operand(e.op, e.left)
 
-        # Note that we perform these checks *before* we take into account
-        # the analysis from the semanal phase below. We assume that nodes
-        # marked as unreachable during semantic analysis were done so intentionally.
-        # So, we shouldn't report an error.
-        if self.chk.should_report_unreachable_issues():
-            if right_map is None:
-                self.msg.unreachable_right_operand(e.op, e.right)
-
-        if e.right_unreachable:
-            right_map = None
-        elif e.right_always:
-            left_map = None
+        if (
+            self.chk.should_report_unreachable_issues()
+            and right_map is None
+            # don't report an error if it's intentional
+            and not e.right_unreachable
+        ):
+            self.msg.unreachable_right_operand(e.op, e.right)
 
         # If right_map is None then we know mypy considers the right branch
         # to be unreachable and therefore any errors found in the right branch
@@ -2821,6 +2815,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # The boolean expression is statically known to be the right value
             assert right_map is not None  # find_isinstance_check guarantees this
             return right_type
+
+        if e.op == 'and':
+            restricted_left_type = false_only(left_type)
+            result_is_left = not left_type.can_be_true
+        elif e.op == 'or':
+            restricted_left_type = true_only(left_type)
+            result_is_left = not left_type.can_be_false
 
         if isinstance(restricted_left_type, UninhabitedType):
             # The left operand can never be the result

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2774,6 +2774,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         assert e.op in ('and', 'or')  # Checked by visit_op_expr
 
+        left_map: mypy.checker.TypeMap
+        right_map: mypy.checker.TypeMap
         if e.right_always:
             left_map, right_map = None, {}
         elif e.right_unreachable:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1735,9 +1735,9 @@ class OpExpr(Expression):
     right = None  # type: Expression
     # Inferred type for the operator method type (when relevant).
     method_type = None  # type: Optional[mypy.types.Type]
-    # Is the right side going to be evaluated every time?
+    # Per static analysis only: Is the right side going to be evaluated every time?
     right_always = False
-    # Is the right side unreachable?
+    # Per static analysis only: Is the right side unreachable?
     right_unreachable = False
 
     def __init__(self, op: str, left: Expression, right: Expression) -> None:

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -621,14 +621,20 @@ from typing import Literal
 
 indeterminate: bool
 COMPILE_TIME_FALSE: Literal[True]  # type-narrowing: mapped in 'if' only
-_ = COMPILE_TIME_FALSE or indeterminate
+a = COMPILE_TIME_FALSE or indeterminate
+reveal_type(a)  # N: Revealed type is "builtins.bool"
+b = indeterminate or COMPILE_TIME_FALSE
+reveal_type(b)  # N: Revealed type is "Union[builtins.bool, Literal[True]]"
 [typing fixtures/typing-medium.pyi]
 
 [case testSemanticAnalysisTrueButTypeNarrowingFalse]
 # flags: --always-true COMPILE_TIME_TRUE
 indeterminate: bool
-COMPILE_TIME_TRUE: None  # type-narrowing: mapped in 'else' only
-_ = COMPILE_TIME_TRUE or indeterminate
+COMPILE_TIME_TRUE: None  # type narrowed to `else` only
+a = COMPILE_TIME_TRUE or indeterminate
+reveal_type(a)  # N: Revealed type is "None"
+b = indeterminate or COMPILE_TIME_TRUE
+reveal_type(b)  # N: Revealed type is "Union[builtins.bool, None]"
 
 [case testConditionalAssertWithoutElse]
 import typing

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -615,6 +615,21 @@ if MYPY or mypy_only:
     pass
 [builtins fixtures/ops.pyi]
 
+[case testSemanticAnalysisFalseButTypeNarrowingTrue]
+# flags: --always-false COMPILE_TIME_FALSE
+from typing import Literal
+
+indeterminate: bool
+COMPILE_TIME_FALSE: Literal[True]  # type-narrowing: mapped in 'if' only
+_ = COMPILE_TIME_FALSE or indeterminate
+[typing fixtures/typing-medium.pyi]
+
+[case testSemanticAnalysisTrueButTypeNarrowingFalse]
+# flags: --always-true COMPILE_TIME_TRUE
+indeterminate: bool
+COMPILE_TIME_TRUE: None  # type-narrowing: mapped in 'else' only
+_ = COMPILE_TIME_TRUE or indeterminate
+
 [case testConditionalAssertWithoutElse]
 import typing
 


### PR DESCRIPTION
`ExpressionChecker.check_boolean_op` supports two potentially conflicting ways of determining whether an expression is always true/false: name-based checks from semantic analysis (e.g. `name in options.always_true`) and type narrowing in `TypeChecker.find_isinstance_check` (*). The two ways can be set to conflict, e.g.
```python
# flags: --always-true COMPILE_TIME_TRUE
COMPILE_TIME_TRUE: None
```
In the above case, `COMPILE_TIME_TRUE` would be always true per semanal and always false per `find_isinstance_check`, which results in an assertion failure here:
https://github.com/python/mypy/blob/5eb4de443269b906d2e8b2292dbf472ce17d0e1f/mypy/checkexpr.py#L2828
and here:
https://github.com/python/mypy/blob/5eb4de443269b906d2e8b2292dbf472ce17d0e1f/mypy/checkexpr.py#L2832

This change reconciles the two, by prioritizing the semanal flags (e.right_always, e.right_unreachable) over type-narrowing (if_map, else_map). Then we explicitly avoid flagging reachability errors when the semanal flags are set, since they're obviously used intentionally.

(*) which seems to do slightly more than `isinstance` checks