### PR TITLE
CI: Do not run mypy_primer on stubtest/stubgen PRs

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -8,6 +8,10 @@ on:
     - '**/*.rst'
     - '**/*.md'
     - 'mypyc/**'
+    - 'mypy/stubtest.py'
+    - 'mypy/stubgen.py'
+    - 'mypy/stubgenc.py'
+    - 'mypy/test/**'
 
 jobs:
   mypy_primer:


### PR DESCRIPTION
PRs that only affect stubtest or stubgen are never going to have any effect on mypy_primer's output, so we can safely skip the CI check for those PRs. The same goes for PRs that only alter files in the tests directory.
