### PR TITLE
fix: ignore[typeddict-item] also ignore associated notes

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1244,7 +1244,7 @@ class MessageBuilder:
             matches = best_matches(item_name, typ.items.keys())
             if matches:
                 self.note("Did you mean {}?".format(
-                    pretty_seq(matches[:3], "or")), context)
+                    pretty_seq(matches[:3], "or")), context, code=codes.TYPEDDICT_ITEM)
 
     def typeddict_context_ambiguous(
             self,

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -472,6 +472,17 @@ a['y']  # E: TypedDict "D" has no key "y"  [typeddict-item]
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testErrorCodeTypedDictNoteIgnore]
+from typing_extensions import TypedDict
+class A(TypedDict):
+    one_commonpart: int
+    two_commonparts: int
+
+a: A = {'one_commonpart': 1, 'two_commonparts': 2}
+a['other_commonpart'] = 3  # type: ignore[typeddict-item]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testErrorCodeCannotDetermineType]
 y = x  # E: Cannot determine type of "x"  [has-type]
 reveal_type(y)  # N: Revealed type is "Any"


### PR DESCRIPTION
### Description

When we use `# ignore[typeddict-item]` associated notes are not ignored

## Test Plan

I have added a unittests to cover it