### PR TITLE
Revert "Support MYPY_VERSION for overriding version"

### DIFF
--- a/mypy/version.py
+++ b/mypy/version.py
@@ -5,22 +5,12 @@ from mypy import git
 # - Release versions have the form "0.NNN".
 # - Dev versions have the form "0.NNN+dev" (PLUS sign to conform to PEP 440).
 # - For 1.0 we'll switch back to 1.2.3 form.
-base_version = '0.950+dev'
-# Overridden by setup.py
-__version__ = base_version
+__version__ = '0.950+dev'
+base_version = __version__
 
-
-def setup_compute_version() -> str:
-    # We allow an environment variable to override version, but we should probably
-    # enforce that it is consistent with the existing version minus additional information.
-    if "MYPY_VERSION" in os.environ:
-        assert os.environ["MYPY_VERSION"].startswith(base_version)
-        return os.environ["MYPY_VERSION"]
-
-    mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-    if base_version.endswith('+dev') and git.is_git_repo(mypy_dir) and git.have_git():
-        version = base_version + '.' + git.git_revision(mypy_dir).decode('utf-8')
-        if git.is_dirty(mypy_dir):
-            return version + ".dirty"
-        return version
-    return base_version
+mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+if __version__.endswith('+dev') and git.is_git_repo(mypy_dir) and git.have_git():
+    __version__ += '.' + git.git_revision(mypy_dir).decode('utf-8')
+    if git.is_dirty(mypy_dir):
+        __version__ += '.dirty'
+del mypy_dir

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 # alternative forms of installing, as suggested by README.md).
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
-from mypy.version import setup_compute_version
+from mypy.version import __version__ as version
 
 description = 'Optional static typing for Python'
 long_description = '''
@@ -31,8 +31,6 @@ actually having to run it.  Mypy has a powerful type system with
 features such as type inference, gradual typing, generics and union
 types.
 '''.lstrip()
-
-version = setup_compute_version()
 
 
 def find_package_data(base, globs, root='mypy'):


### PR DESCRIPTION
This reverts commit 3a5b2a996af8e0333e5eebbdbadc9eec3d1f310e.

Attempting to fix builds. I think that we need the commit hash in the version.