### PR TITLE
Message 1

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1519,8 +1519,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 # Check that a *arg is valid as varargs.
                 if (actual_kind == nodes.ARG_STAR and
                     not self.is_valid_var_arg(actual_type)):
-                    if not len(context.args) == 1:
-                        messages.invalid_var_arg(actual_type, context)
+                    messages.invalid_var_arg(actual_type, context)
                         
                 if (actual_kind == nodes.ARG_STAR2 and
                         not self.is_valid_keyword_var_arg(actual_type)):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1511,14 +1511,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         mapper = ArgTypeExpander(self.argument_infer_context())
         for i, actuals in enumerate(formal_to_actual):
             for actual in actuals:
+                
                 actual_type = arg_types[actual]
                 if actual_type is None:
                     continue  # Some kind of error was already reported.
                 actual_kind = arg_kinds[actual]
                 # Check that a *arg is valid as varargs.
                 if (actual_kind == nodes.ARG_STAR and
-                        not self.is_valid_var_arg(actual_type)):
-                    messages.invalid_var_arg(actual_type, context)
+                    not self.is_valid_var_arg(actual_type)):
+                    if not len(context.args) == 1:
+                        messages.invalid_var_arg(actual_type, context)
+                        
                 if (actual_kind == nodes.ARG_STAR2 and
                         not self.is_valid_keyword_var_arg(actual_type)):
                     is_mapping = is_subtype(actual_type, self.chk.named_type('typing.Mapping'))

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -582,7 +582,6 @@ class MessageBuilder:
             else:
                 msg = 'expression has type {}， variable has type {}'.format(
                     quote_type_string(arg_type_str), quote_type_string(expected_type_str))
-                    # expression has type Foo[float], variable has type Foo[int]
 
             object_type = get_proper_type(object_type)
             if isinstance(object_type, TypedDictType):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -580,9 +580,10 @@ class MessageBuilder:
                     outer_context.index.value, quote_type_string(arg_type_str),
                     quote_type_string(expected_type_str))
             else:
-                msg = 'Argument {} {}has incompatible type {}; expected {}'.format(
-                    arg_label, target, quote_type_string(arg_type_str),
-                    quote_type_string(expected_type_str))
+                msg = 'expression has type {}， variable has type {}'.format(
+                    quote_type_string(arg_type_str), quote_type_string(expected_type_str))
+                    # expression has type Foo[float], variable has type Foo[int]
+
             object_type = get_proper_type(object_type)
             if isinstance(object_type, TypedDictType):
                 code = codes.TYPEDDICT_ITEM
@@ -947,10 +948,10 @@ class MessageBuilder:
             self.fail('Cannot infer function type argument', context)
 
     def invalid_var_arg(self, typ: Type, context: Context) -> None:
-        if not len(context.args) == 1:
-            self.fail('List or tuple expected as variable arguments', context)
-        else:
-            self.fail('variadic arguments', context)
+        # if not len(context.args) == 1:
+        self.fail('List or tuple expected as variable arguments', context)
+        # else:
+        #     self.fail('variadic arguments', context)
 
     def invalid_keyword_var_arg(self, typ: Type, is_mapping: bool, context: Context) -> None:
         typ = get_proper_type(typ)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -947,7 +947,10 @@ class MessageBuilder:
             self.fail('Cannot infer function type argument', context)
 
     def invalid_var_arg(self, typ: Type, context: Context) -> None:
-        self.fail('List or tuple expected as variable arguments', context)
+        if not len(context.args) == 1:
+            self.fail('List or tuple expected as variable arguments', context)
+        else:
+            self.fail('variadic arguments', context)
 
     def invalid_keyword_var_arg(self, typ: Type, is_mapping: bool, context: Context) -> None:
         typ = get_proper_type(typ)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -948,10 +948,7 @@ class MessageBuilder:
             self.fail('Cannot infer function type argument', context)
 
     def invalid_var_arg(self, typ: Type, context: Context) -> None:
-        # if not len(context.args) == 1:
         self.fail('List or tuple expected as variable arguments', context)
-        # else:
-        #     self.fail('variadic arguments', context)
 
     def invalid_keyword_var_arg(self, typ: Type, is_mapping: bool, context: Context) -> None:
         typ = get_proper_type(typ)

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -549,6 +549,8 @@ if int():
 if int():
     b, a = f(b, *aa)
 if int():
+     a, b = f(*a)     # E: variadic arguments
+if int():
     b, a = f(b, a, *aa)
 
 def f(a: S, *b: T) -> Tuple[S, T]:
@@ -754,4 +756,5 @@ bar(*good1)
 bar(*good2)
 bar(*good3)
 bar(*bad1)  # E: Argument 1 to "bar" has incompatible type "*I[str]"; expected "float"
+bar(*bad2)  # E: variadic arguments
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -275,6 +275,7 @@ class CC(C): pass
 a = None # type: A
 
 f(*None)
+f(*a)    # E: List or tuple expected as variable arguments
 f(*(a,))
 
 def f(a: 'A') -> None:
@@ -547,9 +548,9 @@ if int():
 if int():
     a, a = f(*aa)
 if int():
-    b, a = f(b, *aa)
+     a, b = f(*a)     # E: List or tuple expected as variable arguments
 if int():
-     a, b = f(*a)     # E: variadic arguments
+    b, a = f(b, *aa)
 if int():
     b, a = f(b, a, *aa)
 
@@ -756,5 +757,5 @@ bar(*good1)
 bar(*good2)
 bar(*good3)
 bar(*bad1)  # E: Argument 1 to "bar" has incompatible type "*I[str]"; expected "float"
-bar(*bad2)  # E: variadic arguments
+bar(*bad2)  # E: List or tuple expected as variable arguments
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -275,7 +275,6 @@ class CC(C): pass
 a = None # type: A
 
 f(*None)
-f(*a)    # E: List or tuple expected as variable arguments
 f(*(a,))
 
 def f(a: 'A') -> None:
@@ -546,9 +545,6 @@ if int():
 if int():
     a, b = f(a, *a)  # E: List or tuple expected as variable arguments
 if int():
-    a, b = f(*a)     # E: List or tuple expected as variable arguments
-
-if int():
     a, a = f(*aa)
 if int():
     b, a = f(b, *aa)
@@ -758,5 +754,4 @@ bar(*good1)
 bar(*good2)
 bar(*good3)
 bar(*bad1)  # E: Argument 1 to "bar" has incompatible type "*I[str]"; expected "float"
-bar(*bad2)  # E: List or tuple expected as variable arguments
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
### Fixes #8934

The initial error is that the error message is unclear as it claims an incompatible type. But the real case is after the class receives an int, it expects the next argument to also be an int.
## Test Plan
We locate the error in message.py and change the format of the original error message. We review the discussion under the issue and produce something like”expression has type xx, variable has type xx.” One thing we miss is that the discussion suggested adding the function name, which is foo. But as we looked into the code and context, we found that ast/mypy got the context as FloatExpr instead of Foo(the original function name). So it’s hard for us to get the function name. The change won’t affect the tests cases and we can still pass them. 

### Description

"Fixes https://github.com/python/mypy/issues/8934"
The format was “Argument {} to {} has incompatible type {}; expected {}
 ”. Now, the format is “Argument {} {}has incompatible type {}; expected {} due to target type {}”.
expression has type Foo[float], variable has type Foo[int]
Update test plan:
We fix the issue within message.py by changing the error message.

