### PR TITLE
Use `format_type` for `msg.type_not_iterable`

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -798,7 +798,7 @@ class MessageBuilder:
         self.fail("Unpacking a string is disallowed", context)
 
     def type_not_iterable(self, type: Type, context: Context) -> None:
-        self.fail('"{}" object is not iterable'.format(type), context)
+        self.fail('{} object is not iterable'.format(format_type(type)), context)
 
     def incompatible_operator_assignment(self, op: str,
                                          context: Context) -> None:
@@ -1613,8 +1613,8 @@ class MessageBuilder:
         for i, (lhs_t, rhs_t) in enumerate(zip(lhs_types, rhs_types)):
             if not is_subtype(lhs_t, rhs_t):
                 if error_cnt < 3:
-                    notes.append('Expression tuple item {} has type "{}"; "{}" expected; '
-                        .format(str(i), format_type_bare(rhs_t), format_type_bare(lhs_t)))
+                    notes.append('Expression tuple item {} has type {}; {} expected; '
+                        .format(str(i), format_type(rhs_t), format_type(lhs_t)))
                 error_cnt += 1
 
         error_msg = msg + ' ({} tuple items are incompatible'.format(str(error_cnt))

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -287,8 +287,8 @@ main:6: error: Need more than 3 values to unpack (4 expected)
 [case testInvalidRvalueTypeInInferredMultipleLvarDefinition]
 import typing
 def f() -> None:
-    a, b = f   # E: "def ()" object is not iterable
-    c, d = A() # E: "__main__.A" object is not iterable
+    a, b = f   # E: "Callable[[], None]" object is not iterable
+    c, d = A() # E: "A" object is not iterable
 class A: pass
 [builtins fixtures/for.pyi]
 [out]
@@ -296,8 +296,8 @@ class A: pass
 [case testInvalidRvalueTypeInInferredNestedTupleAssignment]
 import typing
 def f() -> None:
-    a1, (a2, b) = A(), f   # E: "def ()" object is not iterable
-    a3, (c, d) = A(), A() # E: "__main__.A" object is not iterable
+    a1, (a2, b) = A(), f   # E: "Callable[[], None]" object is not iterable
+    a3, (c, d) = A(), A() # E: "A" object is not iterable
 class A: pass
 [builtins fixtures/for.pyi]
 [out]
@@ -1004,7 +1004,7 @@ main:4: error: Incompatible types in assignment (expression has type "A", variab
 main:5: error: Incompatible types in assignment (expression has type "B", variable has type "C")
 main:6: error: Incompatible types in assignment (expression has type "C", variable has type "A")
 main:10: error: Need more than 2 values to unpack (3 expected)
-main:12: error: "__main__.B" object is not iterable
+main:12: error: "B" object is not iterable
 
 [case testInferenceOfFor3]
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1676,10 +1676,10 @@ reveal_type(n2.b)  # N: Revealed type is "builtins.str"
 reveal_type(m3.a)  # N: Revealed type is "builtins.str"
 reveal_type(n3.b)  # N: Revealed type is "builtins.str"
 
-x, y = m  # E: "types.ModuleType" object is not iterable
+x, y = m  # E: Module object is not iterable
 x, y, z = m, n  # E: Need more than 2 values to unpack (3 expected)
 x, y = m, m, m  # E: Too many values to unpack (2 expected, 3 provided)
-x, (y, z) = m, n  # E: "types.ModuleType" object is not iterable
+x, (y, z) = m, n  # E: Module object is not iterable
 x, (y, z) = m, (n, n, n)  # E: Too many values to unpack (2 expected, 3 provided)
 
 [file m.py]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -405,7 +405,7 @@ a, b = None, None # type: (A, B)
 
 a1, b1 = a, a # type: (A, B)  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 a2, b2 = b, b # type: (A, B)  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-a3, b3 = a # type: (A, B)     # E: "__main__.A" object is not iterable
+a3, b3 = a # type: (A, B)     # E: "A" object is not iterable
 a4, b4 = None # type: (A, B)  # E: "None" object is not iterable
 a5, b5 = a, b, a # type: (A, B)  # E: Too many values to unpack (2 expected, 3 provided)
 
@@ -421,8 +421,8 @@ a, b = None, None # type: (A, B)
 def f(): pass
 
 a, b = None # E: "None" object is not iterable
-a, b = a   # E: "__main__.A" object is not iterable
-a, b = f   # E: "def () -> Any" object is not iterable
+a, b = a   # E: "A" object is not iterable
+a, b = f   # E: "Callable[[], Any]" object is not iterable
 
 class A: pass
 class B: pass
@@ -1468,7 +1468,7 @@ x9, y9, x10, y10, z5 = *points2, 1, *points2 # E: Contiguous iterable with same 
 () = []  # E: can't assign to ()
 
 [case testAssignEmptyBogus]
-() = 1  # E: "Literal[1]?" object is not iterable
+() = 1  # E: "int" object is not iterable
 [builtins fixtures/tuple.pyi]
 
 [case testMultiplyTupleByIntegerLiteral]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -556,7 +556,7 @@ reveal_type(d1)  # N: Revealed type is "Union[Any, builtins.float]"
 reveal_type(d2)  # N: Revealed type is "Union[Any, builtins.float]"
 
 e: Union[Any, Tuple[float, float], int]
-(e1, e2) = e  # E: "builtins.int" object is not iterable
+(e1, e2) = e  # E: "int" object is not iterable
 [builtins fixtures/tuple.pyi]
 
 [case testUnionMultiassignNotJoin]
@@ -694,7 +694,7 @@ reveal_type(d) # N: Revealed type is "builtins.list[builtins.int*]"
 from typing import Union
 bad: Union[int, str]
 
-x, y = bad # E: "builtins.int" object is not iterable \
+x, y = bad # E: "int" object is not iterable \
            # E: Unpacking a string is disallowed
 reveal_type(x) # N: Revealed type is "Any"
 reveal_type(y) # N: Revealed type is "Any"


### PR DESCRIPTION
### Description

Related https://github.com/python/mypy/issues/5072

Uses `format_type` to get a more concise output.