### PR TITLE
Skip compiling mypyc/__main__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ if USE_MYPYC:
     )) + (
         # Don't want to grab this accidentally
         os.path.join('mypyc', 'lib-rt', 'setup.py'),
-    ) + (
+        # Uses __file__ at top level https://github.com/mypyc/mypyc/issues/700
         os.path.join('mypyc', '__main__.py'),
     )
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,8 @@ if USE_MYPYC:
     )) + (
         # Don't want to grab this accidentally
         os.path.join('mypyc', 'lib-rt', 'setup.py'),
+    ) + (
+        os.path.join('mypyc', '__main__.py'),
     )
 
     everything = (


### PR DESCRIPTION
### Description

Skip compiling `mypyc/__main__.py` to fix https://github.com/mypyc/mypyc/issues/912

## Test Plan

With this patch, the tests `testCompileMypyc` and `testErrorOutput` pass during the building of the mypy 0.930 binary packages for Debian.

As for CI testing, in Debian we don't build via `python3 setup.py --use-mypyc build_ext --inplace` we use `MYPY_USE_MYPYC=1 python3 setup.py build` and then copy the results into a temporary directory, where we then run the tests.