### PR TITLE
Make dispatch types of `verify` subtypes of `verify`'s first argument

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -172,7 +172,7 @@ def test_module(module_name: str) -> Iterator[Error]:
 
 @singledispatch
 def verify(
-    stub: nodes.Node, runtime: MaybeMissing[Any], object_path: List[str]
+    stub: MaybeMissing[nodes.Node], runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
     """Entry point for comparing a stub to a runtime object.
 


### PR DESCRIPTION
This changes the type of the first argument of `verify` to be a supertype of the dispatch types of all registered implementations, including the implementation for `Missing`.

This allows the singledispatch plugin from #10694 to type check stubtest.py, as the plugin requires that the dispatch type for all registered implementations is a subtype of the first argument of the main singledispatch function to make type checking calls to singledispatch functions easier.