### PR TITLE
[mypyc] Remove decorator_helper_name

### DIFF
--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -70,10 +70,6 @@ RUNTIME_C_FILES: Final = [
 JsonDict = Dict[str, Any]
 
 
-def decorator_helper_name(func_name: str) -> str:
-    return '__mypyc_{}_decorator_helper__'.format(func_name)
-
-
 def shared_lib_name(group_name: str) -> str:
     """Given a group name, return the actual name of its extension module.
 

--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -7,7 +7,6 @@ from mypy.nodes import FuncItem
 from mypyc.ir.ops import Value, BasicBlock
 from mypyc.ir.func_ir import INVALID_FUNC_DEF
 from mypyc.ir.class_ir import ClassIR
-from mypyc.common import decorator_helper_name
 from mypyc.irbuild.targets import AssignmentTarget
 
 
@@ -24,7 +23,7 @@ class FuncInfo:
                  is_decorated: bool = False,
                  in_non_ext: bool = False) -> None:
         self.fitem = fitem
-        self.name = name if not is_decorated else decorator_helper_name(name)
+        self.name = name
         self.class_name = class_name
         self.ns = namespace
         # Callable classes implement the '__call__' method, and are used to represent functions

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2930,7 +2930,7 @@ L0:
     r0.g = r2; r4 = is_error
     r5 = r0.g
     return r5
-def __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj.__get__(__mypyc_self__, instance, owner):
+def d_c_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
     r1 :: bit
     r2 :: object
@@ -2943,9 +2943,9 @@ L1:
 L2:
     r2 = PyMethod_New(__mypyc_self__, instance)
     return r2
-def __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj.__call__(__mypyc_self__):
-    __mypyc_self__ :: __main__.__mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj
-    r0 :: __main__.__mypyc_c_decorator_helper___env
+def d_c_obj.__call__(__mypyc_self__):
+    __mypyc_self__ :: __main__.d_c_obj
+    r0 :: __main__.c_env
     r1, d :: object
     r2 :: str
     r3 :: object
@@ -2961,9 +2961,9 @@ L0:
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = PyObject_CallFunctionObjArgs(r5, r2, 0)
     return 1
-def __mypyc_c_decorator_helper__():
-    r0 :: __main__.__mypyc_c_decorator_helper___env
-    r1 :: __main__.__mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj
+def c():
+    r0 :: __main__.c_env
+    r1 :: __main__.d_c_obj
     r2 :: bool
     r3 :: dict
     r4 :: str
@@ -2981,8 +2981,8 @@ def __mypyc_c_decorator_helper__():
     r18 :: str
     r19, r20, r21, r22 :: object
 L0:
-    r0 = __mypyc_c_decorator_helper___env()
-    r1 = __mypyc_d_decorator_helper_____mypyc_c_decorator_helper___obj()
+    r0 = c_env()
+    r1 = d_c_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     r3 = __main__.globals :: static
     r4 = 'b'
@@ -3062,7 +3062,7 @@ L2:
     r17 = CPyDict_SetItem(r5, r16, r15)
     r18 = r17 >= 0 :: signed
     r19 = __main__.globals :: static
-    r20 = '__mypyc_c_decorator_helper__'
+    r20 = 'c'
     r21 = CPyDict_GetItem(r19, r20)
     r22 = __main__.globals :: static
     r23 = 'b'

--- a/mypyc/test-data/run-functions.test
+++ b/mypyc/test-data/run-functions.test
@@ -1183,3 +1183,12 @@ with assertRaises(TypeError, "varargs4() missing required keyword-only argument 
     varargs4(1, 2, 3)
 with assertRaises(TypeError, "varargs4() missing required argument 'a' (pos 1)"):
     varargs4(y=20)
+
+[case testDecoratorName]
+def dec(f): return f
+
+@dec
+def foo(): pass
+
+def test_decorator_name():
+    assert foo.__name__ == "foo"


### PR DESCRIPTION
### Description

Per mypyc/mypyc#718, renaming the original function name in the module
mapping causes the `__name__` of decorated functions to have be
something like `__mypyc_*_decorator_helper__`. When checking if just
using the original name as the module name (and then later the function
will be overridden by the decorated value) no tests fail. And there are
indeed tests that exhibit rather complex decorator behavior so it seems
there may not actually be anything wrong with using the original name.

## Test Plan

Added a runtime test that exhibits better `__name__` behavior, existing tests to prevent regression.
