### PR TITLE
Improve type inference special case that involves union with Any

### DIFF
--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1375,3 +1375,11 @@ def f(x: Callable[..., T]) -> T:
 
 x: G[str] = f(G)
 [out]
+
+[case testConditionalExpressionWithEmptyListAndUnionWithAny]
+from typing import Union, List, Any
+
+def f(x: Union[List[str], Any]) -> None:
+    a = x if x else []
+    reveal_type(a)  # N: Revealed type is "Union[builtins.list[builtins.str], Any]"
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
When trying to match `list[T]` and `list[str] | Any`, previously we
gave up, because the union items caused conflicting inferred values
for `T` (`str` and `Any`). Work around the issue by dropping `Any`
constraints if there are multiple sets of contraints, since we
prefer more precise types.

This fixes false positives resulting from python/typeshed#5557,
which changed some return types to contain unions with `Any` items.
See mypy primer results in #10881 for a real-world example of this
in sphinx.