### PR TITLE
Speed up ArgKind methods by changing them into top-level functions

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -33,7 +33,7 @@ def map_actuals_to_formals(actual_kinds: List[nodes.ArgKind],
     for ai, actual_kind in enumerate(actual_kinds):
         if actual_kind == nodes.ARG_POS:
             if fi < nformals:
-                if not formal_kinds[fi].is_star():
+                if not nodes.is_star(formal_kinds[fi]):
                     formal_to_actual[fi].append(ai)
                     fi += 1
                 elif formal_kinds[fi] == nodes.ARG_STAR:
@@ -55,14 +55,14 @@ def map_actuals_to_formals(actual_kinds: List[nodes.ArgKind],
                 # Assume that it is an iterable (if it isn't, there will be
                 # an error later).
                 while fi < nformals:
-                    if formal_kinds[fi].is_named(star=True):
+                    if nodes.is_named(formal_kinds[fi], star=True):
                         break
                     else:
                         formal_to_actual[fi].append(ai)
                     if formal_kinds[fi] == nodes.ARG_STAR:
                         break
                     fi += 1
-        elif actual_kind.is_named():
+        elif nodes.is_named(actual_kind):
             assert actual_names is not None, "Internal error: named kinds without names given"
             name = actual_names[ai]
             if name in formal_names:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -36,7 +36,7 @@ from mypy.types import (
     Instance, NoneType, strip_type, TypeType, TypeOfAny,
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType,
     is_named_instance, union_items, TypeQuery, LiteralType,
-    is_optional, remove_optional, TypeTranslator, StarType, get_proper_type, ProperType,
+    is_optional_type, remove_optional, TypeTranslator, StarType, get_proper_type, ProperType,
     get_proper_types, is_literal_type, TypeAliasType, TypeGuardedType)
 from mypy.sametypes import is_same_type
 from mypy.messages import (
@@ -4512,11 +4512,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     collection_type = operand_types[right_index]
 
                     # We only try and narrow away 'None' for now
-                    if not is_optional(item_type):
+                    if not is_optional_type(item_type):
                         continue
 
                     collection_item_type = get_proper_type(builtin_item_type(collection_type))
-                    if collection_item_type is None or is_optional(collection_item_type):
+                    if collection_item_type is None or is_optional_type(collection_item_type):
                         continue
                     if (isinstance(collection_item_type, Instance)
                             and collection_item_type.type.fullname == 'builtins.object'):
@@ -4904,7 +4904,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         non_optional_types = []
         for i in chain_indices:
             typ = operand_types[i]
-            if not is_optional(typ):
+            if not is_optional_type(typ):
                 non_optional_types.append(typ)
 
         # Make sure we have a mixture of optional and non-optional types.
@@ -4914,7 +4914,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if_map = {}
         for i in narrowable_operand_indices:
             expr_type = operand_types[i]
-            if not is_optional(expr_type):
+            if not is_optional_type(expr_type):
                 continue
             if any(is_overlapping_erased_types(expr_type, t) for t in non_optional_types):
                 if_map[operands[i]] = remove_optional(expr_type)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -14,7 +14,7 @@ from mypy.subtypes import (
     is_subtype, is_equivalent, is_subtype_ignoring_tvars, is_proper_subtype,
     is_protocol_implementation, find_member
 )
-from mypy.nodes import INVARIANT, COVARIANT, CONTRAVARIANT
+from mypy.nodes import INVARIANT, COVARIANT, CONTRAVARIANT, is_named
 import mypy.typeops
 from mypy import state
 
@@ -532,7 +532,7 @@ def combine_arg_names(t: CallableType, s: CallableType) -> List[Optional[str]]:
     for i in range(num_args):
         t_name = t.arg_names[i]
         s_name = s.arg_names[i]
-        if t_name == s_name or t.arg_kinds[i].is_named() or s.arg_kinds[i].is_named():
+        if t_name == s_name or is_named(t.arg_kinds[i]) or is_named(s.arg_kinds[i]):
             new_names.append(t_name)
         else:
             new_names.append(None)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1625,9 +1625,9 @@ class MemberExpr(RefExpr):
         return visitor.visit_member_expr(self)
 
 
-# Kinds of arguments
 @unique
 class ArgKind(Enum):
+    """Kinds of arguments"""
     # Positional argument
     ARG_POS = 0
     # Positional, optional argument (functions only, not calls)
@@ -1642,28 +1642,32 @@ class ArgKind(Enum):
     ARG_NAMED_OPT = 5
 
 
-def is_positional(self: ArgKind, star: bool = False) -> bool:
+def is_positional(kind: ArgKind, star: bool = False) -> bool:
     return (
-        self == ARG_POS
-        or self == ARG_OPT
-        or (star and self == ARG_STAR)
+        kind == ARG_POS
+        or kind == ARG_OPT
+        or (star and kind == ARG_STAR)
     )
 
-def is_named(self: ArgKind, star: bool = False) -> bool:
+
+def is_named(kind: ArgKind, star: bool = False) -> bool:
     return (
-        self == ARG_NAMED
-        or self == ARG_NAMED_OPT
-        or (star and self == ARG_STAR2)
+        kind == ARG_NAMED
+        or kind == ARG_NAMED_OPT
+        or (star and kind == ARG_STAR2)
     )
 
-def is_required(self: ArgKind) -> bool:
-    return self == ARG_POS or self == ARG_NAMED
 
-def is_optional(self: ArgKind) -> bool:
-    return self == ARG_OPT or self == ARG_NAMED_OPT
+def is_required(kind: ArgKind) -> bool:
+    return kind == ARG_POS or kind == ARG_NAMED
 
-def is_star(self: ArgKind) -> bool:
-    return self == ARG_STAR or self == ARG_STAR2
+
+def is_optional(kind: ArgKind) -> bool:
+    return kind == ARG_OPT or kind == ARG_NAMED_OPT
+
+
+def is_star(kind: ArgKind) -> bool:
+    return kind == ARG_STAR or kind == ARG_STAR2
 
 
 ARG_POS: Final = ArgKind.ARG_POS

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1641,28 +1641,29 @@ class ArgKind(Enum):
     # In an argument list, keyword-only and also optional
     ARG_NAMED_OPT = 5
 
-    def is_positional(self, star: bool = False) -> bool:
-        return (
-            self == ARG_POS
-            or self == ARG_OPT
-            or (star and self == ARG_STAR)
-        )
 
-    def is_named(self, star: bool = False) -> bool:
-        return (
-            self == ARG_NAMED
-            or self == ARG_NAMED_OPT
-            or (star and self == ARG_STAR2)
-        )
+def is_positional(self: ArgKind, star: bool = False) -> bool:
+    return (
+        self == ARG_POS
+        or self == ARG_OPT
+        or (star and self == ARG_STAR)
+    )
 
-    def is_required(self) -> bool:
-        return self == ARG_POS or self == ARG_NAMED
+def is_named(self: ArgKind, star: bool = False) -> bool:
+    return (
+        self == ARG_NAMED
+        or self == ARG_NAMED_OPT
+        or (star and self == ARG_STAR2)
+    )
 
-    def is_optional(self) -> bool:
-        return self == ARG_OPT or self == ARG_NAMED_OPT
+def is_required(self: ArgKind) -> bool:
+    return self == ARG_POS or self == ARG_NAMED
 
-    def is_star(self) -> bool:
-        return self == ARG_STAR or self == ARG_STAR2
+def is_optional(self: ArgKind) -> bool:
+    return self == ARG_OPT or self == ARG_NAMED_OPT
+
+def is_star(self: ArgKind) -> bool:
+    return self == ARG_STAR or self == ARG_STAR2
 
 
 ARG_POS: Final = ArgKind.ARG_POS

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -6,7 +6,7 @@ from typing_extensions import Final
 from mypy.nodes import (
     ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_POS, MDEF, Argument, AssignmentStmt, CallExpr,
     Context, Expression, JsonDict, NameExpr, RefExpr,
-    SymbolTableNode, TempNode, TypeInfo, Var, TypeVarExpr, PlaceholderNode
+    SymbolTableNode, TempNode, TypeInfo, Var, TypeVarExpr, PlaceholderNode, is_named
 )
 from mypy.plugin import ClassDefContext, SemanticAnalyzerPluginInterface
 from mypy.plugins.common import (
@@ -495,8 +495,8 @@ def _collect_field_args(expr: Expression,
         # field() only takes keyword arguments.
         args = {}
         for name, arg, kind in zip(expr.arg_names, expr.args, expr.arg_kinds):
-            if not kind.is_named():
-                if kind.is_named(star=True):
+            if not is_named(kind):
+                if is_named(kind, star=True):
                     # This means that `field` is used with `**` unpacking,
                     # the best we can do for now is not to fail.
                     # TODO: we can infer what's inside `**` and try to collect it.

--- a/mypy/plugins/functools.py
+++ b/mypy/plugins/functools.py
@@ -3,7 +3,7 @@ from typing import Dict, NamedTuple, Optional
 from typing_extensions import Final
 
 import mypy.plugin
-from mypy.nodes import ARG_POS, ARG_STAR2, Argument, FuncItem, Var
+from mypy.nodes import ARG_POS, ARG_STAR2, Argument, FuncItem, Var, is_positional
 from mypy.plugins.common import add_method_to_class
 from mypy.types import AnyType, CallableType, get_proper_type, Type, TypeOfAny, UnboundType
 
@@ -66,7 +66,7 @@ def _find_other_type(method: _MethodInfo) -> Type:
     cur_pos_arg = 0
     other_arg = None
     for arg_kind, arg_type in zip(method.type.arg_kinds, method.type.arg_types):
-        if arg_kind.is_positional():
+        if is_positional(arg_kind):
             if cur_pos_arg == first_arg_pos:
                 other_arg = arg_type
                 break

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -1,7 +1,7 @@
 from mypy.messages import format_type
 from mypy.plugins.common import add_method_to_class
 from mypy.nodes import (
-    ARG_POS, Argument, Block, ClassDef, SymbolTable, TypeInfo, Var, Context
+    ARG_POS, Argument, Block, ClassDef, SymbolTable, TypeInfo, Var, Context, is_positional
 )
 from mypy.subtypes import is_subtype
 from mypy.types import (
@@ -100,7 +100,7 @@ def create_singledispatch_function_callback(ctx: FunctionContext) -> Type:
             )
             return ctx.default_return_type
 
-        elif not func_type.arg_kinds[0].is_positional(star=True):
+        elif not is_positional(func_type.arg_kinds[0], star=True):
             fail(
                 ctx,
                 'First argument to singledispatch function must be a positional argument',

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -76,8 +76,7 @@ from mypy.nodes import (
     get_nongen_builtins, get_member_expr_fullname, REVEAL_TYPE,
     REVEAL_LOCALS, is_final_node, TypedDictExpr, type_aliases_source_versions,
     EnumCallExpr, RUNTIME_PROTOCOL_DECOS, FakeExpression, Statement, AssignmentExpr,
-    ParamSpecExpr, EllipsisExpr,
-    FuncBase, implicit_module_attrs,
+    ParamSpecExpr, EllipsisExpr, FuncBase, implicit_module_attrs, is_named
 )
 from mypy.tvar_scope import TypeVarLikeScope
 from mypy.typevars import fill_typevars
@@ -3142,7 +3141,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         contravariant = False
         upper_bound: Type = self.object_type()
         for param_value, param_name, param_kind in zip(args, names, kinds):
-            if not param_kind.is_named():
+            if not is_named(param_kind):
                 self.fail("Unexpected argument to TypeVar()", context)
                 return None
             if param_name == 'covariant':

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -62,9 +62,9 @@ class StrConv(NodeVisitor[str]):
         extra: List[Tuple[str, List[mypy.nodes.Var]]] = []
         for arg in o.arguments:
             kind: mypy.nodes.ArgKind = arg.kind
-            if kind.is_required():
+            if mypy.nodes.is_required(kind):
                 args.append(arg.variable)
-            elif kind.is_optional():
+            elif mypy.nodes.is_optional(kind):
                 assert arg.initializer is not None
                 args.append(('default', [arg.variable, arg.initializer]))
             elif kind == mypy.nodes.ARG_STAR:

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -72,7 +72,7 @@ from mypy.nodes import (
     TupleExpr, ListExpr, ComparisonExpr, CallExpr, IndexExpr, EllipsisExpr,
     ClassDef, MypyFile, Decorator, AssignmentStmt, TypeInfo,
     IfStmt, ImportAll, ImportFrom, Import, FuncDef, FuncBase, Block,
-    Statement, OverloadedFuncDef, ARG_POS, ARG_STAR, ARG_STAR2, ARG_NAMED,
+    Statement, OverloadedFuncDef, ARG_POS, ARG_STAR, ARG_STAR2, ARG_NAMED, is_named
 )
 from mypy.stubgenc import generate_stub_for_c_module
 from mypy.stubutil import (
@@ -650,7 +650,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
                 if not isinstance(get_proper_type(annotated_type), AnyType):
                     annotation = ": {}".format(self.print_annotation(annotated_type))
             if arg_.initializer:
-                if kind.is_named() and not any(arg.startswith('*') for arg in args):
+                if is_named(kind) and not any(arg.startswith('*') for arg in args):
                     args.append('*')
                 if not annotation:
                     typename = self.get_str_type_of_node(arg_.initializer, True, False)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -341,7 +341,7 @@ def _verify_arg_default_value(
 ) -> Iterator[str]:
     """Checks whether argument default values are compatible."""
     if runtime_arg.default != inspect.Parameter.empty:
-        if stub_arg.kind.is_required():
+        if nodes.is_required(stub_arg.kind):
             yield (
                 'runtime argument "{}" has a default value but stub argument does not'.format(
                     runtime_arg.name
@@ -370,7 +370,7 @@ def _verify_arg_default_value(
                     )
                 )
     else:
-        if stub_arg.kind.is_optional():
+        if nodes.is_optional(stub_arg.kind):
             yield (
                 'stub argument "{}" has a default value but runtime argument does not'.format(
                     stub_arg.variable.name
@@ -413,7 +413,7 @@ class Signature(Generic[T]):
             if isinstance(arg, inspect.Parameter):
                 return arg.default != inspect.Parameter.empty
             if isinstance(arg, nodes.Argument):
-                return arg.kind.is_optional()
+                return nodes.is_optional(arg.kind)
             raise AssertionError
 
         def get_desc(arg: Any) -> str:
@@ -440,9 +440,9 @@ class Signature(Generic[T]):
         stub_sig: Signature[nodes.Argument] = Signature()
         stub_args = maybe_strip_cls(stub.name, stub.arguments)
         for stub_arg in stub_args:
-            if stub_arg.kind.is_positional():
+            if nodes.is_positional(stub_arg.kind):
                 stub_sig.pos.append(stub_arg)
-            elif stub_arg.kind.is_named():
+            elif nodes.is_named(stub_arg.kind):
                 stub_sig.kwonly[stub_arg.variable.name] = stub_arg
             elif stub_arg.kind == nodes.ARG_STAR:
                 stub_sig.varpos = stub_arg
@@ -538,9 +538,9 @@ class Signature(Generic[T]):
                 initializer=None,
                 kind=get_kind(arg_name),
             )
-            if arg.kind.is_positional():
+            if nodes.is_positional(arg.kind):
                 sig.pos.append(arg)
-            elif arg.kind.is_named():
+            elif nodes.is_named(arg.kind):
                 sig.kwonly[arg.variable.name] = arg
             elif arg.kind == nodes.ARG_STAR:
                 sig.varpos = arg

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -18,6 +18,7 @@ from mypy.erasetype import erase_type
 # import mypy.solve
 from mypy.nodes import (
     FuncBase, Var, Decorator, OverloadedFuncDef, TypeInfo, CONTRAVARIANT, COVARIANT,
+    is_star, is_positional, is_optional
 
 )
 from mypy.maptype import map_instance_to_supertype
@@ -966,8 +967,8 @@ def is_callable_compatible(left: CallableType, right: CallableType,
 
         i = right_star.pos
         assert i is not None
-        while i < len(left.arg_kinds) and left.arg_kinds[i].is_positional():
-            if allow_partial_overlap and left.arg_kinds[i].is_optional():
+        while i < len(left.arg_kinds) and is_positional(left.arg_kinds[i]):
+            if allow_partial_overlap and is_optional(left.arg_kinds[i]):
                 break
 
             left_by_position = left.argument_by_position(i)
@@ -986,7 +987,7 @@ def is_callable_compatible(left: CallableType, right: CallableType,
         right_names = {name for name in right.arg_names if name is not None}
         left_only_names = set()
         for name, kind in zip(left.arg_names, left.arg_kinds):
-            if name is None or kind.is_star() or name in right_names:
+            if name is None or is_star(kind) or name in right_names:
                 continue
             left_only_names.add(name)
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -24,7 +24,7 @@ from mypy.nodes import (
     TypeInfo, Context, SymbolTableNode, Var, Expression,
     get_nongen_builtins, check_arg_names, check_arg_kinds, ArgKind, ARG_POS, ARG_NAMED,
     ARG_OPT, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2, TypeVarExpr, TypeVarLikeExpr, ParamSpecExpr,
-    TypeAlias, PlaceholderNode, SYMBOL_FUNCBASE_TYPES, Decorator, MypyFile
+    TypeAlias, PlaceholderNode, SYMBOL_FUNCBASE_TYPES, Decorator, MypyFile, is_star
 )
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.tvar_scope import TypeVarLikeScope
@@ -782,7 +782,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     assert found.fullname is not None
                     kind = ARG_KINDS_BY_CONSTRUCTOR[found.fullname]
                     kinds.append(kind)
-                    if arg.name is not None and kind.is_star():
+                    if arg.name is not None and is_star(kind):
                         self.fail("{} arguments should not have names".format(
                             arg.constructor), arg)
                         return None

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -3,7 +3,7 @@
 from typing import List, Optional, Sequence
 from typing_extensions import Final
 
-from mypy.nodes import FuncDef, Block, ArgKind, ARG_POS
+from mypy.nodes import FuncDef, Block, ArgKind, ARG_POS, is_optional
 
 from mypyc.common import JsonDict, get_id_from_name, short_id_from_name
 from mypyc.ir.ops import (
@@ -28,7 +28,7 @@ class RuntimeArg:
 
     @property
     def optional(self) -> bool:
-        return self.kind.is_optional()
+        return is_optional(self.kind)
 
     def __repr__(self) -> str:
         return 'RuntimeArg(name=%s, type=%s, optional=%r, pos_only=%r)' % (


### PR DESCRIPTION
Mypyc can't call enum methods as native methods. This seems to speed
up compiled mypy by around 1% (rough measurement).