### PR TITLE
Run build a second time when using --install-types --non-interactive 

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -153,13 +153,13 @@ def run_build(sources: List[BuildSource],
             # Collect messages and possibly show them later.
             return
         f = stderr if serious else stdout
-        show_messages(messages, f, formatter, options)
+        show_messages(new_messages, f, formatter, options)
 
     serious = False
     blockers = False
     res = None
     try:
-        # Keep a dummy reference (res) for memory profiling below, as otherwise
+        # Keep a dummy reference (res) for memory profiling afterwards, as otherwise
         # the result could be freed.
         res = build.build(sources, options, None, flush_errors, fscache, stdout, stderr)
     except CompileError as e:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -118,7 +118,7 @@ def main(script_path: Optional[str],
 
     if options.install_types and not options.non_interactive:
         result = install_types(options.cache_dir, formatter, after_run=True,
-                               non_interactive=options.non_interactive)
+                               non_interactive=False)
         if result:
             print()
             print("note: Run mypy again for up-to-date results with installed types")

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -117,11 +117,12 @@ def main(script_path: Optional[str],
         stdout.flush()
 
     if options.install_types and not options.non_interactive:
-        install_types(options.cache_dir, formatter, after_run=True,
-                      non_interactive=options.non_interactive)
-        print()
-        print("Hint: Run mypy again for up-to-date results with installed types")
-        return
+        result = install_types(options.cache_dir, formatter, after_run=True,
+                               non_interactive=options.non_interactive)
+        if result:
+            print()
+            print("Hint: Run mypy again for up-to-date results with installed types")
+            return
 
     if options.fast_exit:
         # Exit without freeing objects -- it's faster.
@@ -1144,12 +1145,12 @@ def install_types(cache_dir: str,
                   formatter: util.FancyFormatter,
                   *,
                   after_run: bool = False,
-                  non_interactive: bool = False) -> None:
+                  non_interactive: bool = False) -> bool:
     """Install stub packages using pip if some missing stubs were detected."""
     packages = read_types_packages_to_install(cache_dir, after_run)
     if not packages:
         # If there are no missing stubs, generate no output.
-        return
+        return False
     if after_run and not non_interactive:
         print()
     print('Installing missing stub packages:')
@@ -1163,3 +1164,4 @@ def install_types(cache_dir: str,
             sys.exit(2)
         print()
     subprocess.run(cmd)
+    return True

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -71,13 +71,13 @@ def main(script_path: Optional[str],
 
     if options.install_types and (stdout is not sys.stdout or stderr is not sys.stderr):
         # Since --install-types performs user input, we want regular stdout and stderr.
-        fail("Error: --install-types not supported in this mode of running mypy", stderr, options)
+        fail("error: --install-types not supported in this mode of running mypy", stderr, options)
 
     if options.non_interactive and not options.install_types:
-        fail("Error: --non-interactive is only supported with --install-types", stderr, options)
+        fail("error: --non-interactive is only supported with --install-types", stderr, options)
 
     if options.install_types and not options.incremental:
-        fail("Error: --install-types not supported with incremental mode disabled",
+        fail("error: --install-types not supported with incremental mode disabled",
              stderr, options)
 
     if options.install_types and not sources:
@@ -121,8 +121,8 @@ def main(script_path: Optional[str],
                                non_interactive=options.non_interactive)
         if result:
             print()
-            print("Hint: Run mypy again for up-to-date results with installed types")
-            return
+            print("note: Run mypy again for up-to-date results with installed types")
+            code = 2
 
     if options.fast_exit:
         # Exit without freeing objects -- it's faster.
@@ -1125,12 +1125,12 @@ def read_types_packages_to_install(cache_dir: str, after_run: bool) -> List[str]
     if not os.path.isdir(cache_dir):
         if not after_run:
             sys.stderr.write(
-                "Error: Can't determine which types to install with no files to check " +
+                "error: Can't determine which types to install with no files to check " +
                 "(and no cache from previous mypy run)\n"
             )
         else:
             sys.stderr.write(
-                "Error: --install-types failed (no mypy cache directory)\n"
+                "error: --install-types failed (no mypy cache directory)\n"
             )
         sys.exit(2)
     fnam = build.missing_stubs_file(cache_dir)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -120,7 +120,7 @@ def main(script_path: Optional[str],
         install_types(options.cache_dir, formatter, after_run=True,
                       non_interactive=options.non_interactive)
         print()
-        print("Hint: Run mypy again to get up-to-date results with installed types")
+        print("Hint: Run mypy again for up-to-date results with installed types")
         return
 
     if options.fast_exit:

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1288,3 +1288,10 @@ Error: --non-interactive is only supported with --install-types
 [file pkg.py]
 1()
 [out]
+pkg.py:1: error: "int" not callable
+
+[case testCmdlineNonInteractiveInstallTypesNothingToDoNoError]
+# cmd: mypy --install-types --non-interactive -m pkg
+[file pkg.py]
+1 + 2
+[out]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1295,3 +1295,10 @@ pkg.py:1: error: "int" not callable
 [file pkg.py]
 1 + 2
 [out]
+
+[case testCmdlineInteractiveInstallTypesNothingToDo]
+# cmd: mypy --install-types -m pkg
+[file pkg.py]
+1()
+[out]
+pkg.py:1: error: "int" not callable

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1280,7 +1280,7 @@ pkg.py:1: error: Incompatible types in assignment (expression has type "int", va
 [case testCmdlineNonInteractiveWithoutInstallTypes]
 # cmd: mypy --non-interactive -m pkg
 [out]
-Error: --non-interactive is only supported with --install-types
+error: --non-interactive is only supported with --install-types
 == Return code: 2
 
 [case testCmdlineNonInteractiveInstallTypesNothingToDo]


### PR DESCRIPTION
If the first build finds missing stub packages, run the build a second
time after installing types. Only show errors from the final build.

Example output:
```
$ mypy --install-types --non-interactive t.py
Installing missing stub packages:
/Users/jukka/venv/mypy/bin/python3 -m pip install types-redis

Collecting types-redis
  Using cached types_redis-3.5.2-py2.py3-none-any.whl (11 kB)
Installing collected packages: types-redis
Successfully installed types-redis-3.5.2

t.py:2: error: Unsupported operand types for + ("int" and "str")
Found 1 error in 1 file (checked 1 source file)
```

Work on #10600.