### PR TITLE
Support module-level `strict` config flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -22,7 +22,7 @@ from mypy.find_sources import create_source_list, InvalidSourceList
 from mypy.fscache import FileSystemCache
 from mypy.errors import CompileError
 from mypy.errorcodes import error_codes
-from mypy.options import Options, BuildType
+from mypy.options import Options, BuildType, PER_MODULE_OPTIONS
 from mypy.config_parser import get_config_module_names, parse_version, parse_config_file
 from mypy.split_namespace import SplitNamespace
 
@@ -911,9 +911,10 @@ def process_options(args: List[str],
 
     options = Options()
 
-    def set_strict_flags() -> None:
+    def set_strict_flags(toplevel: bool, results: Dict[str, object]) -> None:
         for dest, value in strict_flag_assignments:
-            setattr(options, dest, value)
+            if toplevel or dest in PER_MODULE_OPTIONS:
+                results[dest] = value
 
     # Parse config file first, so command line can override.
     parse_config_file(options, set_strict_flags, config_file, stdout, stderr)
@@ -921,7 +922,8 @@ def process_options(args: List[str],
     # Set strict flags before parsing (if strict mode enabled), so other command
     # line options can override.
     if getattr(dummy, 'special-opts:strict'):  # noqa
-        set_strict_flags()
+        for dest, value in strict_flag_assignments:
+            setattr(options, dest, value)
 
     # Override cache_dir if provided in the environment
     environ_cache_dir = os.getenv('MYPY_CACHE_DIR', '')

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1207,8 +1207,8 @@ def test_stubs(args: argparse.Namespace, use_builtins_fixtures: bool = False) ->
     options.use_builtins_fixtures = use_builtins_fixtures
 
     if options.config_file:
-        def set_strict_flags() -> None:  # not needed yet
-            return
+        def set_strict_flags(toplevel: bool, results: Dict[str, object]) -> None:  # not needed yet
+            print("note: set_strict_flags called with toplevel={}".format(toplevel))
         parse_config_file(options, set_strict_flags, options.config_file, sys.stdout, sys.stderr)
 
     try:

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -160,7 +160,7 @@ class FineGrainedSuite(DataSuite):
 
         for name, _ in testcase.files:
             if 'mypy.ini' in name or 'pyproject.toml' in name:
-                parse_config_file(options, lambda: None, name)
+                parse_config_file(options, lambda t, r: None, name)
                 break
 
         return options

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1047,3 +1047,17 @@ class StubtestMiscUnit(unittest.TestCase):
         )
         output = run_stubtest(stub=stub, runtime=runtime, options=[], config_file=config_file)
         assert output == ""
+
+    def test_config_file_strict(self) -> None:
+        config_file = (
+            "[mypy]\n"
+            "strict = True\n"
+        )
+        output = run_stubtest(stub="", runtime="", options=[], config_file=config_file)
+        assert output == "note: set_strict_flags called with toplevel=True\n"
+        config_file = (
+            "[mypy-submodule.*]\n"
+            "strict = True\n"
+        )
+        output = run_stubtest(stub="", runtime="", options=[], config_file=config_file)
+        assert output == "note: set_strict_flags called with toplevel=False\n"


### PR DESCRIPTION
### Description

The current behavior of `strict = True` in a module-level config section actually enables all strictness flags globally, which seems like a bug. This change changes a module-level `strict = True` option to act as though all of the per-module strictness flags were enabled.

## Test Plan

In addition to adding a basic unit test (the `strict` flag is hard to test since it is essentially a macro flag) I tested manually using a config file like this:

```ini
[mypy]
strict = True
[mypy-foo.*]
strict = False
```

I then confirmed that strictness flags were applied to non-`foo` packages (I removed some type hints and saw an error) and that strictness was not applied to the `foo` package (removed some type hints and saw no errors).

Personally I expected the `strict` config flag to behave this way already, so I don't think a change to the docs is needed.
