### PR TITLE
Restore removed builtin_type() api method

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -258,6 +258,12 @@ class SemanticAnalyzerPluginInterface:
         raise NotImplementedError
 
     @abstractmethod
+    def builtin_type(self, fully_qualified_name: str) -> Instance:
+        """Legacy function -- use named_type() instead."""
+        # NOTE: Do not delete this since many plugins may still use it.
+        raise NotImplementedError
+
+    @abstractmethod
     def named_type_or_none(self, fullname: str,
                            args: Optional[List[Type]] = None) -> Optional[Instance]:
         """Construct an instance of a type with given type arguments.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4567,6 +4567,10 @@ class SemanticAnalyzer(NodeVisitor[None],
             return Instance(node, args)
         return Instance(node, [AnyType(TypeOfAny.unannotated)] * len(node.defn.type_vars))
 
+    def builtin_type(self, fully_qualified_name: str) -> Instance:
+        """Legacy function -- use named_type() instead."""
+        return self.named_type(fully_qualified_name)
+
     def lookup_current_scope(self, name: str) -> Optional[SymbolTableNode]:
         if self.locals[-1] is not None:
             return self.locals[-1].get(name)


### PR DESCRIPTION
It shouldn't be used for new code, but adding it back makes it
unnecessary to update existing plugins that no longer worked with mypy
0.930.

Related issue: https://github.com/dropbox/sqlalchemy-stubs/issues/232