### PR TITLE
mypy/build: Use` _load_json_file` in `load_tree`

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1978,17 +1978,17 @@ class State:
     def load_tree(self, temporary: bool = False) -> None:
         assert self.meta is not None, "Internal error: this method must be called only" \
                                       " for cached modules"
+
+        data = _load_json_file(self.meta.data_json, self.manager, "Load tree ",
+                               "Could not load tree: ")
+        if data is None:
+            return None
+
         t0 = time.time()
-        raw = self.manager.metastore.read(self.meta.data_json)
-        t1 = time.time()
-        data = json.loads(raw)
-        t2 = time.time()
         # TODO: Assert data file wasn't changed.
         self.tree = MypyFile.deserialize(data)
-        t3 = time.time()
-        self.manager.add_stats(data_read_time=t1 - t0,
-                               data_json_load_time=t2 - t1,
-                               deserialize_time=t3 - t2)
+        t1 = time.time()
+        self.manager.add_stats(deserialize_time=t1 - t0)
         if not temporary:
             self.manager.modules[self.id] = self.tree
             self.manager.add_stats(fresh_trees=1)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1095,7 +1095,9 @@ def _load_json_file(file: str, manager: BuildManager,
     if manager.verbosity() >= 2:
         manager.trace(log_success + data.rstrip())
     try:
+        t1 = time.time()
         result = json.loads(data)
+        manager.add_stats(data_json_load_time=time.time() - t1)
     except json.JSONDecodeError:
         manager.errors.set_file(file, None)
         manager.errors.report(-1, -1,


### PR DESCRIPTION
### Description

This is a variant of https://github.com/python/mypy/issues/6156, albeit **not** the same exact failure site.

In one of my professional projects, we use `mypy` to lint a relatively complex Python codebase. For reasons that haven't been fully root-caused, we occasionally see JSON corruption errors that look like this:

```
Traceback (most recent call last):
  File "/usr/local/bin/mypy", line 8, in <module>
    sys.exit(console_entry())
  File "/usr/local/lib/python3.8/dist-packages/mypy/__main__.py", line 11, in console_entry
    main(None, sys.stdout, sys.stderr)
  File "mypy/main.py", line 87, in main
  File "mypy/main.py", line 165, in run_build
  File "mypy/build.py", line 179, in build
  File "mypy/build.py", line 254, in _build
  File "mypy/build.py", line 2697, in dispatch
  File "mypy/build.py", line 3014, in process_graph
  File "mypy/build.py", line 3089, in process_fresh_modules
  File "mypy/build.py", line 1975, in load_tree
  File "/usr/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.8/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1 column 5069 (char 5068)
```

That's with the latest MyPy (0.910), Python 3.8, Ubuntu 20.04. Note that the error here happens in `load_tree` and **not** `_load_json_file`. 

We're not 100% sure what causes this error, but we *do* know how to make the error more comprehensible: by reusing the error handling functionality that's already been added to `_load_json_file` with #6156. So, that's all this PR does: it reuses that utility function to turn the uncontrolled exception into something more recognizable as a MyPy cache error.

## Test Plan

I haven't made any test changes, but I've confirmed that the test suite passes locally with the functional changes that I've applied:

```bash
source venv/bin/activate
python3 runtests.py
```