### PR TITLE
stubgen: never generate variable initializer

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -678,7 +678,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         self.visit_func_def(o.func, is_abstract=is_abstract)
 
     def process_decorator(self, o: Decorator) -> Tuple[bool, bool]:
-        """Process a series of decorataors.
+        """Process a series of decorators.
 
         Only preserve certain special decorators such as @abstractmethod.
 
@@ -1070,9 +1070,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
                 typename += '[{}]'.format(final_arg)
         else:
             typename = self.get_str_type_of_node(rvalue)
-        has_rhs = not (isinstance(rvalue, TempNode) and rvalue.no_rhs)
-        initializer = " = ..." if has_rhs and not self.is_top_level() else ""
-        return '%s%s: %s%s\n' % (self._indent, lvalue, typename, initializer)
+        return '%s%s: %s\n' % (self._indent, lvalue, typename)
 
     def add(self, string: str) -> None:
         """Add text to generated stub."""

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -72,7 +72,7 @@ from mypy.nodes import (
     Expression, IntExpr, UnaryExpr, StrExpr, BytesExpr, NameExpr, FloatExpr, MemberExpr,
     TupleExpr, ListExpr, ComparisonExpr, CallExpr, IndexExpr, EllipsisExpr,
     ClassDef, MypyFile, Decorator, AssignmentStmt, TypeInfo,
-    IfStmt, ImportAll, ImportFrom, Import, FuncDef, FuncBase, TempNode, Block,
+    IfStmt, ImportAll, ImportFrom, Import, FuncDef, FuncBase, Block,
     Statement, OverloadedFuncDef, ARG_POS, ARG_STAR, ARG_STAR2, ARG_NAMED, ARG_NAMED_OPT
 )
 from mypy.stubgenc import generate_stub_for_c_module

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -161,7 +161,7 @@ class C:
     x = 1
 [out]
 class C:
-    x: int = ...
+    x: int
 
 [case testInitTypeAnnotationPreserved]
 class C:
@@ -178,7 +178,7 @@ class C:
         x.y = 2
 [out]
 class C:
-    x: int = ...
+    x: int
     def __init__(self) -> None: ...
 
 [case testSelfAndClassBodyAssignment]
@@ -192,7 +192,7 @@ class C:
 x: int
 
 class C:
-    x: int = ...
+    x: int
     def __init__(self) -> None: ...
 
 [case testEmptyClass]
@@ -244,7 +244,7 @@ class A:
 _x: int
 
 class A:
-    _y: int = ...
+    _y: int
 
 [case testSpecialInternalVar]
 __all__ = []
@@ -438,7 +438,7 @@ class A:
     def f(self): ...
 [out]
 class A:
-    x: int = ...
+    x: int
     def f(self) -> None: ...
 
 [case testSkipMultiplePrivateDefs]
@@ -720,7 +720,7 @@ class A:
 [out]
 class A:
     class B:
-        x: int = ...
+        x: int
         def f(self) -> None: ...
     def g(self) -> None: ...
 
@@ -775,7 +775,7 @@ class A:
 from typing import Any, Optional
 
 class A:
-    x: Any = ...
+    x: Any
     def __init__(self, a: Optional[Any] = ...) -> None: ...
     def method(self, a: Optional[Any] = ...) -> None: ...
 
@@ -911,7 +911,7 @@ class Foo:
 from typing import Any
 
 class Foo:
-    alias: Any = ...
+    alias: Any
 
 [case testAliasExceptions]
 noalias1 = None
@@ -1561,14 +1561,14 @@ class B:
 from typing import Any
 
 class A:
-    y: str = ...
+    y: str
     @property
     def x(self): ...
 
 class B:
     @property
     def x(self): ...
-    y: str = ...
+    y: str
     @x.setter
     def x(self, value: Any) -> None: ...
 
@@ -2174,7 +2174,7 @@ class C:
 from typing import Any
 
 class C:
-    x: Any = ...
+    x: Any
     def __init__(self, x: Any) -> None: ...
     def __lt__(self, other: Any) -> Any: ...
     def __le__(self, other: Any) -> Any: ...


### PR DESCRIPTION
### Description

Previously, the generation of a variable initialized (`= ...`) was
inconsistent between top-level and class-level variables. Since the
initializer has no function in stubs, stubgen will now never generate
it.

## Test Plan

Existing unit tests were updated.
