### PR TITLE
Respect the semantics of EXPLICIT

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -443,9 +443,9 @@ How mypy determines fully qualified module names depends on if the options
 
    With :option:`--explicit-package-bases <mypy --explicit-package-bases>`, mypy
    will locate the nearest parent directory that is a member of the ``MYPYPATH``
-   environment variable, the :confval:`mypy_path` config or is the current
-   working directory. Mypy will then use the relative path to determine the
-   fully qualified module name.
+   environment variable, the :confval:`mypy_path` config or, if neither of those
+   configuration options are specified, then the current working directory.
+   Mypy will then use the relative path to determine the fully qualified module name.
 
    For example, say your directory tree consists solely of
    ``src/namespace_pkg/mod.py``. If you run the command following command, mypy

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -73,7 +73,7 @@ def normalise_package_base(root: str) -> str:
 def get_explicit_package_bases(options: Options) -> Optional[List[str]]:
     """Returns explicit package bases to use if the option is enabled, or None if disabled.
 
-    We currently use MYPYPATH and the current directory as the package bases. In the future,
+    We currently use MYPYPATH or the current directory as the package bases. In the future,
     when --namespace-packages is the default could also use the values passed with the
     --package-root flag, see #9632.
 
@@ -82,7 +82,7 @@ def get_explicit_package_bases(options: Options) -> Optional[List[str]]:
     """
     if not options.explicit_package_bases:
         return None
-    roots = mypy_path() + options.mypy_path + [os.getcwd()]
+    roots = mypy_path() + options.mypy_path or [os.getcwd()]
     return [normalise_package_base(root) for root in roots]
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -162,7 +162,8 @@ def run_build(sources: List[BuildSource],
     try:
         # Keep a dummy reference (res) for memory profiling afterwards, as otherwise
         # the result could be freed.
-        res = build.build(sources, options, None, flush_errors, fscache, stdout, stderr)
+        alt_lib_path = "" if options.explicit_package_bases else None
+        res = build.build(sources, options, alt_lib_path, flush_errors, fscache, stdout, stderr)
     except CompileError as e:
         blockers = True
         if not e.use_stdout:
@@ -862,7 +863,7 @@ def process_options(args: List[str],
                     "mypy.readthedocs.io/en/stable/running_mypy.html#running-mypy")
     add_invertible_flag(
         '--explicit-package-bases', default=False,
-        help="Use current directory and MYPYPATH to determine module names of files passed",
+        help="Use current directory or MYPYPATH to determine module names of files passed",
         group=code_group)
     code_group.add_argument(
         "--exclude",

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -698,7 +698,7 @@ def compute_search_paths(sources: List[BuildSource],
     # alt_lib_path is used by some tests to bypass the normal lib_path mechanics.
     # If we don't have one, grab directories of source files.
     python_path: List[str] = []
-    if not alt_lib_path:
+    if alt_lib_path is None:
         for source in sources:
             # Include directory of the program file in the module search path.
             if source.base_dir:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -93,7 +93,7 @@ class Options:
         # multiple directories. This flag affects both import discovery and the association of
         # input files/modules/packages to the relevant file and fully qualified module name.
         self.namespace_packages = False
-        # Use current directory and MYPYPATH to determine fully qualified module names of files
+        # Use current directory or MYPYPATH to determine fully qualified module names of files
         # passed by automatically considering their subdirectories as packages. This is only
         # relevant if namespace packages are enabled, since otherwise examining __init__.py's is
         # sufficient to determine module names for files. As a possible alternative, add a single


### PR DESCRIPTION
### Description

This PR removes the _implicitly_ added current working directory when `--explicit-package-bases` is specified
**and** either `MYPYPATH` or `mypy_path` (or both) are non-empty.  This follows the principle of least surprise,
as it respects the reasonable expectation that prescribing _explicit_ package bases will not magically  include
implicit bases.  On the other hand, when explicit bases are not actually present, it does fall back to the current
practice of including the current working directory.

Rationale:
*  With the `--explicit-package-bases` option, `mypy` has a tendency to erroneously treat folders
    in the current working directory that happen to match the name of an imported module in a source
    file being checked as "**the**" implementation of said module, producing errors like the following:
    ```console
    user@host:~/Projects/test$ MYPYPATH=src mypy \
        --namespace-packages \
        --explicit-package-bases \
        --ignore-missing-imports \
        --exclude "$PWD/docker" \
        src/ns/mod.py
    src/ns/mod.py:1: error: Module "docker" has no attribute "api"
    Found 1 error in 1 file (checked 1 source file)
    user@host:~/Projects/test$
   ```
   Ideally, any such directory _should_ be possible to `--exclude`, but I've yet to figure out _how_.
   The seemingly obvious `--exclude "$PWD/docker"` certainly doesn't work (as evidenced above).
   [NB#1: I've also tried endless variations of absolute and relative paths with or without a trailing slash.]
   [NB#2: Including `--follow-imports=skip` has no effect on the above.]

*  Setting `MYPYPATH` _explicitly_ to *include* the current working directory is simple,
    but telling `mypy` not to use the current working directory appears close to impossible.

*  As noted in `docs/source/running_mypy.rst`:
    > Setting :confval:`mypy_path`/``MYPYPATH`` is mostly useful in the case
    > where you want to try running mypy against multiple distinct
    > sets of files that happen to share some common dependencies.

    In such a situation, the working directory may or may not hold relevant Python modules.
    This is not a problem when `__init__.py` markers can be used to decide what is a valid module.
    The `--explicit-package-bases` option, however, precludes that possibility.

*  The following comment in `mypy/modulefinder.py` appears to display some confusion
    regarding *why* and *when* including the working directory is actually useful:
    ```python
        # Do this even if running as a file, for sanity (mainly because with
        # multiple builds, there could be a mix of files/modules, so its easier
        # to just define the semantics that we always add the current director
        # to the lib_path
        # TODO: Don't do this in some cases; for motivation see see
        # https://github.com/python/mypy/issues/4195#issuecomment-341915031
    ```
    In my mind, this is a clear warning flag that control should be passed to the user.



## Test Plan

Unfortunately, it's unclear how to write good test cases for this change, since the existing tests
for the relevant modules (essentially, `mypy/test/{test_find_sources,testmodulefinder}.py`)
appear to pass unaffected, which is not all too surprising, considering that the error reported
as part of this PR depends on the _contents_ of the files and the tests only consider paths.

Here's a short script that recreates a minimal test case:
```bash
cd $(mktemp -d)
cleanup_mypy_test() {
    rm -frv "$PWD"
    cd -
}
mkdir -pv docker src/ns
echo FROM scratch > docker/Dockerfile
printf 'from docker import api\n\nhelp(api)\n' > src/ns/mod.py
MYPYPATH=src mypy --namespace-packages --explicit-package-bases --ignore-missing-imports --exclude docker src/ns/mod.py
```
The results with stock `mypy` are included above.  With the changes in this PR, the output becomes:
> Success: no issues found in 1 source file

The standard battery of test cases still succeeds, albeit I only tested on Python 3.8,
since I don't have any of the earlier versions installed.  Tests were run using:
```console
$ sed -i s/7/8/ tox.ini
$ tox
[... skip detailed output ...]
_____________________________________________ summary ______________________________________________
SKIPPED:  py35: InterpreterNotFound: python3.5                                                      
SKIPPED:  py36: InterpreterNotFound: python3.6                                                      
  py38: commands succeeded                                                                          
  lint: commands succeeded                                                                          
  type: commands succeeded                                                                          
  docs: commands succeeded                                                                          
  congratulations :) 
$
```




