### PR TITLE
Expose modules attribute in CheckerPluginInterface

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -212,6 +212,7 @@ class CheckerPluginInterface:
     docstrings in checker.py for more details.
     """
 
+    modules: Dict[str, MypyFile]
     msg: MessageBuilder
     options: Options
     path: str

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -157,7 +157,7 @@ def add_method_to_class(
 
 
 def deserialize_and_fixup_type(
-    data: Union[str, JsonDict], api: SemanticAnalyzerPluginInterface
+    data: Union[str, JsonDict], api: Union[SemanticAnalyzerPluginInterface, CheckerPluginInterface]
 ) -> Type:
     typ = deserialize_type(data)
     typ.accept(TypeFixer(api.modules, allow_missing=False))


### PR DESCRIPTION
### Description

The `TypeChecker` class already has the same `modules` attribute as `SemanticAnalyzer`, but it's not exposed through the plugin interface. I need this to call `deserialize_and_fixup_type` with either interface. I've been using this with a type ignore comment in an experimental project of mine and it seems to be working.

## Test Plan

I'm not too familiar with Mypy's codebase, but let me know if you want me to add tests for this. The change seems small enough to me that it might not need any tests, as it's just exposing an already existing attribute.

There's no direct tests for `deserialize_and_fixup_type` either, but then again I haven't changed the runtime behaviour of that function either.
