### PR TITLE
Correctly handle cls in protocol classmethod

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -710,7 +710,7 @@ def find_node_type(node: Union[Var, FuncBase], itype: Instance, subtype: Type) -
                 and node.is_initialized_in_class
                 and not node.is_staticmethod)):
         assert isinstance(typ, FunctionLike)
-        signature = bind_self(typ, subtype)
+        signature = bind_self(typ, subtype, isinstance(node, Var) and node.is_classmethod)
         if node.is_property:
             assert isinstance(signature, CallableType)
             typ = signature.ret_type

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -710,7 +710,8 @@ def find_node_type(node: Union[Var, FuncBase], itype: Instance, subtype: Type) -
                 and node.is_initialized_in_class
                 and not node.is_staticmethod)):
         assert isinstance(typ, FunctionLike)
-        signature = bind_self(typ, subtype, isinstance(node, Var) and node.is_classmethod)
+        signature = bind_self(typ, subtype,
+                              is_classmethod=isinstance(node, Var) and node.is_classmethod)
         if node.is_property:
             assert isinstance(signature, CallableType)
             typ = signature.ret_type

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -802,6 +802,37 @@ class Bad(metaclass=Meta):
 Good.do_x()
 Bad.do_x()  # E: Invalid self argument "Type[Bad]" to attribute function "do_x" with type "Callable[[Type[T]], T]"
 
+[case testSelfTypeProtocolClassmethodMatch]
+from typing import Type, TypeVar, Protocol
+
+T = TypeVar('T')
+
+class HasDoX(Protocol):
+    @classmethod
+    def do_x(cls: Type[T]) -> T:
+        ...
+
+class Good:
+    @classmethod
+    def do_x(cls) -> 'Good':
+        ...
+
+class Bad:
+    @classmethod
+    def do_x(cls) -> Good:
+        ...
+
+good: HasDoX = Good()
+bad: HasDoX = Bad()
+[builtins fixtures/classmethod.pyi]
+[out]
+main:21: error: Incompatible types in assignment (expression has type "Bad", variable has type "HasDoX")
+main:21: note: Following member(s) of "Bad" have conflicts:
+main:21: note:     Expected:
+main:21: note:         def do_x(cls) -> Bad
+main:21: note:     Got:
+main:21: note:         def do_x(cls) -> Good
+
 [case testSelfTypeNotSelfType]
 # Friendlier error messages for common mistakes. See #2950
 class A:


### PR DESCRIPTION
### Description

Correctly handle cls in generic classmethods of protocol. Closes #11115
<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

This should correctly handle cls in classmethods. Current behavior of not passing is_classmethod seems like an omission in implementation, so this should only correct buggy behavior and shouldn't break something else.

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

I've included a test in the test suite (testSelfTypeProtocolClassmethodMatch)
