### PR TITLE
Add UnpackType type and basic semanal

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -8,8 +8,7 @@ from mypy.types import (
     TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeVarId, TypeQuery, is_named_instance, TypeOfAny, LiteralType,
     ProperType, ParamSpecType, get_proper_type, TypeAliasType, is_union_with_any,
-    callable_with_ellipsis,
-    TUPLE_LIKE_INSTANCE_NAMES,
+    UnpackType, callable_with_ellipsis, TUPLE_LIKE_INSTANCE_NAMES,
 )
 from mypy.maptype import map_instance_to_supertype
 import mypy.subtypes
@@ -403,6 +402,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
     def visit_param_spec(self, template: ParamSpecType) -> List[Constraint]:
         # Can't infer ParamSpecs from component values (only via Callable[P, T]).
         return []
+
+    def visit_unpack_type(self, template: UnpackType) -> List[Constraint]:
+        raise NotImplementedError
 
     # Non-leaf types
 

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -4,7 +4,7 @@ from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneType, TypeVarId, Instance, TypeVarType,
     CallableType, TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType,
     DeletedType, TypeTranslator, UninhabitedType, TypeType, TypeOfAny, LiteralType, ProperType,
-    get_proper_type, get_proper_types, TypeAliasType, ParamSpecType
+    get_proper_type, get_proper_types, TypeAliasType, ParamSpecType, UnpackType
 )
 from mypy.nodes import ARG_STAR, ARG_STAR2
 
@@ -58,6 +58,9 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
 
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
         return AnyType(TypeOfAny.special_form)
+
+    def visit_unpack_type(self, t: UnpackType) -> ProperType:
+        raise NotImplementedError
 
     def visit_callable_type(self, t: CallableType) -> ProperType:
         # We must preserve the fallback type for overload resolution to work.

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -5,7 +5,7 @@ from mypy.types import (
     NoneType, Overloaded, TupleType, TypedDictType, UnionType,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
     FunctionLike, TypeVarType, LiteralType, get_proper_type, ProperType,
-    TypeAliasType, ParamSpecType, TypeVarLikeType
+    TypeAliasType, ParamSpecType, TypeVarLikeType, UnpackType
 )
 
 
@@ -110,6 +110,9 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
             return repl.with_flavor(t.flavor)
         else:
             return repl
+
+    def visit_unpack_type(self, t: UnpackType) -> Type:
+        raise NotImplementedError
 
     def visit_callable_type(self, t: CallableType) -> Type:
         param_spec = t.param_spec()

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -10,7 +10,8 @@ from mypy.nodes import (
 from mypy.types import (
     CallableType, Instance, Overloaded, TupleType, TypedDictType,
     TypeVarType, UnboundType, UnionType, TypeVisitor, LiteralType,
-    TypeType, NOT_READY, TypeAliasType, AnyType, TypeOfAny, ParamSpecType
+    TypeType, NOT_READY, TypeAliasType, AnyType, TypeOfAny, ParamSpecType,
+    UnpackType,
 )
 from mypy.visitor import NodeVisitor
 from mypy.lookup import lookup_fully_qualified
@@ -250,6 +251,9 @@ class TypeFixer(TypeVisitor[None]):
 
     def visit_param_spec(self, p: ParamSpecType) -> None:
         p.upper_bound.accept(self)
+
+    def visit_unpack_type(self, u: UnpackType) -> None:
+        u.type.accept(self)
 
     def visit_unbound_type(self, o: UnboundType) -> None:
         for a in o.args:

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -67,6 +67,9 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
     def visit_param_spec(self, t: types.ParamSpecType) -> Set[str]:
         return set()
 
+    def visit_unpack_type(self, t: types.UnpackType) -> Set[str]:
+        return t.type.accept(self)
+
     def visit_instance(self, t: types.Instance) -> Set[str]:
         out = self._visit(t.args)
         if t.type:

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -7,7 +7,8 @@ from mypy.types import (
     Type, AnyType, NoneType, TypeVisitor, Instance, UnboundType, TypeVarType, CallableType,
     TupleType, TypedDictType, ErasedType, UnionType, FunctionLike, Overloaded, LiteralType,
     PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, get_proper_type,
-    ProperType, get_proper_types, TypeAliasType, PlaceholderType, ParamSpecType
+    ProperType, get_proper_types, TypeAliasType, PlaceholderType, ParamSpecType,
+    UnpackType
 )
 from mypy.maptype import map_instance_to_supertype
 from mypy.subtypes import (
@@ -255,6 +256,9 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
         if self.s == t:
             return t
         return self.default(self.s)
+
+    def visit_unpack_type(self, t: UnpackType) -> UnpackType:
+        raise NotImplementedError
 
     def visit_instance(self, t: Instance) -> ProperType:
         if isinstance(self.s, Instance):

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -862,6 +862,8 @@ def process_options(args: List[str],
     # Must be followed by another flag or by '--' (and then only file args may follow).
     parser.add_argument('--cache-map', nargs='+', dest='special-opts:cache_map',
                         help=argparse.SUPPRESS)
+    parser.add_argument('--enable-incomplete-features', default=False,
+                        help=argparse.SUPPRESS)
 
     # options specifying code to check
     code_group = parser.add_argument_group(

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -6,7 +6,7 @@ from mypy.types import (
     TupleType, TypedDictType, ErasedType, UnionType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike, LiteralType,
     ProperType, get_proper_type, get_proper_types, TypeAliasType, TypeGuardedType,
-    ParamSpecType
+    ParamSpecType, UnpackType,
 )
 from mypy.subtypes import is_equivalent, is_subtype, is_callable_compatible, is_proper_subtype
 from mypy.erasetype import erase_type
@@ -505,6 +505,9 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
             return self.s
         else:
             return self.default(self.s)
+
+    def visit_unpack_type(self, t: UnpackType) -> ProperType:
+        raise NotImplementedError
 
     def visit_instance(self, t: Instance) -> ProperType:
         if isinstance(self.s, Instance):

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -152,6 +152,7 @@ BARE_GENERIC: Final = "Missing type parameters for generic type {}"
 IMPLICIT_GENERIC_ANY_BUILTIN: Final = (
     'Implicit generic "Any". Use "{}" and specify generic parameters'
 )
+INVALID_UNPACK = "{} cannot be unpacked (must be tuple or TypeVarTuple)"
 
 # TypeVar
 INCOMPATIBLE_TYPEVAR_VALUE: Final = 'Value of type variable "{}" of {} cannot be {}'

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -258,6 +258,7 @@ class Options:
         self.dump_type_stats = False
         self.dump_inference_stats = False
         self.dump_build_stats = False
+        self.enable_incomplete_features = False
 
         # -- test options --
         # Stop after the semantic analysis phase

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -4,7 +4,7 @@ from mypy.types import (
     Type, UnboundType, AnyType, NoneType, TupleType, TypedDictType,
     UnionType, CallableType, TypeVarType, Instance, TypeVisitor, ErasedType,
     Overloaded, PartialType, DeletedType, UninhabitedType, TypeType, LiteralType,
-    ProperType, get_proper_type, TypeAliasType, ParamSpecType
+    ProperType, get_proper_type, TypeAliasType, ParamSpecType, UnpackType
 )
 from mypy.typeops import tuple_fallback, make_simplified_union
 
@@ -101,6 +101,10 @@ class SameTypeVisitor(TypeVisitor[bool]):
         # Ignore upper bound since it's derived from flavor.
         return (isinstance(self.right, ParamSpecType) and
                 left.id == self.right.id and left.flavor == self.right.flavor)
+
+    def visit_unpack_type(self, left: UnpackType) -> bool:
+        return (isinstance(self.right, UnpackType) and
+                is_same_type(left.type, self.right.type))
 
     def visit_callable_type(self, left: CallableType) -> bool:
         # FIX generics

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -59,7 +59,8 @@ from mypy.nodes import (
 from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneType, UninhabitedType,
     ErasedType, DeletedType, Instance, TypeVarType, CallableType, TupleType, TypedDictType,
-    UnionType, Overloaded, PartialType, TypeType, LiteralType, TypeAliasType, ParamSpecType
+    UnionType, Overloaded, PartialType, TypeType, LiteralType, TypeAliasType, ParamSpecType,
+    UnpackType,
 )
 from mypy.util import get_prefix
 
@@ -316,6 +317,9 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
                 typ.id.meta_level,
                 typ.flavor,
                 snapshot_type(typ.upper_bound))
+
+    def visit_unpack_type(self, typ: UnpackType) -> SnapshotItem:
+        return ('UnpackType', snapshot_type(typ.type))
 
     def visit_callable_type(self, typ: CallableType) -> SnapshotItem:
         # FIX generics

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -59,7 +59,8 @@ from mypy.types import (
     Type, SyntheticTypeVisitor, Instance, AnyType, NoneType, CallableType, ErasedType, DeletedType,
     TupleType, TypeType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     Overloaded, TypeVarType, TypeList, CallableArgument, EllipsisType, StarType, LiteralType,
-    RawExpressionType, PartialType, PlaceholderType, TypeAliasType, ParamSpecType
+    RawExpressionType, PartialType, PlaceholderType, TypeAliasType, ParamSpecType,
+    UnpackType
 )
 from mypy.util import get_prefix, replace_object_state
 from mypy.typestate import TypeState
@@ -410,6 +411,9 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
 
     def visit_param_spec(self, typ: ParamSpecType) -> None:
         pass
+
+    def visit_unpack_type(self, typ: UnpackType) -> None:
+        typ.type.accept(self)
 
     def visit_typeddict_type(self, typ: TypedDictType) -> None:
         for value_type in typ.items.values():

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -99,7 +99,7 @@ from mypy.types import (
     Type, Instance, AnyType, NoneType, TypeVisitor, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     FunctionLike, Overloaded, TypeOfAny, LiteralType, ErasedType, get_proper_type, ProperType,
-    TypeAliasType, ParamSpecType
+    TypeAliasType, ParamSpecType, UnpackType
 )
 from mypy.server.trigger import make_trigger, make_wildcard_trigger
 from mypy.util import correct_relative_import
@@ -960,6 +960,9 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
             triggers.append(make_trigger(typ.fullname))
         triggers.extend(self.get_type_triggers(typ.upper_bound))
         return triggers
+
+    def visit_unpack_type(self, typ: UnpackType) -> List[str]:
+        return typ.type.accept(self)
 
     def visit_typeddict_type(self, typ: TypedDictType) -> List[str]:
         triggers = []

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -8,7 +8,7 @@ from mypy.types import (
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
     FunctionLike, TypeOfAny, LiteralType, get_proper_type, TypeAliasType, ParamSpecType,
-    TUPLE_LIKE_INSTANCE_NAMES,
+    UnpackType, TUPLE_LIKE_INSTANCE_NAMES,
 )
 import mypy.applytype
 import mypy.constraints
@@ -326,6 +326,9 @@ class SubtypeVisitor(TypeVisitor[bool]):
         ):
             return True
         return self._is_subtype(left.upper_bound, self.right)
+
+    def visit_unpack_type(self, left: UnpackType) -> bool:
+        raise NotImplementedError
 
     def visit_callable_type(self, left: CallableType) -> bool:
         right = self.right
@@ -1356,6 +1359,9 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
         ):
             return True
         return self._is_proper_subtype(left.upper_bound, self.right)
+
+    def visit_unpack_type(self, left: UnpackType) -> bool:
+        raise NotImplementedError
 
     def visit_callable_type(self, left: CallableType) -> bool:
         right = self.right

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -49,6 +49,7 @@ def get_semanal_options(program_text: str, testcase: DataDrivenTestCase) -> Opti
     options.semantic_analysis_only = True
     options.show_traceback = True
     options.python_version = PYTHON3_VERSION
+    options.enable_incomplete_features = True
     return options
 
 

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -23,7 +23,7 @@ from mypy.types import (
     RawExpressionType, Instance, NoneType, TypeType,
     UnionType, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarLikeType,
     UnboundType, ErasedType, StarType, EllipsisType, TypeList, CallableArgument,
-    PlaceholderType, TypeAliasType, ParamSpecType, get_proper_type
+    PlaceholderType, TypeAliasType, ParamSpecType, UnpackType, get_proper_type
 )
 
 
@@ -107,6 +107,10 @@ class TypeVisitor(Generic[T]):
     def visit_type_alias_type(self, t: TypeAliasType) -> T:
         pass
 
+    @abstractmethod
+    def visit_unpack_type(self, t: UnpackType) -> T:
+        pass
+
 
 @trait
 @mypyc_attr(allow_interpreted_subclasses=True)
@@ -188,6 +192,9 @@ class TypeTranslator(TypeVisitor[Type]):
 
     def visit_partial_type(self, t: PartialType) -> Type:
         return t
+
+    def visit_unpack_type(self, t: UnpackType) -> Type:
+        return t.type.accept(self)
 
     def visit_callable_type(self, t: CallableType) -> Type:
         return t.copy_modified(arg_types=self.translate_types(t.arg_types),
@@ -300,6 +307,9 @@ class TypeQuery(SyntheticTypeVisitor[T]):
 
     def visit_param_spec(self, t: ParamSpecType) -> T:
         return self.strategy([])
+
+    def visit_unpack_type(self, t: UnpackType) -> T:
+        return self.query_types([t.type])
 
     def visit_partial_type(self, t: PartialType) -> T:
         return self.strategy([])

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -17,8 +17,9 @@ from mypy.types import (
     StarType, PartialType, EllipsisType, UninhabitedType, TypeType, CallableArgument,
     TypeQuery, union_items, TypeOfAny, LiteralType, RawExpressionType,
     PlaceholderType, Overloaded, get_proper_type, TypeAliasType, RequiredType,
-    TypeVarLikeType, ParamSpecType, ParamSpecFlavor, callable_with_ellipsis,
-    TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES, LITERAL_TYPE_NAMES, ANNOTATED_TYPE_NAMES,
+    TypeVarLikeType, ParamSpecType, ParamSpecFlavor, UnpackType,
+    callable_with_ellipsis, TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES,
+    LITERAL_TYPE_NAMES, ANNOTATED_TYPE_NAMES,
 )
 
 from mypy.nodes import (
@@ -377,6 +378,14 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         elif self.anal_type_guard_arg(t, fullname) is not None:
             # In most contexts, TypeGuard[...] acts as an alias for bool (ignoring its args)
             return self.named_type('builtins.bool')
+        elif fullname in ('typing.Unpack', 'typing_extensions.Unpack'):
+            # We don't want people to try to use this yet.
+            if not self.options.enable_incomplete_features:
+                self.fail('"Unpack" is not supported by mypy yet', t)
+                return AnyType(TypeOfAny.from_error)
+            return UnpackType(
+                self.anal_type(t.args[0]), line=t.line, column=t.column,
+            )
         return None
 
     def get_omitted_any(self, typ: Type, fullname: Optional[str] = None) -> AnyType:
@@ -557,6 +566,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def visit_param_spec(self, t: ParamSpecType) -> Type:
         return t
+
+    def visit_unpack_type(self, t: UnpackType) -> Type:
+        raise NotImplementedError
 
     def visit_callable_type(self, t: CallableType, nested: bool = True) -> Type:
         # Every Callable can bind its own type variables, if they're not in the outer scope

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -764,6 +764,35 @@ class TypeList(ProperType):
         assert False, "Synthetic types don't serialize"
 
 
+class UnpackType(ProperType):
+    """Type operator Unpack from PEP646. Can be either with Unpack[]
+    or unpacking * syntax.
+
+    The inner type should be either a TypeVarTuple, a constant size
+    tuple, or a variable length tuple, or a union of one of those.
+    """
+    __slots__ = ["type"]
+
+    def __init__(self, typ: Type, line: int = -1, column: int = -1) -> None:
+        super().__init__(line, column)
+        self.type = typ
+
+    def accept(self, visitor: 'TypeVisitor[T]') -> T:
+        return visitor.visit_unpack_type(self)
+
+    def serialize(self) -> JsonDict:
+        return {
+            ".class": "UnpackType",
+            "type": self.type.serialize(),
+        }
+
+    @classmethod
+    def deserialize(cls, data: JsonDict) -> "UnpackType":
+        assert data[".class"] == "UnpackType"
+        typ = data["type"]
+        return UnpackType(deserialize_type(typ))
+
+
 class AnyType(ProperType):
     """The type 'Any'."""
 
@@ -2473,6 +2502,9 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             self.any_as_dots = False
             return type_str
         return '<alias (unfixed)>'
+
+    def visit_unpack_type(self, t: UnpackType) -> str:
+        return 'Unpack[{}]'.format(t.type.accept(self))
 
     def list_str(self, a: Iterable[Type]) -> str:
         """Convert items of an array to strings (pretty-print types)

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -6,7 +6,8 @@ from mypy.types import (
     Type, SyntheticTypeVisitor, AnyType, UninhabitedType, NoneType, ErasedType, DeletedType,
     TypeVarType, LiteralType, Instance, CallableType, TupleType, TypedDictType, UnionType,
     Overloaded, TypeType, CallableArgument, UnboundType, TypeList, StarType, EllipsisType,
-    PlaceholderType, PartialType, RawExpressionType, TypeAliasType, ParamSpecType
+    PlaceholderType, PartialType, RawExpressionType, TypeAliasType, ParamSpecType,
+    UnpackType
 )
 
 
@@ -99,6 +100,9 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
 
     def visit_type_alias_type(self, t: TypeAliasType) -> None:
         self.traverse_types(t.args)
+
+    def visit_unpack_type(self, t: UnpackType) -> None:
+        t.type.accept(self)
 
     # Helpers
 

--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -29,6 +29,8 @@ TypeAlias: _SpecialForm
 TypeGuard: _SpecialForm
 Never: _SpecialForm
 
+Unpack: _SpecialForm
+
 # Fallback type for all typed dicts (does not exist at runtime).
 class _TypedDict(Mapping[str, object]):
     # Needed to make this class non-abstract. It is explicitly declared abstract in

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1442,3 +1442,12 @@ TP2: int = ParamSpec('TP2')  # E: Cannot declare the type of a parameter specifi
 from typing_extensions import Annotated
 # Next line should not crash:
 class A(Annotated): pass  # E: Annotated[...] must have exactly one type argument and at least one annotation
+
+[case testInvalidUnpackTypes]
+from typing_extensions import Unpack
+from typing import Tuple
+
+heterogenous_tuple: Tuple[Unpack[Tuple[int, str]]]
+homogenous_tuple: Tuple[Unpack[Tuple[int, ...]]]
+bad: Tuple[Unpack[int]]  # E: builtins.int cannot be unpacked (must be tuple or TypeVarTuple)
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Adds very basic support for Unpack expressions (where Unpack
is either from typing or typing_extensions). Many of the visitors
implementations are not implemented yet.

The only supported feature we have so far is validating that the
argument to UnpackType actually makes sense. Currently we don't
support unions, though. Since TypeVarTuple isn't yet implemented,
we don't support that from UnpackType either.

We don't want anyone to start using variadic generics at all until
we have real support for it. We also don't want to implement it in
one huge PR. So mypy is learning a new flag called
--enable-incomplete-features which we can enable by default in any
testsuite that needs to use incomplete features, as well as pass on
the command line for debugging, but it is undocumented and suppressed
from the help output so nobody should find it.