### PR TITLE
[mypyc] Rewrite CPyStr_Build using a simplification of _PyUnicode_JoinArray

### DIFF
--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -25,7 +25,8 @@ from mypyc.ir.ops import (
 )
 from mypyc.ir.rtypes import (
     RType, RTuple, str_rprimitive, list_rprimitive, dict_rprimitive, set_rprimitive,
-    bool_rprimitive, is_dict_rprimitive, c_int_rprimitive, is_str_rprimitive
+    bool_rprimitive, is_dict_rprimitive, c_int_rprimitive, is_str_rprimitive,
+    c_pyssize_t_rprimitive
 )
 from mypyc.primitives.dict_ops import (
     dict_keys_op, dict_values_op, dict_items_op, dict_setdefault_spec_init_op
@@ -378,7 +379,7 @@ def translate_str_format(
 
         # The first parameter is the total size of the following PyObject* merged from
         # two lists alternatively.
-        result_list: List[Value] = [Integer(0, c_int_rprimitive)]
+        result_list: List[Value] = [Integer(0, c_pyssize_t_rprimitive)]
         for a, b in zip(literals, variables):
             if a:
                 result_list.append(builder.load_str(a))
@@ -393,7 +394,7 @@ def translate_str_format(
         if not variables and len(result_list) == 2:
             return result_list[1]
 
-        result_list[0] = Integer(len(result_list) - 1, c_int_rprimitive)
+        result_list[0] = Integer(len(result_list) - 1, c_pyssize_t_rprimitive)
         return builder.call_c(str_build_op, result_list, expr.line)
     return None
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -384,7 +384,7 @@ static inline char CPyDict_CheckSize(PyObject *dict, CPyTagged size) {
 // Str operations
 
 
-PyObject *CPyStr_Build(int len, ...);
+PyObject *CPyStr_Build(Py_ssize_t len, ...);
 PyObject *CPyStr_GetItem(PyObject *str, CPyTagged index);
 PyObject *CPyStr_Split(PyObject *str, PyObject *sep, CPyTagged max_split);
 PyObject *CPyStr_Replace(PyObject *str, PyObject *old_substr, PyObject *new_substr, CPyTagged max_replace);

--- a/mypyc/lib-rt/str_ops.c
+++ b/mypyc/lib-rt/str_ops.c
@@ -68,11 +68,12 @@ PyObject *CPyStr_Build(Py_ssize_t len, ...) {
         if (PyUnicode_READY(item) == -1)
             return NULL;
 
-        Py_ssize_t add_sz = PyUnicode_GET_LENGTH(item);
+        size_t add_sz = PyUnicode_GET_LENGTH(item);
         Py_UCS4 item_maxchar = PyUnicode_MAX_CHAR_VALUE(item);
         maxchar = Py_MAX(maxchar, item_maxchar);
 
-        if (add_sz + sz > (Py_ssize_t)PY_SSIZE_T_MAX) {
+        // Using size_t to avoid overflow during arithmetic calculation
+        if (add_sz > (size_t)(PY_SSIZE_T_MAX - sz)) {
             PyErr_SetString(PyExc_OverflowError,
                             "join() result is too long for a Python string");
             return NULL;

--- a/mypyc/lib-rt/str_ops.c
+++ b/mypyc/lib-rt/str_ops.c
@@ -43,7 +43,7 @@ PyObject *CPyStr_GetItem(PyObject *str, CPyTagged index) {
     }
 }
 
-// A simplification of _PyUnicode_JoinArray()
+// A simplification of _PyUnicode_JoinArray() from CPython 3.9.6
 PyObject *CPyStr_Build(Py_ssize_t len, ...) {
     Py_ssize_t i;
     va_list args;

--- a/mypyc/primitives/str_ops.py
+++ b/mypyc/primitives/str_ops.py
@@ -45,7 +45,7 @@ method_op(
 )
 
 str_build_op = custom_op(
-    arg_types=[c_int_rprimitive],
+    arg_types=[c_pyssize_t_rprimitive],
     return_type=str_rprimitive,
     c_function_name='CPyStr_Build',
     error_kind=ERR_MAGIC,

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -271,6 +271,10 @@ def test_fstring_python_doc() -> None:
 from typing import Tuple
 
 def test_format_method_basics() -> None:
+    x = str()
+    assert 'x{}'.format(x) == 'x'
+    assert 'ā{}'.format(x) == 'ā'
+    assert '😀{}'.format(x) == '😀'
     assert ''.format() == ''
     assert 'abc'.format() == 'abc'
     assert '{}{}'.format(1, 2) == '12'
@@ -347,6 +351,10 @@ def test_format_method_different_kind() -> None:
     assert 'Revealed type is {}'.format(s1) == "Revealed type is Literal['😀']"
     s2 = "Revealed type is"
     assert "{} Literal['😀']".format(s2) == "Revealed type is Literal['😀']"
+    s3 = "测试："
+    assert "{}{} {}".format(s3, s2, s1) == "测试：Revealed type is Literal['😀']"
+    assert "Test: {}{}".format(s3, s1) == "Test: 测试：Literal['😀']"
+    assert "Test: {}{}".format(s3, s2) == "Test: 测试：Revealed type is"
 
 class Point:
     def __init__(self, x, y):

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -342,6 +342,12 @@ def test_format_method_args() -> None:
     assert format_kwargs(x=10, y=2, z=1) == 'c10d2'
     assert format_kwargs_self(x=10, y=2, z=1) == "{'x': 10, 'y': 2, 'z': 1}"
 
+def test_format_method_different_kind() -> None:
+    s1 = "Literal['😀']"
+    assert 'Revealed type is {}'.format(s1) == "Revealed type is Literal['😀']"
+    s2 = "Revealed type is"
+    assert "{} Literal['😀']".format(s2) == "Revealed type is Literal['😀']"
+
 class Point:
     def __init__(self, x, y):
         self.x, self.y = x, y


### PR DESCRIPTION
### Description

Closes https://github.com/mypyc/mypyc/issues/876

## Test Plan

```py
@benchmark
def str_format_format_method() -> None:
    a = []
    tmp_str = "Foobar"
    for i in range(1000):
        for _ in range(5):
            a.append('{}'.format(tmp_str))
        a.append('{}-{}'.format(tmp_str, i))
        a.append('{} {} str'.format(i, i * 2.0))

    n = 0
    for i in range(100):
        for s in a:
            n += len("foobar {} stuff".format(s))
            ss = "foobar {} stuff".format(s)
            n += len("{}-{}-{}".format(i, s, ss))
    assert n == 36897500, n
```

```
running str_format_format_method
..........
interpreted: 0.574899s (avg of 5 iterations; stdev 0.25%)
compiled:    0.156026s (avg of 5 iterations; stdev 0.63%)

compiled is 3.685x faster
```
