### PR TITLE
Do not auto-infer `TypeGuard` return type for `lambda`, refs #9927

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3560,6 +3560,12 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         callable_ctx = get_proper_type(replace_meta_vars(ctx, ErasedType()))
         assert isinstance(callable_ctx, CallableType)
 
+        if callable_ctx.type_guard is not None:
+            # Lambda's return type cannot be treated as a `TypeGuard`,
+            # because it is implicit. And `TypeGuard`s must be explicit.
+            # See https://github.com/python/mypy/issues/9927
+            return None, None
+
         arg_kinds = [arg.kind for arg in e.arguments]
 
         if callable_ctx.is_ellipsis_args:

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -247,7 +247,7 @@ def main1(a: object) -> None:
 
 [builtins fixtures/tuple.pyi]
 
-[case testTypeGuardOverload-skip]
+[case testTypeGuardOverload]
 # flags: --strict-optional
 from typing import overload, Any, Callable, Iterable, Iterator, List, Optional, TypeVar
 from typing_extensions import TypeGuard


### PR DESCRIPTION
Here's what was happening in this example:

```python
from typing import Callable, Iterable, Iterator, List, Optional, TypeVar

T = TypeVar("T")
R = TypeVar("R")

def filter(f: Callable[[T], TypeGuard[R]], it: Iterable[T]) -> Iterator[R]: ...

a: List[Optional[int]]
bb = filter(lambda x: x is not None, a)
reveal_type(bb)  # error, actually it is now: Revealed type is "typing.Iterator[R`2]"
```

Mypy uses special logic in `infer_lambda_type_using_context` to infer `lambda` type args and return type. Basically, it just returns the current callable context type. Which is `Callable[[T], TypeGuard[R]]` in our case.

But, now I've limited this function to ignore contexts with `TypeGuard`. Because I believe that `TypeGuard` must always be explicit.

After this change Mypy works correctly:

```
» mypy out/ex.py --show-traceback
out/ex.py:13: error: Argument 1 to "filter" has incompatible type "Callable[[Any], bool]"; expected "Callable[[Optional[int]], TypeGuard[bool]]"
out/ex.py:14: note: Revealed type is "typing.Iterator[builtins.bool*]"
Found 1 error in 1 file (checked 1 source file)
```

Because we don't allow `bool` return type where `TypeGuard` is expected after https://github.com/python/mypy/pull/11314

The test from @gvanrossum that used to be skipped now passes 🎉 

Closes #9927