### PR TITLE
Now `lambda` is counted as a valid context in `handle_cannot_determine_type`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -389,8 +389,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.deferred_nodes.append(DeferredNode(node, enclosing_class))
 
     def handle_cannot_determine_type(self, name: str, context: Context) -> None:
-        node = self.scope.top_non_lambda_function()
-        if self.pass_num < self.last_pass and isinstance(node, FuncDef):
+        node = self.scope.top_function()
+        if self.pass_num < self.last_pass and isinstance(node, (FuncDef, LambdaExpr)):
             # Don't report an error yet. Just defer. Note that we don't defer
             # lambdas because they are coupled to the surrounding function
             # through the binder and the inferred type of the lambda, so it

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2821,7 +2821,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # to be unreachable and therefore any errors found in the right branch
         # should be suppressed.
         with (self.msg.disable_errors() if right_map is None else nullcontext()):
-            right_type = self.analyze_cond_branch(right_map, e.right, left_type)
+            # We also need to be have the correct amount of binder frames.
+            # Sometimes it can be missing for unreachable parts.
+            with (
+                self.chk.binder.top_frame_context()
+                if right_map is None and len(self.chk.binder.frames) <= 1
+                else nullcontext()
+            ):
+                right_type = self.analyze_cond_branch(right_map, e.right, left_type)
 
         if right_map is None:
             # The boolean expression is statically known to be the left value

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -301,6 +301,28 @@ def f(t: T) -> A:
 
 [builtins fixtures/callable.pyi]
 
+[case testCallableTypeVarBoundAndLambdaDefer]
+# See https://github.com/python/mypy/issues/11212
+from typing import Callable, TypeVar
+
+C = TypeVar('C', bound=Callable)
+
+def dec(val: None) -> Callable[[C], C]:
+    def wrapper(f):
+        return f
+    return wrapper
+
+lambda: foo() + 2  # error was here
+
+@dec(None)
+def foo() -> int:
+    return 2
+
+lambda: foo() + 2  # double check
+
+reveal_type(foo() + 2)  # N: Revealed type is "builtins.int"
+[builtins fixtures/callable.pyi]
+
 [case testCallableTypeUnion]
 from abc import ABCMeta, abstractmethod
 from typing import Type, Union

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -738,8 +738,11 @@ class A:
 
     def f(self, x: Optional['A']) -> None:
         assert x
-        lambda: (self.y, x.a) # E: Cannot determine type of "y"
+        lambda: (self.y, x.a)
         self.y = int()
+[out]
+main:8: error: Cannot determine type of "y"
+main:8: error: Item "None" of "Optional[A]" has no attribute "a"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testDeferredAndOptionalInferenceSpecialCase]


### PR DESCRIPTION
Closes #11212

Previously `mypy` was ignoring `lambda` scope in `handle_cannot_determine_type`.
I guess it was done to fix some `lambda` related crashes.

I've also noticed one crash with this new solution in existing test. I happened because when right `or` part is unreachable, there's not `binder.frame` for it. So, I've made a temporary scope of it.