### PR TITLE
[stubgen] Fix a few bugs with stubgen of c modules

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -148,13 +148,16 @@ class DocStringParser:
 
             if token.string == ')':
                 self.state.pop()
-            try:
-                self.args.append(ArgSig(name=self.arg_name, type=self.arg_type,
-                                        default=bool(self.arg_default)))
-            except ValueError:
-                # wrong type, use Any
-                self.args.append(ArgSig(name=self.arg_name, type=None,
-                                        default=bool(self.arg_default)))
+
+            # arg_name is empty when there are no args. e.g. func()
+            if self.arg_name:
+                try:
+                    self.args.append(ArgSig(name=self.arg_name, type=self.arg_type,
+                                            default=bool(self.arg_default)))
+                except ValueError:
+                    # wrong type, use Any
+                    self.args.append(ArgSig(name=self.arg_name, type=None,
+                                            default=bool(self.arg_default)))
             self.arg_name = ""
             self.arg_type = None
             self.arg_default = None

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -188,6 +188,10 @@ def generate_c_function_stub(module: ModuleType,
                                         args=infer_arg_sig_from_anon_docstring(
                                             sigs.get(name, '(*args, **kwargs)')),
                                         ret_type=ret_type)]
+        elif class_name and self_var:
+            args = inferred[0].args
+            if not args or args[0].name != self_var:
+                args.insert(0, ArgSig(name=self_var))
 
     is_overloaded = len(inferred) > 1 if inferred else False
     if is_overloaded:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -182,7 +182,8 @@ def generate_c_function_stub(module: ModuleType,
                 del inferred[-1]
         if not inferred:
             if class_name and name not in sigs:
-                inferred = [FunctionSig(name, args=infer_method_sig(name), ret_type=ret_type)]
+                inferred = [FunctionSig(name, args=infer_method_sig(name, self_var),
+                                        ret_type=ret_type)]
             else:
                 inferred = [FunctionSig(name=name,
                                         args=infer_arg_sig_from_anon_docstring(
@@ -442,7 +443,7 @@ def is_skipped_attribute(attr: str) -> bool:
             )
 
 
-def infer_method_sig(name: str) -> List[ArgSig]:
+def infer_method_sig(name: str, self_var: Optional[str] = None) -> List[ArgSig]:
     args: Optional[List[ArgSig]] = None
     if name.startswith('__') and name.endswith('__'):
         name = name[2:-2]
@@ -491,4 +492,4 @@ def infer_method_sig(name: str) -> List[ArgSig]:
     if args is None:
         args = [ArgSig(name='*args'),
                 ArgSig(name='**kwargs')]
-    return [ArgSig(name='self')] + args
+    return [ArgSig(name=self_var or 'self')] + args

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -761,6 +761,19 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ['def test(self, arg0: int) -> Any: ...'])
         assert_equal(imports, [])
 
+    def test_generate_c_type_classmethod(self) -> None:
+        class TestClass:
+            @classmethod
+            def test(cls, arg0: str) -> None:
+                pass
+        output = []  # type: List[str]
+        imports = []  # type: List[str]
+        mod = ModuleType(TestClass.__module__, '')
+        generate_c_function_stub(mod, 'test', TestClass.test, output, imports,
+                                 self_var='cls', class_name='TestClass')
+        assert_equal(output, ['def test(cls, *args, **kwargs) -> Any: ...'])
+        assert_equal(imports, [])
+
     def test_generate_c_type_with_docstring_empty_default(self) -> None:
         class TestClass:
             def test(self, arg0: str = "") -> None:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -746,6 +746,21 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ['def test(self, arg0: int) -> Any: ...'])
         assert_equal(imports, [])
 
+    def test_generate_c_type_with_docstring_no_self_arg(self) -> None:
+        class TestClass:
+            def test(self, arg0: str) -> None:
+                """
+                test(arg0: int)
+                """
+                pass
+        output = []  # type: List[str]
+        imports = []  # type: List[str]
+        mod = ModuleType(TestClass.__module__, '')
+        generate_c_function_stub(mod, 'test', TestClass.test, output, imports,
+                                 self_var='self', class_name='TestClass')
+        assert_equal(output, ['def test(self, arg0: int) -> Any: ...'])
+        assert_equal(imports, [])
+
     def test_generate_c_type_with_docstring_empty_default(self) -> None:
         class TestClass:
             def test(self, arg0: str = "") -> None:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -187,6 +187,8 @@ class StubgenUtilSuite(unittest.TestCase):
     def test_infer_sig_from_docstring(self) -> None:
         assert_equal(infer_sig_from_docstring('\nfunc(x) - y', 'func'),
                      [FunctionSig(name='func', args=[ArgSig(name='x')], ret_type='Any')])
+        assert_equal(infer_sig_from_docstring('\nfunc(x)', 'func'),
+                     [FunctionSig(name='func', args=[ArgSig(name='x')], ret_type='Any')])
 
         assert_equal(infer_sig_from_docstring('\nfunc(x, Y_a=None)', 'func'),
                      [FunctionSig(name='func',
@@ -217,6 +219,13 @@ class StubgenUtilSuite(unittest.TestCase):
         assert_equal(infer_sig_from_docstring('\nfunc(x: int=3)', 'func'),
                      [FunctionSig(name='func', args=[ArgSig(name='x', type='int', default=True)],
                                   ret_type='Any')])
+
+        assert_equal(infer_sig_from_docstring('\nfunc(x=3)', 'func'),
+                     [FunctionSig(name='func', args=[ArgSig(name='x', type=None, default=True)],
+                                  ret_type='Any')])
+
+        assert_equal(infer_sig_from_docstring('\nfunc() -> int', 'func'),
+                     [FunctionSig(name='func', args=[], ret_type='int')])
 
         assert_equal(infer_sig_from_docstring('\nfunc(x: int=3) -> int', 'func'),
                      [FunctionSig(name='func', args=[ArgSig(name='x', type='int', default=True)],


### PR DESCRIPTION

### Description

This fixes three issues encountered while trying to generate stubs from a c module:

1.  Fix bug when inferring signatures with no args.  In this case, the signature has one arg which has an empty name.
2. Add a self arg to the inferred signature for a method, when it is omitted from docstring signature.  stubgen has a feature that will read the signature from the function's docstrings, but it would happily accept methods that did not specify a self-arg.   
3. Use 'cls' as self arg for classmethods without signature info.  Simple fix to produce better stubs for classmethods defined in c modules.

## Test Plan

Each of these changes has a test which clearly shows the change.

I've left each of these changes as their own commit, and each _could_ be a separate MR, but they are so simple I've left them in one MR.  Let me know if you want me to break this up.

