### PR TITLE
Use PYTHONPYCACHEPREFIX as fallback value for cache dir

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -727,8 +727,8 @@ beyond what incremental mode can offer, try running mypy in
     change this folder. This flag can also be useful for controlling
     cache use when using :ref:`remote caching <remote-cache>`.
 
-    This setting will override the ``MYPY_CACHE_DIR`` environment
-    variable if it is set.
+    This setting will take precedence over ``MYPY_CACHE_DIR`` or
+    ``PYTHONPYCACHEPREFIX`` environment variables.
 
     Mypy will also always write to the cache even when incremental
     mode is disabled so it can "warm up" the cache. To disable

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -917,6 +917,8 @@ def process_options(args: List[str],
 
     # Override cache_dir if provided in the environment
     environ_cache_dir = os.getenv('MYPY_CACHE_DIR', '')
+    if not environ_cache_dir:
+        environ_cache_dir = os.getenv('PYTHONPYCACHEPREFIX', '')
     if environ_cache_dir.strip():
         options.cache_dir = environ_cache_dir
     options.cache_dir = os.path.expanduser(options.cache_dir)


### PR DESCRIPTION
### Description

When `MYPY_CACHE_DIR` is not defined but `PYTHONPYCACHEPREFIX` is, use it to store cache files. This allows users to define a single environment variable that defines a safe location for cache files,
avoiding pollution of code repos.

Fixes: #8790
