### PR TITLE
Add TypeVarTupleExpr node

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -32,7 +32,7 @@ from mypy.nodes import (
     DictionaryComprehension, ComplexExpr, EllipsisExpr, StarExpr, AwaitExpr, YieldExpr,
     YieldFromExpr, TypedDictExpr, PromoteExpr, NewTypeExpr, NamedTupleExpr, TypeVarExpr,
     TypeAliasExpr, BackquoteExpr, EnumCallExpr, TypeAlias, SymbolNode, PlaceholderNode,
-    ParamSpecExpr,
+    ParamSpecExpr, TypeVarTupleExpr,
     ArgKind, ARG_POS, ARG_NAMED, ARG_STAR, ARG_STAR2, LITERAL_TYPE, REVEAL_TYPE,
 )
 from mypy.literals import literal
@@ -4184,6 +4184,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return AnyType(TypeOfAny.special_form)
 
     def visit_paramspec_expr(self, e: ParamSpecExpr) -> Type:
+        return AnyType(TypeOfAny.special_form)
+
+    def visit_type_var_tuple_expr(self, e: TypeVarTupleExpr) -> Type:
         return AnyType(TypeOfAny.special_form)
 
     def visit_newtype_expr(self, e: NewTypeExpr) -> Type:

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -9,7 +9,7 @@ from mypy.nodes import (
     TypeApplication, LambdaExpr, ListComprehension, SetComprehension, DictionaryComprehension,
     GeneratorExpr, BackquoteExpr, TypeVarExpr, TypeAliasExpr, NamedTupleExpr, EnumCallExpr,
     TypedDictExpr, NewTypeExpr, PromoteExpr, AwaitExpr, TempNode, AssignmentExpr, ParamSpecExpr,
-    AssertTypeExpr,
+    AssertTypeExpr, TypeVarTupleExpr,
 )
 from mypy.visitor import ExpressionVisitor
 
@@ -222,6 +222,9 @@ class _Hasher(ExpressionVisitor[Optional[Key]]):
         return None
 
     def visit_paramspec_expr(self, e: ParamSpecExpr) -> None:
+        return None
+
+    def visit_type_var_tuple_expr(self, e: TypeVarTupleExpr) -> None:
         return None
 
     def visit_type_alias_expr(self, e: TypeAliasExpr) -> None:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -496,6 +496,18 @@ class StrConv(NodeVisitor[str]):
             a += ['UpperBound({})'.format(o.upper_bound)]
         return self.dump(a, o)
 
+    def visit_type_var_tuple_expr(self, o: 'mypy.nodes.TypeVarTupleExpr') -> str:
+        import mypy.types
+
+        a: List[Any] = []
+        if o.variance == mypy.nodes.COVARIANT:
+            a += ['Variance(COVARIANT)']
+        if o.variance == mypy.nodes.CONTRAVARIANT:
+            a += ['Variance(CONTRAVARIANT)']
+        if not mypy.types.is_named_instance(o.upper_bound, 'builtins.object'):
+            a += ['UpperBound({})'.format(o.upper_bound)]
+        return self.dump(a, o)
+
     def visit_type_alias_expr(self, o: 'mypy.nodes.TypeAliasExpr') -> str:
         return 'TypeAliasExpr({})'.format(o.type)
 

--- a/mypy/test/testtransform.py
+++ b/mypy/test/testtransform.py
@@ -38,6 +38,7 @@ def test_transform(testcase: DataDrivenTestCase) -> None:
         options = parse_options(src, testcase, 1)
         options.use_builtins_fixtures = True
         options.semantic_analysis_only = True
+        options.enable_incomplete_features = True
         options.show_traceback = True
         result = build.build(sources=[BuildSource('main', None, src)],
                              options=options,
@@ -54,8 +55,10 @@ def test_transform(testcase: DataDrivenTestCase) -> None:
             # path.
             # TODO the test is not reliable
             if (not f.path.endswith((os.sep + 'builtins.pyi',
+                                     'typing_extensions.pyi',
                                      'typing.pyi',
-                                     'abc.pyi'))
+                                     'abc.pyi',
+                                     'sys.pyi'))
                     and not os.path.basename(f.path).startswith('_')
                     and not os.path.splitext(
                         os.path.basename(f.path))[0].endswith('_')):

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -20,7 +20,7 @@ from mypy.nodes import (
     YieldFromExpr, NamedTupleExpr, TypedDictExpr, NonlocalDecl, SetComprehension,
     DictionaryComprehension, ComplexExpr, TypeAliasExpr, EllipsisExpr,
     YieldExpr, ExecStmt, Argument, BackquoteExpr, AwaitExpr, AssignmentExpr,
-    OverloadPart, EnumCallExpr, REVEAL_TYPE, GDEF
+    OverloadPart, EnumCallExpr, REVEAL_TYPE, GDEF, TypeVarTupleExpr
 )
 from mypy.types import Type, FunctionLike, ProperType
 from mypy.traverser import TraverserVisitor
@@ -512,6 +512,11 @@ class TransformVisitor(NodeVisitor[Node]):
 
     def visit_paramspec_expr(self, node: ParamSpecExpr) -> ParamSpecExpr:
         return ParamSpecExpr(
+            node.name, node.fullname, self.type(node.upper_bound), variance=node.variance
+        )
+
+    def visit_type_var_tuple_expr(self, node: TypeVarTupleExpr) -> TypeVarTupleExpr:
+        return TypeVarTupleExpr(
             node.name, node.fullname, self.type(node.upper_bound), variance=node.variance
         )
 

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -166,6 +166,10 @@ class ExpressionVisitor(Generic[T]):
         pass
 
     @abstractmethod
+    def visit_type_var_tuple_expr(self, o: 'mypy.nodes.TypeVarTupleExpr') -> T:
+        pass
+
+    @abstractmethod
     def visit_type_alias_expr(self, o: 'mypy.nodes.TypeAliasExpr') -> T:
         pass
 
@@ -588,6 +592,9 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T], Pattern
         pass
 
     def visit_paramspec_expr(self, o: 'mypy.nodes.ParamSpecExpr') -> T:
+        pass
+
+    def visit_type_var_tuple_expr(self, o: 'mypy.nodes.TypeVarTupleExpr') -> T:
         pass
 
     def visit_type_alias_expr(self, o: 'mypy.nodes.TypeAliasExpr') -> T:

--- a/mypyc/irbuild/visitor.py
+++ b/mypyc/irbuild/visitor.py
@@ -17,7 +17,7 @@ from mypy.nodes import (
     NamedTupleExpr, NewTypeExpr, NonlocalDecl, OverloadedFuncDef, PrintStmt, RaiseStmt,
     RevealExpr, SetExpr, SliceExpr, StarExpr, SuperExpr, TryStmt, TypeAliasExpr, TypeApplication,
     TypeVarExpr, TypedDictExpr, UnicodeExpr, WithStmt, YieldFromExpr, YieldExpr, ParamSpecExpr,
-    MatchStmt
+    MatchStmt, TypeVarTupleExpr
 )
 
 from mypyc.ir.ops import Value
@@ -313,6 +313,9 @@ class IRBuilderVisitor(IRVisitor):
         assert False, "can't compile analysis-only expressions"
 
     def visit_paramspec_expr(self, o: ParamSpecExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_type_var_tuple_expr(self, o: TypeVarTupleExpr) -> Value:
         assert False, "can't compile analysis-only expressions"
 
     def visit_typeddict_expr(self, o: TypedDictExpr) -> Value:

--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -29,6 +29,7 @@ TypeAlias: _SpecialForm
 TypeGuard: _SpecialForm
 Never: _SpecialForm
 
+TypeVarTuple: _SpecialForm
 Unpack: _SpecialForm
 
 # Fallback type for all typed dicts (does not exist at runtime).

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1460,3 +1460,13 @@ heterogenous_tuple: Tuple[Unpack[Tuple[int, str]]]
 homogenous_tuple: Tuple[Unpack[Tuple[int, ...]]]
 bad: Tuple[Unpack[int]]  # E: builtins.int cannot be unpacked (must be tuple or TypeVarTuple)
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarTuple]
+from typing_extensions import TypeVarTuple
+
+TVariadic = TypeVarTuple('TVariadic')
+TP = TypeVarTuple('?')  # E: String argument 1 "?" to TypeVarTuple(...) does not match variable name "TP"
+TP2: int = TypeVarTuple('TP2')  # E: Cannot declare the type of a TypeVar or similar construct
+TP3 = TypeVarTuple()  # E: Too few arguments for TypeVarTuple()
+TP4 = TypeVarTuple('TP4', 'TP4')  # E: Only the first argument to TypeVarTuple has defined semantics
+TP5 = TypeVarTuple(t='TP5')  # E: TypeVarTuple() expects a string literal as first argument

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1548,3 +1548,13 @@ MypyFile:1(
   AssignmentStmt:2(
     NameExpr(P* [__main__.P])
     ParamSpecExpr:2()))
+
+[case testTypeVarTuple]
+from typing_extensions import TypeVarTuple
+TV = TypeVarTuple("TV")
+[out]
+MypyFile:1(
+  ImportFrom:1(typing_extensions, [TypeVarTuple])
+  AssignmentStmt:2(
+    NameExpr(TV* [__main__.TV])
+    TypeVarTupleExpr:2()))


### PR DESCRIPTION
This adds minimal support for a TypeVarTupleExpr node, gated behind the
flag to enable incomplete features. It is modeled after paramspec,
including the part where we don't support the various arguments that
have no behavior defined in PEP646.

We also include TypeVarTuple in the typing_extensions stubs for test
data and add some very basic semanal tests to verify the basic things work.