### PR TITLE
Fixes regression with `__module__` and similar non-final `Enum` names

### DIFF
--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -21,6 +21,8 @@ ENUM_BASES: Final = frozenset((
 ))
 ENUM_SPECIAL_PROPS: Final = frozenset((
     'name', 'value', '_name_', '_value_', '_order_', '__order__',
+    # Also attributes from `object`:
+    '__module__', '__annotations__', '__doc__', '__slots__', '__dict__',
 ))
 
 

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1689,6 +1689,11 @@ class E(Enum):
     _value_ = 'b2'
     _order_ = 'X Y'
     __order__ = 'X Y'
+    __slots__ = ()
+    __doc__ = 'doc'
+    __module__ = 'module'
+    __annotations__ = {'a': int}
+    __dict__ = {'a': 1}
 
 class EI(IntEnum):
     name = 'a'
@@ -1697,10 +1702,15 @@ class EI(IntEnum):
     _value_ = 2
     _order_ = 'X Y'
     __order__ = 'X Y'
+    __slots__ = ()
+    __doc__ = 'doc'
+    __module__ = 'module'
+    __annotations__ = {'a': int}
+    __dict__ = {'a': 1}
 
 E._order_ = 'a'  # E: Cannot assign to final attribute "_order_"
 EI.value = 2     # E: Cannot assign to final attribute "value"
-[builtins fixtures/bool.pyi]
+[builtins fixtures/dict.pyi]
 
 [case testEnumNotFinalWithMethodsAndUninitializedValues]
 # https://github.com/python/mypy/issues/11578


### PR DESCRIPTION
I've copied special names from `object` type as well.

Closes #11820
