### PR TITLE
Check duplicate bases when defining TypedDict

### DIFF
--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -80,7 +80,8 @@ class TypedDictAnalyzer:
                         typeddict_bases_set.add(expr.fullname)
                         typeddict_bases.append(expr)
                     else:
-                        self.fail('Duplicate base class "%s"' % expr.name, defn)
+                        assert isinstance(expr.node, TypeInfo)
+                        self.fail('Duplicate base class "%s"' % expr.node.name, defn)
             keys: List[str] = []
             types = []
             required_keys = set()

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -72,16 +72,22 @@ class TypedDictAnalyzer:
             typeddict_bases = []
             typeddict_bases_set = set()
             for expr in defn.base_type_exprs:
-                if (not isinstance(expr, RefExpr) or
-                        expr.fullname not in TPDICT_NAMES and not self.is_typeddict(expr)):
-                    self.fail("All bases of a new TypedDict must be TypedDict types", defn)
-                elif self.is_typeddict(expr):
+                if isinstance(expr, RefExpr) and expr.fullname in TPDICT_NAMES:
+                    if 'TypedDict' not in typeddict_bases_set:
+                        typeddict_bases_set.add('TypedDict')
+                    else:
+                        self.fail('Duplicate base class "TypedDict"', defn)
+                elif isinstance(expr, RefExpr) and self.is_typeddict(expr):
+                    assert expr.fullname
                     if expr.fullname not in typeddict_bases_set:
                         typeddict_bases_set.add(expr.fullname)
                         typeddict_bases.append(expr)
                     else:
                         assert isinstance(expr.node, TypeInfo)
                         self.fail('Duplicate base class "%s"' % expr.node.name, defn)
+                else:
+                    self.fail("All bases of a new TypedDict must be TypedDict types", defn)
+
             keys: List[str] = []
             types = []
             required_keys = set()
@@ -336,3 +342,6 @@ class TypedDictAnalyzer:
 
     def fail(self, msg: str, ctx: Context, *, code: Optional[ErrorCode] = None) -> None:
         self.api.fail(msg, ctx, code=code)
+
+    def note(self, msg: str, ctx: Context) -> None:
+        self.api.note(msg, ctx)

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -171,6 +171,18 @@ p: Point2D
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point2D', {'x': builtins.int, 'y': builtins.int})"
 [builtins fixtures/dict.pyi]
 
+[case testCannotCreateTypedDictWithDuplicateBases]
+# https://github.com/python/mypy/issues/3673
+from typing import TypedDict
+
+class A(TypedDict):
+    x: str
+    y: int
+
+class B(A, A): # E: Duplicate base class "A"
+    z: str
+[typing fixtures/typing-typeddict.pyi]
+
 [case testCannotCreateTypedDictWithClassWithOtherStuff]
 # flags: --python-version 3.6
 from mypy_extensions import TypedDict

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -181,6 +181,9 @@ class A(TypedDict):
 
 class B(A, A): # E: Duplicate base class "A"
     z: str
+
+class C(TypedDict, TypedDict): # E: Duplicate base class "TypedDict"
+    c1: int
 [typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictWithClassWithOtherStuff]


### PR DESCRIPTION
### Description

Closes https://github.com/python/mypy/issues/3673

Adds a trivial for-loop and a helper set to check duplicates of `typeddict_bases`.

## Test Plan

Adds a new test case `testCannotCreateTypedDictWithDuplicateBases`