### PR TITLE
Removes unused `mypy.errors` import from `stubgen`

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -60,7 +60,6 @@ from typing_extensions import Final
 
 import mypy.build
 import mypy.parse
-import mypy.errors
 import mypy.traverser
 import mypy.mixedtraverser
 import mypy.util


### PR DESCRIPTION
That's the last unsued import I found.
Related #11041
