### PR TITLE
Narrow type with typevar when the lower bound of its upper bound and that type is same

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -7,6 +7,7 @@ from mypy.types import (
     UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike, LiteralType,
     ProperType, get_proper_type, get_proper_types, TypeAliasType, TypeGuardType
 )
+from mypy.sametypes import is_same_type
 from mypy.subtypes import is_equivalent, is_subtype, is_callable_compatible, is_proper_subtype
 from mypy.erasetype import erase_type
 from mypy.maptype import map_instance_to_supertype
@@ -77,6 +78,10 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
           and narrowed.type.is_metaclass()):
         # We'd need intersection types, so give up.
         return declared
+    elif isinstance(narrowed, TypeVarType):
+        if is_same_type(narrowed.upper_bound, meet_types(narrowed.upper_bound, declared)):
+            return narrowed
+        return meet_types(declared, narrowed)
     elif isinstance(declared, (Instance, TupleType, TypeType, LiteralType)):
         return meet_types(declared, narrowed)
     elif isinstance(declared, TypedDictType) and isinstance(narrowed, Instance):

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -7,7 +7,6 @@ from mypy.types import (
     UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike, LiteralType,
     ProperType, get_proper_type, get_proper_types, TypeAliasType, TypeGuardType
 )
-from mypy.sametypes import is_same_type
 from mypy.subtypes import is_equivalent, is_subtype, is_callable_compatible, is_proper_subtype
 from mypy.erasetype import erase_type
 from mypy.maptype import map_instance_to_supertype
@@ -71,6 +70,8 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
                                       for x in narrowed.relevant_items()])
     elif isinstance(narrowed, AnyType):
         return narrowed
+    elif isinstance(narrowed, TypeVarType) and is_subtype(narrowed.upper_bound, declared):
+        return narrowed
     elif isinstance(declared, TypeType) and isinstance(narrowed, TypeType):
         return TypeType.make_normalized(narrow_declared_type(declared.item, narrowed.item))
     elif (isinstance(declared, TypeType)
@@ -78,10 +79,6 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
           and narrowed.type.is_metaclass()):
         # We'd need intersection types, so give up.
         return declared
-    elif isinstance(narrowed, TypeVarType):
-        if is_same_type(narrowed.upper_bound, meet_types(narrowed.upper_bound, declared)):
-            return narrowed
-        return meet_types(declared, narrowed)
     elif isinstance(declared, (Instance, TupleType, TypeType, LiteralType)):
         return meet_types(declared, narrowed)
     elif isinstance(declared, TypedDictType) and isinstance(narrowed, Instance):

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1073,3 +1073,23 @@ def f(t: Type[C]) -> None:
     else:
         reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
     reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
+
+[case testNarrowingUsingTypeVar]
+# flags: --strict-optional
+from typing import Type, TypeVar
+
+class A: pass
+class B(A): pass
+
+T = TypeVar("T", bound=A)
+
+def f(t: Type[T], a: A, b: B) -> None:
+    if type(a) is t:
+        reveal_type(a)  # N: Revealed type is "T`-1"
+    else:
+        reveal_type(a)  # N: Revealed type is "__main__.A"
+
+    if type(b) is t:
+        reveal_type(b)  # N: Revealed type is "<nothing>"
+    else:
+        reveal_type(b)  # N: Revealed type is "__main__.B"


### PR DESCRIPTION
### Description

Fixes #10605 

This PR extends type narrowing by a type from a generic argument. This is achieved by handling a specific case while narrowing some type with `TypeVarType`: if the lower bound of that type and `upper_bound` of type variable is the same type as `upper_bound`, then the type can be narrowed to that type variable.