### PR TITLE
Fix shell syntax in build_wheel

### DIFF
--- a/mypyc/test/config.py
+++ b/mypyc/test/config.py
@@ -1,7 +1,11 @@
 import os
 
-this_file_dir = os.path.dirname(os.path.realpath(__file__))
-prefix = os.path.dirname(os.path.dirname(this_file_dir))
+provided_prefix = os.getenv('MYPY_TEST_PREFIX', None)
+if provided_prefix:
+    PREFIX = provided_prefix
+else:
+    this_file_dir = os.path.dirname(os.path.realpath(__file__))
+    PREFIX = os.path.dirname(os.path.dirname(this_file_dir))
 
-# Locations of test data files such as test case descriptions (.test).
-test_data_prefix = os.path.join(prefix, 'mypyc', 'test-data')
+# Location of test data files such as test case descriptions.
+test_data_prefix = os.path.join(PREFIX, 'mypyc', 'test-data')


### PR DESCRIPTION
Follow up to #11872
The cross repo split makes this a bit of a pain to test.