### PR TITLE
fix(11064): fix crash due to undefined cyclic `import *`

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4670,7 +4670,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         symbol = SymbolTableNode(node.kind, node.node,
                                  module_public=module_public,
                                  module_hidden=module_hidden)
-        self.add_symbol_table_node(name, symbol, context)
+        self.add_symbol_table_node(name, symbol, context, can_defer=not self.final_iteration)
 
     def add_unknown_imported_symbol(self,
                                     name: str,

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -3132,3 +3132,35 @@ main:2: error: Cannot find implementation or library stub for module named "blea
 import bleach.xyz
 from bleach.abc import fgh
 [file bleach/__init__.pyi]
+
+[case testCyclicUndefinedImportWithName]
+import a
+[file a.py]
+from b import no_such_export
+[file b.py]
+from a import no_such_export  # E: Module "a" has no attribute "no_such_export"
+
+[case testCyclicUndefinedImportWithStar1]
+import a
+[file a.py]
+from b import no_such_export  # E: Module "b" has no attribute "no_such_export"
+[file b.py]
+from a import *
+
+[case testCyclicUndefinedImportWithStar2]
+import a
+[file a.py]
+from b import no_such_export  # E: Module "b" has no attribute "no_such_export"
+[file b.py]
+from c import *
+[file c.py]
+from a import *
+
+[case testCyclicUndefinedImportWithStar3]
+import test1
+[file test1.py]
+from dir1 import *
+[file dir1/__init__.py]
+from .test2 import *
+[file dir1/test2.py]
+from test1 import aaaa  # E: Module "test1" has no attribute "aaaa"


### PR DESCRIPTION
~(Sorry for another draft PR. I wanted to see CI's results. I'll soon write a detail below)~
Sorry for stalling this PR so long. I updated the description below.

### Description

Fixes https://github.com/python/mypy/issues/11064

It seems that the original issue has been fixed already (which corresponds to the test case `testCyclicUndefinedImportWithStar3`). However, the other two cases (`testCyclicUndefinedImportWithStar1` and `testCyclicUndefinedImportWithStar2`) still cause crash, so this PR is indended to fix them.
While working on the fix, first I tried to detect cyclic import during semanal (e.g. from `add_imported_symbol`), but in the end, it turns out simply setting `can_defer` produces sensible error message, so that's what this PR does.


## Test Plan

I added four tests related to cyclic import in `check-modules.test`:

- `testCyclicUndefinedImportWithName`
- `testCyclicUndefinedImportWithStar1`
- `testCyclicUndefinedImportWithStar2`
- `testCyclicUndefinedImportWithStar3` (replication of the linked issue)

where `testCyclicUndefinedImportWithName` and `testCyclicUndefinedImportWithStar3` are already working in current master, and the other two are addressed in this PR.
