### PR TITLE
[docs] state that `reveal_locals()` only reveals inferred variables

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -507,7 +507,10 @@ understand how mypy handles a particular piece of code. Example:
    reveal_type((1, 'hello'))  # Revealed type is "Tuple[builtins.int, builtins.str]"
 
 You can also use ``reveal_locals()`` at any line in a file
-to see the types of all local variables at once. Example:
+to see the types of all local variables at once. ``reveal_locals()``
+will only list the names and types of inferred variables.
+
+Example:
 
 .. code-block:: python
 


### PR DESCRIPTION
Wouldn't it be funny if it was 'infrared' instead of 'inferred', that would would be funny I think.
