### PR TITLE
readme: add pypi badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Mypy: Static Typing for Python
 =======================================
 
+[![Stable Version](https://img.shields.io/pypi/v/mypy?color=blue)](https://pypi.org/project/mypy/)
+[![Downloads](https://img.shields.io/pypi/dm/mypy)](https://pypistats.org/packages/mypy)
 [![Build Status](https://api.travis-ci.com/python/mypy.svg?branch=master)](https://travis-ci.com/python/mypy)
 [![Documentation Status](https://readthedocs.org/projects/mypy/badge/?version=latest)](https://mypy.readthedocs.io/en/latest/?badge=latest)
 [![Chat at https://gitter.im/python/typing](https://badges.gitter.im/python/typing.svg)](https://gitter.im/python/typing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
### Description

Add pypi badge to readme:

I forced the label color to blue because shields thought 0.941 was a pre-release(😅)
![image](https://user-images.githubusercontent.com/65446343/159392818-7b4a7941-5212-40c9-b06f-6d966dec5dbf.png)
## Test Plan

N/A
