### PR TITLE
Changes how errors are disabled in `visit_comparison_expr`

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2230,16 +2230,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
                 # Keep track of whether we get type check errors (these won't be reported, they
                 # are just to verify whether something is valid typing wise).
-                local_errors = self.msg.copy()
-                with local_errors.disable_errors():
-                    _, method_type = self.check_method_call_by_name(
-                        method='__contains__',
-                        base_type=right_type,
-                        args=[left],
-                        arg_kinds=[ARG_POS],
-                        context=e,
-                        local_errors=local_errors,
-                    )
+                local_errors = self.msg.clean_copy()
+                _, method_type = self.check_method_call_by_name(
+                    method='__contains__',
+                    base_type=right_type,
+                    args=[left],
+                    arg_kinds=[ARG_POS],
+                    context=e,
+                    local_errors=local_errors,
+                )
                 sub_result = self.bool_type()
                 # Container item type for strict type overlap checks. Note: we need to only
                 # check for nominal type, because a usual "Unsupported operands for in"

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2231,9 +2231,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 # Keep track of whether we get type check errors (these won't be reported, they
                 # are just to verify whether something is valid typing wise).
                 local_errors = self.msg.copy()
-                local_errors.disable_count = 0
-                _, method_type = self.check_method_call_by_name(
-                    '__contains__', right_type, [left], [ARG_POS], e, local_errors)
+                with local_errors.disable_errors():
+                    _, method_type = self.check_method_call_by_name(
+                        method='__contains__',
+                        base_type=right_type,
+                        args=[left],
+                        arg_kinds=[ARG_POS],
+                        context=e,
+                        local_errors=local_errors,
+                    )
                 sub_result = self.bool_type()
                 # Container item type for strict type overlap checks. Note: we need to only
                 # check for nominal type, because a usual "Unsupported operands for in"


### PR DESCRIPTION
It now has a better API for that.

I've also changed `self.check_method_call_by_name` to use named args to make this call more readable.