### PR TITLE
Now you can run separate mypy test modules :tada:

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -550,12 +550,12 @@ def pytest_pycollect_makeitem(collector: Any, name: str,
             # The collect method of the returned DataSuiteCollector instance will be called later,
             # with self.obj being obj.
             return DataSuiteCollector.from_parent(  # type: ignore[no-untyped-call]
-                parent=collector, name=name
+                parent=collector, name=name,
             )
     return None
 
 
-def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
+def split_test_cases(parent: 'DataFileCollector', suite: 'DataSuite',
                      file: str) -> Iterator['DataDrivenTestCase']:
     """Iterate over raw test cases in file, at collection time, ignoring sub items.
 
@@ -596,7 +596,7 @@ def split_test_cases(parent: 'DataSuiteCollector', suite: 'DataSuite',
 
 
 class DataSuiteCollector(pytest.Class):
-    def collect(self) -> Iterator[pytest.Item]:
+    def collect(self) -> Iterator['DataFileCollector']:
         """Called by pytest on each of the object returned from pytest_pycollect_makeitem"""
 
         # obj is the object for which pytest_pycollect_makeitem returned self.
@@ -605,8 +605,33 @@ class DataSuiteCollector(pytest.Class):
         assert os.path.isdir(suite.data_prefix), \
             'Test data prefix ({}) not set correctly'.format(suite.data_prefix)
 
-        for f in suite.files:
-            yield from split_test_cases(self, suite, os.path.join(suite.data_prefix, f))
+        for data_file in suite.files:
+            yield DataFileCollector.from_parent(parent=self, name=data_file)
+
+
+class DataFileCollector(pytest.Class):
+    """Represents a single `.test` data driven test file.
+
+    More context: https://github.com/python/mypy/issues/11662
+    """
+
+    @classmethod  # We have to fight with pytest here:
+    def from_parent(  # type: ignore[override]
+        cls,
+        parent: DataSuiteCollector,
+        *,
+        name: str,
+    ) -> 'DataFileCollector':
+        instance = super().from_parent(parent, name=name)  # type: ignore[no-untyped-call]
+        instance.obj = parent.obj  # We need to copy `DataSuite` object deeper.
+        return instance
+
+    def collect(self) -> Iterator['DataDrivenTestCase']:
+        yield from split_test_cases(
+            parent=self,
+            suite=self.obj,
+            file=os.path.join(self.obj.data_prefix, self.name),
+        )
 
 
 def add_test_name_suffix(name: str, suffix: str) -> str:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -247,7 +247,9 @@ class DataDrivenTestCase(pytest.Item):
         # TODO: add a better error message for when someone uses skip and xfail at the same time
         elif self.xfail:
             self.add_marker(pytest.mark.xfail)
-        suite = self.getparent(DataSuiteCollector).obj()
+        parent = self.getparent(DataSuiteCollector)
+        assert parent is not None, 'Should not happen'
+        suite = parent.obj()
         suite.setup()
         try:
             suite.run_case(self)
@@ -623,7 +625,7 @@ class DataFileCollector(pytest.Collector):
         *,
         name: str,
     ) -> 'DataFileCollector':
-        return super().from_parent(parent, name=name)  # type: ignore[no-untyped-call]
+        return super().from_parent(parent, name=name)
 
     def collect(self) -> Iterator['DataDrivenTestCase']:
         yield from split_test_cases(

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -96,7 +96,7 @@ typecheck_files = [
     'check-functools.test',
     'check-singledispatch.test',
     'check-slots.test',
-    'check-formatting.test'
+    'check-formatting.test',
 ]
 
 # Tests that use Python 3.8-only AST features (like expression-scoped ignores):

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -4,7 +4,6 @@
 [case testAssignmentAndVarDef]
 a = None # type: A
 b = None # type: B
-reveal_type(a)
 if int():
     a = a
 if int():

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -4,6 +4,7 @@
 [case testAssignmentAndVarDef]
 a = None # type: A
 b = None # type: B
+reveal_type(a)
 if int():
     a = a
 if int():


### PR DESCRIPTION
One test is failing right now on purpose, so you can take a look on how new namespaces work.
I will fix it in the next commit, I hope the logs will be preserved for some time to see them.

Here's a quick recap of everything in this PR:

- Here's how collect tree looks like: https://github.com/python/mypy/issues/11662#issuecomment-986284991
- You can now run a single `.test` file with `mypy/test/testcheck.py::TypeCheckSuite::check-basic.test`
- Single test will now be `mypy/test/testcheck.py::TypeCheckSuite::check-basic.test::testAssignmentAndVarDef`

Screenshots:
<img width="752" alt="Снимок экрана 2021-12-06 в 1 08 08" src="https://user-images.githubusercontent.com/4660275/144765943-d4b79de7-7e09-4ddf-8b4e-b0b882b8e528.png">
<img width="752" alt="Снимок экрана 2021-12-06 в 1 08 23" src="https://user-images.githubusercontent.com/4660275/144765949-a6da3faa-d707-4bbd-8315-aec3342095ca.png">
<img width="752" alt="Снимок экрана 2021-12-06 в 1 15 00" src="https://user-images.githubusercontent.com/4660275/144766034-8049980e-aea7-4c5f-85e5-7d50e1d34425.png">


Refs #11662