### PR TITLE
Use `__truediv__` for python2 with `__future__` import, refs #11740

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2188,8 +2188,11 @@ class State:
         if not self._type_checker:
             assert self.tree is not None, "Internal error: must be called on parsed file only"
             manager = self.manager
-            self._type_checker = TypeChecker(manager.errors, manager.modules, self.options,
-                                             self.tree, self.xpath, manager.plugin)
+            self._type_checker = TypeChecker(
+                manager.errors, manager.modules, self.options,
+                self.tree, self.xpath, manager.plugin,
+                self.manager.semantic_analyzer.future_import_flags,
+            )
         return self._type_checker
 
     def type_map(self) -> Dict[Expression, Type]:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2191,9 +2191,6 @@ class State:
             self._type_checker = TypeChecker(
                 manager.errors, manager.modules, self.options,
                 self.tree, self.xpath, manager.plugin,
-                self.manager.semantic_analyzer.future_import_flags.get(
-                    self.tree.fullname, set(),
-                ),
             )
         return self._type_checker
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2191,7 +2191,9 @@ class State:
             self._type_checker = TypeChecker(
                 manager.errors, manager.modules, self.options,
                 self.tree, self.xpath, manager.plugin,
-                self.manager.semantic_analyzer.future_import_flags,
+                self.manager.semantic_analyzer.future_import_flags.get(
+                    self.tree.fullname, set(),
+                ),
             )
         return self._type_checker
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -221,7 +221,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     # functions such as open(), etc.
     plugin: Plugin
 
-    # Future flags that we get from semantic analyzer.
+    # Future flags that we get from semantic analyzer for this module.
     future_import_flags: Set[str]
 
     def __init__(self, errors: Errors, modules: Dict[str, MypyFile], options: Options,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -221,12 +221,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     # functions such as open(), etc.
     plugin: Plugin
 
-    # Future flags that we get from semantic analyzer for this module.
-    future_import_flags: Set[str]
-
     def __init__(self, errors: Errors, modules: Dict[str, MypyFile], options: Options,
-                 tree: MypyFile, path: str, plugin: Plugin,
-                 future_import_flags: Set[str]) -> None:
+                 tree: MypyFile, path: str, plugin: Plugin) -> None:
         """Construct a type checker.
 
         Use errors to report type check errors.
@@ -271,8 +267,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # NOTE: we use the context manager to avoid "threading" an additional `is_final_def`
         # argument through various `checker` and `checkmember` functions.
         self._is_final_def = False
-
-        self.future_import_flags = future_import_flags
 
     @property
     def type_context(self) -> List[Optional[Type]]:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -221,8 +221,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     # functions such as open(), etc.
     plugin: Plugin
 
+    # Future flags that we get from semantic analyzer.
+    future_import_flags: Set[str]
+
     def __init__(self, errors: Errors, modules: Dict[str, MypyFile], options: Options,
-                 tree: MypyFile, path: str, plugin: Plugin) -> None:
+                 tree: MypyFile, path: str, plugin: Plugin,
+                 future_import_flags: Set[str]) -> None:
         """Construct a type checker.
 
         Use errors to report type check errors.
@@ -267,6 +271,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # NOTE: we use the context manager to avoid "threading" an additional `is_final_def`
         # argument through various `checker` and `checkmember` functions.
         self._is_final_def = False
+
+        self.future_import_flags = future_import_flags
 
     @property
     def type_context(self) -> List[Optional[Type]]:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2414,8 +2414,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def get_operator_method(self, op: str) -> str:
         if op == '/' and self.chk.options.python_version[0] == 2:
-            # TODO also check for "from __future__ import division"
-            return '__div__'
+            return '__truediv__' if 'division' in self.chk.future_import_flags else '__div__'
         else:
             return operators.op_methods[op]
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2414,7 +2414,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def get_operator_method(self, op: str) -> str:
         if op == '/' and self.chk.options.python_version[0] == 2:
-            return '__truediv__' if 'division' in self.chk.future_import_flags else '__div__'
+            return (
+                '__truediv__'
+                if self.chk.tree.is_future_flag_set('division')
+                else '__div__'
+            )
         else:
             return operators.op_methods[op]
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -255,7 +255,8 @@ class MypyFile(SymbolNode):
 
     __slots__ = ('_fullname', 'path', 'defs', 'alias_deps',
                  'is_bom', 'names', 'imports', 'ignored_lines', 'is_stub',
-                 'is_cache_skeleton', 'is_partial_stub_package', 'plugin_deps')
+                 'is_cache_skeleton', 'is_partial_stub_package', 'plugin_deps',
+                 'future_import_flags')
 
     # Fully qualified module name
     _fullname: Bogus[str]
@@ -284,6 +285,8 @@ class MypyFile(SymbolNode):
     is_partial_stub_package: bool
     # Plugin-created dependencies
     plugin_deps: Dict[str, Set[str]]
+    # Future imports defined in this file. Populated during semantic analysis.
+    future_import_flags: Set[str]
 
     def __init__(self,
                  defs: List[Statement],
@@ -306,6 +309,7 @@ class MypyFile(SymbolNode):
         self.is_stub = False
         self.is_cache_skeleton = False
         self.is_partial_stub_package = False
+        self.future_import_flags = set()
 
     def local_definitions(self) -> Iterator[Definition]:
         """Return all definitions within the module (including nested).
@@ -328,6 +332,9 @@ class MypyFile(SymbolNode):
     def is_package_init_file(self) -> bool:
         return len(self.path) != 0 and os.path.basename(self.path).startswith('__init__.')
 
+    def is_future_flag_set(self, flag: str) -> bool:
+        return flag in self.future_import_flags
+
     def serialize(self) -> JsonDict:
         return {'.class': 'MypyFile',
                 '_fullname': self._fullname,
@@ -335,6 +342,7 @@ class MypyFile(SymbolNode):
                 'is_stub': self.is_stub,
                 'path': self.path,
                 'is_partial_stub_package': self.is_partial_stub_package,
+                'future_import_flags': list(self.future_import_flags),
                 }
 
     @classmethod
@@ -347,6 +355,7 @@ class MypyFile(SymbolNode):
         tree.path = data['path']
         tree.is_partial_stub_package = data['is_partial_stub_package']
         tree.is_cache_skeleton = True
+        tree.future_import_flags = set(data['future_import_flags'])
         return tree
 
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -219,7 +219,6 @@ class SemanticAnalyzer(NodeVisitor[None],
     errors: Errors  # Keeps track of generated errors
     plugin: Plugin  # Mypy plugin for special casing of library features
     statement: Optional[Statement] = None  # Statement/definition being analyzed
-    future_import_flags: Dict[str, Set[str]]  # Module name / future imports
 
     # Mapping from 'async def' function definitions to their return type wrapped as a
     # 'Coroutine[Any, Any, T]'. Used to keep track of whether a function definition's
@@ -283,8 +282,6 @@ class SemanticAnalyzer(NodeVisitor[None],
         # Trace line numbers for every file where deferral happened during analysis of
         # current SCC or top-level function.
         self.deferral_debug_context: List[Tuple[str, int]] = []
-
-        self.future_import_flags: Dict[str, Set[str]] = {}
 
     # mypyc doesn't properly handle implementing an abstractproperty
     # with a regular attribute so we make them properties
@@ -5252,12 +5249,12 @@ class SemanticAnalyzer(NodeVisitor[None],
 
     def set_future_import_flags(self, module_name: str) -> None:
         if module_name in FUTURE_IMPORTS:
-            self.future_import_flags.setdefault(
-                self.cur_mod_id, set(),
-            ).add(FUTURE_IMPORTS[module_name])
+            self.modules[self.cur_mod_id].future_import_flags.add(
+                FUTURE_IMPORTS[module_name],
+            )
 
     def is_future_flag_set(self, flag: str) -> bool:
-        return flag in self.future_import_flags.setdefault(self.cur_mod_id, set())
+        return self.modules[self.cur_mod_id].is_future_flag_set(flag)
 
 
 class HasPlaceholders(TypeQuery[bool]):

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -228,6 +228,44 @@ reveal_type(a / 'b')  # N: Revealed type is "builtins.str"
 a / 1  # E: Unsupported operand types for / ("A" and "int")
 [builtins fixtures/bool.pyi]
 
+[case testDivPython2FutureImportNotLeaking]
+# flags: --python-version 2.7
+import m1
+
+[file m1.py]
+import m2
+
+class A(object):
+    def __div__(self, other):
+        # type: (A, str) -> str
+        return 'a'
+
+a = A()
+reveal_type(a / 'b')  # N: Revealed type is "builtins.str"
+a / 1  # E: Unsupported operand types for / ("A" and "int")
+[file m2.py]
+from __future__ import division
+[builtins fixtures/bool.pyi]
+
+[case testDivPython2FutureImportNotLeaking2]
+# flags: --python-version 2.7
+import m1
+
+[file m1.py]
+import m2
+
+class A(object):
+    def __div__(self, other):
+        # type: (A, str) -> str
+        return 'a'
+
+a = A()
+reveal_type(a / 'b')  # N: Revealed type is "builtins.str"
+a / 1  # E: Unsupported operand types for / ("A" and "int")
+[file m2.py]
+# empty
+[builtins fixtures/bool.pyi]
+
 [case testIntDiv]
 a, b, c = None, None, None # type: (A, B, C)
 if int():

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -202,6 +202,32 @@ class C:
     pass
 [builtins fixtures/tuple.pyi]
 
+[case testDivPython2]
+# flags: --python-version 2.7
+class A(object):
+    def __div__(self, other):
+        # type: (A, str) -> str
+        return 'a'
+
+a = A()
+reveal_type(a / 'b')  # N: Revealed type is "builtins.str"
+a / 1  # E: Unsupported operand types for / ("A" and "int")
+[builtins fixtures/bool.pyi]
+
+[case testDivPython2FutureImport]
+# flags: --python-version 2.7
+from __future__ import division
+
+class A(object):
+    def __truediv__(self, other):
+        # type: (A, str) -> str
+        return 'a'
+
+a = A()
+reveal_type(a / 'b')  # N: Revealed type is "builtins.str"
+a / 1  # E: Unsupported operand types for / ("A" and "int")
+[builtins fixtures/bool.pyi]
+
 [case testIntDiv]
 a, b, c = None, None, None # type: (A, B, C)
 if int():


### PR DESCRIPTION
Now `__future__` imports do not leak in `semanal.py`.

Closes #11740
Refs https://github.com/python/mypy/pull/11741
Refs https://github.com/python/mypy/pull/11276
Refs https://github.com/python/mypy/issues/11700