### PR TITLE
Now TypedDict member access is routed via `checkmember`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3236,25 +3236,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         """
         self.try_infer_partial_type_from_indexed_assignment(lvalue, rvalue)
         basetype = get_proper_type(self.expr_checker.accept(lvalue.base))
-        if (isinstance(basetype, TypedDictType) or (isinstance(basetype, TypeVarType)
-                and isinstance(get_proper_type(basetype.upper_bound), TypedDictType))):
-            if isinstance(basetype, TypedDictType):
-                typed_dict_type = basetype
-            else:
-                upper_bound_type = get_proper_type(basetype.upper_bound)
-                assert isinstance(upper_bound_type, TypedDictType)
-                typed_dict_type = upper_bound_type
-            item_type = self.expr_checker.visit_typeddict_index_expr(typed_dict_type, lvalue.index)
-            method_type: Type = CallableType(
-                arg_types=[self.named_type('builtins.str'), item_type],
-                arg_kinds=[ARG_POS, ARG_POS],
-                arg_names=[None, None],
-                ret_type=NoneType(),
-                fallback=self.named_type('builtins.function')
-            )
-        else:
-            method_type = self.expr_checker.analyze_external_member_access(
-                '__setitem__', basetype, context)
+        method_type = self.expr_checker.analyze_external_member_access(
+            '__setitem__', basetype, lvalue)
+
         lvalue.method_type = method_type
         self.expr_checker.check_method_call(
             '__setitem__', basetype, method_type, [lvalue.index, rvalue],

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -858,7 +858,7 @@ def analyze_enum_class_attribute_access(itype: Instance,
 
 
 def analyze_typeddict_access(name: str, typ: TypedDictType,
-                             mx: MemberContext, override_info: Optional[TypeInfo]) -> bool:
+                             mx: MemberContext, override_info: Optional[TypeInfo]) -> Type:
     if name == '__setitem__':
         # Since we can only get this during `a['key'] = ...`
         # it is safe to assume that the context is `IndexExpr`.

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -46,8 +46,6 @@ class DefaultPlugin(Plugin):
             return typed_dict_pop_signature_callback
         elif fullname in set(n + '.update' for n in TPDICT_FB_NAMES):
             return typed_dict_update_signature_callback
-        elif fullname in set(n + '.__delitem__' for n in TPDICT_FB_NAMES):
-            return typed_dict_delitem_signature_callback
         elif fullname == 'ctypes.Array.__setitem__':
             return ctypes.array_setitem_callback
         elif fullname == singledispatch.SINGLEDISPATCH_CALLABLE_CALL_METHOD:
@@ -388,12 +386,6 @@ def typed_dict_setdefault_callback(ctx: MethodContext) -> Type:
 
         return make_simplified_union(value_types)
     return ctx.default_return_type
-
-
-def typed_dict_delitem_signature_callback(ctx: MethodSigContext) -> CallableType:
-    # Replace NoReturn as the argument type.
-    str_type = ctx.api.named_generic_type('builtins.str', [])
-    return ctx.default_signature.copy_modified(arg_types=[str_type])
 
 
 def typed_dict_delitem_callback(ctx: MethodContext) -> Type:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1975,7 +1975,7 @@ T = TypeVar('T')
 
 class A:
     def f(self) -> None:
-        self.g() # E: Too few arguments for "g" of "A"   
+        self.g() # E: Too few arguments for "g" of "A"
         self.g(1)
     @dec
     def g(self, x: str) -> None: pass

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2137,7 +2137,7 @@ class Foo2(TypedDict):
 def func(foo: Union[Foo1, Foo2]) -> str:
     reveal_type(foo["z"])  # N: Revealed type is "builtins.str"
     # ok, but type is incorrect:
-    foo.__getitem__("z")  # N: Revealed type is "builtins.object*"
+    reveal_type(foo.__getitem__("z"))  # N: Revealed type is "builtins.object*"
 
     reveal_type(foo["a"])  # N: Revealed type is "Union[builtins.int, Any]" \
                            # E: TypedDict "Foo2" has no key "a"

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1681,8 +1681,8 @@ s = ''
 del a[s] # E: Expected TypedDict key to be string literal
 del b[s] # E: Expected TypedDict key to be string literal
 alias = b.__delitem__
-alias('x') # E: Argument 1 has incompatible type "str"; expected "NoReturn"
-alias(s) # E: Argument 1 has incompatible type "str"; expected "NoReturn"
+alias('x')
+alias(s)
 [builtins fixtures/dict.pyi]
 
 [case testPluginUnionsOfTypedDicts]
@@ -2109,7 +2109,7 @@ class TD(TypedDict):
 
 d: TD = {b'foo': 2} # E: Expected TypedDict key to be string literal
 d[b'foo'] = 3 # E: TypedDict key must be a string literal; expected one of ("foo") \
-    # E: Argument 1 has incompatible type "bytes"; expected "str"
+    # E: Argument 1 to "__setitem__" has incompatible type "bytes"; expected "str"
 d[b'foo'] # E: TypedDict key must be a string literal; expected one of ("foo")
 d[3] # E: TypedDict key must be a string literal; expected one of ("foo")
 d[True] # E: TypedDict key must be a string literal; expected one of ("foo")
@@ -2220,5 +2220,40 @@ main:16: error: TypedDict "Foo1" has no key "missing"
 main:16: error: TypedDict "Foo2" has no key "missing"
 main:17: error: Expected TypedDict key to be string literal
 main:17: error: Argument 1 to "__delitem__" has incompatible type "int"; expected "str"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
+[case testTypedDictTypeVarUnionSetItem]
+from typing import TypedDict, Union, TypeVar
+
+F1 = TypeVar('F1', bound='Foo1')
+F2 = TypeVar('F2', bound='Foo2')
+
+class Foo1(TypedDict):
+    z: str
+    a: int
+class Foo2(TypedDict):
+    z: str
+    b: int
+
+def func(foo: Union[F1, F2]):
+    foo["z"] = "a"  # ok
+    foo["z"] = 1
+
+    foo["a"] = 1
+    foo["b"] = 2
+
+    foo["missing"] = 1
+    foo[1] = "m"
+[out]
+main:15: error: Value of "z" has incompatible type "int"; expected "str"
+main:17: error: TypedDict "Foo2" has no key "a"
+main:18: error: TypedDict "Foo1" has no key "b"
+main:20: error: TypedDict "Foo1" has no key "missing"
+main:20: error: TypedDict "Foo2" has no key "missing"
+main:21: error: TypedDict key must be a string literal; expected one of ("z", "a")
+main:21: error: TypedDict key must be a string literal; expected one of ("z", "b")
+main:21: error: Argument 1 to "__setitem__" has incompatible type "int"; expected "str"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2122,3 +2122,103 @@ from mypy_extensions import TypedDict
 Foo = TypedDict('Foo', {'camelCaseKey': str})
 value: Foo = {}  # E: Missing key "camelCaseKey" for TypedDict "Foo"
 [builtins fixtures/dict.pyi]
+
+
+[case testTypedDictUnionGetItem]
+from typing import TypedDict, Union
+
+class Foo1(TypedDict):
+    z: str
+    a: int
+class Foo2(TypedDict):
+    z: str
+    b: int
+
+def func(foo: Union[Foo1, Foo2]) -> str:
+    reveal_type(foo["z"])  # ok
+
+    reveal_type(foo["a"])
+    reveal_type(foo["b"])
+    reveal_type(foo["missing"])
+    reveal_type(foo[1])
+
+    return foo["z"]
+[out]
+main:11: note: Revealed type is "builtins.str"
+main:13: note: Revealed type is "Union[builtins.int, Any]"
+main:13: error: TypedDict "Foo2" has no key "a"
+main:14: note: Revealed type is "Union[Any, builtins.int]"
+main:14: error: TypedDict "Foo1" has no key "b"
+main:15: note: Revealed type is "Any"
+main:15: error: TypedDict "Foo1" has no key "missing"
+main:15: error: TypedDict "Foo2" has no key "missing"
+main:16: note: Revealed type is "Any"
+main:16: error: TypedDict key must be a string literal; expected one of ("z", "a")
+main:16: error: TypedDict key must be a string literal; expected one of ("z", "b")
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
+[case testTypedDictUnionSetItem]
+from typing import TypedDict, Union
+
+class Foo1(TypedDict):
+    z: str
+    a: int
+class Foo2(TypedDict):
+    z: str
+    b: int
+
+def func(foo: Union[Foo1, Foo2]):
+    foo["z"] = "a"  # ok
+    foo["z"] = 1
+
+    foo["a"] = 1
+    foo["b"] = 2
+
+    foo["missing"] = 1
+    foo[1] = "m"
+[out]
+main:12: error: Value of "z" has incompatible type "int"; expected "str"
+main:14: error: TypedDict "Foo2" has no key "a"
+main:15: error: TypedDict "Foo1" has no key "b"
+main:17: error: TypedDict "Foo1" has no key "missing"
+main:17: error: TypedDict "Foo2" has no key "missing"
+main:18: error: TypedDict key must be a string literal; expected one of ("z", "a")
+main:18: error: TypedDict key must be a string literal; expected one of ("z", "b")
+main:18: error: Argument 1 to "__setitem__" has incompatible type "int"; expected "str"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
+[case testTypedDictUnionDelItem]
+from typing import TypedDict, Union
+
+class Foo1(TypedDict):
+    z: str
+    a: int
+class Foo2(TypedDict):
+    z: str
+    b: int
+
+def func(foo: Union[Foo1, Foo2]):
+    del foo["z"]
+
+    del foo["a"]
+    del foo["b"]
+
+    del foo["missing"]
+    del foo[1]
+[out]
+main:11: error: Key "z" of TypedDict "Foo1" cannot be deleted
+main:11: error: Key "z" of TypedDict "Foo2" cannot be deleted
+main:13: error: Key "a" of TypedDict "Foo1" cannot be deleted
+main:13: error: TypedDict "Foo2" has no key "a"
+main:14: error: TypedDict "Foo1" has no key "b"
+main:14: error: Key "b" of TypedDict "Foo2" cannot be deleted
+main:16: error: TypedDict "Foo1" has no key "missing"
+main:16: error: TypedDict "Foo2" has no key "missing"
+main:17: error: Expected TypedDict key to be string literal
+main:17: error: Argument 1 to "__delitem__" has incompatible type "int"; expected "str"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2135,26 +2135,22 @@ class Foo2(TypedDict):
     b: int
 
 def func(foo: Union[Foo1, Foo2]) -> str:
-    reveal_type(foo["z"])  # ok
+    reveal_type(foo["z"])  # N: Revealed type is "builtins.str"
+    # ok, but type is incorrect:
+    foo.__getitem__("z")  # N: Revealed type is "builtins.object*"
 
-    reveal_type(foo["a"])
-    reveal_type(foo["b"])
-    reveal_type(foo["missing"])
-    reveal_type(foo[1])
+    reveal_type(foo["a"])  # N: Revealed type is "Union[builtins.int, Any]" \
+                           # E: TypedDict "Foo2" has no key "a"
+    reveal_type(foo["b"])  # N: Revealed type is "Union[Any, builtins.int]" \
+                           # E: TypedDict "Foo1" has no key "b"
+    reveal_type(foo["missing"])  # N: Revealed type is "Any" \
+                                 # E: TypedDict "Foo1" has no key "missing" \
+                                 # E: TypedDict "Foo2" has no key "missing"
+    reveal_type(foo[1])  # N: Revealed type is "Any" \
+                         # E: TypedDict key must be a string literal; expected one of ("z", "a") \
+                         # E: TypedDict key must be a string literal; expected one of ("z", "b")
 
     return foo["z"]
-[out]
-main:11: note: Revealed type is "builtins.str"
-main:13: note: Revealed type is "Union[builtins.int, Any]"
-main:13: error: TypedDict "Foo2" has no key "a"
-main:14: note: Revealed type is "Union[Any, builtins.int]"
-main:14: error: TypedDict "Foo1" has no key "b"
-main:15: note: Revealed type is "Any"
-main:15: error: TypedDict "Foo1" has no key "missing"
-main:15: error: TypedDict "Foo2" has no key "missing"
-main:16: note: Revealed type is "Any"
-main:16: error: TypedDict key must be a string literal; expected one of ("z", "a")
-main:16: error: TypedDict key must be a string literal; expected one of ("z", "b")
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -2171,22 +2167,18 @@ class Foo2(TypedDict):
 
 def func(foo: Union[Foo1, Foo2]):
     foo["z"] = "a"  # ok
-    foo["z"] = 1
+    foo.__setitem__("z", "a")  # ok
 
-    foo["a"] = 1
-    foo["b"] = 2
+    foo["z"] = 1  # E: Value of "z" has incompatible type "int"; expected "str"
 
-    foo["missing"] = 1
-    foo[1] = "m"
-[out]
-main:12: error: Value of "z" has incompatible type "int"; expected "str"
-main:14: error: TypedDict "Foo2" has no key "a"
-main:15: error: TypedDict "Foo1" has no key "b"
-main:17: error: TypedDict "Foo1" has no key "missing"
-main:17: error: TypedDict "Foo2" has no key "missing"
-main:18: error: TypedDict key must be a string literal; expected one of ("z", "a")
-main:18: error: TypedDict key must be a string literal; expected one of ("z", "b")
-main:18: error: Argument 1 to "__setitem__" has incompatible type "int"; expected "str"
+    foo["a"] = 1  # E: TypedDict "Foo2" has no key "a"
+    foo["b"] = 2  # E: TypedDict "Foo1" has no key "b"
+
+    foo["missing"] = 1  # E: TypedDict "Foo1" has no key "missing" \
+                        # E: TypedDict "Foo2" has no key "missing"
+    foo[1] = "m"  # E: TypedDict key must be a string literal; expected one of ("z", "a") \
+                  # E: TypedDict key must be a string literal; expected one of ("z", "b") \
+                  # E: Argument 1 to "__setitem__" has incompatible type "int"; expected "str"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -2202,24 +2194,20 @@ class Foo2(TypedDict):
     b: int
 
 def func(foo: Union[Foo1, Foo2]):
-    del foo["z"]
+    del foo["z"]  # E: Key "z" of TypedDict "Foo1" cannot be deleted \
+                  # E: Key "z" of TypedDict "Foo2" cannot be deleted
+    foo.__delitem__("z")  # E: Key "z" of TypedDict "Foo1" cannot be deleted \
+                          # E: Key "z" of TypedDict "Foo2" cannot be deleted
 
-    del foo["a"]
-    del foo["b"]
+    del foo["a"]  # E: Key "a" of TypedDict "Foo1" cannot be deleted \
+                  # E: TypedDict "Foo2" has no key "a"
+    del foo["b"]  # E: TypedDict "Foo1" has no key "b" \
+                  # E: Key "b" of TypedDict "Foo2" cannot be deleted
 
-    del foo["missing"]
-    del foo[1]
-[out]
-main:11: error: Key "z" of TypedDict "Foo1" cannot be deleted
-main:11: error: Key "z" of TypedDict "Foo2" cannot be deleted
-main:13: error: Key "a" of TypedDict "Foo1" cannot be deleted
-main:13: error: TypedDict "Foo2" has no key "a"
-main:14: error: TypedDict "Foo1" has no key "b"
-main:14: error: Key "b" of TypedDict "Foo2" cannot be deleted
-main:16: error: TypedDict "Foo1" has no key "missing"
-main:16: error: TypedDict "Foo2" has no key "missing"
-main:17: error: Expected TypedDict key to be string literal
-main:17: error: Argument 1 to "__delitem__" has incompatible type "int"; expected "str"
+    del foo["missing"]  # E: TypedDict "Foo1" has no key "missing" \
+                        # E: TypedDict "Foo2" has no key "missing"
+    del foo[1]  # E: Expected TypedDict key to be string literal \
+                # E: Argument 1 to "__delitem__" has incompatible type "int"; expected "str"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -2239,21 +2227,15 @@ class Foo2(TypedDict):
 
 def func(foo: Union[F1, F2]):
     foo["z"] = "a"  # ok
-    foo["z"] = 1
+    foo["z"] = 1  # E: Value of "z" has incompatible type "int"; expected "str"
 
-    foo["a"] = 1
-    foo["b"] = 2
+    foo["a"] = 1  # E: TypedDict "Foo2" has no key "a"
+    foo["b"] = 2  # E: TypedDict "Foo1" has no key "b"
 
-    foo["missing"] = 1
-    foo[1] = "m"
-[out]
-main:15: error: Value of "z" has incompatible type "int"; expected "str"
-main:17: error: TypedDict "Foo2" has no key "a"
-main:18: error: TypedDict "Foo1" has no key "b"
-main:20: error: TypedDict "Foo1" has no key "missing"
-main:20: error: TypedDict "Foo2" has no key "missing"
-main:21: error: TypedDict key must be a string literal; expected one of ("z", "a")
-main:21: error: TypedDict key must be a string literal; expected one of ("z", "b")
-main:21: error: Argument 1 to "__setitem__" has incompatible type "int"; expected "str"
+    foo["missing"] = 1  # E: TypedDict "Foo1" has no key "missing" \
+                        # E: TypedDict "Foo2" has no key "missing"
+    foo[1] = "m"  # E: TypedDict key must be a string literal; expected one of ("z", "a") \
+                  # E: TypedDict key must be a string literal; expected one of ("z", "b") \
+                  # E: Argument 1 to "__setitem__" has incompatible type "int"; expected "str"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]


### PR DESCRIPTION
Changes:
1. I've removed `sig` plugin for `typed_dict_delitem`, because now it properly handled in `checkmember`
2. Initial problem is now automatically solved 🙂 

Closes #10631