### PR TITLE
Removes unused import from `test-data/unit/plugins`

### DIFF
--- a/test-data/unit/plugins/arg_kinds.py
+++ b/test-data/unit/plugins/arg_kinds.py
@@ -1,7 +1,4 @@
-import sys
 from typing import Optional, Callable
-
-from mypy.nodes import Context
 from mypy.plugin import Plugin, MethodContext, FunctionContext
 from mypy.types import Type
 

--- a/test-data/unit/plugins/decimal_to_int.py
+++ b/test-data/unit/plugins/decimal_to_int.py
@@ -1,8 +1,5 @@
-import builtins
-from typing import Optional, Callable
 
-from mypy.plugin import Plugin, AnalyzeTypeContext
-from mypy.types import CallableType, Type
+from mypy.plugin import Plugin
 
 
 class MyPlugin(Plugin):

--- a/test-data/unit/plugins/depshook.py
+++ b/test-data/unit/plugins/depshook.py
@@ -1,4 +1,4 @@
-from typing import Optional, Callable, List, Tuple
+from typing import List, Tuple
 
 from mypy.plugin import Plugin
 from mypy.nodes import MypyFile

--- a/test-data/unit/plugins/type_anal_hook.py
+++ b/test-data/unit/plugins/type_anal_hook.py
@@ -1,7 +1,7 @@
 from typing import Optional, Callable
 
 from mypy.plugin import Plugin, AnalyzeTypeContext
-from mypy.types import Type, UnboundType, TypeList, AnyType, CallableType, TypeOfAny
+from mypy.types import Type, TypeList, AnyType, CallableType, TypeOfAny
 # The official name changed to NoneType but we have an alias for plugin compat reasons
 # so we'll keep testing that here.
 from mypy.types import NoneTyp


### PR DESCRIPTION
Refs https://github.com/python/mypy/pull/11242

Looks like this is it, no more unused imports.