### PR TITLE
Factor out field_makers alongside dataclass_makers

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -24,6 +24,11 @@ dataclass_makers: Final = {
     'dataclass',
     'dataclasses.dataclass',
 }
+# The set of functions that generate dataclass fields.
+field_makers: Final = {
+    'dataclasses.field',
+}
+
 
 SELF_TVAR_NAME: Final = "_DT"
 
@@ -490,7 +495,7 @@ def _collect_field_args(expr: Expression,
     if (
             isinstance(expr, CallExpr) and
             isinstance(expr.callee, RefExpr) and
-            expr.callee.fullname == 'dataclasses.field'
+            expr.callee.fullname in field_makers
     ):
         # field() only takes keyword arguments.
         args = {}


### PR DESCRIPTION
### Description

This is a very minor change that moves the `field_makers` constant up to the global scope.

Currently, I have duplicated this entire plugin here https://github.com/NeilGirdhar/tjax/blob/master/tjax/mypy_plugin.py, but it keeps changing.

I would like to simply add my custom dataclass and its field maker to the constant sets, and having them in the global scope (and non-final) makes that easy.