### PR TITLE
Fix TypedDict subtyping

### DIFF
--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -493,6 +493,26 @@ reveal_type(fun(b))  # N: Revealed type is "builtins.object*"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictTempTestName]
+from typing import Any, Type, TypeVar
+from typing_extensions import TypedDict
+
+T = TypeVar('T')
+class C(TypedDict):
+    x: str
+
+def gen() -> Any:
+    return {'x': 1}
+def foo(cls: Type[T]) -> T:
+    return gen()
+def fun(c: C):
+    pass
+
+fun(foo(C))
+reveal_type(foo(C)) # N: Revealed type is "__main__.C*"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
+
 -- Join
 
 [case testJoinOfTypedDictHasOnlyCommonKeysAndNewFallback]


### PR DESCRIPTION
### Description

Fixes https://github.com/python/mypy/issues/5593
Fixes https://github.com/python/mypy/issues/10024
Fixes https://github.com/python/mypy/issues/9827
Partially solves https://github.com/python/mypy/issues/10593 and https://github.com/python/mypy/issues/11644

This PR moves special cases (introduced by https://github.com/python/mypy/pull/2407 and https://github.com/python/mypy/pull/11236) in `SubtypeVisitor.visit_instance` to the end of the func and also adds support for `TypedDictType`.

## Test Plan

A new test case [testTypedDictTempTestName] under the `subtyping` section of `check-typeddict.test`. However I don't have an idea about its name.