### PR TITLE
Marks unique enums as `@unique`

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -10,7 +10,7 @@ import os
 import re
 import subprocess
 import sys
-from enum import Enum
+from enum import Enum, unique
 
 from typing import Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Union
 from typing_extensions import Final
@@ -41,6 +41,7 @@ PYTHON2_STUB_DIR: Final = "@python2"
 # TODO: Consider adding more reasons here?
 # E.g. if we deduce a module would likely be found if the user were
 # to set the --namespace-packages flag.
+@unique
 class ModuleNotFoundReason(Enum):
     # The module was not found: we found neither stubs nor a plausible code
     # implementation (with or without a py.typed file).

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1,7 +1,7 @@
 """Abstract syntax tree node classes (i.e. parse tree)."""
 
 import os
-from enum import Enum
+from enum import Enum, unique
 from abc import abstractmethod
 from mypy.backports import OrderedDict
 from collections import defaultdict
@@ -1521,7 +1521,7 @@ class MemberExpr(RefExpr):
 
 
 # Kinds of arguments
-
+@unique
 class ArgKind(Enum):
     # Positional argument
     ARG_POS = 0

--- a/mypyc/irbuild/format_str_tokenizer.py
+++ b/mypyc/irbuild/format_str_tokenizer.py
@@ -2,7 +2,7 @@
 
 from typing import List, Tuple, Optional
 from typing_extensions import Final
-from enum import Enum
+from enum import Enum, unique
 
 from mypy.checkstrformat import (
     parse_format_value, ConversionSpecifier, parse_conversion_specifiers
@@ -22,6 +22,7 @@ from mypyc.primitives.int_ops import int_to_str_op
 from mypyc.primitives.str_ops import str_build_op, str_op
 
 
+@unique
 class FormatOp(Enum):
     """FormatOp represents conversion operations of string formatting during
     compile time.


### PR DESCRIPTION
All enums in `mypy` are unique. Eventhough, current state of `enum_plugin` does not support `@unique` checking during `mypy` run, it is a good thing to have.

It will raise `ValueError: duplicate values found in <enum 'ArgKind'>: CUSTOM -> ARG_NAMED` during development if this rule is violated.