### PR TITLE
Cherry pick the typeshed fix for 12339

### DIFF
--- a/mypy/typeshed/stdlib/email/message.pyi
+++ b/mypy/typeshed/stdlib/email/message.pyi
@@ -2,7 +2,9 @@ from email.charset import Charset
 from email.contentmanager import ContentManager
 from email.errors import MessageDefect
 from email.policy import Policy
-from typing import Any, Generator, Iterator, Optional, Sequence, TypeVar, Union
+
+# using a type alias ("_HeaderType = Any") breaks mypy, who knows why
+from typing import Any, Any as _HeaderType, Generator, Iterator, Optional, Sequence, TypeVar, Union
 
 _T = TypeVar("_T")
 
@@ -10,7 +12,6 @@ _PayloadType = Union[list[Message], str, bytes]
 _CharsetType = Union[Charset, str, None]
 _ParamsType = Union[str, None, tuple[str, Optional[str], str]]
 _ParamType = Union[str, tuple[Optional[str], Optional[str], str]]
-_HeaderType = Any
 
 class Message:
     policy: Policy  # undocumented


### PR DESCRIPTION
### Description

Typeshed cherry-pick: Use import instead of type alias in `email/message.pyi` (#7022)

Fixes #12339 

(Explain how this PR changes mypy.)

I've confirmed that this resolves the type checking error introduced in 0.940 using hamcrest as a testbed. 