### PR TITLE
Fix union simplification performance regression

### DIFF
--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -465,7 +465,12 @@ class TypeOpsSuite(Suite):
         self.assert_simplified_union([fx.a, UnionType([fx.a])], fx.a)
         self.assert_simplified_union([fx.b, UnionType([fx.c, UnionType([fx.d])])],
                                      UnionType([fx.b, fx.c, fx.d]))
+
+    def test_simplified_union_with_literals(self) -> None:
+        fx = self.fx
+
         self.assert_simplified_union([fx.lit1, fx.a], fx.a)
+        self.assert_simplified_union([fx.lit1, fx.lit2, fx.a], fx.a)
         self.assert_simplified_union([fx.lit1, fx.lit1], fx.lit1)
         self.assert_simplified_union([fx.lit1, fx.lit2], UnionType([fx.lit1, fx.lit2]))
         self.assert_simplified_union([fx.lit1, fx.lit3], UnionType([fx.lit1, fx.lit3]))
@@ -480,6 +485,40 @@ class TypeOpsSuite(Suite):
         self.assert_simplified_union([fx.lit1, fx.lit1_inst], UnionType([fx.lit1, fx.lit1_inst]))
         self.assert_simplified_union([fx.lit1, fx.lit2_inst], UnionType([fx.lit1, fx.lit2_inst]))
         self.assert_simplified_union([fx.lit1, fx.lit3_inst], UnionType([fx.lit1, fx.lit3_inst]))
+
+    def test_simplified_union_with_str_literals(self) -> None:
+        fx = self.fx
+
+        self.assert_simplified_union([fx.lit_str1, fx.lit_str2, fx.str_type], fx.str_type)
+        self.assert_simplified_union([fx.lit_str1, fx.lit_str1, fx.lit_str1], fx.lit_str1)
+        self.assert_simplified_union([fx.lit_str1, fx.lit_str2, fx.lit_str3],
+                                     UnionType([fx.lit_str1, fx.lit_str2, fx.lit_str3]))
+        self.assert_simplified_union([fx.lit_str1, fx.lit_str2, fx.uninhabited],
+                                     UnionType([fx.lit_str1, fx.lit_str2]))
+
+    def test_simplified_union_with_str_instance_literals(self) -> None:
+        fx = self.fx
+
+        self.assert_simplified_union([fx.lit_str1_inst, fx.lit_str2_inst, fx.str_type],
+                                     fx.str_type)
+        self.assert_simplified_union([fx.lit_str1_inst, fx.lit_str1_inst, fx.lit_str1_inst],
+                                     fx.lit_str1_inst)
+        self.assert_simplified_union([fx.lit_str1_inst, fx.lit_str2_inst, fx.lit_str3_inst],
+                                     UnionType([fx.lit_str1_inst,
+                                                fx.lit_str2_inst,
+                                                fx.lit_str3_inst]))
+        self.assert_simplified_union([fx.lit_str1_inst, fx.lit_str2_inst, fx.uninhabited],
+                                     UnionType([fx.lit_str1_inst, fx.lit_str2_inst]))
+
+    def test_simplified_union_with_mixed_str_literals(self) -> None:
+        fx = self.fx
+
+        self.assert_simplified_union([fx.lit_str1, fx.lit_str2, fx.lit_str3_inst],
+                                     UnionType([fx.lit_str1,
+                                                fx.lit_str2,
+                                                fx.lit_str3_inst]))
+        self.assert_simplified_union([fx.lit_str1, fx.lit_str1, fx.lit_str1_inst],
+                                     UnionType([fx.lit_str1, fx.lit_str1_inst]))
 
     def assert_simplified_union(self, original: List[Type], union: Type) -> None:
         assert_equal(make_simplified_union(original), union)

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -65,6 +65,7 @@ class TypeFixture:
                                               variances=[COVARIANT])   # class tuple
         self.type_typei = self.make_type_info('builtins.type')         # class type
         self.bool_type_info = self.make_type_info('builtins.bool')
+        self.str_type_info = self.make_type_info('builtins.str')
         self.functioni = self.make_type_info('builtins.function')  # function TODO
         self.ai = self.make_type_info('A', mro=[self.oi])              # class A
         self.bi = self.make_type_info('B', mro=[self.ai, self.oi])     # class B(A)
@@ -109,6 +110,7 @@ class TypeFixture:
         self.std_tuple = Instance(self.std_tuplei, [self.anyt])        # tuple
         self.type_type = Instance(self.type_typei, [])        # type
         self.function = Instance(self.functioni, [])  # function TODO
+        self.str_type = Instance(self.str_type_info, [])
         self.a = Instance(self.ai, [])          # A
         self.b = Instance(self.bi, [])          # B
         self.c = Instance(self.ci, [])          # C
@@ -162,6 +164,13 @@ class TypeFixture:
         self.lit2_inst = Instance(self.ai, [], last_known_value=self.lit2)
         self.lit3_inst = Instance(self.di, [], last_known_value=self.lit3)
         self.lit4_inst = Instance(self.ai, [], last_known_value=self.lit4)
+
+        self.lit_str1 = LiteralType("x", self.str_type)
+        self.lit_str2 = LiteralType("y", self.str_type)
+        self.lit_str3 = LiteralType("z", self.str_type)
+        self.lit_str1_inst = Instance(self.str_type_info, [], last_known_value=self.lit_str1)
+        self.lit_str2_inst = Instance(self.str_type_info, [], last_known_value=self.lit_str2)
+        self.lit_str3_inst = Instance(self.str_type_info, [], last_known_value=self.lit_str3)
 
         self.type_a = TypeType.make_normalized(self.a)
         self.type_b = TypeType.make_normalized(self.b)


### PR DESCRIPTION
#11962 can generate large unions with many `Instance` types with 
`last_known_value` set. This caused our union simplification algorithm
to be extremely slow, as it hit an O(n**2) code path.

We already had a fast code path for unions of regular literal types. This 
generalizes it for unions containing `Instance` types with last known
values (which behave similarly to literals in a literal type context).

Also fix a union simplification bug that I encountered while writing tests
for this change.

Work on #12408.