### PR TITLE
Add no-overload-impl error code

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -657,6 +657,28 @@ consistently when using the call-based syntax. Example:
     # Error: First argument to namedtuple() should be "Point2D", not "Point"
     Point2D = NamedTuple("Point", [("x", int), ("y", int)])
 
+Check that overloaded functions have an implementation [no-overload-impl]
+-------------------------------------------------------------------------
+
+Overloaded functions outside of stub files must be followed by a non overloaded
+implementation.
+
+.. code-block:: python
+
+   from typing import overload
+
+   @overload
+   def func(value: int) -> int:
+       ...
+
+   @overload
+   def func(value: str) -> str:
+       ...
+
+   # presence of required function below is checked
+   def func(value):
+       <actual implementation>
+
 Report syntax errors [syntax]
 -----------------------------
 

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -677,7 +677,7 @@ implementation.
 
    # presence of required function below is checked
    def func(value):
-       <actual implementation>
+       pass  # actual implementation
 
 Report syntax errors [syntax]
 -----------------------------

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -133,6 +133,11 @@ TRUTHY_BOOL: Final[ErrorCode] = ErrorCode(
 NAME_MATCH: Final = ErrorCode(
     "name-match", "Check that type definition has consistent naming", "General"
 )
+NO_OVERLOAD_IMPL: Final = ErrorCode(
+    "no-overload-impl",
+    "Check that overloaded functions outside stub files have an implementation",
+    "General",
+)
 
 
 # Syntax errors are often blocking.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -878,7 +878,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             else:
                 self.fail(
                     "An overloaded function outside a stub file must have an implementation",
-                    defn)
+                    defn, code=codes.NO_OVERLOAD_IMPL)
 
     def process_final_in_overload(self, defn: OverloadedFuncDef) -> None:
         """Detect the @final status of an overloaded function (and perform checks)."""

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -898,6 +898,17 @@ if lst:
     pass
 [builtins fixtures/list.pyi]
 
+[case testNoOverloadImplementation]
+from typing import overload
+
+@overload  # E: An overloaded function outside a stub file must have an implementation  [no-overload-impl]
+def f(arg: int) -> int:
+    ...
+
+@overload
+def f(arg: str) -> str:
+    ...
+
 [case testSliceInDict39]
 # flags: --python-version 3.9 --show-column-numbers
 from typing import Dict


### PR DESCRIPTION
### Description

Adds a new `no-overload-impl` error code that is raised when overloaded functions outside of stub files are not followed by an implementation. 

## Test Plan

I validated the doc changes and all tests are passing locally. I did not find anywhere in the tests that the error code of specific failures is checked, but please let me know if I missed something.
