### PR TITLE
Fix #11971

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2871,7 +2871,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         outer = self.is_global_or_nonlocal(name)
         if kind == MDEF and isinstance(self.type, TypeInfo) and self.type.is_enum:
             # Special case: we need to be sure that `Enum` keys are unique.
-            if existing:
+            if existing is not None and not isinstance(existing.node, PlaceholderNode):
                 self.fail('Attempted to reuse member name "{}" in Enum definition "{}"'.format(
                     name, self.type.name,
                 ), lvalue)

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1457,17 +1457,6 @@ class Foo(Enum):
 x = 4
 [builtins fixtures/bool.pyi]
 
-[case testEnumValueWithPlaceholderNodeType]
-# https://github.com/python/mypy/issues/11971
-from enum import Enum
-from typing import Callable, Dict
-
-class Foo(Enum):
-    Bar: Foo = Callable[[str], None]  # E: Value of type "int" is not indexable
-    Baz: Foo = Callable[[Dict[str, "Missing"]], None]  # E: Value of type "int" is not indexable \
-                                                       # E: Name "Missing" is not defined
-[builtins fixtures/dict.pyi]
-
 [case testEnumImplicitlyFinalForSubclassing]
 from enum import Enum, IntEnum, Flag, IntFlag
 

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1457,6 +1457,17 @@ class Foo(Enum):
 x = 4
 [builtins fixtures/bool.pyi]
 
+[case testEnumValueWithPlaceholderNodeType]
+# https://github.com/python/mypy/issues/11971
+from enum import Enum
+from typing import Callable, Dict
+
+class Foo(Enum):
+    Bar: Foo = Callable[[str], None]  # E: Value of type "int" is not indexable
+    Baz: Foo = Callable[[Dict[str, "Missing"]], None]  # E: Value of type "int" is not indexable \
+                                                       # E: Name "Missing" is not defined
+[builtins fixtures/dict.pyi]
+
 [case testEnumImplicitlyFinalForSubclassing]
 from enum import Enum, IntEnum, Flag, IntFlag
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1573,3 +1573,15 @@ x: OrderedDict[str, str] = OrderedDict({})
 reveal_type(x)  # Revealed type is "collections.OrderedDict[builtins.str, builtins.int]"
 [out]
 _testTypingExtensionsOrderedDictAlias.py:3: note: Revealed type is "collections.OrderedDict[builtins.str, builtins.str]"
+
+[case testEnumValueWithPlaceholderNodeType]
+# https://github.com/python/mypy/issues/11971
+from enum import Enum
+from typing import Callable, Dict
+class Foo(Enum):
+    Bar: Foo = Callable[[str], None]
+    Baz: Foo = Callable[[Dict[str, "Missing"]], None]
+[out]
+_testEnumValueWithPlaceholderNodeType.py:5: error: Incompatible types in assignment (expression has type "object", variable has type "Foo")
+_testEnumValueWithPlaceholderNodeType.py:6: error: Incompatible types in assignment (expression has type "object", variable has type "Foo")
+_testEnumValueWithPlaceholderNodeType.py:6: error: Name "Missing" is not defined


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Allows `PlaceholderNode` objects before raising an error for the attempted
reuse of a member name inside an `Enum`.

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

As explained in #11971 I (unfortunately) was not yet able to find a minimal reproducing example for this.
I can verify that this fixes my scenario via which I encountered the bug, but this is obviously not sufficient.

If you have any ideas how we can reproduce this, I am happy to add a corresponding unittest.
