### PR TITLE
[mypyc] Add initial support for compiling singledispatch functions

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -115,6 +115,7 @@ class IRBuilder:
         self.encapsulating_funcs = pbv.encapsulating_funcs
         self.nested_fitems = pbv.nested_funcs.keys()
         self.fdefs_to_decorators = pbv.funcs_to_decorators
+        self.singledispatch_impls = pbv.singledispatch_impls
 
         self.visitor = visitor
 

--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -22,7 +22,8 @@ class FuncInfo:
                  is_nested: bool = False,
                  contains_nested: bool = False,
                  is_decorated: bool = False,
-                 in_non_ext: bool = False) -> None:
+                 in_non_ext: bool = False,
+                 is_singledispatch: bool = False) -> None:
         self.fitem = fitem
         self.name = name if not is_decorated else decorator_helper_name(name)
         self.class_name = class_name
@@ -47,6 +48,7 @@ class FuncInfo:
         self.contains_nested = contains_nested
         self.is_decorated = is_decorated
         self.in_non_ext = in_non_ext
+        self.is_singledispatch = is_singledispatch
 
         # TODO: add field for ret_type: RType = none_rprimitive
 

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -84,7 +84,10 @@ def transform_decorator(builder: IRBuilder, dec: Decorator) -> None:
         decorated_func = load_decorated_func(builder, dec.func, func_reg)
         builder.assign(get_func_target(builder, dec.func), decorated_func, dec.func.line)
         func_reg = decorated_func
-    else:
+    # If the prebuild pass didn't put this function in the function to decorators map (for example
+    # if this is a registered singledispatch implementation with no other decorators), we should
+    # treat this function as a regular function, not a decorated function
+    elif dec.func in builder.fdefs_to_decorators:
         # Obtain the the function name in order to construct the name of the helper function.
         name = dec.func.fullname.split('.')[-1]
         helper_name = decorator_helper_name(name)

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -777,10 +777,11 @@ def add_singledispatch_registered_impls(builder: IRBuilder) -> None:
     assert isinstance(fitem, FuncDef)
     impls = builder.singledispatch_impls[fitem]
     line = fitem.line
+    current_func_decl = builder.mapper.func_to_decl[fitem]
+    arg_info = get_args(builder, current_func_decl.sig.args, line)
     for dispatch_type, impl in impls:
         func_decl = builder.mapper.func_to_decl[impl]
         call_impl, next_impl = BasicBlock(), BasicBlock()
-        arg_info = get_args(builder, func_decl.sig.args, line)
         should_call_impl = check_if_isinstance(builder, arg_info.args[0], dispatch_type, line)
         builder.add_bool_branch(should_call_impl, call_impl, next_impl)
 

--- a/mypyc/irbuild/prebuildvisitor.py
+++ b/mypyc/irbuild/prebuildvisitor.py
@@ -185,6 +185,10 @@ def get_singledispatch_register_call_info(decorator: Expression, func: FuncDef
     # @fun.register
     # def g(arg: int): ...
     elif isinstance(decorator, MemberExpr):
+        # we don't know if this is a register call yet, so we can't be sure that the function
+        # actually has arguments
+        if not func.arguments:
+            return None
         arg_type = get_proper_type(func.arguments[0].variable.type)
         if not isinstance(arg_type, Instance):
             return None

--- a/mypyc/irbuild/prebuildvisitor.py
+++ b/mypyc/irbuild/prebuildvisitor.py
@@ -162,9 +162,11 @@ class PreBuildVisitor(TraverserVisitor):
         func = self.symbols_to_funcs[symbol]
         self.free_variables.setdefault(func, set()).add(symbol)
 
+
 class RegisteredImpl(NamedTuple):
     singledispatch_func: FuncDef
     dispatch_type: TypeInfo
+
 
 def get_singledispatch_register_call_info(decorator: Expression) -> Optional[RegisteredImpl]:
     # @fun.register(complex)

--- a/mypyc/irbuild/prebuildvisitor.py
+++ b/mypyc/irbuild/prebuildvisitor.py
@@ -178,10 +178,15 @@ def get_singledispatch_register_call_info(decorator: Expression) -> Optional[Reg
         if not isinstance(dispatch_type, TypeInfo):
             return None
 
-        if (isinstance(callee, MemberExpr) and callee.name == 'register'
-                and isinstance(callee.expr, NameExpr)):
-            expr = callee.expr
-            node = expr.node
-            if isinstance(node, Decorator):
-                return RegisteredImpl(node.func, dispatch_type)
+        if isinstance(callee, MemberExpr):
+            return registered_impl_from_possible_register_call(callee, dispatch_type)
+    return None
+
+
+def registered_impl_from_possible_register_call(expr: MemberExpr, dispatch_type: TypeInfo
+                                                ) -> Optional[RegisteredImpl]:
+    if expr.name == 'register' and isinstance(expr.expr, NameExpr):
+        node = expr.expr.node
+        if isinstance(node, Decorator):
+            return RegisteredImpl(node.func, dispatch_type)
     return None

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -141,7 +141,7 @@ get_module_dict_op = custom_op(
     is_borrowed=True)
 
 # isinstance(obj, cls)
-function_op(
+slow_isinstance_op = function_op(
     name='builtins.isinstance',
     arg_types=[object_rprimitive, object_rprimitive],
     return_type=c_int_rprimitive,

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -387,3 +387,18 @@ def test_verify() -> None:
     assert verify_list(MypyFile(), 5, ['a', 'b']) == ['in TypeInfo', 'hello']
     assert verify_list(TypeInfo(), str, ['a', 'b']) == ['in TypeInfo', 'hello']
     assert verify_list(TypeVarExpr(), 'a', ['x', 'y']) == ['x', 'y']
+
+[case testArgsInRegisteredImplNamedDifferentlyFromMainFunction]
+from functools import singledispatch
+
+@singledispatch
+def f(a) -> bool:
+    return False
+
+@f.register
+def g(b: int) -> bool:
+    return True
+
+def test_singledispatch():
+    assert f(5)
+    assert not f('a')

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -402,3 +402,40 @@ def g(b: int) -> bool:
 def test_singledispatch():
     assert f(5)
     assert not f('a')
+
+[case testKeywordArguments]
+from functools import singledispatch
+
+@singledispatch
+def f(arg, *, kwarg: bool = False) -> bool:
+    return not kwarg
+
+@f.register
+def g(arg: int, *, kwarg: bool = True) -> bool:
+    return kwarg
+
+def test_keywords():
+    assert f('a')
+    assert f('a', kwarg=False)
+    assert not f('a', kwarg=True)
+
+    assert f(1)
+    assert f(1, kwarg=True)
+    assert not f(1, kwarg=False)
+
+[case testGeneratorAndMultipleTypesOfIterable-xfail]
+from functools import singledispatch
+from typing import *
+
+@singledispatch
+def f(arg: Any) -> Iterable[int]:
+    yield 1
+
+@f.register
+def g(arg: str) -> Iterable[int]:
+    return [0]
+
+def test_iterables():
+    assert f(1) != [1]
+    assert list(f(1)) == [1]
+    assert f('a') == [0]

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -2,7 +2,7 @@
 # Most of these tests are marked as xfails because mypyc doesn't support singledispatch yet
 # (These tests will be re-enabled when mypyc supports singledispatch)
 
-[case testSpecializedImplementationUsed-xfail]
+[case testSpecializedImplementationUsed]
 from functools import singledispatch
 
 @singledispatch
@@ -17,7 +17,7 @@ def test_specialize() -> None:
     assert fun('a')
     assert not fun(3)
 
-[case testSubclassesOfExpectedTypeUseSpecialized-xfail]
+[case testSubclassesOfExpectedTypeUseSpecialized]
 from functools import singledispatch
 class A: pass
 class B(A): pass
@@ -76,7 +76,7 @@ def test_singledispatch() -> None:
     assert fun('a') == 'str'
     assert fun({'a': 'b'}) == 'default'
 
-[case testCanRegisterCompiledClasses-xfail]
+[case testCanRegisterCompiledClasses]
 from functools import singledispatch
 class A: pass
 
@@ -136,7 +136,9 @@ def fun_specialized(arg: int) -> bool:
 def test_singledispatch() -> None:
     assert fun_specialized('a')
 
-[case testTypeAnnotationsDisagreeWithRegisterArgument-xfail]
+# TODO: remove this test when type annotations and register arguments disagreeing becomes a
+# mypy error
+[case testTypeAnnotationsDisagreeWithRegisterArgument]
 from functools import singledispatch
 
 @singledispatch

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -386,7 +386,7 @@ def test_singledispatch():
     assert f(5)
     assert not f('a')
 
-[case testKeywordArguments]
+[case testKeywordArguments-xfail]
 from functools import singledispatch
 
 @singledispatch

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -136,23 +136,6 @@ def fun_specialized(arg: int) -> bool:
 def test_singledispatch() -> None:
     assert fun_specialized('a')
 
-# TODO: remove this test when type annotations and register arguments disagreeing becomes a
-# mypy error
-[case testTypeAnnotationsDisagreeWithRegisterArgument]
-from functools import singledispatch
-
-@singledispatch
-def fun(arg) -> bool:
-    return False
-
-@fun.register(int)
-def fun_specialized(arg: str) -> bool:
-    return True
-
-def test_singledispatch() -> None:
-    assert fun(3) # type: ignore
-    assert not fun('a')
-
 [case testNoneIsntATypeWhenUsedAsArgumentToRegister-xfail]
 from functools import singledispatch
 


### PR DESCRIPTION
This PR adds initial support for compiling functions marked with singledispatch by generating IR that checks the type of the first argument and calls the correct implementation, falling back to the main singledispatch function if none of the registered implementations have a dispatch type that matches the argument.

Currently, this only supports both one-argument versions of `register` (passing a type as an argument to register or using type annotations), and only works if `register` is used as a decorator.

## Test Plan

Several of the tests in run-singledispatch.test that were previously marked as xfail are now able to pass, so those are changed to regular tests.