### PR TITLE
Revert "stubtest pos-only differences in dunders (#12184)"

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -618,6 +618,7 @@ def _verify_signature(
             runtime_arg.kind == inspect.Parameter.POSITIONAL_ONLY
             and not stub_arg.variable.name.startswith("__")
             and not stub_arg.variable.name.strip("_") == "self"
+            and not is_dunder(function_name, exclude_special=True)  # noisy for dunder methods
         ):
             yield (
                 'stub argument "{}" should be positional-only '


### PR DESCRIPTION
This reverts commit 777885f2c26cce195f6d23c80fefae1e66dfaac2.

To help with https://github.com/python/typeshed/issues/7441 and reduce risk of stubtest issues interfering with a mypy release. The extra type correctness here is really minimal.