### PR TITLE
Use type variable bound to infer constraints

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -513,6 +513,10 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             return infer_constraints(template,
                                      mypy.typeops.tuple_fallback(actual),
                                      self.direction)
+        elif isinstance(actual, TypeVarType):
+            if not actual.values:
+                return infer_constraints(template, actual.upper_bound, self.direction)
+            return []
         else:
             return []
 

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2806,3 +2806,24 @@ class MyClass:
         assert isinstance(self, MyProtocol)
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testProtocolAndTypeVariableSpecialCase]
+from typing import TypeVar, Iterable, Optional, Callable, Protocol
+
+T_co = TypeVar('T_co', covariant=True)
+
+class SupportsNext(Protocol[T_co]):
+    def __next__(self) -> T_co: ...
+
+N = TypeVar("N", bound=SupportsNext, covariant=True)
+
+class SupportsIter(Protocol[T_co]):
+    def __iter__(self) -> T_co: ...
+
+def f(i: SupportsIter[N]) -> N: ...
+
+I = TypeVar('I', bound=Iterable)
+
+def g(x: I, y: Iterable) -> None:
+    f(x)
+    f(y)


### PR DESCRIPTION
This fixes a regression where `iter(x)` could generate a false
positive if `x` has a type variable type with a bound.