### PR TITLE
Support --install-types --non-interactive that doesn't prompt

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -297,6 +297,9 @@ class Options:
         self.show_absolute_path = False  # type: bool
         # Install missing stub packages if True
         self.install_types = False
+        # Install missing stub packages in non-interactive mode (don't prompt for
+        # confirmation, and don't show any errors)
+        self.non_interactive = False
         # When we encounter errors that may cause many additional errors,
         # skip most errors after this many messages have been reported.
         # -1 means unlimited.

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1276,3 +1276,15 @@ x = 0  # type: str
 y = 0  # type: str
 [out]
 pkg.py:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+[case testCmdlineNonInteractiveWithoutInstallTypes]
+# cmd: mypy --non-interactive -m pkg
+[out]
+Error: --non-interactive is only supported with --install-types
+== Return code: 2
+
+[case testCmdlineNonInteractiveInstallTypesNothingToDo]
+# cmd: mypy --install-types --non-interactive -m pkg
+[file pkg.py]
+1()
+[out]


### PR DESCRIPTION
It also doesn't show errors, making it useful in CI jobs.

Example:
```
$ mypy --install-types --non-interactive -c 'import click'
Installing missing stub packages:
/Users/jukka/venv/mypy/bin/python3 -m pip install types-click

Collecting types-click
  Using cached types_click-7.1.0-py2.py3-none-any.whl (13 kB)
Installing collected packages: types-click
Successfully installed types-click-7.1.0
```

Work on #10600.