### PR TITLE
Revert "Now `lambda` is counted as a valid context in …"

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -404,8 +404,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.deferred_nodes.append(DeferredNode(node, enclosing_class))
 
     def handle_cannot_determine_type(self, name: str, context: Context) -> None:
-        node = self.scope.top_function()
-        if self.pass_num < self.last_pass and isinstance(node, (FuncDef, LambdaExpr)):
+        node = self.scope.top_non_lambda_function()
+        if self.pass_num < self.last_pass and isinstance(node, FuncDef):
             # Don't report an error yet. Just defer. Note that we don't defer
             # lambdas because they are coupled to the surrounding function
             # through the binder and the inferred type of the lambda, so it

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3928,13 +3928,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def analyze_cond_branch(self, map: Optional[Dict[Expression, Type]],
                             node: Expression, context: Optional[Type],
                             allow_none_return: bool = False) -> Type:
-        # We need to be have the correct amount of binder frames.
-        # Sometimes it can be missing for unreachable parts.
-        with (
-            self.chk.binder.frame_context(can_skip=True, fall_through=0)
-            if len(self.chk.binder.frames) > 1
-            else self.chk.binder.top_frame_context()
-        ):
+        with self.chk.binder.frame_context(can_skip=True, fall_through=0):
             if map is None:
                 # We still need to type check node, in case we want to
                 # process it for isinstance checks later

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -351,28 +351,6 @@ def f(t: T) -> A:
 
 [builtins fixtures/callable.pyi]
 
-[case testCallableTypeVarBoundAndLambdaDefer]
-# See https://github.com/python/mypy/issues/11212
-from typing import Callable, TypeVar
-
-C = TypeVar('C', bound=Callable)
-
-def dec(val: None) -> Callable[[C], C]:
-    def wrapper(f):
-        return f
-    return wrapper
-
-lambda: foo() + 2  # error was here
-
-@dec(None)
-def foo() -> int:
-    return 2
-
-lambda: foo() + 2  # double check
-
-reveal_type(foo() + 2)  # N: Revealed type is "builtins.int"
-[builtins fixtures/callable.pyi]
-
 [case testCallableTypeUnion]
 from abc import ABCMeta, abstractmethod
 from typing import Type, Union

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -738,11 +738,8 @@ class A:
 
     def f(self, x: Optional['A']) -> None:
         assert x
-        lambda: (self.y, x.a)
+        lambda: (self.y, x.a) # E: Cannot determine type of "y"
         self.y = int()
-[out]
-main:8: error: Cannot determine type of "y"
-main:8: error: Item "None" of "Optional[A]" has no attribute "a"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testDeferredAndOptionalInferenceSpecialCase]


### PR DESCRIPTION
This reverts commit d37c2be0f7a2002a0a8c160622d937518f902cc7.

Lambdas can't be safely deferred. There are various subtle assumptions about 
lambdas not being deferred in different parts of the codebase, and figuring out 
how to do this safely is almost certainly not worth the trouble. This would be 
very difficult to validate, since lambda deferral would probably happen very 
rarely in practice.

Also, I've seen some crashes which might be caused by this (not sure though).