### PR TITLE
Exhaustiveness checking for match statements

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5676,9 +5676,9 @@ def conditional_types(current_type: Type,
             target = get_proper_type(target)
             if isinstance(target, LiteralType) and target.is_enum_literal():
                 enum_name = target.fallback.type.fullname
-                current_type = try_expanding_enum_to_union(current_type,
-                                                           enum_name,
-                                                           ignore_custom_equals=False)
+                current_type = try_expanding_sum_type_to_union(current_type,
+                                                               enum_name,
+                                                               ignore_custom_equals=False)
         proposed_items = [type_range.item for type_range in proposed_type_ranges]
         proposed_type = make_simplified_union(proposed_items)
         if isinstance(proposed_type, AnyType):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4174,7 +4174,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         return inferred_types
 
     def remove_capture_conflicts(self, type_map: TypeMap, inferred_types: Dict[Var, Type]) -> None:
-        if type_map is not None:
+        if type_map:
             for expr, typ in type_map.copy().items():
                 if isinstance(expr, NameExpr):
                     node = expr.node
@@ -5675,8 +5675,7 @@ def conditional_types(current_type: Type,
                                                     or isinstance(target.value, bool)):
                 enum_name = target.fallback.type.fullname
                 current_type = try_expanding_sum_type_to_union(current_type,
-                                                               enum_name,
-                                                               ignore_custom_equals=False)
+                                                               enum_name)
         proposed_items = [type_range.item for type_range in proposed_type_ranges]
         proposed_type = make_simplified_union(proposed_items)
         if isinstance(proposed_type, AnyType):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5674,7 +5674,8 @@ def conditional_types(current_type: Type,
         if len(proposed_type_ranges) == 1:
             target = proposed_type_ranges[0].item
             target = get_proper_type(target)
-            if isinstance(target, LiteralType) and target.is_enum_literal():
+            if isinstance(target, LiteralType) and (target.is_enum_literal()
+                                                    or isinstance(target.value, bool)):
                 enum_name = target.fallback.type.fullname
                 current_type = try_expanding_sum_type_to_union(current_type,
                                                                enum_name,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5671,6 +5671,14 @@ def conditional_types(current_type: Type,
     None means no new information can be inferred. If default is set it is returned
     instead."""
     if proposed_type_ranges:
+        if len(proposed_type_ranges) == 1:
+            target = proposed_type_ranges[0].item
+            target = get_proper_type(target)
+            if isinstance(target, LiteralType) and target.is_enum_literal():
+                enum_name = target.fallback.type.fullname
+                current_type = try_expanding_enum_to_union(current_type,
+                                                           enum_name,
+                                                           ignore_custom_equals=False)
         proposed_items = [type_range.item for type_range in proposed_type_ranges]
         proposed_type = make_simplified_union(proposed_items)
         if isinstance(proposed_type, AnyType):

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -693,6 +693,7 @@ def get_var(expr: Expression) -> Var:
 
 
 def get_type_range(typ: Type) -> 'mypy.checker.TypeRange':
+    typ = get_proper_type(typ)
     if (isinstance(typ, Instance)
             and typ.last_known_value
             and isinstance(typ.last_known_value.value, bool)):

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -693,6 +693,10 @@ def get_var(expr: Expression) -> Var:
 
 
 def get_type_range(typ: Type) -> 'mypy.checker.TypeRange':
+    if (isinstance(typ, Instance)
+            and typ.last_known_value
+            and isinstance(typ.last_known_value.value, bool)):
+        typ = typ.last_known_value
     return mypy.checker.TypeRange(typ, is_upper_bound=False)
 
 

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -1,4 +1,5 @@
 """Pattern checker. This file is conceptually part of TypeChecker."""
+
 from collections import defaultdict
 from typing import List, Optional, Tuple, Dict, NamedTuple, Set, Union
 from typing_extensions import Final
@@ -56,7 +57,7 @@ PatternType = NamedTuple(
     'PatternType',
     [
         ('type', Type),  # The type the match subject can be narrowed to
-        ('rest_type', Type),
+        ('rest_type', Type),  # The remaining type if the pattern didn't match
         ('captures', Dict[Expression, Type]),  # The variables captured by the pattern
     ])
 

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -56,7 +56,7 @@ PatternType = NamedTuple(
     'PatternType',
     [
         ('type', Type),  # The type the match subject can be narrowed to
-        ('rest_type', Type),  # For exhaustiveness checking. Not used yet
+        ('rest_type', Type),
         ('captures', Dict[Expression, Type]),  # The variables captured by the pattern
     ])
 

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -355,8 +355,7 @@ class PatternChecker(PatternVisitor[PatternType]):
                                      star_pos: Optional[int],
                                      num_types: int
                                      ) -> List[Type]:
-        """
-        Undoes the contraction done by contract_starred_pattern_types.
+        """Undoes the contraction done by contract_starred_pattern_types.
 
         For example if the sequence pattern is [a, *b, c] and types [bool, int, str] are extended
         to lenght 4 the result is [bool, int, int, str].

--- a/mypy/patterns.py
+++ b/mypy/patterns.py
@@ -21,6 +21,7 @@ class Pattern(Node):
 
 
 class AsPattern(Pattern):
+    """The pattern <pattern> as <name>"""
     # The python ast, and therefore also our ast merges capture, wildcard and as patterns into one
     # for easier handling.
     # If pattern is None this is a capture pattern. If name and pattern are both none this is a
@@ -39,6 +40,7 @@ class AsPattern(Pattern):
 
 
 class OrPattern(Pattern):
+    """The pattern <pattern> | <pattern> | ..."""
     patterns: List[Pattern]
 
     def __init__(self, patterns: List[Pattern]) -> None:
@@ -50,6 +52,7 @@ class OrPattern(Pattern):
 
 
 class ValuePattern(Pattern):
+    """The pattern x.y (or x.y.z, ...)"""
     expr: Expression
 
     def __init__(self, expr: Expression):
@@ -73,6 +76,7 @@ class SingletonPattern(Pattern):
 
 
 class SequencePattern(Pattern):
+    """The pattern [<pattern>, ...]"""
     patterns: List[Pattern]
 
     def __init__(self, patterns: List[Pattern]):
@@ -114,6 +118,7 @@ class MappingPattern(Pattern):
 
 
 class ClassPattern(Pattern):
+    """The pattern Cls(...)"""
     class_ref: RefExpr
     positionals: List[Pattern]
     keyword_keys: List[str]

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1237,11 +1237,13 @@ def _is_proper_subtype(left: Type, right: Type, *,
 class ProperSubtypeVisitor(TypeVisitor[bool]):
     def __init__(self, right: Type, *,
                  ignore_promotions: bool = False,
+                 ignore_last_known_value: bool = False,
                  erase_instances: bool = False,
                  keep_erased_types: bool = False) -> None:
         self.right = get_proper_type(right)
         self.orig_right = right
         self.ignore_promotions = ignore_promotions
+        self.ignore_last_known_value = ignore_last_known_value
         self.erase_instances = erase_instances
         self.keep_erased_types = keep_erased_types
         self._subtype_kind = ProperSubtypeVisitor.build_subtype_kind(
@@ -1297,6 +1299,10 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
         if isinstance(right, Instance):
             if TypeState.is_cached_subtype_check(self._subtype_kind, left, right):
                 return True
+            if not self.ignore_last_known_value:
+                if right.last_known_value is not None and \
+                        right.last_known_value != left.last_known_value:
+                    return False
             if not self.ignore_promotions:
                 for base in left.type.mro:
                     if base._promote and self._is_proper_subtype(base._promote, right):

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -683,13 +683,14 @@ def is_singleton_type(typ: Type) -> bool:
     )
 
 
-def enum_has_custom_equals(enum: Instance):
+def enum_has_custom_equals(enum: Instance) -> bool:
     assert enum.type.is_enum
     for typ in enum.type.mro:
         if typ.fullname == "enum.Enum":
             return False
         if "__eq__" in typ.names:
             return True
+    assert False
 
 
 def try_expanding_sum_type_to_union(typ: Type,

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -683,10 +683,7 @@ def is_singleton_type(typ: Type) -> bool:
     )
 
 
-def try_expanding_sum_type_to_union(typ: Type,
-                                    target_fullname: str,
-                                    *,
-                                    ignore_custom_equals: bool = True) -> ProperType:
+def try_expanding_sum_type_to_union(typ: Type, target_fullname: str) -> ProperType:
     """Attempts to recursively expand any enum Instances with the given target_fullname
     into a Union of all of its component LiteralTypes.
 

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -683,16 +683,6 @@ def is_singleton_type(typ: Type) -> bool:
     )
 
 
-def enum_has_custom_equals(enum: Instance) -> bool:
-    assert enum.type.is_enum
-    for typ in enum.type.mro:
-        if typ.fullname == "enum.Enum":
-            return False
-        if "__eq__" in typ.names:
-            return True
-    assert False
-
-
 def try_expanding_sum_type_to_union(typ: Type,
                                     target_fullname: str,
                                     *,

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -683,7 +683,19 @@ def is_singleton_type(typ: Type) -> bool:
     )
 
 
-def try_expanding_sum_type_to_union(typ: Type, target_fullname: str) -> ProperType:
+def enum_has_custom_equals(enum: Instance):
+    assert enum.type.is_enum
+    for typ in enum.type.mro:
+        if typ.fullname == "enum.Enum":
+            return False
+        if "__eq__" in typ.names:
+            return True
+
+
+def try_expanding_sum_type_to_union(typ: Type,
+                                    target_fullname: str,
+                                    *,
+                                    ignore_custom_equals: bool = True) -> ProperType:
     """Attempts to recursively expand any enum Instances with the given target_fullname
     into a Union of all of its component LiteralTypes.
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -14,14 +14,15 @@ m: object
 
 match m:
     case 1:
-        reveal_type(m)  # N: Revealed type is "Literal[1]?"
+        reveal_type(m)  # N: Revealed type is "Literal[1]"
 
-[case testLiteralPatternAlreadyNarrower]
+[case testLiteralPatternAlreadyNarrower-skip]
 m: bool
 
 match m:
     case 1:
-        reveal_type(m)  # N: Revealed type is "builtins.bool"
+        reveal_type(m)  # This should probably be unreachable, but isn't detected as such.
+[builtins fixtures/primitives.pyi]
 
 [case testLiteralPatternUnreachable]
 # primitives are needed because otherwise mypy doesn't see that int and str are incompatible
@@ -269,7 +270,7 @@ m: Tuple[object, object]
 
 match m:
     case [1, "str"]:
-        reveal_type(m)  # N: Revealed type is "Tuple[Literal[1]?, Literal['str']?]"
+        reveal_type(m)  # N: Revealed type is "Tuple[Literal[1], Literal['str']]"
 [builtins fixtures/list.pyi]
 
 [case testSequencePatternTupleStarred]
@@ -968,7 +969,7 @@ m: object
 
 match m:
     case 1 | 2 as n:
-        reveal_type(n)  # N: Revealed type is "Union[Literal[1]?, Literal[2]?]"
+        reveal_type(n)  # N: Revealed type is "Union[Literal[1], Literal[2]]"
 
 [case testAsPatternAlreadyNarrower]
 m: bool
@@ -984,21 +985,21 @@ m: object
 
 match m:
     case 1 | 2:
-        reveal_type(m)  # N: Revealed type is "Union[Literal[1]?, Literal[2]?]"
+        reveal_type(m)  # N: Revealed type is "Union[Literal[1], Literal[2]]"
 
 [case testOrPatternNarrowsStr]
 m: object
 
 match m:
     case "foo" | "bar":
-        reveal_type(m)  # N: Revealed type is "Union[Literal['foo']?, Literal['bar']?]"
+        reveal_type(m)  # N: Revealed type is "Union[Literal['foo'], Literal['bar']]"
 
 [case testOrPatternNarrowsUnion]
 m: object
 
 match m:
     case 1 | "foo":
-        reveal_type(m)  # N: Revealed type is "Union[Literal[1]?, Literal['foo']?]"
+        reveal_type(m)  # N: Revealed type is "Union[Literal[1], Literal['foo']]"
 
 [case testOrPatterCapturesMissing]
 from typing import List
@@ -1057,7 +1058,6 @@ match m:
     case a:
         reveal_type(a)  # N: Revealed type is "builtins.bool"
 
-# This is actually correct, as case a has to be taken.
 reveal_type(a)  # N: Revealed type is "builtins.bool"
 a = 3
 reveal_type(a)  # N: Revealed type is "builtins.int"
@@ -1260,3 +1260,62 @@ match value:
     case o:
         assert_never(o)
 [typing fixtures/typing-medium.pyi]
+
+[case testSequencePatternNegativeNarrowing]
+from typing import Union, Sequence, Tuple
+
+m1: Sequence[Union[int, str]]
+
+match m1:
+    case [int()]:
+        reveal_type(m1)  # N: Revealed type is "typing.Sequence[builtins.int]"
+    case r:
+        reveal_type(m1)  # N: Revealed type is "typing.Sequence[Union[builtins.int, builtins.str]]"
+
+m2: Tuple[Union[int, str]]
+
+match m2:
+    case (int(),):
+        reveal_type(m2)  # N: Revealed type is "Tuple[builtins.int]"
+    case r2:
+        reveal_type(m2)  # N: Revealed type is "Tuple[builtins.str]"
+
+m3: Tuple[Union[int, str]]
+
+match m3:
+    case (1,):
+        reveal_type(m3)  # N: Revealed type is "Tuple[Literal[1]]"
+    case r2:
+        reveal_type(m3)  # N: Revealed type is "Tuple[Union[builtins.int, builtins.str]]"
+
+[case testLiteralPatternEnumNegativeNarrowing]
+from enum import Enum
+class Medal(Enum):
+    gold = 1
+    silver = 2
+    bronze = 3
+
+m: Medal
+
+match m:
+    case Medal.gold:
+        reveal_type(m)  # N: Revealed type is "Literal[__main__.Medal.gold]"
+    case _:
+        reveal_type(m)  # N: Revealed type is "Union[Literal[__main__.Medal.silver], Literal[__main__.Medal.bronze]]"
+
+[case testLiteralPatternEnumCustomEquals]
+from enum import Enum
+class Medal(Enum):
+    gold = 1
+    silver = 2
+    bronze = 3
+
+    def __eq__(self, other) -> bool: ...
+
+m: Medal
+
+match m:
+    case Medal.gold:
+        reveal_type(m)  # N: Revealed type is "Literal[__main__.Medal.gold]"
+    case _:
+        reveal_type(m)  # N: Revealed type is "__main__.Medal"

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1287,6 +1287,7 @@ match m3:
         reveal_type(m3)  # N: Revealed type is "Tuple[Literal[1]]"
     case r2:
         reveal_type(m3)  # N: Revealed type is "Tuple[Union[builtins.int, builtins.str]]"
+[builtins fixtures/tuple.pyi]
 
 [case testLiteralPatternEnumNegativeNarrowing]
 from enum import Enum

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1304,7 +1304,7 @@ match m:
     case _:
         reveal_type(m)  # N: Revealed type is "Union[Literal[__main__.Medal.silver], Literal[__main__.Medal.bronze]]"
 
-[case testLiteralPatternEnumCustomEquals]
+[case testLiteralPatternEnumCustomEquals-skip]
 from enum import Enum
 class Medal(Enum):
     gold = 1

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1049,6 +1049,19 @@ match m:
     case a:
         reveal_type(a)  # N: Revealed type is "builtins.int"
 
+[case testCapturePatternPreexistingNarrows]
+a: int
+m: bool
+
+match m:
+    case a:
+        reveal_type(a)  # N: Revealed type is "builtins.bool"
+
+# This is actually correct, as case a has to be taken.
+reveal_type(a)  # N: Revealed type is "builtins.bool"
+a = 3
+reveal_type(a)  # N: Revealed type is "builtins.int"
+
 [case testCapturePatternPreexistingIncompatible]
 a: str
 m: int
@@ -1056,6 +1069,8 @@ m: int
 match m:
     case a:  # E: Incompatible types in capture pattern (pattern captures type "int", variable has type "str")
         reveal_type(a)  # N: Revealed type is "builtins.str"
+
+reveal_type(a)  # N: Revealed type is "builtins.str"
 
 [case testCapturePatternPreexistingIncompatibleLater]
 a: str
@@ -1066,6 +1081,8 @@ match m:
         reveal_type(a)  # N: Revealed type is "builtins.str"
     case int(a):  # E: Incompatible types in capture pattern (pattern captures type "int", variable has type "str")
         reveal_type(a)  # N: Revealed type is "builtins.str"
+
+reveal_type(a)  # N: Revealed type is "builtins.str"
 
 
 -- Guards --
@@ -1135,7 +1152,7 @@ match m:
 [builtins fixtures/isinstancelist.pyi]
 
 -- Exhaustiveness --
-[case testUnionNegativeNarrowing-skip]
+[case testUnionNegativeNarrowing]
 from typing import Union
 
 m: Union[str, int]
@@ -1148,7 +1165,7 @@ match m:
         reveal_type(b)  # N: Revealed type is "builtins.int"
         reveal_type(m)  # N: Revealed type is "builtins.int"
 
-[case testOrPatternNegativeNarrowing-skip]
+[case testOrPatternNegativeNarrowing]
 from typing import Union
 
 m: Union[str, bytes, int]
@@ -1160,7 +1177,7 @@ match m:
     case b:
         reveal_type(b)  # N: Revealed type is "builtins.int"
 
-[case testExhaustiveReturn-skip]
+[case testExhaustiveReturn]
 def foo(value) -> int:
   match value:
     case "bar":
@@ -1168,7 +1185,7 @@ def foo(value) -> int:
     case _:
       return 2
 
-[case testNoneExhaustiveReturn-skip]
+[case testNoneExhaustiveReturn]
 def foo(value) -> int:  # E: Missing return statement
   match value:
     case "bar":
@@ -1216,3 +1233,30 @@ class A:
 class B:
     def __enter__(self) -> B: ...
     def __exit__(self, x, y, z) -> None: ...
+
+[case testNonExhaustiveError]
+from typing import NoReturn
+def assert_never(x: NoReturn) -> None: ...
+
+value: int
+match value:
+    case 1:
+        pass
+    case 2:
+        pass
+    case o:
+        assert_never(o)  # E: Argument 1 to "assert_never" has incompatible type "int"; expected "NoReturn"
+
+[case testExhaustiveNoError]
+from typing import NoReturn, Union, Literal
+def assert_never(x: NoReturn) -> None: ...
+
+value: Union[Literal[1], Literal[2]]
+match value:
+    case 1:
+        pass
+    case 2:
+        pass
+    case o:
+        assert_never(o)
+[typing fixtures/typing-medium.pyi]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1208,7 +1208,7 @@ def g(value: int | None) -> int:
         case None:
             return 1
 
-[case testMiscNonExhaustiveReturn-skip]
+[case testMiscNonExhaustiveReturn]
 class C:
     a: int | str
 
@@ -1383,3 +1383,68 @@ def f(x: int | str) -> int:  # E: Missing return statement
         case int():
             return 1
 [builtins fixtures/isinstance.pyi]
+
+[case testNarrowingDownUnionPartially]
+# flags: --strict-optional
+
+def f(x: int | str) -> None:
+    match x:
+        case int():
+            return
+    reveal_type(x)  # N: Revealed type is "builtins.str"
+
+def g(x: int | str | None) -> None:
+    match x:
+        case int() | None:
+            return
+    reveal_type(x)  # N: Revealed type is "builtins.str"
+
+def h(x: int | str | None) -> None:
+    match x:
+        case int() | str():
+            return
+    reveal_type(x)  # N: Revealed type is "None"
+
+[case testNarrowDownUsingLiteralMatch]
+from enum import Enum
+class Medal(Enum):
+    gold = 1
+    silver = 2
+
+def b1(x: bool) -> None:
+    match x:
+        case True:
+            return
+    # Possibly we could have Literal[False] here?
+    reveal_type(x)  # N: Revealed type is "builtins.bool"
+
+def b2(x: bool) -> None:
+    match x:
+        case False:
+            return
+    # Possibly we could have Literal[True] here?
+    reveal_type(x)  # N: Revealed type is "builtins.bool"
+
+def e1(x: Medal) -> None:
+    match x:
+        case Medal.gold:
+            return
+    reveal_type(x)  # N: Revealed type is "Literal[__main__.Medal.silver]"
+
+def e2(x: Medal) -> None:
+    match x:
+        case Medal.silver:
+            return
+    reveal_type(x)  # N: Revealed type is "Literal[__main__.Medal.gold]"
+
+def i(x: int) -> None:
+    match x:
+        case 1:
+            return
+    reveal_type(x)  # N: Revealed type is "builtins.int"
+
+def s(x: str) -> None:
+    match x:
+        case 'x':
+            return
+    reveal_type(x)  # N: Revealed type is "builtins.str"

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1476,6 +1476,16 @@ def f(x: int | str | None) -> None:
         reveal_type(x)  # N: Revealed type is "None"
     reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str, None]"
 
+[case testMatchNarrowDownWithStarred-skip]
+from typing import List
+def f(x: List[int] | int) -> None:
+    match x:
+        case [*y]:
+            reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int*]"
+            return
+    reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/list.pyi]
+
 -- Misc
 
 [case testMatchAndWithStatementScope]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1,5 +1,6 @@
 -- Capture Pattern --
-[case testCapturePatternType]
+
+[case testMatchCapturePatternType]
 class A: ...
 m: A
 
@@ -7,16 +8,16 @@ match m:
     case a:
         reveal_type(a)  # N: Revealed type is "__main__.A"
 
-
 -- Literal Pattern --
-[case testLiteralPatternNarrows]
+
+[case testMatchLiteralPatternNarrows]
 m: object
 
 match m:
     case 1:
         reveal_type(m)  # N: Revealed type is "Literal[1]"
 
-[case testLiteralPatternAlreadyNarrower-skip]
+[case testMatchLiteralPatternAlreadyNarrower-skip]
 m: bool
 
 match m:
@@ -24,7 +25,7 @@ match m:
         reveal_type(m)  # This should probably be unreachable, but isn't detected as such.
 [builtins fixtures/primitives.pyi]
 
-[case testLiteralPatternUnreachable]
+[case testMatchLiteralPatternUnreachable]
 # primitives are needed because otherwise mypy doesn't see that int and str are incompatible
 m: int
 
@@ -33,9 +34,9 @@ match m:
         reveal_type(m)
 [builtins fixtures/primitives.pyi]
 
-
 -- Value Pattern --
-[case testValuePatternNarrows]
+
+[case testMatchValuePatternNarrows]
 import b
 m: object
 
@@ -45,7 +46,7 @@ match m:
 [file b.py]
 b: int
 
-[case testValuePatternAlreadyNarrower]
+[case testMatchValuePatternAlreadyNarrower]
 import b
 m: bool
 
@@ -55,7 +56,7 @@ match m:
 [file b.py]
 b: int
 
-[case testValuePatternIntersect]
+[case testMatchValuePatternIntersect]
 import b
 
 class A: ...
@@ -68,7 +69,7 @@ match m:
 class B: ...
 b: B
 
-[case testValuePatternUnreachable]
+[case testMatchValuePatternUnreachable]
 # primitives are needed because otherwise mypy doesn't see that int and str are incompatible
 import b
 
@@ -81,9 +82,9 @@ match m:
 b: str
 [builtins fixtures/primitives.pyi]
 
-
 -- Sequence Pattern --
-[case testSequencePatternCaptures]
+
+[case testMatchSequencePatternCaptures]
 from typing import List
 m: List[int]
 
@@ -92,7 +93,7 @@ match m:
         reveal_type(a)  # N: Revealed type is "builtins.int*"
 [builtins fixtures/list.pyi]
 
-[case testSequencePatternCapturesStarred]
+[case testMatchSequencePatternCapturesStarred]
 from typing import Sequence
 m: Sequence[int]
 
@@ -102,7 +103,7 @@ match m:
         reveal_type(b)  # N: Revealed type is "builtins.list[builtins.int*]"
 [builtins fixtures/list.pyi]
 
-[case testSequencePatternNarrowsInner]
+[case testMatchSequencePatternNarrowsInner]
 from typing import Sequence
 m: Sequence[object]
 
@@ -110,7 +111,7 @@ match m:
     case [1, True]:
         reveal_type(m)  # N: Revealed type is "typing.Sequence[builtins.int]"
 
-[case testSequencePatternNarrowsOuter]
+[case testMatchSequencePatternNarrowsOuter]
 from typing import Sequence
 m: object
 
@@ -118,7 +119,7 @@ match m:
     case [1, True]:
         reveal_type(m)  # N: Revealed type is "typing.Sequence[builtins.int]"
 
-[case testSequencePatternAlreadyNarrowerInner]
+[case testMatchSequencePatternAlreadyNarrowerInner]
 from typing import Sequence
 m: Sequence[bool]
 
@@ -126,7 +127,7 @@ match m:
     case [1, True]:
         reveal_type(m)  # N: Revealed type is "typing.Sequence[builtins.bool]"
 
-[case testSequencePatternAlreadyNarrowerOuter]
+[case testMatchSequencePatternAlreadyNarrowerOuter]
 from typing import Sequence
 m: Sequence[object]
 
@@ -134,7 +135,7 @@ match m:
     case [1, True]:
         reveal_type(m)  # N: Revealed type is "typing.Sequence[builtins.int]"
 
-[case testSequencePatternAlreadyNarrowerBoth]
+[case testMatchSequencePatternAlreadyNarrowerBoth]
 from typing import Sequence
 m: Sequence[bool]
 
@@ -142,7 +143,7 @@ match m:
     case [1, True]:
         reveal_type(m)  # N: Revealed type is "typing.Sequence[builtins.bool]"
 
-[case testNestedSequencePatternNarrowsInner]
+[case testMatchNestedSequencePatternNarrowsInner]
 from typing import Sequence
 m: Sequence[Sequence[object]]
 
@@ -150,7 +151,7 @@ match m:
     case [[1], [True]]:
         reveal_type(m)  # N: Revealed type is "typing.Sequence[typing.Sequence[builtins.int]]"
 
-[case testNestedSequencePatternNarrowsOuter]
+[case testMatchNestedSequencePatternNarrowsOuter]
 from typing import Sequence
 m: object
 
@@ -158,7 +159,7 @@ match m:
     case [[1], [True]]:
         reveal_type(m)  # N: Revealed type is "typing.Sequence[typing.Sequence[builtins.int]]"
 
-[case testSequencePatternDoesntNarrowInvariant]
+[case testMatchSequencePatternDoesntNarrowInvariant]
 from typing import List
 m: List[object]
 
@@ -167,7 +168,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "builtins.list[builtins.object]"
 [builtins fixtures/list.pyi]
 
-[case testSequencePatternMatches]
+[case testMatchSequencePatternMatches]
 import array, collections
 from typing import Sequence, Iterable
 
@@ -230,8 +231,7 @@ match m11:
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-full.pyi]
 
-
-[case testSequencePatternCapturesTuple]
+[case testMatchSequencePatternCapturesTuple]
 from typing import Tuple
 m: Tuple[int, str, bool]
 
@@ -243,7 +243,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "Tuple[builtins.int, builtins.str, builtins.bool]"
 [builtins fixtures/list.pyi]
 
-[case testSequencePatternTupleTooLong]
+[case testMatchSequencePatternTupleTooLong]
 from typing import Tuple
 m: Tuple[int, str]
 
@@ -254,7 +254,7 @@ match m:
         reveal_type(c)
 [builtins fixtures/list.pyi]
 
-[case testSequencePatternTupleTooShort]
+[case testMatchSequencePatternTupleTooShort]
 from typing import Tuple
 m: Tuple[int, str, bool]
 
@@ -264,7 +264,7 @@ match m:
         reveal_type(b)
 [builtins fixtures/list.pyi]
 
-[case testSequencePatternTupleNarrows]
+[case testMatchSequencePatternTupleNarrows]
 from typing import Tuple
 m: Tuple[object, object]
 
@@ -273,7 +273,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "Tuple[Literal[1], Literal['str']]"
 [builtins fixtures/list.pyi]
 
-[case testSequencePatternTupleStarred]
+[case testMatchSequencePatternTupleStarred]
 from typing import Tuple
 m: Tuple[int, str, bool]
 
@@ -285,7 +285,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "Tuple[builtins.int, builtins.str, builtins.bool]"
 [builtins fixtures/list.pyi]
 
-[case testSequencePatternTupleStarredUnion]
+[case testMatchSequencePatternTupleStarredUnion]
 from typing import Tuple
 m: Tuple[int, str, float, bool]
 
@@ -297,8 +297,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "Tuple[builtins.int, builtins.str, builtins.float, builtins.bool]"
 [builtins fixtures/list.pyi]
 
-
-[case testSequencePatternTupleStarredTooShort]
+[case testMatchSequencePatternTupleStarredTooShort]
 from typing import Tuple
 m: Tuple[int]
 reveal_type(m)  # N: Revealed type is "Tuple[builtins.int]"
@@ -310,7 +309,7 @@ match m:
         reveal_type(c)
 [builtins fixtures/list.pyi]
 
-[case testNonMatchingSequencePattern]
+[case testMatchNonMatchingSequencePattern]
 from typing import List
 
 x: List[int]
@@ -318,7 +317,7 @@ match x:
     case [str()]:
         pass
 
-[case testSequenceUnion-skip]
+[case testMatchSequenceUnion-skip]
 from typing import List, Union
 m: Union[List[List[str]], str]
 
@@ -328,7 +327,8 @@ match m:
 [builtins fixtures/list.pyi]
 
 -- Mapping Pattern --
-[case testMappingPatternCaptures]
+
+[case testMatchMappingPatternCaptures]
 from typing import Dict
 import b
 m: Dict[str, int]
@@ -342,7 +342,7 @@ match m:
 b: str
 [builtins fixtures/dict.pyi]
 
-[case testMappingPatternCapturesWrongKeyType]
+[case testMatchMappingPatternCapturesWrongKeyType]
 # This is not actually unreachable, as a subclass of dict could accept keys with different types
 from typing import Dict
 import b
@@ -357,7 +357,7 @@ match m:
 b: int
 [builtins fixtures/dict.pyi]
 
-[case testMappingPatternCapturesTypedDict]
+[case testMatchMappingPatternCapturesTypedDict]
 from typing import TypedDict
 
 class A(TypedDict):
@@ -378,7 +378,7 @@ match m:
         reveal_type(v5)  # N: Revealed type is "builtins.object*"
 [typing fixtures/typing-typeddict.pyi]
 
-[case testMappingPatternCapturesTypedDictWithLiteral]
+[case testMatchMappingPatternCapturesTypedDictWithLiteral]
 from typing import TypedDict
 import b
 
@@ -405,7 +405,7 @@ b: Literal["b"] = "b"
 o: Final[str] = "o"
 [typing fixtures/typing-typeddict.pyi]
 
-[case testMappingPatternCapturesTypedDictWithNonLiteral]
+[case testMatchMappingPatternCapturesTypedDictWithNonLiteral]
 from typing import TypedDict
 import b
 
@@ -423,7 +423,7 @@ from typing import Final, Literal
 a: str
 [typing fixtures/typing-typeddict.pyi]
 
-[case testMappingPatternCapturesTypedDictUnreachable]
+[case testMatchMappingPatternCapturesTypedDictUnreachable]
 # TypedDict keys are always str, so this is actually unreachable
 from typing import TypedDict
 import b
@@ -443,7 +443,7 @@ match m:
 b: int
 [typing fixtures/typing-typeddict.pyi]
 
-[case testMappingPatternCaptureRest]
+[case testMatchMappingPatternCaptureRest]
 m: object
 
 match m:
@@ -451,7 +451,7 @@ match m:
         reveal_type(r)  # N: Revealed type is "builtins.dict[builtins.object, builtins.object]"
 [builtins fixtures/dict.pyi]
 
-[case testMappingPatternCaptureRestFromMapping]
+[case testMatchMappingPatternCaptureRestFromMapping]
 from typing import Mapping
 
 m: Mapping[str, int]
@@ -461,10 +461,11 @@ match m:
         reveal_type(r)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
 [builtins fixtures/dict.pyi]
 
--- Mapping patterns currently don't narrow --
+-- Mapping patterns currently do not narrow --
 
 -- Class Pattern --
-[case testClassPatternCapturePositional]
+
+[case testMatchClassPatternCapturePositional]
 from typing import Final
 
 class A:
@@ -480,7 +481,7 @@ match m:
         reveal_type(j)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternMemberClassCapturePositional]
+[case testMatchClassPatternMemberClassCapturePositional]
 import b
 
 m: b.A
@@ -498,7 +499,7 @@ class A:
     b: int
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternCaptureKeyword]
+[case testMatchClassPatternCaptureKeyword]
 class A:
     a: str
     b: int
@@ -510,7 +511,7 @@ match m:
         reveal_type(i)  # N: Revealed type is "builtins.str"
         reveal_type(j)  # N: Revealed type is "builtins.int"
 
-[case testClassPatternCaptureSelf]
+[case testMatchClassPatternCaptureSelf]
 m: object
 
 match m:
@@ -538,7 +539,7 @@ match m:
         reveal_type(k)  # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/primitives.pyi]
 
-[case testClassPatternNarrowSelfCapture]
+[case testMatchClassPatternNarrowSelfCapture]
 m: object
 
 match m:
@@ -566,7 +567,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/primitives.pyi]
 
-[case testClassPatternCaptureDataclass]
+[case testMatchClassPatternCaptureDataclass]
 from dataclasses import dataclass
 
 @dataclass
@@ -582,7 +583,7 @@ match m:
         reveal_type(j)  # N: Revealed type is "builtins.int"
 [builtins fixtures/dataclasses.pyi]
 
-[case testClassPatternCaptureDataclassNoMatchArgs]
+[case testMatchClassPatternCaptureDataclassNoMatchArgs]
 from dataclasses import dataclass
 
 @dataclass(match_args=False)
@@ -597,7 +598,7 @@ match m:
         pass
 [builtins fixtures/dataclasses.pyi]
 
-[case testClassPatternCaptureDataclassPartialMatchArgs]
+[case testMatchClassPatternCaptureDataclassPartialMatchArgs]
 from dataclasses import dataclass, field
 
 @dataclass
@@ -614,7 +615,7 @@ match m:
         reveal_type(k)  # N: Revealed type is "builtins.str"
 [builtins fixtures/dataclasses.pyi]
 
-[case testClassPatternCaptureNamedTupleInline]
+[case testMatchClassPatternCaptureNamedTupleInline]
 from collections import namedtuple
 
 A = namedtuple("A", ["a", "b"])
@@ -627,7 +628,7 @@ match m:
         reveal_type(j)  # N: Revealed type is "Any"
 [builtins fixtures/list.pyi]
 
-[case testClassPatternCaptureNamedTupleInlineTyped]
+[case testMatchClassPatternCaptureNamedTupleInlineTyped]
 from typing import NamedTuple
 
 A = NamedTuple("A", [("a", str), ("b", int)])
@@ -640,7 +641,7 @@ match m:
         reveal_type(j)  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
-[case testClassPatternCaptureNamedTupleClass]
+[case testMatchClassPatternCaptureNamedTupleClass]
 from typing import NamedTuple
 
 class A(NamedTuple):
@@ -655,7 +656,7 @@ match m:
         reveal_type(j)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternCaptureGeneric]
+[case testMatchClassPatternCaptureGeneric]
 from typing import Generic, TypeVar
 
 T = TypeVar('T')
@@ -670,7 +671,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "__main__.A[Any]"
         reveal_type(i)  # N: Revealed type is "Any"
 
-[case testClassPatternCaptureGenericAlreadyKnown]
+[case testMatchClassPatternCaptureGenericAlreadyKnown]
 from typing import Generic, TypeVar
 
 T = TypeVar('T')
@@ -685,7 +686,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "__main__.A[builtins.int]"
         reveal_type(i)  # N: Revealed type is "builtins.int*"
 
-[case testClassPatternCaptureFilledGenericTypeAlias]
+[case testMatchClassPatternCaptureFilledGenericTypeAlias]
 from typing import Generic, TypeVar
 
 T = TypeVar('T')
@@ -701,7 +702,7 @@ match m:
     case B(a=i):  # E: Class pattern class must not be a type alias with type parameters
         reveal_type(i)
 
-[case testClassPatternCaptureGenericTypeAlias]
+[case testMatchClassPatternCaptureGenericTypeAlias]
 from typing import Generic, TypeVar
 
 T = TypeVar('T')
@@ -717,7 +718,7 @@ match m:
     case B(a=i):
         pass
 
-[case testClassPatternNarrows]
+[case testMatchClassPatternNarrows]
 from typing import Final
 
 class A:
@@ -734,7 +735,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "__main__.A"
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternNarrowsUnion]
+[case testMatchClassPatternNarrowsUnion]
 from typing import Final, Union
 
 class A:
@@ -770,7 +771,7 @@ match m:
         reveal_type(l)  # N: Revealed type is "builtins.str"
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternAlreadyNarrower]
+[case testMatchClassPatternAlreadyNarrower]
 from typing import Final
 
 class A:
@@ -790,7 +791,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "__main__.B"
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternIntersection]
+[case testMatchClassPatternIntersection]
 from typing import Final
 
 class A:
@@ -808,7 +809,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">1"
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternNonexistentKeyword]
+[case testMatchClassPatternNonexistentKeyword]
 class A: ...
 
 m: object
@@ -818,7 +819,7 @@ match m:
         reveal_type(m)  # N: Revealed type is "__main__.A"
         reveal_type(j)  # N: Revealed type is "Any"
 
-[case testClassPatternDuplicateKeyword]
+[case testMatchClassPatternDuplicateKeyword]
 class A:
     a: str
 
@@ -828,7 +829,7 @@ match m:
     case A(a=i, a=j):  # E: Duplicate keyword pattern "a"
         pass
 
-[case testClassPatternDuplicateImplicitKeyword]
+[case testMatchClassPatternDuplicateImplicitKeyword]
 from typing import Final
 
 class A:
@@ -842,7 +843,7 @@ match m:
         pass
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternTooManyPositionals]
+[case testMatchClassPatternTooManyPositionals]
 from typing import Final
 
 class A:
@@ -857,7 +858,7 @@ match m:
         pass
 [builtins fixtures/tuple.pyi]
 
-[case testClassPatternIsNotType]
+[case testMatchClassPatternIsNotType]
 a = 1
 m: object
 
@@ -866,7 +867,7 @@ match m:
         reveal_type(i)
         reveal_type(j)
 
-[case testClassPatternNestedGenerics]
+[case testMatchClassPatternNestedGenerics]
 # From cpython test_patma.py
 x = [[{0: 0}]]
 match x:
@@ -878,7 +879,7 @@ reveal_type(y)  # N: Revealed type is "builtins.int"
 reveal_type(z)  # N: Revealed type is "builtins.int*"
 [builtins fixtures/dict.pyi]
 
-[case testNonFinalMatchArgs]
+[case testMatchNonFinalMatchArgs]
 class A:
     __match_args__ = ("a", "b")  # N: __match_args__ must be final for checking of match statements to work
     a: str
@@ -892,7 +893,7 @@ match m:
         reveal_type(j)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
-[case testAnyTupleMatchArgs]
+[case testMatchAnyTupleMatchArgs]
 from typing import Tuple, Any
 
 class A:
@@ -909,7 +910,7 @@ match m:
         reveal_type(k)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
-[case testNonLiteralMatchArgs]
+[case testMatchNonLiteralMatchArgs]
 from typing import Final
 
 b: str = "b"
@@ -928,7 +929,7 @@ match m:
         reveal_type(j)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
-[case testExternalMatchArgs]
+[case testMatchExternalMatchArgs]
 from typing import Final, Literal
 
 args: Final = ("a", "b")
@@ -947,9 +948,9 @@ class B:
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-medium.pyi]
 
-
 -- As Pattern --
-[case testAsPattern]
+
+[case testMatchAsPattern]
 m: int
 
 match m:
@@ -957,51 +958,51 @@ match m:
         reveal_type(x)  # N: Revealed type is "builtins.int"
         reveal_type(l)  # N: Revealed type is "builtins.int"
 
-[case testAsPatternNarrows]
+[case testMatchAsPatternNarrows]
 m: object
 
 match m:
     case int() as l:
         reveal_type(l)  # N: Revealed type is "builtins.int"
 
-[case testAsPatternCapturesOr]
+[case testMatchAsPatternCapturesOr]
 m: object
 
 match m:
     case 1 | 2 as n:
         reveal_type(n)  # N: Revealed type is "Union[Literal[1], Literal[2]]"
 
-[case testAsPatternAlreadyNarrower]
+[case testMatchAsPatternAlreadyNarrower]
 m: bool
 
 match m:
     case int() as l:
         reveal_type(l)  # N: Revealed type is "builtins.bool"
 
-
 -- Or Pattern --
-[case testOrPatternNarrows]
+
+[case testMatchOrPatternNarrows]
 m: object
 
 match m:
     case 1 | 2:
         reveal_type(m)  # N: Revealed type is "Union[Literal[1], Literal[2]]"
 
-[case testOrPatternNarrowsStr]
+[case testMatchOrPatternNarrowsStr]
 m: object
 
 match m:
     case "foo" | "bar":
         reveal_type(m)  # N: Revealed type is "Union[Literal['foo'], Literal['bar']]"
 
-[case testOrPatternNarrowsUnion]
+[case testMatchOrPatternNarrowsUnion]
 m: object
 
 match m:
     case 1 | "foo":
         reveal_type(m)  # N: Revealed type is "Union[Literal[1], Literal['foo']]"
 
-[case testOrPatterCapturesMissing]
+[case testMatchOrPatterCapturesMissing]
 from typing import List
 m: List[int]
 
@@ -1011,7 +1012,7 @@ match m:
         reveal_type(y)  # N: Revealed type is "builtins.int*"
 [builtins fixtures/list.pyi]
 
-[case testOrPatternCapturesJoin]
+[case testMatchOrPatternCapturesJoin]
 m: object
 
 match m:
@@ -1019,9 +1020,9 @@ match m:
         reveal_type(x)  # N: Revealed type is "typing.Iterable[Any]"
 [builtins fixtures/dict.pyi]
 
-
 -- Interactions --
-[case testCapturePatternMultipleCases]
+
+[case testMatchCapturePatternMultipleCases]
 m: object
 
 match m:
@@ -1032,7 +1033,7 @@ match m:
 
 reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testCapturePatternMultipleCaptures]
+[case testMatchCapturePatternMultipleCaptures]
 from typing import Iterable
 
 m: Iterable[int]
@@ -1042,7 +1043,7 @@ match m:
         reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
-[case testCapturePatternPreexistingSame]
+[case testMatchCapturePatternPreexistingSame]
 a: int
 m: int
 
@@ -1050,7 +1051,7 @@ match m:
     case a:
         reveal_type(a)  # N: Revealed type is "builtins.int"
 
-[case testCapturePatternPreexistingNarrows]
+[case testMatchCapturePatternPreexistingNarrows]
 a: int
 m: bool
 
@@ -1062,7 +1063,7 @@ reveal_type(a)  # N: Revealed type is "builtins.bool"
 a = 3
 reveal_type(a)  # N: Revealed type is "builtins.int"
 
-[case testCapturePatternPreexistingIncompatible]
+[case testMatchCapturePatternPreexistingIncompatible]
 a: str
 m: int
 
@@ -1072,7 +1073,7 @@ match m:
 
 reveal_type(a)  # N: Revealed type is "builtins.str"
 
-[case testCapturePatternPreexistingIncompatibleLater]
+[case testMatchCapturePatternPreexistingIncompatibleLater]
 a: str
 m: object
 
@@ -1084,9 +1085,9 @@ match m:
 
 reveal_type(a)  # N: Revealed type is "builtins.str"
 
-
 -- Guards --
-[case testSimplePatternGuard]
+
+[case testMatchSimplePatternGuard]
 m: str
 
 def guard() -> bool: ...
@@ -1095,21 +1096,21 @@ match m:
     case a if guard():
         reveal_type(a)  # N: Revealed type is "builtins.str"
 
-[case testAlwaysTruePatternGuard]
+[case testMatchAlwaysTruePatternGuard]
 m: str
 
 match m:
     case a if True:
         reveal_type(a)  # N: Revealed type is "builtins.str"
 
-[case testAlwaysFalsePatternGuard]
+[case testMatchAlwaysFalsePatternGuard]
 m: str
 
 match m:
     case a if False:
         reveal_type(a)
 
-[case testRedefiningPatternGuard]
+[case testMatchRedefiningPatternGuard]
 # flags: --strict-optional
 m: str
 
@@ -1117,14 +1118,14 @@ match m:
     case a if a := 1:  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
         reveal_type(a)  # N: Revealed type is "<nothing>"
 
-[case testAssigningPatternGuard]
+[case testMatchAssigningPatternGuard]
 m: str
 
 match m:
     case a if a := "test":
         reveal_type(a)  # N: Revealed type is "builtins.str"
 
-[case testNarrowingPatternGuard]
+[case testMatchNarrowingPatternGuard]
 m: object
 
 match m:
@@ -1132,7 +1133,7 @@ match m:
         reveal_type(a)  # N: Revealed type is "builtins.str"
 [builtins fixtures/isinstancelist.pyi]
 
-[case testIncompatiblePatternGuard]
+[case testMatchIncompatiblePatternGuard]
 class A: ...
 class B: ...
 
@@ -1143,7 +1144,7 @@ match m:
         reveal_type(a)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
 [builtins fixtures/isinstancelist.pyi]
 
-[case testUnreachablePatternGuard]
+[case testMatchUnreachablePatternGuard]
 m: str
 
 match m:
@@ -1153,7 +1154,7 @@ match m:
 
 -- Exhaustiveness --
 
-[case testUnionNegativeNarrowing]
+[case testMatchUnionNegativeNarrowing]
 from typing import Union
 
 m: Union[str, int]
@@ -1166,7 +1167,7 @@ match m:
         reveal_type(b)  # N: Revealed type is "builtins.int"
         reveal_type(m)  # N: Revealed type is "builtins.int"
 
-[case testOrPatternNegativeNarrowing]
+[case testMatchOrPatternNegativeNarrowing]
 from typing import Union
 
 m: Union[str, bytes, int]
@@ -1178,7 +1179,7 @@ match m:
     case b:
         reveal_type(b)  # N: Revealed type is "builtins.int"
 
-[case testExhaustiveReturn]
+[case testMatchExhaustiveReturn]
 def foo(value) -> int:
   match value:
     case "bar":
@@ -1186,7 +1187,7 @@ def foo(value) -> int:
     case _:
       return 2
 
-[case testNonExhaustiveReturn]
+[case testMatchNonExhaustiveReturn]
 def foo(value) -> int:  # E: Missing return statement
   match value:
     case "bar":
@@ -1194,14 +1195,7 @@ def foo(value) -> int:  # E: Missing return statement
     case 2:
       return 2
 
-[case testMoreExhaustiveReturnChecking]
-def f(value: int | str | None) -> int:  # E: Missing return statement
-    match value:
-        case int():
-            return 0
-        case None:
-            return 1
-
+[case testMatchMoreExhaustiveReturnCases]
 def g(value: int | None) -> int:
     match value:
         case int():
@@ -1216,77 +1210,43 @@ def b(value: bool) -> int:
         case False:
             return 3
 
-[case testMiscNonExhaustiveReturn]
+[case testMatchMiscNonExhaustiveReturn]
 class C:
     a: int | str
 
-def f(c: C) -> int:  # E: Missing return statement
+def f1(value: int | str | None) -> int:  # E: Missing return statement
+    match value:
+        case int():
+            return 0
+        case None:
+            return 1
+
+def f2(c: C) -> int:  # E: Missing return statement
     match c:
         case C(a=int()):
             return 0
         case C(a=str()):
             return 1
 
-def g(x: list[str]) -> int:  # E: Missing return statement
+def f3(x: list[str]) -> int:  # E: Missing return statement
     match x:
         case [a]:
             return 0
         case [a, b]:
             return 1
 
-def h(x: dict[str, int]) -> int:  # E: Missing return statement
+def f4(x: dict[str, int]) -> int:  # E: Missing return statement
     match x:
         case {'x': a}:
             return 0
 
-def ff(x: bool) -> int:  # E: Missing return statement
+def f5(x: bool) -> int:  # E: Missing return statement
     match x:
         case True:
             return 0
 [builtins fixtures/dict.pyi]
 
-[case testWithStatementScopeAndMatchStatement]
-from m import A, B
-
-with A() as x:
-    pass
-with B() as x: \
-    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    pass
-
-with A() as y:
-    pass
-with B() as y: \
-    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    pass
-
-with A() as z:
-    pass
-with B() as z: \
-    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    pass
-
-with A() as zz:
-    pass
-with B() as zz: \
-    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    pass
-
-match x:
-    case str(y) as z:
-        zz = y
-
-[file m.pyi]
-from typing import Any
-
-class A:
-    def __enter__(self) -> A: ...
-    def __exit__(self, x, y, z) -> None: ...
-class B:
-    def __enter__(self) -> B: ...
-    def __exit__(self, x, y, z) -> None: ...
-
-[case testNonExhaustiveError]
+[case testMatchNonExhaustiveError]
 from typing import NoReturn
 def assert_never(x: NoReturn) -> None: ...
 
@@ -1299,7 +1259,7 @@ def f(value: int) -> int:  # E: Missing return statement
         case o:
             assert_never(o)  # E: Argument 1 to "assert_never" has incompatible type "int"; expected "NoReturn"
 
-[case testExhaustiveNoError]
+[case testMatchExhaustiveNoError]
 from typing import NoReturn, Union, Literal
 def assert_never(x: NoReturn) -> None: ...
 
@@ -1313,7 +1273,7 @@ def f(value: Literal[1] | Literal[2]) -> int:
             assert_never(o)
 [typing fixtures/typing-medium.pyi]
 
-[case testSequencePatternNegativeNarrowing]
+[case testMatchSequencePatternNegativeNarrowing]
 from typing import Union, Sequence, Tuple
 
 m1: Sequence[int | str]
@@ -1341,7 +1301,7 @@ match m3:
         reveal_type(m3)  # N: Revealed type is "Tuple[Union[builtins.int, builtins.str]]"
 [builtins fixtures/tuple.pyi]
 
-[case testLiteralPatternEnumNegativeNarrowing]
+[case testMatchLiteralPatternEnumNegativeNarrowing]
 from enum import Enum
 class Medal(Enum):
     gold = 1
@@ -1366,7 +1326,7 @@ def g(m: Medal) -> int:
         case Medal.bronze:
             return 2
 
-[case testLiteralPatternEnumCustomEquals-skip]
+[case testMatchLiteralPatternEnumCustomEquals-skip]
 from enum import Enum
 class Medal(Enum):
     gold = 1
@@ -1383,7 +1343,7 @@ match m:
     case _:
         reveal_type(m)  # N: Revealed type is "__main__.Medal"
 
-[case testNarrowUsingPatternGuardSpecialCase]
+[case testMatchNarrowUsingPatternGuardSpecialCase]
 def f(x: int | str) -> int:  # E: Missing return statement
     match x:
         case x if isinstance(x, str):
@@ -1392,7 +1352,7 @@ def f(x: int | str) -> int:  # E: Missing return statement
             return 1
 [builtins fixtures/isinstance.pyi]
 
-[case testNarrowingDownUnionPartially]
+[case testMatchNarrowDownUnionPartially]
 # flags: --strict-optional
 
 def f(x: int | str) -> None:
@@ -1413,7 +1373,7 @@ def h(x: int | str | None) -> None:
             return
     reveal_type(x)  # N: Revealed type is "None"
 
-[case testNarrowDownUsingLiteralMatch]
+[case testMatchNarrowDownUsingLiteralMatch]
 from enum import Enum
 class Medal(Enum):
     gold = 1
@@ -1481,3 +1441,46 @@ def g(c: C) -> int:
         case C(a=str()):
             return 1
     assert False
+
+-- Misc
+
+[case testMatchAndWithStatementScope]
+from m import A, B
+
+with A() as x:
+    pass
+with B() as x: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+with A() as y:
+    pass
+with B() as y: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+with A() as z:
+    pass
+with B() as z: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+with A() as zz:
+    pass
+with B() as zz: \
+    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+    pass
+
+match x:
+    case str(y) as z:
+        zz = y
+
+[file m.pyi]
+from typing import Any
+
+class A:
+    def __enter__(self) -> A: ...
+    def __exit__(self, x, y, z) -> None: ...
+class B:
+    def __enter__(self) -> B: ...
+    def __exit__(self, x, y, z) -> None: ...

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1185,13 +1185,57 @@ def foo(value) -> int:
     case _:
       return 2
 
-[case testNoneExhaustiveReturn]
+[case testNonExhaustiveReturn]
 def foo(value) -> int:  # E: Missing return statement
   match value:
     case "bar":
       return 1
     case 2:
       return 2
+
+[case testMoreExhaustiveReturnChecking]
+def f(value: int | str | None) -> int:  # E: Missing return statement
+    match value:
+        case int():
+            return 0
+        case None:
+            return 1
+
+def g(value: int | None) -> int:
+    match value:
+        case int():
+            return 0
+        case None:
+            return 1
+
+[case testMiscNonExhaustiveReturn-skip]
+class C:
+    a: int | str
+
+def f(c: C) -> int:  # E: Missing return statement
+    match c:
+        case C(a=int()):
+            return 0
+        case C(a=str()):
+            return 1
+
+def g(x: list[str]) -> int:  # E: Missing return statement
+    match x:
+        case [a]:
+            return 0
+        case [a, b]:
+            return 1
+
+def h(x: dict[str, int]) -> int:  # E: Missing return statement
+    match x:
+        case {'x': a}:
+            return 0
+
+def ff(x: bool) -> int:  # E: Missing return statement
+    match x:
+        case True:
+            return 0
+[builtins fixtures/dict.pyi]
 
 [case testWithStatementScopeAndMatchStatement]
 from m import A, B
@@ -1238,33 +1282,33 @@ class B:
 from typing import NoReturn
 def assert_never(x: NoReturn) -> None: ...
 
-value: int
-match value:
-    case 1:
-        pass
-    case 2:
-        pass
-    case o:
-        assert_never(o)  # E: Argument 1 to "assert_never" has incompatible type "int"; expected "NoReturn"
+def f(value: int) -> int:  # E: Missing return statement
+    match value:
+        case 1:
+            return 0
+        case 2:
+            return 1
+        case o:
+            assert_never(o)  # E: Argument 1 to "assert_never" has incompatible type "int"; expected "NoReturn"
 
 [case testExhaustiveNoError]
 from typing import NoReturn, Union, Literal
 def assert_never(x: NoReturn) -> None: ...
 
-value: Union[Literal[1], Literal[2]]
-match value:
-    case 1:
-        pass
-    case 2:
-        pass
-    case o:
-        assert_never(o)
+def f(value: Literal[1] | Literal[2]) -> int:
+    match value:
+        case 1:
+            return 0
+        case 2:
+            return 1
+        case o:
+            assert_never(o)
 [typing fixtures/typing-medium.pyi]
 
 [case testSequencePatternNegativeNarrowing]
 from typing import Union, Sequence, Tuple
 
-m1: Sequence[Union[int, str]]
+m1: Sequence[int | str]
 
 match m1:
     case [int()]:
@@ -1272,7 +1316,7 @@ match m1:
     case r:
         reveal_type(m1)  # N: Revealed type is "typing.Sequence[Union[builtins.int, builtins.str]]"
 
-m2: Tuple[Union[int, str]]
+m2: Tuple[int | str]
 
 match m2:
     case (int(),):
@@ -1296,13 +1340,23 @@ class Medal(Enum):
     silver = 2
     bronze = 3
 
-m: Medal
+def f(m: Medal) -> int:
+    match m:
+        case Medal.gold:
+            reveal_type(m)  # N: Revealed type is "Literal[__main__.Medal.gold]"
+            return 0
+        case _:
+            reveal_type(m)  # N: Revealed type is "Union[Literal[__main__.Medal.silver], Literal[__main__.Medal.bronze]]"
+            return 1
 
-match m:
-    case Medal.gold:
-        reveal_type(m)  # N: Revealed type is "Literal[__main__.Medal.gold]"
-    case _:
-        reveal_type(m)  # N: Revealed type is "Union[Literal[__main__.Medal.silver], Literal[__main__.Medal.bronze]]"
+def g(m: Medal) -> int:
+    match m:
+        case Medal.gold:
+            return 0
+        case Medal.silver:
+            return 1
+        case Medal.bronze:
+            return 2
 
 [case testLiteralPatternEnumCustomEquals-skip]
 from enum import Enum
@@ -1320,3 +1374,12 @@ match m:
         reveal_type(m)  # N: Revealed type is "Literal[__main__.Medal.gold]"
     case _:
         reveal_type(m)  # N: Revealed type is "__main__.Medal"
+
+[case testNarrowUsingPatternGuardSpecialCase]
+def f(x: int | str) -> int:  # E: Missing return statement
+    match x:
+        case x if isinstance(x, str):
+            return 0
+        case int():
+            return 1
+[builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1442,6 +1442,19 @@ def g(c: C) -> int:
             return 1
     assert False
 
+[case testMatchAsPatternIntersection-skip]
+class A: pass
+class B: pass
+class C: pass
+
+def f(x: A) -> None:
+    match x:
+        case B() as y:
+            reveal_type(y)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        case C() as y:
+            reveal_type(y)  # N: Revealed type is "__main__.<subclass of "A" and "C">"
+    reveal_type(y)  # N: Revealed type is "Union[__main__.<subclass of "A" and "B">, __main__.<subclass of "A" and "C">]"
+
 -- Misc
 
 [case testMatchAndWithStatementScope]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -64,7 +64,7 @@ m: A
 
 match m:
     case b.b:
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "A" and "B">1"
 [file b.py]
 class B: ...
 b: B
@@ -804,9 +804,9 @@ m: B
 
 match m:
     case A():
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">"
+        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">2"
     case A(i, j):
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">1"
+        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">3"
 [builtins fixtures/tuple.pyi]
 
 [case testMatchClassPatternNonexistentKeyword]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1152,6 +1152,7 @@ match m:
 [builtins fixtures/isinstancelist.pyi]
 
 -- Exhaustiveness --
+
 [case testUnionNegativeNarrowing]
 from typing import Union
 
@@ -1207,6 +1208,13 @@ def g(value: int | None) -> int:
             return 0
         case None:
             return 1
+
+def b(value: bool) -> int:
+    match value:
+        case True:
+            return 2
+        case False:
+            return 3
 
 [case testMiscNonExhaustiveReturn]
 class C:
@@ -1415,15 +1423,13 @@ def b1(x: bool) -> None:
     match x:
         case True:
             return
-    # Possibly we could have Literal[False] here?
-    reveal_type(x)  # N: Revealed type is "builtins.bool"
+    reveal_type(x)  # N: Revealed type is "Literal[False]"
 
 def b2(x: bool) -> None:
     match x:
         case False:
             return
-    # Possibly we could have Literal[True] here?
-    reveal_type(x)  # N: Revealed type is "builtins.bool"
+    reveal_type(x)  # N: Revealed type is "Literal[True]"
 
 def e1(x: Medal) -> None:
     match x:
@@ -1448,3 +1454,30 @@ def s(x: str) -> None:
         case 'x':
             return
     reveal_type(x)  # N: Revealed type is "builtins.str"
+
+def union(x: str | bool) -> None:
+    match x:
+        case True:
+            return
+    reveal_type(x)  # N: Revealed type is "Union[builtins.str, Literal[False]]"
+
+[case testMatchAssertFalseToSilenceFalsePositives]
+class C:
+    a: int | str
+
+def f(c: C) -> int:
+    match c:
+        case C(a=int()):
+            return 0
+        case C(a=str()):
+            return 1
+        case _:
+            assert False
+
+def g(c: C) -> int:
+    match c:
+        case C(a=int()):
+            return 0
+        case C(a=str()):
+            return 1
+    assert False

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1442,6 +1442,14 @@ def g(c: C) -> int:
             return 1
     assert False
 
+[case testMatchAsPatternExhaustiveness]
+def f(x: int | str) -> int:
+    match x:
+        case int() as n:
+            return n
+        case str() as s:
+            return 1
+
 [case testMatchAsPatternIntersection-skip]
 class A: pass
 class B: pass

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1455,6 +1455,19 @@ def f(x: A) -> None:
             reveal_type(y)  # N: Revealed type is "__main__.<subclass of "A" and "C">"
     reveal_type(y)  # N: Revealed type is "Union[__main__.<subclass of "A" and "B">, __main__.<subclass of "A" and "C">]"
 
+[case testMatchWithBreakAndContinue]
+# flags: --strict-optional
+def f(x: int | str | None) -> None:
+    i = int()
+    while i:
+        match x:
+            case int():
+                continue
+            case str():
+                break
+        reveal_type(x)  # N: Revealed type is "None"
+    reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str, None]"
+
 -- Misc
 
 [case testMatchAndWithStatementScope]


### PR DESCRIPTION
Closes #12010.

Mypy can now detect if a match statement covers all the possible values.
Example:
```
def f(x: int | str) -> int:
    match x:
        case str():
            return 0
        case int():
            return 1
    # Mypy knows that we can't reach here
```

Most of the work was done by @freundTech. I did various minor updates
and changes to tests.

This doesn't handle some cases properly, including these:
1. We don't recognize that `match [*args]` fully covers a list type
2. Fake intersections don't work quite right (some tests are skipped)
3. We assume enums don't have custom `__eq__` methods