### PR TITLE
Enums with annotations and no values are fine to be subclassed

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -840,6 +840,7 @@ VAR_FLAGS: Final = [
     'is_classmethod', 'is_property', 'is_settable_property', 'is_suppressed_import',
     'is_classvar', 'is_abstract_var', 'is_final', 'final_unset_in_class', 'final_set_in_init',
     'explicit_self_type', 'is_ready', 'from_module_getattr',
+    'has_explicit_value',
 ]
 
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -870,6 +870,7 @@ class Var(SymbolNode):
                  'is_suppressed_import',
                  'explicit_self_type',
                  'from_module_getattr',
+                 'has_explicit_value',
                  )
 
     def __init__(self, name: str, type: 'Optional[mypy.types.Type]' = None) -> None:
@@ -914,6 +915,9 @@ class Var(SymbolNode):
         self.explicit_self_type = False
         # If True, this is an implicit Var created due to module-level __getattr__.
         self.from_module_getattr = False
+        # Var can be created with an explicit value `a = 1` or without one `a: int`,
+        # we need a way to tell which one is which.
+        self.has_explicit_value = False
 
     @property
     def name(self) -> str:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1609,7 +1609,9 @@ class SemanticAnalyzer(NodeVisitor[None],
             for node in base.type.defn.defs.body:
                 if isinstance(node, (FuncBase, Decorator)):
                     continue  # A method
-                if isinstance(node, AssignmentStmt) and isinstance(node.rvalue, TempNode):
+                if (isinstance(node, AssignmentStmt)
+                        and isinstance(node.rvalue, TempNode)
+                        and node.rvalue.no_rhs):
                     continue  # Corner case: assignments like `x: int` are fine.
                 return True
         return False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1609,10 +1609,13 @@ class SemanticAnalyzer(NodeVisitor[None],
             for node in base.type.defn.defs.body:
                 if isinstance(node, (FuncBase, Decorator)):
                     continue  # A method
-                if (isinstance(node, AssignmentStmt)
+                if (not self.is_stub_file
+                        and isinstance(node, AssignmentStmt)
                         and isinstance(node.rvalue, TempNode)
                         and node.rvalue.no_rhs):
-                    continue  # Corner case: assignments like `x: int` are fine.
+                    # Corner case: assignments like `x: int` are fine.
+                    # But, only in `.py` files. Stub files can still be unintialized.
+                    continue
                 return True
         return False
 

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1722,6 +1722,13 @@ class A2(Enum):
     x = 2
 class B2(A2):  # E: Cannot inherit from final class "A2"
     pass
+
+# We leave this `Final` without a value,
+# because we need to test annotation only mode:
+class A3(Enum):
+    x: Final[int]  # type: ignore
+class B3(A3):
+    x = 1  # E: Cannot override final attribute "x" (previously declared in base class "A3")
 [builtins fixtures/bool.pyi]
 
 [case testEnumNotFinalWithMethodsAndUninitializedValuesStub]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1710,13 +1710,34 @@ from typing import Final
 class A(Enum):
     x: int
     def method(self) -> int: pass
-
 class B(A):
     x = 1  # E: Cannot override writable attribute "x" with a final one
 
 class A1(Enum):
     x: int = 1
-
 class B1(A1):  # E: Cannot inherit from final class "A1"
     pass
+
+class A2(Enum):
+    x = 2
+class B2(A2):  # E: Cannot inherit from final class "A2"
+    pass
+[builtins fixtures/bool.pyi]
+
+[case testEnumNotFinalWithMethodsAndUninitializedValuesStub]
+import lib
+reveal_type(lib.A)
+reveal_type(lib.B)
+
+[file lib.pyi]
+from enum import Enum
+class A(Enum):
+    x: int
+class B(A):
+    x = 1
+[out]
+tmp/lib.pyi:4: error: Cannot inherit from final class "A"
+tmp/lib.pyi:5: error: Cannot override writable attribute "x" with a final one
+main:2: note: Revealed type is "def (value: builtins.object) -> lib.A*"
+main:3: note: Revealed type is "def (value: builtins.object) -> lib.B*"
 [builtins fixtures/bool.pyi]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1678,7 +1678,6 @@ class A(Enum):
 class B(A): pass  # E: Cannot inherit from final class "A"
 [builtins fixtures/bool.pyi]
 
-
 [case testEnumFinalSpecialProps]
 # https://github.com/python/mypy/issues/11699
 from enum import Enum, IntEnum
@@ -1701,4 +1700,23 @@ class EI(IntEnum):
 
 E._order_ = 'a'  # E: Cannot assign to final attribute "_order_"
 EI.value = 2     # E: Cannot assign to final attribute "value"
+[builtins fixtures/bool.pyi]
+
+[case testEnumNotFinalWithMethodsAndUninitializedValues]
+# https://github.com/python/mypy/issues/11578
+from enum import Enum
+from typing import Final
+
+class A(Enum):
+    x: int
+    def method(self) -> int: pass
+
+class B(A):
+    x = 1  # E: Cannot override writable attribute "x" with a final one
+
+class A1(Enum):
+    x: int = 1
+
+class B1(A1):  # E: Cannot inherit from final class "A1"
+    pass
 [builtins fixtures/bool.pyi]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1726,18 +1726,16 @@ class B2(A2):  # E: Cannot inherit from final class "A2"
 
 [case testEnumNotFinalWithMethodsAndUninitializedValuesStub]
 import lib
-reveal_type(lib.A)
-reveal_type(lib.B)
 
 [file lib.pyi]
 from enum import Enum
 class A(Enum):
     x: int
-class B(A):
+class B(A):  # E: Cannot inherit from final class "A"
+    x = 1    # E: Cannot override writable attribute "x" with a final one
+
+class C(Enum):
     x = 1
-[out]
-tmp/lib.pyi:4: error: Cannot inherit from final class "A"
-tmp/lib.pyi:5: error: Cannot override writable attribute "x" with a final one
-main:2: note: Revealed type is "def (value: builtins.object) -> lib.A*"
-main:3: note: Revealed type is "def (value: builtins.object) -> lib.B*"
+class D(C):  # E: Cannot inherit from final class "C"
+    x: int   # E: Cannot assign to final name "x"
 [builtins fixtures/bool.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5610,3 +5610,26 @@ class C:
     pass
 [rechecked]
 [stale]
+
+
+[case testEnumAreStillFinalAfterCache]
+import a
+class Ok(a.RegularEnum):
+    x = 1
+class NotOk(a.FinalEnum):
+    x = 1
+[file a.py]
+from enum import Enum
+class RegularEnum(Enum):
+    x: int
+class FinalEnum(Enum):
+    x = 1
+[builtins fixtures/isinstance.pyi]
+[out]
+main:3: error: Cannot override writable attribute "x" with a final one
+main:4: error: Cannot inherit from final class "FinalEnum"
+main:5: error: Cannot override final attribute "x" (previously declared in base class "FinalEnum")
+[out2]
+main:3: error: Cannot override writable attribute "x" with a final one
+main:4: error: Cannot inherit from final class "FinalEnum"
+main:5: error: Cannot override final attribute "x" (previously declared in base class "FinalEnum")


### PR DESCRIPTION
I am using AST here, because `Var` does not seem to have information about having an explicit value.
I left a TODO item for it. Should we add this to `Var`?

Closes https://github.com/python/mypy/issues/11578