### PR TITLE
fix(11060): check `left_expr` in `check_generator_or_comprehension`

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3761,6 +3761,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         with self.chk.binder.frame_context(can_skip=True, fall_through=0):
             self.check_for_comp(gen)
 
+            # Check `left_expr` to analyze variables introduced by `AssignmentExpr` if any
+            gen.left_expr.accept(self)
+
             # Infer the type of the list comprehension by using a synthetic generic
             # callable type.
             tv = TypeVarType('T', 'T', -1, [], self.object_type())

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -546,3 +546,28 @@ def foo() -> None:
     x = 0
     [x := x + y for y in [1, 2, 3]]
 [builtins fixtures/dict.pyi]
+
+[case testWalrusUndefinedRecursiveReference1]
+(x := x) # E: Cannot determine type of "x"
+
+[case testWalrusUndefinedRecursiveReference2]
+z = [x := x for y in [1, 2, 3]] # E: Cannot determine type of "x"
+
+[case testWalrusUndefinedRecursiveReference3]
+from typing import Any
+
+def f(x: Any) -> None:
+    pass
+
+f(x := x) # E: Cannot determine type of "x"
+
+[case testWalrusUndefinedRecursiveReference4]
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def f(x: T) -> None:
+    pass
+
+# TODO: should be the same error as others?
+f(x := x)


### PR DESCRIPTION
### Description

Fixes https://github.com/python/mypy/issues/11060 (This PR fixes 2nd example `[z := z + y for y in range(2)]`. 1st example is already fixed by https://github.com/python/mypy/pull/11153)

I changed `check_generator_or_comprehension` so that it checks `Generator.left_expr` before doing "synthetic generic callable" based inference using `check_call`.

It seems that the reason why the error is not reported is that because "synthetic generic callable"s `check_call` hides such error due to `self.msg.disable_errors` in `infer_function_type_arguments`. I made a test case `testWalrusUndefinedRecursiveReference4` to demonstrate the same issue without using comprehension (which isn't fixed by this PR).

So, I attempted to explicitly check `Generator.left_expr` independent from `check_call` and this seems to fix at least the specific issue with comprehension (and I didn't see any regression in existing tests).
I don't believe this change is a legitimate fix for the issue, but I thought this is something worth sharing, so I made a PR here. I hope you don't mind and I would appreciate any feedback about this approach.
Thanks a lot!

## Test Plan

I added `testWalrusUndefinedRecursiveReference1, 2, 3, 4`. The errors in `1` and `3` were already detected. `2` is the one this PR fixed. `4` is not handled correctly and I think it demonstrates some issue about function call inference with `TypeVar`.
