### PR TITLE
Improve type checking of ParamSpec in calls

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, List, Optional, Sequence, Callable, Set
 
 from mypy.maptype import map_instance_to_supertype
 from mypy.types import (
-    Type, Instance, TupleType, AnyType, TypeOfAny, TypedDictType, get_proper_type
+    Type, Instance, TupleType, AnyType, TypeOfAny, TypedDictType, ParamSpecType, get_proper_type
 )
 from mypy import nodes
 
@@ -191,6 +191,9 @@ class ArgTypeExpander:
                 else:
                     self.tuple_index += 1
                 return actual_type.items[self.tuple_index - 1]
+            elif isinstance(actual_type, ParamSpecType):
+                # ParamSpec is valid in *args but it can't be unpacked.
+                return actual_type
             else:
                 return AnyType(TypeOfAny.from_error)
         elif actual_kind == nodes.ARG_STAR2:
@@ -215,6 +218,9 @@ class ArgTypeExpander:
                     actual_type,
                     self.context.mapping_type.type,
                 ).args[1]
+            elif isinstance(actual_type, ParamSpecType):
+                # ParamSpec is valid in **kwargs but it can't be unpacked.
+                return actual_type
             else:
                 return AnyType(TypeOfAny.from_error)
         else:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -106,6 +106,8 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
             # Return copy of instance with type erasure flag on.
             return Instance(inst.type, inst.args, line=inst.line,
                             column=inst.column, erased=True)
+        elif isinstance(repl, ParamSpecType):
+            return repl.with_flavor(t.flavor)
         else:
             return repl
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -491,6 +491,10 @@ class ParamSpecType(TypeVarLikeType):
         return ParamSpecType(old.name, old.fullname, new_id, old.flavor, old.upper_bound,
                              line=old.line, column=old.column)
 
+    def with_flavor(self, flavor: int) -> 'ParamSpecType':
+        return ParamSpecType(self.name, self.fullname, self.id, flavor,
+                             upper_bound=self.upper_bound)
+
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         return visitor.visit_param_spec(self)
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -346,3 +346,35 @@ reveal_type(register(lambda x: f(x), x=1))  # N: Revealed type is "def (x: Any)"
 register(lambda x: f(x))  # E: Missing positional argument "x" in call to "register"
 register(lambda x: f(x), y=1)  # E: Unexpected keyword argument "y" for "register"
 [builtins fixtures/dict.pyi]
+
+[case testParamSpecInvalidCalls]
+from typing import Callable, Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+P2 = ParamSpec('P2')
+
+class C(Generic[P, P2]):
+    def m1(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        self.m1(*args, **kwargs)
+        self.m2(*args, **kwargs)  # E: Argument 1 to "m2" of "C" has incompatible type "*P.args"; expected "P2.args" \
+            # E: Argument 2 to "m2" of "C" has incompatible type "**P.kwargs"; expected "P2.kwargs"
+        self.m1(*kwargs, **args)  # E: Argument 1 to "m1" of "C" has incompatible type "*P.kwargs"; expected "P.args" \
+            # E: Argument 2 to "m1" of "C" has incompatible type "**P.args"; expected "P.kwargs"
+        self.m3(*args, **kwargs)  # E: Argument 1 to "m3" of "C" has incompatible type "*P.args"; expected "int" \
+            # E: Argument 2 to "m3" of "C" has incompatible type "**P.kwargs"; expected "int"
+        self.m4(*args, **kwargs)  # E: Argument 1 to "m4" of "C" has incompatible type "*P.args"; expected "int" \
+            # E: Argument 2 to "m4" of "C" has incompatible type "**P.kwargs"; expected "int"
+
+        self.m1(*args, **args)  # E: Argument 2 to "m1" of "C" has incompatible type "**P.args"; expected "P.kwargs"
+        self.m1(*kwargs, **kwargs)  # E: Argument 1 to "m1" of "C" has incompatible type "*P.kwargs"; expected "P.args"
+
+    def m2(self, *args: P2.args, **kwargs: P2.kwargs) -> None:
+        pass
+
+    def m3(self, *args: int, **kwargs: int) -> None:
+        pass
+
+    def m4(self, x: int) -> None:
+        pass
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Check that the correct ParamSpec and flavor are used in
`*args` and `**kwargs`.

Follow-up to #11594.