### PR TITLE
[mypyc] Initial optimization for f-string through a str.join() specializer

### DIFF
--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -459,7 +459,8 @@ def translate_fstring(
     # Special case for f-string, which is translated into str.join() in mypy AST.
     # This specializer optimizes simplest f-strings which don't contain any
     # format operation.
-    if (isinstance(callee.expr, StrExpr) and callee.expr.value == ''
+    if (isinstance(callee, MemberExpr)
+            and isinstance(callee.expr, StrExpr) and callee.expr.value == ''
             and expr.arg_kinds == [ARG_POS] and isinstance(expr.args[0], ListExpr)):
         for item in expr.args[0].items:
             if isinstance(item, StrExpr):

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -459,7 +459,8 @@ def translate_fstring(
     # Special case for f-string, which is translated into str.join() in mypy AST.
     # This specializer optimizes simplest f-strings which don't contain any
     # format operation.
-    if expr.arg_kinds == [ARG_POS] and isinstance(expr.args[0], ListExpr):
+    if (isinstance(callee.expr, StrExpr) and callee.expr.value == ''
+            and expr.arg_kinds == [ARG_POS] and isinstance(expr.args[0], ListExpr)):
         for item in expr.args[0].items:
             if isinstance(item, StrExpr):
                 continue
@@ -478,7 +479,7 @@ def translate_fstring(
 
         result_list: List[Value] = [Integer(0, c_pyssize_t_rprimitive)]
         for item in expr.args[0].items:
-            if isinstance(item, StrExpr):
+            if isinstance(item, StrExpr) and item.value != '':
                 result_list.append(builder.accept(item))
             elif isinstance(item, CallExpr):
                 result_list.append(builder.call_c(str_op,

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -452,6 +452,7 @@ def split_braces(format_str: str) -> List[str]:
     ret_list.append(tmp_str)
     return ret_list
 
+
 @specialize_function('join', str_rprimitive)
 def translate_fstring(
         builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Optional[Value]:
@@ -463,9 +464,9 @@ def translate_fstring(
             if isinstance(item, StrExpr):
                 continue
             elif isinstance(item, CallExpr):
-                if item.callee.name != 'format':
-                    return None
-                if item.callee.expr.value != '{:{}}':
+                if (not isinstance(item.callee, MemberExpr)
+                        or item.callee.name != 'format'
+                        or item.callee.expr.value != '{:{}}'):
                     return None
                 if not isinstance(item.args[1], StrExpr) or item.args[1].value != '':
                     return None

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -465,9 +465,12 @@ def translate_fstring(
                 continue
             elif isinstance(item, CallExpr):
                 if (not isinstance(item.callee, MemberExpr)
-                        or item.callee.name != 'format'
+                        or item.callee.name != 'format'):
+                    return None
+                elif (not isinstance(item.callee.expr, StrExpr)
                         or item.callee.expr.value != '{:{}}'):
                     return None
+
                 if not isinstance(item.args[1], StrExpr) or item.args[1].value != '':
                     return None
             else:

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -245,7 +245,7 @@ L0:
     r18 = get_element_ptr r17 ob_item :: PyListObject
     r19 = load_mem r18 :: ptr*
     set_mem r19, r8 :: builtins.object*
-    r20 = r19 + 8
+    r20 = r19 + WORD_SIZE*1
     set_mem r20, r16 :: builtins.object*
     keep_alive r17
     r21 = PyUnicode_Join(r7, r17)

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -201,3 +201,58 @@ L0:
     r17 = CPyStr_Build(6, r14, r9, r15, r11, r16, r13)
     s3 = r17
     return 1
+
+[case testFStrings]
+def f(var: str, num: int) -> None:
+    s1 = f"Hi! I'm {var}. I am {num} years old."
+    s2 = f'Hello {var:>{num}}'
+    s3 = f''
+    s4 = f'abc'
+[out]
+def f(var, num):
+    var :: str
+    num :: int
+    r0, r1, r2 :: str
+    r3 :: object
+    r4, r5, r6, s1, r7, r8, r9, r10 :: str
+    r11 :: object
+    r12, r13, r14 :: str
+    r15 :: object
+    r16 :: str
+    r17 :: list
+    r18, r19, r20 :: ptr
+    r21, s2, r22, s3, r23, s4 :: str
+L0:
+    r0 = "Hi! I'm "
+    r1 = PyObject_Str(var)
+    r2 = '. I am '
+    r3 = box(int, num)
+    r4 = PyObject_Str(r3)
+    r5 = ' years old.'
+    r6 = CPyStr_Build(5, r0, r1, r2, r4, r5)
+    s1 = r6
+    r7 = ''
+    r8 = 'Hello '
+    r9 = '{:{}}'
+    r10 = '>'
+    r11 = box(int, num)
+    r12 = PyObject_Str(r11)
+    r13 = CPyStr_Build(2, r10, r12)
+    r14 = 'format'
+    r15 = CPyObject_CallMethodObjArgs(r9, r14, var, r13, 0)
+    r16 = cast(str, r15)
+    r17 = PyList_New(2)
+    r18 = get_element_ptr r17 ob_item :: PyListObject
+    r19 = load_mem r18 :: ptr*
+    set_mem r19, r8 :: builtins.object*
+    r20 = r19 + 8
+    set_mem r20, r16 :: builtins.object*
+    keep_alive r17
+    r21 = PyUnicode_Join(r7, r17)
+    s2 = r21
+    r22 = ''
+    s3 = r22
+    r23 = 'abc'
+    s4 = r23
+    return 1
+

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -149,14 +149,6 @@ def test_str_to_bool() -> None:
         assert is_true(x)
         assert not is_false(x)
 
-def test_str_join() -> None:
-    var = 'mypyc'
-    num = 10
-    assert ''.join(['a', 'b', '{}'.format(var), 'c']) == 'abmypycc'
-    assert ''.join(['a', 'b', '{:{}}'.format(var, ''), 'c']) == 'abmypycc'
-    assert ''.join(['a', 'b', '{:{}}'.format(var, '>10'), 'c']) == 'ab     mypycc'
-    assert ''.join(['a', 'b', '{:{}}'.format(var, '>{}'.format(num)), 'c']) == 'ab     mypycc'
-
 [case testFStrings]
 import decimal
 from datetime import datetime
@@ -199,6 +191,21 @@ def test_fstring_basics() -> None:
     nan_num = float('nan')
     inf_num = float('inf')
     assert f'{nan_num}, {inf_num}' == 'nan, inf'
+
+# F-strings would be translated into ''.join[string literals, format method call, ...] in mypy AST.
+# Currently we are using a str.join specializer for f-string speed up. We might not cover all cases
+# and the rest ones should fall back to a normal str.join method call.
+# TODO: Once we have a new pipeline for f-strings, this test case can be moved to testStringOps.
+def test_str_join() -> None:
+    var = 'mypyc'
+    num = 10
+    assert ''.join(['a', 'b', '{}'.format(var), 'c']) == 'abmypycc'
+    assert ''.join(['a', 'b', '{:{}}'.format(var, ''), 'c']) == 'abmypycc'
+    assert ''.join(['a', 'b', '{:{}}'.format(var, '>10'), 'c']) == 'ab     mypycc'
+    assert ''.join(['a', 'b', '{:{}}'.format(var, '>{}'.format(num)), 'c']) == 'ab     mypycc'
+    assert var.join(['a', '{:{}}'.format(var, ''), 'b']) == 'amypycmypycmypycb'
+    assert ','.join(['a', '{:{}}'.format(var, ''), 'b']) == 'a,mypyc,b'
+    assert ''.join(['x', var]) == 'xmypyc'
 
 class A:
     def __init__(self, name, age):

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -149,6 +149,14 @@ def test_str_to_bool() -> None:
         assert is_true(x)
         assert not is_false(x)
 
+def test_str_join() -> None:
+    var = 'mypyc'
+    num = 10
+    assert ''.join(['a', 'b', '{}'.format(var), 'c']) == 'abmypycc'
+    assert ''.join(['a', 'b', '{:{}}'.format(var, ''), 'c']) == 'abmypycc'
+    assert ''.join(['a', 'b', '{:{}}'.format(var, '>10'), 'c']) == 'ab     mypycc'
+    assert ''.join(['a', 'b', '{:{}}'.format(var, '>{}'.format(num)), 'c']) == 'ab     mypycc'
+
 [case testFStrings]
 import decimal
 from datetime import datetime
@@ -355,6 +363,13 @@ def test_format_method_different_kind() -> None:
     assert "{}{} {}".format(s3, s2, s1) == "测试：Revealed type is Literal['😀']"
     assert "Test: {}{}".format(s3, s1) == "Test: 测试：Literal['😀']"
     assert "Test: {}{}".format(s3, s2) == "Test: 测试：Revealed type is"
+
+def test_format_method_nested() -> None:
+    var = 'mypyc'
+    num = 10
+    assert '{:{}}'.format(var, '') == 'mypyc'
+    assert '{:{}}'.format(var, '>10') == '     mypyc'
+    assert '{:{}}'.format(var, '>{}'.format(num)) == '     mypyc'
 
 class Point:
     def __init__(self, x, y):


### PR DESCRIPTION
### Description

This pull request adds a specializer for faster constructing f-string, which is translated into str.join() previously in mypy AST. 

## Test Plan

IR building tests: 
* {var}
* empty string
* literal string
* unsupported method

Speed up:
```
running str_format_fstring
..........
interpreted: 0.295028s (avg of 5 iterations; stdev 2.3%)
compiled:    0.188493s (avg of 5 iterations; stdev 1.7%)

compiled is 1.565x faster
```
on this case:
```
@benchmark
 def str_format_fstring() -> None:
     a = []
     tmp_str = "Foobar"
     for i in range(1000):
         for _ in range(5):
             a.append(f'{tmp_str}')
         a.append(f'{tmp_str}-{i}')
         a.append(f'{i} {i*2.0} str')

     n = 0
     for i in range(100):
         for s in a:
             n += len(f"foobar {s} stuff")
             ss = f"foobar {s} stuff"
             n += len(f"{i}-{s}-{ss}")
     assert n == 36897500, n
```
Current master branch is 0.380x.