### PR TITLE
Fix join of Any against a union type

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -175,14 +175,14 @@ def join_types(s: Type, t: Type, instance_joiner: Optional[InstanceJoiner] = Non
         s = mypy.typeops.true_or_false(s)
         t = mypy.typeops.true_or_false(t)
 
+    if isinstance(s, UnionType) and not isinstance(t, UnionType):
+        s, t = t, s
+
     if isinstance(s, AnyType):
         return s
 
     if isinstance(s, ErasedType):
         return t
-
-    if isinstance(s, UnionType) and not isinstance(t, UnionType):
-        s, t = t, s
 
     if isinstance(s, NoneType) and not isinstance(t, NoneType):
         s, t = t, s

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1881,4 +1881,8 @@ class C(IntEnum):
 def f1(c: C) -> None:
     x = {'x': c.value}
     reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int]"
+
+def f2(c: C, a: Any) -> None:
+    x = {'x': c.value, 'y': a}
+    reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, Any]"
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1885,4 +1885,6 @@ def f1(c: C) -> None:
 def f2(c: C, a: Any) -> None:
     x = {'x': c.value, 'y': a}
     reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, Any]"
+    y = {'y': a, 'x': c.value}
+    reveal_type(y)  # N: Revealed type is "builtins.dict[builtins.str*, Any]"
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
Make the join of a union type and Any commutative.
Previously the result dependend on the order of the operands,
which was clearly incorrect.

Fix #12051, but other use cases are affected as well.

This change was split off from #12054.