### PR TITLE
Change `mypy_primer` output name

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   mypy_primer:
-    name: Run
+    name: Run mypy_primer
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This is how it is now:
<img width="786" alt="Снимок экрана 2021-11-01 в 1 32 33" src="https://user-images.githubusercontent.com/4660275/139603362-bf051d9d-48ce-42a1-bece-84b8bba29145.png">
Taken from here: https://github.com/python/mypy/pull/11151
Click "View details" to see it.

I guess that new name would have better readability.

