### PR TITLE
stubtest: error for pos-only differences for dunder methods, too

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -594,7 +594,6 @@ def _verify_signature(
             runtime_arg.kind == inspect.Parameter.POSITIONAL_ONLY
             and not stub_arg.variable.name.startswith("__")
             and not stub_arg.variable.name.strip("_") == "self"
-            and not is_dunder(function_name, exclude_special=True)  # noisy for dunder methods
         ):
             yield (
                 'stub argument "{}" should be positional-only '


### PR DESCRIPTION
### Description

stubtest currently does not complain if a dunder method in a stub file has an argument that should be positional-only, but is marked in the stub as being positional-or-keyword. This PR proposes to remove this exception.

Removing the exception will increase our confidence in the accuracy of typeshed stubs with regard to positional-only arguments.

The rationale for the exception was the very large number of complaints stubtest had when checking typeshed. However, I have been using this patch over the past few days to file a series of PRs to typeshed, in order to minimise the impact of this PR:

<details>

- https://github.com/python/typeshed/pull/7220
- https://github.com/python/typeshed/pull/7221
- https://github.com/python/typeshed/pull/7223
- https://github.com/python/typeshed/pull/7224
- https://github.com/python/typeshed/pull/7225
- https://github.com/python/typeshed/pull/7226
- https://github.com/python/typeshed/pull/7227

</details>

As a result, this PR means that only the following new hits are generated when running stubtest on typeshed:

<details>

```diff
+ error: sqlite3.Connection.__exit__ is inconsistent, stub argument "t" should be positional-only (rename with a leading double underscore, i.e. "__type")
+ error: sqlite3.Connection.__exit__ is inconsistent, stub argument "exc" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.Connection.__exit__ is inconsistent, stub argument "tb" should be positional-only (rename with a leading double underscore, i.e. "__traceback")
+ error: sqlite3.Row.__eq__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.Row.__ge__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.Row.__getitem__ is inconsistent, stub argument "index" should be positional-only (rename with a leading double underscore, i.e. "__key")
+ error: sqlite3.Row.__gt__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.Row.__le__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.Row.__lt__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.Row.__ne__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.dbapi2.Connection.__exit__ is inconsistent, stub argument "t" should be positional-only (rename with a leading double underscore, i.e. "__type")
+ error: sqlite3.dbapi2.Connection.__exit__ is inconsistent, stub argument "exc" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.dbapi2.Connection.__exit__ is inconsistent, stub argument "tb" should be positional-only (rename with a leading double underscore, i.e. "__traceback")
+ error: sqlite3.dbapi2.Row.__eq__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.dbapi2.Row.__ge__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.dbapi2.Row.__getitem__ is inconsistent, stub argument "index" should be positional-only (rename with a leading double underscore, i.e. "__key")
+ error: sqlite3.dbapi2.Row.__gt__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.dbapi2.Row.__le__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.dbapi2.Row.__lt__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ error: sqlite3.dbapi2.Row.__ne__ is inconsistent, stub argument "other" should be positional-only (rename with a leading double underscore, i.e. "__value")
```

</details>

All of these remaining hits will be resolved by one final outstanding PR to typeshed (EDIT: now merged -- thanks @JelleZijlstra!): 
- https://github.com/python/typeshed/pull/7222.

The full command I ran to obtain this diff was the following (with `../typeshed` being the path to my clone of typeshed):

```
> python -m mypy.stubtest --check-typeshed --custom-typeshed-dir ../typeshed --allowlist ../typeshed/tests/stubtest_allowlists/py3_common.txt --allowlist ../typeshed/tests/stubtest_allowlists/py310.txt --allowlist ../typeshed/tests/stubtest_allowlists/win32.txt --allowlist ../typeshed/tests/stubtest_allowlists/win32-py310.txt > pos_only_report.txt
```

I ran this command without this patch applied, and with this patch applied. The command was run on Windows, with Python 3.10.

## Test Plan

The existing exception does not appear to be tested; this PR does not _appear_ to break any existing tests. I'm happy to add some tests for this change, if they'd be appreciated, however :)

## Design question

We could add a new command-line option to turn this exception back on. Thoughts on that?