### PR TITLE
[mypyc] Reject instance attribute access through class object

### DIFF
--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -14,14 +14,14 @@ from mypy.nodes import (
     AssignmentExpr,
     Var, RefExpr, MypyFile, TypeInfo, TypeApplication, LDEF, ARG_POS
 )
-from mypy.types import TupleType, Instance, TypeType, get_proper_type
+from mypy.types import TupleType, Instance, TypeType, ProperType, get_proper_type
 
 from mypyc.common import MAX_SHORT_INT
 from mypyc.ir.ops import (
     Value, Register, TupleGet, TupleSet, BasicBlock, Assign, LoadAddress, RaiseStandardError
 )
 from mypyc.ir.rtypes import (
-    RTuple, RInstance, object_rprimitive, is_none_rprimitive, int_rprimitive, is_int_rprimitive
+    RTuple, object_rprimitive, is_none_rprimitive, int_rprimitive, is_int_rprimitive
 )
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD
 from mypyc.primitives.registry import CFunctionDescription, builtin_names
@@ -134,7 +134,15 @@ def transform_member_expr(builder: IRBuilder, expr: MemberExpr) -> Value:
             index = builder.builder.load_int(fields.index(expr.name))
             return builder.gen_method_call(obj, '__getitem__', [index], rtype, expr.line)
 
-    # Report error if accessing an instance attribute through class object.
+    check_instance_attribute_access_through_class(builder, expr, typ)
+
+    return builder.builder.get_attr(obj, expr.name, rtype, expr.line)
+
+
+def check_instance_attribute_access_through_class(builder: IRBuilder,
+                                                  expr: MemberExpr,
+                                                  typ: Optional[ProperType]) -> None:
+    """Report error if accessing an instance attribute through class object."""
     if isinstance(expr.expr, RefExpr):
         node = expr.expr.node
         if isinstance(typ, TypeType) and isinstance(typ.item, Instance):
@@ -158,10 +166,6 @@ def transform_member_expr(builder: IRBuilder, expr: MemberExpr) -> Value:
                         'a class attribute)',
                         expr.line
                     )
-    if isinstance(typ, RInstance) and obj.type.class_ir.is_ext_class:
-        assert False, typ
-
-    return builder.builder.get_attr(obj, expr.name, rtype, expr.line)
 
 
 def transform_super_expr(builder: IRBuilder, o: SuperExpr) -> Value:

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -137,6 +137,7 @@ def transform_member_expr(builder: IRBuilder, expr: MemberExpr) -> Value:
     if isinstance(expr.expr, RefExpr):
         node = expr.expr.node
         if isinstance(typ, TypeType) and isinstance(typ.item, Instance):
+            # TODO: Handle other item types
             node = typ.item.type
         if isinstance(node, TypeInfo):
             class_ir = builder.mapper.type_to_ir.get(node)

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -134,6 +134,7 @@ def transform_member_expr(builder: IRBuilder, expr: MemberExpr) -> Value:
             index = builder.builder.load_int(fields.index(expr.name))
             return builder.gen_method_call(obj, '__getitem__', [index], rtype, expr.line)
 
+    # Report error if accessing an instance attribute through class object.
     if isinstance(expr.expr, RefExpr):
         node = expr.expr.node
         if isinstance(typ, TypeType) and isinstance(typ.item, Instance):

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1146,7 +1146,7 @@ class DeletableFinal2:
     __deletable__ = ['X']
 
 [case testNeedAnnotateClassVar]
-from typing import Final, ClassVar
+from typing import Final, ClassVar, Type
 
 class C:
     a = 'A'
@@ -1171,3 +1171,14 @@ def f() -> None:
          # N: (Hint: Use "x: Final = ..." or "x: ClassVar = ..." to define a class attribute)
     D.f
     D.c
+
+def g(c: Type[C], d: Type[D]) -> None:
+    c.a  # E: Cannot access instance attribute "a" through class object \
+         # N: (Hint: Use "x: Final = ..." or "x: ClassVar = ..." to define a class attribute)
+    c.f
+    c.c
+
+    d.a  # E: Cannot access instance attribute "a" through class object \
+         # N: (Hint: Use "x: Final = ..." or "x: ClassVar = ..." to define a class attribute)
+    d.f
+    d.c

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1144,3 +1144,30 @@ class DeletableFinal2:
     X: Final = 0  # E: Deletable attribute cannot be final
 
     __deletable__ = ['X']
+
+[case testNeedAnnotateClassVar]
+from typing import Final, ClassVar
+
+class C:
+    a = 'A'
+    b: str = 'B'
+    f: Final = 'F'
+    c: ClassVar = 'C'
+
+class D(C):
+    pass
+
+def f() -> None:
+    C.a  # E: Cannot access instance attribute "a" through class object \
+         # N: (Hint: Use "x: Final = ..." or "x: ClassVar = ..." to define a class attribute)
+    C.b  # E: Cannot access instance attribute "b" through class object \
+         # N: (Hint: Use "x: Final = ..." or "x: ClassVar = ..." to define a class attribute)
+    C.f
+    C.c
+
+    D.a  # E: Cannot access instance attribute "a" through class object \
+         # N: (Hint: Use "x: Final = ..." or "x: ClassVar = ..." to define a class attribute)
+    D.b  # E: Cannot access instance attribute "b" through class object \
+         # N: (Hint: Use "x: Final = ..." or "x: ClassVar = ..." to define a class attribute)
+    D.f
+    D.c

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -247,6 +247,8 @@ o = Overload()
 assert get(o, "test") == "test"
 assert o.get(20) == 20
 
+assert get_class_var() == 'xy'
+
 [case testEnum]
 from enum import Enum
 
@@ -260,8 +262,6 @@ class TestEnum(Enum):
         return 3
 
 assert TestEnum.test() == 3
-
-assert get_class_var() == 'xy'
 
 [file other.py]
 # Force a multi-module test to make sure we can compile multi-file with

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -225,8 +225,15 @@ class Overload:
 def get(c: Overload, s: str) -> str:
     return c.get(s)
 
+@decorator
+class Var:
+    x = 'xy'
+
+def get_class_var() -> str:
+    return Var.x
+
 [file driver.py]
-from native import A, Overload, get
+from native import A, Overload, get, get_class_var
 a = A()
 assert a.a == 1
 assert a.b == 2
@@ -253,6 +260,8 @@ class TestEnum(Enum):
         return 3
 
 assert TestEnum.test() == 3
+
+assert get_class_var() == 'xy'
 
 [file other.py]
 # Force a multi-module test to make sure we can compile multi-file with


### PR DESCRIPTION
Accessing an instance attribute through a native class object results in
unexpected behavior at runtime (e.g. `<attribute 'x' of 'C' objects>`)
so reject these during compilation.

Also produce a note that suggests how to work around the issue.

Fixes mypyc/mypyc#814.