### PR TITLE
Fix tests for Python 3.10.1 (2)

### DIFF
--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -34,10 +34,8 @@ reveal_type(1) # N: Revealed type is "Literal[1]?"
 1 ''
 [out]
 main:1: error: invalid syntax  [syntax]
-[out version>=3.10]
+[out version==3.10.0]
 main:1: error: invalid syntax. Perhaps you forgot a comma?  [syntax]
-[out version>=3.10.1]
-main:1: error: invalid syntax  [syntax]
 
 [case testErrorCodeSyntaxError2]
 def f(): # E: Type signature has too many arguments  [syntax]

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -156,14 +156,9 @@ class C:
 a.py:1: error: invalid syntax
 ==
 main:5: error: Missing positional argument "x" in call to "f" of "C"
-[out version>=3.10]
+[out version==3.10.0]
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
-==
-main:5: error: Missing positional argument "x" in call to "f" of "C"
-[out version>=3.10.1]
-==
-a.py:1: error: invalid syntax
 ==
 main:5: error: Missing positional argument "x" in call to "f" of "C"
 
@@ -181,18 +176,11 @@ main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missin
 a.py:1: error: invalid syntax
 ==
 main:2: error: Too many arguments for "f"
-[out version>=3.10]
+[out version==3.10.0]
 main:1: error: Cannot find implementation or library stub for module named "a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
-==
-main:2: error: Too many arguments for "f"
-[out version>=3.10.1]
-main:1: error: Cannot find implementation or library stub for module named "a"
-main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-==
-a.py:1: error: invalid syntax
 ==
 main:2: error: Too many arguments for "f"
 
@@ -271,18 +259,11 @@ a.py:1: error: invalid syntax
 a.py:1: error: invalid syntax
 ==
 a.py:2: error: Missing positional argument "x" in call to "f"
-[out version>=3.10]
+[out version==3.10.0]
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
-==
-a.py:2: error: Missing positional argument "x" in call to "f"
-[out version>=3.10.1]
-==
-a.py:1: error: invalid syntax
-==
-a.py:1: error: invalid syntax
 ==
 a.py:2: error: Missing positional argument "x" in call to "f"
 
@@ -349,16 +330,9 @@ a.py:1: error: invalid syntax
 main:1: error: Cannot find implementation or library stub for module named "a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 b.py:1: error: Cannot find implementation or library stub for module named "a"
-[out version>=3.10]
+[out version==3.10.0]
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
-==
-main:1: error: Cannot find implementation or library stub for module named "a"
-main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-b.py:1: error: Cannot find implementation or library stub for module named "a"
-[out version>=3.10.1]
-==
-a.py:1: error: invalid syntax
 ==
 main:1: error: Cannot find implementation or library stub for module named "a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
@@ -384,16 +358,9 @@ a.py:1: error: invalid syntax
 b.py:1: error: Cannot find implementation or library stub for module named "a"
 b.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 main:1: error: Cannot find implementation or library stub for module named "a"
-[out version>=3.10]
+[out version==3.10.0]
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
-==
-b.py:1: error: Cannot find implementation or library stub for module named "a"
-b.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-main:1: error: Cannot find implementation or library stub for module named "a"
-[out version>=3.10.1]
-==
-a.py:1: error: invalid syntax
 ==
 b.py:1: error: Cannot find implementation or library stub for module named "a"
 b.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
@@ -421,19 +388,11 @@ a.py:1: error: invalid syntax
 ==
 b.py:2: error: Module has no attribute "f"
 b.py:3: error: "int" not callable
-[out version>=3.10]
+[out version==3.10.0]
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
-==
-b.py:2: error: Module has no attribute "f"
-b.py:3: error: "int" not callable
-[out version>=3.10.1]
-==
-a.py:1: error: invalid syntax
-==
-a.py:1: error: invalid syntax
 ==
 b.py:2: error: Module has no attribute "f"
 b.py:3: error: "int" not callable
@@ -452,14 +411,9 @@ def f() -> None: pass
 <ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax
 ==
 a.py:1: error: "int" not callable
-[out version>=3.10]
+[out version==3.10.0]
 ==
 <ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax. Perhaps you forgot a comma?
-==
-a.py:1: error: "int" not callable
-[out version>=3.10.1]
-==
-<ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax
 ==
 a.py:1: error: "int" not callable
 
@@ -536,18 +490,11 @@ a.py:1: error: invalid syntax
 <ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax
 ==
 a.py:2: error: "int" not callable
-[out version>=3.10]
+[out version==3.10.0]
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 <ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax. Perhaps you forgot a comma?
-==
-a.py:2: error: "int" not callable
-[out version>=3.10.1]
-==
-a.py:1: error: invalid syntax
-==
-<ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax
 ==
 a.py:2: error: "int" not callable
 
@@ -568,13 +515,8 @@ a.py:1: error: invalid syntax
 ==
 b.py:2: error: Incompatible return value type (got "str", expected "int")
 ==
-[out version>=3.10]
+[out version==3.10.0]
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
-==
-b.py:2: error: Incompatible return value type (got "str", expected "int")
-==
-[out version>=3.10.1]
-a.py:1: error: invalid syntax
 ==
 b.py:2: error: Incompatible return value type (got "str", expected "int")
 ==

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -161,6 +161,11 @@ main:5: error: Missing positional argument "x" in call to "f" of "C"
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 main:5: error: Missing positional argument "x" in call to "f" of "C"
+[out version>=3.10.1]
+==
+a.py:1: error: invalid syntax
+==
+main:5: error: Missing positional argument "x" in call to "f" of "C"
 
 [case testAddFileWithBlockingError]
 import a
@@ -181,6 +186,13 @@ main:1: error: Cannot find implementation or library stub for module named "a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+main:2: error: Too many arguments for "f"
+[out version>=3.10.1]
+main:1: error: Cannot find implementation or library stub for module named "a"
+main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+==
+a.py:1: error: invalid syntax
 ==
 main:2: error: Too many arguments for "f"
 
@@ -266,6 +278,13 @@ a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 a.py:2: error: Missing positional argument "x" in call to "f"
+[out version>=3.10.1]
+==
+a.py:1: error: invalid syntax
+==
+a.py:1: error: invalid syntax
+==
+a.py:2: error: Missing positional argument "x" in call to "f"
 
 [case testModifyTwoFilesIntroduceTwoBlockingErrors]
 import a
@@ -337,6 +356,13 @@ a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 main:1: error: Cannot find implementation or library stub for module named "a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 b.py:1: error: Cannot find implementation or library stub for module named "a"
+[out version>=3.10.1]
+==
+a.py:1: error: invalid syntax
+==
+main:1: error: Cannot find implementation or library stub for module named "a"
+main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+b.py:1: error: Cannot find implementation or library stub for module named "a"
 
 [case testDeleteFileWithBlockingError2-only_when_cache]
 -- Different cache/no-cache tests because:
@@ -361,6 +387,13 @@ main:1: error: Cannot find implementation or library stub for module named "a"
 [out version>=3.10]
 ==
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+b.py:1: error: Cannot find implementation or library stub for module named "a"
+b.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+main:1: error: Cannot find implementation or library stub for module named "a"
+[out version>=3.10.1]
+==
+a.py:1: error: invalid syntax
 ==
 b.py:1: error: Cannot find implementation or library stub for module named "a"
 b.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
@@ -396,6 +429,14 @@ a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 ==
 b.py:2: error: Module has no attribute "f"
 b.py:3: error: "int" not callable
+[out version>=3.10.1]
+==
+a.py:1: error: invalid syntax
+==
+a.py:1: error: invalid syntax
+==
+b.py:2: error: Module has no attribute "f"
+b.py:3: error: "int" not callable
 
 [case testImportBringsAnotherFileWithBlockingError1]
 import a
@@ -414,6 +455,11 @@ a.py:1: error: "int" not callable
 [out version>=3.10]
 ==
 <ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax. Perhaps you forgot a comma?
+==
+a.py:1: error: "int" not callable
+[out version>=3.10.1]
+==
+<ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax
 ==
 a.py:1: error: "int" not callable
 
@@ -497,6 +543,13 @@ a.py:1: error: invalid syntax. Perhaps you forgot a comma?
 <ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax. Perhaps you forgot a comma?
 ==
 a.py:2: error: "int" not callable
+[out version>=3.10.1]
+==
+a.py:1: error: invalid syntax
+==
+<ROOT>/test-data/unit/lib-stub/blocker.pyi:2: error: invalid syntax
+==
+a.py:2: error: "int" not callable
 
 [case testInitialBlocker]
 # cmd: mypy a.py b.py
@@ -517,6 +570,11 @@ b.py:2: error: Incompatible return value type (got "str", expected "int")
 ==
 [out version>=3.10]
 a.py:1: error: invalid syntax. Perhaps you forgot a comma?
+==
+b.py:2: error: Incompatible return value type (got "str", expected "int")
+==
+[out version>=3.10.1]
+a.py:1: error: invalid syntax
 ==
 b.py:2: error: Incompatible return value type (got "str", expected "int")
 ==

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -935,10 +935,8 @@ MypyFile:1(
 x not y
 [out]
 main:1: error: invalid syntax
-[out version>=3.10]
+[out version==3.10.0]
 main:1: error: invalid syntax. Perhaps you forgot a comma?
-[out version>=3.10.1]
-main:1: error: invalid syntax
 
 [case testNotIs]
 x not is y # E: invalid syntax
@@ -948,10 +946,8 @@ x not is y # E: invalid syntax
 1 ~ 2
 [out]
 main:1: error: invalid syntax
-[out version>=3.10]
+[out version==3.10.0]
 main:1: error: invalid syntax. Perhaps you forgot a comma?
-[out version>=3.10.1]
-main:1: error: invalid syntax
 
 [case testSliceInList39]
 # flags: --python-version 3.9

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -937,6 +937,8 @@ x not y
 main:1: error: invalid syntax
 [out version>=3.10]
 main:1: error: invalid syntax. Perhaps you forgot a comma?
+[out version>=3.10.1]
+main:1: error: invalid syntax
 
 [case testNotIs]
 x not is y # E: invalid syntax
@@ -948,6 +950,8 @@ x not is y # E: invalid syntax
 main:1: error: invalid syntax
 [out version>=3.10]
 main:1: error: invalid syntax. Perhaps you forgot a comma?
+[out version>=3.10.1]
+main:1: error: invalid syntax
 
 [case testSliceInList39]
 # flags: --python-version 3.9


### PR DESCRIPTION
### Description
Followup to #11752 The syntax error changed between `3.10.0` and `3.10.1`.
https://bugs.python.org/issue46004

I missed a few the first time around unfortunately.
https://bugs.python.org/issue46004

Instead of duplicating the original output, I chose to extend the test syntax introduced with #10404 and added support for `==` version checks.

## Test Plan
The test runner here still uses `3.10.0`.
To test `3.10.1` I opened the same PR on my own fork: https://github.com/cdce8p/mypy/pull/2. There it runs on `3.10.1`.