### PR TITLE
Marks `mypy/typeshed` as vendored path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# We vendor typeshed from https://github.com/python/typeshed
+mypy/typeshed/ linguist-vendored


### PR DESCRIPTION
Current mypy stats are not quite correct, because `mypy/typeshed` takes a lot of space!
<img width="311" alt="Снимок экрана 2021-12-13 в 15 30 50" src="https://user-images.githubusercontent.com/4660275/145812760-bd928b98-c52a-49a9-bcc6-50c77ba4a163.png">

I propose marking `mypy/typeshed/` as vendored, so it would be excluded from stats.

Docs: https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes