### PR TITLE
stubtest: fix literal type construction

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -40,6 +40,7 @@ from mypy import message_registry, errorcodes as codes
 from mypy.errors import Errors
 from mypy.options import Options
 from mypy.reachability import mark_block_unreachable
+from mypy.util import bytes_to_human_readable_repr
 
 try:
     # pull this into a final variable to make mypyc be quiet about the
@@ -1638,17 +1639,3 @@ def stringify_name(n: AST) -> Optional[str]:
         if sv is not None:
             return "{}.{}".format(sv, n.attr)
     return None  # Can't do it.
-
-
-def bytes_to_human_readable_repr(b: bytes) -> str:
-    """Converts bytes into some human-readable representation. Unprintable
-    bytes such as the nul byte are escaped. For example:
-
-        >>> b = bytes([102, 111, 111, 10, 0])
-        >>> s = bytes_to_human_readable_repr(b)
-        >>> print(s)
-        foo\n\x00
-        >>> print(repr(s))
-        'foo\\n\\x00'
-    """
-    return repr(b)[2:-1]

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -47,10 +47,11 @@ from mypy.types import (
 from mypy import message_registry, errorcodes as codes
 from mypy.errors import Errors
 from mypy.fastparse import (
-    TypeConverter, parse_type_comment, bytes_to_human_readable_repr, parse_type_ignore_tag,
+    TypeConverter, parse_type_comment, parse_type_ignore_tag,
     TYPE_IGNORE_PATTERN, INVALID_TYPE_IGNORE
 )
 from mypy.options import Options
+from mypy.util import bytes_to_human_readable_repr
 from mypy.reachability import mark_block_unreachable
 
 try:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1035,8 +1035,10 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
         value = bytes_to_human_readable_repr(runtime)
     elif isinstance(runtime, enum.Enum):
         value = runtime.name
-    else:
+    elif isinstance(runtime, (int, str, bool)):
         value = runtime
+    else:
+        return fallback
 
     return mypy.types.LiteralType(value=value, fallback=fallback)
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -713,7 +713,6 @@ def verify_var(
         and not is_subtype_helper(runtime_type, stub.type)
     ):
         should_error = True
-        # TODO: is this still necessary
         # Avoid errors when defining enums, since runtime_type is the enum itself, but we'd
         # annotate it with the type of runtime.value
         if isinstance(runtime, enum.Enum):
@@ -1038,16 +1037,8 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
         value = runtime.name
     else:
         value = runtime
-    try:
-        # Literals are supposed to be only bool, int, str, bytes or enums, but this seems to work
-        # well (when not using mypyc, for which bytes and enums are also problematic).
-        return mypy.types.LiteralType(
-            value=value,
-            fallback=fallback,
-        )
-    except TypeError:
-        # Ask for forgiveness if we're using mypyc.
-        return fallback
+
+    return mypy.types.LiteralType(value=value, fallback=fallback)
 
 
 _all_stubs: Dict[str, nodes.MypyFile] = {}

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -942,15 +942,6 @@ def is_subtype_helper(left: mypy.types.Type, right: mypy.types.Type) -> bool:
     ):
         # Pretend Literal[0, 1] is a subtype of bool to avoid unhelpful errors.
         return True
-    if (
-        isinstance(left, mypy.types.LiteralType)
-        and isinstance(left.value, bytes)
-        and isinstance(right, mypy.types.LiteralType)
-        and isinstance(right.value, str)
-        and right.fallback.type.fullname == 'builtins.bytes'
-    ):
-        # This is a representation mismatch.
-        return bytes_to_human_readable_repr(left.value) == right.value
     with mypy.state.strict_optional_set(True):
         return mypy.subtypes.is_subtype(left, right)
 
@@ -1038,6 +1029,8 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
         return mypy.types.TupleType(items, fallback)
 
     fallback = mypy.types.Instance(type_info, [anytype() for _ in type_info.type_vars])
+    if isinstance(runtime, bytes):
+        runtime = bytes_to_human_readable_repr(runtime)
     try:
         # Literals are supposed to be only bool, int, str, bytes or enums, but this seems to work
         # well (when not using mypyc, for which bytes and enums are also problematic).

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1031,11 +1031,12 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
 
     fallback = mypy.types.Instance(type_info, [anytype() for _ in type_info.type_vars])
 
+    value: Union[bool, int, str]
     if isinstance(runtime, bytes):
         value = bytes_to_human_readable_repr(runtime)
     elif isinstance(runtime, enum.Enum):
         value = runtime.name
-    elif isinstance(runtime, (int, str, bool)):
+    elif isinstance(runtime, (bool, int, str)):
         value = runtime
     else:
         return fallback

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -750,6 +750,30 @@ class StubtestUnit(unittest.TestCase):
             error="X.__init__"
         )
 
+    @collect_cases
+    def test_literal(self) -> Iterator[Case]:
+        yield Case(
+            stub=r"""
+            from typing_extensions import Literal
+
+            NUM: Literal[1]
+            CHAR: Literal['a']
+            FLAG: Literal[True]
+            NON: Literal[None]
+            BYT1: Literal[b'abc']
+            BYT2: Literal[b'\x90']
+            """,
+            runtime=r"""
+            NUM = 1
+            CHAR = 'a'
+            NON = None
+            FLAG = True
+            BYT1 = b"abc"
+            BYT2 = b'\x90'
+            """,
+            error=None,
+        )
+
 
 def remove_color_code(s: str) -> str:
     return re.sub("\\x1b.*?m", "", s)  # this works!

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -751,7 +751,7 @@ class StubtestUnit(unittest.TestCase):
         )
 
     @collect_cases
-    def test_literal(self) -> Iterator[Case]:
+    def test_correct_literal(self) -> Iterator[Case]:
         yield Case(
             stub=r"""
             from typing_extensions import Literal
@@ -772,6 +772,88 @@ class StubtestUnit(unittest.TestCase):
             BYT2 = b'\x90'
             """,
             error=None,
+        )
+
+    @collect_cases
+    def test_invalid_int_float_literal(self) -> Iterator[Case]:
+        yield Case(
+            stub="""
+            from typing_extensions import Literal
+
+            WRONG_NUM: Literal[1]
+            """,
+            runtime='WRONG_NUM = 1.0',
+            error='WRONG_NUM',
+        )
+
+    @collect_cases
+    def test_invalid_int_literal(self) -> Iterator[Case]:
+        yield Case(
+            stub="""
+            from typing_extensions import Literal
+
+            WRONG_NUM: Literal[1]
+            """,
+            runtime='WRONG_NUM = 2',
+            error='WRONG_NUM',
+        )
+
+    @collect_cases
+    def test_invalid_str_literal(self) -> Iterator[Case]:
+        yield Case(
+            stub="""
+            from typing_extensions import Literal
+
+            WRONG_STR: Literal['a']
+            """,
+            runtime="WRONG_STR = 'b'",
+            error='WRONG_STR',
+        )
+
+    @collect_cases
+    def test_invalid_str_bytes_literal(self) -> Iterator[Case]:
+        yield Case(
+            stub="""
+            from typing_extensions import Literal
+
+            WRONG_STR1: Literal[b'a']
+            """,
+            runtime="WRONG_STR1 = 'a'",
+            error='WRONG_STR1',
+        )
+        yield Case(
+            stub="WRONG_STR2: Literal['b']",
+            runtime="WRONG_STR2 = b'b'",
+            error='WRONG_STR2',
+        )
+
+    @collect_cases
+    def test_invalid_bytes_literal(self) -> Iterator[Case]:
+        yield Case(
+            stub="""
+            from typing_extensions import Literal
+
+            WRONG_BYTES1: Literal[b'a']
+            """,
+            runtime="WRONG_BYTES1 = b'b'",
+            error='WRONG_BYTES1',
+        )
+
+    @collect_cases
+    def test_invalid_bool_literal(self) -> Iterator[Case]:
+        yield Case(
+            stub="""
+            from typing_extensions import Literal
+
+            WRONG_BOOL1: Literal[True]
+            """,
+            runtime="WRONG_BOOL1 = False",
+            error='WRONG_BOOL1',
+        )
+        yield Case(
+            stub="WRONG_BOOL2: Literal[False]",
+            runtime="WRONG_BOOL2 = True",
+            error='WRONG_BOOL2',
         )
 
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -751,10 +751,14 @@ class StubtestUnit(unittest.TestCase):
         )
 
     @collect_cases
-    def test_correct_literal(self) -> Iterator[Case]:
+    def test_good_literal(self) -> Iterator[Case]:
         yield Case(
             stub=r"""
             from typing_extensions import Literal
+
+            import enum
+            class Color(enum.Enum):
+                RED: int
 
             NUM: Literal[1]
             CHAR: Literal['a']
@@ -762,98 +766,66 @@ class StubtestUnit(unittest.TestCase):
             NON: Literal[None]
             BYT1: Literal[b'abc']
             BYT2: Literal[b'\x90']
+            ENUM: Literal[Color.RED]
             """,
             runtime=r"""
+            import enum
+            class Color(enum.Enum):
+                RED = 3
+
             NUM = 1
             CHAR = 'a'
             NON = None
             FLAG = True
             BYT1 = b"abc"
             BYT2 = b'\x90'
+            ENUM = Color.RED
             """,
             error=None,
         )
 
     @collect_cases
-    def test_invalid_int_float_literal(self) -> Iterator[Case]:
+    def test_bad_literal(self) -> Iterator[Case]:
+        yield Case("from typing_extensions import Literal", "", None)  # dummy case
         yield Case(
-            stub="""
-            from typing_extensions import Literal
-
-            WRONG_NUM: Literal[1]
-            """,
-            runtime='WRONG_NUM = 1.0',
-            error='WRONG_NUM',
+            stub="INT_FLOAT_MISMATCH: Literal[1]",
+            runtime="INT_FLOAT_MISMATCH = 1.0",
+            error="INT_FLOAT_MISMATCH",
         )
-
-    @collect_cases
-    def test_invalid_int_literal(self) -> Iterator[Case]:
         yield Case(
-            stub="""
-            from typing_extensions import Literal
-
-            WRONG_NUM: Literal[1]
-            """,
-            runtime='WRONG_NUM = 2',
-            error='WRONG_NUM',
+            stub="WRONG_INT: Literal[1]",
+            runtime="WRONG_INT = 2",
+            error="WRONG_INT",
         )
-
-    @collect_cases
-    def test_invalid_str_literal(self) -> Iterator[Case]:
         yield Case(
-            stub="""
-            from typing_extensions import Literal
-
-            WRONG_STR: Literal['a']
-            """,
+            stub="WRONG_STR: Literal['a']",
             runtime="WRONG_STR = 'b'",
-            error='WRONG_STR',
-        )
-
-    @collect_cases
-    def test_invalid_str_bytes_literal(self) -> Iterator[Case]:
-        yield Case(
-            stub="""
-            from typing_extensions import Literal
-
-            WRONG_STR1: Literal[b'a']
-            """,
-            runtime="WRONG_STR1 = 'a'",
-            error='WRONG_STR1',
+            error="WRONG_STR",
         )
         yield Case(
-            stub="WRONG_STR2: Literal['b']",
-            runtime="WRONG_STR2 = b'b'",
-            error='WRONG_STR2',
-        )
-
-    @collect_cases
-    def test_invalid_bytes_literal(self) -> Iterator[Case]:
-        yield Case(
-            stub="""
-            from typing_extensions import Literal
-
-            WRONG_BYTES1: Literal[b'a']
-            """,
-            runtime="WRONG_BYTES1 = b'b'",
-            error='WRONG_BYTES1',
-        )
-
-    @collect_cases
-    def test_invalid_bool_literal(self) -> Iterator[Case]:
-        yield Case(
-            stub="""
-            from typing_extensions import Literal
-
-            WRONG_BOOL1: Literal[True]
-            """,
-            runtime="WRONG_BOOL1 = False",
-            error='WRONG_BOOL1',
+            stub="BYTES_STR_MISMATCH: Literal[b'value']",
+            runtime="BYTES_STR_MISMATCH = 'value'",
+            error="BYTES_STR_MISMATCH",
         )
         yield Case(
-            stub="WRONG_BOOL2: Literal[False]",
-            runtime="WRONG_BOOL2 = True",
-            error='WRONG_BOOL2',
+            stub="STR_BYTES_MISMATCH: Literal['value']",
+            runtime="STR_BYTES_MISMATCH = b'value'",
+            error="STR_BYTES_MISMATCH",
+        )
+        yield Case(
+            stub="WRONG_BYTES: Literal[b'abc']",
+            runtime="WRONG_BYTES = b'xyz'",
+            error="WRONG_BYTES",
+        )
+        yield Case(
+            stub="WRONG_BOOL_1: Literal[True]",
+            runtime="WRONG_BOOL_1 = False",
+            error='WRONG_BOOL_1',
+        )
+        yield Case(
+            stub="WRONG_BOOL_2: Literal[False]",
+            runtime="WRONG_BOOL_2 = True",
+            error='WRONG_BOOL_2',
         )
 
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -105,6 +105,20 @@ def find_python_encoding(text: bytes, pyversion: Tuple[int, int]) -> Tuple[str, 
         return default_encoding, -1
 
 
+def bytes_to_human_readable_repr(b: bytes) -> str:
+    """Converts bytes into some human-readable representation. Unprintable
+    bytes such as the nul byte are escaped. For example:
+
+        >>> b = bytes([102, 111, 111, 10, 0])
+        >>> s = bytes_to_human_readable_repr(b)
+        >>> print(s)
+        foo\n\x00
+        >>> print(repr(s))
+        'foo\\n\\x00'
+    """
+    return repr(b)[2:-1]
+
+
 class DecodeError(Exception):
     """Exception raised when a file cannot be decoded due to an unknown encoding type.
 


### PR DESCRIPTION
I've started with a new unit test that illustrates the problem.

Closes https://github.com/python/typeshed/pull/6845