### PR TITLE
testcheck: Automated detection of .test files #8650

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -3,6 +3,8 @@
 import os
 import re
 import sys
+from os import listdir
+from os.path import isfile, join
 
 from typing import Dict, List, Set, Tuple
 
@@ -23,81 +25,9 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-typecheck_files = [
-    'check-basic.test',
-    'check-union-or-syntax.test',
-    'check-callable.test',
-    'check-classes.test',
-    'check-statements.test',
-    'check-generics.test',
-    'check-dynamic-typing.test',
-    'check-inference.test',
-    'check-inference-context.test',
-    'check-kwargs.test',
-    'check-overloading.test',
-    'check-type-checks.test',
-    'check-abstract.test',
-    'check-multiple-inheritance.test',
-    'check-super.test',
-    'check-modules.test',
-    'check-typevar-values.test',
-    'check-unsupported.test',
-    'check-unreachable-code.test',
-    'check-unions.test',
-    'check-isinstance.test',
-    'check-lists.test',
-    'check-namedtuple.test',
-    'check-narrowing.test',
-    'check-typeddict.test',
-    'check-type-aliases.test',
-    'check-ignore.test',
-    'check-type-promotion.test',
-    'check-semanal-error.test',
-    'check-flags.test',
-    'check-incremental.test',
-    'check-serialize.test',
-    'check-bound.test',
-    'check-optional.test',
-    'check-fastparse.test',
-    'check-warnings.test',
-    'check-async-await.test',
-    'check-newtype.test',
-    'check-class-namedtuple.test',
-    'check-selftype.test',
-    'check-python2.test',
-    'check-columns.test',
-    'check-functions.test',
-    'check-tuples.test',
-    'check-expressions.test',
-    'check-generic-subtyping.test',
-    'check-varargs.test',
-    'check-newsyntax.test',
-    'check-protocols.test',
-    'check-underscores.test',
-    'check-classvar.test',
-    'check-enum.test',
-    'check-incomplete-fixture.test',
-    'check-custom-plugin.test',
-    'check-default-plugin.test',
-    'check-attr.test',
-    'check-ctypes.test',
-    'check-dataclasses.test',
-    'check-final.test',
-    'check-redefine.test',
-    'check-literal.test',
-    'check-newsemanal.test',
-    'check-inline-config.test',
-    'check-reports.test',
-    'check-errorcodes.test',
-    'check-annotated.test',
-    'check-parameter-specification.test',
-    'check-generic-alias.test',
-    'check-typeguard.test',
-    'check-functools.test',
-    'check-singledispatch.test',
-    'check-slots.test',
-    'check-formatting.test'
-]
+test_path = '../../test-data/unit/'
+typecheck_files = [f for f in listdir(test_path) if isfile(join(test_path, f)) and f.startswith('check-')]
+
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):
 if sys.version_info >= (3, 8):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -24,12 +24,7 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-test_path = Path.cwd().parent.parent / 'test-data' / 'unit'
-
-typecheck_files = []
-for path in test_path.rglob('check-*.test'):
-    typecheck_files.append(path.name)
-
+typecheck_files = [path.name for path in (Path.cwd().parent.parent / 'test-data' / 'unit').rglob('check-*.test')]
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):
 if sys.version_info >= (3, 8):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -24,7 +24,10 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-typecheck_files = [path.name for path in (Path.cwd().parent.parent / 'test-data' / 'unit').rglob('check-*.test') if path.name != 'check-python38.test' and path.name != 'check-python39.test']
+typecheck_files = []
+for path in (Path.cwd().parent.parent / 'test-data' / 'unit').rglob('check-*.test'):
+    if path.name != 'check-python38.test' and path.name != 'check-python39.test':
+        typecheck_files.append(path.name)
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):
 if sys.version_info >= (3, 8):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -24,7 +24,7 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-test_path = Path(os.getcwd())
+test_path = Path.cwd()
 test_path = Path(test_path).parents[1]
 test_path = test_path / Path('test-data')
 test_path = test_path / Path('unit')

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -3,8 +3,7 @@
 import os
 import re
 import sys
-from os import listdir
-from os.path import isfile, join
+from pathlib import Path
 
 from typing import Dict, List, Set, Tuple
 
@@ -25,8 +24,15 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-test_path = '../../test-data/unit/'
-typecheck_files = [f for f in listdir(test_path) if isfile(join(test_path, f)) and f.startswith('check-')]
+test_path = os.getcwd()
+test_path = Path(test_path).parents[1]
+test_path = test_path / 'test-data'
+test_path = test_path / 'unit'
+
+typecheck_files = []
+for dirpath, dirnames, filenames in os.walk(test_path):
+    for filename in [f for f in filenames if f.endswith(".test") and f.startswith("check")]:
+        typecheck_files.append(filename)
 
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -24,15 +24,11 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-test_path = Path.cwd()
-test_path = Path(test_path).parents[1]
-test_path = test_path / Path('test-data')
-test_path = test_path / Path('unit')
+test_path = Path.cwd().parent.parent / 'test-data' / 'unit'
 
 typecheck_files = []
-for dirpath, dirnames, filenames in os.walk(test_path):
-    for filename in [f for f in filenames if f.endswith(".test") and f.startswith("check-")]:
-        typecheck_files.append(filename)
+for path in test_path.rglob('check-*.test'):
+    typecheck_files.append(path.name)
 
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -24,7 +24,7 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-typecheck_files = [path.name for path in (Path.cwd().parent.parent / 'test-data' / 'unit').rglob('check-*.test')]
+typecheck_files = [path.name for path in (Path.cwd().parent.parent / 'test-data' / 'unit').rglob('check-*.test') if path.name != 'check-python38.test' and path.name != 'check-python39.test']
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):
 if sys.version_info >= (3, 8):

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -24,14 +24,14 @@ from mypy.semanal_main import core_modules
 
 
 # List of files that contain test case descriptions.
-test_path = os.getcwd()
+test_path = Path(os.getcwd())
 test_path = Path(test_path).parents[1]
-test_path = test_path / 'test-data'
-test_path = test_path / 'unit'
+test_path = test_path / Path('test-data')
+test_path = test_path / Path('unit')
 
 typecheck_files = []
 for dirpath, dirnames, filenames in os.walk(test_path):
-    for filename in [f for f in filenames if f.endswith(".test") and f.startswith("check")]:
+    for filename in [f for f in filenames if f.endswith(".test") and f.startswith("check-")]:
         typecheck_files.append(filename)
 
 


### PR DESCRIPTION
Fixed: issue #8650

On merging this PR, the testcheck.py script will automatically walk the test file directory and record all the test files starting with 'check-'. This is very crucial in order for this problem to not emerge in future endeavors when new test files are added into the repository, as the file searching is automated to detect any new such files.
This approach is not using regex, rather uses simple python os library methods.

The changes have been verified on my local system, the python script after changes runs smoothly. The newly detected test files are shown in this helper local python script terminal (an additional 4 files are detected from a subdirectory):

![image](https://user-images.githubusercontent.com/41104465/140272726-a4bc48cb-6758-4e4c-9789-3e034a555081.png)


On suggestions from the contributors, I have used the pathlib library to make it work across various platforms. Also, walking is enabled so that 'check-' test files from deeper subdirectories can also be detected. 
It would be great if this PR is authorized, I could henceforth start my journey to contributing to mypy after this.

Thanks @JukkaL @ethanhs @davidzwa