### PR TITLE
Fix handling of default arguments in generated glue methods

### DIFF
--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -19,20 +19,24 @@ class RuntimeArg:
     Argument kind is one of ARG_* constants defined in mypy.nodes.
     """
 
-    def __init__(self, name: str, typ: RType, kind: ArgKind = ARG_POS) -> None:
+    def __init__(
+            self, name: str, typ: RType, kind: ArgKind = ARG_POS, pos_only: bool = False) -> None:
         self.name = name
         self.type = typ
         self.kind = kind
+        self.pos_only = pos_only
 
     @property
     def optional(self) -> bool:
         return self.kind.is_optional()
 
     def __repr__(self) -> str:
-        return 'RuntimeArg(name=%s, type=%s, optional=%r)' % (self.name, self.type, self.optional)
+        return 'RuntimeArg(name=%s, type=%s, optional=%r, pos_only=%r)' % (
+            self.name, self.type, self.optional, self.pos_only)
 
     def serialize(self) -> JsonDict:
-        return {'name': self.name, 'type': self.type.serialize(), 'kind': int(self.kind.value)}
+        return {'name': self.name, 'type': self.type.serialize(), 'kind': int(self.kind.value),
+                'pos_only': self.pos_only}
 
     @classmethod
     def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> 'RuntimeArg':
@@ -40,6 +44,7 @@ class RuntimeArg:
             data['name'],
             deserialize_type(data['type'], ctx),
             ArgKind(data['kind']),
+            data['pos_only'],
         )
 
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -9,12 +9,12 @@ level---it has *no knowledge* of mypy types or expressions.
 """
 
 from typing import (
-    Callable, List, Tuple, Optional, Union, Sequence, cast
+    Callable, List, Tuple, Optional, Sequence
 )
 
 from typing_extensions import Final
 
-from mypy.nodes import ArgKind, ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2
+from mypy.nodes import ArgKind, ARG_POS, ARG_STAR, ARG_STAR2
 from mypy.operators import op_methods
 from mypy.types import AnyType, TypeOfAny
 from mypy.checkexpr import map_actuals_to_formals
@@ -73,6 +73,7 @@ from mypyc.subtype import is_subtype
 from mypyc.sametype import is_same_type
 from mypyc.irbuild.mapper import Mapper
 from mypyc.options import CompilerOptions
+from mypyc.irbuild.util import concrete_arg_kind
 
 
 DictEntry = Tuple[Optional[Value], Value]
@@ -178,6 +179,34 @@ class LowLevelIRBuilder:
             return tmp
         return src
 
+    def coerce_nullable(self, src: Value, target_type: RType, line: int) -> Value:
+        """Generate a coercion from a potentially null value."""
+        if (
+            src.type.is_unboxed == target_type.is_unboxed
+            and (
+                (target_type.is_unboxed and is_runtime_subtype(src.type, target_type))
+                or (not target_type.is_unboxed and is_subtype(src.type, target_type))
+            )
+        ):
+            return src
+
+        target = Register(target_type)
+
+        valid, invalid, out = BasicBlock(), BasicBlock(), BasicBlock()
+        self.add(Branch(src, invalid, valid, Branch.IS_ERROR))
+
+        self.activate_block(valid)
+        coerced = self.coerce(src, target_type, line)
+        self.add(Assign(target, coerced, line))
+        self.goto(out)
+
+        self.activate_block(invalid)
+        error = self.add(LoadErrorValue(target_type))
+        self.add(Assign(target, error, line))
+
+        self.goto_and_activate(out)
+        return target
+
     # Attribute access
 
     def get_attr(self, obj: Value, attr: str, result_type: RType, line: int) -> Value:
@@ -255,6 +284,190 @@ class LowLevelIRBuilder:
 
     # Calls
 
+    def _construct_varargs(self,
+                           args: Sequence[Tuple[Value, ArgKind, Optional[str]]],
+                           line: int,
+                           *,
+                           has_star: bool,
+                           has_star2: bool) -> Tuple[Optional[Value], Optional[Value]]:
+        """Construct *args and **kwargs from a collection of arguments
+
+        This is pretty complicated, and almost all of the complication here stems from
+        one of two things (but mostly the second):
+          * The handling of ARG_STAR/ARG_STAR2. We want to create as much of the args/kwargs
+            values in one go as we can, so we collect values until our hand is forced, and
+            then we emit creation of the list/tuple, and expand it from there if needed.
+
+          * Support potentially nullable argument values. This has very narrow applicability,
+            as this will never be done by our compiled Python code, but is critically used
+            by gen_glue_method when generating glue methods to mediate between the function
+            signature of a parent class and its subclasses.
+
+            For named-only arguments, this is quite simple: if it is
+            null, don't put it in the dict.
+
+            For positional-or-named arguments, things are much more complicated.
+              * First, anything that was passed as a positional arg
+                must be forwarded along as a positional arg. It *must
+                not* be converted to a named arg. This is because mypy
+                does not enforce that positional-or-named arguments
+                have the same name in subclasses, and it is not
+                uncommon for code to have different names in
+                subclasses (a bunch of mypy's visitors do this, for
+                example!). This is arguably a bug in both mypy and code doing
+                this, and they ought to be using positional-only arguments, but
+                positional-only arguments are new and ugly.
+
+              * On the flip side, we're willing to accept the
+                infelicity of sometimes turning an argument that was
+                passed by keyword into a positional argument. It's wrong,
+                but it's very marginal, and avoiding it would require passing
+                a bitmask of which arguments were named with every function call,
+                or something similar.
+                (See some discussion of this in testComplicatedArgs)
+
+            Thus, our strategy for positional-or-named arguments is to
+            always pass them as positional, except in the one
+            situation where we can not, and where we can be absolutely
+            sure they were passed by name: when an *earlier*
+            positional argument was missing its value.
+
+            This means that if we have a method `f(self, x: int=..., y: object=...)`:
+              * x and y present:      args=(x, y), kwargs={}
+              * x present, y missing: args=(x,),   kwargs={}
+              * x missing, y present: args=(),     kwargs={'y': y}
+
+            To implement this, when we have multiple optional
+            positional arguments, we maintain a flag in a register
+            that tracks whether an argument has been missing, and for
+            each such optional argument (except the first), we check
+            the flag to determine whether to append the argument to
+            the *args list or add it to the **kwargs dict. What a
+            mess!
+
+            This is what really makes everything here such a tangle;
+            otherwise the *args and **kwargs code could be separated.
+        """
+
+        star_result: Optional[Value] = None
+        star2_result: Optional[Value] = None
+        # We aggregate values that need to go into *args and **kwargs
+        # in these lists. Once all arguments are processed (in the
+        # happiest case), or we encounter an ARG_STAR/ARG_STAR2 or a
+        # nullable arg, then we create the list and/or dict.
+        star_values: List[Value] = []
+        star2_keys: List[Value] = []
+        star2_values: List[Value] = []
+
+        seen_empty_reg: Optional[Register] = None
+
+        for value, kind, name in args:
+            if kind == ARG_STAR:
+                if star_result is None:
+                    star_result = self.new_list_op(star_values, line)
+                self.call_c(list_extend_op, [star_result, value], line)
+            elif kind == ARG_STAR2:
+                if star2_result is None:
+                    star2_result = self._create_dict(star2_keys, star2_values, line)
+
+                self.call_c(
+                    dict_update_in_display_op,
+                    [star2_result, value],
+                    line=line
+                )
+            else:
+                nullable = kind.is_optional()
+                maybe_pos = kind.is_positional() and has_star
+                maybe_named = kind.is_named() or (kind.is_optional() and name and has_star2)
+
+                # If the argument is nullable, we need to create the
+                # relevant args/kwargs objects so that we can
+                # conditionally modify them.
+                if nullable:
+                    if maybe_pos and star_result is None:
+                        star_result = self.new_list_op(star_values, line)
+                    if maybe_named and star2_result is None:
+                        star2_result = self._create_dict(star2_keys, star2_values, line)
+
+                # Easy cases: just collect the argument.
+                if maybe_pos and star_result is None:
+                    star_values.append(value)
+                    continue
+
+                if maybe_named and star2_result is None:
+                    assert name is not None
+                    key = self.load_str(name)
+                    star2_keys.append(key)
+                    star2_values.append(value)
+                    continue
+
+                # OK, anything that is nullable or *after* a nullable arg needs to be here
+                # TODO: We could try harder to avoid creating basic blocks in the common case
+                new_seen_empty_reg = seen_empty_reg
+
+                out = BasicBlock()
+                if nullable:
+                    # If this is the first nullable positional arg we've seen, create
+                    # a register to track whether anything has been null.
+                    # (We won't *check* the register until the next argument, though.)
+                    if maybe_pos and not seen_empty_reg:
+                        new_seen_empty_reg = Register(bool_rprimitive)
+                        self.add(Assign(new_seen_empty_reg, self.false(), line))
+
+                    skip = BasicBlock() if maybe_pos else out
+                    keep = BasicBlock()
+                    self.add(Branch(value, skip, keep, Branch.IS_ERROR))
+                    self.activate_block(keep)
+
+                # If this could be positional or named and we /might/ have seen a missing
+                # positional arg, then we need to compile *both* a positional and named
+                # version! What a pain!
+                if maybe_pos and maybe_named and seen_empty_reg:
+                    pos_block, named_block = BasicBlock(), BasicBlock()
+                    self.add(Branch(seen_empty_reg, named_block, pos_block, Branch.BOOL))
+                else:
+                    pos_block = named_block = BasicBlock()
+                    self.goto(pos_block)
+
+                if maybe_pos:
+                    self.activate_block(pos_block)
+                    assert star_result
+                    self.translate_special_method_call(
+                        star_result, 'append', [value], result_type=None, line=line)
+                    self.goto(out)
+
+                if maybe_named and (not maybe_pos or seen_empty_reg):
+                    self.activate_block(named_block)
+                    assert name is not None
+                    key = self.load_str(name)
+                    assert star2_result
+                    self.translate_special_method_call(
+                        star2_result, '__setitem__', [key, value], result_type=None, line=line)
+                    self.goto(out)
+
+                if nullable and maybe_pos and new_seen_empty_reg:
+                    assert skip is not out
+                    self.activate_block(skip)
+                    self.add(Assign(new_seen_empty_reg, self.true(), line))
+                    self.goto(out)
+
+                self.activate_block(out)
+
+                seen_empty_reg = new_seen_empty_reg
+
+        if has_star:
+            # If we managed to make it this far without creating a
+            # *args list, then we can directly create a
+            # tuple. Otherwise create the tuple from the list.
+            if star_result is None:
+                star_result = self.new_tuple(star_values, line)
+            else:
+                star_result = self.call_c(list_tuple_op, [star_result], line)
+        if has_star2 and star2_result is None:
+            star2_result = self._create_dict(star2_keys, star2_values, line)
+
+        return star_result, star2_result
+
     def py_call(self,
                 function: Value,
                 arg_values: List[Value],
@@ -278,37 +491,10 @@ class LowLevelIRBuilder:
         # Otherwise fallback to py_call_with_kwargs_op.
         assert arg_names is not None
 
-        pos_arg_values = []
-        kw_arg_key_value_pairs: List[DictEntry] = []
-        star_arg_values = []
-        for value, kind, name in zip(arg_values, arg_kinds, arg_names):
-            if kind == ARG_POS:
-                pos_arg_values.append(value)
-            elif kind == ARG_NAMED:
-                assert name is not None
-                key = self.load_str(name)
-                kw_arg_key_value_pairs.append((key, value))
-            elif kind == ARG_STAR:
-                star_arg_values.append(value)
-            elif kind == ARG_STAR2:
-                # NOTE: mypy currently only supports a single ** arg, but python supports multiple.
-                # This code supports multiple primarily to make the logic easier to follow.
-                kw_arg_key_value_pairs.append((None, value))
-            else:
-                assert False, ("Argument kind should not be possible:", kind)
-
-        if len(star_arg_values) == 0:
-            # We can directly construct a tuple if there are no star args.
-            pos_args_tuple = self.new_tuple(pos_arg_values, line)
-        else:
-            # Otherwise we construct a list and call extend it with the star args, since tuples
-            # don't have an extend method.
-            pos_args_list = self.new_list_op(pos_arg_values, line)
-            for star_arg_value in star_arg_values:
-                self.call_c(list_extend_op, [pos_args_list, star_arg_value], line)
-            pos_args_tuple = self.call_c(list_tuple_op, [pos_args_list], line)
-
-        kw_args_dict = self.make_dict(kw_arg_key_value_pairs, line)
+        pos_args_tuple, kw_args_dict = self._construct_varargs(
+            list(zip(arg_values, arg_kinds, arg_names)), line, has_star=True, has_star2=True
+        )
+        assert pos_args_tuple and kw_args_dict
 
         return self.call_c(
             py_call_with_kwargs_op, [function, pos_args_tuple, kw_args_dict], line)
@@ -324,8 +510,9 @@ class LowLevelIRBuilder:
         Return the return value if successful. Return None if a non-vectorcall
         API should be used instead.
         """
-        # We can do this if all args are positional or named (no *args or **kwargs).
-        if arg_kinds is None or all(not kind.is_star() for kind in arg_kinds):
+        # We can do this if all args are positional or named (no *args or **kwargs, not optional).
+        if arg_kinds is None or all(not kind.is_star() and not kind.is_optional()
+                                    for kind in arg_kinds):
             if arg_values:
                 # Create a C array containing all arguments as boxed values.
                 array = Register(RArray(object_rprimitive, len(arg_values)))
@@ -396,7 +583,8 @@ class LowLevelIRBuilder:
         Return the return value if successful. Return None if a non-vectorcall
         API should be used instead.
         """
-        if arg_kinds is None or all(not kind.is_star() for kind in arg_kinds):
+        if arg_kinds is None or all(not kind.is_star() and not kind.is_optional()
+                                    for kind in arg_kinds):
             method_name_reg = self.load_str(method_name)
             array = Register(RArray(object_rprimitive, len(arg_values) + 1))
             self_arg = self.coerce(obj, object_rprimitive, line)
@@ -449,11 +637,26 @@ class LowLevelIRBuilder:
 
         sig_arg_kinds = [arg.kind for arg in sig.args]
         sig_arg_names = [arg.name for arg in sig.args]
-        formal_to_actual = map_actuals_to_formals(arg_kinds,
+        concrete_kinds = [concrete_arg_kind(arg_kind) for arg_kind in arg_kinds]
+        formal_to_actual = map_actuals_to_formals(concrete_kinds,
                                                   arg_names,
                                                   sig_arg_kinds,
                                                   sig_arg_names,
                                                   lambda n: AnyType(TypeOfAny.special_form))
+
+        # First scan for */** and construct those
+        has_star = has_star2 = False
+        star_arg_entries = []
+        for lst, arg in zip(formal_to_actual, sig.args):
+            if arg.kind.is_star():
+                for i in lst:
+                    star_arg_entries.append((args[i], arg_kinds[i], arg_names[i]))
+            has_star = has_star or arg.kind == ARG_STAR
+            has_star2 = has_star2 or arg.kind == ARG_STAR2
+
+        star_arg, star2_arg = self._construct_varargs(
+            star_arg_entries, line, has_star=has_star, has_star2=has_star2
+        )
 
         # Flatten out the arguments, loading error values for default
         # arguments, constructing tuples/dicts for star args, and
@@ -462,17 +665,22 @@ class LowLevelIRBuilder:
         for lst, arg in zip(formal_to_actual, sig.args):
             output_arg = None
             if arg.kind == ARG_STAR:
-                items = [args[i] for i in lst]
-                output_arg = self.new_tuple(items, line)
+                assert star_arg
+                output_arg = star_arg
             elif arg.kind == ARG_STAR2:
-                dict_entries = [(self.load_str(cast(str, arg_names[i])), args[i])
-                                for i in lst]
-                output_arg = self.make_dict(dict_entries, line)
+                assert star2_arg
+                output_arg = star2_arg
             elif not lst:
                 output_arg = self.add(LoadErrorValue(arg.type, is_borrowed=True))
             else:
-                output_arg = args[lst[0]]
-            output_args.append(self.coerce(output_arg, arg.type, line))
+                base_arg = args[lst[0]]
+
+                if arg_kinds[lst[0]].is_optional():
+                    output_arg = self.coerce_nullable(base_arg, arg.type, line)
+                else:
+                    output_arg = self.coerce(base_arg, arg.type, line)
+
+            output_args.append(output_arg)
 
         return output_args
 
@@ -619,11 +827,7 @@ class LowLevelIRBuilder:
         return self.add(LoadStatic(object_rprimitive, name, module, NAMESPACE_TYPE))
 
     # Other primitive operations
-    def binary_op(self,
-                  lreg: Value,
-                  rreg: Value,
-                  op: str,
-                  line: int) -> Value:
+    def binary_op(self, lreg: Value, rreg: Value, op: str, line: int) -> Value:
         ltype = lreg.type
         rtype = rreg.type
 
@@ -879,7 +1083,7 @@ class LowLevelIRBuilder:
         return target
 
     def make_dict(self, key_value_pairs: Sequence[DictEntry], line: int) -> Value:
-        result: Union[Value, None] = None
+        result: Optional[Value] = None
         keys: List[Value] = []
         values: List[Value] = []
         for key, value in key_value_pairs:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -347,6 +347,11 @@ class LowLevelIRBuilder:
 
             This is what really makes everything here such a tangle;
             otherwise the *args and **kwargs code could be separated.
+
+        The arguments has_star and has_star2 indicate whether the target function
+        takes an ARG_STAR and ARG_STAR2 argument, respectively.
+        (These will always be true when making a pycall, and be based
+        on the actual target signature for a native call.)
         """
 
         star_result: Optional[Value] = None
@@ -455,6 +460,8 @@ class LowLevelIRBuilder:
 
                 seen_empty_reg = new_seen_empty_reg
 
+        assert not (star_result or star_values) or has_star
+        assert not (star2_result or star2_values) or has_star2
         if has_star:
             # If we managed to make it this far without creating a
             # *args list, then we can directly create a
@@ -649,8 +656,7 @@ class LowLevelIRBuilder:
         star_arg_entries = []
         for lst, arg in zip(formal_to_actual, sig.args):
             if arg.kind.is_star():
-                for i in lst:
-                    star_arg_entries.append((args[i], arg_kinds[i], arg_names[i]))
+                star_arg_entries.extend((args[i], arg_kinds[i], arg_names[i]) for i in lst)
             has_star = has_star or arg.kind == ARG_STAR
             has_star2 = has_star2 or arg.kind == ARG_STAR2
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -656,7 +656,7 @@ class LowLevelIRBuilder:
         star_arg_entries = []
         for lst, arg in zip(formal_to_actual, sig.args):
             if arg.kind.is_star():
-                star_arg_entries.extend((args[i], arg_kinds[i], arg_names[i]) for i in lst)
+                star_arg_entries.extend([(args[i], arg_kinds[i], arg_names[i]) for i in lst])
             has_star = has_star or arg.kind == ARG_STAR
             has_star2 = has_star2 or arg.kind == ARG_STAR2
 

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -122,10 +122,12 @@ class Mapper:
         if isinstance(fdef.type, CallableType):
             arg_types = [self.get_arg_rtype(typ, kind)
                          for typ, kind in zip(fdef.type.arg_types, fdef.type.arg_kinds)]
+            arg_pos_onlys = [name is None for name in fdef.type.arg_names]
             ret = self.type_to_rtype(fdef.type.ret_type)
         else:
             # Handle unannotated functions
             arg_types = [object_rprimitive for arg in fdef.arguments]
+            arg_pos_onlys = [arg.pos_only for arg in fdef.arguments]
             # We at least know the return type for __init__ methods will be None.
             is_init_method = fdef.name == '__init__' and bool(fdef.info)
             if is_init_method:
@@ -146,8 +148,9 @@ class Mapper:
         else:
             arg_names = [name or '' for name in fdef.arg_names]
 
-        args = [RuntimeArg(arg_name, arg_type, arg_kind)
-                for arg_name, arg_kind, arg_type in zip(arg_names, fdef.arg_kinds, arg_types)]
+        args = [RuntimeArg(arg_name, arg_type, arg_kind, arg_pos_only)
+                for arg_name, arg_kind, arg_type, arg_pos_only
+                in zip(arg_names, fdef.arg_kinds, arg_types, arg_pos_onlys)]
 
         # We force certain dunder methods to return objects to support letting them
         # return NotImplemented. It also avoids some pointless boxing and unboxing,

--- a/mypyc/test-data/fixtures/testutil.py
+++ b/mypyc/test-data/fixtures/testutil.py
@@ -1,7 +1,10 @@
 # Simple support library for our run tests.
 
 from contextlib import contextmanager
-from typing import Iterator, TypeVar, Generator, Optional, List, Tuple, Sequence, Union
+from typing import (
+    Any, Iterator, TypeVar, Generator, Optional, List, Tuple, Sequence,
+    Union, Callable,
+)
 
 @contextmanager
 def assertRaises(typ: type, msg: str = '') -> Iterator[None]:
@@ -37,3 +40,13 @@ def run_generator(gen: Generator[T, V, U],
             print(val)
         res.append(val)
         i += 1
+
+F = TypeVar('F', bound=Callable)
+
+
+# Wrap a mypyc-generated function in a real python function, to allow it to be
+# stuck into classes and the like.
+def make_python_function(f: F) -> F:
+    def g(*args: Any, **kwargs: Any) -> Any:
+        return f(*args, **kwargs)
+    return g  # type: ignore

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1748,10 +1748,10 @@ def g():
     r6, r7 :: dict
     r8 :: str
     r9 :: object
-    r10 :: tuple
-    r11 :: dict
-    r12 :: int32
-    r13 :: bit
+    r10 :: dict
+    r11 :: int32
+    r12 :: bit
+    r13 :: tuple
     r14 :: object
     r15 :: tuple[int, int, int]
 L0:
@@ -1765,11 +1765,11 @@ L0:
     r7 = __main__.globals :: static
     r8 = 'f'
     r9 = CPyDict_GetItem(r7, r8)
-    r10 = PyTuple_Pack(0)
-    r11 = PyDict_New()
-    r12 = CPyDict_UpdateInDisplay(r11, r6)
-    r13 = r12 >= 0 :: signed
-    r14 = PyObject_Call(r9, r10, r11)
+    r10 = PyDict_New()
+    r11 = CPyDict_UpdateInDisplay(r10, r6)
+    r12 = r11 >= 0 :: signed
+    r13 = PyTuple_Pack(0)
+    r14 = PyObject_Call(r9, r13, r10)
     r15 = unbox(tuple[int, int, int], r14)
     return r15
 def h():
@@ -1777,11 +1777,12 @@ def h():
     r2, r3 :: object
     r4, r5 :: dict
     r6 :: str
-    r7, r8 :: object
-    r9 :: tuple
-    r10 :: dict
-    r11 :: int32
-    r12 :: bit
+    r7 :: object
+    r8 :: dict
+    r9 :: int32
+    r10 :: bit
+    r11 :: object
+    r12 :: tuple
     r13 :: object
     r14 :: tuple[int, int, int]
 L0:
@@ -1793,12 +1794,12 @@ L0:
     r5 = __main__.globals :: static
     r6 = 'f'
     r7 = CPyDict_GetItem(r5, r6)
-    r8 = box(short_int, 2)
-    r9 = PyTuple_Pack(1, r8)
-    r10 = PyDict_New()
-    r11 = CPyDict_UpdateInDisplay(r10, r4)
-    r12 = r11 >= 0 :: signed
-    r13 = PyObject_Call(r7, r9, r10)
+    r8 = PyDict_New()
+    r9 = CPyDict_UpdateInDisplay(r8, r4)
+    r10 = r9 >= 0 :: signed
+    r11 = box(short_int, 2)
+    r12 = PyTuple_Pack(1, r11)
+    r13 = PyObject_Call(r7, r12, r8)
     r14 = unbox(tuple[int, int, int], r13)
     return r14
 

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -997,11 +997,11 @@ b(B())
 
 [case testMethodOverrideDefault2]
 class A:
-    def foo(self, *, x: int = 0) -> None:
+    def foo(self, *, x: int = -1) -> None:
         pass
-    def bar(self, *, x: int = 0, y: int = 0) -> None:
+    def bar(self, *, x: int = -1, y: int = -1) -> None:
         pass
-    def baz(self, x: int = 0) -> None:
+    def baz(self, x: int = -1) -> None:
         pass
 class B(A):
     def foo(self, *, y: int = 0, x: int = 0) -> None:
@@ -1079,6 +1079,146 @@ a(B())
 B
 1 0
 10
+
+[case testMethodOverrideDefault4]
+class Foo:
+    def f(self, x: int=20, *, z: int=10) -> None:
+        pass
+
+class Bar(Foo):
+    def f(self, *args: int, **kwargs: int) -> None:
+        print("stuff", args, kwargs)
+
+z: Foo = Bar()
+z.f(1, z=50)
+z.f()
+
+[out]
+stuff (1,) {'z': 50}
+stuff () {}
+
+[case testMethodOverrideDefault5]
+from testutil import make_python_function
+from mypy_extensions import mypyc_attr
+from typing import TypeVar, Any
+
+@mypyc_attr(allow_interpreted_subclasses=True)
+class Foo:
+    def f(self, x: int=20, *, z: int=10) -> None:
+        print("Foo", x, z)
+
+@make_python_function
+def baz_f(self: Any, *args: int, **kwargs: int) -> None:
+    print("Baz", args, kwargs)
+
+# Make an "interpreted" subtype of Foo
+type2: Any = type
+Bar = type2('Bar', (Foo,), {})
+Baz = type2('Baz', (Foo,), {'f': baz_f})
+
+y: Foo = Bar()
+y.f(1, z=2)
+y.f()
+
+z: Foo = Baz()
+z.f(1, z=2)
+z.f()
+
+[out]
+Foo 1 2
+Foo 20 10
+Baz (1,) {'z': 2}
+Baz () {}
+
+[case testMethodOverrideDefault6]
+from typing import Optional
+
+class Foo:
+    def f(self, x: int=20) -> None:
+        pass
+
+class Bar(Foo):
+    def f(self, x: Optional[int]=None) -> None:
+        print(x)
+
+z: Foo = Bar()
+z.f(1)
+z.f()
+
+[out]
+1
+None
+
+[case testMethodOverrideDefault7]
+from typing import TypeVar, Any
+
+class Foo:
+    def f(self, x: int, *args: int, **kwargs: int) -> None:
+        print("Foo", x, args, kwargs)
+
+class Bar(Foo):
+    def f(self, *args: int, **kwargs: int) -> None:
+        print("Bar", args, kwargs)
+
+z: Foo = Bar()
+z.f(1, z=2)
+z.f(1, 2, 3)
+
+[out]
+Bar (1,) {'z': 2}
+Bar (1, 2, 3) {}
+
+[case testMethodOverrideDefault8]
+from typing import TypeVar, Any
+
+class Foo:
+    def f(self, *args: int, **kwargs: int) -> None:
+        print("Foo", args, kwargs)
+
+class Bar(Foo):
+    def f(self, x: int = 10, *args: int, **kwargs: int) -> None:
+        print("Bar", x, args, kwargs)
+
+z: Foo = Bar()
+z.f(1, z=2)
+z.f(1, 2, 3)
+z.f()
+
+[out]
+Bar 1 () {'z': 2}
+Bar 1 (2, 3) {}
+Bar 10 () {}
+
+[case testMethodOverrideDefault9]
+from testutil import make_python_function
+from mypy_extensions import mypyc_attr
+from typing import TypeVar, Any
+
+@mypyc_attr(allow_interpreted_subclasses=True)
+class Foo:
+    def f(self, x: int=20, y: int=40) -> None:
+        print("Foo", x, y)
+
+# This sort of argument renaming is dodgy and not really sound but we
+# shouldn't break it when they aren't actually used by name...
+# (They *ought* to be positional only!)
+@make_python_function
+def baz_f(self, a: int=30, y: int=50) -> None:
+    print("Baz", a, y)
+
+# Make an "interpreted" subtype of Foo
+type2: Any = type
+Baz = type2('Baz', (Foo,), {'f': baz_f})
+
+z: Foo = Baz()
+z.f()
+z.f(y=1)
+z.f(1, 2)
+
+[out]
+Baz 30 50
+Baz 30 1
+Baz 1 2
 
 [case testOverride]
 class A:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -1163,10 +1163,12 @@ class Bar(Foo):
 z: Foo = Bar()
 z.f(1, z=2)
 z.f(1, 2, 3)
+# z.f(x=5)  # Not tested because we (knowingly) do the wrong thing and pass it as positional
 
 [out]
 Bar (1,) {'z': 2}
 Bar (1, 2, 3) {}
+--Bar () {'x': 5}
 
 [case testMethodOverrideDefault8]
 from typing import TypeVar, Any
@@ -1214,6 +1216,10 @@ z: Foo = Baz()
 z.f()
 z.f(y=1)
 z.f(1, 2)
+# Not tested because we don't (and probably won't) match cpython here
+# from testutil import assertRaises
+# with assertRaises(TypeError):
+#     z.f(x=7)
 
 [out]
 Baz 30 50

--- a/mypyc/test-data/run-functions.test
+++ b/mypyc/test-data/run-functions.test
@@ -1092,6 +1092,7 @@ assert kwonly4(y=2, x=1) == (1, 2)
 # varargs tests
 assert varargs1() == ()
 assert varargs1(1, 2, 3) == (1, 2, 3)
+assert varargs1(1, *[2, 3, 4], 5, *[6, 7, 8], 9) == (1, 2, 3, 4, 5, 6, 7, 8, 9)
 assert varargs2(1, 2, 3) == ((1, 2, 3), {})
 assert varargs2(1, 2, 3, x=4) == ((1, 2, 3), {'x': 4})
 assert varargs2(x=4) == ((), {'x': 4})

--- a/mypyc/test-data/run-python38.test
+++ b/mypyc/test-data/run-python38.test
@@ -78,7 +78,11 @@ class Bar(Foo):
 z: Foo = Bar()
 z.f(1, z=50)
 z.f()
+z.f(1)
+z.f(z=50)
 
 [out]
 stuff (1,) {'z': 50}
 stuff () {}
+stuff (1,) {}
+stuff () {'z': 50}

--- a/mypyc/test-data/run-python38.test
+++ b/mypyc/test-data/run-python38.test
@@ -65,3 +65,20 @@ def test_fstring_equal_sign() -> None:
     assert f"{line = }" == 'line = "The mill\'s closed"'
     assert f"{line = :20}" == "line = The mill's closed   "
     assert f"{line = !r:20}" == 'line = "The mill\'s closed" '
+
+[case testMethodOverrideDefaultPosOnly1]
+class Foo:
+    def f(self, x: int=20, /, *, z: int=10) -> None:
+        pass
+
+class Bar(Foo):
+    def f(self, *args: int, **kwargs: int) -> None:
+        print("stuff", args, kwargs)
+
+z: Foo = Bar()
+z.f(1, z=50)
+z.f()
+
+[out]
+stuff (1,) {'z': 50}
+stuff () {}

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -371,7 +371,7 @@ def test_singledispatch():
     assert f(5)
     assert not f('a')
 
-[case testKeywordArguments-xfail]
+[case testKeywordArguments]
 from functools import singledispatch
 
 @singledispatch


### PR DESCRIPTION
Currently these mostly segfault.

The main tricky case here is with *args and **kwargs (which we need to
deal with always when generating pycall glue and also when a native
function takes them), though we also need to take care to coerce error
values when forwarding optional arguments.

I also accidentally fixed a bug where we would compile `f(a, *b, c)`
as `f(a, c, *b)`.
