### PR TITLE
Changed DIGIT.DIGIT to MAJOR.MINOR resolving #11122

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -323,7 +323,7 @@ Platform configuration
     :type: string
 
     Specifies the Python version used to parse and check the target
-    program.  The string should be in the format ``DIGIT.DIGIT`` --
+    program.  The string should be in the format ``MAJOR.MINOR`` --
     for example ``2.7``.  The default is the version of the Python
     interpreter used to run mypy.
 


### PR DESCRIPTION
### Description
Closes #11122

This PR makes solves the described issue and makes the documentation better for users.
File location : docs/source/config_file.rst

## Test Plan

To describe a Python version instead of DIGIT.DIGIT, it is better as MAJOR.MINOR since Python 3.10 version has minor '10' which is not a digit.

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
