### PR TITLE
Suggest `typing.Callable` when using `callable` as type

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -494,6 +494,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             message = 'Function "{}" is not valid as a type'
             if name == 'builtins.any':
                 notes.append('Perhaps you meant "typing.Any" instead of "any"?')
+            elif name == 'builtins.callable':
+                notes.append('Perhaps you meant "typing.Callable" instead of "callable"?')
             else:
                 notes.append('Perhaps you need "Callable[...]" or a callback protocol?')
         elif isinstance(sym.node, MypyFile):

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2610,3 +2610,8 @@ reveal_type(foo()) # N: Revealed type is "None"
 def a(b: any): pass # E: Function "builtins.any" is not valid as a type \
                     # N: Perhaps you meant "typing.Any" instead of "any"?
 [builtins fixtures/any.pyi]
+
+[case testCallableArgument]
+def a(b: callable): pass # E: Function "builtins.callable" is not valid as a type \
+                         # N: Perhaps you meant "typing.Callable" instead of "callable"?
+[builtins fixtures/callable.pyi]


### PR DESCRIPTION
### Description

Follow-up PR based on [this comment](https://github.com/python/mypy/pull/12185#pullrequestreview-883767917). Now for:

```python
def c(d: callable): pass
```

mypy will suggest:

```
callable.py:1: error: Function "builtins.callable" is not valid as a type
callable.py:1: note: Perhaps you meant "typing.Callable" instead of "callable"?
```

## Test Plan

Added a unit test to verify the new output.