### PR TITLE
Improve checking of "__slots__"

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -60,6 +60,7 @@ INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AEXIT: Final = (
     'Incompatible types in "async with" for "__aexit__"'
 )
 INCOMPATIBLE_TYPES_IN_ASYNC_FOR: Final = 'Incompatible types in "async for"'
+INVALID_TYPE_FOR_SLOTS: Final = 'Invalid type for "__slots__"'
 
 ASYNC_FOR_OUTSIDE_COROUTINE: Final = '"async for" outside async function'
 ASYNC_WITH_OUTSIDE_COROUTINE: Final = '"async with" outside async function'

--- a/mypy/typeshed/stdlib/builtins.pyi
+++ b/mypy/typeshed/stdlib/builtins.pyi
@@ -85,7 +85,6 @@ class _SupportsAiter(Protocol[_T_co]):
 class object:
     __doc__: str | None
     __dict__: dict[str, Any]
-    __slots__: str | Iterable[str]
     __module__: str
     __annotations__: dict[str, Any]
     @property

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1312,13 +1312,17 @@ f(E)
 g(E)
 
 [case testInvalidSlots]
+from typing import List
 class A:
     __slots__ = 1
 class B:
     __slots__ = (1, 2)
+class C:
+    __slots__: List[int] = []
 [out]
-_testInvalidSlots.py:2: error: Incompatible types in assignment (expression has type "int", base class "object" defined the type as "Union[str, Iterable[str]]")
-_testInvalidSlots.py:4: error: Incompatible types in assignment (expression has type "Tuple[int, int]", base class "object" defined the type as "Union[str, Iterable[str]]")
+_testInvalidSlots.py:3: error: Invalid type for "__slots__" (actual type "int", expected type "Union[str, Iterable[str]]")
+_testInvalidSlots.py:5: error: Invalid type for "__slots__" (actual type "Tuple[int, int]", expected type "Union[str, Iterable[str]]")
+_testInvalidSlots.py:7: error: Invalid type for "__slots__" (actual type "List[int]", expected type "Union[str, Iterable[str]]")
 
 [case testDictWithStarStarSpecialCase]
 from typing import Dict


### PR DESCRIPTION
Don't rely on `object.__slots__` being defined, since it's not
defined at runtime (and currently it's removed in typeshed).