### PR TITLE
Skip overlapping overload checks in ignored files

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -466,6 +466,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # At this point we should have set the impl already, and all remaining
         # items are decorators
 
+        if self.msg.errors.file in self.msg.errors.ignored_files:
+            # This is a little hacky, however, the quadratic check here is really expensive, this
+            # method has no side effects, so we should skip it if we aren't going to report
+            # anything. In some other places we swallow errors in stubs, but this error is very
+            # useful for stubs!
+            return
+
         # Compute some info about the implementation (if it exists) for use below
         impl_type: Optional[CallableType] = None
         if defn.impl:


### PR DESCRIPTION
Resolves #9691

As mentioned in that issue, this is a huge performance win. On the
codebase I'm currently working on, it halves a cacheless interpreted
mypy runtime. The linked issue contains a benchmark run.