### PR TITLE
Improve suggestion when using `any` as type

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -493,7 +493,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         elif isinstance(sym.node, (SYMBOL_FUNCBASE_TYPES, Decorator)):
             message = 'Function "{}" is not valid as a type'
             if name == 'builtins.any':
-                notes.append('Perhaps you meant "Any" instead of "any"?')
+                notes.append('Perhaps you meant "typing.Any" instead of "any"?')
             else:
                 notes.append('Perhaps you need "Callable[...]" or a callback protocol?')
         elif isinstance(sym.node, MypyFile):

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -492,7 +492,10 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             message = 'Variable "{}" is not valid as a type'
         elif isinstance(sym.node, (SYMBOL_FUNCBASE_TYPES, Decorator)):
             message = 'Function "{}" is not valid as a type'
-            notes.append('Perhaps you need "Callable[...]" or a callback protocol?')
+            if name == 'builtins.any':
+                notes.append('Perhaps you meant "Any" instead of "any"?')
+            else:
+                notes.append('Perhaps you need "Callable[...]" or a callback protocol?')
         elif isinstance(sym.node, MypyFile):
             # TODO: suggest a protocol when supported.
             message = 'Module "{}" is not valid as a type'

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2608,5 +2608,5 @@ reveal_type(foo()) # N: Revealed type is "None"
 
 [case testAnyArgument]
 def a(b: any): pass # E: Function "builtins.any" is not valid as a type \
-                    # N: Perhaps you meant "Any" instead of "any"?
+                    # N: Perhaps you meant "typing.Any" instead of "any"?
 [builtins fixtures/any.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2605,3 +2605,8 @@ def foo() -> None:
     pass
 
 reveal_type(foo()) # N: Revealed type is "None"
+
+[case testAnyArgument]
+def a(b: any): pass # E: Function "builtins.any" is not valid as a type \
+                    # N: Perhaps you meant "Any" instead of "any"?
+[builtins fixtures/any.pyi]

--- a/test-data/unit/fixtures/any.pyi
+++ b/test-data/unit/fixtures/any.pyi
@@ -1,0 +1,8 @@
+from typing import TypeVar, Iterable
+
+T = TypeVar('T')
+
+class int: pass
+class str: pass
+
+def any(i: Iterable[T]) -> bool: pass


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Using `any` instead of `Any` is an easy mistake to make because "any" has been used as a type in docstrings, editors may highlight it as it's the name for the built-in function and at least TypeScript uses it as a keyword. Here are [some examples](https://grep.app/search?q=%3A%20any%28%5C%5B%7C%2C%7C%20%3D%29&regexp=true&case=true&filter[lang][0]=Python) of this mistake in real-world Python code.

For example, for the following code:

```python
def a(b: any): pass
```

mypy currently outputs:

```
any.py:1: error: Function "builtins.any" is not valid as a type
any.py:1: note: Perhaps you need "Callable[...]" or a callback protocol?
```

I think that the given suggestion is misleading and could be improved. This pull request changes the output to:

```
any.py:1: error: Function "builtins.any" is not valid as a type
any.py:1: note: Perhaps you meant "Any" instead of "any"?
```

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

Added a unit test to verify the new output.