### PR TITLE
Add Github Action definition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,9 @@ inputs:
     required: false
   paths:
     description: >
-      Explicit paths to run mypy on. Defaults to the current directory and
-      the `files` value from mypy configuration file.
+      Explicit paths to run mypy on. Defaults to the current directory.
     required: false
-    default: ""
+    default: "."
   version:
     description: >
       Mypy version to use (PEP440) - e.g. "0.910"


### PR DESCRIPTION
Define a Github Action that can be used as a canonical way of running mypy as part of Github CI workflows as easy as:

    jobs:
      lint:
        runs-on: ubuntu-latest
        steps:
          - uses: python/mypy@master

The action is inspired by its equivalent in [black](https://github.com/psf/black/blob/main/action.yml) and supports the following options:

    with:
       options: "..."  # mypy command-line options
       paths: "."  # a list of paths to check
       version: "0.910"  # mypy version to use
       install_types: yes|no  # whether to auto-install stubs

[Example run](https://github.com/edgedb/metapkg/runs/3875374320?check_suite_focus=true#step:4:45)