### PR TITLE
Use binary file objects with tomli to avoid `DeprecationWarning`

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
 typing_extensions>=3.7.4
 mypy_extensions>=0.4.3,<0.5.0
 typed_ast>=1.4.0,<1.5.0
-tomli<2.0.0
+tomli>=1.1.0,<2.0.0

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -168,7 +168,7 @@ def parse_config_file(options: Options, set_strict_flags: Callable[[], None],
             continue
         try:
             if is_toml(config_file):
-                with open(config_file, encoding="utf-8") as f:
+                with open(config_file, 'rb') as f:
                     toml_data = tomli.load(f)
                 # Filter down to just mypy relevant toml keys
                 toml_data = toml_data.get('tool', {})

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -434,7 +434,7 @@ class FindModuleCache:
         if os.path.isfile(metadata_fnam):
             # Delay import for a possible minor performance win.
             import tomli
-            with open(metadata_fnam, 'r', encoding="utf-8") as f:
+            with open(metadata_fnam, 'rb') as f:
                 metadata = tomli.load(f)
             if self.python_major_ver == 2:
                 return bool(metadata.get('python2', False))

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(name='mypy',
       install_requires=["typed_ast >= 1.4.0, < 1.5.0; python_version<'3.8'",
                         'typing_extensions>=3.7.4',
                         'mypy_extensions >= 0.4.3, < 0.5.0',
-                        'tomli<2.0.0',
+                        'tomli >= 1.1.0, < 2.0.0',
                         ],
       # Same here.
       extras_require={'dmypy': 'psutil >= 4.0', 'python2': 'typed_ast >= 1.4.0, < 1.5.0'},


### PR DESCRIPTION
tomli recently (in 1.2.0) deprecated support for passing file objects opened in text mode to `tomli.load`, which is causing DeprecationWarnings in CI runs (see https://app.travis-ci.com/github/python/mypy/jobs/529150228 for an example).

This updates the 2 uses of tomli in mypy to open the toml file in binary mode, and also updates the requirements for tomli to be at least 1.1.0 (because support for binary file objects was added in 1.1.0).

## Test Plan

I ran the tests for the test files that previously caused DeprecationWarnings with tomli 1.2.0 installed and confirmed that there were no DeprecationWarnings.