### PR TITLE
Fix conditional_type_map to not broaden the type (#10739)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -71,7 +71,9 @@ from mypy.visitor import NodeVisitor
 from mypy.join import join_types
 from mypy.treetransform import TransformVisitor
 from mypy.binder import ConditionalTypeBinder, get_declaration
-from mypy.meet import is_overlapping_erased_types, is_overlapping_types
+from mypy.meet import (
+    is_overlapping_erased_types, is_overlapping_types, narrow_declared_type
+)
 from mypy.options import Options
 from mypy.plugin import Plugin, CheckerPluginInterface
 from mypy.sharedparse import BINARY_MAGIC_METHODS
@@ -5130,7 +5132,8 @@ def conditional_type_map(expr: Expression,
                                           for type_range in proposed_type_ranges
                                           if not type_range.is_upper_bound])
                 remaining_type = restrict_subtype_away(current_type, proposed_precise_type)
-                return {expr: proposed_type}, {expr: remaining_type}
+                narrowed_proposed_type = narrow_declared_type(current_type, proposed_type)
+                return {expr: narrowed_proposed_type}, {expr: remaining_type}
         else:
             return {expr: proposed_type}, {}
     else:

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -2552,6 +2552,61 @@ if isinstance(foo, Ambiguous):
     reveal_type(foo.x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/isinstance.pyi]
 
+[case testIsInstanceWithNonSubsetOverlap]
+from typing import Union
+class A: pass
+class B: pass
+class C: pass
+
+x: Union[A, B, C]
+if isinstance(x, (A, B)):
+    reveal_type(x)  # N: Revealed type is "Union[__main__.A, __main__.B]"
+    if isinstance(x, (B, C)):
+        # This is the key clause of the test.
+        # Avoid a regression to "Union[__main__.B, __main__.C]" because
+        # we know that x is not C.
+        reveal_type(x)  # N: Revealed type is "__main__.B"
+    else:
+        reveal_type(x)  # N: Revealed type is "__main__.A"
+else:
+    reveal_type(x)  # N: Revealed type is "__main__.C"
+[builtins fixtures/isinstancelist.pyi]
+
+[case testIsInstanceWithTypeVar]
+from typing import Any, TypeVar, Union
+
+T = TypeVar("T", bound=Any)
+U = TypeVar("U", bound=Union[float, int])
+V = TypeVar("V")
+
+def f(x: T) -> None:
+    if isinstance(x, int):
+        x + 1
+def g(y: U) -> None:
+    if isinstance(y, int):
+        y + 1
+def h(z: V) -> None:
+    if isinstance(z, int):
+        z + 1
+[builtins fixtures/isinstance.pyi]
+
+[case testIsInstanceWithTypeVarAndSubclass]
+from typing import Any, TypeVar, Union
+
+class A: pass
+class B(A): pass
+
+T = TypeVar("T", bound=A)
+U = TypeVar("U", bound=B)
+
+def f(x: T) -> None:
+    if isinstance(x, B):
+        reveal_type(x)  # N: Revealed type is "__main__.B"
+def g(y: U) -> None:
+    if isinstance(y, A):
+        reveal_type(y)  # N: Revealed type is "U`-1"
+[builtins fixtures/isinstance.pyi]
+
 [case testIsSubclassAdHocIntersection]
 # flags: --warn-unreachable
 from typing import Type


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Fixes #10739

Previously, if you used an isinstance check that is more broad than the current type, it would broaden the current type to the type of the isinstance.

After this change, an isinstance check can only narrow the type, not expand it.

## Test Plan

I added a test `testIsInstanceWithNonSubsetOverlap` and ran it locally, both the individual test and with `./runtests.py`. My new test failed before my change and succeeded after my change.

Then I tried it out on a codebase and I saw a few new failures. I added regression tests to maintain the old behavior
* `testIsInstanceWithTypeVar`
* `testIsInstanceWithTypeVarAndSubclass`

The change I made to pass those new regression tests was to switch from `meet_types` to `narrow_declared_type`.
