### PR TITLE
[mypyc] Implement boxed constant integers as literals

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -149,6 +149,8 @@ class LowLevelIRBuilder:
 
     def box(self, src: Value) -> Value:
         if src.type.is_unboxed:
+            if isinstance(src, Integer) and is_tagged(src.type):
+                return self.add(LoadLiteral(src.value >> 1, rtype=object_rprimitive))
             return self.add(Box(src))
         else:
             return src

--- a/mypyc/test-data/exceptions-freq.test
+++ b/mypyc/test-data/exceptions-freq.test
@@ -85,7 +85,8 @@ def f(x):
     r1 :: bit
     r2 :: None
 L0:
-    r0 = box(short_int, 2)
+    r0 = object 1
+    inc_ref r0
     r1 = CPyList_SetItem(x, 0, r0)
     if not r1 goto L2 (error at f:3) else goto L1 :: bool
 L1:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -720,7 +720,7 @@ L0:
     r0 = builtins :: module
     r1 = 'print'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = box(short_int, 10)
+    r3 = object 5
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
     return 1
 
@@ -738,7 +738,7 @@ L0:
     r0 = builtins :: module
     r1 = 'print'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = box(short_int, 10)
+    r3 = object 5
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
     return 1
 
@@ -810,7 +810,7 @@ def g(y):
 L0:
     r0 = g(y)
     r1 = PyList_New(1)
-    r2 = box(short_int, 2)
+    r2 = object 1
     r3 = get_element_ptr r1 ob_item :: PyListObject
     r4 = load_mem r3 :: ptr*
     set_mem r4, r2 :: builtins.object*
@@ -838,7 +838,7 @@ def g(y):
     r7 :: bit
     r8, r9 :: object
 L0:
-    r0 = box(short_int, 2)
+    r0 = object 1
     r1 = g(r0)
     r2 = PyList_New(1)
     r3 = get_element_ptr r2 ob_item :: PyListObject
@@ -851,7 +851,7 @@ L0:
     r7 = CPyList_SetItem(a, 0, r6)
     r8 = box(bool, 1)
     y = r8
-    r9 = box(short_int, 6)
+    r9 = object 3
     return r9
 
 [case testCoerceToObject2]
@@ -869,7 +869,7 @@ def f(a, o):
     r2 :: int
     r3 :: object
 L0:
-    r0 = box(short_int, 2)
+    r0 = object 1
     a.x = r0; r1 = is_error
     r2 = a.n
     r3 = box(int, r2)
@@ -1204,7 +1204,7 @@ L0:
     r0 = load_address PyLong_Type
     r1 = 'base'
     r2 = PyTuple_Pack(1, x)
-    r3 = box(short_int, 4)
+    r3 = object 2
     r4 = CPyDict_Build(1, r1, r3)
     r5 = PyObject_Call(r0, r2, r4)
     r6 = unbox(int, r5)
@@ -1231,7 +1231,7 @@ L0:
     r0 = 'insert'
     r1 = CPyObject_GetAttr(xs, r0)
     r2 = 'x'
-    r3 = box(short_int, 0)
+    r3 = object 0
     r4 = PyTuple_Pack(1, r3)
     r5 = box(int, first)
     r6 = CPyDict_Build(1, r2, r5)
@@ -1242,7 +1242,7 @@ L0:
     r11 = 'i'
     r12 = PyTuple_Pack(0)
     r13 = box(int, second)
-    r14 = box(short_int, 2)
+    r14 = object 1
     r15 = CPyDict_Build(2, r10, r13, r11, r14)
     r16 = PyObject_Call(r9, r12, r15)
     return xs
@@ -1482,7 +1482,7 @@ L1:
 L2:
     r5 = __main__.globals :: static
     r6 = 'x'
-    r7 = box(short_int, 2)
+    r7 = object 1
     r8 = CPyDict_SetItem(r5, r6, r7)
     r9 = r8 >= 0 :: signed
     r10 = __main__.globals :: static
@@ -1516,7 +1516,7 @@ L0:
     r0 = m :: module
     r1 = 'f'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = box(short_int, 2)
+    r3 = object 1
     r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
     r5 = cast(str, r4)
     return r5
@@ -1545,7 +1545,7 @@ def main():
     r1 :: union[int, str]
     r2, x :: int
 L0:
-    r0 = box(short_int, 0)
+    r0 = object 0
     r1 = foo(r0)
     r2 = unbox(int, r1)
     x = r2
@@ -1598,7 +1598,7 @@ def main():
     r1 :: __main__.A
     r2, x :: __main__.B
 L0:
-    r0 = box(short_int, 0)
+    r0 = object 0
     r1 = foo(r0)
     r2 = cast(__main__.B, r1)
     x = r2
@@ -1713,7 +1713,7 @@ L0:
     r2 = 'f'
     r3 = CPyDict_GetItem(r1, r2)
     r4 = PyList_New(1)
-    r5 = box(short_int, 2)
+    r5 = object 1
     r6 = get_element_ptr r4 ob_item :: PyListObject
     r7 = load_mem r6 :: ptr*
     set_mem r7, r5 :: builtins.object*
@@ -1757,9 +1757,9 @@ L0:
     r0 = 'a'
     r1 = 'b'
     r2 = 'c'
-    r3 = box(short_int, 2)
-    r4 = box(short_int, 4)
-    r5 = box(short_int, 6)
+    r3 = object 1
+    r4 = object 2
+    r5 = object 3
     r6 = CPyDict_Build(3, r0, r3, r1, r4, r2, r5)
     r7 = __main__.globals :: static
     r8 = 'f'
@@ -1787,8 +1787,8 @@ def h():
 L0:
     r0 = 'b'
     r1 = 'c'
-    r2 = box(short_int, 4)
-    r3 = box(short_int, 6)
+    r2 = object 2
+    r3 = object 3
     r4 = CPyDict_Build(2, r0, r2, r1, r3)
     r5 = __main__.globals :: static
     r6 = 'f'
@@ -1796,7 +1796,7 @@ L0:
     r8 = PyDict_New()
     r9 = CPyDict_UpdateInDisplay(r8, r4)
     r10 = r9 >= 0 :: signed
-    r11 = box(short_int, 2)
+    r11 = object 1
     r12 = PyTuple_Pack(1, r11)
     r13 = PyObject_Call(r7, r12, r8)
     r14 = unbox(tuple[int, int, int], r13)
@@ -1913,9 +1913,9 @@ def f():
 L0:
     r0 = PyList_New(0)
     r1 = PyList_New(3)
-    r2 = box(short_int, 2)
-    r3 = box(short_int, 4)
-    r4 = box(short_int, 6)
+    r2 = object 1
+    r3 = object 2
+    r4 = object 3
     r5 = get_element_ptr r1 ob_item :: PyListObject
     r6 = load_mem r5 :: ptr*
     set_mem r6, r2 :: builtins.object*
@@ -2012,9 +2012,9 @@ def f():
 L0:
     r0 = PyDict_New()
     r1 = PyList_New(3)
-    r2 = box(short_int, 2)
-    r3 = box(short_int, 4)
-    r4 = box(short_int, 6)
+    r2 = object 1
+    r3 = object 2
+    r4 = object 3
     r5 = get_element_ptr r1 ob_item :: PyListObject
     r6 = load_mem r5 :: ptr*
     set_mem r6, r2 :: builtins.object*
@@ -2429,7 +2429,7 @@ def SubclassedTrait.boxed(self):
     self :: __main__.SubclassedTrait
     r0 :: object
 L0:
-    r0 = box(short_int, 6)
+    r0 = object 3
     return r0
 def DerivingObject.this(self):
     self :: __main__.DerivingObject
@@ -2637,7 +2637,7 @@ L2:
     r57 = __main__.globals :: static
     r58 = 'Lol'
     r59 = CPyDict_GetItem(r57, r58)
-    r60 = box(short_int, 2)
+    r60 = object 1
     r61 = PyObject_CallFunctionObjArgs(r59, r60, r56, 0)
     r62 = cast(tuple, r61)
     r63 = __main__.globals :: static
@@ -2666,9 +2666,9 @@ L2:
     r86 = CPyDict_SetItem(r84, r85, r83)
     r87 = r86 >= 0 :: signed
     r88 = PyList_New(3)
-    r89 = box(short_int, 2)
-    r90 = box(short_int, 4)
-    r91 = box(short_int, 6)
+    r89 = object 1
+    r90 = object 2
+    r91 = object 3
     r92 = get_element_ptr r88 ob_item :: PyListObject
     r93 = load_mem r92 :: ptr*
     set_mem r93, r89 :: builtins.object*
@@ -3738,9 +3738,9 @@ def range_object():
     r10 :: bit
 L0:
     r0 = load_address PyRange_Type
-    r1 = box(short_int, 8)
-    r2 = box(short_int, 24)
-    r3 = box(short_int, 4)
+    r1 = object 4
+    r2 = object 12
+    r3 = object 2
     r4 = PyObject_CallFunctionObjArgs(r0, r1, r2, r3, 0)
     r5 = cast(range, r4)
     r = r5
@@ -3784,6 +3784,7 @@ L3:
     goto L1
 L4:
     return 1
+
 [case testLocalRedefinition]
 # mypy: allow-redefinition
 def f() -> None:

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -145,13 +145,13 @@ def unsupported_div():
     r4, r5, r6 :: object
     r7, y :: float
 L0:
-    r0 = box(short_int, 8)
-    r1 = box(short_int, 12)
+    r0 = object 4
+    r1 = object 6
     r2 = PyNumber_TrueDivide(r0, r1)
     r3 = cast(float, r2)
     x = r3
-    r4 = box(short_int, 20)
-    r5 = box(short_int, 10)
+    r4 = object 10
+    r5 = object 5
     r6 = PyNumber_TrueDivide(r4, r5)
     r7 = cast(float, r6)
     y = r7
@@ -160,8 +160,8 @@ def unsupported_pow():
     r0, r1, r2 :: object
     r3, p :: float
 L0:
-    r0 = box(short_int, 6)
-    r1 = box(short_int, -2)
+    r0 = object 3
+    r1 = object -1
     r2 = CPyNumber_Power(r0, r1)
     r3 = cast(float, r2)
     p = r3

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -8,7 +8,7 @@ def f(d):
     r0, r1 :: object
     r2 :: bool
 L0:
-    r0 = box(short_int, 0)
+    r0 = object 0
     r1 = CPyDict_GetItem(d, r0)
     r2 = unbox(bool, r1)
     return r2
@@ -24,7 +24,7 @@ def f(d):
     r2 :: int32
     r3 :: bit
 L0:
-    r0 = box(short_int, 0)
+    r0 = object 0
     r1 = box(bool, 0)
     r2 = CPyDict_SetItem(d, r0, r1)
     r3 = r2 >= 0 :: signed
@@ -66,8 +66,8 @@ def f(x):
     r3, d :: dict
 L0:
     r0 = ''
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 4)
+    r1 = object 1
+    r2 = object 2
     r3 = CPyDict_Build(2, r1, r2, r0, x)
     d = r3
     return 1
@@ -87,7 +87,7 @@ def f(d):
     r2 :: bit
     r3 :: bool
 L0:
-    r0 = box(short_int, 8)
+    r0 = object 4
     r1 = PyDict_Contains(d, r0)
     r2 = r1 >= 0 :: signed
     r3 = truncate r1: int32 to builtins.bool
@@ -114,7 +114,7 @@ def f(d):
     r2 :: bit
     r3, r4 :: bool
 L0:
-    r0 = box(short_int, 8)
+    r0 = object 4
     r1 = PyDict_Contains(d, r0)
     r2 = r1 >= 0 :: signed
     r3 = truncate r1: int32 to builtins.bool
@@ -178,7 +178,7 @@ L2:
     r8 = cast(str, r7)
     k = r8
     r9 = CPyDict_GetItem(d, k)
-    r10 = box(short_int, 2)
+    r10 = object 1
     r11 = PyNumber_InPlaceAdd(r9, r10)
     r12 = CPyDict_SetItem(d, k, r11)
     r13 = r12 >= 0 :: signed
@@ -208,11 +208,11 @@ def f(x, y):
     r7 :: bit
 L0:
     r0 = 'z'
-    r1 = box(short_int, 4)
+    r1 = object 2
     r2 = CPyDict_Build(1, x, r1)
     r3 = CPyDict_UpdateInDisplay(r2, y)
     r4 = r3 >= 0 :: signed
-    r5 = box(short_int, 6)
+    r5 = object 3
     r6 = CPyDict_SetItem(r2, r0, r5)
     r7 = r6 >= 0 :: signed
     return r2
@@ -423,7 +423,7 @@ L1:
 L2:
     r2 = 'a'
     r3 = PyList_New(1)
-    r4 = box(short_int, 2)
+    r4 = object 1
     r5 = get_element_ptr r3 ob_item :: PyListObject
     r6 = load_mem r5 :: ptr*
     set_mem r6, r4 :: builtins.object*
@@ -451,10 +451,11 @@ L1:
 L2:
     r2 = 'a'
     r3 = 'c'
-    r4 = box(short_int, 2)
+    r4 = object 1
     r5 = CPyDict_Build(1, r3, r4)
     r6 = CPyDict_SetDefault(d, r2, r5)
     return r6
 L3:
     r7 = box(None, 1)
     return r7
+

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -60,7 +60,7 @@ def f():
 L0:
     r0 = C()
     c = r0
-    r1 = box(short_int, 2)
+    r1 = object 1
     c.x = r1; r2 = is_error
     r3 = c.x
     r4 = unbox(int, r3)
@@ -118,7 +118,7 @@ L0:
     r2 = CPyTagged_Add(y, 2)
     r3 = box(int, r2)
     r4 = x.set(r3)
-    r5 = box(short_int, 4)
+    r5 = object 2
     r6 = C(r5)
     x = r6
     return 1

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -54,7 +54,7 @@ def f(x):
     r0 :: object
     r1 :: bit
 L0:
-    r0 = box(short_int, 2)
+    r0 = object 1
     r1 = CPyList_SetItem(x, 0, r0)
     return 1
 
@@ -95,8 +95,8 @@ def f():
     x :: list
 L0:
     r0 = PyList_New(2)
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 4)
+    r1 = object 1
+    r2 = object 2
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3 :: ptr*
     set_mem r4, r1 :: builtins.object*
@@ -145,7 +145,7 @@ L0:
     r0 = CPySequence_Multiply(a, 4)
     b = r0
     r1 = PyList_New(1)
-    r2 = box(short_int, 8)
+    r2 = object 4
     r3 = get_element_ptr r1 ob_item :: PyListObject
     r4 = load_mem r3 :: ptr*
     set_mem r4, r2 :: builtins.object*
@@ -217,7 +217,7 @@ L1:
     if r4 goto L2 else goto L4 :: bool
 L2:
     r5 = CPyList_GetItem(l, i)
-    r6 = box(short_int, 2)
+    r6 = object 1
     r7 = PyNumber_InPlaceAdd(r5, r6)
     r8 = CPyList_SetItem(l, i, r7)
 L3:
@@ -242,8 +242,8 @@ def f(x, y):
     r10 :: bit
 L0:
     r0 = PyList_New(2)
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 4)
+    r1 = object 1
+    r2 = object 2
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3 :: ptr*
     set_mem r4, r1 :: builtins.object*
@@ -252,7 +252,7 @@ L0:
     keep_alive r0
     r6 = CPyList_Extend(r0, x)
     r7 = CPyList_Extend(r0, y)
-    r8 = box(short_int, 6)
+    r8 = object 3
     r9 = PyList_Append(r0, r8)
     r10 = r9 >= 0 :: signed
     return r0

--- a/mypyc/test-data/irbuild-optional.test
+++ b/mypyc/test-data/irbuild-optional.test
@@ -142,11 +142,11 @@ L0:
     r1 = A()
     x = r1
     x = y
-    r2 = box(short_int, 2)
+    r2 = object 1
     z = r2
     r3 = A()
     a = r3
-    r4 = box(short_int, 2)
+    r4 = object 1
     a.a = r4; r5 = is_error
     r6 = box(None, 1)
     a.a = r6; r7 = is_error
@@ -166,7 +166,7 @@ def f(x):
     r2 :: object
     r3 :: bit
 L0:
-    r0 = box(short_int, 0)
+    r0 = object 0
     r1 = CPyList_SetItem(x, 0, r0)
     r2 = box(None, 1)
     r3 = CPyList_SetItem(x, 2, r2)
@@ -417,13 +417,13 @@ L2:
     if r11 goto L3 else goto L4 :: bool
 L3:
     r12 = cast(__main__.B, o)
-    r13 = box(short_int, 2)
+    r13 = object 1
     r14 = r12.f(r13)
     r7 = r14
     goto L5
 L4:
     r15 = cast(__main__.C, o)
-    r16 = box(short_int, 2)
+    r16 = object 1
     r17 = r15.f(r16)
     r18 = box(int, r17)
     r7 = r18

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -16,13 +16,13 @@ def f():
     r9 :: bit
 L0:
     r0 = PySet_New(0)
-    r1 = box(short_int, 2)
+    r1 = object 1
     r2 = PySet_Add(r0, r1)
     r3 = r2 >= 0 :: signed
-    r4 = box(short_int, 4)
+    r4 = object 2
     r5 = PySet_Add(r0, r4)
     r6 = r5 >= 0 :: signed
-    r7 = box(short_int, 6)
+    r7 = object 3
     r8 = PySet_Add(r0, r7)
     r9 = r8 >= 0 :: signed
     return r0
@@ -96,9 +96,9 @@ def test1():
     a :: set
 L0:
     r0 = PyList_New(3)
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 6)
-    r3 = box(short_int, 10)
+    r1 = object 1
+    r2 = object 3
+    r3 = object 5
     r4 = get_element_ptr r0 ob_item :: PyListObject
     r5 = load_mem r4 :: ptr*
     set_mem r5, r1 :: builtins.object*
@@ -186,9 +186,9 @@ L0:
     r0 = '1'
     r1 = '3'
     r2 = '5'
-    r3 = box(short_int, 2)
-    r4 = box(short_int, 6)
-    r5 = box(short_int, 10)
+    r3 = object 1
+    r4 = object 3
+    r5 = object 5
     r6 = CPyDict_Build(3, r3, r0, r4, r1, r5, r2)
     tmp_dict = r6
     r7 = PySet_New(0)
@@ -347,11 +347,11 @@ def test():
     a :: set
 L0:
     r0 = PyList_New(5)
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 4)
-    r3 = box(short_int, 6)
-    r4 = box(short_int, 8)
-    r5 = box(short_int, 10)
+    r1 = object 1
+    r2 = object 2
+    r3 = object 3
+    r4 = object 4
+    r5 = object 5
     r6 = get_element_ptr r0 ob_item :: PyListObject
     r7 = load_mem r6 :: ptr*
     set_mem r7, r1 :: builtins.object*
@@ -465,13 +465,13 @@ def f():
     r12 :: short_int
 L0:
     r0 = PySet_New(0)
-    r1 = box(short_int, 2)
+    r1 = object 1
     r2 = PySet_Add(r0, r1)
     r3 = r2 >= 0 :: signed
-    r4 = box(short_int, 4)
+    r4 = object 2
     r5 = PySet_Add(r0, r4)
     r6 = r5 >= 0 :: signed
-    r7 = box(short_int, 6)
+    r7 = object 3
     r8 = PySet_Add(r0, r7)
     r9 = r8 >= 0 :: signed
     r10 = get_element_ptr r0 used :: PySetObject
@@ -501,14 +501,14 @@ def f():
     r10 :: bool
 L0:
     r0 = PySet_New(0)
-    r1 = box(short_int, 6)
+    r1 = object 3
     r2 = PySet_Add(r0, r1)
     r3 = r2 >= 0 :: signed
-    r4 = box(short_int, 8)
+    r4 = object 4
     r5 = PySet_Add(r0, r4)
     r6 = r5 >= 0 :: signed
     x = r0
-    r7 = box(short_int, 10)
+    r7 = object 5
     r8 = PySet_Contains(x, r7)
     r9 = r8 >= 0 :: signed
     r10 = truncate r8: int32 to builtins.bool
@@ -528,7 +528,7 @@ def f():
 L0:
     r0 = PySet_New(0)
     x = r0
-    r1 = box(short_int, 2)
+    r1 = object 1
     r2 = CPySet_Remove(x, r1)
     return x
 
@@ -547,7 +547,7 @@ def f():
 L0:
     r0 = PySet_New(0)
     x = r0
-    r1 = box(short_int, 2)
+    r1 = object 1
     r2 = PySet_Discard(x, r1)
     r3 = r2 >= 0 :: signed
     return x
@@ -567,7 +567,7 @@ def f():
 L0:
     r0 = PySet_New(0)
     x = r0
-    r1 = box(short_int, 2)
+    r1 = object 1
     r2 = PySet_Add(x, r1)
     r3 = r2 >= 0 :: signed
     return x
@@ -641,17 +641,17 @@ def f(x, y):
     r13 :: bit
 L0:
     r0 = PySet_New(0)
-    r1 = box(short_int, 2)
+    r1 = object 1
     r2 = PySet_Add(r0, r1)
     r3 = r2 >= 0 :: signed
-    r4 = box(short_int, 4)
+    r4 = object 2
     r5 = PySet_Add(r0, r4)
     r6 = r5 >= 0 :: signed
     r7 = _PySet_Update(r0, x)
     r8 = r7 >= 0 :: signed
     r9 = _PySet_Update(r0, y)
     r10 = r9 >= 0 :: signed
-    r11 = box(short_int, 6)
+    r11 = object 3
     r12 = PySet_Add(r0, r11)
     r13 = r12 >= 0 :: signed
     return r0

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -760,8 +760,8 @@ def delList():
     r8 :: bit
 L0:
     r0 = PyList_New(2)
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 4)
+    r1 = object 1
+    r2 = object 2
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3 :: ptr*
     set_mem r4, r1 :: builtins.object*
@@ -769,7 +769,7 @@ L0:
     set_mem r5, r2 :: builtins.object*
     keep_alive r0
     l = r0
-    r6 = box(short_int, 2)
+    r6 = object 1
     r7 = PyObject_DelItem(l, r6)
     r8 = r7 >= 0 :: signed
     return 1
@@ -789,13 +789,13 @@ def delListMultiple():
     r24 :: bit
 L0:
     r0 = PyList_New(7)
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 4)
-    r3 = box(short_int, 6)
-    r4 = box(short_int, 8)
-    r5 = box(short_int, 10)
-    r6 = box(short_int, 12)
-    r7 = box(short_int, 14)
+    r1 = object 1
+    r2 = object 2
+    r3 = object 3
+    r4 = object 4
+    r5 = object 5
+    r6 = object 6
+    r7 = object 7
     r8 = get_element_ptr r0 ob_item :: PyListObject
     r9 = load_mem r8 :: ptr*
     set_mem r9, r1 :: builtins.object*
@@ -813,13 +813,13 @@ L0:
     set_mem r15, r7 :: builtins.object*
     keep_alive r0
     l = r0
-    r16 = box(short_int, 2)
+    r16 = object 1
     r17 = PyObject_DelItem(l, r16)
     r18 = r17 >= 0 :: signed
-    r19 = box(short_int, 4)
+    r19 = object 2
     r20 = PyObject_DelItem(l, r19)
     r21 = r20 >= 0 :: signed
-    r22 = box(short_int, 6)
+    r22 = object 3
     r23 = PyObject_DelItem(l, r22)
     r24 = r23 >= 0 :: signed
     return 1
@@ -842,8 +842,8 @@ def delDict():
 L0:
     r0 = 'one'
     r1 = 'two'
-    r2 = box(short_int, 2)
-    r3 = box(short_int, 4)
+    r2 = object 1
+    r3 = object 2
     r4 = CPyDict_Build(2, r0, r2, r1, r3)
     d = r4
     r5 = 'one'
@@ -864,10 +864,10 @@ L0:
     r1 = 'two'
     r2 = 'three'
     r3 = 'four'
-    r4 = box(short_int, 2)
-    r5 = box(short_int, 4)
-    r6 = box(short_int, 6)
-    r7 = box(short_int, 8)
+    r4 = object 1
+    r5 = object 2
+    r6 = object 3
+    r7 = object 4
     r8 = CPyDict_Build(4, r0, r4, r1, r5, r2, r6, r3, r7)
     d = r8
     r9 = 'one'

--- a/mypyc/test-data/irbuild-strip-asserts.test
+++ b/mypyc/test-data/irbuild-strip-asserts.test
@@ -7,6 +7,7 @@ def g():
 def g():
     r0, x :: object
 L0:
-    r0 = box(short_int, 6)
+    r0 = object 3
     x = r0
     return x
+

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -108,8 +108,8 @@ def f(x, y):
     r11 :: tuple
 L0:
     r0 = PyList_New(2)
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 4)
+    r1 = object 1
+    r2 = object 2
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3 :: ptr*
     set_mem r4, r1 :: builtins.object*
@@ -118,7 +118,7 @@ L0:
     keep_alive r0
     r6 = CPyList_Extend(r0, x)
     r7 = CPyList_Extend(r0, y)
-    r8 = box(short_int, 6)
+    r8 = object 3
     r9 = PyList_Append(r0, r8)
     r10 = r9 >= 0 :: signed
     r11 = PyList_AsTuple(r0)
@@ -310,9 +310,9 @@ def test():
     a :: tuple
 L0:
     r0 = PyList_New(3)
-    r1 = box(short_int, 2)
-    r2 = box(short_int, 4)
-    r3 = box(short_int, 6)
+    r1 = object 1
+    r2 = object 2
+    r3 = object 3
     r4 = get_element_ptr r0 ob_item :: PyListObject
     r5 = load_mem r4 :: ptr*
     set_mem r5, r1 :: builtins.object*
@@ -348,7 +348,6 @@ L3:
 L4:
     a = r10
     return 1
-
 
 [case testTupleBuiltFromStr]
 def f2(val: str) -> str:

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -548,12 +548,14 @@ def f():
     a :: list
 L0:
     r0 = PyList_New(2)
-    r1 = box(short_int, 0)
-    r2 = box(short_int, 2)
+    r1 = object 0
+    r2 = object 1
     r3 = get_element_ptr r0 ob_item :: PyListObject
     r4 = load_mem r3 :: ptr*
+    inc_ref r1
     set_mem r4, r1 :: builtins.object*
     r5 = r4 + WORD_SIZE*1
+    inc_ref r2
     set_mem r5, r2 :: builtins.object*
     a = r0
     dec_ref a
@@ -682,9 +684,8 @@ L0:
     r0 = load_address PyLong_Type
     r1 = 'base'
     r2 = PyTuple_Pack(1, x)
-    r3 = box(short_int, 4)
+    r3 = object 2
     r4 = CPyDict_Build(1, r1, r3)
-    dec_ref r3
     r5 = PyObject_Call(r0, r2, r4)
     dec_ref r2
     dec_ref r4


### PR DESCRIPTION
This avoids (potentially) creating a new int object 
every time we evaluate an integer literal in a context that
requires a boxed value. In any case this reduces the number
of C calls required.

This speeds up this microbenchmark by about 60%:
```
def f() -> None:
    for j in range(1000 * 1000):
        a = []
        for i in range(10):
            a.append(10)
```

In more realistic workloads the impact is hard to
measure and is likely below the noise floor.