### PR TITLE
Unify a codepath in typevarlike semanal

### DIFF
--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1081,7 +1081,7 @@ x = TypeVar('x') # E: Cannot redefine "x" as a type variable
 
 [case testTypevarWithType]
 from typing import TypeVar
-x = TypeVar('x') # type: int # E: Cannot declare the type of a type variable
+x = TypeVar('x') # type: int # E: Cannot declare the type of a TypeVar or similar construct
 [out]
 
 [case testRedefineTypevar]
@@ -1432,7 +1432,7 @@ from typing_extensions import ParamSpec
 
 TParams = ParamSpec('TParams')
 TP = ParamSpec('?')  # E: String argument 1 "?" to ParamSpec(...) does not match variable name "TP"
-TP2: int = ParamSpec('TP2')  # E: Cannot declare the type of a parameter specification
+TP2: int = ParamSpec('TP2')  # E: Cannot declare the type of a TypeVar or similar construct
 
 [out]
 


### PR DESCRIPTION
I don't want to have to copy paste this again for `TypeVarTuple`. The downside is the error is less specific. We could fix that by passing in a string or checking `call.callee.name`, but I think it isn't worth it. This error should still be clear enough.