### PR TITLE
Remove the * for inferred types from reveal_type output

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2344,8 +2344,6 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         else:
             s = t.type.fullname or t.type.name or '<???>'
 
-        if t.erased:
-            s += '*'
         if t.args:
             if t.type.fullname == 'builtins.tuple':
                 assert len(t.args) == 1

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -1004,8 +1004,8 @@ my_abstract_types = {
   'B': MyAbstractB,
 }
 
-reveal_type(my_concrete_types)  # N: Revealed type is "builtins.dict[builtins.str*, def () -> __main__.MyAbstractType]"
-reveal_type(my_abstract_types)  # N: Revealed type is "builtins.dict[builtins.str*, def () -> __main__.MyAbstractType]"
+reveal_type(my_concrete_types)  # N: Revealed type is "builtins.dict[builtins.str, def () -> __main__.MyAbstractType]"
+reveal_type(my_abstract_types)  # N: Revealed type is "builtins.dict[builtins.str, def () -> __main__.MyAbstractType]"
 
 a = my_concrete_types['A']()
 a.do()

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -39,7 +39,7 @@ main:4: error: Return value expected
 
 async def f() -> int:
     x = await f()
-    reveal_type(x)  # N: Revealed type is "builtins.int*"
+    reveal_type(x)  # N: Revealed type is "builtins.int"
     return x
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
@@ -150,7 +150,7 @@ class C(AsyncIterator[int]):
     async def __anext__(self) -> int: return 0
 async def f() -> None:
     async for x in C():
-        reveal_type(x)  # N: Revealed type is "builtins.int*"
+        reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
 
@@ -201,23 +201,23 @@ class asyncify(Generic[T], AsyncIterator[T]):
 
 async def listcomp(obj: Iterable[int]):
     lst = [i async for i in asyncify(obj)]
-    reveal_type(lst)  # N: Revealed type is "builtins.list[builtins.int*]"
+    reveal_type(lst)  # N: Revealed type is "builtins.list[builtins.int]"
     lst2 = [i async for i in asyncify(obj) for j in obj]
-    reveal_type(lst2)  # N: Revealed type is "builtins.list[builtins.int*]"
+    reveal_type(lst2)  # N: Revealed type is "builtins.list[builtins.int]"
 
 async def setcomp(obj: Iterable[int]):
     lst = {i async for i in asyncify(obj)}
-    reveal_type(lst)  # N: Revealed type is "builtins.set[builtins.int*]"
+    reveal_type(lst)  # N: Revealed type is "builtins.set[builtins.int]"
 
 async def dictcomp(obj: Iterable[Tuple[int, str]]):
     lst = {i: j async for i, j in asyncify(obj)}
-    reveal_type(lst)  # N: Revealed type is "builtins.dict[builtins.int*, builtins.str*]"
+    reveal_type(lst)  # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
 
 async def generatorexp(obj: Iterable[int]):
     lst = (i async for i in asyncify(obj))
-    reveal_type(lst)  # N: Revealed type is "typing.AsyncGenerator[builtins.int*, None]"
+    reveal_type(lst)  # N: Revealed type is "typing.AsyncGenerator[builtins.int, None]"
     lst2 = (i async for i in asyncify(obj) for i in obj)
-    reveal_type(lst2)  # N: Revealed type is "typing.AsyncGenerator[builtins.int*, None]"
+    reveal_type(lst2)  # N: Revealed type is "typing.AsyncGenerator[builtins.int, None]"
 
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
@@ -260,7 +260,7 @@ class C:
     async def __aexit__(self, x, y, z) -> None: pass
 async def f() -> None:
     async with C() as x:
-        reveal_type(x)  # N: Revealed type is "builtins.int*"
+        reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
 
@@ -435,7 +435,7 @@ async def f() -> int:
 
 async def g() -> AsyncGenerator[int, None]:
     value = await f()
-    reveal_type(value)  # N: Revealed type is "builtins.int*"
+    reveal_type(value)  # N: Revealed type is "builtins.int"
     yield value
 
     yield 'not an int'  # E: Incompatible types in "yield" (actual type "str", expected type "int")
@@ -446,7 +446,7 @@ reveal_type(g())  # N: Revealed type is "typing.AsyncGenerator[builtins.int, Non
 
 async def h() -> None:
     async for item in g():
-        reveal_type(item)  # N: Revealed type is "builtins.int*"
+        reveal_type(item)  # N: Revealed type is "builtins.int"
 
 async def wrong_return() -> Generator[int, None, None]:  # E: The return type of an async generator function should be "AsyncGenerator" or one of its supertypes
     yield 3
@@ -465,7 +465,7 @@ async def gen() -> AsyncIterator[int]:
 
 async def use_gen() -> None:
     async for item in gen():
-        reveal_type(item)  # N: Revealed type is "builtins.int*"
+        reveal_type(item)  # N: Revealed type is "builtins.int"
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-async.pyi]
@@ -481,9 +481,9 @@ async def genfunc() -> AsyncGenerator[int, None]:
 async def user() -> None:
     gen = genfunc()
 
-    reveal_type(gen.__aiter__())  # N: Revealed type is "typing.AsyncGenerator[builtins.int*, None]"
+    reveal_type(gen.__aiter__())  # N: Revealed type is "typing.AsyncGenerator[builtins.int, None]"
 
-    reveal_type(await gen.__anext__())  # N: Revealed type is "builtins.int*"
+    reveal_type(await gen.__anext__())  # N: Revealed type is "builtins.int"
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-async.pyi]
@@ -504,7 +504,7 @@ async def gen() -> AsyncGenerator[int, str]:
 async def h() -> None:
     g = gen()
     await g.asend(())  # E: Argument 1 to "asend" of "AsyncGenerator" has incompatible type "Tuple[]"; expected "str"
-    reveal_type(await g.asend('hello'))  # N: Revealed type is "builtins.int*"
+    reveal_type(await g.asend('hello'))  # N: Revealed type is "builtins.int"
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-async.pyi]
@@ -522,8 +522,8 @@ async def gen() -> AsyncGenerator[str, int]:
 async def h() -> None:
     g = gen()
     v = await g.asend(1)
-    reveal_type(v)  # N: Revealed type is "builtins.str*"
-    reveal_type(await g.athrow(BaseException))  # N: Revealed type is "builtins.str*"
+    reveal_type(v)  # N: Revealed type is "builtins.str"
+    reveal_type(await g.athrow(BaseException))  # N: Revealed type is "builtins.str"
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -445,9 +445,9 @@ class A(Generic[T]):
         return self.x  # E: Incompatible return value type (got "List[T]", expected "T")
 reveal_type(A) # N: Revealed type is "def [T] (x: builtins.list[T`1], y: T`1) -> __main__.A[T`1]"
 a = A([1], 2)
-reveal_type(a)  # N: Revealed type is "__main__.A[builtins.int*]"
-reveal_type(a.x)  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type(a.y)  # N: Revealed type is "builtins.int*"
+reveal_type(a)  # N: Revealed type is "__main__.A[builtins.int]"
+reveal_type(a.x)  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(a.y)  # N: Revealed type is "builtins.int"
 
 A(['str'], 7)  # E: Cannot infer type argument 1 of "A"
 A([1], '2')  # E: Cannot infer type argument 1 of "A"
@@ -492,12 +492,12 @@ class Sub(Base[S]):
     pass
 
 sub_int = Sub[int](attr=1)
-reveal_type(sub_int)  # N: Revealed type is "__main__.Sub[builtins.int*]"
-reveal_type(sub_int.attr)  # N: Revealed type is "builtins.int*"
+reveal_type(sub_int)  # N: Revealed type is "__main__.Sub[builtins.int]"
+reveal_type(sub_int.attr)  # N: Revealed type is "builtins.int"
 
 sub_str = Sub[str](attr='ok')
-reveal_type(sub_str)  # N: Revealed type is "__main__.Sub[builtins.str*]"
-reveal_type(sub_str.attr)  # N: Revealed type is "builtins.str*"
+reveal_type(sub_str)  # N: Revealed type is "__main__.Sub[builtins.str]"
+reveal_type(sub_str.attr)  # N: Revealed type is "builtins.str"
 
 [builtins fixtures/bool.pyi]
 
@@ -522,9 +522,9 @@ class Sub(Base[int, str, float]):
 
 sub = Sub(one=1, two='ok', three=3.14)
 reveal_type(sub)  # N: Revealed type is "__main__.Sub"
-reveal_type(sub.one)  # N: Revealed type is "builtins.int*"
-reveal_type(sub.two)  # N: Revealed type is "builtins.str*"
-reveal_type(sub.three)  # N: Revealed type is "builtins.float*"
+reveal_type(sub.one)  # N: Revealed type is "builtins.int"
+reveal_type(sub.two)  # N: Revealed type is "builtins.str"
+reveal_type(sub.three)  # N: Revealed type is "builtins.float"
 
 [builtins fixtures/bool.pyi]
 
@@ -551,8 +551,8 @@ class Sub(Middle[str]):
 
 sub = Sub(base_attr=1, middle_attr='ok')
 reveal_type(sub)  # N: Revealed type is "__main__.Sub"
-reveal_type(sub.base_attr)  # N: Revealed type is "builtins.int*"
-reveal_type(sub.middle_attr)  # N: Revealed type is "builtins.str*"
+reveal_type(sub.base_attr)  # N: Revealed type is "builtins.int"
+reveal_type(sub.middle_attr)  # N: Revealed type is "builtins.str"
 
 [builtins fixtures/bool.pyi]
 

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -310,7 +310,7 @@ def f(t: T) -> None:
             # N: Revealed type is "builtins.int"  \
             # N: Revealed type is "builtins.str"
     else:
-        reveal_type(t)  # N: Revealed type is "builtins.int*"  # N: Revealed type is "builtins.str"
+        reveal_type(t)  # N: Revealed type is "builtins.int"  # N: Revealed type is "builtins.str"
 
 [builtins fixtures/callable.pyi]
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1543,8 +1543,8 @@ class A:
     f = D(10)
     g = D('10')
 a = A()
-reveal_type(a.f)  # N: Revealed type is "builtins.int*"
-reveal_type(a.g)  # N: Revealed type is "builtins.str*"
+reveal_type(a.f)  # N: Revealed type is "builtins.int"
+reveal_type(a.g)  # N: Revealed type is "builtins.str"
 
 [case testSettingGenericDataDescriptor]
 from typing import TypeVar, Type, Generic, Any
@@ -1568,10 +1568,10 @@ from d import D
 class A:
     f = D(10)  # type: D[A, int]
     g = D('10')  # type: D[A, str]
-reveal_type(A.f)  # N: Revealed type is "d.D[__main__.A*, builtins.int*]"
-reveal_type(A.g)  # N: Revealed type is "d.D[__main__.A*, builtins.str*]"
-reveal_type(A().f)  # N: Revealed type is "builtins.int*"
-reveal_type(A().g)  # N: Revealed type is "builtins.str*"
+reveal_type(A.f)  # N: Revealed type is "d.D[__main__.A, builtins.int]"
+reveal_type(A.g)  # N: Revealed type is "d.D[__main__.A, builtins.str]"
+reveal_type(A().f)  # N: Revealed type is "builtins.int"
+reveal_type(A().g)  # N: Revealed type is "builtins.str"
 [file d.pyi]
 from typing import TypeVar, Type, Generic, overload
 T = TypeVar('T')
@@ -1606,8 +1606,8 @@ class D(Generic[T, V]):
     def __get__(self, inst: T, own: Type[T]) -> V: pass
 [builtins fixtures/bool.pyi]
 [out]
-main:8: note: Revealed type is "d.D[__main__.A*, builtins.int*]"
-main:9: note: Revealed type is "d.D[__main__.A*, builtins.str*]"
+main:8: note: Revealed type is "d.D[__main__.A, builtins.int]"
+main:9: note: Revealed type is "d.D[__main__.A, builtins.str]"
 
 [case testAccessingGenericDescriptorFromClassBadOverload]
 # flags: --strict-optional
@@ -1677,8 +1677,8 @@ class A:
     f = D(10)
     g = D('10')
 a = A()
-reveal_type(a.f)  # N: Revealed type is "builtins.int*"
-reveal_type(a.g)  # N: Revealed type is "builtins.str*"
+reveal_type(a.f)  # N: Revealed type is "builtins.int"
+reveal_type(a.g)  # N: Revealed type is "builtins.str"
 
 [case testSettingGenericDataDescriptorSubclass]
 from typing import TypeVar, Type, Generic
@@ -2299,7 +2299,7 @@ class Fraction(Real):
 
 # Note: When doing A + B and if B is a subtype of A, we will always call B.__radd__(A) first
 # and only try A.__add__(B) second if necessary.
-reveal_type(Real() + Fraction())      # N: Revealed type is "__main__.Real*"
+reveal_type(Real() + Fraction())      # N: Revealed type is "__main__.Real"
 
 # Note: When doing A + A, we only ever call A.__add__(A), never A.__radd__(A).
 reveal_type(Fraction() + Fraction())  # N: Revealed type is "builtins.str"
@@ -2312,7 +2312,7 @@ class Real:
 class Fraction(Real):
     def __radd__(self, other: T) -> T: ...  # E: Signatures of "__radd__" of "Fraction" and "__add__" of "T" are unsafely overlapping
 
-reveal_type(Real() + Fraction())      # N: Revealed type is "__main__.Real*"
+reveal_type(Real() + Fraction())      # N: Revealed type is "__main__.Real"
 reveal_type(Fraction() + Fraction())  # N: Revealed type is "builtins.str"
 
 
@@ -2324,7 +2324,7 @@ class Real:
 class Fraction(Real):
     def __radd__(self, other: T) -> T: ...  # E: Signatures of "__radd__" of "Fraction" and "__add__" of "Real" are unsafely overlapping
 
-reveal_type(Real() + Fraction())      # N: Revealed type is "__main__.Real*"
+reveal_type(Real() + Fraction())      # N: Revealed type is "__main__.Real"
 reveal_type(Fraction() + Fraction())  # N: Revealed type is "builtins.str"
 
 [case testReverseOperatorTypeVar3]
@@ -2336,8 +2336,8 @@ class Fraction(Real):
     def __radd__(self, other: T) -> T: ...  # E: Signatures of "__radd__" of "Fraction" and "__add__" of "T" are unsafely overlapping
 class FractionChild(Fraction): pass
 
-reveal_type(Real() + Fraction())                # N: Revealed type is "__main__.Real*"
-reveal_type(FractionChild() + Fraction())       # N: Revealed type is "__main__.FractionChild*"
+reveal_type(Real() + Fraction())                # N: Revealed type is "__main__.Real"
+reveal_type(FractionChild() + Fraction())       # N: Revealed type is "__main__.FractionChild"
 reveal_type(FractionChild() + FractionChild())  # N: Revealed type is "builtins.str"
 
 # Runtime error: we try calling __add__, it doesn't match, and we don't try __radd__ since
@@ -2512,7 +2512,7 @@ def sum(x: Iterable[T]) -> Union[T, int]: ...
 def len(x: Iterable[T]) -> int: ...
 
 x = [1.1, 2.2, 3.3]
-reveal_type(sum(x))  # N: Revealed type is "builtins.float*"
+reveal_type(sum(x))  # N: Revealed type is "builtins.float"
 reveal_type(sum(x) / len(x))  # N: Revealed type is "builtins.float"
 [builtins fixtures/floatdict.pyi]
 
@@ -2528,7 +2528,7 @@ def sum(x: Iterable[T], default: S) -> Union[T, S]: ...
 def sum(*args): pass
 
 x = ["a", "b", "c"]
-reveal_type(x + sum([x, x, x], []))  # N: Revealed type is "builtins.list[builtins.str*]"
+reveal_type(x + sum([x, x, x], []))  # N: Revealed type is "builtins.list[builtins.str]"
 [builtins fixtures/floatdict.pyi]
 
 [case testAbstractReverseOperatorMethod]
@@ -3136,7 +3136,7 @@ class A(Generic[T]):
 class B(Generic[T]):
     a: Type[A[T]] = A
 
-reveal_type(B[int]().a) # N: Revealed type is "Type[__main__.A[builtins.int*]]"
+reveal_type(B[int]().a) # N: Revealed type is "Type[__main__.A[builtins.int]]"
 B[int]().a('hi') # E: Argument 1 to "A" has incompatible type "str"; expected "int"
 
 class C(Generic[T]):
@@ -3168,7 +3168,7 @@ class C:
     def __init__(self) -> None:
         self.aa = self.a_int()
 
-reveal_type(C().aa) # N: Revealed type is "__main__.A[builtins.int*, builtins.int*]"
+reveal_type(C().aa) # N: Revealed type is "__main__.A[builtins.int, builtins.int]"
 [out]
 
 
@@ -3217,7 +3217,7 @@ pro_user = new_user(ProUser)
 reveal_type(pro_user)
 [out]
 main:7: note: Revealed type is "U`-1"
-main:10: note: Revealed type is "__main__.ProUser*"
+main:10: note: Revealed type is "__main__.ProUser"
 
 [case testTypeUsingTypeCTypeVarDefaultInit]
 from typing import Type, TypeVar
@@ -3254,7 +3254,7 @@ reveal_type(wiz)
 def error(u_c: Type[U]) -> P:
     return new_pro(u_c)  # Error here, see below
 [out]
-main:11: note: Revealed type is "__main__.WizUser*"
+main:11: note: Revealed type is "__main__.WizUser"
 main:13: error: Value of type variable "P" of "new_pro" cannot be "U"
 main:13: error: Incompatible return value type (got "U", expected "P")
 
@@ -3279,7 +3279,7 @@ class C(Generic[T_co]):
     def meth(self) -> None:
         reveal_type(self.x) # N: Revealed type is "T_co`1"
 
-reveal_type(C(1).x) # N: Revealed type is "builtins.int*"
+reveal_type(C(1).x) # N: Revealed type is "builtins.int"
 [builtins fixtures/property.pyi]
 [out]
 
@@ -3524,7 +3524,7 @@ y = None # type: Type[Any]
 z = None # type: Type[C]
 
 lst = [x, y, z]
-reveal_type(lst) # N: Revealed type is "builtins.list[builtins.type*]"
+reveal_type(lst) # N: Revealed type is "builtins.list[builtins.type]"
 
 T1 = TypeVar('T1', bound=type)
 T2 = TypeVar('T2', bound=Type[Any])
@@ -4423,14 +4423,14 @@ class ImplicitMeta(type):
 class Implicit(metaclass=ImplicitMeta): pass
 
 for _ in Implicit: pass
-reveal_type(list(Implicit))  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(list(Implicit))  # N: Revealed type is "builtins.list[builtins.int]"
 
 class ExplicitMeta(type, Iterable[int]):
     def __iter__(self) -> Iterator[int]: yield 1
 
 class Explicit(metaclass=ExplicitMeta): pass
 for _ in Explicit: pass
-reveal_type(list(Explicit))  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(list(Explicit))  # N: Revealed type is "builtins.list[builtins.int]"
 
 [builtins fixtures/list.pyi]
 
@@ -4490,7 +4490,7 @@ class M1(M):
     def foo(cls: Type[T]) -> T: ...
 
 class A(metaclass=M1): pass
-reveal_type(A.foo())  # N: Revealed type is "__main__.A*"
+reveal_type(A.foo())  # N: Revealed type is "__main__.A"
 
 [case testMetaclassAndSkippedImport]
 # flags: --ignore-missing-imports
@@ -4567,7 +4567,7 @@ class A(metaclass=M):
     def foo(self): pass
 
 reveal_type(A.g1)  # N: Revealed type is "def () -> __main__.A"
-reveal_type(A.g2)  # N: Revealed type is "def () -> __main__.A*"
+reveal_type(A.g2)  # N: Revealed type is "def () -> __main__.A"
 reveal_type(A.g3)  # N: Revealed type is "def () -> def () -> __main__.A"
 reveal_type(A.g4)  # N: Revealed type is "def () -> def () -> __main__.A"
 
@@ -4584,7 +4584,7 @@ reveal_type(B.g4)  # N: Revealed type is "def () -> def () -> __main__.B"
 ta: Type[A] = m  # E: Incompatible types in assignment (expression has type "M", variable has type "Type[A]")
 a: A = ta()
 reveal_type(ta.g1)  # N: Revealed type is "def () -> __main__.A"
-reveal_type(ta.g2)  # N: Revealed type is "def () -> __main__.A*"
+reveal_type(ta.g2)  # N: Revealed type is "def () -> __main__.A"
 reveal_type(ta.g3)  # N: Revealed type is "def () -> Type[__main__.A]"
 reveal_type(ta.g4)  # N: Revealed type is "def () -> Type[__main__.A]"
 
@@ -4592,7 +4592,7 @@ x: M = ta
 x.g1  # E: Invalid self argument "M" to attribute function "g1" with type "Callable[[Type[A]], A]"
 x.g2  # E: Invalid self argument "M" to attribute function "g2" with type "Callable[[Type[TA]], TA]"
 x.g3  # E: Invalid self argument "M" to attribute function "g3" with type "Callable[[TTA], TTA]"
-reveal_type(x.g4)  # N: Revealed type is "def () -> __main__.M*"
+reveal_type(x.g4)  # N: Revealed type is "def () -> __main__.M"
 
 def r(ta: Type[TA], tta: TTA) -> None:
     x: M = ta
@@ -4665,7 +4665,7 @@ class ExampleDict(Generic[K, V]): ...
 
 D = TypeVar('D')
 def mkdict(dict_type: Type[D]) -> D: ...
-reveal_type(mkdict(ExampleDict))  # N: Revealed type is "__main__.ExampleDict*[Any, Any]"
+reveal_type(mkdict(ExampleDict))  # N: Revealed type is "__main__.ExampleDict[Any, Any]"
 
 [case testTupleForwardBase]
 from m import a
@@ -4766,7 +4766,7 @@ def parse_ast(name_dict: NameDict) -> None:
     if isinstance(name_dict[''], int):
         pass
     x = name_dict['']
-    reveal_type(x) # N: Revealed type is "__main__.NameInfo*"
+    reveal_type(x) # N: Revealed type is "__main__.NameInfo"
     if int():
         x = NameInfo(Base()) # OK
         x = Base() # E: Incompatible types in assignment (expression has type "Base", variable has type "NameInfo")
@@ -5136,8 +5136,8 @@ C1().foo()
 D1().foo()
 C1().bar()  # E: "C1" has no attribute "bar"
 D1().bar()  # E: "D1" has no attribute "bar"
-for x in C1: reveal_type(x)  # N: Revealed type is "builtins.int*"
-for x in C2: reveal_type(x)  # N: Revealed type is "builtins.int*"
+for x in C1: reveal_type(x)  # N: Revealed type is "builtins.int"
+for x in C2: reveal_type(x)  # N: Revealed type is "builtins.int"
 C2().foo()
 D2().foo()
 C2().bar()
@@ -5163,8 +5163,8 @@ class Arc1(Generic[T_co], Destroyable):
     pass
 class MyDestr(Destroyable):
     pass
-reveal_type(Arc[MyDestr]())  # N: Revealed type is "__main__.Arc[__main__.MyDestr*]"
-reveal_type(Arc1[MyDestr]())  # N: Revealed type is "__main__.Arc1[__main__.MyDestr*]"
+reveal_type(Arc[MyDestr]())  # N: Revealed type is "__main__.Arc[__main__.MyDestr]"
+reveal_type(Arc1[MyDestr]())  # N: Revealed type is "__main__.Arc1[__main__.MyDestr]"
 [builtins fixtures/bool.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -5276,8 +5276,8 @@ reveal_type(type(C1).x)  # N: Revealed type is "builtins.int"
 reveal_type(type(C2).x)  # N: Revealed type is "builtins.int"
 C1().foo()
 C1().bar()  # E: "C1" has no attribute "bar"
-for x in C1: reveal_type(x)  # N: Revealed type is "builtins.int*"
-for x in C2: reveal_type(x)  # N: Revealed type is "builtins.int*"
+for x in C1: reveal_type(x)  # N: Revealed type is "builtins.int"
+for x in C2: reveal_type(x)  # N: Revealed type is "builtins.int"
 C2().foo()
 C2().bar()
 C2().baz()  # E: "C2" has no attribute "baz"
@@ -5297,7 +5297,7 @@ class Arc(future.utils.with_metaclass(ArcMeta, Generic[T_co], Destroyable)):
     pass
 class MyDestr(Destroyable):
     pass
-reveal_type(Arc[MyDestr]())  # N: Revealed type is "__main__.Arc[__main__.MyDestr*]"
+reveal_type(Arc[MyDestr]())  # N: Revealed type is "__main__.Arc[__main__.MyDestr]"
 [builtins fixtures/bool.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -5405,7 +5405,7 @@ T = TypeVar('T')
 class C(Any):
     def bar(self: T) -> Type[T]: pass
     def foo(self) -> None:
-        reveal_type(self.bar()) # N: Revealed type is "Type[__main__.C*]"
+        reveal_type(self.bar()) # N: Revealed type is "Type[__main__.C]"
         reveal_type(self.bar().__name__) # N: Revealed type is "builtins.str"
 [builtins fixtures/type.pyi]
 [out]
@@ -5580,7 +5580,7 @@ class D(C[Descr]):
 
 d: D
 reveal_type(d.normal)  # N: Revealed type is "builtins.int"
-reveal_type(d.dynamic)  # N: Revealed type is "__main__.Descr*"
+reveal_type(d.dynamic)  # N: Revealed type is "__main__.Descr"
 reveal_type(D.other)  # N: Revealed type is "builtins.int"
 D.dynamic  # E: "Type[D]" has no attribute "dynamic"
 [out]
@@ -5645,7 +5645,7 @@ class B(Generic[T]): ...
 y: A
 z: A[int]
 x = [y, z]
-reveal_type(x)  # N: Revealed type is "builtins.list[__main__.B*[Any]]"
+reveal_type(x)  # N: Revealed type is "builtins.list[__main__.B[Any]]"
 
 A = B
 [builtins fixtures/list.pyi]
@@ -5668,8 +5668,8 @@ class C(dynamic):
     name = Descr(str)
 
 c: C
-reveal_type(c.id)  # N: Revealed type is "builtins.int*"
-reveal_type(C.name)  # N: Revealed type is "d.Descr[builtins.str*]"
+reveal_type(c.id)  # N: Revealed type is "builtins.int"
+reveal_type(C.name)  # N: Revealed type is "d.Descr[builtins.str]"
 
 [file d.pyi]
 from typing import Any, overload, Generic, TypeVar, Type
@@ -5699,8 +5699,8 @@ class C:
     def foo(cls) -> int:
         return 42
 
-reveal_type(C.foo)  # N: Revealed type is "builtins.int*"
-reveal_type(C().foo)  # N: Revealed type is "builtins.int*"
+reveal_type(C.foo)  # N: Revealed type is "builtins.int"
+reveal_type(C().foo)  # N: Revealed type is "builtins.int"
 [out]
 
 [case testMultipleInheritanceCycle]
@@ -6064,7 +6064,7 @@ class A(b.B):
     @c.deco
     def meth(self) -> int:
         y = super().meth()
-        reveal_type(y)  # N: Revealed type is "Tuple[builtins.int*, builtins.int]"
+        reveal_type(y)  # N: Revealed type is "Tuple[builtins.int, builtins.int]"
         return 0
 [file b.py]
 from a import A
@@ -6123,7 +6123,7 @@ class A(b.B):
     @c.deco
     def meth(self) -> int:
         y = super().meth()
-        reveal_type(y)  # N: Revealed type is "Tuple[builtins.int*, builtins.int]"
+        reveal_type(y)  # N: Revealed type is "Tuple[builtins.int, builtins.int]"
         reveal_type(other.x)  # N: Revealed type is "builtins.int"
         return 0
 
@@ -6565,8 +6565,8 @@ class X:
         pass
 class Y(X): pass
 
-reveal_type(X(20))  # N: Revealed type is "__main__.X*"
-reveal_type(Y(20))  # N: Revealed type is "__main__.Y*"
+reveal_type(X(20))  # N: Revealed type is "__main__.X"
+reveal_type(Y(20))  # N: Revealed type is "__main__.Y"
 
 [case testNewReturnType5]
 from typing import Any, TypeVar, Generic, overload

--- a/test-data/unit/check-ctypes.test
+++ b/test-data/unit/check-ctypes.test
@@ -7,7 +7,7 @@ class MyCInt(ctypes.c_int):
 intarr4 = ctypes.c_int * 4
 a = intarr4(1, ctypes.c_int(2), MyCInt(3), 4)
 intarr4(1, 2, 3, "invalid")  # E: Array constructor argument 4 of type "str" is not convertible to the array element type "c_int"
-reveal_type(a)  # N: Revealed type is "ctypes.Array[ctypes.c_int*]"
+reveal_type(a)  # N: Revealed type is "ctypes.Array[ctypes.c_int]"
 reveal_type(a[0])  # N: Revealed type is "builtins.int"
 reveal_type(a[1:3])  # N: Revealed type is "builtins.list[builtins.int]"
 a[0] = 42
@@ -18,7 +18,7 @@ a[3] = b"bytes"  # E: No overload variant of "__setitem__" of "Array" matches ar
                  # N:     def __setitem__(self, int, Union[c_int, int]) -> None \
                  # N:     def __setitem__(self, slice, List[Union[c_int, int]]) -> None
 for x in a:
-    reveal_type(x)  # N: Revealed type is "builtins.int*"
+    reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/floatdict.pyi]
 
 [case testCtypesArrayCustomElementType]
@@ -32,9 +32,9 @@ myintarr4 = MyCInt * 4
 mya = myintarr4(1, 2, MyCInt(3), 4)
 myintarr4(1, ctypes.c_int(2), MyCInt(3), "invalid")  # E: Array constructor argument 2 of type "c_int" is not convertible to the array element type "MyCInt" \
                                                      # E: Array constructor argument 4 of type "str" is not convertible to the array element type "MyCInt"
-reveal_type(mya)  # N: Revealed type is "ctypes.Array[__main__.MyCInt*]"
-reveal_type(mya[0])  # N: Revealed type is "__main__.MyCInt*"
-reveal_type(mya[1:3])  # N: Revealed type is "builtins.list[__main__.MyCInt*]"
+reveal_type(mya)  # N: Revealed type is "ctypes.Array[__main__.MyCInt]"
+reveal_type(mya[0])  # N: Revealed type is "__main__.MyCInt"
+reveal_type(mya[1:3])  # N: Revealed type is "builtins.list[__main__.MyCInt]"
 mya[0] = 42
 mya[1] = ctypes.c_int(42)  # E: No overload variant of "__setitem__" of "Array" matches argument types "int", "c_int" \
                            # N: Possible overload variants: \
@@ -46,11 +46,11 @@ mya[3] = b"bytes"  # E: No overload variant of "__setitem__" of "Array" matches 
                    # N:     def __setitem__(self, int, Union[MyCInt, int]) -> None \
                    # N:     def __setitem__(self, slice, List[Union[MyCInt, int]]) -> None
 for myx in mya:
-    reveal_type(myx)  # N: Revealed type is "__main__.MyCInt*"
+    reveal_type(myx)  # N: Revealed type is "__main__.MyCInt"
 
 myu: Union[ctypes.Array[ctypes.c_int], List[str]]
 for myi in myu:
-    reveal_type(myi)  # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+    reveal_type(myi)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/floatdict.pyi]
 
 [case testCtypesArrayUnionElementType]
@@ -168,10 +168,10 @@ intarr4 = ctypes.c_int * 4
 intarr6 = ctypes.c_int * 6
 int_values = [1, 2, 3, 4]
 c_int_values = [ctypes.c_int(1), ctypes.c_int(2), ctypes.c_int(3), ctypes.c_int(4)]
-reveal_type(intarr4(*int_values))  # N: Revealed type is "ctypes.Array[ctypes.c_int*]"
-reveal_type(intarr4(*c_int_values))  # N: Revealed type is "ctypes.Array[ctypes.c_int*]"
-reveal_type(intarr6(1, ctypes.c_int(2), *int_values))  # N: Revealed type is "ctypes.Array[ctypes.c_int*]"
-reveal_type(intarr6(1, ctypes.c_int(2), *c_int_values))  # N: Revealed type is "ctypes.Array[ctypes.c_int*]"
+reveal_type(intarr4(*int_values))  # N: Revealed type is "ctypes.Array[ctypes.c_int]"
+reveal_type(intarr4(*c_int_values))  # N: Revealed type is "ctypes.Array[ctypes.c_int]"
+reveal_type(intarr6(1, ctypes.c_int(2), *int_values))  # N: Revealed type is "ctypes.Array[ctypes.c_int]"
+reveal_type(intarr6(1, ctypes.c_int(2), *c_int_values))  # N: Revealed type is "ctypes.Array[ctypes.c_int]"
 
 float_values = [1.0, 2.0, 3.0, 4.0]
 intarr4(*float_values) # E: Array constructor argument 1 of type "List[float]" is not convertible to the array element type "Iterable[c_int]"

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -345,8 +345,8 @@ class C:
 
 c = C()
 reveal_type(c.x)  # N: Revealed type is "Union[builtins.int, None]"
-reveal_type(c.y)  # N: Revealed type is "builtins.int*"
-reveal_type(c.z)  # N: Revealed type is "Union[builtins.int*, None]"
+reveal_type(c.y)  # N: Revealed type is "builtins.int"
+reveal_type(c.z)  # N: Revealed type is "Union[builtins.int, None]"
 
 [file mod.py]
 from typing import Generic, TypeVar, Type
@@ -558,7 +558,7 @@ reveal_type(foo[3]) # N: Revealed type is "builtins.int"
 reveal_type(foo(4, 5, 6)) # N: Revealed type is "builtins.int"
 foo[4] = 5
 for x in foo:
-    reveal_type(x) # N: Revealed type is "builtins.int*"
+    reveal_type(x) # N: Revealed type is "builtins.int"
 
 [file mypy.ini]
 \[mypy]
@@ -649,7 +649,7 @@ from mod import declarative_base
 
 Base1 = Base2 = declarative_base()
 
-class C1(Base1): ...  
+class C1(Base1): ...
 class C2(Base2): ...
 [file mod.py]
 def declarative_base(): ...
@@ -762,9 +762,9 @@ T = TypeVar("T")
 class Class(Generic[T]):
     def __init__(self, one: T): ...
     def __call__(self, two: T) -> int: ...
-reveal_type(Class("hi")("there"))  # N: Revealed type is "builtins.str*"
+reveal_type(Class("hi")("there"))  # N: Revealed type is "builtins.str"
 instance = Class(3.14)
-reveal_type(instance(2))  # N: Revealed type is "builtins.float*"
+reveal_type(instance(2))  # N: Revealed type is "builtins.float"
 
 [file mypy.ini]
 \[mypy]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -608,10 +608,10 @@ class A(Generic[T]):
 reveal_type(A)  # N: Revealed type is "def [T] (x: T`1, y: T`1, z: builtins.list[T`1]) -> __main__.A[T`1]"
 A(1, 2, ["a", "b"])  # E: Cannot infer type argument 1 of "A"
 a = A(1, 2, [1, 2])
-reveal_type(a)  # N: Revealed type is "__main__.A[builtins.int*]"
-reveal_type(a.x)  # N: Revealed type is "builtins.int*"
-reveal_type(a.y)  # N: Revealed type is "builtins.int*"
-reveal_type(a.z)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(a)  # N: Revealed type is "__main__.A[builtins.int]"
+reveal_type(a.x)  # N: Revealed type is "builtins.int"
+reveal_type(a.y)  # N: Revealed type is "builtins.int"
+reveal_type(a.z)  # N: Revealed type is "builtins.list[builtins.int]"
 s: str = a.bar()  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [builtins fixtures/dataclasses.pyi]
@@ -656,12 +656,12 @@ class Sub(Base[S]):
     pass
 
 sub_int = Sub[int](attr=1)
-reveal_type(sub_int)  # N: Revealed type is "__main__.Sub[builtins.int*]"
-reveal_type(sub_int.attr)  # N: Revealed type is "builtins.int*"
+reveal_type(sub_int)  # N: Revealed type is "__main__.Sub[builtins.int]"
+reveal_type(sub_int.attr)  # N: Revealed type is "builtins.int"
 
 sub_str = Sub[str](attr='ok')
-reveal_type(sub_str)  # N: Revealed type is "__main__.Sub[builtins.str*]"
-reveal_type(sub_str.attr)  # N: Revealed type is "builtins.str*"
+reveal_type(sub_str)  # N: Revealed type is "__main__.Sub[builtins.str]"
+reveal_type(sub_str.attr)  # N: Revealed type is "builtins.str"
 
 [builtins fixtures/dataclasses.pyi]
 
@@ -686,9 +686,9 @@ class Sub(Base[int, str, float]):
 
 sub = Sub(one=1, two='ok', three=3.14)
 reveal_type(sub)  # N: Revealed type is "__main__.Sub"
-reveal_type(sub.one)  # N: Revealed type is "builtins.int*"
-reveal_type(sub.two)  # N: Revealed type is "builtins.str*"
-reveal_type(sub.three)  # N: Revealed type is "builtins.float*"
+reveal_type(sub.one)  # N: Revealed type is "builtins.int"
+reveal_type(sub.two)  # N: Revealed type is "builtins.str"
+reveal_type(sub.three)  # N: Revealed type is "builtins.float"
 
 [builtins fixtures/dataclasses.pyi]
 
@@ -715,8 +715,8 @@ class Sub(Middle[str]):
 
 sub = Sub(base_attr=1, middle_attr='ok')
 reveal_type(sub)  # N: Revealed type is "__main__.Sub"
-reveal_type(sub.base_attr)  # N: Revealed type is "builtins.int*"
-reveal_type(sub.middle_attr)  # N: Revealed type is "builtins.str*"
+reveal_type(sub.base_attr)  # N: Revealed type is "builtins.int"
+reveal_type(sub.middle_attr)  # N: Revealed type is "builtins.str"
 
 [builtins fixtures/dataclasses.pyi]
 
@@ -739,7 +739,7 @@ class A(Generic[T]):
   @classmethod
   def other(cls, x: T) -> A[T]: ...
 
-reveal_type(A(0).other)  # N: Revealed type is "def (x: builtins.int*) -> __main__.A[builtins.int*]"
+reveal_type(A(0).other)  # N: Revealed type is "def (x: builtins.int) -> __main__.A[builtins.int]"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesForwardRefs]

--- a/test-data/unit/check-default-plugin.test
+++ b/test-data/unit/check-default-plugin.test
@@ -16,7 +16,7 @@ def yield_id(item: T) -> Iterator[T]:
 reveal_type(yield_id) # N: Revealed type is "def [T] (item: T`-1) -> contextlib.GeneratorContextManager[T`-1]"
 
 with yield_id(1) as x:
-    reveal_type(x) # N: Revealed type is "builtins.int*"
+    reveal_type(x) # N: Revealed type is "builtins.int"
 
 f = yield_id
 def g(x, y): pass
@@ -39,7 +39,7 @@ reveal_type(yield_id) # N: Revealed type is "def [T] (item: T`-1) -> typing.Asyn
 
 async def f() -> None:
     async with yield_id(1) as x:
-        reveal_type(x) # N: Revealed type is "builtins.int*"
+        reveal_type(x) # N: Revealed type is "builtins.int"
 [typing fixtures/typing-async.pyi]
 [builtins fixtures/tuple.pyi]
 
@@ -69,7 +69,7 @@ def identity(x: int) -> int: return x
 
 with _thread_mapper(1) as m:
     lst = list(m(identity, [2, 3]))
-    reveal_type(lst) # N: Revealed type is "builtins.list[builtins.int*]"
+    reveal_type(lst) # N: Revealed type is "builtins.list[builtins.int]"
 [typing fixtures/typing-medium.pyi]
 [builtins fixtures/list.pyi]
 
@@ -79,6 +79,6 @@ from typing import Callable, Iterator
 
 c: Callable[..., Iterator[int]]
 reveal_type(c) # N: Revealed type is "def (*Any, **Any) -> typing.Iterator[builtins.int]"
-reveal_type(contextmanager(c)) # N: Revealed type is "def (*Any, **Any) -> contextlib.GeneratorContextManager[builtins.int*]"
+reveal_type(contextmanager(c)) # N: Revealed type is "def (*Any, **Any) -> contextlib.GeneratorContextManager[builtins.int]"
 [typing fixtures/typing-medium.pyi]
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -300,7 +300,7 @@ class E(IntEnum):
 x = None  # type: int
 reveal_type(E(x))
 [out]
-main:5: note: Revealed type is "__main__.E*"
+main:5: note: Revealed type is "__main__.E"
 
 [case testEnumIndex]
 from enum import IntEnum
@@ -345,7 +345,7 @@ class F(Generic[T], Enum):  # E: Enum class cannot be generic
     x: T
     y: T
 
-reveal_type(F[int].x)  # N: Revealed type is "__main__.F[builtins.int*]"
+reveal_type(F[int].x)  # N: Revealed type is "__main__.F[builtins.int]"
 
 [case testEnumFlag]
 from enum import Flag
@@ -542,8 +542,8 @@ from enum import IntEnum
 Color = IntEnum('Color', 'red green blue')
 reveal_type(Color['green'])  # N: Revealed type is "__main__.Color"
 for c in Color:
-    reveal_type(c)  # N: Revealed type is "__main__.Color*"
-reveal_type(list(Color))  # N: Revealed type is "builtins.list[__main__.Color*]"
+    reveal_type(c)  # N: Revealed type is "__main__.Color"
+reveal_type(list(Color))  # N: Revealed type is "builtins.list[__main__.Color]"
 
 [builtins fixtures/list.pyi]
 
@@ -2012,13 +2012,13 @@ class C(IntEnum):
 
 def f1(c: C) -> None:
     x = {'x': c.value}
-    reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int]"
+    reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
 
 def f2(c: C, a: Any) -> None:
     x = {'x': c.value, 'y': a}
-    reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str*, Any]"
+    reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str, Any]"
     y = {'y': a, 'x': c.value}
-    reveal_type(y)  # N: Revealed type is "builtins.dict[builtins.str*, Any]"
+    reveal_type(y)  # N: Revealed type is "builtins.dict[builtins.str, Any]"
 [builtins fixtures/dict.pyi]
 
 [case testEnumIgnoreIsDeleted]

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -250,7 +250,7 @@ class C(Generic[T]):
         self.x: Final = x
         self.y: Final = 1
 
-reveal_type(C((1, 2)).x)  # N: Revealed type is "Tuple[builtins.int*, builtins.int*]"
+reveal_type(C((1, 2)).x)  # N: Revealed type is "Tuple[builtins.int, builtins.int]"
 C.x  # E: Cannot access final instance attribute "x" on class object \
      # E: Access to generic instance variables via class is ambiguous
 C.y  # E: Cannot access final instance attribute "y" on class object

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2300,7 +2300,7 @@ def g(__x: T) -> T: pass
 f = g
 reveal_type(f)  # N: Revealed type is "def [T] (T`-1) -> T`-1"
 i = f(3)
-reveal_type(i)  # N: Revealed type is "builtins.int*"
+reveal_type(i)  # N: Revealed type is "builtins.int"
 
 [case testFunctionReturningGenericFunction]
 from typing import Callable, TypeVar
@@ -2311,7 +2311,7 @@ reveal_type(deco)  # N: Revealed type is "def () -> def [T] (T`-1) -> T`-1"
 f = deco()
 reveal_type(f)  # N: Revealed type is "def [T] (T`-1) -> T`-1"
 i = f(3)
-reveal_type(i)  # N: Revealed type is "builtins.int*"
+reveal_type(i)  # N: Revealed type is "builtins.int"
 
 [case testFunctionReturningGenericFunctionPartialBinding]
 from typing import Callable, TypeVar
@@ -2322,9 +2322,9 @@ U = TypeVar('U')
 def deco(x: U) -> Callable[[T, U], T]: pass
 reveal_type(deco)  # N: Revealed type is "def [U] (x: U`-1) -> def [T] (T`-2, U`-1) -> T`-2"
 f = deco("foo")
-reveal_type(f)  # N: Revealed type is "def [T] (T`-2, builtins.str*) -> T`-2"
+reveal_type(f)  # N: Revealed type is "def [T] (T`-2, builtins.str) -> T`-2"
 i = f(3, "eggs")
-reveal_type(i)  # N: Revealed type is "builtins.int*"
+reveal_type(i)  # N: Revealed type is "builtins.int"
 
 [case testFunctionReturningGenericFunctionTwoLevelBinding]
 from typing import Callable, TypeVar
@@ -2335,9 +2335,9 @@ def deco() -> Callable[[T], Callable[[T, R], R]]: pass
 f = deco()
 reveal_type(f)  # N: Revealed type is "def [T] (T`-1) -> def [R] (T`-1, R`-2) -> R`-2"
 g = f(3)
-reveal_type(g)  # N: Revealed type is "def [R] (builtins.int*, R`-2) -> R`-2"
+reveal_type(g)  # N: Revealed type is "def [R] (builtins.int, R`-2) -> R`-2"
 s = g(4, "foo")
-reveal_type(s)  # N: Revealed type is "builtins.str*"
+reveal_type(s)  # N: Revealed type is "builtins.str"
 
 [case testGenericFunctionReturnAsDecorator]
 from typing import Callable, TypeVar

--- a/test-data/unit/check-generic-alias.test
+++ b/test-data/unit/check-generic-alias.test
@@ -252,7 +252,7 @@ B = tuple[int, str]
 x: B = (1, 'x')
 y: B = ('x', 1)  # E: Incompatible types in assignment (expression has type "Tuple[str, int]", variable has type "Tuple[int, str]")
 
-reveal_type(tuple[int, ...]())  # N: Revealed type is "builtins.tuple[builtins.int*, ...]"
+reveal_type(tuple[int, ...]())  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeAliasWithBuiltinTupleInStub]
@@ -290,7 +290,7 @@ d: type[str]
 [case testTypeAliasWithBuiltinListAliasInStub]
 # flags: --python-version 3.6
 import m
-reveal_type(m.a()[0])  # N: Revealed type is "builtins.int*"
+reveal_type(m.a()[0])  # N: Revealed type is "builtins.int"
 
 [file m.pyi]
 List = list

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -882,43 +882,43 @@ class X1(Iterator[U], Generic[T, U]):
     pass
 
 x1: X1[str, int]
-reveal_type(list(x1))  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type([*x1])  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(list(x1))  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type([*x1])  # N: Revealed type is "builtins.list[builtins.int]"
 
 class X2(Iterator[T], Generic[T, U]):
     pass
 
 x2: X2[str, int]
-reveal_type(list(x2))  # N: Revealed type is "builtins.list[builtins.str*]"
-reveal_type([*x2])  # N: Revealed type is "builtins.list[builtins.str*]"
+reveal_type(list(x2))  # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type([*x2])  # N: Revealed type is "builtins.list[builtins.str]"
 
 class X3(Generic[T, U], Iterator[U]):
     pass
 
 x3: X3[str, int]
-reveal_type(list(x3))  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type([*x3])  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(list(x3))  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type([*x3])  # N: Revealed type is "builtins.list[builtins.int]"
 
 class X4(Generic[T, U], Iterator[T]):
     pass
 
 x4: X4[str, int]
-reveal_type(list(x4))  # N: Revealed type is "builtins.list[builtins.str*]"
-reveal_type([*x4])  # N: Revealed type is "builtins.list[builtins.str*]"
+reveal_type(list(x4))  # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type([*x4])  # N: Revealed type is "builtins.list[builtins.str]"
 
 class X5(Iterator[T]):
     pass
 
 x5: X5[str]
-reveal_type(list(x5))  # N: Revealed type is "builtins.list[builtins.str*]"
-reveal_type([*x5])  # N: Revealed type is "builtins.list[builtins.str*]"
+reveal_type(list(x5))  # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type([*x5])  # N: Revealed type is "builtins.list[builtins.str]"
 
 class X6(Generic[T, U], Iterator[bool]):
     pass
 
 x6: X6[str, int]
-reveal_type(list(x6))  # N: Revealed type is "builtins.list[builtins.bool*]"
-reveal_type([*x6])  # N: Revealed type is "builtins.list[builtins.bool*]"
+reveal_type(list(x6))  # N: Revealed type is "builtins.list[builtins.bool]"
+reveal_type([*x6])  # N: Revealed type is "builtins.list[builtins.bool]"
 [builtins fixtures/list.pyi]
 
 [case testSubtypingIterableUnpacking2]
@@ -930,15 +930,15 @@ class X1(Generic[T, U], Iterator[U], Mapping[U, T]):
     pass
 
 x1: X1[str, int]
-reveal_type(list(x1))  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type([*x1])  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(list(x1))  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type([*x1])  # N: Revealed type is "builtins.list[builtins.int]"
 
 class X2(Generic[T, U], Iterator[U], Mapping[T, U]):
     pass
 
 x2: X2[str, int]
-reveal_type(list(x2))  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type([*x2])  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(list(x2))  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type([*x2])  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testSubtypingMappingUnpacking1]
@@ -951,22 +951,22 @@ class X1(Generic[T, U],  Mapping[U, T]):
     pass
 
 x1: X1[str, int]
-reveal_type(iter(x1))  # N: Revealed type is "typing.Iterator[builtins.int*]"
-reveal_type({**x1})  # N: Revealed type is "builtins.dict[builtins.int*, builtins.str*]"
+reveal_type(iter(x1))  # N: Revealed type is "typing.Iterator[builtins.int]"
+reveal_type({**x1})  # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
 
 class X2(Generic[T, U],  Mapping[T, U]):
     pass
 
 x2: X2[str, int]
-reveal_type(iter(x2))  # N: Revealed type is "typing.Iterator[builtins.str*]"
-reveal_type({**x2})  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+reveal_type(iter(x2))  # N: Revealed type is "typing.Iterator[builtins.str]"
+reveal_type({**x2})  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
 
 class X3(Generic[T, U],  Mapping[bool, float]):
     pass
 
 x3: X3[str, int]
-reveal_type(iter(x3))  # N: Revealed type is "typing.Iterator[builtins.bool*]"
-reveal_type({**x3})  # N: Revealed type is "builtins.dict[builtins.bool*, builtins.float*]"
+reveal_type(iter(x3))  # N: Revealed type is "typing.Iterator[builtins.bool]"
+reveal_type({**x3})  # N: Revealed type is "builtins.dict[builtins.bool, builtins.float]"
 [builtins fixtures/dict.pyi]
 
 [case testSubtypingMappingUnpacking2]
@@ -985,8 +985,8 @@ reveal_type(iter(x1))
 reveal_type({**x1})
 func_with_kwargs(**x1)
 [out]
-main:12: note: Revealed type is "typing.Iterator[builtins.int*]"
-main:13: note: Revealed type is "builtins.dict[builtins.int*, builtins.str*]"
+main:12: note: Revealed type is "typing.Iterator[builtins.int]"
+main:13: note: Revealed type is "builtins.dict[builtins.int, builtins.str]"
 main:14: error: Keywords must be strings
 main:14: error: Argument 1 to "func_with_kwargs" has incompatible type "**X1[str, int]"; expected "int"
 [builtins fixtures/dict.pyi]
@@ -1000,8 +1000,8 @@ class X1(Generic[T, U],  Mapping[U, T], Iterable[U]):
     pass
 
 x1: X1[str, int]
-reveal_type(iter(x1))  # N: Revealed type is "typing.Iterator[builtins.int*]"
-reveal_type({**x1})  # N: Revealed type is "builtins.dict[builtins.int*, builtins.str*]"
+reveal_type(iter(x1))  # N: Revealed type is "typing.Iterator[builtins.int]"
+reveal_type({**x1})  # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
 
 # Some people would expect this to raise an error, but this currently does not:
 # `Mapping` has `Iterable[U]` base class, `X2` has direct `Iterable[T]` base class.
@@ -1010,8 +1010,8 @@ class X2(Generic[T, U],  Mapping[U, T], Iterable[T]):
     pass
 
 x2: X2[str, int]
-reveal_type(iter(x2))  # N: Revealed type is "typing.Iterator[builtins.int*]"
-reveal_type({**x2})  # N: Revealed type is "builtins.dict[builtins.int*, builtins.str*]"
+reveal_type(iter(x2))  # N: Revealed type is "typing.Iterator[builtins.int]"
+reveal_type({**x2})  # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
 [builtins fixtures/dict.pyi]
 
 [case testNotDirectIterableAndMappingSubtyping]
@@ -1023,13 +1023,13 @@ class X1(Generic[T, U], Dict[U, T], Iterable[U]):
     def __iter__(self) -> Iterator[U]: pass
 
 x1: X1[str, int]
-reveal_type(iter(x1))  # N: Revealed type is "typing.Iterator[builtins.int*]"
-reveal_type({**x1})  # N: Revealed type is "builtins.dict[builtins.int*, builtins.str*]"
+reveal_type(iter(x1))  # N: Revealed type is "typing.Iterator[builtins.int]"
+reveal_type({**x1})  # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
 
 class X2(Generic[T, U], List[U]):
     def __iter__(self) -> Iterator[U]: pass
 
 x2: X2[str, int]
-reveal_type(iter(x2))  # N: Revealed type is "typing.Iterator[builtins.int*]"
-reveal_type([*x2])  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(iter(x2))  # N: Revealed type is "typing.Iterator[builtins.int]"
+reveal_type([*x2])  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -468,8 +468,8 @@ class Dummy(Generic[T]):
 
 Dummy[int]().meth(1)
 Dummy[int]().meth('a')  # E: Argument 1 to "meth" of "Dummy" has incompatible type "str"; expected "int"
-reveal_type(Dummy[int]())  # N: Revealed type is "__main__.Dummy[builtins.int*]"
-reveal_type(Dummy[int]().methout())  # N: Revealed type is "builtins.int*"
+reveal_type(Dummy[int]())  # N: Revealed type is "__main__.Dummy[builtins.int]"
+reveal_type(Dummy[int]().methout())  # N: Revealed type is "builtins.int"
 [out]
 
 [case testTypeApplicationArgTypesSubclasses]
@@ -565,7 +565,7 @@ reveal_type(func) # N: Revealed type is "def [T] (x: __main__.Node[builtins.int,
 
 func(1) # E: Argument 1 to "func" has incompatible type "int"; expected "Node[int, <nothing>]"
 func(Node('x', 1)) # E: Argument 1 to "Node" has incompatible type "str"; expected "int"
-reveal_type(func(Node(1, 'x'))) # N: Revealed type is "__main__.Node[builtins.int, builtins.str*]"
+reveal_type(func(Node(1, 'x'))) # N: Revealed type is "__main__.Node[builtins.int, builtins.str]"
 
 def func2(x: SameNode[T]) -> SameNode[T]:
     return x
@@ -573,13 +573,13 @@ reveal_type(func2) # N: Revealed type is "def [T] (x: __main__.Node[T`-1, T`-1])
 
 func2(Node(1, 'x')) # E: Cannot infer type argument 1 of "func2"
 y = func2(Node('x', 'x'))
-reveal_type(y) # N: Revealed type is "__main__.Node[builtins.str*, builtins.str*]"
+reveal_type(y) # N: Revealed type is "__main__.Node[builtins.str, builtins.str]"
 
 def wrap(x: T) -> IntNode[T]:
     return Node(1, x)
 
 z = None # type: str
-reveal_type(wrap(z)) # N: Revealed type is "__main__.Node[builtins.int, builtins.str*]"
+reveal_type(wrap(z)) # N: Revealed type is "__main__.Node[builtins.int, builtins.str]"
 
 [out]
 main:13: error: Argument 2 to "Node" has incompatible type "int"; expected "str"
@@ -640,7 +640,7 @@ Third = Union[int, Second[str]]
 
 def f2(x: T) -> Second[T]:
     return Node([1], [x])
-reveal_type(f2('a')) # N: Revealed type is "__main__.Node[builtins.list[builtins.int], builtins.list[builtins.str*]]"
+reveal_type(f2('a')) # N: Revealed type is "__main__.Node[builtins.list[builtins.int], builtins.list[builtins.str]]"
 
 def f3() -> Third:
     return Node([1], ['x'])
@@ -688,7 +688,7 @@ ListedNode = Node[List[T]]
 l = None # type: ListedNode[int]
 l.x.append(1)
 l.meth().append(1)
-reveal_type(l.meth()) # N: Revealed type is "builtins.list*[builtins.int]"
+reveal_type(l.meth()) # N: Revealed type is "builtins.list[builtins.int]"
 l.meth().append('x') # E: Argument 1 to "append" of "list" has incompatible type "str"; expected "int"
 
 ListedNode[str]([]).x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "List[str]")
@@ -720,7 +720,7 @@ y = D(5) # type: D[int] # E: Argument 1 to "D" has incompatible type "int"; expe
 
 def f(x: T) -> D[T]:
     return D((x, x))
-reveal_type(f('a'))  # N: Revealed type is "__main__.D[builtins.str*]"
+reveal_type(f('a'))  # N: Revealed type is "__main__.D[builtins.str]"
 
 [builtins fixtures/list.pyi]
 [out]
@@ -741,7 +741,7 @@ class C(TupledNode): ... # Same as TupledNode[Any]
 class D(TupledNode[T]): ...
 class E(Generic[T], UNode[T]): ... # E: Invalid base class "UNode"
 
-reveal_type(D((1, 1))) # N: Revealed type is "__main__.D[builtins.int*]"
+reveal_type(D((1, 1))) # N: Revealed type is "__main__.D[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testGenericTypeAliasesUnion]
@@ -769,7 +769,7 @@ def f(x: T) -> UNode[T]:
     else:
         return 1
 
-reveal_type(f(1)) # N: Revealed type is "Union[builtins.int, __main__.Node[builtins.int*]]"
+reveal_type(f(1)) # N: Revealed type is "Union[builtins.int, __main__.Node[builtins.int]]"
 
 TNode = Union[T, Node[int]]
 s = 1 # type: TNode[str] # E: Incompatible types in assignment (expression has type "int", variable has type "Union[str, Node[int]]")
@@ -801,7 +801,7 @@ def f2(x: IntTP[T]) -> IntTP[T]:
     return x
 
 f2((1, 2, 3)) # E: Argument 1 to "f2" has incompatible type "Tuple[int, int, int]"; expected "Tuple[int, <nothing>]"
-reveal_type(f2((1, 'x'))) # N: Revealed type is "Tuple[builtins.int, builtins.str*]"
+reveal_type(f2((1, 'x'))) # N: Revealed type is "Tuple[builtins.int, builtins.str]"
 
 [builtins fixtures/for.pyi]
 
@@ -820,7 +820,7 @@ C2 = Callable[[T, T], Node[T]]
 def make_cb(x: T) -> C[T]:
     return lambda *args: x
 
-reveal_type(make_cb(1)) # N: Revealed type is "def (*Any, **Any) -> builtins.int*"
+reveal_type(make_cb(1)) # N: Revealed type is "def (*Any, **Any) -> builtins.int"
 
 def use_cb(arg: T, cb: C2[T]) -> Node[T]:
     return cb(arg, arg)
@@ -848,11 +848,11 @@ def fun1(v: Vec[T]) -> T:
 def fun2(v: Vec[T], scale: T) -> Vec[T]:
     return v
 
-reveal_type(fun1([(1, 1)])) # N: Revealed type is "builtins.int*"
+reveal_type(fun1([(1, 1)])) # N: Revealed type is "builtins.int"
 fun1(1) # E: Argument 1 to "fun1" has incompatible type "int"; expected "List[Tuple[bool, bool]]"
 fun1([(1, 'x')]) # E: Cannot infer type argument 1 of "fun1"
 
-reveal_type(fun2([(1, 1)], 1)) # N: Revealed type is "builtins.list[Tuple[builtins.int*, builtins.int*]]"
+reveal_type(fun2([(1, 1)], 1)) # N: Revealed type is "builtins.list[Tuple[builtins.int, builtins.int]]"
 fun2([('x', 'x')], 'x') # E: Value of type variable "T" of "fun2" cannot be "str"
 
 [builtins fixtures/list.pyi]
@@ -872,7 +872,7 @@ def f(x: Node[T, T]) -> TupledNode[T]:
 
 f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "Node[<nothing>, <nothing>]"
 f(Node(1, 'x')) # E: Cannot infer type argument 1 of "f"
-reveal_type(Node('x', 'x')) # N: Revealed type is "a.Node[builtins.str*, builtins.str*]"
+reveal_type(Node('x', 'x')) # N: Revealed type is "a.Node[builtins.str, builtins.str]"
 
 [file a.py]
 from typing import TypeVar, Generic, Tuple
@@ -1012,7 +1012,7 @@ ff = SameNode[T](1, 1)
 a = SameNode(1, 'x')
 reveal_type(a) # N: Revealed type is "__main__.Node[Any, Any]"
 b = SameNode[int](1, 1)
-reveal_type(b) # N: Revealed type is "__main__.Node[builtins.int*, builtins.int*]"
+reveal_type(b) # N: Revealed type is "__main__.Node[builtins.int, builtins.int]"
 SameNode[int](1, 'x') # E: Argument 2 to "Node" has incompatible type "str"; expected "int"
 
 [out]
@@ -1059,8 +1059,8 @@ class C(Generic[T]):
     a = None # type: SameA[T]
     b = SameB[T]([], [])
 
-reveal_type(C[int]().a) # N: Revealed type is "__main__.A[builtins.int*, builtins.int*]"
-reveal_type(C[str]().b) # N: Revealed type is "__main__.B[builtins.str*, builtins.str*]"
+reveal_type(C[int]().a) # N: Revealed type is "__main__.A[builtins.int, builtins.int]"
+reveal_type(C[str]().b) # N: Revealed type is "__main__.B[builtins.str, builtins.str]"
 
 [builtins fixtures/list.pyi]
 
@@ -1110,7 +1110,7 @@ BuiltinAlias[int]() # E: "list" is not subscriptable
 T = TypeVar('T')
 BadGenList = list[T] # E: "list" is not subscriptable
 
-reveal_type(BadGenList[int]()) # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(BadGenList[int]()) # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(BadGenList()) # N: Revealed type is "builtins.list[Any]"
 
 [builtins fixtures/list.pyi]
@@ -1120,11 +1120,11 @@ reveal_type(BadGenList()) # N: Revealed type is "builtins.list[Any]"
 from m import Alias
 
 n = Alias[int]([1])
-reveal_type(n)  # N: Revealed type is "m.Node[builtins.list*[builtins.int]]"
+reveal_type(n)  # N: Revealed type is "m.Node[builtins.list[builtins.int]]"
 bad = Alias[str]([1])  # E: List item 0 has incompatible type "int"; expected "str"
 
 n2 = Alias([1]) # Same as Node[List[Any]]
-reveal_type(n2)  # N: Revealed type is "m.Node[builtins.list*[Any]]"
+reveal_type(n2)  # N: Revealed type is "m.Node[builtins.list[Any]]"
 [file m.py]
 from typing import TypeVar, Generic, List
 T = TypeVar('T')
@@ -1152,8 +1152,8 @@ class C(Generic[T]):
 
 class D(B[T], C[S]): ...
 
-reveal_type(D[str, int]().b()) # N: Revealed type is "builtins.str*"
-reveal_type(D[str, int]().c()) # N: Revealed type is "builtins.int*"
+reveal_type(D[str, int]().b()) # N: Revealed type is "builtins.str"
+reveal_type(D[str, int]().c()) # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1166,7 +1166,7 @@ class B(Generic[T]):
 
 class D(B[Callable[[T], S]]): ...
 
-reveal_type(D[str, int]().b()) # N: Revealed type is "def (builtins.str*) -> builtins.int*"
+reveal_type(D[str, int]().b()) # N: Revealed type is "def (builtins.str) -> builtins.int"
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1187,7 +1187,7 @@ class C(A[S, B[T, int]], B[U, A[int, T]]):
     pass
 
 c = C[object, int, str]()
-reveal_type(c.m()) # N: Revealed type is "Tuple[builtins.str*, __main__.A*[builtins.int, builtins.int*]]"
+reveal_type(c.m()) # N: Revealed type is "Tuple[builtins.str, __main__.A[builtins.int, builtins.int]]"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -1205,8 +1205,8 @@ class C(Generic[T]):
 
 class D(B[T], C[S], Generic[S, T]): ...
 
-reveal_type(D[str, int]().b()) # N: Revealed type is "builtins.int*"
-reveal_type(D[str, int]().c()) # N: Revealed type is "builtins.str*"
+reveal_type(D[str, int]().b()) # N: Revealed type is "builtins.int"
+reveal_type(D[str, int]().c()) # N: Revealed type is "builtins.str"
 [builtins fixtures/list.pyi]
 [out]
 
@@ -1475,10 +1475,10 @@ class A:
     class B(Generic[T]):
         def meth(self) -> T:  ...
     B[int]()
-    reveal_type(B[int]().meth) # N: Revealed type is "def () -> builtins.int*"
+    reveal_type(B[int]().meth) # N: Revealed type is "def () -> builtins.int"
 
 A.B[int]()
-reveal_type(A.B[int]().meth) # N: Revealed type is "def () -> builtins.int*"
+reveal_type(A.B[int]().meth) # N: Revealed type is "def () -> builtins.int"
 
 [case testGenericClassInnerFunctionTypeVariable]
 from typing import TypeVar, Generic
@@ -1748,7 +1748,7 @@ g = f3
 from typing import TypeVar, Container
 T = TypeVar('T')
 def f(x: Container[T]) -> T: ...
-reveal_type(f((1, 2))) # N: Revealed type is "builtins.int*"
+reveal_type(f((1, 2))) # N: Revealed type is "builtins.int"
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/tuple.pyi]
 
@@ -1870,8 +1870,8 @@ class C(Generic[T]):
 
 class D(C[str]): ...
 
-reveal_type(D.get())  # N: Revealed type is "builtins.str*"
-reveal_type(D().get())  # N: Revealed type is "builtins.str*"
+reveal_type(D.get())  # N: Revealed type is "builtins.str"
+reveal_type(D().get())  # N: Revealed type is "builtins.str"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassMethodExpansion]
@@ -1884,8 +1884,8 @@ class C(Generic[T]):
 class D(C[Tuple[T, T]]): ...
 class E(D[str]): ...
 
-reveal_type(E.get())  # N: Revealed type is "Tuple[builtins.str*, builtins.str*]"
-reveal_type(E().get())  # N: Revealed type is "Tuple[builtins.str*, builtins.str*]"
+reveal_type(E.get())  # N: Revealed type is "Tuple[builtins.str, builtins.str]"
+reveal_type(E().get())  # N: Revealed type is "Tuple[builtins.str, builtins.str]"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassMethodExpansionReplacingTypeVar]
@@ -1900,8 +1900,8 @@ class C(Generic[T]):
 class D(C[S]): ...
 class E(D[int]): ...
 
-reveal_type(E.get())  # N: Revealed type is "builtins.int*"
-reveal_type(E().get())  # N: Revealed type is "builtins.int*"
+reveal_type(E.get())  # N: Revealed type is "builtins.int"
+reveal_type(E().get())  # N: Revealed type is "builtins.int"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassMethodUnboundOnClass]
@@ -1915,9 +1915,9 @@ class C(Generic[T]):
     def make_one(cls, x: T) -> C[T]: ...
 
 reveal_type(C.get)  # N: Revealed type is "def [T] () -> T`1"
-reveal_type(C[int].get)  # N: Revealed type is "def () -> builtins.int*"
+reveal_type(C[int].get)  # N: Revealed type is "def () -> builtins.int"
 reveal_type(C.make_one)  # N: Revealed type is "def [T] (x: T`1) -> __main__.C[T`1]"
-reveal_type(C[int].make_one)  # N: Revealed type is "def (x: builtins.int*) -> __main__.C[builtins.int*]"
+reveal_type(C[int].make_one)  # N: Revealed type is "def (x: builtins.int) -> __main__.C[builtins.int]"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassMethodUnboundOnSubClass]
@@ -1934,9 +1934,9 @@ class D(C[Tuple[T, S]]): ...
 class E(D[S, str]): ...
 
 reveal_type(D.make_one)  # N: Revealed type is "def [T, S] (x: Tuple[T`1, S`2]) -> __main__.C[Tuple[T`1, S`2]]"
-reveal_type(D[int, str].make_one)  # N: Revealed type is "def (x: Tuple[builtins.int*, builtins.str*]) -> __main__.C[Tuple[builtins.int*, builtins.str*]]"
-reveal_type(E.make_one)  # N: Revealed type is "def [S] (x: Tuple[S`1, builtins.str*]) -> __main__.C[Tuple[S`1, builtins.str*]]"
-reveal_type(E[int].make_one)  # N: Revealed type is "def (x: Tuple[builtins.int*, builtins.str*]) -> __main__.C[Tuple[builtins.int*, builtins.str*]]"
+reveal_type(D[int, str].make_one)  # N: Revealed type is "def (x: Tuple[builtins.int, builtins.str]) -> __main__.C[Tuple[builtins.int, builtins.str]]"
+reveal_type(E.make_one)  # N: Revealed type is "def [S] (x: Tuple[S`1, builtins.str]) -> __main__.C[Tuple[S`1, builtins.str]]"
+reveal_type(E[int].make_one)  # N: Revealed type is "def (x: Tuple[builtins.int, builtins.str]) -> __main__.C[Tuple[builtins.int, builtins.str]]"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassClsNonGeneric]
@@ -2074,8 +2074,8 @@ class Base(Generic[T]):
         return cls(item)
 
 reveal_type(Base.make_some)  # N: Revealed type is "Overload(def [T] (item: T`1) -> __main__.Base[T`1], def [T] (item: T`1, n: builtins.int) -> builtins.tuple[__main__.Base[T`1], ...])"
-reveal_type(Base.make_some(1))  # N: Revealed type is "__main__.Base[builtins.int*]"
-reveal_type(Base.make_some(1, 1))  # N: Revealed type is "builtins.tuple[__main__.Base[builtins.int*], ...]"
+reveal_type(Base.make_some(1))  # N: Revealed type is "__main__.Base[builtins.int]"
+reveal_type(Base.make_some(1, 1))  # N: Revealed type is "builtins.tuple[__main__.Base[builtins.int], ...]"
 
 class Sub(Base[str]): ...
 Sub.make_some(1)  # E: No overload variant of "make_some" of "Base" matches argument type "int" \
@@ -2131,7 +2131,7 @@ class Base(Generic[T]):
 class Sub(Base[T]):
     ...
 
-reveal_type(Sub.make_pair('yes'))  # N: Revealed type is "Tuple[__main__.Sub[builtins.str*], __main__.Sub[builtins.str*]]"
+reveal_type(Sub.make_pair('yes'))  # N: Revealed type is "Tuple[__main__.Sub[builtins.str], __main__.Sub[builtins.str]]"
 Sub[int].make_pair('no')  # E: Argument 1 to "make_pair" of "Base" has incompatible type "str"; expected "int"
 [builtins fixtures/classmethod.pyi]
 
@@ -2182,8 +2182,8 @@ class C(Generic[T]):
 
 class D(C[str]): ...
 
-reveal_type(D.get())  # N: Revealed type is "builtins.str*"
-reveal_type(D.get(42))  # N: Revealed type is "builtins.tuple[builtins.str*, ...]"
+reveal_type(D.get())  # N: Revealed type is "builtins.str"
+reveal_type(D.get(42))  # N: Revealed type is "builtins.tuple[builtins.str, ...]"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassMethodAnnotation]
@@ -2202,14 +2202,14 @@ def f(o: Maker[T]) -> T:
         return o.x
     return o.get()
 b = f(B())
-reveal_type(b)  # N: Revealed type is "__main__.B*"
+reveal_type(b)  # N: Revealed type is "__main__.B"
 
 def g(t: Type[Maker[T]]) -> T:
     if bool():
         return t.x
     return t.get()
 bb = g(B)
-reveal_type(bb)  # N: Revealed type is "__main__.B*"
+reveal_type(bb)  # N: Revealed type is "__main__.B"
 [builtins fixtures/classmethod.pyi]
 
 [case testGenericClassMethodAnnotationDecorator]
@@ -2338,16 +2338,16 @@ class Test():
                 mte: MakeTwoConcrete[A],
                 mtgsa: MakeTwoGenericSubAbstract[A],
                 mtasa: MakeTwoAppliedSubAbstract) -> None:
-    reveal_type(mts(2)) # N: Revealed type is "__main__.TwoTypes[A`-1, builtins.int*]"
-    reveal_type(mte(2)) # N: Revealed type is "__main__.TwoTypes[A`-1, builtins.int*]"
-    reveal_type(mtgsa(2)) # N: Revealed type is "__main__.TwoTypes[A`-1, builtins.int*]"
-    reveal_type(mtasa(2)) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.int*]"
-    reveal_type(MakeTwoConcrete[int]()('foo')) # N: Revealed type is "__main__.TwoTypes[builtins.int, builtins.str*]"
-    reveal_type(MakeTwoConcrete[str]()(2)) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.int*]"
-    reveal_type(MakeTwoAppliedSubAbstract()('foo')) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.str*]"
-    reveal_type(MakeTwoAppliedSubAbstract()(2)) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.int*]"
-    reveal_type(MakeTwoGenericSubAbstract[str]()('foo')) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.str*]"
-    reveal_type(MakeTwoGenericSubAbstract[str]()(2)) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.int*]"
+    reveal_type(mts(2)) # N: Revealed type is "__main__.TwoTypes[A`-1, builtins.int]"
+    reveal_type(mte(2)) # N: Revealed type is "__main__.TwoTypes[A`-1, builtins.int]"
+    reveal_type(mtgsa(2)) # N: Revealed type is "__main__.TwoTypes[A`-1, builtins.int]"
+    reveal_type(mtasa(2)) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.int]"
+    reveal_type(MakeTwoConcrete[int]()('foo')) # N: Revealed type is "__main__.TwoTypes[builtins.int, builtins.str]"
+    reveal_type(MakeTwoConcrete[str]()(2)) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.int]"
+    reveal_type(MakeTwoAppliedSubAbstract()('foo')) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.str]"
+    reveal_type(MakeTwoAppliedSubAbstract()(2)) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.int]"
+    reveal_type(MakeTwoGenericSubAbstract[str]()('foo')) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.str]"
+    reveal_type(MakeTwoGenericSubAbstract[str]()(2)) # N: Revealed type is "__main__.TwoTypes[builtins.str, builtins.int]"
 
 [case testGenericClassPropertyBound]
 from typing import Generic, TypeVar, Callable, Type, List, Dict
@@ -2368,23 +2368,23 @@ class G(C[List[T]]): ...
 
 x: C[int]
 y: Type[C[int]]
-reveal_type(x.test)  # N: Revealed type is "builtins.int*"
-reveal_type(y.test)  # N: Revealed type is "builtins.int*"
+reveal_type(x.test)  # N: Revealed type is "builtins.int"
+reveal_type(y.test)  # N: Revealed type is "builtins.int"
 
 xd: D
 yd: Type[D]
-reveal_type(xd.test)  # N: Revealed type is "builtins.str*"
-reveal_type(yd.test)  # N: Revealed type is "builtins.str*"
+reveal_type(xd.test)  # N: Revealed type is "builtins.str"
+reveal_type(yd.test)  # N: Revealed type is "builtins.str"
 
 ye1: Type[E1[int, str]]
 ye2: Type[E2[int, str]]
-reveal_type(ye1.test)  # N: Revealed type is "builtins.int*"
-reveal_type(ye2.test)  # N: Revealed type is "builtins.str*"
+reveal_type(ye1.test)  # N: Revealed type is "builtins.int"
+reveal_type(ye2.test)  # N: Revealed type is "builtins.str"
 
 xg: G[int]
 yg: Type[G[int]]
-reveal_type(xg.test)  # N: Revealed type is "builtins.list*[builtins.int*]"
-reveal_type(yg.test)  # N: Revealed type is "builtins.list*[builtins.int*]"
+reveal_type(xg.test)  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(yg.test)  # N: Revealed type is "builtins.list[builtins.int]"
 
 class Sup:
     attr: int
@@ -2394,8 +2394,8 @@ def func(tp: Type[C[S]]) -> S:
     reveal_type(tp.test.attr)  # N: Revealed type is "builtins.int"
 
     reg: Dict[S, G[S]]
-    reveal_type(reg[tp.test])  # N: Revealed type is "__main__.G*[S`-1]"
-    reveal_type(reg[tp.test].test)  # N: Revealed type is "builtins.list*[S`-1]"
+    reveal_type(reg[tp.test])  # N: Revealed type is "__main__.G[S`-1]"
+    reveal_type(reg[tp.test].test)  # N: Revealed type is "builtins.list[S`-1]"
 
     if bool():
         return tp.test
@@ -2413,7 +2413,7 @@ gen_a = gen
 S = TypeVar("S", int, str)
 class C: ...
 def test() -> Optional[S]:
-    reveal_type(gen_a(C()))  # N: Revealed type is "__main__.C*"
+    reveal_type(gen_a(C()))  # N: Revealed type is "__main__.C"
     return None
 
 [case testGenericFunctionMemberExpand]
@@ -2428,7 +2428,7 @@ class A:
 S = TypeVar("S", int, str)
 class C: ...
 def test() -> Optional[S]:
-    reveal_type(A().gen(C()))  # N: Revealed type is "__main__.C*"
+    reveal_type(A().gen(C()))  # N: Revealed type is "__main__.C"
     return None
 
 [case testGenericJoinCovariant]
@@ -2447,8 +2447,8 @@ b: B
 a_c: Container[A]
 b_c: Container[B]
 
-reveal_type([a, b])  # N: Revealed type is "builtins.list[__main__.Base*]"
-reveal_type([a_c, b_c])  # N: Revealed type is "builtins.list[__main__.Container*[__main__.Base]]"
+reveal_type([a, b])  # N: Revealed type is "builtins.list[__main__.Base]"
+reveal_type([a_c, b_c])  # N: Revealed type is "builtins.list[__main__.Container[__main__.Base]]"
 [builtins fixtures/list.pyi]
 
 [case testGenericJoinContravariant]
@@ -2464,7 +2464,7 @@ a_c: Container[A]
 b_c: Container[B]
 
 # TODO: this can be more precise than "object", see a comment in mypy/join.py
-reveal_type([a_c, b_c])  # N: Revealed type is "builtins.list[builtins.object*]"
+reveal_type([a_c, b_c])  # N: Revealed type is "builtins.list[builtins.object]"
 [builtins fixtures/list.pyi]
 
 [case testGenericJoinRecursiveTypes]
@@ -2476,7 +2476,7 @@ class B(Sequence[B]): ...
 a: A
 b: B
 
-reveal_type([a, b])  # N: Revealed type is "builtins.list[typing.Sequence*[builtins.object]]"
+reveal_type([a, b])  # N: Revealed type is "builtins.list[typing.Sequence[builtins.object]]"
 [builtins fixtures/list.pyi]
 
 [case testGenericJoinRecursiveInvariant]
@@ -2490,7 +2490,7 @@ class B(I[B]): ...
 
 a: A
 b: B
-reveal_type([a, b])  # N: Revealed type is "builtins.list[builtins.object*]"
+reveal_type([a, b])  # N: Revealed type is "builtins.list[builtins.object]"
 [builtins fixtures/list.pyi]
 
 [case testGenericJoinNestedInvariantAny]
@@ -2501,6 +2501,6 @@ class I(Generic[T]): ...
 
 a: I[I[int]]
 b: I[I[Any]]
-reveal_type([a, b])  # N: Revealed type is "builtins.list[__main__.I*[__main__.I[Any]]]"
-reveal_type([b, a])  # N: Revealed type is "builtins.list[__main__.I*[__main__.I[Any]]]"
+reveal_type([a, b])  # N: Revealed type is "builtins.list[__main__.I[__main__.I[Any]]]"
+reveal_type([b, a])  # N: Revealed type is "builtins.list[__main__.I[__main__.I[Any]]]"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1980,14 +1980,14 @@ class D:
 reveal_type(D().a)
 [out1]
 tmp/crash.py:8: note: Revealed type is "crash.A@5"
-tmp/crash.py:17: note: Revealed type is "crash.B@13[builtins.int*]"
+tmp/crash.py:17: note: Revealed type is "crash.B@13[builtins.int]"
 main:2: note: Revealed type is "crash.A@5"
-main:3: note: Revealed type is "crash.B@13[builtins.int*]"
+main:3: note: Revealed type is "crash.B@13[builtins.int]"
 [out2]
 tmp/crash.py:8: note: Revealed type is "crash.A@5"
-tmp/crash.py:17: note: Revealed type is "crash.B@13[builtins.int*]"
+tmp/crash.py:17: note: Revealed type is "crash.B@13[builtins.int]"
 main:2: note: Revealed type is "crash.A@5"
-main:3: note: Revealed type is "crash.B@13[builtins.int*]"
+main:3: note: Revealed type is "crash.B@13[builtins.int]"
 
 [case testGenericMethodRestoreMetaLevel]
 from typing import Dict

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -913,7 +913,7 @@ from typing import TypeVar, Union, List
 T = TypeVar('T')
 
 def f(x: Union[T, List[int]]) -> Union[T, List[int]]: pass
-reveal_type(f(1)) # N: Revealed type is "Union[builtins.int*, builtins.list[builtins.int]]"
+reveal_type(f(1)) # N: Revealed type is "Union[builtins.int, builtins.list[builtins.int]]"
 reveal_type(f([])) # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(f(None)) # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
@@ -925,7 +925,7 @@ from typing import TypeVar, Union, List
 T = TypeVar('T')
 
 def f(x: Union[T, List[int]]) -> Union[T, List[int]]: pass
-reveal_type(f(1)) # N: Revealed type is "Union[builtins.int*, builtins.list[builtins.int]]"
+reveal_type(f(1)) # N: Revealed type is "Union[builtins.int, builtins.list[builtins.int]]"
 reveal_type(f([])) # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(f(None)) # N: Revealed type is "Union[None, builtins.list[builtins.int]]"
 [builtins fixtures/list.pyi]
@@ -940,7 +940,7 @@ class C(Generic[T]):
     def f(self, x: Union[T, S]) -> Union[T, S]: pass
 
 c = C[List[int]]()
-reveal_type(c.f('')) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.str*]"
+reveal_type(c.f('')) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.str]"
 reveal_type(c.f([1])) # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(c.f([])) # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(c.f(None)) # N: Revealed type is "builtins.list[builtins.int]"
@@ -991,7 +991,7 @@ class D(C): ...
 
 def f(x: Sequence[T], y: Sequence[T]) -> List[T]: ...
 
-reveal_type(f([C()], [D()])) # N: Revealed type is "builtins.list[__main__.C*]"
+reveal_type(f([C()], [D()])) # N: Revealed type is "builtins.list[__main__.C]"
 [builtins fixtures/list.pyi]
 
 [case testInferTypeVariableFromTwoGenericTypes2]
@@ -1023,7 +1023,7 @@ def f(x: A[T], y: A[T]) -> B[T]: ...
 
 c: B[C]
 d: B[D]
-reveal_type(f(c, d)) # N: Revealed type is "__main__.B[__main__.D*]"
+reveal_type(f(c, d)) # N: Revealed type is "__main__.B[__main__.D]"
 
 [case testInferTypeVariableFromTwoGenericTypes4]
 from typing import Generic, TypeVar, Callable, List
@@ -1043,7 +1043,7 @@ def f(x: Callable[[B[T]], None],
 def gc(x: A[C]) -> None: pass  # B[C]
 def gd(x: A[D]) -> None: pass  # B[C]
 
-reveal_type(f(gc, gd)) # N: Revealed type is "builtins.list[__main__.C*]"
+reveal_type(f(gc, gd)) # N: Revealed type is "builtins.list[__main__.C]"
 [builtins fixtures/list.pyi]
 
 [case testWideOuterContextSubClassBound]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -699,7 +699,7 @@ def f(x: Callable[..., T]) -> T: return x()
 class A: pass
 x = None  # type: Type[A]
 y = f(x)
-reveal_type(y)  # N: Revealed type is "__main__.A*"
+reveal_type(y)  # N: Revealed type is "__main__.A"
 
 -- Generic function inference with unions
 -- --------------------------------------
@@ -854,7 +854,7 @@ class V(T[_T], U[_T]): pass
 
 def wait_for(fut: Union[T[_T], U[_T]]) -> _T: ...
 
-reveal_type(wait_for(V[str]()))  # N: Revealed type is "builtins.str*"
+reveal_type(wait_for(V[str]()))  # N: Revealed type is "builtins.str"
 
 [case testAmbiguousUnionContextAndMultipleInheritance2]
 from typing import TypeVar, Union, Generic
@@ -869,7 +869,7 @@ class V(T[_T, _S], U[_T, _S]): pass
 def wait_for(fut: Union[T[_T, _S], U[_T, _S]]) -> T[_T, _S]: ...
 
 reveal_type(wait_for(V[int, str]()))  \
-    # N: Revealed type is "__main__.T[builtins.int*, builtins.str*]"
+    # N: Revealed type is "__main__.T[builtins.int, builtins.str]"
 
 
 -- Literal expressions
@@ -907,8 +907,8 @@ if int():
 [case testSetWithStarExpr]
 s = {1, 2, *(3, 4)}
 t = {1, 2, *s}
-reveal_type(s)  # N: Revealed type is "builtins.set[builtins.int*]"
-reveal_type(t)  # N: Revealed type is "builtins.set[builtins.int*]"
+reveal_type(s)  # N: Revealed type is "builtins.set[builtins.int]"
+reveal_type(t)  # N: Revealed type is "builtins.set[builtins.int]"
 [builtins fixtures/set.pyi]
 
 [case testListLiteralWithFunctionsErasesNames]
@@ -1556,7 +1556,7 @@ def f(blocks: object):
 a = []
 if bool():
     a = [1]
-reveal_type(a) # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(a) # N: Revealed type is "builtins.list[builtins.int]"
 
 def f():
     return [1]
@@ -1568,7 +1568,7 @@ reveal_type(b) # N: Revealed type is "builtins.list[Any]"
 d = {}
 if bool():
     d = {1: 'x'}
-reveal_type(d) # N: Revealed type is "builtins.dict[builtins.int*, builtins.str*]"
+reveal_type(d) # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
 
 dd = {} # E: Need type annotation for "dd" (hint: "dd: Dict[<type>, <type>] = ...")
 if bool():
@@ -1586,7 +1586,7 @@ reveal_type(o) # N: Revealed type is "collections.OrderedDict[builtins.int, buil
 d = {1: 'x'}
 oo = OrderedDict()
 oo.update(d)
-reveal_type(oo) # N: Revealed type is "collections.OrderedDict[builtins.int*, builtins.str*]"
+reveal_type(oo) # N: Revealed type is "collections.OrderedDict[builtins.int, builtins.str]"
 [builtins fixtures/dict.pyi]
 
 [case testEmptyCollectionAssignedToVariableTwiceIncremental]
@@ -1618,7 +1618,7 @@ class C:
         self.a = []
         if bool():
             self.a = [1]
-reveal_type(C().a)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(C().a)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testInferAttributeInitializedToEmptyAndAppended]
@@ -1773,13 +1773,13 @@ def f() -> None:
 [case testInferListTypeFromInplaceAdd]
 a = []
 a += [1]
-reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testInferSetTypeFromInplaceOr]
 a = set()
 a |= {'x'}
-reveal_type(a)  # N: Revealed type is "builtins.set[builtins.str*]"
+reveal_type(a)  # N: Revealed type is "builtins.set[builtins.str]"
 [builtins fixtures/set.pyi]
 
 
@@ -2998,15 +2998,15 @@ def q2(x: Union[Z[F], F]) -> F:
         return x
 
 b: B
-reveal_type(q1(b))  # N: Revealed type is "__main__.B*"
-reveal_type(q2(b))  # N: Revealed type is "__main__.B*"
+reveal_type(q1(b))  # N: Revealed type is "__main__.B"
+reveal_type(q2(b))  # N: Revealed type is "__main__.B"
 
 z: Z[B]
-reveal_type(q1(z))  # N: Revealed type is "__main__.B*"
-reveal_type(q2(z))  # N: Revealed type is "__main__.B*"
+reveal_type(q1(z))  # N: Revealed type is "__main__.B"
+reveal_type(q2(z))  # N: Revealed type is "__main__.B"
 
-reveal_type(q1(Z(b)))  # N: Revealed type is "__main__.B*"
-reveal_type(q2(Z(b)))  # N: Revealed type is "__main__.B*"
+reveal_type(q1(Z(b)))  # N: Revealed type is "__main__.B"
+reveal_type(q2(Z(b)))  # N: Revealed type is "__main__.B"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testUnionInvariantSubClassAndCovariantBase]
@@ -3022,7 +3022,7 @@ X = Union[Cov[T], Inv[T]]
 
 def f(x: X[T]) -> T: ...
 x: Inv[int]
-reveal_type(f(x))  # N: Revealed type is "builtins.int*"
+reveal_type(f(x))  # N: Revealed type is "builtins.int"
 
 [case testOptionalTypeVarAgainstOptional]
 # flags: --strict-optional
@@ -3035,7 +3035,7 @@ def filter(__function: None, __iterable: Iterable[Optional[_T]]) -> List[_T]: ..
 x: Optional[str]
 
 y = filter(None, [x])
-reveal_type(y)  # N: Revealed type is "builtins.list[builtins.str*]"
+reveal_type(y)  # N: Revealed type is "builtins.list[builtins.str]"
 [builtins fixtures/list.pyi]
 
 [case testPartialDefaultDict]
@@ -3125,7 +3125,7 @@ from collections import defaultdict
 
 x = defaultdict(list)
 x['a'] = [1, 2, 3]
-reveal_type(x)  # N: Revealed type is "collections.defaultdict[builtins.str, builtins.list[builtins.int*]]"
+reveal_type(x)  # N: Revealed type is "collections.defaultdict[builtins.str, builtins.list[builtins.int]]"
 
 y = defaultdict(list)  # E: Need type annotation for "y"
 y['a'] = []
@@ -3149,7 +3149,7 @@ def f(x: Callable[[], T]) -> T:
     return x()
 
 reveal_type(f(lambda: None))  # N: Revealed type is "None"
-reveal_type(f(lambda: 1))  # N: Revealed type is "builtins.int*"
+reveal_type(f(lambda: 1))  # N: Revealed type is "builtins.int"
 
 def g() -> None: pass
 
@@ -3165,7 +3165,7 @@ def f(x: Callable[[], T]) -> T:
     return x()
 
 reveal_type(f(lambda: None))  # N: Revealed type is "None"
-reveal_type(f(lambda: 1))  # N: Revealed type is "builtins.int*"
+reveal_type(f(lambda: 1))  # N: Revealed type is "builtins.int"
 
 def g() -> None: pass
 
@@ -3236,9 +3236,9 @@ class C(NamedTuple):
 t: Optional[C]
 d: Dict[C, bytes]
 x = t and d[t]
-reveal_type(x)  # N: Revealed type is "Union[None, builtins.bytes*]"
+reveal_type(x)  # N: Revealed type is "Union[None, builtins.bytes]"
 if x:
-    reveal_type(x)  # N: Revealed type is "builtins.bytes*"
+    reveal_type(x)  # N: Revealed type is "builtins.bytes"
 [builtins fixtures/dict.pyi]
 
 [case testRegression11705_NoStrict]
@@ -3251,7 +3251,7 @@ class C(NamedTuple):
 t: Optional[C]
 d: Dict[C, bytes]
 x = t and d[t]
-reveal_type(x)  # N: Revealed type is "builtins.bytes*"
+reveal_type(x)  # N: Revealed type is "builtins.bytes"
 if x:
-    reveal_type(x)  # N: Revealed type is "builtins.bytes*"
+    reveal_type(x)  # N: Revealed type is "builtins.bytes"
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1434,9 +1434,9 @@ a = [] # type: List[Union[int, str]]
 l = [x for x in a if isinstance(x, int)]
 g = (x for x in a if isinstance(x, int))
 d = {0: x for x in a if isinstance(x, int)}
-reveal_type(l) # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type(g) # N: Revealed type is "typing.Generator[builtins.int*, None, None]"
-reveal_type(d) # N: Revealed type is "builtins.dict[builtins.int*, builtins.int*]"
+reveal_type(l) # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(g) # N: Revealed type is "typing.Generator[builtins.int, None, None]"
+reveal_type(d) # N: Revealed type is "builtins.dict[builtins.int, builtins.int]"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testIsinstanceInWrongOrderInBooleanOp]
@@ -2417,14 +2417,14 @@ else:
 y: A[Parent]
 if isinstance(y, B):
     reveal_type(y)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
-    reveal_type(y.f())  # N: Revealed type is "__main__.Parent*"
+    reveal_type(y.f())  # N: Revealed type is "__main__.Parent"
 else:
     reveal_type(y)      # N: Revealed type is "__main__.A[__main__.Parent]"
 
 z: A[Child]
 if isinstance(z, B):
     reveal_type(z)      # N: Revealed type is "__main__.<subclass of "A" and "B">1"
-    reveal_type(z.f())  # N: Revealed type is "__main__.Child*"
+    reveal_type(z.f())  # N: Revealed type is "__main__.Child"
 else:
     reveal_type(z)      # N: Revealed type is "__main__.A[__main__.Child]"
 [builtins fixtures/isinstance.pyi]
@@ -2443,21 +2443,21 @@ class C:
 T1 = TypeVar('T1', A, B)
 def f1(x: T1) -> T1:
     if isinstance(x, A):
-        reveal_type(x)      # N: Revealed type is "__main__.A*" \
+        reveal_type(x)      # N: Revealed type is "__main__.A" \
                             # N: Revealed type is "__main__.<subclass of "B" and "A">"
         if isinstance(x, B):
             reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "B">" \
                             # N: Revealed type is "__main__.<subclass of "B" and "A">"
         else:
-            reveal_type(x)  # N: Revealed type is "__main__.A*"
+            reveal_type(x)  # N: Revealed type is "__main__.A"
     else:
-        reveal_type(x)      # N: Revealed type is "__main__.B*"
+        reveal_type(x)      # N: Revealed type is "__main__.B"
     return x
 
 T2 = TypeVar('T2', B, C)
 def f2(x: T2) -> T2:
     if isinstance(x, B):
-        reveal_type(x)      # N: Revealed type is "__main__.B*"
+        reveal_type(x)      # N: Revealed type is "__main__.B"
         # Note: even though --warn-unreachable is set, we don't report
         # errors for the below: we don't yet have a way of filtering out
         # reachability errors that occur for only one variation of the
@@ -2465,9 +2465,9 @@ def f2(x: T2) -> T2:
         if isinstance(x, C):
             reveal_type(x)
         else:
-            reveal_type(x)  # N: Revealed type is "__main__.B*"
+            reveal_type(x)  # N: Revealed type is "__main__.B"
     else:
-        reveal_type(x)      # N: Revealed type is "__main__.C*"
+        reveal_type(x)      # N: Revealed type is "__main__.C"
     return x
 [builtins fixtures/isinstance.pyi]
 

--- a/test-data/unit/check-lists.test
+++ b/test-data/unit/check-lists.test
@@ -71,17 +71,17 @@ class C: pass
 [case testListWithStarExpr]
 (x, *a) = [1, 2, 3]
 a = [1, *[2, 3]]
-reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int]"
 b = [0, *a]
-reveal_type(b)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(b)  # N: Revealed type is "builtins.list[builtins.int]"
 c = [*a, 0]
-reveal_type(c)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(c)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testComprehensionShadowBinder]
 # flags: --strict-optional
 def foo(x: object) -> None:
     if isinstance(x, str):
-        [reveal_type(x) for x in [1, 2, 3]]  # N: Revealed type is "builtins.int*"
+        [reveal_type(x) for x in [1, 2, 3]]  # N: Revealed type is "builtins.int"
 
 [builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1480,11 +1480,11 @@ g: List[List[List[Literal[1, 2, 3]]]] = [[[1, 2, 3], [3]]]
 h: List[Literal[1]] = []
 
 reveal_type(a)  # N: Revealed type is "builtins.list[Literal[1]]"
-reveal_type(b)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(b)  # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(c)  # N: Revealed type is "builtins.list[Union[Literal[1], Literal[2], Literal[3]]]"
-reveal_type(d)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(d)  # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(e)  # N: Revealed type is "builtins.list[Union[Literal[1], Literal['x']]]"
-reveal_type(f)  # N: Revealed type is "builtins.list[builtins.object*]"
+reveal_type(f)  # N: Revealed type is "builtins.list[builtins.object]"
 reveal_type(g)  # N: Revealed type is "builtins.list[builtins.list[builtins.list[Union[Literal[1], Literal[2], Literal[3]]]]]"
 reveal_type(h)  # N: Revealed type is "builtins.list[Literal[1]]"
 
@@ -1499,10 +1499,10 @@ arr4 = [lit1, lit2, lit3]
 arr5 = [object(), lit1]
 
 reveal_type(arr1)  # N: Revealed type is "builtins.list[Literal[1]]"
-reveal_type(arr2)  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type(arr3)  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type(arr4)  # N: Revealed type is "builtins.list[builtins.object*]"
-reveal_type(arr5)  # N: Revealed type is "builtins.list[builtins.object*]"
+reveal_type(arr2)  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(arr3)  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(arr4)  # N: Revealed type is "builtins.list[builtins.object]"
+reveal_type(arr5)  # N: Revealed type is "builtins.list[builtins.object]"
 
 bad: List[Literal[1, 2]] = [1, 2, 3]  # E: List item 2 has incompatible type "Literal[3]"; expected "Literal[1, 2]"
 
@@ -1533,7 +1533,7 @@ a = {"x": 1, "y": 2}
 b: Dict[str, Literal[1, 2]] = {"x": 1, "y": 2}
 c: Dict[Literal["x", "y"], int] = {"x": 1, "y": 2}
 
-reveal_type(a)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+reveal_type(a)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
 
 [builtins fixtures/dict.pyi]
 [out]
@@ -1674,7 +1674,7 @@ def f1(x: T, y: str) -> Union[T, str]: ...
 def f1(x, y): pass
 
 a: Literal[1]
-reveal_type(f1(1, 1))  # N: Revealed type is "builtins.int*"
+reveal_type(f1(1, 1))  # N: Revealed type is "builtins.int"
 reveal_type(f1(a, 1))  # N: Revealed type is "Literal[1]"
 
 @overload
@@ -1683,7 +1683,7 @@ def f2(x: T, y: Literal[3]) -> T: ...
 def f2(x: T, y: str) -> Union[T]: ...
 def f2(x, y): pass
 
-reveal_type(f2(1, 3))  # N: Revealed type is "builtins.int*"
+reveal_type(f2(1, 3))  # N: Revealed type is "builtins.int"
 reveal_type(f2(a, 3))  # N: Revealed type is "Literal[1]"
 
 @overload
@@ -1692,7 +1692,7 @@ def f3(x: Literal[3]) -> Literal[3]: ...
 def f3(x: T) -> T: ...
 def f3(x): pass
 
-reveal_type(f3(1))  # N: Revealed type is "builtins.int*"
+reveal_type(f3(1))  # N: Revealed type is "builtins.int"
 reveal_type(f3(a))  # N: Revealed type is "Literal[1]"
 
 @overload
@@ -1702,7 +1702,7 @@ def f4(x: T) -> T: ...
 def f4(x): pass
 
 b: Literal['foo']
-reveal_type(f4(1))      # N: Revealed type is "builtins.int*"
+reveal_type(f4(1))      # N: Revealed type is "builtins.int"
 reveal_type(f4(a))      # N: Revealed type is "Literal[1]"
 reveal_type(f4("foo"))  # N: Revealed type is "builtins.str"
 
@@ -1879,7 +1879,7 @@ def expects_literal(x: Literal[3]) -> None: pass
 def expects_int(x: int) -> None: pass
 
 a: Literal[3]
-reveal_type(foo(3))  # N: Revealed type is "builtins.int*"
+reveal_type(foo(3))  # N: Revealed type is "builtins.int"
 reveal_type(foo(a))  # N: Revealed type is "Literal[3]"
 
 expects_literal(3)
@@ -1944,7 +1944,7 @@ def expects_literal(a: Literal[3]) -> None: pass
 def expects_literal_wrapper(x: Wrapper[Literal[3]]) -> None: pass
 
 a: Literal[3]
-reveal_type(Wrapper(3))              # N: Revealed type is "__main__.Wrapper[builtins.int*]"
+reveal_type(Wrapper(3))              # N: Revealed type is "__main__.Wrapper[builtins.int]"
 reveal_type(Wrapper[Literal[3]](3))  # N: Revealed type is "__main__.Wrapper[Literal[3]]"
 reveal_type(Wrapper(a))              # N: Revealed type is "__main__.Wrapper[Literal[3]]"
 
@@ -1996,13 +1996,13 @@ reveal_type(func1(4))   # E: Value of type variable "TLiteral" of "func1" cannot
 reveal_type(func1(b))   # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]" \
                         # N: Revealed type is "Literal[4]"
 reveal_type(func1(c))   # E: Value of type variable "TLiteral" of "func1" cannot be "int" \
-                        # N: Revealed type is "builtins.int*"
+                        # N: Revealed type is "builtins.int"
 
-reveal_type(func2(3))   # N: Revealed type is "builtins.int*"
+reveal_type(func2(3))   # N: Revealed type is "builtins.int"
 reveal_type(func2(a))   # N: Revealed type is "Literal[3]"
-reveal_type(func2(4))   # N: Revealed type is "builtins.int*"
+reveal_type(func2(4))   # N: Revealed type is "builtins.int"
 reveal_type(func2(b))   # N: Revealed type is "Literal[4]"
-reveal_type(func2(c))   # N: Revealed type is "builtins.int*"
+reveal_type(func2(c))   # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -2042,7 +2042,7 @@ reveal_type(func1(4))       # E: Value of type variable "TLiteral" of "func1" ca
 reveal_type(func1(i2))      # E: Value of type variable "TLiteral" of "func1" cannot be "Literal[4]" \
                             # N: Revealed type is "Literal[4]"
 reveal_type(func1(i))       # E: Value of type variable "TLiteral" of "func1" cannot be "int" \
-                            # N: Revealed type is "builtins.int*"
+                            # N: Revealed type is "builtins.int"
 reveal_type(func1("foo"))   # N: Revealed type is "Literal['foo']"
 reveal_type(func1(s1))      # N: Revealed type is "Literal['foo']"
 reveal_type(func1("bar"))   # E: Value of type variable "TLiteral" of "func1" cannot be "Literal['bar']" \
@@ -2050,16 +2050,16 @@ reveal_type(func1("bar"))   # E: Value of type variable "TLiteral" of "func1" ca
 reveal_type(func1(s2))      # E: Value of type variable "TLiteral" of "func1" cannot be "Literal['bar']" \
                             # N: Revealed type is "Literal['bar']"
 reveal_type(func1(s))       # E: Value of type variable "TLiteral" of "func1" cannot be "str" \
-                            # N: Revealed type is "builtins.str*"
+                            # N: Revealed type is "builtins.str"
 
-reveal_type(func2(3))       # N: Revealed type is "builtins.int*"
-reveal_type(func2(i1))      # N: Revealed type is "builtins.int*"
-reveal_type(func2(4))       # N: Revealed type is "builtins.int*"
-reveal_type(func2(i2))      # N: Revealed type is "builtins.int*"
-reveal_type(func2("foo"))   # N: Revealed type is "builtins.str*"
-reveal_type(func2(s1))      # N: Revealed type is "builtins.str*"
-reveal_type(func2("bar"))   # N: Revealed type is "builtins.str*"
-reveal_type(func2(s2))      # N: Revealed type is "builtins.str*"
+reveal_type(func2(3))       # N: Revealed type is "builtins.int"
+reveal_type(func2(i1))      # N: Revealed type is "builtins.int"
+reveal_type(func2(4))       # N: Revealed type is "builtins.int"
+reveal_type(func2(i2))      # N: Revealed type is "builtins.int"
+reveal_type(func2("foo"))   # N: Revealed type is "builtins.str"
+reveal_type(func2(s1))      # N: Revealed type is "builtins.str"
+reveal_type(func2("bar"))   # N: Revealed type is "builtins.str"
+reveal_type(func2(s2))      # N: Revealed type is "builtins.str"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -2106,7 +2106,7 @@ arr4 = [a, d]
 arr5 = [a, e]
 
 reveal_type(arr1)  # N: Revealed type is "builtins.list[def (Literal[1]) -> builtins.int]"
-reveal_type(arr2)  # N: Revealed type is "builtins.list[builtins.function*]"
+reveal_type(arr2)  # N: Revealed type is "builtins.list[builtins.function]"
 reveal_type(arr3)  # N: Revealed type is "builtins.list[def (Literal[1]) -> builtins.object]"
 reveal_type(arr4)  # N: Revealed type is "builtins.list[def (Literal[1]) -> builtins.object]"
 reveal_type(arr5)  # N: Revealed type is "builtins.list[def (Literal[1]) -> builtins.object]"
@@ -2143,7 +2143,7 @@ b: Callable[[Literal[2]], str]
 lit: Literal[1]
 
 arr = [a, b]
-reveal_type(arr)  # N: Revealed type is "builtins.list[builtins.function*]"
+reveal_type(arr)  # N: Revealed type is "builtins.list[builtins.function]"
 reveal_type(arr[0](lit))  # E: Cannot call function of unknown type \
                           # N: Revealed type is "Any"
 
@@ -2342,7 +2342,7 @@ reveal_type(test.get(good_keys, 3))               # N: Revealed type is "Union[_
 reveal_type(test.pop(optional_keys))              # N: Revealed type is "Union[__main__.D, __main__.E]"
 reveal_type(test.pop(optional_keys, 3))           # N: Revealed type is "Union[__main__.D, __main__.E, Literal[3]?]"
 reveal_type(test.setdefault(good_keys, AAndB()))  # N: Revealed type is "Union[__main__.A, __main__.B]"
-reveal_type(test.get(bad_keys))                   # N: Revealed type is "builtins.object*"
+reveal_type(test.get(bad_keys))                   # N: Revealed type is "builtins.object"
 reveal_type(test.get(bad_keys, 3))                # N: Revealed type is "builtins.object"
 del test[optional_keys]
 
@@ -2440,7 +2440,7 @@ x[bad_keys]         # E: TypedDict "D1" has no key "d" \
 reveal_type(x[good_keys])           # N: Revealed type is "Union[__main__.B, __main__.C]"
 reveal_type(x.get(good_keys))       # N: Revealed type is "Union[__main__.B, __main__.C]"
 reveal_type(x.get(good_keys, 3))    # N: Revealed type is "Union[__main__.B, Literal[3]?, __main__.C]"
-reveal_type(x.get(bad_keys))        # N: Revealed type is "builtins.object*"
+reveal_type(x.get(bad_keys))        # N: Revealed type is "builtins.object"
 reveal_type(x.get(bad_keys, 3))     # N: Revealed type is "builtins.object"
 
 [builtins fixtures/dict.pyi]
@@ -2704,21 +2704,21 @@ direct = [1]
 def force1(x: List[Literal[1]]) -> None: pass
 def force2(x: Literal[1]) -> None: pass
 
-reveal_type(implicit)            # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(implicit)            # N: Revealed type is "builtins.list[builtins.int]"
 force1(reveal_type(implicit))    # E: Argument 1 to "force1" has incompatible type "List[int]"; expected "List[Literal[1]]" \
-                                 # N: Revealed type is "builtins.list[builtins.int*]"
+                                 # N: Revealed type is "builtins.list[builtins.int]"
 force2(reveal_type(implicit[0])) # E: Argument 1 to "force2" has incompatible type "int"; expected "Literal[1]" \
-                                 # N: Revealed type is "builtins.int*"
+                                 # N: Revealed type is "builtins.int"
 
 reveal_type(explicit)            # N: Revealed type is "builtins.list[Literal[1]]"
 force1(reveal_type(explicit))    # N: Revealed type is "builtins.list[Literal[1]]"
 force2(reveal_type(explicit[0])) # N: Revealed type is "Literal[1]"
 
-reveal_type(direct)              # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(direct)              # N: Revealed type is "builtins.list[builtins.int]"
 force1(reveal_type(direct))      # E: Argument 1 to "force1" has incompatible type "List[int]"; expected "List[Literal[1]]" \
-                                 # N: Revealed type is "builtins.list[builtins.int*]"
+                                 # N: Revealed type is "builtins.list[builtins.int]"
 force2(reveal_type(direct[0]))   # E: Argument 1 to "force2" has incompatible type "int"; expected "Literal[1]" \
-                                 # N: Revealed type is "builtins.int*"
+                                 # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 [out]
 
@@ -2821,25 +2821,25 @@ def over_literal(x: WrapperClass[Literal[99]]) -> None: pass
 var1: Final = 99
 w1 = WrapperClass(var1)
 force(reveal_type(w1.data))                     # E: Argument 1 to "force" has incompatible type "int"; expected "Literal[99]" \
-                                                # N: Revealed type is "builtins.int*"
+                                                # N: Revealed type is "builtins.int"
 force(reveal_type(WrapperClass(var1).data))     # E: Argument 1 to "force" has incompatible type "int"; expected "Literal[99]" \
-                                                # N: Revealed type is "builtins.int*"
+                                                # N: Revealed type is "builtins.int"
 force(reveal_type(wrapper_func(var1)))          # N: Revealed type is "Literal[99]"
-over_int(reveal_type(w1))                       # N: Revealed type is "__main__.WrapperClass[builtins.int*]"
+over_int(reveal_type(w1))                       # N: Revealed type is "__main__.WrapperClass[builtins.int]"
 over_literal(reveal_type(w1))                   # E: Argument 1 to "over_literal" has incompatible type "WrapperClass[int]"; expected "WrapperClass[Literal[99]]" \
-                                                # N: Revealed type is "__main__.WrapperClass[builtins.int*]"
+                                                # N: Revealed type is "__main__.WrapperClass[builtins.int]"
 over_int(reveal_type(WrapperClass(var1)))       # N: Revealed type is "__main__.WrapperClass[builtins.int]"
 over_literal(reveal_type(WrapperClass(var1)))   # N: Revealed type is "__main__.WrapperClass[Literal[99]]"
 
 w2 = WrapperClass(99)
 force(reveal_type(w2.data))                     # E: Argument 1 to "force" has incompatible type "int"; expected "Literal[99]" \
-                                                # N: Revealed type is "builtins.int*"
+                                                # N: Revealed type is "builtins.int"
 force(reveal_type(WrapperClass(99).data))       # E: Argument 1 to "force" has incompatible type "int"; expected "Literal[99]" \
-                                                # N: Revealed type is "builtins.int*"
+                                                # N: Revealed type is "builtins.int"
 force(reveal_type(wrapper_func(99)))            # N: Revealed type is "Literal[99]"
-over_int(reveal_type(w2))                       # N: Revealed type is "__main__.WrapperClass[builtins.int*]"
+over_int(reveal_type(w2))                       # N: Revealed type is "__main__.WrapperClass[builtins.int]"
 over_literal(reveal_type(w2))                   # E: Argument 1 to "over_literal" has incompatible type "WrapperClass[int]"; expected "WrapperClass[Literal[99]]" \
-                                                # N: Revealed type is "__main__.WrapperClass[builtins.int*]"
+                                                # N: Revealed type is "__main__.WrapperClass[builtins.int]"
 over_int(reveal_type(WrapperClass(99)))         # N: Revealed type is "__main__.WrapperClass[builtins.int]"
 over_literal(reveal_type(WrapperClass(99)))     # N: Revealed type is "__main__.WrapperClass[Literal[99]]"
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1445,7 +1445,7 @@ def deco(f: Callable[[T], int]) -> Callable[[T], int]:
     a.x
     return f
 [out]
-tmp/a.py:6: note: Revealed type is "def (builtins.str*) -> builtins.int"
+tmp/a.py:6: note: Revealed type is "def (builtins.str) -> builtins.int"
 
 [case testDeferredClassContext]
 class A:
@@ -1549,9 +1549,9 @@ second = XT[str]()
 last = XT[G]()
 
 reveal_type(notes) # N: Revealed type is "y.G[y.G[builtins.int]]"
-reveal_type(another) # N: Revealed type is "y.G[y.G*[builtins.int]]"
-reveal_type(second) # N: Revealed type is "y.G[builtins.str*]"
-reveal_type(last) # N: Revealed type is "y.G[y.G*[Any]]"
+reveal_type(another) # N: Revealed type is "y.G[y.G[builtins.int]]"
+reveal_type(second) # N: Revealed type is "y.G[builtins.str]"
+reveal_type(last) # N: Revealed type is "y.G[y.G[Any]]"
 
 [file y.py]
 from typing import Generic, TypeVar
@@ -1962,7 +1962,7 @@ x = 42
 [case testModuleAliasToQualifiedImport]
 import package.module
 alias = package.module
-reveal_type(alias.whatever('/'))  # N: Revealed type is "builtins.str*"
+reveal_type(alias.whatever('/'))  # N: Revealed type is "builtins.str"
 [file package/__init__.py]
 
 [file package/module.py]
@@ -1975,7 +1975,7 @@ def whatever(x: T) -> T: pass
 import mod
 import othermod
 alias = mod.submod
-reveal_type(alias.whatever('/'))  # N: Revealed type is "builtins.str*"
+reveal_type(alias.whatever('/'))  # N: Revealed type is "builtins.str"
 if int():
     alias = othermod  # E: Cannot assign multiple modules to name "alias" without explicit "types.ModuleType" annotation
 [file mod.py]

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -543,7 +543,7 @@ c: C[int]
 c2: C[int, str] # E: "C" expects 1 type argument, but 2 given
 c3: C
 c = C('') # E: Argument 1 to "C" has incompatible type "str"; expected "int"
-reveal_type(c.get()) # N: Revealed type is "builtins.int*"
+reveal_type(c.get()) # N: Revealed type is "builtins.int"
 reveal_type(c2) # N: Revealed type is "__main__.C[Any]"
 reveal_type(c3) # N: Revealed type is "__main__.C[Any]"
 
@@ -571,7 +571,7 @@ T = TypeVar('T')
 c: C[int]
 reveal_type(c) # N: Revealed type is "__main__.C[builtins.int]"
 c = C('') # E: Argument 1 to "C" has incompatible type "str"; expected "int"
-reveal_type(c.get()) # N: Revealed type is "builtins.int*"
+reveal_type(c.get()) # N: Revealed type is "builtins.int"
 
 [case testNewAnalyzerTypeAlias]
 from typing import Union, TypeVar, Generic
@@ -820,7 +820,7 @@ class E: pass
 def f(x: T) -> T:
     return x
 
-reveal_type(f(D())) # N: Revealed type is "__main__.D*"
+reveal_type(f(D())) # N: Revealed type is "__main__.D"
 f(E()) # E: Value of type variable "T" of "f" cannot be "E"
 
 [case testNewAnalyzerNameExprRefersToIncompleteType]
@@ -1393,7 +1393,7 @@ from a import x
 
 class B(List[B]): pass
 
-reveal_type(x[0][0])  # N: Revealed type is "b.B*"
+reveal_type(x[0][0])  # N: Revealed type is "b.B"
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerAliasToNotReadyClass2]
@@ -1404,7 +1404,7 @@ x: A
 class A(List[B]): pass
 B = A
 
-reveal_type(x[0][0])  # N: Revealed type is "__main__.A*"
+reveal_type(x[0][0])  # N: Revealed type is "__main__.A"
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerAliasToNotReadyClass3]
@@ -1415,7 +1415,7 @@ B = A
 A = C
 class C(List[B]): pass
 
-reveal_type(x[0][0])  # N: Revealed type is "__main__.C*"
+reveal_type(x[0][0])  # N: Revealed type is "__main__.C"
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerAliasToNotReadyNestedClass]
@@ -1432,7 +1432,7 @@ from a import x
 class Out:
     class B(List[B]): pass
 
-reveal_type(x[0][0])  # N: Revealed type is "b.Out.B*"
+reveal_type(x[0][0])  # N: Revealed type is "b.Out.B"
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerAliasToNotReadyNestedClass2]
@@ -1444,7 +1444,7 @@ class Out:
     class A(List[B]): pass
 B = Out.A
 
-reveal_type(x[0][0])  # N: Revealed type is "__main__.Out.A*"
+reveal_type(x[0][0])  # N: Revealed type is "__main__.Out.A"
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerAliasToNotReadyClassGeneric]
@@ -1522,7 +1522,7 @@ A = C
 class C(List[A]): pass
 
 reveal_type(x)  # N: Revealed type is "builtins.list[__main__.C]"
-reveal_type(x[0][0])  # N: Revealed type is "__main__.C*"
+reveal_type(x[0][0])  # N: Revealed type is "__main__.C"
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerAliasToNotReadyDirectBase]
@@ -1966,18 +1966,18 @@ class NTStr(NamedTuple):
     y: str
 
 t1: T
-reveal_type(t1.__iter__) # N: Revealed type is "def () -> typing.Iterator[__main__.A*]"
+reveal_type(t1.__iter__) # N: Revealed type is "def () -> typing.Iterator[__main__.A]"
 
 t2: NTInt
-reveal_type(t2.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.int*]"
+reveal_type(t2.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.int]"
 nt: Union[NTInt, NTStr]
-reveal_type(nt.__iter__) # N: Revealed type is "Union[def () -> typing.Iterator[builtins.int*], def () -> typing.Iterator[builtins.str*]]"
+reveal_type(nt.__iter__) # N: Revealed type is "Union[def () -> typing.Iterator[builtins.int], def () -> typing.Iterator[builtins.str]]"
 for nx in nt:
-    reveal_type(nx) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+    reveal_type(nx) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 t: Union[Tuple[int, int], Tuple[str, str]]
 for x in t:
-    reveal_type(x) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/for.pyi]
 [out]
 
@@ -2003,7 +2003,7 @@ class G(Generic[T]): pass
 
 t: Tuple[G[B], G[C]] # E: Type argument "B" of "G" must be a subtype of "A" \
                      # E: Type argument "C" of "G" must be a subtype of "A"
-reveal_type(t.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.object*]"
+reveal_type(t.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.object]"
 [builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerClassKeywordsForward]
@@ -2102,7 +2102,7 @@ A = NewType('A', str)  # E: Cannot redefine "A" as a NewType \
 from typing import NewType, List
 
 x: C
-reveal_type(x[0])  # N: Revealed type is "__main__.C*"
+reveal_type(x[0])  # N: Revealed type is "__main__.C"
 
 C = NewType('C', B)
 
@@ -2114,7 +2114,7 @@ class B(List[C]):
 from typing import NewType, List
 
 x: D
-reveal_type(x[0])  # N: Revealed type is "__main__.C*"
+reveal_type(x[0])  # N: Revealed type is "__main__.C"
 
 D = C
 C = NewType('C', B)
@@ -2127,7 +2127,7 @@ class B(List[D]):
 from typing import NewType, List
 
 x: D
-reveal_type(x[0][0])  # N: Revealed type is "__main__.C*"
+reveal_type(x[0][0])  # N: Revealed type is "__main__.C"
 
 D = C
 C = NewType('C', List[B])
@@ -2203,7 +2203,7 @@ class C: ...
 
 x: B[int]  # E: Type argument "int" of "B" must be a subtype of "B[Any]"
 y: B[B[Any]]
-reveal_type(y.x)  # N: Revealed type is "__main__.B*[Any]"
+reveal_type(y.x)  # N: Revealed type is "__main__.B[Any]"
 
 [case testNewAnalyzerDuplicateTypeVarImportCycle]
 import a
@@ -2227,7 +2227,7 @@ y: B[B[Any]]
 reveal_type(y.x)
 [out]
 tmp/b.py:8: error: Type argument "int" of "B" must be a subtype of "B[Any]"
-tmp/b.py:10: note: Revealed type is "b.B*[Any]"
+tmp/b.py:10: note: Revealed type is "b.B[Any]"
 tmp/a.py:5: error: Cannot redefine "T" as a type variable
 tmp/a.py:5: error: Invalid assignment target
 tmp/a.py:5: error: "int" not callable
@@ -2256,7 +2256,7 @@ y: B[B[Any]]
 reveal_type(y.x)
 [out]
 tmp/b.py:9: error: Type argument "int" of "B" must be a subtype of "B[Any]"
-tmp/b.py:11: note: Revealed type is "b.B*[Any]"
+tmp/b.py:11: note: Revealed type is "b.B[Any]"
 tmp/a.py:5: error: Cannot redefine "T" as a type variable
 tmp/a.py:5: error: Invalid assignment target
 
@@ -2329,7 +2329,7 @@ C = NamedTuple('C', [('x', int)])
 from typing import Generic, TypeVar
 
 x = C[int]()
-reveal_type(x)  # N: Revealed type is "__main__.C[builtins.int*]"
+reveal_type(x)  # N: Revealed type is "__main__.C[builtins.int]"
 
 T = TypeVar('T')
 class C(Generic[T]): ...
@@ -2341,7 +2341,7 @@ T = TypeVar('T')
 class C(Generic[T]): ...
 
 x = C['A']()
-reveal_type(x)  # N: Revealed type is "__main__.C[__main__.A*]"
+reveal_type(x)  # N: Revealed type is "__main__.C[__main__.A]"
 
 class A: ...
 
@@ -2349,7 +2349,7 @@ class A: ...
 from typing import Generic, TypeVar
 
 x = C[A]()
-reveal_type(x)  # N: Revealed type is "__main__.C[__main__.A*]"
+reveal_type(x)  # N: Revealed type is "__main__.C[__main__.A]"
 
 T = TypeVar('T')
 class C(Generic[T]): ...
@@ -2360,7 +2360,7 @@ class A: ...
 from typing import Generic, TypeVar
 
 x = C[A]()  # E: Value of type variable "T" of "C" cannot be "A"
-reveal_type(x)  # N: Revealed type is "__main__.C[__main__.A*]"
+reveal_type(x)  # N: Revealed type is "__main__.C[__main__.A]"
 
 T = TypeVar('T', bound='D')
 class C(Generic[T]): ...
@@ -3074,7 +3074,7 @@ from typing import Tuple
 def f() -> None:
     t: Tuple[str, Tuple[str, str, str]]
     x, (y, *z) = t
-    reveal_type(z)  # N: Revealed type is "builtins.list[builtins.str*]"
+    reveal_type(z)  # N: Revealed type is "builtins.list[builtins.str]"
 [builtins fixtures/list.pyi]
 
 [case testNewAnalyzerIdentityAssignment1]

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -41,7 +41,7 @@ def tst_local(dct: Dict[int, T]) -> Dict[T, int]:
     ret: Dict[T, int] = {}
     return ret
 
-reveal_type(tst_local({1: 'a'}))  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int]"
+reveal_type(tst_local({1: 'a'}))  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
 [builtins fixtures/dict.pyi]
 [out]
 

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -68,7 +68,7 @@ bar = IdList([UserId(2)])
 baz = foo + bar
 reveal_type(foo)  # N: Revealed type is "__main__.IdList"
 reveal_type(bar)  # N: Revealed type is "__main__.IdList"
-reveal_type(baz)  # N: Revealed type is "builtins.list[__main__.UserId*]"
+reveal_type(baz)  # N: Revealed type is "builtins.list[__main__.UserId]"
 
 [builtins fixtures/list.pyi]
 [out]
@@ -96,7 +96,7 @@ Derived2(Base('a'))
 Derived3(Base(1))
 Derived3(Base('a'))
 
-reveal_type(Derived1(Base('a')).getter())  # N: Revealed type is "builtins.str*"
+reveal_type(Derived1(Base('a')).getter())  # N: Revealed type is "builtins.str"
 reveal_type(Derived3(Base('a')).getter())  # N: Revealed type is "Any"
 [out]
 

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -466,7 +466,7 @@ def f() -> Generator[str, None, None]: pass
 x = f()
 reveal_type(x)  # N: Revealed type is "typing.Generator[builtins.str, None, None]"
 l = [f()]
-reveal_type(l)  # N: Revealed type is "builtins.list[typing.Generator*[builtins.str, None, None]]"
+reveal_type(l)  # N: Revealed type is "builtins.list[typing.Generator[builtins.str, None, None]]"
 [builtins fixtures/list.pyi]
 
 [case testNoneListTernary]
@@ -648,14 +648,14 @@ def u(x: T, y: S) -> Union[S, T]: pass
 a = None # type: Any
 
 # Test both orders
-reveal_type(u(C(), None))  # N: Revealed type is "Union[None, __main__.C*]"
-reveal_type(u(None, C()))  # N: Revealed type is "Union[__main__.C*, None]"
+reveal_type(u(C(), None))  # N: Revealed type is "Union[None, __main__.C]"
+reveal_type(u(None, C()))  # N: Revealed type is "Union[__main__.C, None]"
 
 reveal_type(u(a, None))  # N: Revealed type is "Union[None, Any]"
 reveal_type(u(None, a))  # N: Revealed type is "Union[Any, None]"
 
-reveal_type(u(1, None))  # N: Revealed type is "Union[None, builtins.int*]"
-reveal_type(u(None, 1))  # N: Revealed type is "Union[builtins.int*, None]"
+reveal_type(u(1, None))  # N: Revealed type is "Union[None, builtins.int]"
+reveal_type(u(None, 1))  # N: Revealed type is "Union[builtins.int, None]"
 
 [case testOptionalAndAnyBaseClass]
 from typing import Any, Optional

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1870,7 +1870,7 @@ def make(*args):
     pass
 
 c = make(MyInt)
-reveal_type(c) # N: Revealed type is "mod.MyInt*"
+reveal_type(c) # N: Revealed type is "mod.MyInt"
 
 [file mod.pyi]
 from typing import overload
@@ -2571,7 +2571,7 @@ def f1(x: A) -> B: ...
 def f2(x: B) -> C: ...
 def f3(x: C) -> D: ...
 
-reveal_type(chain_call(A(), f1, f2))       # N: Revealed type is "__main__.C*"
+reveal_type(chain_call(A(), f1, f2))       # N: Revealed type is "__main__.C"
 reveal_type(chain_call(A(), f1, f2, f3))   # N: Revealed type is "Any"
 reveal_type(chain_call(A(), f, f, f, f))   # N: Revealed type is "__main__.A"
 [builtins fixtures/list.pyi]
@@ -3326,11 +3326,11 @@ def wrapper() -> None:
     a1: A = foo(obj1)
     a2 = foo(obj1)
     reveal_type(a1)  # N: Revealed type is "__main__.A"
-    reveal_type(a2)  # N: Revealed type is "__main__.A*"
+    reveal_type(a2)  # N: Revealed type is "__main__.A"
 
     obj2: Union[W1[A], W2[B]]
 
-    reveal_type(foo(obj2))  # N: Revealed type is "Union[__main__.A*, __main__.B*]"
+    reveal_type(foo(obj2))  # N: Revealed type is "Union[__main__.A, __main__.B]"
     bar(obj2)  # E: Cannot infer type argument 1 of "bar"
 
     b1_overload: A = foo(obj2)  # E: Incompatible types in assignment (expression has type "Union[A, B]", variable has type "A")
@@ -3359,7 +3359,7 @@ def wrapper() -> None:
     obj1: Union[W1[A], W2[A]]
 
     a1 = SomeType[A]().foo(obj1)
-    reveal_type(a1)  # N: Revealed type is "__main__.A*"
+    reveal_type(a1)  # N: Revealed type is "__main__.A"
 
     # Note: These should be fine, but mypy has an unrelated bug
     #       that makes them error out?
@@ -3462,7 +3462,7 @@ def t_is_same_bound(arg1: T1, arg2: S) -> Tuple[T1, S]:
 
     x4: Union[List[int], List[Tuple[C, int]]]
     y4: int
-    reveal_type(Dummy[C]().foo(x4, y4))  # N: Revealed type is "Union[builtins.int*, __main__.C]"
+    reveal_type(Dummy[C]().foo(x4, y4))  # N: Revealed type is "Union[builtins.int, __main__.C]"
     Dummy[A]().foo(x4, y4)               # E: Argument 1 to "foo" of "Dummy" has incompatible type "Union[List[int], List[Tuple[C, int]]]"; expected "List[Tuple[A, int]]"
 
     return arg1, arg2
@@ -3535,8 +3535,8 @@ def t_is_compatible_bound(arg1: T3, arg2: S) -> Tuple[T3, S]:
 [out]
 main:22: note: Revealed type is "Union[S`-2, __main__.B]"
 main:22: note: Revealed type is "Union[S`-2, __main__.C]"
-main:26: note: Revealed type is "__main__.B*"
-main:26: note: Revealed type is "__main__.C*"
+main:26: note: Revealed type is "__main__.B"
+main:26: note: Revealed type is "__main__.C"
 
 [case testOverloadInferUnionReturnWithInconsistentTypevarNames]
 from typing import overload, TypeVar, Union
@@ -3635,9 +3635,9 @@ f1: Callable[[int], str]
 f2: None
 f3: Optional[Callable[[int], str]]
 
-reveal_type(mymap(f1, seq))  # N: Revealed type is "typing.Iterable[builtins.str*]"
-reveal_type(mymap(f2, seq))  # N: Revealed type is "typing.Iterable[builtins.int*]"
-reveal_type(mymap(f3, seq))  # N: Revealed type is "typing.Iterable[builtins.str*]"
+reveal_type(mymap(f1, seq))  # N: Revealed type is "typing.Iterable[builtins.str]"
+reveal_type(mymap(f2, seq))  # N: Revealed type is "typing.Iterable[builtins.int]"
+reveal_type(mymap(f3, seq))  # N: Revealed type is "typing.Iterable[builtins.str]"
 
 [builtins fixtures/list.pyi]
 [typing fixtures/typing-medium.pyi]
@@ -3660,9 +3660,9 @@ f1: Callable[[int], str]
 f2: None
 f3: Optional[Callable[[int], str]]
 
-reveal_type(mymap(f1, seq))  # N: Revealed type is "typing.Iterable[builtins.str*]"
-reveal_type(mymap(f2, seq))  # N: Revealed type is "typing.Iterable[builtins.int*]"
-reveal_type(mymap(f3, seq))  # N: Revealed type is "Union[typing.Iterable[builtins.str*], typing.Iterable[builtins.int*]]"
+reveal_type(mymap(f1, seq))  # N: Revealed type is "typing.Iterable[builtins.str]"
+reveal_type(mymap(f2, seq))  # N: Revealed type is "typing.Iterable[builtins.int]"
+reveal_type(mymap(f3, seq))  # N: Revealed type is "Union[typing.Iterable[builtins.str], typing.Iterable[builtins.int]]"
 
 [builtins fixtures/list.pyi]
 [typing fixtures/typing-medium.pyi]
@@ -3978,11 +3978,11 @@ class MyModel:
 reveal_type(MyModel().my_number)  # N: Revealed type is "builtins.int"
 MyModel().my_number.foo()         # E: "int" has no attribute "foo"
 
-reveal_type(MyModel.my_number)        # N: Revealed type is "__main__.NumberAttribute[__main__.MyModel*]"
+reveal_type(MyModel.my_number)        # N: Revealed type is "__main__.NumberAttribute[__main__.MyModel]"
 reveal_type(MyModel.my_number.foo())  # N: Revealed type is "builtins.str"
 
-reveal_type(NumberAttribute[MyModel]().__get__(None, MyModel))  # N: Revealed type is "__main__.NumberAttribute[__main__.MyModel*]"
-reveal_type(NumberAttribute[str]().__get__(None, str))      # N: Revealed type is "__main__.NumberAttribute[builtins.str*]"
+reveal_type(NumberAttribute[MyModel]().__get__(None, MyModel))  # N: Revealed type is "__main__.NumberAttribute[__main__.MyModel]"
+reveal_type(NumberAttribute[str]().__get__(None, str))      # N: Revealed type is "__main__.NumberAttribute[builtins.str]"
 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-medium.pyi]
@@ -4025,7 +4025,7 @@ def add_proxy(x, y):
 
 # The lambda definition is a syntax error in Python 3
 tup = (1, '2')
-reveal_type(foo(lambda (x, y): add_proxy(x, y), tup))  # N: Revealed type is "builtins.str*"
+reveal_type(foo(lambda (x, y): add_proxy(x, y), tup))  # N: Revealed type is "builtins.str"
 [builtins fixtures/primitives.pyi]
 
 [case testOverloadWithClassMethods]
@@ -4536,10 +4536,10 @@ class Child(Parent):
     def child_only(self) -> int: pass
 
 x: Union[int, str]
-reveal_type(Parent().foo(3))                  # N: Revealed type is "__main__.Parent*"
-reveal_type(Child().foo(3))                   # N: Revealed type is "__main__.Child*"
+reveal_type(Parent().foo(3))                  # N: Revealed type is "__main__.Parent"
+reveal_type(Child().foo(3))                   # N: Revealed type is "__main__.Child"
 reveal_type(Child().foo("..."))               # N: Revealed type is "builtins.str"
-reveal_type(Child().foo(x))                   # N: Revealed type is "Union[__main__.Child*, builtins.str]"
+reveal_type(Child().foo(x))                   # N: Revealed type is "Union[__main__.Child, builtins.str]"
 reveal_type(Child().foo(3).child_only())      # N: Revealed type is "builtins.int"
 
 [case testOverloadAndClassTypes]
@@ -4567,10 +4567,10 @@ class Child(Parent):
     def child_only(self) -> int: pass
 
 x: Union[int, str]
-reveal_type(Parent.foo(3))                  # N: Revealed type is "Type[__main__.Parent*]"
-reveal_type(Child.foo(3))                   # N: Revealed type is "Type[__main__.Child*]"
+reveal_type(Parent.foo(3))                  # N: Revealed type is "Type[__main__.Parent]"
+reveal_type(Child.foo(3))                   # N: Revealed type is "Type[__main__.Child]"
 reveal_type(Child.foo("..."))               # N: Revealed type is "builtins.str"
-reveal_type(Child.foo(x))                   # N: Revealed type is "Union[Type[__main__.Child*], builtins.str]"
+reveal_type(Child.foo(x))                   # N: Revealed type is "Union[Type[__main__.Child], builtins.str]"
 reveal_type(Child.foo(3)().child_only())    # N: Revealed type is "builtins.int"
 [builtins fixtures/classmethod.pyi]
 
@@ -4893,7 +4893,7 @@ def f() -> None:
                      # N: Possible overload variants: \
                      # N:     def g(x: str) -> str \
                      # N:     def [T] g(x: T, y: int) -> T
-    reveal_type(g(str(), int()))  # N: Revealed type is "builtins.str*"
+    reveal_type(g(str(), int()))  # N: Revealed type is "builtins.str"
 [out]
 
 [case testNestedOverloadsTypeVarOverlap]
@@ -4922,14 +4922,14 @@ def f() -> None:
     @overload
     def g(x: T) -> Dict[int, T]: ...
     def g(*args, **kwargs) -> Any:
-        reveal_type(h(C()))  # N: Revealed type is "builtins.dict[builtins.str, __main__.C*]"
+        reveal_type(h(C()))  # N: Revealed type is "builtins.dict[builtins.str, __main__.C]"
 
     @overload
     def h() -> None: ...
     @overload
     def h(x: T) -> Dict[str, T]: ...
     def h(*args, **kwargs) -> Any:
-        reveal_type(g(C()))  # N: Revealed type is "builtins.dict[builtins.int, __main__.C*]"
+        reveal_type(g(C()))  # N: Revealed type is "builtins.dict[builtins.int, __main__.C]"
 
 [builtins fixtures/dict.pyi]
 [out]
@@ -4938,7 +4938,7 @@ def f() -> None:
 from lib import attr
 from typing import Any
 
-reveal_type(attr(1))  # N: Revealed type is "builtins.int*"
+reveal_type(attr(1))  # N: Revealed type is "builtins.int"
 reveal_type(attr("hi"))  # N: Revealed type is "builtins.int"
 x: Any
 reveal_type(attr(x)) # N: Revealed type is "Any"
@@ -4961,7 +4961,7 @@ def attr(default: Any = ...) -> int: ...
 from lib import attr
 from typing import Any
 
-reveal_type(attr(1))  # N: Revealed type is "builtins.int*"
+reveal_type(attr(1))  # N: Revealed type is "builtins.int"
 reveal_type(attr("hi"))  # N: Revealed type is "builtins.int"
 x: Any
 reveal_type(attr(x)) # N: Revealed type is "Any"
@@ -5298,7 +5298,7 @@ def compose(f: Callable[[U], V], g: Callable[[W], U]) -> Callable[[W], V]:
 ID = NewType("ID", fakeint)
 
 compose(ID, fakeint)("test")
-reveal_type(compose(ID, fakeint))  # N: Revealed type is "def (Union[builtins.str, builtins.bytes]) -> __main__.ID*"
+reveal_type(compose(ID, fakeint))  # N: Revealed type is "def (Union[builtins.str, builtins.bytes]) -> __main__.ID"
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -50,8 +50,8 @@ def tmpcontextmanagerlike(x: Callable[P, Iterator[T]]) -> Callable[P, List[T]]: 
 def whatever(x: int) -> Iterator[int]:
     yield x
 
-reveal_type(whatever)  # N: Revealed type is "def (x: builtins.int) -> builtins.list[builtins.int*]"
-reveal_type(whatever(217))  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(whatever)  # N: Revealed type is "def (x: builtins.int) -> builtins.list[builtins.int]"
+reveal_type(whatever(217))  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/tuple.pyi]
 
 [case testInvalidParamSpecType]
@@ -217,7 +217,7 @@ def dec(f: Callable[P, T]) -> Callable[P, List[T]]:
 @dec
 def g(x: int, y: str = '') -> int: ...
 
-reveal_type(g)  # N: Revealed type is "def (x: builtins.int, y: builtins.str =) -> builtins.list[builtins.int*]"
+reveal_type(g)  # N: Revealed type is "def (x: builtins.int, y: builtins.str =) -> builtins.list[builtins.int]"
 [builtins fixtures/dict.pyi]
 
 [case testParamSpecArgsAndKwargsTypes]
@@ -298,19 +298,19 @@ def join(x: T, y: T) -> T: ...
 class C(Generic[P, P2]):
     def m(self, f: Callable[P, None], g: Callable[P2, None]) -> None:
         reveal_type(join(f, f))  # N: Revealed type is "def (*P.args, **P.kwargs)"
-        reveal_type(join(f, g))  # N: Revealed type is "builtins.function*"
+        reveal_type(join(f, g))  # N: Revealed type is "builtins.function"
 
     def m2(self, *args: P.args, **kwargs: P.kwargs) -> None:
         reveal_type(join(args, args))  # N: Revealed type is "P.args`1"
         reveal_type(join(kwargs, kwargs))  # N: Revealed type is "P.kwargs`1"
-        reveal_type(join(args, kwargs))  # N: Revealed type is "builtins.object*"
+        reveal_type(join(args, kwargs))  # N: Revealed type is "builtins.object"
         def f(*args2: P2.args, **kwargs2: P2.kwargs) -> None:
-            reveal_type(join(args, args2))  # N: Revealed type is "builtins.object*"
-            reveal_type(join(kwargs, kwargs2))  # N: Revealed type is "builtins.object*"
+            reveal_type(join(args, args2))  # N: Revealed type is "builtins.object"
+            reveal_type(join(kwargs, kwargs2))  # N: Revealed type is "builtins.object"
 
     def m3(self, c: C[P, P3]) -> None:
-        reveal_type(join(c, c))  # N: Revealed type is "__main__.C*[P`1, P3`-1]"
-        reveal_type(join(self, c))  # N: Revealed type is "builtins.object*"
+        reveal_type(join(c, c))  # N: Revealed type is "__main__.C[P`1, P3`-1]"
+        reveal_type(join(self, c))  # N: Revealed type is "builtins.object"
 [builtins fixtures/dict.pyi]
 
 [case testParamSpecClassWithAny]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -625,10 +625,10 @@ def close_all(args: Sequence[Closeable[T]]) -> T:
 
 arg: Closeable[int]
 
-reveal_type(close(F())) # N: Revealed type is "builtins.int*"
-reveal_type(close(arg)) # N: Revealed type is "builtins.int*"
-reveal_type(close_all([F()])) # N: Revealed type is "builtins.int*"
-reveal_type(close_all([arg])) # N: Revealed type is "builtins.int*"
+reveal_type(close(F())) # N: Revealed type is "builtins.int"
+reveal_type(close(arg)) # N: Revealed type is "builtins.int"
+reveal_type(close_all([F()])) # N: Revealed type is "builtins.int"
+reveal_type(close_all([arg])) # N: Revealed type is "builtins.int"
 [builtins fixtures/isinstancelist.pyi]
 [typing fixtures/typing-medium.pyi]
 
@@ -647,7 +647,7 @@ class C:
 
 def fun3(x: P[T, T]) -> T:
     pass
-reveal_type(fun3(C())) # N: Revealed type is "builtins.int*"
+reveal_type(fun3(C())) # N: Revealed type is "builtins.int"
 
 [case testProtocolGenericInferenceCovariant]
 from typing import Generic, TypeVar, Protocol
@@ -665,7 +665,7 @@ class C:
 
 def fun4(x: U, y: P[U, U]) -> U:
     pass
-reveal_type(fun4('a', C())) # N: Revealed type is "builtins.object*"
+reveal_type(fun4('a', C())) # N: Revealed type is "builtins.object"
 
 [case testUnrealtedGenericProtolsEquivalent]
 from typing import TypeVar, Protocol
@@ -912,7 +912,7 @@ class L:
 def last(seq: Linked[T]) -> T:
     pass
 
-reveal_type(last(L())) # N: Revealed type is "builtins.int*"
+reveal_type(last(L())) # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
 [case testRecursiveProtocolSubtleMismatch]
@@ -1050,7 +1050,7 @@ class C(Generic[T]):
 
 x: C[int]
 def f(arg: P[T]) -> T: pass
-reveal_type(f(x)) #E: Revealed type is "builtins.int*"
+reveal_type(f(x)) #E: Revealed type is "builtins.int"
 
 -- @property, @classmethod and @staticmethod in protocol types
 -- -----------------------------------------------------------
@@ -1353,9 +1353,9 @@ y: P2
 l0 = [x, x]
 l1 = [y, y]
 l = [x, y]
-reveal_type(l0) # N: Revealed type is "builtins.list[__main__.P*]"
-reveal_type(l1) # N: Revealed type is "builtins.list[__main__.P2*]"
-reveal_type(l) # N: Revealed type is "builtins.list[__main__.P*]"
+reveal_type(l0) # N: Revealed type is "builtins.list[__main__.P]"
+reveal_type(l1) # N: Revealed type is "builtins.list[__main__.P2]"
+reveal_type(l) # N: Revealed type is "builtins.list[__main__.P]"
 [builtins fixtures/list.pyi]
 
 [case testJoinOfIncompatibleProtocols]
@@ -1368,7 +1368,7 @@ class P2(Protocol):
 
 x: P
 y: P2
-reveal_type([x, y]) # N: Revealed type is "builtins.list[builtins.object*]"
+reveal_type([x, y]) # N: Revealed type is "builtins.list[builtins.object]"
 [builtins fixtures/list.pyi]
 
 [case testJoinProtocolWithNormal]
@@ -1385,7 +1385,7 @@ y: C
 
 l = [x, y]
 
-reveal_type(l) # N: Revealed type is "builtins.list[__main__.P*]"
+reveal_type(l) # N: Revealed type is "builtins.list[__main__.P]"
 [builtins fixtures/list.pyi]
 
 [case testMeetProtocolWithProtocol]
@@ -1400,7 +1400,7 @@ class P2(Protocol):
 T = TypeVar('T')
 def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: P, y: P2) -> None: pass
-reveal_type(f(g)) # N: Revealed type is "__main__.P2*"
+reveal_type(f(g)) # N: Revealed type is "__main__.P2"
 
 [case testMeetOfIncompatibleProtocols]
 from typing import Protocol, Callable, TypeVar
@@ -1426,7 +1426,7 @@ class C:
 T = TypeVar('T')
 def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: P, y: C) -> None: pass
-reveal_type(f(g)) # N: Revealed type is "__main__.C*"
+reveal_type(f(g)) # N: Revealed type is "__main__.C"
 
 [case testInferProtocolFromProtocol]
 from typing import Protocol, Sequence, TypeVar, Generic
@@ -1445,8 +1445,8 @@ class L(Generic[T]):
 def last(seq: Linked[T]) -> T:
     pass
 
-reveal_type(last(L[int]())) # N: Revealed type is "__main__.Box*[builtins.int*]"
-reveal_type(last(L[str]()).content) # N: Revealed type is "builtins.str*"
+reveal_type(last(L[int]())) # N: Revealed type is "__main__.Box[builtins.int]"
+reveal_type(last(L[str]()).content) # N: Revealed type is "builtins.str"
 
 [case testOverloadOnProtocol]
 from typing import overload, Protocol, runtime_checkable
@@ -1828,9 +1828,9 @@ fun(N2(1)) # E: Argument 1 to "fun" has incompatible type "N2"; expected "P[int,
            # N: "N2" is missing following "P" protocol member: \
            # N:     y
 
-reveal_type(fun3(z)) # N: Revealed type is "builtins.object*"
+reveal_type(fun3(z)) # N: Revealed type is "builtins.object"
 
-reveal_type(fun3(z3)) # N: Revealed type is "builtins.int*"
+reveal_type(fun3(z3)) # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
 [case testBasicCallableStructuralSubtyping]
@@ -1849,7 +1849,7 @@ T = TypeVar('T')
 def apply_gen(f: Callable[[T], T]) -> T:
     pass
 
-reveal_type(apply_gen(Add5())) # N: Revealed type is "builtins.int*"
+reveal_type(apply_gen(Add5())) # N: Revealed type is "builtins.int"
 def apply_str(f: Callable[[str], int], x: str) -> int:
     return f(x)
 apply_str(Add5(), 'a') # E: Argument 1 to "apply_str" has incompatible type "Add5"; expected "Callable[[str], int]" \
@@ -1890,7 +1890,7 @@ def inc(a: int, temp: str) -> int:
 def foo(f: Callable[[int], T]) -> T:
     return f(1)
 
-reveal_type(foo(partial(inc, 'temp'))) # N: Revealed type is "builtins.int*"
+reveal_type(foo(partial(inc, 'temp'))) # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
 [case testStructuralInferenceForCallable]
@@ -1903,7 +1903,7 @@ class Actual:
     def __call__(self, arg: int) -> str: pass
 
 def fun(cb: Callable[[T], S]) -> Tuple[T, S]: pass
-reveal_type(fun(Actual())) # N: Revealed type is "Tuple[builtins.int*, builtins.str*]"
+reveal_type(fun(Actual())) # N: Revealed type is "Tuple[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
 -- Standard protocol types (SupportsInt, Sized, etc.)
@@ -2028,8 +2028,8 @@ class A:
 
 class B(A): pass
 
-reveal_type(list(b for b in B()))  # N: Revealed type is "builtins.list[__main__.B*]"
-reveal_type(list(B()))  # N: Revealed type is "builtins.list[__main__.B*]"
+reveal_type(list(b for b in B()))  # N: Revealed type is "builtins.list[__main__.B]"
+reveal_type(list(B()))  # N: Revealed type is "builtins.list[__main__.B]"
 [builtins fixtures/list.pyi]
 
 [case testIterableProtocolOnMetaclass]
@@ -2045,8 +2045,8 @@ class E(metaclass=EMeta):
 class C(E):
     pass
 
-reveal_type(list(c for c in C))  # N: Revealed type is "builtins.list[__main__.C*]"
-reveal_type(list(C))  # N: Revealed type is "builtins.list[__main__.C*]"
+reveal_type(list(c for c in C))  # N: Revealed type is "builtins.list[__main__.C]"
+reveal_type(list(C))  # N: Revealed type is "builtins.list[__main__.C]"
 [builtins fixtures/list.pyi]
 
 [case testClassesGetattrWithProtocols]
@@ -2452,7 +2452,7 @@ def call(x: int, y: str) -> Tuple[int, str]: ...
 def func(caller: Caller[T, S]) -> Tuple[T, S]:
     pass
 
-reveal_type(func(call))  # N: Revealed type is "Tuple[builtins.int*, builtins.str*]"
+reveal_type(func(call))  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -2689,10 +2689,10 @@ foo(ONE)
 foo(TWO)
 foo(3)
 
-reveal_type(abs(ONE))  # N: Revealed type is "builtins.int*"
-reveal_type(abs(TWO))  # N: Revealed type is "builtins.int*"
-reveal_type(abs(3))  # N: Revealed type is "builtins.int*"
-reveal_type(abs(ALL))  # N: Revealed type is "builtins.int*"
+reveal_type(abs(ONE))  # N: Revealed type is "builtins.int"
+reveal_type(abs(TWO))  # N: Revealed type is "builtins.int"
+reveal_type(abs(3))  # N: Revealed type is "builtins.int"
+reveal_type(abs(ALL))  # N: Revealed type is "builtins.int"
 [builtins fixtures/float.pyi]
 [typing fixtures/typing-full.pyi]
 
@@ -2744,13 +2744,13 @@ class Blooper:
     flap = None
 
     def bloop(self, x: Flapper) -> None:
-        reveal_type([self, x])  # N: Revealed type is "builtins.list[builtins.object*]"
+        reveal_type([self, x])  # N: Revealed type is "builtins.list[builtins.object]"
 
 class Gleemer:
     flap = []  # E: Need type annotation for "flap" (hint: "flap: List[<type>] = ...")
 
     def gleem(self, x: Flapper) -> None:
-        reveal_type([self, x])  # N: Revealed type is "builtins.list[builtins.object*]"
+        reveal_type([self, x])  # N: Revealed type is "builtins.list[builtins.object]"
 [builtins fixtures/tuple.pyi]
 
 
@@ -2768,7 +2768,7 @@ class DataArray(ObjectHashable):
     __hash__ = None
 
     def f(self, x: Hashable) -> None:
-        reveal_type([self, x])  # N: Revealed type is "builtins.list[builtins.object*]"
+        reveal_type([self, x])  # N: Revealed type is "builtins.list[builtins.object]"
 [builtins fixtures/tuple.pyi]
 
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -90,7 +90,7 @@ m: List[int]
 
 match m:
     case [a]:
-        reveal_type(a)  # N: Revealed type is "builtins.int*"
+        reveal_type(a)  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
 [case testMatchSequencePatternCapturesStarred]
@@ -99,8 +99,8 @@ m: Sequence[int]
 
 match m:
     case [a, *b]:
-        reveal_type(a)  # N: Revealed type is "builtins.int*"
-        reveal_type(b)  # N: Revealed type is "builtins.list[builtins.int*]"
+        reveal_type(a)  # N: Revealed type is "builtins.int"
+        reveal_type(b)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testMatchSequencePatternNarrowsInner]
@@ -191,27 +191,27 @@ match m1:
 
 match m2:
     case [b]:
-        reveal_type(b)  # N: Revealed type is "builtins.int*"
+        reveal_type(b)  # N: Revealed type is "builtins.int"
 
 match m3:
     case [c]:
-        reveal_type(c)  # N: Revealed type is "builtins.int*"
+        reveal_type(c)  # N: Revealed type is "builtins.int"
 
 match m4:
     case [d]:
-        reveal_type(d)  # N: Revealed type is "builtins.int*"
+        reveal_type(d)  # N: Revealed type is "builtins.int"
 
 match m5:
     case [e]:
-        reveal_type(e)  # N: Revealed type is "builtins.int*"
+        reveal_type(e)  # N: Revealed type is "builtins.int"
 
 match m6:
     case [f]:
-        reveal_type(f)  # N: Revealed type is "builtins.int*"
+        reveal_type(f)  # N: Revealed type is "builtins.int"
 
 match m7:
     case [g]:
-        reveal_type(g)  # N: Revealed type is "builtins.int*"
+        reveal_type(g)  # N: Revealed type is "builtins.int"
 
 match m8:
     case [h]:
@@ -335,9 +335,9 @@ m: Dict[str, int]
 
 match m:
     case {"key": v}:
-        reveal_type(v)  # N: Revealed type is "builtins.int*"
+        reveal_type(v)  # N: Revealed type is "builtins.int"
     case {b.b: v2}:
-        reveal_type(v2)  # N: Revealed type is "builtins.int*"
+        reveal_type(v2)  # N: Revealed type is "builtins.int"
 [file b.py]
 b: str
 [builtins fixtures/dict.pyi]
@@ -350,9 +350,9 @@ m: Dict[str, int]
 
 match m:
     case {1: v}:
-        reveal_type(v)  # N: Revealed type is "builtins.int*"
+        reveal_type(v)  # N: Revealed type is "builtins.int"
     case {b.b: v2}:
-        reveal_type(v2)  # N: Revealed type is "builtins.int*"
+        reveal_type(v2)  # N: Revealed type is "builtins.int"
 [file b.py]
 b: int
 [builtins fixtures/dict.pyi]
@@ -375,7 +375,7 @@ match m:
         reveal_type(v3)  # N: Revealed type is "builtins.str"
         reveal_type(v4)  # N: Revealed type is "builtins.int"
     case {"o": v5}:
-        reveal_type(v5)  # N: Revealed type is "builtins.object*"
+        reveal_type(v5)  # N: Revealed type is "builtins.object"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testMatchMappingPatternCapturesTypedDictWithLiteral]
@@ -397,7 +397,7 @@ match m:
         reveal_type(v3)  # N: Revealed type is "builtins.str"
         reveal_type(v4)  # N: Revealed type is "builtins.int"
     case {b.o: v5}:
-        reveal_type(v5)  # N: Revealed type is "builtins.object*"
+        reveal_type(v5)  # N: Revealed type is "builtins.object"
 [file b.py]
 from typing import Final, Literal
 a: Final = "a"
@@ -417,7 +417,7 @@ m: A
 
 match m:
     case {b.a: v}:
-        reveal_type(v)  # N: Revealed type is "builtins.object*"
+        reveal_type(v)  # N: Revealed type is "builtins.object"
 [file b.py]
 from typing import Final, Literal
 a: str
@@ -458,7 +458,7 @@ m: Mapping[str, int]
 
 match m:
     case {'k': 1, **r}:
-        reveal_type(r)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+        reveal_type(r)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
 [builtins fixtures/dict.pyi]
 
 -- Mapping patterns currently do not narrow --
@@ -698,7 +698,7 @@ m: A[int]
 match m:
     case A(a=i):
         reveal_type(m)  # N: Revealed type is "__main__.A[builtins.int]"
-        reveal_type(i)  # N: Revealed type is "builtins.int*"
+        reveal_type(i)  # N: Revealed type is "builtins.int"
 
 [case testMatchClassPatternCaptureFilledGenericTypeAlias]
 from typing import Generic, TypeVar
@@ -888,9 +888,9 @@ match x:
     case list([({-0-0j: int(real=0+0j, imag=0-0j) | (1) as z},)]):
         y = 0
 
-reveal_type(x)  # N: Revealed type is "builtins.list[builtins.list*[builtins.dict*[builtins.int*, builtins.int*]]]"
+reveal_type(x)  # N: Revealed type is "builtins.list[builtins.list[builtins.dict[builtins.int, builtins.int]]]"
 reveal_type(y)  # N: Revealed type is "builtins.int"
-reveal_type(z)  # N: Revealed type is "builtins.int*"
+reveal_type(z)  # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
 
 [case testMatchNonFinalMatchArgs]
@@ -1023,7 +1023,7 @@ m: List[int]
 match m:
     case [x, y] | list(x):  # E: Alternative patterns bind different names
         reveal_type(x)  # N: Revealed type is "builtins.object"
-        reveal_type(y)  # N: Revealed type is "builtins.int*"
+        reveal_type(y)  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
 [case testMatchOrPatternCapturesJoin]
@@ -1495,7 +1495,7 @@ from typing import List
 def f(x: List[int] | int) -> None:
     match x:
         case [*y]:
-            reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int*]"
+            reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int]"
             return
     reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -222,23 +222,23 @@ while b := "x":
 
 l = [y2 := 1, y2 + 2, y2 + 3]
 reveal_type(y2)  # N: Revealed type is "builtins.int"
-reveal_type(l)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(l)  # N: Revealed type is "builtins.list[builtins.int]"
 
 filtered_data = [y3 for x in l if (y3 := a) is not None]
-reveal_type(filtered_data)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(filtered_data)  # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(y3)  # N: Revealed type is "builtins.int"
 
 d = {'a': (a2 := 1), 'b': a2 + 1, 'c': a2 + 2}
-reveal_type(d)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+reveal_type(d)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
 reveal_type(a2)  # N: Revealed type is "builtins.int"
 
 d2 = {(prefix := 'key_') + 'a': (start_val := 1), prefix + 'b': start_val + 1, prefix + 'c': start_val + 2}
-reveal_type(d2)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+reveal_type(d2)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
 reveal_type(prefix)  # N: Revealed type is "builtins.str"
 reveal_type(start_val)  # N: Revealed type is "builtins.int"
 
 filtered_dict = {k: new_v for k, v in [('a', 1), ('b', 2), ('c', 3)] if (new_v := v + 1) == 2}
-reveal_type(filtered_dict)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+reveal_type(filtered_dict)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
 reveal_type(new_v)  # N: Revealed type is "builtins.int"
 
 def f(x: int = (c := 4)) -> int:
@@ -255,23 +255,23 @@ def f(x: int = (c := 4)) -> int:
 
     l = [y2 := 1, y2 + 2, y2 + 3]
     reveal_type(y2)  # N: Revealed type is "builtins.int"
-    reveal_type(l)  # N: Revealed type is "builtins.list[builtins.int*]"
+    reveal_type(l)  # N: Revealed type is "builtins.list[builtins.int]"
 
     filtered_data = [y3 for x in l if (y3 := a) is not None]
-    reveal_type(filtered_data)  # N: Revealed type is "builtins.list[builtins.int*]"
+    reveal_type(filtered_data)  # N: Revealed type is "builtins.list[builtins.int]"
     reveal_type(y3)  # N: Revealed type is "builtins.int"
 
     d = {'a': (a2 := 1), 'b': a2 + 1, 'c': a2 + 2}
-    reveal_type(d)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+    reveal_type(d)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
     reveal_type(a2)  # N: Revealed type is "builtins.int"
 
     d2 = {(prefix := 'key_') + 'a': (start_val := 1), prefix + 'b': start_val + 1, prefix + 'c': start_val + 2}
-    reveal_type(d2)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+    reveal_type(d2)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
     reveal_type(prefix)  # N: Revealed type is "builtins.str"
     reveal_type(start_val)  # N: Revealed type is "builtins.int"
 
     filtered_dict = {k: new_v for k, v in [('a', 1), ('b', 2), ('c', 3)] if (new_v := v + 1) == 2}
-    reveal_type(filtered_dict)  # N: Revealed type is "builtins.dict[builtins.str*, builtins.int*]"
+    reveal_type(filtered_dict)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
     reveal_type(new_v)  # N: Revealed type is "builtins.int"
 
     # https://www.python.org/dev/peps/pep-0572/#exceptional-cases
@@ -372,10 +372,10 @@ class AssignmentExpressionsClass:
 
         l = [z2 := 1, z2 + 2, z2 + 3]
         reveal_type(z2)  # N: Revealed type is "builtins.int"
-        reveal_type(l)  # N: Revealed type is "builtins.list[builtins.int*]"
+        reveal_type(l)  # N: Revealed type is "builtins.list[builtins.int]"
 
         filtered_data = [z3 for x in l if (z3 := 1) is not None]
-        reveal_type(filtered_data)  # N: Revealed type is "builtins.list[builtins.int*]"
+        reveal_type(filtered_data)  # N: Revealed type is "builtins.list[builtins.int]"
         reveal_type(z3)  # N: Revealed type is "builtins.int"
 
 # Assignment expressions from inside the class should not escape the class scope.

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -57,10 +57,10 @@ T = TypeVar('T')
 
 def f(x: int) -> None:
     x = g(x)
-    reveal_type(x)  # N: Revealed type is "Union[builtins.int*, builtins.str]"
+    reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
     y = 1
     y = g(y)
-    reveal_type(y)  # N: Revealed type is "Union[builtins.int*, builtins.str]"
+    reveal_type(y)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 def g(x: T) -> Union[T, str]: pass
 
@@ -71,11 +71,11 @@ def f(a: Iterable[int], b: Iterable[str]) -> None:
     for x in a:
         x = '' \
         # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-    reveal_type(x) # N: Revealed type is "builtins.int*"
+    reveal_type(x) # N: Revealed type is "builtins.int"
     for x in b:
         x = 1 \
         # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-    reveal_type(x) # N: Revealed type is "builtins.str*"
+    reveal_type(x) # N: Revealed type is "builtins.str"
 
 def g(a: Iterable[int]) -> None:
     for x in a: pass
@@ -376,10 +376,10 @@ for x in it2:
     reveal_type(x)
 reveal_type(x)
 [out]
-tmp/m.py:6: note: Revealed type is "builtins.int*"
-tmp/m.py:8: note: Revealed type is "builtins.str*"
-tmp/m.py:9: note: Revealed type is "builtins.str*"
-main:3: note: Revealed type is "builtins.str*"
+tmp/m.py:6: note: Revealed type is "builtins.int"
+tmp/m.py:8: note: Revealed type is "builtins.str"
+tmp/m.py:9: note: Revealed type is "builtins.str"
+main:3: note: Revealed type is "builtins.str"
 
 [case testRedefineGlobalBasedOnPreviousValues]
 # flags: --allow-redefinition
@@ -388,7 +388,7 @@ T = TypeVar('T')
 def f(x: T) -> Iterable[T]: pass
 a = 0
 a = f(a)
-reveal_type(a) # N: Revealed type is "typing.Iterable[builtins.int*]"
+reveal_type(a) # N: Revealed type is "typing.Iterable[builtins.int]"
 
 [case testRedefineGlobalWithSeparateDeclaration]
 # flags: --allow-redefinition
@@ -412,7 +412,7 @@ x = 0
 reveal_type(x)  # N: Revealed type is "builtins.int"
 for x in f(x):
     pass
-reveal_type(x)  # N: Revealed type is "Union[builtins.int*, builtins.str]"
+reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testNoRedefinitionIfOnlyInitialized]
 # flags: --allow-redefinition --no-strict-optional

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -9,10 +9,10 @@ class A:
 class B(A):
     pass
 
-reveal_type(A().copy)  # N: Revealed type is "def () -> __main__.A*"
-reveal_type(B().copy)  # N: Revealed type is "def () -> __main__.B*"
-reveal_type(A().copy())  # N: Revealed type is "__main__.A*"
-reveal_type(B().copy())  # N: Revealed type is "__main__.B*"
+reveal_type(A().copy)  # N: Revealed type is "def () -> __main__.A"
+reveal_type(B().copy)  # N: Revealed type is "def () -> __main__.B"
+reveal_type(A().copy())  # N: Revealed type is "__main__.A"
+reveal_type(B().copy())  # N: Revealed type is "__main__.B"
 
 [builtins fixtures/bool.pyi]
 
@@ -99,10 +99,10 @@ class C:
             return cls()  # E: Missing positional argument "a" in call to "C"
 
 
-reveal_type(A.new)  # N: Revealed type is "def () -> __main__.A*"
-reveal_type(B.new)  # N: Revealed type is "def () -> __main__.B*"
-reveal_type(A.new())  # N: Revealed type is "__main__.A*"
-reveal_type(B.new())  # N: Revealed type is "__main__.B*"
+reveal_type(A.new)  # N: Revealed type is "def () -> __main__.A"
+reveal_type(B.new)  # N: Revealed type is "def () -> __main__.B"
+reveal_type(A.new())  # N: Revealed type is "__main__.A"
+reveal_type(B.new())  # N: Revealed type is "__main__.B"
 
 [builtins fixtures/classmethod.pyi]
 
@@ -121,10 +121,10 @@ Q = TypeVar('Q', bound='C', covariant=True)
 class C(A):
     def copy(self: Q) -> Q: pass
 
-reveal_type(C().copy)  # N: Revealed type is "def () -> __main__.C*"
-reveal_type(C().copy())  # N: Revealed type is "__main__.C*"
-reveal_type(cast(A, C()).copy)  # N: Revealed type is "def () -> __main__.A*"
-reveal_type(cast(A, C()).copy())  # N: Revealed type is "__main__.A*"
+reveal_type(C().copy)  # N: Revealed type is "def () -> __main__.C"
+reveal_type(C().copy())  # N: Revealed type is "__main__.C"
+reveal_type(cast(A, C()).copy)  # N: Revealed type is "def () -> __main__.A"
+reveal_type(cast(A, C()).copy())  # N: Revealed type is "__main__.A"
 
 [builtins fixtures/bool.pyi]
 
@@ -164,10 +164,10 @@ class A:
 class B(A):
     pass
 
-reveal_type(A().copy)  # N: Revealed type is "def (factory: def (__main__.A*) -> __main__.A*) -> __main__.A*"
-reveal_type(B().copy)  # N: Revealed type is "def (factory: def (__main__.B*) -> __main__.B*) -> __main__.B*"
-reveal_type(A.new)  # N: Revealed type is "def (factory: def (__main__.A*) -> __main__.A*) -> __main__.A*"
-reveal_type(B.new)  # N: Revealed type is "def (factory: def (__main__.B*) -> __main__.B*) -> __main__.B*"
+reveal_type(A().copy)  # N: Revealed type is "def (factory: def (__main__.A) -> __main__.A) -> __main__.A"
+reveal_type(B().copy)  # N: Revealed type is "def (factory: def (__main__.B) -> __main__.B) -> __main__.B"
+reveal_type(A.new)  # N: Revealed type is "def (factory: def (__main__.A) -> __main__.A) -> __main__.A"
+reveal_type(B.new)  # N: Revealed type is "def (factory: def (__main__.B) -> __main__.B) -> __main__.B"
 
 [builtins fixtures/classmethod.pyi]
 
@@ -220,10 +220,10 @@ class C:
 
 class D(C): pass
 
-reveal_type(D.new)  # N: Revealed type is "def () -> __main__.D*"
-reveal_type(D().new)  # N: Revealed type is "def () -> __main__.D*"
-reveal_type(D.new())  # N: Revealed type is "__main__.D*"
-reveal_type(D().new())  # N: Revealed type is "__main__.D*"
+reveal_type(D.new)  # N: Revealed type is "def () -> __main__.D"
+reveal_type(D().new)  # N: Revealed type is "def () -> __main__.D"
+reveal_type(D.new())  # N: Revealed type is "__main__.D"
+reveal_type(D().new())  # N: Revealed type is "__main__.D"
 
 Q = TypeVar('Q', bound=C)
 
@@ -381,13 +381,13 @@ class B(A):
     pass
 
 reveal_type(A().g)  # N: Revealed type is "builtins.int"
-reveal_type(A().gt)  # N: Revealed type is "__main__.A*"
+reveal_type(A().gt)  # N: Revealed type is "__main__.A"
 reveal_type(A().f())  # N: Revealed type is "builtins.int"
-reveal_type(A().ft())  # N: Revealed type is "__main__.A*"
+reveal_type(A().ft())  # N: Revealed type is "__main__.A"
 reveal_type(B().g)  # N: Revealed type is "builtins.int"
-reveal_type(B().gt)  # N: Revealed type is "__main__.B*"
+reveal_type(B().gt)  # N: Revealed type is "__main__.B"
 reveal_type(B().f())  # N: Revealed type is "builtins.int"
-reveal_type(B().ft())  # N: Revealed type is "__main__.B*"
+reveal_type(B().ft())  # N: Revealed type is "__main__.B"
 
 [builtins fixtures/property.pyi]
 
@@ -556,8 +556,8 @@ reveal_type(P(use_str=True))  # N: Revealed type is "lib.P[builtins.str]"
 reveal_type(P(use_str=False))  # N: Revealed type is "lib.P[builtins.int]"
 
 reveal_type(C)  # N: Revealed type is "Overload(def [T] (item: T`1, use_tuple: Literal[False]) -> lib.C[T`1], def [T] (item: T`1, use_tuple: Literal[True]) -> lib.C[builtins.tuple[T`1, ...]])"
-reveal_type(C(0, use_tuple=False))  # N: Revealed type is "lib.C[builtins.int*]"
-reveal_type(C(0, use_tuple=True))  # N: Revealed type is "lib.C[builtins.tuple[builtins.int*, ...]]"
+reveal_type(C(0, use_tuple=False))  # N: Revealed type is "lib.C[builtins.int]"
+reveal_type(C(0, use_tuple=True))  # N: Revealed type is "lib.C[builtins.tuple[builtins.int, ...]]"
 
 T = TypeVar('T')
 class SubP(P[T]):
@@ -674,7 +674,7 @@ b: Bad
 f.atomic_close()  # OK
 b.atomic_close()  # E: Invalid self argument "Bad" to attribute function "atomic_close" with type "Callable[[Resource], int]"
 
-reveal_type(f.copy())  # N: Revealed type is "__main__.File*"
+reveal_type(f.copy())  # N: Revealed type is "__main__.File"
 b.copy()  # E: Invalid self argument "Bad" to attribute function "copy" with type "Callable[[T], T]"
 [builtins fixtures/tuple.pyi]
 
@@ -873,7 +873,7 @@ class Super(Generic[Q]):
 class Sub(Super[int]): ...
 
 def test(x: List[Sub]) -> None:
-    reveal_type(Sub.meth(x))  # N: Revealed type is "builtins.list[__main__.Sub*]"
+    reveal_type(Sub.meth(x))  # N: Revealed type is "builtins.list[__main__.Sub]"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testSelfTypeNoTypeVarsRestrict]
@@ -885,7 +885,7 @@ S = TypeVar('S')
 class C(Generic[T]):
     def limited(self: C[str], arg: S) -> S: ...
 
-reveal_type(C[str]().limited(0))  # N: Revealed type is "builtins.int*"
+reveal_type(C[str]().limited(0))  # N: Revealed type is "builtins.int"
 
 [case testSelfTypeMultipleTypeVars]
 from typing import Generic, TypeVar, Tuple
@@ -912,7 +912,7 @@ class C:
     def same(self: T) -> T: ...
 
 x: Union[A, C]
-reveal_type(x.same)  # N: Revealed type is "Union[builtins.int, def () -> __main__.C*]"
+reveal_type(x.same)  # N: Revealed type is "Union[builtins.int, def () -> __main__.C]"
 
 [case testSelfTypeOnUnionClassMethod]
 from typing import TypeVar, Union, Type
@@ -927,7 +927,7 @@ class C:
     def same(cls: Type[T]) -> T: ...
 
 x: Union[A, C]
-reveal_type(x.same)  # N: Revealed type is "Union[builtins.int, def () -> __main__.C*]"
+reveal_type(x.same)  # N: Revealed type is "Union[builtins.int, def () -> __main__.C]"
 [builtins fixtures/classmethod.pyi]
 
 [case SelfTypeOverloadedClassMethod]
@@ -948,8 +948,8 @@ class Sub(Base):
 class Other(Base): ...
 class Double(Sub): ...
 
-reveal_type(Other.make())  # N: Revealed type is "__main__.Other*"
-reveal_type(Other.make(3))  # N: Revealed type is "builtins.tuple[__main__.Other*, ...]"
+reveal_type(Other.make())  # N: Revealed type is "__main__.Other"
+reveal_type(Other.make(3))  # N: Revealed type is "builtins.tuple[__main__.Other, ...]"
 reveal_type(Double.make())  # N: Revealed type is "__main__.Sub"
 reveal_type(Double.make(3))  # N: Revealed type is "builtins.tuple[__main__.Sub, ...]"
 [file lib.pyi]
@@ -978,9 +978,9 @@ class B(A): ...
 class C(A): ...
 
 t: Type[Union[B, C]]
-reveal_type(t.meth)  # N: Revealed type is "Union[def () -> __main__.B*, def () -> __main__.C*]"
+reveal_type(t.meth)  # N: Revealed type is "Union[def () -> __main__.B, def () -> __main__.C]"
 x = t.meth()
-reveal_type(x)  # N: Revealed type is "Union[__main__.B*, __main__.C*]"
+reveal_type(x)  # N: Revealed type is "Union[__main__.B, __main__.C]"
 [builtins fixtures/classmethod.pyi]
 
 [case testSelfTypeClassMethodOnUnionGeneric]
@@ -1011,7 +1011,7 @@ class C(A): ...
 
 t: Type[Union[B, C]]
 x = t.meth()[0]
-reveal_type(x)  # N: Revealed type is "Union[__main__.B*, __main__.C*]"
+reveal_type(x)  # N: Revealed type is "Union[__main__.B, __main__.C]"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testSelfTypeClassMethodOverloadedOnInstance]
@@ -1035,14 +1035,14 @@ class AClass:
         ...
 
 def foo(x: Type[AClass]) -> None:
-    reveal_type(x.delete)  # N: Revealed type is "Overload(def (id: builtins.int, id2: builtins.int) -> builtins.int, def (id: __main__.AClass*, id2: None =) -> builtins.int)"
+    reveal_type(x.delete)  # N: Revealed type is "Overload(def (id: builtins.int, id2: builtins.int) -> builtins.int, def (id: __main__.AClass, id2: None =) -> builtins.int)"
     y = x()
-    reveal_type(y.delete)  # N: Revealed type is "Overload(def (id: builtins.int, id2: builtins.int) -> builtins.int, def (id: __main__.AClass*, id2: None =) -> builtins.int)"
+    reveal_type(y.delete)  # N: Revealed type is "Overload(def (id: builtins.int, id2: builtins.int) -> builtins.int, def (id: __main__.AClass, id2: None =) -> builtins.int)"
     y.delete(10, 20)
     y.delete(y)
 
 def bar(x: AClass) -> None:
-    reveal_type(x.delete)  # N: Revealed type is "Overload(def (id: builtins.int, id2: builtins.int) -> builtins.int, def (id: __main__.AClass*, id2: None =) -> builtins.int)"
+    reveal_type(x.delete)  # N: Revealed type is "Overload(def (id: builtins.int, id2: builtins.int) -> builtins.int, def (id: __main__.AClass, id2: None =) -> builtins.int)"
     x.delete(10, 20)
 [builtins fixtures/classmethod.pyi]
 
@@ -1062,7 +1062,7 @@ class Base(Generic[T]): ...
 class Sub(Base[T]):
     def __init__(self: Base[T], item: T) -> None: ...
 
-reveal_type(Sub(42))  # N: Revealed type is "__main__.Sub[builtins.int*]"
+reveal_type(Sub(42))  # N: Revealed type is "__main__.Sub[builtins.int]"
 
 [case testSelfTypeBadTypeIgnoredInConstructorOverload]
 from typing import overload

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -81,8 +81,8 @@ T = TypeVar('T')
 
 def f(x: T) -> T: return x
 [out2]
-tmp/a.py:2: note: Revealed type is "builtins.int*"
-tmp/a.py:3: note: Revealed type is "builtins.str*"
+tmp/a.py:2: note: Revealed type is "builtins.int"
+tmp/a.py:3: note: Revealed type is "builtins.str"
 
 [case testSerializeFunctionReturningGenericFunction]
 import a
@@ -100,7 +100,7 @@ T = TypeVar('T')
 def f() -> Callable[[T], T]: pass
 [out2]
 tmp/a.py:2: note: Revealed type is "def () -> def [T] (T`-1) -> T`-1"
-tmp/a.py:3: note: Revealed type is "builtins.str*"
+tmp/a.py:3: note: Revealed type is "builtins.str"
 
 [case testSerializeArgumentKinds]
 import a
@@ -369,8 +369,8 @@ class A(Generic[T, S]):
         return self.x
 [out2]
 tmp/a.py:3: error: Argument 1 to "A" has incompatible type "str"; expected "int"
-tmp/a.py:4: note: Revealed type is "builtins.str*"
-tmp/a.py:5: note: Revealed type is "builtins.int*"
+tmp/a.py:4: note: Revealed type is "builtins.str"
+tmp/a.py:5: note: Revealed type is "builtins.int"
 
 [case testSerializeAbstractClass]
 import a
@@ -484,8 +484,8 @@ T = TypeVar('T', bound='A')
 class A:
     def f(self: T) -> T: return self
 [out2]
-tmp/a.py:2: note: Revealed type is "b.A*"
-tmp/a.py:4: note: Revealed type is "a.B*"
+tmp/a.py:2: note: Revealed type is "b.A"
+tmp/a.py:4: note: Revealed type is "a.B"
 
 [case testSerializeInheritance]
 import a
@@ -529,7 +529,7 @@ class A(Generic[T]):
 class B(A[A[T]]):
     pass
 [out2]
-tmp/a.py:3: note: Revealed type is "b.A*[builtins.int*]"
+tmp/a.py:3: note: Revealed type is "b.A[builtins.int]"
 
 [case testSerializeFixedLengthTupleBaseClass]
 import a
@@ -565,7 +565,7 @@ class A(Tuple[int, ...]):
 [builtins fixtures/tuple.pyi]
 [out2]
 tmp/a.py:3: error: Too many arguments for "f" of "A"
-tmp/a.py:4: note: Revealed type is "Tuple[builtins.int*, builtins.int*]"
+tmp/a.py:4: note: Revealed type is "Tuple[builtins.int, builtins.int]"
 
 [case testSerializePlainTupleBaseClass]
 import a

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1298,7 +1298,7 @@ T = TypeVar('T')
 def f(a: T) -> Generator[int, str, T]: pass
 def g() -> Generator[int, str, float]:
     r = yield from f('')
-    reveal_type(r)  # N: Revealed type is "builtins.str*"
+    reveal_type(r)  # N: Revealed type is "builtins.str"
     return 3.14
 
 [case testYieldFromTupleStatement]
@@ -2107,14 +2107,14 @@ class A:
 [case testAugmentedAssignmentIntFloatDict]
 from typing import Dict
 d = {'weight0': 65.5}
-reveal_type(d['weight0'])  # N: Revealed type is "builtins.float*"
+reveal_type(d['weight0'])  # N: Revealed type is "builtins.float"
 d['weight0'] = 65
-reveal_type(d['weight0'])  # N: Revealed type is "builtins.float*"
+reveal_type(d['weight0'])  # N: Revealed type is "builtins.float"
 d['weight0'] *= 'a'  # E: Unsupported operand types for * ("float" and "str")
 d['weight0'] *= 0.5
-reveal_type(d['weight0'])  # N: Revealed type is "builtins.float*"
+reveal_type(d['weight0'])  # N: Revealed type is "builtins.float"
 d['weight0'] *= object()  # E: Unsupported operand types for * ("float" and "object")
-reveal_type(d['weight0']) # N: Revealed type is "builtins.float*"
+reveal_type(d['weight0']) # N: Revealed type is "builtins.float"
 
 [builtins fixtures/floatdict.pyi]
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -674,9 +674,9 @@ c1, *c2 = c
 d1, *d2 = d
 e1, *e2 = e
 
-reveal_type(a2)  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type(b2)  # N: Revealed type is "builtins.list[builtins.int*]"
-reveal_type(c2)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(a2)  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(b2)  # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(c2)  # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(d2)  # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(e2)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/tuple.pyi]
@@ -985,15 +985,15 @@ reveal_type(b)  # N: Revealed type is "Tuple[builtins.int, builtins.int, builtin
 [case testTupleWithStarExpr2]
 a = [1]
 b = (0, *a)
-reveal_type(b)  # N: Revealed type is "builtins.tuple[builtins.int*, ...]"
+reveal_type(b)  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 [builtins fixtures/tuple.pyi]
 
 [case testTupleWithStarExpr3]
 a = ['']
 b = (0, *a)
-reveal_type(b)  # N: Revealed type is "builtins.tuple[builtins.object*, ...]"
+reveal_type(b)  # N: Revealed type is "builtins.tuple[builtins.object, ...]"
 c = (*a, '')
-reveal_type(c)  # N: Revealed type is "builtins.tuple[builtins.str*, ...]"
+reveal_type(c)  # N: Revealed type is "builtins.tuple[builtins.str, ...]"
 [builtins fixtures/tuple.pyi]
 
 [case testTupleWithStarExpr4]
@@ -1132,8 +1132,8 @@ reveal_type(empty if int() else vartup)  # N: Revealed type is "builtins.tuple[_
 reveal_type(vartup if int() else empty)  # N: Revealed type is "builtins.tuple[__main__.A, ...]"
 
 lst = None  # type: List[A]
-reveal_type(empty if int() else lst)  # N: Revealed type is "typing.Sequence[__main__.A*]"
-reveal_type(lst if int() else empty)  # N: Revealed type is "typing.Sequence[__main__.A*]"
+reveal_type(empty if int() else lst)  # N: Revealed type is "typing.Sequence[__main__.A]"
+reveal_type(lst if int() else empty)  # N: Revealed type is "typing.Sequence[__main__.A]"
 
 [builtins fixtures/tuple.pyi]
 [out]
@@ -1277,7 +1277,7 @@ def f(x: Base[T]) -> T: pass
 class DT(Tuple[str, str], Base[int]):
     pass
 
-reveal_type(f(DT())) # N: Revealed type is "builtins.int*"
+reveal_type(f(DT())) # N: Revealed type is "builtins.int"
 
 [builtins fixtures/tuple.pyi]
 [out]
@@ -1364,10 +1364,10 @@ from typing import Union, Tuple, List
 
 tup: Union[Tuple[int, str], List[int]]
 reveal_type(tup[0])  # N: Revealed type is "builtins.int"
-reveal_type(tup[1])  # N: Revealed type is "Union[builtins.str, builtins.int*]"
+reveal_type(tup[1])  # N: Revealed type is "Union[builtins.str, builtins.int]"
 reveal_type(tup[2])  # E: Tuple index out of range \
-                     # N: Revealed type is "Union[Any, builtins.int*]"
-reveal_type(tup[:])  # N: Revealed type is "Union[Tuple[builtins.int, builtins.str], builtins.list[builtins.int*]]"
+                     # N: Revealed type is "Union[Any, builtins.int]"
+reveal_type(tup[:])  # N: Revealed type is "Union[Tuple[builtins.int, builtins.str], builtins.list[builtins.int]]"
 
 [builtins fixtures/tuple.pyi]
 
@@ -1433,24 +1433,24 @@ reveal_type(z) # N: Revealed type is "builtins.int"
 points2 = [1,2]
 x2, y2, z2= *points2, "test"
 
-reveal_type(x2) # N: Revealed type is "builtins.int*"
-reveal_type(y2) # N: Revealed type is "builtins.int*"
+reveal_type(x2) # N: Revealed type is "builtins.int"
+reveal_type(y2) # N: Revealed type is "builtins.int"
 reveal_type(z2) # N: Revealed type is "builtins.str"
 
 x3, x4, y3, y4, z3 = *points, *points2, "test"
 
 reveal_type(x3) # N: Revealed type is "builtins.int"
 reveal_type(x4) # N: Revealed type is "builtins.str"
-reveal_type(y3) # N: Revealed type is "builtins.int*"
-reveal_type(y4) # N: Revealed type is "builtins.int*"
+reveal_type(y3) # N: Revealed type is "builtins.int"
+reveal_type(y4) # N: Revealed type is "builtins.int"
 reveal_type(z3) # N: Revealed type is "builtins.str"
 
 x5, x6, y5, y6, z4 = *points2, *points2, "test"
 
-reveal_type(x5) # N: Revealed type is "builtins.int*"
-reveal_type(x6) # N: Revealed type is "builtins.int*"
-reveal_type(y5) # N: Revealed type is "builtins.int*"
-reveal_type(y6) # N: Revealed type is "builtins.int*"
+reveal_type(x5) # N: Revealed type is "builtins.int"
+reveal_type(x6) # N: Revealed type is "builtins.int"
+reveal_type(y5) # N: Revealed type is "builtins.int"
+reveal_type(y6) # N: Revealed type is "builtins.int"
 reveal_type(z4) # N: Revealed type is "builtins.str"
 
 points3 = ["test1", "test2"]
@@ -1481,7 +1481,7 @@ t3 = ('', 1) * 2
 reveal_type(t3)  # N: Revealed type is "Tuple[builtins.str, builtins.int, builtins.str, builtins.int]"
 def f() -> Tuple[str, ...]:
     return ('', )
-reveal_type(f() * 2)  # N: Revealed type is "builtins.tuple[builtins.str*, ...]"
+reveal_type(f() * 2)  # N: Revealed type is "builtins.tuple[builtins.str, ...]"
 [builtins fixtures/tuple.pyi]
 
 [case testMultiplyTupleByIntegerLiteralReverse]
@@ -1494,7 +1494,7 @@ t3 = 2 * ('', 1)
 reveal_type(t3)  # N: Revealed type is "Tuple[builtins.str, builtins.int, builtins.str, builtins.int]"
 def f() -> Tuple[str, ...]:
     return ('', )
-reveal_type(2 * f())  # N: Revealed type is "builtins.tuple[builtins.str*, ...]"
+reveal_type(2 * f())  # N: Revealed type is "builtins.tuple[builtins.str, ...]"
 [builtins fixtures/tuple.pyi]
 
 [case testSingleUndefinedTypeAndTuple]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -341,14 +341,14 @@ x: N.A[C]
 reveal_type(x)  # N: Revealed type is "__main__.C[__main__.C[Any]]"
 
 xx = N.A[C]()
-reveal_type(xx)  # N: Revealed type is "__main__.C[__main__.C*[Any]]"
+reveal_type(xx)  # N: Revealed type is "__main__.C[__main__.C[Any]]"
 
 y = N.A()
 reveal_type(y)  # N: Revealed type is "__main__.C[Any]"
 
 M = N
 b = M.A[int]()
-reveal_type(b)  # N: Revealed type is "__main__.C[builtins.int*]"
+reveal_type(b)  # N: Revealed type is "__main__.C[builtins.int]"
 
 n: Type[N]
 w = n.B()
@@ -457,8 +457,8 @@ class C:
 
 class D(C): ...
 
-reveal_type(D.meth(1))  # N: Revealed type is "Union[__main__.D*, builtins.int]"
-reveal_type(D().meth(1))  # N: Revealed type is "Union[__main__.D*, builtins.int]"
+reveal_type(D.meth(1))  # N: Revealed type is "Union[__main__.D, builtins.int]"
+reveal_type(D().meth(1))  # N: Revealed type is "Union[__main__.D, builtins.int]"
 [builtins fixtures/classmethod.pyi]
 [out]
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -6,7 +6,7 @@ Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(x=42, y=1337)
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})"
 # Use values() to check fallback value type.
-reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object*]"
+reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 [targets sys, __main__]
@@ -17,7 +17,7 @@ Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337))
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})"
 # Use values() to check fallback value type.
-reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object*]"
+reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -27,7 +27,7 @@ Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point({'x': 42, 'y': 1337})
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})"
 # Use values() to check fallback value type.
-reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object*]"
+reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -37,7 +37,7 @@ from mypy_extensions import TypedDict
 EmptyDict = TypedDict('EmptyDict', {})
 p = EmptyDict()
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.EmptyDict', {})"
-reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object*]"
+reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -488,8 +488,8 @@ def fun(arg: StrMap[T]) -> T:
     return arg['whatever']
 a: A
 b: B
-reveal_type(fun(a))  # N: Revealed type is "builtins.object*"
-reveal_type(fun(b))  # N: Revealed type is "builtins.object*"
+reveal_type(fun(a))  # N: Revealed type is "builtins.object"
+reveal_type(fun(b))  # N: Revealed type is "builtins.object"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -502,8 +502,8 @@ Point3D = TypedDict('Point3D', {'x': int, 'y': int, 'z': int})
 p1 = TaggedPoint(type='2d', x=0, y=0)
 p2 = Point3D(x=1, y=1, z=1)
 joined_points = [p1, p2][0]
-reveal_type(p1.values())   # N: Revealed type is "typing.Iterable[builtins.object*]"
-reveal_type(p2.values())   # N: Revealed type is "typing.Iterable[builtins.object*]"
+reveal_type(p1.values())   # N: Revealed type is "typing.Iterable[builtins.object]"
+reveal_type(p2.values())   # N: Revealed type is "typing.Iterable[builtins.object]"
 reveal_type(joined_points)  # N: Revealed type is "TypedDict({'x': builtins.int, 'y': builtins.int})"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
@@ -540,8 +540,8 @@ left = Cell(value=42)
 right = {'score': 999}  # type: Mapping[str, int]
 joined1 = [left, right]
 joined2 = [right, left]
-reveal_type(joined1)  # N: Revealed type is "builtins.list[typing.Mapping*[builtins.str, builtins.object]]"
-reveal_type(joined2)  # N: Revealed type is "builtins.list[typing.Mapping*[builtins.str, builtins.object]]"
+reveal_type(joined1)  # N: Revealed type is "builtins.list[typing.Mapping[builtins.str, builtins.object]]"
+reveal_type(joined2)  # N: Revealed type is "builtins.list[typing.Mapping[builtins.str, builtins.object]]"
 [builtins fixtures/dict.pyi]
 
 [case testJoinOfTypedDictWithCompatibleMappingSupertypeIsSupertype]
@@ -552,8 +552,8 @@ left = Cell(value=42)
 right = {'score': 999}  # type: Sized
 joined1 = [left, right]
 joined2 = [right, left]
-reveal_type(joined1)  # N: Revealed type is "builtins.list[typing.Sized*]"
-reveal_type(joined2)  # N: Revealed type is "builtins.list[typing.Sized*]"
+reveal_type(joined1)  # N: Revealed type is "builtins.list[typing.Sized]"
+reveal_type(joined2)  # N: Revealed type is "builtins.list[typing.Sized]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -565,8 +565,8 @@ left = Cell(value=42)
 right = 42
 joined1 = [left, right]
 joined2 = [right, left]
-reveal_type(joined1)  # N: Revealed type is "builtins.list[builtins.object*]"
-reveal_type(joined2)  # N: Revealed type is "builtins.list[builtins.object*]"
+reveal_type(joined1)  # N: Revealed type is "builtins.list[builtins.object]"
+reveal_type(joined2)  # N: Revealed type is "builtins.list[builtins.object]"
 [builtins fixtures/dict.pyi]
 
 
@@ -687,7 +687,7 @@ T = TypeVar('T')
 def f(x: Iterable[T]) -> T: pass
 A = TypedDict('A', {'x': int})
 a: A
-reveal_type(f(a)) # N: Revealed type is "builtins.str*"
+reveal_type(f(a)) # N: Revealed type is "builtins.str"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -868,11 +868,11 @@ m_s_s: Mapping[str, str]
 m_i_i: Mapping[int, int]
 m_s_a: Mapping[str, Any]
 
-reveal_type(u(c, m_s_o)) # N: Revealed type is "typing.Mapping*[builtins.str, builtins.object]"
-reveal_type(u(m_s_o, c)) # N: Revealed type is "typing.Mapping*[builtins.str, builtins.object]"
-reveal_type(u(c, m_s_s)) # N: Revealed type is "Union[typing.Mapping*[builtins.str, builtins.str], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]"
-reveal_type(u(c, m_i_i)) # N: Revealed type is "Union[typing.Mapping*[builtins.int, builtins.int], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]"
-reveal_type(u(c, m_s_a)) # N: Revealed type is "Union[typing.Mapping*[builtins.str, Any], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]"
+reveal_type(u(c, m_s_o)) # N: Revealed type is "typing.Mapping[builtins.str, builtins.object]"
+reveal_type(u(m_s_o, c)) # N: Revealed type is "typing.Mapping[builtins.str, builtins.object]"
+reveal_type(u(c, m_s_s)) # N: Revealed type is "Union[typing.Mapping[builtins.str, builtins.str], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]"
+reveal_type(u(c, m_i_i)) # N: Revealed type is "Union[typing.Mapping[builtins.int, builtins.int], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]"
+reveal_type(u(c, m_s_a)) # N: Revealed type is "Union[typing.Mapping[builtins.str, Any], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]"
 [builtins fixtures/dict.pyi]
 
 [case testTypedDictUnionUnambiguousCase]
@@ -989,7 +989,7 @@ d: D
 reveal_type(d.get('x', [])) # N: Revealed type is "builtins.list[builtins.int]"
 d.get('x', ['x']) # E: List item 0 has incompatible type "str"; expected "int"
 a = ['']
-reveal_type(d.get('x', a)) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.str*]]"
+reveal_type(d.get('x', a)) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.str]]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -1006,10 +1006,10 @@ d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument
                  # N:     def get(self, k: str) -> object \
                  # N:     def [V] get(self, k: str, default: Union[int, V]) -> object
 x = d.get('z')
-reveal_type(x) # N: Revealed type is "builtins.object*"
+reveal_type(x) # N: Revealed type is "builtins.object"
 s = ''
 y = d.get(s)
-reveal_type(y) # N: Revealed type is "builtins.object*"
+reveal_type(y) # N: Revealed type is "builtins.object"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -1558,7 +1558,7 @@ def f1(x: T, y: S) -> Union[T, S]: ...
 
 A = TypedDict('A', {'y': int, 'x': str})
 a: A
-reveal_type(f1(**a)) # N: Revealed type is "Union[builtins.str*, builtins.int*]"
+reveal_type(f1(**a)) # N: Revealed type is "Union[builtins.str, builtins.int]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypedDictAsStarStarArgCalleeKwargs]
@@ -1725,7 +1725,7 @@ td: Union[TDA, TDB]
 
 reveal_type(td.get('a'))  # N: Revealed type is "builtins.int"
 reveal_type(td.get('b'))  # N: Revealed type is "Union[builtins.str, builtins.int]"
-reveal_type(td.get('c'))  # N: Revealed type is "builtins.object*"
+reveal_type(td.get('c'))  # N: Revealed type is "builtins.object"
 
 reveal_type(td['a'])  # N: Revealed type is "builtins.int"
 reveal_type(td['b'])  # N: Revealed type is "Union[builtins.str, builtins.int]"
@@ -2299,7 +2299,7 @@ class Foo2(TypedDict):
 def func(foo: Union[Foo1, Foo2]) -> str:
     reveal_type(foo["z"])  # N: Revealed type is "builtins.str"
     # ok, but type is incorrect:
-    reveal_type(foo.__getitem__("z"))  # N: Revealed type is "builtins.object*"
+    reveal_type(foo.__getitem__("z"))  # N: Revealed type is "builtins.object"
 
     reveal_type(foo["a"])  # N: Revealed type is "Union[builtins.int, Any]" \
                            # E: TypedDict "Foo2" has no key "a"

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -121,7 +121,7 @@ def filter(f: Callable[[T], TypeGuard[R]], it: Iterable[T]) -> Iterable[R]: pass
 def is_float(a: object) -> TypeGuard[float]: pass
 a: List[object] = ["a", 0, 0.0]
 b = filter(is_float, a)
-reveal_type(b)  # N: Revealed type is "typing.Iterable[builtins.float*]"
+reveal_type(b)  # N: Revealed type is "typing.Iterable[builtins.float]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeGuardMethod]
@@ -242,8 +242,8 @@ def main1(a: object) -> None:
 
     la = [a]
     if is_float(*la):  # E: Type guard requires positional argument
-        reveal_type(la)  # N: Revealed type is "builtins.list[builtins.object*]"
-        reveal_type(a)  # N: Revealed type is "builtins.object*"
+        reveal_type(la)  # N: Revealed type is "builtins.list[builtins.object]"
+        reveal_type(a)  # N: Revealed type is "builtins.object"
 
 [builtins fixtures/tuple.pyi]
 
@@ -269,7 +269,7 @@ def main(a: List[Optional[int]]) -> None:
     reveal_type(bb)  # N: Revealed type is "typing.Iterator[Union[builtins.int, None]]"
     # Also, if you replace 'bool' with 'Any' in the second overload, bb is Iterator[Any]
     cc = filter(is_int_typeguard, a)
-    reveal_type(cc)  # N: Revealed type is "typing.Iterator[builtins.int*]"
+    reveal_type(cc)  # N: Revealed type is "typing.Iterator[builtins.int]"
     dd = filter(is_int_bool, a)
     reveal_type(dd)  # N: Revealed type is "typing.Iterator[Union[builtins.int, None]]"
 
@@ -525,8 +525,8 @@ class filter(Generic[_T]):
 def is_int_typeguard(a: object) -> TypeGuard[int]: pass
 def returns_bool(a: object) -> bool: pass
 
-reveal_type(filter(is_int_typeguard))  # N: Revealed type is "__main__.filter[builtins.int*]"
-reveal_type(filter(returns_bool))  # N: Revealed type is "__main__.filter[builtins.object*]"
+reveal_type(filter(is_int_typeguard))  # N: Revealed type is "__main__.filter[builtins.int]"
+reveal_type(filter(returns_bool))  # N: Revealed type is "__main__.filter[builtins.object]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeGuardSubtypingVariance]

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -344,8 +344,8 @@ class C(Generic[X]):
         self.x = x  # type: X
 ci: C[int]
 cs: C[str]
-reveal_type(ci.x) # N: Revealed type is "builtins.int*"
-reveal_type(cs.x) # N: Revealed type is "builtins.str*"
+reveal_type(ci.x) # N: Revealed type is "builtins.int"
+reveal_type(cs.x) # N: Revealed type is "builtins.str"
 
 [case testAttributeInGenericTypeWithTypevarValuesUsingInference1]
 from typing import TypeVar, Generic
@@ -659,7 +659,7 @@ T = TypeVar("T", bound=Union[Data, Dict[str, str]])
 
 
 def f(data: T) -> None:
-    reveal_type(data["x"]) # N: Revealed type is "Union[builtins.int, builtins.str*]"
+    reveal_type(data["x"]) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [builtins fixtures/tuple.pyi]
 [builtins fixtures/dict.pyi]
@@ -688,7 +688,7 @@ T = TypeVar("T", bound="Indexable")
 
 class Indexable:
     def __init__(self, index: str) -> None:
-        self.index = index 
+        self.index = index
 
     def __getitem__(self: T, index: str) -> T:
         return self._new_instance(index)

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -209,13 +209,13 @@ def u(x: T, y: S) -> Union[S, T]: pass
 
 a = None # type: Any
 
-reveal_type(u(C(), None))  # N: Revealed type is "__main__.C*"
-reveal_type(u(None, C()))  # N: Revealed type is "__main__.C*"
+reveal_type(u(C(), None))  # N: Revealed type is "__main__.C"
+reveal_type(u(None, C()))  # N: Revealed type is "__main__.C"
 
-reveal_type(u(C(), a))  # N: Revealed type is "Union[Any, __main__.C*]"
-reveal_type(u(a, C()))  # N: Revealed type is "Union[__main__.C*, Any]"
+reveal_type(u(C(), a))  # N: Revealed type is "Union[Any, __main__.C]"
+reveal_type(u(a, C()))  # N: Revealed type is "Union[__main__.C, Any]"
 
-reveal_type(u(C(), C()))  # N: Revealed type is "__main__.C*"
+reveal_type(u(C(), C()))  # N: Revealed type is "__main__.C"
 reveal_type(u(a, a))  # N: Revealed type is "Any"
 
 [case testUnionSimplificationSpecialCase2]
@@ -228,8 +228,8 @@ S = TypeVar('S')
 def u(x: T, y: S) -> Union[S, T]: pass
 
 def f(x: T) -> None:
-    reveal_type(u(C(), x)) # N: Revealed type is "Union[T`-1, __main__.C*]"
-    reveal_type(u(x, C())) # N: Revealed type is "Union[__main__.C*, T`-1]"
+    reveal_type(u(C(), x)) # N: Revealed type is "Union[T`-1, __main__.C]"
+    reveal_type(u(x, C())) # N: Revealed type is "Union[__main__.C, T`-1]"
 
 [case testUnionSimplificationSpecialCase3]
 from typing import Any, TypeVar, Generic, Union
@@ -258,32 +258,32 @@ def u(x: T, y: S) -> Union[S, T]: pass
 a = None # type: Any
 
 # Base-class-Any and None, simplify
-reveal_type(u(C(), None))  # N: Revealed type is "__main__.C*"
-reveal_type(u(None, C()))  # N: Revealed type is "__main__.C*"
+reveal_type(u(C(), None))  # N: Revealed type is "__main__.C"
+reveal_type(u(None, C()))  # N: Revealed type is "__main__.C"
 
 # Normal instance type and None, simplify
-reveal_type(u(1, None))  # N: Revealed type is "builtins.int*"
-reveal_type(u(None, 1))  # N: Revealed type is "builtins.int*"
+reveal_type(u(1, None))  # N: Revealed type is "builtins.int"
+reveal_type(u(None, 1))  # N: Revealed type is "builtins.int"
 
 # Normal instance type and base-class-Any, no simplification
-reveal_type(u(C(), 1))  # N: Revealed type is "Union[builtins.int*, __main__.C*]"
-reveal_type(u(1, C()))  # N: Revealed type is "Union[__main__.C*, builtins.int*]"
+reveal_type(u(C(), 1))  # N: Revealed type is "Union[builtins.int, __main__.C]"
+reveal_type(u(1, C()))  # N: Revealed type is "Union[__main__.C, builtins.int]"
 
 # Normal instance type and Any, no simplification
-reveal_type(u(1, a))  # N: Revealed type is "Union[Any, builtins.int*]"
-reveal_type(u(a, 1))  # N: Revealed type is "Union[builtins.int*, Any]"
+reveal_type(u(1, a))  # N: Revealed type is "Union[Any, builtins.int]"
+reveal_type(u(a, 1))  # N: Revealed type is "Union[builtins.int, Any]"
 
 # Any and base-class-Any, no simplificaiton
-reveal_type(u(C(), a))  # N: Revealed type is "Union[Any, __main__.C*]"
-reveal_type(u(a, C()))  # N: Revealed type is "Union[__main__.C*, Any]"
+reveal_type(u(C(), a))  # N: Revealed type is "Union[Any, __main__.C]"
+reveal_type(u(a, C()))  # N: Revealed type is "Union[__main__.C, Any]"
 
 # Two normal instance types, simplify
-reveal_type(u(1, object()))  # N: Revealed type is "builtins.object*"
-reveal_type(u(object(), 1))  # N: Revealed type is "builtins.object*"
+reveal_type(u(1, object()))  # N: Revealed type is "builtins.object"
+reveal_type(u(object(), 1))  # N: Revealed type is "builtins.object"
 
 # Two normal instance types, no simplification
-reveal_type(u(1, ''))  # N: Revealed type is "Union[builtins.str*, builtins.int*]"
-reveal_type(u('', 1))  # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+reveal_type(u(1, ''))  # N: Revealed type is "Union[builtins.str, builtins.int]"
+reveal_type(u('', 1))  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testUnionSimplificationWithDuplicateItems]
 from typing import Any, TypeVar, Union
@@ -297,11 +297,11 @@ def u(x: T, y: S, z: R) -> Union[R, S, T]: pass
 
 a = None # type: Any
 
-reveal_type(u(1, 1, 1))  # N: Revealed type is "builtins.int*"
-reveal_type(u(C(), C(), None))  # N: Revealed type is "__main__.C*"
-reveal_type(u(a, a, 1))  # N: Revealed type is "Union[builtins.int*, Any]"
-reveal_type(u(a, C(), a))  # N: Revealed type is "Union[Any, __main__.C*]"
-reveal_type(u('', 1, 1))  # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+reveal_type(u(1, 1, 1))  # N: Revealed type is "builtins.int"
+reveal_type(u(C(), C(), None))  # N: Revealed type is "__main__.C"
+reveal_type(u(a, a, 1))  # N: Revealed type is "Union[builtins.int, Any]"
+reveal_type(u(a, C(), a))  # N: Revealed type is "Union[Any, __main__.C]"
+reveal_type(u('', 1, 1))  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testUnionAndBinaryOperation]
 from typing import Union
@@ -335,10 +335,10 @@ T = TypeVar('T')
 S = TypeVar('S')
 def u(x: T, y: S) -> Union[S, T]: pass
 
-reveal_type(u(1, 2.3))  # N: Revealed type is "builtins.float*"
-reveal_type(u(2.3, 1))  # N: Revealed type is "builtins.float*"
-reveal_type(u(False, 2.2)) # N: Revealed type is "builtins.float*"
-reveal_type(u(2.2, False)) # N: Revealed type is "builtins.float*"
+reveal_type(u(1, 2.3))  # N: Revealed type is "builtins.float"
+reveal_type(u(2.3, 1))  # N: Revealed type is "builtins.float"
+reveal_type(u(False, 2.2)) # N: Revealed type is "builtins.float"
+reveal_type(u(2.2, False)) # N: Revealed type is "builtins.float"
 [builtins fixtures/primitives.pyi]
 
 [case testSimplifyingUnionWithTypeTypes1]
@@ -359,14 +359,14 @@ reveal_type(u(t_a, t_a)) # N: Revealed type is "Type[Any]"
 reveal_type(u(type, type)) # N: Revealed type is "def (x: builtins.object) -> builtins.type"
 
 # One type, other non-type
-reveal_type(u(t_s, 1)) # N: Revealed type is "Union[builtins.int*, Type[builtins.str]]"
-reveal_type(u(1, t_s)) # N: Revealed type is "Union[Type[builtins.str], builtins.int*]"
-reveal_type(u(type, 1)) # N: Revealed type is "Union[builtins.int*, def (x: builtins.object) -> builtins.type]"
-reveal_type(u(1, type)) # N: Revealed type is "Union[def (x: builtins.object) -> builtins.type, builtins.int*]"
-reveal_type(u(t_a, 1)) # N: Revealed type is "Union[builtins.int*, Type[Any]]"
-reveal_type(u(1, t_a)) # N: Revealed type is "Union[Type[Any], builtins.int*]"
-reveal_type(u(t_o, 1)) # N: Revealed type is "Union[builtins.int*, Type[builtins.object]]"
-reveal_type(u(1, t_o)) # N: Revealed type is "Union[Type[builtins.object], builtins.int*]"
+reveal_type(u(t_s, 1)) # N: Revealed type is "Union[builtins.int, Type[builtins.str]]"
+reveal_type(u(1, t_s)) # N: Revealed type is "Union[Type[builtins.str], builtins.int]"
+reveal_type(u(type, 1)) # N: Revealed type is "Union[builtins.int, def (x: builtins.object) -> builtins.type]"
+reveal_type(u(1, type)) # N: Revealed type is "Union[def (x: builtins.object) -> builtins.type, builtins.int]"
+reveal_type(u(t_a, 1)) # N: Revealed type is "Union[builtins.int, Type[Any]]"
+reveal_type(u(1, t_a)) # N: Revealed type is "Union[Type[Any], builtins.int]"
+reveal_type(u(t_o, 1)) # N: Revealed type is "Union[builtins.int, Type[builtins.object]]"
+reveal_type(u(1, t_o)) # N: Revealed type is "Union[Type[builtins.object], builtins.int]"
 
 [case testSimplifyingUnionWithTypeTypes2]
 from typing import TypeVar, Union, Type, Any
@@ -381,12 +381,12 @@ t_a = None  # type: Type[Any]
 t = None    # type: type
 
 # Union with object
-reveal_type(u(t_o, object())) # N: Revealed type is "builtins.object*"
-reveal_type(u(object(), t_o)) # N: Revealed type is "builtins.object*"
-reveal_type(u(t_s, object())) # N: Revealed type is "builtins.object*"
-reveal_type(u(object(), t_s)) # N: Revealed type is "builtins.object*"
-reveal_type(u(t_a, object())) # N: Revealed type is "builtins.object*"
-reveal_type(u(object(), t_a)) # N: Revealed type is "builtins.object*"
+reveal_type(u(t_o, object())) # N: Revealed type is "builtins.object"
+reveal_type(u(object(), t_o)) # N: Revealed type is "builtins.object"
+reveal_type(u(t_s, object())) # N: Revealed type is "builtins.object"
+reveal_type(u(object(), t_s)) # N: Revealed type is "builtins.object"
+reveal_type(u(t_a, object())) # N: Revealed type is "builtins.object"
+reveal_type(u(object(), t_a)) # N: Revealed type is "builtins.object"
 
 # Union between type objects
 reveal_type(u(t_o, t_a)) # N: Revealed type is "Union[Type[Any], Type[builtins.object]]"
@@ -395,12 +395,12 @@ reveal_type(u(t_s, t_o)) # N: Revealed type is "Type[builtins.object]"
 reveal_type(u(t_o, t_s)) # N: Revealed type is "Type[builtins.object]"
 reveal_type(u(t_o, type)) # N: Revealed type is "Type[builtins.object]"
 reveal_type(u(type, t_o)) # N: Revealed type is "Type[builtins.object]"
-reveal_type(u(t_a, t)) # N: Revealed type is "builtins.type*"
-reveal_type(u(t, t_a)) # N: Revealed type is "builtins.type*"
+reveal_type(u(t_a, t)) # N: Revealed type is "builtins.type"
+reveal_type(u(t, t_a)) # N: Revealed type is "builtins.type"
 # The following should arguably not be simplified, but it's unclear how to fix then
 # without causing regressions elsewhere.
-reveal_type(u(t_o, t)) # N: Revealed type is "builtins.type*"
-reveal_type(u(t, t_o)) # N: Revealed type is "builtins.type*"
+reveal_type(u(t_o, t)) # N: Revealed type is "builtins.type"
+reveal_type(u(t, t_o)) # N: Revealed type is "builtins.type"
 
 [case testNotSimplifyingUnionWithMetaclass]
 from typing import TypeVar, Union, Type, Any
@@ -416,11 +416,11 @@ def u(x: T, y: S) -> Union[S, T]: pass
 a: Any
 t_a: Type[A]
 
-reveal_type(u(M(*a), t_a)) # N: Revealed type is "__main__.M*"
-reveal_type(u(t_a, M(*a))) # N: Revealed type is "__main__.M*"
+reveal_type(u(M(*a), t_a)) # N: Revealed type is "__main__.M"
+reveal_type(u(t_a, M(*a))) # N: Revealed type is "__main__.M"
 
-reveal_type(u(M2(*a), t_a)) # N: Revealed type is "Union[Type[__main__.A], __main__.M2*]"
-reveal_type(u(t_a, M2(*a))) # N: Revealed type is "Union[__main__.M2*, Type[__main__.A]]"
+reveal_type(u(M2(*a), t_a)) # N: Revealed type is "Union[Type[__main__.A], __main__.M2]"
+reveal_type(u(t_a, M2(*a))) # N: Revealed type is "Union[__main__.M2, Type[__main__.A]]"
 
 [case testSimplifyUnionWithCallable]
 from typing import TypeVar, Union, Any, Callable
@@ -548,8 +548,8 @@ def pack_two(x: T, y: S) -> Union[Tuple[T, T], Tuple[S, S]]:
     pass
 
 (x, y) = pack_two(1, 'a')
-reveal_type(x)  # N: Revealed type is "Union[builtins.int*, builtins.str*]"
-reveal_type(y)  # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+reveal_type(y)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
 [case testUnionMultiassignAny]
@@ -572,7 +572,7 @@ class B(A): pass
 class C(A): pass
 a: Union[List[B], List[C]]
 x, y = a
-reveal_type(x)  # N: Revealed type is "Union[__main__.B*, __main__.C*]"
+reveal_type(x)  # N: Revealed type is "Union[__main__.B, __main__.C]"
 [builtins fixtures/list.pyi]
 
 [case testUnionMultiassignRebind]
@@ -584,8 +584,8 @@ class C(A): pass
 obj: object
 a: Union[List[B], List[C]]
 obj, new = a
-reveal_type(obj)  # N: Revealed type is "Union[__main__.B*, __main__.C*]"
-reveal_type(new)  # N: Revealed type is "Union[__main__.B*, __main__.C*]"
+reveal_type(obj)  # N: Revealed type is "Union[__main__.B, __main__.C]"
+reveal_type(new)  # N: Revealed type is "Union[__main__.B, __main__.C]"
 
 obj = 1
 reveal_type(obj)  # N: Revealed type is "builtins.int"
@@ -631,7 +631,7 @@ b: B
 
 a: Union[Tuple[int, int], Tuple[int, object]]
 (x[0], b.x) = a
-reveal_type(x[0])  # N: Revealed type is "builtins.int*"
+reveal_type(x[0])  # N: Revealed type is "builtins.int"
 reveal_type(b.x)  # N: Revealed type is "builtins.object"
 [builtins fixtures/list.pyi]
 
@@ -648,7 +648,7 @@ b: B
 a: Union[Tuple[int, int], Tuple[int, object]]
 (x[0], b.x) = a  # E: Incompatible types in assignment (expression has type "int", target has type "A") \
                  # E: Incompatible types in assignment (expression has type "object", variable has type "int")
-reveal_type(x[0])  # N: Revealed type is "__main__.A*"
+reveal_type(x[0])  # N: Revealed type is "__main__.A"
 reveal_type(b.x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
@@ -661,7 +661,7 @@ a2: object
 (a1, *xs, a2) = a
 
 reveal_type(a1)  # N: Revealed type is "builtins.int"
-reveal_type(xs)  # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(xs)  # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(a2)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/list.pyi]
 
@@ -676,8 +676,8 @@ def f(x: bool) -> Union[List[int], List[str]]:
 
 def g(x: bool) -> None:
     a, b = f(x)
-    reveal_type(a) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
-    reveal_type(b) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+    reveal_type(a) # N: Revealed type is "Union[builtins.int, builtins.str]"
+    reveal_type(b) # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/list.pyi]
 
 [case testUnionOfVariableLengthTupleUnpacking]
@@ -692,7 +692,7 @@ a, b = x # E: Too many values to unpack (2 expected, 3 provided)
 a, b, c = x # E: Need more than 2 values to unpack (3 expected)
 c, *d = x
 reveal_type(c) # N: Revealed type is "builtins.int"
-reveal_type(d) # N: Revealed type is "builtins.list[builtins.int*]"
+reveal_type(d) # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/tuple.pyi]
 
 [case testUnionOfNonIterableUnpacking]
@@ -780,8 +780,8 @@ from typing import Union, List
 good: Union[List[int], List[str]]
 
 lst = x, y = good
-reveal_type(x) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
-reveal_type(y) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+reveal_type(y) # N: Revealed type is "Union[builtins.int, builtins.str]"
 reveal_type(lst) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.str]]"
 [builtins fixtures/list.pyi]
 [out]
@@ -791,9 +791,9 @@ from typing import Union, List
 good: Union[List[int], List[str]]
 
 x, *y, z = lst = good
-reveal_type(x) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
-reveal_type(y) # N: Revealed type is "Union[builtins.list[builtins.int*], builtins.list[builtins.str*]]"
-reveal_type(z) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+reveal_type(y) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.str]]"
+reveal_type(z) # N: Revealed type is "Union[builtins.int, builtins.str]"
 reveal_type(lst) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.str]]"
 [builtins fixtures/list.pyi]
 [out]
@@ -808,15 +808,15 @@ class NTStr(NamedTuple):
     y: str
 
 t1: NTInt
-reveal_type(t1.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.int*]"
+reveal_type(t1.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.int]"
 nt: Union[NTInt, NTStr]
-reveal_type(nt.__iter__) # N: Revealed type is "Union[def () -> typing.Iterator[builtins.int*], def () -> typing.Iterator[builtins.str*]]"
+reveal_type(nt.__iter__) # N: Revealed type is "Union[def () -> typing.Iterator[builtins.int], def () -> typing.Iterator[builtins.str]]"
 for nx in nt:
-    reveal_type(nx) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+    reveal_type(nx) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 t: Union[Tuple[int, int], Tuple[str, str]]
 for x in t:
-    reveal_type(x) # N: Revealed type is "Union[builtins.int*, builtins.str*]"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/for.pyi]
 [out]
 

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1002,9 +1002,9 @@ def test1(x: T1) -> T1:
 
 def test2(x: T2) -> T2:
     if isinstance(x, int):
-        reveal_type(x)  # N: Revealed type is "builtins.int*"
+        reveal_type(x)  # N: Revealed type is "builtins.int"
     else:
-        reveal_type(x)  # N: Revealed type is "builtins.str*"
+        reveal_type(x)  # N: Revealed type is "builtins.str"
 
     if False:
         # This is unreachable, but we don't report an error, unfortunately.
@@ -1020,9 +1020,9 @@ class Test3(Generic[T2]):
 
     def func(self) -> None:
         if isinstance(self.x, int):
-            reveal_type(self.x)  # N: Revealed type is "builtins.int*"
+            reveal_type(self.x)  # N: Revealed type is "builtins.int"
         else:
-            reveal_type(self.x)  # N: Revealed type is "builtins.str*"
+            reveal_type(self.x)  # N: Revealed type is "builtins.str"
 
         if False:
             # Same issue as above

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -123,7 +123,7 @@ T4 = TypeVar('T4')
 def f(a: T1, b: T2, c: T3, d: T4) -> Tuple[T1, T2, T3, T4]: ...
 x: Tuple[int, str]
 y: Tuple[float, bool]
-reveal_type(f(*x, *y)) # N: Revealed type is "Tuple[builtins.int*, builtins.str*, builtins.float*, builtins.bool*]"
+reveal_type(f(*x, *y)) # N: Revealed type is "Tuple[builtins.int, builtins.str, builtins.float, builtins.bool]"
 [builtins fixtures/list.pyi]
 
 [case testCallVarargsFunctionWithIterableAndPositional]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8760,7 +8760,7 @@ from typing_extensions import Literal
 bar: Literal[3] = 3
 [builtins fixtures/tuple.pyi]
 [out]
-main:2: note: Revealed type is "builtins.int*"
+main:2: note: Revealed type is "builtins.int"
 ==
 main:2: note: Revealed type is "Literal[3]"
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -905,9 +905,9 @@ _testCollectionsAliases.py:5: note: Revealed type is "collections.Counter[builti
 _testCollectionsAliases.py:6: error: Invalid index type "str" for "Counter[int]"; expected type "int"
 _testCollectionsAliases.py:9: note: Revealed type is "collections.ChainMap[builtins.int, builtins.str]"
 _testCollectionsAliases.py:12: note: Revealed type is "collections.deque[builtins.int]"
-_testCollectionsAliases.py:15: note: Revealed type is "collections.Counter[builtins.int*]"
-_testCollectionsAliases.py:18: note: Revealed type is "collections.ChainMap[builtins.int*, builtins.str*]"
-_testCollectionsAliases.py:21: note: Revealed type is "collections.deque[builtins.int*]"
+_testCollectionsAliases.py:15: note: Revealed type is "collections.Counter[builtins.int]"
+_testCollectionsAliases.py:18: note: Revealed type is "collections.ChainMap[builtins.int, builtins.str]"
+_testCollectionsAliases.py:21: note: Revealed type is "collections.deque[builtins.int]"
 
 [case testChainMapUnimported]
 ChainMap[int, str]()
@@ -1060,10 +1060,10 @@ reveal_type(g)
 with f('') as s:
     reveal_type(s)
 [out]
-_program.py:13: note: Revealed type is "def (x: builtins.int) -> contextlib._GeneratorContextManager[builtins.str*]"
-_program.py:14: note: Revealed type is "def (*x: builtins.str) -> contextlib._GeneratorContextManager[builtins.int*]"
+_program.py:13: note: Revealed type is "def (x: builtins.int) -> contextlib._GeneratorContextManager[builtins.str]"
+_program.py:14: note: Revealed type is "def (*x: builtins.str) -> contextlib._GeneratorContextManager[builtins.int]"
 _program.py:16: error: Argument 1 to "f" has incompatible type "str"; expected "int"
-_program.py:17: note: Revealed type is "builtins.str*"
+_program.py:17: note: Revealed type is "builtins.str"
 
 [case testTypedDictGet]
 # Test that TypedDict get plugin works with typeshed stubs
@@ -1081,12 +1081,12 @@ reveal_type(d.get(s))
 [out]
 _testTypedDictGet.py:7: note: Revealed type is "builtins.int"
 _testTypedDictGet.py:8: note: Revealed type is "builtins.str"
-_testTypedDictGet.py:9: note: Revealed type is "builtins.object*"
+_testTypedDictGet.py:9: note: Revealed type is "builtins.object"
 _testTypedDictGet.py:10: error: All overload variants of "get" of "Mapping" require at least one argument
 _testTypedDictGet.py:10: note: Possible overload variants:
 _testTypedDictGet.py:10: note:     def get(self, key: str) -> object
 _testTypedDictGet.py:10: note:     def [_T] get(self, str, object) -> object
-_testTypedDictGet.py:12: note: Revealed type is "builtins.object*"
+_testTypedDictGet.py:12: note: Revealed type is "builtins.object"
 
 [case testTypedDictMappingMethods]
 from mypy_extensions import TypedDict
@@ -1111,8 +1111,8 @@ Cell2 = TypedDict('Cell2', {'value': int}, total=False)
 c2 = Cell2()
 reveal_type(c2.pop('value'))
 [out]
-_testTypedDictMappingMethods.py:5: note: Revealed type is "builtins.str*"
-_testTypedDictMappingMethods.py:6: note: Revealed type is "typing.Iterator*[builtins.str*]"
+_testTypedDictMappingMethods.py:5: note: Revealed type is "builtins.str"
+_testTypedDictMappingMethods.py:6: note: Revealed type is "typing.Iterator[builtins.str]"
 _testTypedDictMappingMethods.py:7: note: Revealed type is "builtins.int"
 _testTypedDictMappingMethods.py:8: note: Revealed type is "builtins.bool"
 _testTypedDictMappingMethods.py:9: note: Revealed type is "typing.KeysView[builtins.str]"
@@ -1203,8 +1203,8 @@ _testNoCrashOnGenericUnionUnpacking.py:6: note: Revealed type is "builtins.str"
 _testNoCrashOnGenericUnionUnpacking.py:7: note: Revealed type is "builtins.str"
 _testNoCrashOnGenericUnionUnpacking.py:10: note: Revealed type is "Union[builtins.str, builtins.int]"
 _testNoCrashOnGenericUnionUnpacking.py:11: note: Revealed type is "Union[builtins.str, builtins.int]"
-_testNoCrashOnGenericUnionUnpacking.py:15: note: Revealed type is "Union[builtins.int*, builtins.str*]"
-_testNoCrashOnGenericUnionUnpacking.py:16: note: Revealed type is "Union[builtins.int*, builtins.str*]"
+_testNoCrashOnGenericUnionUnpacking.py:15: note: Revealed type is "Union[builtins.int, builtins.str]"
+_testNoCrashOnGenericUnionUnpacking.py:16: note: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testMetaclassOpAccess]
 from typing import Type
@@ -1272,8 +1272,8 @@ class E(Enum):
 for e in E:
     reveal_type(e)
 [out]
-_testEnumIterationAndPreciseElementType.py:5: note: Revealed type is "_testEnumIterationAndPreciseElementType.E*"
-_testEnumIterationAndPreciseElementType.py:7: note: Revealed type is "_testEnumIterationAndPreciseElementType.E*"
+_testEnumIterationAndPreciseElementType.py:5: note: Revealed type is "_testEnumIterationAndPreciseElementType.E"
+_testEnumIterationAndPreciseElementType.py:7: note: Revealed type is "_testEnumIterationAndPreciseElementType.E"
 
 [case testEnumIterable]
 from enum import Enum
@@ -1297,7 +1297,7 @@ f(N)
 g(N)
 reveal_type(list(N))
 [out]
-_testIntEnumIterable.py:11: note: Revealed type is "builtins.list[_testIntEnumIterable.N*]"
+_testIntEnumIterable.py:11: note: Revealed type is "builtins.list[_testIntEnumIterable.N]"
 
 [case testDerivedEnumIterable]
 from enum import Enum
@@ -1357,7 +1357,7 @@ def print_custom_table() -> None:
     for row in simple_map(format_row, a, a, a, a, a, a, a, a):  # 8 columns
         reveal_type(row)
 [out]
-_testLoadsOfOverloads.py:24: note: Revealed type is "builtins.str*"
+_testLoadsOfOverloads.py:24: note: Revealed type is "builtins.str"
 
 [case testReduceWithAnyInstance]
 from typing import Iterable
@@ -1423,7 +1423,7 @@ from typing import Dict, List, Tuple
 x: Dict[str, List[int]]
 reveal_type(x['test'][0])
 [out]
-_testNewAnalyzerBasicTypeshed_newsemanal.py:4: note: Revealed type is "builtins.int*"
+_testNewAnalyzerBasicTypeshed_newsemanal.py:4: note: Revealed type is "builtins.int"
 
 [case testNewAnalyzerTypedDictInStub_newsemanal]
 import stub


### PR DESCRIPTION
### Description
This PR removes `*` from `reveal_type` output for inferred types.


<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->
Closes #10076

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->
Tests are updated accordingly. `*` is also removed from expected test outputs.
