### PR TITLE
Don't look in user site packages when using a virtual env

### DIFF
--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -24,7 +24,11 @@ def getprefixes():
 
 def getsitepackages():
     # type: () -> List[str]
-    if hasattr(site, 'getusersitepackages') and hasattr(site, 'getsitepackages'):
+    if (
+        hasattr(site, 'getusersitepackages')
+        and hasattr(site, 'getsitepackages')
+        and site.ENABLE_USER_SITE
+    ):
         user_dir = site.getusersitepackages()
         return site.getsitepackages() + [user_dir]
     else:

--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -25,7 +25,7 @@ def getprefixes():
 def getsitepackages():
     # type: () -> List[str]
     res = []
-    if  hasattr(site, 'getsitepackages'):
+    if hasattr(site, 'getsitepackages'):
         res.extend(site.getsitepackages())
 
         if hasattr(site, 'getsitepackages') and site.ENABLE_USER_SITE:

--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -24,16 +24,16 @@ def getprefixes():
 
 def getsitepackages():
     # type: () -> List[str]
-    if (
-        hasattr(site, 'getusersitepackages')
-        and hasattr(site, 'getsitepackages')
-        and site.ENABLE_USER_SITE
-    ):
-        user_dir = site.getusersitepackages()
-        return site.getsitepackages() + [user_dir]
+    res = []
+    if  hasattr(site, 'getsitepackages'):
+        res.extend(site.getsitepackages())
+
+        if hasattr(site, 'getsitepackages') and site.ENABLE_USER_SITE:
+            res.insert(0, site.getusersitepackages())
     else:
         from distutils.sysconfig import get_python_lib
-        return [get_python_lib()]
+        res = [get_python_lib()]
+    return res
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


### Description

Fixes #11274

As suggested in the above issue, we need to add user site packages to the list of directories *only* if site.ENABLE_USER_SITE is True.

## Test Plan

Before the patch:

```
$ ./venv/bin/python mypy/pyinfo.py getsitepackages
['/mnt/data/dmerej/src/mypy/venv/lib/python3.9/site-packages', '/home/dmerej/.local/lib/python3.9/site-packages']
```

After the patch:
```
$ ./venv/bin/python mypy/pyinfo.py getsitepackages
['/mnt/data/dmerej/src/mypy/venv/lib/python3.9/site-packages']
```

where `venv` is the virtualenv for mypy development, as indicated in CONTRIBUTING.txt

Finally, we can check that pinfo still works outside a virtualenv:

```
$ python mypy/pyinfo.py getsitepackages
['/mnt/data/dmerej/src/mypy/venv/lib/python3.9/site-packages', '/home/dmerej/.local/lib/python3.9/site-packages']
```

