### PR TITLE
[backport] cherry-pick slice-syntax fix for 0.920

### DIFF
--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -126,3 +126,20 @@ class Meta:
 x = Annotated[int, Meta()]
 reveal_type(x)  # N: Revealed type is "def () -> builtins.int"
 [builtins fixtures/tuple.pyi]
+
+[case testSliceAnnotated39]
+# flags: --python-version 3.9
+from typing_extensions import Annotated
+
+a: Annotated[int, 1:2]
+reveal_type(a)  # N: Revealed type is "builtins.int"
+
+[builtins fixtures/tuple.pyi]
+[case testSliceAnnotated38]
+# flags: --python-version 3.8
+from typing_extensions import Annotated
+
+a: Annotated[int, 1:2]
+reveal_type(a)  # N: Revealed type is "builtins.int"
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -873,3 +873,39 @@ lst: List[int] = []
 if lst:
     pass
 [builtins fixtures/list.pyi]
+
+[case testSliceInDict39]
+# flags: --python-version 3.9 --show-column-numbers
+from typing import Dict
+b: Dict[int, x:y]
+c: Dict[x:y]
+
+[builtins fixtures/dict.pyi]
+[out]
+main:3:14: error: Invalid type comment or annotation  [valid-type]
+main:3:14: note: did you mean to use ',' instead of ':' ?
+main:4:4: error: "dict" expects 2 type arguments, but 1 given  [type-arg]
+main:4:9: error: Invalid type comment or annotation  [valid-type]
+main:4:9: note: did you mean to use ',' instead of ':' ?
+
+[case testSliceInDict38]
+# flags: --python-version 3.8 --show-column-numbers
+from typing import Dict
+b: Dict[int, x:y]
+c: Dict[x:y]
+
+[builtins fixtures/dict.pyi]
+[out]
+main:3:14: error: Invalid type comment or annotation  [valid-type]
+main:3:14: note: did you mean to use ',' instead of ':' ?
+main:4:4: error: "dict" expects 2 type arguments, but 1 given  [type-arg]
+main:4:9: error: Invalid type comment or annotation  [valid-type]
+main:4:9: note: did you mean to use ',' instead of ':' ?
+
+
+[case testSliceInCustomTensorType]
+# syntactically mimics torchtyping.TensorType
+class TensorType: ...
+t: TensorType["batch":..., float]  # type: ignore
+reveal_type(t)  # N: Revealed type is "__main__.TensorType"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -321,8 +321,12 @@ x @= 1
 
 from typing import Dict
 x = None # type: Dict[x: y]
+
+[builtins fixtures/dict.pyi]
 [out]
-main:3: error: syntax error in type comment
+main:3: error: "dict" expects 2 type arguments, but 1 given
+main:3: error: Invalid type comment or annotation
+main:3: note: did you mean to use ',' instead of ':' ?
 
 [case testPrintStatementTrailingCommaFastParser_python2]
 

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -949,6 +949,21 @@ main:1: error: invalid syntax
 [out version>=3.10]
 main:1: error: invalid syntax. Perhaps you forgot a comma?
 
+[case testSliceInList39]
+# flags: --python-version 3.9
+x = [1, 2][1:2]
+[out]
+MypyFile:1(
+  AssignmentStmt:2(
+    NameExpr(x)
+    IndexExpr:2(
+      ListExpr:2(
+        IntExpr(1)
+        IntExpr(2))
+      SliceExpr:2(
+        IntExpr(1)
+        IntExpr(2)))))
+
 [case testDictionaryExpression]
 {}
 {1:x}


### PR DESCRIPTION
This PR cherrypicks #11345 onto the 0.920 release branch, as requested by @ilevkivskyi in https://github.com/python/mypy/issues/11158#issuecomment-954030303.