### PR TITLE
Extend contextmanager to asynccontextmanager

### DIFF
--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -15,6 +15,7 @@ from mypy.types import (
 from mypy.subtypes import is_subtype
 from mypy.typeops import make_simplified_union
 from mypy.checkexpr import is_literal_type_like
+from mypy.checker import detach_callable
 
 
 class DefaultPlugin(Plugin):
@@ -183,12 +184,12 @@ def contextmanager_callback(ctx: FunctionContext) -> Type:
                 and isinstance(default_return, CallableType)):
             # The stub signature doesn't preserve information about arguments so
             # add them back here.
-            return default_return.copy_modified(
+            return detach_callable(default_return.copy_modified(
                 arg_types=arg_type.arg_types,
                 arg_kinds=arg_type.arg_kinds,
                 arg_names=arg_type.arg_names,
                 variables=arg_type.variables,
-                is_ellipsis_args=arg_type.is_ellipsis_args)
+                is_ellipsis_args=arg_type.is_ellipsis_args))
     return ctx.default_return_type
 
 

--- a/test-data/unit/check-default-plugin.test
+++ b/test-data/unit/check-default-plugin.test
@@ -24,15 +24,37 @@ f = g # E: Incompatible types in assignment (expression has type "Callable[[Any,
 [typing fixtures/typing-medium.pyi]
 [builtins fixtures/tuple.pyi]
 
+[case testContextManagerWithGenericFunctionAndSendType]
+from contextlib import contextmanager
+from typing import TypeVar, Generator
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+@contextmanager
+def yield_id(item: T) -> Generator[T, S, None]:
+    yield item
+
+reveal_type(yield_id) # N: Revealed type is "def [T] (item: T`-1) -> contextlib.GeneratorContextManager[T`-1]"
+
+with yield_id(1) as x:
+    reveal_type(x) # N: Revealed type is "builtins.int*"
+
+f = yield_id
+def g(x, y): pass
+f = g # E: Incompatible types in assignment (expression has type "Callable[[Any, Any], Any]", variable has type "Callable[[T], GeneratorContextManager[T]]")
+[typing fixtures/typing-medium.pyi]
+[builtins fixtures/tuple.pyi]
+
 [case testAsyncContextManagerWithGenericFunction]
 # flags: --python-version 3.7
 from contextlib import asynccontextmanager
-from typing import TypeVar, AsyncGenerator
+from typing import TypeVar, AsyncIterator
 
 T = TypeVar('T')
 
 @asynccontextmanager
-async def yield_id(item: T) -> AsyncGenerator[T, None]:
+async def yield_id(item: T) -> AsyncIterator[T]:
     yield item
 
 reveal_type(yield_id) # N: Revealed type is "def [T] (item: T`-1) -> typing.AsyncContextManager[T`-1]"
@@ -54,7 +76,7 @@ S = TypeVar('S')
 async def yield_id(item: T) -> AsyncGenerator[T, S]:
     yield item
 
-reveal_type(yield_id) # N: Revealed type is "def [T, S] (item: T`-1) -> typing.AsyncContextManager[T`-1]"
+reveal_type(yield_id) # N: Revealed type is "def [T] (item: T`-1) -> typing.AsyncContextManager[T`-1]"
 
 async with yield_id(1) as x:
     reveal_type(x) # N: Revealed type is "builtins.int*"


### PR DESCRIPTION
Closes  #9922

### Description

Extending the existing special case for `contextlib.contextmanager` to `contextlib.asynccontextmanager`. When used with `TypeVar` gives much better type.


## Test Plan

I hope I have included the unit test you need. My minimal reproduction is:

```
from contextlib import asynccontextmanager
from typing import AsyncGenerator, Type, TypeVar

R = TypeVar("R")


@asynccontextmanager
async def foo(
    cls: Type[R],
) -> AsyncGenerator[R, None]:
    yield cls()


async def bar() -> int:
    async with foo(int) as foo_int:
        return (
            foo_int  # error: Incompatible return value type (got "R", expected "int")
        )
```