### PR TITLE
[mypyc] Use a cache to speed up singledispatch calls

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -203,7 +203,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     fields['tp_name'] = '"{}"'.format(name)
 
     generate_full = not cl.is_trait and not cl.builtin_base
-    needs_getseters = not cl.is_generated
+    needs_getseters = cl.needs_getseters or not cl.is_generated
 
     if not cl.builtin_base:
         fields['tp_new'] = new_name

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -102,6 +102,9 @@ class ClassIR:
         self.has_dict = False
         # Do we allow interpreted subclasses? Derived from a mypyc_attr.
         self.allow_interpreted_subclasses = False
+        # Does this class need getseters to be generated for its attributes? (getseters are also
+        # added if is_generated is False)
+        self.needs_getseters = False
         # If this a subclass of some built-in python class, the name
         # of the object for that class. We currently only support this
         # in a few ad-hoc cases.
@@ -279,6 +282,7 @@ class ClassIR:
             'inherits_python': self.inherits_python,
             'has_dict': self.has_dict,
             'allow_interpreted_subclasses': self.allow_interpreted_subclasses,
+            'needs_getseters': self.needs_getseters,
             'builtin_base': self.builtin_base,
             'ctor': self.ctor.serialize(),
             # We serialize dicts as lists to ensure order is preserved
@@ -329,6 +333,7 @@ class ClassIR:
         ir.inherits_python = data['inherits_python']
         ir.has_dict = data['has_dict']
         ir.allow_interpreted_subclasses = data['allow_interpreted_subclasses']
+        ir.needs_getseters = data['needs_getseters']
         ir.builtin_base = data['builtin_base']
         ir.ctor = FuncDecl.deserialize(data['ctor'], ctx)
         ir.attributes = OrderedDict(

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -841,7 +841,7 @@ def generate_singledispatch_dispatch_function(
     current_func_decl = builder.mapper.func_to_decl[fitem]
     arg_info = get_args(builder, current_func_decl.sig.args, line)
 
-    dispatch_func_obj = load_func(builder, fitem.name, fitem.fullname, line)
+    dispatch_func_obj = builder.self()
 
     arg_type = builder.builder.get_type_of_obj(arg_info.args[0], line)
     dispatch_cache = builder.builder.get_attr(
@@ -942,6 +942,7 @@ def gen_dispatch_func_ir(
     builder.fn_info.callable_class.ir.attributes['registry'] = dict_rprimitive
     builder.fn_info.callable_class.ir.attributes['dispatch_cache'] = dict_rprimitive
     builder.fn_info.callable_class.ir.has_dict = True
+    builder.fn_info.callable_class.ir.needs_getseters = True
     generate_singledispatch_callable_class_ctor(builder)
 
     generate_singledispatch_dispatch_function(builder, main_func_name, fitem)

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -1023,6 +1023,10 @@ def maybe_insert_into_registry_dict(builder: IRBuilder, fitem: FuncDef) -> None:
         for typ in types:
             loaded_type = load_type(builder, typ, line)
             builder.call_c(dict_set_item_op, [registry, loaded_type, to_insert], line)
+        dispatch_cache = builder.builder.get_attr(
+            dispatch_func_obj, 'dispatch_cache', dict_rprimitive, line
+        )
+        builder.gen_method_call(dispatch_cache, 'clear', [], None, line)
 
 
 def get_native_impl_ids(builder: IRBuilder, singledispatch_func: FuncDef) -> Dict[FuncDef, int]:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -842,7 +842,6 @@ def generate_singledispatch_dispatch_function(
     arg_info = get_args(builder, current_func_decl.sig.args, line)
 
     dispatch_func_obj = load_func(builder, fitem.name, fitem.fullname, line)
-    registry = load_singledispatch_registry(builder, dispatch_func_obj, line)
 
     arg_type = builder.builder.get_type_of_obj(arg_info.args[0], line)
     dispatch_cache = builder.builder.get_attr(
@@ -860,6 +859,7 @@ def generate_singledispatch_dispatch_function(
 
     builder.activate_block(call_find_impl)
     find_impl = builder.load_module_attr_by_fullname('functools._find_impl', line)
+    registry = load_singledispatch_registry(builder, dispatch_func_obj, line)
     uncached_impl = builder.py_call(find_impl, [arg_type, registry], line)
     builder.call_c(dict_set_item_op, [dispatch_cache, arg_type, uncached_impl], line)
     builder.assign(impl_to_use, uncached_impl, line)

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -766,6 +766,11 @@ PyObject *CPySingledispatch_RegisterFunction(PyObject *singledispatch_func,
         goto fail;
     }
 
+    // clear the cache so we consider the newly added function when dispatching
+    PyObject *dispatch_cache = PyObject_GetAttrString(singledispatch_func, "dispatch_cache");
+    if (dispatch_cache == NULL) goto fail;
+    PyDict_Clear(dispatch_cache);
+
     Py_INCREF(func);
     return func;
 

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -119,7 +119,7 @@ method_op(
     error_kind=ERR_MAGIC)
 
 # dict.get(key)
-method_op(
+dict_get_method_with_none = method_op(
     name='get',
     arg_types=[dict_rprimitive, object_rprimitive],
     return_type=object_rprimitive,

--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -16,9 +16,17 @@ def f_obj.__init__(__mypyc_self__):
     __mypyc_self__ :: __main__.f_obj
     r0 :: dict
     r1 :: bool
+    r2 :: dict
+    r3 :: str
+    r4 :: int32
+    r5 :: bit
 L0:
     r0 = PyDict_New()
     __mypyc_self__.registry = r0; r1 = is_error
+    r2 = PyDict_New()
+    r3 = 'dispatch_cache'
+    r4 = PyObject_SetAttr(__mypyc_self__, r3, r2)
+    r5 = r4 >= 0 :: signed
     return 1
 def f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
@@ -46,53 +54,81 @@ def f_obj.__call__(__mypyc_self__, arg):
     r1 :: str
     r2 :: object
     r3 :: str
-    r4, r5 :: object
-    r6 :: str
-    r7 :: object
-    r8 :: ptr
-    r9, r10, r11 :: object
-    r12 :: ptr
-    r13 :: object
-    r14 :: bit
-    r15 :: int
-    r16 :: bit
-    r17 :: int
-    r18 :: bool
-    r19 :: object
-    r20 :: bool
+    r4 :: object
+    r5 :: ptr
+    r6 :: object
+    r7 :: str
+    r8 :: object
+    r9 :: int32
+    r10 :: bit
+    r11 :: bool
+    r12 :: dict
+    r13, r14, r15 :: object
+    r16 :: str
+    r17, r18 :: object
+    r19 :: dict
+    r20 :: int32
+    r21 :: bit
+    r22 :: object
+    r23 :: ptr
+    r24 :: object
+    r25 :: bit
+    r26 :: int
+    r27 :: bit
+    r28 :: int
+    r29 :: bool
+    r30 :: object
+    r31 :: bool
 L0:
     r0 = __main__.globals :: static
     r1 = 'f'
     r2 = CPyDict_GetItem(r0, r1)
     r3 = 'registry'
     r4 = CPyObject_GetAttr(r2, r3)
-    r5 = functools :: module
-    r6 = '_find_impl'
-    r7 = CPyObject_GetAttr(r5, r6)
-    r8 = get_element_ptr arg ob_type :: PyObject
-    r9 = load_mem r8 :: builtins.object*
+    r5 = get_element_ptr arg ob_type :: PyObject
+    r6 = load_mem r5 :: builtins.object*
     keep_alive arg
-    r10 = PyObject_CallFunctionObjArgs(r7, r9, r4, 0)
-    r11 = load_address PyLong_Type
-    r12 = get_element_ptr r10 ob_type :: PyObject
-    r13 = load_mem r12 :: builtins.object*
-    keep_alive r10
-    r14 = r13 == r11
-    if r14 goto L1 else goto L4 :: bool
+    r7 = 'dispatch_cache'
+    r8 = CPyObject_GetAttr(r2, r7)
+    r9 = PySequence_Contains(r8, r6)
+    r10 = r9 >= 0 :: signed
+    r11 = truncate r9: int32 to builtins.bool
+    if r11 goto L1 else goto L2 :: bool
 L1:
-    r15 = unbox(int, r10)
-    r16 = r15 == 0
-    if r16 goto L2 else goto L3 :: bool
+    r12 = cast(dict, r8)
+    r13 = CPyDict_GetItem(r12, r6)
+    r14 = r13
+    goto L3
 L2:
-    r17 = unbox(int, arg)
-    r18 = g(r17)
-    return r18
+    r15 = functools :: module
+    r16 = '_find_impl'
+    r17 = CPyObject_GetAttr(r15, r16)
+    r18 = PyObject_CallFunctionObjArgs(r17, r6, r4, 0)
+    r19 = cast(dict, r8)
+    r20 = CPyDict_SetItem(r19, r6, r18)
+    r21 = r20 >= 0 :: signed
+    r14 = r18
 L3:
-    unreachable
+    r22 = load_address PyLong_Type
+    r23 = get_element_ptr r14 ob_type :: PyObject
+    r24 = load_mem r23 :: builtins.object*
+    keep_alive r14
+    r25 = r24 == r22
+    if r25 goto L4 else goto L7 :: bool
 L4:
-    r19 = PyObject_CallFunctionObjArgs(r10, arg, 0)
-    r20 = unbox(bool, r19)
-    return r20
+    r26 = unbox(int, r14)
+    r27 = r26 == 0
+    if r27 goto L5 else goto L6 :: bool
+L5:
+    r28 = unbox(int, arg)
+    r29 = g(r28)
+    return r29
+L6:
+    unreachable
+L7:
+    r30 = PyObject_CallFunctionObjArgs(r14, arg, 0)
+    r31 = unbox(bool, r30)
+    return r31
 def g(arg):
     arg :: int
 L0:

--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -50,85 +50,70 @@ L0:
 def f_obj.__call__(__mypyc_self__, arg):
     __mypyc_self__ :: __main__.f_obj
     arg :: object
-    r0 :: dict
-    r1 :: str
-    r2 :: object
-    r3 :: str
-    r4 :: object
-    r5 :: ptr
-    r6 :: object
-    r7 :: str
-    r8 :: object
-    r9 :: int32
-    r10 :: bit
-    r11 :: bool
-    r12 :: dict
-    r13, r14, r15 :: object
-    r16 :: str
-    r17, r18 :: object
-    r19 :: dict
-    r20 :: int32
-    r21 :: bit
+    r0 :: ptr
+    r1 :: object
+    r2 :: dict
+    r3, r4 :: object
+    r5 :: bit
+    r6, r7 :: object
+    r8 :: str
+    r9 :: object
+    r10 :: dict
+    r11 :: object
+    r12 :: int32
+    r13 :: bit
+    r14 :: object
+    r15 :: ptr
+    r16 :: object
+    r17 :: bit
+    r18 :: int
+    r19 :: bit
+    r20 :: int
+    r21 :: bool
     r22 :: object
-    r23 :: ptr
-    r24 :: object
-    r25 :: bit
-    r26 :: int
-    r27 :: bit
-    r28 :: int
-    r29 :: bool
-    r30 :: object
-    r31 :: bool
+    r23 :: bool
 L0:
-    r0 = __main__.globals :: static
-    r1 = 'f'
-    r2 = CPyDict_GetItem(r0, r1)
-    r3 = 'registry'
-    r4 = CPyObject_GetAttr(r2, r3)
-    r5 = get_element_ptr arg ob_type :: PyObject
-    r6 = load_mem r5 :: builtins.object*
+    r0 = get_element_ptr arg ob_type :: PyObject
+    r1 = load_mem r0 :: builtins.object*
     keep_alive arg
-    r7 = 'dispatch_cache'
-    r8 = CPyObject_GetAttr(r2, r7)
-    r9 = PySequence_Contains(r8, r6)
-    r10 = r9 >= 0 :: signed
-    r11 = truncate r9: int32 to builtins.bool
-    if r11 goto L1 else goto L2 :: bool
+    r2 = __mypyc_self__.dispatch_cache
+    r3 = CPyDict_GetWithNone(r2, r1)
+    r4 = load_address _Py_NoneStruct
+    r5 = r3 != r4
+    if r5 goto L1 else goto L2 :: bool
 L1:
-    r12 = cast(dict, r8)
-    r13 = CPyDict_GetItem(r12, r6)
-    r14 = r13
+    r6 = r3
     goto L3
 L2:
-    r15 = functools :: module
-    r16 = '_find_impl'
-    r17 = CPyObject_GetAttr(r15, r16)
-    r18 = PyObject_CallFunctionObjArgs(r17, r6, r4, 0)
-    r19 = cast(dict, r8)
-    r20 = CPyDict_SetItem(r19, r6, r18)
-    r21 = r20 >= 0 :: signed
-    r14 = r18
+    r7 = functools :: module
+    r8 = '_find_impl'
+    r9 = CPyObject_GetAttr(r7, r8)
+    r10 = __mypyc_self__.registry
+    r11 = PyObject_CallFunctionObjArgs(r9, r1, r10, 0)
+    r12 = CPyDict_SetItem(r2, r1, r11)
+    r13 = r12 >= 0 :: signed
+    r6 = r11
 L3:
-    r22 = load_address PyLong_Type
-    r23 = get_element_ptr r14 ob_type :: PyObject
-    r24 = load_mem r23 :: builtins.object*
-    keep_alive r14
-    r25 = r24 == r22
-    if r25 goto L4 else goto L7 :: bool
+    r14 = load_address PyLong_Type
+    r15 = get_element_ptr r6 ob_type :: PyObject
+    r16 = load_mem r15 :: builtins.object*
+    keep_alive r6
+    r17 = r16 == r14
+    if r17 goto L4 else goto L7 :: bool
 L4:
-    r26 = unbox(int, r14)
-    r27 = r26 == 0
-    if r27 goto L5 else goto L6 :: bool
+    r18 = unbox(int, r6)
+    r19 = r18 == 0
+    if r19 goto L5 else goto L6 :: bool
 L5:
-    r28 = unbox(int, arg)
-    r29 = g(r28)
-    return r29
+    r20 = unbox(int, arg)
+    r21 = g(r20)
+    return r21
 L6:
     unreachable
 L7:
-    r30 = PyObject_CallFunctionObjArgs(r14, arg, 0)
-    r31 = unbox(bool, r30)
-    return r31
+    r22 = PyObject_CallFunctionObjArgs(r6, arg, 0)
+    r23 = unbox(bool, r22)
+    return r23
 def g(arg):
     arg :: int
 L0:

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -655,3 +655,44 @@ with assertRaises(TypeError, 'Invalid first argument to `register()`'):
     @f.register
     def _():
         pass
+
+[file driver.py]
+import register
+
+[case testCacheClearedWhenNewFunctionRegistered]
+from functools import singledispatch
+
+@singledispatch
+def f(arg) -> str:
+    return 'default'
+
+[file register.py]
+from native import f
+class A: pass
+class B: pass
+class C: pass
+
+# annotated function
+assert f(A()) == 'default'
+@f.register
+def _(arg: A) -> str:
+    return 'a'
+assert f(A()) == 'a'
+
+# type passed as argument
+assert f(B()) == 'default'
+@f.register(B)
+def _(arg: B) -> str:
+    return 'b'
+assert f(B()) == 'b'
+
+# 2 argument form
+assert f(C()) == 'default'
+def c(arg) -> str:
+    return 'c'
+f.register(C, c)
+assert f(C()) == 'c'
+
+
+[file driver.py]
+import register


### PR DESCRIPTION
This adds a cache to the dispatching code for singledispatch functions, which makes calling singledispatch functions much faster.

The benchmark results for the [sum_tree_singledispatch](https://github.com/mypyc/mypyc-benchmarks/blob/735dff13e7c2c079a9881bcc4792a7363b98822e/microbenchmarks/singledispatch.py#L45) benchmark:
```
running sum_tree_singledispatch
..........
interpreted: 0.325256s (avg of 5 iterations; stdev 0.21%)
compiled:    0.057567s (avg of 5 iterations; stdev 3.3%)

compiled is 5.650x faster
```

## Test Plan

I added a test to make sure that the cache is correctly invalidated when a new function is registered.
