### PR TITLE
Improves `urls` on https://pypi.org/project/mypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,5 +201,7 @@ setup(name='mypy',
       include_package_data=True,
       project_urls={
           'News': 'http://mypy-lang.org/news.html',
+          'Documentation': 'https://mypy.readthedocs.io/en/stable/introduction.html',
+          'Repository': 'https://github.com/python/mypy',
       },
       )


### PR DESCRIPTION
Right now it is impossible to navigate from `pypi.org` to docs or github repo.
<img width="1228" alt="Снимок экрана 2021-07-22 в 13 04 49" src="https://user-images.githubusercontent.com/4660275/126622901-9573572e-9ee0-4929-8583-d2d73650cc09.png">


This commit fixes it. 