### PR TITLE
feat: creating allow-same-name-modules option

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -535,6 +535,11 @@ of the above sections.
            items = "100"  # valid, items now has type str
            items = int(items)  # valid, items now has type int
 
+.. option:: --allow-same-name-modules
+
+    This flag allow to create different files with the same name in different paths, 
+    for example, one/router.py two/router.py.
+
 .. option:: --local-partial-types
 
     In mypy, the most common cases for partial types are variables initialized using ``None``,

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -634,6 +634,14 @@ section of the command line docs.
            items = "100"  # valid, items now has type str
            items = int(items)  # valid, items now has type int
 
+.. confval:: allow_same_name_modules
+
+    :type: boolean
+    :default: False
+
+    Allows to create different files with the same name in different paths.
+    For example, one/router.py two/router.py
+
 .. confval:: local_partial_types
 
     :type: boolean

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2841,26 +2841,27 @@ def load_graph(sources: List[BuildSource], manager: BuildManager,
             continue
         if st.id in graph:
             manager.errors.set_file(st.xpath, st.id)
-            manager.errors.report(
-                -1, -1,
-                'Duplicate module named "%s" (also at "%s")' % (st.id, graph[st.id].xpath),
-                blocker=True,
-            )
-            manager.errors.report(
-                -1, -1,
-                "See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules "  # noqa: E501
-                "for more info",
-                severity='note',
-            )
-            manager.errors.report(
-                -1, -1,
-                "Common resolutions include: a) using `--exclude` to avoid checking one of them, "
-                "b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or "
-                "adjusting MYPYPATH",
-                severity='note'
-            )
+            if manager.options.allow_same_name_modules is False:
+                manager.errors.report(
+                    -1, -1,
+                    'Duplicate module named "%s" (also at "%s")' % (st.id, graph[st.id].xpath),
+                    blocker=True,
+                )
+                manager.errors.report(
+                    -1, -1,
+                    "See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules "  # noqa: E501
+                    "for more info",
+                    severity='note',
+                )
+                manager.errors.report(
+                    -1, -1,
+                    "Common resolutions include: a) using `--exclude` to avoid checking one of them, "  # noqa: E501
+                    "b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or "
+                    "adjusting MYPYPATH, d) using --allow-same-name-modules",
+                    severity='note'
+                )
 
-            manager.errors.raise_error()
+                manager.errors.raise_error()
         graph[st.id] = st
         new.append(st)
         entry_points.add(bs.module)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -669,6 +669,10 @@ def process_options(args: List[str],
                         help="Allow unconditional variable redefinition with a new type",
                         group=strictness_group)
 
+    add_invertible_flag('--allow-same-name-modules', default=False, strict_flag=False,
+                        help="Suppress toplevel errors caused by duplicated module named",
+                        group=strictness_group)
+
     add_invertible_flag('--no-implicit-reexport', default=True, strict_flag=True,
                         dest='implicit_reexport',
                         help="Treat imports as private unless aliased",

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -22,6 +22,7 @@ class BuildType:
 PER_MODULE_OPTIONS: Final = {
     # Please keep this list sorted
     "allow_redefinition",
+    "allow_same_name_modules",
     "allow_untyped_globals",
     "always_false",
     "always_true",
@@ -178,6 +179,10 @@ class Options:
         # Allow variable to be redefined with an arbitrary type in the same block
         # and the same nesting level as the initialization
         self.allow_redefinition = False
+
+        # Suppress Duplicate module named "...". Recomended to use this option in
+        # monorepos.
+        self.allow_same_name_modules = False
 
         # Prohibit equality, identity, and container checks for non-overlapping types.
         # This makes 1 == '1', 1 in ['1'], and 1 is '1' errors.

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -60,8 +60,16 @@ undef
 [out]
 dir/a.py: error: Duplicate module named "a" (also at "dir/subdir/a.py")
 dir/a.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
-dir/a.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH
+dir/a.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH, d) using --allow-same-name-modules
 == Return code: 2
+
+[case testCmdlineSuppressNonPackageDuplicate]
+# cmd: mypy dir --allow-same-name-modules
+[file dir/a.py]
+undef
+[file dir/subdir/a.py]
+undef
+[out]
 
 [case testCmdlineNonPackageSlash]
 # cmd: mypy dir/
@@ -127,8 +135,16 @@ mypy: can't decode file 'a.py': unknown encoding: uft-8
 [out]
 two/mod/__init__.py: error: Duplicate module named "mod" (also at "one/mod/__init__.py")
 two/mod/__init__.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
-two/mod/__init__.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH
+two/mod/__init__.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH, d) using --allow-same-name-modules
 == Return code: 2
+
+[case testIgnoreDuplicateModule]
+# cmd: mypy one/mod/__init__.py two/mod/__init__.py --allow-same-name-modules
+[file one/mod/__init__.py]
+# type: ignore
+[file two/mod/__init__.py]
+# type: ignore
+[out]
 
 [case testFlagsFile]
 # cmd: mypy @flagsfile


### PR DESCRIPTION
### Description

This PR is related with issue [10428](https://github.com/python/mypy/issues/10428). I create an option to suppress message `Duplicate module named 'xxx'`. It can be used in mono repo projects and others.

## Test Plan

I created unit tests for this. However if you can test it in your environment you could create this folder structure:

```
[file dir/a.py]
[file dir/subdir/a.py]
[out]
```
And then run command `mypy dir --allow-same-name-modules`. With `--allow-same-name-modules` misc error will be ignored.