### PR TITLE
WIP: we can now make use of `__class_getitem__` for non-generic types

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -235,7 +235,7 @@ def analyze_type_callable_member_access(name: str,
     if isinstance(ret_type, TupleType):
         ret_type = tuple_fallback(ret_type)
     if isinstance(ret_type, Instance):
-        if not mx.is_operator:
+        if not mx.is_operator or name == '__class_getitem__':
             # When Python sees an operator (eg `3 == 4`), it automatically translates that
             # into something like `int.__eq__(3, 4)` instead of `(3).__eq__(4)` as an
             # optimization.
@@ -250,6 +250,9 @@ def analyze_type_callable_member_access(name: str,
             # the corresponding method in the current instance to avoid this edge case.
             # See https://github.com/python/mypy/pull/1787 for more info.
             # TODO: do not rely on same type variables being present in all constructor overloads.
+
+            # We also allow `SomeClass[1]` acccess via `__class_getitem__`,
+            # it is very special. It only works this way for non-generic types.
             result = analyze_class_attribute_access(ret_type, name, mx,
                                                     original_vars=typ.items[0].variables)
             if result:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1072,6 +1072,12 @@ def fix_instance(t: Instance, fail: MsgCallback, note: MsgCallback,
 
     Also emit a suitable error if this is not due to implicit Any's.
     """
+    if not t.type.is_generic() and t.type.has_readable_member('__class_getitem__'):
+        # Corner case: we might have a non-generic class with `__class_getitem__`
+        # which is used for something else: not type application.
+        # So, in this case: we allow using this type without type arguments.
+        return
+
     if len(t.args) == 0:
         if use_generic_error:
             fullname: Optional[str] = None
@@ -1081,6 +1087,7 @@ def fix_instance(t: Instance, fail: MsgCallback, note: MsgCallback,
                                    unexpanded_type)
         t.args = (any_type,) * len(t.type.type_vars)
         return
+
     # Invalid number of type parameters.
     n = len(t.type.type_vars)
     s = '{} type arguments'.format(n)


### PR DESCRIPTION
Now this code typechecks with no problems:

```python
class A:
    def __class_getitem__(cls, a: int) -> type[A]:
        return cls

A[1]
```

But, this code raises:

```python
class A:
    def __class_getitem__(cls, a: str) -> type[A]:
        return cls

A[1]  # E: Argument 1 to "__class_getitem__" of "A" has incompatible type "int"; expected "str"
```

This is a WIP, because I want to know how many things will break because of this. I'm intersted in both primer and test outputs. I will add tests in next commits.

Closes #11501