### PR TITLE
Don't replace type of singledispatch-registered function with None

### DIFF
--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -5,8 +5,7 @@ from mypy.nodes import (
 )
 from mypy.subtypes import is_subtype
 from mypy.types import (
-    AnyType, CallableType, Instance, NoneType, Overloaded, Type, TypeOfAny, get_proper_type,
-    FunctionLike
+    AnyType, CallableType, Instance, Overloaded, Type, TypeOfAny, get_proper_type, FunctionLike
 )
 from mypy.plugin import CheckerPluginInterface, FunctionContext, MethodContext, MethodSigContext
 from typing import List, NamedTuple, Optional, Sequence, TypeVar, Union

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -289,3 +289,17 @@ def h(a: Missing) -> None:
     pass
 
 [builtins fixtures/args.pyi]
+
+[case testCallingRegisteredImplDirectlyWorksCorrectly]
+from functools import singledispatch
+@singledispatch
+def fun(arg) -> bool:
+    pass
+
+@fun.register(int)
+def fun_specialized(arg) -> bool:
+    pass
+
+fun_specialized(1)
+
+[builtins fixtures/args.pyi]


### PR DESCRIPTION
Previously, the singledispatch plugin would replace the type of registered functions with None when types were passed as arguments to `register`, leading to a 'None not callable' error when trying to call registered functions directly.

This fixes that by preserving what typeshed says the function's type should be after being registered (which is `Callable[..., _T]`, where `_T` is the return type of the main singledispatch function). #10756 should improve that type by preserving the original type of the registered function, instead of just the return type, but this should also help by avoiding those 'None not callable' errors in case of a bug in the singledispatch plugin.

## Test Plan

I added a test to reproduce the error.