### PR TITLE
Fix propagated Any constraint

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -407,6 +407,10 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         raise NotImplementedError
 
     def visit_parameters(self, template: Parameters) -> List[Constraint]:
+        # constraining Any against C[P] turns into infer_against_any([P], Any)
+        # ... which seems like the only case this can happen. Better to fail loudly.
+        if isinstance(self.actual, AnyType):
+            return self.infer_against_any(template.arg_types, self.actual)
         raise RuntimeError("Parameters cannot be constrained to")
 
     # Non-leaf types

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1026,3 +1026,17 @@ P = ParamSpec("P")
 
 def x(f: Callable[Concatenate[int, Concatenate[int, P]], None]) -> None: ...  # E: Nested Concatenates are invalid
 [builtins fixtures/tuple.pyi]
+
+[case testPropagatedAnyConstraintsAreOK]
+from typing import Any, Callable, Generic, TypeVar
+from typing_extensions import ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+def callback(func: Callable[[Any], Any]) -> None: ...
+class Job(Generic[P]): ...
+
+@callback
+def run_job(job: Job[...]) -> T: ...
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
### Description

Fixes #12542

This allows `parameters` to constrain to `Any`. Likely a more general solution would be allowing constraints but I'm not exactly sure of the wanted behavior here so I left in the error (to collect more samples if they exist -- failing loudly).

## Test Plan

Added crashing case (in a minimal format)