### PR TITLE
Remove py2 parts of mypy testing section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ Tests
 The basic way to run tests:
 
     $ pip3 install -r test-requirements.txt
-    $ python2 -m pip install -U typing
     $ ./runtests.py
 
 For more on the tests, such as how to write tests and how to control

--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -84,11 +84,6 @@ First install any additional dependencies needed for testing:
 
     $ python3 -m pip install -U -r test-requirements.txt
 
-You must also have a Python 2.7 binary installed that can import the `typing`
-module:
-
-    $ python2 -m pip install -U typing
-
 The unit test suites are driven by the `pytest` framework. To run all mypy tests,
 run `pytest` in the mypy repository:
 


### PR DESCRIPTION
### Description

As far as I can tell, mypy does not seem to support py2 at all in its test targets. Its tox file and github workflows both only run py3. So I'm confused why we need to have a py2 binary with `typing` anymore?

If I'm mistaken, feel free to close!

## Test Plan

Just readme changes, so I don't know if I need to rebuild any rst docs or run any unit tests. I did run the unit tests locally without a py2 binary with typing and things did still seem to pass!