### PR TITLE
Add more precise error message for Callable annotation

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -813,7 +813,10 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     return AnyType(TypeOfAny.from_error)
                 ret = maybe_ret
         else:
-            self.fail('Please use "Callable[[<parameters>], <return type>]" or "Callable"', t)
+            if self.options.disallow_any_generics:
+                self.fail('Please use "Callable[[<parameters>], <return type>]"', t)
+            else:
+                self.fail('Please use "Callable[[<parameters>], <return type>]" or "Callable"', t)
             return AnyType(TypeOfAny.from_error)
         assert isinstance(ret, CallableType)
         return ret.accept(self)


### PR DESCRIPTION


### Description

Adds a more precise error message for a `Callable` annotation, if the
option `--disallow-any-generics` (part of `--strict` mode) has been used. The suggestion in the old
message was incorrect in this scenario.

Fixes #11757


## Test Plan

Contents of test.py:

```python
from typing import Callable

def my_function(callback: Callable[...]) -> None:
    callback()
```

Results:

```bash
$ mypy test.py --disallow-any-generics
test.py:3: error: Please use "Callable[[<parameters>], <return type>]" or "Callable[..., Any]"
Found 1 error in 1 file (checked 1 source file)
$ mypy test.py
test.py:3: error: Please use "Callable[[<parameters>], <return type>]" or "Callable"
Found 1 error in 1 file (checked 1 source file)
```
