### PR TITLE
Revert to treating exclude in .ini as single string

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -207,9 +207,18 @@ section of the command line docs.
 
       [mypy]
       exclude = (?x)(
-          ^file1\.py$
-          |^file2\.py$
+          ^one\.py$    # files named "one.py"
+          | two\.pyi$  # or files ending with "two.pyi"
+          | ^three\.   # or files starting with "three."
         )
+
+    Crafting a single regular expression that excludes multiple files while remaining
+    human-readable can be a challenge. The above example demonstrates one approach.
+    ``(?x)`` enables the ``VERBOSE`` flag for the subsequent regular expression, which
+    `ignores most whitespace and supports comments`__. The above is equivalent to:
+    ``(^one\.py$|two\.pyi$|^three\.)``.
+
+    .. __: https://docs.python.org/3/library/re.html#re.X
 
     For more details, see :option:`--exclude <mypy --exclude>`.
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -197,18 +197,19 @@ section of the command line docs.
 
 .. confval:: exclude
 
-    :type: newline separated list of regular expressions
+    :type: regular expressions
 
-    A newline list of regular expression that matches file names, directory names and paths
+    A regular expression that matches file names, directory names and paths
     which mypy should ignore while recursively discovering files to check.
     Use forward slashes on all platforms.
 
     .. code-block:: ini
 
       [mypy]
-      exclude =
+      exclude = (?x)(
           ^file1\.py$
-          ^file2\.py$
+          |^file2\.py$
+        )
 
     For more details, see :option:`--exclude <mypy --exclude>`.
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -197,7 +197,7 @@ section of the command line docs.
 
 .. confval:: exclude
 
-    :type: regular expressions
+    :type: regular expression
 
     A regular expression that matches file names, directory names and paths
     which mypy should ignore while recursively discovering files to check.

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -126,7 +126,7 @@ ini_config_types: Final[Dict[str, _INI_PARSER_CALLABLE]] = {
     'cache_dir': expand_path,
     'python_executable': expand_path,
     'strict': bool,
-    'exclude': lambda s: [p.strip() for p in s.split('\n') if p.strip()],
+    'exclude': lambda s: [s.strip()],
 }
 
 # Reuse the ini_config_types and overwrite the diff

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1354,9 +1354,10 @@ b/bpkg.py:1: error: "int" not callable
 # cmd: mypy .
 [file mypy.ini]
 \[mypy]
-exclude =
-    abc
-    b
+exclude = (?x)(
+    ^abc/
+    |^b/
+  )
 [file abc/apkg.py]
 1()
 [file b/bpkg.py]


### PR DESCRIPTION
Partially reverts #11329 (with respect to `.ini` documentation).
Modifies existing unit tests.

Fixes #11830.