### PR TITLE
fix: do not crash if "_" is parsed in builtins

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4296,7 +4296,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             assert isinstance(b.node, MypyFile)
             table = b.node.names
             if name in table:
-                if name[0] == "_" and name[1] != "_":
+                if len(name) > 1 and name[0] == "_" and name[1] != "_":
                     if not suppress_errors:
                         self.name_not_defined(name, ctx)
                     return None


### PR DESCRIPTION
allows the definiton of "_" as function in builtins (e.g via typeshed).

fixes issue #9802

### Description

Fixes #9802

## Test Plan

