### PR TITLE
Turns `disable_type_names` into a context manager

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2072,7 +2072,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                          arg_names: Optional[Sequence[Optional[str]]],
                          context: Context,
                          arg_messages: MessageBuilder) -> Tuple[Type, Type]:
-        with self.msg.temporary_disable_type_names():
+        with self.msg.disable_type_names():
             results = [
                 self.check_call(
                     subtype,
@@ -2477,7 +2477,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         for typ in base_type.relevant_items():
             # Format error messages consistently with
             # mypy.checkmember.analyze_union_member_access().
-            with local_errors.temporary_disable_type_names():
+            with local_errors.disable_type_names():
                 item, meth_item = self.check_method_call_by_name(
                     method, typ, args, arg_kinds,
                     context, local_errors, original_type,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2072,11 +2072,19 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                          arg_names: Optional[Sequence[Optional[str]]],
                          context: Context,
                          arg_messages: MessageBuilder) -> Tuple[Type, Type]:
-        self.msg.disable_type_names += 1
-        results = [self.check_call(subtype, args, arg_kinds, context, arg_names,
-                                   arg_messages=arg_messages)
-                   for subtype in callee.relevant_items()]
-        self.msg.disable_type_names -= 1
+        with self.msg.temporary_disable_type_names():
+            results = [
+                self.check_call(
+                    subtype,
+                    args,
+                    arg_kinds,
+                    context,
+                    arg_names,
+                    arg_messages=arg_messages,
+                )
+                for subtype in callee.relevant_items()
+            ]
+
         return (make_simplified_union([res[0] for res in results]),
                 callee)
 
@@ -2469,11 +2477,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         for typ in base_type.relevant_items():
             # Format error messages consistently with
             # mypy.checkmember.analyze_union_member_access().
-            local_errors.disable_type_names += 1
-            item, meth_item = self.check_method_call_by_name(method, typ, args, arg_kinds,
-                                                             context, local_errors,
-                                                             original_type)
-            local_errors.disable_type_names -= 1
+            with local_errors.temporary_disable_type_names():
+                item, meth_item = self.check_method_call_by_name(
+                    method, typ, args, arg_kinds,
+                    context, local_errors, original_type,
+                )
             res.append(item)
             meth_res.append(meth_item)
         return make_simplified_union(res), make_simplified_union(meth_res)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -311,13 +311,12 @@ def analyze_type_type_member_access(name: str,
 
 
 def analyze_union_member_access(name: str, typ: UnionType, mx: MemberContext) -> Type:
-    mx.msg.disable_type_names += 1
-    results = []
-    for subtype in typ.relevant_items():
-        # Self types should be bound to every individual item of a union.
-        item_mx = mx.copy_modified(self_type=subtype)
-        results.append(_analyze_member_access(name, subtype, item_mx))
-    mx.msg.disable_type_names -= 1
+    with mx.msg.temporary_disable_type_names():
+        results = []
+        for subtype in typ.relevant_items():
+            # Self types should be bound to every individual item of a union.
+            item_mx = mx.copy_modified(self_type=subtype)
+            results.append(_analyze_member_access(name, subtype, item_mx))
     return make_simplified_union(results)
 
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -311,7 +311,7 @@ def analyze_type_type_member_access(name: str,
 
 
 def analyze_union_member_access(name: str, typ: UnionType, mx: MemberContext) -> Type:
-    with mx.msg.temporary_disable_type_names():
+    with mx.msg.disable_type_names():
         results = []
         for subtype in typ.relevant_items():
             # Self types should be bound to every individual item of a union.

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -145,6 +145,14 @@ class MessageBuilder:
         finally:
             self.disable_count -= 1
 
+    @contextmanager
+    def temporary_disable_type_names(self) -> Iterator[None]:
+        self.disable_type_names += 1
+        try:
+            yield
+        finally:
+            self.disable_type_names -= 1
+
     def is_errors(self) -> bool:
         return self.errors.is_errors()
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -107,13 +107,13 @@ class MessageBuilder:
     disable_count = 0
 
     # Hack to deduplicate error messages from union types
-    disable_type_names = 0
+    disable_type_names_count = 0
 
     def __init__(self, errors: Errors, modules: Dict[str, MypyFile]) -> None:
         self.errors = errors
         self.modules = modules
         self.disable_count = 0
-        self.disable_type_names = 0
+        self.disable_type_names_count = 0
 
     #
     # Helpers
@@ -122,7 +122,7 @@ class MessageBuilder:
     def copy(self) -> 'MessageBuilder':
         new = MessageBuilder(self.errors.copy(), self.modules)
         new.disable_count = self.disable_count
-        new.disable_type_names = self.disable_type_names
+        new.disable_type_names_count = self.disable_type_names_count
         return new
 
     def clean_copy(self) -> 'MessageBuilder':
@@ -146,12 +146,12 @@ class MessageBuilder:
             self.disable_count -= 1
 
     @contextmanager
-    def temporary_disable_type_names(self) -> Iterator[None]:
-        self.disable_type_names += 1
+    def disable_type_names(self) -> Iterator[None]:
+        self.disable_type_names_count += 1
         try:
             yield
         finally:
-            self.disable_type_names -= 1
+            self.disable_type_names_count -= 1
 
     def is_errors(self) -> bool:
         return self.errors.is_errors()
@@ -306,7 +306,7 @@ class MessageBuilder:
                 extra = ' (not iterable)'
             elif member == '__aiter__':
                 extra = ' (not async iterable)'
-            if not self.disable_type_names:
+            if not self.disable_type_names_count:
                 failed = False
                 if isinstance(original_type, Instance) and original_type.type.names:
                     alternatives = set(original_type.type.names.keys())
@@ -388,7 +388,7 @@ class MessageBuilder:
         else:
             right_str = format_type(right_type)
 
-        if self.disable_type_names:
+        if self.disable_type_names_count:
             msg = 'Unsupported operand types for {} (likely involving Union)'.format(op)
         else:
             msg = 'Unsupported operand types for {} ({} and {})'.format(
@@ -397,7 +397,7 @@ class MessageBuilder:
 
     def unsupported_left_operand(self, op: str, typ: Type,
                                  context: Context) -> None:
-        if self.disable_type_names:
+        if self.disable_type_names_count:
             msg = 'Unsupported left operand type for {} (some union)'.format(op)
         else:
             msg = 'Unsupported left operand type for {} ({})'.format(


### PR DESCRIPTION
It felt like a good candidate for this refactoring.