### PR TITLE
stubtest: Fix wrong assumption about relative path

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,8 +7,8 @@ flake8-pyi>=20.5
 lxml>=4.4.0; python_version<'3.11'
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10
-pytest>=6.2.4,<7.0.0
-pytest-xdist>=1.34.0,<2.0.0
+pytest>=6.2.4
+pytest-xdist>=1.34.0
 pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0,<3.0.0
 py>=1.5.2


### PR DESCRIPTION
### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?

yes

### Description

Fixes https://github.com/python/mypy/issues/11019

`run_stubtest` creates temp directory and prepend `sys.path` with relative path (dot `.`) wrongly assuming that the dot will be resolved to absolute path on *every* import attempt.

But in Python dot(`.`) in sys.path is actually resolved by PathFinder and cached in `sys.path_importer_cache` like:
```
sys.path_importer_cache['.']
FileFinder('/somepath/.')
```
later calls for `find_module` return None and import of `test_module` fails. This resulted in only the first test in stubtest's suite passed in non-pytest-xdist environments.

This issue was hidden with bug or feature in pytest-xdist < 2.3.0:
https://github.com/pytest-dev/pytest-xdist/issues/421

It was fixed in pytest-xdist 2.3.0:
https://github.com/pytest-dev/pytest-xdist/pull/667/

- sys.path for pytest-xdist < 2.3.0
  `'.', 'project_path', ''`

- sys.path for pytest-xdist >= 2.3.0 or without xdist
  `'.', 'project_path'`

### Proposed fix
In Python for denoting cwd the empty path `''` can be used as a special case, but for readability `sys.path` is prepended with resolved absolute path of temp directory. Also it's essential to restore back `sys.path` after a test to not break subsequent tests.

