### PR TITLE
[mypyc] Refactor: reuse format string parser

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -624,7 +624,7 @@ class StringFormatterChecker:
                                                      spec=spec, ctx=ctx)
 
     # TODO: In Python 3, the bytes formatting has a more restricted set of options
-    # compared to string formatting.
+    #       compared to string formatting.
     def check_str_interpolation(self,
                                 expr: FormatStringExpr,
                                 replacements: Expression) -> Type:

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -114,7 +114,7 @@ FLOAT_TYPES: Final = {"e", "E", "f", "F", "g", "G"}
 
 
 class ConversionSpecifier:
-    def __init__(self, type: str,
+    def __init__(self, type: str, whole_seq: str,
                  key: Optional[str],
                  flags: Optional[str],
                  width: Optional[str],
@@ -122,9 +122,10 @@ class ConversionSpecifier:
                  format_spec: Optional[str] = None,
                  conversion: Optional[str] = None,
                  field: Optional[str] = None,
-                 whole_seq: Optional[str] = None,
                  start_pos: int = -1) -> None:
         self.type = type
+        self.whole_seq = whole_seq
+
         self.key = key
         self.flags = flags
         self.width = width
@@ -139,7 +140,6 @@ class ConversionSpecifier:
         # Used only for str.format() calls.
         self.field = field
 
-        self.whole_seq = whole_seq
         self.start_pos = start_pos
 
     @classmethod
@@ -147,7 +147,7 @@ class ConversionSpecifier:
                    non_standard_spec: bool = False) -> 'ConversionSpecifier':
         """Construct specifier from match object resulted from parsing str.format() call."""
         if non_standard_spec:
-            spec = cls(type='',
+            spec = cls(type='', whole_seq=match.group(),
                        key=match.group('key'),
                        flags='', width='', precision='',
                        format_spec=match.group('format_spec'),
@@ -157,6 +157,7 @@ class ConversionSpecifier:
             return spec
         # Replace unmatched optional groups with empty matches (for convenience).
         return cls(type=match.group('type') or '',
+                   whole_seq=match.group(),
                    key=match.group('key'),
                    flags=match.group('flags') or '',
                    width=match.group('width') or '',
@@ -176,8 +177,9 @@ def parse_conversion_specifiers(format_str: str) -> List[ConversionSpecifier]:
     specifiers: List[ConversionSpecifier] = []
     for m in re.finditer(FORMAT_RE, format_str):
         whole_seq, parens_key, key, flags, width, precision, conversion_type = m.groups()
-        specifiers.append(ConversionSpecifier(conversion_type, key, flags, width, precision,
-                                              whole_seq=whole_seq, start_pos=m.start()))
+        specifiers.append(ConversionSpecifier(conversion_type, whole_seq,
+                                              key, flags, width, precision,
+                                              start_pos=m.start()))
     return specifiers
 
 

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -12,7 +12,8 @@ generator comprehensions as the argument.
 See comment below for more documentation.
 """
 
-from typing import Callable, Optional, Dict, Tuple, List, Final
+from typing import Callable, Optional, Dict, Tuple, List
+from typing_extensions import Final
 
 from mypy.checkstrformat import parse_format_value
 from mypy.errors import Errors

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -391,10 +391,9 @@ def translate_dict_setdefault(
     return None
 
 
-# The empty Context and MessageBuilder for parse_format_value().
-# They wouldn't be used since the code has passed the type-checking.
+# The empty Context as an argument for parse_format_value().
+# It wouldn't be used since the code has passed the type-checking.
 EMPTY_CONTEXT: Final = Context()
-EMPTY_MSG: Final = MessageBuilder(Errors(), {})
 
 
 @specialize_function('format', str_rprimitive)
@@ -403,7 +402,11 @@ def translate_str_format(
     if (isinstance(callee, MemberExpr) and isinstance(callee.expr, StrExpr)
             and expr.arg_kinds.count(ARG_POS) == len(expr.arg_kinds)):
         format_str = callee.expr.value
-        specifiers = parse_format_value(format_str, EMPTY_CONTEXT, EMPTY_MSG)
+
+        # Creates an empty MessageBuilder here.
+        # It wouldn't be used since the code has passed the type-checking.
+        specifiers = parse_format_value(format_str, EMPTY_CONTEXT,
+                                        MessageBuilder(Errors(), {}))
         if specifiers is None:
             return None
 

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -14,9 +14,12 @@ See comment below for more documentation.
 
 from typing import Callable, Optional, Dict, Tuple, List
 
+from mypy.checkstrformat import parse_format_value
+from mypy.errors import Errors
+from mypy.messages import MessageBuilder
 from mypy.nodes import (
     CallExpr, RefExpr, MemberExpr, NameExpr, TupleExpr, GeneratorExpr,
-    ListExpr, DictExpr, StrExpr, ARG_POS
+    ListExpr, DictExpr, StrExpr, ARG_POS, Context, MypyFile
 )
 from mypy.types import AnyType, TypeOfAny
 
@@ -388,17 +391,31 @@ def translate_dict_setdefault(
     return None
 
 
+# The empty Context and MessageBuilder for parse_format_value().
+# They wouldn't be used since the code has passed the type-checking.
+EMPTY_CONTEXT = Context()
+EMPTY_MSG = MessageBuilder(Errors(), {'': MypyFile([], [])})
+
+
 @specialize_function('format', str_rprimitive)
 def translate_str_format(
         builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Optional[Value]:
     if (isinstance(callee, MemberExpr) and isinstance(callee.expr, StrExpr)
             and expr.arg_kinds.count(ARG_POS) == len(expr.arg_kinds)):
-
         format_str = callee.expr.value
-        if not can_optimize_format(format_str):
-            return None
+        specifiers = parse_format_value(format_str, EMPTY_CONTEXT, EMPTY_MSG)
+        literals = []
+        last_pos = 0
+        for spec in specifiers:
+            # Only empty curly brace is allowed
+            if spec.whole_seq:
+                return None
+            literals.append(format_str[last_pos:spec.start_pos-1])
+            last_pos = spec.start_pos + len(spec.whole_seq) + 1
+        literals.append(format_str[last_pos:])
 
-        literals = split_braces(format_str)
+        # Deal with escaped {{
+        literals = [x.replace('{{', '{').replace('}}', '}') for x in literals]
 
         # Convert variables to strings
         variables = []
@@ -414,61 +431,6 @@ def translate_str_format(
 
         return join_formatted_strings(builder, literals, variables, expr.line)
     return None
-
-
-def can_optimize_format(format_str: str) -> bool:
-    # TODO
-    # Only empty braces can be optimized
-    prev = ''
-    for c in format_str:
-        if (c == '{' and prev == '{'
-                or c == '}' and prev == '}'):
-            prev = ''
-            continue
-        if (prev != '' and (c == '}' and prev != '{'
-                            or prev == '{' and c != '}')):
-            return False
-        prev = c
-    return True
-
-
-def split_braces(format_str: str) -> List[str]:
-    # This function can only be called after format_str passes
-    # 'can_optimize_format()'.
-    tmp_str = ''
-    ret_list = []
-    prev = ''
-    for c in format_str:
-        # There are three cases: {, }, others
-        #     when c is '}': prev is '{' -> match empty braces
-        #                            '}' -> merge into one } in literal
-        #                            others -> pass
-        #          c is '{': prev is '{' -> merge into one { in literal
-        #                            '}' -> pass
-        #                            others -> pass
-        #          c is others: add c into literal
-        clear_prev = True
-        if c == '}':
-            if prev == '{':
-                ret_list.append(tmp_str)
-                tmp_str = ''
-            elif prev == '}':
-                tmp_str += '}'
-            else:
-                clear_prev = False
-        elif c == '{':
-            if prev == '{':
-                tmp_str += '{'
-            else:
-                clear_prev = False
-        else:
-            tmp_str += c
-            clear_prev = False
-        prev = c
-        if clear_prev:
-            prev = ''
-    ret_list.append(tmp_str)
-    return ret_list
 
 
 @specialize_function('join', str_rprimitive)

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -12,14 +12,14 @@ generator comprehensions as the argument.
 See comment below for more documentation.
 """
 
-from typing import Callable, Optional, Dict, Tuple, List
+from typing import Callable, Optional, Dict, Tuple, List, Final
 
 from mypy.checkstrformat import parse_format_value
 from mypy.errors import Errors
 from mypy.messages import MessageBuilder
 from mypy.nodes import (
     CallExpr, RefExpr, MemberExpr, NameExpr, TupleExpr, GeneratorExpr,
-    ListExpr, DictExpr, StrExpr, ARG_POS, Context, MypyFile
+    ListExpr, DictExpr, StrExpr, ARG_POS, Context
 )
 from mypy.types import AnyType, TypeOfAny
 
@@ -393,8 +393,8 @@ def translate_dict_setdefault(
 
 # The empty Context and MessageBuilder for parse_format_value().
 # They wouldn't be used since the code has passed the type-checking.
-EMPTY_CONTEXT = Context()
-EMPTY_MSG = MessageBuilder(Errors(), {'': MypyFile([], [])})
+EMPTY_CONTEXT: Final = Context()
+EMPTY_MSG: Final = MessageBuilder(Errors(), {})
 
 
 @specialize_function('format', str_rprimitive)
@@ -404,7 +404,8 @@ def translate_str_format(
             and expr.arg_kinds.count(ARG_POS) == len(expr.arg_kinds)):
         format_str = callee.expr.value
         specifiers = parse_format_value(format_str, EMPTY_CONTEXT, EMPTY_MSG)
-        assert specifiers is not None
+        if specifiers is None:
+            return None
 
         literals = []
         last_pos = 0

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -404,6 +404,8 @@ def translate_str_format(
             and expr.arg_kinds.count(ARG_POS) == len(expr.arg_kinds)):
         format_str = callee.expr.value
         specifiers = parse_format_value(format_str, EMPTY_CONTEXT, EMPTY_MSG)
+        assert specifiers is not None
+
         literals = []
         last_pos = 0
         for spec in specifiers:

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -164,12 +164,12 @@ def f(s: str, num: int) -> None:
     s1 = "Hi! I'm {}, and I'm {} years old.".format(s, num)
     s2 = ''.format()
     s3 = 'abc'.format()
-    s3 = '}}{}{{{}}}{{{}'.format(num, num, num)
+    s4 = '}}{}{{{}}}{{{}'.format(num, num, num)
 [out]
 def f(s, num):
     s :: str
     num :: int
-    r0, r1, r2, r3, r4, s1, r5, s2, r6, s3, r7, r8, r9, r10, r11, r12, r13 :: str
+    r0, r1, r2, r3, r4, s1, r5, s2, r6, s3, r7, r8, r9, r10, r11, r12, r13, s4 :: str
 L0:
     r0 = CPyTagged_Str(num)
     r1 = "Hi! I'm "
@@ -188,7 +188,7 @@ L0:
     r11 = '{'
     r12 = '}{'
     r13 = CPyStr_Build(6, r10, r7, r11, r8, r12, r9)
-    s3 = r13
+    s4 = r13
     return 1
 
 [case testFStrings]


### PR DESCRIPTION
### Description

`parse_conversion_specifiers` and `parse_format_value` from `mypy.checkstrformat` can be reused when compiling string formatting. `can_optimize_format` and `split_braces` are useless now.

Adding a `start_pos` as an attribute of `ConversionSpecifier` can not only help parse literals but also help generate useful error messages in the future.

## Test Plan
