### PR TITLE
Fix crash involving explicit any flag and Required

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -360,6 +360,9 @@ class RequiredType(Type):
         else:
             return "NotRequired[{}]".format(self.item)
 
+    def accept(self, visitor: 'TypeVisitor[T]') -> T:
+        return self.item.accept(visitor)
+
 
 class ProperType(Type):
     """Not a type alias.

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2208,6 +2208,12 @@ class Movie(TypedDict, total=False):
     year: int
 [typing fixtures/typing-typeddict.pyi]
 
+[case testRequiredExplicitAny]
+# flags: --disallow-any-explicit
+from typing import TypedDict
+from typing import Required
+Foo = TypedDict("Foo", {"a.x": Required[int]})
+[typing fixtures/typing-typeddict.pyi]
 
 -- NotRequired[]
 
@@ -2269,6 +2275,13 @@ from typing import NotRequired
 class Movie(TypedDict):
     title: NotRequired[str, bytes]  # E: NotRequired[] must have exactly one type argument
     year: int
+[typing fixtures/typing-typeddict.pyi]
+
+[case testNotRequiredExplicitAny]
+# flags: --disallow-any-explicit
+from typing import TypedDict
+from typing import NotRequired
+Foo = TypedDict("Foo", {"a.x": NotRequired[int]})
 [typing fixtures/typing-typeddict.pyi]
 
 -- Union dunders

--- a/test-data/unit/fixtures/typing-typeddict.pyi
+++ b/test-data/unit/fixtures/typing-typeddict.pyi
@@ -43,7 +43,8 @@ class Iterator(Iterable[T_co], Protocol):
     def __next__(self) -> T_co: pass
 
 class Sequence(Iterable[T_co]):
-    def __getitem__(self, n: Any) -> T_co: pass # type: ignore
+    # misc is for explicit Any.
+    def __getitem__(self, n: Any) -> T_co: pass # type: ignore[misc]
 
 class Mapping(Iterable[T], Generic[T, T_co], metaclass=ABCMeta):
     def __getitem__(self, key: T) -> T_co: pass

--- a/test-data/unit/fixtures/typing-typeddict.pyi
+++ b/test-data/unit/fixtures/typing-typeddict.pyi
@@ -43,7 +43,7 @@ class Iterator(Iterable[T_co], Protocol):
     def __next__(self) -> T_co: pass
 
 class Sequence(Iterable[T_co]):
-    def __getitem__(self, n: Any) -> T_co: pass
+    def __getitem__(self, n: Any) -> T_co: pass # type: ignore
 
 class Mapping(Iterable[T], Generic[T, T_co], metaclass=ABCMeta):
     def __getitem__(self, key: T) -> T_co: pass


### PR DESCRIPTION
### Description

Fixes #12038. This adds an accept method to Required that delegates to the inner type. @davidfstr 

## Test Plan

I ran the tests locally and they passed. I added two small test cases to check-typeddict.test that correspond to fixed crash.