### PR TITLE
Docs: show how `--no-implicit-reexport` handles `from X import Y as Z`

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -565,8 +565,13 @@ of the above sections.
 
        # This won't re-export the value
        from foo import bar
+
+       # Neither will this
+       from foo import bar as bang
+
        # This will re-export it as bar and allow other modules to import it
        from foo import bar as bar
+
        # This will also re-export bar
        from foo import bar
        __all__ = ['bar']


### PR DESCRIPTION
### Description

In our testing, mypy appears to treat code like this as an *implicit* re-export. If `--no-implicit-reexport` is given, mypy will disallow it.

```python
from X import Y as Z  # Non-matching name.
```

Even though it treats code like this as an *explicit* re-export:

```python
from X import Y as Y  # Matching name.
```

For stub files specifically, [PEP 484 has this note](https://www.python.org/dev/peps/pep-0484/#stub-files), emphasis mine:

> Modules and variables imported into the stub are not considered exported from the stub unless the import uses the `import ... as ...` form or the equivalent `from ... import ... as ...` form. (UPDATE: To clarify, the intention here is that **only names imported using the form `X as X` will be exported, i.e. the name before and after as must be the same.**)

**I am therefore assuming that this mypy behavior is intentional.** (Even though I find it unfortunate and surprising, and even though `--no-implicit-reexport` seems meant for more than just stub files.) So this PR documents it.

## Test Plan

* Verify that the rendered docs look good: <img width="724" alt="Screen Shot 2021-09-09 at 2 42 41 PM" src="https://user-images.githubusercontent.com/3236864/132744489-da0bea0a-65db-46a7-82c7-4c07ba0cf494.png">
* If anyone can authoritatively confirm that this is indeed intended behavior of `--no-implicit-reexport`, that would be helpful.
