### PR TITLE
Minor proper subtype check optimization

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1377,13 +1377,13 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
                     if isinstance(tvar, TypeVarType):
                         variance = tvar.variance
                         if variance == COVARIANT:
-                            nominal = nominal and self._is_proper_subtype(ta, ra)
+                            nominal = self._is_proper_subtype(ta, ra)
                         elif variance == CONTRAVARIANT:
-                            nominal = nominal and self._is_proper_subtype(ra, ta)
+                            nominal = self._is_proper_subtype(ra, ta)
                         else:
-                            nominal = nominal and mypy.sametypes.is_same_type(ta, ra)
+                            nominal = mypy.sametypes.is_same_type(ta, ra)
                     else:
-                        nominal = nominal and mypy.sametypes.is_same_type(ta, ra)
+                        nominal = mypy.sametypes.is_same_type(ta, ra)
                     if not nominal:
                         break
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1384,6 +1384,8 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
                             nominal = nominal and mypy.sametypes.is_same_type(ta, ra)
                     else:
                         nominal = nominal and mypy.sametypes.is_same_type(ta, ra)
+                    if not nominal:
+                        break
 
                 if nominal:
                     TypeState.record_subtype_cache_entry(self._subtype_kind, left, right)


### PR DESCRIPTION
Mypyc is bad at compiling nested functions. In one use case
we were spending 7% of the mypy runtime just creating closure
objects for `check_argument`. Here I manually inline the nested
function to avoid this overhead.

Work on #12526.