### PR TITLE
[mypyc] Use Py_TYPE and Py_IsNone

### DIFF
--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -139,8 +139,8 @@ int CPyDict_UpdateInDisplay(PyObject *dict, PyObject *stuff) {
     if (ret < 0) {
         if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
             PyErr_Format(PyExc_TypeError,
-                    "'%.200s' object is not a mapping",
-                    stuff->ob_type->tp_name);
+                         "'%.200s' object is not a mapping",
+                         Py_TYPE(stuff)->tp_name);
         }
     }
     return ret;

--- a/mypyc/lib-rt/exc_ops.c
+++ b/mypyc/lib-rt/exc_ops.c
@@ -140,7 +140,7 @@ out:
 // Get the type of a value as a string, expanding tuples to include
 // all the element types.
 static PyObject *CPy_FormatTypeName(PyObject *value) {
-    if (value == Py_None) {
+    if (Py_IsNone(value)) {
         return PyUnicode_FromString("None");
     }
 

--- a/mypyc/lib-rt/generic_ops.c
+++ b/mypyc/lib-rt/generic_ops.c
@@ -33,7 +33,7 @@ PyObject *CPyObject_GetAttr3(PyObject *v, PyObject *name, PyObject *defl)
 
 PyObject *CPyIter_Next(PyObject *iter)
 {
-    return (*iter->ob_type->tp_iternext)(iter);
+    return (*Py_TYPE(iter)->tp_iternext)(iter);
 }
 
 PyObject *CPyNumber_Power(PyObject *base, PyObject *index)

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -3,14 +3,13 @@
 // These are registered in mypyc.primitives.misc_ops.
 
 #include <Python.h>
-#include "pythoncapi_compat.h"
 #include "CPy.h"
 
 PyObject *CPy_GetCoro(PyObject *obj)
 {
     // If the type has an __await__ method, call it,
     // otherwise, fallback to calling __iter__.
-    PyAsyncMethods* async_struct = obj->ob_type->tp_as_async;
+    PyAsyncMethods* async_struct = Py_TYPE(obj)->tp_as_async;
     if (async_struct != NULL && async_struct->am_await != NULL) {
         return (async_struct->am_await)(obj);
     } else {
@@ -25,7 +24,7 @@ PyObject *CPyIter_Send(PyObject *iter, PyObject *val)
     // Do a send, or a next if second arg is None.
     // (This behavior is to match the PEP 380 spec for yield from.)
     _Py_IDENTIFIER(send);
-    if (val == Py_None) {
+    if (Py_IsNone(val)) {
         return CPyIter_Next(iter);
     } else {
         return _PyObject_CallMethodIdOneArg(iter, &PyId_send, val);
@@ -640,7 +639,7 @@ CPy_Super(PyObject *builtins, PyObject *self) {
     if (!super_type)
         return NULL;
     PyObject *result = PyObject_CallFunctionObjArgs(
-        super_type, (PyObject*)self->ob_type, self, NULL);
+        super_type, (PyObject*)Py_TYPE(self), self, NULL);
     Py_DECREF(super_type);
     return result;
 }


### PR DESCRIPTION
We are using `Py_TYPE` in many places, however keeping several direct calls to `ob_type`. Replace them with `Py_TYPE` to maintain consistency. This PR also replaces `== Py_None` with `Py_IsNone` as `pythoncapi_compat` suggests.