### PR TITLE
Fix Windows test failures in CI

### DIFF
--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -263,7 +263,7 @@ class TestRun(MypycDataSuite):
 
         # Assert that an output file got created
         suffix = 'pyd' if sys.platform == 'win32' else 'so'
-        assert glob.glob('native.*.{}'.format(suffix))
+        assert glob.glob('native.*.{}'.format(suffix)) or glob.glob('native.{}'.format(suffix))
 
         driver_path = 'driver.py'
         if not os.path.isfile(driver_path):


### PR DESCRIPTION
Allow extension file names such as `native.pyd` in addition to
`native.<python-version>.<ext>`. I'm not sure why the file names have
changed, but the new file names seem okay as well.

Fixes #12460.