### PR TITLE
Fix

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -593,7 +593,12 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             if len(t.args) != 1:
                 self.fail("TypeGuard must have exactly one type argument", t)
                 return AnyType(TypeOfAny.from_error)
-            return self.anal_type(t.args[0])
+            typ = self.anal_type(t.args[0])
+            if _explicit_any_rule_enabled(self.options, self.is_typeshed_stub) \
+                    and has_explicit_any(typ):
+                self.fail('Explicit "Any" is not allowed', t)
+            return typ
+
         return None
 
     def anal_star_arg_type(self, t: Type, kind: ArgKind, nested: bool) -> Type:
@@ -1301,13 +1306,16 @@ class TypeVarLikeQuery(TypeQuery[TypeVarLikeList]):
             return []
 
 
+def _explicit_any_rule_enabled(options: Options, is_typeshed_stub: bool) -> bool:
+    return options.disallow_any_explicit and not is_typeshed_stub
+
+
 def check_for_explicit_any(typ: Optional[Type],
                            options: Options,
                            is_typeshed_stub: bool,
                            msg: MessageBuilder,
                            context: Context) -> None:
-    if (options.disallow_any_explicit and
-            not is_typeshed_stub and
+    if (_explicit_any_rule_enabled(options, is_typeshed_stub) and
             typ and
             has_explicit_any(typ)):
         msg.explicit_any(context)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -360,6 +360,9 @@ class RequiredType(Type):
         else:
             return "NotRequired[{}]".format(self.item)
 
+    def accept(self, visitor: 'TypeVisitor[T]') -> T:
+        return self.item.accept(visitor)
+
 
 class ProperType(Type):
     """Not a type alias.

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2,7 +2,7 @@
 
 import copy
 import sys
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from typing import (
     Any, TypeVar, Dict, List, Tuple, cast, Set, Optional, Union, Iterable, NamedTuple,
@@ -171,7 +171,7 @@ def deserialize_type(data: Union[JsonDict, str]) -> 'Type':
     raise NotImplementedError('unexpected .class {}'.format(classname))
 
 
-class Type(mypy.nodes.Context):
+class Type(mypy.nodes.Context, ABC):
     """Abstract base class for all types."""
 
     __slots__ = ('can_be_true', 'can_be_false')
@@ -196,6 +196,7 @@ class Type(mypy.nodes.Context):
     def can_be_false_default(self) -> bool:
         return True
 
+    @abstractmethod
     def accept(self, visitor: 'TypeVisitor[T]') -> T:
         raise RuntimeError('Not implemented')
 
@@ -341,6 +342,9 @@ class TypeGuardedType(Type):
     def __init__(self, type_guard: Type):
         super().__init__(line=type_guard.line, column=type_guard.column)
         self.type_guard = type_guard
+
+    def accept(self, visitor: 'TypeVisitor[T]') -> T:
+        return self.type_guard.accept(visitor)
 
     def __repr__(self) -> str:
         return "TypeGuard({})".format(self.type_guard)

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2208,6 +2208,12 @@ class Movie(TypedDict, total=False):
     year: int
 [typing fixtures/typing-typeddict.pyi]
 
+[case testRequiredExplicitAny]
+# flags: --disallow-any-explicit
+from typing import TypedDict
+from typing import Required
+Foo = TypedDict("Foo", {"a.x": Required[int]})
+[typing fixtures/typing-typeddict.pyi]
 
 -- NotRequired[]
 
@@ -2269,6 +2275,13 @@ from typing import NotRequired
 class Movie(TypedDict):
     title: NotRequired[str, bytes]  # E: NotRequired[] must have exactly one type argument
     year: int
+[typing fixtures/typing-typeddict.pyi]
+
+[case testNotRequiredExplicitAny]
+# flags: --disallow-any-explicit
+from typing import TypedDict
+from typing import NotRequired
+Foo = TypedDict("Foo", {"a.x": NotRequired[int]})
 [typing fixtures/typing-typeddict.pyi]
 
 -- Union dunders

--- a/test-data/unit/fixtures/typing-typeddict.pyi
+++ b/test-data/unit/fixtures/typing-typeddict.pyi
@@ -43,7 +43,8 @@ class Iterator(Iterable[T_co], Protocol):
     def __next__(self) -> T_co: pass
 
 class Sequence(Iterable[T_co]):
-    def __getitem__(self, n: Any) -> T_co: pass # type: ignore
+    # misc is for explicit Any.
+    def __getitem__(self, n: Any) -> T_co: pass # type: ignore[misc]
 
 class Mapping(Iterable[T], Generic[T, T_co], metaclass=ABCMeta):
     def __getitem__(self, key: T) -> T_co: pass

--- a/test-data/unit/fixtures/typing-typeddict.pyi
+++ b/test-data/unit/fixtures/typing-typeddict.pyi
@@ -43,7 +43,7 @@ class Iterator(Iterable[T_co], Protocol):
     def __next__(self) -> T_co: pass
 
 class Sequence(Iterable[T_co]):
-    def __getitem__(self, n: Any) -> T_co: pass
+    def __getitem__(self, n: Any) -> T_co: pass # type: ignore
 
 class Mapping(Iterable[T], Generic[T, T_co], metaclass=ABCMeta):
     def __getitem__(self, key: T) -> T_co: pass


### PR DESCRIPTION
### Description

Fixes #12049. This pr is stacked on top of this [pr](https://github.com/python/mypy/pull/12039). I would only review the last commit for this pr and ignored required portion of it.

This adds an explicit Any check for TypeGuard argument. This requires adding an accept method to TypeGuard. To avoid new type classes not defining accept I marked accept abstract method.

Two open questions,

1. The way I handled explicit Any check was by adding it to the argument analysis. Ideally function def analysis for explicit Any would take care of this but it doesn't work because the return type is transformed to bool for typeguards. Removing that transformation looks like a harder change.
2. My accept implementation just delegates to the inner type for typeguards. Maybe type visitor should have a new method added of visit_type_guard(...) with the default being visit the inner type but allow other visitors to do something else. Maybe this issue can be avoided until a visitor that cares about typeguardness appears.

## Test Plan

I ran local tests and checked that my test case in the bug report is fixed. The error message produced is,

```
typeguard_any.py:6: error: Explicit "Any" is not allowed
Found 1 error in 1 file (checked 1 source file)

```

 I'll add a test case after agreement this approach is reasonable.
