### PR TITLE
Disallow invalid identifiers from getting implicit bazel __init__.py

### DIFF
--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -107,6 +107,9 @@ class FileSystemCache:
         dirname, basename = os.path.split(path)
         if basename != '__init__.py':
             return False
+        if not os.path.basename(dirname).isidentifier():
+            # Can't put an __init__.py in a place that's not an identifier
+            return False
         try:
             st = self.stat(dirname)
         except OSError:

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -946,7 +946,13 @@ emarg/foo.py:1: error: Name "fail" is not defined
 emarg/hatch/villip/mankangulisk.py:1: error: Name "fail" is not defined
 
 [case testPackageRootEmpty]
-# cmd: mypy --package-root= a/b/c.py main.py
+# cmd: mypy --no-namespace-packages --package-root= a/b/c.py main.py
+[file a/b/c.py]
+[file main.py]
+import a.b.c
+
+[case testPackageRootEmptyNamespacePackage]
+# cmd: mypy --namespace-packages --package-root= a/b/c.py main.py
 [file a/b/c.py]
 [file main.py]
 import a.b.c


### PR DESCRIPTION
This helps unblock #9636. With namespace packages, the
code to crawl upward would not stop anywhere and would
run into temp directories with invalid module names. Normally
it would stop when it found a dir without an __init__.py,
but it was placing an implicit fake bazel __init__ there.
Bazeled environments can't really have invalid module name
directories, so this should help fix.

Added tests for namespace-packages and no-namespace-packages
