### PR TITLE
Suggest documentation link for corner cases for missing imports error in modulefinder.py

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -76,8 +76,8 @@ class ModuleNotFoundReason(Enum):
             msg = (
                 'Skipping analyzing "{module}": module is installed, but missing library stubs '
                 'or py.typed marker. note: See '
-                'https://mypy.readthedocs.io/en/latest/more_types.html#advanced-uses-of-self-types '
-                'for advanced usage'
+                'https://mypy.readthedocs.io/en/latest/more_types.html'
+                '#advanced-uses-of-self-types for advanced usage'
             )
             notes = [doc_link]
         elif self is ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED:

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -75,7 +75,8 @@ class ModuleNotFoundReason(Enum):
         elif self is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
             msg = (
                 'Skipping analyzing "{module}": module is installed, but missing library stubs '
-                'or py.typed marker'
+                'or py.typed marker. note: See https://mypy.readthedocs.io/en/latest/more_types.html#advanced-uses-of-self-types '
+                'for advanced usage'
             )
             notes = [doc_link]
         elif self is ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED:

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -75,7 +75,8 @@ class ModuleNotFoundReason(Enum):
         elif self is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
             msg = (
                 'Skipping analyzing "{module}": module is installed, but missing library stubs '
-                'or py.typed marker. note: See https://mypy.readthedocs.io/en/latest/more_types.html#advanced-uses-of-self-types '
+                'or py.typed marker. note: See '
+                'https://mypy.readthedocs.io/en/latest/more_types.html#advanced-uses-of-self-types '
                 'for advanced usage'
             )
             notes = [doc_link]


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Add documentation source for tricky or corner cases when mypy throws error as described here:
https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports

Use cases like these are often resolved by referring to sections such as here: https://mypy.readthedocs.io/en/latest/more_types.html#mixin-classes

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

The best thing to do is to reproduce the issue i faced with a mixin class as highlighted in the [mypy docs here](https://mypy.readthedocs.io/en/latest/more_types.html#mixin-classes);
It still needs to be understood what would be the best place, I believe dropping the test somewhere here: 
mypy/test/testmodulefinder.py although I have not seen any test required for this particular snippet already so it's best left to the project's authors to decide if this is needed at all.