### PR TITLE
Update getting_started.rst

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -351,7 +351,7 @@ additional stubs using pip (see :ref:`fix-missing-imports` and
 :ref:`installed-packages` for the details). For example, you can install
 the stubs for the ``requests`` package like this:
 
-.. code-block::
+.. code-block:: shell
 
   python3 -m pip install types-requests
 


### PR DESCRIPTION
### Description

Installation instruction example for requests (https://mypy.readthedocs.io/en/stable/getting_started.html#library-stubs-and-typeshed)  wasn't showing up in documentation due to missing `shell`.

