### PR TITLE
[docs] add more info to allow_redefinition

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -516,9 +516,6 @@ of the above sections.
     unrelated type. This flag enables redefinition of a variable with an
     arbitrary type *in some contexts*: only redefinitions within the
     same block and nesting depth as the original definition are allowed.
-
-    The expression for the new value must contain a reference to the variable.
-
     Example where this can be useful:
 
     .. code-block:: python
@@ -528,7 +525,15 @@ of the above sections.
            items = [item.split() for item in items]
            # 'items' now has type list[list[str]]
 
-           items = "mypy"  # invalid redefinition to str because the expression doesn't contain a reference to 'items'
+    The variable must be used before it can be redefined:
+
+    .. code-block:: python
+
+        def process(items: list[str]) -> None:
+           items = "mypy"  # invalid redefinition to str because the variable hasn't been used yet
+           print(items)
+           items = "100"  # valid, items not has type str
+           items = int(items)  # valid, items not has type int
 
 .. option:: --local-partial-types
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -516,6 +516,9 @@ of the above sections.
     unrelated type. This flag enables redefinition of a variable with an
     arbitrary type *in some contexts*: only redefinitions within the
     same block and nesting depth as the original definition are allowed.
+
+    The expression for the new value must contain a reference to the variable.
+
     Example where this can be useful:
 
     .. code-block:: python
@@ -524,7 +527,8 @@ of the above sections.
            # 'items' has type list[str]
            items = [item.split() for item in items]
            # 'items' now has type list[list[str]]
-           ...
+
+           items = "mypy"  # invalid redefinition to str because the expression doesn't contain a reference to 'items'
 
 .. option:: --local-partial-types
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -532,8 +532,8 @@ of the above sections.
         def process(items: list[str]) -> None:
            items = "mypy"  # invalid redefinition to str because the variable hasn't been used yet
            print(items)
-           items = "100"  # valid, items not has type str
-           items = int(items)  # valid, items not has type int
+           items = "100"  # valid, items now has type str
+           items = int(items)  # valid, items now has type int
 
 .. option:: --local-partial-types
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -613,8 +613,7 @@ section of the command line docs.
 
     Allows variables to be redefined with an arbitrary type, as long as the redefinition
     is in the same block and nesting level as the original definition.
-
-    The expression for the new value must contain a reference to the variable:
+    Example where this can be useful:
 
     .. code-block:: python
 
@@ -623,7 +622,15 @@ section of the command line docs.
            items = [item.split() for item in items]
            # 'items' now has type list[list[str]]
 
-           items = "mypy"  # invalid redefinition to str because the expression doesn't contain a reference to 'items'
+    The variable must be used before it can be redefined:
+
+    .. code-block:: python
+
+        def process(items: list[str]) -> None:
+           items = "mypy"  # invalid redefinition to str because the variable hasn't been used yet
+           print(items)
+           items = "100"  # valid, items not has type str
+           items = int(items)  # valid, items not has type int
 
 .. confval:: local_partial_types
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -614,6 +614,17 @@ section of the command line docs.
     Allows variables to be redefined with an arbitrary type, as long as the redefinition
     is in the same block and nesting level as the original definition.
 
+    The expression for the new value must contain a reference to the variable:
+
+    .. code-block:: python
+
+       def process(items: list[str]) -> None:
+           # 'items' has type list[str]
+           items = [item.split() for item in items]
+           # 'items' now has type list[list[str]]
+
+           items = "mypy"  # invalid redefinition to str because the expression doesn't contain a reference to 'items'
+
 .. confval:: local_partial_types
 
     :type: boolean

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -629,8 +629,8 @@ section of the command line docs.
         def process(items: list[str]) -> None:
            items = "mypy"  # invalid redefinition to str because the variable hasn't been used yet
            print(items)
-           items = "100"  # valid, items not has type str
-           items = int(items)  # valid, items not has type int
+           items = "100"  # valid, items now has type str
+           items = int(items)  # valid, items now has type int
 
 .. confval:: local_partial_types
 


### PR DESCRIPTION
I noticed the docs don't mention a rule of `allow_redefinition`