### PR TITLE
Allow overriding an attribute with a property (#4125)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2406,7 +2406,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if isinstance(base_node, Var):
                     if base_node.property_funcdef:
                         type_ = base_node.property_funcdef.type
-                        assert isinstance(type, CallableType)
+                        assert isinstance(type_, CallableType)
                         base_type = type_.ret_type
                         if (len(rvalue.args) < 2) and base_node.is_settable_property:
                             self.fail(message_registry.READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE, rvalue)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2406,11 +2406,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if isinstance(base_node, Var):
                     if base_node.property_funcdef:
                         type_ = base_node.property_funcdef.type
-                        assert isinstance(type_, CallableType)
-                        base_type = type_.ret_type
-                        if (len(rvalue.args) < 2) and base_node.is_settable_property:
-                            self.fail(message_registry.READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE, rvalue)
-                            return False
+                        if isinstance(type_, CallableType):
+                            base_type = type_.ret_type
+                            if (len(rvalue.args) < 2) and base_node.is_settable_property:
+                                self.fail(message_registry.READ_ONLY_PROPERTY_OVERRIDES_READ_WRITE, rvalue)
+                                return False
                     else:
                         if len(rvalue.args) < 2:
                             self.fail('Overriding an attribute with a property requires '

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1540,8 +1540,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if context.is_property and isinstance(original_node, Var):
                 if isinstance(defn, Decorator):
                     if defn.var.is_settable_property:
-                        assert isinstance(defn.var.type, CallableType)
-                        if not is_equivalent(defn.var.type.ret_type, original_type):
+                        assert isinstance(typ, CallableType)
+                        if not is_equivalent(typ.ret_type, original_type):
                             self.fail('Signature of "{}" incompatible with {}'.format(
                                       defn.name, base.name), context)
                     else:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1543,10 +1543,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         assert isinstance(typ, CallableType)
                         if not is_equivalent(typ.ret_type, original_type):
                             self.fail('Signature of "{}" incompatible with {}'.format(
-                                      defn.name, base.name), context)
+                                      defn.name, base.name), context, code=codes.OVERRIDE)
                     else:
                         self.fail('Overriding an attribute with a property requires '
-                                  'defining a setter method', context)
+                                  'defining a setter method', context, code=codes.OVERRIDE)
                 elif isinstance(defn, OverloadedFuncDef):
                     # potential errors already reported by the checks above
                     pass

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -559,10 +559,11 @@ def analyze_var(name: str,
     """
     # Found a member variable.
     itype = map_instance_to_supertype(itype, var.info)
-    if var.property_funcdef:
-        typ = var.property_funcdef.type.ret_type
-    else:
+    if not var.property_funcdef:
         typ = var.type
+    else:
+        assert isinstance(var.property_funcdef.type, CallableType)
+        typ = var.property_funcdef.type.ret_type
     if typ:
         if isinstance(typ, PartialType):
             return mx.chk.handle_partial_var_type(typ, mx.is_lvalue, var, mx.context)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -559,7 +559,10 @@ def analyze_var(name: str,
     """
     # Found a member variable.
     itype = map_instance_to_supertype(itype, var.info)
-    typ = var.type
+    if var.property_funcdef:
+        typ = var.property_funcdef.type.ret_type
+    else:
+        typ = var.type
     if typ:
         if isinstance(typ, PartialType):
             return mx.chk.handle_partial_var_type(typ, mx.is_lvalue, var, mx.context)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -561,9 +561,12 @@ def analyze_var(name: str,
     itype = map_instance_to_supertype(itype, var.info)
     if not var.property_funcdef:
         typ = var.type
-    else:
-        assert isinstance(var.property_funcdef.type, CallableType)
+    elif isinstance(var.property_funcdef.type, CallableType):
         typ = var.property_funcdef.type.ret_type
+    elif not var.property_funcdef.type:
+        typ = None
+    else:
+        assert False, str(type(var.property_funcdef.type))
     if typ:
         if isinstance(typ, PartialType):
             return mx.chk.handle_partial_var_type(typ, mx.is_lvalue, var, mx.context)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -564,7 +564,9 @@ def analyze_var(name: str,
     elif isinstance(var.property_funcdef.type, CallableType):
         typ = var.property_funcdef.type.ret_type
     elif not var.property_funcdef.type:
-        typ = None
+        if mx.is_lvalue and not var.is_settable_property:
+            mx.msg.read_only_property(name, itype.type, mx.context)
+        return AnyType(TypeOfAny.special_form)
     else:
         assert False, str(type(var.property_funcdef.type))
     if typ:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -856,6 +856,7 @@ class Var(SymbolNode):
                  'is_classmethod',
                  'is_property',
                  'is_settable_property',
+                 'property_funcdef',
                  'is_classvar',
                  'is_abstract_var',
                  'is_final',
@@ -884,6 +885,7 @@ class Var(SymbolNode):
         self.is_classmethod = False
         self.is_property = False
         self.is_settable_property = False
+        self.property_funcdef = None  # Optional[FuncDef]
         self.is_classvar = False
         self.is_abstract_var = False
         # Set to true when this variable refers to a module we were unable to

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -885,7 +885,7 @@ class Var(SymbolNode):
         self.is_classmethod = False
         self.is_property = False
         self.is_settable_property = False
-        self.property_funcdef = None  # Optional[FuncDef]
+        self.property_funcdef: Optional[FuncDef] = None
         self.is_classvar = False
         self.is_abstract_var = False
         # Set to true when this variable refers to a module we were unable to

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2285,6 +2285,20 @@ class SemanticAnalyzer(NodeVisitor[None],
             self.analyze_lvalue(lval,
                                 explicit_type=explicit,
                                 is_final=s.is_final_def)
+            if len(s.lvalues) == 1:
+                rval = s.rvalue
+                if (
+                    (len(s.lvalues) == 1)
+                    and isinstance(lval.node, Var)
+                    and isinstance(rval, CallExpr)
+                    and (rval.callee is not None)
+                    and refers_to_fullname(rval.callee, 'builtins.property')
+                ):
+                    lval.node.is_property = True
+                    lval.node.property_funcdef = rval.args[0].node
+                    if len(rval.args) > 1:
+                        lval.node.is_settable_property = True
+
 
     def apply_dynamic_class_hook(self, s: AssignmentStmt) -> None:
         if len(s.lvalues) > 1:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2285,19 +2285,22 @@ class SemanticAnalyzer(NodeVisitor[None],
             self.analyze_lvalue(lval,
                                 explicit_type=explicit,
                                 is_final=s.is_final_def)
-            if len(s.lvalues) == 1:
-                rval = s.rvalue
-                if (
-                    (len(s.lvalues) == 1)
-                    and isinstance(lval.node, Var)
-                    and isinstance(rval, CallExpr)
-                    and (rval.callee is not None)
-                    and refers_to_fullname(rval.callee, 'builtins.property')
-                ):
-                    lval.node.is_property = True
-                    lval.node.property_funcdef = rval.args[0].node
-                    if len(rval.args) > 1:
-                        lval.node.is_settable_property = True
+        rval = s.rvalue
+        if (
+            (len(s.lvalues) == 1)
+            and isinstance(lval, NameExpr)
+            and isinstance(lval.node, Var)
+            and isinstance(rval, CallExpr)
+            and (rval.callee is not None)
+            and refers_to_fullname(rval.callee, 'builtins.property')
+            and rval.args
+            and isinstance(rval.args[0], NameExpr)
+            and isinstance(rval.args[0].node, FuncDef)
+        ):
+            lval.node.is_property = True
+            lval.node.property_funcdef = rval.args[0].node
+            if len(rval.args) > 1:
+                lval.node.is_settable_property = True
 
 
     def apply_dynamic_class_hook(self, s: AssignmentStmt) -> None:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1360,6 +1360,29 @@ a.f = a.f # E: Property "f" defined in "A" is read-only
 a.f.x # E: "int" has no attribute "x"
 [builtins fixtures/property.pyi]
 
+[case testOverrideAttributeWithProperty]
+class A:
+    x: int
+    y: int
+    z: int
+class B(A):
+    @property
+    def x(self) -> int:
+        ...
+    @x.setter
+    def x(self, v: int) -> None:
+        ...
+    @property
+    def y(self) -> int:  # E: Overriding an attribute with a property requires defining a setter method
+        ...
+    @property
+    def z(self) -> str:  # E: Signature of "z" incompatible with A
+        ...
+    @z.setter
+    def z(self, v: str) -> None:
+        ...
+[builtins fixtures/property.pyi]
+
 -- Descriptors
 -- -----------
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1278,20 +1278,38 @@ main:8: note:          def f(self) -> None
 
 
 [case testAccessingReadOnlyProperty]
-import typing
 class A:
     @property
-    def f(self) -> str: pass
+    def x1(self) -> str: pass
+    def gx2(self) -> str: pass
+    x2 = property(gx2)
+    @property
+    def x3(self): pass
+    def gx4(self): pass
+    x4 = property(gx4)
 a = A()
-reveal_type(a.f)  # N: Revealed type is "builtins.str"
+reveal_type(a.x1)  # N: Revealed type is "builtins.str"
+reveal_type(a.x2)  # N: Revealed type is "builtins.str"
+reveal_type(a.x3)  # N: Revealed type is "Any"
+reveal_type(a.x4)  # N: Revealed type is "Any"
 [builtins fixtures/property.pyi]
 
 [case testAssigningToReadOnlyProperty]
 import typing
 class A:
     @property
-    def f(self) -> str: pass
-A().f = '' # E: Property "f" defined in "A" is read-only
+    def x1(self) -> str: pass
+    def gx2(self) -> str: pass
+    x2 = property(gx2)
+    @property
+    def x3(self): pass
+    def gx4(self): pass
+    x4 = property(gx4)
+a = A()
+a.x1 = '' # E: Property "x1" defined in "A" is read-only
+a.x2 = '' # E: Property "x2" defined in "A" is read-only
+a.x3 = '' # E: Property "x3" defined in "A" is read-only
+a.x4 = '' # E: Property "x4" defined in "A" is read-only
 [builtins fixtures/property.pyi]
 
 [case testAssigningToInheritedReadOnlyProperty]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1360,7 +1360,7 @@ a.f = a.f # E: Property "f" defined in "A" is read-only
 a.f.x # E: "int" has no attribute "x"
 [builtins fixtures/property.pyi]
 
-[case testOverrideAttributeWithProperty]
+[case testOverrideAttributeWithDecoratedProperty]
 class A:
     x: int
     y: int
@@ -1381,7 +1381,265 @@ class B(A):
     @z.setter
     def z(self, v: str) -> None:
         ...
+b: B
+reveal_type(b.x)  # N: Revealed type is "builtins.int"
+b.x = "y"  #  E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/property.pyi]
+
+[case testOverrideAttributeWithAssignedProperty]
+class A:
+    x: int
+    y: int
+    z: int
+class B(A):
+    def gx(self) -> int:
+        ...
+    def sx(self, v: int) -> None:
+        ...
+    x = property(gx, sx)
+    def gy(self) -> int:
+        ...
+    y = property(gy)  # E: Overriding an attribute with a property requires defining a setter method
+    def gz(self) -> str:
+        ...
+    def sz(self, v: str) -> None:
+        ...
+    z = property(gz, sz)  # E: Signature of "z" incompatible with A
+b: B
+reveal_type(b.x)  # N: Revealed type is "builtins.int"
+b.x = "y"  #  E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/property.pyi]
+
+[case testOverrideDecoratedPropertyWithDecoratedProperty]
+class A:
+    @property
+    def v(self) -> int:
+        ...
+    @v.setter
+    def v(self, v: int) -> None:
+        ...
+    @property
+    def w(self) -> int:
+        ...
+    @w.setter
+    def w(self, v: int) -> None:
+        ...
+    @property
+    def x(self) -> int:
+        ...
+    @property
+    def y(self) -> int:
+        ...
+    @property
+    def z(self) -> int:
+        ...
+    @z.setter
+    def z(self, v: int) -> None:
+        ...
+class B(A):
+    @property
+    def v(self) -> int:
+        ...
+    @w.setter
+    def v(self, v: int) -> None:
+        ...
+    @property  # E
+    def w(self) -> int:
+        ...
+    @property
+    def x(self) -> int:
+        ...
+    @property
+    def y(self) -> int:
+        ...
+    @y.setter
+    def y(self, v: int) -> None:
+        ...
+    @property
+    def z(self) -> str:  # E
+        ...
+    @z.setter
+    def z(self, v: str) -> None:
+        ...
+b: B
+reveal_type(b.v)
+b.v = "w"
+[out]
+main:33: error: Read-only property cannot override read-write property
+main:45: error: Signature of "z" incompatible with supertype "A"
+main:45: note:      Superclass:
+main:45: note:          @overload
+main:45: note:          def z(self) -> int
+main:45: note:      Subclass:
+main:45: note:          @overload
+main:45: note:          def z(self) -> str
+main:46: error: Signature of "z" incompatible with supertype "A"
+main:46: note:      Superclass:
+main:46: note:          @overload
+main:46: note:          def z(self) -> int
+main:46: note:      Subclass:
+main:46: note:          def z(self) -> str
+main:52: note: Revealed type is "builtins.int"
+main:53: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/property.pyi]
+
+[case testOverrideAssignedPropertyWithDecoratedProperty]
+class A:
+    def gv(self) -> int:
+        ...
+    def sv(self, v: int) -> None:
+        ...
+    v = property(gv, sv)
+    def gw(self) -> int:
+        ...
+    def sw(self, v: int) -> None:
+        ...
+    w = property(gw, sw)
+    def sx(self) -> int:
+        ...
+    x = property(sx)
+    def gy(self) -> int:
+        ...
+    y = property(gy)
+    def gz(self) -> int:
+        ...
+    def sz(self, v: int) -> None:
+        ...
+    z = property(gz, sz)
+class B(A):
+    @property
+    def v(self) -> int:
+        ...
+    @w.setter
+    def v(self, v: int) -> None:
+        ...
+    @property
+    def w(self) -> int:  # E: Read-only property cannot override read-write property
+        ...
+    @property
+    def x(self) -> int:
+        ...
+    @property
+    def y(self) -> int:
+        ...
+    @y.setter
+    def y(self, v: int) -> None:
+        ...
+    @property
+    def z(self) -> str:  # E: Signature of "z" incompatible with A
+        ...
+    @z.setter
+    def z(self, v: str) -> None:
+        ...
+b: B
+reveal_type(b.v) # N: Revealed type is "builtins.int"
+b.v = "w"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/property.pyi]
+
+[case testOverrideDecoratedPropertyWithAssignedProperty]
+class A:
+    @property
+    def v(self) -> int:
+        ...
+    @v.setter
+    def v(self, v: int) -> None:
+        ...
+    @property
+    def w(self) -> int:
+        ...
+    @w.setter
+    def w(self, v: int) -> None:
+        ...
+    @property
+    def x(self) -> int:
+        ...
+    @property
+    def y(self) -> int:
+        ...
+    @property
+    def z(self) -> int:
+        ...
+    @z.setter
+    def z(self, v: int) -> None:
+        ...
+class B(A):
+    def gv(self) -> int:
+        ...
+    def sv(self, v: int) -> None:
+        ...
+    v = property(gv, sv)
+    def gw(self) -> int:
+        ...
+    w = property(gw)  # E: Read-only property cannot override read-write property
+    def gx(self) -> int:
+        ...
+    x = property(gx)
+    def gy(self) -> int:
+        ...
+    def sy(self, v: int) -> None:
+        ...
+    y = property(gy, sy)
+    def gz(self) -> str:
+        ...
+    def sz(self, v: str) -> None:
+        ...
+    z = property(gz, sz)  # E: Signature of "z" incompatible with A
+b: B
+reveal_type(b.v) # N: Revealed type is "builtins.int"
+b.v = "w"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/property.pyi]
+
+
+[case testOverrideAssignedPropertyWithAssignedProperty]
+class A:
+    def gv(self) -> int:
+        ...
+    def sv(self, v: int) -> None:
+        ...
+    v = property(gv, sv)
+    def gw(self) -> int:
+        ...
+    def sw(self, v: int) -> None:
+        ...
+    w = property(gw, sw)
+    def sx(self) -> int:
+        ...
+    x = property(sx)
+    def gy(self) -> int:
+        ...
+    y = property(gy)
+    def gz(self) -> int:
+        ...
+    def sz(self, v: int) -> None:
+        ...
+    z = property(gz, sz)
+class B(A):
+    def gv(self) -> int:
+        ...
+    def sv(self, v: int) -> None:
+        ...
+    v = property(gv, sv)
+    def gw(self) -> int:
+        ...
+    w = property(gw)  # E: Read-only property cannot override read-write property
+    def gx(self) -> int:
+        ...
+    x = property(gx)
+    def gy(self) -> int:
+        ...
+    def sy(self, v: int) -> None:
+        ...
+    y = property(gy, sy)
+    def _gz(self) -> str:
+        ...
+    def _sz(self, v: str) -> None:
+        ...
+    z = property(_gz, _sz)  # E: Signature of "z" incompatible with A
+b: B
+reveal_type(b.v) # N: Revealed type is "builtins.int"
+b.v = "w"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/property.pyi]
+
 
 -- Descriptors
 -- -----------

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1245,8 +1245,9 @@ class A:
 @dataclass
 class B(A):
     @property
-    def foo(self) -> int: pass  # E: Signature of "foo" incompatible with supertype "A"
-
+    def foo(self) -> int: pass
+    @foo.setter
+    def foo(self, v: int) -> None: pass
 reveal_type(B)  # N: Revealed type is "def (foo: builtins.int) -> __main__.B"
 
 [builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -762,8 +762,13 @@ class B(A):
 class C(A):
     @property  # E: Cannot override final attribute "x" (previously declared in base class "A")
     def x(self) -> None: pass
+    @x.setter
+    def x(self, v: int) -> None: pass
     @property  # E: Cannot override final attribute "y" (previously declared in base class "A")
     def y(self) -> None: pass
+    @y.setter
+    def y(self, v: int) -> None: pass
+
 [builtins fixtures/property.pyi]
 [out]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1475,10 +1475,12 @@ class A:
         self.x = [] # E: Need type annotation for "x" (hint: "x: List[<type>] = ...")
 
 class B(A):
-    # TODO?: This error is kind of a false positive, unfortunately
     @property
-    def x(self) -> List[int]:  # E: Signature of "x" incompatible with supertype "A"
+    def x(self) -> List[int]:
         return [123]
+    @x.setter
+    def x(self, v: int) -> None:
+        ...
 [builtins fixtures/list.pyi]
 
 [case testInferSetInitializedToEmpty]

--- a/test-data/unit/fixtures/property.pyi
+++ b/test-data/unit/fixtures/property.pyi
@@ -11,7 +11,7 @@ class type:
 class function: pass
 
 class property(object):
-    def __init__(self, fget, fset=None) -> None:
+    def __init__(self, fget: typing.Any, fset: typing.Any = None) -> None:
         ...
 
 class dict: pass

--- a/test-data/unit/fixtures/property.pyi
+++ b/test-data/unit/fixtures/property.pyi
@@ -10,7 +10,9 @@ class type:
 
 class function: pass
 
-property = object()  # Dummy definition
+class property(object):
+    def __init__(self, fget, fset=None) -> None:
+        ...
 
 class dict: pass
 class int: pass


### PR DESCRIPTION
This PR fixes the bug reported [here](https://github.com/python/mypy/issues/4125#issue-265920831).  Note that it does not fix the bugs noted later (e.g. [this one](https://github.com/python/mypy/issues/4125#issuecomment-439856006)) in the same issue.  It seems like mypy does not realise the "x = property(getter, setter)" syntax at all (during semantic analysis), or am I missing something?

Also, note that I check for equality rather than a subtype relationship for the attribute and the property's return type.  As far as I know, properties still do not allow different setter and getter types.  As long as this holds, allowing a subtype relationship would violate LSP.