### PR TITLE
Remove duplicated indefinite articles in doc strings

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5472,7 +5472,7 @@ def is_literal_enum(type_map: Mapping[Expression, Type], n: Expression) -> bool:
             B = 2
 
     ...and if the expression 'Foo' referred to that enum within the current type context,
-    then the expression 'Foo.A' would be a a literal enum. However, if we did 'a = Foo.A',
+    then the expression 'Foo.A' would be a literal enum. However, if we did 'a = Foo.A',
     then the variable 'a' would *not* be a literal enum.
 
     We occasionally special-case expressions like 'Foo.A' and treat them as a single primitive

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4482,7 +4482,7 @@ def merge_typevars_in_callables_by_name(
     "S", but we treat them as distinct, unrelated typevars. (E.g. they could both have
     distinct ids.)
 
-    If we pass in both callables into this function, it returns a a list containing two
+    If we pass in both callables into this function, it returns a list containing two
     new callables that are identical in signature, but use the same underlying TypeVarType
     for T and S.
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -837,7 +837,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             #
             # 1. If the user attempts use an explicit Any as a parameter
             # 2. If the user is trying to use an enum value imported from a module with
-            #    no type hints, giving it an an implicit type of 'Any'
+            #    no type hints, giving it an implicit type of 'Any'
             # 3. If there's some other underlying problem with the parameter.
             #
             # We report an error in only the first two cases. In the third case, we assume


### PR DESCRIPTION
### Description
Teeny weeny change to fix a typo I found in a doc string (there were duplicated indefinite articles 😳😳😳😳😳😳😳😳😳😳😳😳😳😳😳😳😳)

## Test Plan

I don't think we need to write any tests for this change as it's purely a doc string change.

