### PR TITLE
Fix testNonBooleanContainsReturnValue

### DIFF
--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -434,18 +434,18 @@ class D(Iterable[A]):
 [builtins fixtures/bool.pyi]
 
 [case testNonBooleanContainsReturnValue]
-a, b, c = None, None, None # type: (A, bool, int)
+a, b, c = None, None, None # type: (A, bool, str)
 if int():
     b = a not in a
 if int():
     b = a in a
 if int():
-    c = a not in a  # E: Incompatible types in assignment (expression has type "bool", variable has type "int")
+    c = a not in a  # E: Incompatible types in assignment (expression has type "bool", variable has type "str")
 if int():
-    c = a in a  # E: Incompatible types in assignment (expression has type "bool", variable has type "int")
+    c = a in a  # E: Incompatible types in assignment (expression has type "bool", variable has type "str")
 
 class A:
-  def __contains__(self, x: 'A') -> int: pass
+  def __contains__(self, x: 'A') -> str: pass
 [builtins fixtures/bool.pyi]
 
 [case testInWithInvalidArgs]

--- a/test-data/unit/fixtures/bool.pyi
+++ b/test-data/unit/fixtures/bool.pyi
@@ -10,8 +10,8 @@ class object:
 class type: pass
 class tuple(Generic[T]): pass
 class function: pass
-class bool: pass
 class int: pass
+class bool(int): pass
 class float: pass
 class str: pass
 class unicode: pass


### PR DESCRIPTION
`testNonBooleanContainsReturnValue` is testing that `in` always evaluates as bool (per https://github.com/python/mypy/pull/5688).

This test worked due to fixture's lack of knowledge that `issubclass(bool, int)`. To more correctly test, let's use distinct types bool and str.