### PR TITLE
Try removing skipped test on macOS

### DIFF
--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -177,9 +177,6 @@ def parse_mypy_args(line: str) -> List[str]:
     return m.group(1).split()
 
 
-@pytest.mark.skipif(sys.platform == 'darwin' and hasattr(sys, 'base_prefix') and
-                    sys.base_prefix != sys.prefix,
-                    reason="Temporarily skip to avoid having a virtualenv within a venv.")
 def test_mypy_path_is_respected() -> None:
     assert False
     packages = 'packages'


### PR DESCRIPTION
This test was original skipped because nesting a virtualenv inside of a venv on macOS was a problem, but now that we use a newer virtualenv, hopefully that issue has gone away.