### PR TITLE
Support new union syntax in stubs always in runtime context 

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2027,6 +2027,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             with self.enter_final_context(s.is_final_def):
                 self.check_assignment(s.lvalues[-1], s.rvalue, s.type is None, s.new_syntax)
 
+        if s.is_alias_def:
+            # We do this mostly for compatibility with old semantic analyzer.
+            # TODO: should we get rid of this?
+            self.store_type(s.lvalues[-1], self.expr_checker.accept(s.rvalue))
+
         if (s.type is not None and
                 self.options.disallow_any_unimported and
                 has_any_from_unimported_type(s.type)):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2075,6 +2075,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     accept_items(e.left)
                     accept_items(e.right)
                 else:
+                    # Nested union types have been converted to type context
+                    # in semantic analysis (such as in 'list[int | str]'),
+                    # so we don't need to deal with them here.
                     self.expr_checker.accept(e)
 
             accept_items(s.rvalue)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2023,6 +2023,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         Handle all kinds of assignment statements (simple, indexed, multiple).
         """
+        # Avoid type checking type aliases in stubs to avoid false
+        # positives about modern type syntax available in stubs such
+        # as X | Y.
         if not (s.is_alias_def and self.is_stub):
             with self.enter_final_context(s.is_final_def):
                 self.check_assignment(s.lvalues[-1], s.rvalue, s.type is None, s.new_syntax)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2023,13 +2023,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         Handle all kinds of assignment statements (simple, indexed, multiple).
         """
-        with self.enter_final_context(s.is_final_def):
-            self.check_assignment(s.lvalues[-1], s.rvalue, s.type is None, s.new_syntax)
-
-        if s.is_alias_def:
-            # We do this mostly for compatibility with old semantic analyzer.
-            # TODO: should we get rid of this?
-            self.store_type(s.lvalues[-1], self.expr_checker.accept(s.rvalue))
+        if not (s.is_alias_def and self.is_stub):
+            with self.enter_final_context(s.is_final_def):
+                self.check_assignment(s.lvalues[-1], s.rvalue, s.type is None, s.new_syntax)
 
         if (s.type is not None and
                 self.options.disallow_any_unimported and

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -357,6 +357,11 @@ class SemanticAnalyzerPluginInterface:
         """Is this the final iteration of semantic analysis?"""
         raise NotImplementedError
 
+    @property
+    @abstractmethod
+    def is_stub_file(self) -> bool:
+        raise NotImplementedError
+
 
 # A context for querying for configuration data about a module for
 # cache invalidation purposes.

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -552,7 +552,7 @@ def _attribute_from_attrib_maker(ctx: 'mypy.plugin.ClassDefContext',
     type_arg = _get_argument(rvalue, 'type')
     if type_arg and not init_type:
         try:
-            un_type = expr_to_unanalyzed_type(type_arg, ctx.api.options)
+            un_type = expr_to_unanalyzed_type(type_arg, ctx.api.options, ctx.api.is_stub_file)
         except TypeTranslationError:
             ctx.api.fail('Invalid argument to type', type_arg)
         else:

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -356,7 +356,7 @@ class NamedTupleAnalyzer:
                     self.fail("Invalid NamedTuple() field name", item)
                     return None
                 try:
-                    type = expr_to_unanalyzed_type(type_node, self.options)
+                    type = expr_to_unanalyzed_type(type_node, self.options, self.api.is_stub_file)
                 except TypeTranslationError:
                     self.fail('Invalid field type', type_node)
                     return None

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -160,7 +160,7 @@ class NewTypeAnalyzer:
         # Check second argument
         msg = "Argument 2 to NewType(...) must be a valid type"
         try:
-            unanalyzed_type = expr_to_unanalyzed_type(args[1], self.options)
+            unanalyzed_type = expr_to_unanalyzed_type(args[1], self.options, self.api.is_stub_file)
         except TypeTranslationError:
             self.fail(msg, context)
             return None, False

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -290,7 +290,8 @@ class TypedDictAnalyzer:
                 self.fail_typeddict_arg("Invalid TypedDict() field name", name_context)
                 return [], [], False
             try:
-                type = expr_to_unanalyzed_type(field_type_expr, self.options)
+                type = expr_to_unanalyzed_type(field_type_expr, self.options,
+                                               self.api.is_stub_file)
             except TypeTranslationError:
                 self.fail_typeddict_arg('Invalid field type', field_type_expr)
                 return [], [], False

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -141,8 +141,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         self.allow_tuple_literal = allow_tuple_literal
         # Positive if we are analyzing arguments of another (outer) type
         self.nesting_level = 0
-        # Should we allow unnormalized types like `list[int]`
-        # (currently allowed in stubs)?
+        # Should we allow new type syntax when targeting older Python versions
+        # like 'list[int]' or 'X | Y' (allowed in stubs)?
         self.allow_new_syntax = allow_new_syntax
         # Should we accept unbound type variables (always OK in aliases)?
         self.allow_unbound_tvars = allow_unbound_tvars or defining_alias

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -69,7 +69,7 @@ def analyze_type_alias(node: Expression,
                        plugin: Plugin,
                        options: Options,
                        is_typeshed_stub: bool,
-                       allow_unnormalized: bool = False,
+                       allow_new_syntax: bool = False,
                        allow_placeholder: bool = False,
                        in_dynamic_func: bool = False,
                        global_scope: bool = True) -> Optional[Tuple[Type, Set[str]]]:
@@ -80,12 +80,12 @@ def analyze_type_alias(node: Expression,
     Return None otherwise. 'node' must have been semantically analyzed.
     """
     try:
-        type = expr_to_unanalyzed_type(node, options)
+        type = expr_to_unanalyzed_type(node, options, allow_new_syntax)
     except TypeTranslationError:
         api.fail('Invalid type alias: expression is not a valid type', node)
         return None
     analyzer = TypeAnalyser(api, tvar_scope, plugin, options, is_typeshed_stub,
-                            allow_unnormalized=allow_unnormalized, defining_alias=True,
+                            allow_new_syntax=allow_new_syntax, defining_alias=True,
                             allow_placeholder=allow_placeholder)
     analyzer.in_dynamic_func = in_dynamic_func
     analyzer.global_scope = global_scope
@@ -126,7 +126,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                  is_typeshed_stub: bool, *,
                  defining_alias: bool = False,
                  allow_tuple_literal: bool = False,
-                 allow_unnormalized: bool = False,
+                 allow_new_syntax: bool = False,
                  allow_unbound_tvars: bool = False,
                  allow_placeholder: bool = False,
                  report_invalid_types: bool = True) -> None:
@@ -143,7 +143,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         self.nesting_level = 0
         # Should we allow unnormalized types like `list[int]`
         # (currently allowed in stubs)?
-        self.allow_unnormalized = allow_unnormalized
+        self.allow_new_syntax = allow_new_syntax
         # Should we accept unbound type variables (always OK in aliases)?
         self.allow_unbound_tvars = allow_unbound_tvars or defining_alias
         # If false, record incomplete ref if we generate PlaceholderType.
@@ -199,7 +199,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 return hook(AnalyzeTypeContext(t, t, self))
             if (fullname in get_nongen_builtins(self.options.python_version)
                     and t.args and
-                    not self.allow_unnormalized and
+                    not self.allow_new_syntax and
                     not self.api.is_future_flag_set("annotations")):
                 self.fail(no_subscript_builtin_alias(fullname,
                                                      propose_alt=not self.defining_alias), t)
@@ -282,7 +282,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         elif (fullname == 'typing.Tuple' or
              (fullname == 'builtins.tuple' and (self.options.python_version >= (3, 9) or
                                                 self.api.is_future_flag_set('annotations') or
-                                                self.allow_unnormalized))):
+                                                self.allow_new_syntax))):
             # Tuple is special because it is involved in builtin import cycle
             # and may be not ready when used.
             sym = self.api.lookup_fully_qualified_or_none('builtins.tuple')

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -155,3 +155,14 @@ def f() -> object: pass
 reveal_type(cast(str | None, f()))  # N: Revealed type is "Union[builtins.str, None]"
 reveal_type(list[str | None]())  # N: Revealed type is "builtins.list[Union[builtins.str, None]]"
 [builtins fixtures/type.pyi]
+
+[case testUnionOrSyntaxRuntimeContextInStubFile]
+import lib
+reveal_type(lib.x)  # N: Revealed type is "Union[builtins.int, builtins.list[builtins.str], None]"
+
+[file lib.pyi]
+A = int | list[str] | None
+x: A
+class C(list[int | None]):
+    pass
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -159,10 +159,13 @@ reveal_type(list[str | None]())  # N: Revealed type is "builtins.list[Union[buil
 [case testUnionOrSyntaxRuntimeContextInStubFile]
 import lib
 reveal_type(lib.x)  # N: Revealed type is "Union[builtins.int, builtins.list[builtins.str], None]"
+reveal_type(lib.y)  # N: Revealed type is "builtins.list[Union[builtins.int, None]]"
 
 [file lib.pyi]
 A = int | list[str] | None
 x: A
+B = list[int | None]
+y: B
 class C(list[int | None]):
     pass
 [builtins fixtures/list.pyi]


### PR DESCRIPTION
Previously it only worked when the target Python version was 3.10. Now type
aliases like these work in stubs on all Python versions:

```
A = str | None
```

Since type objects don't support `__or__` before 3.10 (in typeshed), skip some 
type checking of type alias definitions in stubs. Defensively only skip these things
in stubs, even though they could be redundant in other contexts as well.

Work on #9880.