### PR TITLE
Add tests for singledispatch

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -95,6 +95,7 @@ typecheck_files = [
     'check-generic-alias.test',
     'check-typeguard.test',
     'check-functools.test',
+    'check-singledispatch.test',
 ]
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -1,4 +1,4 @@
-[case testIncorrectDispatchArgumentWhenDoesntMatchFallback-skip]
+[case testIncorrectDispatchArgumentWhenDoesntMatchFallback-xfail]
 from functools import singledispatch
 
 class A: pass
@@ -16,7 +16,7 @@ fun(1) # E: Argument 1 to "fun" has incompatible type "int"; expected "__main__.
 # probably won't be required after singledispatch is special cased
 [builtins fixtures/args.pyi]
 
-[case testMultipleUnderscoreFunctionsIsntError-skip]
+[case testMultipleUnderscoreFunctionsIsntError-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -31,7 +31,7 @@ def _(arg: int) -> None:
 
 [builtins fixtures/args.pyi]
 
-[case testCheckNonDispatchArgumentsWithTypeAlwaysTheSame-skip]
+[case testCheckNonDispatchArgumentsWithTypeAlwaysTheSame-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -50,7 +50,7 @@ f('b', 1) # E: Argument 2 to "fun" has incompatible type "int"; expected "str"
 
 [builtins fixtures/args.pyi]
 
-[case testCheckNonDispatchArgumentsUsingMoreSpecificTypeInSpecializedVersion-skip]
+[case testCheckNonDispatchArgumentsUsingMoreSpecificTypeInSpecializedVersion-xfail]
 from functools import singledispatch
 
 class A: pass
@@ -72,7 +72,7 @@ f('b', B())
 
 [builtins fixtures/args.pyi]
 
-[case testImplementationHasSameDispatchTypeAsFallback-skip]
+[case testImplementationHasSameDispatchTypeAsFallback-xfail]
 from functools import singledispatch
 
 # TODO: differentiate between fallback and other implementations in error message
@@ -86,7 +86,7 @@ def g(arg: int) -> None:
 
 [builtins fixtures/args.pyi]
 
-[case testMultipleImplementationsHaveSameDispatchTypes-skip]
+[case testMultipleImplementationsHaveSameDispatchTypes-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -103,7 +103,7 @@ def h(arg: int) -> None:
 
 [builtins fixtures/args.pyi]
     
-[case testRegisterHasDifferentTypeThanTypeSignature-skip]
+[case testRegisterHasDifferentTypeThanTypeSignature-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -116,7 +116,7 @@ def g(arg: int) -> None: # E: Argument to register "str" is incompatible with ty
 
 [builtins fixtures/args.pyi]
 
-[case testMoreSpecificGenericNonDispatchArgumentInImplementations-skip]
+[case testMoreSpecificGenericNonDispatchArgumentInImplementations-xfail]
 from functools import singledispatch
 from typing import TypeVar, Optional, Any, Type
 
@@ -146,7 +146,7 @@ f('a', None)
 
 [builtins fixtures/args.pyi]
 
-[case testDispatchBasedOnTypeAnnotationsRequires37-skip]
+[case testDispatchBasedOnTypeAnnotationsRequires37-xfail]
 # flags: --python-version 3.6
 # the docs for singledispatch say that register didn't accept type annotations until python 3.7
 from functools import singledispatch

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -1,0 +1,161 @@
+[case testIncorrectDispatchArgumentWhenDoesntMatchFallback-skip]
+from functools import singledispatch
+
+class A: pass
+class B(A): pass
+
+@singledispatch
+def fun(arg: A) -> None:
+    pass
+@fun.register
+def fun_b(arg: B) -> None:
+    pass
+
+fun(1) # E: Argument 1 to "fun" has incompatible type "int"; expected "__main__.A"
+
+# probably won't be required after singledispatch is special cased
+[builtins fixtures/args.pyi]
+
+[case testMultipleUnderscoreFunctionsIsntError-skip]
+from functools import singledispatch
+
+@singledispatch
+def fun(arg) -> None:
+    pass
+@fun.register
+def _(arg: str) -> None:
+    pass
+@fun.register
+def _(arg: int) -> None:
+    pass
+
+[builtins fixtures/args.pyi]
+
+[case testCheckNonDispatchArgumentsWithTypeAlwaysTheSame-skip]
+from functools import singledispatch
+
+@singledispatch
+def f(arg: int, arg2: str) -> None:
+    pass
+
+@f.register
+def g(arg: str, arg2: str) -> None:
+    pass
+
+f(1, 'a') 
+f(1, 5) # E: Argument 2 to "fun" has incompatible type "int"; expected "str"
+
+f('b', 'a')
+f('b', 1) # E: Argument 2 to "fun" has incompatible type "int"; expected "str"
+
+[builtins fixtures/args.pyi]
+
+[case testCheckNonDispatchArgumentsUsingMoreSpecificTypeInSpecializedVersion-skip]
+from functools import singledispatch
+
+class A: pass
+class B(A): pass
+
+@singledispatch
+def f(arg: int, arg2: A) -> None:
+    pass
+
+@f.register
+def g(arg: str, arg2: B) -> None:
+    pass
+
+f(1, A()) 
+f(1, B())
+
+f('b', A()) # E: Argument 2 to "fun" has incompatible type "__main__.A"; expected "__main__.B"
+f('b', B())
+
+[builtins fixtures/args.pyi]
+
+[case testImplementationHasSameDispatchTypeAsFallback-skip]
+from functools import singledispatch
+
+# TODO: differentiate between fallback and other implementations in error message
+@singledispatch
+def f(arg: int) -> None: # E: singledispatch implementation 1 will never be used: implementation 2's dispatch type is the same
+    pass
+
+@f.register
+def g(arg: int) -> None:
+    pass
+
+[builtins fixtures/args.pyi]
+
+[case testMultipleImplementationsHaveSameDispatchTypes-skip]
+from functools import singledispatch
+
+@singledispatch
+def f(arg) -> None: 
+    pass
+
+@f.register
+def g(arg: int) -> None: # E: singledispatch implementation 2 will never be used: implementation 3's dispatch type is the same
+    pass
+
+@f.register
+def h(arg: int) -> None:
+    pass
+
+[builtins fixtures/args.pyi]
+    
+[case testRegisterHasDifferentTypeThanTypeSignature-skip]
+from functools import singledispatch
+
+@singledispatch
+def f(arg) -> None: 
+    pass
+
+@f.register(str)
+def g(arg: int) -> None: # E: Argument to register "str" is incompatible with type "int" in function signature
+    pass
+
+[builtins fixtures/args.pyi]
+
+[case testMoreSpecificGenericNonDispatchArgumentInImplementations-skip]
+from functools import singledispatch
+from typing import TypeVar, Optional, Any, Type
+
+T = TypeVar('T')
+
+Alias = Optional[T]
+
+@singledispatch
+def f(arg, arg2: Alias[Any]) -> None: 
+    pass
+
+@f.register
+def g(arg: int, arg2: Alias[int]) -> None:
+    pass
+
+@f.register
+def h(arg: str, arg2: Alias[Type[Any]]) -> None:
+    pass
+
+f((3, 5), 'a')
+f(1, 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "Union[int, None]"
+
+f('a', 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "Union[Type[Any], None]"
+f('a', str)
+f('a', int)
+f('a', None)
+
+[builtins fixtures/args.pyi]
+
+[case testDispatchBasedOnTypeAnnotationsRequires37-skip]
+# flags: --python-version 3.6
+# the docs for singledispatch say that register didn't accept type annotations until python 3.7
+from functools import singledispatch
+
+@singledispatch
+def f(arg) -> None:
+    pass
+@f.register
+def g(arg: int) -> None: # E: Singledispatch based on type annotations is only supported in Python 3.7 and greater
+    pass
+
+[builtins fixtures/args.pyi]


### PR DESCRIPTION
This adds mypy tests for singledispatch, most of which are either based on the use of singledispatch in stubtest.py or seem like they would be common errors. All of these tests are currently skipped because mypy unsurprisingly doesn't catch these errors yet due to the lack of singledispatch support.

I ended up adding some new error messages for some tests, but I'm not intending for those to be the final error messages that we actually end up using. I just wanted to put something for those errors as a stand-in that we can replace later if anyone has any other preferences.
