### PR TITLE
[mypyc] Add a simple irchecking analysis system

### DIFF
--- a/mypyc/analysis/ircheck.py
+++ b/mypyc/analysis/ircheck.py
@@ -1,0 +1,157 @@
+from typing import List, Union
+from mypyc.ir.ops import (
+    OpVisitor, BasicBlock, Register, Op, ControlOp, Goto, Branch, Return, Unreachable,
+    Assign, AssignMulti, LoadErrorValue, LoadLiteral, GetAttr, SetAttr, LoadStatic,
+    InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast,
+    Box, Unbox, RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp,
+    LoadMem, SetMem, GetElementPtr, LoadAddress, KeepAlive
+)
+from mypyc.ir.func_ir import FuncIR
+
+
+class FnError(object):
+    def __init__(self, source: Union[Op, BasicBlock], desc: str) -> None:
+        self.source = source
+        self.desc = desc
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, FnError) and self.source == other.source and \
+            self.desc == other.desc
+
+    def __repr__(self) -> str:
+        return f"FnError(source={self.source}, desc={self.desc})"
+
+
+def check_funcdef(fn: FuncIR) -> List[FnError]:
+    """Check a list of basic blocks (e.g. from a function definition) in surrounding
+    context (e.g. args).
+    """
+    # deal with args later
+    assert not fn.arg_regs
+
+    errors = []
+
+    for block in fn.blocks:
+        if not block.terminated:
+            errors.append(FnError(
+                source=block.ops[-1] if block.ops else block,
+                desc="Block not terminated",
+            ))
+
+    op_checker = OpChecker(fn)
+    for block in fn.blocks:
+        for op in block.ops:
+            op.accept(op_checker)
+
+    return errors + op_checker.errors
+
+
+class OpChecker(OpVisitor[None]):
+    def __init__(self, parent_fn: FuncIR) -> None:
+        self.parent_fn = parent_fn
+        self.errors: List[FnError] = []
+
+    def fail(self, source: Op, desc: str) -> None:
+        self.errors.append(FnError(source=source, desc=desc))
+
+    def check_control_op_targets(self, op: ControlOp) -> None:
+        for target in op.targets():
+            if target not in self.parent_fn.blocks:
+                self.fail(source=op, desc=f"Invalid control operation target: {target.label}")
+
+    def visit_goto(self, op: Goto) -> None:                            
+        self.check_control_op_targets(op)
+              
+    def visit_branch(self, op: Branch) -> None:                    
+        self.check_control_op_targets(op)
+                                                                       
+    def visit_return(self, op: Return) -> None:
+        # TODO: check return
+        pass
+                                                                                 
+    def visit_unreachable(self, op: Unreachable) -> None:
+        raise NotImplementedError           
+                                           
+    def visit_assign(self, op: Assign) -> None:
+        raise NotImplementedError
+                                        
+    def visit_assign_multi(self, op: AssignMulti) -> None:
+        raise NotImplementedError   
+                                                                      
+    def visit_load_error_value(self, op: LoadErrorValue) -> None:        
+        raise NotImplementedError
+
+    def visit_load_literal(self, op: LoadLiteral) -> None:
+        raise NotImplementedError
+
+    def visit_get_attr(self, op: GetAttr) -> None:
+        raise NotImplementedError
+
+    def visit_set_attr(self, op: SetAttr) -> None:
+        raise NotImplementedError
+
+    def visit_load_static(self, op: LoadStatic) -> None:
+        raise NotImplementedError
+
+    def visit_init_static(self, op: InitStatic) -> None:
+        raise NotImplementedError
+
+    def visit_tuple_get(self, op: TupleGet) -> None:
+        raise NotImplementedError
+
+    def visit_tuple_set(self, op: TupleSet) -> None:
+        raise NotImplementedError
+
+    def visit_inc_ref(self, op: IncRef) -> None:
+        raise NotImplementedError
+
+    def visit_dec_ref(self, op: DecRef) -> None:
+        raise NotImplementedError
+
+    def visit_call(self, op: Call) -> None:
+        raise NotImplementedError
+
+    def visit_method_call(self, op: MethodCall) -> None:
+        raise NotImplementedError
+
+    def visit_cast(self, op: Cast) -> None:
+        raise NotImplementedError
+
+    def visit_box(self, op: Box) -> None:
+        raise NotImplementedError
+
+    def visit_unbox(self, op: Unbox) -> None:
+        raise NotImplementedError
+
+    def visit_raise_standard_error(self, op: RaiseStandardError) -> None:
+        raise NotImplementedError
+
+    def visit_call_c(self, op: CallC) -> None:
+        raise NotImplementedError
+
+    def visit_truncate(self, op: Truncate) -> None:
+        raise NotImplementedError
+
+    def visit_load_global(self, op: LoadGlobal) -> None:
+        raise NotImplementedError
+
+    def visit_int_op(self, op: IntOp) -> None:
+        raise NotImplementedError
+
+    def visit_comparison_op(self, op: ComparisonOp) -> None:
+        raise NotImplementedError
+
+    def visit_load_mem(self, op: LoadMem) -> None:
+        raise NotImplementedError
+
+    def visit_set_mem(self, op: SetMem) -> None:
+        raise NotImplementedError
+
+    def visit_get_element_ptr(self, op: GetElementPtr) -> None:
+        raise NotImplementedError
+
+    def visit_load_address(self, op: LoadAddress) -> None:
+        raise NotImplementedError
+
+    def visit_keep_alive(self, op: KeepAlive) -> None:
+        raise NotImplementedError

--- a/mypyc/analysis/ircheck.py
+++ b/mypyc/analysis/ircheck.py
@@ -1,4 +1,5 @@
 from typing import List, Union
+from mypyc.ir.pprint import format_func
 from mypyc.ir.ops import (
     OpVisitor, BasicBlock, Register, Op, ControlOp, Goto, Branch, Return, Unreachable,
     Assign, AssignMulti, LoadErrorValue, LoadLiteral, GetAttr, SetAttr, LoadStatic,
@@ -26,9 +27,6 @@ def check_funcdef(fn: FuncIR) -> List[FnError]:
     """Check a list of basic blocks (e.g. from a function definition) in surrounding
     context (e.g. args).
     """
-    # deal with args later
-    assert not fn.arg_regs
-
     errors = []
 
     for block in fn.blocks:
@@ -44,6 +42,16 @@ def check_funcdef(fn: FuncIR) -> List[FnError]:
             op.accept(op_checker)
 
     return errors + op_checker.errors
+
+
+class IrCheckException(Exception):
+    pass
+
+
+def check_funcdef_and_crash(fn: FuncIR) -> None:
+    errors = check_funcdef(fn)
+    if errors:
+        raise IrCheckException("Internal error: Generated invalid IR: \n" + "\n".join(format_func(fn, [(e.source, e.desc) for e in errors])))
 
 
 class OpChecker(OpVisitor[None]):
@@ -66,92 +74,91 @@ class OpChecker(OpVisitor[None]):
         self.check_control_op_targets(op)
                                                                        
     def visit_return(self, op: Return) -> None:
-        # TODO: check return
         pass
                                                                                  
     def visit_unreachable(self, op: Unreachable) -> None:
-        raise NotImplementedError           
+        pass           
                                            
     def visit_assign(self, op: Assign) -> None:
-        raise NotImplementedError
+        pass
                                         
     def visit_assign_multi(self, op: AssignMulti) -> None:
-        raise NotImplementedError   
+        pass   
                                                                       
     def visit_load_error_value(self, op: LoadErrorValue) -> None:        
-        raise NotImplementedError
+        pass
 
     def visit_load_literal(self, op: LoadLiteral) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_get_attr(self, op: GetAttr) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_set_attr(self, op: SetAttr) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_load_static(self, op: LoadStatic) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_init_static(self, op: InitStatic) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_tuple_get(self, op: TupleGet) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_tuple_set(self, op: TupleSet) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_inc_ref(self, op: IncRef) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_dec_ref(self, op: DecRef) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_call(self, op: Call) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_method_call(self, op: MethodCall) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_cast(self, op: Cast) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_box(self, op: Box) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_unbox(self, op: Unbox) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_raise_standard_error(self, op: RaiseStandardError) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_call_c(self, op: CallC) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_truncate(self, op: Truncate) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_load_global(self, op: LoadGlobal) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_int_op(self, op: IntOp) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_comparison_op(self, op: ComparisonOp) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_load_mem(self, op: LoadMem) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_set_mem(self, op: SetMem) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_load_address(self, op: LoadAddress) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_keep_alive(self, op: KeepAlive) -> None:
-        raise NotImplementedError
+        pass

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -19,6 +19,7 @@ from mypyc.ir.rtypes import is_bool_rprimitive, is_int_rprimitive, RType
 
 ErrorSource = Union[BasicBlock, Op]
 
+
 class IRPrettyPrintVisitor(OpVisitor[str]):
     """Internal visitor that pretty-prints ops."""
 
@@ -314,6 +315,7 @@ def format_blocks(blocks: List[BasicBlock],
             # Each basic block needs to exit somewhere.
             lines.append('    [MISSING BLOCK EXIT OPCODE]')
     return lines
+
 
 def format_func(fn: FuncIR, errors: Sequence[Tuple[ErrorSource, str]] = ()) -> List[str]:
     lines = []

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -1,6 +1,7 @@
 """Utilities for pretty-printing IR in a human-readable form."""
 
-from typing import Any, Dict, List
+from collections import defaultdict
+from typing import Any, Dict, List, Union, Sequence, Tuple
 
 from typing_extensions import Final
 
@@ -10,12 +11,13 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast, Box, Unbox,
     RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp, LoadMem, SetMem,
     GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp, LoadLiteral,
-    AssignMulti, KeepAlive
+    AssignMulti, KeepAlive, Op
 )
 from mypyc.ir.func_ir import FuncIR, all_values_full
 from mypyc.ir.module_ir import ModuleIRs
 from mypyc.ir.rtypes import is_bool_rprimitive, is_int_rprimitive, RType
 
+ErrorSource = Union[BasicBlock, Op]
 
 class IRPrettyPrintVisitor(OpVisitor[str]):
     """Internal visitor that pretty-prints ops."""
@@ -269,7 +271,8 @@ def format_registers(func_ir: FuncIR,
 
 
 def format_blocks(blocks: List[BasicBlock],
-                  names: Dict[Value, str]) -> List[str]:
+                  names: Dict[Value, str],
+                  source_to_error: Dict[ErrorSource, List[str]]) -> List[str]:
     """Format a list of IR basic blocks into a human-readable form."""
     # First label all of the blocks
     for i, block in enumerate(blocks):
@@ -290,22 +293,29 @@ def format_blocks(blocks: List[BasicBlock],
             handler_msg = ' (handler for {})'.format(', '.join(labels))
 
         lines.append('L%d:%s' % (block.label, handler_msg))
+        if block in source_to_error:
+            for error in source_to_error[block]:
+                lines.append(f"  ERR: {error}")
         ops = block.ops
         if (isinstance(ops[-1], Goto) and i + 1 < len(blocks)
-                and ops[-1].label == blocks[i + 1]):
-            # Hide the last goto if it just goes to the next basic block.
+                and ops[-1].label == blocks[i + 1]
+                and not source_to_error.get(ops[-1], [])):
+            # Hide the last goto if it just goes to the next basic block,
+            # and there are no assocatiated errors with the op.
             ops = ops[:-1]
         for op in ops:
             line = '    ' + op.accept(visitor)
             lines.append(line)
+            if op in source_to_error:
+                for error in source_to_error[op]:
+                    lines.append(f"  ERR: {error}")
 
         if not isinstance(block.ops[-1], (Goto, Branch, Return, Unreachable)):
             # Each basic block needs to exit somewhere.
             lines.append('    [MISSING BLOCK EXIT OPCODE]')
     return lines
 
-
-def format_func(fn: FuncIR) -> List[str]:
+def format_func(fn: FuncIR, errors: Sequence[Tuple[ErrorSource, str]] = ()) -> List[str]:
     lines = []
     cls_prefix = fn.class_name + '.' if fn.class_name else ''
     lines.append('def {}{}({}):'.format(cls_prefix, fn.name,
@@ -313,7 +323,12 @@ def format_func(fn: FuncIR) -> List[str]:
     names = generate_names_for_ir(fn.arg_regs, fn.blocks)
     for line in format_registers(fn, names):
         lines.append('    ' + line)
-    code = format_blocks(fn.blocks, names)
+
+    source_to_error = defaultdict(list)
+    for source, error in errors:
+        source_to_error[source].append(error)
+
+    code = format_blocks(fn.blocks, names, source_to_error)
     lines.extend(code)
     return lines
 

--- a/mypyc/test/test_ircheck.py
+++ b/mypyc/test/test_ircheck.py
@@ -1,0 +1,75 @@
+import unittest
+from typing import List
+
+from mypyc.analysis.ircheck import check_funcdef, FnError
+from mypyc.ir.rtypes import none_rprimitive
+from mypyc.ir.ops import BasicBlock, Op, Return, Integer, Goto
+from mypyc.ir.func_ir import FuncIR, FuncDecl, FuncSignature
+
+
+def assert_has_error(fn: FuncIR, error: FnError) -> None:
+    errors = check_funcdef(fn)
+    assert errors == [error]
+
+
+def assert_no_errors(fn: FuncIR) -> None:
+    assert not check_funcdef(fn)
+
+
+NONE_VALUE = Integer(0, rtype=none_rprimitive)
+
+
+class TestIrcheck(unittest.TestCase):
+    def setUp(self) -> None:
+        self.label = 0
+
+    def basic_block(self, ops: List[Op]) -> BasicBlock:
+        self.label += 1
+        block = BasicBlock(self.label)
+        block.ops = ops
+        return block
+
+    def func_decl(self, name: str) -> FuncDecl:
+        return FuncDecl(name=name, class_name=None, module_name="module", sig=FuncSignature(
+            args=[], ret_type=none_rprimitive,
+        ))
+
+    def test_valid_fn(self) -> None:
+        assert_no_errors(FuncIR(
+            decl=self.func_decl(name="func_1"),
+            arg_regs=[],
+            blocks=[self.basic_block(ops=[
+                Return(value=NONE_VALUE),
+            ])],
+        ))
+
+    def test_block_not_terminated_empty_block(self) -> None:
+        block = self.basic_block([])
+        fn = FuncIR(
+            decl=self.func_decl(name="func_1"),
+            arg_regs=[],
+            blocks=[block],
+        )
+        assert_has_error(fn, FnError(source=block, desc="Block not terminated"))
+
+    def test_valid_goto(self) -> None:
+        block_1 = self.basic_block([Return(value=NONE_VALUE)])
+        block_2 = self.basic_block([Goto(label=block_1)])
+        fn = FuncIR(
+            decl=self.func_decl(name="func_1"),
+            arg_regs=[],
+            blocks=[block_1, block_2],
+        )
+        assert_no_errors(fn)
+
+    def test_invalid_goto(self) -> None:
+        block_1 = self.basic_block([Return(value=NONE_VALUE)])
+        goto = Goto(label=block_1)
+        block_2 = self.basic_block([goto])
+        fn = FuncIR(
+            decl=self.func_decl(name="func_1"),
+            arg_regs=[],
+            # block_1 omitted
+            blocks=[block_2],
+        )
+        assert_has_error(fn, FnError(source=goto, desc="Invalid control operation target: 1"))

--- a/mypyc/test/test_ircheck.py
+++ b/mypyc/test/test_ircheck.py
@@ -5,6 +5,7 @@ from mypyc.analysis.ircheck import check_funcdef, FnError
 from mypyc.ir.rtypes import none_rprimitive
 from mypyc.ir.ops import BasicBlock, Op, Return, Integer, Goto
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FuncSignature
+from mypyc.ir.pprint import format_func
 
 
 def assert_has_error(fn: FuncIR, error: FnError) -> None:
@@ -73,3 +74,22 @@ class TestIrcheck(unittest.TestCase):
             blocks=[block_2],
         )
         assert_has_error(fn, FnError(source=goto, desc="Invalid control operation target: 1"))
+
+    def test_pprint(self) -> None:
+        block_1 = self.basic_block([Return(value=NONE_VALUE)])
+        goto = Goto(label=block_1)
+        block_2 = self.basic_block([goto])
+        fn = FuncIR(
+            decl=self.func_decl(name="func_1"),
+            arg_regs=[],
+            # block_1 omitted
+            blocks=[block_2],
+        )
+        errors = [(goto, "Invalid control operation target: 1")]
+        formatted = format_func(fn, errors)
+        assert formatted == [
+            "def func_1():",
+            "L0:",
+            "    goto L1",
+            "  ERR: Invalid control operation target: 1",
+        ]

--- a/mypyc/test/test_ircheck.py
+++ b/mypyc/test/test_ircheck.py
@@ -1,7 +1,7 @@
 import unittest
 from typing import List
 
-from mypyc.analysis.ircheck import check_funcdef, FnError
+from mypyc.analysis.ircheck import check_func_ir, FnError
 from mypyc.ir.rtypes import none_rprimitive
 from mypyc.ir.ops import BasicBlock, Op, Return, Integer, Goto
 from mypyc.ir.func_ir import FuncIR, FuncDecl, FuncSignature
@@ -9,12 +9,12 @@ from mypyc.ir.pprint import format_func
 
 
 def assert_has_error(fn: FuncIR, error: FnError) -> None:
-    errors = check_funcdef(fn)
+    errors = check_func_ir(fn)
     assert errors == [error]
 
 
 def assert_no_errors(fn: FuncIR) -> None:
-    assert not check_funcdef(fn)
+    assert not check_func_ir(fn)
 
 
 NONE_VALUE = Integer(0, rtype=none_rprimitive)

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -15,6 +15,7 @@ from mypy.test.config import test_temp_dir
 from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.options import CompilerOptions
+from mypyc.analysis.ircheck import check_funcdef_and_crash
 from mypyc.ir.func_ir import FuncIR
 from mypyc.errors import Errors
 from mypyc.irbuild.main import build_ir
@@ -118,6 +119,8 @@ def build_ir_for_single_file(input_lines: List[str],
         raise CompileError(errors.new_messages())
 
     module = list(modules.values())[0]
+    for fn in module.functions:
+        check_funcdef_and_crash(fn)
     return module.functions
 
 

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -15,7 +15,7 @@ from mypy.test.config import test_temp_dir
 from mypy.test.helpers import assert_string_arrays_equal
 
 from mypyc.options import CompilerOptions
-from mypyc.analysis.ircheck import check_funcdef_and_crash
+from mypyc.analysis.ircheck import assert_func_ir_valid
 from mypyc.ir.func_ir import FuncIR
 from mypyc.errors import Errors
 from mypyc.irbuild.main import build_ir
@@ -120,7 +120,7 @@ def build_ir_for_single_file(input_lines: List[str],
 
     module = list(modules.values())[0]
     for fn in module.functions:
-        check_funcdef_and_crash(fn)
+        assert_func_ir_valid(fn)
     return module.functions
 
 


### PR DESCRIPTION
Adds a new module for performing analysis checks on ir as several bugs
in mypy had underlying issues in which the ir produced by mypy was
invalid and guaranteed to have issues at runtime.

For now the checks are relatively simple - the only two supported are
some validity on basic blocks: that they terminate and that control
ops reference a basic block within the same function.

In addition it would be useful if we had an ir parser so we could have a
test framework similar to other parts of mypyc in which we simply write
the IR in text format instead of constructing the IR ast from within
python.

The first commit here implements the checking but not the presentation;
the second implements basic presentation and integrates it into the test framework.