### PR TITLE
Microrefactoring: "not callable" error message is now a const

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -134,6 +134,7 @@ FUNCTION_ALWAYS_TRUE: Final = ErrorMessage(
     'Function "{}" could always be true in boolean context',
     code=codes.TRUTHY_BOOL,
 )
+NOT_CALLABLE: Final = '{} not callable'
 
 # Generic
 GENERIC_INSTANCE_VAR_CLASS_ACCESS: Final = (

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -289,8 +289,8 @@ class MessageBuilder:
                 # Explain that the problem is that the type of the function is not known.
                 self.fail('Cannot call function of unknown type', context, code=codes.OPERATOR)
             else:
-                self.fail('{} not callable'.format(format_type(original_type)), context,
-                          code=codes.OPERATOR)
+                self.fail(message_registry.NOT_CALLABLE.format(
+                    format_type(original_type)), context, code=codes.OPERATOR)
         else:
             # The non-special case: a missing ordinary attribute.
             extra = ''
@@ -397,7 +397,7 @@ class MessageBuilder:
         self.fail(msg, context, code=codes.OPERATOR)
 
     def not_callable(self, typ: Type, context: Context) -> Type:
-        self.fail('{} not callable'.format(format_type(typ)), context)
+        self.fail(message_registry.NOT_CALLABLE.format(format_type(typ)), context)
         return AnyType(TypeOfAny.from_error)
 
     def untyped_function_call(self, callee: CallableType, context: Context) -> Type:


### PR DESCRIPTION
It was duplicated, so I've decided to move it into a separate constant.