### PR TITLE
[mypyc] Fix order of dispatch type checking in singledispatch functions

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -22,7 +22,7 @@ import time
 import types
 
 from typing import (AbstractSet, Any, Dict, Iterable, Iterator, List, Sequence,
-                    Mapping, NamedTuple, Optional, Set, Tuple, Union, Callable, TextIO)
+                    Mapping, NamedTuple, Optional, Set, Tuple, TypeVar, Union, Callable, TextIO)
 from typing_extensions import ClassVar, Final, TYPE_CHECKING
 from mypy_extensions import TypedDict
 
@@ -3234,21 +3234,22 @@ def strongly_connected_components(vertices: AbstractSet[str],
             yield from dfs(v)
 
 
-def topsort(data: Dict[AbstractSet[str],
-                       Set[AbstractSet[str]]]) -> Iterable[Set[AbstractSet[str]]]:
+T = TypeVar("T")
+
+
+def topsort(data: Dict[T, Set[T]]) -> Iterable[Set[T]]:
     """Topological sort.
 
     Args:
-      data: A map from SCCs (represented as frozen sets of strings) to
-            sets of SCCs, its dependencies.  NOTE: This data structure
+      data: A map from vertices to all vertices that it has an edge
+            connecting it to.  NOTE: This data structure
             is modified in place -- for normalization purposes,
             self-dependencies are removed and entries representing
             orphans are added.
 
     Returns:
-      An iterator yielding sets of SCCs that have an equivalent
-      ordering.  NOTE: The algorithm doesn't care about the internal
-      structure of SCCs.
+      An iterator yielding sets of vertices that have an equivalent
+      ordering.
 
     Example:
       Suppose the input has the following structure:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -10,7 +10,7 @@ as an environment containing non-local variables, is stored in the
 instance of the callable class.
 """
 
-from typing import Iterable, NamedTuple, Optional, List, Sequence, Tuple, Union, Dict
+from typing import NamedTuple, Optional, List, Sequence, Tuple, Union, Dict
 
 from mypy.nodes import (
     ClassDef, FuncDef, OverloadedFuncDef, Decorator, Var, YieldFromExpr, AwaitExpr, YieldExpr,

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -869,13 +869,9 @@ def sort_with_subclasses_first(
 ) -> Iterator[Tuple[TypeInfo, FuncDef]]:
 
     # graph with edges pointing from every class to their subclasses
-    graph: DefaultDict[TypeInfo, Set[TypeInfo]] = defaultdict(set)
-    for impl in impls:
-        typ, _ = impl
-        for t in typ.mro[1:]:
-            graph[typ].add(t)
+    graph = {typ: set(typ.mro[1:]) for typ, _ in impls}
 
-    dispatch_types = topsort(dict(graph))
+    dispatch_types = topsort(graph)
     impl_dict = {typ: func for typ, func in impls}
 
     for group in reversed(list(dispatch_types)):

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -862,20 +862,40 @@ def gen_dispatch_func_ir(
 
 def sort_with_subclasses_first(
     impls: List[Tuple[TypeInfo, FuncDef]]
-) -> Iterable[Tuple[TypeInfo, FuncDef]]:
-    def is_subclass(typ1: TypeInfo, typ2: TypeInfo) -> bool:
-        return typ2 in typ1.mro
-    dispatch_types: List[TypeInfo] = []
-    funcs: List[FuncDef] = []
+) -> List[Tuple[TypeInfo, FuncDef]]:
+    def is_related(typ1: TypeInfo, typ2: TypeInfo) -> bool:
+        return typ2 in typ1.mro or typ2 in typ1.mro
+
+    def overlapping_with_related_impl_list(typ: TypeInfo, func: FuncDef) -> bool:
+        """Place the dispatch type and registered function in the correct related_types list
+
+        Returns True if the type and function were placed in a related_types list, and False if
+        they weren't
+        """
+        for group in related_types:
+            if any(is_related(prev_type, typ) for prev_type, _ in group):
+                group.append((typ, func))
+                return True
+        for i, (prev_type, impl) in enumerate(unrelated_types):
+            if is_related(typ, prev_type):
+                related_types.append([(prev_type, impl), (typ, func)])
+                del unrelated_types[i]
+                return True
+        return False
+
+    # a list of impls with dispatch types that are unrelated (none of the dispatch types overlap)
+    unrelated_types: List[Tuple[TypeInfo, FuncDef]] = []
+    # each inner list of impls is a collection of impls that have overlapping dispatch types
+    related_types: List[List[Tuple[TypeInfo, FuncDef]]] = []
     for typ, impl in impls:
-        # If this type is a subclass of anything we've seen previously, put it in the front so it
-        # gets checked first
-        if any(is_subclass(typ, prev_type) for prev_type in dispatch_types):
-            dispatch_types.insert(0, typ)
-            funcs.insert(0, impl)
-        # Otherwise, this type isn't related to any of the other dispatch types, so we can just put
-        # it at the back
-        else:
-            dispatch_types.append(typ)
-            funcs.append(impl)
-    return zip(dispatch_types, funcs)
+        if not overlapping_with_related_impl_list(typ, impl):
+            unrelated_types.append((typ, impl))
+    sorted_impls = unrelated_types
+    for group in related_types:
+        # Classes with the longest MRO should be checked first because they have more superclasses,
+        # meaning they are probably subclasses of classes with shorter MROs
+        # TODO: check if that's always true (especially when dealing with multiple classes having a
+        # common base class)
+        group.sort(key=lambda impl: len(impl[0].mro), reverse=True)
+        sorted_impls.extend(group)
+    return sorted_impls

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -10,10 +10,9 @@ as an environment containing non-local variables, is stored in the
 instance of the callable class.
 """
 
-from collections import defaultdict
 from mypy.build import topsort
 from typing import (
-    NamedTuple, Optional, List, Sequence, Tuple, Union, Dict, DefaultDict, Iterator, Set,
+    NamedTuple, Optional, List, Sequence, Tuple, Union, Dict, Iterator,
 )
 
 from mypy.nodes import (

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -465,3 +465,25 @@ def h(arg: str) -> int:
 def test_singledispatch():
     assert f('a') == 35
     assert f(A()) == 10
+
+[case testMoreSpecificTypeBeforeLessSpecificType]
+from functools import singledispatch
+class A: pass
+class B(A): pass
+
+@singledispatch
+def f(arg) -> str:
+    return 'default'
+
+@f.register
+def g(arg: B) -> str:
+    return 'b'
+
+@f.register
+def h(arg: A) -> str:
+    return 'a'
+
+def test_singledispatch():
+    assert f(B()) == 'b'
+    assert f(A()) == 'a'
+    assert f(5) == 'default'

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -487,3 +487,28 @@ def test_singledispatch():
     assert f(B()) == 'b'
     assert f(A()) == 'a'
     assert f(5) == 'default'
+
+[case testMultipleRelatedClassesBeingRegistered]
+from functools import singledispatch
+
+class A: pass
+class B(A): pass
+class C(B): pass
+
+@singledispatch
+def f(arg) -> str: return 'default'
+
+@f.register
+def _(arg: A) -> str: return 'a'
+
+@f.register
+def _(arg: C) -> str: return 'c'
+
+@f.register
+def _(arg: B) -> str: return 'b'
+
+def test_singledispatch():
+    assert f(A()) == 'a'
+    assert f(B()) == 'b'
+    assert f(C()) == 'c'
+    assert f(1) == 'default'


### PR DESCRIPTION
This PR changes the order that the dispatch function checks dispatch types of registered implementations to always check any of the class's subclasses (if any have registered implementations) before checking the class itself.

That matches the semantics of the standard library implementation of singledispatch more closely, which goes up the MRO of the argument's type and uses the registered implementation that corresponds with the first type that it finds that is also a dispatch type.

## Test Plan

I added a test to run-singledispatch.test that reproduces this bug.
