### PR TITLE
[mypyc] Use MRO of argument for dispatch in singledispatch functions

### DIFF
--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -812,7 +812,6 @@ def get_func_target(builder: IRBuilder, fdef: FuncDef) -> AssignmentTarget:
 
 
 def load_type(builder: IRBuilder, typ: TypeInfo, line: int) -> Value:
-    # TODO: refactor check_if_isinstance to use this instead of copying code
     if typ in builder.mapper.type_to_ir:
         class_ir = builder.mapper.type_to_ir[typ]
         class_obj = builder.builder.get_native_type(class_ir)

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -35,7 +35,7 @@ from mypyc.primitives.generic_ops import py_setattr_op, next_raw_op, iter_op
 from mypyc.primitives.misc_ops import (
     check_stop_op, yield_from_except_op, coro_op, send_op
 )
-from mypyc.primitives.dict_ops import dict_set_item_op, dict_new_op
+from mypyc.primitives.dict_ops import dict_set_item_op
 from mypyc.common import SELF_NAME, LAMBDA_NAME, decorator_helper_name
 from mypyc.sametype import is_same_method_signature
 from mypyc.irbuild.util import is_constant
@@ -928,12 +928,6 @@ def gen_dispatch_func_ir(
 def load_singledispatch_registry(builder: IRBuilder, fitem: FuncDef, line: int) -> Value:
     name = get_registry_identifier(fitem)
     return builder.add(LoadStatic(dict_rprimitive, name, builder.module_name, line=line))
-
-
-
-
-
-
 
 
 def singledispatch_main_func_name(orig_name: str) -> str:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -226,7 +226,7 @@ def gen_func_item(builder: IRBuilder,
         class_name = cdef.name
 
     if is_singledispatch:
-        func_name = '__mypyc_singledispatch_main_function_{}__'.format(name)
+        func_name = singledispatch_main_func_name(name)
     else:
         func_name = name
     builder.enter(FuncInfo(fitem, func_name, class_name, gen_func_ns(builder),
@@ -919,3 +919,6 @@ def sort_with_subclasses_first(
 
     for group in reversed(list(dispatch_types)):
         yield from ((typ, impl_dict[typ]) for typ in group if typ in impl_dict)
+
+def singledispatch_main_func_name(orig_name: str) -> str:
+    return '__mypyc_singledispatch_main_function_{}__'.format(orig_name)

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -927,7 +927,8 @@ def gen_dispatch_func_ir(
 
 def load_singledispatch_registry(builder: IRBuilder, fitem: FuncDef, line: int) -> Value:
     name = get_registry_identifier(fitem)
-    return builder.add(LoadStatic(dict_rprimitive, name, builder.module_name, line=line))
+    module_name = fitem.fullname.rsplit('.', maxsplit=1)[0]
+    return builder.add(LoadStatic(dict_rprimitive, name, module_name, line=line))
 
 
 def singledispatch_main_func_name(orig_name: str) -> str:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -884,7 +884,8 @@ def generate_singledispatch_dispatch_function(
     ret_val = builder.py_call(
         impl_to_use, arg_info.args, line, arg_info.arg_kinds, arg_info.arg_names
     )
-    builder.nonlocal_control[-1].gen_return(builder, ret_val, line)
+    coerced = builder.coerce(ret_val, current_func_decl.sig.ret_type, line)
+    builder.nonlocal_control[-1].gen_return(builder, coerced, line)
 
 
 def gen_dispatch_func_ir(

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -10,10 +10,8 @@ as an environment containing non-local variables, is stored in the
 instance of the callable class.
 """
 
-from mypyc.irbuild.prepare import RegisterImplInfo
-from mypy.build import topsort
 from typing import (
-    NamedTuple, Optional, List, Sequence, Tuple, Union, Dict, Iterator,
+    NamedTuple, Optional, List, Sequence, Tuple, Union, Dict,
 )
 
 from mypy.nodes import (
@@ -901,20 +899,6 @@ def gen_dispatch_func_ir(
     func_decl = FuncDecl(dispatch_name, None, builder.module_name, sig)
     dispatch_func_ir = FuncIR(func_decl, args, blocks)
     return dispatch_func_ir
-
-
-def sort_with_subclasses_first(
-    impls: List[RegisterImplInfo]
-) -> Iterator[RegisterImplInfo]:
-
-    # graph with edges pointing from every class to their subclasses
-    graph = {typ: set(typ.mro[1:]) for typ, _ in impls}
-
-    dispatch_types = topsort(graph)
-    impl_dict = {typ: func for typ, func in impls}
-
-    for group in reversed(list(dispatch_types)):
-        yield from ((typ, impl_dict[typ]) for typ in group if typ in impl_dict)
 
 
 def load_singledispatch_registry(builder: IRBuilder, main_func_name: str, line: int) -> Value:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -862,6 +862,11 @@ def generate_singledispatch_dispatch_function(
         builder.nonlocal_control[-1].gen_return(builder, coerced, line)
 
     registry = load_singledispatch_registry(builder, fitem, line)
+
+    # TODO: cache the output of _find_impl - without adding that caching, this implementation is
+    # probably slower than the standard library functools implementation because functools caches
+    # the output of _find_impl and _find_impl looks like it is very slow
+
     find_impl = builder.load_module_attr_by_fullname('functools._find_impl', line)
     arg_type = builder.builder.get_type_of_obj(arg_info.args[0], line)
     impl_to_use = builder.py_call(find_impl, [arg_type, registry], line)

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -964,3 +964,7 @@ def initialize_singledispatch_dispatch_dictionary(
 
 def singledispatch_main_func_name(orig_name: str) -> str:
     return '__mypyc_singledispatch_main_function_{}__'.format(orig_name)
+
+
+def get_registry_identifier(fitem: FuncDef) -> str:
+    return f'__mypyc_singledispatch_registry_{fitem.fullname}__'

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -251,13 +251,7 @@ def gen_func_item(builder: IRBuilder,
         gen_generator_func(builder)
         args, _, blocks, ret_type, fn_info = builder.leave()
         func_ir, func_reg = gen_func_ir(
-            builder,
-            args,
-            blocks,
-            sig,
-            fn_info,
-            cdef,
-            is_singledispatch,
+            builder, args, blocks, sig, fn_info, cdef, is_singledispatch,
         )
 
         # Re-enter the FuncItem and visit the body of the function this time.
@@ -326,13 +320,7 @@ def gen_func_item(builder: IRBuilder,
             builder, fn_info, sig, args, blocks, fitem.is_coroutine)
     else:
         func_ir, func_reg = gen_func_ir(
-            builder,
-            args,
-            blocks,
-            sig,
-            fn_info,
-            cdef,
-            is_singledispatch,
+            builder, args, blocks, sig, fn_info, cdef, is_singledispatch,
         )
 
     # Evaluate argument defaults in the surrounding scope, since we

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -915,7 +915,6 @@ def gen_dispatch_func_ir(
     """Create a dispatch function (a function that checks the first argument type and dispatches
     to the correct implementation)
     """
-    # initialize_singledispatch_dispatch_dictionary(builder, fitem, main_func_name)
     builder.enter()
     generate_singledispatch_dispatch_function(builder, main_func_name, fitem)
     args, _, blocks, _, fn_info = builder.leave()

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -966,8 +966,6 @@ def maybe_insert_into_registry_dict(builder: IRBuilder, fitem: FuncDef) -> None:
         if fitem not in native_ids:
             to_insert = load_func(builder, fitem.name, fitem.fullname, line)
         else:
-            # The length is also the index of the next element that will get added (which will be
-            # this function)
             current_id = native_ids[fitem]
             load_literal = LoadLiteral(current_id, object_rprimitive)
             to_insert = builder.add(load_literal)

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -844,8 +844,8 @@ def generate_singledispatch_dispatch_function(
 
     registry = load_singledispatch_registry(builder, fitem, line)
     find_impl = builder.load_module_attr_by_fullname('functools._find_impl', line)
-    # FIXME: should pass type of first argument to _find_impl, not first argument itself
-    impl_to_use = builder.py_call(find_impl, [arg_info.args[0], registry], line)
+    arg_type = builder.builder.get_type_of_obj(arg_info.args[0], line)
+    impl_to_use = builder.py_call(find_impl, [arg_type, registry], line)
 
     typ, src = builtin_names['builtins.int']
     int_type_obj = builder.add(LoadAddress(typ, src, line))

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -58,7 +58,6 @@ from mypyc.irbuild.env_class import (
 )
 
 from mypyc.primitives.registry import builtin_names
-from mypyc.primitives.int_ops import int_equal_
 
 
 # Top-level transform functions
@@ -863,8 +862,14 @@ def generate_singledispatch_dispatch_function(
         call_impl, next_impl = BasicBlock(), BasicBlock()
 
         current_id = builder.load_int(i)
-        should_call_impl = builder.call_c(int_equal_, [passed_id, current_id], line)
-        builder.add_bool_branch(should_call_impl, call_impl, next_impl)
+        builder.builder.compare_tagged_condition(
+            passed_id,
+            current_id,
+            '==',
+            call_impl,
+            next_impl,
+            line,
+        )
 
         # Call the registered implementation
         builder.activate_block(call_impl)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -259,11 +259,15 @@ class LowLevelIRBuilder:
             ret = self.shortcircuit_helper('or', bool_rprimitive, lambda: ret, other, line)
         return ret
 
-    def type_is_op(self, obj: Value, type_obj: Value, line: int) -> Value:
+    def get_type_of_obj(self, obj: Value, line: int) -> Value:
         ob_type_address = self.add(GetElementPtr(obj, PyObject, 'ob_type', line))
         ob_type = self.add(LoadMem(object_rprimitive, ob_type_address))
         self.add(KeepAlive([obj]))
-        return self.add(ComparisonOp(ob_type, type_obj, ComparisonOp.EQ, line))
+        return ob_type
+
+    def type_is_op(self, obj: Value, type_obj: Value, line: int) -> Value:
+        typ = self.get_type_of_obj(obj, line)
+        return self.add(ComparisonOp(typ, type_obj, ComparisonOp.EQ, line))
 
     def isinstance_native(self, obj: Value, class_ir: ClassIR, line: int) -> Value:
         """Fast isinstance() check for a native class.

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -20,7 +20,6 @@ For the core of the IR transform implementation, look at build_ir()
 below, mypyc.irbuild.builder, and mypyc.irbuild.visitor.
 """
 
-from mypyc.irbuild.function import initialize_all_singledispatch_dictionaries
 from mypy.backports import OrderedDict
 from typing import List, Dict, Callable, Any, TypeVar, cast
 
@@ -124,12 +123,6 @@ def transform_mypy_file(builder: IRBuilder, mypyfile: MypyFile) -> None:
     # Generate ops.
     for node in mypyfile.defs:
         builder.accept(node)
-
-    # HACK: this needs to happen here because we can only initialize the singledispatch
-    # dictionaries with registered implementations after all decorated functions are stored in the
-    # globals dict, and the code for that is not generated until after we generate the main
-    # singledispatch function
-    initialize_all_singledispatch_dictionaries(builder)
 
     builder.maybe_add_implicit_return()
 

--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -8,38 +8,56 @@ def f(arg) -> bool:
 def g(arg: int) -> bool:
     return True
 [out]
-def __mypyc___mypyc_singledispatch_main_function_f___decorator_helper__(arg):
+def __mypyc_singledispatch_main_function_f__(arg):
     arg :: object
 L0:
     return 0
-def __mypyc_f_decorator_helper__(arg):
-    arg, r0 :: object
-    r1 :: int32
-    r2 :: bit
-    r3 :: bool
-    r4 :: int
-    r5 :: bool
-    r6 :: dict
-    r7 :: str
-    r8, r9 :: object
-    r10 :: bool
+def f(arg):
+    arg :: object
+    r0 :: dict
+    r1 :: object
+    r2 :: str
+    r3 :: object
+    r4 :: ptr
+    r5, r6, r7 :: object
+    r8 :: ptr
+    r9 :: object
+    r10 :: bit
+    r11 :: int
+    r12 :: bit
+    r13 :: int
+    r14 :: bool
+    r15 :: object
+    r16 :: bool
 L0:
-    r0 = load_address PyLong_Type
-    r1 = PyObject_IsInstance(arg, r0)
-    r2 = r1 >= 0 :: signed
-    r3 = truncate r1: int32 to builtins.bool
-    if r3 goto L1 else goto L2 :: bool
+    r0 = __main__.__mypyc_singledispatch_registry___main__.f__ :: static
+    r1 = functools :: module
+    r2 = '_find_impl'
+    r3 = CPyObject_GetAttr(r1, r2)
+    r4 = get_element_ptr arg ob_type :: PyObject
+    r5 = load_mem r4 :: builtins.object*
+    keep_alive arg
+    r6 = PyObject_CallFunctionObjArgs(r3, r5, r0, 0)
+    r7 = load_address PyLong_Type
+    r8 = get_element_ptr r6 ob_type :: PyObject
+    r9 = load_mem r8 :: builtins.object*
+    keep_alive r6
+    r10 = r9 == r7
+    if r10 goto L1 else goto L4 :: bool
 L1:
-    r4 = unbox(int, arg)
-    r5 = g(r4)
-    return r5
+    r11 = unbox(int, r6)
+    r12 = r11 == 0
+    if r12 goto L2 else goto L3 :: bool
 L2:
-    r6 = __main__.globals :: static
-    r7 = '__mypyc___mypyc_singledispatch_main_function_f___decorator_helper__'
-    r8 = CPyDict_GetItem(r6, r7)
-    r9 = PyObject_CallFunctionObjArgs(r8, arg, 0)
-    r10 = unbox(bool, r9)
-    return r10
+    r13 = unbox(int, arg)
+    r14 = g(r13)
+    return r14
+L3:
+    unreachable
+L4:
+    r15 = PyObject_CallFunctionObjArgs(r6, arg, 0)
+    r16 = unbox(bool, r15)
+    return r16
 def g(arg):
     arg :: int
 L0:

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -571,3 +571,33 @@ def fb(arg: B) -> str:
 def test_singledispatch():
     assert f(AB()) == "a"
     assert f(BA()) == "b"
+
+[case testCallingFunctionBeforeAllImplementationsRegistered]
+from functools import singledispatch
+
+class A: pass
+class B(A): pass
+
+@singledispatch
+def f(arg) -> str:
+    return 'default'
+
+assert f(A()) == 'default'
+assert f(B()) == 'default'
+assert f(1) == 'default'
+
+@f.register
+def g(arg: A) -> str:
+    return 'a'
+
+assert f(A()) == 'a'
+assert f(B()) == 'a'
+assert f(1) == 'default'
+
+@f.register
+def _(arg: B) -> str:
+    return 'b'
+
+assert f(A()) == 'a'
+assert f(B()) == 'b'
+assert f(1) == 'default'

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -543,3 +543,31 @@ def f(arg) -> int:
 @f.register
 def g(arg: B) -> int:
     return 1
+
+[case testOrderCanOnlyBeDeterminedFromMRONotIsinstanceChecks]
+from mypy_extensions import trait
+from functools import singledispatch
+
+@trait
+class A: pass
+@trait
+class B: pass
+class AB(A, B): pass
+class BA(B, A): pass
+
+@singledispatch
+def f(arg) -> str:
+    return "default"
+    pass
+
+@f.register
+def fa(arg: A) -> str:
+    return "a"
+
+@f.register
+def fb(arg: B) -> str:
+    return "b"
+
+def test_singledispatch():
+    assert f(AB()) == "a"
+    assert f(BA()) == "b"

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -114,7 +114,7 @@ def test_singledispatch() -> None:
     assert fun(1)
     assert not fun('a')
 
-[case testUseRegisterAsAFunction]
+[case testUseRegisterAsAFunction-xfail]
 from functools import singledispatch
 
 @singledispatch
@@ -145,7 +145,7 @@ def test_singledispatch() -> None:
     assert fun_specialized('a')
 
 # TODO: turn this into a mypy error
-[case testNoneIsntATypeWhenUsedAsArgumentToRegister]
+[case testNoneIsntATypeWhenUsedAsArgumentToRegister-xfail]
 from functools import singledispatch
 
 @singledispatch


### PR DESCRIPTION
This changes the implementation of singledispatch to look up the correct registered implementation to use at runtime using the MRO of the passed argument, instead of using a chain of `isinstance` checks for each registered implementation, for the reasons mentioned in https://github.com/mypyc/mypyc/issues/802#issuecomment-886119662.

This doesn't support dynamically registering implementations yet, so 2 of the existing singledispatch tests that rely on that are marked as xfails for now.

## Test Plan

I added a test based on the example in https://github.com/mypyc/mypyc/issues/802#issuecomment-886119662.