### PR TITLE
Drop version upper bound for mypy-extensions

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
 typing_extensions>=3.10
-mypy_extensions>=0.4.3,<0.5.0
+mypy_extensions>=0.4.3
 typed_ast>=1.4.0,<2; python_version<'3.8'
 tomli>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ setup(name='mypy',
       # When changing this, also update mypy-requirements.txt.
       install_requires=["typed_ast >= 1.4.0, < 2; python_version<'3.8'",
                         'typing_extensions>=3.10',
-                        'mypy_extensions >= 0.4.3, < 0.5.0',
+                        'mypy_extensions >= 0.4.3',
                         'tomli>=1.1.0',
                         ],
       # Same here.


### PR DESCRIPTION
This may avoid some package version conflicts in the future. We just
need to be careful to avoid making incompatible changes to
mypy-extensions, which seems like a good idea in any case.