### PR TITLE
Error on unused awaitable expressions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -85,7 +85,7 @@ from mypy.sharedparse import BINARY_MAGIC_METHODS
 from mypy.scope import Scope
 from mypy import state, errorcodes as codes
 from mypy.traverser import has_return_statement, all_return_statements
-from mypy.errorcodes import ErrorCode
+from mypy.errorcodes import ErrorCode, UNUSED_AWAITABLE, UNUSED_COROUTINE
 from mypy.util import is_typeshed_file, is_dunder, is_sunder
 
 T = TypeVar('T')
@@ -3432,24 +3432,30 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                                            [key_type, value_type])
                         del partial_types[var]
 
-    def type_requires_usage(self, typ: Type) -> Optional[str]:
+    def type_requires_usage(self, typ: Type) -> Optional[Tuple[str, ErrorCode]]:
         """Some types require usage in all cases. The classic example is
         an unused coroutine.
 
         In the case that it does require usage, returns a note to attach
         to the error message.
         """
-        if isinstance(typ, Instance):
-            if typ.type.get("__await__") is not None:
-                return "Are you missing an await?"
+        proper_type = get_proper_type(typ)
+        if isinstance(proper_type, Instance):
+            # We use different error codes for generic awaitable vs coroutine.
+            # Coroutines are on by default, whereas generic awaitables are not.
+            if proper_type.type.fullname == "typing.Coroutine":
+                return ("Are you missing an await?", UNUSED_COROUTINE)
+            if proper_type.type.get("__await__") is not None:
+                return ("Are you missing an await?", UNUSED_AWAITABLE)
         return None
 
     def visit_expression_stmt(self, s: ExpressionStmt) -> None:
         expr_type = self.expr_checker.accept(s.expr, allow_none_return=True, always_allow_any=True)
-        error_note = self.type_requires_usage(expr_type)
-        if error_note:
-            self.fail(message_registry.TYPE_MUST_BE_USED.format(format_type(expr_type)), s)
-            self.note(error_note, s)
+        error_note_and_code = self.type_requires_usage(expr_type)
+        if error_note_and_code:
+            error_note, code = error_note_and_code
+            self.fail(message_registry.TYPE_MUST_BE_USED.format(format_type(expr_type)), s, code=code)
+            self.note(error_note, s, code=code)
 
     def visit_return_stmt(self, s: ReturnStmt) -> None:
         """Type check a return statement."""

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3454,7 +3454,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         error_note_and_code = self.type_requires_usage(expr_type)
         if error_note_and_code:
             error_note, code = error_note_and_code
-            self.fail(message_registry.TYPE_MUST_BE_USED.format(format_type(expr_type)), s, code=code)
+            self.fail(
+                message_registry.TYPE_MUST_BE_USED.format(format_type(expr_type)), s, code=code
+            )
             self.note(error_note, s, code=code)
 
     def visit_return_stmt(self, s: ReturnStmt) -> None:

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -98,7 +98,7 @@ LITERAL_REQ: Final = ErrorCode(
     "literal-required", "Check that value is a literal", 'General'
 )
 UNUSED_COROUTINE: Final = ErrorCode(
-    "unused-coroutine", "Ensure that all coroutines are used", "Genera"
+    "unused-coroutine", "Ensure that all coroutines are used", "General"
 )
 
 # These error codes aren't enabled by default.
@@ -152,7 +152,7 @@ IGNORE_WITHOUT_CODE: Final = ErrorCode(
 )
 UNUSED_AWAITABLE: Final = ErrorCode(
     "unused-awaitable",
-    "Ensure that all coroutines are used",
+    "Ensure that all awaitable values are used",
     "General",
     default_enabled=False,
 )

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -97,6 +97,9 @@ EXIT_RETURN: Final = ErrorCode(
 LITERAL_REQ: Final = ErrorCode(
     "literal-required", "Check that value is a literal", 'General'
 )
+UNUSED_COROUTINE: Final = ErrorCode(
+    "unused-coroutine", "Ensure that all coroutines are used", "Genera"
+)
 
 # These error codes aren't enabled by default.
 NO_UNTYPED_DEF: Final[ErrorCode] = ErrorCode(
@@ -144,6 +147,12 @@ NO_OVERLOAD_IMPL: Final = ErrorCode(
 IGNORE_WITHOUT_CODE: Final = ErrorCode(
     "ignore-without-code",
     "Warn about '# type: ignore' comments which do not have error codes",
+    "General",
+    default_enabled=False,
+)
+UNUSED_AWAITABLE: Final = ErrorCode(
+    "unused-awaitable",
+    "Ensure that all coroutines are used",
     "General",
     default_enabled=False,
 )

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -141,6 +141,7 @@ NOT_CALLABLE: Final = '{} not callable'
 PYTHON2_PRINT_FILE_TYPE: Final = (
     'Argument "file" to "print" has incompatible type "{}"; expected "{}"'
 )
+TYPE_MUST_BE_USED: Final = 'Value of type {} must be used'
 
 # Generic
 GENERIC_INSTANCE_VAR_CLASS_ACCESS: Final = (

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -12,7 +12,7 @@ async def f() -> int:
 
 async def f() -> int:
     return 0
-reveal_type(f())  # N: Revealed type is "typing.Coroutine[Any, Any, builtins.int]"
+_ = reveal_type(f())  # N: Revealed type is "typing.Coroutine[Any, Any, builtins.int]"
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
 
@@ -796,6 +796,31 @@ async def precise1(futures: Iterable[Future[int]]) -> None:
 async def precise2(futures: Iterable[Awaitable[int]]) -> None:
     done, pending = await wait(futures)
     reveal_type(done)  # N: Revealed type is "builtins.list[__main__.Task[builtins.int]]"
+
+[builtins fixtures/async_await.pyi]
+[typing fixtures/typing-async.pyi]
+
+[case testUnusedAwaitable]
+from typing import Iterable
+
+async def foo() -> None:
+    pass
+
+class A:
+    def __await__(self) -> Iterable[int]:
+        yield 5
+
+# Things with __getattr__ should not simply be considered awaitable.
+class B:
+    def __getattr__(self, attr) -> object:
+        return 0
+
+def bar() -> None:
+    foo()  # E: Value of type "Coroutine[Any, Any, None]" must be used \
+           # N: Are you missing an await?
+    A()  # E: Value of type "A" must be used \
+         # N: Are you missing an await?
+    B()
 
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -801,6 +801,7 @@ async def precise2(futures: Iterable[Awaitable[int]]) -> None:
 [typing fixtures/typing-async.pyi]
 
 [case testUnusedAwaitable]
+# flags: --show-error-codes --enable-error-code unused-awaitable
 from typing import Iterable
 
 async def foo() -> None:
@@ -816,10 +817,10 @@ class B:
         return 0
 
 def bar() -> None:
-    foo()  # E: Value of type "Coroutine[Any, Any, None]" must be used \
-           # N: Are you missing an await?
-    A()  # E: Value of type "A" must be used \
+    A()  # E: Value of type "A" must be used  [unused-awaitable] \
          # N: Are you missing an await?
+    foo()  # E: Value of type "Coroutine[Any, Any, None]" must be used  [unused-coroutine] \
+           # N: Are you missing an await?
     B()
 
 [builtins fixtures/async_await.pyi]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -538,7 +538,7 @@ class XRepr(NamedTuple):
         return 0
 
 reveal_type(XMeth(1).double()) # N: Revealed type is "builtins.int"
-reveal_type(XMeth(1).asyncdouble())  # N: Revealed type is "typing.Coroutine[Any, Any, builtins.int]"
+_ = reveal_type(XMeth(1).asyncdouble())  # N: Revealed type is "typing.Coroutine[Any, Any, builtins.int]"
 reveal_type(XMeth(42).x)  # N: Revealed type is "builtins.int"
 reveal_type(XRepr(42).__str__())  # N: Revealed type is "builtins.str"
 reveal_type(XRepr(1, 2).__sub__(XRepr(3)))  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -405,7 +405,8 @@ async def g() -> NoReturn:
   await f()
 
 async def h() -> NoReturn:  # E: Implicit return in function which does not return
-  f()
+  # Purposely not evaluating coroutine
+  _ = f()
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-async.pyi]
 

--- a/test-data/unit/pythoneval-asyncio.test
+++ b/test-data/unit/pythoneval-asyncio.test
@@ -78,7 +78,7 @@ def slow_operation(future: 'Future[str]') -> 'Generator[Any, None, None]':
 
 loop = asyncio.get_event_loop()
 future = asyncio.Future()  # type: Future[str]
-asyncio.Task(slow_operation(future))
+_ = asyncio.Task(slow_operation(future))
 loop.run_until_complete(future)
 print(future.result())
 loop.close()
@@ -102,7 +102,7 @@ def got_result(future: 'Future[str]') -> None:
 
 loop = asyncio.get_event_loop() # type: AbstractEventLoop
 future = asyncio.Future()  # type: Future[str]
-asyncio.Task(slow_operation(future))  # Here create a task with the function. (The Task need a Future[T] as first argument)
+_ = asyncio.Task(slow_operation(future))  # Here create a task with the function. (The Task need a Future[T] as first argument)
 future.add_done_callback(got_result)  # and assign the callback to the future
 try:
     loop.run_forever()
@@ -314,7 +314,7 @@ def slow_operation(future: 'Future[str]') -> 'Generator[Any, None, None]':
 
 loop = asyncio.get_event_loop()
 future = asyncio.Future()  # type: Future[str]
-asyncio.Task(slow_operation(future))
+_ = asyncio.Task(slow_operation(future))
 loop.run_until_complete(future)
 print(future.result())
 loop.close()
@@ -334,7 +334,7 @@ def slow_operation(future: 'Future[int]') -> 'Generator[Any, None, None]':
 
 loop = asyncio.get_event_loop()
 future = asyncio.Future()  # type: Future[str]
-asyncio.Task(slow_operation(future))  # Error
+_ = asyncio.Task(slow_operation(future))  # Error
 loop.run_until_complete(future)
 print(future.result())
 loop.close()
@@ -353,7 +353,7 @@ def slow_operation(future: 'Future[int]') -> 'Generator[Any, None, None]':
 
 loop = asyncio.get_event_loop()
 future = asyncio.Future()  # type: Future[str]
-asyncio.Task(slow_operation(future))  # Error
+_ = asyncio.Task(slow_operation(future))  # Error
 loop.run_until_complete(future)
 print(future.result())
 loop.close()
@@ -378,7 +378,7 @@ def got_result(future: 'Future[int]') -> None:
 
 loop = asyncio.get_event_loop() # type: AbstractEventLoop
 future = asyncio.Future()  # type: Future[str]
-asyncio.Task(slow_operation(future))
+_ = asyncio.Task(slow_operation(future))
 future.add_done_callback(got_result)  # Error
 
 try:

--- a/test-data/unit/pythoneval-asyncio.test
+++ b/test-data/unit/pythoneval-asyncio.test
@@ -78,7 +78,7 @@ def slow_operation(future: 'Future[str]') -> 'Generator[Any, None, None]':
 
 loop = asyncio.get_event_loop()
 future = asyncio.Future()  # type: Future[str]
-_ = asyncio.Task(slow_operation(future))
+asyncio.Task(slow_operation(future))
 loop.run_until_complete(future)
 print(future.result())
 loop.close()
@@ -102,7 +102,7 @@ def got_result(future: 'Future[str]') -> None:
 
 loop = asyncio.get_event_loop() # type: AbstractEventLoop
 future = asyncio.Future()  # type: Future[str]
-_ = asyncio.Task(slow_operation(future))  # Here create a task with the function. (The Task need a Future[T] as first argument)
+asyncio.Task(slow_operation(future))  # Here create a task with the function. (The Task need a Future[T] as first argument)
 future.add_done_callback(got_result)  # and assign the callback to the future
 try:
     loop.run_forever()
@@ -314,7 +314,7 @@ def slow_operation(future: 'Future[str]') -> 'Generator[Any, None, None]':
 
 loop = asyncio.get_event_loop()
 future = asyncio.Future()  # type: Future[str]
-_ = asyncio.Task(slow_operation(future))
+asyncio.Task(slow_operation(future))
 loop.run_until_complete(future)
 print(future.result())
 loop.close()
@@ -334,7 +334,7 @@ def slow_operation(future: 'Future[int]') -> 'Generator[Any, None, None]':
 
 loop = asyncio.get_event_loop()
 future = asyncio.Future()  # type: Future[str]
-_ = asyncio.Task(slow_operation(future))  # Error
+asyncio.Task(slow_operation(future))  # Error
 loop.run_until_complete(future)
 print(future.result())
 loop.close()
@@ -353,7 +353,7 @@ def slow_operation(future: 'Future[int]') -> 'Generator[Any, None, None]':
 
 loop = asyncio.get_event_loop()
 future = asyncio.Future()  # type: Future[str]
-_ = asyncio.Task(slow_operation(future))  # Error
+asyncio.Task(slow_operation(future))  # Error
 loop.run_until_complete(future)
 print(future.result())
 loop.close()
@@ -378,7 +378,7 @@ def got_result(future: 'Future[int]') -> None:
 
 loop = asyncio.get_event_loop() # type: AbstractEventLoop
 future = asyncio.Future()  # type: Future[str]
-_ = asyncio.Task(slow_operation(future))
+asyncio.Task(slow_operation(future))
 future.add_done_callback(got_result)  # Error
 
 try:


### PR DESCRIPTION
Generates an error when an expression has a type which has a
defined __await__ in its MRO but is not used. This includes all
builtin awaitable objects (e.g. futures, coroutines, and tasks)
but also anything a user might define which is also awaitable.

A hint is attached to suggest awaiting.

This can be extended in the future to other types of values that
may lead to a resource leak if needed, or even exposed as a plugin.