### PR TITLE
Support union type syntax in runtime contexts

### DIFF
--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -4,13 +4,13 @@ from typing import Optional
 
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, IndexExpr, RefExpr, TupleExpr, IntExpr, FloatExpr, UnaryExpr,
-    ComplexExpr, ListExpr, StrExpr, BytesExpr, UnicodeExpr, EllipsisExpr, CallExpr,
+    ComplexExpr, ListExpr, StrExpr, BytesExpr, UnicodeExpr, EllipsisExpr, CallExpr, OpExpr,
     get_member_expr_fullname
 )
 from mypy.fastparse import parse_type_string
 from mypy.types import (
     Type, UnboundType, TypeList, EllipsisType, AnyType, CallableArgument, TypeOfAny,
-    RawExpressionType, ProperType
+    RawExpressionType, ProperType, UnionType
 )
 
 
@@ -150,5 +150,8 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
         return RawExpressionType(None, 'builtins.complex', line=expr.line, column=expr.column)
     elif isinstance(expr, EllipsisExpr):
         return EllipsisType(expr.line)
+    elif isinstance(expr, OpExpr) and expr.op == '|':
+        return UnionType([expr_to_unanalyzed_type(expr.left),
+                          expr_to_unanalyzed_type(expr.right)])
     else:
         raise TypeTranslationError()

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -80,7 +80,10 @@ def expr_to_unanalyzed_type(expr: Expression,
             return base
         else:
             raise TypeTranslationError()
-    elif isinstance(expr, OpExpr) and expr.op == '|' and options.python_version >= (3, 10):
+    elif (isinstance(expr, OpExpr)
+          and expr.op == '|'
+          and options
+          and options.python_version >= (3, 10)):
         return UnionType([expr_to_unanalyzed_type(expr.left, options),
                           expr_to_unanalyzed_type(expr.right, options)])
     elif isinstance(expr, CallExpr) and isinstance(_parent, ListExpr):

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -12,6 +12,7 @@ from mypy.types import (
     Type, UnboundType, TypeList, EllipsisType, AnyType, CallableArgument, TypeOfAny,
     RawExpressionType, ProperType, UnionType
 )
+from mypy.options import Options
 
 
 class TypeTranslationError(Exception):
@@ -29,7 +30,9 @@ def _extract_argument_name(expr: Expression) -> Optional[str]:
         raise TypeTranslationError()
 
 
-def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = None) -> ProperType:
+def expr_to_unanalyzed_type(expr: Expression,
+                            options: Optional[Options] = None,
+                            _parent: Optional[Expression] = None) -> ProperType:
     """Translate an expression to the corresponding type.
 
     The result is not semantically analyzed. It can be UnboundType or TypeList.
@@ -53,7 +56,7 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
         else:
             raise TypeTranslationError()
     elif isinstance(expr, IndexExpr):
-        base = expr_to_unanalyzed_type(expr.base, expr)
+        base = expr_to_unanalyzed_type(expr.base, options, expr)
         if isinstance(base, UnboundType):
             if base.args:
                 raise TypeTranslationError()
@@ -69,14 +72,17 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
                 # of the Annotation definition and only returning the type information,
                 # losing all the annotations.
 
-                return expr_to_unanalyzed_type(args[0], expr)
+                return expr_to_unanalyzed_type(args[0], options, expr)
             else:
-                base.args = tuple(expr_to_unanalyzed_type(arg, expr) for arg in args)
+                base.args = tuple(expr_to_unanalyzed_type(arg, options, expr) for arg in args)
             if not base.args:
                 base.empty_tuple_index = True
             return base
         else:
             raise TypeTranslationError()
+    elif isinstance(expr, OpExpr) and expr.op == '|' and options.python_version >= (3, 10):
+        return UnionType([expr_to_unanalyzed_type(expr.left, options),
+                          expr_to_unanalyzed_type(expr.right, options)])
     elif isinstance(expr, CallExpr) and isinstance(_parent, ListExpr):
         c = expr.callee
         names = []
@@ -109,19 +115,19 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
                     if typ is not default_type:
                         # Two types
                         raise TypeTranslationError()
-                    typ = expr_to_unanalyzed_type(arg, expr)
+                    typ = expr_to_unanalyzed_type(arg, options, expr)
                     continue
                 else:
                     raise TypeTranslationError()
             elif i == 0:
-                typ = expr_to_unanalyzed_type(arg, expr)
+                typ = expr_to_unanalyzed_type(arg, options, expr)
             elif i == 1:
                 name = _extract_argument_name(arg)
             else:
                 raise TypeTranslationError()
         return CallableArgument(typ, name, arg_const, expr.line, expr.column)
     elif isinstance(expr, ListExpr):
-        return TypeList([expr_to_unanalyzed_type(t, expr) for t in expr.items],
+        return TypeList([expr_to_unanalyzed_type(t, options, expr) for t in expr.items],
                         line=expr.line, column=expr.column)
     elif isinstance(expr, StrExpr):
         return parse_type_string(expr.value, 'builtins.str', expr.line, expr.column,
@@ -133,7 +139,7 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
         return parse_type_string(expr.value, 'builtins.unicode', expr.line, expr.column,
                                  assume_str_is_unicode=True)
     elif isinstance(expr, UnaryExpr):
-        typ = expr_to_unanalyzed_type(expr.expr)
+        typ = expr_to_unanalyzed_type(expr.expr, options)
         if isinstance(typ, RawExpressionType):
             if isinstance(typ.literal_value, int) and expr.op == '-':
                 typ.literal_value *= -1
@@ -150,8 +156,5 @@ def expr_to_unanalyzed_type(expr: Expression, _parent: Optional[Expression] = No
         return RawExpressionType(None, 'builtins.complex', line=expr.line, column=expr.column)
     elif isinstance(expr, EllipsisExpr):
         return EllipsisType(expr.line)
-    elif isinstance(expr, OpExpr) and expr.op == '|':
-        return UnionType([expr_to_unanalyzed_type(expr.left),
-                          expr_to_unanalyzed_type(expr.right)])
     else:
         raise TypeTranslationError()

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -552,7 +552,7 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
     type_arg = _get_argument(rvalue, 'type')
     if type_arg and not init_type:
         try:
-            un_type = expr_to_unanalyzed_type(type_arg)
+            un_type = expr_to_unanalyzed_type(type_arg, ctx.api.options)
         except TypeTranslationError:
             ctx.api.fail('Invalid argument to type', type_arg)
         else:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2101,7 +2101,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             return self.should_wait_rhs(rv.callee)
         return False
 
-    def can_be_type_alias(self, rv: Expression) -> bool:
+    def can_be_type_alias(self, rv: Expression, allow_none: bool = False) -> bool:
         """Is this a valid r.h.s. for an alias definition?
 
         Note: this function should be only called for expressions where self.should_wait_rhs()
@@ -2112,6 +2112,13 @@ class SemanticAnalyzer(NodeVisitor[None],
         if isinstance(rv, IndexExpr) and self.is_type_ref(rv.base, bare=False):
             return True
         if self.is_none_alias(rv):
+            return True
+        if allow_none and isinstance(rv, NameExpr) and rv.fullname == 'builtins.None':
+            return True
+        if (isinstance(rv, OpExpr)
+                and rv.op == '|'
+                and self.can_be_type_alias(rv.left, allow_none=True)
+                and self.can_be_type_alias(rv.right, allow_none=True)):
             return True
         return False
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1267,7 +1267,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             self.analyze_type_expr(base_expr)
 
             try:
-                base = expr_to_unanalyzed_type(base_expr)
+                base = expr_to_unanalyzed_type(base_expr, self.options)
             except TypeTranslationError:
                 # This error will be caught later.
                 continue
@@ -1373,7 +1373,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         for i, base_expr in enumerate(base_type_exprs):
             if i not in removed:
                 try:
-                    base = expr_to_unanalyzed_type(base_expr)
+                    base = expr_to_unanalyzed_type(base_expr, self.options)
                 except TypeTranslationError:
                     # This error will be caught later.
                     continue
@@ -3202,7 +3202,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         result: List[Type] = []
         for node in items:
             try:
-                analyzed = self.anal_type(expr_to_unanalyzed_type(node),
+                analyzed = self.anal_type(expr_to_unanalyzed_type(node, self.options),
                                           allow_placeholder=True)
                 if analyzed is None:
                     # Type variables are special: we need to place them in the symbol table
@@ -3645,7 +3645,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 return
             # Translate first argument to an unanalyzed type.
             try:
-                target = expr_to_unanalyzed_type(expr.args[0])
+                target = expr_to_unanalyzed_type(expr.args[0], self.options)
             except TypeTranslationError:
                 self.fail('Cast target is not a type', expr)
                 return
@@ -3703,7 +3703,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 return
             # Translate first argument to an unanalyzed type.
             try:
-                target = expr_to_unanalyzed_type(expr.args[0])
+                target = expr_to_unanalyzed_type(expr.args[0], self.options)
             except TypeTranslationError:
                 self.fail('Argument 1 to _promote is not a type', expr)
                 return
@@ -3899,7 +3899,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             items = [index]
         for item in items:
             try:
-                typearg = expr_to_unanalyzed_type(item)
+                typearg = expr_to_unanalyzed_type(item, self.options)
             except TypeTranslationError:
                 self.fail('Type expected within [...]', expr)
                 return None
@@ -4206,7 +4206,7 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     def lookup_type_node(self, expr: Expression) -> Optional[SymbolTableNode]:
         try:
-            t = expr_to_unanalyzed_type(expr)
+            t = expr_to_unanalyzed_type(expr, self.options)
         except TypeTranslationError:
             return None
         if isinstance(t, UnboundType):
@@ -4926,7 +4926,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             assert info.tuple_type, "NamedTuple without tuple type"
             fallback = Instance(info, [])
             return TupleType(info.tuple_type.items, fallback=fallback)
-        typ = expr_to_unanalyzed_type(expr)
+        typ = expr_to_unanalyzed_type(expr, self.options)
         return self.anal_type(typ, report_invalid_types=report_invalid_types,
                               allow_placeholder=allow_placeholder)
 

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -356,7 +356,7 @@ class NamedTupleAnalyzer:
                     self.fail("Invalid NamedTuple() field name", item)
                     return None
                 try:
-                    type = expr_to_unanalyzed_type(type_node)
+                    type = expr_to_unanalyzed_type(type_node, self.options)
                 except TypeTranslationError:
                     self.fail('Invalid field type', type_node)
                     return None

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -160,7 +160,7 @@ class NewTypeAnalyzer:
         # Check second argument
         msg = "Argument 2 to NewType(...) must be a valid type"
         try:
-            unanalyzed_type = expr_to_unanalyzed_type(args[1])
+            unanalyzed_type = expr_to_unanalyzed_type(args[1], self.options)
         except TypeTranslationError:
             self.fail(msg, context)
             return None, False

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -290,7 +290,7 @@ class TypedDictAnalyzer:
                 self.fail_typeddict_arg("Invalid TypedDict() field name", name_context)
                 return [], [], False
             try:
-                type = expr_to_unanalyzed_type(field_type_expr)
+                type = expr_to_unanalyzed_type(field_type_expr, self.options)
             except TypeTranslationError:
                 self.fail_typeddict_arg('Invalid field type', field_type_expr)
                 return [], [], False

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -80,7 +80,7 @@ def analyze_type_alias(node: Expression,
     Return None otherwise. 'node' must have been semantically analyzed.
     """
     try:
-        type = expr_to_unanalyzed_type(node)
+        type = expr_to_unanalyzed_type(node, options)
     except TypeTranslationError:
         api.fail('Invalid type alias: expression is not a valid type', node)
         return None

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3154,7 +3154,7 @@ def foo(arg: Type[Any]):
 from typing import Type, Any
 def foo(arg: Type[Any]):
     reveal_type(arg.__str__)  # N: Revealed type is "def () -> builtins.str"
-    reveal_type(arg.mro())  # N: Revealed type is "builtins.list[builtins.type]"
+    reveal_type(arg.mro())  # N: Revealed type is "builtins.list[builtins.type[Any]]"
 [builtins fixtures/type.pyi]
 [out]
 

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -11,7 +11,6 @@ def f(x: int | str) -> int | str:
 reveal_type(f)  # N: Revealed type is "def (x: Union[builtins.int, builtins.str]) -> Union[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
-
 [case testUnionOrSyntaxWithThreeBuiltinsTypes]
 # flags: --python-version 3.10
 def f(x: int | str | float) -> int | str | float:
@@ -20,7 +19,6 @@ def f(x: int | str | float) -> int | str | float:
     reveal_type(z)  # N: Revealed type is "Union[builtins.int, builtins.str, builtins.float]"
     return x
 reveal_type(f)  # N: Revealed type is "def (x: Union[builtins.int, builtins.str, builtins.float]) -> Union[builtins.int, builtins.str, builtins.float]"
-
 
 [case testUnionOrSyntaxWithTwoTypes]
 # flags: --python-version 3.10
@@ -32,7 +30,6 @@ def f(x: A | B) -> A | B:
     reveal_type(z)  # N: Revealed type is "Union[__main__.A, __main__.B]"
     return x
 reveal_type(f)  # N: Revealed type is "def (x: Union[__main__.A, __main__.B]) -> Union[__main__.A, __main__.B]"
-
 
 [case testUnionOrSyntaxWithThreeTypes]
 # flags: --python-version 3.10
@@ -46,18 +43,15 @@ def f(x: A | B | C) -> A | B | C:
     return x
 reveal_type(f)  # N: Revealed type is "def (x: Union[__main__.A, __main__.B, __main__.C]) -> Union[__main__.A, __main__.B, __main__.C]"
 
-
 [case testUnionOrSyntaxWithLiteral]
 # flags: --python-version 3.10
 from typing_extensions import Literal
 reveal_type(Literal[4] | str)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
-
 [case testUnionOrSyntaxWithBadOperator]
 # flags: --python-version 3.10
 x: 1 + 2  # E: Invalid type comment or annotation
-
 
 [case testUnionOrSyntaxWithBadOperands]
 # flags: --python-version 3.10
@@ -65,14 +59,12 @@ x: int | 42  # E: Invalid type: try using Literal[42] instead?
 y: 42 | int  # E: Invalid type: try using Literal[42] instead?
 z: str | 42 | int  # E: Invalid type: try using Literal[42] instead?
 
-
 [case testUnionOrSyntaxWithGenerics]
 # flags: --python-version 3.10
 from typing import List
 x: List[int | str]
 reveal_type(x)  # N: Revealed type is "builtins.list[Union[builtins.int, builtins.str]]"
 [builtins fixtures/list.pyi]
-
 
 [case testUnionOrSyntaxWithQuotedFunctionTypes]
 # flags: --python-version 3.4
@@ -87,12 +79,10 @@ def g(x: "int | str | None") -> "int | None":
     return 42
 reveal_type(g)  # N: Revealed type is "def (x: Union[builtins.int, builtins.str, None]) -> Union[builtins.int, None]"
 
-
 [case testUnionOrSyntaxWithQuotedVariableTypes]
 # flags: --python-version 3.6
 y: "int | str" = 42
 reveal_type(y)  # N: Revealed type is "Union[builtins.int, builtins.str]"
-
 
 [case testUnionOrSyntaxWithTypeAliasWorking]
 # flags: --python-version 3.10
@@ -113,7 +103,6 @@ b: X  # E: Variable "__main__.X" is not valid as a type \
     # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 [builtins fixtures/type.pyi]
 
-
 [case testUnionOrSyntaxWithinRuntimeContextNotAllowed]
 # flags: --python-version 3.9
 from __future__ import annotations
@@ -126,7 +115,6 @@ class C(List[int | str]):  # E: Type expected within [...] \
 C()
 [builtins fixtures/tuple.pyi]
 
-
 [case testUnionOrSyntaxWithinRuntimeContextNotAllowed2]
 # flags: --python-version 3.9
 from __future__ import annotations
@@ -135,11 +123,9 @@ cast(str | int, 'x')  # E: Cast target is not a type
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
 
-
 [case testUnionOrSyntaxInComment]
 # flags: --python-version 3.6
 x = 1  # type: int | str
-
 
 [case testUnionOrSyntaxFutureImport]
 # flags: --python-version 3.7
@@ -147,18 +133,15 @@ from __future__ import annotations
 x: int | None
 [builtins fixtures/tuple.pyi]
 
-
 [case testUnionOrSyntaxMissingFutureImport]
 # flags: --python-version 3.9
 x: int | None  # E: X | Y syntax for unions requires Python 3.10
-
 
 [case testUnionOrSyntaxInStubFile]
 # flags: --python-version 3.6
 from lib import x
 [file lib.pyi]
 x: int | None
-
 
 [case testUnionOrSyntaxInMiscRuntimeContexts]
 # flags: --python-version 3.10

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -96,10 +96,22 @@ reveal_type(y)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testUnionOrSyntaxWithTypeAliasWorking]
 # flags: --python-version 3.10
-from typing import Union
-T = Union[int, str]
+T = int | str
 x: T
 reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+S = list[int] | str | None
+y: S
+reveal_type(y)  # N: Revealed type is "Union[builtins.list[builtins.int], builtins.str, None]"
+U = str | None
+z: U
+reveal_type(z)  # N: Revealed type is "Union[builtins.str, None]"
+
+def f(): pass
+
+X = int | str | f()
+b: X  # E: Variable "__main__.X" is not valid as a type \
+    # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+[builtins fixtures/type.pyi]
 
 
 [case testUnionOrSyntaxWithTypeAliasNotAllowed]
@@ -131,3 +143,17 @@ x: int | None  # E: X | Y syntax for unions requires Python 3.10
 from lib import x
 [file lib.pyi]
 x: int | None
+
+
+[case testUnionOrSyntaxInMiscRuntimeContexts]
+# flags: --python-version 3.10
+from typing import cast
+
+class C(list[int | None]):
+    pass
+
+def f() -> object: pass
+
+reveal_type(cast(str | None, f()))  # N: Revealed type is "Union[builtins.str, None]"
+reveal_type(list[str | None]())  # N: Revealed type is "builtins.list[Union[builtins.str, None]]"
+[builtins fixtures/type.pyi]

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -114,11 +114,26 @@ b: X  # E: Variable "__main__.X" is not valid as a type \
 [builtins fixtures/type.pyi]
 
 
-[case testUnionOrSyntaxWithTypeAliasNotAllowed]
+[case testUnionOrSyntaxWithinRuntimeContextNotAllowed]
 # flags: --python-version 3.9
 from __future__ import annotations
-T = int | str  # E: Unsupported left operand type for | ("Type[int]")
+from typing import List
+T = int | str  # E: Invalid type alias: expression is not a valid type \
+               # E: Unsupported left operand type for | ("Type[int]")
+class C(List[int | str]):  # E: Type expected within [...] \
+                           # E: Invalid base class "List"
+    pass
+C()
 [builtins fixtures/tuple.pyi]
+
+
+[case testUnionOrSyntaxWithinRuntimeContextNotAllowed2]
+# flags: --python-version 3.9
+from __future__ import annotations
+from typing import cast
+cast(str | int, 'x')  # E: Cast target is not a type
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
 
 
 [case testUnionOrSyntaxInComment]

--- a/test-data/unit/fixtures/type.pyi
+++ b/test-data/unit/fixtures/type.pyi
@@ -1,6 +1,6 @@
 # builtins stub used in type-related test cases.
 
-from typing import Generic, TypeVar, List
+from typing import Generic, TypeVar, List, Union
 
 T = TypeVar('T')
 
@@ -10,8 +10,9 @@ class object:
 
 class list(Generic[T]): pass
 
-class type:
+class type(Generic[T]):
     __name__: str
+    def __or__(self, other: Union[type, None]) -> type: pass
     def mro(self) -> List['type']: pass
 
 class tuple(Generic[T]): pass

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -10,7 +10,7 @@ from abc import abstractmethod, ABCMeta
 
 class GenericMeta(type): pass
 
-cast = 0
+def cast(t, o): ...
 overload = 0
 Any = 0
 Union = 0


### PR DESCRIPTION
Support the `X | Y` syntax (PEP 604) in type aliases, casts, type applications 
and base classes.

These are only available in Python 3.10 mode and probably won't work in
stubs when targeting earlier Python versions yet.

Work on #9880.