### PR TITLE
mypyc build: when windows use correct optimization and debug flags

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -523,10 +523,20 @@ def mypycify(
             # This flag is needed for gcc but does not exist on clang.
             cflags += ['-Wno-unused-but-set-variable']
     elif compiler.compiler_type == 'msvc':
-        if opt_level == '3':
+        # msvc doesn't have levels, '/O2' is full and '/Od' is disable
+        if opt_level == '0':
+            opt_level = 'd'
+        elif opt_level in ('1', '2', '3'):
             opt_level = '2'
+        if debug_level == '0':
+            debug_level = "NONE"
+        elif debug_level == '1':
+            debug_level = "FASTLINK"
+        elif debug_level in ('2', '3'):
+            debug_level = "FULL"
         cflags += [
             '/O{}'.format(opt_level),
+            f'/DEBUG:{debug_level}',
             '/wd4102',  # unreferenced label
             '/wd4101',  # unreferenced local variable
             '/wd4146',  # negating unsigned int


### PR DESCRIPTION
### Description

Send some more accurate optimization and debug flags to msvc.

This shouldn't fix the broken CI, but I think it's still a good idea to send correct parameters

[GCC](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options): 
`-O0` Reduce compilation time and make debugging produce the expected results. This is the default.
`-O`/`-O1` Optimize. Optimizing compilation takes somewhat more time, and a lot more memory for a large function.
`-O2` Optimize even more.
`-O3` Optimize yet more.
`-Os` Optimize for size

[MSVC](https://docs.microsoft.com/en-us/cpp/build/reference/o-options-optimize-code?view=msvc-170):
`/O1` sets a combination of optimizations that generate minimum size code.
`/O2` sets a combination of optimizations that optimizes code for maximum speed.
`/Od` disables optimization, to speed compilation and simplify debugging.
[here's some more info](https://docs.microsoft.com/en-us/cpp/build/reference/o1-o2-minimize-size-maximize-speed?view=msvc-170)

## Test Plan

N/A