### PR TITLE
Consider column numbers when removing duplicate errors

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -1006,7 +1006,12 @@ class Errors:
                         conflicts_notes = True
                     j -= 1
                 j = i - 1
-                while j >= 0 and errors[j][0] == errors[i][0] and errors[j][1] == errors[i][1]:
+                while (
+                    j >= 0
+                    and errors[j][0] == errors[i][0]
+                    and errors[j][1] == errors[i][1]
+                    and errors[j][2] == errors[i][2]
+                ):
                     if (
                         errors[j][5] == errors[i][5]
                         and

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1379,7 +1379,8 @@ from typing import List, Union
 x = []
 y = ""
 x.append(y) if bool() else x.append(y)
-z = x.append(y) if bool() else x.append(y) # E: "append" of "list" does not return a value
+z = x.append(y) if bool() else x.append(y) # E: "append" of "list" does not return a value \
+ # E: "append" of "list" does not return a value
 [builtins fixtures/list.pyi]
 
 -- Special cases

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1135,7 +1135,7 @@ def f(s):
     yield s
 
 x = f(0)  # E: Expression has type "Any"
-for x in f(0):  # E: Expression has type "Any"
+for x in f(0):  # E: Expression has type "Any"  # E: Expression has type "Any"
     g(x)  # E: Expression has type "Any"
 
 def g(x) -> Any:

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2061,7 +2061,7 @@ class Base(Generic[T]):
     @classmethod
     def make_pair(cls: Type[Q], item: T) -> Tuple[Q, Q]:
         if bool():
-            return cls(0), cls(0)  # E: Argument 1 to "Base" has incompatible type "int"; expected "T"
+            return cls(0), cls(0)  # E: Argument 1 to "Base" has incompatible type "int"; expected "T"  # E: Argument 1 to "Base" has incompatible type "int"; expected "T"
         return cls(item), cls(item)
 [builtins fixtures/classmethod.pyi]
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -773,7 +773,7 @@ class C(Generic[T]):
     def __init__(self, x: T) -> None: ...
 def func(x: U) -> U: ...
 
-U = TypeVar('U', asdf, asdf)  # E: Name "asdf" is not defined
+U = TypeVar('U', asdf, asdf)  # E: Name "asdf" is not defined  # E: Name "asdf" is not defined
 T = TypeVar('T', bound=asdf)  # E: Name "asdf" is not defined
 
 reveal_type(C)  # N: Revealed type is "def [T <: Any] (x: T`1) -> __main__.C[T`1]"
@@ -3122,7 +3122,7 @@ reveal_type(C()) # N: Revealed type is "__main__.C"
 reveal_type(x) # N: Revealed type is "__main__.C"
 
 [case testNewAnalyzerIdentityAssignment7]
-C = C # E: Name "C" is not defined
+C = C # E: Name "C" is not defined # E: Name "C" is not defined
 
 reveal_type(C) # E: Name "C" is not defined \
                # N: Revealed type is "Any"

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -23,12 +23,15 @@ x: P  # E: ParamSpec "P" is unbound
 def foo1(x: Callable[P, int]) -> Callable[P, str]:  ...
 
 def foo2(x: P) -> P: ...  # E: Invalid location for ParamSpec "P" \
+                          # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]' \
+                          # E: Invalid location for ParamSpec "P" \
                           # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
 
 def foo3(x: Concatenate[int, P]) -> int: ...  # E: Invalid location for Concatenate \
                                               # N: You can use Concatenate as the first argument to Callable
 
 def foo4(x: List[P]) -> None: ...  # E: Invalid location for ParamSpec "P" \
+                                   # E: Invalid location for ParamSpec "P" \
                                    # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
 
 def foo5(x: Callable[[int, str], P]) -> None: ...  # E: Invalid location for ParamSpec "P" \

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -409,6 +409,8 @@ reveal_type(g())  # N: Revealed type is "Any"
 
 def local() -> None:
     L = List[Union[int, L]]  # E: Cannot resolve name "L" (possible cyclic definition) \
+                             # N: Recursive types are not allowed at function scope \
+                             # E: Cannot resolve name "L" (possible cyclic definition) \
                              # N: Recursive types are not allowed at function scope
     x: L
     reveal_type(x)  # N: Revealed type is "builtins.list[Union[builtins.int, Any]]"

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -277,6 +277,8 @@ def f() -> None:
     y = TypeVar('y')  # E: Cannot redefine "y" as a type variable \
                       # E: "int" not callable
     def h(a: y) -> y: return a # E: Variable "y" is not valid as a type \
+                               # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases \
+                               # E: Variable "y" is not valid as a type \
                                # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 
 [case testCannotRedefineVarAsModule]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -201,9 +201,9 @@ Alias = Tuple[int, T]
 # Recursive aliases are not supported yet.
 from typing import Type, Callable, Union
 
-A = Union[A, int] # E: Cannot resolve name "A" (possible cyclic definition)
-B = Callable[[B], int] # E: Cannot resolve name "B" (possible cyclic definition)
-C = Type[C] # E: Cannot resolve name "C" (possible cyclic definition)
+A = Union[A, int] # E: Cannot resolve name "A" (possible cyclic definition) # E: Cannot resolve name "A" (possible cyclic definition)
+B = Callable[[B], int] # E: Cannot resolve name "B" (possible cyclic definition) # E: Cannot resolve name "B" (possible cyclic definition)
+C = Type[C] # E: Cannot resolve name "C" (possible cyclic definition) # E: Cannot resolve name "C" (possible cyclic definition)
 
 [case testRecursiveAliasesErrors2]
 
@@ -247,7 +247,9 @@ reveal_type(x[0].x) # N: Revealed type is "builtins.str"
 # Recursive aliases are not supported yet.
 from typing import List, Union, Dict
 x: JSON # E: Cannot resolve name "JSON" (possible cyclic definition)
-JSON = Union[int, str, List[JSON], Dict[str, JSON]] # E: Cannot resolve name "JSON" (possible cyclic definition)
+JSON = Union[int, str, List[JSON], Dict[str, JSON]] # E: Cannot resolve name "JSON" (possible cyclic definition) \
+ # E: Cannot resolve name "JSON" (possible cyclic definition) \
+ # E: Cannot resolve name "JSON" (possible cyclic definition)
 reveal_type(x) # N: Revealed type is "Any"
 if isinstance(x, list):
     reveal_type(x) # N: Revealed type is "builtins.list[Any]"

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1264,7 +1264,8 @@ Point = TypedDict('Point', {int: int, int: int})  # E: Invalid TypedDict() field
 
 [case testCannotCreateTypedDictTypeWithInvalidItemType]
 from mypy_extensions import TypedDict
-Point = TypedDict('Point', {'x': 1, 'y': 1})  # E: Invalid type: try using Literal[1] instead?
+Point = TypedDict('Point', {'x': 1, 'y': 1})  # E: Invalid type: try using Literal[1] instead? \
+                                              # E: Invalid type: try using Literal[1] instead?
 [builtins fixtures/dict.pyi]
 
 [case testCannotCreateTypedDictTypeWithInvalidName2]
@@ -1642,7 +1643,8 @@ a.clear() # E: "A" has no attribute "clear"
 a.setdefault('invalid', 1) # E: TypedDict "A" has no key "invalid"
 reveal_type(a.setdefault('x', 1)) # N: Revealed type is "builtins.int"
 reveal_type(a.setdefault('y', [])) # N: Revealed type is "builtins.list[builtins.int]"
-a.setdefault('y', '') # E: Argument 2 to "setdefault" of "TypedDict" has incompatible type "str"; expected "List[int]"
+a.setdefault('y', '') # E: Argument 2 to "setdefault" of "TypedDict" has incompatible type "str"; expected "List[int]" \
+    # E: Argument 2 to "setdefault" of "TypedDict" has incompatible type "str"; expected "List[int]"
 x = ''
 a.setdefault(x, 1) # E: Expected TypedDict key to be string literal
 alias = a.setdefault

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -314,7 +314,8 @@ def ismethod(a: object) -> TypeGuard[float]:
 def isfunction(a: object) -> TypeGuard[str]:
     pass
 def isclassmethod(obj: Any) -> bool:
-    if ismethod(obj) and obj.__self__ is not None and isclass(obj.__self__):  # E: "float" has no attribute "__self__"
+    if ismethod(obj) and obj.__self__ is not None and isclass(obj.__self__):  # E: "float" has no attribute "__self__" \
+                                                                              # E: "float" has no attribute "__self__"
         return True
 
     return False

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -994,7 +994,7 @@ takes_int(x)  # E: Argument 1 to "takes_int" has incompatible type "Union[Extrem
 [case testRecursiveForwardReferenceInUnion]
 
 from typing import List, Union
-MYTYPE = List[Union[str, "MYTYPE"]] # E: Cannot resolve name "MYTYPE" (possible cyclic definition)
+MYTYPE = List[Union[str, "MYTYPE"]] # E: Cannot resolve name "MYTYPE" (possible cyclic definition)  # E: Cannot resolve name "MYTYPE" (possible cyclic definition)
 [builtins fixtures/list.pyi]
 
 [case testNonStrictOptional]

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -915,7 +915,7 @@ a = True or foo()                        # E: Right operand of "or" is never eva
 b = 42 or False                          # E: Right operand of "or" is never evaluated
 d = False and foo()                      # E: Right operand of "and" is never evaluated
 e = True or (True or (True or foo()))    # E: Right operand of "or" is never evaluated
-f = (True or foo()) or (True or foo())   # E: Right operand of "or" is never evaluated
+f = (True or foo()) or (True or foo())   # E: Right operand of "or" is never evaluated  # E: Right operand of "or" is never evaluated
 
 k = [x for x in lst if isinstance(x, int) or foo()]  # E: Right operand of "or" is never evaluated
 [builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5322,6 +5322,7 @@ def T() -> None:
 [out]
 ==
 main:4: error: "C" expects no type arguments, but 1 given
+main:4: error: "C" expects no type arguments, but 1 given
 main:4: error: Function "a.T" is not valid as a type
 main:4: note: Perhaps you need "Callable[...]" or a callback protocol?
 main:6: error: Free type variable expected in Generic[...]
@@ -5353,6 +5354,7 @@ import T
 [out]
 ==
 ==
+main:4: error: "C" expects no type arguments, but 1 given
 main:4: error: "C" expects no type arguments, but 1 given
 main:4: error: Module "T" is not valid as a type
 main:6: error: Free type variable expected in Generic[...]
@@ -5404,6 +5406,7 @@ from typing import TypeVar
 T = int
 [out]
 ==
+main:4: error: "C" expects no type arguments, but 1 given
 main:4: error: "C" expects no type arguments, but 1 given
 main:6: error: Free type variable expected in Generic[...]
 main:10: error: Bad number of arguments for type alias, expected: 0, given: 1
@@ -7900,7 +7903,11 @@ a.py:1: error: Name "TypeVar" is not defined
 a.py:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import TypeVar")
 a.py:7: error: Variable "a.T" is not valid as a type
 a.py:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+a.py:7: error: Variable "a.T" is not valid as a type
+a.py:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 a.py:10: error: Name "bar" already defined on line 6
+a.py:11: error: Variable "a.T" is not valid as a type
+a.py:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 a.py:11: error: Variable "a.T" is not valid as a type
 a.py:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 ==
@@ -7908,7 +7915,11 @@ a.py:1: error: Name "TypeVar" is not defined
 a.py:1: note: Did you forget to import it from "typing"? (Suggestion: "from typing import TypeVar")
 a.py:7: error: Variable "a.T" is not valid as a type
 a.py:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+a.py:7: error: Variable "a.T" is not valid as a type
+a.py:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 a.py:10: error: Name "bar" already defined on line 6
+a.py:11: error: Variable "a.T" is not valid as a type
+a.py:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 a.py:11: error: Variable "a.T" is not valid as a type
 a.py:11: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -986,8 +986,10 @@ a.x = None # type: int \
 [case testInvalidLvalueWithExplicitType3]
 a = 1
 a.y, a.x = None, None # type: int, int \
+    # E: Type cannot be declared in assignment to non-self attribute \
     # E: Type cannot be declared in assignment to non-self attribute
 a[1], a[2] = None, None # type: int, int \
+    # E: Unexpected type declaration \
     # E: Unexpected type declaration
 [builtins fixtures/tuple.pyi]
 [out]


### PR DESCRIPTION
### Description

```py
def foo(a: int) -> int: ...

(foo(""), foo(""),)
(
    foo(""),
    foo(""),
)
```
```
main.py:3:6: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
main.py:5:9: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
main.py:6:9: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
Found 3 errors in 1 file (checked 1 source file)
```

It's misleading to hide similar errors when they appear on the same line, especially when those errors are shown inline in an IDE.

When all the errors aren't shown, the write / check / fix cycle is heavily impacted.

After this PR:
```
main.py:3:6: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
main.py:3:15: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
main.py:5:9: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
main.py:6:9: error: Argument 1 to "foo" has incompatible type "str"; expected "int"  [arg-type]
Found 3 errors in 1 file (checked 1 source file)
```
## Test Plan
I don't think there need to be any tests for this, as it is currently covered by several other tests.

The tests that I've updated have unearthed a couple of bugs related to column numbers(#12272, #12271, and #12274). All of the alterations to the tests in this pr look like situations where I would want to know about multiple errors appearing(except the defective ones mentioned).