### PR TITLE
Basic support for ParamSpec type checking

### DIFF
--- a/misc/proper_plugin.py
+++ b/misc/proper_plugin.py
@@ -66,6 +66,7 @@ def is_special_target(right: ProperType) -> bool:
         if right.type_object().fullname in (
             'mypy.types.UnboundType',
             'mypy.types.TypeVarType',
+            'mypy.types.ParamSpecType',
             'mypy.types.RawExpressionType',
             'mypy.types.EllipsisType',
             'mypy.types.StarType',

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -5,7 +5,7 @@ import mypy.sametypes
 from mypy.expandtype import expand_type
 from mypy.types import (
     Type, TypeVarId, TypeVarType, CallableType, AnyType, PartialType, get_proper_types,
-    TypeVarLikeType, ProperType, ParamSpecType
+    TypeVarLikeType, ProperType, ParamSpecType, get_proper_type
 )
 from mypy.nodes import Context
 
@@ -88,6 +88,14 @@ def apply_generic_arguments(
         )
         if target_type is not None:
             id_to_type[tvar.id] = target_type
+
+    param_spec = callable.param_spec2()
+    if param_spec is not None:
+        nt = id_to_type.get(param_spec.id)
+        if nt is not None:
+            nt = get_proper_type(nt)
+            if isinstance(nt, CallableType):
+                callable = callable.expand_param_spec(nt)
 
     # Apply arguments to argument types.
     arg_types = [expand_type(at, id_to_type) for at in callable.arg_types]

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -18,9 +18,8 @@ def get_target_type(
     context: Context,
     skip_unsatisfied: bool
 ) -> Optional[Type]:
-    # TODO(PEP612): fix for ParamSpecType
     if isinstance(tvar, ParamSpecType):
-        return None
+        return type
     assert isinstance(tvar, TypeVarType)
     values = get_proper_types(tvar.values)
     if values:

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -89,7 +89,7 @@ def apply_generic_arguments(
         if target_type is not None:
             id_to_type[tvar.id] = target_type
 
-    param_spec = callable.param_spec2()
+    param_spec = callable.param_spec()
     if param_spec is not None:
         nt = id_to_type.get(param_spec.id)
         if nt is not None:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -977,13 +977,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                 ctx = typ
                             self.fail(message_registry.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, ctx)
                     if typ.arg_kinds[i] == nodes.ARG_STAR:
-                        arg_type = get_proper_type(arg_type)
                         if not isinstance(arg_type, ParamSpecType):
                             # builtins.tuple[T] is typing.Tuple[T, ...]
                             arg_type = self.named_generic_type('builtins.tuple',
                                                                [arg_type])
                     elif typ.arg_kinds[i] == nodes.ARG_STAR2:
-                        arg_type = get_proper_type(arg_type)
                         if not isinstance(arg_type, ParamSpecType):
                             arg_type = self.named_generic_type('builtins.dict',
                                                                [self.str_type(),

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -978,10 +978,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             self.fail(message_registry.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, ctx)
                     if typ.arg_kinds[i] == nodes.ARG_STAR:
                         # builtins.tuple[T] is typing.Tuple[T, ...]
+                        arg_type = get_proper_type(arg_type)
                         if not isinstance(arg_type, ParamSpecType):
                             arg_type = self.named_generic_type('builtins.tuple',
                                                                [arg_type])
                     elif typ.arg_kinds[i] == nodes.ARG_STAR2:
+                        arg_type = get_proper_type(arg_type)
                         if not isinstance(arg_type, ParamSpecType):
                             arg_type = self.named_generic_type('builtins.dict',
                                                                [self.str_type(),

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -37,7 +37,8 @@ from mypy.types import (
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType,
     is_named_instance, union_items, TypeQuery, LiteralType,
     is_optional, remove_optional, TypeTranslator, StarType, get_proper_type, ProperType,
-    get_proper_types, is_literal_type, TypeAliasType, TypeGuardedType)
+    get_proper_types, is_literal_type, TypeAliasType, TypeGuardedType, ParamSpecType
+)
 from mypy.sametypes import is_same_type
 from mypy.messages import (
     MessageBuilder, make_inferred_type_note, append_invariance_notes, pretty_seq,
@@ -977,12 +978,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             self.fail(message_registry.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, ctx)
                     if typ.arg_kinds[i] == nodes.ARG_STAR:
                         # builtins.tuple[T] is typing.Tuple[T, ...]
-                        arg_type = self.named_generic_type('builtins.tuple',
-                                                           [arg_type])
+                        if not isinstance(arg_type, ParamSpecType):
+                            arg_type = self.named_generic_type('builtins.tuple',
+                                                               [arg_type])
                     elif typ.arg_kinds[i] == nodes.ARG_STAR2:
-                        arg_type = self.named_generic_type('builtins.dict',
-                                                           [self.str_type(),
-                                                            arg_type])
+                        if not isinstance(arg_type, ParamSpecType):
+                            arg_type = self.named_generic_type('builtins.dict',
+                                                               [self.str_type(),
+                                                                arg_type])
                     item.arguments[i].variable.type = arg_type
 
                 # Type check initialization expressions.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1883,7 +1883,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 expected = CONTRAVARIANT
             else:
                 expected = INVARIANT
-            if expected != tvar.variance:
+            if isinstance(tvar, TypeVarType) and expected != tvar.variance:
                 self.msg.bad_proto_variance(tvar.variance, tvar.name, expected, defn)
 
     def check_multiple_inheritance(self, typ: TypeInfo) -> None:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -977,9 +977,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                 ctx = typ
                             self.fail(message_registry.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, ctx)
                     if typ.arg_kinds[i] == nodes.ARG_STAR:
-                        # builtins.tuple[T] is typing.Tuple[T, ...]
                         arg_type = get_proper_type(arg_type)
                         if not isinstance(arg_type, ParamSpecType):
+                            # builtins.tuple[T] is typing.Tuple[T, ...]
                             arg_type = self.named_generic_type('builtins.tuple',
                                                                [arg_type])
                     elif typ.arg_kinds[i] == nodes.ARG_STAR2:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1041,11 +1041,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             arg1 = get_proper_type(self.accept(args[0]))
             arg2 = get_proper_type(self.accept(args[1]))
             if (is_named_instance(arg1, 'builtins.tuple')
-                and is_named_instance(arg2, 'builtins.dict')):
+                    and is_named_instance(arg2, 'builtins.dict')):
                 assert isinstance(arg1, Instance)
                 assert isinstance(arg2, Instance)
                 if (isinstance(get_proper_type(arg1.args[0]), ParamSpecType)
-                    and isinstance(get_proper_type(arg2.args[1]), ParamSpecType)):
+                        and isinstance(get_proper_type(arg2.args[1]), ParamSpecType)):
                     # TODO: Check ParamSpec ids and flavors
                     return callee.ret_type, callee
 
@@ -4004,6 +4004,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def is_valid_keyword_var_arg(self, typ: Type) -> bool:
         """Is a type valid as a **kwargs argument?"""
+        typ = get_proper_type(typ)
         ret = (
                 is_subtype(typ, self.chk.named_generic_type('typing.Mapping',
                     [self.named_type('builtins.str'), AnyType(TypeOfAny.special_form)])) or

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1031,14 +1031,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         if callee.param_spec is not None:
             if arg_kinds == [ARG_STAR, ARG_STAR2]:
-                arg1 = self.accept(args[0])
-                arg2 = self.accept(args[1])
+                arg1 = get_proper_type(self.accept(args[0]))
+                arg2 = get_proper_type(self.accept(args[1]))
                 if (is_named_instance(arg1, 'builtins.tuple')
                     and is_named_instance(arg2, 'builtins.dict')):
                     assert isinstance(arg1, Instance)
                     assert isinstance(arg2, Instance)
-                    if (isinstance(arg1.args[0], ParamSpecType)
-                        and isinstance(arg2.args[1], ParamSpecType)):
+                    if (isinstance(get_proper_type(arg1.args[0]), ParamSpecType)
+                        and isinstance(get_proper_type(arg2.args[1]), ParamSpecType)):
                         # TODO: Check ParamSpec ids and flavors
                         return callee.ret_type, callee
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -18,7 +18,7 @@ from mypy.types import (
     Type, AnyType, CallableType, Overloaded, NoneType, TypeVarType,
     TupleType, TypedDictType, Instance, ErasedType, UnionType,
     PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, LiteralType, LiteralValue,
-    is_named_instance, FunctionLike, ParamSpecType,
+    is_named_instance, FunctionLike, ParamSpecType, ParamSpecFlavor,
     StarType, is_optional, remove_optional, is_generic_instance, get_proper_type, ProperType,
     get_proper_types, flatten_nested_unions
 )
@@ -3999,7 +3999,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return (isinstance(typ, TupleType) or
                 is_subtype(typ, self.chk.named_generic_type('typing.Iterable',
                                                             [AnyType(TypeOfAny.special_form)])) or
-                isinstance(typ, AnyType))
+                isinstance(typ, AnyType) or
+                (isinstance(typ, ParamSpecType) and typ.flavor == ParamSpecFlavor.ARGS))
 
     def is_valid_keyword_var_arg(self, typ: Type) -> bool:
         """Is a type valid as a **kwargs argument?"""
@@ -4007,7 +4008,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 is_subtype(typ, self.chk.named_generic_type('typing.Mapping',
                     [self.named_type('builtins.str'), AnyType(TypeOfAny.special_form)])) or
                 is_subtype(typ, self.chk.named_generic_type('typing.Mapping',
-                    [UninhabitedType(), UninhabitedType()])))
+                    [UninhabitedType(), UninhabitedType()])) or
+                (isinstance(typ, ParamSpecType) and typ.flavor == ParamSpecFlavor.KWARGS)
+        )
         if self.chk.options.python_version[0] < 3:
             ret = ret or is_subtype(typ, self.chk.named_generic_type('typing.Mapping',
                 [self.named_type('builtins.unicode'), AnyType(TypeOfAny.special_form)]))

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1023,13 +1023,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             lambda i: self.accept(args[i]))
 
         if callee.is_generic():
-            refresh_map = any(isinstance(v, ParamSpecType) for v in callee.variables)
+            need_refresh = any(isinstance(v, ParamSpecType) for v in callee.variables)
             callee = freshen_function_type_vars(callee)
             callee = self.infer_function_type_arguments_using_context(
                 callee, context)
             callee = self.infer_function_type_arguments(
                 callee, args, arg_kinds, formal_to_actual, context)
-            if refresh_map:
+            if need_refresh:
                 # Argument kinds etc. may have changed; recalculate actual-to-formal map
                 formal_to_actual = map_actuals_to_formals(
                     arg_kinds, arg_names,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1029,6 +1029,19 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             callee = self.infer_function_type_arguments(
                 callee, args, arg_kinds, formal_to_actual, context)
 
+        if callee.param_spec is not None:
+            if arg_kinds == [ARG_STAR, ARG_STAR2]:
+                arg1 = self.accept(args[0])
+                arg2 = self.accept(args[1])
+                if (is_named_instance(arg1, 'builtins.tuple')
+                    and is_named_instance(arg2, 'builtins.dict')):
+                    assert isinstance(arg1, Instance)
+                    assert isinstance(arg2, Instance)
+                    if (isinstance(arg1.args[0], ParamSpecType)
+                        and isinstance(arg2.args[1], ParamSpecType)):
+                        # TODO: Check ParamSpec ids and flavors
+                        return callee.ret_type, callee
+
         arg_types = self.infer_arg_types_in_context(
             callee, args, arg_kinds, formal_to_actual)
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1044,8 +1044,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     and is_named_instance(arg2, 'builtins.dict')):
                 assert isinstance(arg1, Instance)
                 assert isinstance(arg2, Instance)
-                if (isinstance(get_proper_type(arg1.args[0]), ParamSpecType)
-                        and isinstance(get_proper_type(arg2.args[1]), ParamSpecType)):
+                if (isinstance(arg1.args[0], ParamSpecType)
+                        and isinstance(arg2.args[1], ParamSpecType)):
                     # TODO: Check ParamSpec ids and flavors
                     return callee.ret_type, callee
 
@@ -4004,7 +4004,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def is_valid_keyword_var_arg(self, typ: Type) -> bool:
         """Is a type valid as a **kwargs argument?"""
-        typ = get_proper_type(typ)
         ret = (
                 is_subtype(typ, self.chk.named_generic_type('typing.Mapping',
                     [self.named_type('builtins.str'), AnyType(TypeOfAny.special_form)])) or

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -666,7 +666,7 @@ def check_self_arg(functype: FunctionLike,
             selfarg = item.arg_types[0]
             if subtypes.is_subtype(dispatched_arg_type, erase_typevars(erase_to_bound(selfarg))):
                 new_items.append(item)
-            elif isinstance(get_proper_type(selfarg), ParamSpecType):
+            elif isinstance(selfarg, ParamSpecType):
                 # TODO: This is not always right. What's the most reasonable thing to do here?
                 new_items.append(item)
     if not new_items:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -6,7 +6,7 @@ from typing_extensions import TYPE_CHECKING
 from mypy.types import (
     Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike,
     TypeVarLikeType, Overloaded, TypeVarType, UnionType, PartialType, TypeOfAny, LiteralType,
-    DeletedType, NoneType, TypeType, has_type_vars, get_proper_type, ProperType
+    DeletedType, NoneType, TypeType, has_type_vars, get_proper_type, ProperType, ParamSpecType
 )
 from mypy.nodes import (
     TypeInfo, FuncBase, Var, FuncDef, SymbolNode, SymbolTable, Context,
@@ -665,6 +665,9 @@ def check_self_arg(functype: FunctionLike,
         else:
             selfarg = item.arg_types[0]
             if subtypes.is_subtype(dispatched_arg_type, erase_typevars(erase_to_bound(selfarg))):
+                new_items.append(item)
+            elif isinstance(get_proper_type(selfarg), ParamSpecType):
+                # TODO: This is not always right. What's the most reasonable thing to do here?
                 new_items.append(item)
     if not new_items:
         # Choose first item for the message (it may be not very helpful for overloads).

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -546,7 +546,8 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         if isinstance(self.actual, CallableType):
             res: List[Constraint] = []
             cactual = self.actual
-            if template.param_spec is None:
+            param_spec = template.param_spec()
+            if param_spec is None:
                 # FIX verify argument counts
                 # FIX what if one of the functions is generic
 
@@ -559,7 +560,8 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         res.extend(infer_constraints(t, a, neg_op(self.direction)))
             else:
                 # TODO: Direction
-                res.append(Constraint(template.param_spec.id,
+                # TODO: Deal with arguments that come before param spec ones?
+                res.append(Constraint(param_spec.id,
                                       SUBTYPE_OF,
                                       cactual.copy_modified(ret_type=NoneType())))
 

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -128,6 +128,11 @@ class TypeVarEraser(TypeTranslator):
             return self.replacement
         return t
 
+    def visit_param_spec(self, t: ParamSpecType) -> Type:
+        if self.erase_id(t.id):
+            return self.replacement
+        return t
+
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:
         # Type alias target can't contain bound type variables, so
         # it is safe to just erase the arguments.

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -4,7 +4,7 @@ from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneType, TypeVarId, Instance, TypeVarType,
     CallableType, TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType,
     DeletedType, TypeTranslator, UninhabitedType, TypeType, TypeOfAny, LiteralType, ProperType,
-    get_proper_type, TypeAliasType
+    get_proper_type, TypeAliasType, ParamSpecType
 )
 from mypy.nodes import ARG_STAR, ARG_STAR2
 
@@ -55,6 +55,9 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
         return Instance(t.type, [AnyType(TypeOfAny.special_form)] * len(t.args), t.line)
 
     def visit_type_var(self, t: TypeVarType) -> ProperType:
+        return AnyType(TypeOfAny.special_form)
+
+    def visit_param_spec(self, t: ParamSpecType) -> ProperType:
         return AnyType(TypeOfAny.special_form)
 
     def visit_callable_type(self, t: CallableType) -> ProperType:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -5,7 +5,7 @@ from mypy.types import (
     NoneType, Overloaded, TupleType, TypedDictType, UnionType,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
     FunctionLike, TypeVarType, LiteralType, get_proper_type, ProperType,
-    TypeAliasType, ParamSpecType
+    TypeAliasType, ParamSpecType, TypeVarLikeType
 )
 
 
@@ -43,7 +43,7 @@ def freshen_function_type_vars(callee: F) -> F:
         for v in callee.variables:
             # TODO(PEP612): fix for ParamSpecType
             if isinstance(v, TypeVarType):
-                tv = TypeVarType.new_unification_variable(v)
+                tv: TypeVarLikeType = TypeVarType.new_unification_variable(v)
             else:
                 assert isinstance(v, ParamSpecType)
                 tv = ParamSpecType.new_unification_variable(v)
@@ -99,7 +99,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
         else:
             return repl
 
-    def visit_param_spec(self, t: TypeVarType) -> Type:
+    def visit_param_spec(self, t: ParamSpecType) -> Type:
         repl = get_proper_type(self.variables.get(t.id, t))
         if isinstance(repl, Instance):
             inst = repl

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -113,8 +113,15 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
         param_spec = t.param_spec()
         if param_spec is not None:
             repl = get_proper_type(self.variables.get(param_spec.id))
+            # If a ParamSpec in a callable type is substituted with a
+            # callable type, we can't use normal substitution logic,
+            # since ParamSpec is actually split into two components
+            # *P.args and **P.kwargs in the original type. Instead, we
+            # must expand both of them with all the argument types,
+            # kinds and names in the replacement. The return type in
+            # the replacement is ignored.
             if isinstance(repl, CallableType):
-                # Substitute *args, **kwargs
+                # Substitute *args: P.args, **kwargs: P.kwargs
                 t = t.expand_param_spec(repl)
                 # TODO: Substitute remaining arg types
                 return t.copy_modified(ret_type=t.ret_type.accept(self),

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -111,7 +111,27 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
 
     def visit_callable_type(self, t: CallableType) -> Type:
         if t.param_spec is None:
-            arg_types = self.expand_types(t.arg_types)
+            arg_types = t.arg_types
+            if (
+                len(arg_types) >= 2
+                and isinstance(arg_types[-2], ParamSpecType)
+                and isinstance(arg_types[-1], ParamSpecType)
+            ):
+                param_spec = arg_types[-2]
+                repl = get_proper_type(self.variables.get(param_spec.id))
+                if isinstance(repl, CallableType):
+                    # Substitute *args, **kwargs
+                    arg_types = arg_types[:-2] + repl.arg_types
+                    arg_kinds = t.arg_kinds[:-2] + repl.arg_kinds
+                    arg_names = t.arg_names[:-2] + repl.arg_names
+                    return t.copy_modified(arg_types=arg_types,
+                                           arg_kinds=arg_kinds,
+                                           arg_names=arg_names,
+                                           ret_type=t.ret_type.accept(self),
+                                           type_guard=(t.type_guard.accept(self)
+                                                       if t.type_guard is not None else None),
+                                           param_spec=None)
+            arg_types = self.expand_types(arg_types)
         else:
             repl = get_proper_type(self.variables.get(t.param_spec.id))
             if isinstance(repl, CallableType):

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -249,7 +249,7 @@ class TypeFixer(TypeVisitor[None]):
             tvt.upper_bound.accept(self)
 
     def visit_param_spec(self, p: ParamSpecType) -> None:
-        pass  # Nothing to descend into.
+        p.upper_bound.accept(self)
 
     def visit_unbound_type(self, o: UnboundType) -> None:
         for a in o.args:

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -10,7 +10,7 @@ from mypy.nodes import (
 from mypy.types import (
     CallableType, Instance, Overloaded, TupleType, TypedDictType,
     TypeVarType, UnboundType, UnionType, TypeVisitor, LiteralType,
-    TypeType, NOT_READY, TypeAliasType, AnyType, TypeOfAny
+    TypeType, NOT_READY, TypeAliasType, AnyType, TypeOfAny, ParamSpecType
 )
 from mypy.visitor import NodeVisitor
 from mypy.lookup import lookup_fully_qualified
@@ -121,9 +121,10 @@ class NodeFixer(NodeVisitor[None]):
 
     def visit_class_def(self, c: ClassDef) -> None:
         for v in c.type_vars:
-            for value in v.values:
-                value.accept(self.type_fixer)
-            v.upper_bound.accept(self.type_fixer)
+            if isinstance(v, TypeVarType):
+                for value in v.values:
+                    value.accept(self.type_fixer)
+                v.upper_bound.accept(self.type_fixer)
 
     def visit_type_var_expr(self, tv: TypeVarExpr) -> None:
         for value in tv.values:
@@ -246,6 +247,9 @@ class TypeFixer(TypeVisitor[None]):
                 vt.accept(self)
         if tvt.upper_bound is not None:
             tvt.upper_bound.accept(self)
+
+    def visit_param_spec(self, p: ParamSpecType) -> None:
+        pass  # Nothing to descend into.
 
     def visit_unbound_type(self, o: UnboundType) -> None:
         for a in o.args:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -64,6 +64,9 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
     def visit_type_var(self, t: types.TypeVarType) -> Set[str]:
         return self._visit(t.values) | self._visit(t.upper_bound)
 
+    def visit_param_spec(self, t: types.ParamSpecType) -> Set[str]:
+        return set()
+
     def visit_instance(self, t: types.Instance) -> Set[str]:
         out = self._visit(t.args)
         if t.type:

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -7,7 +7,7 @@ from mypy.types import (
     Type, AnyType, NoneType, TypeVisitor, Instance, UnboundType, TypeVarType, CallableType,
     TupleType, TypedDictType, ErasedType, UnionType, FunctionLike, Overloaded, LiteralType,
     PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, get_proper_type,
-    ProperType, get_proper_types, TypeAliasType, PlaceholderType
+    ProperType, get_proper_types, TypeAliasType, PlaceholderType, ParamSpecType
 )
 from mypy.maptype import map_instance_to_supertype
 from mypy.subtypes import (
@@ -46,22 +46,28 @@ class InstanceJoiner:
                     new_type = AnyType(TypeOfAny.from_another_any, ta_proper)
                 elif isinstance(sa_proper, AnyType):
                     new_type = AnyType(TypeOfAny.from_another_any, sa_proper)
-                elif type_var.variance == COVARIANT:
-                    new_type = join_types(ta, sa, self)
-                    if len(type_var.values) != 0 and new_type not in type_var.values:
-                        self.seen_instances.pop()
-                        return object_from_instance(t)
-                    if not is_subtype(new_type, type_var.upper_bound):
-                        self.seen_instances.pop()
-                        return object_from_instance(t)
-                # TODO: contravariant case should use meet but pass seen instances as
-                # an argument to keep track of recursive checks.
-                elif type_var.variance in (INVARIANT, CONTRAVARIANT):
+                elif isinstance(type_var, TypeVarType):
+                    if type_var.variance == COVARIANT:
+                        new_type = join_types(ta, sa, self)
+                        if len(type_var.values) != 0 and new_type not in type_var.values:
+                            self.seen_instances.pop()
+                            return object_from_instance(t)
+                        if not is_subtype(new_type, type_var.upper_bound):
+                            self.seen_instances.pop()
+                            return object_from_instance(t)
+                    # TODO: contravariant case should use meet but pass seen instances as
+                    # an argument to keep track of recursive checks.
+                    elif type_var.variance in (INVARIANT, CONTRAVARIANT):
+                        if not is_equivalent(ta, sa):
+                            self.seen_instances.pop()
+                            return object_from_instance(t)
+                        # If the types are different but equivalent, then an Any is involved
+                        # so using a join in the contravariant case is also OK.
+                        new_type = join_types(ta, sa, self)
+                else:
+                    # ParamSpec type variables behave the same, independent of variance
                     if not is_equivalent(ta, sa):
-                        self.seen_instances.pop()
-                        return object_from_instance(t)
-                    # If the types are different but equivalent, then an Any is involved
-                    # so using a join in the contravariant case is also OK.
+                        return type_var.upper_bound
                     new_type = join_types(ta, sa, self)
                 assert new_type is not None
                 args.append(new_type)
@@ -244,6 +250,11 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             return self.s
         else:
             return self.default(self.s)
+
+    def visit_param_spec(self, t: ParamSpecType) -> ProperType:
+        if self.s == t:
+            return t
+        return self.default(self.s)
 
     def visit_instance(self, t: Instance) -> ProperType:
         if isinstance(self.s, Instance):
@@ -444,6 +455,8 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
         elif isinstance(typ, FunctionLike):
             return self.default(typ.fallback)
         elif isinstance(typ, TypeVarType):
+            return self.default(typ.upper_bound)
+        elif isinstance(typ, ParamSpecType):
             return self.default(typ.upper_bound)
         else:
             return AnyType(TypeOfAny.special_form)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -67,7 +67,7 @@ class InstanceJoiner:
                 else:
                     # ParamSpec type variables behave the same, independent of variance
                     if not is_equivalent(ta, sa):
-                        return type_var.upper_bound
+                        return get_proper_type(type_var.upper_bound)
                     new_type = join_types(ta, sa, self)
                 assert new_type is not None
                 args.append(new_type)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -501,8 +501,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
             return self.default(self.s)
 
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
-        # TODO: use flavor
-        if isinstance(self.s, ParamSpecType) and self.s.id == t.id:
+        if self.s == t:
             return self.s
         else:
             return self.default(self.s)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -5,7 +5,8 @@ from mypy.types import (
     Type, AnyType, TypeVisitor, UnboundType, NoneType, TypeVarType, Instance, CallableType,
     TupleType, TypedDictType, ErasedType, UnionType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike, LiteralType,
-    ProperType, get_proper_type, get_proper_types, TypeAliasType, TypeGuardedType
+    ProperType, get_proper_type, get_proper_types, TypeAliasType, TypeGuardedType,
+    ParamSpecType
 )
 from mypy.subtypes import is_equivalent, is_subtype, is_callable_compatible, is_proper_subtype
 from mypy.erasetype import erase_type
@@ -495,6 +496,13 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
 
     def visit_type_var(self, t: TypeVarType) -> ProperType:
         if isinstance(self.s, TypeVarType) and self.s.id == t.id:
+            return self.s
+        else:
+            return self.default(self.s)
+
+    def visit_param_spec(self, t: ParamSpecType) -> ProperType:
+        # TODO: use flavor
+        if isinstance(self.s, ParamSpecType) and self.s.id == t.id:
             return self.s
         else:
             return self.default(self.s)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1762,6 +1762,9 @@ def format_type_inner(typ: Type,
                 return_type = format(func.ret_type)
             if func.is_ellipsis_args:
                 return 'Callable[..., {}]'.format(return_type)
+            param_spec = func.param_spec()
+            if param_spec is not None:
+                return f'Callable[{param_spec.name}, {return_type}]'
             arg_strings = []
             for arg_name, arg_type, arg_kind in zip(
                     func.arg_names, func.arg_types, func.arg_kinds):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -24,7 +24,7 @@ from mypy.types import (
     Type, CallableType, Instance, TypeVarType, TupleType, TypedDictType, LiteralType,
     UnionType, NoneType, AnyType, Overloaded, FunctionLike, DeletedType, TypeType,
     UninhabitedType, TypeOfAny, UnboundType, PartialType, get_proper_type, ProperType,
-    get_proper_types
+    ParamSpecType, get_proper_types
 )
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.nodes import (
@@ -1693,6 +1693,8 @@ def format_type_inner(typ: Type,
     elif isinstance(typ, TypeVarType):
         # This is similar to non-generic instance types.
         return typ.name
+    elif isinstance(typ, ParamSpecType):
+        return typ.name_with_suffix()
     elif isinstance(typ, TupleType):
         # Prefer the name of the fallback class (if not tuple), as it's more informative.
         if typ.partial_fallback.type.fullname != 'builtins.tuple':

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -963,7 +963,7 @@ class ClassDef(Statement):
     name: str  # Name of the class without module prefix
     fullname: Bogus[str]  # Fully qualified name of the class
     defs: "Block"
-    type_vars: List["mypy.types.TypeVarType"]
+    type_vars: List["mypy.types.TypeVarLikeType"]
     # Base class expressions (not semantically analyzed -- can be arbitrary expressions)
     base_type_exprs: List[Expression]
     # Special base classes like Generic[...] get moved here during semantic analysis
@@ -978,7 +978,7 @@ class ClassDef(Statement):
     def __init__(self,
                  name: str,
                  defs: 'Block',
-                 type_vars: Optional[List['mypy.types.TypeVarType']] = None,
+                 type_vars: Optional[List['mypy.types.TypeVarLikeType']] = None,
                  base_type_exprs: Optional[List[Expression]] = None,
                  metaclass: Optional[Expression] = None,
                  keywords: Optional[List[Tuple[str, Expression]]] = None) -> None:

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -4,7 +4,8 @@ from mypy.types import (
     Type, UnboundType, AnyType, NoneType, TupleType, TypedDictType,
     UnionType, CallableType, TypeVarType, Instance, TypeVisitor, ErasedType,
     Overloaded, PartialType, DeletedType, UninhabitedType, TypeType, LiteralType,
-    ProperType, get_proper_type, TypeAliasType)
+    ProperType, get_proper_type, TypeAliasType, ParamSpecType
+)
 from mypy.typeops import tuple_fallback, make_simplified_union
 
 
@@ -95,6 +96,10 @@ class SameTypeVisitor(TypeVisitor[bool]):
     def visit_type_var(self, left: TypeVarType) -> bool:
         return (isinstance(self.right, TypeVarType) and
                 left.id == self.right.id)
+
+    def visit_param_spec(self, left: ParamSpecType) -> bool:
+        return (isinstance(self.right, ParamSpecType) and
+                left.id == self.right.id and left.flavor == self.right.flavor)
 
     def visit_callable_type(self, left: CallableType) -> bool:
         # FIX generics

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -98,6 +98,7 @@ class SameTypeVisitor(TypeVisitor[bool]):
                 left.id == self.right.id)
 
     def visit_param_spec(self, left: ParamSpecType) -> bool:
+        # Ignore upper bound since it's derived from flavor.
         return (isinstance(self.right, ParamSpecType) and
                 left.id == self.right.id and left.flavor == self.right.flavor)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -77,8 +77,7 @@ from mypy.nodes import (
     REVEAL_LOCALS, is_final_node, TypedDictExpr, type_aliases_source_versions,
     typing_extensions_aliases,
     EnumCallExpr, RUNTIME_PROTOCOL_DECOS, FakeExpression, Statement, AssignmentExpr,
-    ParamSpecExpr, EllipsisExpr,
-    FuncBase, implicit_module_attrs,
+    ParamSpecExpr, EllipsisExpr, TypeVarLikeExpr, FuncBase, implicit_module_attrs,
 )
 from mypy.tvar_scope import TypeVarLikeScope
 from mypy.typevars import fill_typevars
@@ -1393,14 +1392,14 @@ class SemanticAnalyzer(NodeVisitor[None],
             return tvars, is_proto
         return None
 
-    def analyze_unbound_tvar(self, t: Type) -> Optional[Tuple[str, TypeVarExpr]]:
+    def analyze_unbound_tvar(self, t: Type) -> Optional[Tuple[str, TypeVarLikeExpr]]:
         if not isinstance(t, UnboundType):
             return None
         unbound = t
         sym = self.lookup_qualified(unbound.name, unbound)
         if sym and isinstance(sym.node, PlaceholderNode):
             self.record_incomplete_ref()
-        if isinstance(sym.node, ParamSpecExpr):
+        if sym and isinstance(sym.node, ParamSpecExpr):
             if sym.fullname and not self.tvar_scope.allow_binding(sym.fullname):
                 # It's bound by our type variable scope
                 return None

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -70,23 +70,24 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
         if isinstance(info, FakeInfo):
             return  # https://github.com/python/mypy/issues/11079
         for (i, arg), tvar in zip(enumerate(t.args), info.defn.type_vars):
-            if tvar.values:
-                if isinstance(arg, TypeVarType):
-                    arg_values = arg.values
-                    if not arg_values:
-                        self.fail(
-                            message_registry.INVALID_TYPEVAR_AS_TYPEARG.format(
-                                arg.name, info.name),
-                            t, code=codes.TYPE_VAR)
-                        continue
-                else:
-                    arg_values = [arg]
-                self.check_type_var_values(info, arg_values, tvar.name, tvar.values, i + 1, t)
-            if not is_subtype(arg, tvar.upper_bound):
-                self.fail(
-                    message_registry.INVALID_TYPEVAR_ARG_BOUND.format(
-                        format_type(arg), info.name, format_type(tvar.upper_bound)),
-                    t, code=codes.TYPE_VAR)
+            if isinstance(tvar, TypeVarType):
+                if tvar.values:
+                    if isinstance(arg, TypeVarType):
+                        arg_values = arg.values
+                        if not arg_values:
+                            self.fail(
+                                message_registry.INVALID_TYPEVAR_AS_TYPEARG.format(
+                                    arg.name, info.name),
+                                t, code=codes.TYPE_VAR)
+                            continue
+                    else:
+                        arg_values = [arg]
+                    self.check_type_var_values(info, arg_values, tvar.name, tvar.values, i + 1, t)
+                if not is_subtype(arg, tvar.upper_bound):
+                    self.fail(
+                        message_registry.INVALID_TYPEVAR_ARG_BOUND.format(
+                            format_type(arg), info.name, format_type(tvar.upper_bound)),
+                        t, code=codes.TYPE_VAR)
         super().visit_instance(t)
 
     def check_type_var_values(self, type: TypeInfo, actuals: List[Type], arg_name: str,

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -72,6 +72,7 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
             return  # https://github.com/python/mypy/issues/11079
         for (i, arg), tvar in zip(enumerate(t.args), info.defn.type_vars):
             if isinstance(tvar, TypeVarType):
+                arg = get_proper_type(arg)
                 if isinstance(arg, ParamSpecType):
                     # TODO: Better message
                     self.fail(f'Invalid location for ParamSpec "{arg.name}"', t)

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -9,7 +9,8 @@ from typing import List, Optional, Set
 
 from mypy.nodes import TypeInfo, Context, MypyFile, FuncItem, ClassDef, Block, FakeInfo
 from mypy.types import (
-    Type, Instance, TypeVarType, AnyType, get_proper_types, TypeAliasType, get_proper_type
+    Type, Instance, TypeVarType, AnyType, get_proper_types, TypeAliasType, ParamSpecType,
+    get_proper_type
 )
 from mypy.mixedtraverser import MixedTraverserVisitor
 from mypy.subtypes import is_subtype
@@ -71,6 +72,10 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
             return  # https://github.com/python/mypy/issues/11079
         for (i, arg), tvar in zip(enumerate(t.args), info.defn.type_vars):
             if isinstance(tvar, TypeVarType):
+                if isinstance(arg, ParamSpecType):
+                    # TODO: Better message
+                    self.fail(f'Invalid location for ParamSpec "{arg.name}"', t)
+                    continue
                 if tvar.values:
                     if isinstance(arg, TypeVarType):
                         arg_values = arg.values

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -72,7 +72,6 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
             return  # https://github.com/python/mypy/issues/11079
         for (i, arg), tvar in zip(enumerate(t.args), info.defn.type_vars):
             if isinstance(tvar, TypeVarType):
-                arg = get_proper_type(arg)
                 if isinstance(arg, ParamSpecType):
                     # TODO: Better message
                     self.fail(f'Invalid location for ParamSpec "{arg.name}"', t)

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -59,7 +59,7 @@ from mypy.nodes import (
 from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneType, UninhabitedType,
     ErasedType, DeletedType, Instance, TypeVarType, CallableType, TupleType, TypedDictType,
-    UnionType, Overloaded, PartialType, TypeType, LiteralType, TypeAliasType
+    UnionType, Overloaded, PartialType, TypeType, LiteralType, TypeAliasType, ParamSpecType
 )
 from mypy.util import get_prefix
 
@@ -309,6 +309,9 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
                 snapshot_types(typ.values),
                 snapshot_type(typ.upper_bound),
                 typ.variance)
+
+    def visit_param_spec(self, typ: ParamSpecType) -> SnapshotItem:
+        return ('ParamSpec', typ.id.raw_id, typ.id.meta_level, typ.flavor)
 
     def visit_callable_type(self, typ: CallableType) -> SnapshotItem:
         # FIX generics

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -311,7 +311,11 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
                 typ.variance)
 
     def visit_param_spec(self, typ: ParamSpecType) -> SnapshotItem:
-        return ('ParamSpec', typ.id.raw_id, typ.id.meta_level, typ.flavor)
+        return ('ParamSpec',
+                typ.id.raw_id,
+                typ.id.meta_level,
+                typ.flavor,
+                snapshot_type(typ.upper_bound))
 
     def visit_callable_type(self, typ: CallableType) -> SnapshotItem:
         # FIX generics

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -59,7 +59,7 @@ from mypy.types import (
     Type, SyntheticTypeVisitor, Instance, AnyType, NoneType, CallableType, ErasedType, DeletedType,
     TupleType, TypeType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     Overloaded, TypeVarType, TypeList, CallableArgument, EllipsisType, StarType, LiteralType,
-    RawExpressionType, PartialType, PlaceholderType, TypeAliasType
+    RawExpressionType, PartialType, PlaceholderType, TypeAliasType, ParamSpecType
 )
 from mypy.util import get_prefix, replace_object_state
 from mypy.typestate import TypeState
@@ -173,7 +173,8 @@ class NodeReplaceVisitor(TraverserVisitor):
         node.defs.body = self.replace_statements(node.defs.body)
         info = node.info
         for tv in node.type_vars:
-            self.process_type_var_def(tv)
+            if isinstance(tv, TypeVarType):
+                self.process_type_var_def(tv)
         if info:
             if info.is_named_tuple:
                 self.process_synthetic_type_info(info)
@@ -406,6 +407,9 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
         typ.upper_bound.accept(self)
         for value in typ.values:
             value.accept(self)
+
+    def visit_param_spec(self, typ: ParamSpecType) -> None:
+        pass
 
     def visit_typeddict_type(self, typ: TypedDictType) -> None:
         for value_type in typ.items.values():

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -99,7 +99,7 @@ from mypy.types import (
     Type, Instance, AnyType, NoneType, TypeVisitor, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     FunctionLike, Overloaded, TypeOfAny, LiteralType, ErasedType, get_proper_type, ProperType,
-    TypeAliasType
+    TypeAliasType, ParamSpecType
 )
 from mypy.server.trigger import make_trigger, make_wildcard_trigger
 from mypy.util import correct_relative_import
@@ -950,6 +950,11 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         for val in typ.values:
             triggers.extend(self.get_type_triggers(val))
         return triggers
+
+    def visit_param_spec(self, typ: ParamSpecType) -> List[str]:
+        if typ.fullname:
+            return [make_trigger(typ.fullname)]
+        return []
 
     def visit_typeddict_type(self, typ: TypedDictType) -> List[str]:
         triggers = []

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -952,9 +952,11 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         return triggers
 
     def visit_param_spec(self, typ: ParamSpecType) -> List[str]:
+        triggers = []
         if typ.fullname:
-            return [make_trigger(typ.fullname)]
-        return []
+            triggers.append(make_trigger(typ.fullname))
+        triggers.extend(self.get_type_triggers(typ.upper_bound))
+        return triggers
 
     def visit_typeddict_type(self, typ: TypedDictType) -> List[str]:
         triggers = []

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -314,8 +314,14 @@ class SubtypeVisitor(TypeVisitor[bool]):
         return self._is_subtype(left.upper_bound, self.right)
 
     def visit_param_spec(self, left: ParamSpecType) -> bool:
-        # TODO: What should we do here?
-        return False
+        right = self.right
+        if (
+            isinstance(right, ParamSpecType)
+            and right.id == left.id
+            and right.flavor == left.flavor
+        ):
+            return True
+        return self._is_subtype(left.upper_bound, self.right)
 
     def visit_callable_type(self, left: CallableType) -> bool:
         right = self.right
@@ -1332,6 +1338,16 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
             return True
         if left.values and self._is_proper_subtype(
                 mypy.typeops.make_simplified_union(left.values), self.right):
+            return True
+        return self._is_proper_subtype(left.upper_bound, self.right)
+
+    def visit_param_spec(self, left: ParamSpecType) -> bool:
+        right = self.right
+        if (
+            isinstance(right, ParamSpecType)
+            and right.id == left.id
+            and right.flavor == left.flavor
+        ):
             return True
         return self._is_proper_subtype(left.upper_bound, self.right)
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -274,7 +274,8 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 t = map_instance_to_supertype(left, right.type)
                 nominal = all(self.check_type_parameter(lefta, righta, tvar.variance)
                               for lefta, righta, tvar in
-                              zip(t.args, right.args, right.type.defn.type_vars))
+                              zip(t.args, right.args, right.type.defn.type_vars)
+                              if isinstance(tvar, TypeVarType))
                 if nominal:
                     TypeState.record_subtype_cache_entry(self._subtype_kind, left, right)
                 return nominal

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -7,7 +7,7 @@ from mypy.types import (
     Type, AnyType, UnboundType, TypeVisitor, FormalArgument, NoneType,
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
-    FunctionLike, TypeOfAny, LiteralType, get_proper_type, TypeAliasType
+    FunctionLike, TypeOfAny, LiteralType, get_proper_type, TypeAliasType, ParamSpecType
 )
 import mypy.applytype
 import mypy.constraints
@@ -312,6 +312,10 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 mypy.typeops.make_simplified_union(left.values), right):
             return True
         return self._is_subtype(left.upper_bound, self.right)
+
+    def visit_param_spec(self, left: ParamSpecType) -> bool:
+        # TODO: What should we do here?
+        return False
 
     def visit_callable_type(self, left: CallableType) -> bool:
         right = self.right

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -8,7 +8,8 @@ from typing import List, Optional, Tuple
 from mypy.semanal_shared import set_callable_name
 from mypy.types import (
     Type, AnyType, NoneType, Instance, CallableType, TypeVarType, TypeType,
-    UninhabitedType, TypeOfAny, TypeAliasType, UnionType, LiteralType
+    UninhabitedType, TypeOfAny, TypeAliasType, UnionType, LiteralType,
+    TypeVarLikeType
 )
 from mypy.nodes import (
     TypeInfo, ClassDef, FuncDef, Block, ARG_POS, ARG_OPT, ARG_STAR, SymbolTable,
@@ -234,7 +235,7 @@ class TypeFixture:
                 module_name = '__main__'
 
         if typevars:
-            v: List[TypeVarType] = []
+            v: List[TypeVarLikeType] = []
             for id, n in enumerate(typevars, 1):
                 if variances:
                     variance = variances[id - 1]

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -1,5 +1,5 @@
 from typing import Optional, Dict, Union
-from mypy.types import TypeVarLikeType, TypeVarType, ParamSpecType
+from mypy.types import TypeVarLikeType, TypeVarType, ParamSpecType, ParamSpecFlavor
 from mypy.nodes import ParamSpecExpr, TypeVarExpr, TypeVarLikeExpr, SymbolTableNode
 
 
@@ -78,6 +78,7 @@ class TypeVarLikeScope:
                 name,
                 tvar_expr.fullname,
                 i,
+                flavor=ParamSpecFlavor.BARE,
                 line=tvar_expr.line,
                 column=tvar_expr.column
             )

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -79,6 +79,7 @@ class TypeVarLikeScope:
                 tvar_expr.fullname,
                 i,
                 flavor=ParamSpecFlavor.BARE,
+                upper_bound=tvar_expr.upper_bound,
                 line=tvar_expr.line,
                 column=tvar_expr.column
             )

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -23,7 +23,7 @@ from mypy.types import (
     RawExpressionType, Instance, NoneType, TypeType,
     UnionType, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarLikeType,
     UnboundType, ErasedType, StarType, EllipsisType, TypeList, CallableArgument,
-    PlaceholderType, TypeAliasType, get_proper_type
+    PlaceholderType, TypeAliasType, ParamSpecType, get_proper_type
 )
 
 
@@ -61,6 +61,10 @@ class TypeVisitor(Generic[T]):
 
     @abstractmethod
     def visit_type_var(self, t: TypeVarType) -> T:
+        pass
+
+    @abstractmethod
+    def visit_param_spec(self, t: ParamSpecType) -> T:
         pass
 
     @abstractmethod

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -65,7 +65,6 @@ class TypeVisitor(Generic[T]):
 
     @abstractmethod
     def visit_param_spec(self, t: ParamSpecType) -> T:
-        assert False
         pass
 
     @abstractmethod

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -65,6 +65,7 @@ class TypeVisitor(Generic[T]):
 
     @abstractmethod
     def visit_param_spec(self, t: ParamSpecType) -> T:
+        assert False
         pass
 
     @abstractmethod
@@ -181,6 +182,9 @@ class TypeTranslator(TypeVisitor[Type]):
         )
 
     def visit_type_var(self, t: TypeVarType) -> Type:
+        return t
+
+    def visit_param_spec(self, t: ParamSpecType) -> Type:
         return t
 
     def visit_partial_type(self, t: PartialType) -> Type:

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -295,6 +295,9 @@ class TypeQuery(SyntheticTypeVisitor[T]):
     def visit_type_var(self, t: TypeVarType) -> T:
         return self.query_types([t.upper_bound] + t.values)
 
+    def visit_param_spec(self, t: ParamSpecType) -> T:
+        return self.strategy([])
+
     def visit_partial_type(self, t: PartialType) -> T:
         return self.strategy([])
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1000,9 +1000,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         finally:
             if nested:
                 self.nesting_level -= 1
-        # Use type(...) to ignore proper/non-proper type distinction.
         if (not allow_param_spec
-                and type(analyzed) is ParamSpecType
+                and isinstance(analyzed, ParamSpecType)
                 and analyzed.flavor == ParamSpecFlavor.BARE):
             self.fail('Invalid location for ParamSpec "{}"'.format(analyzed.name), t)
             self.note(

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -547,6 +547,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                                             else self.named_type('builtins.function')),
                                   variables=self.anal_var_defs(variables),
                                   type_guard=special,
+                                  param_spec=t.param_spec,
                                   )
         return ret
 
@@ -694,14 +695,14 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         if not isinstance(tvar_def, ParamSpecType):
             return None
 
-        # TODO(PEP612): construct correct type for paramspec
         return CallableType(
             [AnyType(TypeOfAny.explicit), AnyType(TypeOfAny.explicit)],
             [nodes.ARG_STAR, nodes.ARG_STAR2],
             [None, None],
             ret_type=ret_type,
             fallback=fallback,
-            is_ellipsis_args=True
+            is_ellipsis_args=True,
+            param_spec=tvar_def,
         )
 
     def analyze_callable_type(self, t: UnboundType) -> Type:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -209,7 +209,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 if tvar_def is None:
                     self.fail('ParamSpec "{}" is unbound'.format(t.name), t)
                     return AnyType(TypeOfAny.from_error)
-                assert isinstance(tvar_def , ParamSpecType)
+                assert isinstance(tvar_def, ParamSpecType)
                 if len(t.args) > 0:
                     self.fail('ParamSpec "{}" used with arguments'.format(t.name), t)
                 # Change the line number
@@ -745,7 +745,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         if len(t.args) == 0:
             # Callable (bare). Treat as Callable[..., Any].
             any_type = self.get_omitted_any(t)
-            ret = callable_with_ellipsis(any_type, any_type,fallback)
+            ret = callable_with_ellipsis(any_type, any_type, fallback)
         elif len(t.args) == 2:
             callable_args = t.args[0]
             ret_type = t.args[1]
@@ -1000,8 +1000,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         finally:
             if nested:
                 self.nesting_level -= 1
+        # Use type(...) to ignore proper/non-proper type distinction.
         if (not allow_param_spec
-                and isinstance(analyzed, ParamSpecType)
+                and type(analyzed) is ParamSpecType
                 and analyzed.flavor == ParamSpecFlavor.BARE):
             self.fail('Invalid location for ParamSpec "{}"'.format(analyzed.name), t)
             self.note(

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -744,7 +744,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             [None, None],
             ret_type=ret_type,
             fallback=fallback,
-            is_ellipsis_args=True,
         )
 
     def analyze_callable_type(self, t: UnboundType) -> Type:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1255,8 +1255,9 @@ class TypeVarLikeQuery(TypeQuery[TypeVarLikeList]):
             if name.endswith('.args') or name.endswith('.kwargs'):
                 base = '.'.join(name.split('.')[:-1])
                 n = self.lookup(base, t)
-                if isinstance(n.node, ParamSpecExpr):
+                if n is not None and isinstance(n.node, ParamSpecExpr):
                     node = n
+                    name = base
         if node is None:
             node = self.lookup(name, t)
         if node and isinstance(node.node, TypeVarLikeExpr) and (

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -215,7 +215,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 # Change the line number
                 return ParamSpecType(
                     tvar_def.name, tvar_def.fullname, tvar_def.id, tvar_def.flavor,
-                    line=t.line, column=t.column,
+                    tvar_def.upper_bound, line=t.line, column=t.column,
                 )
                 #self.fail('Invalid location for ParamSpec "{}"'.format(t.name), t)
                 #self.note(
@@ -601,6 +601,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     else:
                         assert False, kind
                     return ParamSpecType(tvar_def.name, tvar_def.fullname, tvar_def.id, flavor,
+                                         upper_bound=self.named_type('builtins.object'),
                                          line=t.line, column=t.column)
         return self.anal_type(t, nested=nested)
 
@@ -732,9 +733,13 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         if not isinstance(tvar_def, ParamSpecType):
             return None
 
+        # TODO: Use tuple[...] or Mapping[..] instead?
+        obj = self.named_type('builtins.object')
         return CallableType(
-            [ParamSpecType(tvar_def.name, tvar_def.fullname, tvar_def.id, ParamSpecFlavor.ARGS),
-             ParamSpecType(tvar_def.name, tvar_def.fullname, tvar_def.id, ParamSpecFlavor.KWARGS)],
+            [ParamSpecType(tvar_def.name, tvar_def.fullname, tvar_def.id, ParamSpecFlavor.ARGS,
+                           upper_bound=obj),
+             ParamSpecType(tvar_def.name, tvar_def.fullname, tvar_def.id, ParamSpecFlavor.KWARGS,
+                           upper_bound=obj)],
             [nodes.ARG_STAR, nodes.ARG_STAR2],
             [None, None],
             ret_type=ret_type,

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -566,7 +566,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                                             else self.named_type('builtins.function')),
                                   variables=self.anal_var_defs(variables),
                                   type_guard=special,
-                                  param_spec=t.param_spec,
                                   )
         return ret
 
@@ -734,13 +733,13 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             return None
 
         return CallableType(
-            [AnyType(TypeOfAny.explicit), AnyType(TypeOfAny.explicit)],
+            [ParamSpecType(tvar_def.name, tvar_def.fullname, tvar_def.id, ParamSpecFlavor.ARGS),
+             ParamSpecType(tvar_def.name, tvar_def.fullname, tvar_def.id, ParamSpecFlavor.KWARGS)],
             [nodes.ARG_STAR, nodes.ARG_STAR2],
             [None, None],
             ret_type=ret_type,
             fallback=fallback,
             is_ellipsis_args=True,
-            param_spec=tvar_def,
         )
 
     def analyze_callable_type(self, t: UnboundType) -> Type:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2176,10 +2176,15 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
     def visit_param_spec(self, t: ParamSpecType) -> str:
         if t.name is None:
             # Anonymous type variable type (only numeric id).
-            s = '`{}'.format(t.id)
+            s = f'`{t.id}'
         else:
             # Named type variable type.
-            s = '{}`{}'.format(t.name, t.id)
+            suffix = ''
+            if t.flavor == ParamSpecFlavor.ARGS:
+                suffix = '.args'
+            elif t.flavor == ParamSpecFlavor.KWARGS:
+                suffix = '.kwargs'
+            s = f'{t.name}{suffix}`{t.id}'
         return s
 
     def visit_callable_type(self, t: CallableType) -> str:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1294,6 +1294,22 @@ class CallableType(FunctionLike):
             a.append(tv.id)
         return a
 
+    def param_spec2(self) -> Optional[ParamSpecType]:
+        """Return ParamSpec if callable can be called with one."""
+        if len(self.arg_types) < 2:
+            return None
+        if self.arg_kinds[-2] != ARG_STAR or self.arg_kinds[-1] != ARG_STAR2:
+            return None
+        arg_type = get_proper_type(self.arg_types[-2])
+        if not isinstance(arg_type, ParamSpecType):
+            return None
+        return ParamSpecType(arg_type.name, arg_type.fullname, arg_type.id, ParamSpecFlavor.BARE)
+
+    def expand_param_spec(self, c: 'CallableType') -> 'CallableType':
+        return self.copy_modified(arg_types=self.arg_types[:-2] + c.arg_types,
+                                  arg_kinds=self.arg_kinds[:-2] + c.arg_kinds,
+                                  arg_names=self.arg_names[:-2] + c.arg_names)
+
     def __hash__(self) -> int:
         return hash((self.ret_type, self.is_type_obj(),
                      self.is_ellipsis_args, self.name,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -467,6 +467,11 @@ class ParamSpecType(TypeVarLikeType):
      * P (ParamSpecFlavor.BARE)
      * P.args (ParamSpecFlavor.ARGS)
      * P.kwargs (ParamSpecFLavor.KWARGS)
+
+    The upper_bound is really used as a fallback type -- it's shared
+    with TypeVarType for simplicity. It can't be specified by the user
+    and the value is directly derived from the flavor (currently
+    always just 'object').
     """
 
     __slots__ = ('flavor',)
@@ -503,6 +508,7 @@ class ParamSpecType(TypeVarLikeType):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ParamSpecType):
             return NotImplemented
+        # Upper bound can be ignored, since it's determined by flavor.
         return self.id == other.id and self.flavor == other.flavor
 
     def serialize(self) -> JsonDict:
@@ -1319,7 +1325,7 @@ class CallableType(FunctionLike):
             return None
         if self.arg_kinds[-2] != ARG_STAR or self.arg_kinds[-1] != ARG_STAR2:
             return None
-        arg_type = get_proper_type(self.arg_types[-2])
+        arg_type = self.arg_types[-2]
         if not isinstance(arg_type, ParamSpecType):
             return None
         return ParamSpecType(arg_type.name, arg_type.fullname, arg_type.id, ParamSpecFlavor.BARE,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -454,6 +454,14 @@ class ParamSpecType(TypeVarLikeType):
     def __repr__(self) -> str:
         return self.name
 
+    @staticmethod
+    def new_unification_variable(old: 'ParamSpecType') -> 'ParamSpecType':
+        new_id = TypeVarId.new(meta_level=1)
+        return ParamSpecType(old.name, old.fullname, new_id, old.line, old.column)
+
+    def accept(self, visitor: 'TypeVisitor[T]') -> T:
+        return visitor.visit_param_spec(self)
+
     def serialize(self) -> JsonDict:
         assert not self.id.is_meta_var()
         return {

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3,7 +3,6 @@
 import copy
 import sys
 from abc import abstractmethod
-from enum import Enum
 
 from typing import (
     Any, TypeVar, Dict, List, Tuple, cast, Set, Optional, Union, Iterable, NamedTuple,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2489,3 +2489,15 @@ deserialize_map: Final = {
     for key, obj in names.items()
     if isinstance(obj, type) and issubclass(obj, Type) and obj is not Type
 }
+
+
+def callable_with_ellipsis(any_type: AnyType,
+                           ret_type: Type,
+                           fallback: Instance) -> CallableType:
+    """Construct type Callable[..., ret_type]."""
+    return CallableType([any_type, any_type],
+                        [ARG_STAR, ARG_STAR2],
+                        [None, None],
+                        ret_type=ret_type,
+                        fallback=fallback,
+                        is_ellipsis_args=True)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -391,7 +391,7 @@ class TypeVarLikeType(ProperType):
 
 
 class TypeVarType(TypeVarLikeType):
-    """Definition of a single type variable."""
+    """Type that refers to a type variable."""
 
     __slots__ = ('values', 'variance')
 
@@ -457,7 +457,17 @@ class ParamSpecFlavor:
 
 
 class ParamSpecType(TypeVarLikeType):
-    """Definition of a single ParamSpec variable."""
+    """Type that refers to a ParamSpec.
+
+    A ParamSpec is a type variable that represents the parameter
+    types, names and kinds of a callable (i.e., the signature without
+    the return type).
+
+    This can be one of these forms
+     * P (ParamSpecFlavor.BARE)
+     * P.args (ParamSpecFlavor.ARGS)
+     * P.kwargs (ParamSpecFLavor.KWARGS)
+    """
 
     __slots__ = ('flavor',)
 

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -6,7 +6,7 @@ from mypy.types import (
     Type, SyntheticTypeVisitor, AnyType, UninhabitedType, NoneType, ErasedType, DeletedType,
     TypeVarType, LiteralType, Instance, CallableType, TupleType, TypedDictType, UnionType,
     Overloaded, TypeType, CallableArgument, UnboundType, TypeList, StarType, EllipsisType,
-    PlaceholderType, PartialType, RawExpressionType, TypeAliasType
+    PlaceholderType, PartialType, RawExpressionType, TypeAliasType, ParamSpecType
 )
 
 
@@ -35,6 +35,9 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
         # Note that type variable values and upper bound aren't treated as
         # components, since they are components of the type variable
         # definition. We want to traverse everything just once.
+        pass
+
+    def visit_param_spec(self, t: ParamSpecType) -> None:
         pass
 
     def visit_literal_type(self, t: LiteralType) -> None:

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -23,7 +23,8 @@ def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
             )
         else:
             assert isinstance(tv, ParamSpecType)
-            tv = ParamSpecType(tv.name, tv.fullname, tv.id, tv.flavor, line=-1, column=-1)
+            tv = ParamSpecType(tv.name, tv.fullname, tv.id, tv.flavor, tv.upper_bound,
+                               line=-1, column=-1)
         tvs.append(tv)
     inst = Instance(typ, tvs)
     if typ.tuple_type is None:

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -22,6 +22,7 @@ def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
                 tv.upper_bound, tv.variance, line=-1, column=-1,
             )
         else:
+            assert isinstance(tv, ParamSpecType)
             tv = ParamSpecType(tv.name, tv.fullname, tv.id, tv.flavor, line=-1, column=-1)
         tvs.append(tv)
     inst = Instance(typ, tvs)

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -3,7 +3,7 @@ from typing import Union, List
 from mypy.nodes import TypeInfo
 
 from mypy.erasetype import erase_typevars
-from mypy.types import Instance, TypeVarType, TupleType, Type, TypeOfAny, AnyType
+from mypy.types import Instance, TypeVarType, TupleType, Type, TypeOfAny, AnyType, ParamSpecType
 
 
 def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
@@ -16,10 +16,13 @@ def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
     for i in range(len(typ.defn.type_vars)):
         tv = typ.defn.type_vars[i]
         # Change the line number
-        tv = TypeVarType(
-            tv.name, tv.fullname, tv.id, tv.values,
-            tv.upper_bound, tv.variance, line=-1, column=-1,
-        )
+        if isinstance(tv, TypeVarType):
+            tv = TypeVarType(
+                tv.name, tv.fullname, tv.id, tv.values,
+                tv.upper_bound, tv.variance, line=-1, column=-1,
+            )
+        else:
+            tv = ParamSpecType(tv.name, tv.fullname, tv.id, line=-1, column=-1)
         tvs.append(tv)
     inst = Instance(typ, tvs)
     if typ.tuple_type is None:

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -22,7 +22,7 @@ def fill_typevars(typ: TypeInfo) -> Union[Instance, TupleType]:
                 tv.upper_bound, tv.variance, line=-1, column=-1,
             )
         else:
-            tv = ParamSpecType(tv.name, tv.fullname, tv.id, line=-1, column=-1)
+            tv = ParamSpecType(tv.name, tv.fullname, tv.id, tv.flavor, line=-1, column=-1)
         tvs.append(tv)
     inst = Instance(typ, tvs)
     if typ.tuple_type is None:

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -28,19 +28,11 @@ def foo6(x: Callable[[P], int]) -> None: ...  # E: Invalid location for ParamSpe
                                               # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
 [builtins fixtures/tuple.pyi]
 
-[case testParamSpecTemporaryAnyBehaviour]
-# TODO(PEP612): behaviour tested here should change
-# This is a test of mypy's temporary behaviour in lieu of full support for ParamSpec
+[case testParamSpecContextManagerLike]
 from typing import Callable, List, Iterator, TypeVar
 from typing_extensions import ParamSpec
 P = ParamSpec('P')
 T = TypeVar('T')
-
-def changes_return_type_to_str(x: Callable[P, int]) -> Callable[P, str]: ...
-
-def returns_int(a: str, b: bool) -> int: ...
-
-reveal_type(changes_return_type_to_str(returns_int))  # N: Revealed type is "def (*Any, **Any) -> builtins.str"
 
 def tmpcontextmanagerlike(x: Callable[P, Iterator[T]]) -> Callable[P, List[T]]: ...
 
@@ -48,7 +40,7 @@ def tmpcontextmanagerlike(x: Callable[P, Iterator[T]]) -> Callable[P, List[T]]: 
 def whatever(x: int) -> Iterator[int]:
     yield x
 
-reveal_type(whatever)  # N: Revealed type is "def (*Any, **Any) -> builtins.list[builtins.int*]"
+reveal_type(whatever)  # N: Revealed type is "def (x: builtins.int) -> builtins.list[builtins.int*]"
 reveal_type(whatever(217))  # N: Revealed type is "builtins.list[builtins.int*]"
 [builtins fixtures/tuple.pyi]
 
@@ -109,7 +101,36 @@ P = ParamSpec('P')
 class C(Generic[P]):
     def __init__(self, x: Callable[P, None]) -> None: ...
 
+    def m(self, *args: P.args, **kwargs: P.kwargs) -> int:
+        return 1
+
 def f(x: int, y: str) -> None: ...
 
 reveal_type(C(f))  # N: Revealed type is "__main__.C[def (x: builtins.int, y: builtins.str)]"
-[builtins fixtures/tuple.pyi]
+reveal_type(C(f).m)  # N: Revealed type is "def (x: builtins.int, y: builtins.str) -> builtins.int"
+[builtins fixtures/dict.pyi]
+
+[case testParamSpecDecorator]
+from typing import Callable, TypeVar, Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+R = TypeVar('R')
+
+class W(Generic[P, R]):
+    f: Callable[P, R]
+    x: int
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        reveal_type(self.f(*args, **kwargs))  # N: Revealed type is "R`2"
+        return self.f(*args, **kwargs)
+
+def dec() -> Callable[[Callable[P, R]], W[P, R]]:
+    pass
+
+@dec()
+def f(a: int, b: str) -> None: ...
+
+reveal_type(f)  # N: Revealed type is "__main__.W[def (a: builtins.int, b: builtins.str), None]"
+reveal_type(f(1, ''))  # N: Revealed type is "None"
+reveal_type(f.x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -110,6 +110,24 @@ reveal_type(C(f))  # N: Revealed type is "__main__.C[def (x: builtins.int, y: bu
 reveal_type(C(f).m)  # N: Revealed type is "def (x: builtins.int, y: builtins.str) -> builtins.int"
 [builtins fixtures/dict.pyi]
 
+[case testParamSpecClassWithPrefixArgument]
+from typing import Callable, TypeVar, Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+
+class C(Generic[P]):
+    def __init__(self, x: Callable[P, None]) -> None: ...
+
+    def m(self, a: str, *args: P.args, **kwargs: P.kwargs) -> int:
+        return 1
+
+def f(x: int, y: str) -> None: ...
+
+reveal_type(C(f).m)  # N: Revealed type is "def (a: builtins.str, x: builtins.int, y: builtins.str) -> builtins.int"
+reveal_type(C(f).m('', 1, ''))  # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]
+
 [case testParamSpecDecorator]
 from typing import Callable, TypeVar, Generic
 from typing_extensions import ParamSpec
@@ -133,4 +151,29 @@ def f(a: int, b: str) -> None: ...
 reveal_type(f)  # N: Revealed type is "__main__.W[def (a: builtins.int, b: builtins.str), None]"
 reveal_type(f(1, ''))  # N: Revealed type is "None"
 reveal_type(f.x)  # N: Revealed type is "builtins.int"
+
+class C:
+    @dec()
+    def m(self, x: int) -> str: ...
+
+#reveal_type(C().m(x=1))  # xN: x
+[builtins fixtures/dict.pyi]
+
+[case testParamSpecFunction]
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+R = TypeVar('R')
+
+def f(x: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+    return x(*args, **kwargs)
+
+def g(x: int, y: str) -> None: ...
+
+reveal_type(f(g, 1, y='x'))  # N: Revealed type is "None"
+f(g, 'x', y='x')  # E: Argument 2 to "f" has incompatible type "str"; expected "int"
+f(g, 1, y=1)  # E: Argument "y" to "f" has incompatible type "int"; expected "str"
+f(g)  # E: Missing positional arguments "x", "y" in call to "f"
+
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -318,3 +318,29 @@ class C(Generic[P, P2]):
         reveal_type(join(c, c))  # N: Revealed type is "__main__.C*[P`1, P3`-1]"
         reveal_type(join(self, c))  # N: Revealed type is "builtins.object*"
 [builtins fixtures/dict.pyi]
+
+[case testParamSpecClassWithAny]
+from typing import Callable, Generic, Any
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+
+class C(Generic[P]):
+    def __init__(self, x: Callable[P, None]) -> None: ...
+
+    def m(self, *args: P.args, **kwargs: P.kwargs) -> int:
+        return 1
+
+c: C[Any]
+reveal_type(c)  # N: Revealed type is "__main__.C[Any]"
+reveal_type(c.m)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> builtins.int"
+c.m(4, 6, y='x')
+c = c
+
+def f() -> None: pass
+
+c2 = C(f)
+c2 = c
+c3 = C(f)
+c = c3
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -152,11 +152,13 @@ reveal_type(f)  # N: Revealed type is "__main__.W[def (a: builtins.int, b: built
 reveal_type(f(1, ''))  # N: Revealed type is "None"
 reveal_type(f.x)  # N: Revealed type is "builtins.int"
 
-class C:
-    @dec()
-    def m(self, x: int) -> str: ...
-
-#reveal_type(C().m(x=1))  # xN: x
+## TODO: How should this work?
+#
+# class C:
+#     @dec()
+#     def m(self, x: int) -> str: ...
+#
+# reveal_type(C().m(x=1))
 [builtins fixtures/dict.pyi]
 
 [case testParamSpecFunction]
@@ -205,3 +207,21 @@ reveal_type(f(g))  # N: Revealed type is "def (*Any, **Any) -> builtins.str"
 
 f(g)(1, 3, x=1, y=2)
 [builtins fixtures/tuple.pyi]
+
+[case testParamSpecDecoratorImplementation]
+from typing import Callable, Any, TypeVar, List
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+T = TypeVar('T')
+
+def dec(f: Callable[P, T]) -> Callable[P, List[T]]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> List[T]:
+        return [f(*args, **kwargs)]
+    return wrapper
+
+@dec
+def g(x: int, y: str = '') -> int: ...
+
+reveal_type(g)  # N: Revealed type is "def (x: builtins.int, y: builtins.str =) -> builtins.list[builtins.int*]"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -191,3 +191,17 @@ def f(x: int, y: str, z: int, a: str) -> None: ...
 
 x = register(f, 1, '', 1, '')
 [builtins fixtures/dict.pyi]
+
+[case testParamSpecInferredFromAny]
+from typing import Callable, Any
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+
+def f(x: Callable[P, int]) -> Callable[P, str]: ...
+
+g: Any
+reveal_type(f(g))  # N: Revealed type is "def (*Any, **Any) -> builtins.str"
+
+f(g)(1, 3, x=1, y=2)
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -287,7 +287,7 @@ def join(x: T, y: T) -> T: ...
 
 class C(Generic[P, P2]):
     def m(self, f: Callable[P, None], g: Callable[P2, None]) -> None:
-        reveal_type(join(f, f))  # N: Revealed type is "def (*P.args, **P.kwargs) -> None"
+        reveal_type(join(f, f))  # N: Revealed type is "def (*P.args, **P.kwargs)"
         reveal_type(join(f, g))  # N: Revealed type is "builtins.function*"
 
     def m2(self, *args: P.args, **kwargs: P.kwargs) -> None:

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -225,3 +225,17 @@ def g(x: int, y: str = '') -> int: ...
 
 reveal_type(g)  # N: Revealed type is "def (x: builtins.int, y: builtins.str =) -> builtins.list[builtins.int*]"
 [builtins fixtures/dict.pyi]
+
+[case testParamSpecArgsAndKwargsTypes]
+from typing import Callable, TypeVar, Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+
+class C(Generic[P]):
+    def __init__(self, x: Callable[P, None]) -> None: ...
+
+    def m(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        reveal_type(args)  # N: Revealed type is "P.args`1"
+        reveal_type(kwargs)  # N: Revealed type is "P.kwargs`1"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -44,30 +44,14 @@ reveal_type(whatever)  # N: Revealed type is "def (x: builtins.int) -> builtins.
 reveal_type(whatever(217))  # N: Revealed type is "builtins.list[builtins.int*]"
 [builtins fixtures/tuple.pyi]
 
-[case testGenericParamSpecTemporaryBehaviour]
-# flags: --python-version 3.10
-# TODO(PEP612): behaviour tested here should change
-from typing import Generic, TypeVar, Callable, ParamSpec
-
-T = TypeVar("T")
-P = ParamSpec("P")
-
-class X(Generic[T, P]):  # E: Free type variable expected in Generic[...]
-  f: Callable[P, int]  # E: The first argument to Callable must be a list of types or "..."
-  x: T
-[out]
-
 [case testInvalidParamSpecType]
 # flags: --python-version 3.10
 from typing import ParamSpec
 
 P = ParamSpec("P")
 
-class MyFunction(P):  # E: Invalid location for ParamSpec "P" \
-                      # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
+class MyFunction(P):  # E: Invalid base class "P"
     ...
-
-a: MyFunction[int]  # E: "MyFunction" expects no type arguments, but 1 given
 
 [case testParamSpecRevealType]
 from typing import Callable

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -76,3 +76,13 @@ class MyFunction(P):  # E: Invalid location for ParamSpec "P" \
     ...
 
 a: MyFunction[int]  # E: "MyFunction" expects no type arguments, but 1 given
+
+[case testParamSpecRevealType]
+from typing import Callable
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+
+def f(x: Callable[P, int]) -> None: ...
+reveal_type(f)  # N: Revealed type is "def [P] (x: def (*P.args, **P.kwargs) -> builtins.int)"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -240,7 +240,7 @@ class C(Generic[P]):
         reveal_type(kwargs)  # N: Revealed type is "P.kwargs`1"
 [builtins fixtures/dict.pyi]
 
-[case testParamSpecSubtypeChecking]
+[case testParamSpecSubtypeChecking1]
 from typing import Callable, TypeVar, Generic, Any
 from typing_extensions import ParamSpec
 
@@ -265,4 +265,26 @@ class C(Generic[P]):
         kwargs = args  # E: Incompatible types in assignment (expression has type "P.args", variable has type "P.kwargs")
         args = a
         kwargs = a
+[builtins fixtures/dict.pyi]
+
+[case testParamSpecSubtypeChecking2]
+from typing import Callable, Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+P2 = ParamSpec('P2')
+
+class C(Generic[P]):
+    def m(self, c1: C[P], c2: C[P2]) -> None:
+        c1 = c1
+        c2 = c2
+        c1 = c2  # E: Incompatible types in assignment (expression has type "C[P2]", variable has type "C[P]")
+        c2 = c1  # E: Incompatible types in assignment (expression has type "C[P]", variable has type "C[P2]")
+
+class D(Generic[P, P2]):
+    def m(self, f: Callable[P, None], g: Callable[P2, None]) -> None:
+        f = f
+        g = g
+        f = g  # E: Incompatible types in assignment (expression has type "Callable[P2, None]", variable has type "Callable[P, None]")
+        g = f  # E: Incompatible types in assignment (expression has type "Callable[P, None]", variable has type "Callable[P2, None]")
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -239,3 +239,30 @@ class C(Generic[P]):
         reveal_type(args)  # N: Revealed type is "P.args`1"
         reveal_type(kwargs)  # N: Revealed type is "P.kwargs`1"
 [builtins fixtures/dict.pyi]
+
+[case testParamSpecSubtypeChecking]
+from typing import Callable, TypeVar, Generic, Any
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+
+class C(Generic[P]):
+    def __init__(self, x: Callable[P, None]) -> None: ...
+
+    def m(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        args = args
+        kwargs = kwargs
+        o: object
+        o = args
+        o = kwargs
+        o2: object
+        args = o2  # E: Incompatible types in assignment (expression has type "object", variable has type "P.args")
+        kwargs = o2  # E: Incompatible types in assignment (expression has type "object", variable has type "P.kwargs")
+        a: Any
+        a = args
+        a = kwargs
+        args = kwargs  # E: Incompatible types in assignment (expression has type "P.kwargs", variable has type "P.args")
+        kwargs = args  # E: Incompatible types in assignment (expression has type "P.args", variable has type "P.kwargs")
+        args = a
+        kwargs = a
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -92,11 +92,24 @@ from typing import Callable, TypeVar
 from typing_extensions import ParamSpec
 
 P = ParamSpec('P')
-T = TypeVar('T')
 
 def changes_return_type_to_str(x: Callable[P, int]) -> Callable[P, str]: ...
 
 def returns_int(a: str, b: bool) -> int: ...
 
 reveal_type(changes_return_type_to_str(returns_int))  # N: Revealed type is "def (a: builtins.str, b: builtins.bool) -> builtins.str"
+[builtins fixtures/tuple.pyi]
+
+[case testParamSpecSimpleClass]
+from typing import Callable, TypeVar, Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+
+class C(Generic[P]):
+    def __init__(self, x: Callable[P, None]) -> None: ...
+
+def f(x: int, y: str) -> None: ...
+
+reveal_type(C(f))  # N: Revealed type is "__main__.C[def (x: builtins.int, y: builtins.str)]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -86,3 +86,17 @@ P = ParamSpec('P')
 def f(x: Callable[P, int]) -> None: ...
 reveal_type(f)  # N: Revealed type is "def [P] (x: def (*P.args, **P.kwargs) -> builtins.int)"
 [builtins fixtures/tuple.pyi]
+
+[case testParamSpecSimpleFunction]
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+T = TypeVar('T')
+
+def changes_return_type_to_str(x: Callable[P, int]) -> Callable[P, str]: ...
+
+def returns_int(a: str, b: bool) -> int: ...
+
+reveal_type(changes_return_type_to_str(returns_int))  # N: Revealed type is "def (a: builtins.str, b: builtins.bool) -> builtins.str"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -275,16 +275,46 @@ P = ParamSpec('P')
 P2 = ParamSpec('P2')
 
 class C(Generic[P]):
-    def m(self, c1: C[P], c2: C[P2]) -> None:
-        c1 = c1
-        c2 = c2
-        c1 = c2  # E: Incompatible types in assignment (expression has type "C[P2]", variable has type "C[P]")
-        c2 = c1  # E: Incompatible types in assignment (expression has type "C[P]", variable has type "C[P2]")
+    pass
 
-class D(Generic[P, P2]):
+def f(c1: C[P], c2: C[P2]) -> None:
+    c1 = c1
+    c2 = c2
+    c1 = c2  # E: Incompatible types in assignment (expression has type "C[P2]", variable has type "C[P]")
+    c2 = c1  # E: Incompatible types in assignment (expression has type "C[P]", variable has type "C[P2]")
+
+def g(f: Callable[P, None], g: Callable[P2, None]) -> None:
+    f = f
+    g = g
+    f = g  # E: Incompatible types in assignment (expression has type "Callable[P2, None]", variable has type "Callable[P, None]")
+    g = f  # E: Incompatible types in assignment (expression has type "Callable[P, None]", variable has type "Callable[P2, None]")
+[builtins fixtures/dict.pyi]
+
+[case testParamSpecJoin]
+from typing import Callable, Generic, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+P2 = ParamSpec('P2')
+P3 = ParamSpec('P3')
+T = TypeVar('T')
+
+def join(x: T, y: T) -> T: ...
+
+class C(Generic[P, P2]):
     def m(self, f: Callable[P, None], g: Callable[P2, None]) -> None:
-        f = f
-        g = g
-        f = g  # E: Incompatible types in assignment (expression has type "Callable[P2, None]", variable has type "Callable[P, None]")
-        g = f  # E: Incompatible types in assignment (expression has type "Callable[P, None]", variable has type "Callable[P2, None]")
+        reveal_type(join(f, f))  # N: Revealed type is "def (*P.args, **P.kwargs) -> None"
+        reveal_type(join(f, g))  # N: Revealed type is "builtins.function*"
+
+    def m2(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        reveal_type(join(args, args))  # N: Revealed type is "P.args`1"
+        reveal_type(join(kwargs, kwargs))  # N: Revealed type is "P.kwargs`1"
+        reveal_type(join(args, kwargs))  # N: Revealed type is "builtins.object*"
+        def f(*args2: P2.args, **kwargs2: P2.kwargs) -> None:
+            reveal_type(join(args, args2))  # N: Revealed type is "builtins.object*"
+            reveal_type(join(kwargs, kwargs2))  # N: Revealed type is "builtins.object*"
+
+    def m3(self, c: C[P, P3]) -> None:
+        reveal_type(join(c, c))  # N: Revealed type is "__main__.C*[P`1, P3`-1]"
+        reveal_type(join(self, c))  # N: Revealed type is "builtins.object*"
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -177,3 +177,17 @@ f(g, 1, y=1)  # E: Argument "y" to "f" has incompatible type "int"; expected "st
 f(g)  # E: Missing positional arguments "x", "y" in call to "f"
 
 [builtins fixtures/dict.pyi]
+
+[case testParamSpecSpecialCase]
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+T = TypeVar('T')
+
+def register(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Callable[P, T]: ...
+
+def f(x: int, y: str, z: int, a: str) -> None: ...
+
+x = register(f, 1, '', 1, '')
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Add support for type checking several ParamSpec use cases (PEP 612).

@hauntsaninja previously added support for semantic analysis of ParamSpec
definitions, and this builds on top that foundation.

The implementation has these main things going on:
 * `ParamSpecType` that is similar to `TypeVarType` but has three "flavors" that
   correspond to `P`, `P.args` and `P.kwargs`
 * `CallableType` represents `Callable[P, T]` if the arguments are 
   (`*args: P.args`, `**kwargs: P.kwargs`) -- and more generally, there can also
   be arbitrary additional prefix arguments
 * Type variables of functions and classes can now be represented using
   `ParamSpecType` in addition to `TypeVarType`

There are still a bunch of TODOs. Some of these are important to address before the
release that includes this. I believe that this is good enough to merge and remaining 
issues can be fixed in follow-up PRs.

Notable missing features include these:
 * `Concatenate`
 * Specifying the value of ParamSpec explicitly (e.g. `Z[[int, str, bool]]`)
 * Various validity checks -- currently only some errors are caught
 * Special case of decorating a method (python/typeshed#6347)