### PR TITLE
[mypyc] Constant fold int operations and str concat

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -543,6 +543,9 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             if val >= (1 << 31):
                 # Avoid overflowing signed 32-bit int
                 s += 'U'
+            if val == -(1 << 63):
+                # Avoid overflow C integer literal
+                s = '(-9223372036854775807 - 1)'
             return s
         else:
             return self.emitter.reg(reg)

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -484,14 +484,18 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         lhs_cast = ""
         rhs_cast = ""
         if op.op in (ComparisonOp.SLT, ComparisonOp.SGT, ComparisonOp.SLE, ComparisonOp.SGE):
+            # Always signed comparison op
             lhs_cast = self.emit_signed_int_cast(op.lhs.type)
             rhs_cast = self.emit_signed_int_cast(op.rhs.type)
         elif op.op in (ComparisonOp.ULT, ComparisonOp.UGT, ComparisonOp.ULE, ComparisonOp.UGE):
+            # Always unsigned comparison op
             lhs_cast = self.emit_unsigned_int_cast(op.lhs.type)
             rhs_cast = self.emit_unsigned_int_cast(op.rhs.type)
         elif isinstance(op.lhs, Integer) and op.lhs.value < 0:
+            # Force signed ==/!= with negative operand
             rhs_cast = self.emit_signed_int_cast(op.rhs.type)
         elif isinstance(op.rhs, Integer) and op.rhs.value < 0:
+            # Force signed ==/!= with negative operand
             lhs_cast = self.emit_signed_int_cast(op.lhs.type)
         self.emit_line('%s = %s%s %s %s%s;' % (dest, lhs_cast, lhs,
                                                op.op_str[op.op], rhs_cast, rhs))
@@ -546,7 +550,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                 # Avoid overflowing signed 32-bit int
                 s += 'U'
             if val == -(1 << 63):
-                # Avoid overflow C integer literal
+                # Avoid overflowing C integer literal
                 s = '(-9223372036854775807 - 1)'
             return s
         else:

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -483,14 +483,16 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         rhs = self.reg(op.rhs)
         lhs_cast = ""
         rhs_cast = ""
-        signed_op = {ComparisonOp.SLT, ComparisonOp.SGT, ComparisonOp.SLE, ComparisonOp.SGE}
-        unsigned_op = {ComparisonOp.ULT, ComparisonOp.UGT, ComparisonOp.ULE, ComparisonOp.UGE}
-        if op.op in signed_op:
+        if op.op in (ComparisonOp.SLT, ComparisonOp.SGT, ComparisonOp.SLE, ComparisonOp.SGE):
             lhs_cast = self.emit_signed_int_cast(op.lhs.type)
             rhs_cast = self.emit_signed_int_cast(op.rhs.type)
-        elif op.op in unsigned_op:
+        elif op.op in (ComparisonOp.ULT, ComparisonOp.UGT, ComparisonOp.ULE, ComparisonOp.UGE):
             lhs_cast = self.emit_unsigned_int_cast(op.lhs.type)
             rhs_cast = self.emit_unsigned_int_cast(op.rhs.type)
+        elif isinstance(op.lhs, Integer) and op.lhs.value < 0:
+            rhs_cast = self.emit_signed_int_cast(op.rhs.type)
+        elif isinstance(op.rhs, Integer) and op.rhs.value < 0:
+            lhs_cast = self.emit_signed_int_cast(op.lhs.type)
         self.emit_line('%s = %s%s %s %s%s;' % (dest, lhs_cast, lhs,
                                                op.op_str[op.op], rhs_cast, rhs))
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -548,10 +548,12 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             s = str(val)
             if val >= (1 << 31):
                 # Avoid overflowing signed 32-bit int
-                s += 'U'
-            if val == -(1 << 63):
+                s += 'ULL'
+            elif val == -(1 << 63):
                 # Avoid overflowing C integer literal
-                s = '(-9223372036854775807 - 1)'
+                s = '(-9223372036854775807LL - 1)'
+            elif val <= -(1 << 31):
+                s += 'LL'
             return s
         else:
             return self.emitter.reg(reg)

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -48,6 +48,7 @@ MAX_SHORT_INT: Final = sys.maxsize >> 1
 # Note: Assume that the compiled code uses the same bit width as mypyc, except for
 #       Python 3.5 on macOS.
 MAX_LITERAL_SHORT_INT: Final = sys.maxsize >> 1 if not IS_MIXED_32_64_BIT_BUILD else 2 ** 30 - 1
+MIN_LITERAL_SHORT_INT: Final = -MAX_LITERAL_SHORT_INT - 1
 
 # Runtime C library files
 RUNTIME_C_FILES: Final = [

--- a/mypyc/irbuild/constant_fold.py
+++ b/mypyc/irbuild/constant_fold.py
@@ -59,4 +59,6 @@ def constant_fold_unary_op(op: str, value: Value) -> Optional[Value]:
             return Integer(-value.value // 2, line=value.line)
         elif op == '~':
             return Integer(~value.value // 2, line=value.line)
+        elif op == '+':
+            return value
     return None

--- a/mypyc/irbuild/constant_fold.py
+++ b/mypyc/irbuild/constant_fold.py
@@ -1,0 +1,62 @@
+"""Constant folding of IR values.
+
+For example, 3 + 5 can be constant folded into 8.
+"""
+
+from typing import Optional
+
+from mypyc.ir.ops import Value, Integer
+from mypyc.ir.rtypes import is_short_int_rprimitive
+
+
+def constant_fold_binary_op(op: str, left: Value, right: Value) -> Optional[Value]:
+    if (
+        isinstance(left, Integer)
+        and isinstance(right, Integer)
+        and is_short_int_rprimitive(left.type)
+        and is_short_int_rprimitive(right.type)
+    ):
+        value = constant_fold_binary_int_op(op, left.value // 2, right.value // 2)
+        if value is not None:
+            return Integer(value, line=left.line)
+    return None
+
+
+def constant_fold_binary_int_op(op: str, left: int, right: int) -> Optional[int]:
+    if op == '+':
+        return left + right
+    if op == '-':
+        return left - right
+    elif op == '*':
+        return left * right
+    elif op == '//':
+        if right != 0:
+            return left // right
+    elif op == '%':
+        if right != 0:
+            return left % right
+    elif op == '&':
+        return left & right
+    elif op == '|':
+        return left | right
+    elif op == '^':
+        return left ^ right
+    elif op == '<<':
+        if right >= 0:
+            return left << right
+    elif op == '>>':
+        if right >= 0:
+            return left >> right
+    elif op == '**':
+        if right >= 0:
+            return left ** right
+    return None
+
+
+def constant_fold_unary_op(op: str, value: Value) -> Optional[Value]:
+    if isinstance(value, Integer) and is_short_int_rprimitive(value.type):
+        if op == '-':
+            return Integer(-value.value // 2, line=value.line)
+        elif op == '~':
+            return Integer(~value.value // 2, line=value.line)
+    return None

--- a/mypyc/irbuild/constant_fold.py
+++ b/mypyc/irbuild/constant_fold.py
@@ -4,6 +4,7 @@ For example, 3 + 5 can be constant folded into 8.
 """
 
 from typing import Optional, Union
+from typing_extensions import Final
 
 from mypy.nodes import Expression, IntExpr, StrExpr, OpExpr, UnaryExpr, NameExpr, MemberExpr, Var
 from mypyc.irbuild.builder import IRBuilder
@@ -11,9 +12,14 @@ from mypyc.irbuild.builder import IRBuilder
 
 # All possible result types of constant folding
 ConstantValue = Union[int, str]
+CONST_TYPES: Final = (int, str)
 
 
 def constant_fold_expr(builder: IRBuilder, expr: Expression) -> Optional[ConstantValue]:
+    """Return the constant value of an expression for supported operations.
+
+    Return None otherwise.
+    """
     if isinstance(expr, IntExpr):
         return expr.value
     if isinstance(expr, StrExpr):
@@ -22,7 +28,7 @@ def constant_fold_expr(builder: IRBuilder, expr: Expression) -> Optional[Constan
         node = expr.node
         if isinstance(node, Var) and node.is_final:
             value = node.final_value
-            if isinstance(value, int):
+            if isinstance(value, (CONST_TYPES)):
                 return value
     elif isinstance(expr, MemberExpr):
         final = builder.get_final_ref(expr)
@@ -30,7 +36,7 @@ def constant_fold_expr(builder: IRBuilder, expr: Expression) -> Optional[Constan
             fn, final_var, native = final
             if final_var.is_final:
                 value = final_var.final_value
-                if isinstance(value, int):
+                if isinstance(value, (CONST_TYPES)):
                     return value
     elif isinstance(expr, OpExpr):
         left = constant_fold_expr(builder, expr.left)

--- a/mypyc/irbuild/constant_fold.py
+++ b/mypyc/irbuild/constant_fold.py
@@ -5,6 +5,7 @@ For example, 3 + 5 can be constant folded into 8.
 
 from typing import Optional
 
+from mypyc.common import MAX_LITERAL_SHORT_INT, MIN_LITERAL_SHORT_INT
 from mypyc.ir.ops import Value, Integer
 from mypyc.ir.rtypes import is_short_int_rprimitive
 
@@ -17,7 +18,8 @@ def constant_fold_binary_op(op: str, left: Value, right: Value) -> Optional[Valu
         and is_short_int_rprimitive(right.type)
     ):
         value = constant_fold_binary_int_op(op, left.value // 2, right.value // 2)
-        if value is not None:
+        # TODO: Also constant fold operations that produce long integers
+        if value is not None and MIN_LITERAL_SHORT_INT <= value <= MAX_LITERAL_SHORT_INT:
             return Integer(value, line=left.line)
     return None
 

--- a/mypyc/irbuild/constant_fold.py
+++ b/mypyc/irbuild/constant_fold.py
@@ -5,15 +5,18 @@ For example, 3 + 5 can be constant folded into 8.
 
 from typing import Optional, Union
 
-from mypy.nodes import Expression, IntExpr, OpExpr, UnaryExpr, NameExpr, MemberExpr, Var
+from mypy.nodes import Expression, IntExpr, StrExpr, OpExpr, UnaryExpr, NameExpr, MemberExpr, Var
 from mypyc.irbuild.builder import IRBuilder
 
 
-ConstantValue = Union[int]
+# All possible result types of constant folding
+ConstantValue = Union[int, str]
 
 
 def constant_fold_expr(builder: IRBuilder, expr: Expression) -> Optional[ConstantValue]:
     if isinstance(expr, IntExpr):
+        return expr.value
+    if isinstance(expr, StrExpr):
         return expr.value
     elif isinstance(expr, NameExpr):
         node = expr.node
@@ -34,6 +37,8 @@ def constant_fold_expr(builder: IRBuilder, expr: Expression) -> Optional[Constan
         right = constant_fold_expr(builder, expr.right)
         if isinstance(left, int) and isinstance(right, int):
             return constant_fold_binary_int_op(expr.op, left, right)
+        elif isinstance(left, str) and isinstance(right, str):
+            return constant_fold_binary_str_op(expr.op, left, right)
     elif isinstance(expr, UnaryExpr):
         value = constant_fold_expr(builder, expr.expr)
         if isinstance(value, int):
@@ -79,4 +84,10 @@ def constant_fold_unary_int_op(op: str, value: int) -> Optional[int]:
         return ~value
     elif op == '+':
         return value
+    return None
+
+
+def constant_fold_binary_str_op(op: str, left: str, right: str) -> Optional[str]:
+    if op == '+':
+        return left + right
     return None

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -429,6 +429,8 @@ def try_constant_fold(builder: IRBuilder, expr: Expression) -> Optional[Value]:
     value = constant_fold_expr(builder, expr)
     if isinstance(value, int):
         return builder.load_int(value)
+    elif isinstance(value, str):
+        return builder.load_str(value)
     return None
 
 

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -383,9 +383,7 @@ def transform_unary_expr(builder: IRBuilder, expr: UnaryExpr) -> Value:
     if folded:
         return folded
 
-    value = builder.accept(expr.expr)
-
-    return builder.unary_op(value, expr.op, expr.line)
+    return builder.unary_op(builder.accept(expr.expr), expr.op, expr.line)
 
 
 def transform_op_expr(builder: IRBuilder, expr: OpExpr) -> Value:
@@ -402,10 +400,9 @@ def transform_op_expr(builder: IRBuilder, expr: OpExpr) -> Value:
     if folded:
         return folded
 
-    left = builder.accept(expr.left)
-    right = builder.accept(expr.right)
-
-    return builder.binary_op(left, right, expr.op, expr.line)
+    return builder.binary_op(
+        builder.accept(expr.left), builder.accept(expr.right), expr.op, expr.line
+    )
 
 
 def transform_index_expr(builder: IRBuilder, expr: IndexExpr) -> Value:
@@ -426,11 +423,16 @@ def transform_index_expr(builder: IRBuilder, expr: IndexExpr) -> Value:
 
 
 def try_constant_fold(builder: IRBuilder, expr: Expression) -> Optional[Value]:
+    """Return the constant value of an expression if possible.
+
+    Return None otherwise.
+    """
     value = constant_fold_expr(builder, expr)
     if isinstance(value, int):
         return builder.load_int(value)
     elif isinstance(value, str):
         return builder.load_str(value)
+    assert value is None
     return None
 
 

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -432,7 +432,6 @@ def try_constant_fold(builder: IRBuilder, expr: Expression) -> Optional[Value]:
         return builder.load_int(value)
     elif isinstance(value, str):
         return builder.load_str(value)
-    assert value is None
     return None
 
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -39,8 +39,8 @@ from mypyc.ir.rtypes import (
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.common import (
-    FAST_ISINSTANCE_MAX_SUBCLASSES, MAX_LITERAL_SHORT_INT, PLATFORM_SIZE, use_vectorcall,
-    use_method_vectorcall
+    FAST_ISINSTANCE_MAX_SUBCLASSES, MAX_LITERAL_SHORT_INT, MIN_LITERAL_SHORT_INT, PLATFORM_SIZE,
+    use_vectorcall, use_method_vectorcall
 )
 from mypyc.primitives.registry import (
     method_call_ops, CFunctionDescription, function_ops,
@@ -789,7 +789,7 @@ class LowLevelIRBuilder:
 
     def load_int(self, value: int) -> Value:
         """Load a tagged (Python) integer literal value."""
-        if abs(value) > MAX_LITERAL_SHORT_INT:
+        if value > MAX_LITERAL_SHORT_INT or value < MIN_LITERAL_SHORT_INT:
             return self.add(LoadLiteral(value, int_rprimitive))
         else:
             return Integer(value)

--- a/mypyc/test-data/analysis.test
+++ b/mypyc/test-data/analysis.test
@@ -536,10 +536,8 @@ def lol(x):
     r2 :: object
     r3 :: str
     r4 :: object
-    r5 :: bit
-    r6 :: int
-    r7 :: bit
-    r8, r9 :: int
+    r5, r6 :: bit
+    r7, r8 :: int
 L0:
 L1:
     r0 = CPyTagged_Id(x)
@@ -555,9 +553,8 @@ L3:
     r5 = CPy_ExceptionMatches(r4)
     if r5 goto L4 else goto L5 :: bool
 L4:
-    r6 = CPyTagged_Negate(2)
     CPy_RestoreExcInfo(r1)
-    return r6
+    return -2
 L5:
     CPy_Reraise()
     if not 0 goto L8 else goto L6 :: bool
@@ -568,16 +565,16 @@ L7:
     goto L10
 L8:
     CPy_RestoreExcInfo(r1)
-    r7 = CPy_KeepPropagating()
-    if not r7 goto L11 else goto L9 :: bool
+    r6 = CPy_KeepPropagating()
+    if not r6 goto L11 else goto L9 :: bool
 L9:
     unreachable
 L10:
-    r8 = CPyTagged_Add(st, 2)
-    return r8
+    r7 = CPyTagged_Add(st, 2)
+    return r7
 L11:
-    r9 = <error> :: int
-    return r9
+    r8 = <error> :: int
+    return r8
 (0, 0)   {x}                     {x}
 (1, 0)   {x}                     {r0}
 (1, 1)   {r0}                    {st}
@@ -589,20 +586,18 @@ L11:
 (2, 4)   {r1, r4}                {r1, r4}
 (3, 0)   {r1, r4}                {r1, r5}
 (3, 1)   {r1, r5}                {r1}
-(4, 0)   {r1}                    {r1, r6}
-(4, 1)   {r1, r6}                {r6}
-(4, 2)   {r6}                    {}
+(4, 0)   {r1}                    {}
+(4, 1)   {}                      {}
 (5, 0)   {r1}                    {r1}
 (5, 1)   {r1}                    {r1}
 (6, 0)   {}                      {}
 (7, 0)   {r1, st}                {st}
 (7, 1)   {st}                    {st}
 (8, 0)   {r1}                    {}
-(8, 1)   {}                      {r7}
-(8, 2)   {r7}                    {}
+(8, 1)   {}                      {r6}
+(8, 2)   {r6}                    {}
 (9, 0)   {}                      {}
-(10, 0)  {st}                    {r8}
-(10, 1)  {r8}                    {}
-(11, 0)  {}                      {r9}
-(11, 1)  {r9}                    {}
-
+(10, 0)  {st}                    {r7}
+(10, 1)  {r7}                    {}
+(11, 0)  {}                      {r8}
+(11, 1)  {r8}                    {}

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -272,6 +272,10 @@ class NotImplementedError(RuntimeError): pass
 class StopIteration(Exception):
     value: Any
 
+class ArithmeticError(Exception): pass
+
+class ZeroDivisionError(Exception): pass
+
 def any(i: Iterable[T]) -> bool: pass
 def all(i: Iterable[T]) -> bool: pass
 def reversed(object: Sequence[T]) -> Iterator[T]: ...

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -36,6 +36,7 @@ class int:
     def __mul__(self, n: int) -> int: pass
     def __pow__(self, n: int, modulo: Optional[int] = None) -> int: pass
     def __floordiv__(self, x: int) -> int: pass
+    def __truediv__(self, x: float) -> float: pass
     def __mod__(self, x: int) -> int: pass
     def __neg__(self) -> int: pass
     def __pos__(self) -> int: pass

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -581,12 +581,12 @@ L8:
 
 [case testUnaryMinus]
 def f(n: int) -> int:
-    return -1
+    return -n
 [out]
 def f(n):
     n, r0 :: int
 L0:
-    r0 = CPyTagged_Negate(2)
+    r0 = CPyTagged_Negate(n)
     return r0
 
 [case testConditionalExpr]

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -1,0 +1,166 @@
+[case testIntConstantFolding]
+def bin_ops() -> None:
+    add = 15 + 47
+    add_mul = (2 + 3) * 5
+    sub = 7 - 11
+    bit_and = 6 & 10
+    bit_or = 6 | 10
+    bit_xor = 6 ^ 10
+    lshift = 5 << 2
+    rshift = 13 >> 2
+    lshift0 = 5 << 0
+    rshift0 = 13 >> 0
+def unary_ops() -> None:
+    neg1 = -5
+    neg2 = --1
+    neg3 = -0
+    inverted1 = ~0
+    inverted2 = ~5
+    inverted3 = ~3
+def pow() -> None:
+    p0 = 3**0
+    p1 = 3**5
+    p2 = (-5)**3
+    p3 = 0**0
+[out]
+def bin_ops():
+    add, add_mul, sub, bit_and, bit_or, bit_xor, lshift, rshift, lshift0, rshift0 :: int
+L0:
+    add = 124
+    add_mul = 50
+    sub = -8
+    bit_and = 4
+    bit_or = 28
+    bit_xor = 24
+    lshift = 40
+    rshift = 6
+    lshift0 = 10
+    rshift0 = 26
+    return 1
+def unary_ops():
+    neg1, neg2, neg3, inverted1, inverted2, inverted3 :: int
+L0:
+    neg1 = -10
+    neg2 = 2
+    neg3 = 0
+    inverted1 = -2
+    inverted2 = -12
+    inverted3 = -8
+    return 1
+def pow():
+    p0, p1, p2, p3 :: int
+L0:
+    p0 = 2
+    p1 = 486
+    p2 = -250
+    p3 = 2
+    return 1
+
+[case testIntConstantFoldingDivMod]
+def div() -> None:
+    div1 = 25 // 5
+    div2 = 24 // 5
+    div3 = 29 // 5
+    div4 = 30 // 5
+    div_zero = 0 // 5
+    neg1 = -1 // 3
+    neg2 = -2 // 3
+    neg3 = -3 // 3
+    neg4 = -4 // 3
+    neg_neg = -765467 // -234
+    pos_neg = 983745 // -7864
+def mod() -> None:
+    mod1 = 25 % 5
+    mod2 = 24 % 5
+    mod3 = 29 % 5
+    mod4 = 30 % 5
+    mod_zero = 0 % 5
+    neg1 = -4 % 3
+    neg2 = -5 % 3
+    neg3 = -6 % 3
+    neg4 = -7 % 3
+    neg_neg = -765467 % -234
+    pos_neg = 983745 % -7864
+[out]
+def div():
+    div1, div2, div3, div4, div_zero, neg1, neg2, neg3, neg4, neg_neg, pos_neg :: int
+L0:
+    div1 = 10
+    div2 = 8
+    div3 = 10
+    div4 = 12
+    div_zero = 0
+    neg1 = -2
+    neg2 = -2
+    neg3 = -2
+    neg4 = -4
+    neg_neg = 6542
+    pos_neg = -252
+    return 1
+def mod():
+    mod1, mod2, mod3, mod4, mod_zero, neg1, neg2, neg3, neg4, neg_neg, pos_neg :: int
+L0:
+    mod1 = 0
+    mod2 = 8
+    mod3 = 8
+    mod4 = 0
+    mod_zero = 0
+    neg1 = 4
+    neg2 = 2
+    neg3 = 0
+    neg4 = 4
+    neg_neg = -106
+    pos_neg = -14238
+    return 1
+
+[case testIntConstantFoldingUnsupportedCases]
+def error_cases() -> None:
+    div_by_zero = 5 // 0
+    mod_by_zero = 5 % 0
+    lshift_neg = 6 << -1
+    rshift_neg = 7 >> -1
+def unsupported_div() -> None:
+    x = 4 / 6
+    y = 10 / 5
+def unsupported_pow() -> None:
+    p = 3 ** (-1)
+[out]
+def error_cases():
+    r0, div_by_zero, r1, mod_by_zero, r2, lshift_neg, r3, rshift_neg :: int
+L0:
+    r0 = CPyTagged_FloorDivide(10, 0)
+    div_by_zero = r0
+    r1 = CPyTagged_Remainder(10, 0)
+    mod_by_zero = r1
+    r2 = CPyTagged_Lshift(12, -2)
+    lshift_neg = r2
+    r3 = CPyTagged_Rshift(14, -2)
+    rshift_neg = r3
+    return 1
+def unsupported_div():
+    r0, r1, r2 :: object
+    r3, x :: float
+    r4, r5, r6 :: object
+    r7, y :: float
+L0:
+    r0 = box(short_int, 8)
+    r1 = box(short_int, 12)
+    r2 = PyNumber_TrueDivide(r0, r1)
+    r3 = cast(float, r2)
+    x = r3
+    r4 = box(short_int, 20)
+    r5 = box(short_int, 10)
+    r6 = PyNumber_TrueDivide(r4, r5)
+    r7 = cast(float, r6)
+    y = r7
+    return 1
+def unsupported_pow():
+    r0, r1, r2 :: object
+    r3, p :: float
+L0:
+    r0 = box(short_int, 6)
+    r1 = box(short_int, -2)
+    r2 = CPyNumber_Power(r0, r1)
+    r3 = cast(float, r2)
+    p = r3
+    return 1

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -243,3 +243,17 @@ def f():
 L0:
     a = 12
     return 1
+
+[case testStrConstantFolding]
+def f() -> None:
+    x = 'foo' + 'bar'
+    y = 'x' + 'y' + 'z'
+[out]
+def f():
+    r0, x, r1, y :: str
+L0:
+    r0 = 'foobar'
+    x = r0
+    r1 = 'xyz'
+    y = r1
+    return 1

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -14,6 +14,7 @@ def unary_ops() -> None:
     neg1 = -5
     neg2 = --1
     neg3 = -0
+    pos = +5
     inverted1 = ~0
     inverted2 = ~5
     inverted3 = ~3
@@ -38,11 +39,12 @@ L0:
     rshift0 = 26
     return 1
 def unary_ops():
-    neg1, neg2, neg3, inverted1, inverted2, inverted3 :: int
+    neg1, neg2, neg3, pos, inverted1, inverted2, inverted3 :: int
 L0:
     neg1 = -10
     neg2 = 2
     neg3 = 0
+    pos = 10
     inverted1 = -2
     inverted2 = -12
     inverted3 = -8

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -169,7 +169,7 @@ L0:
 
 [case testIntConstantFoldingBigIntResult_64bit]
 def long_and_short() -> None:
-    # Smaller and largest representable short integers
+    # The smallest and largest representable short integers
     short1 =  0x3ffffffffffffff0 + 0xf  # (1 << 62) - 1
     short2 = -0x3fffffffffffffff - 1    # -(1 << 62)
     short3 = -0x4000000000000000
@@ -245,9 +245,13 @@ L0:
     return 1
 
 [case testStrConstantFolding]
+from typing_extensions import Final
+
+S: Final = 'z'
+
 def f() -> None:
     x = 'foo' + 'bar'
-    y = 'x' + 'y' + 'z'
+    y = 'x' + 'y' + S
 [out]
 def f():
     r0, x, r1, y :: str

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -209,3 +209,49 @@ L0:
     r3 = CPyTagged_Negate(r2)
     big = r3
     return 1
+
+[case testIntConstantFoldingFinal]
+from typing_extensions import Final
+X: Final = 5
+Y: Final = 2 + 4
+
+def f() -> None:
+    a = X + 1
+    # TODO: Constant fold this as well
+    a = Y + 1
+[out]
+def f():
+    a, r0 :: int
+    r1 :: bool
+    r2 :: int
+L0:
+    a = 12
+    r0 = __main__.Y :: static
+    if is_error(r0) goto L1 else goto L2
+L1:
+    r1 = raise NameError('value for final name "Y" was not set')
+    unreachable
+L2:
+    r2 = CPyTagged_Add(r0, 2)
+    a = r2
+    return 1
+
+[case testIntConstantFoldingClassFinal]
+from typing_extensions import Final
+class C:
+    X: Final = 5
+
+def f() -> None:
+    a = C.X + 1
+[out]
+def C.__mypyc_defaults_setup(__mypyc_self__):
+    __mypyc_self__ :: __main__.C
+    r0 :: bool
+L0:
+    __mypyc_self__.X = 10; r0 = is_error
+    return 1
+def f():
+    a :: int
+L0:
+    a = 12
+    return 1

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -168,46 +168,34 @@ L0:
     return 1
 
 [case testIntConstantFoldingBigIntResult_64bit]
-def binary_op() -> None:
+def long_and_short() -> None:
     # Smaller and largest representable short integers
-    short1 =  0x3ffffffffffffff0 + 0xf  # (1 << 63) - 1
-    short2 = -0x3fffffffffffffff - 1    # -(1 << 63)
+    short1 =  0x3ffffffffffffff0 + 0xf  # (1 << 62) - 1
+    short2 = -0x3fffffffffffffff - 1    # -(1 << 62)
+    short3 = -0x4000000000000000
     # Smallest big integers by absolute value
-    big1 = 1 << 63
-    big2 = 18446744073709551616  # 1 << 63
-    big3 = -(1 << 63) - 1
-    big4 = -18446744073709551617  # -(1 << 63) - 1
-def unary_op() -> None:
-    # TODO: This should be constant folded but isn't right now
-    short = -0x4000000000000000
-    big = -0x4000000000000001
+    big1 = 1 << 62
+    big2 = 0x4000000000000000  # 1 << 62
+    big3 = -(1 << 62) - 1
+    big4 = -0x4000000000000001  # -(1 << 62) - 1
+    big5 = 123**41
 [out]
-def binary_op():
-    short1, short2, r0, big1, r1, big2, r2, r3, r4, big3, r5, r6, big4 :: int
+def long_and_short():
+    short1, short2, short3, r0, big1, r1, big2, r2, big3, r3, big4, r4, big5 :: int
 L0:
     short1 = 9223372036854775806
     short2 = -9223372036854775808
-    r0 = CPyTagged_Lshift(2, 126)
-    big1 = r0
-    r1 = object 18446744073709551616
-    big2 = r1
-    r2 = CPyTagged_Lshift(2, 126)
-    r3 = CPyTagged_Negate(r2)
-    r4 = CPyTagged_Subtract(r3, 2)
-    big3 = r4
-    r5 = object 18446744073709551617
-    r6 = CPyTagged_Negate(r5)
-    big4 = r6
-    return 1
-def unary_op():
-    r0, r1, short, r2, r3, big :: int
-L0:
+    short3 = -9223372036854775808
     r0 = object 4611686018427387904
-    r1 = CPyTagged_Negate(r0)
-    short = r1
-    r2 = object 4611686018427387905
-    r3 = CPyTagged_Negate(r2)
-    big = r3
+    big1 = r0
+    r1 = object 4611686018427387904
+    big2 = r1
+    r2 = object -4611686018427387905
+    big3 = r2
+    r3 = object -4611686018427387905
+    big4 = r3
+    r4 = object 48541095000524544750127162673405880068636916264012200797813591925035550682238127143323
+    big5 = r4
     return 1
 
 [case testIntConstantFoldingFinal]

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -166,3 +166,46 @@ L0:
     r3 = cast(float, r2)
     p = r3
     return 1
+
+[case testIntConstantFoldingBigIntResult_64bit]
+def binary_op() -> None:
+    # Smaller and largest representable short integers
+    short1 =  0x3ffffffffffffff0 + 0xf  # (1 << 63) - 1
+    short2 = -0x3fffffffffffffff - 1    # -(1 << 63)
+    # Smallest big integers by absolute value
+    big1 = 1 << 63
+    big2 = 18446744073709551616  # 1 << 63
+    big3 = -(1 << 63) - 1
+    big4 = -18446744073709551617  # -(1 << 63) - 1
+def unary_op() -> None:
+    # TODO: This should be constant folded but isn't right now
+    short = -0x4000000000000000
+    big = -0x4000000000000001
+[out]
+def binary_op():
+    short1, short2, r0, big1, r1, big2, r2, r3, r4, big3, r5, r6, big4 :: int
+L0:
+    short1 = 9223372036854775806
+    short2 = -9223372036854775808
+    r0 = CPyTagged_Lshift(2, 126)
+    big1 = r0
+    r1 = object 18446744073709551616
+    big2 = r1
+    r2 = CPyTagged_Lshift(2, 126)
+    r3 = CPyTagged_Negate(r2)
+    r4 = CPyTagged_Subtract(r3, 2)
+    big3 = r4
+    r5 = object 18446744073709551617
+    r6 = CPyTagged_Negate(r5)
+    big4 = r6
+    return 1
+def unary_op():
+    r0, r1, short, r2, r3, big :: int
+L0:
+    r0 = object 4611686018427387904
+    r1 = CPyTagged_Negate(r0)
+    short = r1
+    r2 = object 4611686018427387905
+    r3 = CPyTagged_Negate(r2)
+    big = r3
+    return 1

--- a/mypyc/test-data/irbuild-strip-asserts.test
+++ b/mypyc/test-data/irbuild-strip-asserts.test
@@ -5,11 +5,8 @@ def g():
   return x
 [out]
 def g():
-    r0 :: int
-    r1, x :: object
+    r0, x :: object
 L0:
-    r0 = CPyTagged_Add(2, 4)
-    r1 = box(int, r0)
-    x = r1
+    r0 = box(short_int, 6)
+    x = r0
     return x
-

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -88,8 +88,11 @@ def big_int() -> None:
     d_64_bit = 9223372036854775808
     max_32_bit = 2147483647
     max_31_bit = 1073741823
-    min_62_bit = -4611686018427387904
-    min_63_bit = -9223372036854775808
+    min_signed_63_bit = -4611686018427387904
+    underflow = -4611686018427387905
+    min_signed_64_bit = -9223372036854775808
+    min_signed_31_bit = -1073741824
+    min_signed_32_bit = -2147483648
     print(a_62_bit)
     print(max_62_bit)
     print(b_63_bit)
@@ -98,8 +101,11 @@ def big_int() -> None:
     print(d_64_bit)
     print(max_32_bit)
     print(max_31_bit)
-    print(min_62_bit)
-    print(min_63_bit)
+    print(min_signed_63_bit)
+    print(underflow)
+    print(min_signed_64_bit)
+    print(min_signed_31_bit)
+    print(min_signed_32_bit)
 [file driver.py]
 from native import big_int
 big_int()
@@ -113,7 +119,10 @@ big_int()
 2147483647
 1073741823
 -4611686018427387904
+-4611686018427387905
 -9223372036854775808
+-1073741824
+-2147483648
 
 [case testNeg]
 def neg(x: int) -> int:

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -88,10 +88,13 @@ def big_int() -> None:
     d_64_bit = 9223372036854775808
     max_32_bit = 2147483647
     max_31_bit = 1073741823
+    neg = -1234567
     min_signed_63_bit = -4611686018427387904
     underflow = -4611686018427387905
     min_signed_64_bit = -9223372036854775808
     min_signed_31_bit = -1073741824
+    min_signed_31_bit_plus1 = -1073741823
+    min_signed_31_bit_minus1 = -1073741825
     min_signed_32_bit = -2147483648
     print(a_62_bit)
     print(max_62_bit)
@@ -101,10 +104,13 @@ def big_int() -> None:
     print(d_64_bit)
     print(max_32_bit)
     print(max_31_bit)
+    print(neg)
     print(min_signed_63_bit)
     print(underflow)
     print(min_signed_64_bit)
     print(min_signed_31_bit)
+    print(min_signed_31_bit_plus1)
+    print(min_signed_31_bit_minus1)
     print(min_signed_32_bit)
 [file driver.py]
 from native import big_int
@@ -118,10 +124,13 @@ big_int()
 9223372036854775808
 2147483647
 1073741823
+-1234567
 -4611686018427387904
 -4611686018427387905
 -9223372036854775808
 -1073741824
+-1073741823
+-1073741825
 -2147483648
 
 [case testNeg]

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -87,7 +87,9 @@ def big_int() -> None:
     max_63_bit = 9223372036854775807
     d_64_bit = 9223372036854775808
     max_32_bit = 2147483647
+    max_32_bit_plus1 = 2147483648
     max_31_bit = 1073741823
+    max_31_bit_plus1 = 1073741824
     neg = -1234567
     min_signed_63_bit = -4611686018427387904
     underflow = -4611686018427387905
@@ -102,8 +104,11 @@ def big_int() -> None:
     print(c_63_bit)
     print(max_63_bit)
     print(d_64_bit)
+    print('==')
     print(max_32_bit)
+    print(max_32_bit_plus1)
     print(max_31_bit)
+    print(max_31_bit_plus1)
     print(neg)
     print(min_signed_63_bit)
     print(underflow)
@@ -122,8 +127,11 @@ big_int()
 9223372036854775806
 9223372036854775807
 9223372036854775808
+==
 2147483647
+2147483648
 1073741823
+1073741824
 -1234567
 -4611686018427387904
 -4611686018427387905

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -368,3 +368,9 @@ def test_constant_fold() -> None:
         pass
     else:
         assert False, "no exception raised"
+
+    x = int()
+    y = int() - 1
+    assert x == -1 or y != -3
+    assert -1 <= x
+    assert -1 == y

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -343,3 +343,22 @@ def test_mod() -> None:
         for y in range(-100, 100):
             if y != 0:
                 assert x % y == getattr(x, "__mod__")(y)
+
+def test_constant_fold() -> None:
+    assert str(-5 + 3) == "-2"
+    assert str(15 - 3) == "12"
+    assert str(1000 * 1000) == "1000000"
+    assert str(12325 // 12 ) == "1027"
+    assert str(87645 % 321) == "12"
+    assert str(674253 | 76544) == "748493"
+    assert str(765 ^ 82) == "687"
+    assert str(6546 << 3) == "52368"
+    assert str(6546 >> 7) == "51"
+    assert str(3**5) == "243"
+    assert str(~76) == "-77"
+    try:
+        2 / 0
+    except ZeroDivisionError:
+        pass
+    else:
+        assert False, "no exception raised"

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -88,6 +88,8 @@ def big_int() -> None:
     d_64_bit = 9223372036854775808
     max_32_bit = 2147483647
     max_31_bit = 1073741823
+    min_62_bit = -4611686018427387904
+    min_63_bit = -9223372036854775808
     print(a_62_bit)
     print(max_62_bit)
     print(b_63_bit)
@@ -96,6 +98,8 @@ def big_int() -> None:
     print(d_64_bit)
     print(max_32_bit)
     print(max_31_bit)
+    print(min_62_bit)
+    print(min_63_bit)
 [file driver.py]
 from native import big_int
 big_int()
@@ -108,6 +112,8 @@ big_int()
 9223372036854775808
 2147483647
 1073741823
+-4611686018427387904
+-9223372036854775808
 
 [case testNeg]
 def neg(x: int) -> int:

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -400,3 +400,30 @@ def test_constant_fold() -> None:
     assert x == -1 or y != -3
     assert -1 <= x
     assert -1 == y
+
+    # Use int() to avoid constant propagation
+    i30 = (1 << 30) + int()
+    assert i30 == 1 << 30
+    i31 = (1 << 31) + int()
+    assert i31 == 1 << 31
+    i32 = (1 << 32) + int()
+    assert i32 == 1 << 32
+    i62 = (1 << 62) + int()
+    assert i62 == 1 << 62
+    i63 = (1 << 63) + int()
+    assert i63 == 1 << 63
+    i64 = (1 << 64) + int()
+    assert i64 == 1 << 64
+
+    n30 = -(1 << 30) + int()
+    assert n30 == -(1 << 30)
+    n31 = -(1 << 31) + int()
+    assert n31 == -(1 << 31)
+    n32 = -(1 << 32) + int()
+    assert n32 == -(1 << 32)
+    n62 = -(1 << 62) + int()
+    assert n62 == -(1 << 62)
+    n63 = -(1 << 63) + int()
+    assert n63 == -(1 << 63)
+    n64 = -(1 << 64) + int()
+    assert n64 == -(1 << 64)

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -372,9 +372,16 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_long_unsigned(self) -> None:
         a = Register(int64_rprimitive, 'a')
         self.assert_emit(Assign(a, Integer(1 << 31, int64_rprimitive)),
-                         """cpy_r_a = 2147483648U;""")
+                         """cpy_r_a = 2147483648ULL;""")
         self.assert_emit(Assign(a, Integer((1 << 31) - 1, int64_rprimitive)),
                          """cpy_r_a = 2147483647;""")
+
+    def test_long_signed(self) -> None:
+        a = Register(int64_rprimitive, 'a')
+        self.assert_emit(Assign(a, Integer(-(1 << 31) + 1, int64_rprimitive)),
+                         """cpy_r_a = -2147483647;""")
+        self.assert_emit(Assign(a, Integer(-(1 << 31), int64_rprimitive)),
+                         """cpy_r_a = -2147483648LL;""")
 
     def assert_emit(self, op: Op, expected: str, next_block: Optional[BasicBlock] = None) -> None:
         block = BasicBlock(0)

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -36,6 +36,7 @@ files = [
     'irbuild-isinstance.test',
     'irbuild-dunders.test',
     'irbuild-singledispatch.test',
+    'irbuild-constant-fold.test',
 ]
 
 


### PR DESCRIPTION
Work on mypyc/mypyc#772.

Replace things like '5 + 8' with '13' during IR building. Also adds
support for negative int literals, such as -5 (the negation gets
constant folded).

Arithmetic and bitwise operations that produce int results
are supported, plus string concatenation. Comparisons and float
operations are not supported yet, among other things.

This is a little tricky because of error cases, such as division by
zero. The approach here is to avoid constant folding error cases. We
still won't produce compile-time errors for them.

We do potentially lots of extra work by repeatedly trying to constant
fold expressions, but it didn't seem to slow down self-compilation 
measurably, so the effect seems minor at most. Some caching could 
help this if it becomes a problem.