### PR TITLE
Correct example in `runtime_troubles.rst`

### DIFF
--- a/docs/source/runtime_troubles.rst
+++ b/docs/source/runtime_troubles.rst
@@ -254,7 +254,7 @@ sections, these can be dealt with by using :ref:`typing.TYPE_CHECKING
 
    from typing import TYPE_CHECKING
    if TYPE_CHECKING:
-       from _typeshed import SupportsLessThan
+       from _typeshed import SupportsRichComparison
 
 .. _generic-builtins:
 


### PR DESCRIPTION
`SupportsLessThan` was removed from `_typeshed` in https://github.com/python/typeshed/pull/6583 and replaced with a new `SupportsRichComparison` type, which better reflects the types at runtime.

Fixes #12355
