### PR TITLE
[mypyc] Use native calls in singledispatch dispatch functions

### DIFF
--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -1,0 +1,47 @@
+[case testNativeCallsUsedInDispatchFunction]
+from functools import singledispatch
+@singledispatch
+def f(arg) -> bool:
+    return False
+
+@f.register
+def g(arg: int) -> bool:
+    return True
+[out]
+def __mypyc___mypyc_singledispatch_main_function_f___decorator_helper__(arg):
+    arg :: object
+L0:
+    return 0
+def __mypyc_f_decorator_helper__(arg):
+    arg, r0 :: object
+    r1 :: int32
+    r2 :: bit
+    r3 :: bool
+    r4 :: int
+    r5 :: bool
+    r6 :: dict
+    r7 :: str
+    r8, r9 :: object
+    r10 :: bool
+L0:
+    r0 = load_address PyLong_Type
+    r1 = PyObject_IsInstance(arg, r0)
+    r2 = r1 >= 0 :: signed
+    r3 = truncate r1: int32 to builtins.bool
+    if r3 goto L1 else goto L2 :: bool
+L1:
+    r4 = unbox(int, arg)
+    r5 = g(r4)
+    return r5
+L2:
+    r6 = __main__.globals :: static
+    r7 = '__mypyc___mypyc_singledispatch_main_function_f___decorator_helper__'
+    r8 = CPyDict_GetItem(r6, r7)
+    r9 = PyObject_CallFunctionObjArgs(r8, arg, 0)
+    r10 = unbox(bool, r9)
+    return r10
+def g(arg):
+    arg :: int
+L0:
+    return 1
+

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -34,6 +34,7 @@ files = [
     'irbuild-unreachable.test',
     'irbuild-isinstance.test',
     'irbuild-dunders.test',
+    'irbuild-singledispatch.test',
 ]
 
 


### PR DESCRIPTION
This adds support for using native calls to registered implementations when generating dispatch functions for singledispatch functions, instead of always using non-native calls, which can significantly speed up singledispatch (see benchmark results below). We don't use native calls when the registered implementation is a decorated function, as using a native call would ignore any changes the decorator made to the function.

### Benchmark Results

These are the results from running the sum_tree_singledispatch both with this change and on the current master (7808e8265cd4cb29dc7f05ff58ab945ab3f2d20b).

#### Current master
```
interpreted: 0.694200s (avg of 5 iterations; stdev 1%)
compiled:    0.661199s (avg of 5 iterations; stdev 1.3%)

compiled is 1.050x faster
```
#### This PR
```
interpreted: 0.701401s (avg of 5 iterations; stdev 1.4%)
compiled:    0.603199s (avg of 5 iterations; stdev 1.7%)

compiled is 1.163x faster
```
## Test Plan

I added an irbuild test to make sure we are actually using native calls when there are no non-register decorators.
