### PR TITLE
stubgen: use sys.version_info, rather than hardcoding 3.6

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1646,7 +1646,7 @@ def parse_options(args: List[str]) -> Options:
 
     ns = parser.parse_args(args)
 
-    pyversion = defaults.PYTHON2_VERSION if ns.py2 else defaults.PYTHON3_VERSION
+    pyversion = defaults.PYTHON2_VERSION if ns.py2 else sys.version_info[:2]
     if not ns.interpreter:
         ns.interpreter = sys.executable if pyversion[0] == 3 else default_py2_interpreter()
     if ns.modules + ns.packages and ns.files:


### PR DESCRIPTION
Not too familiar with stubgen, so maybe there's a good reason for
hardcoding, e.g. to ensure stubs capture sys.version checks in the
source? Even if that's the case, most stubs in typeshed use
sys.version checks for a) checking Python 2, b) if they're stdlib
backports. So hopefully this is a reasonable change.

Fixes #10905, fixes #10791