### PR TITLE
Fixes RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+version: 2
+
+python:
+  version: 3.7
+  install:
+    - requirements: test-requirements.txt
+
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: true
+
+formats: all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 python:
   version: 3.7
   install:
-    - requirements: test-requirements.txt
+    - requirements: docs/requirements-docs.txt
 
 sphinx:
   configuration: docs/source/conf.py

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,2 +1,2 @@
-Sphinx >= 1.4.4
-sphinx-rtd-theme >= 0.1.9
+sphinx>=4.2.0,<5.0.0
+sphinx-rtd-theme>=1.0.0,<2.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,5 +14,4 @@ py>=1.5.2
 typed_ast>=1.4.0,<1.5.0; python_version>='3.8'
 virtualenv>=20.6.0
 setuptools!=50
-sphinx>=4.2.0,<5.0.0
 importlib-metadata>=4.6.1,<5.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,4 +14,5 @@ py>=1.5.2
 typed_ast>=1.4.0,<1.5.0; python_version>='3.8'
 virtualenv>=20.6.0
 setuptools!=50
+sphinx>=4.2.0,<5.0.0
 importlib-metadata>=4.6.1,<5.0.0


### PR DESCRIPTION
It passes locally:

```
» make html         
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v4.2.0
making output directory... done
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://six.readthedocs.io/objects.inv...
loading intersphinx inventory from http://www.attrs.org/en/stable/objects.inv...
loading intersphinx inventory from http://docs.cython.org/en/latest/objects.inv...
loading intersphinx inventory from https://monkeytype.readthedocs.io/en/latest/objects.inv...
loading intersphinx inventory from https://setuptools.readthedocs.io/en/latest/objects.inv...
intersphinx inventory has moved: http://www.attrs.org/en/stable/objects.inv -> https://www.attrs.org/en/stable/objects.inv
intersphinx inventory has moved: https://setuptools.readthedocs.io/en/latest/objects.inv -> https://setuptools.pypa.io/en/latest/objects.inv
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 37 source files that are out of date
updating environment: [new config] 37 added, 0 changed, 0 removed
reading sources... [100%] type_narrowing                                              
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] type_narrowing                                               
generating indices... genindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
```

Closes #11412

We can also enable "build PR branches" on RTD, if it is not enabled right now.

Checkbox:
<img width="956" alt="Снимок экрана 2021-10-31 в 21 08 55" src="https://user-images.githubusercontent.com/4660275/139596334-9adecd21-f202-4986-83da-23ac0a5addb3.png">

Docs: https://docs.readthedocs.io/en/stable/pull-requests.html and https://docs.readthedocs.io/en/stable/development/design/pr-builder.html

I cannot do that myself 🙂 