### PR TITLE
`cheatsheet_py3.rst`: `IO[str]` to `IO[AnyStr]`

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -296,7 +296,7 @@ Miscellaneous
 
    import sys
    import re
-   from typing import Match, AnyStr, IO
+   from typing import Match, IO
 
    # "typing.Match" describes regex matches from the re module
    x: Match[str] = re.match(r'[0-9]+', "15")
@@ -304,7 +304,7 @@ Miscellaneous
    # Use IO[] for functions that should accept or return any
    # object that comes from an open() call (IO[] does not
    # distinguish between reading, writing or other modes)
-   def get_sys_IO(mode: str = 'w') -> IO[AnyStr]:
+   def get_sys_IO(mode: str = 'w') -> IO[str]:
        if mode == 'w':
            return sys.stdout
        elif mode == 'r':

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -304,7 +304,7 @@ Miscellaneous
    # Use IO[] for functions that should accept or return any
    # object that comes from an open() call (IO[] does not
    # distinguish between reading, writing or other modes)
-   def get_sys_IO(mode: str = 'w') -> IO[str]:
+   def get_sys_IO(mode: str = 'w') -> IO[AnyStr]:
        if mode == 'w':
            return sys.stdout
        elif mode == 'r':


### PR DESCRIPTION
### Description
`AnyStr` is unused in the example. I guess it's intended to be used with `IO` as `IO[AnyStr]`, which should be more suitable than `IO[str]`. 

## Test Plan
Given the commented instructions in the PR template, I'm not sure how I should rebuild the docs. Please let me know if there is anything missing.
<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
