### PR TITLE
Fixes `tomli` warning about non-binary files

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -168,7 +168,7 @@ def parse_config_file(options: Options, set_strict_flags: Callable[[], None],
             continue
         try:
             if is_toml(config_file):
-                with open(config_file, encoding="utf-8") as f:
+                with open(config_file, 'rb', encoding="utf-8") as f:
                     toml_data = tomli.load(f)
                 # Filter down to just mypy relevant toml keys
                 toml_data = toml_data.get('tool', {})

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -434,7 +434,7 @@ class FindModuleCache:
         if os.path.isfile(metadata_fnam):
             # Delay import for a possible minor performance win.
             import tomli
-            with open(metadata_fnam, 'r', encoding="utf-8") as f:
+            with open(metadata_fnam, 'rb', encoding="utf-8") as f:
                 metadata = tomli.load(f)
             if self.python_major_ver == 2:
                 return bool(metadata.get('python2', False))


### PR DESCRIPTION
Warning source: https://github.com/hukkin/tomli/blob/eaa381a341d2a39a62680798e4ad4dceb26326a0/tomli/_parser.py#L71-L77

Output samlpe:
<img width="752" alt="Снимок экрана 2021-08-09 в 12 22 17" src="https://user-images.githubusercontent.com/4660275/128685036-9d31a565-b4ed-4b3d-975c-324ad97836f4.png">
