### PR TITLE
fix testSemanticAnalysisFalseButTypeNarrowingTrue

### DIFF
--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -619,23 +619,26 @@ if MYPY or mypy_only:
 # flags: --always-false COMPILE_TIME_FALSE
 from typing import Literal
 
-indeterminate: bool
+indeterminate: str
 COMPILE_TIME_FALSE: Literal[True]  # type-narrowing: mapped in 'if' only
 a = COMPILE_TIME_FALSE or indeterminate
-reveal_type(a)  # N: Revealed type is "builtins.bool"
+reveal_type(a)  # N: Revealed type is "builtins.str"
 b = indeterminate or COMPILE_TIME_FALSE
-reveal_type(b)  # N: Revealed type is "Union[builtins.bool, Literal[True]]"
+reveal_type(b)  # N: Revealed type is "Union[builtins.str, Literal[True]]"
 [typing fixtures/typing-medium.pyi]
 
 [case testSemanticAnalysisTrueButTypeNarrowingFalse]
 # flags: --always-true COMPILE_TIME_TRUE
-indeterminate: bool
-COMPILE_TIME_TRUE: None  # type narrowed to `else` only
-a = COMPILE_TIME_TRUE or indeterminate
-reveal_type(a)  # N: Revealed type is "None"
-b = indeterminate or COMPILE_TIME_TRUE
-reveal_type(b)  # N: Revealed type is "Union[builtins.bool, None]"
+from typing import Literal
 
+indeterminate: str
+COMPILE_TIME_TRUE: Literal[False]  # type narrowed to `else` only
+a = COMPILE_TIME_TRUE or indeterminate
+reveal_type(a)  # N: Revealed type is "Literal[False]"
+b = indeterminate or COMPILE_TIME_TRUE
+reveal_type(b)  # N: Revealed type is "Union[builtins.str, Literal[False]]"
+
+[typing fixtures/typing-medium.pyi]
 [case testConditionalAssertWithoutElse]
 import typing
 

--- a/test-data/unit/lib-stub/builtins.pyi
+++ b/test-data/unit/lib-stub/builtins.pyi
@@ -11,6 +11,7 @@ class type:
 # These are provided here for convenience.
 class int:
     def __add__(self, other: int) -> int: pass
+class bool(int): pass
 class float: pass
 
 class str: pass


### PR DESCRIPTION
It was indeed weird that `Union[builtins.bool, Literal[True]]` wasn't simplified by `make_simplified_union` to `builtins.bool`. This was simply because `builtins.bool` wasn't defined in test-data/unit/lib-stub/builtins.pyi.

It's important to keep fixtures nimble, but this is too much of a gotcha IMO not to have `bool` defined. (Also, I intend to define it in a follow-up PR anyway so it could have a `__bool__` method.)