### PR TITLE
Adds attribute type inference from super-types for partial types

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2261,7 +2261,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 and lvalue.node.type is None):
             var = lvalue.node
             self.infer_partial_type(var, lvalue,
-                                    self.expr_checker.accept(rvalue))
+                                    get_proper_type(self.expr_checker.accept(rvalue)))
 
         if var is not None:
             partial_types = self.find_partial_types(var)
@@ -2269,12 +2269,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 return
 
             parent_type = self.get_defined_in_base_class(var)
-            if parent_type is not None and is_valid_inferred_type(parent_type):
-                self.set_inferred_type(var, lvalue, parent_type)
-                if isinstance(lvalue, RefExpr):
-                    # We need this to escape another round of inference:
-                    lvalue.is_inferred_def = False
-                del partial_types[var]
+            if parent_type is not None:
+                parent_type = get_proper_type(parent_type)
+                if is_valid_inferred_type(parent_type):
+                    self.set_inferred_type(var, lvalue, parent_type)
+                    if isinstance(lvalue, RefExpr):
+                        # We need this to escape another round of inference:
+                        lvalue.is_inferred_def = False
+                    del partial_types[var]
 
     def check_compatibility_all_supers(self, lvalue: RefExpr, lvalue_type: Optional[Type],
                                        rvalue: Expression) -> bool:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2091,6 +2091,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                                       infer_lvalue_type)
         else:
             self.try_infer_partial_generic_type_from_assignment(lvalue, rvalue, '=')
+            self.try_infer_partial_generic_type_from_super(lvalue, rvalue)
             lvalue_type, index_lvalue, inferred = self.check_lvalue(lvalue)
             # If we're assigning to __getattr__ or similar methods, check that the signature is
             # valid.
@@ -2239,6 +2240,40 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     del partial_types[var]
             elif isinstance(rvalue_type, AnyType):
                 var.type = fill_typevars_with_any(typ.type)
+                del partial_types[var]
+
+    def try_infer_partial_generic_type_from_super(self, lvalue: Lvalue,
+                                                  rvalue: Expression) -> None:
+        """Try to infer a precise type for partial generic type from super types.
+
+        Example where this happens:
+
+            class P:
+                x: List[int]
+
+            class C(P):
+                x = []  # Infer List[int] as type of 'x'
+
+        """
+        var = None
+        if (isinstance(lvalue, NameExpr)
+                and isinstance(lvalue.node, Var)
+                and lvalue.node.type is None):
+            var = lvalue.node
+            self.infer_partial_type(var, lvalue,
+                                    self.expr_checker.accept(rvalue))
+
+        if var is not None:
+            partial_types = self.find_partial_types(var)
+            if partial_types is None:
+                return
+
+            parent_type = self.get_defined_in_base_class(var)
+            if parent_type is not None and is_valid_inferred_type(parent_type):
+                self.set_inferred_type(var, lvalue, parent_type)
+                if isinstance(lvalue, RefExpr):
+                    # We need this to escape another round of inference:
+                    lvalue.is_inferred_def = False
                 del partial_types[var]
 
     def check_compatibility_all_supers(self, lvalue: RefExpr, lvalue_type: Optional[Type],
@@ -4870,12 +4905,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         and not permissive):
                     var.type = NoneType()
                 else:
-                    if is_class:
-                        # Special case: possibly super-type defines the type for us?
-                        parent_type = self.get_defined_in_base_class(var)
-                        if parent_type is not None:
-                            var.type = parent_type
-                            self.partial_reported.add(var)
                     if var not in self.partial_reported and not permissive:
                         self.msg.need_annotation_for_var(var, context, self.options.python_version)
                         self.partial_reported.add(var)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -972,6 +972,39 @@ x = C.x
 [out]
 main:2: error: Need type annotation for "x" (hint: "x: List[<type>] = ...")
 
+[case testAccessingClassAttributeWithTypeInferenceWithSuperType]
+from typing import List
+class P:
+    x: List[int]
+class C(P):
+    x = []
+reveal_type(C.x)  # N: Revealed type is "builtins.list[builtins.int]"
+[builtins fixtures/list.pyi]
+
+[case testAccessingClassAttributeWithTypeInferenceWithMixinType]
+from typing import List
+class P:
+    pass
+class M:
+    x: List[int]
+class C(P, M):
+    x = []
+reveal_type(C.x)  # N: Revealed type is "builtins.list[builtins.int]"
+[builtins fixtures/list.pyi]
+
+[case testClassAttributeWithTypeInferenceInvalidType]
+from typing import List
+class P:
+    x: List[int]
+class C(P):
+    x = ['a']  # E: List item 0 has incompatible type "str"; expected "int"
+[builtins fixtures/list.pyi]
+
+[case testClassSlotsAttributeWithTypeInference]
+class P:
+    __slots__ = []
+[builtins fixtures/list.pyi]
+
 [case testAccessingGenericClassAttribute]
 from typing import Generic, TypeVar
 T = TypeVar('T')

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -992,6 +992,24 @@ class C(P, M):
 reveal_type(C.x)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
+[case testAccessingClassAttributeWithTypeInferenceWithMixinTypeConflict]
+from typing import List
+class P:
+    x: List[int]
+class M:
+    x: List[str]
+class C(P, M):
+    x = []  # E: Incompatible types in assignment (expression has type "List[int]", base class "M" defined the type as "List[str]")
+reveal_type(C.x)  # N: Revealed type is "builtins.list[builtins.int]"
+[builtins fixtures/list.pyi]
+
+[case testClassAttributeWithTypeInferenceNoParentType]
+class P:
+    ...
+class C(P):
+    x = []  # E: Need type annotation for "x" (hint: "x: List[<type>] = ...")
+[builtins fixtures/list.pyi]
+
 [case testClassAttributeWithTypeInferenceInvalidType]
 from typing import List
 class P:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -992,14 +992,23 @@ class C(P, M):
 reveal_type(C.x)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
-[case testAccessingClassAttributeWithTypeInferenceWithMixinTypeConflict]
+[case testClassAttributeWithTypeInferenceInvalidType]
+from typing import List
+class P:
+    x: List[int]
+class C(P):
+    x = ['a']  # E: List item 0 has incompatible type "str"; expected "int"
+[builtins fixtures/list.pyi]
+
+case testAccessingClassAttributeWithTypeInferenceWithMixinTypeConflict]
 from typing import List
 class P:
     x: List[int]
 class M:
     x: List[str]
 class C(P, M):
-    x = []  # E: Incompatible types in assignment (expression has type "List[int]", base class "M" defined the type as "List[str]")
+    x = []  # This hides subclassing issue, but that's how it is for now
+
 reveal_type(C.x)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
@@ -1008,14 +1017,6 @@ class P:
     ...
 class C(P):
     x = []  # E: Need type annotation for "x" (hint: "x: List[<type>] = ...")
-[builtins fixtures/list.pyi]
-
-[case testClassAttributeWithTypeInferenceInvalidType]
-from typing import List
-class P:
-    x: List[int]
-class C(P):
-    x = ['a']  # E: List item 0 has incompatible type "str"; expected "int"
 [builtins fixtures/list.pyi]
 
 [case testAccessingGenericClassAttribute]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1000,11 +1000,6 @@ class C(P):
     x = ['a']  # E: List item 0 has incompatible type "str"; expected "int"
 [builtins fixtures/list.pyi]
 
-[case testClassSlotsAttributeWithTypeInference]
-class P:
-    __slots__ = []
-[builtins fixtures/list.pyi]
-
 [case testAccessingGenericClassAttribute]
 from typing import Generic, TypeVar
 T = TypeVar('T')

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -1,11 +1,10 @@
 # Builtins stub used in list-related test cases.
 
-from typing import TypeVar, Generic, Iterable, Iterator, Union, Sequence, overload
+from typing import TypeVar, Generic, Iterable, Iterator, Sequence, overload
 
 T = TypeVar('T')
 
 class object:
-    __slots__: Union['str', Iterable['str']]
     def __init__(self) -> None: pass
 
 class type: pass

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -1,10 +1,11 @@
 # Builtins stub used in list-related test cases.
 
-from typing import TypeVar, Generic, Iterable, Iterator, Sequence, overload
+from typing import TypeVar, Generic, Iterable, Iterator, Union, Sequence, overload
 
 T = TypeVar('T')
 
 class object:
+    __slots__: Union['str', Iterable['str']]
     def __init__(self) -> None: pass
 
 class type: pass


### PR DESCRIPTION
This PR implements the suggested general case from https://github.com/python/mypy/issues/10870#issuecomment-886231425

What we do? When we are stuck with the partial type inside a class definition, we try to fetch types from parent definitions.
If this definition exist, we reuse the type.

This way, we won't have a warning here:

```python
from typing import List

class P:
   x: List[int]

class C(P):
   x = []  # used to be an error here: "Need type annotation for "x" (hint: "x: List[<type>] = ...")"

reveal_type(C.x)  # revealed type is: "List[int]"
```

Closes #10870

## Test Plan

I am going to add more tests after someone from the core team approves this approach 🙂 
