### PR TITLE
WIP: checks annotations of assignments, refs #11582

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2073,6 +2073,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             with self.enter_final_context(s.is_final_def):
                 self.check_assignment(s.lvalues[-1], s.rvalue, s.type is None, s.new_syntax)
 
+        # If this assignment is annotated and we are not in stubs,
+        # then we need to be sure that this annotation will work in runtime.
+        # For example `x: 'int' | str` is a valid annotation for mypy, but it fails in runtime.
+        if not self.is_stub and s.annotation is not None:
+            with self.expr_checker.with_annotation_context(True):
+                self.expr_checker.accept(s.annotation)
+
         if s.is_alias_def:
             self.check_type_alias_rvalue(s)
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -793,7 +793,13 @@ class ASTConverter:
         typ = TypeConverter(self.errors, line=line).visit(n.annotation)
         assert typ is not None
         typ.column = n.annotation.col_offset
-        s = AssignmentStmt([self.visit(n.target)], rvalue, type=typ, new_syntax=True)
+        s = AssignmentStmt(
+            lvalues=[self.visit(n.target)],
+            rvalue=rvalue,
+            annotation=self.visit(n.annotation),
+            type=typ,
+            new_syntax=True,
+        )
         return self.set_line(s, n)
 
     # AugAssign(expr target, operator op, expr value)

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -619,6 +619,7 @@ class ASTConverter:
     # Assign(expr* targets, expr value, string? type_comment)
     def visit_Assign(self, n: ast27.Assign) -> AssignmentStmt:
         typ = self.translate_type_comment(n, n.type_comment)
+        # AssignmentStmt cannot have `annotation` expression in python2.
         stmt = AssignmentStmt(self.translate_expr_list(n.targets),
                               self.visit(n.value),
                               type=typ)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2050,6 +2050,8 @@ class SemanticAnalyzer(NodeVisitor[None],
 
         tag = self.track_incomplete_refs()
         s.rvalue.accept(self)
+        if s.annotation is not None:
+            s.annotation.accept(self)
         if self.found_incomplete_ref(tag) or self.should_wait_rhs(s.rvalue):
             # Initializer couldn't be fully analyzed. Defer the current node and give up.
             # Make sure that if we skip the definition of some local names, they can't be
@@ -2732,7 +2734,8 @@ class SemanticAnalyzer(NodeVisitor[None],
                                s.column,
                                alias_tvars=alias_tvars,
                                no_args=no_args,
-                               eager=eager)
+                               eager=eager,
+                               is_forward_ref=isinstance(rvalue, StrExpr))
         if isinstance(s.rvalue, (IndexExpr, CallExpr)):  # CallExpr is for `void = type(None)`
             s.rvalue.analyzed = TypeAliasExpr(alias_node)
             s.rvalue.analyzed.line = s.line


### PR DESCRIPTION
It requires a lot more work, but the basic case from the issue works:

```python
from typing import TypeAlias

AMONGUS: TypeAlias = "int"
IMPOSTER: TypeAlias = "str"

a: AMONGUS | IMPOSTER = 0
reveal_type(a)
```

Output:

```
out/ex.py:6: error: Unsupported left operand type for | ("str")
out/ex.py:7: note: Revealed type is "Union[builtins.int, builtins.str]"
```

Closes #11582