### PR TITLE
Don't use ModuleType.__getattr__ if we know module symbols

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -381,7 +381,10 @@ def analyze_member_var_access(name: str,
     elif isinstance(v, FuncDef):
         assert False, "Did not expect a function"
     elif (not v and name not in ['__getattr__', '__setattr__', '__getattribute__'] and
-          not mx.is_operator):
+          not mx.is_operator and mx.module_symbol_table is None):
+        # Above we skip ModuleType.__getattr__ etc. if we have a
+        # module symbol table, since the symbol table allows precise
+        # checking.
         if not mx.is_lvalue:
             for method_name in ('__getattribute__', '__getattr__'):
                 method = info.get_method(method_name)


### PR DESCRIPTION
python/typeshed#6302 added `__getattr__`, but we don't want to always
use it, as it can result in undefined references to module attributes
being undetected.

This is an alternative to python/typeshed#6357.

Tested manually with a recent typeshed.