### PR TITLE
stubtest: error if an attribute is a read-only property at runtime, but isn't read-only in the stub

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1060,7 +1060,7 @@ def is_probably_a_function(runtime: Any) -> bool:
 
 
 def is_read_only_property(runtime: object) -> bool:
-    return isinstance(runtime, property) and property.fset is None
+    return isinstance(runtime, property) and runtime.fset is None
 
 
 def safe_inspect_signature(runtime: Any) -> Optional[inspect.Signature]:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -772,8 +772,7 @@ def verify_var(
 
     if (
         stub.is_initialized_in_class
-        and isinstance(runtime, property)
-        and runtime.fset is None
+        and is_read_only_property(runtime)
         and (stub.is_settable_property or not stub.is_property)
     ):
         yield Error(
@@ -816,14 +815,13 @@ def verify_overloadedfuncdef(
 
     if stub.is_property:
         # Any property with a setter is represented as an OverloadedFuncDef
-        if isinstance(runtime, property):
-            if runtime.fset is None:
-                yield Error(
-                    object_path,
-                    "is read-only at runtime but not in the stub",
-                    stub,
-                    runtime
-                )
+        if is_read_only_property(runtime):
+            yield Error(
+                object_path,
+                "is read-only at runtime but not in the stub",
+                stub,
+                runtime
+            )
         return
 
     if not is_probably_a_function(runtime):
@@ -1059,6 +1057,10 @@ def is_probably_a_function(runtime: Any) -> bool:
         or isinstance(runtime, (types.MethodType, types.BuiltinMethodType))
         or (inspect.ismethoddescriptor(runtime) and callable(runtime))
     )
+
+
+def is_read_only_property(runtime: object) -> bool:
+    return isinstance(runtime, property) and property.fset is None
 
 
 def safe_inspect_signature(runtime: Any) -> Optional[inspect.Signature]:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -593,6 +593,36 @@ class StubtestUnit(unittest.TestCase):
             """,
             error="BadReadOnly.f",
         )
+        yield Case(
+            stub="""
+            class X:
+                @property
+                def read_only_attr(self) -> int: ...
+            """,
+            runtime="""
+            class X:
+                @property
+                def read_only_attr(self): return 5
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class Z:
+                @property
+                def read_write_attr(self) -> int: ...
+                @read_write_attr.setter
+                def read_write_attr(self, val: int) -> None: ...
+            """,
+            runtime="""
+            class Z:
+                @property
+                def read_write_attr(self): return self._val
+                @read_write_attr.setter
+                def read_write_attr(self, val): self._val = val
+            """,
+            error=None,
+        )
 
     @collect_cases
     def test_var(self) -> Iterator[Case]:
@@ -628,6 +658,32 @@ class StubtestUnit(unittest.TestCase):
             class X:
                 def __init__(self):
                     self.f = "asdf"
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class Y:
+                read_only_attr: int
+            """,
+            runtime="""
+            class Y:
+                @property
+                def read_only_attr(self): return 5
+            """,
+            error="Y.read_only_attr",
+        )
+        yield Case(
+            stub="""
+            class Z:
+                read_write_attr: int
+            """,
+            runtime="""
+            class Z:
+                @property
+                def read_write_attr(self): return self._val
+                @read_write_attr.setter
+                def read_write_attr(self, val): self._val = val
             """,
             error=None,
         )

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -548,12 +548,12 @@ class StubtestUnit(unittest.TestCase):
             stub="""
             class Good:
                 @property
-                def f(self) -> int: ...
+                def read_only_attr(self) -> int: ...
             """,
             runtime="""
             class Good:
                 @property
-                def f(self) -> int: return 1
+                def read_only_attr(self): return 1
             """,
             error=None,
         )
@@ -592,19 +592,6 @@ class StubtestUnit(unittest.TestCase):
                 f = 1
             """,
             error="BadReadOnly.f",
-        )
-        yield Case(
-            stub="""
-            class X:
-                @property
-                def read_only_attr(self) -> int: ...
-            """,
-            runtime="""
-            class X:
-                @property
-                def read_only_attr(self): return 5
-            """,
-            error=None,
         )
         yield Case(
             stub="""

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -608,6 +608,21 @@ class StubtestUnit(unittest.TestCase):
         )
         yield Case(
             stub="""
+            class Y:
+                @property
+                def read_only_attr(self) -> int: ...
+                @read_only_attr.setter
+                def read_only_attr(self, val: int) -> None: ...
+            """,
+            runtime="""
+            class Y:
+                @property
+                def read_only_attr(self): return 5
+            """,
+            error="Y.read_only_attr",
+        )
+        yield Case(
+            stub="""
             class Z:
                 @property
                 def read_write_attr(self) -> int: ...


### PR DESCRIPTION
### Description

This PR proposes adding checks to stubtest so that it raises an error if a variable is annotated as being writeable in the stub, but is a read-only property at runtime.

### New errors reported by stubtest with this patch applied, when checking typeshed

0; however, this patch was used to prepare the following PR, fixing roughly 50 hits:

- https://github.com/python/typeshed/pull/7395

### Things I tried, which ultimately proved unfruitful

- Checking the opposite scenario as well: raising an error if an attribute was marked as read-only in a stub but was a read-write property at runtime. This resulted in many false positives and 0 true positives.
- Adding a similar check for other common descriptors, such as instances of `types.GetSetDescriptorType`. Unfortunately, it is much harder to accurately determine whether or not an instance of `GetSetDescriptorType` is a read-only data descriptor, or a read-write data descriptor. (All instances of `GetSetDescriptorType` have a `__set__` method, but many of these `__set__` methods raise `AttributeError`. Whereas with properties you can do a simple `if prop.fset is None` check, there's no equivalent test for `GetSetDescriptor`s.)

### Test Plan

~~Four Five~~ Four new test cases added, one modified.

cc. @hauntsaninja