### PR TITLE
Improve consistency of NoReturn

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -378,8 +378,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if isinstance(e.callee, MemberExpr) and e.callee.name == 'format':
             self.check_str_format_call(e)
         ret_type = get_proper_type(ret_type)
-        if isinstance(ret_type, UnionType):
-            ret_type = make_simplified_union(ret_type.items)
         if isinstance(ret_type, UninhabitedType) and not ret_type.ambiguous:
             self.chk.binder.unreachable()
         # Warn on calls to functions that always return None. The check

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -480,6 +480,12 @@ class TypeOpsSuite(Suite):
         self.assert_simplified_union([fx.lit1, fx.lit2_inst], UnionType([fx.lit1, fx.lit2_inst]))
         self.assert_simplified_union([fx.lit1, fx.lit3_inst], UnionType([fx.lit1, fx.lit3_inst]))
 
+        self.assert_simplified_union([fx.noreturn], fx.noreturn)
+        self.assert_simplified_union([fx.noreturn, fx.noreturn], fx.noreturn)
+        self.assert_simplified_union([fx.a, fx.noreturn], UnionType([fx.a, fx.noreturn]))
+        self.assert_simplified_union([fx.lit1_inst, fx.noreturn],
+                                     UnionType([fx.lit1_inst, fx.noreturn]))
+
     def assert_simplified_union(self, original: List[Type], union: Type) -> None:
         assert_equal(make_simplified_union(original), union)
         assert_equal(make_simplified_union(list(reversed(original))), union)

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -46,6 +46,7 @@ class TypeFixture:
         self.anyt = AnyType(TypeOfAny.special_form)
         self.nonet = NoneType()
         self.uninhabited = UninhabitedType()
+        self.noreturn = UninhabitedType(is_noreturn=True)
 
         # Abstract class TypeInfos
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -385,7 +385,7 @@ from mypy_extensions import NoReturn
 def no_return() -> NoReturn: pass
 def f() -> int:
   return 0
-reveal_type(f() or no_return())  # N: Revealed type is "builtins.int"
+reveal_type(f() or no_return())  # N: Revealed type is "Union[builtins.int]"
 [builtins fixtures/dict.pyi]
 
 [case testNoReturnVariable]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -146,8 +146,29 @@ f('') # E: Argument 1 to "f" has incompatible type "str"; expected "Optional[int
 
 [case testUnionWithNoReturn]
 from typing import Union, NoReturn
-def f() -> Union[int, NoReturn]: ...
-reveal_type(f()) # N: Revealed type is "builtins.int"
+
+def func() -> Union[int, NoReturn]: ...
+reveal_type(func()) # N: Revealed type is "Union[builtins.int]"
+
+a: Union[NoReturn]
+reveal_type(a) # N: Revealed type is "<nothing>"
+
+b: Union[NoReturn, NoReturn]
+reveal_type(b) # N: Revealed type is "Union[<nothing>]"
+
+c: Union[str, NoReturn]
+reveal_type(c) # N: Revealed type is "Union[builtins.str]"
+
+A = Union[str, NoReturn]
+d: A
+reveal_type(d) # N: Revealed type is "Union[builtins.str]"
+
+e: Union[str, Union[NoReturn, int]]
+reveal_type(e) # N: Revealed type is "Union[builtins.str, builtins.int]"
+
+B = Union[str, int]
+f: Union[NoReturn, B]
+reveal_type(f) # N: Revealed type is "Union[Union[builtins.str, builtins.int]]"
 
 [case testUnionSimplificationGenericFunction]
 from typing import TypeVar, Union, List


### PR DESCRIPTION
## Motivation

Follow-up pull request for https://github.com/python/mypy/pull/11996, implementing proposals from @JukkaL.

The mentioned PR used `make_simplified_union` to enable the following behavior:

```
from typing import Union, NoReturn
def f() -> Union[int, NoReturn]: ...
reveal_type(f()) # N: Revealed type is "builtins.int"
```

However, there are two problems with it:

1. This does not solve the problem in general:
```
from typing import Union, NoReturn
x: Union[str, NoReturn]
x + 's'  # Unsupported left operand type for + ("NoReturn")
```
2. The outcome of the type checker should not change depending on whether a `Union` was simplified or not.

## Implementation

1. Undo the changes made in https://github.com/python/mypy/pull/11996. This will lead to a regression because of a bug in the format checking, that is "hidden" by the call of `make_simplified_union` (I am planning to work on this bug afterwards):

```
spark (https://github.com/apache/spark)
+ python/pyspark/pandas/series.py:4246: error: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior  [str-bytes-safe]
```

We could also keep it, to avoid this minor regression (the fix was never released so actually there is no regression).

2. Remove `NoReturn` types during the construction (after running `flatten_nested_unions`). For code readability reasons I decided to introduce another method `reduce_proper_noreturn_types` to perform this job (instead of doing the operation in `flatten_nested_unions`).

3. In order to fulfill the invariant for non changing semantic for `make_simplified_union`, the method was changed in order to ignore `NoReturn` types (except for reducing `Union[NoReturn]` to `NoReturn`. In fact, this check is kind of useless, at the moment, because `NoReturns` were already removed during the `Union` construction. However, it might help with consistency (for future code changes).

## Limitations

The implementation cannot handle type aliases:

```
Never = NoReturn
v: Union[Never, int]
reveal_type(v) # N: Revealed type is "Union[<nothing>, int]"
```

The problem is that `Unions` are created before type aliases are fully expanded. 

However, we can get the expected behavior with the following horribly "hacky" code. Are there any idea how to solve this elegantly?

```
def is_noreturn_type(t: Type) -> bool:
    try:
        t = get_proper_type(t)
    except:
        pass
    return isinstance(t, UninhabitedType) and t.is_noreturn
```

## Test Plan

1. Extend `[case testUnionWithNoReturn]` to include more checks
2. Add `NoReturn` checks into `test_simplified_union`.

## mypy_primer
Reverse of https://github.com/python/mypy/pull/11996.

