### PR TITLE
Simplify unions when erasing last known values

### DIFF
--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -161,3 +161,12 @@ class LastKnownValueEraser(TypeTranslator):
         # Type aliases can't contain literal values, because they are
         # always constructed as explicit types.
         return t
+
+    def visit_union_type(self, t: UnionType) -> Type:
+        new = super().visit_union_type(t)
+        new = get_proper_type(new)
+        if isinstance(new, UnionType):
+            from mypy.typeops import make_simplified_union
+            # Erasure can result in many duplicate items; remove them.
+            new = make_simplified_union(new.items)
+        return new

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -1,10 +1,10 @@
-from typing import Optional, Container, Callable
+from typing import Optional, Container, Callable, List, Dict, cast
 
 from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneType, TypeVarId, Instance, TypeVarType,
     CallableType, TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType,
     DeletedType, TypeTranslator, UninhabitedType, TypeType, TypeOfAny, LiteralType, ProperType,
-    get_proper_type, TypeAliasType, ParamSpecType
+    get_proper_type, get_proper_types, TypeAliasType, ParamSpecType
 )
 from mypy.nodes import ARG_STAR, ARG_STAR2
 
@@ -163,10 +163,32 @@ class LastKnownValueEraser(TypeTranslator):
         return t
 
     def visit_union_type(self, t: UnionType) -> Type:
-        new = super().visit_union_type(t)
-        new = get_proper_type(new)
-        if isinstance(new, UnionType):
-            from mypy.typeops import make_simplified_union
-            # Erasure can result in many duplicate items; remove them.
-            new = make_simplified_union(new.items)
+        new = cast(UnionType, super().visit_union_type(t))
+        # Erasure can result in many duplicate items; merge them.
+        # Call make_simplified_union only on lists of instance types
+        # that all have the same fullname, to avoid simplifying too
+        # much.
+        instances = [item for item in new.items
+                     if isinstance(get_proper_type(item), Instance)]
+        # Avoid merge in simple cases such as optional types.
+        if len(instances) > 1:
+            instances_by_name: Dict[str, List[Instance]] = {}
+            new_items = get_proper_types(new.items)
+            for item in new_items:
+                if isinstance(item, Instance) and not item.args:
+                    instances_by_name.setdefault(item.type.fullname, []).append(item)
+            merged: List[Type] = []
+            for item in new_items:
+                if isinstance(item, Instance) and not item.args:
+                    types = instances_by_name.get(item.type.fullname)
+                    if types is not None:
+                        if len(types) == 1:
+                            merged.append(item)
+                        else:
+                            from mypy.typeops import make_simplified_union
+                            merged.append(make_simplified_union(types))
+                            del instances_by_name[item.type.fullname]
+                else:
+                    merged.append(item)
+            return UnionType.make_union(merged)
         return new

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -175,14 +175,14 @@ def join_types(s: Type, t: Type, instance_joiner: Optional[InstanceJoiner] = Non
         s = mypy.typeops.true_or_false(s)
         t = mypy.typeops.true_or_false(t)
 
+    if isinstance(s, UnionType) and not isinstance(t, UnionType):
+        s, t = t, s
+
     if isinstance(s, AnyType):
         return s
 
     if isinstance(s, ErasedType):
         return t
-
-    if isinstance(s, UnionType) and not isinstance(t, UnionType):
-        s, t = t, s
 
     if isinstance(s, NoneType) and not isinstance(t, NoneType):
         s, t = t, s

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -175,14 +175,14 @@ def join_types(s: Type, t: Type, instance_joiner: Optional[InstanceJoiner] = Non
         s = mypy.typeops.true_or_false(s)
         t = mypy.typeops.true_or_false(t)
 
-    if isinstance(s, UnionType) and not isinstance(t, UnionType):
-        s, t = t, s
-
     if isinstance(s, AnyType):
         return s
 
     if isinstance(s, ErasedType):
         return t
+
+    if isinstance(s, UnionType) and not isinstance(t, UnionType):
+        s, t = t, s
 
     if isinstance(s, NoneType) and not isinstance(t, NoneType):
         s, t = t, s

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -157,9 +157,11 @@ class TypeFixture:
         self.lit1 = LiteralType(1, self.a)
         self.lit2 = LiteralType(2, self.a)
         self.lit3 = LiteralType("foo", self.d)
+        self.lit4 = LiteralType(3, self.a)
         self.lit1_inst = Instance(self.ai, [], last_known_value=self.lit1)
         self.lit2_inst = Instance(self.ai, [], last_known_value=self.lit2)
         self.lit3_inst = Instance(self.di, [], last_known_value=self.lit3)
+        self.lit4_inst = Instance(self.ai, [], last_known_value=self.lit4)
 
         self.type_a = TypeType.make_normalized(self.a)
         self.type_b = TypeType.make_normalized(self.b)

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -157,7 +157,7 @@ class TypeFixture:
         self.lit1 = LiteralType(1, self.a)
         self.lit2 = LiteralType(2, self.a)
         self.lit3 = LiteralType("foo", self.d)
-        self.lit4 = LiteralType(3, self.a)
+        self.lit4 = LiteralType(4, self.a)
         self.lit1_inst = Instance(self.ai, [], last_known_value=self.lit1)
         self.lit2_inst = Instance(self.ai, [], last_known_value=self.lit2)
         self.lit3_inst = Instance(self.di, [], last_known_value=self.lit3)

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1868,3 +1868,21 @@ class WithOverload(enum.IntEnum):
 class SubWithOverload(WithOverload):  # Should pass
     pass
 [builtins fixtures/tuple.pyi]
+
+[case testEnumtValueUnionSimplification]
+from enum import IntEnum
+from typing import Any
+
+class C(IntEnum):
+    X = 0
+    Y = 1
+    Z = 2
+
+def f1(c: C) -> None:
+    x = {'x': c.value}
+    reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int]"
+
+def f2(c: C, a: Any) -> None:
+    x = {'x': c.value, 'y': a}
+    reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, Any]"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1881,8 +1881,4 @@ class C(IntEnum):
 def f1(c: C) -> None:
     x = {'x': c.value}
     reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int]"
-
-def f2(c: C, a: Any) -> None:
-    x = {'x': c.value, 'y': a}
-    reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, Any]"
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
When we erase last known values in an union with multiple
Instance types, make sure that the resulting union doesn't have
duplicate erased types. The duplicate items weren't incorrect as such,
but they could cause overly complex error messages and potentially
slow type checking performance.

This is one of the fixes extracted from #12054. Since some of the
changes may cause regressions, it's better to split the PR.

Work on #12051.