### PR TITLE
Understand the self-destructing nature of Enum._ignore_

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -832,7 +832,7 @@ def analyze_enum_class_attribute_access(itype: Instance,
                                         mx: MemberContext,
                                         ) -> Optional[Type]:
     # Skip "_order_" and "__order__", since Enum will remove it
-    if name in ("_order_", "__order__"):
+    if name in ("_ignore_", "_order_", "__order__"):
         return mx.msg.has_no_attr(
             mx.original_type, itype, name, mx.context, mx.module_symbol_table
         )

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -6,7 +6,8 @@ from typing_extensions import TYPE_CHECKING
 from mypy.types import (
     Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike,
     TypeVarLikeType, Overloaded, TypeVarType, UnionType, PartialType, TypeOfAny, LiteralType,
-    DeletedType, NoneType, TypeType, has_type_vars, get_proper_type, ProperType, ParamSpecType
+    DeletedType, NoneType, TypeType, has_type_vars, get_proper_type, ProperType, ParamSpecType,
+    ENUM_REMOVED_PROPS
 )
 from mypy.nodes import (
     TypeInfo, FuncBase, Var, FuncDef, SymbolNode, SymbolTable, Context,
@@ -831,8 +832,8 @@ def analyze_enum_class_attribute_access(itype: Instance,
                                         name: str,
                                         mx: MemberContext,
                                         ) -> Optional[Type]:
-    # Skip "_order_" and "__order__", since Enum will remove it
-    if name in ("_ignore_", "_order_", "__order__"):
+    # Skip these since Enum will remove it
+    if name in ENUM_REMOVED_PROPS:
         return mx.msg.has_no_attr(
             mx.original_type, itype, name, mx.context, mx.module_symbol_table
         )

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -13,7 +13,7 @@ from mypy.nodes import (
 )
 from mypy.semanal_shared import SemanticAnalyzerInterface
 from mypy.options import Options
-from mypy.types import get_proper_type, LiteralType
+from mypy.types import get_proper_type, LiteralType, ENUM_REMOVED_PROPS
 
 # Note: 'enum.EnumMeta' is deliberately excluded from this list. Classes that directly use
 # enum.EnumMeta do not necessarily automatically have the 'name' and 'value' attributes.
@@ -21,7 +21,7 @@ ENUM_BASES: Final = frozenset((
     'enum.Enum', 'enum.IntEnum', 'enum.Flag', 'enum.IntFlag',
 ))
 ENUM_SPECIAL_PROPS: Final = frozenset((
-    'name', 'value', '_name_', '_value_', '_ignore_', '_order_', '__order__',
+    'name', 'value', '_name_', '_value_', *ENUM_REMOVED_PROPS,
     # Also attributes from `object`:
     '__module__', '__annotations__', '__doc__', '__slots__', '__dict__',
 ))

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -21,7 +21,7 @@ ENUM_BASES: Final = frozenset((
     'enum.Enum', 'enum.IntEnum', 'enum.Flag', 'enum.IntFlag',
 ))
 ENUM_SPECIAL_PROPS: Final = frozenset((
-    'name', 'value', '_name_', '_value_', '_order_', '__order__',
+    'name', 'value', '_name_', '_value_', '_ignore_', '_order_', '__order__',
     # Also attributes from `object`:
     '__module__', '__annotations__', '__doc__', '__slots__', '__dict__',
 ))

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -715,8 +715,8 @@ def try_expanding_sum_type_to_union(typ: Type, target_fullname: str) -> ProperTy
             for name, symbol in typ.type.names.items():
                 if not isinstance(symbol.node, Var):
                     continue
-                # Skip "_order_" and "__order__", since Enum will remove it
-                if name in ("_order_", "__order__"):
+                # Skip "_ignore", "_order_" and "__order__", since Enum will remove it
+                if name in ("_ignore", "_order_", "__order__"):
                     continue
                 new_items.append(LiteralType(name, typ))
             # SymbolTables are really just dicts, and dicts are guaranteed to preserve

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -715,8 +715,8 @@ def try_expanding_sum_type_to_union(typ: Type, target_fullname: str) -> ProperTy
             for name, symbol in typ.type.names.items():
                 if not isinstance(symbol.node, Var):
                     continue
-                # Skip "_ignore", "_order_" and "__order__", since Enum will remove it
-                if name in ("_ignore", "_order_", "__order__"):
+                # Skip "_ignore_", "_order_" and "__order__", since Enum will remove it
+                if name in ("_ignore_", "_order_", "__order__"):
                     continue
                 new_items.append(LiteralType(name, typ))
             # SymbolTables are really just dicts, and dicts are guaranteed to preserve

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -14,7 +14,8 @@ from mypy.types import (
     TupleType, Instance, FunctionLike, Type, CallableType, TypeVarLikeType, Overloaded,
     TypeVarType, UninhabitedType, FormalArgument, UnionType, NoneType,
     AnyType, TypeOfAny, TypeType, ProperType, LiteralType, get_proper_type, get_proper_types,
-    copy_type, TypeAliasType, TypeQuery, ParamSpecType
+    copy_type, TypeAliasType, TypeQuery, ParamSpecType,
+    ENUM_REMOVED_PROPS
 )
 from mypy.nodes import (
     FuncBase, FuncItem, FuncDef, OverloadedFuncDef, TypeInfo, ARG_STAR, ARG_STAR2, ARG_POS,
@@ -715,8 +716,8 @@ def try_expanding_sum_type_to_union(typ: Type, target_fullname: str) -> ProperTy
             for name, symbol in typ.type.names.items():
                 if not isinstance(symbol.node, Var):
                     continue
-                # Skip "_ignore_", "_order_" and "__order__", since Enum will remove it
-                if name in ("_ignore_", "_order_", "__order__"):
+                # Skip these since Enum will remove it
+                if name in ENUM_REMOVED_PROPS:
                     continue
                 new_items.append(LiteralType(name, typ))
             # SymbolTables are really just dicts, and dicts are guaranteed to preserve

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -132,6 +132,14 @@ REVEAL_TYPE_NAMES: Final = (
     'typing_extensions.reveal_type',
 )
 
+# Attributes that can optionally be defined in the body of a subclass of
+# enum.Enum but are removed from the class __dict__ by EnumMeta.
+ENUM_REMOVED_PROPS: Final = (
+    '_ignore_',
+    '_order_',
+    '__order__',
+)
+
 # A placeholder used for Bogus[...] parameters
 _dummy: Final[Any] = object()
 

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -8,7 +8,7 @@ from mypy.nodes import (
     ClassDef, FuncDef, OverloadedFuncDef, PassStmt, AssignmentStmt, CallExpr, NameExpr, StrExpr,
     ExpressionStmt, TempNode, Decorator, Lvalue, MemberExpr, RefExpr, TypeInfo, is_class_var
 )
-from mypy.types import Instance, get_proper_type
+from mypy.types import Instance, get_proper_type, ENUM_REMOVED_PROPS
 from mypyc.ir.ops import (
     Value, Register, Call, LoadErrorValue, LoadStatic, InitStatic, TupleSet, SetAttr, Return,
     BasicBlock, Branch, MethodCall, NAMESPACE_TYPE, LoadAddress
@@ -517,8 +517,8 @@ def add_non_ext_class_attr(builder: IRBuilder,
         if (
             cdef.info.bases
             and cdef.info.bases[0].type.fullname == 'enum.Enum'
-            # Skip "_ignore_", "_order_" and "__order__", since Enum will remove it
-            and lvalue.name not in ('_ignore_', '_order_', '__order__')
+            # Skip these since Enum will remove it
+            and lvalue.name not in ENUM_REMOVED_PROPS
         ):
             # Enum values are always boxed, so use object_rprimitive.
             attr_to_cache.append((lvalue, object_rprimitive))

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -517,8 +517,8 @@ def add_non_ext_class_attr(builder: IRBuilder,
         if (
             cdef.info.bases
             and cdef.info.bases[0].type.fullname == 'enum.Enum'
-            # Skip "_order_" and "__order__", since Enum will remove it
-            and lvalue.name not in ('_order_', '__order__')
+            # Skip "_ignore_", "_order_" and "__order__", since Enum will remove it
+            and lvalue.name not in ('_ignore_', '_order_', '__order__')
         ):
             # Enum values are always boxed, so use object_rprimitive.
             attr_to_cache.append((lvalue, object_rprimitive))

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -1888,3 +1888,12 @@ def f2(c: C, a: Any) -> None:
     y = {'y': a, 'x': c.value}
     reveal_type(y)  # N: Revealed type is "builtins.dict[builtins.str*, Any]"
 [builtins fixtures/dict.pyi]
+
+[case testEnumIgnoreIsDeleted]
+from enum import Enum
+
+class C(Enum):
+    _ignore_ = 'X'
+
+C._ignore_ # E: "Type[C]" has no attribute "_ignore_"
+[typing fixtures/typing-medium.pyi]


### PR DESCRIPTION
Similar to \_order\_ (which mypy already handles), \_ignore\_ is deleted by EnumMeta. Currently, (#12121) mypy thinks it's an error to set \_ignore\_ in an Enum subclass because 'Cannot override writable attribute "\_ignore\_" with a final one.' This PR both:
1. Makes mypy ok with setting `_ignore_` in the class body; and
2. Makes it an error to later access the (deleted) `_ignore_` attribute ('Type[E] has no attribute "\_ignore\_"')

The PR adds a test that accessing `_ignore_` after the class definition is flagged as an error. I wanted to test that (1) above has been fixed, but I couldn't figure out how to make a failing test. So I went "out of band" from the unit test themselves; I created a simple test file:
```py
from enum import Enum
class E(Enum):
    _ignore_ = '' # how to assert that old mypy "Cannot override writable"
E._ignore_
```
And checked that before this PR, mypy raised an error on line 3 but not line 4, and after this PR line 3 was ok but line 4 was now in error.

This PR does not cause mypy itself to ignore the attributes. That is, after this definition:
```py
from enum import Enum
class E(Enum):
    _ignore_ = "X"
    X = 1
```
mypy still thinks E.X exists. I suppose mypy could parse the value of `_ignore_` when it's a literal , but I don't have plans to look into that.