### PR TITLE
Use descriptive names in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Tests
 
 on:
   push:
@@ -19,72 +19,68 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [windows-py37-32, windows-py37-64,
-               ubuntu-py37, ubuntu-py38,
-               ubuntu-py36-mypyc, ubuntu-py39-mypyc,
-               macos-py36, ubuntu-py-36-debug-build,
-               type-checking, code-style]
         include:
-        - name: windows-py37-32
+        - name: Test suite with windows-py37-32
           python: '3.7'
           arch: x86
           os: windows-latest
           toxenv: py37
-        - name: windows-py37-64
+        - name: Test suite with windows-py37-64
           python: '3.7'
           arch: x64
           os: windows-latest
           toxenv: py37
-        - name: ubuntu-py37
+        - name: Test suite with ubuntu-py37
           python: '3.7'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
-        - name: ubuntu-py38
+        - name: Test suite with ubuntu-py38
           python: '3.8'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
-        - name: ubuntu-py36-mypyc
+        - name: Test suite with ubuntu-py36, mypyc-compiled
           python: '3.6'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
           test_mypyc: true
-        - name: ubuntu-py39-mypyc
+        - name: Test suite with ubuntu-py39, mypyc-compiled
           python: '3.9'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
           test_mypyc: true
-        - name: macos-py36
+        - name: mypyc runtime tests with macos-py36
           python: '3.6'
           arch: x64
           os: macos-latest
           toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"
-        - name: ubuntu-py-36-debug-build
+        - name: mypyc runtime tests with ubuntu-py-36-debug-build
           python: '3.6.8'
           arch: x64
           os: ubuntu-latest
           toxenv: py36
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"
           debug_build: true
-        - name: type-checking
+        - name: Type check our own code
           python: '3.7'
           arch: x64
           os: ubuntu-latest
           toxenv: type
-        - name: code-style
+        - name: Code style with flake8
           python: '3.7'
           arch: x64
           os: ubuntu-latest
           toxenv: lint
 
+    name: ${{ matrix.name }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -113,6 +109,7 @@ jobs:
 
   python-nightly:
     runs-on: ubuntu-latest
+    name: Test suite with Python nightly
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,49 +20,49 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Test suite with windows-py37-32
+        - name: Test suite with py37-windows-32
           python: '3.7'
           arch: x86
           os: windows-latest
           toxenv: py37
-        - name: Test suite with windows-py37-64
+        - name: Test suite with py37-windows-64
           python: '3.7'
           arch: x64
           os: windows-latest
           toxenv: py37
-        - name: Test suite with ubuntu-py37
+        - name: Test suite with py37-ubuntu
           python: '3.7'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
-        - name: Test suite with ubuntu-py38
+        - name: Test suite with py38-ubuntu
           python: '3.8'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
-        - name: Test suite with ubuntu-py36, mypyc-compiled
+        - name: Test suite with py36-ubuntu, mypyc-compiled
           python: '3.6'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
           test_mypyc: true
-        - name: Test suite with ubuntu-py39, mypyc-compiled
+        - name: Test suite with py39-ubuntu, mypyc-compiled
           python: '3.9'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
           test_mypyc: true
-        - name: mypyc runtime tests with macos-py36
+        - name: mypyc runtime tests with py36-macos
           python: '3.6'
           arch: x64
           os: macos-latest
           toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"
-        - name: mypyc runtime tests with ubuntu-py-36-debug-build
+        - name: mypyc runtime tests with py36-debug-build-ubuntu
           python: '3.6.8'
           arch: x64
           os: ubuntu-latest


### PR DESCRIPTION
I liked the names we had in Travis. In particular, this helps disambiguate mypyc tests from mypy tests when mypy is compiled with mypyc.