### PR TITLE
Add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.{py,c,cpp,h,rst,md,yml,json}]
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+
+[*.{py,c,h,json}]
+indent_size = 4
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
Happy New Year, everyone!

What is an `.editorconfig`? It is a standard for cross-ide settings. Focused on text editing.
It helps to have better IDE experience and more consistent style.

For example, I've seen lots and lots of trailing white-spaces in Mypy.
This tool will help to reduce this amount.

Docs: https://editorconfig.org/

CPython has one: https://github.com/python/cpython/blob/main/.editorconfig
Typeshed will probably have one: https://github.com/python/typeshed/pull/6771