### PR TITLE
Add success msg for only notes output

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -772,14 +772,11 @@ class Server:
                                                       fixed_terminal_width=terminal_width)
         if self.options.error_summary:
             summary: Optional[str] = None
-            if messages:
-                n_errors, n_notes, n_files = count_stats(messages)
-                if n_errors:
-                    summary = self.formatter.format_error(n_errors, n_files, n_sources,
-                                                          use_color=use_color)
-                elif n_notes == len(messages):
-                    summary = self.formatter.format_success(n_sources, use_color)
-            else:
+            n_errors, n_notes, n_files = count_stats(messages)
+            if n_errors:
+                summary = self.formatter.format_error(n_errors, n_files, n_sources,
+                                                      use_color=use_color)
+            elif not messages or n_notes == len(messages):
                 summary = self.formatter.format_success(n_sources, use_color)
             if summary:
                 # Create new list to avoid appending multiple summaries on successive runs.

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -773,10 +773,12 @@ class Server:
         if self.options.error_summary:
             summary: Optional[str] = None
             if messages:
-                n_errors, n_files = count_stats(messages)
+                n_errors, n_notes, n_files = count_stats(messages)
                 if n_errors:
                     summary = self.formatter.format_error(n_errors, n_files, n_sources,
                                                           use_color=use_color)
+                elif n_notes == len(messages):
+                    summary = self.formatter.format_success(n_sources, use_color)
             else:
                 summary = self.formatter.format_success(n_sources, use_color)
             if summary:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -113,18 +113,15 @@ def main(script_path: Optional[str],
     if messages:
         code = 2 if blockers else 1
     if options.error_summary:
-        if messages:
-            n_errors, n_notes, n_files = util.count_stats(messages)
-            if n_errors:
-                summary = formatter.format_error(
-                    n_errors, n_files, len(sources), blockers=blockers,
-                    use_color=options.color_output
-                )
-                stdout.write(summary + '\n')
-            # Only notes should also output success
-            elif n_notes == len(messages):
-                stdout.write(formatter.format_success(len(sources), options.color_output) + '\n')
-        else:
+        n_errors, n_notes, n_files = util.count_stats(messages)
+        if n_errors:
+            summary = formatter.format_error(
+                n_errors, n_files, len(sources), blockers=blockers,
+                use_color=options.color_output
+            )
+            stdout.write(summary + '\n')
+        # Only notes should also output success
+        elif not messages or n_notes == len(messages):
             stdout.write(formatter.format_success(len(sources), options.color_output) + '\n')
         stdout.flush()
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -114,13 +114,16 @@ def main(script_path: Optional[str],
         code = 2 if blockers else 1
     if options.error_summary:
         if messages:
-            n_errors, n_files = util.count_stats(messages)
+            n_errors, n_notes, n_files = util.count_stats(messages)
             if n_errors:
                 summary = formatter.format_error(
                     n_errors, n_files, len(sources), blockers=blockers,
                     use_color=options.color_output
                 )
                 stdout.write(summary + '\n')
+            # Only notes should also output success
+            elif n_notes == len(messages):
+                stdout.write(formatter.format_success(len(sources), options.color_output) + '\n')
         else:
             stdout.write(formatter.format_success(len(sources), options.color_output) + '\n')
         stdout.flush()

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -435,11 +435,12 @@ def check_python_version(program: str) -> None:
                  "please upgrade to 3.6 or newer".format(name=program))
 
 
-def count_stats(errors: List[str]) -> Tuple[int, int]:
-    """Count total number of errors and files in error list."""
-    errors = [e for e in errors if ': error:' in e]
-    files = {e.split(':')[0] for e in errors}
-    return len(errors), len(files)
+def count_stats(messages: List[str]) -> Tuple[int, int, int]:
+    """Count total number of errors, notes and error_files in message list."""
+    errors = [e for e in messages if ': error:' in e]
+    error_files = {e.split(':')[0] for e in errors}
+    notes = [e for e in messages if ': note:' in e]
+    return len(errors), len(notes), len(error_files)
 
 
 def split_words(msg: str) -> List[str]:


### PR DESCRIPTION
Closes #12302 

The `messages` here could be neither error nor note, thus I modify the `count_stats ` to also count `note`.