### PR TITLE
Make the test system marginally less hostile to external reuse

### DIFF
--- a/mypy/test/config.py
+++ b/mypy/test/config.py
@@ -11,9 +11,6 @@ else:
 test_data_prefix = os.path.join(PREFIX, 'test-data', 'unit')
 package_path = os.path.join(PREFIX, 'test-data', 'packages')
 
-assert os.path.isdir(test_data_prefix), \
-    'Test data prefix ({}) not set correctly'.format(test_data_prefix)
-
 # Temp directory used for the temp files created when running test cases.
 # This is *within* the tempfile.TemporaryDirectory that is chroot'ed per testcase.
 # It is also hard-coded in numerous places, so don't change it.

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -594,6 +594,10 @@ class DataSuiteCollector(pytest.Class):
 
         # obj is the object for which pytest_pycollect_makeitem returned self.
         suite: DataSuite = self.obj
+
+        assert os.path.isdir(suite.data_prefix), \
+            'Test data prefix ({}) not set correctly'.format(suite.data_prefix)
+
         for f in suite.files:
             yield from split_test_cases(self, suite, os.path.join(suite.data_prefix, f))
 


### PR DESCRIPTION
We currently assert that test-data is present in `mypy.test.config`;
delay that until we actually do collection, so that things are at
least importable.