### PR TITLE
Fix error message for dataclasses.field with positional argument

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -471,6 +471,7 @@ def _collect_field_args(expr: Expression,
                     message = '"field()" does not accept positional arguments'
                 ctx.api.fail(message, expr)
                 return True, {}
+            assert name is not None
             args[name] = arg
         return True, args
     return False, {}

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -460,15 +460,16 @@ def _collect_field_args(expr: Expression,
     ):
         # field() only takes keyword arguments.
         args = {}
-        for name, arg in zip(expr.arg_names, expr.args):
-            if name is None:
-                # This means that `field` is used with `**` unpacking,
-                # the best we can do for now is not to fail.
-                # TODO: we can infer what's inside `**` and try to collect it.
-                ctx.api.fail(
-                    'Unpacking **kwargs in "field()" is not supported',
-                    expr,
-                )
+        for name, arg, kind in zip(expr.arg_names, expr.args, expr.arg_kinds):
+            if not kind.is_named():
+                if kind.is_named(star=True):
+                    # This means that `field` is used with `**` unpacking,
+                    # the best we can do for now is not to fail.
+                    # TODO: we can infer what's inside `**` and try to collect it.
+                    message = 'Unpacking **kwargs in "field()" is not supported'
+                else:
+                    message = '"field()" does not accept positional arguments'
+                ctx.api.fail(message, expr)
                 return True, {}
             args[name] = arg
         return True, args

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1320,6 +1320,19 @@ main:7: note:     def [_T] field(*, default_factory: Callable[[], _T], init: boo
 main:7: note:     def field(*, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> Any
 [builtins fixtures/dataclasses.pyi]
 
+[case testDataclassFieldWithPositionalArguments]
+# flags: --python-version 3.7
+from dataclasses import dataclass, field
+
+@dataclass
+class C:
+    x: int = field(0)  # E: "field()" does not accept positional arguments \
+                       # E: No overload variant of "field" matches argument type "int" \
+                       # N: Possible overload variants: \
+                       # N:     def [_T] field(*, default: _T, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> _T \
+                       # N:     def [_T] field(*, default_factory: Callable[[], _T], init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> _T \
+                       # N:     def field(*, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> Any
+[builtins fixtures/dataclasses.pyi]
 
 [case testDataclassFieldWithTypedDictUnpacking]
 # flags: --python-version 3.7


### PR DESCRIPTION
### Description

Fixes https://github.com/python/mypy/issues/10248

The crash due to `dataclasses.field` was fixed in the recent PR https://github.com/python/mypy/pull/11137, but the error message was wrong when positional arguments are used.
I update the error message based on the https://github.com/python/mypy/issues/10248#issuecomment-924904033 (Thanks @JelleZijlstra!)

In `_collect_field_args`, I used `CallExpr.arg_kinds` to filter only "named" keyword argument, which hopefully is not the wrong usage of `ArgKind`.
I appreciate any feedback and thanks for the review!

## Test Plan

Please see `testDataclassFieldWithPositionalArguments` in `test-data/unit/check-dataclasses.test`.