### PR TITLE
Add --allow-empty-dir option

### DIFF
--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -18,8 +18,7 @@ class InvalidSourceList(Exception):
 
 
 def create_source_list(paths: Sequence[str], options: Options,
-                       fscache: Optional[FileSystemCache] = None,
-                       allow_empty_dir: bool = False) -> List[BuildSource]:
+                       fscache: Optional[FileSystemCache] = None) -> List[BuildSource]:
     """From a list of source files/directories, makes a list of BuildSources.
 
     Raises InvalidSourceList on errors.
@@ -36,7 +35,7 @@ def create_source_list(paths: Sequence[str], options: Options,
             sources.append(BuildSource(path, name, None, base_dir))
         elif fscache.isdir(path):
             sub_sources = finder.find_sources_in_dir(path)
-            if not sub_sources and not allow_empty_dir:
+            if not sub_sources and not options.allow_empty_dir:
                 raise InvalidSourceList(
                     "There are no .py[i] files in directory '{}'".format(path)
                 )

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -810,6 +810,10 @@ def process_options(args: List[str],
                         help=("Install stubs without asking for confirmation and hide " +
                               "errors, with --install-types"),
                         group=other_group, inverse="--interactive")
+    add_invertible_flag('--allow-empty-dir', default=False, strict_flag=False,
+                        help=("Do not stop when a directory does not contain any python files " +
+                              "when searching for source."),
+                        group=other_group, inverse="--disallow-empty-dir")
 
     if server_options:
         # TODO: This flag is superfluous; remove after a short transition (2018-03-16)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -301,6 +301,8 @@ class Options:
         # skip most errors after this many messages have been reported.
         # -1 means unlimited.
         self.many_errors_threshold = defaults.MANY_ERRORS_THRESHOLD
+        # Do not raise an exception when a directory has no python files.
+        self.allow_empty_dir = False
 
     # To avoid breaking plugin compatibility, keep providing new_semantic_analyzer
     @property

--- a/mypy/test/test_find_sources.py
+++ b/mypy/test/test_find_sources.py
@@ -377,3 +377,17 @@ class SourceFinderSuite(unittest.TestCase):
             }
             fscache = FakeFSCache(files)
             assert len(find_sources(["."], options, fscache)) == len(files)
+
+    def test_find_sources_allow_empty_dir(self) -> None:
+        options = Options()
+
+        files = {
+            "/scripts/a.sh",
+        }
+        fscache = FakeFSCache(files)
+        # default options.allow_empty_dir is False
+        with pytest.raises(InvalidSourceList):
+            find_sources(["/scripts"], options, fscache)
+
+        options.allow_empty_dir = True
+        assert len(find_sources(["/scripts"], options, fscache)) == 0

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -292,10 +292,10 @@ class FineGrainedSuite(DataSuite):
             return create_source_list(paths, options)
         else:
             base = BuildSource(os.path.join(test_temp_dir, 'main'), '__main__', None)
+            options_allow_empty_dir = options.apply_changes(changes={'allow_empty_dir': True})
             # Use expand_dir instead of create_source_list to avoid complaints
             # when there aren't any .py files in an increment
-            return [base] + create_source_list([test_temp_dir], options,
-                                               allow_empty_dir=True)
+            return [base] + create_source_list([test_temp_dir], options_allow_empty_dir)
 
     def maybe_suggest(self, step: int, server: Server, src: str, tmp_dir: str) -> List[str]:
         output: List[str] = []


### PR DESCRIPTION
### Description

When searching for source files, an empty directory does no have
to be seen as error.
Default behaviour unchanged (empty dir is an error).

Context:
I use cookiecutter to generate skeletons of new repositories. This creates, among other things a `scripts` directory, where python scripts could end up. I thus want this directory to be mypy'ed by default, but no files there is not an issue.

The core of this change already existed, but it was not possible to pass the option from the cli. It now is.

## Test Plan

In mypy.test.test_find_sources.SourceFinderSuite.test_find_sources_allow_empty_dir

Plus tested manually:
```shell
mkdir empty
mypy empty
# There are no .py[i] files in directory 'empty' + error code
mypy empty --disallow-empty-dir
# There are no .py[i] files in directory 'empty' + error code
mypy empty --allow-empty-dir
# Nothing to do?! 
# Success: no issues found in 0 source files + succesful exit code
```
