### PR TITLE
Change the rules for structural subtyping of TypedDicts:…

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -400,19 +400,14 @@ class SubtypeVisitor(TypeVisitor[bool]):
             if not left.names_are_wider_than(right):
                 return False
             for name, l, r in left.zip(right):
-                if not is_equivalent(l, r,
-                                     ignore_type_params=self.ignore_type_params):
+                if not is_subtype(l, r,
+                                  ignore_type_params=self.ignore_type_params):
                     return False
                 # Non-required key is not compatible with a required key since
                 # indexing may fail unexpectedly if a required key is missing.
-                # Required key is not compatible with a non-required key since
-                # the prior doesn't support 'del' but the latter should support
-                # it.
                 #
-                # NOTE: 'del' support is currently not implemented (#3550). We
-                #       don't want to have to change subtyping after 'del' support
-                #       lands so here we are anticipating that change.
-                if (name in left.required_keys) != (name in right.required_keys):
+                # Required key *is* compatible with a non-required key.
+                if (name in right.required_keys) and (name not in left.required_keys):
                     return False
             # (NOTE: Fallbacks don't matter.)
             return True

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -320,14 +320,6 @@ def convert(op: ObjectPoint) -> Point:
     return op  # E: Incompatible return value type (got "ObjectPoint", expected "Point")
 [builtins fixtures/dict.pyi]
 
-[case testCannotConvertTypedDictToSimilarTypedDictWithWiderItemTypes]
-from mypy_extensions import TypedDict
-Point = TypedDict('Point', {'x': int, 'y': int})
-ObjectPoint = TypedDict('ObjectPoint', {'x': object, 'y': object})
-def convert(p: Point) -> ObjectPoint:
-    return p  # E: Incompatible return value type (got "Point", expected "ObjectPoint")
-[builtins fixtures/dict.pyi]
-
 [case testCannotConvertTypedDictToSimilarTypedDictWithIncompatibleItemTypes]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
@@ -1121,9 +1113,41 @@ c: C
 fb(b)
 fc(c)
 fb(c)
-fb(a) # E: Argument 1 to "fb" has incompatible type "A"; expected "B"
+fb(a)
 fa(b) # E: Argument 1 to "fa" has incompatible type "B"; expected "A"
 fc(b) # E: Argument 1 to "fc" has incompatible type "B"; expected "C"
+[builtins fixtures/dict.pyi]
+
+[case testTypedDictSubtypingWithOptional]
+# flags: --strict-optional
+from typing import Optional
+from mypy_extensions import TypedDict
+A = TypedDict('A', {'x': int})
+B = TypedDict('B', {'x': Optional[int]})
+def fa(a: A) -> None: pass
+def fb(b: B) -> None: pass
+a: A
+b: B
+fb(a)
+fa(b) # E: Argument 1 to "fa" has incompatible type "B"; expected "A"
+[builtins fixtures/dict.pyi]
+
+[case testTypedDictSubtypingWithSubclass]
+# flags: --strict-optional
+from typing import Optional
+from mypy_extensions import TypedDict
+class Foo: pass
+
+class Bar(Foo): pass
+
+A = TypedDict('A', {'x': Bar})
+B = TypedDict('B', {'x': Foo})
+def fa(a: A) -> None: pass
+def fb(b: B) -> None: pass
+a: A
+b: B
+fb(a)
+fa(b) # E: Argument 1 to "fa" has incompatible type "B"; expected "A"
 [builtins fixtures/dict.pyi]
 
 [case testTypedDictJoinWithTotalFalse]


### PR DESCRIPTION
… a TypedDict with a more-specific type is now considered a subtype of a TypedDict with a less-specific type.

Examples:
* `{'a': str}` is now a subtype of `{'a': NotRequired[str]}`
* `{'a': str}` is now a subtype of `{'a': Optional[str]}`

This PR came up in the context of #12095 - in that PR I wrote a narrowing pass that would narrow the required properties of typed dicts with code that checked properties like `"key" in td`. Except that was causing errors because the narrowed type was considered incompatible with the original type.

This does somewhat alter the ergonomics and safety guarantees of the type system: because you could then do things like mutate the more generic type and make changes that were incompatible with the specific type. However in most structural-subtyping systems (including typescript), you're allowed to convert from a more-specific type to the less-specific type, with the understanding that this could allow type-incorrect mutations to occur.

## Test Plan

Automated/unit tests cover the primary functionality of this PR. I await the mypy_primer results: I do not expect any errors as this PR is strictly looser than previously, but it's possibly that type-ignore comments are no longer required in some places.

@davidfstr @JukkaL tagging you because of your prior relationship with TypedDict typing and this code.