### PR TITLE
Don't ask to install a stub package if stubs are installed

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2447,13 +2447,14 @@ def find_module_and_diagnose(manager: BuildManager,
         # Don't honor a global (not per-module) ignore_missing_imports
         # setting for modules that used to have bundled stubs, as
         # otherwise updating mypy can silently result in new false
-        # negatives.
+        # negatives. (Unless there are stubs but they are incomplete.)
         global_ignore_missing_imports = manager.options.ignore_missing_imports
         py_ver = options.python_version[0]
         if ((is_legacy_bundled_package(top_level, py_ver)
                 or is_legacy_bundled_package(second_level, py_ver))
                 and global_ignore_missing_imports
-                and not options.ignore_missing_imports_per_module):
+                and not options.ignore_missing_imports_per_module
+                and result is ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED):
             ignore_missing_imports = False
 
         if skip_diagnose:

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -232,8 +232,11 @@ class FindModuleCache:
                 plausible_match = True
         if (is_legacy_bundled_package(components[0], self.python_major_ver)
                 or is_legacy_bundled_package('.'.join(components[:2]), self.python_major_ver)):
-            return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
-        elif plausible_match:
+            if (len(components) == 1
+                    or (self.find_module(components[0]) is
+                        ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED)):
+                return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
+        if plausible_match:
             return ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS
         else:
             return ModuleNotFoundReason.NOT_FOUND

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -230,12 +230,13 @@ class FindModuleCache:
             elif not plausible_match and (self.fscache.isdir(dir_path)
                                           or self.fscache.isfile(dir_path + ".py")):
                 plausible_match = True
-        if (is_legacy_bundled_package(components[0], self.python_major_ver)
-                or is_legacy_bundled_package('.'.join(components[:2]), self.python_major_ver)):
+        if is_legacy_bundled_package(components[0], self.python_major_ver):
             if (len(components) == 1
                     or (self.find_module(components[0]) is
                         ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED)):
                 return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
+        if is_legacy_bundled_package('.'.join(components[:2]), self.python_major_ver):
+            return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
         if plausible_match:
             return ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS
         else:

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -3107,3 +3107,18 @@ from google.cloud import x
 main:1: error: Cannot find implementation or library stub for module named "google.cloud"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 main:1: error: Cannot find implementation or library stub for module named "google"
+
+[case testMissingSubmoduleOfInstalledStubPackage]
+import bleach.xyz
+from bleach.abc import fgh
+[file bleach/__init__.pyi]
+[out]
+main:1: error: Cannot find implementation or library stub for module named "bleach.xyz"
+main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+main:2: error: Cannot find implementation or library stub for module named "bleach.abc"
+
+[case testMissingSubmoduleOfInstalledStubPackageIgnored]
+# flags: --ignore-missing-imports
+import bleach.xyz
+from bleach.abc import fgh
+[file bleach/__init__.pyi]


### PR DESCRIPTION
If we encounter an import of a submodule of a package with installed
stubs, and the submodule doesn't exist, don't ask to install stubs
since that's not going to help. Also make it possible to ignore this
error using `--ignore-missing-imports`.

Work on #10645.