### PR TITLE
Add new regex example to --exclude docs

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -58,7 +58,9 @@ for full details, see :ref:`running-mypy`.
     For instance, to avoid discovering any files named `setup.py` you could
     pass ``--exclude '/setup\.py$'``. Similarly, you can ignore discovering
     directories with a given name by e.g. ``--exclude /build/`` or
-    those matching a subpath with ``--exclude /project/vendor/``.
+    those matching a subpath with ``--exclude /project/vendor/``. In adition,
+    to ignore multiple file or directory names, you can combine expressions
+    with ``|`` and pass e.g ``--exclude '/setup\.py$|/build/'``.
 
     Note that this flag only affects recursive discovery, that is, when mypy is
     discovering files within a directory tree or submodules of a package to

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -58,9 +58,9 @@ for full details, see :ref:`running-mypy`.
     For instance, to avoid discovering any files named `setup.py` you could
     pass ``--exclude '/setup\.py$'``. Similarly, you can ignore discovering
     directories with a given name by e.g. ``--exclude /build/`` or
-    those matching a subpath with ``--exclude /project/vendor/``. In adition,
-    to ignore multiple file or directory names, you can combine expressions
-    with ``|`` and pass e.g ``--exclude '/setup\.py$|/build/'``.
+    those matching a subpath with ``--exclude /project/vendor/``. To ignore
+    multiple files / directories / paths, you can combine expressions with
+    ``|``, e.g ``--exclude '/setup\.py$|/build/'``.
 
     Note that this flag only affects recursive discovery, that is, when mypy is
     discovering files within a directory tree or submodules of a package to


### PR DESCRIPTION
### Description

Fixes #10250 

Adds an example on how to use the OR-operator to combine two regular expressions in order to ignore multiple file or directory names.