### PR TITLE
Discard deprecated `builtin_type` api

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -438,7 +438,7 @@ def check_final_member(name: str, info: TypeInfo, msg: MessageBuilder, ctx: Cont
 
 def analyze_descriptor_access(instance_type: Type,
                               descriptor_type: Type,
-                              builtin_type: Callable[[str], Instance],
+                              named_type: Callable[[str], Instance],
                               msg: MessageBuilder,
                               context: Context, *,
                               chk: 'mypy.checker.TypeChecker') -> Type:
@@ -460,7 +460,7 @@ def analyze_descriptor_access(instance_type: Type,
     if isinstance(descriptor_type, UnionType):
         # Map the access over union types
         return make_simplified_union([
-            analyze_descriptor_access(instance_type, typ, builtin_type,
+            analyze_descriptor_access(instance_type, typ, named_type,
                                       msg, context, chk=chk)
             for typ in descriptor_type.items
         ])
@@ -476,7 +476,7 @@ def analyze_descriptor_access(instance_type: Type,
         msg.fail(message_registry.DESCRIPTOR_GET_NOT_CALLABLE.format(descriptor_type), context)
         return AnyType(TypeOfAny.from_error)
 
-    function = function_type(dunder_get, builtin_type('builtins.function'))
+    function = function_type(dunder_get, named_type('builtins.function'))
     bound_method = bind_self(function, descriptor_type)
     typ = map_instance_to_supertype(descriptor_type, dunder_get.info)
     dunder_get_type = expand_type_by_instance(bound_method, typ)
@@ -518,7 +518,7 @@ def analyze_descriptor_access(instance_type: Type,
 
 
 def instance_alias_type(alias: TypeAlias,
-                        builtin_type: Callable[[str], Instance]) -> Type:
+                        named_type: Callable[[str], Instance]) -> Type:
     """Type of a type alias node targeting an instance, when appears in runtime context.
 
     As usual, we first erase any unbound type variables to Any.
@@ -528,7 +528,7 @@ def instance_alias_type(alias: TypeAlias,
                       Instance), "Must be called only with aliases to classes"
     target = get_proper_type(set_any_tvars(alias, alias.line, alias.column))
     assert isinstance(target, Instance)
-    tp = type_object_type(target.type, builtin_type)
+    tp = type_object_type(target.type, named_type)
     return expand_type_by_instance(tp, target)
 
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -298,11 +298,6 @@ class SemanticAnalyzerPluginInterface:
         raise NotImplementedError
 
     @abstractmethod
-    def builtin_type(self, fully_qualified_name: str) -> Instance:
-        """Deprecated: use named_type instead."""
-        raise NotImplementedError
-
-    @abstractmethod
     def lookup_fully_qualified(self, name: str) -> SymbolTableNode:
         """Lookup a symbol by its fully qualified name.
 

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -97,7 +97,7 @@ class Attribute:
             converter_type: Optional[Type] = None
             if converter and isinstance(converter.node, TypeInfo):
                 from mypy.checkmember import type_object_type  # To avoid import cycle.
-                converter_type = type_object_type(converter.node, ctx.api.builtin_type)
+                converter_type = type_object_type(converter.node, ctx.api.named_type)
             elif converter and isinstance(converter.node, OverloadedFuncDef):
                 converter_type = converter.node.type
             elif converter and converter.type:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -732,7 +732,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             # This is a property.
             first_item.func.is_overload = True
             self.analyze_property_with_multi_part_definition(defn)
-            typ = function_type(first_item.func, self.builtin_type('builtins.function'))
+            typ = function_type(first_item.func, self.named_type('builtins.function'))
             assert isinstance(typ, CallableType)
             types = [typ]
         else:
@@ -789,7 +789,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 item.accept(self)
             # TODO: support decorated overloaded functions properly
             if isinstance(item, Decorator):
-                callable = function_type(item.func, self.builtin_type('builtins.function'))
+                callable = function_type(item.func, self.named_type('builtins.function'))
                 assert isinstance(callable, CallableType)
                 if not any(refers_to_fullname(dec, 'typing.overload')
                            for dec in item.decorators):
@@ -4403,12 +4403,6 @@ class SemanticAnalyzer(NodeVisitor[None],
             # TODO: More explicit handling of incomplete refs?
             self.record_incomplete_ref()
         return result
-
-    def builtin_type(self, fully_qualified_name: str) -> Instance:
-        sym = self.lookup_fully_qualified(fully_qualified_name)
-        node = sym.node
-        assert isinstance(node, TypeInfo)
-        return Instance(node, [AnyType(TypeOfAny.special_form)] * len(node.defn.type_vars))
 
     def object_type(self) -> Instance:
         return self.named_type('builtins.object')

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -288,7 +288,7 @@ class SuggestionEngine:
             fdef.arg_kinds,
             fdef.arg_names,
             AnyType(TypeOfAny.suggestion_engine),
-            self.builtin_type('builtins.function'))
+            self.named_type('builtins.function'))
 
     def get_starting_type(self, fdef: FuncDef) -> CallableType:
         if isinstance(fdef.type, CallableType):
@@ -351,7 +351,7 @@ class SuggestionEngine:
     def add_adjustments(self, typs: List[Type]) -> List[Type]:
         if not self.try_text or self.manager.options.python_version[0] != 2:
             return typs
-        translator = StrToText(self.builtin_type)
+        translator = StrToText(self.named_type)
         return dedup(typs + [tp.accept(translator) for tp in typs])
 
     def get_guesses(self, is_method: bool, base: CallableType, defaults: List[Optional[Type]],
@@ -648,8 +648,8 @@ class SuggestionEngine:
         assert state.tree is not None
         return state.tree
 
-    def builtin_type(self, s: str) -> Instance:
-        return self.manager.semantic_analyzer.builtin_type(s)
+    def named_type(self, s: str) -> Instance:
+        return self.manager.semantic_analyzer.named_type(s)
 
     def json_suggestion(self, mod: str, func_name: str, node: FuncDef,
                         suggestion: PyAnnotateSignature) -> str:
@@ -850,8 +850,8 @@ class TypeFormatter(TypeStrVisitor):
 
 
 class StrToText(TypeTranslator):
-    def __init__(self, builtin_type: Callable[[str], Instance]) -> None:
-        self.text_type = builtin_type('builtins.unicode')
+    def __init__(self, named_type: Callable[[str], Instance]) -> None:
+        self.text_type = named_type('builtins.unicode')
 
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:
         exp_t = get_proper_type(t)

--- a/test-data/unit/plugins/common_api_incremental.py
+++ b/test-data/unit/plugins/common_api_incremental.py
@@ -24,7 +24,7 @@ def add_info_hook(ctx) -> None:
 
     info = TypeInfo(SymbolTable(), class_def, ctx.api.cur_mod_id)
     class_def.info = info
-    obj = ctx.api.builtin_type('builtins.object')
+    obj = ctx.api.named_type('builtins.object')
     info.mro = [info, obj.type]
     info.bases = [obj]
     ctx.api.add_symbol_table_node(ctx.name, SymbolTableNode(GDEF, info))

--- a/test-data/unit/plugins/dyn_class.py
+++ b/test-data/unit/plugins/dyn_class.py
@@ -23,7 +23,7 @@ def add_info_hook(ctx):
 
     info = TypeInfo(SymbolTable(), class_def, ctx.api.cur_mod_id)
     class_def.info = info
-    obj = ctx.api.builtin_type('builtins.object')
+    obj = ctx.api.named_type('builtins.object')
     info.mro = [info, obj.type]
     info.bases = [obj]
     ctx.api.add_symbol_table_node(ctx.name, SymbolTableNode(GDEF, info))

--- a/test-data/unit/plugins/dyn_class_from_method.py
+++ b/test-data/unit/plugins/dyn_class_from_method.py
@@ -18,7 +18,7 @@ def add_info_hook(ctx: DynamicClassDefContext):
     class_def.info = info
     queryset_type_fullname = ctx.call.args[0].fullname
     queryset_info = ctx.api.lookup_fully_qualified_or_none(queryset_type_fullname).node  # type: TypeInfo
-    obj = ctx.api.builtin_type('builtins.object')
+    obj = ctx.api.named_type('builtins.object')
     info.mro = [info, queryset_info, obj.type]
     info.bases = [Instance(queryset_info, [])]
     ctx.api.add_symbol_table_node(ctx.name, SymbolTableNode(GDEF, info))


### PR DESCRIPTION
### Description

Related to https://github.com/python/mypy/issues/6578.

`builtin_type` could be totally replaced with `named_type` after https://github.com/python/mypy/pull/11332. Also renames other `builtin_type` for consistency since all of them are actually calling `named_type`.