### PR TITLE
Don't crash on unsupported Python 3.10 match statement

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1286,6 +1286,10 @@ class ASTConverter:
         # cast for mypyc's benefit on Python 3.9
         return self.visit(cast(Any, n).value)
 
+    def visit_Match(self, n: Any) -> None:
+        self.fail("Match statement is not supported",
+                  line=n.lineno, column=n.col_offset, blocker=True)
+
 
 class TypeConverter:
     def __init__(self,

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -104,6 +104,8 @@ if sys.version_info >= (3, 8):
     typecheck_files.append('check-python38.test')
 if sys.version_info >= (3, 9):
     typecheck_files.append('check-python39.test')
+if sys.version_info >= (3, 10):
+    typecheck_files.append('check-python310.test')
 
 # Special tests for platforms with case-insensitive filesystems.
 if sys.platform in ('darwin', 'win32'):

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1,0 +1,7 @@
+[case testMatchStatementNotSupported]
+# flags: --python-version 3.10
+match str():  # E: Match statement is not supported
+    case 'x':
+        1 + ''
+    case _:
+        1 + b''


### PR DESCRIPTION
Generate a syntax error instead.