### PR TITLE
Fix typos

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -607,7 +607,7 @@ method signature.  E.g.:
 
 The third line elicits an error because mypy sees the argument type
 ``bytes`` as a reference to the method by that name.  Other than
-renaming the method, a work-around is to use an alias:
+renaming the method, a workaround is to use an alias:
 
 .. code-block:: python
 

--- a/docs/source/literal_types.rst
+++ b/docs/source/literal_types.rst
@@ -431,7 +431,7 @@ You can use enums to annotate types as you would expect:
           self.speed = speed
 
   Movement(Direction.up, 5.0)  # ok
-  Movement('up', 5.0)  # E: Argument 1 to "Movemement" has incompatible type "str"; expected "Direction"
+  Movement('up', 5.0)  # E: Argument 1 to "Movement" has incompatible type "str"; expected "Direction"
 
 Exhaustiveness checking
 ***********************
@@ -505,7 +505,7 @@ the same way Python's runtime does:
         left = 'left'
         right = 'right'
 
-- All ``Enum`` fields are implictly ``final`` as well.
+- All ``Enum`` fields are implicitly ``final`` as well.
 
   .. code-block:: python
 

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -3,7 +3,7 @@
 Since mypy still changes, the API was kept utterly simple and non-intrusive.
 It just mimics command line activation without starting a new interpreter.
 So the normal docs about the mypy command line apply.
-Changes in the command line version of mypy will be immediately useable.
+Changes in the command line version of mypy will be immediately usable.
 
 Just import this module and then call the 'run' function with a parameter of
 type List[str], containing what normally would have been the command line

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -211,7 +211,7 @@ CANNOT_MAKE_DELETABLE_FINAL: Final = ErrorMessage("Deletable attribute cannot be
 
 # Enum
 ENUM_MEMBERS_ATTR_WILL_BE_OVERRIDEN: Final = ErrorMessage(
-    'Assigned "__members__" will be overriden by "Enum" internally'
+    'Assigned "__members__" will be overridden by "Enum" internally'
 )
 
 # ClassVar

--- a/mypy/typeshed/stdlib/asyncio/unix_events.pyi
+++ b/mypy/typeshed/stdlib/asyncio/unix_events.pyi
@@ -9,7 +9,7 @@ from .events import AbstractEventLoop, BaseDefaultEventLoopPolicy, _ProtocolFact
 from .selector_events import BaseSelectorEventLoop
 
 # This is also technically not available on Win,
-# but other parts of typeshed need this defintion.
+# but other parts of typeshed need this definition.
 # So, it is special cased.
 class AbstractChildWatcher:
     def add_child_handler(self, pid: int, callback: Callable[..., Any], *args: Any) -> None: ...

--- a/mypy/typeshed/stdlib/builtins.pyi
+++ b/mypy/typeshed/stdlib/builtins.pyi
@@ -847,7 +847,7 @@ class dict(MutableMapping[_KT, _VT], Generic[_KT, _VT]):
     def values(self) -> dict_values[_KT, _VT]: ...
     def items(self) -> dict_items[_KT, _VT]: ...
     # Signature of `dict.fromkeys` should be kept identical to `fromkeys` methods of `OrderedDict`/`ChainMap`/`UserDict` in `collections`
-    # TODO: the true signature of `dict.fromkeys` is not expressable in the current type system.
+    # TODO: the true signature of `dict.fromkeys` is not expressible in the current type system.
     # See #3800 & https://github.com/python/typing/issues/548#issuecomment-683336963.
     @classmethod
     @overload

--- a/mypy/typeshed/stdlib/collections/__init__.pyi
+++ b/mypy/typeshed/stdlib/collections/__init__.pyi
@@ -277,7 +277,7 @@ class OrderedDict(dict[_KT, _VT], Reversible[_KT], Generic[_KT, _VT]):
     def items(self) -> _OrderedDictItemsView[_KT, _VT]: ...
     def values(self) -> _OrderedDictValuesView[_KT, _VT]: ...
     # `fromkeys` is actually inherited from `dict` at runtime, so the signature should be kept in line with `dict.fromkeys`.
-    # Ideally we would not redefine it here, but the true signature of `dict.fromkeys` is not expressable in the current type system.
+    # Ideally we would not redefine it here, but the true signature of `dict.fromkeys` is not expressible in the current type system.
     # See #3800 & https://github.com/python/typing/issues/548#issuecomment-683336963.
     @classmethod
     @overload

--- a/mypy/typeshed/stdlib/os/__init__.pyi
+++ b/mypy/typeshed/stdlib/os/__init__.pyi
@@ -352,7 +352,7 @@ class stat_result(structseq[float], tuple[int, int, int, int, int, int, int, flo
     if sys.platform == "darwin":
         @property
         def st_flags(self) -> int: ...  # user defined flags for file
-    # Atributes documented as sometimes appearing, but deliberately omitted from the stub: `st_creator`, `st_rsize`, `st_type`.
+    # Attributes documented as sometimes appearing, but deliberately omitted from the stub: `st_creator`, `st_rsize`, `st_type`.
     # See https://github.com/python/typeshed/pull/6560#issuecomment-991253327
 
 @runtime_checkable

--- a/mypyc/doc/introduction.rst
+++ b/mypyc/doc/introduction.rst
@@ -139,7 +139,7 @@ Mypyc uses several techniques to produce fast code:
 * Mypyc treats compiled functions, classes, and attributes declared
   ``Final`` as immutable.
 
-* Mypyc has memory-efficient, unboxed representions for integers and
+* Mypyc has memory-efficient, unboxed representations for integers and
   booleans.
 
 Development status

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -1816,7 +1816,7 @@ class B(A):
     def x(self, val : int) -> None:
         self._x = val + 1
 
-#Inerits base property setters and getters
+#Inherits base property setters and getters
 class C(A):
     def __init__(self) -> None:
         A.__init__(self)

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2064,7 +2064,7 @@ import typing
 from enum import Enum
 
 class WritingMembers(Enum):
-    __members__: typing.Dict[Enum, Enum] = {}  # E: Assigned "__members__" will be overriden by "Enum" internally
+    __members__: typing.Dict[Enum, Enum] = {}  # E: Assigned "__members__" will be overridden by "Enum" internally
 
 class OnlyAnnotatedMembers(Enum):
     __members__: typing.Dict[Enum, Enum]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -273,7 +273,7 @@ reveal_type(u(1, C()))  # N: Revealed type is "Union[__main__.C, builtins.int]"
 reveal_type(u(1, a))  # N: Revealed type is "Union[Any, builtins.int]"
 reveal_type(u(a, 1))  # N: Revealed type is "Union[builtins.int, Any]"
 
-# Any and base-class-Any, no simplificaiton
+# Any and base-class-Any, no simplification
 reveal_type(u(C(), a))  # N: Revealed type is "Union[Any, __main__.C]"
 reveal_type(u(a, C()))  # N: Revealed type is "Union[__main__.C, Any]"
 


### PR DESCRIPTION
Found via `codespell -q 3 -S ./mypyc/external/googletest -L alo,ans,asend,ba,bre,dne,fo,haa,ist,larg,myu,nams,spawnve,statics,thow,ure,whet,wont,zar`