### PR TITLE
Microrefactoring: use more constants for type names

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -21,7 +21,7 @@ from mypy.types import (
     PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, LiteralType, LiteralValue,
     is_named_instance, FunctionLike, ParamSpecType, ParamSpecFlavor,
     StarType, is_optional, remove_optional, is_generic_instance, get_proper_type, ProperType,
-    get_proper_types, flatten_nested_unions
+    get_proper_types, flatten_nested_unions, LITERAL_TYPE_NAMES,
 )
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
@@ -4550,10 +4550,9 @@ def try_getting_literal(typ: Type) -> ProperType:
 
 def is_expr_literal_type(node: Expression) -> bool:
     """Returns 'true' if the given node is a Literal"""
-    valid = ('typing.Literal', 'typing_extensions.Literal')
     if isinstance(node, IndexExpr):
         base = node.base
-        return isinstance(base, RefExpr) and base.fullname in valid
+        return isinstance(base, RefExpr) and base.fullname in LITERAL_TYPE_NAMES
     if isinstance(node, NameExpr):
         underlying = node.node
         return isinstance(underlying, TypeAlias) and isinstance(get_proper_type(underlying.target),

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -10,7 +10,7 @@ from mypy.nodes import (
 from mypy.fastparse import parse_type_string
 from mypy.types import (
     Type, UnboundType, TypeList, EllipsisType, AnyType, CallableArgument, TypeOfAny,
-    RawExpressionType, ProperType, UnionType
+    RawExpressionType, ProperType, UnionType, ANNOTATED_TYPE_NAMES,
 )
 from mypy.options import Options
 
@@ -69,9 +69,7 @@ def expr_to_unanalyzed_type(expr: Expression,
             else:
                 args = [expr.index]
 
-            if isinstance(expr.base, RefExpr) and expr.base.fullname in [
-                'typing.Annotated', 'typing_extensions.Annotated'
-            ]:
+            if isinstance(expr.base, RefExpr) and expr.base.fullname in ANNOTATED_TYPE_NAMES:
                 # TODO: this is not the optimal solution as we are basically getting rid
                 # of the Annotation definition and only returning the type information,
                 # losing all the annotations.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -92,7 +92,8 @@ from mypy.types import (
     FunctionLike, UnboundType, TypeVarType, TupleType, UnionType, StarType,
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
-    get_proper_type, get_proper_types, TypeAliasType, TypeVarLikeType
+    get_proper_type, get_proper_types, TypeAliasType, TypeVarLikeType,
+    PROTOCOL_NAMES, TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES, FINAL_DECORATOR_NAMES,
 )
 from mypy.typeops import function_type, get_type_vars
 from mypy.type_visitor import TypeQuery
@@ -1154,8 +1155,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             for decorator in defn.decorators:
                 decorator.accept(self)
                 if isinstance(decorator, RefExpr):
-                    if decorator.fullname in ('typing.final',
-                                              'typing_extensions.final'):
+                    if decorator.fullname in FINAL_DECORATOR_NAMES:
                         self.fail("@final cannot be used with TypedDict", decorator)
             if info is None:
                 self.mark_incomplete(defn.name, defn)
@@ -1282,8 +1282,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 else:
                     self.fail('@runtime_checkable can only be used with protocol classes',
                               defn)
-            elif decorator.fullname in ('typing.final',
-                                        'typing_extensions.final'):
+            elif decorator.fullname in FINAL_DECORATOR_NAMES:
                 defn.info.is_final = True
 
     def clean_up_bases_and_infer_type_variables(
@@ -1328,8 +1327,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             if isinstance(base, UnboundType):
                 sym = self.lookup_qualified(base.name, base)
                 if sym is not None and sym.node is not None:
-                    if (sym.node.fullname in ('typing.Protocol', 'typing_extensions.Protocol') and
-                            i not in removed):
+                    if sym.node.fullname in PROTOCOL_NAMES and i not in removed:
                         # also remove bare 'Protocol' bases
                         removed.append(i)
                         is_protocol = True
@@ -1377,8 +1375,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         if sym is None or sym.node is None:
             return None
         if (sym.node.fullname == 'typing.Generic' or
-                sym.node.fullname == 'typing.Protocol' and base.args or
-                sym.node.fullname == 'typing_extensions.Protocol' and base.args):
+                sym.node.fullname in PROTOCOL_NAMES and base.args):
             is_proto = sym.node.fullname != 'typing.Generic'
             tvars: TypeVarLikeList = []
             for arg in unbound.args:
@@ -2638,7 +2635,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         pep_613 = False
         if s.unanalyzed_type is not None and isinstance(s.unanalyzed_type, UnboundType):
             lookup = self.lookup(s.unanalyzed_type.name, s, suppress_errors=True)
-            if lookup and lookup.fullname in ("typing.TypeAlias", "typing_extensions.TypeAlias"):
+            if lookup and lookup.fullname in TYPE_ALIAS_NAMES:
                 pep_613 = True
         if s.unanalyzed_type is not None and not pep_613:
             # Second rule: Explicit type (cls: Type[A] = A) always creates variable, not alias.
@@ -3363,7 +3360,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         sym = self.lookup_qualified(typ.name, typ)
         if not sym or not sym.node:
             return False
-        return sym.node.fullname in ('typing.Final', 'typing_extensions.Final')
+        return sym.node.fullname in FINAL_TYPE_NAMES
 
     def fail_invalid_classvar(self, context: Context) -> None:
         self.fail(message_registry.CLASS_VAR_OUTSIDE_OF_CLASS, context)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -17,7 +17,8 @@ from mypy.types import (
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, CallableArgument,
     TypeQuery, union_items, TypeOfAny, LiteralType, RawExpressionType,
     PlaceholderType, Overloaded, get_proper_type, TypeAliasType, RequiredType,
-    TypeVarLikeType, ParamSpecType, ParamSpecFlavor, callable_with_ellipsis
+    TypeVarLikeType, ParamSpecType, ParamSpecFlavor, callable_with_ellipsis,
+    TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES, LITERAL_TYPE_NAMES, ANNOTATED_TYPE_NAMES,
 )
 
 from mypy.nodes import (
@@ -42,10 +43,8 @@ type_constructors: Final = {
     'typing.Tuple',
     'typing.Type',
     'typing.Union',
-    'typing.Literal',
-    'typing_extensions.Literal',
-    'typing.Annotated',
-    'typing_extensions.Annotated',
+    *LITERAL_TYPE_NAMES,
+    *ANNOTATED_TYPE_NAMES,
 }
 
 ARG_KINDS_BY_CONSTRUCTOR: Final = {
@@ -262,7 +261,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 return res
             elif isinstance(node, TypeInfo):
                 return self.analyze_type_with_type_info(node, t.args, t)
-            elif node.fullname in ("typing_extensions.TypeAlias", "typing.TypeAlias"):
+            elif node.fullname in TYPE_ALIAS_NAMES:
                 return AnyType(TypeOfAny.special_form)
             else:
                 return self.analyze_unbound_type_without_type_info(t, sym, defining_literal)
@@ -286,7 +285,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             return NoneType()
         elif fullname == 'typing.Any' or fullname == 'builtins.Any':
             return AnyType(TypeOfAny.explicit)
-        elif fullname in ('typing.Final', 'typing_extensions.Final'):
+        elif fullname in FINAL_TYPE_NAMES:
             self.fail("Final can be only used as an outermost qualifier"
                       " in a variable annotation", t)
             return AnyType(TypeOfAny.from_error)
@@ -352,9 +351,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             return self.anal_type(t.args[0])
         elif fullname in ('mypy_extensions.NoReturn', 'typing.NoReturn'):
             return UninhabitedType(is_noreturn=True)
-        elif fullname in ('typing_extensions.Literal', 'typing.Literal'):
+        elif fullname in LITERAL_TYPE_NAMES:
             return self.analyze_literal_type(t)
-        elif fullname in ('typing_extensions.Annotated', 'typing.Annotated'):
+        elif fullname in ANNOTATED_TYPE_NAMES:
             if len(t.args) < 2:
                 self.fail("Annotated[...] must have exactly one type argument"
                           " and at least one annotation", t)
@@ -1289,9 +1288,9 @@ class TypeVarLikeQuery(TypeQuery[TypeVarLikeList]):
             return [(name, node.node)]
         elif not self.include_callables and self._seems_like_callable(t):
             return []
-        elif node and node.fullname in ('typing_extensions.Literal', 'typing.Literal'):
+        elif node and node.fullname in LITERAL_TYPE_NAMES:
             return []
-        elif node and node.fullname in ('typing_extensions.Annotated', 'typing.Annotated'):
+        elif node and node.fullname in ANNOTATED_TYPE_NAMES:
             # Don't query the second argument to Annotated for TypeVars
             return self.query_types([t.args[0]])
         else:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -81,6 +81,42 @@ TPDICT_FB_NAMES: Final = (
     "mypy_extensions._TypedDict",
 )
 
+# Supported names of Protocol base class.
+PROTOCOL_NAMES: Final = (
+    'typing.Protocol',
+    'typing_extensions.Protocol',
+)
+
+# Supported TypeAlias names.
+TYPE_ALIAS_NAMES: Final = (
+    "typing.TypeAlias",
+    "typing_extensions.TypeAlias",
+)
+
+# Supported Final type names.
+FINAL_TYPE_NAMES: Final = (
+    'typing.Final',
+    'typing_extensions.Final',
+)
+
+# Supported @final decorator names.
+FINAL_DECORATOR_NAMES: Final = (
+    'typing.final',
+    'typing_extensions.final',
+)
+
+# Supported Literal type names.
+LITERAL_TYPE_NAMES: Final = (
+    'typing.Literal',
+    'typing_extensions.Literal',
+)
+
+# Supported Annotated type names.
+ANNOTATED_TYPE_NAMES: Final = (
+    'typing.Annotated',
+    'typing_extensions.Annotated',
+)
+
 # A placeholder used for Bogus[...] parameters
 _dummy: Final[Any] = object()
 


### PR DESCRIPTION
I've tried to cover all cases when we have to manually re-type all the same type-name-aliases more than once. Any extra ones that I've missed?

It was always catching my eye, but I had no time to refactor it in the past.
