### PR TITLE
Fix mypy for new virtualenv

### DIFF
--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -1,21 +1,25 @@
 from __future__ import print_function
-"""This file is used to find the site packages of a Python executable, which may be Python 2.
+"""Utilities to find the site and prefix information of a Python executable, which may be Python 2.
 
 This file MUST remain compatible with Python 2. Since we cannot make any assumptions about the
 Python being executed, this module should not use *any* dependencies outside of the standard
 library found in Python 2. This file is run each mypy run, so it should be kept as fast as
 possible.
 """
+import site
+import sys
 
 if __name__ == '__main__':
-    import sys
     sys.path = sys.path[1:]  # we don't want to pick up mypy.types
-
-import site
 
 MYPY = False
 if MYPY:
-    from typing import List
+    from typing import List, Tuple
+
+
+def getprefixes():
+    # type: () -> Tuple[str, str]
+    return sys.base_prefix, sys.prefix
 
 
 def getsitepackages():
@@ -29,4 +33,10 @@ def getsitepackages():
 
 
 if __name__ == '__main__':
-    print(repr(getsitepackages()))
+    if sys.argv[-1] == 'getsitepackages':
+        print(repr(getsitepackages()))
+    elif sys.argv[-1] == 'getprefixes':
+        print(repr(getprefixes()))
+    else:
+        print("ERROR: incorrect argument to pyinfo.py.", file=sys.stderr)
+        sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ if USE_MYPYC:
     MYPYC_BLACKLIST = tuple(os.path.join('mypy', x) for x in (
         # Need to be runnable as scripts
         '__main__.py',
-        'sitepkgs.py',
+        'pyinfo.py',
         os.path.join('dmypy', '__main__.py'),
 
         # Uses __getattr__/__setattr__

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,16 +2,15 @@
 -r build-requirements.txt
 attrs>=18.0
 flake8>=3.8.1
-flake8-bugbear; python_version >= '3.5'
-flake8-pyi>=20.5; python_version >= '3.6'
+flake8-bugbear
+flake8-pyi>=20.5
 lxml>=4.4.0
 psutil>=4.0
 pytest>=6.2.0,<7.0.0
 pytest-xdist>=1.34.0,<2.0.0
 pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0,<3.0.0
-typing>=3.5.2; python_version < '3.5'
 py>=1.5.2
-virtualenv
+virtualenv>=20.6.0
 setuptools!=50
-importlib-metadata==0.20
+importlib-metadata>=4.6.1,<5.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,6 +12,6 @@ pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0,<3.0.0
 typing>=3.5.2; python_version < '3.5'
 py>=1.5.2
-virtualenv<16.7.11
+virtualenv
 setuptools!=50
 importlib-metadata==0.20


### PR DESCRIPTION
### Description

This works around a change in virtualenv 20.x where the site-packages folder is added to the `PYTHONPATH` variable. We detect if the python executable is in a virtualenv by comparing the prefix and base prefix, and ignoring the issue if the site-package folder is under the virtualenv prefix.

This is an alternative to https://github.com/python/mypy/pull/10846

Fixes https://github.com/python/mypy/issues/10407