### PR TITLE
Remove `return output` in `refine_parent_types`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4494,8 +4494,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             expr = parent_expr
             expr_type = output[parent_expr] = make_simplified_union(new_parent_types)
 
-        return output
-
     def refine_identity_comparison_expression(self,
                                               operands: List[Expression],
                                               operand_types: List[Type],


### PR DESCRIPTION
### Description

An unnecessary default return was removed, `return` (or any other statement) after a `while True` with no `break` condition will never be executed