### PR TITLE
[mypyc] Optimize __enter__/__exit__ paths for native case

### DIFF
--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -20,7 +20,7 @@ from mypyc.ir.ops import (
     Assign, Unreachable, RaiseStandardError, LoadErrorValue, BasicBlock, TupleGet, Value, Register,
     Branch, MethodCall, Op, NO_TRACEBACK_LINE_NO
 )
-from mypyc.ir.rtypes import RInstance, exc_rtuple
+from mypyc.ir.rtypes import RInstance, exc_rtuple, none_rprimitive
 from mypyc.primitives.generic_ops import py_delattr_op
 from mypyc.primitives.misc_ops import type_op, import_from_op
 from mypyc.primitives.exc_ops import (
@@ -582,7 +582,14 @@ def transform_with(builder: IRBuilder,
             args = [none, none, none]
 
         if is_native:
-            return builder.add(MethodCall(builder.read(mgr), "__exit__", args=args, line=line))
+            assert isinstance(mgr_v.type, RInstance)
+            return builder.gen_method_call(
+                builder.read(mgr),
+                "__exit__",
+                arg_values=args,
+                line=line, 
+                result_type=none_rprimitive,
+            )
         else:
             assert exit_ is not None
             return builder.py_call(builder.read(exit_),

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -416,7 +416,7 @@ L19:
 L20:
     return 1
 
-[case testWithNative]
+[case testWithNativeSimple]
 class DummyContext:
     def __enter__(self) -> None:
         pass

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -416,3 +416,108 @@ L19:
 L20:
     return 1
 
+[case testWithNative]
+class DummyContext:
+    def __enter__(self) -> None:
+        pass
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        pass
+
+def foo(x: DummyContext) -> None:
+    with x:
+        print('hello')
+[out]
+def DummyContext.__enter__(self):
+    self :: __main__.DummyContext
+L0:
+    return 1
+def DummyContext.__exit__(self, exc_type, exc_val, exc_tb):
+    self :: __main__.DummyContext
+    exc_type, exc_val, exc_tb :: object
+L0:
+    return 1
+def foo(x):
+    x :: __main__.DummyContext
+    r0 :: None
+    r1 :: bool
+    r2 :: str
+    r3 :: object
+    r4 :: str
+    r5, r6 :: object
+    r7, r8 :: tuple[object, object, object]
+    r9, r10, r11 :: object
+    r12 :: None
+    r13 :: object
+    r14 :: int32
+    r15 :: bit
+    r16 :: bool
+    r17 :: bit
+    r18, r19, r20 :: tuple[object, object, object]
+    r21 :: object
+    r22 :: None
+    r23 :: bit
+L0:
+    r0 = x.__enter__()
+    r1 = 1
+L1:
+L2:
+    r2 = 'hello'
+    r3 = builtins :: module
+    r4 = 'print'
+    r5 = CPyObject_GetAttr(r3, r4)
+    r6 = PyObject_CallFunctionObjArgs(r5, r2, 0)
+    goto L8
+L3: (handler for L2)
+    r7 = CPy_CatchError()
+    r1 = 0
+    r8 = CPy_GetExcInfo()
+    r9 = r8[0]
+    r10 = r8[1]
+    r11 = r8[2]
+    r12 = x.__exit__(r9, r10, r11)
+    r13 = box(None, r12)
+    r14 = PyObject_IsTrue(r13)
+    r15 = r14 >= 0 :: signed
+    r16 = truncate r14: int32 to builtins.bool
+    if r16 goto L5 else goto L4 :: bool
+L4:
+    CPy_Reraise()
+    unreachable
+L5:
+L6:
+    CPy_RestoreExcInfo(r7)
+    goto L8
+L7: (handler for L3, L4, L5)
+    CPy_RestoreExcInfo(r7)
+    r17 = CPy_KeepPropagating()
+    unreachable
+L8:
+L9:
+L10:
+    r18 = <error> :: tuple[object, object, object]
+    r19 = r18
+    goto L12
+L11: (handler for L1, L6, L7, L8)
+    r20 = CPy_CatchError()
+    r19 = r20
+L12:
+    if r1 goto L13 else goto L14 :: bool
+L13:
+    r21 = load_address _Py_NoneStruct
+    r22 = x.__exit__(r21, r21, r21)
+L14:
+    if is_error(r19) goto L16 else goto L15
+L15:
+    CPy_Reraise()
+    unreachable
+L16:
+    goto L20
+L17: (handler for L12, L13, L14, L15)
+    if is_error(r19) goto L19 else goto L18
+L18:
+    CPy_RestoreExcInfo(r19)
+L19:
+    r23 = CPy_KeepPropagating()
+    unreachable
+L20:
+    return 1

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -189,6 +189,23 @@ yooo? a
 exit! a exception!
 ((1,), 'exception!')
 
+[case testWithNative]
+class DummyContext:
+    def __init__(self) -> None:
+        self.x = 0
+
+    def __enter__(self) -> None:
+        self.x += 1
+
+    def __exit__(self, exc_type, exc_value, exc_tb) -> None:
+        self.x -= 1
+
+def test_basic() -> None:
+    context = DummyContext()
+    with context:
+        assert context.x == 1
+    assert context.x == 0
+
 [case testYieldNested]
 from typing import Callable, Generator
 

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -1155,3 +1155,33 @@ i = b"foo"
 
 def test_redefinition() -> None:
     assert i == b"foo"
+
+[case testWithNative]
+class DummyContext:
+    def __init__(self):
+        self.c = 0
+    def __enter__(self) -> None:
+        self.c += 1
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.c -= 1
+
+def test_dummy_context() -> None:
+    c = DummyContext()
+    with c:
+        assert c.c == 1
+    assert c.c == 0
+
+[case testWithNativeVarArgs]
+class DummyContext:
+    def __init__(self):
+        self.c = 0
+    def __enter__(self) -> None:
+        self.c += 1
+    def __exit__(self, *args: object) -> None:
+        self.c -= 1
+
+def test_dummy_context() -> None:
+    c = DummyContext()
+    with c:
+        assert c.c == 1
+    assert c.c == 0


### PR DESCRIPTION
### Description

Closes https://github.com/mypyc/mypyc/issues/904

Directly calls __enter__ and __exit__ handlers in the case that the context manager is implemented natively.

Unfortunately the implementation becomes a bit more complicated because there are two different places where we call __exit__ in different ways, and they both need to support the native and non-native cases.