### PR TITLE
Switch from `toml` to `tomli` for TOML v1 support

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,3 +1,2 @@
 -r mypy-requirements.txt
 types-typed-ast>=1.4.0,<1.5.0
-types-toml>=0.0

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
 typing_extensions>=3.7.4
 mypy_extensions>=0.4.3,<0.5.0
 typed_ast>=1.4.0,<1.5.0
-toml
+tomli<2.0.0

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -433,9 +433,9 @@ class FindModuleCache:
         metadata_fnam = os.path.join(stub_dir, 'METADATA.toml')
         if os.path.isfile(metadata_fnam):
             # Delay import for a possible minor performance win.
-            import toml
-            with open(metadata_fnam, 'r') as f:
-                metadata = toml.load(f)
+            import tomli
+            with open(metadata_fnam, 'r', encoding="utf-8") as f:
+                metadata = tomli.load(f)
             if self.python_major_ver == 2:
                 return bool(metadata.get('python2', False))
             else:

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(name='mypy',
       install_requires=["typed_ast >= 1.4.0, < 1.5.0; python_version<'3.8'",
                         'typing_extensions>=3.7.4',
                         'mypy_extensions >= 0.4.3, < 0.5.0',
-                        'toml',
+                        'tomli<2.0.0',
                         ],
       # Same here.
       extras_require={'dmypy': 'psutil >= 4.0', 'python2': 'typed_ast >= 1.4.0, < 1.5.0'},


### PR DESCRIPTION
### Description

There wasn't an issue about this so not sure if this PR is welcome. It was a quick drive-by to make, however, so opened it anyways as a discussion starter. :smile: 

This switches TOML parser from `toml` (TOML v0.5 compatible) to `tomli` (TOML v1 compatible) with the idea that it's nice if mypy is able to read pyproject.toml even if it contains newer TOML syntax. Even if mypy doesn't need that syntax, pyproject.toml is shared by many other tools (often company internal ones that we don't know about) so would be great to not block them.

[A couple other](https://github.com/nedbat/coveragepy/issues/1180) projects also made the switch recently.