### PR TITLE
Support basicConfig logger= kwarg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ dmypy.json
 *.egg-info
 *.eggs
 
+# Ctags
+tags
+TAGS
+
 # IDEs
 .idea
 .vscode

--- a/mypy/typeshed/stdlib/logging/__init__.pyi
+++ b/mypy/typeshed/stdlib/logging/__init__.pyi
@@ -706,7 +706,24 @@ def addLevelName(level: int, levelName: str) -> None: ...
 def getLevelName(level: _Level) -> Any: ...
 def makeLogRecord(dict: Mapping[str, Any]) -> LogRecord: ...
 
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 11):
+    def basicConfig(
+        *,
+        filename: Optional[StrPath] = ...,
+        filemode: str = ...,
+        format: str = ...,
+        datefmt: Optional[str] = ...,
+        style: _FormatStyle = ...,
+        level: Optional[_Level] = ...,
+        stream: Optional[SupportsWrite[str]] = ...,
+        handlers: Optional[Iterable[Handler]] = ...,
+        force: Optional[bool] = ...,
+        encoding: Optional[str] = ...,
+        errors: Optional[str] = ...,
+        logger: Optional[Union[str, Logger]] = ...,
+    ) -> None: ...
+
+elif sys.version_info >= (3, 9):
     def basicConfig(
         *,
         filename: Optional[StrPath] = ...,


### PR DESCRIPTION
## Description

This PR accompanies [bpo-45027](https://bugs.python.org/issue45027) and its associated PR, https://github.com/python/cpython/pull/28010. It adds a `logger` kwarg to `logging.basicConfig`.

## Test Plan

I didn't see any tests for this part of the stdlib stubs, and I wasn't really sure how to add any. I'd be happy to add some, but I could use a tutorial on how the test suite works.