### PR TITLE
fix(11090): skip translate_dict_call when type alias dict call

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3786,7 +3786,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             expr.analyzed = PromoteExpr(target)
             expr.analyzed.line = expr.line
             expr.analyzed.accept(self)
-        elif refers_to_fullname(expr.callee, 'builtins.dict'):
+        elif isinstance(expr.callee, RefExpr) and expr.callee.fullname == 'builtins.dict':
             expr.analyzed = self.translate_dict_call(expr)
         elif refers_to_fullname(expr.callee, 'builtins.divmod'):
             if not self.check_fixed_args(expr, 2, 'divmod'):

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -659,3 +659,14 @@ reveal_type(w)  # N: Revealed type is "__main__.Out.In"
 reveal_type(x)  # N: Revealed type is "__main__.Out.In.Inner"
 reveal_type(y)  # N: Revealed type is "__main__.Out.In.Inner"
 reveal_type(z)  # N: Revealed type is "__main__.Out.In"
+
+[case testTypeAliasDictNoVarAnnotatedError]
+from typing import Dict
+D = Dict[str, str]
+d = D()
+[builtins fixtures/dict.pyi]
+
+[case testTypeAliasListNoVarAnnotatedError]
+from typing import List
+L = List[str]
+l = L()


### PR DESCRIPTION
### Description

Fixes https://github.com/python/mypy/issues/11093

I explained what I analyzed about the issue in the comment https://github.com/python/mypy/issues/11093#issuecomment-932667550, so I would appreciate if someone could take a loot it together.

Clearly, my fix doesn't look really solving the issue, but surprisingly there is no regression in exisiting tests. So, I made this PR anyway as a starting point to ask some opinions about the issue itself.

It's highly likely that I'm missing some importance use of `SemanticAnalyzer.translate_dict_call`, but I couldn't figure it out by myself.

Thanks a lot for the review!

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

I added new tests in `check-type-aliases.test`:

- `testTypeAliasDictNoVarAnnotatedError`,
- `testTypeAliasListNoVarAnnotatedError`.

I think the relevant existing tests are mostly in `check-typeddict.test` and especially this test case:

- `testCanCreateTypedDictInstanceWithDictCall`.
