### PR TITLE
attrs namedtuple

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -124,7 +124,7 @@ from typing import Any, Callable, List, Tuple, Optional, NamedTuple, TypeVar, Di
 from mypy_extensions import trait, mypyc_attr
 
 from mypy.nodes import (
-    Expression, Context, ClassDef, SymbolTableNode, MypyFile, CallExpr, ArgKind
+    Expression, Context, ClassDef, SymbolTableNode, MypyFile, CallExpr, ArgKind, TypeInfo
 )
 from mypy.tvar_scope import TypeVarLikeScope
 from mypy.types import (
@@ -266,6 +266,10 @@ class SemanticAnalyzerPluginInterface:
         type name. This is possible when the qualified name includes a
         module name and the module has not been imported.
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def basic_new_typeinfo(self, name: str, basetype_or_fallback: Instance, line: int) -> TypeInfo:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -724,8 +724,6 @@ def _add_attrs_magic_attribute(ctx: 'mypy.plugin.ClassDefContext',
     namedtuple_cls_name = "_AttrsAttributes"
     ti = ctx.api.basic_new_typeinfo(namedtuple_cls_name, fallback_type, 0)
     ti.is_named_tuple = True
-    ti.type_vars = [repr(a) for a in attributes_types]
-    ti.tuple_type = TupleType(attributes_types, fallback=fallback_type)
     for (name, _), attr_type in zip(attrs, attributes_types):
         var = Var(name, attr_type)
         var.is_property = True
@@ -733,9 +731,9 @@ def _add_attrs_magic_attribute(ctx: 'mypy.plugin.ClassDefContext',
         if isinstance(proper_type, Instance):
             var.info = proper_type.type
         ti.names[name] = SymbolTableNode(MDEF, var, plugin_generated=True)
-    attributes_type = Instance(ti, attributes_types)
+    attributes_type = Instance(ti, [])
 
-    var = Var(name=attr_name, type=attributes_type)
+    var = Var(name=attr_name, type=TupleType(attributes_types, fallback=attributes_type))
     var.info = ctx.cls.info
     var.is_classvar = True
     var._fullname = f"{ctx.cls.fullname}.{namedtuple_cls_name}"

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -49,6 +49,7 @@ class FineGrainedSuite(DataSuite):
         'fine-grained-modules.test',
         'fine-grained-follow-imports.test',
         'fine-grained-suggest.test',
+        'fine-grained-attr.test',
     ]
 
     # Whether to use the fine-grained cache in the testing. This is overridden

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1399,7 +1399,37 @@ class A:
     b: int = attr.ib()
     c: str = attr.ib()
 
-reveal_type(A.__attrs_attrs__)  # N: Revealed type is "Tuple[attr.Attribute[builtins.int], attr.Attribute[builtins.str]]"
+reveal_type(A.__attrs_attrs__)  # N: Revealed type is "__main__.A._AttrsAttributes[attr.Attribute[builtins.int], attr.Attribute[builtins.str]]"
+reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[builtins.int]"
+A.__attrs_attrs__.x  # E: "_AttrsAttributes[Attribute[int], Attribute[str]]" has no attribute "x"
+
+[builtins fixtures/attr.pyi]
+
+[case testAttrsBareClassHasAttributeWithAttributes]
+import attr
+
+@attr.s
+class A:
+    b = attr.ib()
+    c = attr.ib()
+
+reveal_type(A.__attrs_attrs__)  # N: Revealed type is "__main__.A._AttrsAttributes[attr.Attribute[Any], attr.Attribute[Any]]"
+reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[Any]"
+A.__attrs_attrs__.x  # E: "_AttrsAttributes[Attribute[Any], Attribute[Any]]" has no attribute "x"
+
+[builtins fixtures/attr.pyi]
+
+[case testAttrsNGClassHasAttributeWithAttributes]
+import attr
+
+@attr.define
+class A:
+    b: int
+    c: str
+
+reveal_type(A.__attrs_attrs__)  # N: Revealed type is "__main__.A._AttrsAttributes[attr.Attribute[builtins.int], attr.Attribute[builtins.str]]"
+reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[builtins.int]"
+A.__attrs_attrs__.x  # E: "_AttrsAttributes[Attribute[int], Attribute[str]]" has no attribute "x"
 
 [builtins fixtures/attr.pyi]
 

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1399,9 +1399,10 @@ class A:
     b: int = attr.ib()
     c: str = attr.ib()
 
-reveal_type(A.__attrs_attrs__)  # N: Revealed type is "__main__.A._AttrsAttributes[attr.Attribute[builtins.int], attr.Attribute[builtins.str]]"
+reveal_type(A.__attrs_attrs__)  # N: Revealed type is "Tuple[attr.Attribute[builtins.int], attr.Attribute[builtins.str], fallback=__main__.A._AttrsAttributes]"
+reveal_type(A.__attrs_attrs__[0])  # N: Revealed type is "attr.Attribute[builtins.int]"
 reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[builtins.int]"
-A.__attrs_attrs__.x  # E: "_AttrsAttributes[Attribute[int], Attribute[str]]" has no attribute "x"
+A.__attrs_attrs__.x  # E: "_AttrsAttributes" has no attribute "x"
 
 [builtins fixtures/attr.pyi]
 
@@ -1413,9 +1414,10 @@ class A:
     b = attr.ib()
     c = attr.ib()
 
-reveal_type(A.__attrs_attrs__)  # N: Revealed type is "__main__.A._AttrsAttributes[attr.Attribute[Any], attr.Attribute[Any]]"
+reveal_type(A.__attrs_attrs__)  # N: Revealed type is "Tuple[attr.Attribute[Any], attr.Attribute[Any], fallback=__main__.A._AttrsAttributes]"
+reveal_type(A.__attrs_attrs__[0])  # N: Revealed type is "attr.Attribute[Any]"
 reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[Any]"
-A.__attrs_attrs__.x  # E: "_AttrsAttributes[Attribute[Any], Attribute[Any]]" has no attribute "x"
+A.__attrs_attrs__.x  # E: "_AttrsAttributes" has no attribute "x"
 
 [builtins fixtures/attr.pyi]
 
@@ -1427,9 +1429,10 @@ class A:
     b: int
     c: str
 
-reveal_type(A.__attrs_attrs__)  # N: Revealed type is "__main__.A._AttrsAttributes[attr.Attribute[builtins.int], attr.Attribute[builtins.str]]"
+reveal_type(A.__attrs_attrs__)  # N: Revealed type is "Tuple[attr.Attribute[builtins.int], attr.Attribute[builtins.str], fallback=__main__.A._AttrsAttributes]"
+reveal_type(A.__attrs_attrs__[0])  # N: Revealed type is "attr.Attribute[builtins.int]"
 reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[builtins.int]"
-A.__attrs_attrs__.x  # E: "_AttrsAttributes[Attribute[int], Attribute[str]]" has no attribute "x"
+A.__attrs_attrs__.x  # E: "_AttrsAttributes" has no attribute "x"
 
 [builtins fixtures/attr.pyi]
 

--- a/test-data/unit/fine-grained-attr.test
+++ b/test-data/unit/fine-grained-attr.test
@@ -1,0 +1,23 @@
+[case updateMagicField]
+from attr import Attribute
+import m
+
+def g() -> Attribute[int]:
+    return m.A.__attrs_attrs__[0]
+
+[file m.py]
+from attr import define
+
+@define
+class A:
+    a: int
+[file m.py.2]
+from attr import define
+
+@define
+class A:
+    a: float
+[builtins fixtures/attr.pyi]
+[out]
+==
+main:5: error: Incompatible return value type (got "Attribute[float]", expected "Attribute[int]")


### PR DESCRIPTION
This PR further enhances the attrs plugin by generating a more correct `__attrs_attrs__` field.

The current version of the plugin generates this field as a tuple of attributes. This enhancement makes it a namedtuple, which is what attrs actually does in runtime. The difference is a large increase in the ergonomics of the field: instead of `A.__attrs_attrs__[0]`, a user can access an attribute using `A.__attrs_attrs__.x`. Also note the end-users don't actually use the `__attrs_attrs__` field directly, but access it using `attr.fields`, which is a very simple getter interface.

This might sound like a trivial change, but it has big repercussions down the line for static checks in libraries building on top of attrs.

I have added 2 extra tests and improved an existing one.