### PR TITLE
Add initial singledispatch typechecking support

### DIFF
--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -111,16 +111,17 @@ def add_method_to_class(
         self_type: Optional[Type] = None,
         tvar_def: Optional[TypeVarDef] = None,
 ) -> None:
-    """Adds a new method to a class definition.
-    """
+    """Adds a new method to a class definition."""
     function_type = api.named_type('__builtins__.function')
-    add_method_to_class_with_function_type(function_type,
-                    cls=cls,
-                    name=name,
-                    args=args,
-                    return_type=return_type,
-                    self_type=self_type,
-                    tvar_def=tvar_def)
+    add_method_to_class_with_function_type(
+        function_type,
+        cls=cls,
+        name=name,
+        args=args,
+        return_type=return_type,
+        self_type=self_type,
+        tvar_def=tvar_def,
+    )
 
 
 def add_method_to_class_with_function_type(

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -78,6 +78,8 @@ class DefaultPlugin(Plugin):
             return path_open_callback
         elif fullname == '{}.register'.format(singledispatch.SINGLEDISPATCH_TYPE):
             return singledispatch.singledispatch_register_callback
+        elif fullname == 'functools.{}.__call__'.format(singledispatch.REGISTER_RETURN_CLASS):
+            return singledispatch.call_singledispatch_function_after_register_argument
         return None
 
     def get_attribute_hook(self, fullname: str

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -22,7 +22,7 @@ class DefaultPlugin(Plugin):
 
     def get_function_hook(self, fullname: str
                           ) -> Optional[Callable[[FunctionContext], Type]]:
-        from mypy.plugins import ctypes
+        from mypy.plugins import ctypes, singledispatch
 
         if fullname == 'contextlib.contextmanager':
             return contextmanager_callback
@@ -30,11 +30,13 @@ class DefaultPlugin(Plugin):
             return open_callback
         elif fullname == 'ctypes.Array':
             return ctypes.array_constructor_callback
+        elif fullname == 'functools.singledispatch':
+            return singledispatch.create_singledispatch_function_callback
         return None
 
     def get_method_signature_hook(self, fullname: str
                                   ) -> Optional[Callable[[MethodSigContext], CallableType]]:
-        from mypy.plugins import ctypes
+        from mypy.plugins import ctypes, singledispatch
 
         if fullname == 'typing.Mapping.get':
             return typed_dict_get_signature_callback
@@ -48,11 +50,13 @@ class DefaultPlugin(Plugin):
             return typed_dict_delitem_signature_callback
         elif fullname == 'ctypes.Array.__setitem__':
             return ctypes.array_setitem_callback
+        elif fullname == '{}.__call__'.format(singledispatch.SINGLEDISPATCH_TYPE):
+            return singledispatch.call_singledispatch_function_callback
         return None
 
     def get_method_hook(self, fullname: str
                         ) -> Optional[Callable[[MethodContext], Type]]:
-        from mypy.plugins import ctypes
+        from mypy.plugins import ctypes, singledispatch
 
         if fullname == 'typing.Mapping.get':
             return typed_dict_get_callback
@@ -72,6 +76,8 @@ class DefaultPlugin(Plugin):
             return ctypes.array_iter_callback
         elif fullname == 'pathlib.Path.open':
             return path_open_callback
+        elif fullname == '{}.register'.format(singledispatch.SINGLEDISPATCH_TYPE):
+            return singledispatch.singledispatch_register_callback
         return None
 
     def get_attribute_hook(self, fullname: str

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -9,7 +9,7 @@ from mypy.plugin import (
 )
 from mypy.plugins.common import try_getting_str_literals
 from mypy.types import (
-    Type, Instance, AnyType, TypeOfAny, CallableType, NoneType, TypedDictType,
+    FunctionLike, Type, Instance, AnyType, TypeOfAny, CallableType, NoneType, TypedDictType,
     TypeVarDef, TypeVarType, TPDICT_FB_NAMES, get_proper_type, LiteralType
 )
 from mypy.subtypes import is_subtype
@@ -35,7 +35,7 @@ class DefaultPlugin(Plugin):
         return None
 
     def get_method_signature_hook(self, fullname: str
-                                  ) -> Optional[Callable[[MethodSigContext], CallableType]]:
+                                  ) -> Optional[Callable[[MethodSigContext], FunctionLike]]:
         from mypy.plugins import ctypes, singledispatch
 
         if fullname == 'typing.Mapping.get':

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -50,7 +50,7 @@ class DefaultPlugin(Plugin):
             return typed_dict_delitem_signature_callback
         elif fullname == 'ctypes.Array.__setitem__':
             return ctypes.array_setitem_callback
-        elif fullname == '{}.__call__'.format(singledispatch.SINGLEDISPATCH_TYPE):
+        elif fullname == singledispatch.SINGLEDISPATCH_CALLABLE_CALL_METHOD:
             return singledispatch.call_singledispatch_function_callback
         return None
 
@@ -76,9 +76,9 @@ class DefaultPlugin(Plugin):
             return ctypes.array_iter_callback
         elif fullname == 'pathlib.Path.open':
             return path_open_callback
-        elif fullname == '{}.register'.format(singledispatch.SINGLEDISPATCH_TYPE):
+        elif fullname == singledispatch.SINGLEDISPATCH_REGISTER_METHOD:
             return singledispatch.singledispatch_register_callback
-        elif fullname == 'functools.{}.__call__'.format(singledispatch.REGISTER_RETURN_CLASS):
+        elif fullname == singledispatch.REGISTER_CALLABLE_CALL_METHOD:
             return singledispatch.call_singledispatch_function_after_register_argument
         return None
 

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -108,6 +108,15 @@ def singledispatch_register_callback(ctx: MethodContext) -> Type:
     return ctx.default_return_type
 
 
+def rename_func(func: CallableType, new_name: CallableType) -> CallableType:
+    """Return a new CallableType that is `function` with the name of `new_name`"""
+    if new_name.name is not None:
+        signature_used = func.with_name(new_name.name)
+    else:
+        signature_used = func
+    return signature_used
+
+
 def call_singledispatch_function_callback(ctx: MethodSigContext) -> CallableType:
     if not isinstance(ctx.type, Instance):
         return ctx.default_signature
@@ -126,9 +135,5 @@ def call_singledispatch_function_callback(ctx: MethodSigContext) -> CallableType
                 # use the fallback's name so that error messages say that the arguments to
                 # the fallback are incorrect (instead of saying arguments to the registered
                 # implementation are incorrect)
-                if fallback.name is not None:
-                    signature_used = func.with_name(fallback.name)
-                else:
-                    signature_used = func
-                return signature_used
+                return rename_func(func, fallback)
     return fallback

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -25,9 +25,6 @@ class RegisterCallableInfo(NamedTuple):
 
 SINGLEDISPATCH_TYPE = 'functools._SingleDispatchCallable'
 
-# key that we use for everything we store in TypeInfo metadata
-METADATA_KEY = 'singledispatch'
-
 SINGLEDISPATCH_REGISTER_METHOD = '{}.register'.format(SINGLEDISPATCH_TYPE)  # type: Final
 
 SINGLEDISPATCH_CALLABLE_CALL_METHOD = '{}.__call__'.format(SINGLEDISPATCH_TYPE)  # type: Final

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -12,16 +12,15 @@ from mypy.plugin import CheckerPluginInterface, FunctionContext, MethodContext, 
 from typing import List, NamedTuple, Optional, Sequence, TypeVar, Union
 from typing_extensions import Final
 
+SingledispatchTypeVars = NamedTuple('SingledispatchTypeVars', [
+    ('return_type', Type),
+    ('fallback', CallableType),
+])
 
-class SingledispatchTypeVars(NamedTuple):
-    return_type: Type
-    fallback: CallableType
-
-
-class RegisterCallableInfo(NamedTuple):
-    register_type: Type
-    singledispatch_obj: Instance
-
+RegisterCallableInfo = NamedTuple('RegisterCallableInfo', [
+    ('register_type', Type),
+    ('singledispatch_obj', Instance),
+])
 
 SINGLEDISPATCH_TYPE = 'functools._SingleDispatchCallable'
 

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -7,7 +7,7 @@ from mypy.types import (
 )
 from mypy.plugin import CheckerPluginInterface, FunctionContext, MethodContext, MethodSigContext
 from typing import Dict, List, Optional, TypeVar, cast
-from typing_extensions import TypedDict
+from typing_extensions import Final, TypedDict
 
 SingledispatchInfo = TypedDict('SingledispatchInfo', {
     'fallback': CallableType,
@@ -27,6 +27,10 @@ SINGLEDISPATCH_TYPE = 'functools._SingleDispatchCallable'
 # key that we use for everything we store in TypeInfo metadata
 METADATA_KEY = 'singledispatch'
 
+SINGLEDISPATCH_REGISTER_METHOD = '{}.register'.format(SINGLEDISPATCH_TYPE)  # type: Final
+
+SINGLEDISPATCH_CALLABLE_CALL_METHOD = '{}.__call__'.format(SINGLEDISPATCH_TYPE)  # type: Final
+
 
 def get_singledispatch_info(typ: Instance) -> 'SingledispatchInfo':
     return typ.type.metadata[METADATA_KEY]  # type: ignore
@@ -44,6 +48,7 @@ def get_first_arg(args: List[List[T]]) -> Optional[T]:
 
 REGISTER_RETURN_CLASS = 'SingleDispatchRegisterCallable'
 
+REGISTER_CALLABLE_CALL_METHOD = 'functools.{}.__call__'.format(REGISTER_RETURN_CLASS)  # type: Final
 
 def make_fake_register_class_instance(api: CheckerPluginInterface) -> Instance:
     defn = ClassDef(REGISTER_RETURN_CLASS, Block([]))

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -1,4 +1,4 @@
-from mypy.plugins.common import add_method_to_class_with_function_type
+from mypy.plugins.common import add_method_to_class
 from mypy.nodes import ARG_POS, Argument, Block, ClassDef, SymbolTable, TypeInfo, Var
 from mypy.checker import TypeChecker
 from mypy.subtypes import is_subtype
@@ -63,10 +63,8 @@ def make_fake_register_class_instance(api: CheckerPluginInterface, type_args: Se
     info.mro = [info, obj_type]
     defn.info = info
 
-    function_type = api.named_generic_type('builtins.function', [])
-
     func_arg = Argument(Var('name'), AnyType(TypeOfAny.implementation_artifact), None, ARG_POS)
-    add_method_to_class_with_function_type(function_type, defn, '__call__', [func_arg], NoneType())
+    add_method_to_class(api, defn, '__call__', [func_arg], NoneType())
 
     return Instance(info, type_args)
 

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -119,6 +119,19 @@ def register_function(singledispatch_obj: Instance, func: Type,
     metadata['registered'].add(expanded_func)
 
 
+def call_singledispatch_function_after_register_argument(ctx: MethodContext) -> Type:
+    """Called on the function after passing a type to register"""
+    register_callable = ctx.type
+    if isinstance(register_callable, Instance):
+        metadata = cast(RegisterCallableInfo, register_callable.type.metadata[METADATA_KEY])
+        func = get_first_arg(ctx.arg_types)
+        if func is not None:
+            register_arg = metadata['register_type']
+            singledispatch_obj = metadata['singledispatch_obj']
+            register_function(singledispatch_obj, func, register_arg)
+    return ctx.default_return_type
+
+
 def rename_func(func: CallableType, new_name: CallableType) -> CallableType:
     """Return a new CallableType that is `function` with the name of `new_name`"""
     if new_name.name is not None:

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -6,7 +6,7 @@ from mypy.checker import TypeChecker
 from mypy.subtypes import is_subtype
 from mypy.types import (
     AnyType, CallableType, Instance, NoneType, Overloaded, Type, TypeOfAny, get_proper_type,
-    UnionType
+    UnionType, FunctionLike
 )
 from mypy.plugin import CheckerPluginInterface, FunctionContext, MethodContext, MethodSigContext
 from typing import Dict, List, NamedTuple, Optional, Sequence, TypeVar, cast
@@ -199,7 +199,7 @@ def rename_func(func: CallableType, new_name: CallableType) -> CallableType:
     return signature_used
 
 
-def call_singledispatch_function_callback(ctx: MethodSigContext) -> CallableType:
+def call_singledispatch_function_callback(ctx: MethodSigContext) -> FunctionLike:
     """Called for functools._SingleDispatchCallable.__call__"""
     if not isinstance(ctx.type, Instance):
         return ctx.default_signature
@@ -223,7 +223,7 @@ def call_singledispatch_function_callback(ctx: MethodSigContext) -> CallableType
         # the type signature technically says we're returning CallableType, but returning
         # Overloaded seems to work fine and there doesn't appear to be a better way of telling
         # mypy that there are multiple possible functions that could get used
-        return Overloaded(possible_impls)  # type: ignore
+        return Overloaded(possible_impls)
     elif len(possible_impls) == 1:
         return possible_impls[0]
     else:

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -209,7 +209,7 @@ def get_possible_impls(passed_type: Type, registered: Dict[Type, CallableType],
             impls.extend(get_possible_impls(item, registered, fallback))
         return impls
     else:
-        for dispatch_type, func, in registered.items():
+        for dispatch_type, func in registered.items():
             # TODO: search in the order that singledispatch would (starting with implementations
             # that have the same class as the passed type and going up the mro) - This might pick
             # a more general implementation than would get picked by singledispatch

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -1,0 +1,86 @@
+from mypy.checker import TypeChecker
+from mypy.subtypes import is_subtype
+from mypy.types import CallableType, Instance, Type, get_proper_type
+from mypy.plugin import FunctionContext, MethodContext, MethodSigContext
+from typing import List, Optional, Set, TypeVar, cast
+from typing_extensions import TypedDict
+
+SingledispatchInfo = TypedDict('SingledispatchInfo', {
+    'fallback': CallableType,
+    # use a set to make sure we don't add the same function multiple times if the register
+    # callback gets called multiple times
+    'registered': Set[CallableType],
+})
+
+SINGLEDISPATCH_TYPE = 'functools._SingleDispatchCallable'
+
+# key that we use for everything we store in TypeInfo metadata
+METADATA_KEY = 'singledispatch'
+
+
+def get_singledispatch_info(typ: Instance) -> 'SingledispatchInfo':
+    return typ.type.metadata[METADATA_KEY]  # type: ignore
+
+
+T = TypeVar('T')
+
+
+def get_first_arg(args: List[List[T]]) -> Optional[T]:
+    """Get the element that corresponds to the first argument passed to the function"""
+    if args and args[0]:
+        return args[0][0]
+    return None
+
+
+def create_singledispatch_function_callback(ctx: FunctionContext) -> Type:
+    # TODO: check that there's only one argument
+    func_type = get_proper_type(get_first_arg(ctx.arg_types))
+    if isinstance(func_type, CallableType):
+        # TODO: support using type as argument to register
+        metadata = {
+            'fallback': func_type,
+            'registered': set()
+        }  # type: SingledispatchInfo
+
+        # singledispatch returns an instance of functools._SingleDispatchCallable according to
+        # typeshed
+        singledispatch_obj = get_proper_type(ctx.default_return_type)
+        assert isinstance(singledispatch_obj, Instance)
+        # mypy shows an error when assigning TypedDict to a regular dict
+        singledispatch_obj.type.metadata[METADATA_KEY] = metadata  # type: ignore
+
+    return ctx.default_return_type
+
+
+def singledispatch_register_callback(ctx: MethodContext) -> Type:
+    # TODO: support passing class to register as argument (and add tests for that)
+    if isinstance(ctx.type, Instance):
+        metadata = get_singledispatch_info(ctx.type)
+        # TODO: check that there's only one argument
+        first_arg_type = get_proper_type(get_first_arg(ctx.arg_types))
+        if isinstance(first_arg_type, CallableType):
+            # TODO: do more checking for registered functions
+            metadata['registered'].add(first_arg_type)
+
+    # register doesn't modify the function it's used on
+    return ctx.default_return_type
+
+
+def call_singledispatch_function_callback(ctx: MethodSigContext) -> CallableType:
+    if not isinstance(ctx.type, Instance):
+        return ctx.default_signature
+    metadata = get_singledispatch_info(ctx.type)
+    first_arg = get_first_arg(ctx.args)
+    if first_arg is None:
+        return ctx.default_signature
+    # TODO: find a way to get the type of the first argument with the public API
+    # (expr_checker probably isn't part of the public API)
+    passed_type = cast(TypeChecker, ctx.api).expr_checker.accept(first_arg)
+    for func in metadata['registered']:
+        if func.arg_types:
+            sig_type = func.arg_types[0]
+            if is_subtype(passed_type, sig_type):
+                # TODO: Should error messages relating to registered functions use fallback's name
+                # or registered name?
+                return func
+    return metadata['fallback']

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -6,7 +6,7 @@ from mypy.types import (
     AnyType, CallableType, Instance, NoneType, Overloaded, Type, TypeOfAny, get_proper_type
 )
 from mypy.plugin import CheckerPluginInterface, FunctionContext, MethodContext, MethodSigContext
-from typing import Dict, List, Optional, TypeVar, cast
+from typing import Dict, List, Optional, Sequence, TypeVar, cast
 from typing_extensions import Final, TypedDict
 
 SingledispatchInfo = TypedDict('SingledispatchInfo', {

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -148,7 +148,7 @@ def call_singledispatch_function_after_register_argument(ctx: MethodContext) -> 
     """Called on the function after passing a type to register"""
     register_callable = ctx.type
     if isinstance(register_callable, Instance):
-        type_args = cast(RegisterCallableInfo, register_callable.args)
+        type_args = RegisterCallableInfo(*register_callable.args)  # type: ignore
         func = get_first_arg(ctx.arg_types)
         if func is not None:
             register_function(type_args.singledispatch_obj, func, type_args.register_type)

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -48,7 +48,9 @@ def get_first_arg(args: List[List[T]]) -> Optional[T]:
 
 REGISTER_RETURN_CLASS = '_SingleDispatchRegisterCallable'
 
-REGISTER_CALLABLE_CALL_METHOD = 'functools.{}.__call__'.format(REGISTER_RETURN_CLASS)  # type: Final
+REGISTER_CALLABLE_CALL_METHOD = 'functools.{}.__call__'.format(
+    REGISTER_RETURN_CLASS
+)  # type: Final
 
 
 def make_fake_register_class_instance(api: CheckerPluginInterface, type_args: Sequence[Type]

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -74,7 +74,6 @@ def make_fake_register_class_instance(api: CheckerPluginInterface, type_args: Se
 
 def create_singledispatch_function_callback(ctx: FunctionContext) -> Type:
     """Called for functools.singledispatch"""
-    # TODO: check that there's only one argument
     func_type = get_proper_type(get_first_arg(ctx.arg_types))
     if isinstance(func_type, CallableType):
         metadata = {

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -46,7 +46,7 @@ def get_first_arg(args: List[List[T]]) -> Optional[T]:
     return None
 
 
-REGISTER_RETURN_CLASS = 'SingleDispatchRegisterCallable'
+REGISTER_RETURN_CLASS = '_SingleDispatchRegisterCallable'
 
 REGISTER_CALLABLE_CALL_METHOD = 'functools.{}.__call__'.format(REGISTER_RETURN_CLASS)  # type: Final
 

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -12,15 +12,16 @@ from mypy.plugin import CheckerPluginInterface, FunctionContext, MethodContext, 
 from typing import List, NamedTuple, Optional, Sequence, TypeVar, Union
 from typing_extensions import Final
 
-SingledispatchTypeVars = NamedTuple('SingledispatchTypeVars', [
-    ('return_type', Type),
-    ('fallback', CallableType),
-])
 
-RegisterCallableInfo = NamedTuple('RegisterCallableInfo', [
-    ('register_type', Type),
-    ('singledispatch_obj', Instance),
-])
+class SingledispatchTypeVars(NamedTuple):
+    return_type: Type
+    fallback: CallableType
+
+
+class RegisterCallableInfo(NamedTuple):
+    register_type: Type
+    singledispatch_obj: Instance
+
 
 SINGLEDISPATCH_TYPE = 'functools._SingleDispatchCallable'
 

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -84,7 +84,6 @@ def create_singledispatch_function_callback(ctx: FunctionContext) -> Type:
 def singledispatch_register_callback(ctx: MethodContext) -> Type:
     # TODO: support passing class to register as argument (and add tests for that)
     if isinstance(ctx.type, Instance):
-        metadata = get_singledispatch_info(ctx.type)
         # TODO: check that there's only one argument
         first_arg_type = get_proper_type(get_first_arg(ctx.arg_types))
         if isinstance(first_arg_type, (CallableType, Overloaded)) and first_arg_type.is_type_obj():
@@ -102,10 +101,22 @@ def singledispatch_register_callback(ctx: MethodContext) -> Type:
             return register_callable
         elif isinstance(first_arg_type, CallableType):
             # TODO: do more checking for registered functions
-            metadata['registered'].add(first_arg_type)
+            register_function(ctx.type, first_arg_type)
 
     # register doesn't modify the function it's used on
     return ctx.default_return_type
+
+
+def register_function(singledispatch_obj: Instance, func: Type,
+                      register_arg: Optional[Type] = None) -> None:
+
+    expanded_func = get_proper_type(func)
+    if not isinstance(expanded_func, CallableType):
+        return
+    metadata = get_singledispatch_info(singledispatch_obj)
+    # TODO: use register_arg
+    # Should we store the expanded or unexpanded function?
+    metadata['registered'].add(expanded_func)
 
 
 def rename_func(func: CallableType, new_name: CallableType) -> CallableType:

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -127,28 +127,28 @@ def create_singledispatch_function_callback(ctx: FunctionContext) -> Type:
 
 def singledispatch_register_callback(ctx: MethodContext) -> Type:
     """Called for functools._SingleDispatchCallable.register"""
-    if isinstance(ctx.type, Instance):
-        # TODO: check that there's only one argument
-        first_arg_type = get_proper_type(get_first_arg(ctx.arg_types))
-        if isinstance(first_arg_type, (CallableType, Overloaded)) and first_arg_type.is_type_obj():
-            # HACK: We receieved a class as an argument to register. We need to be able
-            # to access the function that register is being applied to, and the typeshed definition
-            # of register has it return a generic Callable, so we create a new
-            # SingleDispatchRegisterCallable class, define a __call__ method, and then add a
-            # plugin hook for that.
+    assert isinstance(ctx.type, Instance)
+    # TODO: check that there's only one argument
+    first_arg_type = get_proper_type(get_first_arg(ctx.arg_types))
+    if isinstance(first_arg_type, (CallableType, Overloaded)) and first_arg_type.is_type_obj():
+        # HACK: We receieved a class as an argument to register. We need to be able
+        # to access the function that register is being applied to, and the typeshed definition
+        # of register has it return a generic Callable, so we create a new
+        # SingleDispatchRegisterCallable class, define a __call__ method, and then add a
+        # plugin hook for that.
 
-            # is_subtype doesn't work when the right type is Overloaded, so we need the
-            # actual type
-            register_type = first_arg_type.items()[0].ret_type
-            type_args = RegisterCallableInfo(register_type, ctx.type)
-            register_callable = make_fake_register_class_instance(
-                ctx.api,
-                type_args
-            )
-            return register_callable
-        elif isinstance(first_arg_type, CallableType):
-            # TODO: do more checking for registered functions
-            register_function(ctx.type, first_arg_type)
+        # is_subtype doesn't work when the right type is Overloaded, so we need the
+        # actual type
+        register_type = first_arg_type.items()[0].ret_type
+        type_args = RegisterCallableInfo(register_type, ctx.type)
+        register_callable = make_fake_register_class_instance(
+            ctx.api,
+            type_args
+        )
+        return register_callable
+    elif isinstance(first_arg_type, CallableType):
+        # TODO: do more checking for registered functions
+        register_function(ctx.type, first_arg_type)
 
     # register doesn't modify the function it's used on
     return ctx.default_return_type

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -169,13 +169,14 @@ def register_function(ctx: PluginContext, singledispatch_obj: Instance, func: Ty
         # TODO: report an error here that singledispatch requires at least one argument
         # (might want to do the error reporting in get_dispatch_type)
         return
+    fallback = metadata['fallback']
 
-    fallback_dispatch_type = func.arg_types[0]
+    fallback_dispatch_type = fallback.arg_types[0]
     if not is_subtype(dispatch_type, fallback_dispatch_type):
 
         fail(ctx, 'Dispatch type {} must be subtype of fallback function first argument {}'.format(
                 format_type(dispatch_type), format_type(fallback_dispatch_type)
-            ), ctx.context)
+            ), func.definition)
         return
     # TODO: report an error if we're overwriting another function (which would happen if multiple
     # registered functions have the same dispatch type)

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -73,10 +73,10 @@ def make_fake_register_class_instance(api: CheckerPluginInterface, type_args: Se
 
 
 def create_singledispatch_function_callback(ctx: FunctionContext) -> Type:
+    """Called for functools.singledispatch"""
     # TODO: check that there's only one argument
     func_type = get_proper_type(get_first_arg(ctx.arg_types))
     if isinstance(func_type, CallableType):
-        # TODO: support using type as argument to register
         metadata = {
             'fallback': func_type,
             'registered': {}
@@ -93,6 +93,7 @@ def create_singledispatch_function_callback(ctx: FunctionContext) -> Type:
 
 
 def singledispatch_register_callback(ctx: MethodContext) -> Type:
+    """Called for functools._SingleDispatchCallable.register"""
     if isinstance(ctx.type, Instance):
         # TODO: check that there's only one argument
         first_arg_type = get_proper_type(get_first_arg(ctx.arg_types))
@@ -166,6 +167,7 @@ def rename_func(func: CallableType, new_name: CallableType) -> CallableType:
 
 
 def call_singledispatch_function_callback(ctx: MethodSigContext) -> CallableType:
+    """Called for functools._SingleDispatchCallable.__call__"""
     if not isinstance(ctx.type, Instance):
         return ctx.default_signature
     metadata = get_singledispatch_info(ctx.type)

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -269,3 +269,24 @@ f('a', 'a')
 [builtins fixtures/args.pyi]
 [builtins fixtures/list.pyi]
 [builtins fixtures/dict.pyi]
+
+[case testIncorrectArgumentsInSingledispatchFunctionDefinition]
+from functools import singledispatch
+
+@singledispatch
+def f() -> None: # E: Singledispatch function requires at least one argument
+    pass
+
+@singledispatch
+def g(**kwargs) -> None: # E: First argument to singledispatch function must be a positional argument
+    pass
+
+@singledispatch
+def h(*, x) -> None: # E: First argument to singledispatch function must be a positional argument
+    pass
+
+@singledispatch
+def i(*, x=1) -> None: # E: First argument to singledispatch function must be a positional argument
+    pass
+
+[builtins fixtures/args.pyi]

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -34,41 +34,22 @@ def _(arg: int) -> None:
 [case testCheckNonDispatchArgumentsWithTypeAlwaysTheSame]
 from functools import singledispatch
 
-@singledispatch
-def f(arg: int, arg2: str) -> None:
-    pass
-
-@f.register
-def g(arg: str, arg2: str) -> None:
-    pass
-
-f(1, 'a') 
-f(1, 5) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
-
-f('b', 'a')
-f('b', 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
-
-[builtins fixtures/args.pyi]
-
-[case testCheckNonDispatchArgumentsUsingMoreSpecificTypeInSpecializedVersion]
-from functools import singledispatch
-
 class A: pass
 class B(A): pass
 
 @singledispatch
-def f(arg: int, arg2: A) -> None:
+def f(arg: A, arg2: str) -> None:
     pass
 
 @f.register
-def g(arg: str, arg2: B) -> None:
+def g(arg: B, arg2: str) -> None:
     pass
 
-f(1, A()) 
-f(1, B())
+f(A(), 'a')
+f(A(), 5) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
 
-f('b', A()) # E: Argument 2 to "f" has incompatible type "A"; expected "B"
-f('b', B())
+f(B(), 'a')
+f(B(), 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
 
 [builtins fixtures/args.pyi]
 
@@ -116,36 +97,6 @@ def g(arg: int) -> None: # E: Argument to register "str" is incompatible with ty
 
 [builtins fixtures/args.pyi]
 
-[case testMoreSpecificGenericNonDispatchArgumentInImplementations]
-from functools import singledispatch
-from typing import TypeVar, Optional, Any, Type
-
-T = TypeVar('T')
-
-Alias = Optional[T]
-
-@singledispatch
-def f(arg, arg2: Alias[Any]) -> None: 
-    pass
-
-@f.register
-def g(arg: int, arg2: Alias[int]) -> None:
-    pass
-
-@f.register
-def h(arg: str, arg2: Alias[Type[Any]]) -> None:
-    pass
-
-f((3, 5), 'a')
-f(1, 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "Optional[int]"
-
-f('a', 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "Optional[Type[Any]]"
-f('a', str)
-f('a', int)
-f('a', None)
-
-[builtins fixtures/args.pyi]
-
 [case testDispatchBasedOnTypeAnnotationsRequires37-xfail]
 # flags: --python-version 3.6
 # the docs for singledispatch say that register didn't accept type annotations until python 3.7
@@ -164,17 +115,11 @@ def g(arg: int) -> None: # E: Singledispatch based on type annotations is only s
 from functools import singledispatch
 
 @singledispatch
-def f(arg, arg2) -> None:
+def f(arg: int) -> None:
     pass
-@f.register(int)
-def g(arg, arg2: str) -> None:
+@f.register(str)
+def g(arg) -> None: # E: Dispatch type "str" must be subtype of fallback function first argument "int"
     pass
-
-f(1, 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
-f(1, 'a')
-
-f('a', 1)
-f('a', 'b')
 
 [builtins fixtures/args.pyi]
 
@@ -183,17 +128,11 @@ from functools import singledispatch
 class A: pass
 
 @singledispatch
-def f(arg, arg2) -> None:
+def f(arg: int) -> None:
     pass
 @f.register(A)
-def g(arg, arg2: str) -> None:
+def g(arg) -> None: # E: Dispatch type "A" must be subtype of fallback function first argument "int"
     pass
-
-f(A(), 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
-f(A(), 'a')
-
-f('a', 1)
-f('a', 'b')
 
 [builtins fixtures/args.pyi]
 
@@ -206,7 +145,7 @@ class B(A): pass
 class C: pass
 
 @singledispatch
-def f(arg: A) -> None:
+def f(arg: Union[A, C]) -> None:
     pass
 
 @f.register
@@ -231,7 +170,7 @@ class B(A): pass
 class C: pass
 
 @singledispatch
-def f(arg: A) -> None:
+def f(arg: Union[A, C]) -> None:
     pass
 
 @f.register
@@ -243,28 +182,21 @@ def h(arg: C) -> None:
     pass
 
 x: Union[B, C, int]
-# TODO: improve this error message (ideally it would point out that there's no implementation
-# for int)
-f(x)  # E: Argument 1 to "f" has incompatible type "Union[B, C, int]"; expected "B"
+f(x)  # E: Argument 1 to "f" has incompatible type "Union[B, C, int]"; expected "Union[A, C]"
 
 [builtins fixtures/args.pyi]
 
-[case testABCUsedAsType]
+[case testABCAllowedAsDispatchType]
 from functools import singledispatch
 from collections.abc import Mapping
 
 @singledispatch
-def f(arg, arg2: str) -> None:
+def f(arg) -> None:
     pass
 
 @f.register
-def g(arg: Mapping, arg2: int) -> None:
+def g(arg: Mapping) -> None:
     pass
-
-f({"a": "b"}, 4)
-f({"a": "b"}, 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
-f('a', 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
-f('a', 'a')
 
 [builtins fixtures/args.pyi]
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -221,3 +221,51 @@ x: Union[B, C]
 f(x)
 
 [builtins fixtures/args.pyi]
+
+[case testOnePartOfUnionDoesNotHaveCorrespondingImplementation]
+from functools import singledispatch
+from typing import Union
+
+class A: pass
+class B(A): pass
+class C: pass
+
+@singledispatch
+def f(arg: A) -> None:
+    pass
+
+@f.register
+def g(arg: B) -> None:
+    pass
+
+@f.register
+def h(arg: C) -> None:
+    pass
+
+x: Union[B, C, int]
+# TODO: improve this error message (ideally it would point out that there's no implementation
+# for int)
+f(x)  # E: Argument 1 to "f" has incompatible type "Union[B, C, int]"; expected "B"
+
+[builtins fixtures/args.pyi]
+
+[case testABCUsedAsType]
+from functools import singledispatch
+from collections.abc import Mapping
+
+@singledispatch
+def f(arg, arg2: str) -> None:
+    pass
+
+@f.register
+def g(arg: Mapping, arg2: int) -> None:
+    pass
+
+f({"a": "b"}, 4)
+f({"a": "b"}, 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
+f('a', 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
+f('a', 'a')
+
+[builtins fixtures/args.pyi]
+[builtins fixtures/list.pyi]
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -290,3 +290,24 @@ def i(*, x=1) -> None: # E: First argument to singledispatch function must be a 
     pass
 
 [builtins fixtures/args.pyi]
+
+[case testDispatchTypeIsNotASubtypeOfFallbackFirstArgument]
+from functools import singledispatch
+
+class A: pass
+class B(A): pass
+class C: pass
+
+@singledispatch
+def f(arg: A) -> None:
+    pass
+
+@f.register
+def g(arg: B) -> None:
+    pass
+
+@f.register
+def h(arg: C) -> None: # E: Dispatch type "C" must be subtype of fallback function first argument "A"
+    pass
+
+[builtins fixtures/args.pyi]

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -159,3 +159,40 @@ def g(arg: int) -> None: # E: Singledispatch based on type annotations is only s
     pass
 
 [builtins fixtures/args.pyi]
+
+[case testTypePassedAsArgumentToRegister]
+from functools import singledispatch
+
+@singledispatch
+def f(arg, arg2) -> None:
+    pass
+@f.register(int)
+def g(arg, arg2: str) -> None:
+    pass
+
+f(1, 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
+f(1, 'a')
+
+f('a', 1)
+f('a', 'b')
+
+[builtins fixtures/args.pyi]
+
+[case testCustomClassPassedAsTypeToRegister]
+from functools import singledispatch
+class A: pass
+
+@singledispatch
+def f(arg, arg2) -> None:
+    pass
+@f.register(A)
+def g(arg, arg2: str) -> None:
+    pass
+
+f(A(), 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
+f(A(), 'a')
+
+f('a', 1)
+f('a', 'b')
+
+[builtins fixtures/args.pyi]

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -67,23 +67,6 @@ def g(arg: int) -> None:
 
 [builtins fixtures/args.pyi]
 
-[case testMultipleImplementationsHaveSameDispatchTypes-xfail]
-from functools import singledispatch
-
-@singledispatch
-def f(arg) -> None: 
-    pass
-
-@f.register
-def g(arg: int) -> None: # E: singledispatch implementation 2 will never be used: implementation 3's dispatch type is the same
-    pass
-
-@f.register
-def h(arg: int) -> None:
-    pass
-
-[builtins fixtures/args.pyi]
-    
 [case testRegisterHasDifferentTypeThanTypeSignature-xfail]
 from functools import singledispatch
 

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -247,3 +247,45 @@ def g(arg: B) -> None:
     pass
 
 [builtins fixtures/args.pyi]
+
+[case testAnyInConstructorArgsWithClassPassedToRegister]
+from functools import singledispatch
+from typing import Any
+
+class Base: pass
+class ConstExpr:
+    def __init__(self, **kwargs: Any) -> None: pass
+
+@singledispatch
+def f(arg: Base) -> ConstExpr:
+    pass
+
+@f.register(ConstExpr)
+def g(arg: ConstExpr) -> ConstExpr: # E: Dispatch type "ConstExpr" must be subtype of fallback function first argument "Base"
+    pass
+
+
+[builtins fixtures/args.pyi]
+
+[case testRegisteredImplementationUsedBeforeDefinition]
+from functools import singledispatch
+from typing import Union
+
+class Node: pass
+class MypyFile(Node): pass
+class Missing: pass
+
+@singledispatch
+def f(a: Union[Node, Missing]) -> None:
+    pass
+
+@f.register
+def g(a: MypyFile) -> None:
+    x: Missing
+    f(x)
+
+@f.register
+def h(a: Missing) -> None:
+    pass
+
+[builtins fixtures/args.pyi]

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -243,3 +243,24 @@ def h(arg: C) -> None: # E: Dispatch type "C" must be subtype of fallback functi
     pass
 
 [builtins fixtures/args.pyi]
+
+[case testMultipleSingledispatchFunctionsIntermixed]
+from functools import singledispatch
+
+class A: pass
+class B(A): pass
+class C: pass
+
+@singledispatch
+def f(arg: A) -> None:
+    pass
+
+@singledispatch
+def h(arg: C) -> None:
+    pass
+
+@f.register
+def g(arg: B) -> None:
+    pass
+
+[builtins fixtures/args.pyi]

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -196,3 +196,28 @@ f('a', 1)
 f('a', 'b')
 
 [builtins fixtures/args.pyi]
+
+[case testMultiplePossibleImplementationsForKnownType]
+from functools import singledispatch
+from typing import Union
+
+class A: pass
+class B(A): pass
+class C: pass
+
+@singledispatch
+def f(arg: A) -> None:
+    pass
+
+@f.register
+def g(arg: B) -> None:
+    pass
+
+@f.register
+def h(arg: C) -> None:
+    pass
+
+x: Union[B, C]
+f(x)
+
+[builtins fixtures/args.pyi]

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -1,4 +1,4 @@
-[case testIncorrectDispatchArgumentWhenDoesntMatchFallback-xfail]
+[case testIncorrectDispatchArgumentWhenDoesntMatchFallback]
 from functools import singledispatch
 
 class A: pass
@@ -11,7 +11,7 @@ def fun(arg: A) -> None:
 def fun_b(arg: B) -> None:
     pass
 
-fun(1) # E: Argument 1 to "fun" has incompatible type "int"; expected "__main__.A"
+fun(1) # E: Argument 1 to "fun" has incompatible type "int"; expected "A"
 
 # probably won't be required after singledispatch is special cased
 [builtins fixtures/args.pyi]
@@ -31,7 +31,7 @@ def _(arg: int) -> None:
 
 [builtins fixtures/args.pyi]
 
-[case testCheckNonDispatchArgumentsWithTypeAlwaysTheSame-xfail]
+[case testCheckNonDispatchArgumentsWithTypeAlwaysTheSame]
 from functools import singledispatch
 
 @singledispatch
@@ -43,14 +43,14 @@ def g(arg: str, arg2: str) -> None:
     pass
 
 f(1, 'a') 
-f(1, 5) # E: Argument 2 to "fun" has incompatible type "int"; expected "str"
+f(1, 5) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
 
 f('b', 'a')
-f('b', 1) # E: Argument 2 to "fun" has incompatible type "int"; expected "str"
+f('b', 1) # E: Argument 2 to "f" has incompatible type "int"; expected "str"
 
 [builtins fixtures/args.pyi]
 
-[case testCheckNonDispatchArgumentsUsingMoreSpecificTypeInSpecializedVersion-xfail]
+[case testCheckNonDispatchArgumentsUsingMoreSpecificTypeInSpecializedVersion]
 from functools import singledispatch
 
 class A: pass
@@ -67,7 +67,7 @@ def g(arg: str, arg2: B) -> None:
 f(1, A()) 
 f(1, B())
 
-f('b', A()) # E: Argument 2 to "fun" has incompatible type "__main__.A"; expected "__main__.B"
+f('b', A()) # E: Argument 2 to "f" has incompatible type "A"; expected "B"
 f('b', B())
 
 [builtins fixtures/args.pyi]
@@ -116,7 +116,7 @@ def g(arg: int) -> None: # E: Argument to register "str" is incompatible with ty
 
 [builtins fixtures/args.pyi]
 
-[case testMoreSpecificGenericNonDispatchArgumentInImplementations-xfail]
+[case testMoreSpecificGenericNonDispatchArgumentInImplementations]
 from functools import singledispatch
 from typing import TypeVar, Optional, Any, Type
 
@@ -137,9 +137,9 @@ def h(arg: str, arg2: Alias[Type[Any]]) -> None:
     pass
 
 f((3, 5), 'a')
-f(1, 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "Union[int, None]"
+f(1, 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "Optional[int]"
 
-f('a', 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "Union[Type[Any], None]"
+f('a', 'a') # E: Argument 2 to "f" has incompatible type "str"; expected "Optional[Type[Any]]"
 f('a', str)
 f('a', int)
 f('a', None)


### PR DESCRIPTION
This adds a singledispatch plugin to the default collection of plugins for mypy that type checks uses of singledispatch. The plugin is enough to get some of the tests in check-singledispatch.test to start working (with some modifications to correct some mistakes in the tests), so those tests get changed from xfails to regular tests.

#### Limitations

This has a lot of limitations about what it can type check so far, including:

- no support for passing types as arguments to `register` - Currently the plugin only supports using type annotations, and will not do any type checking if there are any arguments to `register` other than the function to register.
- no support for singledispatchmethod
- no support for using `registry` or `dispatch`

In all of these cases, mypy should default to the typeshed definition of singledispatch, which is far more permissive about what it allows. That means that these limitations shouldn't cause any false positives.