### PR TITLE
Graceful exit on KeyboardInterrupt

### DIFF
--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -23,7 +23,7 @@ def console_entry() -> None:
         if options.show_traceback:
             sys.stdout.write(traceback.format_exc())
         formatter = FancyFormatter(sys.stdout, sys.stderr, False)
-        msg = " KeybordInterrupt called by user. Abort!\n"
+        msg = "Interrupted\n"
         sys.stdout.write(formatter.style(msg, color="red", bold=True))
         sys.stdout.flush()
         sys.stderr.flush()

--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -1,9 +1,9 @@
 """Mypy type checker command line tool."""
-
-import sys
 import os
+import sys
+import traceback
 
-from mypy.main import main
+from mypy.main import main, process_options
 from mypy.util import FancyFormatter
 
 
@@ -19,6 +19,9 @@ def console_entry() -> None:
         os.dup2(devnull, sys.stdout.fileno())
         sys.exit(2)
     except KeyboardInterrupt:
+        _, options = process_options(args=sys.argv[1:])
+        if options.show_traceback:
+            sys.stdout.write(traceback.format_exc())
         formatter = FancyFormatter(sys.stdout, sys.stderr, False)
         msg = " KeybordInterrupt called by user. Abort!\n"
         sys.stdout.write(formatter.style(msg, color="red", bold=True))

--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -17,6 +17,8 @@ def console_entry() -> None:
         devnull = os.open(os.devnull, os.O_WRONLY)
         os.dup2(devnull, sys.stdout.fileno())
         sys.exit(2)
+    except KeyboardInterrupt:
+        sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -4,6 +4,7 @@ import sys
 import os
 
 from mypy.main import main
+from mypy.util import FancyFormatter
 
 
 def console_entry() -> None:
@@ -18,6 +19,11 @@ def console_entry() -> None:
         os.dup2(devnull, sys.stdout.fileno())
         sys.exit(2)
     except KeyboardInterrupt:
+        formatter = FancyFormatter(sys.stdout, sys.stderr, False)
+        msg = " KeybordInterrupt called by user. Abort!\n"
+        sys.stdout.write(formatter.style(msg, color="red", bold=True))
+        sys.stdout.flush()
+        sys.stderr.flush()
         sys.exit(2)
 
 


### PR DESCRIPTION
### Description

Catch `KeyboardInterrupt` to allow graceful exit instead of printing the traceback.

![Screen Shot 2021-08-02 at 09 26 50](https://user-images.githubusercontent.com/30130371/127820872-50086dcc-212a-40cd-9fdc-fdeb17225054.png)

## Test Plan

Run `mypy` and trigger a `KeyboardInterrupt`. No traceback should be shown.