### PR TITLE
Change FunctionLike.items from method to property

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1282,7 +1282,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         reverse_class, reverse_name,
                         forward_base, forward_name, context)
             elif isinstance(forward_item, Overloaded):
-                for item in forward_item.items():
+                for item in forward_item.items:
                     if self.is_unsafe_overlapping_op(item, forward_base, reverse_type):
                         self.msg.operator_method_signatures_overlap(
                             reverse_class, reverse_name,
@@ -1588,7 +1588,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 return tp.arg_types[0]
             return None
         elif isinstance(tp, Overloaded):
-            raw_items = [self.get_op_other_domain(it) for it in tp.items()]
+            raw_items = [self.get_op_other_domain(it) for it in tp.items]
             items = [it for it in raw_items if it]
             if items:
                 return make_simplified_union(items)
@@ -1687,13 +1687,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # (in that order), and if the child swaps the two and does f(str) -> str and
                 # f(int) -> int
                 order = []
-                for child_variant in override.items():
-                    for i, parent_variant in enumerate(original.items()):
+                for child_variant in override.items:
+                    for i, parent_variant in enumerate(original.items):
                         if is_subtype(child_variant, parent_variant):
                             order.append(i)
                             break
 
-                if len(order) == len(original.items()) and order != sorted(order):
+                if len(order) == len(original.items) and order != sorted(order):
                     self.msg.overload_signature_incompatible_with_supertype(
                         name, name_in_super, supertype, override, node)
                     emitted_msg = True
@@ -2435,7 +2435,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                                                       OverloadedFuncDef):
                     # Same for properties with setter
                     if base_node.is_property:
-                        base_type = base_type.items()[0].ret_type
+                        base_type = base_type.items[0].ret_type
 
                 return base_type, base_node
 
@@ -3530,7 +3530,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 continue
 
             if isinstance(ttype, FunctionLike):
-                item = ttype.items()[0]
+                item = ttype.items[0]
                 if not item.is_type_obj():
                     self.fail(message_registry.INVALID_EXCEPTION_TYPE, n)
                     return AnyType(TypeOfAny.from_error)
@@ -5500,7 +5500,7 @@ def get_isinstance_type(expr: Expression,
         if isinstance(typ, FunctionLike) and typ.is_type_obj():
             # Type variables may be present -- erase them, which is the best
             # we can do (outside disallowing them here).
-            erased_type = erase_typevars(typ.items()[0].ret_type)
+            erased_type = erase_typevars(typ.items[0].ret_type)
             types.append(TypeRange(erased_type, is_upper_bound=False))
         elif isinstance(typ, TypeType):
             # Type[A] means "any type that is a subtype of A" rather than "precisely type A"
@@ -5673,9 +5673,9 @@ def is_more_general_arg_prefix(t: FunctionLike, s: FunctionLike) -> bool:
                                           ignore_return=True)
     elif isinstance(t, FunctionLike):
         if isinstance(s, FunctionLike):
-            if len(t.items()) == len(s.items()):
+            if len(t.items) == len(s.items):
                 return all(is_same_arg_prefix(items, itemt)
-                           for items, itemt in zip(t.items(), s.items()))
+                           for items, itemt in zip(t.items, s.items))
     return False
 
 
@@ -6038,13 +6038,13 @@ def is_untyped_decorator(typ: Optional[Type]) -> bool:
         method = typ.type.get_method('__call__')
         if method:
             if isinstance(method.type, Overloaded):
-                return any(is_untyped_decorator(item) for item in method.type.items())
+                return any(is_untyped_decorator(item) for item in method.type.items)
             else:
                 return not is_typed_callable(method.type)
         else:
             return False
     elif isinstance(typ, Overloaded):
-        return any(is_untyped_decorator(item) for item in typ.items())
+        return any(is_untyped_decorator(item) for item in typ.items)
     return True
 
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -778,7 +778,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         else:
             assert isinstance(callee, Overloaded)
             items = []
-            for item in callee.items():
+            for item in callee.items:
                 adjusted = self.apply_signature_hook(
                     item, args, arg_kinds, arg_names, hook)
                 assert isinstance(adjusted, CallableType)
@@ -1079,7 +1079,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 callee = callee.copy_modified(ret_type=item)
             elif isinstance(callee, Overloaded):
                 callee = Overloaded([c.copy_modified(ret_type=item)
-                                     for c in callee.items()])
+                                     for c in callee.items])
             return callee
         # We support Type of namedtuples but not of tuples in general
         if (isinstance(item, TupleType)
@@ -1675,7 +1675,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if kind == ARG_STAR2 and not has_shape(typ):
                 args_have_kw_arg = True
 
-        for typ in overload.items():
+        for typ in overload.items:
             formal_to_actual = map_actuals_to_formals(arg_kinds, arg_names,
                                                       typ.arg_kinds, typ.arg_names,
                                                       lambda i: arg_types[i])
@@ -3223,13 +3223,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return AnyType(TypeOfAny.from_error)
             return self.apply_generic_arguments(tp, args, ctx)
         if isinstance(tp, Overloaded):
-            for it in tp.items():
+            for it in tp.items:
                 if len(it.variables) != len(args):
                     self.msg.incompatible_type_application(len(it.variables),
                                                            len(args), ctx)
                     return AnyType(TypeOfAny.from_error)
             return Overloaded([self.apply_generic_arguments(it, args, ctx)
-                               for it in tp.items()])
+                               for it in tp.items])
         return AnyType(TypeOfAny.special_form)
 
     def visit_list_expr(self, e: ListExpr) -> Type:
@@ -4366,7 +4366,7 @@ def arg_approximate_similarity(actual: Type, formal: Type) -> bool:
         if isinstance(actual, CallableType):
             actual = actual.fallback
         if isinstance(actual, Overloaded):
-            actual = actual.items()[0].fallback
+            actual = actual.items[0].fallback
         if isinstance(actual, TupleType):
             actual = tuple_fallback(actual)
         if isinstance(actual, Instance) and formal.type in actual.type.mro:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -230,7 +230,7 @@ def analyze_type_callable_member_access(name: str,
                                         mx: MemberContext) -> Type:
     # Class attribute.
     # TODO super?
-    ret_type = typ.items()[0].ret_type
+    ret_type = typ.items[0].ret_type
     assert isinstance(ret_type, ProperType)
     if isinstance(ret_type, TupleType):
         ret_type = tuple_fallback(ret_type)
@@ -251,7 +251,7 @@ def analyze_type_callable_member_access(name: str,
             # See https://github.com/python/mypy/pull/1787 for more info.
             # TODO: do not rely on same type variables being present in all constructor overloads.
             result = analyze_class_attribute_access(ret_type, name, mx,
-                                                    original_vars=typ.items()[0].variables)
+                                                    original_vars=typ.items[0].variables)
             if result:
                 return result
         # Look up from the 'type' type.
@@ -481,7 +481,7 @@ def analyze_descriptor_access(instance_type: Type,
     dunder_get_type = expand_type_by_instance(bound_method, typ)
 
     if isinstance(instance_type, FunctionLike) and instance_type.is_type_obj():
-        owner_type = instance_type.items()[0].ret_type
+        owner_type = instance_type.items[0].ret_type
         instance_type = NoneType()
     elif isinstance(instance_type, TypeType):
         owner_type = instance_type.item
@@ -630,7 +630,7 @@ def freeze_type_vars(member_type: Type) -> None:
         for v in member_type.variables:
             v.id.meta_level = 0
     if isinstance(member_type, Overloaded):
-        for it in member_type.items():
+        for it in member_type.items:
             for v in it.variables:
                 v.id.meta_level = 0
 
@@ -664,7 +664,7 @@ def check_self_arg(functype: FunctionLike,
     original type of 'x' is a union. This is done because several special methods
     treat union types in ad-hoc manner, so we can't use MemberContext.self_type yet.
     """
-    items = functype.items()
+    items = functype.items
     if not items:
         return functype
     new_items = []
@@ -907,7 +907,7 @@ def add_class_tvars(t: ProperType, isuper: Optional[Instance],
         return Overloaded([cast(CallableType, add_class_tvars(item, isuper,
                                                               is_classmethod, original_type,
                                                               original_vars=original_vars))
-                           for item in t.items()])
+                           for item in t.items])
     if isuper is not None:
         t = cast(ProperType, expand_type_by_instance(t, isuper))
     return t

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -555,7 +555,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
 
     def visit_overloaded(self, template: Overloaded) -> List[Constraint]:
         res: List[Constraint] = []
-        for t in template.items():
+        for t in template.items:
             res.extend(infer_constraints(t, self.actual, self.direction))
         return res
 
@@ -563,7 +563,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         if isinstance(self.actual, CallableType):
             return infer_constraints(template.item, self.actual.ret_type, self.direction)
         elif isinstance(self.actual, Overloaded):
-            return infer_constraints(template.item, self.actual.items()[0].ret_type,
+            return infer_constraints(template.item, self.actual.items[0].ret_type,
                                      self.direction)
         elif isinstance(self.actual, TypeType):
             return infer_constraints(template.item, self.actual.item, self.direction)
@@ -586,7 +586,7 @@ def neg_op(op: int) -> int:
 
 def find_matching_overload_item(overloaded: Overloaded, template: CallableType) -> CallableType:
     """Disambiguate overload item against a template."""
-    items = overloaded.items()
+    items = overloaded.items
     for item in items:
         # Return type may be indeterminate in the template, so ignore it when performing a
         # subtype check.

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -53,7 +53,7 @@ def freshen_function_type_vars(callee: F) -> F:
     else:
         assert isinstance(callee, Overloaded)
         fresh_overload = Overloaded([freshen_function_type_vars(item)
-                                     for item in callee.items()])
+                                     for item in callee.items])
         return cast(F, fresh_overload)
 
 
@@ -106,7 +106,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
 
     def visit_overloaded(self, t: Overloaded) -> Type:
         items: List[CallableType] = []
-        for item in t.items():
+        for item in t.items:
             new_item = item.accept(self)
             assert isinstance(new_item, ProperType)
             assert isinstance(new_item, CallableType)

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -196,7 +196,7 @@ class TypeFixer(TypeVisitor[None]):
             ct.type_guard.accept(self)
 
     def visit_overloaded(self, t: Overloaded) -> None:
-        for ct in t.items():
+        for ct in t.items:
             ct.accept(self)
 
     def visit_erased_type(self, o: Any) -> None:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -83,7 +83,7 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
         return out
 
     def visit_overloaded(self, t: types.Overloaded) -> Set[str]:
-        return self._visit(t.items()) | self._visit(t.fallback)
+        return self._visit(t.items) | self._visit(t.fallback)
 
     def visit_tuple_type(self, t: types.TupleType) -> Set[str]:
         return self._visit(t.items) | self._visit(t.partial_fallback)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -339,8 +339,8 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
         s = self.s
         if isinstance(s, FunctionLike):
             # The interesting case where both types are function types.
-            for t_item in t.items():
-                for s_item in s.items():
+            for t_item in t.items:
+                for s_item in s.items:
                     if is_similar_callables(t_item, s_item):
                         if is_equivalent(t_item, s_item):
                             result.append(combine_similar_callables(t_item, s_item))

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -131,7 +131,7 @@ def get_possible_variants(typ: Type) -> List[Type]:
     elif isinstance(typ, Overloaded):
         # Note: doing 'return typ.items()' makes mypy
         # infer a too-specific return type of List[CallableType]
-        return list(typ.items())
+        return list(typ.items)
     else:
         return [typ]
 
@@ -575,8 +575,8 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
         # as TypeJoinVisitor.visit_overloaded().
         s = self.s
         if isinstance(s, FunctionLike):
-            if s.items() == t.items():
-                return Overloaded(t.items())
+            if s.items == t.items:
+                return Overloaded(t.items)
             elif is_subtype(s, t):
                 return s
             elif is_subtype(t, s):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1512,7 +1512,7 @@ class MessageBuilder:
                         add_class_or_static_decorator: bool = False,
                         allow_dups: bool = False,
                         code: Optional[ErrorCode] = None) -> None:
-        for item in tp.items()[:max_items]:
+        for item in tp.items[:max_items]:
             self.note('@overload', context, offset=offset, allow_dups=allow_dups, code=code)
 
             if add_class_or_static_decorator:
@@ -1522,7 +1522,7 @@ class MessageBuilder:
 
             self.note(pretty_callable(item), context,
                       offset=offset, allow_dups=allow_dups, code=code)
-        left = len(tp.items()) - max_items
+        left = len(tp.items) - max_items
         if left > 0:
             msg = '<{} more overload{} not shown>'.format(left, plural_s(left))
             self.note(msg, context, offset=offset, allow_dups=allow_dups, code=code)
@@ -1535,11 +1535,11 @@ class MessageBuilder:
                                 max_items: int,
                                 code: ErrorCode) -> None:
         if not targets:
-            targets = func.items()
+            targets = func.items
 
         shown = min(max_items, len(targets))
         max_matching = len(targets)
-        max_available = len(func.items())
+        max_available = len(func.items)
 
         # If there are 3 matches but max_items == 2, we might as well show
         # all three items instead of having the 3rd item be an error message.
@@ -1771,7 +1771,7 @@ def format_type_inner(typ: Type,
         if func.is_type_obj():
             # The type of a type object type can be derived from the
             # return type (this always works).
-            return format(TypeType.make_normalized(erase_type(func.items()[0].ret_type)))
+            return format(TypeType.make_normalized(erase_type(func.items[0].ret_type)))
         elif isinstance(func, CallableType):
             return_type = format(func.ret_type)
             if func.is_ellipsis_args:

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -108,7 +108,7 @@ class Attribute:
                 init_type = ctx.api.anal_type(converter_type.arg_types[0])
             elif isinstance(converter_type, Overloaded):
                 types: List[Type] = []
-                for item in converter_type.items():
+                for item in converter_type.items:
                     # Walk the overloads looking for methods that can accept one argument.
                     num_arg_types = len(item.arg_types)
                     if not num_arg_types:

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -62,7 +62,7 @@ def _get_argument(call: CallExpr, name: str) -> Optional[Expression]:
         callee_node_type = get_proper_type(callee_node.type)
         if isinstance(callee_node_type, Overloaded):
             # We take the last overload.
-            callee_type = callee_node_type.items()[-1]
+            callee_type = callee_node_type.items[-1]
         elif isinstance(callee_node_type, CallableType):
             callee_type = callee_node_type
 

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -131,7 +131,7 @@ def singledispatch_register_callback(ctx: MethodContext) -> Type:
 
         # is_subtype doesn't work when the right type is Overloaded, so we need the
         # actual type
-        register_type = first_arg_type.items()[0].ret_type
+        register_type = first_arg_type.items[0].ret_type
         type_args = RegisterCallableInfo(register_type, ctx.type)
         register_callable = make_fake_register_class_instance(
             ctx.api,

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -159,7 +159,7 @@ class SameTypeVisitor(TypeVisitor[bool]):
 
     def visit_overloaded(self, left: Overloaded) -> bool:
         if isinstance(self.right, Overloaded):
-            return is_same_types(left.items(), self.right.items())
+            return is_same_types(left.items, self.right.items)
         else:
             return False
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -970,7 +970,7 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     def check_classvar_in_signature(self, typ: ProperType) -> None:
         if isinstance(typ, Overloaded):
-            for t in typ.items():  # type: ProperType
+            for t in typ.items:  # type: ProperType
                 self.check_classvar_in_signature(t)
             return
         if not isinstance(typ, CallableType):
@@ -5110,7 +5110,7 @@ def replace_implicit_first_type(sig: FunctionLike, new: Type) -> FunctionLike:
         return sig.copy_modified(arg_types=[new] + sig.arg_types[1:])
     elif isinstance(sig, Overloaded):
         return Overloaded([cast(CallableType, replace_implicit_first_type(i, new))
-                           for i in sig.items()])
+                           for i in sig.items])
     else:
         assert False
 

--- a/mypy/semanal_infer.py
+++ b/mypy/semanal_infer.py
@@ -59,7 +59,7 @@ def infer_decorator_signature_if_simple(dec: Decorator,
             # The outermost decorator always returns the same kind of function,
             # so we know that this is the type of the decorated function.
             orig_sig = function_type(dec.func, analyzer.named_type('__builtins__.function'))
-            sig.name = orig_sig.items()[0].name
+            sig.name = orig_sig.items[0].name
             dec.var.type = sig
 
 

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -339,7 +339,7 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
         return ('TypeGuardType', snapshot_type(typ.type_guard))
 
     def visit_overloaded(self, typ: Overloaded) -> SnapshotItem:
-        return ('Overloaded', snapshot_types(typ.items()))
+        return ('Overloaded', snapshot_types(typ.items))
 
     def visit_partial_type(self, typ: PartialType) -> SnapshotItem:
         # A partial type is not fully defined, so the result is indeterminate. We shouldn't

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -376,7 +376,7 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
                     value.accept(self)
 
     def visit_overloaded(self, t: Overloaded) -> None:
-        for item in t.items():
+        for item in t.items:
             item.accept(self)
         # Fallback can be None for overloaded types that haven't been semantically analyzed.
         if t.fallback is not None:

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -917,7 +917,7 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
 
     def visit_overloaded(self, typ: Overloaded) -> List[str]:
         triggers = []
-        for item in typ.items():
+        for item in typ.items:
             triggers.extend(self.get_type_triggers(item))
         return triggers
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -313,7 +313,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 is_compat=self._is_subtype,
                 ignore_pos_arg_names=self.ignore_pos_arg_names)
         elif isinstance(right, Overloaded):
-            return all(self._is_subtype(left, item) for item in right.items())
+            return all(self._is_subtype(left, item) for item in right.items)
         elif isinstance(right, Instance):
             if right.type.is_protocol and right.type.protocol_members == ['__call__']:
                 # OK, a callable can implement a protocol with a single `__call__` member.
@@ -411,7 +411,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
                     return True
             return self._is_subtype(left.fallback, right)
         elif isinstance(right, CallableType):
-            for item in left.items():
+            for item in left.items:
                 if self._is_subtype(item, right):
                     return True
             return False
@@ -425,10 +425,10 @@ class SubtypeVisitor(TypeVisitor[bool]):
             matched_overloads = set()
             possible_invalid_overloads = set()
 
-            for right_index, right_item in enumerate(right.items()):
+            for right_index, right_item in enumerate(right.items):
                 found_match = False
 
-                for left_index, left_item in enumerate(left.items()):
+                for left_index, left_item in enumerate(left.items):
                     subtype_match = self._is_subtype(left_item, right_item)
 
                     # Order matters: we need to make sure that the index of
@@ -468,7 +468,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
             # All the items must have the same type object status, so
             # it's sufficient to query only (any) one of them.
             # This is unsound, we don't check all the __init__ signatures.
-            return left.is_type_obj() and self._is_subtype(left.items()[0], right)
+            return left.is_type_obj() and self._is_subtype(left.items[0], right)
         else:
             return False
 
@@ -1316,7 +1316,7 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
             return is_callable_compatible(left, right, is_compat=self._is_proper_subtype)
         elif isinstance(right, Overloaded):
             return all(self._is_proper_subtype(left, item)
-                       for item in right.items())
+                       for item in right.items)
         elif isinstance(right, Instance):
             return self._is_proper_subtype(left.fallback, right)
         elif isinstance(right, TypeType):

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -604,7 +604,7 @@ class SuggestionEngine:
 
             if not isinstance(typ, FunctionLike):
                 return None
-            for ct in typ.items():
+            for ct in typ.items:
                 if not (len(ct.arg_types) == 1
                         and isinstance(ct.arg_types[0], TypeVarType)
                         and ct.arg_types[0] == ct.ret_type):

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -233,7 +233,7 @@ class TypeTranslator(TypeVisitor[Type]):
 
     def visit_overloaded(self, t: Overloaded) -> Type:
         items: List[CallableType] = []
-        for item in t.items():
+        for item in t.items:
             new = item.accept(self)
             assert isinstance(new, CallableType)  # type: ignore
             items.append(new)
@@ -330,7 +330,7 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return t.type_guard.accept(self)
 
     def visit_overloaded(self, t: Overloaded) -> T:
-        return self.query_types(t.items())
+        return self.query_types(t.items)
 
     def visit_type_type(self, t: TypeType) -> T:
         return t.item.accept(self)

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -76,9 +76,9 @@ def type_object_type_from_function(signature: FunctionLike,
     default_self = fill_typevars(info)
     if not is_new and not info.is_newtype:
         orig_self_types = [(it.arg_types[0] if it.arg_types and it.arg_types[0] != default_self
-                            and it.arg_kinds[0] == ARG_POS else None) for it in signature.items()]
+                            and it.arg_kinds[0] == ARG_POS else None) for it in signature.items]
     else:
-        orig_self_types = [None] * len(signature.items())
+        orig_self_types = [None] * len(signature.items)
 
     # The __init__ method might come from a generic superclass 'def_info'
     # with type variables that do not map identically to the type variables of
@@ -104,7 +104,7 @@ def type_object_type_from_function(signature: FunctionLike,
         # Overloaded __init__/__new__.
         assert isinstance(signature, Overloaded)
         items: List[CallableType] = []
-        for item, orig_self in zip(signature.items(), orig_self_types):
+        for item, orig_self in zip(signature.items, orig_self_types):
             items.append(class_callable(item, info, fallback, special_sig, is_new, orig_self))
         return Overloaded(items)
 
@@ -213,7 +213,7 @@ def bind_self(method: F, original_type: Optional[Type] = None, is_classmethod: b
 
     if isinstance(method, Overloaded):
         return cast(F, Overloaded([bind_self(c, original_type, is_classmethod)
-                                   for c in method.items()]))
+                                   for c in method.items]))
     assert isinstance(method, CallableType)
     func = method
     if not func.arg_types:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -934,6 +934,7 @@ class FunctionLike(ProperType):
     @abstractmethod
     def type_object(self) -> mypy.nodes.TypeInfo: pass
 
+    @property
     @abstractmethod
     def items(self) -> List['CallableType']: pass
 
@@ -1199,6 +1200,7 @@ class CallableType(FunctionLike):
         else:
             return None
 
+    @property
     def items(self) -> List['CallableType']:
         return [self]
 
@@ -1285,6 +1287,7 @@ class Overloaded(FunctionLike):
         self._items = items
         self.fallback = items[0].fallback
 
+    @property
     def items(self) -> List[CallableType]:
         return self._items
 
@@ -1314,16 +1317,16 @@ class Overloaded(FunctionLike):
         return visitor.visit_overloaded(self)
 
     def __hash__(self) -> int:
-        return hash(tuple(self.items()))
+        return hash(tuple(self.items))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Overloaded):
             return NotImplemented
-        return self.items() == other.items()
+        return self.items == other.items
 
     def serialize(self) -> JsonDict:
         return {'.class': 'Overloaded',
-                'items': [t.serialize() for t in self.items()],
+                'items': [t.serialize() for t in self.items],
                 }
 
     @classmethod
@@ -2102,7 +2105,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 
     def visit_overloaded(self, t: Overloaded) -> str:
         a = []
-        for i in t.items():
+        for i in t.items:
             a.append(i.accept(self))
         return 'Overload({})'.format(', '.join(a))
 
@@ -2208,7 +2211,7 @@ def strip_type(typ: Type) -> ProperType:
         return typ.copy_modified(name=None)
     elif isinstance(typ, Overloaded):
         return Overloaded([cast(CallableType, strip_type(item))
-                           for item in typ.items()])
+                           for item in typ.items])
     else:
         return typ
 

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -66,7 +66,7 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
         t.type_guard.accept(self)
 
     def visit_overloaded(self, t: Overloaded) -> None:
-        self.traverse_types(t.items())
+        self.traverse_types(t.items)
 
     def visit_type_type(self, t: TypeType) -> None:
         t.item.accept(self)


### PR DESCRIPTION
### Description

Closes https://github.com/python/mypy/issues/2112

This PR changes the FunctionLike.items from method to property. By doing so, the `items` field is consistent with other types such as `TupleType` and is distinguished from `dict.items()`

```py
    @property
    @abstractmethod
    def items(self) -> List['CallableType']: pass
```