### PR TITLE
Fix typing_extensions version in requirements

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
-typing_extensions>=3.7.4
+typing_extensions>=3.10
 mypy_extensions>=0.4.3,<0.5.0
 typed_ast>=1.4.0,<2; python_version<'3.8'
 tomli>=1.1.0,<1.2.0

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,7 @@ setup(name='mypy',
       cmdclass=cmdclass,
       # When changing this, also update mypy-requirements.txt.
       install_requires=["typed_ast >= 1.4.0, < 2; python_version<'3.8'",
-                        'typing_extensions>=3.7.4',
+                        'typing_extensions>=3.10',
                         'mypy_extensions >= 0.4.3, < 0.5.0',
                         'tomli>=1.1.0,<1.2.0',
                         ],


### PR DESCRIPTION
### Description

mypy imports TypeAlias in typing_extensions, which
was introduced in typing_extensions 3.10.0.0 by the following commit:

    commit c23141fd08aba8284ce76b096bf08fd7c019b51c
    Author: Ken Jin <28750310+Fidget-Spinner@users.noreply.github.com>
    Date:   Sun Apr 11 03:26:42 2021 +0800

        Support PEP 612 in typing_extensions (Python 3) (#774)


## Test Plan

To test, downgrade `typing_extensions` to the minimal version in the new requirements

```
pip install typing_extensions==3.10.0.0
```

Then run the automated tests.