### PR TITLE
Deduplicate error codes for `ignore-without-code`

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -257,6 +257,8 @@ except that attempting to invoke an undefined method (e.g. ``__len__``) results 
 while attempting to evaluate an object in boolean context without a concrete implementation results in a truthy value.
 
 
+.. _ignore-without-code:
+
 Check that ``# type: ignore`` include an error code [ignore-without-code]
 -------------------------------------------------------------------------
 

--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -282,7 +282,7 @@ Example:
     # - the expected error 'assignment', and
     # - the unexpected error 'attr-defined'
     # are silenced.
-    # Error: "type: ignore" comment without error code (currently ignored: [attr-defined])
+    # Error: "type: ignore" comment without error code (use "type: ignore[attr-defined]" instead)
     f.nme = 42  # type: ignore
 
     # This line warns correctly about the typo in the attribute name

--- a/docs/source/error_codes.rst
+++ b/docs/source/error_codes.rst
@@ -31,6 +31,10 @@ or config `show_error_codes = True` to display error codes. Error codes are show
    $ mypy --show-error-codes prog.py
    prog.py:1: error: "str" has no attribute "trim"  [attr-defined]
 
+It's also possible to require error codes for ``type: ignore`` comments.
+See :ref:`ignore-without-code<ignore-without-code>` for more information.
+
+
 .. _silence-error-codes:
 
 Silencing errors based on error codes

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -532,7 +532,7 @@ class Errors:
                 continue
 
             codes_hint = ''
-            ignored_codes = used_ignored_lines[line]
+            ignored_codes: List[str] = sorted(set(used_ignored_lines[line]))
             if ignored_codes:
                 codes_hint = f' (currently ignored: [{", ".join(ignored_codes)}])'
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -532,7 +532,7 @@ class Errors:
                 continue
 
             codes_hint = ''
-            ignored_codes: List[str] = sorted(set(used_ignored_lines[line]))
+            ignored_codes = sorted(set(used_ignored_lines[line]))
             if ignored_codes:
                 codes_hint = f' (currently ignored: [{", ".join(ignored_codes)}])'
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -534,7 +534,7 @@ class Errors:
             codes_hint = ''
             ignored_codes = sorted(set(used_ignored_lines[line]))
             if ignored_codes:
-                codes_hint = f' (currently ignored: [{", ".join(ignored_codes)}])'
+                codes_hint = f' (use "type: ignore[{", ".join(ignored_codes)}]" instead)'
 
             message = f'"type: ignore" comment without error code{codes_hint}'
             # Don't use report since add_error_info will ignore the error!

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -148,7 +148,7 @@ x # type: ignore[name-defined, attr-defined] # E: Unused "type: ignore[attr-defi
 [case testErrorCodeMissingWhenRequired]
 # flags: --enable-error-code ignore-without-code
 "x" # type: ignore # E: "type: ignore" comment without error code  [ignore-without-code]
-y # type: ignore # E: "type: ignore" comment without error code (currently ignored: [name-defined])  [ignore-without-code]
+y # type: ignore # E: "type: ignore" comment without error code (use "type: ignore[name-defined]" instead)  [ignore-without-code]
 z # type: ignore[name-defined]
 "a" # type: ignore[ignore-without-code]
 
@@ -173,7 +173,7 @@ class A:
 
 a: A | None
 # 'union-attr' should only be listed once (instead of twice) and list should be sorted
-a.func("invalid string").attr  # type: ignore  # E: "type: ignore" comment without error code (currently ignored: [arg-type, union-attr])  [ignore-without-code]
+a.func("invalid string").attr  # type: ignore  # E: "type: ignore" comment without error code (use "type: ignore[arg-type, union-attr]" instead)  [ignore-without-code]
 [builtins fixtures/tuple.pyi]
 
 [case testErrorCodeIgnoreWithExtraSpace]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -164,6 +164,18 @@ z # type: ignore[ignore-without-code] # E: Unused "type: ignore" comment # E: Na
 x
 y # type: ignore  # ignore the lack of error code since we're ignore the whole file
 
+[case testErrorCodeMissingMultiple]
+# flags: --enable-error-code ignore-without-code --python-version 3.7
+from __future__ import annotations
+class A:
+    attr: int
+    def func(self, var: int) -> A | None: ...
+
+a: A | None
+# 'union-attr' should only be listed once (instead of twice) and list should be sorted
+a.func("invalid string").attr  # type: ignore  # E: "type: ignore" comment without error code (currently ignored: [arg-type, union-attr])  [ignore-without-code]
+[builtins fixtures/tuple.pyi]
+
 [case testErrorCodeIgnoreWithExtraSpace]
 x  # type: ignore   [name-defined]
 x2 # type: ignore   [ name-defined ]


### PR DESCRIPTION
### Description

#11633 added the awesome `ignore-without-code` option. During testing I noticed that in some cases an error code would be displayed multiple times. This can be rather annoying, since it's only necessary to ignore an error code once.

```
# current
error: "type: ignore" comment without error code (currently ignored: [union-attr, arg-type, union-attr])
```

```
# new
error: "type: ignore" comment without error code (currently ignored: [arg-type, union-attr])
```

/CC: @PeterJCLaw

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

_Added a new test case._
