### PR TITLE
Fix #11899: "AttributeError: attribute 'arguments' of 'FuncDef' undefined" when running mypy twice

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1948,9 +1948,9 @@ def pretty_callable(tp: CallableType) -> str:
 
     # If we got a "special arg" (i.e: self, cls, etc...), prepend it to the arg list
     if isinstance(tp.definition, FuncDef) and tp.definition.name is not None:
-        definition_args = [arg.variable.name for arg in tp.definition.arguments]
+        definition_args = tp.definition.arg_names
         if definition_args and tp.arg_names != definition_args \
-                and len(definition_args) > 0 and definition_args[0]:
+                and len(definition_args) > 0:
             if s:
                 s = ', ' + s
             s = definition_args[0] + s

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -3190,3 +3190,45 @@ from dir1 import *
 from .test2 import *
 [file dir1/test2.py]
 from test1 import aaaa  # E: Module "test1" has no attribute "aaaa"
+
+[case testIssue11899Incremental]
+import b
+[file a.py]
+class Foo:
+    def frobnicate(self, *args, **kwargs): pass
+[file b.py]
+from a import Foo
+class Bar(Foo):
+    def frobnicate(self) -> None: pass
+[file b.py.2]
+from a import Foo
+class Bar(Foo):
+    def frobnicate(self, *args) -> None: pass
+[file b.py.3]
+from a import Foo
+class Bar(Foo):
+    def frobnicate(self, **kwargs) -> None: pass
+[file b.py.4]
+from a import Foo
+class Bar(Foo):
+    def frobnicate(self, *args, **kwargs) -> None: pass
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[out1]
+tmp/b.py:3: error: Signature of "frobnicate" incompatible with supertype "Foo"
+tmp/b.py:3: note:      Superclass:
+tmp/b.py:3: note:          def frobnicate(self, *args: Any, **kwargs: Any) -> Any
+tmp/b.py:3: note:      Subclass:
+tmp/b.py:3: note:          def frobnicate(self) -> None
+[out2]
+tmp/b.py:3: error: Signature of "frobnicate" incompatible with supertype "Foo"
+tmp/b.py:3: note:      Superclass:
+tmp/b.py:3: note:          def frobnicate(self, *args: Any, **kwargs: Any) -> Any
+tmp/b.py:3: note:      Subclass:
+tmp/b.py:3: note:          def frobnicate(self, *args: Any) -> None
+[out3]
+tmp/b.py:3: error: Signature of "frobnicate" incompatible with supertype "Foo"
+tmp/b.py:3: note:      Superclass:
+tmp/b.py:3: note:          def frobnicate(self, *args: Any, **kwargs: Any) -> Any
+tmp/b.py:3: note:      Subclass:
+tmp/b.py:3: note:          def frobnicate(self, **kwargs: Any) -> None


### PR DESCRIPTION
### Description

Fixes #11899  (at least, a good faith attempt)

Looking at FuncItem / FuncDef in mypy/nodes.py, we can see:

```python
class FuncItem(FuncBase):
    """Base class for nodes usable as overloaded function items."""

    __slots__ = ('arguments',  # Note that can be None if deserialized (type is a lie!)
[ ... ]
    def __init__(self,
                 arguments: List[Argument],
[ ... ]
class FuncDef(FuncItem, SymbolNode, Statement):
[ ... ]
    def serialize(self) -> JsonDict:
        # We're deliberating omitting arguments and storing only arg_names and
        # arg_kinds for space-saving reasons (arguments is not used in later
        # stages of mypy).
        # TODO: After a FuncDef is deserialized, the only time we use `arg_names`
        # and `arg_kinds` is when `type` is None and we need to infer a type. Can
        # we store the inferred type ahead of time?
[ ... ]
    def deserialize(cls, data: JsonDict) -> 'FuncDef':
[ ... ]
        # Leave these uninitialized so that future uses will trigger an error
        del ret.arguments
```

Firstly, the comment is not quite right; `arguments` is not None (or the empty list),  it is in fact not defined (should it be typed as `Optional[List[Argument]]`, and set to None in `deserialize()`?).

Secondly, the comments I quoted above seem to imply the rest of the codebase should use `FuncDef.arg_names/kinds`. However, in d180456b58, the code in messages.py:pretty_callable() was modified to used `FuncDef.arguments` instead. Hence the failure when running mypy twice on the repro I quoted.

## Test Plan

Added a test case triggering the issue I quoted (the issue is seen on the second iteration of `testIssue11899Incremental`).

There is another location where d180456b58 moved from `.arg_names` to `.arguments`. However I'm not smart enough to tell if this needs to be reverted too.

```python
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1077,7 +1077,7 @@ class CallableType(FunctionLike):
             # after serialization, but it is useful in error messages.
             # TODO: decide how to add more info here (file, line, column)
             # without changing interface hash.
-            self.def_extras = {'first_arg': definition.arg_names[0]
+            self.def_extras = {'first_arg': definition.arguments[0].variable.name
                                if definition.arg_names and definition.info and
                                not definition.is_static else None}
```

@msullivan , as the author of d180456b58 I expect you can comment on whether my partial revert is the right option, or if I should have an entirely different approach?

Cheers,
Fred.