### PR TITLE
Fix typo in config_file.rst

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -906,7 +906,7 @@ Instead of using a ``mypy.ini`` file, a ``pyproject.toml`` file (as specified by
   module = 'packagename'
   ...
 
-* Multi-module specific sections can be moved into a single ``[[tools.mypy.overrides]]`` section with a
+* Multi-module specific sections can be moved into a single ``[[tool.mypy.overrides]]`` section with a
   module property set to an array of modules:
 
   * For example, ``[mypy-packagename,packagename2]`` would become:


### PR DESCRIPTION
### Description

One example references `[[tools.mypy.overrides]]` when all other examples reference `[[tool.mypy.overrides]]`.  I'm guessing the odd one out is incorrect.