### PR TITLE
Update `ignore-without-code` message

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -282,7 +282,7 @@ Example:
     # - the expected error 'assignment', and
     # - the unexpected error 'attr-defined'
     # are silenced.
-    # Error: "type: ignore" comment without error code (use "type: ignore[attr-defined]" instead)
+    # Error: "type: ignore" comment without error code (consider "type: ignore[attr-defined]" instead)
     f.nme = 42  # type: ignore
 
     # This line warns correctly about the typo in the attribute name

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -534,7 +534,7 @@ class Errors:
             codes_hint = ''
             ignored_codes = sorted(set(used_ignored_lines[line]))
             if ignored_codes:
-                codes_hint = f' (use "type: ignore[{", ".join(ignored_codes)}]" instead)'
+                codes_hint = f' (consider "type: ignore[{", ".join(ignored_codes)}]" instead)'
 
             message = f'"type: ignore" comment without error code{codes_hint}'
             # Don't use report since add_error_info will ignore the error!

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -148,7 +148,7 @@ x # type: ignore[name-defined, attr-defined] # E: Unused "type: ignore[attr-defi
 [case testErrorCodeMissingWhenRequired]
 # flags: --enable-error-code ignore-without-code
 "x" # type: ignore # E: "type: ignore" comment without error code  [ignore-without-code]
-y # type: ignore # E: "type: ignore" comment without error code (use "type: ignore[name-defined]" instead)  [ignore-without-code]
+y # type: ignore # E: "type: ignore" comment without error code (consider "type: ignore[name-defined]" instead)  [ignore-without-code]
 z # type: ignore[name-defined]
 "a" # type: ignore[ignore-without-code]
 
@@ -173,7 +173,7 @@ class A:
 
 a: A | None
 # 'union-attr' should only be listed once (instead of twice) and list should be sorted
-a.func("invalid string").attr  # type: ignore  # E: "type: ignore" comment without error code (use "type: ignore[arg-type, union-attr]" instead)  [ignore-without-code]
+a.func("invalid string").attr  # type: ignore  # E: "type: ignore" comment without error code (consider "type: ignore[arg-type, union-attr]" instead)  [ignore-without-code]
 [builtins fixtures/tuple.pyi]
 
 [case testErrorCodeIgnoreWithExtraSpace]


### PR DESCRIPTION
### Description
Followup to https://github.com/python/mypy/pull/12194#issuecomment-1043399272
Update message for `ignore-without-code` to better capture the spirit of the check.

I've changed `use` to `consider` as suggested since I also feel this is slightly better. I'm open for other / better ideas.

Another question, do we want to remove the space between different error codes? I feel that might be a tick better.
```diff
- ... (consider "type: ignore[arg-type, union-attr]" instead)
+ ... (consider "type: ignore[arg-type,union-attr]" instead)
```

/CC: @hauntsaninja @PeterJCLaw