### PR TITLE
Ensure TypeVarIds are unique

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1196,14 +1196,13 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     # should this be memoized in TypeInfo?
     def find_maximum_class_id(self, info: TypeInfo) -> int:
-        # top class?
-        if len(info.mro) in (0, 1):
-            return len(info.type_vars)
-        else:
+        if info.bases:
             return len(info.type_vars) + max(
-                self.find_maximum_class_id(cls)
-                for cls in info.mro[1:]
+                self.find_maximum_class_id(cls.type)
+                for cls in info.bases
             )
+        else:
+            return len(info.type_vars)
 
     def is_core_builtin_class(self, defn: ClassDef) -> bool:
         return self.cur_mod_id == 'builtins' and defn.name in CORE_BUILTIN_CLASSES

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1152,7 +1152,10 @@ class SemanticAnalyzer(NodeVisitor[None],
         # update the typevar ids such that they will not conflict with any base classes
         #  (yuck, there has to be a better way to do this.)
         if any(isinstance(base[0], Instance) for base in base_types):
-            offset = max(self.find_maximum_class_id(base[0].type) for base in base_types if isinstance(base[0], Instance))
+            offset = max(
+                self.find_maximum_class_id(base[0].type)
+                for base in base_types if isinstance(base[0], Instance)
+            )
             # mutating the type vars to be what we want (and hoping nothing previously saved them)
             for tvar in tvar_defs:
                 tvar.id.raw_id += offset
@@ -1191,13 +1194,16 @@ class SemanticAnalyzer(NodeVisitor[None],
                 self.analyze_class_decorator(defn, decorator)
             self.analyze_class_body_common(defn)
 
-    # should this be memoized in TypeInfo??
+    # should this be memoized in TypeInfo?
     def find_maximum_class_id(self, info: TypeInfo) -> int:
         # top class?
         if len(info.mro) in (0, 1):
             return len(info.type_vars)
         else:
-            return len(info.type_vars) + max(self.find_maximum_class_id(cls) for cls in info.mro[1:])
+            return len(info.type_vars) + max(
+                self.find_maximum_class_id(cls)
+                for cls in info.mro[1:]
+            )
 
     def is_core_builtin_class(self, defn: ClassDef) -> bool:
         return self.cur_mod_id == 'builtins' and defn.name in CORE_BUILTIN_CLASSES

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1933,9 +1933,9 @@ class C(Generic[T]):
 class D(C[Tuple[T, S]]): ...
 class E(D[S, str]): ...
 
-reveal_type(D.make_one)  # N: Revealed type is "def [T, S] (x: Tuple[T`1, S`2]) -> __main__.C[Tuple[T`1, S`2]]"
+reveal_type(D.make_one)  # N: Revealed type is "def [T, S] (x: Tuple[T`2, S`3]) -> __main__.C[Tuple[T`2, S`3]]"
 reveal_type(D[int, str].make_one)  # N: Revealed type is "def (x: Tuple[builtins.int*, builtins.str*]) -> __main__.C[Tuple[builtins.int*, builtins.str*]]"
-reveal_type(E.make_one)  # N: Revealed type is "def [S] (x: Tuple[S`1, builtins.str*]) -> __main__.C[Tuple[S`1, builtins.str*]]"
+reveal_type(E.make_one)  # N: Revealed type is "def [S] (x: Tuple[S`4, builtins.str*]) -> __main__.C[Tuple[S`4, builtins.str*]]"
 reveal_type(E[int].make_one)  # N: Revealed type is "def (x: Tuple[builtins.int*, builtins.str*]) -> __main__.C[Tuple[builtins.int*, builtins.str*]]"
 [builtins fixtures/classmethod.pyi]
 
@@ -2111,11 +2111,11 @@ class A(Generic[T]):
 
 class B(A[T], Generic[T, S]):
     def meth(self) -> None:
-        reveal_type(A[T].foo)  # N: Revealed type is "def () -> Tuple[T`1, __main__.A[T`1]]"
+        reveal_type(A[T].foo)  # N: Revealed type is "def () -> Tuple[T`2, __main__.A[T`2]]"
     @classmethod
     def other(cls) -> None:
-        reveal_type(cls.foo)  # N: Revealed type is "def () -> Tuple[T`1, __main__.B[T`1, S`2]]"
-reveal_type(B.foo)  # N: Revealed type is "def [T, S] () -> Tuple[T`1, __main__.B[T`1, S`2]]"
+        reveal_type(cls.foo)  # N: Revealed type is "def () -> Tuple[T`2, __main__.B[T`2, S`3]]"
+reveal_type(B.foo)  # N: Revealed type is "def [T, S] () -> Tuple[T`2, __main__.B[T`2, S`3]]"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassAlternativeConstructorPrecise]
@@ -2504,3 +2504,24 @@ b: I[I[Any]]
 reveal_type([a, b])  # N: Revealed type is "builtins.list[__main__.I*[__main__.I[Any]]]"
 reveal_type([b, a])  # N: Revealed type is "builtins.list[__main__.I*[__main__.I[Any]]]"
 [builtins fixtures/list.pyi]
+
+[case testOverlappingTypeVarIds]
+from typing import TypeVar, Generic
+
+class A: ...
+class B: ...
+
+T = TypeVar("T", bound=A)
+V = TypeVar("V", bound=B)
+S = TypeVar("S")
+
+class Whatever(Generic[T]):
+    def something(self: S) -> S:
+        return self
+
+# the "V" here had the same id as "T" and so mypy used to think it could expand one into another.
+# this test is here to make sure that doesn't happen!
+class WhateverPartTwo(Whatever[A], Generic[V]):
+    def something(self: S) -> S:
+        return self
+

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -662,9 +662,9 @@ MypyFile:1(
   ClassDef:4(
     c
     TypeVars(
-      t`1)
+      t`2)
     BaseType(
-      __main__.d[t`1])
+      __main__.d[t`2])
     PassStmt:4()))
 
 [case testTupleType]
@@ -907,7 +907,7 @@ MypyFile:1(
   ClassDef:5(
     A
     TypeVars(
-      t`1)
+      t`2)
     BaseType(
       __main__.B[Any])
     PassStmt:5()))

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -435,7 +435,7 @@ class B(A[C, T], Generic[T]):
 CallExpr(9) : None
 MemberExpr(9) : def (a: C)
 NameExpr(9) : C
-NameExpr(9) : B[T`1]
+NameExpr(9) : B[T`3]
 
 [case testExternalReferenceWithGenericInheritance]
 from typing import TypeVar, Generic


### PR DESCRIPTION
### Description

Closes https://github.com/python/mypy/issues/11605

This PR makes it so that TypeVarIds have to be unique among the class / superclasses. Other parts of mypy use this as a unique identifier (for instance `expandtype.py` has a visitor that has said assumption). This change makes this work!

## Test Plan

I added the case that didn't work for me, but I would recommend looking at the code closely as this fix seems really... icky.

Also, mypy-primer's output is going to be terribly long because of the difference in generic representation :(
