### PR TITLE
Fix narrowing of nested union of TypedDicts

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4676,8 +4676,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # Take each element in the parent union and replay the original lookup procedure
             # to figure out which parents are compatible.
             new_parent_types = []
-            for item in parent_type.items:
-                item = get_proper_type(item)
+            for item in union_items(parent_type):
                 member_type = replay_lookup(item)
                 if member_type is None:
                     # We were unable to obtain the member type. So, we give up on refining this

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1093,3 +1093,32 @@ def f(t: Type[T], a: A, b: B) -> None:
         reveal_type(b)  # N: Revealed type is "<nothing>"
     else:
         reveal_type(b)  # N: Revealed type is "__main__.B"
+
+[case testNarrowingNestedUnionOfTypedDicts]
+from typing import Union
+from typing_extensions import Literal, TypedDict
+
+class A(TypedDict):
+    tag: Literal["A"]
+    a: int
+
+class B(TypedDict):
+    tag: Literal["B"]
+    b: int
+
+class C(TypedDict):
+    tag: Literal["C"]
+    c: int
+
+AB = Union[A, B]
+ABC = Union[AB, C]
+abc: ABC
+
+if abc["tag"] == "A":
+    reveal_type(abc) # N: Revealed type is "TypedDict('__main__.A', {'tag': Literal['A'], 'a': builtins.int})"
+elif abc["tag"] == "C":
+    reveal_type(abc) # N: Revealed type is "TypedDict('__main__.C', {'tag': Literal['C'], 'c': builtins.int})"
+else:
+    reveal_type(abc) # N: Revealed type is "TypedDict('__main__.B', {'tag': Literal['B'], 'b': builtins.int})"
+
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
### Description

Fixes #9308.

The code in `refine_parent_types()` bailed out when it encountered
something other than a TypedDict in the union, including a nested union
of TypedDicts. This caused the narrowing to fail.

Fix it by making it iterate over the flattened union items.

## Test Plan

Added a unit test case. It fails before and passes after.