### PR TITLE
Fix glob in .gitattributes for Github stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # We vendor typeshed from https://github.com/python/typeshed
-mypy/typeshed/**/*.pyi linguist-vendored
+mypy/typeshed/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # We vendor typeshed from https://github.com/python/typeshed
-mypy/typeshed/ linguist-vendored
+mypy/typeshed/**/*.pyi linguist-vendored


### PR DESCRIPTION
I was wrong, it requires the full file glob.
