### PR TITLE
[mypyc] Add mypyc run tests for singledispatch

### DIFF
--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -1,10 +1,8 @@
 # Test cases related to the functools.singledispatch decorator
-# Most of these tests are skipped out because mypyc doesn't support singledispatch yet
+# Most of these tests are marked as xfails because mypyc doesn't support singledispatch yet
 # (These tests will be re-enabled when mypyc supports singledispatch)
 
-# TODO: change these skipped tests to xfails
-
-[case testSpecializedImplementationUsed-skip]
+[case testSpecializedImplementationUsed-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -19,7 +17,7 @@ def test_specialize() -> None:
     assert fun('a')
     assert not fun(3)
 
-[case testSubclassesOfExpectedTypeUseSpecialized-skip]
+[case testSubclassesOfExpectedTypeUseSpecialized-xfail]
 from functools import singledispatch
 class A: pass
 class B(A): pass
@@ -36,7 +34,7 @@ def test_specialize() -> None:
     assert fun(B())
     assert fun(A())
 
-[case testSuperclassImplementationNotUsedWhenSubclassHasImplementation-skip]
+[case testSuperclassImplementationNotUsedWhenSubclassHasImplementation-xfail]
 from functools import singledispatch
 class A: pass
 class B(A): pass
@@ -58,7 +56,7 @@ def test_specialize() -> None:
     assert fun(B())
     assert not fun(A())
 
-[case testMultipleUnderscoreFunctionsIsntError-skip]
+[case testMultipleUnderscoreFunctionsIsntError-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -78,7 +76,7 @@ def test_singledispatch() -> None:
     assert fun('a') == 'str'
     assert fun({'a': 'b'}) == 'default'
 
-[case testCanRegisterCompiledClasses-skip]
+[case testCanRegisterCompiledClasses-xfail]
 from functools import singledispatch
 class A: pass
 
@@ -124,7 +122,7 @@ def test_singledispatch() -> None:
     assert fun(0)
     assert not fun('a')
 
-[case testRegisterDoesntChangeFunction-skip]
+[case testRegisterDoesntChangeFunction-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -138,7 +136,7 @@ def fun_specialized(arg: int) -> bool:
 def test_singledispatch() -> None:
     assert fun_specialized('a')
 
-[case testTypeAnnotationsDisagreeWithRegisterArgument-skip]
+[case testTypeAnnotationsDisagreeWithRegisterArgument-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -153,7 +151,7 @@ def test_singledispatch() -> None:
     assert fun(3) # type: ignore
     assert not fun('a')
 
-[case testNoneIsntATypeWhenUsedAsArgumentToRegister-skip]
+[case testNoneIsntATypeWhenUsedAsArgumentToRegister-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -184,7 +182,7 @@ def test_singledispatch() -> None:
     assert fun('a')
     assert not fun([1, 2])
 
-[case testTypeIsAnABC-skip]
+[case testTypeIsAnABC-xfail]
 from functools import singledispatch
 from collections.abc import Mapping
 
@@ -200,7 +198,7 @@ def test_singledispatch() -> None:
     assert not fun(1)
     assert fun({'a': 'b'})
 
-[case testArgumentDoesntMatchTypeOfAnySpecializedImplementationsOrDefaultImplementation-skip]
+[case testArgumentDoesntMatchTypeOfAnySpecializedImplementationsOrDefaultImplementation-xfail]
 from functools import singledispatch
 class A: pass
 class B(A): pass
@@ -219,7 +217,7 @@ def test_singledispatch() -> None:
     assert not fun([1, 2])
 
 
-[case testSingleDispatchMethod-skip]
+[case testSingleDispatchMethod-xfail]
 from functools import singledispatchmethod
 class A:
     @singledispatchmethod
@@ -240,7 +238,7 @@ def test_singledispatchmethod() -> None:
     assert x.fun('a') == 'str'
     assert x.fun([1, 2]) == 'default'
 
-[case testSingleDispatchMethodWithOtherDecorator-skip]
+[case testSingleDispatchMethodWithOtherDecorator-xfail]
 from functools import singledispatchmethod
 class A:
     @singledispatchmethod
@@ -264,7 +262,7 @@ def test_singledispatchmethod() -> None:
     assert x.fun('a') == 'str'
     assert x.fun([1, 2]) == 'default'
 
-[case testSingledispatchTreeSumAndEqual-skip]
+[case testSingledispatchTreeSumAndEqual-xfail]
 from functools import singledispatch
 
 class Tree:
@@ -322,7 +320,7 @@ def test_sum_and_equal():
     tree3 = build(4)
     assert not equal(tree, tree3)
 
-[case testSimulateMypySingledispatch-skip]
+[case testSimulateMypySingledispatch-xfail]
 from functools import singledispatch
 from mypy_extensions import trait
 from typing import Iterator, Union, TypeVar, Any, List, Type

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -263,3 +263,128 @@ def test_singledispatchmethod() -> None:
     assert x.fun(5) == 'int'
     assert x.fun('a') == 'str'
     assert x.fun([1, 2]) == 'default'
+
+[case testSingledispatchTreeSumAndEqual]
+from functools import singledispatch
+
+class Tree:
+    pass
+class Leaf(Tree):
+    pass
+class Node(Tree):
+    def __init__(self, value: int, left: Tree, right: Tree) -> None:
+        self.value = value
+        self.left = left
+        self.right = right
+
+@singledispatch
+def calc_sum(x: Tree) -> int:
+    raise TypeError('invalid type for x')
+
+@calc_sum.register
+def _(x: Leaf) -> int:
+    return 0
+
+@calc_sum.register
+def _(x: Node) -> int:
+    return x.value + calc_sum(x.left) + calc_sum(x.right)
+
+@singledispatch
+def equal(to_compare: Tree, known: Tree) -> bool:
+    raise TypeError('invalid type for x')
+
+@equal.register
+def _(to_compare: Leaf, known: Tree) -> bool:
+    return isinstance(known, Leaf)
+
+@equal.register
+def _(to_compare: Node, known: Tree) -> bool:
+    if isinstance(known, Node):
+        if to_compare.value != known.value:
+            return False
+        else:
+            return equal(to_compare.left, known.left) and equal(to_compare.right, known.right)
+    return False
+
+def build(n: int) -> Tree:
+    if n == 0:
+        return Leaf()
+    return Node(n, build(n - 1), build(n - 1))
+
+def test_sum_and_equal():
+    tree = build(5)
+    tree2 = build(5)
+    tree2.right.right.right.value = 10
+    assert calc_sum(tree) == 57
+    assert calc_sum(tree2) == 62
+    assert equal(tree, tree)
+    assert not equal(tree, tree2)
+    tree3 = build(4)
+    assert not equal(tree, tree3)
+
+[case testSimulateMypySingledispatch]
+from functools import singledispatch
+from mypy_extensions import trait
+from typing import Iterator, Union, TypeVar, Any, List, Type
+# based on use of singledispatch in stubtest.py
+class Error:
+    def __init__(self, msg: str) -> None:
+        self.msg = msg
+
+@trait
+class Node: pass
+
+class MypyFile(Node): pass
+class TypeInfo(Node): pass
+
+
+class SymbolNode(Node): pass
+class Expression(Node): pass
+class TypeVarLikeExpr(SymbolNode, Expression): pass
+class TypeVarExpr(TypeVarLikeExpr): pass
+
+class Missing: pass
+MISSING = Missing()
+
+T = TypeVar("T")
+
+MaybeMissing = Union[T, Missing]
+
+@singledispatch
+def verify(stub: Node, a: MaybeMissing[Any], b: List[str]) -> Iterator[Error]:
+    yield Error('unknown node type')
+
+@verify.register(MypyFile)
+def verify_mypyfile(stub: MypyFile, a: MaybeMissing[int], b: List[str]) -> Iterator[Error]:
+    if isinstance(a, Missing):
+        yield Error("shouldn't be missing")
+        return
+    if not isinstance(a, int):
+        # this check should be unnecessary because of the type signature and the previous check,
+        # but stubtest.py has this check
+        yield Error("should be an int")
+        return
+    yield from verify(TypeInfo(), str, ['abc', 'def'])
+
+@verify.register(TypeInfo)
+def verify_typeinfo(stub: TypeInfo, a: MaybeMissing[Type[Any]], b: List[str]) -> Iterator[Error]:
+    yield Error('in TypeInfo')
+    yield Error('hello')
+
+@verify.register(TypeVarExpr)
+def verify_typevarexpr(stub: TypeVarExpr, a: MaybeMissing[Any], b: List[str]) -> Iterator[Error]:
+    if False:
+        yield None
+    yield from b
+
+def verify_list(stub, a, b) -> List[str]:
+    """Helper function that converts iterator of errors to list of messages"""
+    return list(err.msg for err in verify(stub, a, b))
+
+def test_verify() -> None:
+    assert verify_list(Node(), 'a', ['a', 'b']) == ['unknown node type']
+    assert verify_list(MypyFile(), 'a', ['a', 'b']) == ['should be an int']
+    assert verify_list(MypyFile(), MISSING, ['a', 'b']) == ["shouldn't be missing"]
+    assert verify_list(MypyFile(), 5, ['a', 'b']) == ['in TypeInfo', 'hello']
+    assert verify_list(TypeInfo(), str, ['a', 'b']) == ['in TypeInfo', 'hello']
+    assert verify_list(TypeVarExpr(), 'a', ['x', 'y']) == ['x', 'y']

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -1,0 +1,264 @@
+# Test cases related to the functools.singledispatch decorator
+# Some of these tests are commented out because mypyc doesn't support singledispatch yet
+# (These tests will be re-enabled when mypyc supports singledispatch)
+
+
+# [case testSpecializedImplementationUsed]
+# from functools import singledispatch
+
+# @singledispatch
+# def fun(arg) -> bool:
+#     return False
+
+# @fun.register
+# def fun_specialized(arg: str) -> bool:
+#     return True
+
+# def test_specialize() -> None:
+#     assert fun('a')
+#     assert not fun(3)
+
+# [case testSubclassesOfExpectedTypeUseSpecialized]
+# from functools import singledispatch
+# class A: pass
+# class B(A): pass
+
+# @singledispatch
+# def fun(arg) -> bool:
+#     return False
+
+# @fun.register
+# def fun_specialized(arg: A) -> bool:
+#     return True
+
+# def test_specialize() -> None:
+#     assert fun(B())
+#     assert fun(A())
+
+# [case testSuperclassImplementationNotUsedWhenSubclassHasImplementation]
+# from functools import singledispatch
+# class A: pass
+# class B(A): pass
+
+# @singledispatch
+# def fun(arg) -> bool:
+#     # shouldn't be using this
+#     assert False
+
+# @fun.register
+# def fun_specialized(arg: A) -> bool:
+#     return False
+
+# @fun.register
+# def fun_specialized2(arg: B) -> bool:
+#     return True
+
+# def test_specialize() -> None:
+#     assert fun(B())
+#     assert not fun(A())
+
+# [case testMultipleUnderscoreFunctionsIsntError]
+# from functools import singledispatch
+
+# @singledispatch
+# def fun(arg) -> str:
+#     return 'default'
+
+# @fun.register
+# def _(arg: str) -> str:
+#     return 'str'
+
+# @fun.register
+# def _(arg: int) -> str:
+#     return 'int'
+
+# def test_singledispatch() -> None:
+#     assert fun(0) == 'int'
+#     assert fun('a') == 'str'
+#     assert fun({'a': 'b'}) == 'default'
+
+# [case testCanRegisterCompiledClasses]
+# from functools import singledispatch
+# class A: pass
+
+# @singledispatch
+# def fun(arg) -> bool:
+#     return False
+# @fun.register
+# def fun_specialized(arg: A) -> bool:
+#     return True
+
+# def test_singledispatch() -> None:
+#     assert fun(A())
+#     assert not fun(1)
+
+[case testTypeUsedAsArgumentToRegister]
+from functools import singledispatch
+
+@singledispatch
+def fun(arg) -> bool:
+    return False
+
+@fun.register(int)
+def fun_specialized(arg) -> bool:
+    return True
+
+def test_singledispatch() -> None:
+    assert fun(1)
+    assert not fun('a')
+
+[case testUseRegisterAsAFunction]
+from functools import singledispatch
+
+@singledispatch
+def fun(arg) -> bool:
+    return False
+
+def fun_specialized_impl(arg) -> bool:
+    return True
+
+fun.register(int, fun_specialized_impl)
+
+def test_singledispatch() -> None:
+    assert fun(0)
+    assert not fun('a')
+
+# [case testRegisterDoesntChangeFunction]
+# from functools import singledispatch
+
+# @singledispatch
+# def fun(arg) -> bool:
+#     return False
+
+# @fun.register
+# def fun_specialized(arg: int) -> bool:
+#     return True
+
+# def test_singledispatch() -> None:
+#     assert fun_specialized('a')
+
+# [case testTypeAnnotationsDisagreeWithRegisterArgument]
+# from functools import singledispatch
+
+# @singledispatch
+# def fun(arg) -> bool:
+#     return False
+
+# @fun.register(int)
+# def fun_specialized(arg: str) -> bool:
+#     return True
+
+# def test_singledispatch() -> None:
+#     assert fun(3) # type: ignore
+#     assert not fun('a')
+
+# [case testNoneIsntATypeWhenUsedAsArgumentToRegister]
+# from functools import singledispatch
+
+# @singledispatch
+# def fun(arg) -> bool:
+#     return False
+
+# try:
+#     @fun.register(None)
+#     def fun_specialized(arg) -> bool:
+#         return True
+# except TypeError:
+#     pass
+
+[case testRegisteringTheSameFunctionSeveralTimes]
+from functools import singledispatch
+
+@singledispatch
+def fun(arg) -> bool:
+    return False
+
+@fun.register(int)
+@fun.register(str)
+def fun_specialized(arg) -> bool:
+    return True
+
+def test_singledispatch() -> None:
+    assert fun(0)
+    assert fun('a')
+    assert not fun([1, 2])
+
+# [case testTypeIsAnABC]
+# from functools import singledispatch
+# from collections.abc import Mapping
+
+# @singledispatch
+# def fun(arg) -> bool:
+#     return False
+
+# @fun.register
+# def fun_specialized(arg: Mapping) -> bool:
+#     return True
+
+# def test_singledispatch() -> None:
+#     assert not fun(1)
+#     assert fun({'a': 'b'})
+
+# [case testArgumentDoesntMatchTypeOfAnySpecializedImplementationsOrDefaultImplementation]
+# from functools import singledispatch
+# class A: pass
+# class B(A): pass
+
+# @singledispatch
+# def fun(arg: A) -> bool:
+#     return False
+
+# @fun.register
+# def fun_specialized(arg: B) -> bool:
+#     return True
+
+# def test_singledispatch() -> None:
+#     assert fun(B())
+#     assert fun(A())
+#     assert not fun([1, 2])
+
+
+# [case testSingleDispatchMethod]
+# from functools import singledispatchmethod
+# class A:
+#     @singledispatchmethod
+#     def fun(self, arg) -> str:
+#         return 'default'
+
+#     @fun.register
+#     def fun_int(self, arg: int) -> str:
+#         return 'int'
+
+#     @fun.register
+#     def fun_str(self, arg: str) -> str:
+#         return 'str'
+
+# def test_singledispatchmethod() -> None:
+#     x = A()
+#     assert x.fun(5) == 'int'
+#     assert x.fun('a') == 'str'
+#     assert x.fun([1, 2]) == 'default'
+
+# [case testSingleDispatchMethodWithOtherDecorator]
+# from functools import singledispatchmethod
+# class A:
+#     @singledispatchmethod
+#     @staticmethod
+#     def fun(arg) -> str:
+#         return 'default'
+
+#     @fun.register
+#     @staticmethod
+#     def fun_int(arg: int) -> str:
+#         return 'int'
+
+#     @fun.register
+#     @staticmethod
+#     def fun_str(arg: str) -> str:
+#         return 'str'
+
+# def test_singledispatchmethod() -> None:
+#     x = A()
+#     assert x.fun(5) == 'int'
+#     assert x.fun('a') == 'str'
+#     assert x.fun([1, 2]) == 'default'

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -1,96 +1,97 @@
 # Test cases related to the functools.singledispatch decorator
-# Some of these tests are commented out because mypyc doesn't support singledispatch yet
+# Most of these tests are skipped out because mypyc doesn't support singledispatch yet
 # (These tests will be re-enabled when mypyc supports singledispatch)
 
+# TODO: change these skipped tests to xfails
 
-# [case testSpecializedImplementationUsed]
-# from functools import singledispatch
+[case testSpecializedImplementationUsed-skip]
+from functools import singledispatch
 
-# @singledispatch
-# def fun(arg) -> bool:
-#     return False
+@singledispatch
+def fun(arg) -> bool:
+    return False
 
-# @fun.register
-# def fun_specialized(arg: str) -> bool:
-#     return True
+@fun.register
+def fun_specialized(arg: str) -> bool:
+    return True
 
-# def test_specialize() -> None:
-#     assert fun('a')
-#     assert not fun(3)
+def test_specialize() -> None:
+    assert fun('a')
+    assert not fun(3)
 
-# [case testSubclassesOfExpectedTypeUseSpecialized]
-# from functools import singledispatch
-# class A: pass
-# class B(A): pass
+[case testSubclassesOfExpectedTypeUseSpecialized-skip]
+from functools import singledispatch
+class A: pass
+class B(A): pass
 
-# @singledispatch
-# def fun(arg) -> bool:
-#     return False
+@singledispatch
+def fun(arg) -> bool:
+    return False
 
-# @fun.register
-# def fun_specialized(arg: A) -> bool:
-#     return True
+@fun.register
+def fun_specialized(arg: A) -> bool:
+    return True
 
-# def test_specialize() -> None:
-#     assert fun(B())
-#     assert fun(A())
+def test_specialize() -> None:
+    assert fun(B())
+    assert fun(A())
 
-# [case testSuperclassImplementationNotUsedWhenSubclassHasImplementation]
-# from functools import singledispatch
-# class A: pass
-# class B(A): pass
+[case testSuperclassImplementationNotUsedWhenSubclassHasImplementation-skip]
+from functools import singledispatch
+class A: pass
+class B(A): pass
 
-# @singledispatch
-# def fun(arg) -> bool:
-#     # shouldn't be using this
-#     assert False
+@singledispatch
+def fun(arg) -> bool:
+    # shouldn't be using this
+    assert False
 
-# @fun.register
-# def fun_specialized(arg: A) -> bool:
-#     return False
+@fun.register
+def fun_specialized(arg: A) -> bool:
+    return False
 
-# @fun.register
-# def fun_specialized2(arg: B) -> bool:
-#     return True
+@fun.register
+def fun_specialized2(arg: B) -> bool:
+    return True
 
-# def test_specialize() -> None:
-#     assert fun(B())
-#     assert not fun(A())
+def test_specialize() -> None:
+    assert fun(B())
+    assert not fun(A())
 
-# [case testMultipleUnderscoreFunctionsIsntError]
-# from functools import singledispatch
+[case testMultipleUnderscoreFunctionsIsntError-skip]
+from functools import singledispatch
 
-# @singledispatch
-# def fun(arg) -> str:
-#     return 'default'
+@singledispatch
+def fun(arg) -> str:
+    return 'default'
 
-# @fun.register
-# def _(arg: str) -> str:
-#     return 'str'
+@fun.register
+def _(arg: str) -> str:
+    return 'str'
 
-# @fun.register
-# def _(arg: int) -> str:
-#     return 'int'
+@fun.register
+def _(arg: int) -> str:
+    return 'int'
 
-# def test_singledispatch() -> None:
-#     assert fun(0) == 'int'
-#     assert fun('a') == 'str'
-#     assert fun({'a': 'b'}) == 'default'
+def test_singledispatch() -> None:
+    assert fun(0) == 'int'
+    assert fun('a') == 'str'
+    assert fun({'a': 'b'}) == 'default'
 
-# [case testCanRegisterCompiledClasses]
-# from functools import singledispatch
-# class A: pass
+[case testCanRegisterCompiledClasses-skip]
+from functools import singledispatch
+class A: pass
 
-# @singledispatch
-# def fun(arg) -> bool:
-#     return False
-# @fun.register
-# def fun_specialized(arg: A) -> bool:
-#     return True
+@singledispatch
+def fun(arg) -> bool:
+    return False
+@fun.register
+def fun_specialized(arg: A) -> bool:
+    return True
 
-# def test_singledispatch() -> None:
-#     assert fun(A())
-#     assert not fun(1)
+def test_singledispatch() -> None:
+    assert fun(A())
+    assert not fun(1)
 
 [case testTypeUsedAsArgumentToRegister]
 from functools import singledispatch
@@ -123,48 +124,48 @@ def test_singledispatch() -> None:
     assert fun(0)
     assert not fun('a')
 
-# [case testRegisterDoesntChangeFunction]
-# from functools import singledispatch
+[case testRegisterDoesntChangeFunction-skip]
+from functools import singledispatch
 
-# @singledispatch
-# def fun(arg) -> bool:
-#     return False
+@singledispatch
+def fun(arg) -> bool:
+    return False
 
-# @fun.register
-# def fun_specialized(arg: int) -> bool:
-#     return True
+@fun.register
+def fun_specialized(arg: int) -> bool:
+    return True
 
-# def test_singledispatch() -> None:
-#     assert fun_specialized('a')
+def test_singledispatch() -> None:
+    assert fun_specialized('a')
 
-# [case testTypeAnnotationsDisagreeWithRegisterArgument]
-# from functools import singledispatch
+[case testTypeAnnotationsDisagreeWithRegisterArgument-skip]
+from functools import singledispatch
 
-# @singledispatch
-# def fun(arg) -> bool:
-#     return False
+@singledispatch
+def fun(arg) -> bool:
+    return False
 
-# @fun.register(int)
-# def fun_specialized(arg: str) -> bool:
-#     return True
+@fun.register(int)
+def fun_specialized(arg: str) -> bool:
+    return True
 
-# def test_singledispatch() -> None:
-#     assert fun(3) # type: ignore
-#     assert not fun('a')
+def test_singledispatch() -> None:
+    assert fun(3) # type: ignore
+    assert not fun('a')
 
-# [case testNoneIsntATypeWhenUsedAsArgumentToRegister]
-# from functools import singledispatch
+[case testNoneIsntATypeWhenUsedAsArgumentToRegister-skip]
+from functools import singledispatch
 
-# @singledispatch
-# def fun(arg) -> bool:
-#     return False
+@singledispatch
+def fun(arg) -> bool:
+    return False
 
-# try:
-#     @fun.register(None)
-#     def fun_specialized(arg) -> bool:
-#         return True
-# except TypeError:
-#     pass
+try:
+    @fun.register(None)
+    def fun_specialized(arg) -> bool:
+        return True
+except TypeError:
+    pass
 
 [case testRegisteringTheSameFunctionSeveralTimes]
 from functools import singledispatch
@@ -183,82 +184,82 @@ def test_singledispatch() -> None:
     assert fun('a')
     assert not fun([1, 2])
 
-# [case testTypeIsAnABC]
-# from functools import singledispatch
-# from collections.abc import Mapping
+[case testTypeIsAnABC-skip]
+from functools import singledispatch
+from collections.abc import Mapping
 
-# @singledispatch
-# def fun(arg) -> bool:
-#     return False
+@singledispatch
+def fun(arg) -> bool:
+    return False
 
-# @fun.register
-# def fun_specialized(arg: Mapping) -> bool:
-#     return True
+@fun.register
+def fun_specialized(arg: Mapping) -> bool:
+    return True
 
-# def test_singledispatch() -> None:
-#     assert not fun(1)
-#     assert fun({'a': 'b'})
+def test_singledispatch() -> None:
+    assert not fun(1)
+    assert fun({'a': 'b'})
 
-# [case testArgumentDoesntMatchTypeOfAnySpecializedImplementationsOrDefaultImplementation]
-# from functools import singledispatch
-# class A: pass
-# class B(A): pass
+[case testArgumentDoesntMatchTypeOfAnySpecializedImplementationsOrDefaultImplementation-skip]
+from functools import singledispatch
+class A: pass
+class B(A): pass
 
-# @singledispatch
-# def fun(arg: A) -> bool:
-#     return False
+@singledispatch
+def fun(arg: A) -> bool:
+    return False
 
-# @fun.register
-# def fun_specialized(arg: B) -> bool:
-#     return True
+@fun.register
+def fun_specialized(arg: B) -> bool:
+    return True
 
-# def test_singledispatch() -> None:
-#     assert fun(B())
-#     assert fun(A())
-#     assert not fun([1, 2])
+def test_singledispatch() -> None:
+    assert fun(B())
+    assert fun(A())
+    assert not fun([1, 2])
 
 
-# [case testSingleDispatchMethod]
-# from functools import singledispatchmethod
-# class A:
-#     @singledispatchmethod
-#     def fun(self, arg) -> str:
-#         return 'default'
+[case testSingleDispatchMethod-skip]
+from functools import singledispatchmethod
+class A:
+    @singledispatchmethod
+    def fun(self, arg) -> str:
+        return 'default'
 
-#     @fun.register
-#     def fun_int(self, arg: int) -> str:
-#         return 'int'
+    @fun.register
+    def fun_int(self, arg: int) -> str:
+        return 'int'
 
-#     @fun.register
-#     def fun_str(self, arg: str) -> str:
-#         return 'str'
+    @fun.register
+    def fun_str(self, arg: str) -> str:
+        return 'str'
 
-# def test_singledispatchmethod() -> None:
-#     x = A()
-#     assert x.fun(5) == 'int'
-#     assert x.fun('a') == 'str'
-#     assert x.fun([1, 2]) == 'default'
+def test_singledispatchmethod() -> None:
+    x = A()
+    assert x.fun(5) == 'int'
+    assert x.fun('a') == 'str'
+    assert x.fun([1, 2]) == 'default'
 
-# [case testSingleDispatchMethodWithOtherDecorator]
-# from functools import singledispatchmethod
-# class A:
-#     @singledispatchmethod
-#     @staticmethod
-#     def fun(arg) -> str:
-#         return 'default'
+[case testSingleDispatchMethodWithOtherDecorator-skip]
+from functools import singledispatchmethod
+class A:
+    @singledispatchmethod
+    @staticmethod
+    def fun(arg) -> str:
+        return 'default'
 
-#     @fun.register
-#     @staticmethod
-#     def fun_int(arg: int) -> str:
-#         return 'int'
+    @fun.register
+    @staticmethod
+    def fun_int(arg: int) -> str:
+        return 'int'
 
-#     @fun.register
-#     @staticmethod
-#     def fun_str(arg: str) -> str:
-#         return 'str'
+    @fun.register
+    @staticmethod
+    def fun_str(arg: str) -> str:
+        return 'str'
 
-# def test_singledispatchmethod() -> None:
-#     x = A()
-#     assert x.fun(5) == 'int'
-#     assert x.fun('a') == 'str'
-#     assert x.fun([1, 2]) == 'default'
+def test_singledispatchmethod() -> None:
+    x = A()
+    assert x.fun(5) == 'int'
+    assert x.fun('a') == 'str'
+    assert x.fun([1, 2]) == 'default'

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -264,7 +264,7 @@ def test_singledispatchmethod() -> None:
     assert x.fun('a') == 'str'
     assert x.fun([1, 2]) == 'default'
 
-[case testSingledispatchTreeSumAndEqual]
+[case testSingledispatchTreeSumAndEqual-skip]
 from functools import singledispatch
 
 class Tree:
@@ -322,7 +322,7 @@ def test_sum_and_equal():
     tree3 = build(4)
     assert not equal(tree, tree3)
 
-[case testSimulateMypySingledispatch]
+[case testSimulateMypySingledispatch-skip]
 from functools import singledispatch
 from mypy_extensions import trait
 from typing import Iterator, Union, TypeVar, Any, List, Type
@@ -375,7 +375,6 @@ def verify_typeinfo(stub: TypeInfo, a: MaybeMissing[Type[Any]], b: List[str]) ->
 def verify_typevarexpr(stub: TypeVarExpr, a: MaybeMissing[Any], b: List[str]) -> Iterator[Error]:
     if False:
         yield None
-    yield from b
 
 def verify_list(stub, a, b) -> List[str]:
     """Helper function that converts iterator of errors to list of messages"""

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -51,6 +51,7 @@ files = [
     'run-bench.test',
     'run-mypy-sim.test',
     'run-dunders.test',
+    'run-singledispatch.test'
 ]
 if sys.version_info >= (3, 7):
     files.append('run-python37.test')


### PR DESCRIPTION
This adds some run tests to run-singledispatch.test for situations that are likely to be common or that seem like they would be edge cases that we don't handle correctly.

Most of these tests are commented out because mypyc doesn't properly support singledispatch yet, and the few that aren't commented out only work because they're written in a way that causes mypyc to use the standard library implementation of singledispatch.

There are some situations where I added tests that check whether mypyc sticks to what the standard library's implementation does, even though those situations are probably bugs that should probably be mypy errors. For example, `testTypeAnnotationsDisagreeWithRegisterArgument` checks whether mypyc uses the argument to register for dispatch instead of the type annotation when they disagree, even though having different types for both of those is probably a bug.

## Test Plan

I ran all of the run tests that I added and commented out the ones that weren't passing.