### PR TITLE
Give "as" variables in with statements separate scopes

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -56,7 +56,7 @@ from mypy.plugins.default import DefaultPlugin
 from mypy.fscache import FileSystemCache
 from mypy.metastore import MetadataStore, FilesystemMetadataStore, SqliteMetadataStore
 from mypy.typestate import TypeState, reset_global_state
-from mypy.renaming import VariableRenameVisitor, VariableRenameVisitor2
+from mypy.renaming import VariableRenameVisitor, LimitedVariableRenameVisitor
 from mypy.config_parser import parse_mypy_comments
 from mypy.freetree import free_tree
 from mypy.stubinfo import legacy_bundled_packages, is_legacy_bundled_package
@@ -2120,10 +2120,11 @@ class State:
         # TODO: Do this while constructing the AST?
         self.tree.names = SymbolTable()
         if not self.tree.is_stub:
+            # Always perform some low-key variable renaming
+            self.tree.accept(LimitedVariableRenameVisitor())
             if options.allow_redefinition:
-                # Perform renaming across the AST to allow variable redefinitions
+                # Perform more renaming across the AST to allow variable redefinitions
                 self.tree.accept(VariableRenameVisitor())
-            self.tree.accept(VariableRenameVisitor2())
 
     def add_dependency(self, dep: str) -> None:
         if dep not in self.dependencies_set:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -56,7 +56,7 @@ from mypy.plugins.default import DefaultPlugin
 from mypy.fscache import FileSystemCache
 from mypy.metastore import MetadataStore, FilesystemMetadataStore, SqliteMetadataStore
 from mypy.typestate import TypeState, reset_global_state
-from mypy.renaming import VariableRenameVisitor
+from mypy.renaming import VariableRenameVisitor, VariableRenameVisitor2
 from mypy.config_parser import parse_mypy_comments
 from mypy.freetree import free_tree
 from mypy.stubinfo import legacy_bundled_packages, is_legacy_bundled_package
@@ -2119,9 +2119,11 @@ class State:
             analyzer.visit_file(self.tree, self.xpath, self.id, options)
         # TODO: Do this while constructing the AST?
         self.tree.names = SymbolTable()
-        if options.allow_redefinition:
-            # Perform renaming across the AST to allow variable redefinitions
-            self.tree.accept(VariableRenameVisitor())
+        if not self.tree.is_stub:
+            if options.allow_redefinition:
+                # Perform renaming across the AST to allow variable redefinitions
+                self.tree.accept(VariableRenameVisitor())
+            self.tree.accept(VariableRenameVisitor2())
 
     def add_dependency(self, dep: str) -> None:
         if dep not in self.dependencies_set:

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -262,14 +262,8 @@ class VariableRenameVisitor(TraverserVisitor):
                 # as it will be publicly visible outside the module.
                 to_rename = refs[:-1]
             for i, item in enumerate(to_rename):
-                self.rename_refs(item, i)
+                rename_refs(item, i)
         self.refs.pop()
-
-    def rename_refs(self, names: List[NameExpr], index: int) -> None:
-        name = names[0].name
-        new_name = name + "'" * (index + 1)
-        for expr in names:
-            expr.name = new_name
 
     # Helpers for determining which assignments define new variables
 
@@ -500,11 +494,12 @@ class VariableRenameVisitor2(TraverserVisitor):
                 # as it may be publicly visible.
                 to_rename = refs[:-1]
                 for i, item in enumerate(to_rename):
-                    self.rename_refs(item, i)
+                    rename_refs(item, i)
         self.refs.pop()
 
-    def rename_refs(self, names: List[NameExpr], index: int) -> None:
-        name = names[0].name
-        new_name = name + "'" * (index + 1)
-        for expr in names:
-            expr.name = new_name
+
+def rename_refs(names: List[NameExpr], index: int) -> None:
+    name = names[0].name
+    new_name = name + "'" * (index + 1)
+    for expr in names:
+        expr.name = new_name

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -510,21 +510,21 @@ class VariableRenameVisitor2(TraverserVisitor):
         self.bad.pop()
 
     def reject_redefinition_of_vars_in_scope(self) -> None:
-        # TODO
-        pass
+        self.record_bad('*')
 
     def record_bad(self, name: str) -> None:
         self.bad[-1].add(name)
 
     def flush_refs(self) -> None:
-        for name, refs in self.refs[-1].items():
-            if len(refs) <= 1 or name in self.bad[-1]:
-                continue
-            # At module top level, don't rename the final definition,
-            # as it may be publicly visible.
-            to_rename = refs[:-1]
-            for i, item in enumerate(to_rename):
-                self.rename_refs(item, i)
+        if '*' not in self.bad[-1]:
+            for name, refs in self.refs[-1].items():
+                if len(refs) <= 1 or name in self.bad[-1]:
+                    continue
+                # At module top level, don't rename the final definition,
+                # as it may be publicly visible.
+                to_rename = refs[:-1]
+                for i, item in enumerate(to_rename):
+                    self.rename_refs(item, i)
         self.refs.pop()
 
     def rename_refs(self, names: List[NameExpr], index: int) -> None:

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -5,7 +5,7 @@ from typing_extensions import Final
 from mypy.nodes import (
     Block, AssignmentStmt, NameExpr, MypyFile, FuncDef, Lvalue, ListExpr, TupleExpr,
     WhileStmt, ForStmt, BreakStmt, ContinueStmt, TryStmt, WithStmt, MatchStmt, StarExpr,
-    ImportFrom, MemberExpr, IndexExpr, Import, ClassDef
+    ImportFrom, MemberExpr, IndexExpr, Import, ImportAll, ClassDef
 )
 from mypy.patterns import AsPattern
 from mypy.traverser import TraverserVisitor
@@ -453,6 +453,9 @@ class VariableRenameVisitor2(TraverserVisitor):
     def visit_import_from(self, imp: ImportFrom) -> None:
         for id, as_id in imp.names:
             self.record_bad(as_id or id)
+
+    def visit_import_all(self, imp: ImportAll) -> None:
+        self.record_bad('*')
 
     #def visit_match_stmt(self, s: MatchStmt) -> None:
     #    for i in range(len(s.patterns)):

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -466,20 +466,6 @@ class LimitedVariableRenameVisitor(TraverserVisitor):
         while len(self.bound_vars) > old_len:
             self.bound_vars.pop()
 
-    def visit_import(self, imp: Import) -> None:
-        # We don't support renaming imports
-        for id, as_id in imp.ids:
-            self.record_skipped(as_id or id)
-
-    def visit_import_from(self, imp: ImportFrom) -> None:
-        # We don't support renaming imports
-        for id, as_id in imp.names:
-            self.record_skipped(as_id or id)
-
-    def visit_import_all(self, imp: ImportAll) -> None:
-        # Give up, since we don't know all imported names yet
-        self.reject_redefinition_of_vars_in_scope()
-
     def analyze_lvalue(self, lvalue: Lvalue) -> None:
         if isinstance(lvalue, NameExpr):
             name = lvalue.name
@@ -502,6 +488,20 @@ class LimitedVariableRenameVisitor(TraverserVisitor):
             lvalue.index.accept(self)
         elif isinstance(lvalue, StarExpr):
             self.analyze_lvalue(lvalue.expr)
+
+    def visit_import(self, imp: Import) -> None:
+        # We don't support renaming imports
+        for id, as_id in imp.ids:
+            self.record_skipped(as_id or id)
+
+    def visit_import_from(self, imp: ImportFrom) -> None:
+        # We don't support renaming imports
+        for id, as_id in imp.names:
+            self.record_skipped(as_id or id)
+
+    def visit_import_all(self, imp: ImportAll) -> None:
+        # Give up, since we don't know all imported names yet
+        self.reject_redefinition_of_vars_in_scope()
 
     def visit_name_expr(self, expr: NameExpr) -> None:
         name = expr.name

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -446,13 +446,13 @@ class VariableRenameVisitor2(TraverserVisitor):
         for name in names:
             self.bound_vars.remove(name)
 
-    #def visit_import(self, imp: Import) -> None:
-    #    for id, as_id in imp.ids:
-    #        self.record_bad(as_id or id)
+    def visit_import(self, imp: Import) -> None:
+        for id, as_id in imp.ids:
+            self.record_bad(as_id or id)
 
-    #def visit_import_from(self, imp: ImportFrom) -> None:
-    #    for id, as_id in imp.names:
-    #        self.record_bad(as_id or id, False)
+    def visit_import_from(self, imp: ImportFrom) -> None:
+        for id, as_id in imp.names:
+            self.record_bad(as_id or id)
 
     #def visit_match_stmt(self, s: MatchStmt) -> None:
     #    for i in range(len(s.patterns)):

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -452,20 +452,6 @@ class VariableRenameVisitor2(TraverserVisitor):
     def visit_import_all(self, imp: ImportAll) -> None:
         self.record_bad('*')
 
-    #def visit_match_stmt(self, s: MatchStmt) -> None:
-    #    for i in range(len(s.patterns)):
-    #        s.patterns[i].accept(self)
-    #        guard = s.guards[i]
-    #        if guard is not None:
-    #            guard.accept(self)
-    #        # We already entered a block, so visit this block's statements directly
-    #        for stmt in s.bodies[i].body:
-    #            stmt.accept(self)
-
-    #def visit_capture_pattern(self, p: AsPattern) -> None:
-    #    if p.name is not None:
-    #        self.analyze_lvalue(p.name)
-
     def analyze_lvalue(self, lvalue: Lvalue) -> None:
         if isinstance(lvalue, NameExpr):
             name = lvalue.name

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -507,7 +507,9 @@ class LimitedVariableRenameVisitor(TraverserVisitor):
         name = expr.name
         if name in self.bound_vars:
             # Record reference so that it can be renamed later
-            self.refs[-1][name][-1].append(expr)
+            for scope in reversed(self.refs):
+                if name in scope:
+                    scope[name][-1].append(expr)
         else:
             self.record_skipped(name)
 

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -421,10 +421,10 @@ class VariableRenameVisitor2(TraverserVisitor):
             print('refs', self.refs)
             print('bad', self.bad)
 
-    #def visit_class_def(self, cdef: ClassDef) -> None:
-    #    self.reject_redefinition_of_vars_in_scope()
-    #    with self.enter_scope():
-    #        super().visit_class_def(cdef)
+    def visit_class_def(self, cdef: ClassDef) -> None:
+        self.reject_redefinition_of_vars_in_scope()
+        with self.enter_scope():
+            super().visit_class_def(cdef)
 
     def visit_with_stmt(self, stmt: WithStmt) -> None:
         for expr in stmt.expr:

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Dict, Iterator, List
+from typing import Dict, Iterator, List, Set
 from typing_extensions import Final
 
 from mypy.nodes import (

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1175,3 +1175,44 @@ def foo(value) -> int:  # E: Missing return statement
       return 1
     case 2:
       return 2
+
+[case testWithStatementScopeAndMatchStatement]
+from m import A, B
+
+with A() as x:
+    pass
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+with A() as y:
+    pass
+with B() as y: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+with A() as z:
+    pass
+with B() as z: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+with A() as zz:
+    pass
+with B() as zz: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+match x:
+    case str(y) as z:
+        zz = y
+
+[file m.pyi]
+from typing import Any
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1836,6 +1836,26 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
+[case testWithStatementScope13]
+from m import A, B
+
+with A() as x, B() as y:
+    reveal_type(x)  # N: Revealed type is "m.A"
+    reveal_type(y)  # N: Revealed type is "m.B"
+with B() as x, A() as y:
+    reveal_type(x)  # N: Revealed type is "m.B"
+    reveal_type(y)  # N: Revealed type is "m.A"
+
+[file m.pyi]
+from typing import Any
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
 
 -- Chained assignment
 -- ------------------

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1764,7 +1764,48 @@ class A:
 class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
-[builtins fixtures/module.pyi]
+
+[case testWithStatementScope10NestedWith]
+from m import A, B
+
+with A() as x:
+    with B() as x: \
+        # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        reveal_type(x)  # N: Revealed type is "m.A"
+
+with B() as x:
+    with A() as x: \
+        # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+        reveal_type(x)  # N: Revealed type is "m.B"
+
+[file m.pyi]
+from typing import Any
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
+[case testWithStatementScope11NestedWith]
+from m import A, B
+
+with A() as x:
+    with A() as y:
+        reveal_type(y)  # N: Revealed type is "m.A"
+    with B() as y:
+        reveal_type(y)  # N: Revealed type is "m.B"
+
+[file m.pyi]
+from typing import Any
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
 
 
 -- Chained assignment

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1897,6 +1897,44 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
+[case testWithStmtScopeInnerScopeReference]
+from m import A, B
+
+with A() as x:
+    def f() -> A:
+        return x
+    f()
+
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+[file m.pyi]
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
+[case testWithStmtScopeAndLambda]
+from m import A, B
+
+# This is technically not correct, since the lambda can outlive the with
+# statement, but this behavior seems more intuitive.
+
+with A() as x:
+    lambda: reveal_type(x)  # N: Revealed type is "m.A"
+
+with B() as x:
+    pass
+[file m.pyi]
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
 
 -- Chained assignment
 -- ------------------

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1744,6 +1744,28 @@ class B:
     def __exit__(self, x, y, z) -> None: ...
 [builtins fixtures/module.pyi]
 
+[case testWithStatementScope9ImportStar]
+from m import A, B
+from m import *
+
+with A() as x:
+    pass
+
+with B() as x: \
+     # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+[file m.pyi]
+from typing import Any
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+[builtins fixtures/module.pyi]
+
 
 -- Chained assignment
 -- ------------------

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1571,7 +1571,7 @@ class C3:
     def __exit__(self, x, y, z) -> Optional[bool]: pass
 [builtins fixtures/bool.pyi]
 
-[case testWithStatementScope1]
+[case testWithStmtScopeBasics]
 from m import A, B
 
 def f1() -> None:
@@ -1596,26 +1596,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope2]
-from m import A, B
-
-def f2() -> None:
-    with A() as x:
-        reveal_type(x)  # N: Revealed type is "m.A"
-    y = x  # Use outside with makes the scope function-level
-    with B() as x: \
-        # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-        reveal_type(x)  # N: Revealed type is "m.A"
-
-[file m.pyi]
-class A:
-    def __enter__(self) -> A: ...
-    def __exit__(self, x, y, z) -> None: ...
-class B:
-    def __enter__(self) -> B: ...
-    def __exit__(self, x, y, z) -> None: ...
-
-[case testWithStatementScope3]
+[case testWithStmtScopeAndFuncDef]
 from m import A, B
 
 with A() as x:
@@ -1636,7 +1617,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope4]
+[case testWithStmtScopeAndFuncDef2]
 from m import A, B
 
 def f() -> None:
@@ -1657,7 +1638,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope5]
+[case testWithStmtScopeAndFuncDef3]
 from m import A, B
 
 with A() as x:
@@ -1678,7 +1659,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope6]
+[case testWithStmtScopeAndFuncDef4]
 from m import A, B
 
 with A() as x:
@@ -1699,7 +1680,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope7Imports]
+[case testWithStmtScopeAndImport1]
 from m import A, B, x
 
 with A() as x: \
@@ -1710,8 +1691,6 @@ with B() as x:
     reveal_type(x)  # N: Revealed type is "m.B"
 
 [file m.pyi]
-from typing import Any
-
 x: B
 
 class A:
@@ -1721,7 +1700,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope8Imports]
+[case testWithStmtScopeAndImport2]
 from m import A, B
 import m as x
 
@@ -1734,8 +1713,6 @@ with B() as x: \
     pass
 
 [file m.pyi]
-from typing import Any
-
 class A:
     def __enter__(self) -> A: ...
     def __exit__(self, x, y, z) -> None: ...
@@ -1744,7 +1721,7 @@ class B:
     def __exit__(self, x, y, z) -> None: ...
 [builtins fixtures/module.pyi]
 
-[case testWithStatementScope9ImportStar]
+[case testWithStmtScopeAndImportStar]
 from m import A, B
 from m import *
 
@@ -1756,8 +1733,6 @@ with B() as x: \
     pass
 
 [file m.pyi]
-from typing import Any
-
 class A:
     def __enter__(self) -> A: ...
     def __exit__(self, x, y, z) -> None: ...
@@ -1765,7 +1740,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope10NestedWith]
+[case testWithStmtScopeNestedWith1]
 from m import A, B
 
 with A() as x:
@@ -1779,8 +1754,6 @@ with B() as x:
         reveal_type(x)  # N: Revealed type is "m.B"
 
 [file m.pyi]
-from typing import Any
-
 class A:
     def __enter__(self) -> A: ...
     def __exit__(self, x, y, z) -> None: ...
@@ -1788,7 +1761,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope11NestedWith]
+[case testWithStmtScopeNestedWith2]
 from m import A, B
 
 with A() as x:
@@ -1798,8 +1771,6 @@ with A() as x:
         reveal_type(y)  # N: Revealed type is "m.B"
 
 [file m.pyi]
-from typing import Any
-
 class A:
     def __enter__(self) -> A: ...
     def __exit__(self, x, y, z) -> None: ...
@@ -1807,7 +1778,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope12Outer]
+[case testWithStmtScopeInnerAndOuterScopes]
 from m import A, B
 
 x = A()  # Outer scope should have no impact
@@ -1827,8 +1798,6 @@ with A() as x:
     pass
 
 [file m.pyi]
-from typing import Any
-
 class A:
     def __enter__(self) -> A: ...
     def __exit__(self, x, y, z) -> None: ...
@@ -1836,7 +1805,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope13]
+[case testWithStmtScopeMultipleContextManagers]
 from m import A, B
 
 with A() as x, B() as y:
@@ -1847,8 +1816,6 @@ with B() as x, A() as y:
     reveal_type(y)  # N: Revealed type is "m.A"
 
 [file m.pyi]
-from typing import Any
-
 class A:
     def __enter__(self) -> A: ...
     def __exit__(self, x, y, z) -> None: ...
@@ -1856,7 +1823,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope14]
+[case testWithStmtScopeMultipleAssignment]
 from m import A, B
 
 with A() as (x, y):
@@ -1867,7 +1834,7 @@ with B() as [x, y]:
     reveal_type(y)  # N: Revealed type is "builtins.str"
 
 [file m.pyi]
-from typing import Any, Tuple
+from typing import Tuple
 
 class A:
     def __enter__(self) -> Tuple[A, int]: ...
@@ -1877,7 +1844,7 @@ class B:
     def __exit__(self, x, y, z) -> None: ...
 [builtins fixtures/tuple.pyi]
 
-[case testWithStatementScope15]
+[case testWithStmtScopeComplexAssignments]
 from m import A, B, f
 
 with A() as x:
@@ -1897,8 +1864,6 @@ with B() as f(y)[0]:
     pass
 
 [file m.pyi]
-from typing import Any
-
 def f(x): ...
 
 class A:
@@ -1908,7 +1873,7 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
-[case testWithStatementScope16]
+[case testWithStmtScopeAndClass]
 from m import A, B
 
 with A() as x:
@@ -1925,8 +1890,6 @@ with B() as x: \
     pass
 
 [file m.pyi]
-from typing import Any
-
 class A:
     def __enter__(self) -> A: ...
     def __exit__(self, x, y, z) -> None: ...

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1856,6 +1856,27 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
+[case testWithStatementScope14]
+from m import A, B
+
+with A() as (x, y):
+    reveal_type(x)  # N: Revealed type is "m.A"
+    reveal_type(y)  # N: Revealed type is "builtins.int"
+with B() as [x, y]:
+    reveal_type(x)  # N: Revealed type is "m.B"
+    reveal_type(y)  # N: Revealed type is "builtins.str"
+
+[file m.pyi]
+from typing import Any, Tuple
+
+class A:
+    def __enter__(self) -> Tuple[A, int]: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> Tuple[B, str]: ...
+    def __exit__(self, x, y, z) -> None: ...
+[builtins fixtures/tuple.pyi]
+
 
 -- Chained assignment
 -- ------------------

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1877,6 +1877,37 @@ class B:
     def __exit__(self, x, y, z) -> None: ...
 [builtins fixtures/tuple.pyi]
 
+[case testWithStatementScope15]
+from m import A, B, f
+
+with A() as x:
+    pass
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+with B() as f(x).x:
+    pass
+
+with A() as y:
+    pass
+with B() as y: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+with B() as f(y)[0]:
+    pass
+
+[file m.pyi]
+from typing import Any, Tuple
+
+def f(x): ...
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
 
 -- Chained assignment
 -- ------------------

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1555,7 +1555,6 @@ class LiteralReturn:
         return False
 [builtins fixtures/bool.pyi]
 
-
 [case testWithStmtBoolExitReturnInStub]
 import stub
 
@@ -1571,6 +1570,36 @@ class C2:
 class C3:
     def __exit__(self, x, y, z) -> Optional[bool]: pass
 [builtins fixtures/bool.pyi]
+
+[case testWithStatementScopeSeparate]
+class A:
+    def __enter__(self) -> A: pass
+    def __exit__(self, x, y, z) -> None: pass
+class B:
+    def __enter__(self) -> B: pass
+    def __exit__(self, x, y, z) -> None: pass
+
+def f() -> None:
+    with A() as x:
+        reveal_type(x)  # N: Revealed type is "__main__.A"
+    with B() as x:
+        reveal_type(x)  # N: Revealed type is "__main__.B"
+
+[case testWithStatementScopeWidening]
+class A:
+    def __enter__(self) -> A: pass
+    def __exit__(self, x, y, z) -> None: pass
+class B:
+    def __enter__(self) -> B: pass
+    def __exit__(self, x, y, z) -> None: pass
+
+def f() -> None:
+    with A() as x:
+        reveal_type(x)  # N: Revealed type is "__main__.A"
+    y = x  # Use outside with makes the scope function-level
+    with B() as x: \
+        # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        reveal_type(x)  # N: Revealed type is "__main__.A"
 
 
 -- Chained assignment

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1571,35 +1571,49 @@ class C3:
     def __exit__(self, x, y, z) -> Optional[bool]: pass
 [builtins fixtures/bool.pyi]
 
-[case testWithStatementScopeSeparate]
-class A:
-    def __enter__(self) -> A: pass
-    def __exit__(self, x, y, z) -> None: pass
-class B:
-    def __enter__(self) -> B: pass
-    def __exit__(self, x, y, z) -> None: pass
+[case testWithStatementScope1]
+from m import A, B
 
-def f() -> None:
+def f1() -> None:
     with A() as x:
-        reveal_type(x)  # N: Revealed type is "__main__.A"
+        reveal_type(x)  # N: Revealed type is "m.A"
     with B() as x:
-        reveal_type(x)  # N: Revealed type is "__main__.B"
+        reveal_type(x)  # N: Revealed type is "m.B"
 
-[case testWithStatementScopeWidening]
-class A:
-    def __enter__(self) -> A: pass
-    def __exit__(self, x, y, z) -> None: pass
-class B:
-    def __enter__(self) -> B: pass
-    def __exit__(self, x, y, z) -> None: pass
-
-def f() -> None:
+def f2() -> None:
     with A() as x:
-        reveal_type(x)  # N: Revealed type is "__main__.A"
+        reveal_type(x)  # N: Revealed type is "m.A"
     y = x  # Use outside with makes the scope function-level
     with B() as x: \
         # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-        reveal_type(x)  # N: Revealed type is "__main__.A"
+        reveal_type(x)  # N: Revealed type is "m.A"
+
+[file m.pyi]
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
+[case testWithStatementScope2]
+from m import A, B
+
+def f2() -> None:
+    with A() as x:
+        reveal_type(x)  # N: Revealed type is "m.A"
+    y = x  # Use outside with makes the scope function-level
+    with B() as x: \
+        # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+        reveal_type(x)  # N: Revealed type is "m.A"
+
+[file m.pyi]
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
 
 
 -- Chained assignment

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1615,6 +1615,90 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
+[case testWithStatementScope3]
+from m import A, B
+
+with A() as x:
+    reveal_type(x)  # N: Revealed type is "m.A"
+
+def f() -> None:
+    pass  # Don't support function definition in the middle
+
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    reveal_type(x)  # N: Revealed type is "m.A"
+
+[file m.pyi]
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
+[case testWithStatementScope4]
+from m import A, B
+
+def f() -> None:
+    pass  # function before with is unsupported
+
+with A() as x:
+    reveal_type(x)  # N: Revealed type is "m.A"
+
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    reveal_type(x)  # N: Revealed type is "m.A"
+
+[file m.pyi]
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
+[case testWithStatementScope5]
+from m import A, B
+
+with A() as x:
+    reveal_type(x)  # N: Revealed type is "m.A"
+
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    reveal_type(x)  # N: Revealed type is "m.A"
+
+def f() -> None:
+    pass  # function after with is unsupported
+
+[file m.pyi]
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
+[case testWithStatementScope6]
+from m import A, B
+
+with A() as x:
+    def f() -> None:
+        pass  # Function within with is unsupported
+
+    reveal_type(x)  # N: Revealed type is "m.A"
+
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    reveal_type(x)  # N: Revealed type is "m.A"
+
+[file m.pyi]
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
 
 -- Chained assignment
 -- ------------------

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1897,9 +1897,35 @@ with B() as f(y)[0]:
     pass
 
 [file m.pyi]
-from typing import Any, Tuple
+from typing import Any
 
 def f(x): ...
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
+[case testWithStatementScope16]
+from m import A, B
+
+with A() as x:
+    pass
+
+class C:
+    with A() as y:
+        pass
+    with B() as y:
+        pass
+
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+[file m.pyi]
+from typing import Any
 
 class A:
     def __enter__(self) -> A: ...

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1807,6 +1807,35 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
+[case testWithStatementScope12Outer]
+from m import A, B
+
+x = A()  # Outer scope should have no impact
+
+with A() as x:
+    pass
+
+def f() -> None:
+    with A() as x:
+        reveal_type(x)  # N: Revealed type is "m.A"
+    with B() as x:
+        reveal_type(x)  # N: Revealed type is "m.B"
+
+y = x
+
+with A() as x:
+    pass
+
+[file m.pyi]
+from typing import Any
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
 
 -- Chained assignment
 -- ------------------

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1699,6 +1699,51 @@ class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
 
+[case testWithStatementScope7Imports]
+from m import A, B, x
+
+with A() as x: \
+    # E: Incompatible types in assignment (expression has type "A", variable has type "B")
+    reveal_type(x)  # N: Revealed type is "m.B"
+
+with B() as x:
+    reveal_type(x)  # N: Revealed type is "m.B"
+
+[file m.pyi]
+from typing import Any
+
+x: B
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+
+[case testWithStatementScope8Imports]
+from m import A, B
+import m as x
+
+with A() as x: \
+     # E: Incompatible types in assignment (expression has type "A", variable has type Module)
+    pass
+
+with B() as x: \
+     # E: Incompatible types in assignment (expression has type "B", variable has type Module)
+    pass
+
+[file m.pyi]
+from typing import Any
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...
+[builtins fixtures/module.pyi]
+
 
 -- Chained assignment
 -- ------------------

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -1058,3 +1058,59 @@ MypyFile:1(
   AssignmentStmt:6(
     NameExpr(x [__main__.x])
     StrExpr()))
+
+[case testSimpleWithRenaming]
+with 0 as y:
+    z = y
+with 1 as y:
+    y = 1
+[out]
+MypyFile:1(
+  WithStmt:1(
+    Expr(
+      IntExpr(0))
+    Target(
+      NameExpr(y'* [__main__.y']))
+    Block:1(
+      AssignmentStmt:2(
+        NameExpr(z* [__main__.z])
+        NameExpr(y' [__main__.y']))))
+  WithStmt:3(
+    Expr(
+      IntExpr(1))
+    Target(
+      NameExpr(y* [__main__.y]))
+    Block:3(
+      AssignmentStmt:4(
+        NameExpr(y [__main__.y])
+        IntExpr(1)))))
+
+[case testSimpleWithRenamingFailure]
+with 0 as y:
+    z = y
+zz = y
+with 1 as y:
+    y = 1
+[out]
+MypyFile:1(
+  WithStmt:1(
+    Expr(
+      IntExpr(0))
+    Target(
+      NameExpr(y* [__main__.y]))
+    Block:1(
+      AssignmentStmt:2(
+        NameExpr(z* [__main__.z])
+        NameExpr(y [__main__.y]))))
+  AssignmentStmt:3(
+    NameExpr(zz* [__main__.zz])
+    NameExpr(y [__main__.y]))
+  WithStmt:4(
+    Expr(
+      IntExpr(1))
+    Target(
+      NameExpr(y [__main__.y]))
+    Block:4(
+      AssignmentStmt:5(
+        NameExpr(y [__main__.y])
+        IntExpr(1)))))


### PR DESCRIPTION
Use renaming to allow two with statements to define the same variable
using incompatible types. The implementation is pretty simple-minded
and doesn't work in cases where there is even a hint of potential 
ambiguity about which variant of a variable a reference targets, typically 
due to functions.

This could be generalized to for statements in the future.

Fixes #12246.