### PR TITLE
Temporarily pin virtualenv to 16.7.10 to fix CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python }}
         architecture: ${{ matrix.arch }}
     - name: install tox
-      run: pip install --upgrade 'setuptools!=50' 'virtualenv<20' tox==3.20.1
+      run: pip install --upgrade 'setuptools!=50' 'virtualenv<16.7.11' tox==3.20.1
     - name: setup tox environment
       run: tox -e ${{ matrix.toxenv }} --notest
     - name: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
 install:
 # pip 21.0 no longer works on Python 3.5
 - pip install -U pip==20.3.4 setuptools
-- pip install -U 'virtualenv<20'
+- pip install -U 'virtualenv<16.7.11'
 - pip install -U tox==3.20.1
 - python2 -m pip install --user -U typing
 - tox --notest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,6 +12,6 @@ pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0,<3.0.0
 typing>=3.5.2; python_version < '3.5'
 py>=1.5.2
-virtualenv<20
+virtualenv<16.7.11
 setuptools!=50
 importlib-metadata==0.20


### PR DESCRIPTION
virtualenv's 16.7.11 release yesterday appears to have broken our CI by updating the embedded version of pip to something that doesn't support python 2 (see https://github.com/python/mypy/issues/10407#issuecomment-883946075 for more info).

This is probably not an ideal long-term fix seeing as we're eventually going to need to switch to virtualenv 20 for python 3.10 support (see #10407), but this should fix CI long enough to find a better fix for this, whether that means:
- Dropping the failing python2 tests entirely (see #10846)
- Figuring out why the installed virtualenv isn't using the embedded pip 20.3.4, which does have python 2 support (maybe try installing virtualenv on python2 or something?)
- Switching to virtualenv 20 and hoping it has a fix for this

## Test Plan

I have no clue how to test this on my computer, but hopefully if the CI passes on this that should be enough confirmation that this works.