### PR TITLE
Remove redundant lookup funcs in fixup.py

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -7,7 +7,7 @@ from typing_extensions import Final
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
-from mypy.fixup import lookup_qualified_stnode
+from mypy.lookup import lookup_fully_qualified
 from mypy.nodes import (
     Context, Argument, Var, ARG_OPT, ARG_POS, TypeInfo, AssignmentStmt,
     TupleExpr, ListExpr, NameExpr, CallExpr, RefExpr, FuncDef,
@@ -87,7 +87,7 @@ class Attribute:
         if self.converter.name:
             # When a converter is set the init_type is overridden by the first argument
             # of the converter method.
-            converter = lookup_qualified_stnode(ctx.api.modules, self.converter.name, True)
+            converter = lookup_fully_qualified(ctx.api.modules, self.converter.name, True)
             if not converter:
                 # The converter may be a local variable. Check there too.
                 converter = ctx.api.lookup_qualified(self.converter.name, self.info, True)


### PR DESCRIPTION
### Description

Removes the redundant lookup funcs in fixup.py. Related to #4082.

* Removes `lookup_qualified_stnode`: uncessary nested call to `lookup_fully_qualified`
* Removes `lookup_qualified`: inconsistency return types with other `lookup_qualified` funcs. Let the callers extract the `SymbolNode` from the `SymbolTableNode`.