### PR TITLE
Fixes how `**` affects inference in `{}` expressions, refs #11691

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3334,13 +3334,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.chk.named_generic_type(fullname, [tv]),
             self.named_type('builtins.function'),
             name=tag,
-            variables=[tv])
-        out = self.check_call(constructor,
-                              [(i.expr if isinstance(i, StarExpr) else i)
-                               for i in items],
-                              [(nodes.ARG_STAR if isinstance(i, StarExpr) else nodes.ARG_POS)
-                               for i in items],
-                              context)[0]
+            variables=[tv],
+        )
+        out = self.check_call(
+            constructor,
+            [(i.expr if isinstance(i, StarExpr) else i) for i in items],
+            [(nodes.ARG_STAR if isinstance(i, StarExpr) else nodes.ARG_POS) for i in items],
+            context,
+        )[0]
         return remove_instance_last_known_values(out)
 
     def visit_tuple_expr(self, e: TupleExpr) -> Type:
@@ -3518,7 +3519,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         variables=[kt, vt])
                     rv = self.check_call(constructor, [arg], [nodes.ARG_POS], arg)[0]
                 else:
-                    self.check_method_call_by_name('update', rv, [arg], [nodes.ARG_POS], arg)
+                    arg_type = arg.accept(self)
+                    rv = join.dict_unpack(rv, arg_type, self.named_type('typing.Mapping'))
         assert rv is not None
         return rv
 


### PR DESCRIPTION
This is a quite common problem, I've seen multiple issue reports about this.

So, the problem is: when a person uses `{**kwargs}`, it uses the same logic we have for `.update()` call. But, this is not right. `.update()` indeed needs matching types.
But, unpacking into a new dict should be allowed with any values.

To achive that I've decided to use `join` for key and value types. This is how it works:
<img width="752" alt="Снимок экрана 2021-12-09 в 18 38 15" src="https://user-images.githubusercontent.com/4660275/145427124-7e825c42-567c-42d4-add9-aa25a6ad14fc.png">

You may ask: why not `Union`? `dict[Union[type, float], str]` looks strange to me. But, I am open to discuss this.

I will add extra tests a bit later, I am currently too tired 😞 

Closes #11691