### PR TITLE
Allow redefinition of underscore functions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -334,7 +334,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 and callee_type.implicit):
             self.msg.untyped_function_call(callee_type, e)
 
-        if isinstance(callee_type, CallableType) and callee_type.name == "_":
+        if (isinstance(callee_type, CallableType)
+                and not callee_type.is_type_obj()
+                and callee_type.name == "_"):
             self.msg.underscore_function_call(e)
             return AnyType(TypeOfAny.from_error)
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -333,6 +333,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 isinstance(callee_type, CallableType)
                 and callee_type.implicit):
             self.msg.untyped_function_call(callee_type, e)
+
+        if isinstance(callee_type, CallableType) and callee_type.name == "_":
+            self.msg.underscore_function_call(e)
+            return AnyType(TypeOfAny.from_error)
+
         # Figure out the full name of the callee for plugin lookup.
         object_type = None
         member = None

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -455,7 +455,7 @@ class ASTConverter:
                 elif len(current_overload) > 1:
                     ret.append(OverloadedFuncDef(current_overload))
 
-                if isinstance(stmt, Decorator) and stmt.name != "_":
+                if isinstance(stmt, Decorator):
                     current_overload = [stmt]
                     current_overload_name = stmt.name
                 else:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -455,7 +455,7 @@ class ASTConverter:
                 elif len(current_overload) > 1:
                     ret.append(OverloadedFuncDef(current_overload))
 
-                if isinstance(stmt, Decorator):
+                if isinstance(stmt, Decorator) and stmt.name != "_":
                     current_overload = [stmt]
                     current_overload_name = stmt.name
                 else:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -701,6 +701,9 @@ class MessageBuilder:
         else:
             self.fail('Function does not return a value', context, code=codes.FUNC_RETURNS_VALUE)
 
+    def underscore_function_call(self, context: Context) -> None:
+        self.fail('Calling function named "_" is not allowed', context)
+
     def deleted_as_rvalue(self, typ: DeletedType, context: Context) -> None:
         """Report an error about using an deleted type as an rvalue."""
         if typ.source is None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -812,7 +812,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 else:
                     self.fail("The implementation for an overloaded function "
                               "must come last", defn.items[idx])
-        else:
+        elif defn.name != "_":
             for idx in non_overload_indexes[1:]:
                 self.name_already_defined(defn.name, defn.items[idx], defn.items[0])
             if defn.impl:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -666,6 +666,8 @@ class SemanticAnalyzer(NodeVisitor[None],
         """
         if isinstance(new, Decorator):
             new = new.func
+        if isinstance(previous, (FuncDef, Decorator)) and new.name == previous.name == "_":
+            return True
         if isinstance(previous, (FuncDef, Var, Decorator)) and new.is_conditional:
             new.original_def = previous
             return True

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2751,12 +2751,6 @@ def foo() -> None:
         pass
     _().method()  # E: "_" has no attribute "method"
 
-[case testUnusedTargetNotDef]
-def foo() -> None:
-    def _() -> int:
-        pass
-    _() + ''  # E: Unsupported operand types for + ("int" and "str")
-
 [case testUnusedTargetForLoop]
 def f() -> None:
     a = [(0, '', 0)]

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -559,3 +559,13 @@ def f(arg):
 @dec2
 def _(arg):
     pass
+
+[case testOverwritingImportedFunctionThatWasAliasedAsUnderscore]
+from a import f as _
+
+def _(arg: str) -> str: # E: Name "_" already defined (possibly by an import)
+    return arg
+
+[file a.py]
+def f(s: str) -> str:
+    return s

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -483,3 +483,79 @@ try:
 except Exception as typing:
     pass
 [builtins fixtures/exception.pyi]
+
+[case testRedefiningUnderscoreFunctionIsntAnError]
+def _(arg):
+    pass
+
+def _(arg):
+    pass
+
+[case testTypeErrorsInUnderscoreFunctionsReported]
+def _(arg: str):
+    x = arg + 1 # E: Unsupported left operand type for + ("str")
+
+def _(arg: int) -> int:
+    return 'a' # E: Incompatible return value type (got "str", expected "int")
+
+[case testCallingUnderscoreFunctionIsNotAllowed]
+def _(arg: str) -> None:
+    pass
+
+def _(arg: int) -> int:
+    return arg
+
+_('a') # E: Calling function named "_" is not allowed
+
+y = _(5) # E: Calling function named "_" is not allowed
+
+[case testFunctionStillTypeCheckedWhenAliasedAsUnderscoreDuringImport]
+from a import f as _
+
+_(1) # E: Argument 1 to "f" has incompatible type "int"; expected "str"
+reveal_type(_('a')) # N: Revealed type is "builtins.str"
+
+[file a.py]
+def f(arg: str) -> str:
+    return arg
+
+[case testCallToFunctionStillTypeCheckedWhenAssignedToUnderscoreVariable]
+from a import g
+_ = g
+
+_('a') # E: Argument 1 has incompatible type "str"; expected "int"
+reveal_type(_(1)) # N: Revealed type is "builtins.int"
+
+[file a.py]
+def g(arg: int) -> int:
+    return arg
+
+[case testRedefiningUnderscoreFunctionWithDecoratorWithUnderscoreFunctionsNextToEachOther]
+def dec(f):
+    return f
+
+@dec
+def _(arg):
+    pass
+
+@dec
+def _(arg):
+    pass
+
+[case testRedefiningUnderscoreFunctionWithDecoratorInDifferentPlaces]
+def dec(f):
+    return f
+
+def dec2(f):
+    return f
+
+@dec
+def _(arg):
+    pass
+
+def f(arg):
+    pass
+
+@dec2
+def _(arg):
+    pass

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -16,7 +16,7 @@ fun(1) # E: Argument 1 to "fun" has incompatible type "int"; expected "A"
 # probably won't be required after singledispatch is special cased
 [builtins fixtures/args.pyi]
 
-[case testMultipleUnderscoreFunctionsIsntError-xfail]
+[case testMultipleUnderscoreFunctionsIsntError]
 from functools import singledispatch
 
 @singledispatch


### PR DESCRIPTION
This PR causes mypy to not show an error if a function named `_` is redefined, as a single underscore is often used as a name for a throwaway function.

This handles the case where `_` is used as an alias for `gettext` by differentiating between functions that are aliased as `_` but defined with another name, and functions that are defined as `_`. Overwriting a function named `_` is allowed, but overwriting a function named something else but aliased as `_` is not allowed, which should prevent people from accidentally overwriting `gettext` after importing it.

This also turns calling a function named `_` directly into an error, as currently we keep track of the type of the first definition if there are multiple functions defined as `_`, instead of the type of the last definition, and functions are usually not meant to be called directly if they're named `_`.

## Test Plan

I added several tests to check-redefine.test.