### PR TITLE
Adds strict mode to pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,7 +19,9 @@ python_classes =
 python_functions =
 
 # always run in parallel (requires pytest-xdist, see test-requirements.txt)
-addopts = -nauto
+# and enable strict mode: require all markers
+# to be defined and raise on invalid config values
+addopts = -nauto --strict-markers --strict-config
 
 # treat xpasses as test failures so they get converted to regular tests as soon as possible
 xfail_strict = true


### PR DESCRIPTION
Why? It is a best practice in pytest's land.
And since we have a quite complex test setup, it is better to be double sure that everything is fine.

Docs: 
- https://docs.pytest.org/en/6.2.x/example/markers.html#registering-markers and https://docs.pytest.org/en/6.2.x/reference.html#confval-markers
- https://docs.pytest.org/en/6.2.x/reference.html#command-line-flags