### PR TITLE
Reduce amount of debug info injected in extension modules

### DIFF
--- a/mypyc/__main__.py
+++ b/mypyc/__main__.py
@@ -22,7 +22,7 @@ from setuptools import setup
 from mypyc.build import mypycify
 
 setup(name='mypyc_output',
-      ext_modules=mypycify({}, opt_level="{}"),
+      ext_modules=mypycify({}, opt_level="{}", debug_level="{}"),
 )
 """
 
@@ -35,10 +35,11 @@ def main() -> None:
         pass
 
     opt_level = os.getenv("MYPYC_OPT_LEVEL", '3')
+    debug_level = os.getenv("MYPYC_DEBUG_LEVEL", '1')
 
     setup_file = os.path.join(build_dir, 'setup.py')
     with open(setup_file, 'w') as f:
-        f.write(setup_format.format(sys.argv[1:], opt_level))
+        f.write(setup_format.format(sys.argv[1:], opt_level, debug_level))
 
     # We don't use run_setup (like we do in the test suite) because it throws
     # away the error code from distutils, and we don't care about the slight

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -431,7 +431,8 @@ def mypycify(
     *,
     only_compile_paths: Optional[Iterable[str]] = None,
     verbose: bool = False,
-    opt_level: str = '3',
+    opt_level: str = "3",
+    debug_level: str = "1",
     strip_asserts: bool = False,
     multi_file: bool = False,
     separate: Union[bool, List[Tuple[List[str], Optional[str]]]] = False,
@@ -454,6 +455,7 @@ def mypycify(
         verbose: Should mypyc be more verbose. Defaults to false.
 
         opt_level: The optimization level, as a string. Defaults to '3' (meaning '-O3').
+        debug_level: The debug level, as a string. Defaults to '1' (meaning '-g1').
         strip_asserts: Should asserts be stripped from the generated code.
 
         multi_file: Should each Python module be compiled into its own C source file.
@@ -511,7 +513,9 @@ def mypycify(
     cflags: List[str] = []
     if compiler.compiler_type == 'unix':
         cflags += [
-            '-O{}'.format(opt_level), '-Werror', '-Wno-unused-function', '-Wno-unused-label',
+            '-O{}'.format(opt_level),
+            '-g{}'.format(debug_level),
+            '-Werror', '-Wno-unused-function', '-Wno-unused-label',
             '-Wno-unreachable-code', '-Wno-unused-variable',
             '-Wno-unused-command-line-argument', '-Wno-unknown-warning-option',
         ]

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -242,6 +242,7 @@ class TestRun(MypycDataSuite):
             check_serialization_roundtrip(ir)
 
         opt_level = int(os.environ.get('MYPYC_OPT_LEVEL', 0))
+        debug_level = int(os.environ.get('MYPYC_DEBUG_LEVEL', 0))
 
         setup_file = os.path.abspath(os.path.join(WORKDIR, 'setup.py'))
         # We pass the C file information to the build script via setup.py unfortunately
@@ -250,7 +251,8 @@ class TestRun(MypycDataSuite):
                                         separate,
                                         cfiles,
                                         self.multi_file,
-                                        opt_level))
+                                        opt_level,
+                                        debug_level))
 
         if not run_setup(setup_file, ['build_ext', '--inplace']):
             if testcase.config.getoption('--mypyc-showc'):

--- a/setup.py
+++ b/setup.py
@@ -144,10 +144,12 @@ if USE_MYPYC:
 
     from mypyc.build import mypycify
     opt_level = os.getenv('MYPYC_OPT_LEVEL', '3')
+    debug_level = os.getenv('MYPYC_DEBUG_LEVEL', '1')
     force_multifile = os.getenv('MYPYC_MULTI_FILE', '') == '1'
     ext_modules = mypycify(
         mypyc_targets + ['--config-file=mypy_bootstrap.ini'],
         opt_level=opt_level,
+        debug_level=debug_level,
         # Use multi-file compilation mode on windows because without it
         # our Appveyor builds run out of memory sometimes.
         multi_file=sys.platform == 'win32' or force_multifile,


### PR DESCRIPTION
Reduce amount of debug info injected in extension modules
    
This can help in decreasing memory resource requirements on CI and
generating relatively thinner binaries
    
Resolves #11507