### PR TITLE
Stricter `None` handling with `--no-strict-optional`, refs #11705

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4550,17 +4550,16 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self._check_for_truthy_type(original_vartype, node)
         vartype = try_expanding_sum_type_to_union(original_vartype, "builtins.bool")
 
-        if_type = true_only(vartype)  # type: Type
-        else_type = false_only(vartype)  # type: Type
-        ref = node  # type: Expression
+        if_type = true_only(vartype)
+        else_type = false_only(vartype)
         if_map = (
-            {ref: if_type}
-            if not isinstance(get_proper_type(if_type), UninhabitedType)
+            {node: if_type}
+            if not isinstance(if_type, UninhabitedType)
             else None
         )
         else_map = (
-            {ref: else_type}
-            if not isinstance(get_proper_type(else_type), UninhabitedType)
+            {node: else_type}
+            if not isinstance(else_type, UninhabitedType)
             else None
         )
         return if_map, else_map

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -704,7 +704,10 @@ def try_expanding_sum_type_to_union(typ: Type, target_fullname: str) -> ProperTy
     typ = get_proper_type(typ)
 
     if isinstance(typ, UnionType):
-        items = [try_expanding_sum_type_to_union(item, target_fullname) for item in typ.items]
+        items = [
+            try_expanding_sum_type_to_union(item, target_fullname)
+            for item in typ.relevant_items()
+        ]
         return make_simplified_union(items, contract_literals=False)
     elif isinstance(typ, Instance) and typ.type.fullname == target_fullname:
         if typ.type.is_enum:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3210,3 +3210,33 @@ def test(seq: List[Union[Iterable, Any]]) -> None:
             k = [k]
             reveal_type(k)  # N: Revealed type is "builtins.list[Any]"
 [builtins fixtures/list.pyi]
+
+[case testRegression11705_Strict]
+# flags: --strict-optional
+# See: https://github.com/python/mypy/issues/11705
+from typing import Dict, Optional, NamedTuple
+class C(NamedTuple):
+    x: int
+
+t: Optional[C]
+d: Dict[C, bytes]
+x = t and d[t]
+reveal_type(x)  # N: Revealed type is "Union[None, builtins.bytes*]"
+if x:
+    reveal_type(x)  # N: Revealed type is "builtins.bytes*"
+[builtins fixtures/dict.pyi]
+
+[case testRegression11705_NoStrict]
+# flags: --no-strict-optional
+# See: https://github.com/python/mypy/issues/11705
+from typing import Dict, Optional, NamedTuple
+class C(NamedTuple):
+    x: int
+
+t: Optional[C]
+d: Dict[C, bytes]
+x = t and d[t]
+reveal_type(x)  # N: Revealed type is "builtins.bytes*"
+if x:
+    reveal_type(x)  # N: Revealed type is "builtins.bytes*"
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
First of all, this is really hard to wrap your head around! Because `--no-strict-optional` is messy.

But, looks like I found several hacks to make this work as expected.
However, I am pretty sure that we do have a lot of other places where things can blow up with `--no-strict-optional`.

Closes #11705