### PR TITLE
Add ``type`` to both lists of generic types (#10985)

### DIFF
--- a/docs/source/builtin_types.rst
+++ b/docs/source/builtin_types.rst
@@ -53,6 +53,7 @@ Type                   Description
 ``Iterable[int]``      iterable object containing ints
 ``Sequence[bool]``     sequence of booleans (read-only)
 ``Mapping[str, int]``  mapping from ``str`` keys to ``int`` values (read-only)
+``type[C]``            type object from ``C`` (``C`` is a class/type variable/union of types)
 ====================== ===============================
 
 The type ``dict`` is a *generic* class, signified by type arguments within
@@ -82,6 +83,7 @@ Type                   Description
 ``Iterable[int]``      iterable object containing ints
 ``Sequence[bool]``     sequence of booleans (read-only)
 ``Mapping[str, int]``  mapping from ``str`` keys to ``int`` values (read-only)
+``Type[C]``            Type object from ``C`` (``C`` is a class/type variable/union of types)
 ====================== ===============================
 
 ``List`` is an alias for the built-in type ``list`` that supports

--- a/docs/source/builtin_types.rst
+++ b/docs/source/builtin_types.rst
@@ -83,7 +83,7 @@ Type                   Description
 ``Iterable[int]``      iterable object containing ints
 ``Sequence[bool]``     sequence of booleans (read-only)
 ``Mapping[str, int]``  mapping from ``str`` keys to ``int`` values (read-only)
-``Type[C]``            Type object of ``C`` (``C`` is a class/type variable/union of types)
+``Type[C]``            type object of ``C`` (``C`` is a class/type variable/union of types)
 ====================== ===============================
 
 ``List`` is an alias for the built-in type ``list`` that supports

--- a/docs/source/builtin_types.rst
+++ b/docs/source/builtin_types.rst
@@ -53,7 +53,7 @@ Type                   Description
 ``Iterable[int]``      iterable object containing ints
 ``Sequence[bool]``     sequence of booleans (read-only)
 ``Mapping[str, int]``  mapping from ``str`` keys to ``int`` values (read-only)
-``type[C]``            type object from ``C`` (``C`` is a class/type variable/union of types)
+``type[C]``            type object of ``C`` (``C`` is a class/type variable/union of types)
 ====================== ===============================
 
 The type ``dict`` is a *generic* class, signified by type arguments within
@@ -83,7 +83,7 @@ Type                   Description
 ``Iterable[int]``      iterable object containing ints
 ``Sequence[bool]``     sequence of booleans (read-only)
 ``Mapping[str, int]``  mapping from ``str`` keys to ``int`` values (read-only)
-``Type[C]``            Type object from ``C`` (``C`` is a class/type variable/union of types)
+``Type[C]``            Type object of ``C`` (``C`` is a class/type variable/union of types)
 ====================== ===============================
 
 ``List`` is an alias for the built-in type ``list`` that supports


### PR DESCRIPTION
### Description

Closes #10985 

This PR adds ``type`` and ``Type`` with a description each to both of the list of generic types in builtin_types section.
