### PR TITLE
[mypyc] Faster len(bytes)

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -33,7 +33,8 @@ from mypyc.ir.rtypes import (
     is_list_rprimitive, is_tuple_rprimitive, is_dict_rprimitive, is_set_rprimitive, PySetObject,
     none_rprimitive, RTuple, is_bool_rprimitive, is_str_rprimitive, c_int_rprimitive,
     pointer_rprimitive, PyObject, PyListObject, bit_rprimitive, is_bit_rprimitive,
-    object_pointer_rprimitive, c_size_t_rprimitive, dict_rprimitive, bytes_rprimitive
+    object_pointer_rprimitive, c_size_t_rprimitive, dict_rprimitive, bytes_rprimitive,
+    is_bytes_rprimitive
 )
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -1348,7 +1349,8 @@ class LowLevelIRBuilder:
         """
         typ = val.type
         size_value = None
-        if is_list_rprimitive(typ) or is_tuple_rprimitive(typ):
+        if (is_list_rprimitive(typ) or is_tuple_rprimitive(typ)
+                or is_bytes_rprimitive(typ)):
             elem_address = self.add(GetElementPtr(val, PyVarObject, 'ob_size'))
             size_value = self.add(LoadMem(c_pyssize_t_rprimitive, elem_address))
             self.add(KeepAlive([val]))

--- a/mypyc/test-data/irbuild-bytes.test
+++ b/mypyc/test-data/irbuild-bytes.test
@@ -62,30 +62,32 @@ L0:
     c = r6
     return 1
 
-[case testBytesOps]
+[case testBytesJoin]
 from typing import List
-def f(b: bytes) -> None:
-    a = len(b)
-def f_join(b: List[bytes]) -> bytes:
+def f(b: List[bytes]) -> bytes:
     return b" ".join(b)
 [out]
 def f(b):
-    b :: bytes
-    r0 :: ptr
-    r1 :: native_int
-    r2 :: short_int
-    a :: int
-L0:
-    r0 = get_element_ptr b ob_size :: PyVarObject
-    r1 = load_mem r0 :: native_int*
-    keep_alive b
-    r2 = r1 << 1
-    a = r2
-    return 1
-def f_join(b):
     b :: list
     r0, r1 :: bytes
 L0:
     r0 = b' '
     r1 = CPyBytes_Join(r0, b)
     return r1
+
+[case testBytesLen]
+def f(b: bytes) -> int:
+    return len(b)
+[out]
+def f(b):
+    b :: bytes
+    r0 :: ptr
+    r1 :: native_int
+    r2 :: short_int
+L0:
+    r0 = get_element_ptr b ob_size :: PyVarObject
+    r1 = load_mem r0 :: native_int*
+    keep_alive b
+    r2 = r1 << 1
+    return r2
+

--- a/mypyc/test-data/irbuild-bytes.test
+++ b/mypyc/test-data/irbuild-bytes.test
@@ -62,14 +62,27 @@ L0:
     c = r6
     return 1
 
-
-[case testBytesJoin]
+[case testBytesOps]
 from typing import List
-
-def f(b: List[bytes]) -> bytes:
+def f(b: bytes) -> None:
+    a = len(b)
+def f_join(b: List[bytes]) -> bytes:
     return b" ".join(b)
 [out]
 def f(b):
+    b :: bytes
+    r0 :: ptr
+    r1 :: native_int
+    r2 :: short_int
+    a :: int
+L0:
+    r0 = get_element_ptr b ob_size :: PyVarObject
+    r1 = load_mem r0 :: native_int*
+    keep_alive b
+    r2 = r1 << 1
+    a = r2
+    return 1
+def f_join(b):
     b :: list
     r0, r1 :: bytes
 L0:

--- a/mypyc/test-data/run-bytes.test
+++ b/mypyc/test-data/run-bytes.test
@@ -57,7 +57,9 @@ def test_indexing() -> None:
 def test_concat() -> None:
     b1 = b'123' + bytes()
     b2 = b'456' + bytes()
-    assert b1 + b2 == b'123456'
+    b3 = b1 + b2
+    assert b3 == b'123456'
+    assert len(b3) == 6
 
 def test_join() -> None:
     seq = (b'1', b'"', b'\xf0')

--- a/mypyc/test-data/run-bytes.test
+++ b/mypyc/test-data/run-bytes.test
@@ -77,7 +77,7 @@ def test_len() -> None:
 [case testBytearrayBasics]
 from typing import Any
 
-def test_init() -> None:
+def test_basics() -> None:
     brr1: bytes = bytearray(3)
     assert brr1 == bytearray(b'\x00\x00\x00')
     assert brr1 == b'\x00\x00\x00'
@@ -91,6 +91,10 @@ def test_init() -> None:
     brr4: bytes = bytearray('string', 'utf-8')
     assert brr4 == bytearray(b'string')
     assert brr4 == b'string'
+    assert len(brr1) == 3
+    assert len(brr2) == 4
+    assert len(brr3) == 5
+    assert len(brr4) == 6
 
 def f(b: bytes) -> bool:
     return True

--- a/mypyc/test-data/run-bytes.test
+++ b/mypyc/test-data/run-bytes.test
@@ -57,9 +57,7 @@ def test_indexing() -> None:
 def test_concat() -> None:
     b1 = b'123' + bytes()
     b2 = b'456' + bytes()
-    b3 = b1 + b2
-    assert b3 == b'123456'
-    assert len(b3) == 6
+    assert b1 + b2 == b'123456'
 
 def test_join() -> None:
     seq = (b'1', b'"', b'\xf0')
@@ -93,8 +91,6 @@ def test_basics() -> None:
     assert brr4 == b'string'
     assert len(brr1) == 3
     assert len(brr2) == 4
-    assert len(brr3) == 5
-    assert len(brr4) == 6
 
 def f(b: bytes) -> bool:
     return True


### PR DESCRIPTION
### Description

Similar to list and tuple, we can directly get length of bytes from `PyVarObject->ob_size`

Implements part of mypyc/mypyc#880.

## Test Plan

* Add an irbuild test
* Add run tests for bytearray(There are already several run tests for bytes)