### PR TITLE
Document ‘strict’ config file option

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -610,6 +610,18 @@ section of the command line docs.
    Prohibit equality checks, identity checks, and container checks between
    non-overlapping types.
 
+.. confval:: strict
+
+    :type: boolean
+    :default: False
+
+   Enable all optional error checking flags.  You can see the list of
+   flags enabled by strict mode in the full :option:`mypy --help`
+   output.
+
+   Note: the exact list of flags enabled by :confval:`strict` may
+   change over time.
+
 
 Configuring error messages
 **************************


### PR DESCRIPTION
### Description

Historically `--strict` was only supported on the command line, but commit cb0ceb02848494f3dab2d976035f0d56682a7045 (#8192) added this option to the config file in 0.770. Document the config file option.

## Test Plan

[Rebuilt](https://github.com/python/mypy/blob/master/docs/README.md#building-the-documentation) the docs.

(Did you know that Read the Docs supports [automatic preview builds for pull requests](https://docs.readthedocs.io/en/stable/pull-requests.html)? It’d be neat if someone would turn that on for this repository.)