### PR TITLE
Fix ErrorCode test for Python 3.10.1

### DIFF
--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -36,6 +36,8 @@ reveal_type(1) # N: Revealed type is "Literal[1]?"
 main:1: error: invalid syntax  [syntax]
 [out version>=3.10]
 main:1: error: invalid syntax. Perhaps you forgot a comma?  [syntax]
+[out version>=3.10.1]
+main:1: error: invalid syntax  [syntax]
 
 [case testErrorCodeSyntaxError2]
 def f(): # E: Type signature has too many arguments  [syntax]


### PR DESCRIPTION
### Description

The syntax error changed between `3.10.0` and `3.10.1`.
https://bugs.python.org/issue46004

So far the Github actions runner still uses Python 3.10.0, which is why it hasn't yet failed on master.
https://github.com/python/mypy/runs/4532892092?check_suite_focus=true#step:3:6