### PR TITLE
Prepare for typeshed sync: __file__ could be None

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -494,6 +494,7 @@ def take_module_snapshot(module: types.ModuleType) -> str:
     (e.g. if there is a change in modules imported by a plugin).
     """
     if hasattr(module, '__file__'):
+        assert module.__file__ is not None
         with open(module.__file__, 'rb') as f:
             digest = hash_digest(f.read())
     else:


### PR DESCRIPTION
Typeshed now declares `__file__` as an optional type.