### PR TITLE
[mypyc] Fix unsupported operand + for AnyStr

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -30,7 +30,7 @@ from typing_extensions import TYPE_CHECKING, NoReturn, Type
 from mypy.main import process_options
 from mypy.errors import CompileError
 from mypy.options import Options
-from mypy.build import BuildSource
+from mypy.build import BuildSource, CORE_BUILTIN_MODULES
 from mypy.fscache import FileSystemCache
 from mypy.util import write_junit_xml
 
@@ -124,6 +124,9 @@ def get_mypy_config(mypy_options: List[str],
 
     for source in mypyc_sources:
         options.per_module_options.setdefault(source.module, {})['mypyc'] = True
+
+    for module in CORE_BUILTIN_MODULES:
+        options.per_module_options.setdefault(module, {})['mypyc'] = True
 
     return mypyc_sources, all_sources, options
 

--- a/mypyc/test-data/fixtures/typing-full.pyi
+++ b/mypyc/test-data/fixtures/typing-full.pyi
@@ -30,6 +30,7 @@ Literal = 0
 TypedDict = 0
 NoReturn = 0
 NewType = 0
+AnyStr = TypeVar('AnyStr', str, bytes)
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -1155,3 +1155,19 @@ i = b"foo"
 
 def test_redefinition() -> None:
     assert i == b"foo"
+
+[case testAnyStr]
+from typing import AnyStr
+
+def f(x: AnyStr, y: AnyStr) -> AnyStr:
+    return x + y
+
+[typing fixtures/typing-full.pyi]
+
+[file driver.py]
+from native import f
+
+print(f("3", "4"))
+
+[out]
+34

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -12,6 +12,7 @@ import sys
 from typing import Any, Iterator, List, cast
 
 from mypy import build
+from mypy.build import CORE_BUILTIN_MODULES
 from mypy.test.data import DataDrivenTestCase
 from mypy.test.config import test_temp_dir
 from mypy.errors import CompileError
@@ -209,6 +210,9 @@ class TestRun(MypycDataSuite):
 
         for source in sources:
             options.per_module_options.setdefault(source.module, {})['mypyc'] = True
+
+        for module in CORE_BUILTIN_MODULES:
+            options.per_module_options.setdefault(module, {})['mypyc'] = True
 
         separate = (self.get_separate('\n'.join(testcase.input), incremental_step) if self.separate
                     else False)


### PR DESCRIPTION
https://github.com/mypyc/mypyc/issues/899

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Closes [#899](https://github.com/mypyc/mypyc/issues/899)

Usually, when mypyc is executed it sets the `mypyc` option when calling mypy code to `True`, which, among other things, results in mypy setting the upper bound for all type variables to `Any` (this is to prevent errors due to mypy not expanding type vars when `mypyc` is set). This, however, wasn't the case for built-in modules before this PR, so the upper bound for `AnyStr` was `object`, which caused mypy to report that `+` wasn't supported for instances of `AnyStr`. This PR addresses the issue by settings `mypyc` for the core builtuin modules.

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

I added a test case that basically repeats the example described in the issue.
