### PR TITLE
Sync `mypy_primer_comment` with `typeshed`

### DIFF
--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -88,12 +88,17 @@ jobs:
             console.log("Diff from mypy_primer:")
             console.log(data)
 
+            let body
             if (data.trim()) {
-              const body = 'Diff from [mypy_primer](https://github.com/hauntsaninja/mypy_primer), showing the effect of this PR on open source code:\n```diff\n' + data + '```'
-              await github.issues.createComment({
-                issue_number: fs.readFileSync("pr_number.txt", { encoding: "utf8" }),
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body
-              })
+              body = 'Diff from [mypy_primer](https://github.com/hauntsaninja/mypy_primer), showing the effect of this PR on open source code:\n```diff\n' + data + '```'
+            } else {
+              body = 'According to [mypy_primer](https://github.com/hauntsaninja/mypy_primer), this change has no effect on the checked open source code. 🤖🎉'
             }
+            const prNumber = parseInt(fs.readFileSync("pr_number.txt", { encoding: "utf8" }))
+            await github.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            })
+            return prNumber


### PR DESCRIPTION
This PR adds a useful feature: now empty `primer` output will still add a comment: "According to mypy_primer, this change has no effect on the checked open source code."

Why is it useful?
Because in some cases it is not clear: is `mypy_primer` happy? Or is it broken?
For example, this PR https://github.com/python/mypy/pull/12118 does not have any comment.

I guess it would also benefit PR authors who can be sure that what they did is correct.

I will wait for `mypy_primer` to comment on this PR 🙂 