### PR TITLE
fix the incorrect, "variable arguments", error

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1519,8 +1519,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 # Check that a *arg is valid as varargs.
                 if (actual_kind == nodes.ARG_STAR and
                     not self.is_valid_var_arg(actual_type)):
-                    if not len(context.args) == 1:
-                        messages.invalid_var_arg(actual_type, context)
+                    messages.invalid_var_arg(actual_type, context)
                         
                 if (actual_kind == nodes.ARG_STAR2 and
                         not self.is_valid_keyword_var_arg(actual_type)):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1511,14 +1511,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         mapper = ArgTypeExpander(self.argument_infer_context())
         for i, actuals in enumerate(formal_to_actual):
             for actual in actuals:
+                
                 actual_type = arg_types[actual]
                 if actual_type is None:
                     continue  # Some kind of error was already reported.
                 actual_kind = arg_kinds[actual]
                 # Check that a *arg is valid as varargs.
                 if (actual_kind == nodes.ARG_STAR and
-                        not self.is_valid_var_arg(actual_type)):
-                    messages.invalid_var_arg(actual_type, context)
+                    not self.is_valid_var_arg(actual_type)):
+                    if not len(context.args) == 1:
+                        messages.invalid_var_arg(actual_type, context)
+                        
                 if (actual_kind == nodes.ARG_STAR2 and
                         not self.is_valid_keyword_var_arg(actual_type)):
                     is_mapping = is_subtype(actual_type, self.chk.named_type('typing.Mapping'))

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -947,7 +947,10 @@ class MessageBuilder:
             self.fail('Cannot infer function type argument', context)
 
     def invalid_var_arg(self, typ: Type, context: Context) -> None:
-        self.fail('List or tuple expected as variable arguments', context)
+        if not len(context.args) == 1:
+            self.fail('List or tuple expected as variable arguments', context)
+        else:
+            self.fail('variadic arguments', context)
 
     def invalid_keyword_var_arg(self, typ: Type, is_mapping: bool, context: Context) -> None:
         typ = get_proper_type(typ)

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -549,6 +549,8 @@ if int():
 if int():
     b, a = f(b, *aa)
 if int():
+     a, b = f(*a)     # E: variadic arguments
+if int():
     b, a = f(b, a, *aa)
 
 def f(a: S, *b: T) -> Tuple[S, T]:
@@ -754,4 +756,5 @@ bar(*good1)
 bar(*good2)
 bar(*good3)
 bar(*bad1)  # E: Argument 1 to "bar" has incompatible type "*I[str]"; expected "float"
+bar(*bad2)  # E: variadic arguments
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -275,7 +275,6 @@ class CC(C): pass
 a = None # type: A
 
 f(*None)
-f(*a)    # E: List or tuple expected as variable arguments
 f(*(a,))
 
 def f(a: 'A') -> None:
@@ -546,9 +545,6 @@ if int():
 if int():
     a, b = f(a, *a)  # E: List or tuple expected as variable arguments
 if int():
-    a, b = f(*a)     # E: List or tuple expected as variable arguments
-
-if int():
     a, a = f(*aa)
 if int():
     b, a = f(b, *aa)
@@ -758,5 +754,4 @@ bar(*good1)
 bar(*good2)
 bar(*good3)
 bar(*bad1)  # E: Argument 1 to "bar" has incompatible type "*I[str]"; expected "float"
-bar(*bad2)  # E: List or tuple expected as variable arguments
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
### Description
"Fixes #12508" 

The initial error is that the Checking sum(*1) produces "error: List or tuple expected as variable arguments". But it’s a variadic argument so should be acceptable. We fix that issue so it won’t produce an error in this case.

## Test Plan
After noticing the issue, we tracked down the code which reports “List or tuple expected as variable arguments”. We found that some test cases contained something like f(*a) which shouldn’t be reported as an error. 

Then, we tracked the error message and found that it was within “check_argument_types”. Within that function, there was an if statement to check whether the actual_kind = node.ASG.STAR and the argument type is not valid argument. 
There are only two circumstances that fit the requirement in the test case: f(*a) and f(a, *a). We evaluated the first one to be acceptable but the second one contains an error. 

In this case, we check the length of those types and only let the function produce an error when there are multiple arguments passed in.

For test cases, we may fail some of them since the original test cases have some problems (false positive). And we delete those incorrect test cases correspondingly. After that, we pass all the remaining test cases.
