### PR TITLE
Fixes error message for `f` string and `str-bytes-safe`

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -380,8 +380,9 @@ class StringFormatterChecker:
                 if (has_type_component(actual_type, 'builtins.bytes') and
                         not custom_special_method(actual_type, '__str__')):
                     self.msg.fail(
-                        "On Python 3 '{}'.format(b'abc') produces \"b'abc'\", not 'abc'; "
-                        "use '{!r}'.format(b'abc') if this is desired behavior",
+                        'On Python 3 formatting string with "{}" and bytes argument '
+                        "produces result with \"b''\" prefix, not a regular string; "
+                        'use "{!r}" if this is desired behavior',
                         call, code=codes.STR_BYTES_PY3)
         if spec.flags:
             numeric_types = UnionType([self.named_type('builtins.int'),
@@ -836,8 +837,9 @@ class StringFormatterChecker:
             if self.chk.options.python_version >= (3, 0):
                 if has_type_component(typ, 'builtins.bytes'):
                     self.msg.fail(
-                        "On Python 3 '%s' % b'abc' produces \"b'abc'\", not 'abc'; "
-                        "use '%r' % b'abc' if this is desired behavior",
+                        'On Python 3 formatting string with "%s" and bytes argument '
+                        "produces result with \"b''\" prefix, not a regular string; "
+                        'use "%r" if this is desired behavior',
                         context, code=codes.STR_BYTES_PY3)
                     return False
             if self.chk.options.python_version < (3, 0):

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -380,8 +380,8 @@ class StringFormatterChecker:
                 if (has_type_component(actual_type, 'builtins.bytes') and
                         not custom_special_method(actual_type, '__str__')):
                     self.msg.fail(
-                        'On Python 3 formatting string with "{}" and bytes argument '
-                        "produces result with \"b''\" prefix, not a regular string; "
+                        'On Python 3 formatting "b\'abc\'" with "{}" '
+                        'produces "b\'abc\'", not "abc"; '
                         'use "{!r}" if this is desired behavior',
                         call, code=codes.STR_BYTES_PY3)
         if spec.flags:
@@ -837,8 +837,8 @@ class StringFormatterChecker:
             if self.chk.options.python_version >= (3, 0):
                 if has_type_component(typ, 'builtins.bytes'):
                     self.msg.fail(
-                        'On Python 3 formatting string with "%s" and bytes argument '
-                        "produces result with \"b''\" prefix, not a regular string; "
+                        'On Python 3 formatting "b\'abc\'" with "%s" '
+                        'produces "b\'abc\'", not "abc"; '
                         'use "%r" if this is desired behavior',
                         context, code=codes.STR_BYTES_PY3)
                     return False

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -218,7 +218,8 @@ def test_fstring_basics() -> None:
 
     x = bytes([1, 2, 3, 4])
     # assert f'bytes: {x}' == "bytes: b'\\x01\\x02\\x03\\x04'"
-    # error: On Python 3 formatting string with "{}" and bytes argument produces result #        with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+    # error: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc";
+    #        use "{!r}" if this is desired behavior behavior
 
     float_num = 123.4
     assert f'{float_num}' == '123.4'

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -218,8 +218,7 @@ def test_fstring_basics() -> None:
 
     x = bytes([1, 2, 3, 4])
     # assert f'bytes: {x}' == "bytes: b'\\x01\\x02\\x03\\x04'"
-    # error: On Python 3 '{}'.format(b'abc') produces "b'abc'", not 'abc';
-    #        use '{!r}'.format(b'abc') if this is desired behavior
+    # error: On Python 3 formatting string with "{}" and bytes argument produces result #        with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
 
     float_num = 123.4
     assert f'{float_num}' == '123.4'
@@ -354,7 +353,7 @@ def test_format_method_basics() -> None:
 def test_format_method_empty_braces() -> None:
     name = 'Eric'
     age = 14
-    
+
     assert 'Hello, {}!'.format(name) == 'Hello, Eric!'
     assert '{}'.format(name) == 'Eric'
     assert '{}! Hi!'.format(name) == 'Eric! Hi!'

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -641,8 +641,8 @@ def g() -> int:
 '%d' % 'no'  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")  [str-format]
 '%d + %d' % (1, 2, 3)  # E: Not all arguments converted during string formatting  [str-format]
 
-'{}'.format(b'abc')  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior  [str-bytes-safe]
-'%s' % b'abc'  # E: On Python 3 formatting string with "%s" and bytes argument produces result with "b''" prefix, not a regular string; use "%r" if this is desired behavior  [str-bytes-safe]
+'{}'.format(b'abc')  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior  [str-bytes-safe]
+'%s' % b'abc'  # E: On Python 3 formatting "b'abc'" with "%s" produces "b'abc'", not "abc"; use "%r" if this is desired behavior  [str-bytes-safe]
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-medium.pyi]
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -641,8 +641,8 @@ def g() -> int:
 '%d' % 'no'  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")  [str-format]
 '%d + %d' % (1, 2, 3)  # E: Not all arguments converted during string formatting  [str-format]
 
-'{}'.format(b'abc')  # E: On Python 3 '{}'.format(b'abc') produces "b'abc'", not 'abc'; use '{!r}'.format(b'abc') if this is desired behavior  [str-bytes-safe]
-'%s' % b'abc'  # E: On Python 3 '%s' % b'abc' produces "b'abc'", not 'abc'; use '%r' % b'abc' if this is desired behavior  [str-bytes-safe]
+'{}'.format(b'abc')  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior  [str-bytes-safe]
+'%s' % b'abc'  # E: On Python 3 formatting string with "%s" and bytes argument produces result with "b''" prefix, not a regular string; use "%r" if this is desired behavior  [str-bytes-safe]
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-medium.pyi]
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1183,8 +1183,8 @@ xb: bytes
 xs: str
 
 '%s' % xs   # OK
-'%s' % xb   # E: On Python 3 '%s' % b'abc' produces "b'abc'", not 'abc'; use '%r' % b'abc' if this is desired behavior
-'%(name)s' % {'name': b'value'}  # E: On Python 3 '%s' % b'abc' produces "b'abc'", not 'abc'; use '%r' % b'abc' if this is desired behavior
+'%s' % xb   # E: On Python 3 formatting string with "%s" and bytes argument produces result with "b''" prefix, not a regular string; use "%r" if this is desired behavior
+'%(name)s' % {'name': b'value'}  # E: On Python 3 formatting string with "%s" and bytes argument produces result with "b''" prefix, not a regular string; use "%r" if this is desired behavior
 [builtins fixtures/primitives.pyi]
 
 [case testStringInterpolationSBytesVsStrResultsPy2]
@@ -1617,22 +1617,32 @@ N = NewType('N', bytes)
 n: N
 
 '{}'.format(a)
-'{}'.format(b)  # E: On Python 3 '{}'.format(b'abc') produces "b'abc'", not 'abc'; use '{!r}'.format(b'abc') if this is desired behavior
-'{}'.format(x)  # E: On Python 3 '{}'.format(b'abc') produces "b'abc'", not 'abc'; use '{!r}'.format(b'abc') if this is desired behavior
-'{}'.format(n)  # E: On Python 3 '{}'.format(b'abc') produces "b'abc'", not 'abc'; use '{!r}'.format(b'abc') if this is desired behavior
+'{}'.format(b)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+'{}'.format(x)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+'{}'.format(n)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+
+f'{b}'  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+f'{x}'  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+f'{n}'  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
 
 class C(Generic[B]):
     x: B
     def meth(self) -> None:
-        '{}'.format(self.x)  # E: On Python 3 '{}'.format(b'abc') produces "b'abc'", not 'abc'; use '{!r}'.format(b'abc') if this is desired behavior
+        '{}'.format(self.x)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
 
 def func(x: A) -> A:
-    '{}'.format(x)  # E: On Python 3 '{}'.format(b'abc') produces "b'abc'", not 'abc'; use '{!r}'.format(b'abc') if this is desired behavior
+    '{}'.format(x)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
     return x
 
+'{!r}'.format(a)
 '{!r}'.format(b)
 '{!r}'.format(x)
 '{!r}'.format(n)
+f'{a}'
+f'{a!r}'
+f'{b!r}'
+f'{x!r}'
+f'{n!r}'
 
 class D(bytes):
     def __str__(self) -> str:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1184,7 +1184,7 @@ xs: str
 
 '%s' % xs   # OK
 '%s' % xb   # E: On Python 3 formatting string with "%s" and bytes argument produces result with "b''" prefix, not a regular string; use "%r" if this is desired behavior
-'%(name)s' % {'name': b'value'}  # E: On Python 3 formatting string with "%s" and bytes argument produces result with "b''" prefix, not a regular string; use "%r" if this is desired behavior
+'%(name)s' % {'name': b'value'}  # E: On Python 3 formatting "b'abc'" with "%s" produces "b'abc'", not "abc"; use "%r" if this is desired behavior
 [builtins fixtures/primitives.pyi]
 
 [case testStringInterpolationSBytesVsStrResultsPy2]
@@ -1617,21 +1617,21 @@ N = NewType('N', bytes)
 n: N
 
 '{}'.format(a)
-'{}'.format(b)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
-'{}'.format(x)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
-'{}'.format(n)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+'{}'.format(b)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+'{}'.format(x)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+'{}'.format(n)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
 
-f'{b}'  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
-f'{x}'  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
-f'{n}'  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+f'{b}'  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+f'{x}'  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+f'{n}'  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
 
 class C(Generic[B]):
     x: B
     def meth(self) -> None:
-        '{}'.format(self.x)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+        '{}'.format(self.x)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
 
 def func(x: A) -> A:
-    '{}'.format(x)  # E: On Python 3 formatting string with "{}" and bytes argument produces result with "b''" prefix, not a regular string; use "{!r}" if this is desired behavior
+    '{}'.format(x)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
     return x
 
 '{!r}'.format(a)

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1183,7 +1183,7 @@ xb: bytes
 xs: str
 
 '%s' % xs   # OK
-'%s' % xb   # E: On Python 3 formatting string with "%s" and bytes argument produces result with "b''" prefix, not a regular string; use "%r" if this is desired behavior
+'%s' % xb   # E: On Python 3 formatting "b'abc'" with "%s" produces "b'abc'", not "abc"; use "%r" if this is desired behavior
 '%(name)s' % {'name': b'value'}  # E: On Python 3 formatting "b'abc'" with "%s" produces "b'abc'", not "abc"; use "%r" if this is desired behavior
 [builtins fixtures/primitives.pyi]
 


### PR DESCRIPTION
It does not mention `.format()` anymore.

Closes #10979