### PR TITLE
Enable --fast-exit by default to speed up mypy

### DIFF
--- a/mypy/api.py
+++ b/mypy/api.py
@@ -67,7 +67,7 @@ def run(args: List[str]) -> Tuple[str, str, int]:
     # Lazy import to avoid needing to import all of mypy to call run_dmypy
     from mypy.main import main
     return _run(lambda stdout, stderr: main(None, args=args,
-                                            stdout=stdout, stderr=stderr))
+                                            stdout=stdout, stderr=stderr, clean_exit=True))
 
 
 def run_dmypy(args: List[str]) -> Tuple[str, str, int]:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -769,7 +769,7 @@ def process_options(args: List[str],
         dest='shadow_file', action='append',
         help="When encountering SOURCE_FILE, read and type check "
              "the contents of SHADOW_FILE instead.")
-    add_invertible_flag('--fast-exit', default=False, help=argparse.SUPPRESS,
+    add_invertible_flag('--fast-exit', default=True, help=argparse.SUPPRESS,
                         group=internals_group)
 
     report_group = parser.add_argument_group(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -48,13 +48,16 @@ def main(script_path: Optional[str],
          stdout: TextIO,
          stderr: TextIO,
          args: Optional[List[str]] = None,
+         clean_exit: bool = False,
          ) -> None:
     """Main entry point to the type checker.
 
     Args:
         script_path: Path to the 'mypy' script (used for finding data files).
         args: Custom command-line arguments.  If not given, sys.argv[1:] will
-        be used.
+            be used.
+        clean_exit: Don't hard kill the process on exit. This allows catching
+            SystemExit.
     """
     util.check_python_version('mypy')
     t0 = time.time()
@@ -66,6 +69,8 @@ def main(script_path: Optional[str],
     fscache = FileSystemCache()
     sources, options = process_options(args, stdout=stdout, stderr=stderr,
                                        fscache=fscache)
+    if clean_exit:
+        options.fast_exit = False
 
     formatter = util.FancyFormatter(stdout, stderr, options.show_error_codes)
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -286,7 +286,7 @@ class Options:
         self.package_root: List[str] = []
         self.cache_map: Dict[str, Tuple[str, str]] = {}
         # Don't properly free objects on exit, just kill the current process.
-        self.fast_exit = False
+        self.fast_exit = True
         # Used to transform source code before parsing if not None
         # TODO: Make the type precise (AnyStr -> AnyStr)
         self.transform_source: Optional[Callable[[Any], Any]] = None


### PR DESCRIPTION
This means that we kill the mypy process at exit instead of cleanly
freeing up memory. This speeds up mypy runs by ~10% in some cases
(with compiled mypy).

We've been using this internally at work for a long time without any
issues.

Previously the slowdown was visible as a small delay after the final
message from mypy was printed.

I measured the impact on a branch with some other optimizations as
well, so on master the fraction would be slightly less, as other
things would be slower.
