### PR TITLE
testcmdline: Sync assumption about error message for Python 3.10.3

### DIFF
--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1249,6 +1249,10 @@ Found 1 error in 1 file (errors prevented further checking)
 pkg/x.py:1: error: invalid syntax. Perhaps you forgot a comma?
 Found 1 error in 1 file (errors prevented further checking)
 == Return code: 2
+[out version>=3.10.3]
+pkg/x.py:1: error: invalid syntax
+Found 1 error in 1 file (errors prevented further checking)
+== Return code: 2
 
 [case testCmdlinePackageAndFile]
 # cmd: mypy -p pkg file


### PR DESCRIPTION
### Have you read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)?
yes

### Description

Python 3.10.3 is more correct about syntax error for
`mypy` test case `testBlocker`.

See https://bugs.python.org/issue46240 for details.

Closes #12451