### PR TITLE
Document special meaning of `...` in overloads

### DIFF
--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -297,8 +297,8 @@ return type by using overloads like so:
 
 The default values of a function's arguments don't affect its signature, only
 the absence or presence of a default value does. So in order to reduce
-redundancy in definitions it's possible to replace default values in
-overload definitions with `...` as a placeholder.
+redundancy it's possible to replace default values in overload definitions with
+`...` as a placeholder.
 
 .. code-block:: python
 

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -295,6 +295,25 @@ return type by using overloads like so:
    subtypes, you can use a :ref:`value restriction
    <type-variable-value-restriction>`.
 
+Sometimes default values of function arguments don't have an effect on its
+overload.  In these cases it is best practice to only specify them once in the
+function signature and use `...` ellipsis as a placeholder for the defaults in
+the overloads:
+
+.. code-block:: python
+
+    from typing import overload
+
+    class M: ...
+
+    @overload
+    def get_model(model_or_pk: M, flag: bool = ...) -> M: ...
+    @overload
+    def get_model(model_or_pk: int, flag: bool = ...) -> M | None: ...
+
+    def get_model(model_or_pk: int | M, flag: bool = True) -> M | None:
+        ...
+
 
 Runtime behavior
 ----------------

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -297,8 +297,8 @@ return type by using overloads like so:
 
 Sometimes default values of function arguments don't have an effect on its
 overload.  In these cases it is best practice to only specify them once in the
-function signature and use `...` ellipsis as a placeholder for the defaults in
-the overloads:
+function signature and use ``...`` ellipsis as a placeholder for the defaults
+in the overloads:
 
 .. code-block:: python
 

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -295,10 +295,10 @@ return type by using overloads like so:
    subtypes, you can use a :ref:`value restriction
    <type-variable-value-restriction>`.
 
-Sometimes default values of function arguments don't have an effect on its
-overload.  In these cases it is best practice to only specify them once in the
-function signature and use ``...`` ellipsis as a placeholder for the defaults
-in the overloads:
+The default values of a function's arguments don't affect its signature, only
+the absence or presence of a default value does. So in order to reduce
+redundancy in definitions it's possible to replace default values in
+overload definitions with `...` as a placeholder.
 
 .. code-block:: python
 


### PR DESCRIPTION
### Description

This PR documents the special meaning of ellipses for default values in overloads. The only reference I could find to this behavior in non-code writing [is this comment](https://github.com/python/mypy/issues/6580#issuecomment-586547247) by @Michael0x2a.

If you think it's inaccurate that this is (or should be) a best practice I'll rephrase that sentence, but it's my impression that it is.

## Test Plan

The change renders like this locally (`make html`):

<img width="741" src="https://user-images.githubusercontent.com/218551/124625379-079e6a00-de7e-11eb-99e7-1d49c9ade954.png">

