### PR TITLE
Clear type alias flag for assignments that are not aliases

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2044,9 +2044,13 @@ class SemanticAnalyzer(NodeVisitor[None],
             special_form = True
         elif self.analyze_enum_assign(s):
             special_form = True
+
         if special_form:
             self.record_special_form_lvalue(s)
             return
+        # Clear the alias flag if assignment turns out not a special form after all. It
+        # may be set to True while there were still placeholders due to forward refs.
+        s.is_alias_def = False
 
         # OK, this is a regular assignment, perform the necessary analysis steps.
         s.is_final_def = self.unwrap_final(s)

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -545,3 +545,17 @@ Some.bad_cls_method(1)  # E: Too many arguments for "bad_cls_method" of "Some" \
 s.bad_st_method(1)  # E: Too many arguments for "bad_st_method" of "Some"
 Some.bad_st_method(1)  # E: Too many arguments for "bad_st_method" of "Some"
 [builtins fixtures/callable.pyi]
+
+[case testClassMethodAliasStub]
+from a import f
+f("no")  # E: Argument 1 has incompatible type "str"; expected "int"
+[file a.pyi]
+from b import C
+f = C.f
+[file b.pyi]
+import a
+class C(B):
+    @classmethod
+    def f(self, x: int) -> C: ...
+class B: ...
+[builtins fixtures/classmethod.pyi]


### PR DESCRIPTION
This flag may be set to `True` if there are tricky forward references.