### PR TITLE
SUBTYPE_OF and SUPERTYPE_OF are now Enum members

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -21,7 +21,7 @@ from mypy.typestate import TypeState
 
 
 @enum.unique
-class SubType(enum.IntEnum):
+class SubType(enum.Enum):
     SUBTYPE_OF = 0
     SUPERTYPE_OF = 1
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -164,10 +164,6 @@ def _infer_constraints(template: Type, actual: Type,
         # We infer constraints eagerly -- try to find constraints for a type
         # variable if possible. This seems to help with some real-world
         # use cases.
-        # print(items)
-        # print([infer_constraints_if_possible(template, a_item, direction)
-        #      for a_item in items])
-        # print()
         return any_constraints(
             [infer_constraints_if_possible(template, a_item, direction)
              for a_item in items],

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1073,7 +1073,7 @@ def flip_compat_check(is_compat: Callable[[Type, Type], bool]) -> Callable[[Type
 
 def unify_generic_callable(type: CallableType, target: CallableType,
                            ignore_return: bool,
-                           return_constraint_direction: Optional[mypy.constraints.SubType] = None,
+                           return_constraint_direction: Optional['mypy.constraints.SubType'] = None,
                            ) -> Optional[CallableType]:
     """Try to unify a generic callable type with another callable type.
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1073,7 +1073,7 @@ def flip_compat_check(is_compat: Callable[[Type, Type], bool]) -> Callable[[Type
 
 def unify_generic_callable(type: CallableType, target: CallableType,
                            ignore_return: bool,
-                           return_constraint_direction: Optional[int] = None,
+                           return_constraint_direction: Optional[mypy.constraints.SubType] = None,
                            ) -> Optional[CallableType]:
     """Try to unify a generic callable type with another callable type.
 


### PR DESCRIPTION
While working on https://github.com/python/mypy/issues/11149 I've decided to isolate this change.
`SUPERTYPE_OF` and `SUBTYPE_OF` are now `enum` members. It feels more natural:
1. For type annotations
2. For lots of compares in `contraints.py`
3. I just love enums and try to use them everywhere I can
4. It is 100% backward compatible (assuming plugin devs used constants and not raw `1` and `0` values)