### PR TITLE
Added reporting extras option to setup.py

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -861,7 +861,9 @@ format into the specified directory.
 
     Causes mypy to generate an HTML type checking coverage report.
 
-    You must install the `lxml`_ library to generate this report.
+    To generate this report, you must either manually install the `lxml`_
+    library or specify mypy installation with the setuptools extra
+    ``mypy[reports]``.
 
 .. option:: --linecount-report DIR
 
@@ -883,13 +885,17 @@ format into the specified directory.
 
     Causes mypy to generate a text file type checking coverage report.
 
-    You must install the `lxml`_ library to generate this report.
+    To generate this report, you must either manually install the `lxml`_
+    library or specify mypy installation with the setuptools extra
+    ``mypy[reports]``.
 
 .. option:: --xml-report DIR
 
     Causes mypy to generate an XML type checking coverage report.
 
-    You must install the `lxml`_ library to generate this report.
+    To generate this report, you must either manually install the `lxml`_
+    library or specify mypy installation with the setuptools extra
+    ``mypy[reports]``.
 
 Miscellaneous
 *************

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -853,7 +853,9 @@ format into the specified directory.
 
     Causes mypy to generate a Cobertura XML type checking coverage report.
 
-    You must install the `lxml`_ library to generate this report.
+    To generate this report, you must either manually install the `lxml`_
+    library or specify mypy installation with the setuptools extra
+    ``mypy[reports]``.
 
 .. option:: --html-report / --xslt-html-report DIR
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -820,7 +820,9 @@ format into the specified directory.
 
     Causes mypy to generate a Cobertura XML type checking coverage report.
 
-    You must install the `lxml`_ library to generate this report.
+    To generate this report, you must either manually install the `lxml`_
+    library or specify mypy installation with the setuptools extra
+    ``mypy[reports]``.
 
 .. confval:: html_report / xslt_html_report
 
@@ -828,7 +830,9 @@ format into the specified directory.
 
     Causes mypy to generate an HTML type checking coverage report.
 
-    You must install the `lxml`_ library to generate this report.
+    To generate this report, you must either manually install the `lxml`_
+    library or specify mypy installation with the setuptools extra
+    ``mypy[reports]``.
 
 .. confval:: linecount_report
 
@@ -858,7 +862,9 @@ format into the specified directory.
 
     Causes mypy to generate a text file type checking coverage report.
 
-    You must install the `lxml`_ library to generate this report.
+    To generate this report, you must either manually install the `lxml`_
+    library or specify mypy installation with the setuptools extra
+    ``mypy[reports]``.
 
 .. confval:: xml_report
 
@@ -866,7 +872,9 @@ format into the specified directory.
 
     Causes mypy to generate an XML type checking coverage report.
 
-    You must install the `lxml`_ library to generate this report.
+    To generate this report, you must either manually install the `lxml`_
+    library or specify mypy installation with the setuptools extra
+    ``mypy[reports]``.
 
 
 Miscellaneous

--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,7 @@ setup(name='mypy',
       extras_require={
           'dmypy': 'psutil >= 4.0',
           'python2': 'typed_ast >= 1.4.0, < 2',
-          'reporting': 'lxml'
+          'reports': 'lxml'
       },
       python_requires=">=3.6",
       include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,11 @@ setup(name='mypy',
                         'tomli>=1.1.0',
                         ],
       # Same here.
-      extras_require={'dmypy': 'psutil >= 4.0', 'python2': 'typed_ast >= 1.4.0, < 2'},
+      extras_require={
+          'dmypy': 'psutil >= 4.0',
+          'python2': 'typed_ast >= 1.4.0, < 2',
+          'reporting': 'lxml'
+      },
       python_requires=">=3.6",
       include_package_data=True,
       project_urls={


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Today, I was looking at the [Report generation](https://mypy.readthedocs.io/en/stable/command_line.html#report-generation) docs, and noticed [`lxml`](https://pypi.org/project/lxml/) is listed as an additional requirement.  I thought it would be nice to add as an extra to mypy's `setup.py`.

This way, inside a `requirements-dev.txt`, someone can include `mypy[reporting]` and have `lxml` installed.

One thing to note: a [comment](https://github.com/python/mypy/blob/master/setup.py#L195) in `setup.py` says this:

```python
# When changing this, also update mypy-requirements.txt.
```

NOTE: I did not update `mypy-requirements.txt`, as I belive extra requirements don't belong there.  This will be up to the PR reviewer if he/she wants to add `lxml` to `mypy-requirements.txt`.

NOTE 2: I did not pin `lxml`.  I only tested this to work with `lxml==4.7.1`.

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

Here is how I verified my change works.

```bash
pip install -e "git+ssh://git@github.com/jamesbraza/mypy.git@reporting#egg=mypy"
pip list
```

outputs:

```
Package           Version
----------------- --------------------------------------------------
mypy              0.940+dev.c7ca8e3d2c5a957510e70163c8155f2cd9a3f017
mypy-extensions   0.4.3
pip               21.3.1
setuptools        56.0.0
tomli             2.0.0
typing_extensions 4.0.1
```

then

```bash
pip install -e "git+ssh://git@github.com/jamesbraza/mypy.git@reporting#egg=mypy[reporting]"
pip list
```

outputs:

```
Package           Version                                            Editable project location
----------------- -------------------------------------------------- ----------------------------------------
lxml              4.7.1
mypy              0.940+dev.c7ca8e3d2c5a957510e70163c8155f2cd9a3f017 /Users/james.braza/code/mypy/hi/src/mypy
mypy-extensions   0.4.3
pip               21.3.1
setuptools        56.0.0
tomli             2.0.0
typing_extensions 4.0.1
```

I also ran the tests as documented in [`CONTRIBUTING.md`](https://github.com/python/mypy/blob/master/CONTRIBUTING.md).