### PR TITLE
Make pyinfo compatible with Python 2

### DIFF
--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -19,7 +19,7 @@ if MYPY:
 
 def getprefixes():
     # type: () -> Tuple[str, str]
-    return sys.base_prefix, sys.prefix
+    return getattr(sys, "base_prefix", sys.prefix), sys.prefix
 
 
 def getsitepackages():


### PR DESCRIPTION
I'm not adding a test because it's Python 2, but I did test locally.

Fixes #12202