### PR TITLE
stubgen: Do not consider nested generators for return type

### DIFF
--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -368,8 +368,20 @@ def has_return_statement(fdef: FuncBase) -> bool:
     return seeker.found
 
 
-class YieldSeeker(TraverserVisitor):
+class FuncCollectorBase(TraverserVisitor):
     def __init__(self) -> None:
+        self.inside_func = False
+
+    def visit_func_def(self, defn: FuncDef) -> None:
+        if not self.inside_func:
+            self.inside_func = True
+            super().visit_func_def(defn)
+            self.inside_func = False
+
+
+class YieldSeeker(FuncCollectorBase):
+    def __init__(self) -> None:
+        super().__init__()
         self.found = False
 
     def visit_yield_expr(self, o: YieldExpr) -> None:
@@ -380,17 +392,6 @@ def has_yield_expression(fdef: FuncBase) -> bool:
     seeker = YieldSeeker()
     fdef.accept(seeker)
     return seeker.found
-
-
-class FuncCollectorBase(TraverserVisitor):
-    def __init__(self) -> None:
-        self.inside_func = False
-
-    def visit_func_def(self, defn: FuncDef) -> None:
-        if not self.inside_func:
-            self.inside_func = True
-            super().visit_func_def(defn)
-            self.inside_func = False
 
 
 class ReturnCollector(FuncCollectorBase):

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -2619,3 +2619,12 @@ class PT(Protocol[T, T2]):
 def func(*, non_default_kwarg: bool, default_kwarg: bool = True): ...
 [out]
 def func(*, non_default_kwarg: bool, default_kwarg: bool = ...): ...
+
+[case testNestedGenerator]
+def f():
+    def g():
+        yield 0
+
+    return 0
+[out]
+def f(): ...


### PR DESCRIPTION
### Description

Since yields in nested functions will not yield outside of the function being analyzed, they can be ignored.
I changed the parent of the class used to find the yields to one that does not search through nested functions.

Fixes #11893

## Test Plan

I added code similar to the one from the issue's example to the unit tests.