### PR TITLE
stubtest: error if a dunder method is missing from a stub

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -594,7 +594,6 @@ def _verify_signature(
             runtime_arg.kind == inspect.Parameter.POSITIONAL_ONLY
             and not stub_arg.variable.name.startswith("__")
             and not stub_arg.variable.name.strip("_") == "self"
-            and not is_dunder(function_name, exclude_special=True)  # noisy for dunder methods
         ):
             yield (
                 'stub argument "{}" should be positional-only '

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -282,10 +282,11 @@ IGNORED_DUNDERS = frozenset({
     # These two are basically useless for type checkers
     "__hash__",
     "__getattr__",
-    "__abstractmethods__",  # For some reason, mypy doesn't infer that classes with ABCMeta as the metaclass have this inherited
+    # For some reason, mypy doesn't infer classes with metaclass=ABCMeta inherit this attribute
+    "__abstractmethods__",
     "__doc__",  # Can only ever be str | None, who cares?
     "__del__",  # Only ever called when an object is being deleted, who cares?
-    "__new_member__",  # If an enum class defines `__new__`, the method is renamed to be `__new_member__`
+    "__new_member__",  # If an enum defines __new__, the method is renamed as __new_member__
 })
 
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -763,12 +763,12 @@ def verify_none(
     stub: Missing, runtime: MaybeMissing[Any], object_path: List[str]
 ) -> Iterator[Error]:
     # Do not error for an object missing from the stub
-    # If the runtime object is a types.WrapperDescriptorType
+    # If the runtime object is a types.WrapperDescriptorType object
     # and has a non-special dunder name.
     # The vast majority of these are false positives.
     if not (
-        isinstance(runtime, types.WrapperDescriptorType)
-        and is_dunder(runtime.__name__, exclude_special=True)
+        isinstance(runtime, type(object.__init__))
+        and is_dunder(getattr(runtime, "__name__", ""), exclude_special=True)
     ):
         yield Error(object_path, "is not present in stub", stub, runtime)
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -256,6 +256,7 @@ IGNORED_DUNDERS = frozenset({
     "__getnewargs__",
     "__getinitargs__",
     "__reduce_ex__",
+    "__reduce__",
     # typing implementation details
     "__parameters__",
     "__origin__",

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -61,7 +61,7 @@ else:
     def is_dunder_slot_wrapper(obj: object) -> bool:
         return (
             isinstance(obj, type(object.__init__))
-            and is_dunder(getattr(obj, "__name__", ""), exclude_special=True)
+            and is_dunder(getattr(obj, "__name__"), exclude_special=True)
         )
 
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -277,9 +277,6 @@ IGNORED_DUNDERS = frozenset({
     "__origin__",
     "__args__",
     "__orig_bases__",
-    "__mro_entries__",
-    "__forward_is_class__",
-    "__forward_module__",
     "__final__",
     # isinstance/issubclass hooks that type-checkers don't usually care about
     "__instancecheck__",
@@ -292,9 +289,6 @@ IGNORED_DUNDERS = frozenset({
     "__ctype_be__",
     "__ctype_le__",
     "__ctypes_from_outparam__",
-    # Two float methods only used internally for CPython test suite, not for public use
-    "__set_format__",
-    "__getformat__",
     # These two are basically useless for type checkers
     "__hash__",
     "__getattr__",

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -37,6 +37,7 @@ KT = TypeVar('KT')
 VT = TypeVar('VT')
 
 class object:
+    __module__: str
     def __init__(self) -> None: pass
 class type: ...
 
@@ -678,7 +679,7 @@ class StubtestUnit(unittest.TestCase):
         yield Case(stub="g: int", runtime="def g(): ...", error="g")
 
     @collect_cases
-    def test_special_dunders(self) -> Iterator[Case]:
+    def test_dunders(self) -> Iterator[Case]:
         yield Case(
             stub="class A:\n  def __init__(self, a: int, b: int) -> None: ...",
             runtime="class A:\n  def __init__(self, a, bx): pass",
@@ -689,21 +690,26 @@ class StubtestUnit(unittest.TestCase):
             runtime="class B:\n  def __call__(self, c, dx): pass",
             error="B.__call__",
         )
+        yield Case(
+            stub="class C:\n  def __or__(self, other: C) -> C: ...",
+            runtime="class C: ...",
+            error="C.__or__",
+        )
         if sys.version_info >= (3, 6):
             yield Case(
                 stub=(
-                    "class C:\n"
+                    "class D:\n"
                     "  def __init_subclass__(\n"
                     "    cls, e: int = ..., **kwargs: int\n"
                     "  ) -> None: ...\n"
                 ),
-                runtime="class C:\n  def __init_subclass__(cls, e=1, **kwargs): pass",
+                runtime="class D:\n  def __init_subclass__(cls, e=1, **kwargs): pass",
                 error=None,
             )
         if sys.version_info >= (3, 9):
             yield Case(
-                stub="class D:\n  def __class_getitem__(cls, type: type) -> type: ...",
-                runtime="class D:\n  def __class_getitem__(cls, type): ...",
+                stub="class E:\n  def __class_getitem__(cls, type: type) -> type: ...",
+                runtime="class E:\n  def __class_getitem__(cls, type): ...",
                 error=None,
             )
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -658,6 +658,16 @@ class StubtestUnit(unittest.TestCase):
         yield Case(
             stub="from mystery import A, B as B, C as D  # type: ignore", runtime="", error="B"
         )
+        yield Case(
+            stub="class Y: ...",
+            runtime="__all__ += ['Y']\nclass Y:\n  def __or__(self, other): return self|other",
+            error="Y.__or__"
+        )
+        yield Case(
+            stub="class Z: ...",
+            runtime="__all__ += ['Z']\nclass Z:\n  def __reduce__(self): return (Z,)",
+            error=None
+        )
 
     @collect_cases
     def test_missing_no_runtime_all(self) -> Iterator[Case]:
@@ -690,26 +700,21 @@ class StubtestUnit(unittest.TestCase):
             runtime="class B:\n  def __call__(self, c, dx): pass",
             error="B.__call__",
         )
-        yield Case(
-            stub="class C:\n  def __or__(self, other: C) -> C: ...",
-            runtime="class C: ...",
-            error="C.__or__",
-        )
         if sys.version_info >= (3, 6):
             yield Case(
                 stub=(
-                    "class D:\n"
+                    "class C:\n"
                     "  def __init_subclass__(\n"
                     "    cls, e: int = ..., **kwargs: int\n"
                     "  ) -> None: ...\n"
                 ),
-                runtime="class D:\n  def __init_subclass__(cls, e=1, **kwargs): pass",
+                runtime="class C:\n  def __init_subclass__(cls, e=1, **kwargs): pass",
                 error=None,
             )
         if sys.version_info >= (3, 9):
             yield Case(
-                stub="class E:\n  def __class_getitem__(cls, type: type) -> type: ...",
-                runtime="class E:\n  def __class_getitem__(cls, type): ...",
+                stub="class D:\n  def __class_getitem__(cls, type: type) -> type: ...",
+                runtime="class D:\n  def __class_getitem__(cls, type): ...",
                 error=None,
             )
 


### PR DESCRIPTION
### Description

This PR alters stubtest so that it raises an error if a dunder method is missing from a stub. Currently, stubtest does raise an error for a few missing dunders (`__call__`, `__class_getitem__`, etc.). However, for the vast majority of them, it does not raise an error.

I have been using this patch to provide a number of fixes to typeshed over the past week or so:

<details>

- https://github.com/python/typeshed/pull/7248
- https://github.com/python/typeshed/pull/7244
- https://github.com/python/typeshed/pull/7242
- https://github.com/python/typeshed/pull/7231
- https://github.com/python/typeshed/pull/7216
- https://github.com/python/typeshed/pull/7214
- https://github.com/python/typeshed/pull/7212
- https://github.com/python/typeshed/pull/7210
- https://github.com/python/typeshed/pull/7210
- https://github.com/python/typeshed/pull/7207
- https://github.com/python/typeshed/pull/7206
- https://github.com/python/typeshed/pull/7205
- https://github.com/python/typeshed/pull/7203
- https://github.com/python/typeshed/pull/7202

</details>

With these typeshed fixes merged, here are the new errors stubtest reports from checking typeshed, with this patch applied:

<details>

```diff
+ _collections_abc.Mapping.__eq__ is inconsistent, stub argument "__o" should be positional or keyword (remove leading double underscore)
+ _collections_abc.Mapping.__reversed__ is not present in stub
+ _collections_abc.Set.__eq__ is inconsistent, stub argument "__o" should be positional or keyword (remove leading double underscore)
+ _collections_abc.Set.__rand__ is not present in stub
+ _collections_abc.Set.__ror__ is not present in stub
+ _collections_abc.Set.__rsub__ is not present in stub
+ _collections_abc.Set.__rxor__ is not present in stub
+ _collections_abc.dict_items.__and__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__contains__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__key")
+ _collections_abc.dict_items.__ge__ is inconsistent, stub argument "s" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__gt__ is inconsistent, stub argument "s" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__le__ is inconsistent, stub argument "s" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__lt__ is inconsistent, stub argument "s" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__or__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__rand__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__ror__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__rsub__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__rxor__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__sub__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_items.__xor__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__and__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__contains__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__key")
+ _collections_abc.dict_keys.__ge__ is inconsistent, stub argument "s" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__gt__ is inconsistent, stub argument "s" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__le__ is inconsistent, stub argument "s" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__lt__ is inconsistent, stub argument "s" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__or__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__rand__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__ror__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__rsub__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__rxor__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__sub__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _collections_abc.dict_keys.__xor__ is inconsistent, stub argument "o" should be positional-only (rename with a leading double underscore, i.e. "__value")
+ _weakref.ProxyType.__bytes__ is not present in stub
+ _weakref.ProxyType.__reversed__ is not present in stub
+ builtins.property.__set_name__ is not present in stub
+ builtins.super.__self__ is not present in stub
+ builtins.super.__self_class__ is not present in stub
+ builtins.super.__thisclass__ is not present in stub
+ collections.ChainMap.__bool__ is not present in stub
+ collections.Counter.__missing__ is not present in stub
+ dbm.dumb._Database.__contains__ is inconsistent, stub argument "__o" should be positional or keyword (remove leading double underscore)
+ enum.EnumMeta.__prepare__ is inconsistent, stub argument "__name" should be positional or keyword (remove leading double underscore)
+ enum.EnumMeta.__prepare__ is inconsistent, stub argument "__bases" should be positional or keyword (remove leading double underscore)
+ functools.partial.__vectorcalloffset__ is not present in stub
+ http.cookies.BaseCookie.__str__ is inconsistent, stub does not have argument "attrs"
+ http.cookies.BaseCookie.__str__ is inconsistent, stub does not have argument "header"
+ http.cookies.BaseCookie.__str__ is inconsistent, stub does not have argument "sep"
+ http.cookies.Morsel.__str__ is inconsistent, stub does not have argument "attrs"
+ http.cookies.Morsel.__str__ is inconsistent, stub does not have argument "header"
+ lib2to3.pytree.Leaf.__unicode__ is not present in stub
+ lib2to3.pytree.Node.__unicode__ is not present in stub
+ platform.uname_result.__getitem__ is inconsistent, stub argument "__x" should be positional or keyword (remove leading double underscore)
+ pstats.FunctionProfile.__eq__ is inconsistent, stub argument "__o" should be positional or keyword (remove leading double underscore)
+ pstats.StatsProfile.__eq__ is inconsistent, stub argument "__o" should be positional or keyword (remove leading double underscore)
+ types.FunctionType.__builtins__ is not present in stub
+ types.LambdaType.__builtins__ is not present in stub
+ uuid.UUID.__setattr__ is inconsistent, stub argument "__name" should be positional or keyword (remove leading double underscore)
+ uuid.UUID.__setattr__ is inconsistent, stub argument "__value" should be positional or keyword (remove leading double underscore)
+ weakref.ProxyType.__bytes__ is not present in stub
+ weakref.ProxyType.__reversed__ is not present in stub
+ xml.dom.minidom.Node.__bool__ is not present in stub
```

</details>

## Notes on the new errors reported

- We have a few new complaints about discrepancies between `typing` and `collections.abc`. These just need to be allowlisted imo, unless and until we find a good general solution to that problem (refs https://github.com/python/typeshed/issues/6257)
- There are a _lot_ of complaints about `dict_keys`, `dict_values` and `dict_items` having positional-only differences with `typing.KeysView`, `typing.ValuesView` and `typing.ItemsView`. The way to resolve that would be essentially duplicate every method from `typing.{Keys, Values, Items}View` into those classes (but with pos-only args instead of pos-or-kw args). I don't really have the stomach to do that. These should probably just be allowlisted.
- `weakref.ProxyType`, `dbm.dum._Database`, `lib2to3.pytree.Leaf`: I don't really know anything about these classes.
- `enum.EnumMeta.__prepare__`: this will be resolved by https://github.com/python/typeshed/pull/7243
- `super` has some really weird dunders.
- `property.__set_name__`: this is a false positive -- it doesn't exist in real life, just needs to be allowlisted.
- `http.cookies` has some really weird `__str__` methods.
- `functools.partial.__vectorcalloffset__`: no idea what this does or is for.
- `platform.uname_result` [is a mess in CPython](https://github.com/python/cpython/blob/fc115c9bde52a58b4fb9be2b80c3d6be8a4d2454/Lib/platform.py#L772).
- `pstats` hits: these relate to a mypy bug in `dataclasses` `__eq__` method generation (#12186).
- `collections.Counter.__missing__`: this always raises an exception, but per https://github.com/python/typeshed/issues/7188, we could maybe add it to the stub.
- There's a few missing `__bool__` overrides stubtest now complains about: we could add these to the stub, though they don't seem particularly useful, since they don't alter the default behaviour of `bool(x)` at all. (But I don't think `__bool__` should be added to the list of ignored dunders: it was useful for this patch to flag the missing `__bool__` method fixed in https://github.com/python/typeshed/pull/7206, as that _is_ an override that changes behaviour from the default.)
- `uuid.UUID.__setattr__`: this always raises an exception, I think it should just be allowlisted.

## Test Plan

I've altered the existing tests so they continue to pass, and added two new test cases.

cc. @hauntsaninja: here is the promised follow-up PR!
