### PR TITLE
Add doc status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Mypy: Optional Static Typing for Python
 =======================================
 
 [![Build Status](https://api.travis-ci.com/python/mypy.svg?branch=master)](https://travis-ci.com/python/mypy)
+[![Documentation Status](https://readthedocs.org/projects/mypy/badge/?version=latest)](https://mypy.readthedocs.io/en/latest/?badge=latest)
 [![Chat at https://gitter.im/python/typing](https://badges.gitter.im/python/typing.svg)](https://gitter.im/python/typing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 


### PR DESCRIPTION
I was always looking for it, but I always had to scroll further for "documentation" link.
It uses `latest` instead of `stable` to be in sync with the `git` repo.
