### PR TITLE
Read pyproject.toml with correct encoding on Windows.

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -511,7 +511,7 @@ def find_config_file_line_number(path: str, section: str, setting_name: str) -> 
     in_desired_section = False
     try:
         results = []
-        with open(path) as f:
+        with open(path, encoding="UTF-8") as f:
             for i, line in enumerate(f):
                 line = line.strip()
                 if line.startswith('[') and line.endswith(']'):

--- a/test-data/unit/cmdline.pyproject.test
+++ b/test-data/unit/cmdline.pyproject.test
@@ -125,3 +125,11 @@ i: int = 0
 This isn't even syntatically valid!
 [file x/please_skipme_.py]
 Neither is this!
+
+[case testPyprojectTOMLUnicode]
+# cmd: mypy x.py
+[file pyproject.toml]
+\[project]
+description = "Factory ⸻ A code generator 🏭"
+\[tool.mypy]
+[file x.py]


### PR DESCRIPTION

### Description

On Windows (where the default encoding for `open` is usually not UTF-8), attempting to load mypy's configuration from a `pyproject.toml` fails due to being unable to decode unicode characters. With this patch, the file is read with UTF-8 as the encoding on all platforms.

Fixes #11058

## Test Plan

Added a test which loads mypy's configuration from a `pyproject.toml` file containing non-ASCII characters.
