### PR TITLE
Correct example annotation `self`

### DIFF
--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -614,7 +614,7 @@ argument is itself generic:
 
 .. code-block:: python
 
-  T = TypeVar('T')
+  T = TypeVar('T', covariant=True)
   S = TypeVar('S')
 
    class Storage(Generic[T]):


### PR DESCRIPTION
Add needed `covariant=True` for example to pass type checking at `page.first_chunk()` as intended.
