### PR TITLE
Workaround to stubtest to handle pyOpenSSL correctly

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -202,11 +202,13 @@ def verify_mypyfile(
     if isinstance(runtime, Missing):
         yield Error(object_path, "is not present at runtime", stub, runtime)
         return
-    if not isinstance(runtime, types.ModuleType) and hasattr(runtime, "_module"):
-        # Workaround for pyOpenSSL that has its submodules
-        # wrapped into cryptography.utils._ModuleWithDeprecations instances.
-        # See https://github.com/python/typeshed/pull/5657 for details.
+
+    # Workaround for pyOpenSSL that has its module objects wrapped.
+    # See https://github.com/python/typeshed/pull/5657 for details.
+    if f"{type(runtime).__module__}.{type(runtime).__name__}" \
+            == "cryptography.utils._ModuleWithDeprecations":
         runtime = runtime._module
+
     if not isinstance(runtime, types.ModuleType):
         yield Error(object_path, "is not a module", stub, runtime)
         return
@@ -657,15 +659,10 @@ def verify_funcitem(
         yield Error(object_path, "is not present at runtime", stub, runtime)
         return
 
-    if (
-        not isinstance(runtime, (types.FunctionType, types.BuiltinFunctionType))
-        and not isinstance(runtime, (types.MethodType, types.BuiltinMethodType))
-        and not inspect.ismethoddescriptor(runtime)
-        and hasattr(runtime, "value")
-    ):
-        # Workaround for pyOpenSSL that has some of its function
-        # wrapped into cryptography.utils._DeprecatedValue instances.
-        # See https://github.com/python/typeshed/pull/5657 for details.
+    # Workaround for pyOpenSSL that has some of its function objects wrapped.
+    # See https://github.com/python/typeshed/pull/5657 for details.
+    if f"{type(runtime).__module__}.{type(runtime).__name__}" \
+            == "cryptography.utils._DeprecatedValue":
         runtime = runtime.value
 
     if (

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -207,7 +207,7 @@ def verify_mypyfile(
     # See https://github.com/python/typeshed/pull/5657 for details.
     if f"{type(runtime).__module__}.{type(runtime).__qualname__}" \
             == "cryptography.utils._ModuleWithDeprecations":
-        runtime = runtime._module
+        runtime = runtime._module # type: ignore[attr-defined]
 
     if not isinstance(runtime, types.ModuleType):
         yield Error(object_path, "is not a module", stub, runtime)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -202,6 +202,10 @@ def verify_mypyfile(
     if isinstance(runtime, Missing):
         yield Error(object_path, "is not present at runtime", stub, runtime)
         return
+    if not isinstance(runtime, types.ModuleType) and hasattr(runtime, "_module"):
+        # Workaround for OpenSSL.crypto that has submodules wrapped into cryptography.utils._ModuleWithDeprecations.
+        # See https://github.com/python/typeshed/pull/5657 for details.
+        runtime = runtime._module
     if not isinstance(runtime, types.ModuleType):
         yield Error(object_path, "is not a module", stub, runtime)
         return

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -660,6 +660,16 @@ def verify_funcitem(
         not isinstance(runtime, (types.FunctionType, types.BuiltinFunctionType))
         and not isinstance(runtime, (types.MethodType, types.BuiltinMethodType))
         and not inspect.ismethoddescriptor(runtime)
+        and hasattr(runtime, "value")
+    ):
+        # Workaround for pyOpenSSL that has some of its function wrapped into cryptography.utils._DeprecatedValue instances.
+        # See https://github.com/python/typeshed/pull/5657 for details.
+        runtime = runtime.value
+
+    if (
+        not isinstance(runtime, (types.FunctionType, types.BuiltinFunctionType))
+        and not isinstance(runtime, (types.MethodType, types.BuiltinMethodType))
+        and not inspect.ismethoddescriptor(runtime)
     ):
         yield Error(object_path, "is not a function", stub, runtime)
         if not callable(runtime):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -203,7 +203,8 @@ def verify_mypyfile(
         yield Error(object_path, "is not present at runtime", stub, runtime)
         return
     if not isinstance(runtime, types.ModuleType) and hasattr(runtime, "_module"):
-        # Workaround for pyOpenSSL that has its submodules wrapped into cryptography.utils._ModuleWithDeprecations instances.
+        # Workaround for pyOpenSSL that has its submodules
+        # wrapped into cryptography.utils._ModuleWithDeprecations instances.
         # See https://github.com/python/typeshed/pull/5657 for details.
         runtime = runtime._module
     if not isinstance(runtime, types.ModuleType):
@@ -662,7 +663,8 @@ def verify_funcitem(
         and not inspect.ismethoddescriptor(runtime)
         and hasattr(runtime, "value")
     ):
-        # Workaround for pyOpenSSL that has some of its function wrapped into cryptography.utils._DeprecatedValue instances.
+        # Workaround for pyOpenSSL that has some of its function
+        # wrapped into cryptography.utils._DeprecatedValue instances.
         # See https://github.com/python/typeshed/pull/5657 for details.
         runtime = runtime.value
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -203,7 +203,7 @@ def verify_mypyfile(
         yield Error(object_path, "is not present at runtime", stub, runtime)
         return
     if not isinstance(runtime, types.ModuleType) and hasattr(runtime, "_module"):
-        # Workaround for OpenSSL.crypto that has submodules wrapped into cryptography.utils._ModuleWithDeprecations.
+        # Workaround for pyOpenSSL that has its submodules wrapped into cryptography.utils._ModuleWithDeprecations instances.
         # See https://github.com/python/typeshed/pull/5657 for details.
         runtime = runtime._module
     if not isinstance(runtime, types.ModuleType):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -205,7 +205,7 @@ def verify_mypyfile(
 
     # Workaround for pyOpenSSL that has its module objects wrapped.
     # See https://github.com/python/typeshed/pull/5657 for details.
-    if f"{type(runtime).__module__}.{type(runtime).__name__}" \
+    if f"{type(runtime).__module__}.{type(runtime).__qualname__}" \
             == "cryptography.utils._ModuleWithDeprecations":
         runtime = runtime._module
 
@@ -661,7 +661,7 @@ def verify_funcitem(
 
     # Workaround for pyOpenSSL that has some of its function objects wrapped.
     # See https://github.com/python/typeshed/pull/5657 for details.
-    if f"{type(runtime).__module__}.{type(runtime).__name__}" \
+    if f"{type(runtime).__module__}.{type(runtime).__qualname__}" \
             == "cryptography.utils._DeprecatedValue":
         runtime = runtime.value
 


### PR DESCRIPTION
### Description

Currently, `stubtest` fails on `pyOpenSSL` stubs because `pyOpenSSL` has its submodules wrapped into `cryptography.utils._ModuleWithDeprecations` instances and some of the methods wrapped into `cryptography.utils._DeprecatedValue` instances.

See https://github.com/python/typeshed/pull/5657#issuecomment-863207175 for details.

This PR adds additional checks to `runtime` field that allows unwrapping `_ModuleWithDeprecations` and `_DeprecatedValue` objects and extracting module and function objects from them.

## Test Plan

After this PR is applied, tests for https://github.com/python/typeshed/pull/5657 should pass without errors.
