### PR TITLE
Do not merge: is `parse-errors.test` skipped?

### DIFF
--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -443,3 +443,7 @@ except KeyError, IndexError:
     pass
 [out]
 file:3: error: invalid syntax
+
+[case testWrongTets]
+@12!--..11@@
+[out]


### PR DESCRIPTION
It looks like `parse-errors.test` might be skipped at all. This PR is checking that.
I've added a wrong test case, which should fail the CI if it works.

Refs https://github.com/python/mypy/issues/10266