### PR TITLE
Add support for Never

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -94,7 +94,7 @@ from mypy.messages import (
 from mypy.errorcodes import ErrorCode
 from mypy import message_registry, errorcodes as codes
 from mypy.types import (
-    FunctionLike, UnboundType, TypeVarType, TupleType, UnionType, StarType,
+    NEVER_NAMES, FunctionLike, UnboundType, TypeVarType, TupleType, UnionType, StarType,
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
     get_proper_type, get_proper_types, TypeAliasType, TypeVarLikeType,
@@ -2227,11 +2227,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             # Assignment color = Color['RED'] defines a variable, not an alias.
             return not rv.node.is_enum
         if isinstance(rv.node, Var):
-            return rv.node.fullname in (
-                'typing.NoReturn',
-                'typing_extensions.NoReturn',
-                'mypy_extensions.NoReturn',
-            )
+            return rv.node.fullname in NEVER_NAMES
 
         if isinstance(rv, NameExpr):
             n = self.lookup(rv.name, rv)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -12,7 +12,7 @@ from mypy_extensions import DefaultNamedArg
 from mypy.messages import MessageBuilder, quote_type_string, format_type_bare
 from mypy.options import Options
 from mypy.types import (
-    Type, UnboundType, TupleType, TypedDictType, UnionType, Instance, AnyType,
+    NEVER_NAMES, Type, UnboundType, TupleType, TypedDictType, UnionType, Instance, AnyType,
     CallableType, NoneType, ErasedType, DeletedType, TypeList, TypeVarType, SyntheticTypeVisitor,
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, CallableArgument,
     TypeQuery, union_items, TypeOfAny, LiteralType, RawExpressionType,
@@ -348,7 +348,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 self.fail('ClassVar[...] must have at most one type argument', t)
                 return AnyType(TypeOfAny.from_error)
             return self.anal_type(t.args[0])
-        elif fullname in ('mypy_extensions.NoReturn', 'typing.NoReturn'):
+        elif fullname in NEVER_NAMES:
             return UninhabitedType(is_noreturn=True)
         elif fullname in LITERAL_TYPE_NAMES:
             return self.analyze_literal_type(t)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -132,6 +132,14 @@ REVEAL_TYPE_NAMES: Final = (
     'typing_extensions.reveal_type',
 )
 
+NEVER_NAMES: Final = (
+    'typing.NoReturn',
+    'typing_extensions.NoReturn',
+    'mypy_extensions.NoReturn',
+    'typing.Never',
+    'typing_extensions.Never',
+)
+
 # A placeholder used for Bogus[...] parameters
 _dummy: Final[Any] = object()
 

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -936,6 +936,26 @@ if False:
     reveal_type(x)
 [builtins fixtures/exception.pyi]
 
+[case testNeverVariants]
+from typing import Never
+from typing_extensions import Never as TENever
+from typing import NoReturn
+from typing_extensions import NoReturn as TENoReturn
+from mypy_extensions import NoReturn as MENoReturn
+
+bottom1: Never
+reveal_type(bottom1)  # N: Revealed type is "<nothing>"
+bottom2: TENever
+reveal_type(bottom2)  # N: Revealed type is "<nothing>"
+bottom3: NoReturn
+reveal_type(bottom3)  # N: Revealed type is "<nothing>"
+bottom4: TENoReturn
+reveal_type(bottom4)  # N: Revealed type is "<nothing>"
+bottom5: MENoReturn
+reveal_type(bottom5)  # N: Revealed type is "<nothing>"
+
+[builtins fixtures/tuple.pyi]
+
 [case testUnreachableFlagExpressions]
 # flags: --warn-unreachable
 def foo() -> bool: ...

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -23,6 +23,7 @@ Type = 0
 ClassVar = 0
 Final = 0
 NoReturn = 0
+Never = 0
 NewType = 0
 ParamSpec = 0
 

--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -1,4 +1,4 @@
-from typing import TypeVar, Any, Mapping, Iterator, NoReturn, Dict, Type
+from typing import TypeVar, Any, Mapping, Iterator, NoReturn as NoReturn, Dict, Type
 from typing import TYPE_CHECKING as TYPE_CHECKING
 from typing import NewType as NewType
 
@@ -27,6 +27,7 @@ Concatenate: _SpecialForm
 TypeAlias: _SpecialForm
 
 TypeGuard: _SpecialForm
+Never: _SpecialForm
 
 # Fallback type for all typed dicts (does not exist at runtime).
 class _TypedDict(Mapping[str, object]):


### PR DESCRIPTION
This will exist in 3.11 and in the next release of typing-extensions. See python/cpython#30842 and python/typing#1060. The implementation simply introduces a new synonym for `NoReturn`.

I didn't do anything with `typing.assert_never` because it doesn't have any special semantics: it should work just based on the annotations.

I also added explicit support for `typing_extensions.NoReturn`. I think that one doesn't matter in practice because the typeshed stub for typing-extensions just re-exports `typing.NoReturn`. Still, it's nice for completeness.