### PR TITLE
Consider field value types when disambiguating a union of TypedDicts

### DIFF
--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -863,6 +863,28 @@ c: Union[A, B] = {'@type': 'a-type', 'a': 'Test'}
 reveal_type(c) # N: Revealed type is "Union[TypedDict('__main__.A', {'@type': Literal['a-type'], 'a': builtins.str}), TypedDict('__main__.B', {'@type': Literal['b-type'], 'b': builtins.int})]"
 [builtins fixtures/tuple.pyi]
 
+[case testTypedDictUnionUnambiguousCaseBasedOnType]
+from typing import Union, Mapping, Any, cast
+from typing_extensions import TypedDict, Literal
+
+A = TypedDict('A', {'@type': Literal['a-type']})
+B = TypedDict('B', {'@type': Literal['b-type']})
+C1 = TypedDict('C1', {'@type': Literal['c-type'], 'extra': int})
+C2 = TypedDict('C2', {'@type': Literal['c-type'], 'extra': str})
+
+x: Union[A, B, C1, C2]
+x = {'@type': 'a-type'}
+reveal_type(x) # N: Revealed type is "TypedDict('__main__.A', {'@type': Literal['a-type']})"
+x = {'@type': 'b-type'}
+reveal_type(x) # N: Revealed type is "TypedDict('__main__.B', {'@type': Literal['b-type']})"
+x = {'@type': 'c-type', 'extra': 10}
+reveal_type(x) # N: Revealed type is "TypedDict('__main__.C1', {'@type': Literal['c-type'], 'extra': builtins.int})"
+x = {'@type': 'c-type', 'extra': 'string'}
+reveal_type(x) # N: Revealed type is "TypedDict('__main__.C2', {'@type': Literal['c-type'], 'extra': builtins.str})"
+
+x = {'@type': 'c-type', 'extra': 10.5} # E: Incompatible types in assignment (expression has type "Dict[str, object]", variable has type "Union[A, B, C1, C2]")
+[builtins fixtures/dict.pyi]
+
 [case testTypedDictUnionAmbiguousCase]
 from typing import Union, Mapping, Any, cast
 from typing_extensions import TypedDict, Literal


### PR DESCRIPTION
### Description

Fixes #8533.

Previously, given a union of TypedDicts, e.g. `A|B` in

```py
from typing import TypedDict, Literal, Union

class A(TypedDict):
    tag: Literal['A']
    extra_a: str

class B(TypedDict):
    tag: Literal['B']
    extra_b: str
```

when needing to disambiguate the union, e.g.

```
td: A|B = {
    'tag': 'A',
    'extra_a': 'foo',
}
```

mypy would only consider the *keys* of the dict expression and
TypedDict, e.g. 'tag' and 'extra_a'. But if multiple members of the
union have the same shape, only distinguished by a value type, the
disambiguation fails, e.g.

```py
class A(TypedDict):
    tag: Literal['A']

class B(TypedDict):
    tag: Literal['B']

td: A|B = {  # E: Type of TypedDict is ambiguous, could be any of ("A", "B")
    'tag': 'A',
}
```

To allow this, also consider the types of the dict expression's values
when narrowing the candidates from the union.

## Test Plan

I've added a test case and also successfully ran on my own code where I've hit this issue. The test fails before and passes after.