### PR TITLE
stubtest: enable verification of `__match_args__` attributes

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1044,8 +1044,7 @@ IGNORABLE_CLASS_DUNDERS = frozenset(
         "__args__",
         "__orig_bases__",
         "__final__",
-        # Consider removing these:
-        "__match_args__",
+        # Consider removing __slots__?
         "__slots__",
     }
 )


### PR DESCRIPTION
### Description

#12415 (included in release 0.942) unblocked typeshed from adding missing `__match_args__` attributes (see https://github.com/python/typeshed/pull/7556). This means stubtest is now unblocked from checking the correctness of `__match_args__` attributes in the stub!

## Test Plan

N/A
