### PR TITLE
infer types from explicitly-typed base if not explicitly typed

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3206,9 +3206,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if (isinstance(lvalue, RefExpr) and lvalue.kind in (MDEF, None)
                 and len(name.info.bases) > 0):  # None for Vars defined via self
             for base in name.info.mro[1:]:
-                base_type, base_node = self.lvalue_type_from_base(name, base)
-                if isinstance(base_node, Var) and not base_node.is_inferred and base_type:
-                    return base_type
+                if base.fullname != "builtins.object":
+                    base_type, base_node = self.lvalue_type_from_base(name, base)
+                    if isinstance(base_node, Var) and not base_node.is_inferred and base_type:
+                        return base_type
 
         return None
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3157,7 +3157,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             name.type = AnyType(TypeOfAny.from_error)
         else:
             # Infer type of the target.
-            base_type = self.try_infer_lvalue_var_type_from_bases(name, lvalue)
+            base_type = self.try_infer_lvalue_var_type_from_explicit_base_member(name, lvalue)
             if base_type:
                 self.set_inferred_type(name, lvalue, strip_type(base_type))
 
@@ -3200,12 +3200,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.partial_types[-1].map[name] = lvalue
         return True
 
-    def try_infer_lvalue_var_type_from_bases(self, name: Var, lvalue: Lvalue) -> Optional[Type]:
+    def try_infer_lvalue_var_type_from_explicit_base_member(self, name: Var, lvalue: Lvalue) -> Optional[Type]:
         if (isinstance(lvalue, RefExpr) and lvalue.kind in (MDEF, None)
                 and len(name.info.bases) > 0):  # None for Vars defined via self
             for base in name.info.mro[1:]:
                 base_type, base_node = self.lvalue_type_from_base(name, base)
-                if base_type:
+                if isinstance(base_node, Var) and not base_node.is_inferred and base_type:
                     return base_type
 
         return None

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3200,7 +3200,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.partial_types[-1].map[name] = lvalue
         return True
 
-    def try_infer_lvalue_var_type_from_explicit_base_member(self, name: Var, lvalue: Lvalue) -> Optional[Type]:
+    def try_infer_lvalue_var_type_from_explicit_base_member(
+        self, name: Var, lvalue: Lvalue
+    ) -> Optional[Type]:
         if (isinstance(lvalue, RefExpr) and lvalue.kind in (MDEF, None)
                 and len(name.info.bases) > 0):  # None for Vars defined via self
             for base in name.info.mro[1:]:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4033,39 +4033,6 @@ class B(A):
     a = 1
 [out]
 
-[case testInferBaseTypeInSubclass]
-from typing import Union, List
-
-class A: pass
-class B: pass
-
-class Base:
-    variable1 : List[Union[A, B]] = []
-    variable2 : List[Union[A, B]] = []
-
-class Derived(Base):
-    variable1 = [A()]
-    variable2 = variable1
-[out]
-
-[case testInferBaseTypeFailAssignment]
-from typing import Union, List
-
-class A: pass
-class B: pass
-
-class Base:
-    variable1 : List[A] = []
-    variable2 : List[Union[A, B]] = []
-
-class Derived(Base):
-    variable1 = [A()]
-    variable2 = variable1
-[out]
-main:12: error: Incompatible types in assignment (expression has type "List[A]", variable has type "List[Union[A, B]]")
-main:12: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
-main:12: note: Consider using "Sequence" instead, which is covariant
-
 [case testVariableSubclassAssignMismatch]
 class A:
     a = 1  # type: int

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4033,6 +4033,39 @@ class B(A):
     a = 1
 [out]
 
+[case testInferBaseTypeInSubclass]
+from typing import Union, List
+
+class A: pass
+class B: pass
+
+class Base:
+    variable1 : List[Union[A, B]] = []
+    variable2 : List[Union[A, B]] = []
+
+class Derived(Base):
+    variable1 = [A()]
+    variable2 = variable1
+[out]
+
+[case testInferBaseTypeFailAssignment]
+from typing import Union, List
+
+class A: pass
+class B: pass
+
+class Base:
+    variable1 : List[A] = []
+    variable2 : List[Union[A, B]] = []
+
+class Derived(Base):
+    variable1 = [A()]
+    variable2 = variable1
+[out]
+main:12: error: Incompatible types in assignment (expression has type "List[A]", variable has type "List[Union[A, B]]")
+main:12: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+main:12: note: Consider using "Sequence" instead, which is covariant
+
 [case testVariableSubclassAssignMismatch]
 class A:
     a = 1  # type: int

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2813,8 +2813,8 @@ class C(A):
     x = ['12']
 
 reveal_type(A.x) # N: Revealed type is "builtins.list[Any]"
-reveal_type(B.x) # N: Revealed type is "builtins.list[builtins.int]"
-reveal_type(C.x) # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type(B.x) # N: Revealed type is "builtins.list[Any]"
+reveal_type(C.x) # N: Revealed type is "builtins.list[Any]"
 
 [builtins fixtures/list.pyi]
 
@@ -3255,3 +3255,36 @@ reveal_type(x)  # N: Revealed type is "builtins.bytes*"
 if x:
     reveal_type(x)  # N: Revealed type is "builtins.bytes*"
 [builtins fixtures/dict.pyi]
+
+[case testInferBaseTypeInSubclass]
+from typing import Union, List
+
+class A: pass
+class B: pass
+
+class Base:
+    variable1 : List[Union[A, B]] = []
+    variable2 : List[Union[A, B]] = []
+
+class Derived(Base):
+    variable1 = [A()]
+    variable2 = variable1
+[out]
+
+[case testInferBaseTypeFailAssignment]
+from typing import Union, List
+
+class A: pass
+class B: pass
+
+class Base:
+    variable1 : List[A] = []
+    variable2 : List[Union[A, B]] = []
+
+class Derived(Base):
+    variable1 = [A()]
+    variable2 = variable1
+[out]
+main:12: error: Incompatible types in assignment (expression has type "List[A]", base class "Base" defined the type as "List[Union[A, B]]")
+main:12: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
+main:12: note: Consider using "Sequence" instead, which is covariant

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2813,8 +2813,8 @@ class C(A):
     x = ['12']
 
 reveal_type(A.x) # N: Revealed type is "builtins.list[Any]"
-reveal_type(B.x) # N: Revealed type is "builtins.list[Any]"
-reveal_type(C.x) # N: Revealed type is "builtins.list[Any]"
+reveal_type(B.x) # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(C.x) # N: Revealed type is "builtins.list[builtins.str]"
 
 [builtins fixtures/list.pyi]
 
@@ -3269,6 +3269,9 @@ class Base:
 class Derived(Base):
     variable1 = [A()]
     variable2 = variable1
+
+reveal_type(Derived.variable1)  # N: Revealed type is "builtins.list[Union[__main__.A, __main__.B]]"
+reveal_type(Derived.variable2)  # N: Revealed type is "builtins.list[Union[__main__.A, __main__.B]]"
 [out]
 
 [case testInferBaseTypeFailAssignment]
@@ -3288,3 +3291,16 @@ class Derived(Base):
 main:12: error: Incompatible types in assignment (expression has type "List[A]", base class "Base" defined the type as "List[Union[A, B]]")
 main:12: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
 main:12: note: Consider using "Sequence" instead, which is covariant
+
+[case testDontInferNonExplicitBase]
+class Base: pass
+class Derived: pass
+
+class A:
+    x = Base()
+
+class B:
+    x = Derived()
+
+reveal_type(B.x)  # N: Revealed type is "__main__.Derived"
+[out]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3304,3 +3304,10 @@ class B:
 
 reveal_type(B.x)  # N: Revealed type is "__main__.Derived"
 [out]
+
+[case testDontInferFromObject]
+class A:
+    __doc__ = __doc__ if __doc__ else "No docs"
+
+reveal_type(A.__doc__)  # N: Revealed type is "builtins.str"
+[out]


### PR DESCRIPTION
Fixes #12268. If the type of an lvalue is not given at definition time, attempt to infer it from the type of a base member.