### PR TITLE
Vent sussy NBSP from test case

### DIFF
--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1991,7 +1991,8 @@ x.trim()  # E: "str" has no attribute "trim"  [attr-defined]
 [case testEnableDifferentErrorCode]
 # flags: --disable-error-code attr-defined --enable-error-code name-defined --show-error-code
 x = 'should not be fine'
-x.trim()  # E: "str" has no attribute "trim"  [attr-defined]
+x.trim()
+y.trim()  # E: Name "y" is not defined  [name-defined]
 
 [case testEnableMultipleErrorCode]
 # flags: \


### PR DESCRIPTION
This fixes a test case, the test case included a sussy NBSP which resulted in the test being completely invalid.

I have now updated the testcase to vent the impostor expect the correct result instead.

With nbsp:
`x.trifdsgdfgm()  # E: AMONGUS [attr-defined]`
```
> pytest -n0 -k testEnableDifferentErrorCode
...
1 passed
```

with space:
`x.trifdsgdfgm()  # E: AMONGUS [attr-defined]`
```
> pytest -n0 -k testEnableDifferentErrorCode
...

_____________________________________________________________________________________________________ testEnableDifferentErrorCode _____________________________________________________________________________________________________
data: /home/amongus/projects/mypy/test-data/unit/check-flags.test:1991:
/home/amongus/projects/mypy/mypy/test/testcheck.py:140: in run_case
    self.run_case_once(testcase)
/home/amongus/projects/mypy/mypy/test/testcheck.py:227: in run_case_once
    assert_string_arrays_equal(output, a, msg.format(testcase.file, testcase.line))
E   AssertionError: Unexpected type checker output (/home/amongus/projects/mypy/test-data/unit/check-flags.test, line 1991)
--------------------------------------------------------------------------------------------------------- Captured stderr call ---------------------------------------------------------------------------------------------------------
Expected:
  main:3: error: AMONGUS [attr-defined]         (diff)
Actual:
  (empty)

======================================================================================================= short test summary info ========================================================================================================
FAILED mypy/test/testcheck.py::TypeCheckSuite::check-flags.test::testEnableDifferentErrorCode

```