### PR TITLE
Remove test case for TypedDict with kwargs

### DIFF
--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -104,15 +104,13 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
 
     def visit_inc_ref(self, op: IncRef) -> str:
         s = self.format('inc_ref %r', op.src)
-        # TODO: Remove bool check (it's unboxed)
-        if is_bool_rprimitive(op.src.type) or is_int_rprimitive(op.src.type):
+        if is_int_rprimitive(op.src.type):
             s += ' :: {}'.format(short_name(op.src.type.name))
         return s
 
     def visit_dec_ref(self, op: DecRef) -> str:
         s = self.format('%sdec_ref %r', 'x' if op.is_xdec else '', op.src)
-        # TODO: Remove bool check (it's unboxed)
-        if is_bool_rprimitive(op.src.type) or is_int_rprimitive(op.src.type):
+        if is_int_rprimitive(op.src.type):
             s += ' :: {}'.format(short_name(op.src.type.name))
         return s
 

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -104,13 +104,15 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
 
     def visit_inc_ref(self, op: IncRef) -> str:
         s = self.format('inc_ref %r', op.src)
-        if is_int_rprimitive(op.src.type):
+        # TODO: Remove bool check (it's unboxed)
+        if is_bool_rprimitive(op.src.type) or is_int_rprimitive(op.src.type):
             s += ' :: {}'.format(short_name(op.src.type.name))
         return s
 
     def visit_dec_ref(self, op: DecRef) -> str:
         s = self.format('%sdec_ref %r', 'x' if op.is_xdec else '', op.src)
-        if is_int_rprimitive(op.src.type):
+        # TODO: Remove bool check (it's unboxed)
+        if is_bool_rprimitive(op.src.type) or is_int_rprimitive(op.src.type):
             s += ' :: {}'.format(short_name(op.src.type.name))
         return s
 

--- a/test-data/unit/semanal-typeddict.test
+++ b/test-data/unit/semanal-typeddict.test
@@ -1,18 +1,6 @@
 -- Create Type
 
 -- TODO: Implement support for this syntax.
---[case testCanCreateTypedDictTypeWithKeywordArguments]
---from mypy_extensions import TypedDict
---Point = TypedDict('Point', x=int, y=int)
---[builtins fixtures/dict.pyi]
---[out]
---MypyFile:1(
---  ImportFrom:1(mypy_extensions, [TypedDict])
---  AssignmentStmt:2(
---    NameExpr(Point* [__main__.Point])
---    TypedDictExpr:2(Point)))
-
--- TODO: Implement support for this syntax.
 --[case testCanCreateTypedDictTypeWithDictCall]
 --from mypy_extensions import TypedDict
 --Point = TypedDict('Point', dict(x=int, y=int))


### PR DESCRIPTION
`mypy` wound't support this syntax since it's deprecated and will be removed.
