### PR TITLE
[mypyc] Fix incorrect borrowed flag for setdefault() primitive

### DIFF
--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -140,7 +140,6 @@ method_op(
     arg_types=[dict_rprimitive, object_rprimitive],
     return_type=object_rprimitive,
     c_function_name='CPyDict_SetDefaultWithNone',
-    is_borrowed=True,
     error_kind=ERR_MAGIC)
 
 # dict.setdefault(key, empty tuple/list/set)


### PR DESCRIPTION
`CPyDict_SetDefaultWithNone` doesn't return a borrowed reference,
since it just calls `CPyDict_SetDefault` which doesn't return a
borrowed reference. Treating the value as borrowed can cause
memory leaks.