### PR TITLE
Report attribute access errors for TypeVar bound to Union.

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -335,7 +335,9 @@ class MessageBuilder:
                             format_type(original_type), member, extra),
                         context,
                         code=codes.ATTR_DEFINED)
-            elif isinstance(original_type, UnionType):
+            elif isinstance(original_type, UnionType) or (
+                    isinstance(original_type, TypeVarType) and
+                    isinstance(original_type.upper_bound, UnionType)):
                 # The checker passes "object" in lieu of "None" for attribute
                 # checks, so we manually convert it back.
                 typ_format, orig_type_format = format_type_distinctly(typ, original_type)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -335,9 +335,7 @@ class MessageBuilder:
                             format_type(original_type), member, extra),
                         context,
                         code=codes.ATTR_DEFINED)
-            elif isinstance(original_type, UnionType) or (
-                    isinstance(original_type, TypeVarType) and
-                    isinstance(original_type.upper_bound, UnionType)):
+            elif isinstance(original_type, UnionType):
                 # The checker passes "object" in lieu of "None" for attribute
                 # checks, so we manually convert it back.
                 typ_format, orig_type_format = format_type_distinctly(typ, original_type)
@@ -347,6 +345,16 @@ class MessageBuilder:
                 self.fail('Item {} of {} has no attribute "{}"{}'.format(
                     typ_format, orig_type_format, member, extra), context,
                     code=codes.UNION_ATTR)
+            elif isinstance(original_type, TypeVarType):
+                bound = get_proper_type(original_type.upper_bound)
+                if isinstance(bound, UnionType):
+                    typ_fmt, bound_fmt = format_type_distinctly(typ, bound)
+                    original_type_fmt = format_type(original_type)
+                    self.fail(
+                        'Item {} of the upper bound {} of type variable {} has no '
+                        'attribute "{}"{}'.format(
+                            typ_fmt, bound_fmt, original_type_fmt, member, extra),
+                        context, code=codes.UNION_ATTR)
         return AnyType(TypeOfAny.from_error)
 
     def unsupported_operand_types(self,

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -821,21 +821,24 @@ class Y(Generic[T]):
 [case testTypeVarBoundToUnionAttributeAccess]
 from typing import Union, TypeVar
 
-class U: pass
-class W: pass
+class U:
+    a: float
+class V:
+    b: float
+class W:
+    c: float
 
-T = TypeVar("T", bound=Union[U, W])
+T = TypeVar("T", bound=Union[U, V, W])
 
 def f(x: T) -> None:
-    x.a
-    x.b = 1.0
-    del x.c
+    x.a  # E
+    x.b = 1.0  # E
+    del x.c  # E
 
 [out]
-main:9: error: Item "U" of "T" has no attribute "a"
-main:9: error: Item "W" of "T" has no attribute "a"
-main:10: error: Item "U" of "T" has no attribute "b"
-main:10: error: Item "W" of "T" has no attribute "b"
-main:11: error: Item "U" of "T" has no attribute "c"
-main:11: error: Item "W" of "T" has no attribute "c"
-
+main:13: error: Item "V" of "T" has no attribute "a"
+main:13: error: Item "W" of "T" has no attribute "a"
+main:14: error: Item "U" of "T" has no attribute "b"
+main:14: error: Item "W" of "T" has no attribute "b"
+main:15: error: Item "U" of "T" has no attribute "c"
+main:15: error: Item "V" of "T" has no attribute "c"

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -817,4 +817,25 @@ class Y(Generic[T]):
     def f(self) -> T:
         return U()  # E: Incompatible return value type (got "U", expected "T")
 
+
+[case testTypeVarBoundToUnionAttributeAccess]
+from typing import Union, TypeVar
+
+class U: pass
+class W: pass
+
+T = TypeVar("T", bound=Union[U, W])
+
+def f(x: T) -> None:
+    x.a
+    x.b = 1.0
+    del x.c
+
 [out]
+main:9: error: Item "U" of "T" has no attribute "a"
+main:9: error: Item "W" of "T" has no attribute "a"
+main:10: error: Item "U" of "T" has no attribute "b"
+main:10: error: Item "W" of "T" has no attribute "b"
+main:11: error: Item "U" of "T" has no attribute "c"
+main:11: error: Item "W" of "T" has no attribute "c"
+

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -836,9 +836,9 @@ def f(x: T) -> None:
     del x.c  # E
 
 [out]
-main:13: error: Item "V" of "T" has no attribute "a"
-main:13: error: Item "W" of "T" has no attribute "a"
-main:14: error: Item "U" of "T" has no attribute "b"
-main:14: error: Item "W" of "T" has no attribute "b"
-main:15: error: Item "U" of "T" has no attribute "c"
-main:15: error: Item "V" of "T" has no attribute "c"
+main:13: error: Item "V" of the upper bound "Union[U, V, W]" of type variable "T" has no attribute "a"
+main:13: error: Item "W" of the upper bound "Union[U, V, W]" of type variable "T" has no attribute "a"
+main:14: error: Item "U" of the upper bound "Union[U, V, W]" of type variable "T" has no attribute "b"
+main:14: error: Item "W" of the upper bound "Union[U, V, W]" of type variable "T" has no attribute "b"
+main:15: error: Item "U" of the upper bound "Union[U, V, W]" of type variable "T" has no attribute "c"
+main:15: error: Item "V" of the upper bound "Union[U, V, W]" of type variable "T" has no attribute "c"


### PR DESCRIPTION
Fixes #10948

I have briefly discussed the problem with @hauntsaninja on Gitter.

The solution is straightforward.  All checks were there, but a missing `isinstance` check prevented the detected errors from being reported.

The added test case includes examples for getting, setting, and deleting undefined attributes.