### PR TITLE
Let overload item have a wider return type than implementation

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -600,7 +600,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     self.msg.overloaded_signatures_arg_specific(i + 1, defn.impl)
 
                 # Is the overload alternative's return type a subtype of the implementation's?
-                if not is_subtype_no_promote(sig1.ret_type, impl.ret_type):
+                if not (is_subtype_no_promote(sig1.ret_type, impl.ret_type) or
+                        is_subtype_no_promote(impl.ret_type, sig1.ret_type)):
                     self.msg.overloaded_signatures_ret_specific(i + 1, defn.impl)
 
     # Here's the scoop about generators and coroutines.

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6340,3 +6340,12 @@ def f(x: int) -> object: ...
 
 def f(x: int = 0) -> int:
     return x
+
+@overload
+def g() -> object: ...
+
+@overload
+def g(x: int) -> str: ...
+
+def g(x: int = 0) -> int:  # E: Overloaded function implementation cannot produce return type of signature 2
+    return x

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6328,3 +6328,15 @@ if True:
 def f2(x): ...
 if True:
     def f2(x): ...  # E: Name "f2" already defined on line 17
+
+[case testOverloadItemHasMoreGeneralReturnType]
+from typing import overload
+
+@overload
+def f() -> object: ...
+
+@overload
+def f(x: int) -> object: ...
+
+def f(x: int = 0) -> int:
+    return x

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2084,6 +2084,7 @@ a.py:5: error: "list" expects 1 type argument, but 2 given
 ==
 
 [case testPreviousErrorInOverloadedFunction]
+# flags: --strict-optional
 import a
 [file a.py]
 from typing import overload


### PR DESCRIPTION
A wider return type can be useful if a decorator used for the overload
implementation gets a more precise return type as part of a typeshed
update.

Closes https://github.com/python/mypy/issues/12434.