### PR TITLE
Removes unused `temp_message_builder`

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2124,11 +2124,6 @@ def find_defining_module(modules: Dict[str, MypyFile], typ: CallableType) -> Opt
     return None
 
 
-def temp_message_builder() -> MessageBuilder:
-    """Return a message builder usable for throwaway errors (which may not format properly)."""
-    return MessageBuilder(Errors(), {})
-
-
 # For hard-coding suggested missing member alternatives.
 COMMON_MISTAKES: Final[Dict[str, Sequence[str]]] = {
     'add': ('append', 'extend'),


### PR DESCRIPTION
It is not used:
<img width="752" alt="Снимок экрана 2021-12-09 в 22 56 17" src="https://user-images.githubusercontent.com/4660275/145466741-46cde57f-1251-45b1-b1c3-f63e21f9eabe.png">

The only concern I have is that some plugins might be using it. But, change it to `chk.msg.clean_copy()` should not be hard 🤔 

Some people might be confused: https://github.com/python/mypy/pull/10386#discussion_r766080260