### PR TITLE
Make ARG_* into an actual enum class instead of just using int everywhere

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -8,9 +8,9 @@ from mypy.types import (
 from mypy import nodes
 
 
-def map_actuals_to_formals(actual_kinds: List[int],
+def map_actuals_to_formals(actual_kinds: List[nodes.ArgKind],
                            actual_names: Optional[Sequence[Optional[str]]],
-                           formal_kinds: List[int],
+                           formal_kinds: List[nodes.ArgKind],
                            formal_names: Sequence[Optional[str]],
                            actual_arg_type: Callable[[int],
                                                      Type]) -> List[List[int]]:
@@ -99,9 +99,9 @@ def map_actuals_to_formals(actual_kinds: List[int],
     return formal_to_actual
 
 
-def map_formals_to_actuals(actual_kinds: List[int],
+def map_formals_to_actuals(actual_kinds: List[nodes.ArgKind],
                            actual_names: Optional[Sequence[Optional[str]]],
-                           formal_kinds: List[int],
+                           formal_kinds: List[nodes.ArgKind],
                            formal_names: List[Optional[str]],
                            actual_arg_type: Callable[[int],
                                                      Type]) -> List[List[int]]:
@@ -149,9 +149,9 @@ class ArgTypeExpander:
 
     def expand_actual_type(self,
                            actual_type: Type,
-                           actual_kind: int,
+                           actual_kind: nodes.ArgKind,
                            formal_name: Optional[str],
-                           formal_kind: int) -> Type:
+                           formal_kind: nodes.ArgKind) -> Type:
         """Return the actual (caller) type(s) of a formal argument with the given kinds.
 
         If the actual argument is a tuple *args, return the next individual tuple item that

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1377,7 +1377,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     argname = callee.arg_names[i] or "?"
                     messages.missing_named_argument(callee, context, argname)
                 ok = False
-            elif kind.is_normal() and is_duplicate_mapping(
+            elif not kind.is_star() and is_duplicate_mapping(
                     formal_to_actual[i], actual_types, actual_kinds):
                 if (self.chk.in_checked_function() or
                         isinstance(get_proper_type(actual_types[formal_to_actual[i][0]]),

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -32,7 +32,7 @@ from mypy.nodes import (
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
     TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode, PlaceholderNode,
     ParamSpecExpr,
-    ARG_POS, ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, LITERAL_TYPE, REVEAL_TYPE,
+    ArgKind, ARG_POS, ARG_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2, LITERAL_TYPE, REVEAL_TYPE,
 )
 from mypy.literals import literal
 from mypy import nodes
@@ -73,7 +73,7 @@ import mypy.errorcodes as codes
 # check_args() below for details.
 ArgChecker = Callable[[Type,
                        Type,
-                       int,
+                       ArgKind,
                        Type,
                        int,
                        int,
@@ -476,7 +476,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                                             attr_members, e)
 
     def check_typeddict_call(self, callee: TypedDictType,
-                             arg_kinds: List[int],
+                             arg_kinds: List[ArgKind],
                              arg_names: Sequence[Optional[str]],
                              args: List[Expression],
                              context: Context) -> Type:
@@ -697,7 +697,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def apply_function_plugin(self,
                               callee: CallableType,
-                              arg_kinds: List[int],
+                              arg_kinds: List[ArgKind],
                               arg_types: List[Type],
                               arg_names: Optional[Sequence[Optional[str]]],
                               formal_to_actual: List[List[int]],
@@ -720,7 +720,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         formal_arg_types: List[List[Type]] = [[] for _ in range(num_formals)]
         formal_arg_exprs: List[List[Expression]] = [[] for _ in range(num_formals)]
         formal_arg_names: List[List[Optional[str]]] = [[] for _ in range(num_formals)]
-        formal_arg_kinds: List[List[int]] = [[] for _ in range(num_formals)]
+        formal_arg_kinds: List[List[ArgKind]] = [[] for _ in range(num_formals)]
         for formal, actuals in enumerate(formal_to_actual):
             for actual in actuals:
                 formal_arg_types[formal].append(arg_types[actual])
@@ -749,7 +749,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def apply_signature_hook(
             self, callee: FunctionLike, args: List[Expression],
-            arg_kinds: List[int],
+            arg_kinds: List[ArgKind],
             arg_names: Optional[Sequence[Optional[str]]],
             hook: Callable[
                 [List[List[Expression]], CallableType],
@@ -779,7 +779,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def apply_function_signature_hook(
             self, callee: FunctionLike, args: List[Expression],
-            arg_kinds: List[int], context: Context,
+            arg_kinds: List[ArgKind], context: Context,
             arg_names: Optional[Sequence[Optional[str]]],
             signature_hook: Callable[[FunctionSigContext], FunctionLike]) -> FunctionLike:
         """Apply a plugin hook that may infer a more precise signature for a function."""
@@ -790,7 +790,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def apply_method_signature_hook(
             self, callee: FunctionLike, args: List[Expression],
-            arg_kinds: List[int], context: Context,
+            arg_kinds: List[ArgKind], context: Context,
             arg_names: Optional[Sequence[Optional[str]]], object_type: Type,
             signature_hook: Callable[[MethodSigContext], FunctionLike]) -> FunctionLike:
         """Apply a plugin hook that may infer a more precise signature for a method."""
@@ -802,7 +802,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def transform_callee_type(
             self, callable_name: Optional[str], callee: Type, args: List[Expression],
-            arg_kinds: List[int], context: Context,
+            arg_kinds: List[ArgKind], context: Context,
             arg_names: Optional[Sequence[Optional[str]]] = None,
             object_type: Optional[Type] = None) -> Type:
         """Attempt to determine a more accurate signature for a method call.
@@ -889,7 +889,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_call(self,
                    callee: Type,
                    args: List[Expression],
-                   arg_kinds: List[int],
+                   arg_kinds: List[ArgKind],
                    context: Context,
                    arg_names: Optional[Sequence[Optional[str]]] = None,
                    callable_node: Optional[Expression] = None,
@@ -965,7 +965,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_callable_call(self,
                             callee: CallableType,
                             args: List[Expression],
-                            arg_kinds: List[int],
+                            arg_kinds: List[ArgKind],
                             context: Context,
                             arg_names: Optional[Sequence[Optional[str]]],
                             callable_node: Optional[Expression],
@@ -1098,7 +1098,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return res
 
     def infer_arg_types_in_context(
-            self, callee: CallableType, args: List[Expression], arg_kinds: List[int],
+            self, callee: CallableType, args: List[Expression], arg_kinds: List[ArgKind],
             formal_to_actual: List[List[int]]) -> List[Type]:
         """Infer argument expression types using a callable type as context.
 
@@ -1197,7 +1197,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def infer_function_type_arguments(self, callee_type: CallableType,
                                       args: List[Expression],
-                                      arg_kinds: List[int],
+                                      arg_kinds: List[ArgKind],
                                       formal_to_actual: List[List[int]],
                                       context: Context) -> CallableType:
         """Infer the type arguments for a generic callee type.
@@ -1260,7 +1260,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def infer_function_type_arguments_pass2(
             self, callee_type: CallableType,
             args: List[Expression],
-            arg_kinds: List[int],
+            arg_kinds: List[ArgKind],
             formal_to_actual: List[List[int]],
             old_inferred_args: Sequence[Optional[Type]],
             context: Context) -> Tuple[CallableType, List[Optional[Type]]]:
@@ -1334,7 +1334,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_argument_count(self,
                              callee: CallableType,
                              actual_types: List[Type],
-                             actual_kinds: List[int],
+                             actual_kinds: List[ArgKind],
                              actual_names: Optional[Sequence[Optional[str]]],
                              formal_to_actual: List[List[int]],
                              context: Optional[Context],
@@ -1377,8 +1377,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     argname = callee.arg_names[i] or "?"
                     messages.missing_named_argument(callee, context, argname)
                 ok = False
-            elif kind in [nodes.ARG_POS, nodes.ARG_OPT,
-                          nodes.ARG_NAMED, nodes.ARG_NAMED_OPT] and is_duplicate_mapping(
+            elif kind.is_normal() and is_duplicate_mapping(
                     formal_to_actual[i], actual_types, actual_kinds):
                 if (self.chk.in_checked_function() or
                         isinstance(get_proper_type(actual_types[formal_to_actual[i][0]]),
@@ -1397,7 +1396,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_for_extra_actual_arguments(self,
                                          callee: CallableType,
                                          actual_types: List[Type],
-                                         actual_kinds: List[int],
+                                         actual_kinds: List[ArgKind],
                                          actual_names: Optional[Sequence[Optional[str]]],
                                          all_actuals: List[int],
                                          context: Context,
@@ -1452,7 +1451,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def check_argument_types(self,
                              arg_types: List[Type],
-                             arg_kinds: List[int],
+                             arg_kinds: List[ArgKind],
                              args: List[Expression],
                              callee: CallableType,
                              formal_to_actual: List[List[int]],
@@ -1494,7 +1493,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_arg(self,
                   caller_type: Type,
                   original_caller_type: Type,
-                  caller_kind: int,
+                  caller_kind: ArgKind,
                   callee_type: Type,
                   n: int,
                   m: int,
@@ -1534,7 +1533,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_overload_call(self,
                             callee: Overloaded,
                             args: List[Expression],
-                            arg_kinds: List[int],
+                            arg_kinds: List[ArgKind],
                             arg_names: Optional[Sequence[Optional[str]]],
                             callable_name: Optional[str],
                             object_type: Optional[Type],
@@ -1640,7 +1639,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def plausible_overload_call_targets(self,
                                         arg_types: List[Type],
-                                        arg_kinds: List[int],
+                                        arg_kinds: List[ArgKind],
                                         arg_names: Optional[Sequence[Optional[str]]],
                                         overload: Overloaded) -> List[CallableType]:
         """Returns all overload call targets that having matching argument counts.
@@ -1690,7 +1689,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                    plausible_targets: List[CallableType],
                                    args: List[Expression],
                                    arg_types: List[Type],
-                                   arg_kinds: List[int],
+                                   arg_kinds: List[ArgKind],
                                    arg_names: Optional[Sequence[Optional[str]]],
                                    callable_name: Optional[str],
                                    object_type: Optional[Type],
@@ -1772,7 +1771,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def overload_erased_call_targets(self,
                                      plausible_targets: List[CallableType],
                                      arg_types: List[Type],
-                                     arg_kinds: List[int],
+                                     arg_kinds: List[ArgKind],
                                      arg_names: Optional[Sequence[Optional[str]]],
                                      args: List[Expression],
                                      context: Context) -> List[CallableType]:
@@ -1791,7 +1790,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                               plausible_targets: List[CallableType],
                               args: List[Expression],
                               arg_types: List[Type],
-                              arg_kinds: List[int],
+                              arg_kinds: List[ArgKind],
                               arg_names: Optional[Sequence[Optional[str]]],
                               callable_name: Optional[str],
                               object_type: Optional[Type],
@@ -1964,7 +1963,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def erased_signature_similarity(self,
                                     arg_types: List[Type],
-                                    arg_kinds: List[int],
+                                    arg_kinds: List[ArgKind],
                                     arg_names: Optional[Sequence[Optional[str]]],
                                     args: List[Expression],
                                     callee: CallableType,
@@ -1984,7 +1983,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         def check_arg(caller_type: Type,
                       original_ccaller_type: Type,
-                      caller_kind: int,
+                      caller_kind: ArgKind,
                       callee_type: Type,
                       n: int,
                       m: int,
@@ -2024,7 +2023,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_union_call(self,
                          callee: UnionType,
                          args: List[Expression],
-                         arg_kinds: List[int],
+                         arg_kinds: List[ArgKind],
                          arg_names: Optional[Sequence[Optional[str]]],
                          context: Context,
                          arg_messages: MessageBuilder) -> Tuple[Type, Type]:
@@ -2375,7 +2374,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                   method: str,
                                   base_type: Type,
                                   args: List[Expression],
-                                  arg_kinds: List[int],
+                                  arg_kinds: List[ArgKind],
                                   context: Context,
                                   local_errors: Optional[MessageBuilder] = None,
                                   original_type: Optional[Type] = None
@@ -2405,7 +2404,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                                         method: str,
                                         base_type: UnionType,
                                         args: List[Expression],
-                                        arg_kinds: List[int],
+                                        arg_kinds: List[ArgKind],
                                         context: Context,
                                         local_errors: MessageBuilder,
                                         original_type: Optional[Type] = None
@@ -2435,7 +2434,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                           base_type: Type,
                           method_type: Type,
                           args: List[Expression],
-                          arg_kinds: List[int],
+                          arg_kinds: List[ArgKind],
                           context: Context,
                           local_errors: Optional[MessageBuilder] = None) -> Tuple[Type, Type]:
         """Type check a call to a method with the given name and type on an object.
@@ -4253,7 +4252,7 @@ def is_non_empty_tuple(t: Type) -> bool:
 
 def is_duplicate_mapping(mapping: List[int],
                          actual_types: List[Type],
-                         actual_kinds: List[int]) -> bool:
+                         actual_kinds: List[ArgKind]) -> bool:
     return (
         len(mapping) > 1
         # Multiple actuals can map to the same formal if they both come from
@@ -4390,7 +4389,7 @@ def arg_approximate_similarity(actual: Type, formal: Type) -> bool:
 def any_causes_overload_ambiguity(items: List[CallableType],
                                   return_types: List[Type],
                                   arg_types: List[Type],
-                                  arg_kinds: List[int],
+                                  arg_kinds: List[ArgKind],
                                   arg_names: Optional[Sequence[Optional[str]]]) -> bool:
     """May an argument containing 'Any' cause ambiguous result type on call to overloaded function?
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -14,7 +14,7 @@ import mypy.subtypes
 import mypy.sametypes
 import mypy.typeops
 from mypy.erasetype import erase_typevars
-from mypy.nodes import COVARIANT, CONTRAVARIANT
+from mypy.nodes import COVARIANT, CONTRAVARIANT, ArgKind
 from mypy.argmap import ArgTypeExpander
 from mypy.typestate import TypeState
 
@@ -45,7 +45,7 @@ class Constraint:
 
 
 def infer_constraints_for_callable(
-        callee: CallableType, arg_types: Sequence[Optional[Type]], arg_kinds: List[int],
+        callee: CallableType, arg_types: Sequence[Optional[Type]], arg_kinds: List[ArgKind],
         formal_to_actual: List[List[int]]) -> List[Constraint]:
     """Infer type variable constraints for a callable and actual arguments.
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -25,7 +25,7 @@ from mypy.nodes import (
     StarExpr, YieldFromExpr, NonlocalDecl, DictionaryComprehension,
     SetComprehension, ComplexExpr, EllipsisExpr, YieldExpr, Argument,
     AwaitExpr, TempNode, Expression, Statement,
-    ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR2,
+    ArgKind, ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR2,
     check_arg_names,
     FakeInfo,
 )
@@ -696,7 +696,7 @@ class ASTConverter:
 
         return new_args
 
-    def make_argument(self, arg: ast3.arg, default: Optional[ast3.expr], kind: int,
+    def make_argument(self, arg: ast3.arg, default: Optional[ast3.expr], kind: ArgKind,
                       no_type_check: bool) -> Argument:
         if no_type_check:
             arg_type = None

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -36,7 +36,7 @@ from mypy.nodes import (
     UnaryExpr, LambdaExpr, ComparisonExpr, DictionaryComprehension,
     SetComprehension, ComplexExpr, EllipsisExpr, YieldExpr, Argument,
     Expression, Statement, BackquoteExpr, PrintStmt, ExecStmt,
-    ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_STAR2, OverloadPart, check_arg_names,
+    ArgKind, ARG_POS, ARG_OPT, ARG_STAR, ARG_NAMED, ARG_STAR2, OverloadPart, check_arg_names,
     FakeInfo,
 )
 from mypy.types import (
@@ -923,7 +923,7 @@ class ASTConverter:
     # keyword = (identifier? arg, expr value)
     def visit_Call(self, n: Call) -> CallExpr:
         arg_types: List[ast27.expr] = []
-        arg_kinds: List[int] = []
+        arg_kinds: List[ArgKind] = []
         signature: List[Optional[str]] = []
 
         args = n.args

--- a/mypy/infer.py
+++ b/mypy/infer.py
@@ -6,12 +6,13 @@ from mypy.constraints import (
     infer_constraints, infer_constraints_for_callable, SUBTYPE_OF, SUPERTYPE_OF
 )
 from mypy.types import Type, TypeVarId, CallableType
+from mypy.nodes import ArgKind
 from mypy.solve import solve_constraints
 
 
 def infer_function_type_arguments(callee_type: CallableType,
                                   arg_types: Sequence[Optional[Type]],
-                                  arg_kinds: List[int],
+                                  arg_kinds: List[ArgKind],
                                   formal_to_actual: List[List[int]],
                                   strict: bool = True) -> List[Optional[Type]]:
     """Infer the type arguments of a generic function.

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -29,7 +29,7 @@ from mypy.types import (
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.nodes import (
     TypeInfo, Context, MypyFile, FuncDef, reverse_builtin_aliases,
-    ARG_POS, ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2,
+    ArgKind, ARG_POS, ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2,
     ReturnStmt, NameExpr, Var, CONTRAVARIANT, COVARIANT, SymbolNode,
     CallExpr, IndexExpr, StrExpr, SymbolTable, TempNode
 )
@@ -397,7 +397,7 @@ class MessageBuilder:
                               m: int,
                               callee: CallableType,
                               arg_type: Type,
-                              arg_kind: int,
+                              arg_kind: ArgKind,
                               object_type: Optional[Type],
                               context: Context,
                               outer_context: Context) -> Optional[ErrorCode]:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1,6 +1,7 @@
 """Abstract syntax tree node classes (i.e. parse tree)."""
 
 import os
+from enum import Enum
 from abc import abstractmethod
 from mypy.backports import OrderedDict
 from collections import defaultdict
@@ -566,7 +567,7 @@ class Argument(Node):
                  variable: 'Var',
                  type_annotation: 'Optional[mypy.types.Type]',
                  initializer: Optional[Expression],
-                 kind: int) -> None:
+                 kind: 'ArgKind') -> None:
         super().__init__()
         self.variable = variable
         self.type_annotation = type_annotation
@@ -619,13 +620,14 @@ class FuncItem(FuncBase):
         super().__init__()
         self.arguments = arguments
         self.arg_names = [arg.variable.name for arg in self.arguments]
-        self.arg_kinds: List[int] = [arg.kind for arg in self.arguments]
-        self.max_pos = self.arg_kinds.count(ARG_POS) + self.arg_kinds.count(ARG_OPT)
-        self.body = body
+        self.arg_kinds: List[ArgKind] = [arg.kind for arg in self.arguments]
+        self.max_pos: int = (
+            self.arg_kinds.count(ARG_POS) + self.arg_kinds.count(ARG_OPT))
+        self.body: 'Block' = body
         self.type = typ
         self.unanalyzed_type = typ
         self.is_overload = False
-        self.is_generator = False
+        self.is_generator: bool = False
         self.is_coroutine = False
         self.is_async_generator = False
         self.is_awaitable_coroutine = False
@@ -701,7 +703,7 @@ class FuncDef(FuncItem, SymbolNode, Statement):
                 'name': self._name,
                 'fullname': self._fullname,
                 'arg_names': self.arg_names,
-                'arg_kinds': self.arg_kinds,
+                'arg_kinds': [int(x.value) for x in self.arg_kinds],
                 'type': None if self.type is None else self.type.serialize(),
                 'flags': get_flags(self, FUNCDEF_FLAGS),
                 # TODO: Do we need expanded, original_def?
@@ -721,7 +723,7 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         set_flags(ret, data['flags'])
         # NOTE: ret.info is set in the fixup phase.
         ret.arg_names = data['arg_names']
-        ret.arg_kinds = data['arg_kinds']
+        ret.arg_kinds = [ArgKind(x) for x in data['arg_kinds']]
         # Leave these uninitialized so that future uses will trigger an error
         del ret.arguments
         del ret.max_pos
@@ -1518,18 +1520,30 @@ class MemberExpr(RefExpr):
 
 # Kinds of arguments
 
-# Positional argument
-ARG_POS: Final = 0
-# Positional, optional argument (functions only, not calls)
-ARG_OPT: Final = 1
-# *arg argument
-ARG_STAR: Final = 2
-# Keyword argument x=y in call, or keyword-only function arg
-ARG_NAMED: Final = 3
-# **arg argument
-ARG_STAR2: Final = 4
-# In an argument list, keyword-only and also optional
-ARG_NAMED_OPT: Final = 5
+class ArgKind(Enum):
+    # Positional argument
+    ARG_POS = 0
+    # Positional, optional argument (functions only, not calls)
+    ARG_OPT = 1
+    # *arg argument
+    ARG_STAR = 2
+    # Keyword argument x=y in call, or keyword-only function arg
+    ARG_NAMED = 3
+    # **arg argument
+    ARG_STAR2 = 4
+    # In an argument list, keyword-only and also optional
+    ARG_NAMED_OPT = 5
+
+    def is_normal(self) -> bool:
+        return self != ARG_STAR and self != ARG_STAR2
+
+
+ARG_POS: Final = ArgKind.ARG_POS
+ARG_OPT: Final = ArgKind.ARG_OPT
+ARG_STAR: Final = ArgKind.ARG_STAR
+ARG_NAMED: Final = ArgKind.ARG_NAMED
+ARG_STAR2: Final = ArgKind.ARG_STAR2
+ARG_NAMED_OPT: Final = ArgKind.ARG_NAMED_OPT
 
 
 class CallExpr(Expression):
@@ -1544,7 +1558,7 @@ class CallExpr(Expression):
     def __init__(self,
                  callee: Expression,
                  args: List[Expression],
-                 arg_kinds: List[int],
+                 arg_kinds: List[ArgKind],
                  arg_names: List[Optional[str]],
                  analyzed: Optional[Expression] = None) -> None:
         super().__init__()
@@ -3109,7 +3123,8 @@ deserialize_map: Final = {
 }
 
 
-def check_arg_kinds(arg_kinds: List[int], nodes: List[T], fail: Callable[[str, T], None]) -> None:
+def check_arg_kinds(
+        arg_kinds: List[ArgKind], nodes: List[T], fail: Callable[[str, T], None]) -> None:
     is_var_arg = False
     is_kw_arg = False
     seen_named = False

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -626,11 +626,11 @@ class FuncItem(FuncBase):
         self.body: 'Block' = body
         self.type = typ
         self.unanalyzed_type = typ
-        self.is_overload = False
+        self.is_overload: bool = False
         self.is_generator: bool = False
-        self.is_coroutine = False
-        self.is_async_generator = False
-        self.is_awaitable_coroutine = False
+        self.is_coroutine: bool = False
+        self.is_async_generator: bool = False
+        self.is_awaitable_coroutine: bool = False
         self.expanded: List[FuncItem] = []
 
         self.min_args = 0
@@ -1534,8 +1534,8 @@ class ArgKind(Enum):
     # In an argument list, keyword-only and also optional
     ARG_NAMED_OPT = 5
 
-    def is_normal(self) -> bool:
-        return self != ARG_STAR and self != ARG_STAR2
+    def is_star(self) -> bool:
+        return self == ARG_STAR or self == ARG_STAR2
 
 
 ARG_POS: Final = ArgKind.ARG_POS

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -124,7 +124,7 @@ from typing import Any, Callable, List, Tuple, Optional, NamedTuple, TypeVar, Di
 from mypy_extensions import trait, mypyc_attr
 
 from mypy.nodes import (
-    Expression, Context, ClassDef, SymbolTableNode, MypyFile, CallExpr
+    Expression, Context, ClassDef, SymbolTableNode, MypyFile, CallExpr, ArgKind
 )
 from mypy.tvar_scope import TypeVarLikeScope
 from mypy.types import (
@@ -167,7 +167,7 @@ class TypeAnalyzerPluginInterface:
 
     @abstractmethod
     def analyze_callable_args(self, arglist: TypeList) -> Optional[Tuple[List[Type],
-                                                                         List[int],
+                                                                         List[ArgKind],
                                                                          List[Optional[str]]]]:
         """Find types, kinds, and names of arguments from extended callable syntax."""
         raise NotImplementedError
@@ -389,8 +389,8 @@ FunctionSigContext = NamedTuple(
 # callback at least sometimes can infer a more precise type.
 FunctionContext = NamedTuple(
     'FunctionContext', [
-        ('arg_types', List[List[Type]]),   # List of actual caller types for each formal argument
-        ('arg_kinds', List[List[int]]),    # Ditto for argument kinds, see nodes.ARG_* constants
+        ('arg_types', List[List[Type]]),     # List of actual caller types for each formal argument
+        ('arg_kinds', List[List[ArgKind]]),  # Ditto for argument kinds, see nodes.ARG_* constants
         # Names of formal parameters from the callee definition,
         # these will be sufficient in most cases.
         ('callee_arg_names', List[Optional[str]]),
@@ -427,7 +427,7 @@ MethodContext = NamedTuple(
         ('type', ProperType),              # Base object type for method call
         ('arg_types', List[List[Type]]),   # List of actual caller types for each formal argument
         # see FunctionContext for details about names and kinds
-        ('arg_kinds', List[List[int]]),
+        ('arg_kinds', List[List[ArgKind]]),
         ('callee_arg_names', List[Optional[str]]),
         ('arg_names', List[List[Optional[str]]]),
         ('default_return_type', Type),     # Return type inferred by mypy

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -67,7 +67,7 @@ from mypy.nodes import (
     SymbolTableNode, ListComprehension, GeneratorExpr,
     LambdaExpr, MDEF, Decorator, SetExpr, TypeVarExpr,
     StrExpr, BytesExpr, PrintStmt, ConditionalExpr, PromoteExpr,
-    ComparisonExpr, StarExpr, ARG_POS, ARG_NAMED, type_aliases,
+    ComparisonExpr, StarExpr, ArgKind, ARG_POS, ARG_NAMED, type_aliases,
     YieldFromExpr, NamedTupleExpr, NonlocalDecl, SymbolNode,
     SetComprehension, DictionaryComprehension, TypeAlias, TypeAliasExpr,
     YieldExpr, ExecStmt, BackquoteExpr, ImportBase, AwaitExpr,
@@ -3054,7 +3054,7 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     def process_typevar_parameters(self, args: List[Expression],
                                    names: List[Optional[str]],
-                                   kinds: List[int],
+                                   kinds: List[ArgKind],
                                    num_values: int,
                                    context: Context) -> Optional[Tuple[int, Type]]:
         has_values = (num_values > 0)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -61,7 +61,7 @@ class StrConv(NodeVisitor[str]):
         args: List[Union[mypy.nodes.Var, Tuple[str, List[mypy.nodes.Node]]]] = []
         extra: List[Tuple[str, List[mypy.nodes.Var]]] = []
         for arg in o.arguments:
-            kind: int = arg.kind
+            kind: mypy.nodes.ArgKind = arg.kind
             if kind in (mypy.nodes.ARG_POS, mypy.nodes.ARG_NAMED):
                 args.append(arg.variable)
             elif kind in (mypy.nodes.ARG_OPT, mypy.nodes.ARG_NAMED_OPT):
@@ -405,7 +405,7 @@ class StrConv(NodeVisitor[str]):
             elif kind == mypy.nodes.ARG_STAR2:
                 extra.append(('DictVarArg', [o.args[i]]))
             else:
-                raise RuntimeError("unknown kind %d" % kind)
+                raise RuntimeError("unknown kind %s" % kind)
         a: List[Any] = [o.callee, ("Args", args)]
         return self.dump(a + extra, o)
 

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -290,7 +290,7 @@ class AliasPrinter(NodeVisitor[str]):
             elif kind == ARG_NAMED:
                 args.append('{}={}'.format(name, arg.accept(self)))
             else:
-                raise ValueError("Unknown argument kind %d in call" % kind)
+                raise ValueError("Unknown argument kind %s in call" % kind)
         return "{}({})".format(callee, ", ".join(args))
 
     def visit_name_expr(self, node: NameExpr) -> str:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -502,7 +502,7 @@ class Signature(Generic[T]):
                 ]
                 return mypy.typeops.make_simplified_union([t for t in all_types if t])
 
-        def get_kind(arg_name: str) -> int:
+        def get_kind(arg_name: str) -> nodes.ArgKind:
             kinds = {arg.kind for arg, _ in all_args[arg_name]}
             if nodes.ARG_STAR in kinds:
                 return nodes.ARG_STAR

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -37,7 +37,7 @@ from mypy.types import (
 )
 from mypy.build import State, Graph
 from mypy.nodes import (
-    ARG_STAR, ARG_NAMED, ARG_STAR2, ARG_NAMED_OPT, FuncDef, MypyFile, SymbolTable,
+    ArgKind, ARG_STAR, ARG_NAMED, ARG_STAR2, ARG_NAMED_OPT, FuncDef, MypyFile, SymbolTable,
     Decorator, RefExpr,
     SymbolNode, TypeInfo, Expression, ReturnStmt, CallExpr,
     reverse_builtin_aliases,
@@ -70,7 +70,7 @@ Callsite = NamedTuple(
     'Callsite',
     [('path', str),
      ('line', int),
-     ('arg_kinds', List[List[int]]),
+     ('arg_kinds', List[List[ArgKind]]),
      ('callee_arg_names', List[Optional[str]]),
      ('arg_names', List[List[Optional[str]]]),
      ('arg_types', List[List[Type]])])
@@ -468,7 +468,7 @@ class SuggestionEngine:
         return self.pyannotate_signature(mod, is_method, best)
 
     def format_args(self,
-                    arg_kinds: List[List[int]],
+                    arg_kinds: List[List[ArgKind]],
                     arg_names: List[List[Optional[str]]],
                     arg_types: List[List[Type]]) -> str:
         args: List[str] = []

--- a/mypy/test/testinfer.py
+++ b/mypy/test/testinfer.py
@@ -6,7 +6,7 @@ from mypy.test.helpers import Suite, assert_equal
 from mypy.argmap import map_actuals_to_formals
 from mypy.checker import group_comparison_operands, DisjointDict
 from mypy.literals import Key
-from mypy.nodes import ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, ARG_NAMED, NameExpr
+from mypy.nodes import ArgKind, ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, ARG_NAMED, NameExpr
 from mypy.types import AnyType, TupleType, Type, TypeOfAny
 from mypy.test.typefixture import TypeFixture
 
@@ -170,8 +170,8 @@ class MapActualsToFormalsSuite(Suite):
                         [[0]])
 
     def assert_map(self,
-                   caller_kinds_: List[Union[int, str]],
-                   callee_kinds_: List[Union[int, Tuple[int, str]]],
+                   caller_kinds_: List[Union[ArgKind, str]],
+                   callee_kinds_: List[Union[ArgKind, Tuple[ArgKind, str]]],
                    expected: List[List[int]],
                    ) -> None:
         caller_kinds, caller_names = expand_caller_kinds(caller_kinds_)
@@ -185,8 +185,8 @@ class MapActualsToFormalsSuite(Suite):
         assert_equal(result, expected)
 
     def assert_vararg_map(self,
-                          caller_kinds: List[int],
-                          callee_kinds: List[int],
+                          caller_kinds: List[ArgKind],
+                          callee_kinds: List[ArgKind],
                           expected: List[List[int]],
                           vararg_type: Type,
                           ) -> None:
@@ -199,8 +199,8 @@ class MapActualsToFormalsSuite(Suite):
         assert_equal(result, expected)
 
 
-def expand_caller_kinds(kinds_or_names: List[Union[int, str]]
-                        ) -> Tuple[List[int], List[Optional[str]]]:
+def expand_caller_kinds(kinds_or_names: List[Union[ArgKind, str]]
+                        ) -> Tuple[List[ArgKind], List[Optional[str]]]:
     kinds = []
     names: List[Optional[str]] = []
     for k in kinds_or_names:
@@ -213,8 +213,8 @@ def expand_caller_kinds(kinds_or_names: List[Union[int, str]]
     return kinds, names
 
 
-def expand_callee_kinds(kinds_and_names: List[Union[int, Tuple[int, str]]]
-                        ) -> Tuple[List[int], List[Optional[str]]]:
+def expand_callee_kinds(kinds_and_names: List[Union[ArgKind, Tuple[ArgKind, str]]]
+                        ) -> Tuple[List[ArgKind], List[Optional[str]]]:
     kinds = []
     names: List[Optional[str]] = []
     for v in kinds_and_names:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -21,7 +21,7 @@ from mypy.types import (
 
 from mypy.nodes import (
     TypeInfo, Context, SymbolTableNode, Var, Expression,
-    get_nongen_builtins, check_arg_names, check_arg_kinds, ARG_POS, ARG_NAMED,
+    get_nongen_builtins, check_arg_names, check_arg_kinds, ArgKind, ARG_POS, ARG_NAMED,
     ARG_OPT, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2, TypeVarExpr, TypeVarLikeExpr, ParamSpecExpr,
     TypeAlias, PlaceholderNode, SYMBOL_FUNCBASE_TYPES, Decorator, MypyFile
 )
@@ -755,10 +755,10 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         return ret.accept(self)
 
     def analyze_callable_args(self, arglist: TypeList) -> Optional[Tuple[List[Type],
-                                                                         List[int],
+                                                                         List[ArgKind],
                                                                          List[Optional[str]]]]:
         args: List[Type] = []
-        kinds: List[int] = []
+        kinds: List[ArgKind] = []
         names: List[Optional[str]] = []
         for arg in arglist.items:
             if isinstance(arg, CallableArgument):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -14,7 +14,8 @@ from typing_extensions import ClassVar, Final, TYPE_CHECKING, overload
 import mypy.nodes
 from mypy import state
 from mypy.nodes import (
-    INVARIANT, SymbolNode, ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, ARG_NAMED, ARG_NAMED_OPT,
+    INVARIANT, SymbolNode, ArgKind,
+    ARG_POS, ARG_OPT, ARG_STAR, ARG_STAR2, ARG_NAMED, ARG_NAMED_OPT,
     FuncDef,
 )
 from mypy.util import IdMapper
@@ -1032,7 +1033,7 @@ class CallableType(FunctionLike):
 
     def __init__(self,
                  arg_types: Sequence[Type],
-                 arg_kinds: List[int],
+                 arg_kinds: List[ArgKind],
                  arg_names: Sequence[Optional[str]],
                  ret_type: Type,
                  fallback: Instance,
@@ -1086,7 +1087,7 @@ class CallableType(FunctionLike):
 
     def copy_modified(self,
                       arg_types: Bogus[Sequence[Type]] = _dummy,
-                      arg_kinds: Bogus[List[int]] = _dummy,
+                      arg_kinds: Bogus[List[ArgKind]] = _dummy,
                       arg_names: Bogus[List[Optional[str]]] = _dummy,
                       ret_type: Bogus[Type] = _dummy,
                       fallback: Bogus[Instance] = _dummy,
@@ -1285,7 +1286,7 @@ class CallableType(FunctionLike):
         # generic functions for non-generic functions.
         return {'.class': 'CallableType',
                 'arg_types': [t.serialize() for t in self.arg_types],
-                'arg_kinds': self.arg_kinds,
+                'arg_kinds': [int(x.value) for x in self.arg_kinds],
                 'arg_names': self.arg_names,
                 'ret_type': self.ret_type.serialize(),
                 'fallback': self.fallback.serialize(),
@@ -1305,7 +1306,7 @@ class CallableType(FunctionLike):
         assert data['.class'] == 'CallableType'
         # TODO: Set definition to the containing SymbolNode?
         return CallableType([deserialize_type(t) for t in data['arg_types']],
-                            data['arg_kinds'],
+                            [ArgKind(x) for x in data['arg_kinds']],
                             data['arg_names'],
                             deserialize_type(data['ret_type']),
                             Instance.deserialize(data['fallback']),

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -10,9 +10,9 @@ The wrappers aren't used for most calls between two native functions
 or methods in a single compilation unit.
 """
 
-from typing import List, Optional, Sequence
+from typing import List, Dict, Optional, Sequence
 
-from mypy.nodes import ARG_POS, ARG_OPT, ARG_NAMED_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2
+from mypy.nodes import ArgKind, ARG_POS, ARG_OPT, ARG_NAMED_OPT, ARG_NAMED, ARG_STAR, ARG_STAR2
 from mypy.operators import op_methods_to_symbols, reverse_op_methods, reverse_op_method_names
 
 from mypyc.common import PREFIX, NATIVE_PREFIX, DUNDER_PREFIX, use_vectorcall
@@ -75,12 +75,12 @@ def generate_traceback_code(fn: FuncIR,
     return traceback_code
 
 
-def make_arg_groups(args: List[RuntimeArg]) -> List[List[RuntimeArg]]:
+def make_arg_groups(args: List[RuntimeArg]) -> Dict[ArgKind, List[RuntimeArg]]:
     """Group arguments by kind."""
-    return [[arg for arg in args if arg.kind == k] for k in range(ARG_NAMED_OPT + 1)]
+    return {k: [arg for arg in args if arg.kind == k] for k in ArgKind}
 
 
-def reorder_arg_groups(groups: List[List[RuntimeArg]]) -> List[RuntimeArg]:
+def reorder_arg_groups(groups: Dict[ArgKind, List[RuntimeArg]]) -> List[RuntimeArg]:
     """Reorder argument groups to match their order in a format string."""
     return groups[ARG_POS] + groups[ARG_OPT] + groups[ARG_NAMED_OPT] + groups[ARG_NAMED]
 
@@ -90,7 +90,7 @@ def make_static_kwlist(args: List[RuntimeArg]) -> str:
     return 'static const char * const kwlist[] = {{{}0}};'.format(arg_names)
 
 
-def make_format_string(func_name: Optional[str], groups: List[List[RuntimeArg]]) -> str:
+def make_format_string(func_name: Optional[str], groups: Dict[ArgKind, List[RuntimeArg]]) -> str:
     """Return a format string that specifies the accepted arguments.
 
     The format string is an extended subset of what is supported by

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -3,7 +3,7 @@
 from typing import List, Optional, Sequence
 from typing_extensions import Final
 
-from mypy.nodes import FuncDef, Block, ARG_POS, ARG_OPT, ARG_NAMED_OPT
+from mypy.nodes import FuncDef, Block, ArgKind, ARG_POS, ARG_OPT, ARG_NAMED_OPT
 
 from mypyc.common import JsonDict
 from mypyc.ir.ops import (
@@ -19,7 +19,7 @@ class RuntimeArg:
     Argument kind is one of ARG_* constants defined in mypy.nodes.
     """
 
-    def __init__(self, name: str, typ: RType, kind: int = ARG_POS) -> None:
+    def __init__(self, name: str, typ: RType, kind: ArgKind = ARG_POS) -> None:
         self.name = name
         self.type = typ
         self.kind = kind
@@ -32,14 +32,14 @@ class RuntimeArg:
         return 'RuntimeArg(name=%s, type=%s, optional=%r)' % (self.name, self.type, self.optional)
 
     def serialize(self) -> JsonDict:
-        return {'name': self.name, 'type': self.type.serialize(), 'kind': self.kind}
+        return {'name': self.name, 'type': self.type.serialize(), 'kind': int(self.kind.value)}
 
     @classmethod
     def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> 'RuntimeArg':
         return RuntimeArg(
             data['name'],
             deserialize_type(data['type'], ctx),
-            data['kind'],
+            ArgKind(data['kind']),
         )
 
 

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -19,7 +19,8 @@ from mypy.build import Graph
 from mypy.nodes import (
     MypyFile, SymbolNode, Statement, OpExpr, IntExpr, NameExpr, LDEF, Var, UnaryExpr,
     CallExpr, IndexExpr, Expression, MemberExpr, RefExpr, Lvalue, TupleExpr,
-    TypeInfo, Decorator, OverloadedFuncDef, StarExpr, ComparisonExpr, GDEF, ARG_POS, ARG_NAMED
+    TypeInfo, Decorator, OverloadedFuncDef, StarExpr, ComparisonExpr, GDEF,
+    ArgKind, ARG_POS, ARG_NAMED,
 )
 from mypy.types import (
     Type, Instance, TupleType, UninhabitedType, get_proper_type
@@ -238,7 +239,7 @@ class IRBuilder:
                 function: Value,
                 arg_values: List[Value],
                 line: int,
-                arg_kinds: Optional[List[int]] = None,
+                arg_kinds: Optional[List[ArgKind]] = None,
                 arg_names: Optional[Sequence[Optional[str]]] = None) -> Value:
         return self.builder.py_call(function, arg_values, line, arg_kinds, arg_names)
 
@@ -254,7 +255,7 @@ class IRBuilder:
                         arg_values: List[Value],
                         result_type: Optional[RType],
                         line: int,
-                        arg_kinds: Optional[List[int]] = None,
+                        arg_kinds: Optional[List[ArgKind]] = None,
                         arg_names: Optional[List[Optional[str]]] = None) -> Value:
         return self.builder.gen_method_call(
             base, name, arg_values, result_type, line, arg_kinds, arg_names
@@ -1013,7 +1014,7 @@ class IRBuilder:
             self_type = RInstance(class_ir)
         self.add_argument(SELF_NAME, self_type)
 
-    def add_argument(self, var: Union[str, Var], typ: RType, kind: int = ARG_POS) -> Register:
+    def add_argument(self, var: Union[str, Var], typ: RType, kind: ArgKind = ARG_POS) -> Register:
         """Declare an argument in the current function.
 
         You should use this instead of directly calling add_local() in new code.

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -14,7 +14,7 @@ from typing import NamedTuple, Optional, List, Sequence, Tuple, Union, Dict
 
 from mypy.nodes import (
     ClassDef, FuncDef, OverloadedFuncDef, Decorator, Var, YieldFromExpr, AwaitExpr, YieldExpr,
-    FuncItem, LambdaExpr, SymbolNode, ARG_NAMED, ARG_NAMED_OPT, TypeInfo
+    FuncItem, LambdaExpr, SymbolNode, ArgKind, ARG_NAMED, ARG_NAMED_OPT, TypeInfo
 )
 from mypy.types import CallableType, get_proper_type
 
@@ -641,7 +641,7 @@ def gen_glue(builder: IRBuilder, sig: FuncSignature, target: FuncIR,
 class ArgInfo(NamedTuple):
     args: List[Value]
     arg_names: List[Optional[str]]
-    arg_kinds: List[int]
+    arg_kinds: List[ArgKind]
 
 
 def get_args(builder: IRBuilder, rt_args: Sequence[RuntimeArg], line: int) -> ArgInfo:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -14,7 +14,7 @@ from typing import (
 
 from typing_extensions import Final
 
-from mypy.nodes import ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2
+from mypy.nodes import ArgKind, ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2
 from mypy.operators import op_methods
 from mypy.types import AnyType, TypeOfAny
 from mypy.checkexpr import map_actuals_to_formals
@@ -259,7 +259,7 @@ class LowLevelIRBuilder:
                 function: Value,
                 arg_values: List[Value],
                 line: int,
-                arg_kinds: Optional[List[int]] = None,
+                arg_kinds: Optional[List[ArgKind]] = None,
                 arg_names: Optional[Sequence[Optional[str]]] = None) -> Value:
         """Call a Python function (non-native and slow).
 
@@ -317,7 +317,7 @@ class LowLevelIRBuilder:
                         function: Value,
                         arg_values: List[Value],
                         line: int,
-                        arg_kinds: Optional[List[int]] = None,
+                        arg_kinds: Optional[List[ArgKind]] = None,
                         arg_names: Optional[Sequence[Optional[str]]] = None) -> Optional[Value]:
         """Call function using the vectorcall API if possible.
 
@@ -365,7 +365,7 @@ class LowLevelIRBuilder:
                        method_name: str,
                        arg_values: List[Value],
                        line: int,
-                       arg_kinds: Optional[List[int]],
+                       arg_kinds: Optional[List[ArgKind]],
                        arg_names: Optional[Sequence[Optional[str]]]) -> Value:
         """Call a Python method (non-native and slow)."""
         if use_method_vectorcall(self.options.capi_version):
@@ -389,7 +389,7 @@ class LowLevelIRBuilder:
                                method_name: str,
                                arg_values: List[Value],
                                line: int,
-                               arg_kinds: Optional[List[int]],
+                               arg_kinds: Optional[List[ArgKind]],
                                arg_names: Optional[Sequence[Optional[str]]]) -> Optional[Value]:
         """Call method using the vectorcall API if possible.
 
@@ -423,7 +423,7 @@ class LowLevelIRBuilder:
     def call(self,
              decl: FuncDecl,
              args: Sequence[Value],
-             arg_kinds: List[int],
+             arg_kinds: List[ArgKind],
              arg_names: Sequence[Optional[str]],
              line: int) -> Value:
         """Call a native function."""
@@ -434,7 +434,7 @@ class LowLevelIRBuilder:
 
     def native_args_to_positional(self,
                                   args: Sequence[Value],
-                                  arg_kinds: List[int],
+                                  arg_kinds: List[ArgKind],
                                   arg_names: Sequence[Optional[str]],
                                   sig: FuncSignature,
                                   line: int) -> List[Value]:
@@ -482,7 +482,7 @@ class LowLevelIRBuilder:
                         arg_values: List[Value],
                         result_type: Optional[RType],
                         line: int,
-                        arg_kinds: Optional[List[int]] = None,
+                        arg_kinds: Optional[List[ArgKind]] = None,
                         arg_names: Optional[List[Optional[str]]] = None) -> Value:
         """Generate either a native or Python method call."""
         # If arg_kinds contains values other than arg_pos and arg_named, then fallback to
@@ -533,7 +533,7 @@ class LowLevelIRBuilder:
                           arg_values: List[Value],
                           return_rtype: Optional[RType],
                           line: int,
-                          arg_kinds: Optional[List[int]],
+                          arg_kinds: Optional[List[ArgKind]],
                           arg_names: Optional[List[Optional[str]]]) -> Value:
         """Generate a method call with a union type for the object."""
         # Union method call needs a return_rtype for the type of the output register.
@@ -1344,7 +1344,7 @@ class LowLevelIRBuilder:
             return self.call_c(dict_new_op, [], line)
 
 
-def num_positional_args(arg_values: List[Value], arg_kinds: Optional[List[int]]) -> int:
+def num_positional_args(arg_values: List[Value], arg_kinds: Optional[List[ArgKind]]) -> int:
     if arg_kinds is None:
         return len(arg_values)
     num_pos = 0

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Optional
 
-from mypy.nodes import FuncDef, TypeInfo, SymbolNode, ARG_STAR, ARG_STAR2
+from mypy.nodes import FuncDef, TypeInfo, SymbolNode, ArgKind, ARG_STAR, ARG_STAR2
 from mypy.types import (
     Instance, Type, CallableType, LiteralType, TypedDictType, UnboundType, PartialType,
     UninhabitedType, Overloaded, UnionType, TypeType, AnyType, NoneTyp, TupleType, TypeVarType,
@@ -110,7 +110,7 @@ class Mapper:
         # actually show up, so anything else is a bug somewhere.
         assert False, 'unexpected type %s' % type(typ)
 
-    def get_arg_rtype(self, typ: Type, kind: int) -> RType:
+    def get_arg_rtype(self, typ: Type, kind: ArgKind) -> RType:
         if kind == ARG_STAR:
             return tuple_rprimitive
         elif kind == ARG_STAR2:

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -4,8 +4,8 @@ from typing import Dict, Any, Union, Optional
 
 from mypy.nodes import (
     ClassDef, FuncDef, Decorator, OverloadedFuncDef, StrExpr, CallExpr, RefExpr, Expression,
-    IntExpr, FloatExpr, Var, TupleExpr, UnaryExpr, BytesExpr, ARG_NAMED, ARG_NAMED_OPT, ARG_POS,
-    ARG_OPT, GDEF
+    IntExpr, FloatExpr, Var, TupleExpr, UnaryExpr, BytesExpr,
+    ArgKind, ARG_NAMED, ARG_NAMED_OPT, ARG_POS, ARG_OPT, GDEF,
 )
 
 
@@ -101,7 +101,7 @@ def get_func_def(op: Union[FuncDef, Decorator, OverloadedFuncDef]) -> FuncDef:
     return op
 
 
-def concrete_arg_kind(kind: int) -> int:
+def concrete_arg_kind(kind: ArgKind) -> ArgKind:
     """Find the concrete version of an arg kind that is being passed."""
     if kind == ARG_OPT:
         return ARG_POS

--- a/test-data/unit/plugins/arg_kinds.py
+++ b/test-data/unit/plugins/arg_kinds.py
@@ -21,12 +21,12 @@ class ArgKindsPlugin(Plugin):
 
 
 def extract_arg_kinds_from_function(ctx: FunctionContext) -> Type:
-    ctx.api.fail(str(ctx.arg_kinds), ctx.context)
+    ctx.api.fail(str([[x.value for x in y] for y in ctx.arg_kinds]), ctx.context)
     return ctx.default_return_type
 
 
 def extract_arg_kinds_from_method(ctx: MethodContext) -> Type:
-    ctx.api.fail(str(ctx.arg_kinds), ctx.context)
+    ctx.api.fail(str([[x.value for x in y] for y in ctx.arg_kinds]), ctx.context)
     return ctx.default_return_type
 
 


### PR DESCRIPTION
This is cleaner and more precise and will allow us to add convenience
methods to the class.
(I added one convenience method so far, to verify that mypyc doesn't
choke on it...)