### PR TITLE
Now `print >>` is properly checked on Python2

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -135,6 +135,9 @@ FUNCTION_ALWAYS_TRUE: Final = ErrorMessage(
     code=codes.TRUTHY_BOOL,
 )
 NOT_CALLABLE: Final = '{} not callable'
+PYTHON2_PRINT_FILE_TYPE: Final = (
+    'Argument "file" to "print" has incompatible type "{}"; expected "{}"'
+)
 
 # Generic
 GENERIC_INSTANCE_VAR_CLASS_ACCESS: Final = (

--- a/test-data/unit/check-python2.test
+++ b/test-data/unit/check-python2.test
@@ -27,10 +27,16 @@ class A:
         # type: (str) -> None
         pass
 
+class B:
+    def write(self):
+        # type: () -> int
+        pass
+
 print >>A(), ''
 print >>None, ''
 print >>1, '' # E: "int" has no attribute "write"
 print >>(None + ''), None # E: Unsupported left operand type for + ("None")
+print >> B(), ''  # E: Argument "file" to "print" has incompatible type "def () -> builtins.int"; expected "def (builtins.str) -> Any"
 
 [case testDivision]
 class A:


### PR DESCRIPTION
Fixes a simple `TODO` item.