### PR TITLE
Fix sdist build for editorconfig

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -41,7 +41,7 @@ include runtests.py
 include pytest.ini
 
 include LICENSE mypyc/README.md
-exclude .gitmodules CONTRIBUTING.md CREDITS ROADMAP.md tox.ini action.yml
+exclude .gitmodules CONTRIBUTING.md CREDITS ROADMAP.md tox.ini action.yml .editorconfig
 
 global-exclude *.py[cod]
 global-exclude .DS_Store


### PR DESCRIPTION
editorconfig was added in #11883 and broke check-manifest in https://github.com/mypyc/mypy_mypyc-wheels/runs/4680413534?check_suite_focus=true