### PR TITLE
Fix format checking for Unions with alias with custom format

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -20,7 +20,7 @@ from typing_extensions import Final, TYPE_CHECKING, TypeAlias as _TypeAlias
 from mypy.types import (
     Type, AnyType, TupleType, Instance, UnionType, TypeOfAny, get_proper_type,
     TypeVarType,
-    LiteralType, get_proper_types, flatten_nested_unions
+    LiteralType, flatten_nested_unions
 )
 from mypy.nodes import (
     StrExpr, BytesExpr, UnicodeExpr, TupleExpr, DictExpr, Context, Expression, StarExpr, CallExpr,

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -18,8 +18,9 @@ from typing import (
 from typing_extensions import Final, TYPE_CHECKING, TypeAlias as _TypeAlias
 
 from mypy.types import (
-    Type, AnyType, TupleType, Instance, UnionType, TypeOfAny, get_proper_type, TypeVarType,
-    LiteralType, get_proper_types
+    Type, AnyType, TupleType, Instance, UnionType, TypeOfAny, get_proper_type,
+    TypeVarType,
+    LiteralType, get_proper_types, flatten_nested_unions
 )
 from mypy.nodes import (
     StrExpr, BytesExpr, UnicodeExpr, TupleExpr, DictExpr, Context, Expression, StarExpr, CallExpr,
@@ -353,9 +354,11 @@ class StringFormatterChecker:
             if expected_type is None:
                 continue
 
-            a_type = get_proper_type(actual_type)
-            actual_items = (get_proper_types(a_type.items) if isinstance(a_type, UnionType)
-                            else [a_type])
+            p_type = get_proper_type(actual_type)
+            if isinstance(p_type, UnionType):
+                actual_items = flatten_nested_unions(p_type.items, handle_type_alias_type=True)
+            else:
+                actual_items = [p_type]
             for a_type in actual_items:
                 if custom_special_method(a_type, '__format__'):
                     continue

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -522,6 +522,19 @@ class D(bytes):
 '{}'.format(D())
 [builtins fixtures/primitives.pyi]
 
+[case testFormatCallFormatTypesUnionAliasWithCustomFormat]
+from typing import Union
+
+class Date:
+    def __format__(self, spec: str) -> str: ...
+
+S = Union[str, bytes, Date]
+s: Union[int, S]
+
+'{}'.format(s)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+f'{s}'  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+[builtins fixtures/primitives.pyi]
+
 [case testFormatCallFormatTypesBytesNotPy2]
 # flags: --py2
 from typing import Union, TypeVar, NewType, Generic


### PR DESCRIPTION
## Motivation

This fix was motivated by the `mypy_primer` output for https://github.com/apache/spark/ in https://github.com/python/mypy/pull/11996.

Consider the following code:

```
Scalar = Union[
    int, float, bool, str, bytes, decimal.Decimal, datetime.date, datetime.datetime, None
]

x: Union[Scalar, "Series"]

'{}'.format(x)  
```

should lead to 

```
On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
```

## Implementation

Ensure that the `Union` is flattened including type aliases before performing the follow checks (for the items):

```
for a_type in actual_items:
    if custom_special_method(a_type, '__format__'):
        continue
     self.check_placeholder_type(a_type, expected_type, call)
     self.perform_special_format_checks(spec, call, repl, a_type, expected_type)
```

## Test Plan

Add `[case testFormatCallFormatTypesUnionAliasWithCustomFormat]`