### PR TITLE
Treat methods with empty bodies in Protocols as abstract

### DIFF
--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -7,7 +7,7 @@ from typing import List, Set, Optional
 from typing_extensions import Final
 
 from mypy.nodes import (
-    Node, TypeInfo, Var, Decorator, OverloadedFuncDef, SymbolTable, CallExpr, PromoteExpr,
+    Node, TypeInfo, Var, Decorator, OverloadedFuncDef, SymbolTable, CallExpr, PromoteExpr, FuncDef
 )
 from mypy.types import Instance, Type
 from mypy.errors import Errors
@@ -78,8 +78,8 @@ def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: E
                     func = None
             else:
                 func = node
-            if isinstance(func, Decorator):
-                fdef = func.func
+            if isinstance(func, Decorator) or (isinstance(func, FuncDef) and not typ.is_protocol):
+                fdef = func.func if isinstance(func, Decorator) else func
                 if fdef.is_abstract and name not in concrete:
                     typ.is_abstract = True
                     abstract.append(name)

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1079,6 +1079,44 @@ class C2(P):
 C()
 C2()
 
+[case testCannotInstantiateEmptyMethodExplicitProtocolSubtypes]
+from typing import Protocol
+
+class P(Protocol):
+    def meth(self) -> int:
+        pass
+
+class A(P):
+    pass
+
+A() # E: Cannot instantiate abstract class "A" with abstract attribute "meth"
+
+class B(P):
+    def meth(self) -> int:
+        return 0
+
+B()
+
+class P2(Protocol):
+    def meth(self) -> int:
+        ...
+
+class A2(P):
+    pass
+
+A2() # E: Cannot instantiate abstract class "A2" with abstract attribute "meth"
+
+class P3(Protocol):
+    def meth(self) -> int:
+        """Docstring for meth.
+
+	This is meth."""
+
+class A3(P):
+    pass
+
+A3() # E: Cannot instantiate abstract class "A3" with abstract attribute "meth"
+
 [case testCannotInstantiateAbstractVariableExplicitProtocolSubtypes]
 from typing import Protocol
 


### PR DESCRIPTION
### Description

Closes #8005

Sending this PR to get feedback. The problem is I don't know where to hook into mypy to implement this. I'm fairly confident about my changes in `semanal_classprop.py`, but the code in `semanal.py` is most likely in the wrong place. One problem I have is that I can't figure out how to identify overloads. That's why I'm currently excluding any function with a decorator, which is clearly the wrong thing to do.

My current plan is to treat any method in a protocol as abstract for which all of the following is true:
1. Function body only consists of `pass`, `...`, and/or a docstring.
2. Return type is _not_ `None` or `Any`.
3. The definition of the protocol is _not_ from a stub file (because stubs never have function bodies).
4. Function is not annotated with `@overload`.

Any help appreciated!

## Test Plan

I added tests for the new behavior.