### PR TITLE
Honor `NoReturn` as `__setitem__` return type to mark unreachable code.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4047,7 +4047,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         )
 
         lvalue.method_type = method_type
-        self.expr_checker.check_method_call(
+        res_type, _ = self.expr_checker.check_method_call(
             "__setitem__",
             basetype,
             method_type,
@@ -4055,6 +4055,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             [nodes.ARG_POS, nodes.ARG_POS],
             context,
         )
+        if isinstance(get_proper_type(res_type), UninhabitedType):
+            self.binder.unreachable()
 
     def try_infer_partial_type_from_indexed_assignment(
         self, lvalue: IndexExpr, rvalue: Expression

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4055,7 +4055,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             [nodes.ARG_POS, nodes.ARG_POS],
             context,
         )
-        if isinstance(get_proper_type(res_type), UninhabitedType):
+        res_type = get_proper_type(res_type)
+        if isinstance(res_type, UninhabitedType) and not res_type.ambiguous:
             self.binder.unreachable()
 
     def try_infer_partial_type_from_indexed_assignment(

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1433,3 +1433,17 @@ class Foo:
 Foo()['a'] = 'a'
 x = 0  # E: Statement is unreachable
 [builtins fixtures/exception.pyi]
+
+[case TestNoImplicNoReturnFromError]
+# flags: --warn-unreachable
+from typing import TypeVar
+
+T = TypeVar("T")
+class Foo:
+    def __setitem__(self, key: str, value: str) -> T:  # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
+        raise Exception
+
+def f() -> None:
+    Foo()['a'] = 'a'
+    x = 0 # This should not be reported as unreachable
+[builtins fixtures/exception.pyi]

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1423,3 +1423,13 @@ def f(value: None) -> None:
 
 x = force_forward_ref()
 [builtins fixtures/exception.pyi]
+
+[case testSetitemNoReturn]
+# flags: --warn-unreachable
+from typing import NoReturn
+class Foo:
+    def __setitem__(self, key: str, value: str) -> NoReturn:
+        raise Exception
+Foo()['a'] = 'a'
+x = 0  # E: Statement is unreachable
+[builtins fixtures/exception.pyi]


### PR DESCRIPTION
### Description

In general code that follows any calls to methods annotated with `NoReturn` is considered unreachable. However calls like `variable['foo'] = 'foo'` are not treated this way. Moreover, `variable.__setitem__('foo', 'foo')` is interpreted properly, so this behavior is inconsistent. After this change both variants result in marking remaining part of the branch as unreachable.

## Test Plan

Added test case where code after indexed assignment should be reported is unreachable:
```python
[case testSetitemNoReturn]
# flags: --warn-unreachable
from typing import NoReturn
class Foo:
    def __setitem__(self, key: str, value: str) -> NoReturn:
        raise Exception
Foo()['a'] = 'a'
x = 0  # E: Statement is unreachable
[builtins fixtures/exception.pyi]
```
