### PR TITLE
Remove redundant `import`'s and `type_obj`

### DIFF
--- a/misc/build_wheel.py
+++ b/misc/build_wheel.py
@@ -26,7 +26,6 @@ Other supported values for platform: linux, windows
 import argparse
 import os
 import subprocess
-import sys
 from typing import Dict
 
 # Clang package we use on Linux

--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -8,7 +8,6 @@ By default, sync to the latest typeshed commit.
 """
 
 import argparse
-import glob
 import os
 import shutil
 import subprocess

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -75,8 +75,6 @@ def transform_class_def(builder: IRBuilder, cdef: ClassDef) -> None:
         non_ext_anns = builder.call_c(dict_new_op, [], cdef.line)
         non_ext = NonExtClassInfo(non_ext_dict, non_ext_bases, non_ext_anns, non_ext_metaclass)
         dataclass_non_ext = None
-        type_obj = None
-
     attrs_to_cache: List[Tuple[Lvalue, RType]] = []
 
     for stmt in cdef.defs.body:

--- a/scripts/mypyc
+++ b/scripts/mypyc
@@ -15,8 +15,6 @@ import os
 import os.path
 import subprocess
 import sys
-import tempfile
-import time
 
 base_path = os.path.join(os.path.dirname(__file__), '..')
 


### PR DESCRIPTION
### Description

Remove redundant `import`'s and `type_obj`