### PR TITLE
Change parsing for exclude field

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -143,7 +143,11 @@ toml_config_types.update({
     'disable_error_code': try_split,
     'enable_error_code': try_split,
     'package_root': try_split,
-    'exclude': lambda s: [p.strip() for p in (s.split('\n') if isinstance(s, str) else s) if p.strip()],
+    'exclude': lambda s: [
+        p.strip() for p in
+        (s.split('\n') if isinstance(s, str) else s)
+        if p.strip()
+    ],
 })
 
 

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -143,6 +143,7 @@ toml_config_types.update({
     'disable_error_code': try_split,
     'enable_error_code': try_split,
     'package_root': try_split,
+    'exclude': lambda s: [p.strip() for p in (s.split('\n') if isinstance(s, str) else s) if p.strip()],
 })
 
 


### PR DESCRIPTION
### Description

#11329 added support for nicer `exclude` lists

TOML has a built-in list syntax, and it would be nice to use that for specifying lists for the `exclude` option.

This change tries the ini-style first: if `exclude` is set to a multiline string, it will split that on newlines, otherwise it will assume it's a list.

Examples:

```toml
[mypy]
exclude = "pattern1"
```

produces:

```python
exclude = ["pattern1"]
```

All of these produce the same result:

```toml
exclude = "pattern1\npattern2"
```

```toml
exclude = """
    pattern1
    pattern2
"""
```

```toml
exclude = [
    "pattern1",
    "pattern2",
]
```

## Test Plan

I've only tested on the commandline.