### PR TITLE
Update strict equality allowlist

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -107,6 +107,8 @@ OVERLAPPING_TYPES_ALLOWLIST: Final = [
     "typing.ItemsView",
     "builtins._dict_keys",
     "builtins._dict_items",
+    "_collections_abc.dict_keys",
+    "_collections_abc.dict_items",
 ]
 
 


### PR DESCRIPTION
Names of some of types have changed in typeshed. Accept both
the old and the new names for now.

Tested manually with the latest typeshed.

Relevant typeshed changes: python/typeshed#6312