### PR TITLE
Infer type of class variables from base classes

### DIFF
--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1067,7 +1067,7 @@ class B(A):
     y = LOL
     z: Optional[str] = None
     b = True
-    bogus = None  # type: int
+    bogus = None  # type: Optional[int]
 [out]
 def A.lol(self):
     self :: __main__.A
@@ -1091,6 +1091,8 @@ def B.__mypyc_defaults_setup(__mypyc_self__):
     r5 :: bool
     r6 :: object
     r7, r8 :: bool
+    r9 :: object
+    r10 :: bool
 L0:
     __mypyc_self__.x = 20; r0 = is_error
     r1 = __main__.globals :: static
@@ -1101,6 +1103,8 @@ L0:
     r6 = box(None, 1)
     __mypyc_self__.z = r6; r7 = is_error
     __mypyc_self__.b = 1; r8 = is_error
+    r9 = box(None, 1)
+    __mypyc_self__.bogus = r9; r10 = is_error
     return 1
 
 [case testSubclassDictSpecalized]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4339,7 +4339,7 @@ class C(B):
     x = object()
 [out]
 main:4: error: Incompatible types in assignment (expression has type "str", base class "A" defined the type as "int")
-main:6: error: Incompatible types in assignment (expression has type "object", base class "B" defined the type as "str")
+main:6: error: Incompatible types in assignment (expression has type "object", variable has type "str")
 
 [case testClassOneErrorPerLine]
 class A:
@@ -7134,3 +7134,27 @@ class B(A):  # E: Final class __main__.B has abstract attributes "foo"
 [case testUndefinedBaseclassInNestedClass]
 class C:
     class C1(XX): pass  # E: Name "XX" is not defined
+
+[case testInheritClassVariableType]
+# flags: --python-version 3.7
+from __future__ import annotations
+class Base:
+  X: list[int] = []
+class Derived0(Base):
+  X = []
+class Derived1(Base):
+  X: list[str] = [] # E: Incompatible types in assignment (expression has type "List[str]", base class "Base" defined the type as "List[int]")
+class Derived2(Base):
+  X = ["a"] # E: List item 0 has incompatible type "str"; expected "int"
+[builtins fixtures/tuple.pyi]
+
+[case testInheritClassVariableTypeIncompatibility]
+# flags: --python-version 3.7
+from __future__ import annotations
+class A:
+    x: list[int]
+class B(A):
+    x: list[str] # E: Incompatible types in assignment (expression has type "List[str]", base class "A" defined the type as "List[int]")
+class C(B):
+    x = ["hi"]
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -524,7 +524,7 @@ class D(bytes):
 
 [case testFormatCallFormatTypesBytesNotPy2]
 # flags: --py2
-from typing import Union, TypeVar, NewType, Generic
+from typing import Union, TypeVar, NewType, Generic, Optional
 
 A = TypeVar('A', str, unicode)
 B = TypeVar('B', bound=str)
@@ -547,7 +547,7 @@ u'{}'.format(x)
 u'{}'.format(n)
 
 class C(Generic[B]):
-    x = None  # type: B
+    x = None  # type: Optional[B]
     def meth(self):
         # type: () -> None
         '{}'.format(self.x)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5205,7 +5205,7 @@ def test() -> None:
 [out]
 [out2]
 
-[case testCannotDetermineTypeFromOtherModule]
+[case testCanDetermineTypeFromOtherModule]
 
 import aa
 
@@ -5233,15 +5233,15 @@ class Base:
     def foo(self) -> int: ...
 
 class Sub(Base):
-    foo = desc(42)  # type: ignore
+    foo = desc(42)
 
 [builtins fixtures/property.pyi]
 [out]
-tmp/a.py:3: error: Cannot determine type of "foo"
-tmp/a.py:4: error: Cannot determine type of "foo"
+tmp/b.py:12: error: Too many arguments for "desc"
+tmp/b.py:12: error: Incompatible types in assignment (expression has type "desc", variable has type "int")
 [out2]
-tmp/a.py:3: error: Cannot determine type of "foo"
-tmp/a.py:4: error: Cannot determine type of "foo"
+tmp/b.py:12: error: Too many arguments for "desc"
+tmp/b.py:12: error: Incompatible types in assignment (expression has type "desc", variable has type "int")
 
 [case testRedefinitionClass]
 import b

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2575,7 +2575,7 @@ class A:
 class B(A):
     x = None
 
-reveal_type(B.x) # N: Revealed type is "None"
+reveal_type(B.x) # N: Revealed type is "Union[builtins.str, None]"
 
 [case testLocalPartialTypesWithInheritance2]
 # flags: --local-partial-types --strict-optional
@@ -2583,7 +2583,7 @@ class A:
     x: str
 
 class B(A):
-    x = None  # E: Incompatible types in assignment (expression has type "None", base class "A" defined the type as "str")
+    x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "str")
 
 [case testLocalPartialTypesWithAnyBaseClass]
 # flags: --local-partial-types --strict-optional
@@ -2611,8 +2611,8 @@ class C(B):
     x = None
 
 # TODO: Inferring None below is unsafe (https://github.com/python/mypy/issues/3208)
-reveal_type(B.x)  # N: Revealed type is "None"
-reveal_type(C.x)  # N: Revealed type is "None"
+reveal_type(B.x)  # N: Revealed type is "Union[builtins.str, None]"
+reveal_type(C.x)  # N: Revealed type is "Union[builtins.str, None]"
 
 [case testLocalPartialTypesWithInheritance3]
 # flags: --local-partial-types
@@ -2628,7 +2628,7 @@ class B(A):
     x = None
     x = Y()
 
-reveal_type(B.x) # N: Revealed type is "Union[__main__.Y, None]"
+reveal_type(B.x) # N: Revealed type is "Union[__main__.X, None]"
 
 [case testLocalPartialTypesBinderSpecialCase]
 # flags: --local-partial-types
@@ -2813,8 +2813,8 @@ class C(A):
     x = ['12']
 
 reveal_type(A.x) # N: Revealed type is "builtins.list[Any]"
-reveal_type(B.x) # N: Revealed type is "builtins.list[builtins.int]"
-reveal_type(C.x) # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type(B.x) # N: Revealed type is "builtins.list[Any]"
+reveal_type(C.x) # N: Revealed type is "builtins.list[Any]"
 
 [builtins fixtures/list.pyi]
 
@@ -2920,7 +2920,7 @@ class A:
 
 class B(A):
     x = None
-    x = 2  # E: Incompatible types in assignment (expression has type "int", base class "A" defined the type as "str")
+    x = 2  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testInheritedAttributeStrictOptional]
 # flags: --strict-optional
@@ -2928,7 +2928,7 @@ class A:
     x: str
 
 class B(A):
-    x = None  # E: Incompatible types in assignment (expression has type "None", base class "A" defined the type as "str")
+    x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "str")
     x = ''
 
 [case testNeedAnnotationForCallable]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -215,14 +215,14 @@ x()  # E: "Dict[str, int]" not callable
 [case testNoneClassVariable]
 from typing import Optional
 class C:
-    x = None  # type: int
+    x = None  # type: Optional[int]
     def __init__(self) -> None:
         self.x = 0
 
 [case testNoneClassVariableInInit]
 from typing import Optional
 class C:
-    x = None  # type: int
+    x = 0  # type: int
     def __init__(self) -> None:
         self.x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
 [out]
@@ -230,7 +230,7 @@ class C:
 [case testMultipleAssignmentNoneClassVariableInInit]
 from typing import Optional
 class C:
-    x, y = None, None  # type: int, str
+    x, y = 0, ""  # type: int, str
     def __init__(self) -> None:
         self.x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
         self.y = None  # E: Incompatible types in assignment (expression has type "None", variable has type "str")

--- a/test-data/unit/deps-types.test
+++ b/test-data/unit/deps-types.test
@@ -279,8 +279,9 @@ def f(arg):
     # type: (Type[C]) -> None
     arg.x
 [file mod.py]
+from typing import Optional
 class M(type):
-    x = None  # type: int
+    x = None  # type: Optional[int]
 class C:
     __metaclass__ = M
 [out]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2962,20 +2962,24 @@ import submod
 class C:
     __metaclass__ = submod.M
 [file submod.py]
+from typing import Optional
 class M(type):
-    x = None  # type: int
+    x = None  # type: Optional[int]
 [file submod.py.2]
+from typing import Optional
 class M(type):
-    x = None  # type: str
+    x = None  # type: Optional[str]
 [file submod.py.3]
+from typing import Optional
 class M(type):
-    y = None  # type: str
+    y = None  # type: Optional[str]
 [file submod.py.4]
+from typing import Optional
 class M(type):
-    x = None  # type: int
+    x = None  # type: Optional[int]
 [out]
 ==
-a.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+a.py:4: error: Incompatible types in assignment (expression has type "int", variable has type "Optional[str]")
 ==
 a.py:4: error: "Type[C]" has no attribute "x"
 ==
@@ -3686,7 +3690,7 @@ class BaseS:
     x: str
 [out]
 ==
-b.py:3: error: Incompatible types in assignment (expression has type "int", base class "BaseS" defined the type as "str")
+b.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAliasFineGenericMod]
 import b


### PR DESCRIPTION
This sets the type of class variables to their types from the superclass (if not set). It unfortunately makes some error messages a bit worse, but I think fixing that properly requires adding a "where did this type come from? inferred/type annotation/type comment/etc." field to `Type`, and that would be a much bigger change.

I also had to delete some suspicious special case code that treated actual type annotations and `# type: ` comments differently for `None`.

Note *this does not pass all tests*. I started modifying them so they would pass, so you can see the effect this has on the output. However it changes quite a lot so I thought it would make more sense to check this is along the right lines before finishing.

### Description

Attempt to fix #10375

## Test Plan

Simple tests added in `check-classes.test`