### PR TITLE
Now `ClassVar` cannot contain type variables, refs #11538

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -204,6 +204,10 @@ CANNOT_OVERRIDE_CLASS_VAR: Final = ErrorMessage(
     'Cannot override class variable (previously declared on base class "{}") with instance '
     "variable"
 )
+CLASS_VAR_WITH_TYPEVARS: Final = 'ClassVar cannot contain type variables'
+CLASS_VAR_OUTSIDE_OF_CLASS: Final = (
+    'ClassVar can only be used for assignments in class body'
+)
 
 # Protocol
 RUNTIME_PROTOCOL_EXPECTED: Final = ErrorMessage(

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -20,20 +20,22 @@ from mypy.options import Options
 # Semantic analyzer test cases: dump parse tree
 
 # Semantic analysis test case description files.
-semanal_files = ['semanal-basic.test',
-                 'semanal-expressions.test',
-                 'semanal-classes.test',
-                 'semanal-types.test',
-                 'semanal-typealiases.test',
-                 'semanal-modules.test',
-                 'semanal-statements.test',
-                 'semanal-abstractclasses.test',
-                 'semanal-namedtuple.test',
-                 'semanal-typeddict.test',
-                 'semenal-literal.test',
-                 'semanal-classvar.test',
-                 'semanal-python2.test',
-                 'semanal-lambda.test']
+semanal_files = [
+    'semanal-basic.test',
+    'semanal-expressions.test',
+    'semanal-classes.test',
+    'semanal-types.test',
+    'semanal-typealiases.test',
+    'semanal-modules.test',
+    'semanal-statements.test',
+    'semanal-abstractclasses.test',
+    'semanal-namedtuple.test',
+    'semanal-typeddict.test',
+    'semenal-literal.test',
+    'semanal-classvar.test',
+    'semanal-python2.test',
+    'semanal-lambda.test',
+]
 
 
 def get_semanal_options(program_text: str, testcase: DataDrivenTestCase) -> Options:

--- a/test-data/unit/check-classvar.test
+++ b/test-data/unit/check-classvar.test
@@ -285,7 +285,7 @@ main:3: error: Cannot assign to class variable "x" via instance
 from typing import ClassVar, Generic, TypeVar
 T = TypeVar('T')
 class A(Generic[T]):
-    x: ClassVar[T]
+    x: ClassVar[T]  # E: ClassVar cannot contain type variables
     @classmethod
     def foo(cls) -> T:
         return cls.x  # OK
@@ -308,7 +308,7 @@ from typing import ClassVar, Generic, Tuple, TypeVar, Union, Type
 T = TypeVar('T')
 U = TypeVar('U')
 class A(Generic[T, U]):
-    x: ClassVar[Union[T, Tuple[U, Type[U]]]]
+    x: ClassVar[Union[T, Tuple[U, Type[U]]]]  # E: ClassVar cannot contain type variables
     @classmethod
     def foo(cls) -> Union[T, Tuple[U, Type[U]]]:
         return cls.x  # OK

--- a/test-data/unit/semanal-classvar.test
+++ b/test-data/unit/semanal-classvar.test
@@ -207,3 +207,14 @@ class B:
         pass
 [out]
 main:4: error: ClassVar can only be used for assignments in class body
+
+[case testClassVarWithTypeVariable]
+from typing import ClassVar, TypeVar, Generic, List
+
+T = TypeVar('T')
+
+class Some(Generic[T]):
+    error: ClassVar[T]  # E: ClassVar cannot contain type variables
+    nested: ClassVar[List[List[T]]]  # E: ClassVar cannot contain type variables
+    ok: ClassVar[int]
+[out]


### PR DESCRIPTION
Some tests might fail, because I've only checked semanal test suite. I will fix them after the initial CI run.

Closes #11538