### PR TITLE
Add helpful message to assert in mypyc

### DIFF
--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -142,7 +142,7 @@ def prepare_method_def(ir: ClassIR, module_name: str, cdef: ClassDef, mapper: Ma
             ir.method_decls[PROPSET_PREFIX + node.name] = decl
 
         if node.func.is_property:
-            assert node.func.type
+            assert node.func.type, f"Expected return type annotation for property '{node.name}'"
             decl.is_prop_getter = True
             ir.property_types[node.name] = decl.sig.ret_type
 


### PR DESCRIPTION
### Description

I've been running `mypyc` on a codebase and hitting frequent `AssertionError` with no helpful message. This change simply adds a helpful error message so the next fool who runs into this doesn't have to poke through `mypyc` code to find out the problem.

## Test Plan

N/A (Should a test be added? I didn't see any failure tests for `irbuild` :thinking: )
