### PR TITLE
New error code for slices syntax, refs #10266

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -135,6 +135,7 @@ NAME_MATCH: Final = ErrorCode(
 
 # Syntax errors are often blocking.
 SYNTAX: Final = ErrorCode("syntax", "Report syntax errors", "General")
+SLICE_SYNTAX: Final = ErrorCode("slice-syntax", "Report slice syntax errors", "General")
 
 # This is a catch-all for remaining uncategorized errors.
 MISC: Final = ErrorCode("misc", "Miscellaneous other checks", "General")

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -374,6 +374,16 @@ class Errors:
                         return
             if file in self.ignored_files:
                 return
+            if (
+                not self.ignored_lines
+                and info.code
+                and self.is_error_code_enabled(info.code) is False
+            ):
+                # We also might want to ignore some errors during `fastparse`.
+                # At that moment `ignored_lines` might not be ready,
+                # so, we only check for specific error codes.
+                # For example, `Dict[{str: int}]` can be ignored this way.
+                return
         if info.only_once:
             if info.message in self.only_once_messages:
                 return

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -897,3 +897,24 @@ lst: List[int] = []
 if lst:
     pass
 [builtins fixtures/list.pyi]
+
+[case testSliceAnnotatedErrorDisabled39]
+# flags: --python-version 3.9 --disable-error-code slice-syntax
+a: Annotated[int, 1:2]
+b: Dict[int, x:y]
+c: Dict[x:y]
+
+reveal_type(a)  # N: Revealed type is "Any"
+reveal_type(b)  # N: Revealed type is "Any"
+reveal_type(c)  # N: Revealed type is "Any"
+
+[case testSliceAnnotatedErrorDisabled38]
+# flags: --python-version 3.8 --disable-error-code slice-syntax
+
+a: Annotated[int, 1:2]
+b: Dict[int, x:y]
+c: Dict[x:y]
+
+reveal_type(a)  # N: Revealed type is "Any"
+reveal_type(b)  # N: Revealed type is "Any"
+reveal_type(c)  # N: Revealed type is "Any"


### PR DESCRIPTION
Now `Dict[x:y]` be silently skipped if `--disable-error-code slice-syntax` is specified.
I hope that this is what our users with custom plugins are looking for.

CC @Zac-HD 