### PR TITLE
Avoid crash in singledispatch plugin for incorrect singledispatch arguments

### DIFF
--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -314,3 +314,13 @@ h(1, 'a')
 h('a', 1) # E: Argument 2 to "h" has incompatible type "int"; expected "str"
 
 [builtins fixtures/args.pyi]
+
+[case testDontCrashWhenRegisteringAfterError]
+import functools
+a = functools.singledispatch('a') # E: Need type annotation for "a" # E: Argument 1 to "singledispatch" has incompatible type "str"; expected "Callable[..., <nothing>]"
+
+@a.register(int)
+def default(val) -> int:
+    return 3
+
+[builtins fixtures/args.pyi]


### PR DESCRIPTION
This fixes a crash that occurs when someone tries to create a singledispatch function with incorrect arguments and then tries to register an implementation for that singledispatch function.

This crash first appeared when type checking ibis in mypy_primer (see https://github.com/python/mypy/pull/10830#issuecomment-881786093) when type checking the use of singledispatch at https://github.com/ibis-project/ibis/blob/0671630426808a9fb55a9f6f4e662e126124c6b1/ibis/backends/spark/datatypes.py#L83.

## Test Plan

I added a new test to reproduce the crash.