### PR TITLE
stubtest: increase coverage

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -207,27 +207,27 @@ def verify_mypyfile(
         if not o.module_hidden and (not m.startswith("_") or hasattr(runtime, m))
     )
 
-    def _belongs_to_runtime(attr: str) -> bool:
-        runtime_attr = getattr(runtime, attr)
-        runtime_attr_module = getattr(runtime_attr, "__module__", None)
-        if runtime_attr_module is not None:
-            return runtime_attr_module == runtime.__name__
-        return not isinstance(runtime_attr, types.ModuleType)
+    def _belongs_to_runtime(r: types.ModuleType, attr: str) -> bool:
+        obj = getattr(r, attr)
+        obj_mod = getattr(obj, "__module__", None)
+        if obj_mod is not None:
+            return obj_mod == r.__name__
+        return not isinstance(obj, types.ModuleType)
 
-    def _runtime_public_contents() -> List[str]:
-        if hasattr(runtime, "__all__"):
-            return getattr(runtime, "__all__")
-        return [
+    runtime_public_contents = (
+        runtime.__all__
+        if hasattr(runtime, "__all__")
+        else [
             m
             for m in dir(runtime)
             if not m.startswith("_")
-            # Ensure that the object's module is `runtime`, since in the absence of __all__ we don't
-            # have a good way to detect re-exports at runtime.
-            and _belongs_to_runtime(m)
+            # Ensure that the object's module is `runtime`, since in the absence of __all__ we
+            # don't have a good way to detect re-exports at runtime.
+            and _belongs_to_runtime(runtime, m)
         ]
-
+    )
     # Check all things declared in module's __all__, falling back to our best guess
-    to_check.update(_runtime_public_contents())
+    to_check.update(runtime_public_contents)
     to_check.difference_update({"__file__", "__doc__", "__name__", "__builtins__", "__package__"})
 
     for entry in sorted(to_check):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -200,23 +200,34 @@ def verify_mypyfile(
         yield Error(object_path, "is not a module", stub, runtime)
         return
 
-    # Check things in the stub that are public
+    # Check things in the stub
     to_check = set(
         m
         for m, o in stub.names.items()
-        # TODO: change `o.module_public` to `not o.module_hidden`
-        if o.module_public and (not m.startswith("_") or hasattr(runtime, m))
+        if not o.module_hidden and (not m.startswith("_") or hasattr(runtime, m))
     )
-    runtime_public_contents = [
-        m
-        for m in dir(runtime)
-        if not m.startswith("_")
-        # Ensure that the object's module is `runtime`, since in the absence of __all__ we don't
-        # have a good way to detect re-exports at runtime.
-        and getattr(getattr(runtime, m), "__module__", None) == runtime.__name__
-    ]
-    # Check all things declared in module's __all__, falling back to runtime_public_contents
-    to_check.update(getattr(runtime, "__all__", runtime_public_contents))
+
+    def _belongs_to_runtime(attr: str) -> bool:
+        runtime_attr = getattr(runtime, attr)
+        runtime_attr_module = getattr(runtime_attr, "__module__", None)
+        if runtime_attr_module is not None:
+            return runtime_attr_module == runtime.__name__
+        return not isinstance(runtime_attr, types.ModuleType)
+
+    def _runtime_public_contents() -> List[str]:
+        if hasattr(runtime, "__all__"):
+            return getattr(runtime, "__all__")
+        return [
+            m
+            for m in dir(runtime)
+            if not m.startswith("_")
+            # Ensure that the object's module is `runtime`, since in the absence of __all__ we don't
+            # have a good way to detect re-exports at runtime.
+            and _belongs_to_runtime(m)
+        ]
+
+    # Check all things declared in module's __all__, falling back to our best guess
+    to_check.update(_runtime_public_contents())
     to_check.difference_update({"__file__", "__doc__", "__name__", "__builtins__", "__package__"})
 
     for entry in sorted(to_check):

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -52,6 +52,8 @@ class bool(int): ...
 class str: ...
 class bytes: ...
 
+class list(Sequence[T]): ...
+
 def property(f: T) -> T: ...
 def classmethod(f: T) -> T: ...
 def staticmethod(f: T) -> T: ...
@@ -661,6 +663,17 @@ class StubtestUnit(unittest.TestCase):
         yield Case(stub="", runtime="import sys", error=None)
         yield Case(stub="", runtime="def g(): ...", error="g")
         yield Case(stub="", runtime="CONSTANT = 0", error="CONSTANT")
+
+    @collect_cases
+    def test_missing_non_public_stub_1(self) -> Iterator[Case]:
+        yield Case(stub="__all__: list[str]", runtime="", error=None)  # dummy case
+        yield Case(stub="_f: int", runtime="def _f(): ...", error="_f")
+
+    @collect_cases
+    def test_missing_non_public_stub_2(self) -> Iterator[Case]:
+        yield Case(stub="__all__: list[str] = ['f']", runtime="__all__ = ['f']", error=None)  # dummy case
+        yield Case(stub="f: int", runtime="def f(): ...", error="f")
+        yield Case(stub="g: int", runtime="def g(): ...", error="g")
 
     @collect_cases
     def test_special_dunders(self) -> Iterator[Case]:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -648,7 +648,7 @@ class StubtestUnit(unittest.TestCase):
             runtime="",
             error="h",
         )
-        yield Case("", "__all__ = []", None)  # dummy case
+        yield Case(stub="", runtime="__all__ = []", error=None)  # dummy case
         yield Case(stub="", runtime="__all__ += ['y']\ny = 5", error="y")
         yield Case(stub="", runtime="__all__ += ['g']\ndef g(): pass", error="g")
         # Here we should only check that runtime has B, since the stub explicitly re-exports it
@@ -660,6 +660,7 @@ class StubtestUnit(unittest.TestCase):
     def test_missing_no_runtime_all(self) -> Iterator[Case]:
         yield Case(stub="", runtime="import sys", error=None)
         yield Case(stub="", runtime="def g(): ...", error="g")
+        yield Case(stub="", runtime="CONSTANT = 0", error="CONSTANT")
 
     @collect_cases
     def test_special_dunders(self) -> Iterator[Case]:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -671,7 +671,9 @@ class StubtestUnit(unittest.TestCase):
 
     @collect_cases
     def test_missing_non_public_stub_2(self) -> Iterator[Case]:
-        yield Case(stub="__all__: list[str] = ['f']", runtime="__all__ = ['f']", error=None)  # dummy case
+        yield Case(
+            stub="__all__: list[str] = ['f']", runtime="__all__ = ['f']", error=None
+        )
         yield Case(stub="f: int", runtime="def f(): ...", error="f")
         yield Case(stub="g: int", runtime="def g(): ...", error="g")
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -665,12 +665,12 @@ class StubtestUnit(unittest.TestCase):
         yield Case(stub="", runtime="CONSTANT = 0", error="CONSTANT")
 
     @collect_cases
-    def test_missing_non_public_stub_1(self) -> Iterator[Case]:
+    def test_non_public_1(self) -> Iterator[Case]:
         yield Case(stub="__all__: list[str]", runtime="", error=None)  # dummy case
         yield Case(stub="_f: int", runtime="def _f(): ...", error="_f")
 
     @collect_cases
-    def test_missing_non_public_stub_2(self) -> Iterator[Case]:
+    def test_non_public_2(self) -> Iterator[Case]:
         yield Case(
             stub="__all__: list[str] = ['f']", runtime="__all__ = ['f']", error=None
         )


### PR DESCRIPTION
With missing stubs and no runtime `__all__`, we now correctly find module level constants of primitive types (like int or str). While this can have some false positives, e.g. with `from module import int_constant`, I think this is an important fix to make since it allows for saner user expectations (see the change to `test_missing_no_runtime_all`).
 
The change from checking `module_public` to `not module_hidden` allows better checking in cases where the stub may wish to type runtime details. This corresponds to checking `_f` and `g` in `test_non_public_1` and `test_non_public_2`. The new errors in typeshed seem largely worthwhile.