### PR TITLE
docs: updating URL in comment

### DIFF
--- a/misc/build_wheel.py
+++ b/misc/build_wheel.py
@@ -3,7 +3,7 @@
 The main GitHub workflow where this script is used:
 https://github.com/mypyc/mypy_mypyc-wheels/blob/master/.github/workflows/build.yml
 
-This uses cibuildwheel (https://github.com/joerick/cibuildwheel) to
+This uses cibuildwheel (https://github.com/pypa/cibuildwheel) to
 build the wheels.
 
 Usage:


### PR DESCRIPTION

### Description

URL update in comment.

I think most of this script is covered by the new "config" mode coming in cibuildwheel 2.0 (probably in a few weeks); but that also only supports Python 3.6+, so 3.5 will need to be dropped before moving to 2.0.

Noticed this when adding https://github.com/mypyc/mypy_mypyc-wheels/pull/23