### PR TITLE
Make --cache-fine-grained imply --local-partial-types

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1009,6 +1009,11 @@ def process_options(args: List[str],
 
         process_cache_map(parser, special_opts, options)
 
+    # An explicitly specified cache_fine_grained implies local_partial_types
+    # (because otherwise the cache is not compatiable with dmypy)
+    if options.cache_fine_grained:
+        options.local_partial_types = True
+
     # Let logical_deps imply cache_fine_grained (otherwise the former is useless).
     if options.logical_deps:
         options.cache_fine_grained = True

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3682,9 +3682,11 @@ x = 0
 [file mypy.ini]
 \[mypy]
 cache_fine_grained = True
+local_partial_types = True
 [file mypy.ini.2]
 \[mypy]
 cache_fine_grained = False
+local_partial_types = True
 -- Nothing should get rechecked
 [rechecked]
 [stale]


### PR DESCRIPTION
dmypy requires local-partial-types, so without specifying it, we generate
a cache that is useless to dmypy.

Prompted by #10735.

## Test Plan

Tested manually generating a cache for mypy and then checking it with dmypy.