### PR TITLE
Make mypy test suite pass mypy type-check on Windows

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -10,25 +10,9 @@ from abc import abstractmethod
 import sys
 
 import pytest
-from typing import (
-    List,
-    Tuple,
-    TYPE_CHECKING,
-    Set,
-    Optional,
-    Iterator,
-    Any,
-    Dict,
-    NamedTuple,
-    Union,
-    overload
-)
-from typing_extensions import Protocol
+from typing import Callable, List, Tuple, Set, Optional, Iterator, Any, Dict, NamedTuple, Union
 
 from mypy.test.config import test_data_prefix, test_temp_dir, PREFIX
-
-if TYPE_CHECKING:
-    from _typeshed import BytesPath, StrPath
 
 root_dir = os.path.normpath(PREFIX)
 
@@ -44,18 +28,6 @@ DeleteFile = NamedTuple('DeleteFile', [('module', str),
 FileOperation = Union[UpdateFile, DeleteFile]
 
 
-class JoinFunction(Protocol):
-    """A callback protocol with which both `ntpath.join()` and `posixpath.join()` are compliant.
-
-    The two functions have different parameter names,
-    meaning this file doesn't type-check on Windows without this protocol.
-    """
-    @overload
-    def __call__(self, __path: 'StrPath', *paths: 'StrPath') -> str: ...
-    @overload
-    def __call__(self, __path: 'BytesPath', *paths: 'BytesPath') -> bytes: ...
-
-
 def parse_test_case(case: 'DataDrivenTestCase') -> None:
     """Parse and prepare a single case from suite with test case descriptions.
 
@@ -63,7 +35,8 @@ def parse_test_case(case: 'DataDrivenTestCase') -> None:
     """
     test_items = parse_test_data(case.data, case.name)
     base_path = case.suite.base_path
-    join: JoinFunction
+    # this file doesn't type-check on Windows without this line, see #11895
+    join: Callable[[str, str], str]
     if case.suite.native_sep:
         join = os.path.join
     else:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -12,7 +12,6 @@ import sys
 import pytest
 from typing import (
     List,
-    Protocol,
     Tuple,
     TYPE_CHECKING,
     Set,
@@ -24,6 +23,7 @@ from typing import (
     Union,
     overload
 )
+from typing_extensions import Protocol
 
 from mypy.test.config import test_data_prefix, test_temp_dir, PREFIX
 


### PR DESCRIPTION
### Description

Mypy's test suite fails mypy on Windows. This PR fixes that. (This is my first non-docs contribution to mypy, so let me know if I'm doing anything wrong in this PR!)

Here is the error I get if I try running the mypy test suite on my Windows machine:

```
(venv) C:\Users\Alex\Desktop\Code dump\mypy>python runtests.py
run self: ['C:\\Users\\Alex\\Desktop\\Code dump\\mypy\\venv\\Scripts\\python.exe', '-m', 'mypy', '--config-file', 'mypy_self_check.ini', '-p', 'mypy']
mypy\test\data.py:41: error: Incompatible types in assignment
(expression has type overloaded function, variable has type overloaded
function)  [assignment]
            join = posixpath.join
                   ^
Found 1 error in 1 file (checked 163 source files)

FAILED: self
```

This error is due to the following lines in `mypy/test/data.py`:

https://github.com/python/mypy/blob/2676cd804d0a72eb3fb9282879a8e426a851969b/mypy/test/data.py#L38-L41

On linux, `os.path.join` and `posixpath.join` have the same signature. However, on Windows, `os.path.join` [is a reexport of `ntpath.join`](https://github.com/python/typeshed/blob/master/stdlib/os/path.pyi), which has a different signature to `posixpath.join` due to the fact that the first parameter has a different name.

Here is how `posixpath.join` [is defined in typeshed](https://github.com/python/typeshed/blob/fdc5a568ab56f71a68948a499195a972c4ec11fc/stdlib/posixpath.pyi#L63-L66):

```python
@overload
def join(a: StrPath, *paths: StrPath) -> str: ...
@overload
def join(a: BytesPath, *paths: BytesPath) -> bytes: ...
```

Here is how `ntpath.join` [is defined in typeshed](https://github.com/python/typeshed/blob/fdc5a568ab56f71a68948a499195a972c4ec11fc/stdlib/ntpath.pyi#L51-L55):

```python
@overload
def join(path: StrPath, *paths: StrPath) -> str: ...
@overload
def join(path: BytesPath, *paths: BytesPath) -> bytes: ...
```

### Test plan

Not sure. Guidance on this would be appreciated.