### PR TITLE
Removes possibly unused `builtin_call`

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -43,7 +43,7 @@ from mypyc.common import (
     use_method_vectorcall
 )
 from mypyc.primitives.registry import (
-    method_call_ops, CFunctionDescription, function_ops,
+    method_call_ops, CFunctionDescription,
     binary_ops, unary_ops, ERR_NEG_INT
 )
 from mypyc.primitives.bytes_ops import bytes_compare

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1186,15 +1186,6 @@ class LowLevelIRBuilder:
     def new_set_op(self, values: List[Value], line: int) -> Value:
         return self.call_c(new_set_op, values, line)
 
-    def builtin_call(self,
-                     args: List[Value],
-                     fn_op: str,
-                     line: int) -> Value:
-        call_c_ops_candidates = function_ops.get(fn_op, [])
-        target = self.matching_call_c(call_c_ops_candidates, args, line)
-        assert target, 'Unsupported builtin function: %s' % fn_op
-        return target
-
     def shortcircuit_helper(self, op: str,
                             expr_type: RType,
                             left: Callable[[], Value],


### PR DESCRIPTION
While working on #11263 I've noticed that this function is not used. It was used only in one place some time ago: https://github.com/python/mypy/commit/818cc4e0ac2b5d17c161fb65547ab77ead23ed28#diff-fb1a240667c19f142d8f7686411c3e8185eb94720e6bb005099ab7c1d57f878aR157

Maybe it is safe to remove it.