### PR TITLE
Try fixing union inference including Any

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -213,6 +213,7 @@ def select_trivial(options: Sequence[Optional[List[Constraint]]]) -> List[List[C
 
 
 def is_union_with_any(tp: Type) -> bool:
+    """Is this a union with Any or a plain Any type?"""
     tp = get_proper_type(tp)
     if isinstance(tp, AnyType):
         return True

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -254,7 +254,7 @@ def any_constraints(options: List[Optional[List[Constraint]]], eager: bool) -> L
             variable_direction_pairs.add(frozenset((c.type_var, c.op) for c in option))
         if len(variable_direction_pairs) == 1:
             # All options have same structure. In this case we can merge-in trivial
-            # options (i.e. those that only have Any and try again.
+            # options (i.e. those that only have Any) and try again.
             trivial_options = select_trivial(valid_options)
             if trivial_options and len(trivial_options) < len(valid_options):
                 # Randomly choose first trivial option for source of Any.

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -618,7 +618,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                                              self.direction))
             return res
         elif isinstance(actual, AnyType):
-            return self.infer_against_any(list(template.items.values()), actual)
+            return self.infer_against_any(template.items.values(), actual)
         else:
             return []
 
@@ -629,7 +629,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
     def visit_type_alias_type(self, template: TypeAliasType) -> List[Constraint]:
         assert False, "This should be never called, got {}".format(template)
 
-    def infer_against_any(self, types: Sequence[Type], any_type: AnyType) -> List[Constraint]:
+    def infer_against_any(self, types: Iterable[Type], any_type: AnyType) -> List[Constraint]:
         res: List[Constraint] = []
         for t in types:
             # Note that we ignore variance and simply always use the

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -606,7 +606,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             types: Sequence[Type],
             any_type: AnyType,
             directions: Optional[List[List[int]]] = None,
-        ) -> List[Constraint]:
+    ) -> List[Constraint]:
         res: List[Constraint] = []
         if directions is None:
             directions = [[self.direction]] * len(types)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -212,8 +212,10 @@ def select_trivial(options: Sequence[Optional[List[Constraint]]]) -> List[List[C
     return res
 
 
-def merge_with_any(constraint: Constraint, any_type: AnyType) -> Constraint:
+def merge_with_any(constraint: Constraint, any_type: Type) -> Constraint:
     """Transform a constraint target into a union with given Any type."""
+    any_type = get_proper_type(any_type)
+    assert isinstance(any_type, AnyType)
     target = constraint.target
     items = [target, AnyType(TypeOfAny.from_another_any, source_any=any_type)]
     return Constraint(
@@ -588,7 +590,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                                              self.direction))
             return res
         elif isinstance(actual, AnyType):
-            return self.infer_against_any(template.items.values(), actual)
+            return self.infer_against_any(list(template.items.values()), actual)
         else:
             return []
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -300,8 +300,16 @@ def is_same_constraints(x: List[Constraint], y: List[Constraint]) -> bool:
 
 
 def is_same_constraint(c1: Constraint, c2: Constraint) -> bool:
+    if (
+        isinstance(get_proper_type(c1.target), AnyType) and
+        isinstance(get_proper_type(c2.target), AnyType)
+    ):
+        # Ignore direction when comparing constraints against Any.
+        skip_op_check = True
+    else:
+        skip_op_check = False
     return (c1.type_var == c2.type_var
-            and c1.op == c2.op
+            and (c1.op == c2.op or skip_op_check)
             and mypy.sametypes.is_same_type(c1.target, c2.target))
 
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1287,7 +1287,6 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
 
             if left.type.has_base(right.type.fullname):
                 def check_argument(leftarg: Type, rightarg: Type, variance: int) -> bool:
-                    print("AAA", leftarg, "BBB", rightarg)
                     if variance == COVARIANT:
                         return self._is_proper_subtype(leftarg, rightarg)
                     elif variance == CONTRAVARIANT:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1287,6 +1287,7 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
 
             if left.type.has_base(right.type.fullname):
                 def check_argument(leftarg: Type, rightarg: Type, variance: int) -> bool:
+                    print("AAA", leftarg, "BBB", rightarg)
                     if variance == COVARIANT:
                         return self._is_proper_subtype(leftarg, rightarg)
                     elif variance == CONTRAVARIANT:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2344,17 +2344,11 @@ def flatten_nested_unions(types: Iterable[Type],
     flat_items: List[Type] = []
     if handle_type_alias_type:
         types = get_proper_types(types)
-    has_any = False
+    # TODO: avoid duplicate types in unions (e.g. using hash)
     for tp in types:
         if isinstance(tp, ProperType) and isinstance(tp, UnionType):
             flat_items.extend(flatten_nested_unions(tp.items,
                               handle_type_alias_type=handle_type_alias_type))
-        elif isinstance(tp, ProperType) and isinstance(tp, AnyType):
-            # Only append single Any per union.
-            # TODO: avoid other duplicates (e.g. using hash)
-            if not has_any:
-                flat_items.append(tp)
-            has_any = True
         else:
             flat_items.append(tp)
     return flat_items

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2369,6 +2369,16 @@ def union_items(typ: Type) -> List[ProperType]:
         return [typ]
 
 
+def is_union_with_any(tp: Type) -> bool:
+    """Is this a union with Any or a plain Any type?"""
+    tp = get_proper_type(tp)
+    if isinstance(tp, AnyType):
+        return True
+    if not isinstance(tp, UnionType):
+        return False
+    return any(is_union_with_any(t) for t in get_proper_types(tp.items))
+
+
 def is_generic_instance(tp: Type) -> bool:
     tp = get_proper_type(tp)
     return isinstance(tp, Instance) and bool(tp.args)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2344,10 +2344,17 @@ def flatten_nested_unions(types: Iterable[Type],
     flat_items: List[Type] = []
     if handle_type_alias_type:
         types = get_proper_types(types)
+    has_any = False
     for tp in types:
         if isinstance(tp, ProperType) and isinstance(tp, UnionType):
             flat_items.extend(flatten_nested_unions(tp.items,
                               handle_type_alias_type=handle_type_alias_type))
+        elif isinstance(tp, ProperType) and isinstance(tp, AnyType):
+            # Only append single Any per union.
+            # TODO: avoid other duplicates (e.g. using hash)
+            if not has_any:
+                flat_items.append(tp)
+            has_any = True
         else:
             flat_items.append(tp)
     return flat_items

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1381,5 +1381,13 @@ from typing import Union, List, Any
 
 def f(x: Union[List[str], Any]) -> None:
     a = x if x else []
-    reveal_type(a)  # N: Revealed type is "Union[builtins.list[builtins.str], Any]"
+    reveal_type(a)  # N: Revealed type is "Union[builtins.list[Union[builtins.str, Any]], builtins.list[builtins.str], Any]"
 [builtins fixtures/list.pyi]
+
+[case testInferMultipleAnyUnion]
+from typing import Any, Mapping, Sequence, Union
+
+def foo(x: Union[Mapping[Any, Any], Mapping[Any, Sequence[Any]]]) -> None:
+    ...
+foo({1: 2})
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1384,6 +1384,14 @@ def f(x: Union[List[str], Any]) -> None:
     reveal_type(a)  # N: Revealed type is "Union[builtins.list[Union[builtins.str, Any]], builtins.list[builtins.str], Any]"
 [builtins fixtures/list.pyi]
 
+[case testConditionalExpressionWithEmptyIteableAndUnionWithAny]
+from typing import Union, Iterable, Any
+
+def f(x: Union[Iterable[str], Any]) -> None:
+    a = x if x else []
+    reveal_type(a)  # N: Revealed type is "Union[builtins.list[Union[builtins.str, Any]], typing.Iterable[builtins.str], Any]"
+[builtins fixtures/list.pyi]
+
 [case testInferMultipleAnyUnion]
 from typing import Any, Mapping, Sequence, Union
 

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1392,10 +1392,30 @@ def f(x: Union[Iterable[str], Any]) -> None:
     reveal_type(a)  # N: Revealed type is "Union[builtins.list[Union[builtins.str, Any]], typing.Iterable[builtins.str], Any]"
 [builtins fixtures/list.pyi]
 
-[case testInferMultipleAnyUnion]
+[case testInferMultipleAnyUnionCovariant]
 from typing import Any, Mapping, Sequence, Union
 
 def foo(x: Union[Mapping[Any, Any], Mapping[Any, Sequence[Any]]]) -> None:
     ...
 foo({1: 2})
+[builtins fixtures/dict.pyi]
+
+[case testInferMultipleAnyUnionInvariant]
+from typing import Any, Dict, Sequence, Union
+
+def foo(x: Union[Dict[Any, Any], Dict[Any, Sequence[Any]]]) -> None:
+    ...
+foo({1: 2})
+[builtins fixtures/dict.pyi]
+
+[case testInferMultipleAnyUnionDifferentVariance]
+from typing import Any, Dict, Mapping, Sequence, Union
+
+def foo(x: Union[Dict[Any, Any], Mapping[Any, Sequence[Any]]]) -> None:
+    ...
+foo({1: 2})
+
+def bar(x: Union[Mapping[Any, Any], Dict[Any, Sequence[Any]]]) -> None:
+    ...
+bar({1: 2})
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3170,3 +3170,43 @@ reveal_type(f(lambda: 1))  # N: Revealed type is "builtins.int*"
 def g() -> None: pass
 
 reveal_type(f(g))  # N: Revealed type is "None"
+
+[case testInferredTypeIsSimpleNestedList]
+from typing import Any, Union, List
+
+y: Union[List[Any], Any]
+x: Union[List[Any], Any]
+x = [y]
+reveal_type(x)  # N: Revealed type is "builtins.list[Any]"
+[builtins fixtures/list.pyi]
+
+[case testInferredTypeIsSimpleNestedIterable]
+from typing import Any, Union, Iterable
+
+y: Union[Iterable[Any], Any]
+x: Union[Iterable[Any], Any]
+x = [y]
+reveal_type(x)  # N: Revealed type is "builtins.list[Any]"
+[builtins fixtures/list.pyi]
+
+[case testInferredTypeIsSimpleNestedListLoop]
+from typing import Any, Union, List
+
+def test(seq: List[Union[List, Any]]) -> None:
+    k: Union[List, Any]
+    for k in seq:
+        if bool():
+            k = [k]
+            reveal_type(k)  # N: Revealed type is "builtins.list[Any]"
+[builtins fixtures/list.pyi]
+
+[case testInferredTypeIsSimpleNestedIterableLoop]
+from typing import Any, Union, List, Iterable
+
+def test(seq: List[Union[Iterable, Any]]) -> None:
+    k: Union[Iterable, Any]
+    for k in seq:
+        if bool():
+            k = [k]
+            reveal_type(k)  # N: Revealed type is "builtins.list[Any]"
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
This replaces dropping trivial (i.e. `Any`-only) constraint sets with merging the `Any` targets into every other existing constraint.

We also ignore constraint direction when comparing constraints if the target is `Any`. This is needed to be able to merge `Any` constraints for both covariant and invariant cases. For example, both `Iterable[str] | Any` and `list[str] | Any` will infer `T = str | Any` against `list[T]`.