### PR TITLE
propertize Callable attributes before freezing dataclasses

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -467,7 +467,9 @@ class DataclassTransformer:
                 var._fullname = info.fullname + '.' + var.name
                 info.names[var.name] = SymbolTableNode(MDEF, var)
 
-    def _propertize_callables(self, attributes: List[DataclassAttribute], settable: bool = True) -> None:
+    def _propertize_callables(self,
+                              attributes: List[DataclassAttribute],
+                              settable: bool = True) -> None:
         """Converts all attributes with callable types to @property methods.
 
         This avoids the typechecker getting confused and thinking that

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -209,10 +209,11 @@ class DataclassTransformer:
                     tvar_def=order_tvar_def,
                 )
 
-        self._propertize_callables(attributes)
-
         if decorator_arguments['frozen']:
+            self._propertize_callables(attributes, settable=False)
             self._freeze(attributes)
+        else:
+            self._propertize_callables(attributes)
 
         if decorator_arguments['slots']:
             self.add_slots(info, attributes, correct_version=py_version >= (3, 10))
@@ -466,7 +467,7 @@ class DataclassTransformer:
                 var._fullname = info.fullname + '.' + var.name
                 info.names[var.name] = SymbolTableNode(MDEF, var)
 
-    def _propertize_callables(self, attributes: List[DataclassAttribute]) -> None:
+    def _propertize_callables(self, attributes: List[DataclassAttribute], settable: bool = True) -> None:
         """Converts all attributes with callable types to @property methods.
 
         This avoids the typechecker getting confused and thinking that
@@ -480,7 +481,7 @@ class DataclassTransformer:
                 var = attr.to_var()
                 var.info = info
                 var.is_property = True
-                var.is_settable_property = True
+                var.is_settable_property = settable
                 var._fullname = info.fullname + '.' + var.name
                 info.names[var.name] = SymbolTableNode(MDEF, var)
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -209,10 +209,10 @@ class DataclassTransformer:
                     tvar_def=order_tvar_def,
                 )
 
+        self._propertize_callables(attributes)
+
         if decorator_arguments['frozen']:
             self._freeze(attributes)
-        else:
-            self._propertize_callables(attributes)
 
         if decorator_arguments['slots']:
             self.add_slots(info, attributes, correct_version=py_version >= (3, 10))

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1550,4 +1550,5 @@ def func() -> None:
 
 reveal_type(A.a)  # N: Revealed type is "def (*Any, **Any)"
 A(a=func).a()
+A(a=func).a = func  # E: Property "a" defined in "A" is read-only
 [builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1536,3 +1536,18 @@ A(a=1, b=2)
 A(1)
 A(a="foo")  # E: Argument "a" to "A" has incompatible type "str"; expected "int"
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassesCallableFrozen]
+# flags: --python-version 3.7
+from dataclasses import dataclass
+from typing import Any, Callable
+@dataclass(frozen=True)
+class A:
+    a: Callable[..., None]
+
+def func() -> None:
+    pass
+
+reveal_type(A.a)  # N: Revealed type is "def (*Any, **Any)"
+A(a=func).a()
+[builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
### Description

Fixes: #12312 

Related: #10292

`Callable` attributes of a `frozen=True` dataclass were not being handled correctly: `Callable` attributes were being propertized if the dataclass was *not* frozen.

This change will always propertize `Callable` attributes before optionally freezing attributes in the dataclass plugin.

## Test Plan

Added a test for Callable types in a frozen dataclass to `test-data/unit/check-dataclasses.test`
