### PR TITLE
Preserve types of functions registered with singledispatch

### DIFF
--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -138,24 +138,25 @@ def singledispatch_register_callback(ctx: MethodContext) -> Type:
         return register_callable
     elif isinstance(first_arg_type, CallableType):
         # TODO: do more checking for registered functions
-        register_function(ctx, ctx.type, first_arg_type)
+        return register_function(ctx, ctx.type, first_arg_type)
 
-    # register doesn't modify the function it's used on
+    # fallback in case we don't recognize the arguments
     return ctx.default_return_type
 
 
 def register_function(ctx: PluginContext, singledispatch_obj: Instance, func: Type,
-                      register_arg: Optional[Type] = None) -> None:
+                      register_arg: Optional[Type] = None) -> Type:
+    """Register a function, returning the type that the function should be set to"""
 
     func = get_proper_type(func)
     if not isinstance(func, CallableType):
-        return
+        return ctx.default_return_type
     metadata = get_singledispatch_info(singledispatch_obj)
     dispatch_type = get_dispatch_type(func, register_arg)
     if dispatch_type is None:
         # TODO: report an error here that singledispatch requires at least one argument
         # (might want to do the error reporting in get_dispatch_type)
-        return
+        return ctx.default_return_type
     fallback = metadata.fallback
 
     fallback_dispatch_type = fallback.arg_types[0]
@@ -164,7 +165,12 @@ def register_function(ctx: PluginContext, singledispatch_obj: Instance, func: Ty
         fail(ctx, 'Dispatch type {} must be subtype of fallback function first argument {}'.format(
                 format_type(dispatch_type), format_type(fallback_dispatch_type)
             ), func.definition)
-        return
+        return ctx.default_return_type
+    # The typeshed stubs for register say that the function returned is Callable[..., T], even
+    # though the function returned is the same as the one passed in. We return the type of the
+    # function so that mypy can properly type check cases where the registered function is used
+    # directly (instead of through singledispatch)
+    return func
 
 
 def get_dispatch_type(func: CallableType, register_arg: Optional[Type]) -> Optional[Type]:
@@ -182,7 +188,8 @@ def call_singledispatch_function_after_register_argument(ctx: MethodContext) -> 
         type_args = RegisterCallableInfo(*register_callable.args)  # type: ignore
         func = get_first_arg(ctx.arg_types)
         if func is not None:
-            register_function(ctx, type_args.singledispatch_obj, func, type_args.register_type)
+            return register_function(ctx, type_args.singledispatch_obj, func,
+                                     type_args.register_type)
     return ctx.default_return_type
 
 

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -289,3 +289,28 @@ def h(a: Missing) -> None:
     pass
 
 [builtins fixtures/args.pyi]
+
+[case testIncorrectArgumentTypeWhenCallingRegisteredImplDirectly]
+from functools import singledispatch
+
+@singledispatch
+def f(arg, arg2: str) -> bool:
+    return False
+
+@f.register
+def g(arg: int, arg2: str) -> bool:
+    pass
+
+@f.register(str)
+def h(arg, arg2: str) -> bool:
+    pass
+
+g('a', 'a') # E: Argument 1 to "g" has incompatible type "str"; expected "int"
+g(1, 1) # E: Argument 2 to "g" has incompatible type "int"; expected "str"
+
+# don't show errors for incorrect first argument here, because there's no type annotation for the
+# first argument
+h(1, 'a')
+h('a', 1) # E: Argument 2 to "h" has incompatible type "int"; expected "str"
+
+[builtins fixtures/args.pyi]


### PR DESCRIPTION
### Description

When calling a function that has been registered as an implementation for a singledispatch function, currently, mypy doesn't type check arguments to those functions when those functions are called directly (instead of through the main singledispatch function). This fixes that by preserving the type of the registered function even after the register decorator has been used.

## Test Plan

I added a test that made sure that we report errors when using registered functions directly.