### PR TITLE
Add new "force exclude" option

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -66,7 +66,8 @@ for full details, see :ref:`running-mypy`.
     is, when mypy is discovering files within a directory tree or submodules of
     a package to check. If you pass a file or module explicitly it will still be
     checked. For instance, ``mypy --exclude '/setup.py$'
-    but_still_check/setup.py``.
+    but_still_check/setup.py``. To ignore files and modules passed explicitly,
+    use :option:`--force-exclude` instead.
 
     In particular, ``--exclude`` does not affect mypy's :ref:`import following
     <follow-imports>`. You can use a per-module :confval:`follow_imports` config
@@ -79,6 +80,14 @@ for full details, see :ref:`running-mypy`.
     '/(site-packages|node_modules|__pycache__|\..*)/$'`` would. Mypy will also
     never recursively discover files with extensions other than ``.py`` or
     ``.pyi``.
+
+
+.. option:: --force-exclude
+
+    Behavior is identical to :option:`--exclude`, except ``--force-exclude`` 
+    also applies to files and modules passed to mypy explicitly. For instance,
+    ``mypy --force-exclude '/setup.py$' some_dir/setup.py`` will not check 
+    ``some_dir/setup.py``.
 
 
 Optional arguments

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -255,6 +255,15 @@ section of the command line docs.
 
        See :ref:`using-a-pyproject-toml`.
 
+.. confval:: force_exclude
+
+    :type: regular expression
+
+    A regular expression that matches file names, directory names and paths
+    which mypy should ignore while recursively discovering files to check.
+    Behavior is identical to :confval:`exclude`, except ``force_exclude`` also
+    applies to files and modules passed to mypy explicitly.
+
 .. confval:: namespace_packages
 
     :type: boolean

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -407,7 +407,7 @@ to modules to type check.
 
 - Mypy will recursively discover and check all files ending in ``.py`` or
   ``.pyi`` in directory paths provided, after accounting for
-  :option:`--exclude <mypy --exclude>`.
+  :option:`--exclude <mypy --exclude>` and :option:`--force-exclude <mypy --exclude>`.
 
 - For each file to be checked, mypy will attempt to associate the file (e.g.
   ``project/foo/bar/baz.py``) with a fully qualified module name (e.g.

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2641,6 +2641,7 @@ def log_configuration(manager: BuildManager, sources: List[BuildSource]) -> None
         ("Cache Dir", manager.options.cache_dir),
         ("Compiled", str(not __file__.endswith(".py"))),
         ("Exclude", manager.options.exclude),
+        ("Force Exclude", manager.options.force_exclude),
     ]
 
     for conf_name, conf_value in configuration_vars:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -880,7 +880,20 @@ def process_options(args: List[str],
         help=(
             "Regular expression to match file names, directory names or paths which mypy should "
             "ignore while recursively discovering files to check, e.g. --exclude '/setup\\.py$'. "
-            "May be specified more than once, eg. --exclude a --exclude b"
+            "May be specified more than once, e.g. --exclude a --exclude b."
+        )
+    )
+    code_group.add_argument(
+        "--force-exclude",
+        action="append",
+        metavar="PATTERN",
+        default=[],
+        help=(
+            "Regular expression to match file names, directory names or paths which mypy should "
+            "ignore while recursively discovering files to check, e.g. --force-exclude "
+            "'/setup\\.py$'. May be specified more than once, e.g. --force-exclude a "
+            "--force-exclude b. Behavior is identical to --exclude, except also applies to files "
+            "and modules passed to mypy explicitly."
         )
     )
     code_group.add_argument(

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -490,7 +490,10 @@ class FindModuleCache:
             subpath = os.path.join(package_path, name)
 
             if self.options and matches_exclude(
-                subpath, self.options.exclude, self.fscache, self.options.verbosity >= 2
+                subpath,
+                self.options.exclude + self.options.force_exclude,
+                self.fscache,
+                self.options.verbosity >= 2
             ):
                 continue
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -101,6 +101,8 @@ class Options:
         self.explicit_package_bases = False
         # File names, directory names or subpaths to avoid checking
         self.exclude: List[str] = []
+        # File names, directory names or subpaths to avoid checking even if explicitly specified
+        self.force_exclude: List[str] = []
 
         # disallow_any options
         self.disallow_any_generics = False


### PR DESCRIPTION
### Description

This PR adds a `--force-exclude` CLI option and corresponding config option that behaves identically to `--exclude`, except files and modules passed explicitly to `mypy` will still be ignored. This addresses problems people have had where individual filepaths are passed to `mypy` (typically by some tool like pre-commit or VSCode) and those individual filepaths unexpectedly get processed despite matching the `--exclude` regex, e.g., issues #11094 and #11760.

The exact case that motivated this PR was a mypy pre-commit hook scanning .py files generated by the protobuf compiler, even though I had `exclude = _pb2\.py$` in `.mypy.ini`.

## Test Plan

I added a new unit test at `test_find_sources.py::test_find_sources_force_exclude`. This is essentially the same as the pre-existing test `test_find_sources_exclude`; I simply removed the default behavior checks at the top and modified the remaining logic to account for the handling of individual filepaths.

I also rebuilt the docs and found no markup errors after manual inspection. Nor did I find problems after running `make linkcheck`.
