### PR TITLE
Improves `TypeVar` error messages

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -152,6 +152,9 @@ CANNOT_USE_TYPEVAR_AS_EXPRESSION: Final = 'Type variable "{}.{}" cannot be used 
 INVALID_TYPEVAR_AS_TYPEARG: Final = 'Type variable "{}" not valid as type argument value for "{}"'
 INVALID_TYPEVAR_ARG_BOUND: Final = 'Type argument {} of "{}" must be a subtype of {}'
 INVALID_TYPEVAR_ARG_VALUE: Final = 'Invalid type argument value for "{}"'
+TYPEVAR_VARIANCE_DEF: Final = 'TypeVar "{}" may only be a literal bool'
+TYPEVAR_BOUND_MUST_BE_TYPE: Final = 'TypeVar "bound" must be a type'
+TYPEVAR_UNEXPECTED_ARGUMENT: Final = 'Unexpected argument to "TypeVar()"'
 
 # Super
 TOO_MANY_ARGS_FOR_SUPER: Final = 'Too many arguments for "super"'

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1030,11 +1030,13 @@ a = TypeVar()       # E: Too few arguments for TypeVar()
 b = TypeVar(x='b')  # E: TypeVar() expects a string literal as first argument
 c = TypeVar(1)      # E: TypeVar() expects a string literal as first argument
 d = TypeVar('D')    # E: String argument 1 "D" to TypeVar(...) does not match variable name "d"
-e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to TypeVar(): "x"
+e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to "TypeVar()": "x"
 f = TypeVar('f', (int, str), int) # E: Type expected
 g = TypeVar('g', int)             # E: TypeVar cannot have only a single constraint
-h = TypeVar('h', x=(int, str))    # E: Unexpected argument to TypeVar(): "x"
+h = TypeVar('h', x=(int, str))    # E: Unexpected argument to "TypeVar()": "x"
 i = TypeVar('i', bound=1)         # E: TypeVar "bound" must be a type
+j = TypeVar('j', covariant=None)  # E: TypeVar "covariant" may only be a literal bool
+k = TypeVar('k', contravariant=1) # E: TypeVar "contravariant" may only be a literal bool
 [out]
 
 [case testMoreInvalidTypevarArguments]
@@ -1046,7 +1048,7 @@ S = TypeVar('S', covariant=True, contravariant=True) \
 
 [case testInvalidTypevarValues]
 from typing import TypeVar
-b = TypeVar('b', *[int]) # E: Unexpected argument to TypeVar()
+b = TypeVar('b', *[int]) # E: Unexpected argument to "TypeVar()"
 c = TypeVar('c', int, 2) # E: Invalid type: try using Literal[2] instead?
 [out]
 

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1284,6 +1284,35 @@ MypyFile:1(
         builtins.int
         builtins.str))))
 
+[case testTypevarWithFalseVariance]
+from typing import TypeVar
+T1 = TypeVar('T1', covariant=False)
+T2 = TypeVar('T2', covariant=False, contravariant=False)
+T3 = TypeVar('T3', contravariant=False)
+T4 = TypeVar('T4', covariant=True, contravariant=False)
+T5 = TypeVar('T5', covariant=False, contravariant=True)
+[builtins fixtures/bool.pyi]
+[out]
+MypyFile:1(
+  ImportFrom:1(typing, [TypeVar])
+  AssignmentStmt:2(
+    NameExpr(T1* [__main__.T1])
+    TypeVarExpr:2())
+  AssignmentStmt:3(
+    NameExpr(T2* [__main__.T2])
+    TypeVarExpr:3())
+  AssignmentStmt:4(
+    NameExpr(T3* [__main__.T3])
+    TypeVarExpr:4())
+  AssignmentStmt:5(
+    NameExpr(T4* [__main__.T4])
+    TypeVarExpr:5(
+      Variance(COVARIANT)))
+  AssignmentStmt:6(
+    NameExpr(T5* [__main__.T5])
+    TypeVarExpr:6(
+      Variance(CONTRAVARIANT))))
+
 [case testTypevarWithBound]
 from typing import TypeVar
 T = TypeVar('T', bound=int)


### PR DESCRIPTION
Changes:
1. I've change some wordings
2. Moved the same strings into `message_registry`
3. Added extra tests for new feature. You can now specify `TypeVar('A', covariant=False)` to mirror the CPython

Closes #11442