### PR TITLE
detect conda gcc for -Wno-unused-but-set-variable as well

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -508,7 +508,7 @@ def mypycify(
             '-Wno-unreachable-code', '-Wno-unused-variable',
             '-Wno-unused-command-line-argument', '-Wno-unknown-warning-option',
         ]
-        if 'gcc' in compiler.compiler[0]:
+        if 'gcc' in compiler.compiler[0] or 'gnu-cc' in compiler.compiler[0]:
             # This flag is needed for gcc but does not exist on clang.
             cflags += ['-Wno-unused-but-set-variable']
     elif compiler.compiler_type == 'msvc':


### PR DESCRIPTION
### Description

Allows mypyc to recognize a conda gcc compiler, so that `-Wno-unused-but-set-variable` may be set so that compilation does not fail.

On arm64, the conda compiler is named `aarch64-conda-linux-gnu-cc` and on x86_65 the conda compiler is named `x86_64-conda-linux-gnu-cc`

```
$ python -c 'from distutils import sysconfig, ccompiler; compiler = ccompiler.new_compiler(); sysconfig.customize_compiler(compiler); print(compiler.compiler[0])'

x86_64-linux-gnu-gcc

$ conda activate

(base) $ python -c 'from distutils import sysconfig, ccompiler; compiler = ccompiler.new_compiler(); sysconfig.customize_compiler(compiler); print(compiler.compiler[0])'

/home/michael/miniconda3/bin/x86_64-conda-linux-gnu-cc
# note the lack of "gcc" in the compiler name
```

See line 947 of https://cloud.drone.io/conda-forge/schema-salad-feedstock/6/4/2 for an example of how this issue caused a build failure

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

If desired, I can refactor the `gcc` testing code to its own function, and then add some unit tests.