### PR TITLE
use explicit getattr instead of __dict__ values

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -8,7 +8,7 @@ import importlib
 import inspect
 import os.path
 import re
-from typing import List, Dict, Tuple, Optional, Mapping, Any, Set
+from typing import List, Dict, Tuple, Optional, Any, Set
 from types import ModuleType
 from typing_extensions import Final
 

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -322,11 +322,10 @@ def generate_c_type_stub(module: ModuleType,
     The result lines will be appended to 'output'. If necessary, any
     required names will be added to 'imports'.
     """
-    attributes: List[str] = list(obj.__dict__)
-    attributes.sort(key=method_name_sort_key)
-    items: List[Tuple[str, Any]] = [
-        (name, getattr(obj, name)) for name in attributes
-    ]
+    # typeshed gives obj.__dict__ the not quite correct type Dict[str, Any]
+    # (it could be a mappingproxy!), which makes mypyc mad, so obfuscate it.
+    obj_dict: Mapping[str, Any] = getattr(obj, "__dict__")  # noqa
+    items = sorted(obj_dict.items(), key=lambda x: method_name_sort_key(x[0]))
     methods: List[str] = []
     types: List[str] = []
     static_properties: List[str] = []
@@ -339,7 +338,7 @@ def generate_c_type_stub(module: ModuleType,
             if not is_skipped_attribute(attr):
                 if attr == '__new__':
                     # TODO: We should support __new__.
-                    if '__init__' in attributes:
+                    if '__init__' in obj_dict:
                         # Avoid duplicate functions if both are present.
                         # But is there any case where .__new__() has a
                         # better signature than __init__() ?

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -117,6 +117,7 @@ def is_c_method(obj: object) -> bool:
 
 def is_c_classmethod(obj: object) -> bool:
     return inspect.isbuiltin(obj) or type(obj).__name__ in ('classmethod',
+                                                            'staticmethod',
                                                             'classmethod_descriptor')
 
 
@@ -349,7 +350,9 @@ def generate_c_type_stub(module: ModuleType,
                     self_var = 'cls'
                 else:
                     self_var = 'self'
-                generate_c_function_stub(module, attr, value, methods, imports=imports,
+                
+                direct_value = getattr(obj, attr)
+                generate_c_function_stub(module, attr, direct_value, methods, imports=imports,
                                          self_var=self_var, sigs=sigs, class_name=class_name,
                                          class_sigs=class_sigs)
         elif is_c_property(value):

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -8,7 +8,7 @@ import importlib
 import inspect
 import os.path
 import re
-from typing import List, Dict, Tuple, Optional, Any, Set
+from typing import List, Dict, Tuple, Optional, Mapping, Any, Set
 from types import ModuleType
 from typing_extensions import Final
 

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -350,7 +350,7 @@ def generate_c_type_stub(module: ModuleType,
                     self_var = 'cls'
                 else:
                     self_var = 'self'
-                
+
                 direct_value = getattr(obj, attr)
                 generate_c_function_stub(module, attr, direct_value, methods, imports=imports,
                                          self_var=self_var, sigs=sigs, class_name=class_name,


### PR DESCRIPTION
### Description

This PR is addressing an issue where a classmethod defined with pybind11 is not correctly infered.

``` python
>>> f1 = MyClass.__dict__["class_method"]
>>> f1
<staticmethod(<built-in method fit of PyCapsule object at 0x7f24511c85a0>)>
>>> inspect.isbuiltin(f1)
False

>>> f2 = MyClass.class_method
>>> f2
<built-in method fit of PyCapsule object at 0x7f24511c85a0>
>>> inspect.isbuiltin(f2)
True
```

This lead to wrong function signatures to an extend that the classmethod / staticmethod was wrongly identified as an instance-method:


```
class MyClass:
    def fit(self, *args, **kwargs) -> Any: ...
```

This changes the c-class inspection to always get the attribute directly from the class and not from the __dict__ object.
Probably this should not differ in the first place, but this seems like an easy and safe fix to me.
