### PR TITLE
Fix get_dynamic_class_hook does not work in some scenarios

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -95,7 +95,6 @@ from mypy.types import (
 )
 from mypy.typeops import function_type
 from mypy.type_visitor import TypeQuery
-from mypy.traverser import all_call_expressions
 from mypy.nodes import implicit_module_attrs
 from mypy.typeanal import (
     TypeAnalyser, analyze_type_alias, no_subscript_builtin_alias,
@@ -2280,24 +2279,31 @@ class SemanticAnalyzer(NodeVisitor[None],
     def apply_dynamic_class_hook(self, s: AssignmentStmt) -> None:
         if not isinstance(s.rvalue, CallExpr):
             return
-        call_expressions = all_call_expressions(s)
+        fname = None
+        call = s.rvalue
+        while True:
+            if isinstance(call.callee, RefExpr):
+                fname = call.callee.fullname
+            # check if method call
+            if fname is None and isinstance(call.callee, MemberExpr):
+                callee_expr = call.callee.expr
+                if isinstance(callee_expr, RefExpr) and callee_expr.fullname:
+                    method_name = call.callee.name
+                    fname = callee_expr.fullname + '.' + method_name
+                elif isinstance(callee_expr, CallExpr):
+                    # check if chain call
+                    call = callee_expr
+                    continue
+            break
+        if not fname:
+            return
+        hook = self.plugin.get_dynamic_class_hook(fname)
+        if not hook:
+            return
         for lval in s.lvalues:
             if not isinstance(lval, NameExpr):
                 continue
-            for call in call_expressions:
-                fname = None
-                if isinstance(call.callee, RefExpr):
-                    fname = call.callee.fullname
-                # check if method call
-                if fname is None and isinstance(call.callee, MemberExpr):
-                    callee_expr = call.callee.expr
-                    if isinstance(callee_expr, RefExpr) and callee_expr.fullname:
-                        method_name = call.callee.name
-                        fname = callee_expr.fullname + '.' + method_name
-                if fname:
-                    hook = self.plugin.get_dynamic_class_hook(fname)
-                    if hook:
-                        hook(DynamicClassDefContext(call, lval.name, self))
+            hook(DynamicClassDefContext(call, lval.name, self))
 
     def unwrap_final(self, s: AssignmentStmt) -> bool:
         """Strip Final[...] if present in an assignment.

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -378,19 +378,3 @@ def all_yield_expressions(node: Node) -> List[Tuple[YieldExpr, bool]]:
     v = YieldCollector()
     node.accept(v)
     return v.yield_expressions
-
-
-class CallCollector(TraverserVisitor):
-    def __init__(self) -> None:
-        super().__init__()
-        self.call_expressions: List[CallExpr] = []
-
-    def visit_call_expr(self, o: CallExpr) -> None:
-        self.call_expressions.append(o)
-        return super().visit_call_expr(o)
-
-
-def all_call_expressions(node: Node) -> List[CallExpr]:
-    v = CallCollector()
-    node.accept(v)
-    return v.call_expressions

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -378,3 +378,19 @@ def all_yield_expressions(node: Node) -> List[Tuple[YieldExpr, bool]]:
     v = YieldCollector()
     node.accept(v)
     return v.yield_expressions
+
+
+class CallCollector(TraverserVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.call_expressions: List[CallExpr] = []
+
+    def visit_call_expr(self, o: CallExpr) -> None:
+        self.call_expressions.append(o)
+        return super().visit_call_expr(o)
+
+
+def all_call_expressions(node: Node) -> List[CallExpr]:
+    v = CallCollector()
+    node.accept(v)
+    return v.call_expressions

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -543,32 +543,58 @@ class Instr(Generic[T]): ...
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/dyn_class.py
 
-[case testDynamicClassPluginNegatives]
+[case testDynamicClassPluginChainCall]
 # flags: --config-file tmp/mypy.ini
-from mod import declarative_base, Column, Instr, non_declarative_base
+from mod import declarative_base, Column, Instr
 
-Bad1 = non_declarative_base()
-Bad2 = Bad3 = declarative_base()
+Base = declarative_base().with_optional_xxx()
 
-class C1(Bad1): ...  # E: Variable "__main__.Bad1" is not valid as a type \
-                     # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases \
-                     # E: Invalid base class "Bad1"
-class C2(Bad2): ...  # E: Variable "__main__.Bad2" is not valid as a type \
-                     # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases \
-                     # E: Invalid base class "Bad2"
-class C3(Bad3): ...  # E: Variable "__main__.Bad3" is not valid as a type \
-                     # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases \
-                     # E: Invalid base class "Bad3"
+class Model(Base):
+    x: Column[int]
+
+reveal_type(Model().x)  # N: Revealed type is "mod.Instr[builtins.int]"
 [file mod.py]
 from typing import Generic, TypeVar
-def declarative_base(): ...
-def non_declarative_base(): ...
+
+class Base:
+    def with_optional_xxx(self) -> Base: ...
+
+def declarative_base() -> Base: ...
 
 T = TypeVar('T')
 
 class Column(Generic[T]): ...
 class Instr(Generic[T]): ...
 
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/dyn_class.py
+
+[case testDynamicClassPluginChainedAssignment]
+# flags: --config-file tmp/mypy.ini
+from mod import declarative_base
+
+Base1 = Base2 = declarative_base()
+
+class C1(Base1): ...  
+class C2(Base2): ...
+[file mod.py]
+def declarative_base(): ...
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/dyn_class.py
+
+[case testDynamicClassPluginNegatives]
+# flags: --config-file tmp/mypy.ini
+from mod import non_declarative_base
+
+Bad1 = non_declarative_base()
+
+class C1(Bad1): ...  # E: Variable "__main__.Bad1" is not valid as a type \
+                     # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases \
+                     # E: Invalid base class "Bad1"
+[file mod.py]
+def non_declarative_base(): ...
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/dyn_class.py


### PR DESCRIPTION
### Description

The `get_dynamic_class_hook` method of the plugin never called if the statement is a chained assignment like `Bad1 = Bad2 = declarative_base()`; Or if the statement is a chain of call expressions like `Base = declarative_base().with_optionalA()`.

## Test Plan

1. Update existed unit test "mypy/test/testcheck.py::TypeCheckSuite::testDynamicClassPluginNegatives"

```plain
[case testDynamicClassPluginNegatives]
# flags: --config-file tmp/mypy.ini
from mod import non_declarative_base

Bad1 = non_declarative_base()

class C1(Bad1): ...  # E: Variable "__main__.Bad1" is not valid as a type \
                     # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases \
                     # E: Invalid base class "Bad1"
[file mod.py]
def non_declarative_base(): ...
[file mypy.ini]
\[mypy]
plugins=<ROOT>/test-data/unit/plugins/dyn_class.py

```

2. Add two new unit tests

```plain
[case testDynamicClassPluginChainCall]
# flags: --config-file tmp/mypy.ini
from mod import declarative_base, Column, Instr

Base = declarative_base().with_optional_xxx()

class Model(Base):
    x: Column[int]

reveal_type(Model().x)  # N: Revealed type is "mod.Instr[builtins.int]"
[file mod.py]
from typing import Generic, TypeVar

class Base:
    def with_optional_xxx(self) -> Base: ...

def declarative_base() -> Base: ...

T = TypeVar('T')

class Column(Generic[T]): ...
class Instr(Generic[T]): ...

[file mypy.ini]
\[mypy]
plugins=<ROOT>/test-data/unit/plugins/dyn_class.py

[case testDynamicClassPluginChainedAssignment]
# flags: --config-file tmp/mypy.ini
from mod import declarative_base

Base1 = Base2 = declarative_base()

class C1(Base1): ...  
class C2(Base2): ...
[file mod.py]
def declarative_base(): ...
[file mypy.ini]
\[mypy]
plugins=<ROOT>/test-data/unit/plugins/dyn_class.py

```