### PR TITLE
Drop version upper bound from tomli

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
 typing_extensions>=3.10
 mypy_extensions>=0.4.3,<0.5.0
 typed_ast>=1.4.0,<2; python_version<'3.8'
-tomli>=1.1.0,<3.0.0
+tomli>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ setup(name='mypy',
       install_requires=["typed_ast >= 1.4.0, < 2; python_version<'3.8'",
                         'typing_extensions>=3.10',
                         'mypy_extensions >= 0.4.3, < 0.5.0',
-                        'tomli>=1.1.0,<3.0.0',
+                        'tomli>=1.1.0',
                         ],
       # Same here.
       extras_require={'dmypy': 'psutil >= 4.0', 'python2': 'typed_ast >= 1.4.0, < 2'},


### PR DESCRIPTION
Tomli seems to be moving fast -- 2.0 was released ~6 months after 1.0. It
seems better to support future releases, since otherwise we risk version
conflicts in the future.
