### PR TITLE
Allow calling a function with name '_'

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1,6 +1,5 @@
 """Expression type checker. This file is conceptually part of TypeChecker."""
 
-from mypy.util import unnamed_function
 from mypy.backports import OrderedDict, nullcontext
 from contextlib import contextmanager
 import itertools
@@ -346,12 +345,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 isinstance(callee_type, CallableType)
                 and callee_type.implicit):
             self.msg.untyped_function_call(callee_type, e)
-
-        if (isinstance(callee_type, CallableType)
-                and not callee_type.is_type_obj()
-                and unnamed_function(callee_type.name)):
-            self.msg.underscore_function_call(e)
-            return AnyType(TypeOfAny.from_error)
 
         # Figure out the full name of the callee for plugin lookup.
         object_type = None

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2230,6 +2230,12 @@ reveal_type(h) # N: Revealed type is "builtins.function"
 h(7) # E: Cannot call function of unknown type
 [builtins fixtures/bool.pyi]
 
+[case testFunctionWithNameUnderscore]
+def _(x: int) -> None: pass
+
+_(1)
+_('x')  # E: Argument 1 to "_" has incompatible type "str"; expected "int"
+
 -- Positional-only arguments
 -- -------------------------
 

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -498,7 +498,8 @@ def _(arg: str):
 def _(arg: int) -> int:
     return 'a' # E: Incompatible return value type (got "str", expected "int")
 
-[case testCallingUnderscoreFunctionIsNotAllowed]
+[case testCallingUnderscoreFunctionIsNotAllowed-skip]
+# Skipped because of https://github.com/python/mypy/issues/11774
 def _(arg: str) -> None:
     pass
 


### PR DESCRIPTION
Fixes #11774. The issue has relevant background information in the
discussion.

It may be worth it to eventually add back some restrictions, but we'd
only focus the restrictions on singledispatch functions. This is a
quick fix to work around a regression.