### PR TITLE
Fix case mismatching modules during namespace package search

### DIFF
--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -220,12 +220,14 @@ class FileSystemCache:
             res = False
         if res:
             # Also recursively check the other path components in case sensitive way.
-            res = self._exists_case(head, prefix)
+            res = self.exists_case(head, prefix)
         self.isfile_case_cache[path] = res
         return res
 
-    def _exists_case(self, path: str, prefix: str) -> bool:
-        """Helper to check path components in case sensitive fashion, up to prefix."""
+    def exists_case(self, path: str, prefix: str) -> bool:
+        """Return whether path exists - checking path components in case sensitive
+        fashion, up to prefix.
+        """
         if path in self.exists_case_cache:
             return self.exists_case_cache[path]
         head, tail = os.path.split(path)
@@ -242,7 +244,7 @@ class FileSystemCache:
             res = False
         if res:
             # Also recursively check other path components.
-            res = self._exists_case(head, prefix)
+            res = self.exists_case(head, prefix)
         self.exists_case_cache[path] = res
         return res
 

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -373,7 +373,7 @@ class FindModuleCache:
 
             # In namespace mode, register a potential namespace package
             if self.options and self.options.namespace_packages:
-                if fscache.isdir(base_path) and not has_init:
+                if fscache.exists_case(base_path, dir_prefix) and not has_init:
                     near_misses.append((base_path, dir_prefix))
 
             # No package, look for module.

--- a/test-data/unit/check-modules-case.test
+++ b/test-data/unit/check-modules-case.test
@@ -1,6 +1,14 @@
 -- Type checker test cases dealing with modules and imports on case-insensitive filesystems.
 
 [case testCaseSensitivityDir]
+# flags: --no-namespace-packages
+from a import B  # E: Module "a" has no attribute "B"
+
+[file a/__init__.py]
+[file a/b/__init__.py]
+
+[case testCaseSensitivityDirNamespacePackages]
+# flags: --namespace-packages
 from a import B  # E: Module "a" has no attribute "B"
 
 [file a/__init__.py]


### PR DESCRIPTION
For example `from a import B` should not find a namespace
package `a/B/`. Fix by using case aware isdir on fscache.

Helps unblock #9636

## Test Plan

There are several existing tests for this area. I split one of the tests by namespace package for straddling.
I also tested this diff on top of #9636 and confirmed it helps!