### PR TITLE
Fix cmdline package tests for namespace packages

### DIFF
--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -79,7 +79,7 @@ dir/subdir/b.py:1: error: Name "undef" is not defined
 [file pkg/__init__.py]
 [file pkg/a.py]
 undef
-import a
+import pkg.a
 [file pkg/subdir/a.py]
 undef
 import pkg.a
@@ -306,13 +306,13 @@ mypy.ini: [mypy-*]: Per-module sections should only specify per-module flags (py
 [file mypy.ini]
 \[mypy]
 mypy_path =
-    foo:bar
-    , baz
-[file foo/foo.pyi]
+    foo_dir:bar_dir
+    , baz_dir
+[file foo_dir/foo.pyi]
 def foo(x: int) -> str: ...
-[file bar/bar.pyi]
+[file bar_dir/bar.pyi]
 def bar(x: str) -> list: ...
-[file baz/baz.pyi]
+[file baz_dir/baz.pyi]
 def baz(x: list) -> dict: ...
 [file file.py]
 import no_stubs


### PR DESCRIPTION
Prep for #9636

First test was failing because a was not a valid import (pkg.a was)

Second test  was failing because `foo.py` resolved in two ways, both
as `foo` and `foo.foo`. Disambiguating the dir from the file made
mypy path work better. The error message was very clear. Came up once
foo can be a namespace package.

Confirmed that all these tests pass here - as well as on top of #9636 