### PR TITLE
[mypyc] Add cleanup at end of init function

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -921,14 +921,13 @@ class GroupGenerator:
 
         emitter.emit_line('return {};'.format(module_static))
         emitter.emit_lines('fail:',
-                           'Py_XDECREF({});'.format(module_static),
+                           'Py_CLEAR({});'.format(module_static),
                            'Py_XDECREF(modname);')
         # the type objects returned from CPyType_FromTemplate are all new references
         # so we have to decref them
         for t in type_structs:
             emitter.emit_line('Py_XDECREF({});'.format(t))
-        emitter.emit_lines('{} = NULL;'.format(module_static),
-                           'return NULL;')
+        emitter.emit_line('return NULL;')
         emitter.emit_line('}')
 
     def generate_top_level_call(self, module: ModuleIR, emitter: Emitter) -> None:

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -923,14 +923,14 @@ class GroupGenerator:
         emitter.emit_lines('fail:',
                            'Py_CLEAR({});'.format(module_static),
                            'Py_CLEAR(modname);')
-        # the type objects returned from CPyType_FromTemplate are all new references
-        # so we have to decref them
         for name, typ in module.final_names:
             static_name = emitter.static_name(name, module_name)
             if emitter.ctype(typ) == 'PyObject *':
                 emitter.emit_line('Py_CLEAR({});'.format(static_name))
             elif is_tagged(typ):
                 emitter.emit_line('CPyTagged_XDecRef({});'.format(static_name))
+        # the type objects returned from CPyType_FromTemplate are all new references
+        # so we have to decref them
         for t in type_structs:
             emitter.emit_line('Py_CLEAR({});'.format(t))
         emitter.emit_line('return NULL;')

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -36,7 +36,7 @@ from mypyc.codegen.emitwrapper import (
     generate_legacy_wrapper_function, legacy_wrapper_function_header,
 )
 from mypyc.ir.ops import DeserMaps, LoadLiteral
-from mypyc.ir.rtypes import RType, RTuple, is_tagged
+from mypyc.ir.rtypes import RType, RTuple
 from mypyc.ir.func_ir import FuncIR
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.module_ir import ModuleIR, ModuleIRs, deserialize_modules
@@ -925,10 +925,9 @@ class GroupGenerator:
                            'Py_CLEAR(modname);')
         for name, typ in module.final_names:
             static_name = emitter.static_name(name, module_name)
-            if emitter.ctype(typ) == 'PyObject *':
-                emitter.emit_line('Py_CLEAR({});'.format(static_name))
-            elif is_tagged(typ):
-                emitter.emit_line('CPyTagged_XDecRef({});'.format(static_name))
+            emitter.emit_dec_ref(static_name, typ, is_xdec=True)
+            undef = emitter.c_undefined_value(typ)
+            emitter.emit_line('{} = {};'.format(static_name, undef))
         # the type objects returned from CPyType_FromTemplate are all new references
         # so we have to decref them
         for t in type_structs:

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -899,9 +899,11 @@ class GroupGenerator:
                            '    goto fail;')
 
         # HACK: Manually instantiate generated classes here
+        type_structs = []  # type: List[str]
         for cl in module.classes:
             if cl.is_generated:
                 type_struct = emitter.type_struct_name(cl)
+                type_structs.append(type_struct)
                 emitter.emit_lines(
                     '{t} = (PyTypeObject *)CPyType_FromTemplate('
                     '(PyObject *){t}_template, NULL, modname);'
@@ -918,7 +920,13 @@ class GroupGenerator:
 
         emitter.emit_line('return {};'.format(module_static))
         emitter.emit_lines('fail:',
-                           '{} = NULL;'.format(module_static),
+                           'Py_XDECREF({});'.format(module_static),
+                           'Py_XDECREF(modname);')
+        # the type objects returned from CPyType_FromTemplate are all new references
+        # so we have to decref them
+        for t in type_structs:
+            emitter.emit_line('Py_XDECREF({});'.format(t))
+        emitter.emit_lines('{} = NULL;'.format(module_static),
                            'return NULL;')
         emitter.emit_line('}')
 

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -902,9 +902,9 @@ class GroupGenerator:
         # HACK: Manually instantiate generated classes here
         type_structs = []  # type: List[str]
         for cl in module.classes:
+            type_struct = emitter.type_struct_name(cl)
+            type_structs.append(type_struct)
             if cl.is_generated:
-                type_struct = emitter.type_struct_name(cl)
-                type_structs.append(type_struct)
                 emitter.emit_lines(
                     '{t} = (PyTypeObject *)CPyType_FromTemplate('
                     '(PyObject *){t}_template, NULL, modname);'

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -922,7 +922,7 @@ class GroupGenerator:
         emitter.emit_line('return {};'.format(module_static))
         emitter.emit_lines('fail:',
                            'Py_CLEAR({});'.format(module_static),
-                           'Py_XDECREF(modname);')
+                           'Py_CLEAR(modname);')
         # the type objects returned from CPyType_FromTemplate are all new references
         # so we have to decref them
         for name, typ in module.final_names:
@@ -932,7 +932,7 @@ class GroupGenerator:
             elif is_tagged(typ):
                 emitter.emit_line('CPyTagged_XDecRef({});'.format(static_name))
         for t in type_structs:
-            emitter.emit_line('Py_XDECREF({});'.format(t))
+            emitter.emit_line('Py_CLEAR({});'.format(t))
         emitter.emit_line('return NULL;')
         emitter.emit_line('}')
 

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -874,6 +874,7 @@ class GroupGenerator:
             declaration = 'PyObject *CPyInit_{}(void)'.format(exported_name(module_name))
         emitter.emit_lines(declaration,
                            '{')
+        emitter.emit_line('PyObject* modname = NULL;')
         # Store the module reference in a static and return it when necessary.
         # This is separate from the *global* reference to the module that will
         # be populated when it is imported by a compiled module. We want that
@@ -890,7 +891,7 @@ class GroupGenerator:
                            'if (unlikely({} == NULL))'.format(module_static),
                            '    goto fail;')
         emitter.emit_line(
-            'PyObject *modname = PyObject_GetAttrString((PyObject *){}, "__name__");'.format(
+            'modname = PyObject_GetAttrString((PyObject *){}, "__name__");'.format(
                 module_static))
 
         module_globals = emitter.static_name('globals', module_name)


### PR DESCRIPTION
This frees everything created in the generated initialization function so that we don't leak memory in the case of an error during initialization, as mentioned in https://github.com/python/mypy/pull/10586#pullrequestreview-678090095.