### PR TITLE
Fixes type narrowing for overlaping runtime types

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5325,9 +5325,11 @@ def conditional_type_map(expr: Expression,
                 return None, {}
             else:
                 # we can only restrict when the type is precise, not bounded
-                proposed_precise_type = UnionType.make_union([type_range.item
-                                          for type_range in proposed_type_ranges
-                                          if not type_range.is_upper_bound])
+                proposed_precise_type = UnionType.make_union([
+                    type_range.item
+                    for type_range in proposed_type_ranges
+                    if not type_range.is_upper_bound
+                ])
                 remaining_type = restrict_subtype_away(current_type, proposed_precise_type)
                 return {expr: proposed_type}, {expr: remaining_type}
         else:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5325,7 +5325,7 @@ def conditional_type_map(expr: Expression,
                 return None, {}
             else:
                 # we can only restrict when the type is precise, not bounded
-                proposed_precise_type = UnionType([type_range.item
+                proposed_precise_type = UnionType.make_union([type_range.item
                                           for type_range in proposed_type_ranges
                                           if not type_range.is_upper_bound])
                 remaining_type = restrict_subtype_away(current_type, proposed_precise_type)

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1131,6 +1131,8 @@ def restrict_subtype_away(t: Type, s: Type, *, ignore_promotions: bool = False) 
                      if (isinstance(get_proper_type(item), AnyType) or
                          not covers_at_runtime(item, s, ignore_promotions))]
         return UnionType.make_union(new_items)
+    elif covers_at_runtime(t, s, ignore_promotions):
+        return UninhabitedType()
     else:
         return t
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1975,7 +1975,7 @@ T = TypeVar('T')
 
 class A:
     def f(self) -> None:
-        self.g() # E: Too few arguments for "g" of "A"   
+        self.g() # E: Too few arguments for "g" of "A"
         self.g(1)
     @dec
     def g(self, x: str) -> None: pass

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1143,3 +1143,24 @@ else:
     reveal_type(abc) # N: Revealed type is "TypedDict('__main__.B', {'tag': Literal['B'], 'b': builtins.int})"
 
 [builtins fixtures/primitives.pyi]
+
+
+[case testNarrowingRuntimeCover]
+from typing import List, Union
+
+def foo(x: Union[str, List[str]]) -> None:
+    if isinstance(x, str):
+        reveal_type(x)  # N: Revealed type is "builtins.str"
+    elif isinstance(x, list):
+        reveal_type(x)  # N: Revealed type is "builtins.list[builtins.str]"
+    else:
+        reveal_type(x)  # N: Revealed type is "<nothing>"
+
+def bar(x: Union[str, List[str], List[int], int]) -> None:
+    if isinstance(x, str):
+        reveal_type(x)  # N: Revealed type is "builtins.str"
+    elif isinstance(x, list):
+        reveal_type(x)  # N: Revealed type is "Union[builtins.list[builtins.str], builtins.list[builtins.int]]"
+    else:
+        reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1146,9 +1146,9 @@ else:
 
 
 [case testNarrowingRuntimeCover]
-from typing import List, Union
+from typing import Dict, List, Union
 
-def foo(x: Union[str, List[str]]) -> None:
+def unreachable(x: Union[str, List[str]]) -> None:
     if isinstance(x, str):
         reveal_type(x)  # N: Revealed type is "builtins.str"
     elif isinstance(x, list):
@@ -1156,11 +1156,19 @@ def foo(x: Union[str, List[str]]) -> None:
     else:
         reveal_type(x)  # N: Revealed type is "<nothing>"
 
-def bar(x: Union[str, List[str], List[int], int]) -> None:
+def all_parts_covered(x: Union[str, List[str], List[int], int]) -> None:
     if isinstance(x, str):
         reveal_type(x)  # N: Revealed type is "builtins.str"
     elif isinstance(x, list):
         reveal_type(x)  # N: Revealed type is "Union[builtins.list[builtins.str], builtins.list[builtins.int]]"
     else:
         reveal_type(x)  # N: Revealed type is "builtins.int"
-[builtins fixtures/list.pyi]
+
+def two_type_vars(x: Union[str, Dict[str, int], Dict[bool, object], int]) -> None:
+    if isinstance(x, str):
+        reveal_type(x)  # N: Revealed type is "builtins.str"
+    elif isinstance(x, dict):
+        reveal_type(x)  # N: Revealed type is "Union[builtins.dict[builtins.str, builtins.int], builtins.dict[builtins.bool, builtins.object]]"
+    else:
+        reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
As always, fixing issues with type narrowing / inference is always very hard, because small changes can backfire.
But, this looks as a simple change. Let's see how tests will behave.

Closes #11272