### PR TITLE
use base type as hint when inferring

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2377,9 +2377,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
             if inferred:
                 type_hint = None
-                if isinstance(lvalue, NameExpr):
+                if isinstance(lvalue, RefExpr):
                     inferred_node = lvalue.node
-                    if (lvalue.kind in (MDEF, None) and  # None for Vars defined via self
+                    if (isinstance(inferred_node, Var) and
+                            lvalue.kind in (MDEF, None) and  # None for Vars defined via self
                             len(inferred_node.info.bases) > 0):
                         for base in inferred_node.info.mro[1:]:
                             base_type, base_node = self.lvalue_type_from_base(inferred_node, base)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3271,4 +3271,3 @@ class Base:
 class Derived(Base):
     variable1 = [A()]
     variable2 = variable1
-[out]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2813,8 +2813,8 @@ class C(A):
     x = ['12']
 
 reveal_type(A.x) # N: Revealed type is "builtins.list[Any]"
-reveal_type(B.x) # N: Revealed type is "builtins.list[builtins.int]"
-reveal_type(C.x) # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type(B.x) # N: Revealed type is "builtins.list[Any]"
+reveal_type(C.x) # N: Revealed type is "builtins.list[Any]"
 
 [builtins fixtures/list.pyi]
 
@@ -3255,3 +3255,20 @@ reveal_type(x)  # N: Revealed type is "builtins.bytes*"
 if x:
     reveal_type(x)  # N: Revealed type is "builtins.bytes*"
 [builtins fixtures/dict.pyi]
+
+[case testInferHintFromBase]
+from typing import Union, List
+
+class A: pass
+class B: pass
+
+U = Union[A, B]
+
+class Base:
+    variable1 : List[U] = []
+    variable2 : List[U] = []
+
+class Derived(Base):
+    variable1 = [A()]
+    variable2 = variable1
+[out]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3271,3 +3271,4 @@ class Base:
 class Derived(Base):
     variable1 = [A()]
     variable2 = variable1
+[out]


### PR DESCRIPTION
Would help with #12268. Modified a test because the two behaviours conflict right now.
