### PR TITLE
[mypyc] Fix segfault when top level raises exception

### DIFF
--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -1143,6 +1143,10 @@ try:
     import native
 except:
     pass
-# try accessing those globals that were never properly initialized
-import native
-native.test()
+try:
+    # try accessing those globals that were never properly initialized
+    import native
+    native.test()
+# should fail with AssertionError due to `assert False` in other function
+except AssertionError:
+    pass

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -1126,3 +1126,23 @@ C = sys.platform == 'x' and (lambda x: y + x)
 assert not A
 assert not B
 assert not C
+
+[case testDoesntSegfaultWhenTopLevelFails]
+# make the initial import fail
+assert False
+
+class C:
+    def __init__(self):
+        self.x = 1
+        self.y = 2
+def test() -> None:
+    a = C()
+[file driver.py]
+# load native, cause PyInit to be run, create the module but don't finish initializing the globals
+try:
+    import native
+except:
+    pass
+# try accessing those globals that were never properly initialized
+import native
+native.test()


### PR DESCRIPTION
Fixes mypyc/mypyc#813

This prevents the compiled code from segfaulting when the top level code raises an exception. In that case, previously, the compiled code would store an internal pointer to the module object and would just return that pointer if the same module was initialized more than once. However, if an exception was raised while running top level code, the internal pointer would still point to the module object even though not everything was completely initialized, leading future attempts to import that module to use functions and classes that were never completely initialized.

This fixes that bug by resetting the internal module pointer to NULL when an error occurs so that the top level code is run again on future attempts to import that same function.

## Test Plan

I added a run test to run-misc.test that reproduces this segfault and made sure it passed after my changes.

I wasn't really sure where I should put that test so I ended up putting it in run-misc.test, but let me know if you want me to move it somewhere else.