### PR TITLE
[mypyc] Add support for underscore functions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1,5 +1,6 @@
 """Expression type checker. This file is conceptually part of TypeChecker."""
 
+from mypy.util import unnamed_function
 from mypy.backports import OrderedDict, nullcontext
 from contextlib import contextmanager
 import itertools
@@ -336,7 +337,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         if (isinstance(callee_type, CallableType)
                 and not callee_type.is_type_obj()
-                and callee_type.name == "_"):
+                and unnamed_function(callee_type.name)):
             self.msg.underscore_function_call(e)
             return AnyType(TypeOfAny.from_error)
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -455,7 +455,12 @@ class ASTConverter:
                 elif len(current_overload) > 1:
                     ret.append(OverloadedFuncDef(current_overload))
 
-                if isinstance(stmt, Decorator):
+                # If we have multiple decorated functions named "_" next to each, we want to treat
+                # them as a series of regular FuncDefs instead of one OverloadedFuncDef because
+                # most of mypy/mypyc assumes that all the functions in an OverloadedFuncDef are
+                # related, but multiple underscore functions next to each other aren't necessarily
+                # related
+                if isinstance(stmt, Decorator) and stmt.name != "_":
                     current_overload = [stmt]
                     current_overload_name = stmt.name
                 else:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1,3 +1,4 @@
+from mypy.util import unnamed_function
 import re
 import sys
 import warnings
@@ -460,7 +461,7 @@ class ASTConverter:
                 # most of mypy/mypyc assumes that all the functions in an OverloadedFuncDef are
                 # related, but multiple underscore functions next to each other aren't necessarily
                 # related
-                if isinstance(stmt, Decorator) and stmt.name != "_":
+                if isinstance(stmt, Decorator) and not unnamed_function(stmt.name):
                     current_overload = [stmt]
                     current_overload_name = stmt.name
                 else:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -313,7 +313,7 @@ class ASTConverter:
                 elif len(current_overload) > 1:
                     ret.append(OverloadedFuncDef(current_overload))
 
-                if isinstance(stmt, Decorator):
+                if isinstance(stmt, Decorator) and stmt.name != "_":
                     current_overload = [stmt]
                     current_overload_name = stmt.name
                 else:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -14,6 +14,7 @@ of redundancy is because the Python 2 AST and the Python 3 AST nodes belong to t
 different class hierarchies, which made it difficult to write a shared visitor between the
 two in a typesafe way.
 """
+from mypy.util import unnamed_function
 import sys
 import warnings
 
@@ -313,7 +314,7 @@ class ASTConverter:
                 elif len(current_overload) > 1:
                     ret.append(OverloadedFuncDef(current_overload))
 
-                if isinstance(stmt, Decorator) and stmt.name != "_":
+                if isinstance(stmt, Decorator) and not unnamed_function(stmt.name):
                     current_overload = [stmt]
                     current_overload_name = stmt.name
                 else:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1,5 +1,6 @@
 """Abstract syntax tree node classes (i.e. parse tree)."""
 
+from mypyc.common import get_id_from_name
 import os
 from enum import Enum
 from abc import abstractmethod
@@ -688,6 +689,11 @@ class FuncDef(FuncItem, SymbolNode, Statement):
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def id(self) -> str:
+        assert isinstance(self.fullname, str)
+        return get_id_from_name(self.name, self.fullname, self.line)
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_func_def(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1,6 +1,5 @@
 """Abstract syntax tree node classes (i.e. parse tree)."""
 
-from mypyc.common import get_id_from_name
 import os
 from enum import Enum
 from abc import abstractmethod
@@ -689,11 +688,6 @@ class FuncDef(FuncItem, SymbolNode, Statement):
     @property
     def name(self) -> str:
         return self._name
-
-    @property
-    def id(self) -> str:
-        assert isinstance(self.fullname, str)
-        return get_id_from_name(self.name, self.fullname, self.line)
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_func_def(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -812,7 +812,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 else:
                     self.fail("The implementation for an overloaded function "
                               "must come last", defn.items[idx])
-        elif defn.name != "_":
+        else:
             for idx in non_overload_indexes[1:]:
                 self.name_already_defined(defn.name, defn.items[idx], defn.items[0])
             if defn.impl:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -107,7 +107,9 @@ from mypy.plugin import (
     Plugin, ClassDefContext, SemanticAnalyzerPluginInterface,
     DynamicClassDefContext
 )
-from mypy.util import correct_relative_import, unmangle, module_prefix, is_typeshed_file
+from mypy.util import (
+    correct_relative_import, unmangle, module_prefix, is_typeshed_file, unnamed_function,
+)
 from mypy.scope import Scope
 from mypy.semanal_shared import (
     SemanticAnalyzerInterface, set_callable_name, calculate_tuple_fallback, PRIORITY_FALLBACKS
@@ -666,7 +668,11 @@ class SemanticAnalyzer(NodeVisitor[None],
         """
         if isinstance(new, Decorator):
             new = new.func
-        if isinstance(previous, (FuncDef, Decorator)) and new.name == previous.name == "_":
+        if (
+            isinstance(previous, (FuncDef, Decorator))
+            and unnamed_function(new.name)
+            and unnamed_function(previous.name)
+        ):
             return True
         if isinstance(previous, (FuncDef, Var, Decorator)) and new.is_conditional:
             new.original_def = previous

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -721,3 +721,7 @@ def is_stub_package_file(file: str) -> bool:
         return False
     return any(component.endswith('-stubs')
                for component in os.path.abspath(file).split(os.sep))
+
+
+def unnamed_function(name: Optional[str]) -> bool:
+    return name is not None and name == "_"

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -23,7 +23,7 @@ from mypyc.irbuild.main import build_ir
 from mypyc.irbuild.prepare import load_type_map
 from mypyc.irbuild.mapper import Mapper
 from mypyc.common import (
-    PREFIX, TOP_LEVEL_NAME, MODULE_PREFIX, RUNTIME_C_FILES, use_fastcall,
+    PREFIX, TOP_LEVEL_NAME, MODULE_PREFIX, RUNTIME_C_FILES, short_id_from_name, use_fastcall,
     use_vectorcall, shared_lib_name,
 )
 from mypyc.codegen.cstring import c_string_initializer
@@ -842,6 +842,7 @@ class GroupGenerator:
         for fn in module.functions:
             if fn.class_name is not None or fn.name == TOP_LEVEL_NAME:
                 continue
+            name = short_id_from_name(fn.name, fn.decl.shortname, fn.line)
             if is_fastcall_supported(fn, emitter.capi_version):
                 flag = 'METH_FASTCALL'
             else:
@@ -849,7 +850,7 @@ class GroupGenerator:
             emitter.emit_line(
                 ('{{"{name}", (PyCFunction){prefix}{cname}, {flag} | METH_KEYWORDS, '
                  'NULL /* docstring */}},').format(
-                     name=fn.name,
+                     name=name,
                      cname=fn.cname(emitter.names),
                      prefix=PREFIX,
                      flag=flag))

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -1,3 +1,4 @@
+from mypy.util import unnamed_function
 import sys
 from typing import Dict, Any, Optional, Tuple
 import sys
@@ -108,14 +109,14 @@ def get_id_from_name(name: str, fullname: str, line: int) -> str:
     a dictionary key. This is usually the fullname of the function, but this is different in that
     it handles the case where the function is named '_', in which case multiple different functions
     could have the same name."""
-    if name == "_":
+    if unnamed_function(name):
         return "{}.{}".format(fullname, line)
     else:
         return fullname
 
 
 def short_id_from_name(func_name: str, shortname: str, line: Optional[int]) -> str:
-    if func_name == "_":
+    if unnamed_function(func_name):
         assert line is not None
         partial_name = "{}.{}".format(shortname, line)
     else:

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -112,3 +112,11 @@ def get_id_from_name(name: str, fullname: str, line: int) -> str:
         return "{}.{}".format(fullname, line)
     else:
         return fullname
+
+
+def short_id_from_name(func_name: str, shortname: str, line: int) -> str:
+    if func_name == "_":
+        partial_name = "{}.{}".format(shortname, line)
+    else:
+        partial_name = shortname
+    return partial_name

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -99,3 +99,16 @@ def use_vectorcall(capi_version: Tuple[int, int]) -> bool:
 def use_method_vectorcall(capi_version: Tuple[int, int]) -> bool:
     # We can use a dedicated vectorcall API to call methods on Python 3.9+.
     return capi_version >= (3, 9)
+
+
+def get_id_from_name(name: str, fullname: str, line: int) -> str:
+    """Create a unique id for a function.
+
+    This creates an id that is unique for any given function definition, so that it can be used as
+    a dictionary key. This is usually the fullname of the function, but this is different in that
+    it handles the case where the function is named '_', in which case multiple different functions
+    could have the same name."""
+    if name == "_":
+        return "{}.{}".format(fullname, line)
+    else:
+        return fullname

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Dict, Any, Tuple
+from typing import Dict, Any, Optional, Tuple
 import sys
 
 from typing_extensions import Final
@@ -114,8 +114,9 @@ def get_id_from_name(name: str, fullname: str, line: int) -> str:
         return fullname
 
 
-def short_id_from_name(func_name: str, shortname: str, line: int) -> str:
+def short_id_from_name(func_name: str, shortname: str, line: Optional[int]) -> str:
     if func_name == "_":
+        assert line is not None
         partial_name = "{}.{}".format(shortname, line)
     else:
         partial_name = shortname

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -285,12 +285,12 @@ class ClassIR:
             'attributes': [(k, t.serialize()) for k, t in self.attributes.items()],
             # We try to serialize a name reference, but if the decl isn't in methods
             # then we can't be sure that will work so we serialize the whole decl.
-            'method_decls': [(k, d.fullname if k in self.methods else d.serialize())
+            'method_decls': [(k, d.id if k in self.methods else d.serialize())
                              for k, d in self.method_decls.items()],
             # We serialize method fullnames out and put methods in a separate dict
-            'methods': [(k, m.fullname) for k, m in self.methods.items()],
+            'methods': [(k, m.id) for k, m in self.methods.items()],
             'glue_methods': [
-                ((cir.fullname, k), m.fullname)
+                ((cir.fullname, k), m.id)
                 for (cir, k), m in self.glue_methods.items()
             ],
 
@@ -383,8 +383,8 @@ def serialize_vtable_entry(entry: VTableMethod) -> JsonDict:
         '.class': 'VTableMethod',
         'cls': entry.cls.fullname,
         'name': entry.name,
-        'method': entry.method.decl.fullname,
-        'shadow_method': entry.shadow_method.decl.fullname if entry.shadow_method else None,
+        'method': entry.method.decl.id,
+        'shadow_method': entry.shadow_method.decl.id if entry.shadow_method else None,
     }
 
 

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -143,6 +143,7 @@ class FuncDecl:
             'kind': self.kind,
             'is_prop_setter': self.is_prop_setter,
             'is_prop_getter': self.is_prop_getter,
+            'line': self.line
         }
 
     @staticmethod

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -101,6 +101,19 @@ class FuncDecl:
             else:
                 self.bound_sig = FuncSignature(sig.args[1:], sig.ret_type)
 
+        # this is optional because this will be set to the line number when the corresponding
+        # FuncIR is created
+        self._line: Optional[int] = None
+
+    @property
+    def line(self) -> int:
+        assert self._line is not None
+        return self._line
+
+    @line.setter
+    def line(self, line: int) -> None:
+        self._line = line
+
     @staticmethod
     def compute_shortname(class_name: Optional[str], name: str) -> str:
         return class_name + '.' + name if class_name else name
@@ -162,11 +175,15 @@ class FuncIR:
         self.arg_regs = arg_regs
         # Body of the function
         self.blocks = blocks
-        self.line = line
+        self.decl.line = line
         # The name that should be displayed for tracebacks that
         # include this function. Function will be omitted from
         # tracebacks if None.
         self.traceback_name = traceback_name
+
+    @property
+    def line(self) -> int:
+        return self.decl.line
 
     @property
     def args(self) -> Sequence[RuntimeArg]:

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -147,13 +147,16 @@ class FuncDecl:
             'kind': self.kind,
             'is_prop_setter': self.is_prop_setter,
             'is_prop_getter': self.is_prop_getter,
-            'line': self.line
         }
 
+    # TODO: move this to FuncIR?
     @staticmethod
-    def get_id_from_json(f: JsonDict) -> str:
-        fullname = f['module_name'] + '.' + FuncDecl.compute_shortname(f['class_name'], f['name'])
-        return get_id_from_name(f['name'], fullname, f['line'])
+    def get_id_from_json(func_ir: JsonDict) -> str:
+        """Get the id from the serialized FuncIR associated with this FuncDecl"""
+        decl = func_ir['decl']
+        shortname = FuncDecl.compute_shortname(decl['class_name'], decl['name'])
+        fullname = decl['module_name'] + '.' + shortname
+        return get_id_from_name(decl['name'], fullname, func_ir['line'])
 
     @classmethod
     def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> 'FuncDecl':

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -132,7 +132,11 @@ class FuncDecl:
         return self.module_name + '.' + self.shortname
 
     def cname(self, names: NameGenerator) -> str:
-        return names.private_name(self.module_name, self.shortname)
+        if self.name == "_":
+            partial_name = "{}.{}".format(self.shortname, self.line)
+        else:
+            partial_name = self.shortname
+        return names.private_name(self.module_name, partial_name)
 
     def serialize(self) -> JsonDict:
         return {

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -132,7 +132,7 @@ class FuncDecl:
         return self.module_name + '.' + self.shortname
 
     def cname(self, names: NameGenerator) -> str:
-        partial_name = short_id_from_name(self.name, self.shortname, self.line)
+        partial_name = short_id_from_name(self.name, self.shortname, self._line)
         return names.private_name(self.module_name, partial_name)
 
     def serialize(self) -> JsonDict:

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -5,7 +5,7 @@ from typing_extensions import Final
 
 from mypy.nodes import FuncDef, Block, ArgKind, ARG_POS
 
-from mypyc.common import JsonDict, get_id_from_name
+from mypyc.common import JsonDict, get_id_from_name, short_id_from_name
 from mypyc.ir.ops import (
     DeserMaps, BasicBlock, Value, Register, Assign, AssignMulti, ControlOp, LoadAddress
 )
@@ -132,10 +132,7 @@ class FuncDecl:
         return self.module_name + '.' + self.shortname
 
     def cname(self, names: NameGenerator) -> str:
-        if self.name == "_":
-            partial_name = "{}.{}".format(self.shortname, self.line)
-        else:
-            partial_name = self.shortname
+        partial_name = short_id_from_name(self.name, self.shortname, self.line)
         return names.private_name(self.module_name, partial_name)
 
     def serialize(self) -> JsonDict:

--- a/mypyc/ir/module_ir.py
+++ b/mypyc/ir/module_ir.py
@@ -39,7 +39,7 @@ class ModuleIR:
         return ModuleIR(
             data['fullname'],
             data['imports'],
-            [ctx.functions[FuncDecl.get_id_from_json(f['decl'])] for f in data['functions']],
+            [ctx.functions[FuncDecl.get_id_from_json(f)] for f in data['functions']],
             [ClassIR.deserialize(c, ctx) for c in data['classes']],
             [(k, deserialize_type(t, ctx)) for k, t in data['final_names']],
         )

--- a/mypyc/ir/module_ir.py
+++ b/mypyc/ir/module_ir.py
@@ -39,7 +39,7 @@ class ModuleIR:
         return ModuleIR(
             data['fullname'],
             data['imports'],
-            [ctx.functions[FuncDecl.get_name_from_json(f['decl'])] for f in data['functions']],
+            [ctx.functions[FuncDecl.get_id_from_json(f['decl'])] for f in data['functions']],
             [ClassIR.deserialize(c, ctx) for c in data['classes']],
             [(k, deserialize_type(t, ctx)) for k, t in data['final_names']],
         )
@@ -72,9 +72,9 @@ def deserialize_modules(data: Dict[str, JsonDict], ctx: DeserMaps) -> Dict[str, 
         # to the class deserialization.
         for method in mod['functions']:
             func = FuncIR.deserialize(method, ctx)
-            assert func.decl.fullname not in ctx.functions, (
+            assert func.decl.id not in ctx.functions, (
                 "Method %s already in map" % func.decl.fullname)
-            ctx.functions[func.decl.fullname] = func
+            ctx.functions[func.decl.id] = func
 
     return {k: ModuleIR.deserialize(v, ctx) for k, v in data.items()}
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1332,7 +1332,7 @@ class OpVisitor(Generic[T]):
 # we might need to reference.
 #
 # Because of these references, we need to maintain maps from class
-# names to ClassIRs and func names to FuncIRs.
+# names to ClassIRs and func IDs to FuncIRs.
 #
 # These are tracked in a DeserMaps which is passed to every
 # deserialization function.

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -32,7 +32,7 @@ from mypyc.primitives.misc_ops import (
     check_stop_op, yield_from_except_op, coro_op, send_op, slow_isinstance_op
 )
 from mypyc.primitives.dict_ops import dict_set_item_op
-from mypyc.common import SELF_NAME, LAMBDA_NAME, decorator_helper_name
+from mypyc.common import SELF_NAME, LAMBDA_NAME, decorator_helper_name, short_id_from_name
 from mypyc.sametype import is_same_method_signature
 from mypyc.irbuild.util import concrete_arg_kind, is_constant
 from mypyc.irbuild.context import FuncInfo, ImplicitClass
@@ -816,7 +816,10 @@ def generate_singledispatch_dispatch_function(
         # Call the registered implementation
         builder.activate_block(call_impl)
 
-        gen_func_call_and_return(impl.name)
+        # The shortname of a function is just '{class}.{func_name}', and we don't support
+        # singledispatchmethod yet, so that is always the same as the function name
+        name = short_id_from_name(impl.name, impl.name, impl.line)
+        gen_func_call_and_return(name)
         builder.activate_block(next_impl)
 
     gen_func_call_and_return(main_singledispatch_function_name)

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -95,7 +95,7 @@ def load_type_map(mapper: 'Mapper',
 
     for module in modules:
         for func in get_module_func_defs(module):
-            mapper.func_to_decl[func] = deser_ctx.functions[func.fullname].decl
+            mapper.func_to_decl[func] = deser_ctx.functions[func.id].decl
 
 
 def get_module_func_defs(module: MypyFile) -> Iterable[FuncDef]:

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -26,7 +26,7 @@ from mypyc.ir.func_ir import (
     FuncDecl, FuncSignature, RuntimeArg, FUNC_NORMAL, FUNC_STATICMETHOD, FUNC_CLASSMETHOD
 )
 from mypyc.ir.class_ir import ClassIR
-from mypyc.common import PROPSET_PREFIX
+from mypyc.common import PROPSET_PREFIX, get_id_from_name
 from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.util import (
     get_func_def, is_dataclass, is_trait, is_extension_class, get_mypyc_attrs
@@ -95,7 +95,8 @@ def load_type_map(mapper: 'Mapper',
 
     for module in modules:
         for func in get_module_func_defs(module):
-            mapper.func_to_decl[func] = deser_ctx.functions[func.id].decl
+            func_id = get_id_from_name(func.name, func.fullname, func.line)
+            mapper.func_to_decl[func] = deser_ctx.functions[func_id].decl
 
 
 def get_module_func_defs(module: MypyFile) -> Iterable[FuncDef]:

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -1076,3 +1076,16 @@ try:
 # should fail with AssertionError due to `assert False` in other function
 except AssertionError:
     pass
+
+[case testRepeatedUnderscoreFunctions]
+def _(arg): pass
+def _(arg): pass
+
+[case testUnderscoreFunctionsInMethods]
+
+class A:
+    def _(arg): pass
+    def _(arg): pass
+class B(A):
+    def _(arg): pass
+    def _(arg): pass

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -56,7 +56,7 @@ def test_specialize() -> None:
     assert fun(B())
     assert not fun(A())
 
-[case testMultipleUnderscoreFunctionsIsntError-xfail]
+[case testMultipleUnderscoreFunctionsIsntError]
 from functools import singledispatch
 
 @singledispatch
@@ -71,9 +71,17 @@ def _(arg: str) -> str:
 def _(arg: int) -> str:
     return 'int'
 
+# extra function to make sure all 3 underscore functions aren't treated as one OverloadedFuncDef
+def a(b): pass
+
+@fun.register
+def _(arg: list) -> str:
+    return 'list'
+
 def test_singledispatch() -> None:
     assert fun(0) == 'int'
     assert fun('a') == 'str'
+    assert fun([1, 2]) == 'list'
     assert fun({'a': 'b'}) == 'default'
 
 [case testCanRegisterCompiledClasses]

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -237,7 +237,7 @@ def test_singledispatchmethod() -> None:
     assert x.fun('a') == 'str'
     assert x.fun([1, 2]) == 'default'
 
-[case testSingledispatchTreeSumAndEqual-xfail]
+[case testSingledispatchTreeSumAndEqual]
 from functools import singledispatch
 
 class Tree:
@@ -289,7 +289,7 @@ def test_sum_and_equal():
     tree2 = build(5)
     tree2.right.right.right.value = 10
     assert calc_sum(tree) == 57
-    assert calc_sum(tree2) == 62
+    assert calc_sum(tree2) == 65
     assert equal(tree, tree)
     assert not equal(tree, tree2)
     tree3 = build(4)


### PR DESCRIPTION
This PR adds support for compiling functions named `_` even when there are multiple functions named `_` (which previously would lead to a C compiler error as we tried to generate 2 functions with the same name).

This also adds support for using a function named `_` for a registered implementation of a singledispatch function.

## Test Plan

I added 2 new tests, and I changed a test for underscore functions in run-singledispatch.test from an xfail test to a regular test.