### PR TITLE
Remove misleading list of default locations

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -13,8 +13,7 @@ to read a different file instead (see :ref:`config-file-flag`).
 It is important to understand that there is no merging of configuration
 files, as it would lead to ambiguity.  The :option:`--config-file <mypy --config-file>` flag
 has the highest precedence and must be correct; otherwise mypy will report
-an error and exit.  Without command line option, mypy will look for defaults in the above mentioned order,
-but will use only one of them.
+an error and exit.  Without command line option, mypy will look for configuration files in the above mentioned order.
 
 Most flags correspond closely to :ref:`command-line flags
 <command-line>` but there are some differences in flag names and some

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -13,9 +13,8 @@ to read a different file instead (see :ref:`config-file-flag`).
 It is important to understand that there is no merging of configuration
 files, as it would lead to ambiguity.  The :option:`--config-file <mypy --config-file>` flag
 has the highest precedence and must be correct; otherwise mypy will report
-an error and exit.  Without command line option, mypy will look for defaults,
-but will use only one of them.  The first one to read is ``mypy.ini``,
-then ``.mypy.ini``, and finally ``setup.cfg``.
+an error and exit.  Without command line option, mypy will look for defaults in the above mentioned order,
+but will use only one of them.
 
 Most flags correspond closely to :ref:`command-line flags
 <command-line>` but there are some differences in flag names and some


### PR DESCRIPTION
The list of locations in the second paragraph of `docs/source/config_file.rst` is missing `pyproject.toml` and the user config files.

### Description

This change refers to the complete list in the previous paragraph instead of listing all locations again.

## Test Plan

No tests needed, as no code was changed. See https://github.com/python/mypy/blob/master/mypy/defaults.py for correctness.