### PR TITLE
Fix `CallableType.formal_arguments` docstring

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1247,7 +1247,7 @@ class CallableType(FunctionLike):
         return sum([kind.is_positional() for kind in self.arg_kinds])
 
     def formal_arguments(self, include_star_args: bool = False) -> List[FormalArgument]:
-        """Return a list of the formal arguments corresponding to this callable, ignoring *arg and **kwargs.
+        """Return a list of the formal arguments of this callable, ignoring *arg and **kwargs.
 
         To handle *args and **kwargs, use the 'callable.var_args' and 'callable.kw_args' fields,
         if they are not None.

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1247,7 +1247,7 @@ class CallableType(FunctionLike):
         return sum([kind.is_positional() for kind in self.arg_kinds])
 
     def formal_arguments(self, include_star_args: bool = False) -> List[FormalArgument]:
-        """Yields the formal arguments corresponding to this callable, ignoring *arg and **kwargs.
+        """Return a list of the formal arguments corresponding to this callable, ignoring *arg and **kwargs.
 
         To handle *args and **kwargs, use the 'callable.var_args' and 'callable.kw_args' fields,
         if they are not None.


### PR DESCRIPTION
### Description

PR #11543 changed the `CallableType.formal_arguments` method to return a list of formal arguments instead of yielding them. However the docstring was not updated at the time to reflect this. This PR correct this docstring.

## Test Plan

N/A, only changes a docstring, which isn't tested.
