### PR TITLE
stubgen: recognize qualified builtins decorators

### DIFF
--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -318,6 +318,93 @@ class A:
     @classmethod
     def f(cls) -> None: ...
 
+[case testQualifiedBuiltins]
+import builtins
+
+class A:
+    @builtins.property
+    def f(self):
+        return 1
+    @f.setter
+    def f(self, x): ...
+    def h(self):
+        self.f = 1
+    @builtins.staticmethod
+    def static(x): ...
+    @builtins.classmethod
+    def cls(cls): ...
+[out]
+import builtins
+
+class A:
+    @builtins.property
+    def f(self): ...
+    @f.setter
+    def f(self, x) -> None: ...
+    def h(self) -> None: ...
+    @builtins.staticmethod
+    def static(x) -> None: ...
+    @builtins.classmethod
+    def cls(cls) -> None: ...
+
+[case testQualifiedAliasedBuiltins]
+import builtins as b
+
+class A:
+    @b.property
+    def f(self):
+        return 1
+    @f.setter
+    def f(self, x): ...
+    def h(self):
+        self.f = 1
+    @b.staticmethod
+    def static(x): ...
+    @b.classmethod
+    def cls(cls): ...
+[out]
+import builtins as b
+
+class A:
+    @b.property
+    def f(self): ...
+    @f.setter
+    def f(self, x) -> None: ...
+    def h(self) -> None: ...
+    @b.staticmethod
+    def static(x) -> None: ...
+    @b.classmethod
+    def cls(cls) -> None: ...
+
+[case testAliasedBuiltins]
+from builtins import property as p, staticmethod as sm, classmethod as cm
+
+class A:
+    @p
+    def f(self):
+        return 1
+    @f.setter
+    def f(self, x): ...
+    def h(self):
+        self.f = 1
+    @sm
+    def static(x): ...
+    @cm
+    def cls(cls): ...
+[out]
+from builtins import classmethod as cm, property as p, staticmethod as sm
+
+class A:
+    @p
+    def f(self): ...
+    @f.setter
+    def f(self, x) -> None: ...
+    def h(self) -> None: ...
+    @sm
+    def static(x) -> None: ...
+    @cm
+    def cls(cls) -> None: ...
+
 [case testIfMainCheck]
 def a(): ...
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
Before this change, stubgen fails to recognize @builtins.property as the property decorator.

## Test Plan

New test cases in https://github.com/python/mypy/commit/4af31ca66309a04f87e9d91e46677a49743c40cd#diff-660bace74255abc117df6428b5fd549fa2a481988030ea96eb96c8b8a96baf3f
