### PR TITLE
Add support for using xfail in test cases

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -223,6 +223,7 @@ class DataDrivenTestCase(pytest.Item):
                  only_when: str,
                  platform: Optional[str],
                  skip: bool,
+                 xfail: bool,
                  data: str,
                  line: int) -> None:
         super().__init__(name, parent)
@@ -234,6 +235,7 @@ class DataDrivenTestCase(pytest.Item):
                 or (platform == 'posix' and sys.platform == 'win32')):
             skip = True
         self.skip = skip
+        self.xfail = xfail
         self.data = data
         self.line = line
         self.old_cwd = None  # type: Optional[str]
@@ -242,6 +244,9 @@ class DataDrivenTestCase(pytest.Item):
     def runtest(self) -> None:
         if self.skip:
             pytest.skip()
+        # TODO: add a better error message for when someone uses skip and xfail at the same time
+        elif self.xfail:
+            self.add_marker(pytest.mark.xfail)
         suite = self.parent.obj()
         suite.setup()
         try:
@@ -553,18 +558,19 @@ def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
     with open(file, encoding='utf-8') as f:
         data = f.read()
     # number of groups in the below regex
-    NUM_GROUPS = 6
+    NUM_GROUPS = 7
     cases = re.split(r'^\[case ([a-zA-Z_0-9]+)'
                      r'(-writescache)?'
                      r'(-only_when_cache|-only_when_nocache)?'
                      r'(-posix|-windows)?'
                      r'(-skip)?'
+                     r'(-xfail)?'
                      r'\][ \t]*$\n',
                      data,
                      flags=re.DOTALL | re.MULTILINE)
     line_no = cases[0].count('\n') + 1
     for i in range(1, len(cases), NUM_GROUPS):
-        name, writescache, only_when, platform_flag, skip, data = cases[i:i + NUM_GROUPS]
+        name, writescache, only_when, platform_flag, skip, xfail, data = cases[i:i + NUM_GROUPS]
         platform = platform_flag[1:] if platform_flag else None
         yield DataDrivenTestCase.from_parent(
             parent=parent,
@@ -575,6 +581,7 @@ def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
             only_when=only_when,
             platform=platform,
             skip=bool(skip),
+            xfail=bool(xfail),
             data=data,
             line=line_no,
         )

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -552,6 +552,8 @@ def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
     """
     with open(file, encoding='utf-8') as f:
         data = f.read()
+    # number of groups in the below regex
+    NUM_GROUPS = 6
     cases = re.split(r'^\[case ([a-zA-Z_0-9]+)'
                      r'(-writescache)?'
                      r'(-only_when_cache|-only_when_nocache)?'
@@ -561,8 +563,8 @@ def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
                      data,
                      flags=re.DOTALL | re.MULTILINE)
     line_no = cases[0].count('\n') + 1
-    for i in range(1, len(cases), 6):
-        name, writescache, only_when, platform_flag, skip, data = cases[i:i + 6]
+    for i in range(1, len(cases), NUM_GROUPS):
+        name, writescache, only_when, platform_flag, skip, data = cases[i:i + NUM_GROUPS]
         platform = platform_flag[1:] if platform_flag else None
         yield DataDrivenTestCase.from_parent(
             parent=parent,

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,3 +20,6 @@ python_functions =
 
 # always run in parallel (requires pytest-xdist, see test-requirements.txt)
 addopts = -nauto
+
+# treat xpasses as test failures so they get converted to regular tests as soon as possible
+xfail_strict = true


### PR DESCRIPTION
Closes #10604

This adds support for marking test cases in *.test files as [xfails](https://docs.pytest.org/en/latest/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail) by adding `-xfail` to the end of the test case name.

I wasn't sure if I should turn on [`xfail_strict`](https://docs.pytest.org/en/latest/how-to/skipping.html#strict-parameter) in the pytest config. Turning that on would probably make it less likely that we would end up with tests that are still marked as xfails long after they're fixed, but it might be annoying have the test suite fail because a test marked as xfail started passing.

## Test Plan

I couldn't find a way to write tests for this change, so I changed some existing tests by marking them as xfail and made sure they were treated as xfails when they failed, and xpasses when they succeeded.