### PR TITLE
[mypyc] Fix suffix assignment when a module contains a submodule with the same name.

### DIFF
--- a/mypyc/test/test_namegen.py
+++ b/mypyc/test/test_namegen.py
@@ -28,6 +28,16 @@ class TestNameGen(unittest.TestCase):
                                                   'fu.bar': 'fu.bar.',
                                                   'foo.baz': 'baz.'}
 
+    def test_possibly_ambiguous_translation_map(self) -> None:
+        assert make_module_translation_map(
+            ['test', 'test.test', 'test.module', 'test.module.file']
+        ) == {
+            'test': 'test.',
+            'test.test': 'test.test.',
+            'test.module': 'module.',
+            'test.module.file': 'file.',
+        }
+
     def test_name_generator(self) -> None:
         g = NameGenerator([['foo', 'foo.zar']])
         assert g.private_name('foo', 'f') == 'foo___f'


### PR DESCRIPTION
## Description

Code that attempts to assign the shortest suffix for the C name of each module currently trips up if you have a module with a submodule that shares the same name. For instance, if you have a module "test" and a submodule "test.test", and run `mypyc test/` instead of compiling you will get a cryptic error message. It appears that this is because of a logic bug that's attempting to assign non-ambiguous suffixes. It sees that "test." is ambiguous, but it is also the only valid choice in this case. So, fix that by allowing the somewhat ambiguous suffix "test." to be given to the "test" module instead of the "test.test" module, fixing the assertion and allowing the code to compile.

This fixes a bug that I noticed and mentioned in https://github.com/mypyc/mypyc/issues/857 but did not open a separate issue for.

## Test Plan

Tested on the repro from https://github.com/mypyc/mypyc/issues/857 to verify that the code compiles. Also, added a new test that failed without the fix and succeeded with the fix applied. Also, all other tests continue to pass and there looks to be decent coverage of the file in question. You can verify by running the mypyc tests.

## Formatting

I ran `black -S` over the changed files and it looks like it changed more than just the code I added, so I reverted the changes black made to sections that I didn't touch.