### PR TITLE
Fixes crash on subclassing `Annotated` without args

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1291,7 +1291,9 @@ class TypeVarLikeQuery(TypeQuery[TypeVarLikeList]):
             return []
         elif node and node.fullname in ('typing_extensions.Literal', 'typing.Literal'):
             return []
-        elif node and node.fullname in ('typing_extensions.Annotated', 'typing.Annotated'):
+        elif (node
+                and node.fullname in ('typing_extensions.Annotated', 'typing.Annotated')
+                and t.args):
             # Don't query the second argument to Annotated for TypeVars
             return self.query_types([t.args[0]])
         else:

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1435,3 +1435,10 @@ TP = ParamSpec('?')  # E: String argument 1 "?" to ParamSpec(...) does not match
 TP2: int = ParamSpec('TP2')  # E: Cannot declare the type of a parameter specification
 
 [out]
+
+
+[case testBaseClassAnnotatedWithoutArgs]
+# https://github.com/python/mypy/issues/11808
+from typing_extensions import Annotated
+# Nest line should not crash:
+class A(Annotated): pass  # E: Annotated[...] must have exactly one type argument and at least one annotation


### PR DESCRIPTION
Closes #11808