### PR TITLE
Properly track positional-only arguments for unannotated functions

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -602,10 +602,12 @@ class ASTConverter:
                                          AnyType(TypeOfAny.unannotated),
                                          _dummy_fallback)
 
-        func_def = FuncDef(n.name,
-                       args,
-                       self.as_required_block(n.body, lineno),
-                       func_type)
+        func_def = FuncDef(
+            n.name,
+            args,
+            self.as_required_block(n.body, lineno),
+            func_type,
+            num_pos_only=len(posonlyargs))
         if isinstance(func_def.type, CallableType):
             # semanal.py does some in-place modifications we want to avoid
             func_def.unanalyzed_type = func_def.type.copy_modified()
@@ -992,8 +994,10 @@ class ASTConverter:
         body.lineno = n.body.lineno
         body.col_offset = n.body.col_offset
 
+        num_pos_only = len(getattr(n.args, "posonlyargs", []))
         e = LambdaExpr(self.transform_args(n.args, n.lineno),
-                       self.as_required_block([body], n.lineno))
+                       self.as_required_block([body], n.lineno),
+                       num_pos_only=num_pos_only)
         e.set_line(n.lineno, n.col_offset)  # Overrides set_line -- can't use self.set_line
         return e
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1936,9 +1936,9 @@ def pretty_callable(tp: CallableType) -> str:
 
     # If we got a "special arg" (i.e: self, cls, etc...), prepend it to the arg list
     if isinstance(tp.definition, FuncDef) and tp.definition.name is not None:
-        definition_args = tp.definition.arg_names
+        definition_args = [arg.variable.name for arg in tp.definition.arguments]
         if definition_args and tp.arg_names != definition_args \
-                and len(definition_args) > 0:
+                and len(definition_args) > 0 and definition_args[0]:
             if s:
                 s = ', ' + s
             s = definition_args[0] + s

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -598,6 +598,7 @@ class FuncItem(FuncBase):
     __slots__ = ('arguments',  # Note that can be None if deserialized (type is a lie!)
                  'arg_names',  # Names of arguments
                  'arg_kinds',  # Kinds of arguments
+                 'num_pos_only',  # Number of positional only args
                  'min_args',  # Minimum number of arguments
                  'max_pos',  # Maximum number of positional arguments, -1 if no explicit
                              # limit (*args not included)
@@ -616,11 +617,13 @@ class FuncItem(FuncBase):
     def __init__(self,
                  arguments: List[Argument],
                  body: 'Block',
-                 typ: 'Optional[mypy.types.FunctionLike]' = None) -> None:
+                 typ: 'Optional[mypy.types.FunctionLike]' = None,
+                 num_pos_only: int = 0) -> None:
         super().__init__()
         self.arguments = arguments
         self.arg_names = [arg.variable.name for arg in self.arguments]
         self.arg_kinds: List[ArgKind] = [arg.kind for arg in self.arguments]
+        self.num_pos_only = num_pos_only
         self.max_pos: int = (
             self.arg_kinds.count(ARG_POS) + self.arg_kinds.count(ARG_OPT))
         self.body: 'Block' = body
@@ -675,8 +678,9 @@ class FuncDef(FuncItem, SymbolNode, Statement):
                  name: str,              # Function name
                  arguments: List[Argument],
                  body: 'Block',
-                 typ: 'Optional[mypy.types.FunctionLike]' = None) -> None:
-        super().__init__(arguments, body, typ)
+                 typ: 'Optional[mypy.types.FunctionLike]' = None,
+                 num_pos_only: int = 0) -> None:
+        super().__init__(arguments, body, typ, num_pos_only)
         self._name = name
         self.is_decorated = False
         self.is_conditional = False  # Defined conditionally (within block)?

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -600,7 +600,6 @@ class FuncItem(FuncBase):
     __slots__ = ('arguments',  # Note that can be None if deserialized (type is a lie!)
                  'arg_names',  # Names of arguments
                  'arg_kinds',  # Kinds of arguments
-                 'num_pos_only',  # Number of positional only args
                  'min_args',  # Minimum number of arguments
                  'max_pos',  # Maximum number of positional arguments, -1 if no explicit
                              # limit (*args not included)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -561,18 +561,20 @@ class OverloadedFuncDef(FuncBase, SymbolNode, Statement):
 class Argument(Node):
     """A single argument in a FuncItem."""
 
-    __slots__ = ('variable', 'type_annotation', 'initializer', 'kind')
+    __slots__ = ('variable', 'type_annotation', 'initializer', 'kind', 'pos_only')
 
     def __init__(self,
                  variable: 'Var',
                  type_annotation: 'Optional[mypy.types.Type]',
                  initializer: Optional[Expression],
-                 kind: 'ArgKind') -> None:
+                 kind: 'ArgKind',
+                 pos_only: bool = False) -> None:
         super().__init__()
         self.variable = variable
         self.type_annotation = type_annotation
         self.initializer = initializer
         self.kind = kind  # must be an ARG_* constant
+        self.pos_only = pos_only
 
     def set_line(self,
                  target: Union[Context, int],
@@ -617,13 +619,11 @@ class FuncItem(FuncBase):
     def __init__(self,
                  arguments: List[Argument],
                  body: 'Block',
-                 typ: 'Optional[mypy.types.FunctionLike]' = None,
-                 num_pos_only: int = 0) -> None:
+                 typ: 'Optional[mypy.types.FunctionLike]' = None) -> None:
         super().__init__()
         self.arguments = arguments
-        self.arg_names = [arg.variable.name for arg in self.arguments]
+        self.arg_names = [None if arg.pos_only else arg.variable.name for arg in arguments]
         self.arg_kinds: List[ArgKind] = [arg.kind for arg in self.arguments]
-        self.num_pos_only = num_pos_only
         self.max_pos: int = (
             self.arg_kinds.count(ARG_POS) + self.arg_kinds.count(ARG_OPT))
         self.body: 'Block' = body
@@ -678,9 +678,8 @@ class FuncDef(FuncItem, SymbolNode, Statement):
                  name: str,              # Function name
                  arguments: List[Argument],
                  body: 'Block',
-                 typ: 'Optional[mypy.types.FunctionLike]' = None,
-                 num_pos_only: int = 0) -> None:
-        super().__init__(arguments, body, typ, num_pos_only)
+                 typ: 'Optional[mypy.types.FunctionLike]' = None) -> None:
+        super().__init__(arguments, body, typ)
         self._name = name
         self.is_decorated = False
         self.is_conditional = False  # Defined conditionally (within block)?

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -564,7 +564,8 @@ def callable_type(fdef: FuncItem, fallback: Instance,
     return CallableType(
         args,
         fdef.arg_kinds,
-        [None if argument_elide_name(n) else n for n in fdef.arg_names],
+        [None if argument_elide_name(n) or i < fdef.num_pos_only else n
+         for i, n in enumerate(fdef.arg_names)],
         ret_type or AnyType(TypeOfAny.unannotated),
         fallback,
         name=fdef.name,

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -22,7 +22,6 @@ from mypy.nodes import (
 )
 from mypy.maptype import map_instance_to_supertype
 from mypy.expandtype import expand_type_by_instance, expand_type
-from mypy.sharedparse import argument_elide_name
 
 from mypy.typevars import fill_typevars
 
@@ -564,8 +563,7 @@ def callable_type(fdef: FuncItem, fallback: Instance,
     return CallableType(
         args,
         fdef.arg_kinds,
-        [None if argument_elide_name(n) or i < fdef.num_pos_only else n
-         for i, n in enumerate(fdef.arg_names)],
+        fdef.arg_names,
         ret_type or AnyType(TypeOfAny.unannotated),
         fallback,
         name=fdef.name,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1077,7 +1077,7 @@ class CallableType(FunctionLike):
             # after serialization, but it is useful in error messages.
             # TODO: decide how to add more info here (file, line, column)
             # without changing interface hash.
-            self.def_extras = {'first_arg': definition.arg_names[0]
+            self.def_extras = {'first_arg': definition.arguments[0].variable.name
                                if definition.arg_names and definition.info and
                                not definition.is_static else None}
         else:

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -133,8 +133,21 @@ class Mapper:
             else:
                 ret = object_rprimitive
 
-        args = [RuntimeArg(arg.variable.name, arg_type, arg.kind)
-                for arg, arg_type in zip(fdef.arguments, arg_types)]
+        # mypyc FuncSignatures (unlike mypy types) want to have a name
+        # present even when the argument is position only, since it is
+        # the sole way that FuncDecl arguments are tracked. This is
+        # generally fine except in some cases (like for computing
+        # init_sig) we need to produce FuncSignatures from a
+        # deserialized FuncDef that lacks arguments. We won't ever
+        # need to use those inside of a FuncIR, so we just make up
+        # some crap.
+        if hasattr(fdef, 'arguments'):
+            arg_names = [arg.variable.name for arg in fdef.arguments]
+        else:
+            arg_names = [name or '' for name in fdef.arg_names]
+
+        args = [RuntimeArg(arg_name, arg_type, arg_kind)
+                for arg_name, arg_kind, arg_type in zip(arg_names, fdef.arg_kinds, arg_types)]
 
         # We force certain dunder methods to return objects to support letting them
         # return NotImplemented. It also avoids some pointless boxing and unboxing,

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -133,8 +133,8 @@ class Mapper:
             else:
                 ret = object_rprimitive
 
-        args = [RuntimeArg(arg_name, arg_type, arg_kind)
-                for arg_name, arg_kind, arg_type in zip(fdef.arg_names, fdef.arg_kinds, arg_types)]
+        args = [RuntimeArg(arg.variable.name, arg_type, arg.kind)
+                for arg, arg_type in zip(fdef.arguments, arg_types)]
 
         # We force certain dunder methods to return objects to support letting them
         # return NotImplemented. It also avoids some pointless boxing and unboxing,

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2759,7 +2759,7 @@ t = Test()
 t.crash = 'test'  # E: "Test" has no attribute "crash"
 
 class A:
-    def __setattr__(self): ...  # E: Invalid signature "def (self: __main__.A) -> Any" for "__setattr__"
+    def __setattr__(self): ...  # E: Invalid signature "def (__main__.A) -> Any" for "__setattr__"
 a = A()
 a.test = 4  # E: "A" has no attribute "test"
 

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -192,6 +192,12 @@ def f(p1: bytes, p2: float, /) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
 
+[case testPEP570Unannotated]
+def f(arg, /): ...
+g = lambda arg, /: arg
+f(arg=0)  # E: Unexpected keyword argument "arg" for "f"
+g(arg=0)  # E: Unexpected keyword argument "arg"
+
 [case testWalrus]
 # flags: --strict-optional
 from typing import NamedTuple, Optional, List
@@ -206,7 +212,7 @@ while b := "x":
 l = [y2 := 1, y2 + 2, y2 + 3]
 reveal_type(y2)  # N: Revealed type is "builtins.int"
 reveal_type(l)  # N: Revealed type is "builtins.list[builtins.int*]"
- 
+
 filtered_data = [y3 for x in l if (y3 := a) is not None]
 reveal_type(filtered_data)  # N: Revealed type is "builtins.list[builtins.int*]"
 reveal_type(y3)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -198,6 +198,12 @@ g = lambda arg, /: arg
 def h(arg=0, /): ...
 i = lambda arg=0, /: arg
 
+f(1)
+g(1)
+h()
+h(1)
+i()
+i(1)
 f(arg=0)  # E: Unexpected keyword argument "arg" for "f"
 g(arg=0)  # E: Unexpected keyword argument "arg"
 h(arg=0)  # E: Unexpected keyword argument "arg" for "h"

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -195,8 +195,13 @@ def f(p1: bytes, p2: float, /) -> None:
 [case testPEP570Unannotated]
 def f(arg, /): ...
 g = lambda arg, /: arg
+def h(arg=0, /): ...
+i = lambda arg=0, /: arg
+
 f(arg=0)  # E: Unexpected keyword argument "arg" for "f"
 g(arg=0)  # E: Unexpected keyword argument "arg"
+h(arg=0)  # E: Unexpected keyword argument "arg" for "h"
+i(arg=0)  # E: Unexpected keyword argument "arg"
 
 [case testWalrus]
 # flags: --strict-optional


### PR DESCRIPTION
I was originally planning to address this by adding an ARG_POS_ONLY
kind (as a concrete win for what I hoped would be a generally positive
refactor), but it was actually really easy to fix it on its own, and
then we can address the refactor purely on its own merits.