### PR TITLE
Fixes TODO item: no more `analyze_external_member_access`

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2087,16 +2087,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
             return member_type
 
-    def analyze_external_member_access(self, member: str, base_type: Type,
-                                       context: Context) -> Type:
-        """Analyse member access that is external, i.e. it cannot
-        refer to private definitions. Return the result type.
-        """
-        # TODO remove; no private definitions in mypy
-        return analyze_member_access(member, base_type, context, False, False, False,
-                                     self.msg, original_type=base_type, chk=self.chk,
-                                     in_literal_context=self.is_literal_context())
-
     def is_literal_context(self) -> bool:
         return is_literal_type_like(self.type_context[-1])
 


### PR DESCRIPTION
I've removed `analyze_external_member_access` method from `expr_checker`.

Why?
1. It was  a simple alias to a more full featured `analyze_member_access`. There was no "specialization" or custom logic, just more arguments.
2. It caused some confusion: I was confused when I saw it the first time. My questions was: is this any different from `analyze_member_access`?
3. It was mark to be removed 🙂 

It might be a breaking change for plugin authors, but this is an easy one to fix: just use `analyze_member_access` directly all the time.