### PR TITLE
[mypyc] Emit messages regardless if there's no errors

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -236,7 +236,7 @@ class SemanticAnalyzer(NodeVisitor[None],
     # 'Coroutine[Any, Any, T]'. Used to keep track of whether a function definition's
     # return type has already been wrapped, by checking if the function definition's
     # type is stored in this mapping and that it still matches.
-    wrapped_coro_return_types: Dict[FuncDef, Type] = {}
+    wrapped_coro_return_types: Dict[FuncDef, Type]
 
     def __init__(self,
                  modules: Dict[str, MypyFile],
@@ -294,6 +294,9 @@ class SemanticAnalyzer(NodeVisitor[None],
         # Trace line numbers for every file where deferral happened during analysis of
         # current SCC or top-level function.
         self.deferral_debug_context: List[Tuple[str, int]] = []
+
+        self.future_import_flags: Set[str] = set()
+        self.wrapped_coro_return_types = {}
 
     # mypyc doesn't properly handle implementing an abstractproperty
     # with a regular attribute so we make them properties

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -225,7 +225,9 @@ def generate_c(sources: List[BuildSource],
 
     if messages:
         print("\n".join(messages))
-        sys.exit(1)
+        # Sometimes only warnings are emitted, in that case don't hardblock the build.
+        if errors.num_errors:
+            sys.exit(1)
 
     return ctext, '\n'.join(format_modules(modules))
 

--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -52,6 +52,13 @@ class TestCommandLine(MypycDataSuite):
             if 'ErrorOutput' in testcase.name or cmd.returncode != 0:
                 out += cmd.stdout
 
+            if 'OnlyWarningOutput' in testcase.name:
+                # Strip out setuptools build related output since we're only
+                # interested in the messages emitted during analysis and
+                # transcompilation.
+                messages, _, _ = cmd.stdout.partition(b"running build_ext")
+                out += messages
+
             if cmd.returncode == 0:
                 # Run main program
                 out += subprocess.check_output(


### PR DESCRIPTION
### Description

Related: https://github.com/mypyc/mypyc/issues/873#issuecomment-871055474

For example the warning for "treating generator comprehension as list"
doesn't get printed unless there were errors too. This was due to
the fact mypyc/build.py was only checking errors.num_errors totally
ignoring the possitibilties of warnings or notes happening alone.

### Test Plan

- Added another commandline run test (and made sure it failed without the patch)