### PR TITLE
Support --exclude more than once on command line

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -59,8 +59,8 @@ for full details, see :ref:`running-mypy`.
     pass ``--exclude '/setup\.py$'``. Similarly, you can ignore discovering
     directories with a given name by e.g. ``--exclude /build/`` or
     those matching a subpath with ``--exclude /project/vendor/``. To ignore
-    multiple files / directories / paths, you can combine expressions with
-    ``|``, e.g ``--exclude '/setup\.py$|/build/'``.
+    multiple files / directories / paths, you can provide the --exclude
+    flag more than once, e.g ``--exclude '/setup\.py$' --exclude '/build/'``.
 
     Note that this flag only affects recursive directory tree discovery, that
     is, when mypy is discovering files within a directory tree or submodules of

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -197,11 +197,18 @@ section of the command line docs.
 
 .. confval:: exclude
 
-    :type: regular expression
+    :type: newline separated list of regular expressions
 
-    A regular expression that matches file names, directory names and paths
+    A newline list of regular expression that matches file names, directory names and paths
     which mypy should ignore while recursively discovering files to check.
     Use forward slashes on all platforms.
+
+    .. code-block:: ini
+
+      [mypy]
+      exclude =
+          ^file1\.py$
+          ^file2\.py$
 
     For more details, see :option:`--exclude <mypy --exclude>`.
 

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -124,6 +124,7 @@ ini_config_types: Final[Dict[str, _INI_PARSER_CALLABLE]] = {
     'cache_dir': expand_path,
     'python_executable': expand_path,
     'strict': bool,
+    'exclude': lambda s: [p.strip() for p in s.split('\n') if p.strip()],
 }
 
 # Reuse the ini_config_types and overwrite the diff

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -864,11 +864,13 @@ def process_options(args: List[str],
         group=code_group)
     code_group.add_argument(
         "--exclude",
+        action="append",
         metavar="PATTERN",
-        default="",
+        default=[],
         help=(
             "Regular expression to match file names, directory names or paths which mypy should "
-            "ignore while recursively discovering files to check, e.g. --exclude '/setup\\.py$'"
+            "ignore while recursively discovering files to check, e.g. --exclude '/setup\\.py$'. "
+            "May be specified more than once, eg. --exclude a --exclude b"
         )
     )
     code_group.add_argument(

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -500,16 +500,21 @@ class FindModuleCache:
         return sources
 
 
-def matches_exclude(subpath: str, exclude: str, fscache: FileSystemCache, verbose: bool) -> bool:
-    if not exclude:
+def matches_exclude(subpath: str,
+                    excludes: List[str],
+                    fscache: FileSystemCache,
+                    verbose: bool) -> bool:
+    if not excludes:
         return False
     subpath_str = os.path.relpath(subpath).replace(os.sep, "/")
     if fscache.isdir(subpath):
         subpath_str += "/"
-    if re.search(exclude, subpath_str):
-        if verbose:
-            print("TRACE: Excluding {}".format(subpath_str), file=sys.stderr)
-        return True
+    for exclude in excludes:
+        if re.search(exclude, subpath_str):
+            if verbose:
+                print("TRACE: Excluding {} (matches pattern {})".format(subpath_str, exclude),
+                      file=sys.stderr)
+            return True
     return False
 
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -100,7 +100,7 @@ class Options:
         # top-level __init__.py to your packages.
         self.explicit_package_bases = False
         # File names, directory names or subpaths to avoid checking
-        self.exclude: str = ""
+        self.exclude: List[str] = []
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1309,3 +1309,57 @@ pkg.py:1: error: "int" not callable
 1()
 [out]
 pkg.py:1: error: "int" not callable
+
+[case testCmdlineExclude]
+# cmd: mypy --exclude abc .
+[file abc/apkg.py]
+1()
+[file b/bpkg.py]
+1()
+[file c/cpkg.py]
+1()
+[out]
+c/cpkg.py:1: error: "int" not callable
+b/bpkg.py:1: error: "int" not callable
+
+[case testCmdlineMultipleExclude]
+# cmd: mypy --exclude abc --exclude b/ .
+[file abc/apkg.py]
+1()
+[file b/bpkg.py]
+1()
+[file c/cpkg.py]
+1()
+[out]
+c/cpkg.py:1: error: "int" not callable
+
+[case testCmdlineCfgExclude]
+# cmd: mypy .
+[file mypy.ini]
+\[mypy]
+exclude = abc
+[file abc/apkg.py]
+1()
+[file b/bpkg.py]
+1()
+[file c/cpkg.py]
+1()
+[out]
+c/cpkg.py:1: error: "int" not callable
+b/bpkg.py:1: error: "int" not callable
+
+[case testCmdlineCfgMultipleExclude]
+# cmd: mypy .
+[file mypy.ini]
+\[mypy]
+exclude =
+    abc
+    b
+[file abc/apkg.py]
+1()
+[file b/bpkg.py]
+1()
+[file c/cpkg.py]
+1()
+[out]
+c/cpkg.py:1: error: "int" not callable


### PR DESCRIPTION
### Description

Support --exclude more than once on command line

The result is an "OR" of all the patterns provided.
Should be fully backward compatible to existing folks.

Fixes #10310

## Test Plan

Added tests for the new behavior to `test_find_sources.py`. Also did a quick manual test to make sure command line arguments are working ok.