### PR TITLE
Special cases `Enum` and some special props to be non-final, refs #11699

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -50,6 +50,7 @@ from mypy.checkmember import (
     type_object_type,
     analyze_decorator_or_funcbase_access,
 )
+from mypy.semanal_enum import ENUM_BASES, ENUM_SPECIAL_PROPS
 from mypy.typeops import (
     map_type_from_supertype, bind_self, erase_to_bound, make_simplified_union,
     erase_def_to_union_or_bound, erase_to_union_or_bound, coerce_to_literal,
@@ -2522,13 +2523,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.msg.cant_override_final(node.name, base.name, node)
             return False
         if node.is_final:
+            if base.fullname in ENUM_BASES and node.name in ENUM_SPECIAL_PROPS:
+                return True
             self.check_if_final_var_override_writable(node.name, base_node, node)
         return True
 
     def check_if_final_var_override_writable(self,
                                              name: str,
-                                             base_node:
-                                             Optional[Node],
+                                             base_node: Optional[Node],
                                              ctx: Context) -> None:
         """Check that a final variable doesn't override writeable attribute.
 
@@ -2541,6 +2543,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             x: C = D()
             x.attr = 3  # Oops!
         """
+        print(locals())
         writable = True
         if base_node:
             writable = self.is_writable_attribute(base_node)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2543,7 +2543,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             x: C = D()
             x.attr = 3  # Oops!
         """
-        print(locals())
         writable = True
         if base_node:
             writable = self.is_writable_attribute(base_node)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -14,6 +14,7 @@ from mypy.typeanal import (
     has_any_from_unimported_type, check_for_explicit_any, set_any_tvars, expand_type_alias,
     make_optional_type,
 )
+from mypy.semanal_enum import ENUM_BASES
 from mypy.types import (
     Type, AnyType, CallableType, Overloaded, NoneType, TypeVarType,
     TupleType, TypedDictType, Instance, ErasedType, UnionType,
@@ -1000,9 +1001,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         ret_type = get_proper_type(callee.ret_type)
         if callee.is_type_obj() and isinstance(ret_type, Instance):
             callable_name = ret_type.type.fullname
-        if (isinstance(callable_node, RefExpr)
-            and callable_node.fullname in ('enum.Enum', 'enum.IntEnum',
-                                           'enum.Flag', 'enum.IntFlag')):
+        if isinstance(callable_node, RefExpr) and callable_node.fullname in ENUM_BASES:
             # An Enum() call that failed SemanticAnalyzerPass2.check_enum_call().
             return callee.ret_type, callee
 

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -20,8 +20,6 @@ from mypy.nodes import TypeInfo
 from mypy.subtypes import is_equivalent
 from mypy.semanal_enum import ENUM_BASES
 
-# Note: 'enum.EnumMeta' is deliberately excluded from this list. Classes that directly use
-# enum.EnumMeta do not necessarily automatically have the 'name' and 'value' attributes.
 ENUM_NAME_ACCESS: Final = {"{}.name".format(prefix) for prefix in ENUM_BASES} | {
     "{}._name_".format(prefix) for prefix in ENUM_BASES
 }

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -18,15 +18,15 @@ from mypy.types import Type, Instance, LiteralType, CallableType, ProperType, ge
 from mypy.typeops import make_simplified_union
 from mypy.nodes import TypeInfo
 from mypy.subtypes import is_equivalent
+from mypy.semanal_enum import ENUM_BASES
 
 # Note: 'enum.EnumMeta' is deliberately excluded from this list. Classes that directly use
 # enum.EnumMeta do not necessarily automatically have the 'name' and 'value' attributes.
-ENUM_PREFIXES: Final = {"enum.Enum", "enum.IntEnum", "enum.Flag", "enum.IntFlag"}
-ENUM_NAME_ACCESS: Final = {"{}.name".format(prefix) for prefix in ENUM_PREFIXES} | {
-    "{}._name_".format(prefix) for prefix in ENUM_PREFIXES
+ENUM_NAME_ACCESS: Final = {"{}.name".format(prefix) for prefix in ENUM_BASES} | {
+    "{}._name_".format(prefix) for prefix in ENUM_BASES
 }
-ENUM_VALUE_ACCESS: Final = {"{}.value".format(prefix) for prefix in ENUM_PREFIXES} | {
-    "{}._value_".format(prefix) for prefix in ENUM_PREFIXES
+ENUM_VALUE_ACCESS: Final = {"{}.value".format(prefix) for prefix in ENUM_BASES} | {
+    "{}._value_".format(prefix) for prefix in ENUM_BASES
 }
 
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -116,7 +116,7 @@ from mypy.semanal_shared import (
 )
 from mypy.semanal_namedtuple import NamedTupleAnalyzer
 from mypy.semanal_typeddict import TypedDictAnalyzer
-from mypy.semanal_enum import EnumCallAnalyzer
+from mypy.semanal_enum import EnumCallAnalyzer, ENUM_BASES
 from mypy.semanal_newtype import NewTypeAnalyzer
 from mypy.reachability import (
     infer_reachability_of_if_statement, infer_condition_value, ALWAYS_FALSE, ALWAYS_TRUE,
@@ -1554,8 +1554,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                     self.fail('Cannot subclass "NewType"', defn)
                 if (
                     base.type.is_enum
-                    and base.type.fullname not in (
-                        'enum.Enum', 'enum.IntEnum', 'enum.Flag', 'enum.IntFlag')
+                    and base.type.fullname not in ENUM_BASES
                     and base.type.names
                     and any(not isinstance(n.node, (FuncBase, Decorator))
                             for n in base.type.names.values())

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1392,7 +1392,7 @@ Medal.silver = 2  # E: Cannot assign to final attribute "silver"
 from enum import Enum
 class Types(Enum):
     key = 0
-    value = 1  # E: Cannot override writable attribute "value" with a final one
+    value = 1
 
 
 [case testEnumReusedKeys]
@@ -1676,4 +1676,29 @@ from enum import Enum
 class A(Enum):
     class Inner: pass
 class B(A): pass  # E: Cannot inherit from final class "A"
+[builtins fixtures/bool.pyi]
+
+
+[case testEnumFinalSpecialProps]
+# https://github.com/python/mypy/issues/11699
+from enum import Enum, IntEnum
+
+class E(Enum):
+    name = 'a'
+    value = 'b'
+    _name_ = 'a1'
+    _value_ = 'b2'
+    _order_ = 'X Y'
+    __order__ = 'X Y'
+
+class EI(IntEnum):
+    name = 'a'
+    value = 1
+    _name_ = 'a1'
+    _value_ = 2
+    _order_ = 'X Y'
+    __order__ = 'X Y'
+
+E._order_ = 'a'  # E: Cannot assign to final attribute "_order_"
+EI.value = 2     # E: Cannot assign to final attribute "value"
 [builtins fixtures/bool.pyi]


### PR DESCRIPTION
My naive attempt to fix bug with some special `Enum` props which are treated as `Final`.
I just special case it and ignore them.

This looks like the simplest solution. And it fits `Enum` pretty well, because `Enum` is special in how class / instances are treated.

Closes #11699