### PR TITLE
Fix crash on join of recursive types

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -17,7 +17,6 @@ from mypy.subtypes import (
 from mypy.nodes import INVARIANT, COVARIANT, CONTRAVARIANT
 import mypy.typeops
 from mypy import state
-from mypy import meet
 
 
 class InstanceJoiner:

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -61,8 +61,9 @@ class InstanceJoiner:
                     if not is_equivalent(ta, sa):
                         self.seen_instances.pop()
                         return object_from_instance(t)
-                    # Randomly choose the left one since they are equivalent.
-                    new_type = ta
+                    # If the types are different but equivalent, then an Any is involved
+                    # so using a join in the contravariant case is also OK.
+                    new_type = join_types(ta, sa, self)
                 assert new_type is not None
                 args.append(new_type)
             result: ProperType = Instance(t.type, args)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -55,18 +55,14 @@ class InstanceJoiner:
                     if not is_subtype(new_type, type_var.upper_bound):
                         self.seen_instances.pop()
                         return object_from_instance(t)
-                elif type_var.variance == CONTRAVARIANT:
-                    new_type = meet.meet_types(ta, sa)
-                    if len(type_var.values) != 0 and new_type not in type_var.values:
-                        self.seen_instances.pop()
-                        return object_from_instance(t)
-                    # No need to check subtype, as ta and sa already have to be subtypes of
-                    # upper_bound
-                elif type_var.variance == INVARIANT:
-                    new_type = join_types(ta, sa)
+                # TODO: contravariant case should use meet but pass seen instances as
+                # an argument to keep track of recursive checks.
+                elif type_var.variance in (INVARIANT, CONTRAVARIANT):
                     if not is_equivalent(ta, sa):
                         self.seen_instances.pop()
                         return object_from_instance(t)
+                    # Randomly choose the left one since they are equivalent.
+                    new_type = ta
                 assert new_type is not None
                 args.append(new_type)
             result: ProperType = Instance(t.type, args)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -653,8 +653,8 @@ class JoinSuite(Suite):
 
     def test_generics_contravariant(self) -> None:
         self.assert_join(self.fx_contra.ga, self.fx_contra.ga, self.fx_contra.ga)
-        self.assert_join(self.fx_contra.ga, self.fx_contra.gb, self.fx_contra.gb)
-        self.assert_join(self.fx_contra.ga, self.fx_contra.gd, self.fx_contra.gn)
+        # TODO: this can be more precise than "object", see a comment in mypy/join.py
+        self.assert_join(self.fx_contra.ga, self.fx_contra.gb, self.fx_contra.o)
         self.assert_join(self.fx_contra.ga, self.fx_contra.g2a, self.fx_contra.o)
 
     def test_generics_with_multiple_args(self) -> None:

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2492,3 +2492,14 @@ a: A
 b: B
 reveal_type([a, b])  # N: Revealed type is "builtins.list[builtins.object*]"
 [builtins fixtures/list.pyi]
+
+[case testGenericJoinNestedInvariantAny]
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+class I(Generic[T]): ...
+
+a: I[int]
+b: I[Any]
+reveal_type([a, b])  # N: Revealed type is "builtins.list[__main__.I*[Any]]"
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2463,7 +2463,8 @@ class B(A): ...
 a_c: Container[A]
 b_c: Container[B]
 
-reveal_type([a_c, b_c])  # N: Revealed type is "builtins.list[__main__.Container*[__main__.B]]"
+# TODO: this can be more precise than "object", see a comment in mypy/join.py
+reveal_type([a_c, b_c])  # N: Revealed type is "builtins.list[builtins.object*]"
 [builtins fixtures/list.pyi]
 
 [case testGenericJoinRecursiveTypes]
@@ -2476,4 +2477,18 @@ a: A
 b: B
 
 reveal_type([a, b])  # N: Revealed type is "builtins.list[typing.Sequence*[builtins.object]]"
+[builtins fixtures/list.pyi]
+
+[case testGenericJoinRecursiveInvariant]
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+class I(Generic[T]): ...
+
+class A(I[A]): ...
+class B(I[B]): ...
+
+a: A
+b: B
+reveal_type([a, b])  # N: Revealed type is "builtins.list[builtins.object*]"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2499,7 +2499,8 @@ from typing import Any, Generic, TypeVar
 T = TypeVar("T")
 class I(Generic[T]): ...
 
-a: I[int]
-b: I[Any]
-reveal_type([a, b])  # N: Revealed type is "builtins.list[__main__.I*[Any]]"
+a: I[I[int]]
+b: I[I[Any]]
+reveal_type([a, b])  # N: Revealed type is "builtins.list[__main__.I*[__main__.I[Any]]]"
+reveal_type([b, a])  # N: Revealed type is "builtins.list[__main__.I*[__main__.I[Any]]]"
 [builtins fixtures/list.pyi]


### PR DESCRIPTION
The initial implementation was not very careful, so I only keep the covariant part, while other cases fall back to old simple logic (which is actually correct for invariant type parameters).