### PR TITLE
Use customized error message for %c interpolation

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -40,7 +40,7 @@ from mypy.subtypes import is_subtype
 from mypy.parse import parse
 
 FormatStringExpr = Union[StrExpr, BytesExpr, UnicodeExpr]
-Checkers = Tuple[Callable[[Expression], None], Callable[[Type], None]]
+Checkers = Tuple[Callable[[Expression], bool], Callable[[Type], None]]
 MatchMap = Dict[Tuple[int, int], Match[str]]  # span -> match
 
 
@@ -813,10 +813,10 @@ class StringFormatterChecker:
         """
         expected = self.named_type('builtins.int')
 
-        def check_type(type: Type) -> None:
+        def check_type(type: Type) -> bool:
             expected = self.named_type('builtins.int')
-            self.chk.check_subtype(type, expected, context, '* wants int',
-                                   code=codes.STRING_FORMATTING)
+            return self.chk.check_subtype(type, expected, context, '* wants int',
+                                          code=codes.STRING_FORMATTING)
 
         def check_expr(expr: Expression) -> None:
             type = self.accept(expr, expected)
@@ -824,11 +824,11 @@ class StringFormatterChecker:
 
         return check_expr, check_type
 
-    def check_placeholder_type(self, typ: Type, expected_type: Type, context: Context) -> None:
-        self.chk.check_subtype(typ, expected_type, context,
-                               message_registry.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
-                               'expression has type', 'placeholder has type',
-                               code=codes.STRING_FORMATTING)
+    def check_placeholder_type(self, typ: Type, expected_type: Type, context: Context) -> bool:
+        return self.chk.check_subtype(typ, expected_type, context,
+                                      message_registry.INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION,
+                                      'expression has type', 'placeholder has type',
+                                      code=codes.STRING_FORMATTING)
 
     def checkers_for_regular_type(self, type: str,
                                   context: Context,
@@ -840,11 +840,12 @@ class StringFormatterChecker:
         if expected_type is None:
             return None
 
-        def check_type(typ: Type) -> None:
+        def check_type(typ: Type) -> bool:
             assert expected_type is not None
-            self.check_placeholder_type(typ, expected_type, context)
-            if type == 's':
-                self.check_s_special_cases(expr, typ, context)
+            ret = self.check_placeholder_type(typ, expected_type, context)
+            if ret and type == 's':
+                ret = self.check_s_special_cases(expr, typ, context)
+            return ret
 
         def check_expr(expr: Expression) -> None:
             type = self.accept(expr, expected_type)
@@ -852,7 +853,7 @@ class StringFormatterChecker:
 
         return check_expr, check_type
 
-    def check_s_special_cases(self, expr: FormatStringExpr, typ: Type, context: Context) -> None:
+    def check_s_special_cases(self, expr: FormatStringExpr, typ: Type, context: Context) -> bool:
         """Additional special cases for %s in bytes vs string context."""
         if isinstance(expr, StrExpr):
             # Couple special cases for string formatting.
@@ -862,6 +863,7 @@ class StringFormatterChecker:
                         "On Python 3 '%s' % b'abc' produces \"b'abc'\", not 'abc'; "
                         "use '%r' % b'abc' if this is desired behavior",
                         context, code=codes.STR_BYTES_PY3)
+                    return False
             if self.chk.options.python_version < (3, 0):
                 if has_type_component(typ, 'builtins.unicode'):
                     self.unicode_upcast = True
@@ -871,6 +873,8 @@ class StringFormatterChecker:
                 if has_type_component(typ, 'builtins.str'):
                     self.msg.fail("On Python 3 b'%s' requires bytes, not string", context,
                                   code=codes.STRING_FORMATTING)
+                    return False
+        return True
 
     def checkers_for_c_type(self, type: str,
                             context: Context,
@@ -882,20 +886,30 @@ class StringFormatterChecker:
         if expected_type is None:
             return None
 
-        def check_type(type: Type) -> None:
+        def check_type(type: Type) -> bool:
             assert expected_type is not None
-            self.check_placeholder_type(type, expected_type, context)
+            if self.chk.options.python_version >= (3, 0) and isinstance(format_expr, BytesExpr):
+                err_msg = '"%c" requires an integer in range(256) or a single byte'
+            else:
+                err_msg = '"%c" requires int or char'
+            return self.chk.check_subtype(type, expected_type, context, err_msg,
+                                          'expression has type',
+                                          code=codes.STRING_FORMATTING)
 
         def check_expr(expr: Expression) -> None:
             """int, or str with length 1"""
             type = self.accept(expr, expected_type)
-            # TODO: Use the same the error message when incompatible types match %c
-            # Python 3 doesn't support b'%c' % str
-            if not (self.chk.options.python_version >= (3, 0)
-                    and isinstance(format_expr, BytesExpr)):
+            # We need further check with expr to make sure that
+            # it has exact one char or one single byte.
+            if check_type(type):
+                # Python 3 doesn't support b'%c' % str
+                if (self.chk.options.python_version >= (3, 0) and isinstance(format_expr, BytesExpr)
+                        and isinstance(expr, BytesExpr) and len(expr.value) != 1):
+                    self.msg.requires_int_or_single_byte(context)
+                    return
+                # In Python 2, b'%c' is the same as '%c'
                 if isinstance(expr, (StrExpr, BytesExpr)) and len(expr.value) != 1:
                     self.msg.requires_int_or_char(context)
-            check_type(type)
 
         return check_expr, check_type
 

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -888,12 +888,12 @@ class StringFormatterChecker:
             # it has exact one char or one single byte.
             if check_type(type):
                 # Python 3 doesn't support b'%c' % str
-                if (self.chk.options.python_version >= (3, 0) and isinstance(format_expr, BytesExpr)
+                if (self.chk.options.python_version >= (3, 0)
+                        and isinstance(format_expr, BytesExpr)
                         and isinstance(expr, BytesExpr) and len(expr.value) != 1):
                     self.msg.requires_int_or_single_byte(context)
-                    return
                 # In Python 2, b'%c' is the same as '%c'
-                if isinstance(expr, (StrExpr, BytesExpr)) and len(expr.value) != 1:
+                elif isinstance(expr, (StrExpr, BytesExpr)) and len(expr.value) != 1:
                     self.msg.requires_int_or_char(context)
 
         return check_expr, check_type

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -786,7 +786,7 @@ class StringFormatterChecker:
     def replacement_checkers(self, specifier: ConversionSpecifier, context: Context,
                              expr: FormatStringExpr) -> Optional[List[Checkers]]:
         """Returns a list of tuples of two functions that check whether a replacement is
-        of the right type for the specifier. The first functions take a node and checks
+        of the right type for the specifier. The first function takes a node and checks
         its type in the right type context. The second function just checks a type.
         """
         checkers: List[Checkers] = []
@@ -874,11 +874,11 @@ class StringFormatterChecker:
 
     def checkers_for_c_type(self, type: str,
                             context: Context,
-                            expr: FormatStringExpr) -> Optional[Checkers]:
+                            format_expr: FormatStringExpr) -> Optional[Checkers]:
         """Returns a tuple of check functions that check whether, respectively,
         a node or a type is compatible with 'type' that is a character type.
         """
-        expected_type = self.conversion_type(type, context, expr)
+        expected_type = self.conversion_type(type, context, format_expr)
         if expected_type is None:
             return None
 
@@ -889,8 +889,12 @@ class StringFormatterChecker:
         def check_expr(expr: Expression) -> None:
             """int, or str with length 1"""
             type = self.accept(expr, expected_type)
-            if isinstance(expr, (StrExpr, BytesExpr)) and len(cast(StrExpr, expr).value) != 1:
-                self.msg.requires_int_or_char(context)
+            # TODO: Use the same the error message when incompatible types match %c
+            # Python 3 doesn't support b'%c' % str
+            if not (self.chk.options.python_version >= (3, 0)
+                    and isinstance(format_expr, BytesExpr)):
+                if isinstance(expr, (StrExpr, BytesExpr)) and len(cast(StrExpr, expr).value) != 1:
+                    self.msg.requires_int_or_char(context)
             check_type(type)
 
         return check_expr, check_type
@@ -939,9 +943,12 @@ class StringFormatterChecker:
                         numeric_types.append(self.named_type('typing.SupportsInt'))
             return UnionType.make_union(numeric_types)
         elif p in ['c']:
-            return UnionType([self.named_type('builtins.int'),
-                              self.named_type('builtins.float'),
-                              self.named_type('builtins.str')])
+            if isinstance(expr, BytesExpr):
+                return UnionType([self.named_type('builtins.int'),
+                                  self.named_type('builtins.bytes')])
+            else:
+                return UnionType([self.named_type('builtins.int'),
+                                  self.named_type('builtins.str')])
         else:
             self.msg.unsupported_placeholder(p, context)
             return None

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -40,7 +40,7 @@ from mypy.subtypes import is_subtype
 from mypy.parse import parse
 
 FormatStringExpr = Union[StrExpr, BytesExpr, UnicodeExpr]
-Checkers = Tuple[Callable[[Expression], bool], Callable[[Type], None]]
+Checkers = Tuple[Callable[[Expression], None], Callable[[Type], bool]]
 MatchMap = Dict[Tuple[int, int], Match[str]]  # span -> match
 
 

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -893,7 +893,7 @@ class StringFormatterChecker:
             # Python 3 doesn't support b'%c' % str
             if not (self.chk.options.python_version >= (3, 0)
                     and isinstance(format_expr, BytesExpr)):
-                if isinstance(expr, (StrExpr, BytesExpr)) and len(cast(StrExpr, expr).value) != 1:
+                if isinstance(expr, (StrExpr, BytesExpr)) and len(expr.value) != 1:
                     self.msg.requires_int_or_char(context)
             check_type(type)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -961,6 +961,12 @@ class MessageBuilder:
         self.fail('String interpolation contains both stars and mapping keys', context,
                   code=codes.STRING_FORMATTING)
 
+    def requires_int_or_single_byte(self, context: Context,
+                                    format_call: bool = False) -> None:
+        self.fail('"{}c" requires an integer in range(256) or a single byte' \
+                  .format(':' if format_call else '%'),
+                  context, code=codes.STRING_FORMATTING)
+
     def requires_int_or_char(self, context: Context,
                              format_call: bool = False) -> None:
         self.fail('"{}c" requires int or char'.format(':' if format_call else '%'),

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -963,7 +963,7 @@ class MessageBuilder:
 
     def requires_int_or_single_byte(self, context: Context,
                                     format_call: bool = False) -> None:
-        self.fail('"{}c" requires an integer in range(256) or a single byte' \
+        self.fail('"{}c" requires an integer in range(256) or a single byte'
                   .format(':' if format_call else '%'),
                   context, code=codes.STRING_FORMATTING)
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1281,41 +1281,49 @@ b'%a' % 3
 [case testStringInterPolationCPython2]
 # flags: --py2 --no-strict-optional
 '%c' % 1
-'%c' % 1.0  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "Union[int, str]")
+'%c' % 1.0   # E: "%c" requires int or char (expression has type "float")
 '%c' % 's'
-'%c' % ''  # E: "%c" requires int or char
+'%c' % ''    # E: "%c" requires int or char
 '%c' % 'ab'  # E: "%c" requires int or char
 '%c' % b'a'
+'%c' % b''   # E: "%c" requires int or char
+'%c' % b'ab' # E: "%c" requires int or char
 [builtins_py2 fixtures/python2.pyi]
 
 [case testStringInterpolationC]
 # flags: --python-version 3.6
 '%c' % 1
-'%c' % 1.0  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "Union[int, str]")
+'%c' % 1.0   # E: "%c" requires int or char (expression has type "float")
 '%c' % 's'
-'%c' % ''  # E: "%c" requires int or char
+'%c' % ''    # E: "%c" requires int or char
 '%c' % 'ab'  # E: "%c" requires int or char
-'%c' % b'a'  # E: Incompatible types in string interpolation (expression has type "bytes", placeholder has type "Union[int, str]")
+'%c' % b'a'  # E: "%c" requires int or char (expression has type "bytes")
+'%c' % b''   # E: "%c" requires int or char (expression has type "bytes")
+'%c' % b'ab' # E: "%c" requires int or char (expression has type "bytes")
 [builtins fixtures/primitives.pyi]
 
 [case testBytesInterPolationCPython2]
 # flags: --py2 --no-strict-optional
 b'%c' % 1
-b'%c' % 1.0  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "Union[int, str]")
+b'%c' % 1.0   # E: "%c" requires int or char (expression has type "float")
 b'%c' % 's'
-b'%c' % ''  # E: "%c" requires int or char
+b'%c' % ''    # E: "%c" requires int or char
 b'%c' % 'ab'  # E: "%c" requires int or char
 b'%c' % b'a'
+b'%c' % b''   # E: "%c" requires int or char
+b'%c' % b'aa' # E: "%c" requires int or char
 [builtins_py2 fixtures/python2.pyi]
 
 [case testBytesInterpolationC]
 # flags: --python-version 3.6
 b'%c' % 1
-b'%c' % 1.0   # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "Union[int, bytes]")
-b'%c' % 's'   # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, bytes]")
-b'%c' % ''    # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, bytes]")
-b'%c' % 'ab'  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, bytes]")
+b'%c' % 1.0   # E: "%c" requires an integer in range(256) or a single byte (expression has type "float")
+b'%c' % 's'   # E: "%c" requires an integer in range(256) or a single byte (expression has type "str")
+b'%c' % ''    # E: "%c" requires an integer in range(256) or a single byte (expression has type "str")
+b'%c' % 'ab'  # E: "%c" requires an integer in range(256) or a single byte (expression has type "str")
 b'%c' % b'a'
+b'%c' % b''   # E: "%c" requires an integer in range(256) or a single byte
+b'%c' % b'aa' # E: "%c" requires an integer in range(256) or a single byte
 [builtins fixtures/primitives.pyi]
 
 [case testStringInterpolationMappingTypes]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1278,11 +1278,44 @@ b'%a' % 3
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-medium.pyi]
 
-[case testStringInterpolationC]
+[case testStringInterPolationCPython2]
+# flags: --py2 --no-strict-optional
 '%c' % 1
+'%c' % 1.0  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "Union[int, str]")
 '%c' % 's'
 '%c' % ''  # E: "%c" requires int or char
 '%c' % 'ab'  # E: "%c" requires int or char
+'%c' % b'a'
+[builtins_py2 fixtures/python2.pyi]
+
+[case testStringInterpolationC]
+# flags: --python-version 3.6
+'%c' % 1
+'%c' % 1.0  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "Union[int, str]")
+'%c' % 's'
+'%c' % ''  # E: "%c" requires int or char
+'%c' % 'ab'  # E: "%c" requires int or char
+'%c' % b'a'  # E: Incompatible types in string interpolation (expression has type "bytes", placeholder has type "Union[int, str]")
+[builtins fixtures/primitives.pyi]
+
+[case testBytesInterPolationCPython2]
+# flags: --py2 --no-strict-optional
+b'%c' % 1
+b'%c' % 1.0  # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "Union[int, str]")
+b'%c' % 's'
+b'%c' % ''  # E: "%c" requires int or char
+b'%c' % 'ab'  # E: "%c" requires int or char
+b'%c' % b'a'
+[builtins_py2 fixtures/python2.pyi]
+
+[case testBytesInterpolationC]
+# flags: --python-version 3.6
+b'%c' % 1
+b'%c' % 1.0   # E: Incompatible types in string interpolation (expression has type "float", placeholder has type "Union[int, bytes]")
+b'%c' % 's'   # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, bytes]")
+b'%c' % ''    # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, bytes]")
+b'%c' % 'ab'  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, bytes]")
+b'%c' % b'a'
 [builtins fixtures/primitives.pyi]
 
 [case testStringInterpolationMappingTypes]
@@ -1540,7 +1573,7 @@ x: Union[Good, Bad]
 
 class C:
     ...
-'{:c}'.format(C())  # E: Incompatible types in string interpolation (expression has type "C", placeholder has type "Union[int, float, str]")
+'{:c}'.format(C())  # E: Incompatible types in string interpolation (expression has type "C", placeholder has type "Union[int, str]")
 x: str
 '{:c}'.format(x)
 [builtins fixtures/primitives.pyi]

--- a/test-data/unit/fixtures/python2.pyi
+++ b/test-data/unit/fixtures/python2.pyi
@@ -18,6 +18,8 @@ class unicode:
     def format(self, *args, **kwars) -> unicode: ...
 class bool(int): pass
 
+bytes = str
+
 T = TypeVar('T')
 S = TypeVar('S')
 class list(Iterable[T], Generic[T]):


### PR DESCRIPTION
### Description

This PR is a follow-up to https://github.com/python/mypy/pull/10869.

* Add more tests for %c interpolation
* The error msg of mypy now is bassically the same  as CPython. We offer hints for incompatible types.
* Change type of `Checkers` from `Tuple[Callable[[Expression], None], Callable[[Type], None]]` to ``Tuple[Callable[[Expression], None], Callable[[Type], bool]]``. `check_expr ` can get a False from `check_type` and stop generating same error message.

## Test Plan

Adds several new test cases.

CPython behaviors:
```py
'%c' % b''   # E: "%c" requires int or char
'%c' % b'ab' # E: "%c" requires int or char
b'%c' % b''   # E: "%c" requires int or char
b'%c' % b'aa' # E: "%c" requires int or char
```