### PR TITLE
Improve documentation for annotating generator functions

### DIFF
--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -743,7 +743,7 @@ called on the object returned from the generator function. In these cases, it ma
 to use ``Iterable`` instead of ``Iterator``.
 
 If you want your generator to accept values via the :py:meth:`~generator.send` method or return
-a value, meanwhile, you should use the
+a value, you should use the
 :py:class:`Generator[YieldType, SendType, ReturnType] <typing.Generator>` generic type instead of
 either ``Iterator`` or ``Iterable``. For example:
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -730,20 +730,18 @@ type of either :py:class:`Iterator[YieldType] <typing.Iterator>` or :py:class:`I
        for i in range(n):
            yield i * i
            
-In general, :py:class:`Iterator[YieldType] <typing.Iterator>` should be preferred over
-:py:class:`Iterable[YieldType] <typing.Iterable>` for the return type of a generator function,
-as it is more precise regarding the type of the returned object. All iterator objects have a
-:py:meth:`~iterator.__next__` method, so using ``Iterator`` as the return type alerts mypy to
-the fact that :py:func:`next` can be called on the object returned from the generator function.
-Using ``Iterable`` runs the risk of mypy raising false-positive errors if a user attempts to call
-`next()` on the returned object.
-
-However, in some cases, it may be considered an implementation detail that ``next()`` can be
-called on the object returned from the generator function. In these cases, it may be preferable
-to use ``Iterable`` instead of ``Iterator``.
+A good rule of thumb is to annotate functions with the most specific return
+type possible. However, you should also take care to avoid leaking implementation
+details into a function's public API. In keeping with these two principles, prefer 
+:py:class:`Iterator[YieldType] <typing.Iterator>` over
+:py:class:`Iterable[YieldType] <typing.Iterable>` as the return-type annotation for a 
+generator function, as it lets mypy know that users are able to call :py:func:`next` on 
+the object returned by the function. Nonetheless, bear in mind that ``Iterable`` may
+sometimes be the better option, if you consider it an implementation detail that 
+``next()`` can be called on the object returned by your function.
 
 If you want your generator to accept values via the :py:meth:`~generator.send` method or return
-a value, however, you should use the
+a value, on the other hand, you should use the
 :py:class:`Generator[YieldType, SendType, ReturnType] <typing.Generator>` generic type instead of
 either ``Iterator`` or ``Iterable``. For example:
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -722,17 +722,30 @@ Generators
 **********
 
 A basic generator that only yields values can be succinctly annotated as having a return
-type of :py:class:`Iterator[YieldType] <typing.Iterator>`. For example:
+type of either :py:class:`Iterator[YieldType] <typing.Iterator>` or :py:class:`Iterable[YieldType] <typing.Iterable>`. For example:
 
 .. code-block:: python
 
    def squares(n: int) -> Iterator[int]:
        for i in range(n):
            yield i * i
+           
+In general, :py:class:`Iterator[YieldType] <typing.Iterator>` should be preferred over
+:py:class:`Iterable[YieldType] <typing.Iterable>` for the return type of a generator function,
+as it is more precise regarding the type of the returned object. All iterator objects have a
+:py:meth:`~iterator.__next__` method, so using ``Iterator`` as the return type alerts mypy to
+the fact that :py:func:`next` can be called on the object returned from the generator function.
+Using ``Iterable`` runs the risk of mypy raising false-positive errors if a user attempts to call
+`next()` on the returned object.
+
+However, in some cases, it may be considered an implementation detail that ``next()`` can be
+called on the object returned from the generator function. In these cases, it may be preferable
+to use ``Iterable`` instead of ``Iterator``.
 
 If you want your generator to accept values via the :py:meth:`~generator.send` method or return
-a value, you should use the
-:py:class:`Generator[YieldType, SendType, ReturnType] <typing.Generator>` generic type instead. For example:
+a value, meanwhile, you should use the
+:py:class:`Generator[YieldType, SendType, ReturnType] <typing.Generator>` generic type instead of
+either ``Iterator`` or ``Iterable``. For example:
 
 .. code-block:: python
 
@@ -758,4 +771,4 @@ annotated the first example as the following:
 This is slightly different from using ``Iterator[int]`` or ``Iterable[int]``,
 since generators have :py:meth:`~generator.close`, :py:meth:`~generator.send`, and :py:meth:`~generator.throw` methods that
 generic iterators and iterables don't. If you plan to call these methods on the returned
-generator, use the :py:class:`~typing.Generator` type instead of :py:class:`~typing.Iterator`.
+generator, use the :py:class:`~typing.Generator` type instead of :py:class:`~typing.Iterator` or :py:class:`~typing.Iterable`.

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -721,8 +721,8 @@ For more details, see :ref:`type-variable-value-restriction`.
 Generators
 **********
 
-A basic generator that only yields values can be annotated as having a return
-type of either :py:class:`Iterator[YieldType] <typing.Iterator>` or :py:class:`Iterable[YieldType] <typing.Iterable>`. For example:
+A basic generator that only yields values can be succinctly annotated as having a return
+type of :py:class:`Iterator[YieldType] <typing.Iterator>`. For example:
 
 .. code-block:: python
 
@@ -755,7 +755,7 @@ annotated the first example as the following:
        for i in range(n):
            yield i * i
 
-This is slightly different from using ``Iterable[int]`` or ``Iterator[int]``,
+This is slightly different from using ``Iterator[int]`` or ``Iterable[int]``,
 since generators have :py:meth:`~generator.close`, :py:meth:`~generator.send`, and :py:meth:`~generator.throw` methods that
-generic iterables don't. If you will call these methods on the returned
-generator, use the :py:class:`~typing.Generator` type instead of :py:class:`~typing.Iterable` or :py:class:`~typing.Iterator`.
+generic iterators and iterables don't. If you plan to call these methods on the returned
+generator, use the :py:class:`~typing.Generator` type instead of :py:class:`~typing.Iterator`.

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -743,7 +743,7 @@ called on the object returned from the generator function. In these cases, it ma
 to use ``Iterable`` instead of ``Iterator``.
 
 If you want your generator to accept values via the :py:meth:`~generator.send` method or return
-a value, you should use the
+a value, however, you should use the
 :py:class:`Generator[YieldType, SendType, ReturnType] <typing.Generator>` generic type instead of
 either ``Iterator`` or ``Iterable``. For example:
 


### PR DESCRIPTION
The mypy documentation is currently ambivalent on whether ``Iterator`` or ``Iterable`` is the better return-type annotation for a simple generator function. The documentation should endorse using ``Iterator`` instead of `Iterable`, in my opinion, as it is a more precise return type, and no less concise.
