### PR TITLE
Now `type(None)` is more consistent, refs #11550

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3220,6 +3220,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return type_object_type(tuple_fallback(item).type, self.named_type)
         elif isinstance(item, AnyType):
             return AnyType(TypeOfAny.from_another_any, source_any=item)
+        elif isinstance(item, NoneType):
+            # This is a special case, `x = type(None)` turns into
+            # `x = TypeAliasType(None)` during semantic analysis.
+            # So, we need to show the real type here. Which is `Type[None]`.
+            return TypeType(item)
         else:
             if alias_definition:
                 return AnyType(TypeOfAny.special_form)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2686,6 +2686,8 @@ class SemanticAnalyzer(NodeVisitor[None],
 
         res: Optional[Type] = None
         if self.is_none_alias(rvalue):
+            # This is really `Type[None]`, not just `None`, but we use
+            # this as a backwards compatible solution. See #11550
             res = NoneType()
             alias_tvars, depends_on, qualified_tvars = \
                 [], set(), []  # type: List[str], Set[str], List[str]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -305,6 +305,39 @@ x = y  # E: Incompatible types in assignment (expression has type "Optional[int]
 y = z
 [builtins fixtures/bool.pyi]
 
+[case testTypeNoneAliases]
+from typing import Type
+
+a = type(None)
+b: Type[None]
+c: Type[None] = type(None)  # E: Too many arguments for "type"
+d: None
+e = None
+
+reveal_type(a)  # N: Revealed type is "Type[None]"
+reveal_type(b)  # N: Revealed type is "Type[None]"
+reveal_type(c)  # N: Revealed type is "Type[None]"
+reveal_type(d)  # N: Revealed type is "None"
+reveal_type(e)  # N: Revealed type is "None"
+[builtins fixtures/bool.pyi]
+
+[case testTypeNoneAliasesStrict]
+# flags: --strict-optional
+from typing import Type
+
+a = type(None)
+b: Type[None]
+c: Type[None] = type(None)
+d: None
+e = None
+
+reveal_type(a)  # N: Revealed type is "Type[None]"
+reveal_type(b)  # N: Revealed type is "Type[None]"
+reveal_type(c)  # N: Revealed type is "Type[None]"
+reveal_type(d)  # N: Revealed type is "None"
+reveal_type(e)  # N: Revealed type is "None"
+[builtins fixtures/bool.pyi]
+
 [case testAliasToTupleAndCallable]
 from typing import Callable, Tuple
 C = Callable


### PR DESCRIPTION
Closes #11550

This might fail in some unexpected cases.
Moreover, is still don't understand why `c: Type[None] = type(None)  # E: Too many arguments for "type"` works this way without `--strict-optional`

This totally needs more work.