### PR TITLE
Call get_method_hook when methods are used in decorators

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3597,8 +3597,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             object_type = None  # type: Optional[Type]
             if fullname is None and isinstance(d, MemberExpr) and d.expr in self.type_map:
                 object_type = self.type_map[d.expr]
-                if fullname is None and object_type is not None:
-                    fullname = self.expr_checker.method_fullname(object_type, d.name)
+                fullname = self.expr_checker.method_fullname(object_type, d.name)
             self.check_for_untyped_decorator(e.func, dec, d)
             sig, t2 = self.expr_checker.check_call(dec, [temp],
                                                    [nodes.ARG_POS], e,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3592,10 +3592,18 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             fullname = None
             if isinstance(d, RefExpr):
                 fullname = d.fullname
+            # if this is a expression like @b.a where b is an object, get the type of b
+            # so we can pass it the method hook in the plugins
+            object_type = None  # type: Optional[Type]
+            if fullname is None and isinstance(d, MemberExpr) and d.expr in self.type_map:
+                object_type = self.type_map[d.expr]
+                if fullname is None and object_type is not None:
+                    fullname = self.expr_checker.method_fullname(object_type, d.name)
             self.check_for_untyped_decorator(e.func, dec, d)
             sig, t2 = self.expr_checker.check_call(dec, [temp],
                                                    [nodes.ARG_POS], e,
-                                                   callable_name=fullname)
+                                                   callable_name=fullname,
+                                                   object_type=object_type)
         self.check_untyped_after_decorator(sig, e.func)
         sig = set_callable_name(sig, e.func)
         e.var.type = sig

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -810,3 +810,31 @@ reveal_type(f())  # N: Revealed type is "builtins.str"
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/method_in_decorator.py
+
+[case testPluginMethodHookMethodAssignedToVariableInDecorator-xfail]
+# flags: --config-file tmp/mypy.ini
+from typing import overload, TypeVar, Callable
+
+T = TypeVar('T')
+class Foo:
+    @overload
+    def a(self, x: Callable[[], T]) -> Callable[[], T]: ...
+
+    @overload
+    def a(self, x: str) -> None: ...
+
+    def a(self, x):
+        pass
+
+b = Foo()
+
+meth = b.a
+@meth
+def f() -> None:
+    pass
+
+reveal_type(f())  # N: Revealed type is "builtins.str"
+
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/method_in_decorator.py

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -786,18 +786,11 @@ plugins=<ROOT>/test-data/unit/plugins/function_sig_hook.py
 
 [case testPluginCalledCorrectlyWhenMethodInDecorator]
 # flags: --config-file tmp/mypy.ini
-from typing import overload, TypeVar, Callable
+from typing import TypeVar, Callable
 
 T = TypeVar('T')
 class Foo:
-    @overload
     def a(self, x: Callable[[], T]) -> Callable[[], T]: ...
-
-    @overload
-    def a(self, x: str) -> None: ...
-
-    def a(self, x):
-        pass
 
 b = Foo()
 
@@ -813,18 +806,11 @@ plugins=<ROOT>/test-data/unit/plugins/method_in_decorator.py
 
 [case testPluginMethodHookMethodAssignedToVariableInDecorator-xfail]
 # flags: --config-file tmp/mypy.ini
-from typing import overload, TypeVar, Callable
+from typing import TypeVar, Callable
 
 T = TypeVar('T')
 class Foo:
-    @overload
     def a(self, x: Callable[[], T]) -> Callable[[], T]: ...
-
-    @overload
-    def a(self, x: str) -> None: ...
-
-    def a(self, x):
-        pass
 
 b = Foo()
 

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -783,3 +783,30 @@ reveal_type(dynamic_signature(1))  # N: Revealed type is "builtins.int"
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/function_sig_hook.py
+
+[case testPluginCalledCorrectlyWhenMethodInDecorator]
+# flags: --config-file tmp/mypy.ini
+from typing import overload, TypeVar, Callable
+
+T = TypeVar('T')
+class Foo:
+    @overload
+    def a(self, x: Callable[[], T]) -> Callable[[], T]: ...
+
+    @overload
+    def a(self, x: str) -> None: ...
+
+    def a(self, x):
+        pass
+
+b = Foo()
+
+@b.a
+def f() -> None:
+    pass
+
+reveal_type(f())  # N: Revealed type is "builtins.str"
+
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/method_in_decorator.py

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -803,24 +803,3 @@ reveal_type(f())  # N: Revealed type is "builtins.str"
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/method_in_decorator.py
-
-[case testPluginMethodHookMethodAssignedToVariableInDecorator-xfail]
-# flags: --config-file tmp/mypy.ini
-from typing import TypeVar, Callable
-
-T = TypeVar('T')
-class Foo:
-    def a(self, x: Callable[[], T]) -> Callable[[], T]: ...
-
-b = Foo()
-
-meth = b.a
-@meth
-def f() -> None:
-    pass
-
-reveal_type(f())  # N: Revealed type is "builtins.str"
-
-[file mypy.ini]
-\[mypy]
-plugins=<ROOT>/test-data/unit/plugins/method_in_decorator.py

--- a/test-data/unit/plugins/method_in_decorator.py
+++ b/test-data/unit/plugins/method_in_decorator.py
@@ -1,0 +1,19 @@
+from mypy.types import CallableType, Type
+from typing import Callable, Optional
+from mypy.plugin import MethodContext, Plugin
+
+
+class MethodDecoratorPlugin(Plugin):
+    def get_method_hook(self, fullname: str) -> Optional[Callable[[MethodContext], Type]]:
+        if 'Foo.a' in fullname:
+            return method_decorator_callback
+        return None
+
+def method_decorator_callback(ctx: MethodContext) -> Type:
+    if isinstance(ctx.default_return_type, CallableType):
+        str_type = ctx.api.named_generic_type('builtins.str', [])
+        return ctx.default_return_type.copy_modified(ret_type=str_type)
+    return ctx.default_return_type
+
+def plugin(version):
+    return MethodDecoratorPlugin


### PR DESCRIPTION
Currently, when methods are used in decorators, instead of correctly calling `get_method_hook` with `'{module_name}.{class_name}.{method_name}'` (with `module_name`, `class_name`, and `method_name` filled in with their correct values), `get_function_hook` is called instead with `'{method_name} of {class_name}'`. This PR fixes this bug by calling `get_method_hook` correctly.

Technically, this may break some plugins if they relied on the fact that `get_function_hook` would be called on methods used in decorators, because with this PR those calls get moved to `get_method_hook`. I'm guessing that this is rare, but I don't know for sure if any plugins rely on that.

Currently, this only works when you access the method in the decorator itself, instead of assigning the method to a local variable. So, for example (assuming `obj` is an object that has a method `meth`), this works:

```python
@obj.meth
def f() -> None:
    pass
```

but this doesn't:

```python
method = obj.meth
@method
def f() -> None:
    pass
```

Currently, the second case causes mypy to pass `__main__.method` to `get_function_hook` instead of passing the same thing as the first case. I added a test that's currently marked as xfail for the second case, but I'm not really sure how to fix it.

## Test Plan

I added a test to check-custom-plugin.test to make sure that the correct method name is getting passed to plugins and that it is getting passed to the correct plugin hook.
