### PR TITLE
[mypyc] Optimize construction via list() & dict()

### DIFF
--- a/mypyc/doc/dict_operations.rst
+++ b/mypyc/doc/dict_operations.rst
@@ -13,6 +13,11 @@ Construct dict from keys and values:
 
 * ``{key: value,  ...}``
 
+Construct empty dict:
+
+* ``{}``
+* ``dict()``
+
 Construct dict from another object:
 
 * ``dict(d: dict)``

--- a/mypyc/doc/list_operations.rst
+++ b/mypyc/doc/list_operations.rst
@@ -13,6 +13,11 @@ Construct list with specific items:
 
 * ``[item0, ..., itemN]``
 
+Construct empty list:
+
+* ``[]``
+* ``list()``
+
 Construct list from iterable:
 
 * ``list(x: Iterable)``

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -17,6 +17,14 @@ load_address_op(
     type=object_rprimitive,
     src='PyDict_Type')
 
+# Construct an empty dictionary via dict().
+function_op(
+    name='builtins.dict',
+    arg_types=[],
+    return_type=dict_rprimitive,
+    c_function_name='PyDict_New',
+    error_kind=ERR_MAGIC)
+
 # Construct an empty dictionary.
 dict_new_op = custom_op(
     arg_types=[],

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -24,6 +24,15 @@ to_list = function_op(
     c_function_name='PySequence_List',
     error_kind=ERR_MAGIC)
 
+# Construct an empty list via list().
+function_op(
+    name='builtins.list',
+    arg_types=[],
+    return_type=list_rprimitive,
+    c_function_name='PyList_New',
+    error_kind=ERR_MAGIC,
+    extra_int_constants=[(0, int_rprimitive)])
+
 new_list_op = custom_op(
     arg_types=[c_pyssize_t_rprimitive],
     return_type=list_rprimitive,

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -42,6 +42,19 @@ L0:
     d = r0
     return 1
 
+[case testNewEmptyDictViaFunc]
+from typing import Dict
+def f() -> None:
+    d: Dict[bool, int] = dict()
+
+[out]
+def f():
+    r0, d :: dict
+L0:
+    r0 = PyDict_New()
+    d = r0
+    return 1
+
 [case testNewDictWithValues]
 def f(x: object) -> None:
     d = {1: 2, '': x}

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -70,6 +70,19 @@ L0:
     x = r0
     return 1
 
+[case testNewListEmptyViaFunc]
+from typing import List
+def f() -> None:
+    x: List[int] = list()
+
+[out]
+def f():
+    r0, x :: list
+L0:
+    r0 = PyList_New(0)
+    x = r0
+    return 1
+
 [case testNewListTwoItems]
 from typing import List
 def f() -> None:


### PR DESCRIPTION
### Description

Resolves mypyc/mypyc#882.

Instead of loading the type and calling it via the vectorcall convention let's use PyList_New / PyDict_New directly to create these empty collections. This mimics the behaviour constructing empty list and dict literals.   

## Test Plan

- Added two more irbuild test cases, one for each type
- Built the mypyc documentation locally and checked it for any markup issues
