### PR TITLE
Improve ParamSpec type inference from lambda

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3608,18 +3608,19 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         arg_kinds = [arg.kind for arg in e.arguments]
 
-        if callable_ctx.is_ellipsis_args:
+        if callable_ctx.is_ellipsis_args or ctx.param_spec() is not None:
             # Fill in Any arguments to match the arguments of the lambda.
             callable_ctx = callable_ctx.copy_modified(
                 is_ellipsis_args=False,
                 arg_types=[AnyType(TypeOfAny.special_form)] * len(arg_kinds),
                 arg_kinds=arg_kinds,
-                arg_names=[None] * len(arg_kinds)
+                arg_names=e.arg_names[:],
             )
 
         if ARG_STAR in arg_kinds or ARG_STAR2 in arg_kinds:
             # TODO treat this case appropriately
             return callable_ctx, None
+
         if callable_ctx.arg_kinds != arg_kinds:
             # Incompatible context; cannot use it to infer types.
             self.chk.fail(message_registry.CANNOT_INFER_LAMBDA_TYPE, e)

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -328,3 +328,21 @@ c2 = c
 c3 = C(f)
 c = c3
 [builtins fixtures/dict.pyi]
+
+[case testParamSpecInferredFromLambda]
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+T = TypeVar('T')
+
+# Similar to atexit.register
+def register(f: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Callable[P, T]: ...  # N: "register" defined here
+
+def f(x: int) -> None: pass
+
+reveal_type(register(lambda: f(1)))  # N: Revealed type is "def ()"
+reveal_type(register(lambda x: f(x), x=1))  # N: Revealed type is "def (x: Any)"
+register(lambda x: f(x))  # E: Missing positional argument "x" in call to "register"
+register(lambda x: f(x), y=1)  # E: Unexpected keyword argument "y" for "register"
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
If ParamSpec is in the context of a lambda, treat it similar
to `Callable[..., Any]`. This allows us to infer at least argument
counts and kinds. Types can't be inferred since that would require
"backwards" type inference, which we don't support.

Follow-up to #11594.