### PR TITLE
Fix PEP 561 tests for latest pip

### DIFF
--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -72,13 +72,16 @@ def install_package(pkg: str,
                 install_cmd.append('develop')
             else:
                 install_cmd.append('install')
+        # Note that newer versions of pip (21.3+) don't
+        # follow this env variable, but this is for compatibility
+        env = {'PIP_BUILD': dir}
+        # Inherit environment for Windows
+        env.update(os.environ)
         proc = subprocess.run(install_cmd,
                               cwd=working_dir,
                               stdout=PIPE,
                               stderr=PIPE,
-                              # Note that newer versions of pip (21.3+) don't
-                              # follow this env variable, but this is for compatibility
-                              env={'PIP_BUILD': dir})
+                              env=env)
     if proc.returncode != 0:
         raise Exception(proc.stdout.decode('utf-8') + proc.stderr.decode('utf-8'))
 


### PR DESCRIPTION
### Description

In pip 21.3 the build argument is removed, so this uses an environment
variable to still work on older versions.

Fixes https://github.com/python/mypy/issues/11355