### PR TITLE
Adds explicit test for overloads with pos-only `self`, refs #11606

### DIFF
--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5339,3 +5339,29 @@ def register(cls: Any) -> Any: return None
 x = register(Foo)
 reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
+
+[case testOverloadWithPositionalOnlySelf]
+# flags: --python-version 3.8 --strict-optional
+# `/` is only available since 3.8
+from typing import overload, Optional
+
+class Foo:
+    @overload
+    def f(self, a: str, /) -> None: ...
+
+    @overload
+    def f(self, *, b: bool = False) -> None: ...
+
+    def f(self, a: Optional[str] = None, /, *, b: bool = False) -> None:  # E: Overloaded function implementation does not accept all possible arguments of signature 2
+        ...
+
+class Bar:
+    @overload
+    def f(self, a: str, /) -> None: ...
+
+    @overload  # Notice `/` in sig below:
+    def f(self, /, *, b: bool = False) -> None: ...
+
+    def f(self, a: Optional[str] = None, /, *, b: bool = False) -> None:
+        ...
+[builtins fixtures/bool.pyi]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5339,29 +5339,3 @@ def register(cls: Any) -> Any: return None
 x = register(Foo)
 reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
-
-[case testOverloadWithPositionalOnlySelf]
-# flags: --python-version 3.8 --strict-optional
-# `/` is only available since 3.8
-from typing import overload, Optional
-
-class Foo:
-    @overload
-    def f(self, a: str, /) -> None: ...
-
-    @overload
-    def f(self, *, b: bool = False) -> None: ...
-
-    def f(self, a: Optional[str] = None, /, *, b: bool = False) -> None:  # E: Overloaded function implementation does not accept all possible arguments of signature 2
-        ...
-
-class Bar:
-    @overload
-    def f(self, a: str, /) -> None: ...
-
-    @overload  # Notice `/` in sig below:
-    def f(self, /, *, b: bool = False) -> None: ...
-
-    def f(self, a: Optional[str] = None, /, *, b: bool = False) -> None:
-        ...
-[builtins fixtures/bool.pyi]

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -546,3 +546,27 @@ def foo() -> None:
     x = 0
     [x := x + y for y in [1, 2, 3]]
 [builtins fixtures/dict.pyi]
+
+[case testOverloadWithPositionalOnlySelf]
+from typing import overload, Optional
+
+class Foo:
+    @overload
+    def f(self, a: str, /) -> None: ...
+
+    @overload
+    def f(self, *, b: bool = False) -> None: ...
+
+    def f(self, a: Optional[str] = None, /, *, b: bool = False) -> None:  # E: Overloaded function implementation does not accept all possible arguments of signature 2
+        ...
+
+class Bar:
+    @overload
+    def f(self, a: str, /) -> None: ...
+
+    @overload  # Notice `/` in sig below:
+    def f(self, /, *, b: bool = False) -> None: ...
+
+    def f(self, a: Optional[str] = None, /, *, b: bool = False) -> None:
+        ...
+[builtins fixtures/bool.pyi]


### PR DESCRIPTION
I was not able to find a similar test.
This is an interesting corner-case. I think it is benefitial to have it covered.

In my opinion it works correctly. No further actions are required.

Closes #11606
