### PR TITLE
Fix handling of NoReturn in Union

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -378,6 +378,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if isinstance(e.callee, MemberExpr) and e.callee.name == 'format':
             self.check_str_format_call(e)
         ret_type = get_proper_type(ret_type)
+        if isinstance(ret_type, UnionType):
+            ret_type = make_simplified_union(ret_type.items)
         if isinstance(ret_type, UninhabitedType) and not ret_type.ambiguous:
             self.chk.binder.unreachable()
         # Warn on calls to functions that always return None. The check

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -146,7 +146,7 @@ f('') # E: Argument 1 to "f" has incompatible type "str"; expected "Optional[int
 
 [case testUnionWithNoReturn]
 from typing import Union, NoReturn
-def f() -> Union[int, NoReturn]: return 1
+def f() -> Union[int, NoReturn]: ...
 reveal_type(f()) # N: Revealed type is "builtins.int"
 
 [case testUnionSimplificationGenericFunction]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -144,6 +144,11 @@ f(1)
 f(None)
 f('') # E: Argument 1 to "f" has incompatible type "str"; expected "Optional[int]"
 
+[case testUnionWithNoReturn]
+from typing import Union, NoReturn
+def f() -> Union[int, NoReturn]: return 1
+reveal_type(f()) # N: Revealed type is "builtins.int"
+
 [case testUnionSimplificationGenericFunction]
 from typing import TypeVar, Union, List
 T = TypeVar('T')


### PR DESCRIPTION
### Description

There are several discussions and comments describing the following problem (references can be found at the end of this post):


```python
def func() -> str | NoReturn:
    ...

func().lower()

```
At the moment the code results in: `"NoReturn" of "Union[str, NoReturn]" has no attribute "lower"`

`Union[int, NoReturn]` should be equivalent to `int`, because in case the function returns it must be `int`.

### Implementation

For every call expression apply `make_simplified_union`, which is already capable of transforming  `Union[int, NoReturn]` to `int`.

```
ret_type = self.check_call_expr_with_callee_type(...)
...
if isinstance(ret_type, UnionType):
    ret_type = make_simplified_union(ret_type.items)
```

## Test Plan

The following test case was added to verify the implementation is working as intended:

```
[case` testUnionWithNoReturn]
from typing import Union, NoReturn
def f() -> Union[int, NoReturn]: return 1
reveal_type(f()) # N: Revealed type is "builtins.int"
```
## References

* https://github.com/python/mypy/issues/11876
* https://github.com/python/typing/discussions/994#discussioncomment-1871267
* https://github.com/python/mypy/issues/4116#issuecomment-336616296)

