### PR TITLE
stubtest: error if a class should be decorated with @final

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -258,15 +258,8 @@ def verify_typeinfo(
         class SubClass(runtime):  # type: ignore
             pass
     except Exception:
-        if (
-            not stub.is_final
-            # Enum classes are implicitly @final
-            and not issubclass(runtime, enum.Enum)
-            # If __init_subclass__ is defined in the class itself (but not in a
-            # base class), it clearly is meant to be subclass, but you
-            # apparently have to do something special to create a subclass without errors
-            and "__init_subclass__" not in runtime.__dict__
-        ):
+        # Enum classes are implicitly @final
+        if not stub.is_final and not issubclass(runtime, enum.Enum):
             yield Error(
                 object_path,
                 "cannot be subclassed at runtime, but isn't marked with @final in the stub",

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -263,7 +263,7 @@ def verify_typeinfo(
             # Enum classes are implicitly @final
             and not issubclass(runtime, enum.Enum)
             # If __init_subclass__ is defined in the class itself (but not in a
-            # base class), it clearly is meant to be subclass, but you
+            # base class), it clearly is meant to be subclassable, but you
             # apparently have to do something special to create a subclass without errors
             and "__init_subclass__" not in runtime.__dict__
         ):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -255,7 +255,7 @@ def verify_typeinfo(
         return
 
     try:
-        class SubClass(runtime):
+        class SubClass(runtime):  # type: ignore
             pass
     except Exception:
         if not stub.is_final:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -263,7 +263,7 @@ def verify_typeinfo(
             # Enum classes are implicitly @final
             and not issubclass(runtime, enum.Enum)
             # If __init_subclass__ is defined in the class itself (but not in a
-            # base class), it clearly is meant to be subclassable, but you
+            # base class), it clearly is meant to be subclass, but you
             # apparently have to do something special to create a subclass without errors
             and "__init_subclass__" not in runtime.__dict__
         ):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -260,8 +260,12 @@ def verify_typeinfo(
     except Exception:
         if not stub.is_final:
             yield Error(
-                object_path, "cannot be subclassed at runtime, but isn't marked with @final in the stub",
-                stub, runtime, stub_desc=repr(stub))
+                object_path,
+                "cannot be subclassed at runtime, but isn't marked with @final in the stub",
+                stub,
+                runtime,
+                stub_desc=repr(stub),
+            )
 
     # Check everything already defined in the stub
     to_check = set(stub.names)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -258,7 +258,8 @@ def verify_typeinfo(
         class SubClass(runtime):  # type: ignore
             pass
     except Exception:
-        if not stub.is_final:
+        # Enum classes are implicitly @final
+        if not stub.is_final and not issubclass(runtime, enum.Enum):
             yield Error(
                 object_path,
                 "cannot be subclassed at runtime, but isn't marked with @final in the stub",

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -258,8 +258,15 @@ def verify_typeinfo(
         class SubClass(runtime):  # type: ignore
             pass
     except Exception:
-        # Enum classes are implicitly @final
-        if not stub.is_final and not issubclass(runtime, enum.Enum):
+        if (
+            not stub.is_final
+            # Enum classes are implicitly @final
+            and not issubclass(runtime, enum.Enum)
+            # If __init_subclass__ is defined in the class itself (but not in a
+            # base class), it clearly is meant to be subclass, but you
+            # apparently have to do something special to create a subclass without errors
+            and "__init_subclass__" not in runtime.__dict__
+        ):
             yield Error(
                 object_path,
                 "cannot be subclassed at runtime, but isn't marked with @final in the stub",

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -257,7 +257,7 @@ def verify_typeinfo(
     try:
         class SubClass(runtime):  # type: ignore
             pass
-    except Exception:
+    except TypeError:
         # Enum classes are implicitly @final
         if not stub.is_final and not issubclass(runtime, enum.Enum):
             yield Error(
@@ -267,6 +267,10 @@ def verify_typeinfo(
                 runtime,
                 stub_desc=repr(stub),
             )
+    except Exception:
+        # The class probably wants its subclasses to do something special.
+        # Examples: ctypes.Array, ctypes._SimpleCData
+        pass
 
     # Check everything already defined in the stub
     to_check = set(stub.names)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -254,6 +254,15 @@ def verify_typeinfo(
         yield Error(object_path, "is not a type", stub, runtime, stub_desc=repr(stub))
         return
 
+    try:
+        class SubClass(runtime):
+            pass
+    except Exception:
+        if not stub.is_final:
+            yield Error(
+                object_path, "cannot be subclassed at runtime, but isn't marked with @final in the stub",
+                stub, runtime, stub_desc=repr(stub))
+
     # Check everything already defined in the stub
     to_check = set(stub.names)
     # There's a reasonable case to be made that we should always check all dunders, but it's

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -691,8 +691,8 @@ class StubtestUnit(unittest.TestCase):
         )
         if sys.version_info >= (3, 6):
             yield Case(
-                stub="class C:\n  def __init_subclass__(cls, e: int, **kwargs: int) -> None: ...",
-                runtime="class C:\n  def __init_subclass__(cls, e, **kwargs): pass",
+                stub="class C:\n  def __init_subclass__(cls, e: int = ..., **kwargs: int) -> None: ...",
+                runtime="class C:\n  def __init_subclass__(cls, e=1, **kwargs): pass",
                 error=None,
             )
         if sys.version_info >= (3, 9):
@@ -704,7 +704,7 @@ class StubtestUnit(unittest.TestCase):
 
     def test_not_subclassable(self) -> None:
         output = run_stubtest(
-            "class CantBeSubclassed:\n  pass",
+            "class CantBeSubclassed:\n  def __init_subclass__(cls): pass",
             "class CantBeSubclassed:\n  def __init_subclass__(cls): raise RuntimeError('nope')",
             [],
         )

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -702,6 +702,17 @@ class StubtestUnit(unittest.TestCase):
                 error=None,
             )
 
+    def test_not_subclassable(self) -> None:
+        output = run_stubtest(
+            "class CantBeSubclassed:\n  pass",
+            "class CantBeSubclassed:\n  def __init_subclass__(cls): raise RuntimeError('nope')",
+            [],
+        )
+        assert (
+            "CantBeSubclassed cannot be subclassed at runtime,"
+            " but isn't marked with @final in the stub"
+        ) in output
+
     @collect_cases
     def test_name_mangling(self) -> Iterator[Case]:
         yield Case(

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -691,7 +691,12 @@ class StubtestUnit(unittest.TestCase):
         )
         if sys.version_info >= (3, 6):
             yield Case(
-                stub="class C:\n  def __init_subclass__(cls, e: int = ..., **kwargs: int) -> None: ...",
+                stub=(
+                    "class C:\n"
+                    "  def __init_subclass__(\n"
+                    "    cls, e: int = ..., **kwargs: int\n"
+                    "  ) -> None: ...\n"
+                ),
                 runtime="class C:\n  def __init_subclass__(cls, e=1, **kwargs): pass",
                 error=None,
             )


### PR DESCRIPTION
### Description

Stubtest now errors if `class SubClass(some_class): pass` errors at runtime, but `some_class` isn't marked with `@final` in the stub.

## Test Plan

New errors from `--check-typeshed`, checked against typeshed commit 92d135a3:

```
_curses.window cannot be subclassed at runtime, but isn't marked with @final in the stub
_json.make_encoder cannot be subclassed at runtime, but isn't marked with @final in the stub
_json.make_scanner cannot be subclassed at runtime, but isn't marked with @final in the stub
_tkinter.TkttType cannot be subclassed at runtime, but isn't marked with @final in the stub
asyncio.constants._SendfileMode cannot be subclassed at runtime, but isn't marked with @final in the stub
ctypes.Array cannot be subclassed at runtime, but isn't marked with @final in the stub
ctypes._SimpleCData cannot be subclassed at runtime, but isn't marked with @final in the stub
curses.window cannot be subclassed at runtime, but isn't marked with @final in the stub
hashlib.blake2b cannot be subclassed at runtime, but isn't marked with @final in the stub
hashlib.blake2s cannot be subclassed at runtime, but isn't marked with @final in the stub
http.HTTPStatus cannot be subclassed at runtime, but isn't marked with @final in the stub
inspect._ParameterKind cannot be subclassed at runtime, but isn't marked with @final in the stub
parser.STType cannot be subclassed at runtime, but isn't marked with @final in the stub
plistlib.PlistFormat cannot be subclassed at runtime, but isn't marked with @final in the stub
pstats.SortKey cannot be subclassed at runtime, but isn't marked with @final in the stub
py_compile.PycInvalidationMode cannot be subclassed at runtime, but isn't marked with @final in the stub
re.RegexFlag cannot be subclassed at runtime, but isn't marked with @final in the stub
select.epoll cannot be subclassed at runtime, but isn't marked with @final in the stub
signal.Handlers cannot be subclassed at runtime, but isn't marked with @final in the stub
signal.Sigmasks cannot be subclassed at runtime, but isn't marked with @final in the stub
signal.Signals cannot be subclassed at runtime, but isn't marked with @final in the stub
socket.AddressFamily cannot be subclassed at runtime, but isn't marked with @final in the stub
socket.AddressInfo cannot be subclassed at runtime, but isn't marked with @final in the stub
socket.MsgFlag cannot be subclassed at runtime, but isn't marked with @final in the stub
socket.SocketKind cannot be subclassed at runtime, but isn't marked with @final in the stub
sqlite3.PrepareProtocol cannot be subclassed at runtime, but isn't marked with @final in the stub
sqlite3.dbapi2.PrepareProtocol cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.AlertDescription cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.MemoryBIO cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.Options cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.Purpose cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.SSLErrorNumber cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.SSLSession cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.TLSVersion cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.VerifyFlags cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl.VerifyMode cannot be subclassed at runtime, but isn't marked with @final in the stub
ssl._SSLMethod cannot be subclassed at runtime, but isn't marked with @final in the stub
tkinter.EventType cannot be subclassed at runtime, but isn't marked with @final in the stub
typing.ForwardRef cannot be subclassed at runtime, but isn't marked with @final in the stub
typing.TypeVar cannot be subclassed at runtime, but isn't marked with @final in the stub
typing._SpecialForm cannot be subclassed at runtime, but isn't marked with @final in the stub
typing_extensions._SpecialForm cannot be subclassed at runtime, but isn't marked with @final in the stub
unicodedata.UCD cannot be subclassed at runtime, but isn't marked with @final in the stub
uuid.SafeUUID cannot be subclassed at runtime, but isn't marked with @final in the stub
xxlimited.Xxo cannot be subclassed at runtime, but isn't marked with @final in the stub
```