### PR TITLE
Pin tomli to 1.1.0

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
 typing_extensions>=3.7.4
 mypy_extensions>=0.4.3,<0.5.0
 typed_ast>=1.4.0,<1.5.0
-tomli<2.0.0
+tomli>=1.1.0,<1.2.0

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(name='mypy',
       install_requires=["typed_ast >= 1.4.0, < 1.5.0; python_version<'3.8'",
                         'typing_extensions>=3.7.4',
                         'mypy_extensions >= 0.4.3, < 0.5.0',
-                        'tomli<2.0.0',
+                        'tomli>=1.1.0,<1.2.0',
                         ],
       # Same here.
       extras_require={'dmypy': 'psutil >= 4.0', 'python2': 'typed_ast >= 1.4.0, < 1.5.0'},


### PR DESCRIPTION
While we figure out what the plan is in coordination with black and
pip (see #10893), just pin to the previous version of tomli that isn't
causing our CI to fail.