### PR TITLE
DOC: Fixes Intelligent indexing example

### DIFF
--- a/docs/source/literal_types.rst
+++ b/docs/source/literal_types.rst
@@ -186,13 +186,13 @@ corresponding to some particular index, we can use Literal types like so:
 
     # But what if we want the index to be a variable? Normally mypy won't
     # know exactly what the index is and so will return a less precise type:
-    int_index = 1
+    int_index = 0
     reveal_type(tup[int_index])  # Revealed type is "Union[str, float]"
 
     # But if we use either Literal types or a Final int, we can gain back
     # the precision we originally had:
-    lit_index: Literal[1] = 1
-    fin_index: Final = 1
+    lit_index: Literal[0] = 0
+    fin_index: Final = 0
     reveal_type(tup[lit_index])  # Revealed type is "str"
     reveal_type(tup[fin_index])  # Revealed type is "str"
 


### PR DESCRIPTION
### Description
The final two `reveal_type` calls [here](https://mypy.readthedocs.io/en/stable/literal_types.html#intelligent-indexing) appear to be incorrectly documented. (Index 1 holds a float, not a str)

![image](https://user-images.githubusercontent.com/39198770/149039817-385f8286-11fa-4a4b-9f2a-660015091028.png)

To verify the error, run mypy against [this gist](https://gist.github.com/ChrisKeefe/b95d4812f31c6f2517b750ed97e8f463) or copy-paste the code from the public docs. 

### Fix
Using the same index across all of these tuple examples feels more readable to me than changing the reported type in the comments, but I'm happy to switch it up if anyone disagrees.

## Test Plan

Docs build successfully: 
![image](https://user-images.githubusercontent.com/39198770/149040241-36d027ec-b87f-4769-8f10-1db7a7d3576c.png)
