### PR TITLE
[mypyc] Tokenizer for printf-style format string

### DIFF
--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -21,18 +21,20 @@ from mypyc.ir.ops import (
     Value, Register, TupleGet, TupleSet, BasicBlock, Assign, LoadAddress, RaiseStandardError
 )
 from mypyc.ir.rtypes import (
-    RTuple, object_rprimitive, is_none_rprimitive, int_rprimitive, is_int_rprimitive
+    RTuple, object_rprimitive, is_none_rprimitive, int_rprimitive, is_int_rprimitive,
+    is_str_rprimitive, is_short_int_rprimitive
 )
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD
-from mypyc.primitives.registry import CFunctionDescription, builtin_names
+from mypyc.irbuild.format_str_tokenizer import tokenizer_printf_style, join_formatted_strings
+from mypyc.primitives.registry import CFunctionDescription, builtin_names, binary_ops
 from mypyc.primitives.generic_ops import iter_op
 from mypyc.primitives.misc_ops import new_slice_op, ellipsis_op, type_op, get_module_dict_op
 from mypyc.primitives.list_ops import list_append_op, list_extend_op, list_slice_op
 from mypyc.primitives.tuple_ops import list_tuple_op, tuple_slice_op
 from mypyc.primitives.dict_ops import dict_new_op, dict_set_item_op, dict_get_item_op
 from mypyc.primitives.set_ops import set_add_op, set_update_op
-from mypyc.primitives.str_ops import str_slice_op
-from mypyc.primitives.int_ops import int_comparison_op_mapping
+from mypyc.primitives.str_ops import str_slice_op, str_op
+from mypyc.primitives.int_ops import int_comparison_op_mapping, int_to_str_op
 from mypyc.irbuild.specialize import specializers
 from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.for_helpers import (
@@ -379,6 +381,11 @@ def transform_unary_expr(builder: IRBuilder, expr: UnaryExpr) -> Value:
 def transform_op_expr(builder: IRBuilder, expr: OpExpr) -> Value:
     if expr.op in ('and', 'or'):
         return builder.shortcircuit_expr(expr)
+
+    # Special case for string formatting
+    if expr.op == '%' and isinstance(expr.left, StrExpr):
+        return translate_str_format_percent_sign(builder, expr.left, expr.right)
+
     return builder.binary_op(
         builder.accept(expr.left), builder.accept(expr.right), expr.op, expr.line
     )
@@ -557,6 +564,42 @@ def transform_basic_comparison(builder: IRBuilder,
     if negate:
         target = builder.unary_op(target, 'not', line)
     return target
+
+
+def translate_str_format_percent_sign(builder: IRBuilder,
+                                      format_expr: StrExpr,
+                                      rhs: Expression) -> Value:
+    literals, conversion_types = tokenizer_printf_style(format_expr.value)
+    variables = []
+    flag = True
+    if isinstance(rhs, TupleExpr):
+        raw_variables = rhs.items
+    elif isinstance(rhs, RefExpr):
+        raw_variables = [rhs]
+    else:
+        raw_variables, flag = [], False
+
+    for typ, var in zip(conversion_types, raw_variables):
+        node_type = builder.node_type(var)
+        if typ == '%d' and (is_int_rprimitive(node_type)
+                            or is_short_int_rprimitive(node_type)):
+            var_str = builder.call_c(int_to_str_op, [builder.accept(var)], format_expr.line)
+        elif typ == '%s':
+            if is_str_rprimitive(node_type):
+                var_str = builder.accept(var)
+            else:
+                var_str = builder.call_c(str_op, [builder.accept(var)], format_expr.line)
+        else:
+            flag = False
+            break
+        variables.append(var_str)
+
+    if flag:
+        return join_formatted_strings(builder, literals, variables, format_expr.line)
+    else:
+        call_c_ops_candidates = binary_ops.get('%', [])
+        return builder.builder.matching_call_c(call_c_ops_candidates,
+                                               [format_expr, rhs], format_expr.line)
 
 
 # Literals

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -573,14 +573,14 @@ def translate_str_format_percent_sign(builder: IRBuilder,
     variables = []
     if isinstance(rhs, TupleExpr):
         raw_variables = rhs.items
-    elif isinstance(rhs, RefExpr):
+    elif isinstance(rhs, Expression):
         raw_variables = [rhs]
     else:
         raw_variables = []
 
-    flag = (len(conversion_types) == len(raw_variables))
+    is_conversion_matched = (len(conversion_types) == len(raw_variables))
 
-    if flag:
+    if is_conversion_matched:
         for typ, var in zip(conversion_types, raw_variables):
             node_type = builder.node_type(var)
             if typ == '%d' and (is_int_rprimitive(node_type)
@@ -592,18 +592,18 @@ def translate_str_format_percent_sign(builder: IRBuilder,
                 else:
                     var_str = builder.call_c(str_op, [builder.accept(var)], format_expr.line)
             else:
-                flag = False
+                is_conversion_matched = False
                 break
             variables.append(var_str)
 
-    if flag:
+    if is_conversion_matched:
         return join_formatted_strings(builder, literals, variables, format_expr.line)
     else:
         call_c_ops_candidates = binary_ops.get('%', [])
         ret = builder.builder.matching_call_c(call_c_ops_candidates,
                                               [builder.accept(format_expr), builder.accept(rhs)],
                                               format_expr.line)
-        assert ret is not None
+        assert ret is not None, 'Cannot use binary op % at line {}'.format(format_expr.line)
         return ret
 
 

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -598,8 +598,11 @@ def translate_str_format_percent_sign(builder: IRBuilder,
         return join_formatted_strings(builder, literals, variables, format_expr.line)
     else:
         call_c_ops_candidates = binary_ops.get('%', [])
-        return builder.builder.matching_call_c(call_c_ops_candidates,
-                                               [format_expr, rhs], format_expr.line)
+        ret = builder.builder.matching_call_c(call_c_ops_candidates,
+                                              [builder.accept(format_expr), builder.accept(rhs)],
+                                              format_expr.line)
+        assert ret is not None
+        return ret
 
 
 # Literals

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -571,28 +571,30 @@ def translate_str_format_percent_sign(builder: IRBuilder,
                                       rhs: Expression) -> Value:
     literals, conversion_types = tokenizer_printf_style(format_expr.value)
     variables = []
-    flag = True
     if isinstance(rhs, TupleExpr):
         raw_variables = rhs.items
     elif isinstance(rhs, RefExpr):
         raw_variables = [rhs]
     else:
-        raw_variables, flag = [], False
+        raw_variables = []
 
-    for typ, var in zip(conversion_types, raw_variables):
-        node_type = builder.node_type(var)
-        if typ == '%d' and (is_int_rprimitive(node_type)
-                            or is_short_int_rprimitive(node_type)):
-            var_str = builder.call_c(int_to_str_op, [builder.accept(var)], format_expr.line)
-        elif typ == '%s':
-            if is_str_rprimitive(node_type):
-                var_str = builder.accept(var)
+    flag = (len(conversion_types) == len(raw_variables))
+
+    if flag:
+        for typ, var in zip(conversion_types, raw_variables):
+            node_type = builder.node_type(var)
+            if typ == '%d' and (is_int_rprimitive(node_type)
+                                or is_short_int_rprimitive(node_type)):
+                var_str = builder.call_c(int_to_str_op, [builder.accept(var)], format_expr.line)
+            elif typ == '%s':
+                if is_str_rprimitive(node_type):
+                    var_str = builder.accept(var)
+                else:
+                    var_str = builder.call_c(str_op, [builder.accept(var)], format_expr.line)
             else:
-                var_str = builder.call_c(str_op, [builder.accept(var)], format_expr.line)
-        else:
-            flag = False
-            break
-        variables.append(var_str)
+                flag = False
+                break
+            variables.append(var_str)
 
     if flag:
         return join_formatted_strings(builder, literals, variables, format_expr.line)

--- a/mypyc/irbuild/format_str_tokenizer.py
+++ b/mypyc/irbuild/format_str_tokenizer.py
@@ -1,0 +1,41 @@
+"""Tokenizers for three string formatting methods"""
+
+import re
+from typing import List, Tuple
+
+
+def tokenizer_printf_style(format_str: str) -> Tuple[List[str], List[str]]:
+    # printf-style String Formatting:
+    # https://docs.python.org/3/library/stdtypes.html#old-string-formatting
+    pattern = re.compile(r"""
+        (
+        %                                # Start sign                                            
+        (?:\((?P<key>[^)]*)\))?          # Optional: Mapping key
+        (?P<flag>[-+#0 ]+)?              # Optional: Conversion flags 
+        (?P<width>\d+|\*)?               # Optional: Minimum field width
+        (?:\.(?P<precision>\d+|\*))?     # Optional: Precision
+        [hlL]?                           # Optional: Length modifier, Ignored  
+        (?P<type>[diouxXeEfFgGcrsa])     # Conversion type
+        | %%)
+        """, re.VERBOSE)
+
+    literals = []
+    format_op = []
+    last_end = 0
+
+    for m in re.finditer(pattern, format_str):
+        cur_start = m.start(1)
+        format_tmp = m.group(1)
+        literals.append(format_str[last_end:cur_start])
+        format_op.append(format_tmp)
+        last_end = cur_start + len(format_tmp)
+
+    literals.append(format_str[last_end:])
+
+    return literals, format_op
+
+
+assert tokenizer_printf_style("I'm %s, id years old") == \
+    (["I'm ", ', id years old'], ['%s'])
+assert tokenizer_printf_style("Test: %i%%, Test: %02d, Test: %.2f") == \
+    (['Test: ', '', ', Test: ', ', Test: ', ''], ['%i', '%%', '%02d', '%.2f'])

--- a/mypyc/irbuild/format_str_tokenizer.py
+++ b/mypyc/irbuild/format_str_tokenizer.py
@@ -3,6 +3,11 @@
 import re
 from typing import List, Tuple
 
+from mypyc.ir.ops import Value, Integer
+from mypyc.ir.rtypes import c_pyssize_t_rprimitive
+from mypyc.irbuild.builder import IRBuilder
+from mypyc.primitives.str_ops import str_build_op
+
 
 def tokenizer_printf_style(format_str: str) -> Tuple[List[str], List[str]]:
     # printf-style String Formatting:
@@ -35,7 +40,24 @@ def tokenizer_printf_style(format_str: str) -> Tuple[List[str], List[str]]:
     return literals, format_op
 
 
-assert tokenizer_printf_style("I'm %s, id years old") == \
-    (["I'm ", ', id years old'], ['%s'])
-assert tokenizer_printf_style("Test: %i%%, Test: %02d, Test: %.2f") == \
-    (['Test: ', '', ', Test: ', ', Test: ', ''], ['%i', '%%', '%02d', '%.2f'])
+def join_formatted_strings(builder: IRBuilder, literals: List[str],
+                           variables: List[Value], line: int) -> Value:
+
+    # The first parameter is the total size of the following PyObject* merged from
+    # two lists alternatively.
+    result_list: List[Value] = [Integer(0, c_pyssize_t_rprimitive)]
+    for a, b in zip(literals, variables):
+        if a:
+            result_list.append(builder.load_str(a))
+        result_list.append(b)
+    # The split_braces() always generates one more element
+    if literals[-1]:
+        result_list.append(builder.load_str(literals[-1]))
+    # Special case for empty string and literal string
+    if len(result_list) == 1:
+        return builder.load_str("")
+    if not variables and len(result_list) == 2:
+        return result_list[1]
+
+    result_list[0] = Integer(len(result_list) - 1, c_pyssize_t_rprimitive)
+    return builder.call_c(str_build_op, result_list, line)

--- a/mypyc/irbuild/format_str_tokenizer.py
+++ b/mypyc/irbuild/format_str_tokenizer.py
@@ -8,55 +8,71 @@ from mypyc.ir.rtypes import c_pyssize_t_rprimitive
 from mypyc.irbuild.builder import IRBuilder
 from mypyc.primitives.str_ops import str_build_op
 
+# printf-style String Formatting:
+# https://docs.python.org/3/library/stdtypes.html#old-string-formatting
+printf_style_pattern = re.compile(r"""
+    (
+    %                                # Start sign
+    (?:\((?P<key>[^)]*)\))?          # Optional: Mapping key
+    (?P<flag>[-+#0 ]+)?              # Optional: Conversion flags
+    (?P<width>\d+|\*)?               # Optional: Minimum field width
+    (?:\.(?P<precision>\d+|\*))?     # Optional: Precision
+    [hlL]?                           # Optional: Length modifier, Ignored
+    (?P<type>[diouxXeEfFgGcrsa])     # Conversion type
+    | %%)
+    """, re.VERBOSE)
+
 
 def tokenizer_printf_style(format_str: str) -> Tuple[List[str], List[str]]:
-    # printf-style String Formatting:
-    # https://docs.python.org/3/library/stdtypes.html#old-string-formatting
-    pattern = re.compile(r"""
-        (
-        %                                # Start sign
-        (?:\((?P<key>[^)]*)\))?          # Optional: Mapping key
-        (?P<flag>[-+#0 ]+)?              # Optional: Conversion flags
-        (?P<width>\d+|\*)?               # Optional: Minimum field width
-        (?:\.(?P<precision>\d+|\*))?     # Optional: Precision
-        [hlL]?                           # Optional: Length modifier, Ignored
-        (?P<type>[diouxXeEfFgGcrsa])     # Conversion type
-        | %%)
-        """, re.VERBOSE)
+    """Tokenize a printf-style format string using regex.
 
+    Return:
+        A list of string literals and a list of conversion operations
+    """
     literals = []
-    format_op = []
+    format_ops = []
     last_end = 0
 
-    for m in re.finditer(pattern, format_str):
+    for m in re.finditer(printf_style_pattern, format_str):
         cur_start = m.start(1)
         format_tmp = m.group(1)
         literals.append(format_str[last_end:cur_start])
-        format_op.append(format_tmp)
+        format_ops.append(format_tmp)
         last_end = cur_start + len(format_tmp)
 
     literals.append(format_str[last_end:])
 
-    return literals, format_op
+    return literals, format_ops
 
 
 def join_formatted_strings(builder: IRBuilder, literals: List[str],
-                           variables: List[Value], line: int) -> Value:
+                           substitutions: List[Value], line: int) -> Value:
+    """Merge the list of literals and the list of substitutions
+    alternatively using 'str_build_op'.
 
-    # The first parameter is the total size of the following PyObject* merged from
-    # two lists alternatively.
+    Args:
+        builder: IRBuilder
+        literals: The literal substrings of the original format string.
+                  After splitting the original format string, the
+                  length of literals should be exactly one more than
+                  substitutions.
+        substitutions: Result Python strings of each conversion
+        line: line number
+    """
+    # The first parameter for str_build_op is the total size of
+    # the following PyObject*
     result_list: List[Value] = [Integer(0, c_pyssize_t_rprimitive)]
-    for a, b in zip(literals, variables):
+    for a, b in zip(literals, substitutions):
         if a:
             result_list.append(builder.load_str(a))
         result_list.append(b)
-    # The split_braces() always generates one more element
     if literals[-1]:
         result_list.append(builder.load_str(literals[-1]))
+
     # Special case for empty string and literal string
     if len(result_list) == 1:
         return builder.load_str("")
-    if not variables and len(result_list) == 2:
+    if not substitutions and len(result_list) == 2:
         return result_list[1]
 
     result_list[0] = Integer(len(result_list) - 1, c_pyssize_t_rprimitive)

--- a/mypyc/irbuild/format_str_tokenizer.py
+++ b/mypyc/irbuild/format_str_tokenizer.py
@@ -14,12 +14,12 @@ def tokenizer_printf_style(format_str: str) -> Tuple[List[str], List[str]]:
     # https://docs.python.org/3/library/stdtypes.html#old-string-formatting
     pattern = re.compile(r"""
         (
-        %                                # Start sign                                            
+        %                                # Start sign
         (?:\((?P<key>[^)]*)\))?          # Optional: Mapping key
-        (?P<flag>[-+#0 ]+)?              # Optional: Conversion flags 
+        (?P<flag>[-+#0 ]+)?              # Optional: Conversion flags
         (?P<width>\d+|\*)?               # Optional: Minimum field width
         (?:\.(?P<precision>\d+|\*))?     # Optional: Precision
-        [hlL]?                           # Optional: Length modifier, Ignored  
+        [hlL]?                           # Optional: Length modifier, Ignored
         (?P<type>[diouxXeEfFgGcrsa])     # Conversion type
         | %%)
         """, re.VERBOSE)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -637,6 +637,10 @@ class LowLevelIRBuilder:
             if value is not None:
                 return value
 
+        # Special case for string formatting
+        if is_str_rprimitive(ltype) and isinstance(rtype, RTuple) and op == '%':
+            return self.translate_str_format_percent_sign(lreg, rreg, line)
+
         # Special case various ops
         if op in ('is', 'is not'):
             return self.translate_is_op(lreg, rreg, op, line)
@@ -654,6 +658,10 @@ class LowLevelIRBuilder:
         target = self.matching_call_c(call_c_ops_candidates, [lreg, rreg], line)
         assert target, 'Unsupported binary operation: %s' % op
         return target
+
+    def translate_str_format_percent_sign(self, lhs: Value, rhs: Value, line: int) -> Value:
+        call_c_ops_candidates = binary_ops.get('%', [])
+        return self.matching_call_c(call_c_ops_candidates, [lhs, rhs], line)
 
     def check_tagged_short_int(self, val: Value, line: int, negated: bool = False) -> Value:
         """Check if a tagged integer is a short integer.

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -637,10 +637,6 @@ class LowLevelIRBuilder:
             if value is not None:
                 return value
 
-        # Special case for string formatting
-        if is_str_rprimitive(ltype) and isinstance(rtype, RTuple) and op == '%':
-            return self.translate_str_format_percent_sign(lreg, rreg, line)
-
         # Special case various ops
         if op in ('is', 'is not'):
             return self.translate_is_op(lreg, rreg, op, line)
@@ -659,9 +655,6 @@ class LowLevelIRBuilder:
         assert target, 'Unsupported binary operation: %s' % op
         return target
 
-    def translate_str_format_percent_sign(self, lhs: Value, rhs: Value, line: int) -> Value:
-        call_c_ops_candidates = binary_ops.get('%', [])
-        return self.matching_call_c(call_c_ops_candidates, [lhs, rhs], line)
 
     def check_tagged_short_int(self, val: Value, line: int, negated: bool = False) -> Value:
         """Check if a tagged integer is a short integer.

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -655,7 +655,6 @@ class LowLevelIRBuilder:
         assert target, 'Unsupported binary operation: %s' % op
         return target
 
-
     def check_tagged_short_int(self, val: Value, line: int, negated: bool = False) -> Value:
         """Check if a tagged integer is a short integer.
 

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -28,6 +28,7 @@ from mypyc.ir.rtypes import (
     bool_rprimitive, c_int_rprimitive, c_pyssize_t_rprimitive, is_dict_rprimitive,
     is_int_rprimitive, is_str_rprimitive, is_short_int_rprimitive
 )
+from mypyc.irbuild.format_str_tokenizer import join_formatted_strings
 from mypyc.primitives.int_ops import int_to_str_op
 from mypyc.primitives.dict_ops import (
     dict_keys_op, dict_values_op, dict_items_op, dict_setdefault_spec_init_op
@@ -386,25 +387,7 @@ def translate_str_format(
                 var_str = builder.call_c(str_op, [builder.accept(x)], expr.line)
             variables.append(var_str)
 
-        # The first parameter is the total size of the following PyObject* merged from
-        # two lists alternatively.
-        result_list: List[Value] = [Integer(0, c_pyssize_t_rprimitive)]
-        for a, b in zip(literals, variables):
-            if a:
-                result_list.append(builder.load_str(a))
-            result_list.append(b)
-        # The split_braces() always generates one more element
-        if literals[-1]:
-            result_list.append(builder.load_str(literals[-1]))
-
-        # Special case for empty string and literal string
-        if len(result_list) == 1:
-            return builder.load_str("")
-        if not variables and len(result_list) == 2:
-            return result_list[1]
-
-        result_list[0] = Integer(len(result_list) - 1, c_pyssize_t_rprimitive)
-        return builder.call_c(str_build_op, result_list, expr.line)
+        return join_formatted_strings(builder, literals, variables, expr.line)
     return None
 
 

--- a/mypyc/test-data/fixtures/typing-full.pyi
+++ b/mypyc/test-data/fixtures/typing-full.pyi
@@ -141,6 +141,9 @@ class MutableMapping(Mapping[T, U], metaclass=ABCMeta):
 class SupportsInt(Protocol):
     def __int__(self) -> int: pass
 
+class SupportsFloat(Protocol):
+    def __float__(self) -> float: pass
+
 def runtime_checkable(cls: T) -> T:
     return cls
 

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -244,3 +244,40 @@ L0:
     r23 = 'abc'
     s4 = r23
     return 1
+
+[case testCStyleStringFormatting]
+def f(var: str, num: int) -> None:
+    s1 = "Hi! I'm %s." % var
+    s2 = "I am %d years old." % num
+    s3 = "Hi! I'm %s. I am %d years old." % (var, num)
+    s4 = "Float: %f" % num
+[typing fixtures/typing-full.pyi]
+[out]
+def f(var, num):
+    var :: str
+    num :: int
+    r0, r1, r2, s1, r3, r4, r5, r6, s2, r7, r8, r9, r10, r11, s3, r12 :: str
+    r13, r14 :: object
+    r15, s4 :: str
+L0:
+    r0 = "Hi! I'm "
+    r1 = '.'
+    r2 = CPyStr_Build(3, r0, var, r1)
+    s1 = r2
+    r3 = CPyTagged_Str(num)
+    r4 = 'I am '
+    r5 = ' years old.'
+    r6 = CPyStr_Build(3, r4, r3, r5)
+    s2 = r6
+    r7 = CPyTagged_Str(num)
+    r8 = "Hi! I'm "
+    r9 = '. I am '
+    r10 = ' years old.'
+    r11 = CPyStr_Build(5, r8, var, r9, r7, r10)
+    s3 = r11
+    r12 = 'Float: %f'
+    r13 = box(int, num)
+    r14 = PyNumber_Remainder(r12, r13)
+    r15 = cast(str, r14)
+    s4 = r15
+    return 1

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -150,45 +150,46 @@ def test_str_to_bool() -> None:
         assert not is_false(x)
 
 [case testCStyleStringFormatting]
+[typing fixtures/typing-full.pyi]
 var = 'mypyc'
 num = 20
 
 def test_basics() -> None:
     assert 'Hello %s, this is a test' % var == "Hello mypyc, this is a test"
 
-    # large_num = 2**65
-    # assert 'number: %d' % large_num == 'number: 36893488147419103232'
-    # neg_num = -3
-    # assert 'negative integer: %d' % neg_num == 'negative integer: -3'
-    # assert 'negative integer: %d' % (-large_num) == 'negative integer: -36893488147419103232'
+    large_num = 2**65
+    assert 'number: %d' % large_num == 'number: 36893488147419103232'
+    neg_num = -3
+    assert 'negative integer: %d' % neg_num == 'negative integer: -3'
+    assert 'negative integer: %d' % (-large_num) == 'negative integer: -36893488147419103232'
 
     bool_var1 = True
     bool_var2 = False
-    # assert 'bool: %s, %s' % (bool_var1, bool_var2) == 'bool: True, False'
+    assert 'bool: %s, %s' % (bool_var1, bool_var2) == 'bool: True, False'
 
     float_num = 123.4
-    # assert '%f' % float_num == '123.400000'
-    # assert '%.2f' % float_num == '123.40'
-    # assert '%.5f' % float_num == '123.40000'
-    # assert '%10.2f' % float_num == '    123.40'
-    # assert '%10.5f' % float_num == ' 123.40000'
-    # assert '%010.5f' % float_num == '0123.40000'
-    # assert '%015.5f' % float_num == '000000123.40000'
-    # assert '%e' % float_num == '1.234000e+02'
+    assert '%f' % float_num == '123.400000'
+    assert '%.2f' % float_num == '123.40'
+    assert '%.5f' % float_num == '123.40000'
+    assert '%10.2f' % float_num == '    123.40'
+    assert '%10.5f' % float_num == ' 123.40000'
+    assert '%010.5f' % float_num == '0123.40000'
+    assert '%015.5f' % float_num == '000000123.40000'
+    assert '%e' % float_num == '1.234000e+02'
     large_float = 1.23e30
     large_float2 = 1234123412341234123400000000000000000
     small_float = 1.23e-20
-    # assert '%f, %f, %f' % (small_float, large_float, large_float2) == \
-    #        '0.000000, 1229999999999999959718843908096.000000, 1234123412341234169005079998930878464.000000'
-    # assert '%s, %s, %s' % (small_float, large_float, large_float2) == \
-    #        '1.23e-20, 1.23e+30, 1234123412341234123400000000000000000'
-    # assert '%d, %d, %d' % (small_float, large_float, large_float2) == \
-    #        '0, 1229999999999999959718843908096, 1234123412341234123400000000000000000'
+    assert '%f, %f, %f' % (small_float, large_float, large_float2) == \
+           '0.000000, 1229999999999999959718843908096.000000, 1234123412341234169005079998930878464.000000'
+    assert '%s, %s, %s' % (small_float, large_float, large_float2) == \
+           '1.23e-20, 1.23e+30, 1234123412341234123400000000000000000'
+    assert '%d, %d, %d' % (small_float, large_float, large_float2) == \
+           '0, 1229999999999999959718843908096, 1234123412341234123400000000000000000'
 
     nan_num = float('nan')
     inf_num = float('inf')
     assert '%s, %s' % (nan_num, inf_num) == 'nan, inf'
-    # assert '%f, %f' % (nan_num, inf_num) == 'nan, inf'
+    assert '%f, %f' % (nan_num, inf_num) == 'nan, inf'
 
 [case testFStrings]
 import decimal

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -149,6 +149,47 @@ def test_str_to_bool() -> None:
         assert is_true(x)
         assert not is_false(x)
 
+[case testCStyleStringFormatting]
+var = 'mypyc'
+num = 20
+
+def test_basics() -> None:
+    assert 'Hello %s, this is a test' % var == "Hello mypyc, this is a test"
+
+    # large_num = 2**65
+    # assert 'number: %d' % large_num == 'number: 36893488147419103232'
+    # neg_num = -3
+    # assert 'negative integer: %d' % neg_num == 'negative integer: -3'
+    # assert 'negative integer: %d' % (-large_num) == 'negative integer: -36893488147419103232'
+
+    bool_var1 = True
+    bool_var2 = False
+    # assert 'bool: %s, %s' % (bool_var1, bool_var2) == 'bool: True, False'
+
+    float_num = 123.4
+    # assert '%f' % float_num == '123.400000'
+    # assert '%.2f' % float_num == '123.40'
+    # assert '%.5f' % float_num == '123.40000'
+    # assert '%10.2f' % float_num == '    123.40'
+    # assert '%10.5f' % float_num == ' 123.40000'
+    # assert '%010.5f' % float_num == '0123.40000'
+    # assert '%015.5f' % float_num == '000000123.40000'
+    # assert '%e' % float_num == '1.234000e+02'
+    large_float = 1.23e30
+    large_float2 = 1234123412341234123400000000000000000
+    small_float = 1.23e-20
+    # assert '%f, %f, %f' % (small_float, large_float, large_float2) == \
+    #        '0.000000, 1229999999999999959718843908096.000000, 1234123412341234169005079998930878464.000000'
+    # assert '%s, %s, %s' % (small_float, large_float, large_float2) == \
+    #        '1.23e-20, 1.23e+30, 1234123412341234123400000000000000000'
+    # assert '%d, %d, %d' % (small_float, large_float, large_float2) == \
+    #        '0, 1229999999999999959718843908096, 1234123412341234123400000000000000000'
+
+    nan_num = float('nan')
+    inf_num = float('inf')
+    assert '%s, %s' % (nan_num, inf_num) == 'nan, inf'
+    # assert '%f, %f' % (nan_num, inf_num) == 'nan, inf'
+
 [case testFStrings]
 import decimal
 from datetime import datetime

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -151,11 +151,16 @@ def test_str_to_bool() -> None:
 
 [case testCStyleStringFormatting]
 [typing fixtures/typing-full.pyi]
+from typing import Tuple
+
 var = 'mypyc'
 num = 20
 
 def test_basics() -> None:
     assert 'Hello %s, this is a test' % var == "Hello mypyc, this is a test"
+    assert 'Hello %s %d, this is a test' % (var, num) == "Hello mypyc 20, this is a test"
+    t: Tuple[str, int] = (var, num)
+    assert 'Hello %s %d, this is a test' % t == "Hello mypyc 20, this is a test"
 
     large_num = 2**65
     assert 'number: %d' % large_num == 'number: 36893488147419103232'

--- a/mypyc/test/test_stringformatting.py
+++ b/mypyc/test/test_stringformatting.py
@@ -9,3 +9,8 @@ class TestStringFormatting(unittest.TestCase):
                (["I'm ", ', id years old'], ['%s'])
         assert tokenizer_printf_style("Test: %i%%, Test: %02d, Test: %.2f") == \
                (['Test: ', '', ', Test: ', ', Test: ', ''], ['%i', '%%', '%02d', '%.2f'])
+        assert tokenizer_printf_style("ioasdfyuia%i%%%20s%d%sdafafadfa%s%d%x%E%.2f") == \
+               (['ioasdfyuia', '', '', '', '', 'dafafadfa', '', '', '', '', ''],
+                ['%i', '%%', '%20s', '%d', '%s', '%s', '%d', '%x', '%E', '%.2f'])
+        assert tokenizer_printf_style("Special: %#20.2f%d, test: ") == \
+               (['Special: ', '', ', test: '], ['%#20.2f', '%d'])

--- a/mypyc/test/test_stringformatting.py
+++ b/mypyc/test/test_stringformatting.py
@@ -1,0 +1,11 @@
+import unittest
+
+from mypyc.irbuild.format_str_tokenizer import tokenizer_printf_style
+
+
+class TestStringFormatting(unittest.TestCase):
+    def test_tokenizer_printf_style(self) -> None:
+        assert tokenizer_printf_style("I'm %s, id years old") == \
+               (["I'm ", ', id years old'], ['%s'])
+        assert tokenizer_printf_style("Test: %i%%, Test: %02d, Test: %.2f") == \
+               (['Test: ', '', ', Test: ', ', Test: ', ''], ['%i', '%%', '%02d', '%.2f'])


### PR DESCRIPTION
### Description

We add a special path for %-style string formatting, which previously is compiled by calling a % binary op. 

The `translate_str_format_percent_sign` serves as an interface from `transform_op_expr` to a specializer for string formatting. A regex tokenizer for %-style format string would parse the original strings into two lists, one is literals and the other is formatting operations.

Currently we directly match the `List[str]` with conversions only for %s and %d cases. In the following PRs, `FormatOp` would be used for better code structure.

`join_formatted_strings`, shared with `str.format()`, merges two lists into one final string using `str_build_op` which is much faster than `str.join`.

## Test Plan

This PR adds several run tests and irbuilding tests. 

The performance on microbenchmarks is: 

master branch:
```
running str_format_percent_operator
..........
interpreted: 0.407026s (avg of 5 iterations; stdev 1.9%)
compiled:    0.309361s (avg of 5 iterations; stdev 2.2%)

compiled is 1.316x faster
```

this PR:
```
running str_format_percent_operator
..........
interpreted: 0.385362s (avg of 5 iterations; stdev 0.75%)
compiled:    0.139198s (avg of 5 iterations; stdev 0.39%)

compiled is 2.768x faster
```

