### PR TITLE
Add missing `enable_error_code` to configuration documentation

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -648,6 +648,14 @@ section of the command line docs.
 
     Allows disabling one or multiple error codes globally.
 
+.. confval:: enable_error_code
+
+    :type: comma-separated list of strings
+
+    Allows enabling one or multiple error codes globally.
+
+    Note: This option will override disabled error codes from the disable_error_code option.
+
 .. confval:: implicit_reexport
 
     :type: boolean


### PR DESCRIPTION
### Description
In the configuration documentation, `disable_error_code` is [documented](https://github.com/python/mypy/blob/0d38613d8bd156a793a2f9f0f8f331499ad31531/docs/source/config_file.rst#miscellaneous-strictness-flags), but its counterpart `enable_error_code` is not, although `--enable-error-code` flag is documented in [the command line documentation](https://github.com/python/mypy/blob/e2852039bafaf0d7463623dd5410c02797eae21b/docs/source/command_line.rst#miscellaneous-strictness-flags).

This PR adds `enable_error_code` to the configuration documentation, with a description similar to `disable_error_code`. It also adds a similar note as the one found for `--enable-error-code` flag documentation.