### PR TITLE
Avoid passing None to verify in stubtest.py

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -216,8 +216,10 @@ def verify_mypyfile(
     to_check.difference_update({"__file__", "__doc__", "__name__", "__builtins__", "__package__"})
 
     for entry in sorted(to_check):
+        stub_to_verify = stub.names[entry].node if entry in stub.names else MISSING
+        assert stub_to_verify is not None
         yield from verify(
-            stub.names[entry].node if entry in stub.names else MISSING,
+            stub_to_verify,
             getattr(runtime, entry, MISSING),
             object_path + [entry],
         )
@@ -247,8 +249,10 @@ def verify_typeinfo(
         mangled_entry = entry
         if entry.startswith("__") and not entry.endswith("__"):
             mangled_entry = "_{}{}".format(stub.name, entry)
+        stub_to_verify = next((t.names[entry].node for t in stub.mro if entry in t.names), MISSING)
+        assert stub_to_verify is not None
         yield from verify(
-            next((t.names[entry].node for t in stub.mro if entry in t.names), MISSING),
+            stub_to_verify,
             getattr(runtime, mangled_entry, MISSING),
             object_path + [entry],
         )


### PR DESCRIPTION
`SymbolTableNode.node` can be None, which means that we may accidentally end up passing None to `verify` for the first argument, despite the fact that `verify` doesn't have any implementations that allow for the dispatch type being None. This PR fixes that by making sure the dispatch type isn't None before calling `verify`.

This also should make it possible for mypy to type check after the introduction of the singledispatch plugin from #10694.