### PR TITLE
Add Python 3.9 support in logging.basicConfig

### DIFF
--- a/mypy/typeshed/stdlib/logging/__init__.pyi
+++ b/mypy/typeshed/stdlib/logging/__init__.pyi
@@ -701,7 +701,22 @@ def addLevelName(level: int, levelName: str) -> None: ...
 def getLevelName(level: _Level) -> Any: ...
 def makeLogRecord(dict: Mapping[str, Any]) -> LogRecord: ...
 
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 9):
+    def basicConfig(
+        *,
+        filename: Optional[StrPath] = ...,
+        filemode: str = ...,
+        format: str = ...,
+        datefmt: Optional[str] = ...,
+        style: str = ...,
+        level: Optional[_Level] = ...,
+        stream: Optional[SupportsWrite[str]] = ...,
+        handlers: Optional[Iterable[Handler]] = ...,
+        force: Optional[bool] = ...,
+        encoding: Optional[str] = ...,
+        errors: Optional[str] = ...,
+    ) -> None: ...
+elif sys.version_info >= (3, 8):
     def basicConfig(
         *,
         filename: Optional[StrPath] = ...,


### PR DESCRIPTION
links to relevant docs: https://docs.python.org/3/library/logging.html#logging.basicConfig https://docs.python.org/3/library/functions.html#open

### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

I glanced over them.

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

In Python 3.9 the two new keyword arguments `encoding` and `errors` were added to `logging.basicConfig`. This PR reflects that change.

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
