### PR TITLE
[mypyc] fix build on windows

### DIFF
--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -512,7 +512,7 @@ int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected) {
 
 // Parse an integer (size_t) encoded as a variable-length binary sequence.
 static const char *parse_int(const char *s, size_t *len) {
-    ssize_t n = 0;
+    Py_ssize_t n = 0;
     while ((unsigned char)*s >= 0x80) {
         n = (n << 7) + (*s & 0x7f);
         s++;


### PR DESCRIPTION
Trying to fix https://github.com/mypyc/mypy_mypyc-wheels/pull/28,
Don't understand why other windows builds don't complain though...

```
build\misc_ops.c(515): error C2065: 'ssize_t': undeclared identifier
build\misc_ops.c(515): error C2146: syntax error: missing ';' before identifier 'n'
build\misc_ops.c(515): error C2065: 'n': undeclared identifier
build\misc_ops.c(517): error C2065: 'n': undeclared identifier
build\misc_ops.c(520): error C2065: 'n': undeclared identifier
build\misc_ops.c(521): error C2065: 'n': undeclared identifier
```