### PR TITLE
incremental testsuite: don't write subsequent step files until they are needed

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -276,6 +276,25 @@ class DataDrivenTestCase(pytest.Item):
             with open(path, 'w', encoding='utf8') as f:
                 f.write(content)
 
+        # Precalculate steps for find_steps()
+        steps: Dict[int, List[FileOperation]] = {}
+        for path, _ in self.files:
+            m = re.match(r'.*\.([0-9]+)$', path)
+            if m:
+                num = int(m.group(1))
+                assert num >= 2
+                target_path = re.sub(r'\.[0-9]+$', '', path)
+                module = module_from_path(target_path)
+                operation = UpdateFile(module, path, target_path)
+                steps.setdefault(num, []).append(operation)
+        for num, paths in self.deleted_paths.items():
+            assert num >= 2
+            for path in paths:
+                module = module_from_path(path)
+                steps.setdefault(num, []).append(DeleteFile(module, path))
+        max_step = max(steps) if steps else 2
+        self.steps = [steps.get(num, []) for num in range(2, max_step + 1)]
+
     def teardown(self) -> None:
         assert self.old_cwd is not None and self.tmpdir is not None, \
             "test was not properly set up"
@@ -312,23 +331,7 @@ class DataDrivenTestCase(pytest.Item):
 
         Defaults to having two steps if there aern't any operations.
         """
-        steps: Dict[int, List[FileOperation]] = {}
-        for path, _ in self.files:
-            m = re.match(r'.*\.([0-9]+)$', path)
-            if m:
-                num = int(m.group(1))
-                assert num >= 2
-                target_path = re.sub(r'\.[0-9]+$', '', path)
-                module = module_from_path(target_path)
-                operation = UpdateFile(module, path, target_path)
-                steps.setdefault(num, []).append(operation)
-        for num, paths in self.deleted_paths.items():
-            assert num >= 2
-            for path in paths:
-                module = module_from_path(path)
-                steps.setdefault(num, []).append(DeleteFile(module, path))
-        max_step = max(steps) if steps else 2
-        return [steps.get(num, []) for num in range(2, max_step + 1)]
+        return self.steps
 
 
 def module_from_path(path: str) -> str:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -18,7 +18,7 @@ root_dir = os.path.normpath(PREFIX)
 
 # File modify/create operation: copy module contents from source_path.
 UpdateFile = NamedTuple('UpdateFile', [('module', str),
-                                       ('source_path', str),
+                                       ('content', str),
                                        ('target_path', str)])
 
 # File delete operation: delete module file.
@@ -270,23 +270,28 @@ class DataDrivenTestCase(pytest.Item):
         self.tmpdir = tempfile.TemporaryDirectory(prefix='mypy-test-')
         os.chdir(self.tmpdir.name)
         os.mkdir(test_temp_dir)
-        for path, content in self.files:
-            dir = os.path.dirname(path)
-            os.makedirs(dir, exist_ok=True)
-            with open(path, 'w', encoding='utf8') as f:
-                f.write(content)
 
         # Precalculate steps for find_steps()
         steps: Dict[int, List[FileOperation]] = {}
-        for path, _ in self.files:
+
+        for path, content in self.files:
             m = re.match(r'.*\.([0-9]+)$', path)
             if m:
+                # Skip writing subsequent incremental steps - rather
+                # store them as operations.
                 num = int(m.group(1))
                 assert num >= 2
                 target_path = re.sub(r'\.[0-9]+$', '', path)
                 module = module_from_path(target_path)
-                operation = UpdateFile(module, path, target_path)
+                operation = UpdateFile(module, content, target_path)
                 steps.setdefault(num, []).append(operation)
+            else:
+                # Write the first incremental steps
+                dir = os.path.dirname(path)
+                os.makedirs(dir, exist_ok=True)
+                with open(path, 'w', encoding='utf8') as f:
+                    f.write(content)
+
         for num, paths in self.deleted_paths.items():
             assert num >= 2
             for path in paths:

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -274,7 +274,7 @@ bar.py:3: (str)
 bar.py:4: (arg=str)
 $ dmypy suggest foo.foo
 (str) -> int
-$ {python} -c "import shutil; shutil.copy('foo.py.2', 'foo.py')"
+$ {python} -c "import shutil; shutil.copy('foo2.py', 'foo.py')"
 $ dmypy check foo.py bar.py
 bar.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 == Return code: 1
@@ -284,7 +284,7 @@ def foo(arg):
 class Bar:
     def bar(self): pass
 var = 0
-[file foo.py.2]
+[file foo2.py]
 def foo(arg: str) -> int:
     return 12
 class Bar:

--- a/test-data/unit/fine-grained-follow-imports.test
+++ b/test-data/unit/fine-grained-follow-imports.test
@@ -638,6 +638,7 @@ import p2.m2
 p1/m1.py:1: error: "int" not callable
 main.py:2: error: Cannot find implementation or library stub for module named "p2.m2"
 main.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+main.py:2: error: Cannot find implementation or library stub for module named "p2"
 ==
 p2/m2.py:1: error: "str" not callable
 p1/m1.py:1: error: "int" not callable


### PR DESCRIPTION
### Description

This matters with namespace packages enabled - since an (otherwise) empty folder with
some .2 files in it will be considered a namespace package. This is
truer - by only writing the files at the point of the step. This helps
unblock #9636

## Test Plan

I confirmed that this helps fix some of the failures in #9636. I confirmed all preexisting tests continue to work.
