### PR TITLE
Forbid extra `ParamSpec` arguments

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3297,9 +3297,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         # So, we need to warn users about possible invalid usage.
         if len(call.args) > 1:
             self.fail(
-                "ParamSpec accepts only a single argument, {} given".format(
-                    len(call.args),
-                ),
+                "Only the first argument to ParamSpec has defined semantics",
                 s,
             )
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3292,6 +3292,17 @@ class SemanticAnalyzer(NodeVisitor[None],
         if not self.check_typevarlike_name(call, name, s):
             return False
 
+        # ParamSpec is different from a regular TypeVar:
+        # arguments are not semantically valid. But, allowed in runtime.
+        # So, we need to warn users about possible invalid usage.
+        if len(call.args) > 1:
+            self.fail(
+                "ParamSpec accepts only a single argument, {} given".format(
+                    len(call.args),
+                ),
+                s,
+            )
+
         # PEP 612 reserves the right to define bound, covariant and contravariant arguments to
         # ParamSpec in a later PEP. If and when that happens, we should do something
         # on the lines of process_typevar_parameters

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -3,6 +3,16 @@ from typing_extensions import ParamSpec
 P = ParamSpec('P')
 [builtins fixtures/tuple.pyi]
 
+[case testInvalidParamSpecDefinitions]
+from typing import ParamSpec
+
+P1 = ParamSpec("P1", covariant=True)  # E: ParamSpec accepts only a single argument, 2 given
+P2 = ParamSpec("P2", contravariant=True)  # E: ParamSpec accepts only a single argument, 2 given
+P3 = ParamSpec("P3", bound=int)  # E: ParamSpec accepts only a single argument, 2 given
+P4 = ParamSpec("P4", int, str)  # E: ParamSpec accepts only a single argument, 3 given
+P5 = ParamSpec("P5", covariant=True, bound=int)  # E: ParamSpec accepts only a single argument, 3 given
+[builtins fixtures/tuple.pyi]
+
 [case testParamSpecLocations]
 from typing import Callable, List
 from typing_extensions import ParamSpec, Concatenate

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -6,11 +6,11 @@ P = ParamSpec('P')
 [case testInvalidParamSpecDefinitions]
 from typing import ParamSpec
 
-P1 = ParamSpec("P1", covariant=True)  # E: ParamSpec accepts only a single argument, 2 given
-P2 = ParamSpec("P2", contravariant=True)  # E: ParamSpec accepts only a single argument, 2 given
-P3 = ParamSpec("P3", bound=int)  # E: ParamSpec accepts only a single argument, 2 given
-P4 = ParamSpec("P4", int, str)  # E: ParamSpec accepts only a single argument, 3 given
-P5 = ParamSpec("P5", covariant=True, bound=int)  # E: ParamSpec accepts only a single argument, 3 given
+P1 = ParamSpec("P1", covariant=True)  # E: Only the first argument to ParamSpec has defined semantics
+P2 = ParamSpec("P2", contravariant=True)  # E: Only the first argument to ParamSpec has defined semantics
+P3 = ParamSpec("P3", bound=int)  # E: Only the first argument to ParamSpec has defined semantics
+P4 = ParamSpec("P4", int, str)  # E: Only the first argument to ParamSpec has defined semantics
+P5 = ParamSpec("P5", covariant=True, bound=int)  # E: Only the first argument to ParamSpec has defined semantics
 [builtins fixtures/tuple.pyi]
 
 [case testParamSpecLocations]


### PR DESCRIPTION
I've decided to add a note to users that other arguments to `ParamSpec` are not supported.
Because right now they are allowed. But, they do not make any sense.

See https://github.com/python/typing/issues/1027