### PR TITLE
stubgen: Handle commas in namedtuple field definition

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -926,7 +926,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         if self._state != EMPTY:
             self.add('\n')
         if isinstance(rvalue.args[1], StrExpr):
-            items = rvalue.args[1].value.split(" ")
+            items = rvalue.args[1].value.replace(',', ' ').split()
         elif isinstance(rvalue.args[1], (ListExpr, TupleExpr)):
             list_items = cast(List[StrExpr], rvalue.args[1].items)
             items = [item.value for item in list_items]

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -605,6 +605,17 @@ class X(NamedTuple):
     a: Any
     b: Any
 
+[case testNamedtupleAltSyntaxUsingMultipleCommas]
+from collections import namedtuple, xx
+X = namedtuple('X', 'a,,   b')
+xx
+[out]
+from typing import Any, NamedTuple
+
+class X(NamedTuple):
+    a: Any
+    b: Any
+
 [case testNamedtupleWithUnderscore]
 from collections import namedtuple as _namedtuple
 def f(): ...

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -594,6 +594,17 @@ class X(NamedTuple):
     a: Any
     b: Any
 
+[case testNamedtupleAltSyntaxUsingComma]
+from collections import namedtuple, xx
+X = namedtuple('X', 'a,    b')
+xx
+[out]
+from typing import Any, NamedTuple
+
+class X(NamedTuple):
+    a: Any
+    b: Any
+
 [case testNamedtupleWithUnderscore]
 from collections import namedtuple as _namedtuple
 def f(): ...


### PR DESCRIPTION
### Description

`namedtuple` accepts field names defined with a combination of comma and spaces ([docs](https://docs.python.org/3/library/collections.html#collections.namedtuple)/[source](https://github.com/python/cpython/blob/919ad537510fdc2c750109e0bc4eceea234324b2/Lib/collections/__init__.py#L355)); update stubgen to handle this case in the same way as the source.

## Test Plan

Added a test for this case.