### PR TITLE
Fix confusion between stubs for google.protobuf and google.cloud

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -230,7 +230,8 @@ class FindModuleCache:
             elif not plausible_match and (self.fscache.isdir(dir_path)
                                           or self.fscache.isfile(dir_path + ".py")):
                 plausible_match = True
-        if components[0] in legacy_bundled_packages:
+        if (components[0] in legacy_bundled_packages
+                or '.'.join(components[:2]) in legacy_bundled_packages):
             return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
         elif plausible_match:
             return ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS

--- a/mypy/stubinfo.py
+++ b/mypy/stubinfo.py
@@ -1,6 +1,8 @@
 # Stubs for these third-party packages used to be shipped with mypy.
 #
 # Map package name to PyPI stub distribution name.
+#
+# Package name can have one or two components ('a' or 'a.b').
 legacy_bundled_packages = {
     'aiofiles': 'types-aiofiles',
     'atomicwrites': 'types-atomicwrites',
@@ -36,7 +38,7 @@ legacy_bundled_packages = {
     'frozendict': 'types-frozendict',
     'geoip2': 'types-geoip2',
     'gflags': 'types-python-gflags',
-    'google': 'types-protobuf',
+    'google.protobuf': 'types-protobuf',
     'ipaddress': 'types-ipaddress',
     'itsdangerous': 'types-itsdangerous',
     'jinja2': 'types-Jinja2',

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -284,6 +284,17 @@ def get_prefix(fullname: str) -> str:
     return fullname.rsplit('.', 1)[0]
 
 
+def get_top_two_prefixes(fullname: str) -> Tuple[str, str]:
+    """Return one and two component prefixes of a fully qualified name.
+
+    Given 'a.b.c.d', return ('a', 'a.b').
+
+    If fullname has only one component, return (fullname, fullname).
+    """
+    components = fullname.split('.', 3)
+    return components[0], '.'.join(components[:2])
+
+
 def correct_relative_import(cur_mod_id: str,
                             relative: int,
                             target: str,

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -3094,3 +3094,16 @@ ignore_missing_imports = true
 \[[tool.mypy.overrides]]
 module = "foobar1"
 ignore_missing_imports = true
+
+[case testIgnoreErrorFromGoogleCloud]
+# flags: --ignore-missing-imports
+import google.cloud
+from google.cloud import x
+
+[case testErrorFromGoogleCloud]
+import google.cloud
+from google.cloud import x
+[out]
+main:1: error: Cannot find implementation or library stub for module named "google.cloud"
+main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+main:1: error: Cannot find implementation or library stub for module named "google"


### PR DESCRIPTION
Previously we used `google` as the package prefix for `google.protobuf`.
That wasn't correct, since there are other, unrelated packages in the Google
namespace, such as `google.cloud`.

This fixes the prefix to to be `google.protobuf`.

Fixes #10601.