### PR TITLE
Fixes `bool` and `Literal[True, False]` subtyping, refs #11701

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -125,7 +125,10 @@ def _is_subtype(left: Type, right: Type,
         # of a union of all enum items as literal types. Only do it if
         # the previous check didn't succeed, since recombining can be
         # expensive.
-        if not is_subtype_of_item and isinstance(left, Instance) and left.type.is_enum:
+        # `bool` is a special case, because `bool` is `Literal[True, False]`.
+        if (not is_subtype_of_item
+                and isinstance(left, Instance)
+                and (left.type.is_enum or left.type.fullname == 'builtins.bool')):
             right = UnionType(mypy.typeops.try_contracting_literals_in_union(right.items))
             is_subtype_of_item = any(is_subtype(orig_left, item,
                                                 ignore_type_params=ignore_type_params,

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -759,8 +759,10 @@ def try_contracting_literals_in_union(types: Sequence[Type]) -> List[ProperType]
     Will replace the first instance of the literal with the sum type and
     remove all others.
 
-    if we call `try_contracting_union(Literal[Color.RED, Color.BLUE, Color.YELLOW])`,
+    If we call `try_contracting_union(Literal[Color.RED, Color.BLUE, Color.YELLOW])`,
     this function will return Color.
+
+    We also treat `Literal[True, False]` as `bool`.
     """
     proper_types = [get_proper_type(typ) for typ in types]
     sum_types: Dict[str, Tuple[Set[Any], List[int]]] = {}

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1060,3 +1060,24 @@ def bad3() -> NamedTuple:
 
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
+
+[case testBoolInTuplesRegression]
+# https://github.com/python/mypy/issues/11701
+from typing import NamedTuple, Literal, List, Tuple
+
+C = NamedTuple("C", [("x", Literal[True, False])])
+
+T = Tuple[Literal[True, False]]
+
+# Was error here:
+# Incompatible types in assignment (expression has type "List[C]", variable has type "List[C]")
+x: List[C] = [C(True)]
+
+t: T
+
+# Was error here:
+# Incompatible types in assignment (expression has type "List[Tuple[bool]]",
+# variable has type "List[Tuple[Union[Literal[True], Literal[False]]]]")
+y: List[T] = [t]
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]

--- a/test-data/unit/fixtures/typing-namedtuple.pyi
+++ b/test-data/unit/fixtures/typing-namedtuple.pyi
@@ -3,6 +3,7 @@ Generic = 0
 Any = 0
 overload = 0
 Type = 0
+Literal = 0
 
 T_co = TypeVar('T_co', covariant=True)
 KT = TypeVar('KT')


### PR DESCRIPTION
In some places in our code `bool` was compared with `Union[Literal[True], Literal[False]]`.
It was later compared with each union item. And `bool` is not subtype of `Literal[True]` and `Literal[False]`

Closes #11701
Refs #11705