### PR TITLE
Check `Enum` definition for invalid base classes

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1837,6 +1837,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             for base in defn.info.mro[1:-1]:  # we don't need self and `object`
                 if base.is_enum and base.fullname not in ENUM_BASES:
                     self.check_final_enum(defn, base)
+            self.check_enum_bases(defn)
 
     def check_final_deletable(self, typ: TypeInfo) -> None:
         # These checks are only for mypyc. Only perform some checks that are easier
@@ -1930,6 +1931,37 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if self.is_stub or sym.node.has_explicit_value:
             return True
         return False
+
+    def check_enum_bases(self, defn: ClassDef) -> None:
+        enum_base = None
+        data_base = None
+        for base in defn.info.bases:
+            if enum_base is None and base.type.fullname in ENUM_BASES:
+                enum_base = base
+                continue
+            elif enum_base is not None:
+                self.fail(
+                    'No base classes are allowed after "{}"'.format(enum_base),
+                    defn,
+                )
+                break
+
+            # This might not be 100% correct, because runtime `__new__`
+            # and `__new__` from `typeshed` are sometimes different,
+            # but it is good enough.
+            new_method = base.type.get('__new__')
+            if (data_base is None
+                    and enum_base is None  # data type is always before `Enum`
+                    and new_method
+                    and new_method.node.fullname != 'builtins.object.__new__'):
+                data_base = base
+                continue
+            elif data_base is not None:
+                self.fail(
+                    'Only a single data type mixin is allowed for Enum subtypes, '
+                    'found extra "{}"'.format(base),
+                    defn,
+                )
 
     def check_protocol_variance(self, defn: ClassDef) -> None:
         """Check that protocol definition is compatible with declared

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1953,6 +1953,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if (data_base is None
                     and enum_base is None  # data type is always before `Enum`
                     and new_method
+                    and new_method.node
                     and new_method.node.fullname != 'builtins.object.__new__'):
                 data_base = base
                 continue

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1933,8 +1933,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         return False
 
     def check_enum_bases(self, defn: ClassDef) -> None:
-        enum_base = None
-        data_base = None
+        enum_base: Optional[Instance] = None
+        data_base: Optional[Instance] = None
         for base in defn.info.bases:
             if enum_base is None and base.type.fullname in ENUM_BASES:
                 enum_base = base

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1868,3 +1868,62 @@ class WithOverload(enum.IntEnum):
 class SubWithOverload(WithOverload):  # Should pass
     pass
 [builtins fixtures/tuple.pyi]
+
+[case testEnumBaseClassesOrder]
+import enum
+
+# Base types:
+
+class First:
+    def __new__(cls, val):
+        pass
+
+class Second:
+    def __new__(cls, val):
+        pass
+
+class Third:
+    def __new__(cls, val):
+        pass
+
+class Mixin:
+    pass
+
+# Correct Enums:
+
+class Correct1(Mixin, First, enum.Enum):
+    pass
+
+class Correct2(First, enum.Enum):
+    pass
+
+class Correct3(Mixin, enum.Enum):
+    pass
+
+class RegularClass(Mixin, First, Second):
+    pass
+
+# Wrong Enums:
+
+class MixinAfterEnum1(enum.Enum, Mixin):  # E: No base classes are allowed after "enum.Enum"
+    pass
+
+class MixinAfterEnum2(First, enum.Enum, Mixin):  # E: No base classes are allowed after "enum.Enum"
+    pass
+
+class TwoDataTypes(First, Second, enum.Enum):  # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Second"
+    pass
+
+class TwoDataTypesAndIntEnumMixin(First, Second, enum.IntEnum, Mixin):  # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Second" \
+                                                                        # E: No base classes are allowed after "enum.IntEnum"
+    pass
+
+class ThreeDataTypes(First, Second, Third, enum.Enum):  # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Second" \
+                                                        # E: # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Third"
+    pass
+
+class ThreeDataTypesAndMixin(First, Second, Third, enum.Enum, Mixin): # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Second" \
+                                                        # E: # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Third" \
+                                                        # E: No base classes are allowed after "enum.Enum"
+    pass
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1926,4 +1926,10 @@ class ThreeDataTypesAndMixin(First, Second, Third, enum.Enum, Mixin): # E: Only 
                                                         # E: # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Third" \
                                                         # E: No base classes are allowed after "enum.Enum"
     pass
+
+class FromEnumAndOther1(Correct2, Second, enum.Enum):  # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Second"
+    pass
+
+class FromEnumAndOther2(Correct2, Second):  # E: Only a single data type mixin is allowed for Enum subtypes, found extra "__main__.Second"
+    pass
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Checks in Python's source:
- No classes after `Enum` base: https://github.com/python/cpython/blob/d05a66339b5e07d72d96e4c30a34cc3821bb61a2/Lib/enum.py#L971-L974
- Only a single data type: https://github.com/python/cpython/blob/d05a66339b5e07d72d96e4c30a34cc3821bb61a2/Lib/enum.py#L1011-L1012

Closes https://github.com/python/mypy/issues/11948