### PR TITLE
Add support for assert_type

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -113,6 +113,9 @@ NO_UNTYPED_CALL: Final = ErrorCode(
 REDUNDANT_CAST: Final = ErrorCode(
     "redundant-cast", "Check that cast changes type of expression", "General"
 )
+ASSERT_TYPE: Final = ErrorCode(
+    "assert-type", "Check that assert_type() call succeeds", "General"
+)
 COMPARISON_OVERLAP: Final = ErrorCode(
     "comparison-overlap", "Check that types in comparisons and 'in' expressions overlap", "General"
 )

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -2,13 +2,14 @@ from typing import Optional, Union, Any, Tuple, Iterable
 from typing_extensions import Final
 
 from mypy.nodes import (
-    AssertTypeExpr, Expression, ComparisonExpr, OpExpr, MemberExpr, UnaryExpr, StarExpr, IndexExpr, LITERAL_YES,
+    Expression, ComparisonExpr, OpExpr, MemberExpr, UnaryExpr, StarExpr, IndexExpr, LITERAL_YES,
     LITERAL_NO, NameExpr, LITERAL_TYPE, IntExpr, FloatExpr, ComplexExpr, StrExpr, BytesExpr,
     UnicodeExpr, ListExpr, TupleExpr, SetExpr, DictExpr, CallExpr, SliceExpr, CastExpr,
     ConditionalExpr, EllipsisExpr, YieldFromExpr, YieldExpr, RevealExpr, SuperExpr,
     TypeApplication, LambdaExpr, ListComprehension, SetComprehension, DictionaryComprehension,
     GeneratorExpr, BackquoteExpr, TypeVarExpr, TypeAliasExpr, NamedTupleExpr, EnumCallExpr,
-    TypedDictExpr, NewTypeExpr, PromoteExpr, AwaitExpr, TempNode, AssignmentExpr, ParamSpecExpr
+    TypedDictExpr, NewTypeExpr, PromoteExpr, AwaitExpr, TempNode, AssignmentExpr, ParamSpecExpr,
+    AssertTypeExpr,
 )
 from mypy.visitor import ExpressionVisitor
 

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -2,7 +2,7 @@ from typing import Optional, Union, Any, Tuple, Iterable
 from typing_extensions import Final
 
 from mypy.nodes import (
-    Expression, ComparisonExpr, OpExpr, MemberExpr, UnaryExpr, StarExpr, IndexExpr, LITERAL_YES,
+    AssertTypeExpr, Expression, ComparisonExpr, OpExpr, MemberExpr, UnaryExpr, StarExpr, IndexExpr, LITERAL_YES,
     LITERAL_NO, NameExpr, LITERAL_TYPE, IntExpr, FloatExpr, ComplexExpr, StrExpr, BytesExpr,
     UnicodeExpr, ListExpr, TupleExpr, SetExpr, DictExpr, CallExpr, SliceExpr, CastExpr,
     ConditionalExpr, EllipsisExpr, YieldFromExpr, YieldExpr, RevealExpr, SuperExpr,
@@ -173,6 +173,9 @@ class _Hasher(ExpressionVisitor[Optional[Key]]):
         return None
 
     def visit_cast_expr(self, e: CastExpr) -> None:
+        return None
+
+    def visit_assert_type_expr(self, e: AssertTypeExpr) -> None:
         return None
 
     def visit_conditional_expr(self, e: ConditionalExpr) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1213,6 +1213,11 @@ class MessageBuilder:
         self.fail('Redundant cast to {}'.format(format_type(typ)), context,
                   code=codes.REDUNDANT_CAST)
 
+    def assert_type_fail(self, source_type: Type, target_type: Type, context: Context) -> None:
+        self.fail(f"Expression is of type {format_type(source_type)}, "
+                  f"not {format_type(target_type)}", context,
+                  code=codes.ASSERT_TYPE)
+
     def unimported_type_becomes_any(self, prefix: str, typ: Type, ctx: Context) -> None:
         self.fail("{} becomes {} due to an unfollowed import".format(prefix, format_type(typ)),
                   ctx, code=codes.NO_ANY_UNIMPORTED)

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from mypy.nodes import (
-    Var, FuncItem, ClassDef, AssignmentStmt, ForStmt, WithStmt,
+    AssertTypeExpr, Var, FuncItem, ClassDef, AssignmentStmt, ForStmt, WithStmt,
     CastExpr, TypeApplication, TypeAliasExpr, TypeVarExpr, TypedDictExpr, NamedTupleExpr,
     PromoteExpr, NewTypeExpr
 )
@@ -77,6 +77,10 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
 
     def visit_cast_expr(self, o: CastExpr) -> None:
         super().visit_cast_expr(o)
+        o.type.accept(self)
+
+    def visit_assert_type_expr(self, o: AssertTypeExpr) -> None:
+        super().visit_assert_type_expr(o)
         o.type.accept(self)
 
     def visit_type_application(self, o: TypeApplication) -> None:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1945,6 +1945,22 @@ class CastExpr(Expression):
         return visitor.visit_cast_expr(self)
 
 
+class AssertTypeExpr(Expression):
+    """Represents a typing.assert_type(expr, type) call."""
+    __slots__ = ('expr', 'type')
+
+    expr: Expression
+    type: "mypy.types.Type"
+
+    def __init__(self, expr: Expression, typ: 'mypy.types.Type') -> None:
+        super().__init__()
+        self.expr = expr
+        self.type = typ
+
+    def accept(self, visitor: ExpressionVisitor[T]) -> T:
+        return visitor.visit_assert_type_expr(self)
+
+
 class RevealExpr(Expression):
     """Reveal type expression reveal_type(expr) or reveal_locals() expression."""
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -94,12 +94,12 @@ from mypy.messages import (
 from mypy.errorcodes import ErrorCode
 from mypy import message_registry, errorcodes as codes
 from mypy.types import (
-    ASSERT_TYPE_NAMES, NEVER_NAMES, FunctionLike, UnboundType, TypeVarType, TupleType, UnionType, StarType,
+    NEVER_NAMES, FunctionLike, UnboundType, TypeVarType, TupleType, UnionType, StarType,
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
     get_proper_type, get_proper_types, TypeAliasType, TypeVarLikeType, Parameters, ParamSpecType,
     PROTOCOL_NAMES, TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES, FINAL_DECORATOR_NAMES, REVEAL_TYPE_NAMES,
-    is_named_instance,
+    ASSERT_TYPE_NAMES, is_named_instance,
 )
 from mypy.typeops import function_type, get_type_vars
 from mypy.type_visitor import TypeQuery

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -56,7 +56,7 @@ from typing import (
 from typing_extensions import Final, TypeAlias as _TypeAlias
 
 from mypy.nodes import (
-    MypyFile, TypeInfo, Node, AssignmentStmt, FuncDef, OverloadedFuncDef,
+    AssertTypeExpr, MypyFile, TypeInfo, Node, AssignmentStmt, FuncDef, OverloadedFuncDef,
     ClassDef, Var, GDEF, FuncItem, Import, Expression, Lvalue,
     ImportFrom, ImportAll, Block, LDEF, NameExpr, MemberExpr,
     IndexExpr, TupleExpr, ListExpr, ExpressionStmt, ReturnStmt,
@@ -94,7 +94,7 @@ from mypy.messages import (
 from mypy.errorcodes import ErrorCode
 from mypy import message_registry, errorcodes as codes
 from mypy.types import (
-    NEVER_NAMES, FunctionLike, UnboundType, TypeVarType, TupleType, UnionType, StarType,
+    ASSERT_TYPE_NAMES, NEVER_NAMES, FunctionLike, UnboundType, TypeVarType, TupleType, UnionType, StarType,
     CallableType, Overloaded, Instance, Type, AnyType, LiteralType, LiteralValue,
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
     get_proper_type, get_proper_types, TypeAliasType, TypeVarLikeType, Parameters, ParamSpecType,
@@ -3897,6 +3897,19 @@ class SemanticAnalyzer(NodeVisitor[None],
             expr.analyzed.line = expr.line
             expr.analyzed.column = expr.column
             expr.analyzed.accept(self)
+        elif refers_to_fullname(expr.callee, ASSERT_TYPE_NAMES):
+            if not self.check_fixed_args(expr, 2, 'assert_type'):
+                return
+            # Translate second argument to an unanalyzed type.
+            try:
+                target = self.expr_to_unanalyzed_type(expr.args[1])
+            except TypeTranslationError:
+                self.fail('assert_type() type is not a type', expr)
+                return
+            expr.analyzed = AssertTypeExpr(expr.args[0], target)
+            expr.analyzed.line = expr.line
+            expr.analyzed.column = expr.column
+            expr.analyzed.accept(self)
         elif refers_to_fullname(expr.callee, REVEAL_TYPE_NAMES):
             if not self.check_fixed_args(expr, 1, 'reveal_type'):
                 return
@@ -4195,6 +4208,12 @@ class SemanticAnalyzer(NodeVisitor[None],
             expr.stride.accept(self)
 
     def visit_cast_expr(self, expr: CastExpr) -> None:
+        expr.expr.accept(self)
+        analyzed = self.anal_type(expr.type)
+        if analyzed is not None:
+            expr.type = analyzed
+
+    def visit_assert_type_expr(self, expr: AssertTypeExpr) -> None:
         expr.expr.accept(self)
         analyzed = self.anal_type(expr.type)
         if analyzed is not None:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -48,7 +48,7 @@ See the main entry point merge_asts for more details.
 from typing import Dict, List, cast, TypeVar, Optional
 
 from mypy.nodes import (
-    MypyFile, SymbolTable, Block, AssignmentStmt, NameExpr, MemberExpr, RefExpr, TypeInfo,
+    AssertTypeExpr, MypyFile, SymbolTable, Block, AssignmentStmt, NameExpr, MemberExpr, RefExpr, TypeInfo,
     FuncDef, ClassDef, NamedTupleExpr, SymbolNode, Var, Statement, SuperExpr, NewTypeExpr,
     OverloadedFuncDef, LambdaExpr, TypedDictExpr, EnumCallExpr, FuncBase, TypeAliasExpr, CallExpr,
     CastExpr, TypeAlias,
@@ -224,6 +224,10 @@ class NodeReplaceVisitor(TraverserVisitor):
 
     def visit_cast_expr(self, node: CastExpr) -> None:
         super().visit_cast_expr(node)
+        self.fixup_type(node.type)
+
+    def visit_assert_type_expr(self, node: AssertTypeExpr) -> None:
+        super().visit_assert_type_expr(node)
         self.fixup_type(node.type)
 
     def visit_super_expr(self, node: SuperExpr) -> None:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -48,10 +48,10 @@ See the main entry point merge_asts for more details.
 from typing import Dict, List, cast, TypeVar, Optional
 
 from mypy.nodes import (
-    AssertTypeExpr, MypyFile, SymbolTable, Block, AssignmentStmt, NameExpr, MemberExpr, RefExpr, TypeInfo,
+    MypyFile, SymbolTable, Block, AssignmentStmt, NameExpr, MemberExpr, RefExpr, TypeInfo,
     FuncDef, ClassDef, NamedTupleExpr, SymbolNode, Var, Statement, SuperExpr, NewTypeExpr,
     OverloadedFuncDef, LambdaExpr, TypedDictExpr, EnumCallExpr, FuncBase, TypeAliasExpr, CallExpr,
-    CastExpr, TypeAlias,
+    CastExpr, TypeAlias, AssertTypeExpr,
     MDEF
 )
 from mypy.traverser import TraverserVisitor

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -84,12 +84,13 @@ from typing_extensions import DefaultDict
 
 from mypy.checkmember import bind_self
 from mypy.nodes import (
-    AssertTypeExpr, Node, Expression, MypyFile, FuncDef, ClassDef, AssignmentStmt, NameExpr, MemberExpr, Import,
+    Node, Expression, MypyFile, FuncDef, ClassDef, AssignmentStmt, NameExpr, MemberExpr, Import,
     ImportFrom, CallExpr, CastExpr, TypeVarExpr, TypeApplication, IndexExpr, UnaryExpr, OpExpr,
     ComparisonExpr, GeneratorExpr, DictionaryComprehension, StarExpr, PrintStmt, ForStmt, WithStmt,
     TupleExpr, OperatorAssignmentStmt, DelStmt, YieldFromExpr, Decorator, Block,
     TypeInfo, FuncBase, OverloadedFuncDef, RefExpr, SuperExpr, Var, NamedTupleExpr, TypedDictExpr,
-    LDEF, MDEF, GDEF, TypeAliasExpr, NewTypeExpr, ImportAll, EnumCallExpr, AwaitExpr
+    LDEF, MDEF, GDEF, TypeAliasExpr, NewTypeExpr, ImportAll, EnumCallExpr, AwaitExpr,
+    AssertTypeExpr,
 )
 from mypy.operators import (
     op_methods, reverse_op_methods, ops_with_inplace_method, unary_op_methods

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -84,7 +84,7 @@ from typing_extensions import DefaultDict
 
 from mypy.checkmember import bind_self
 from mypy.nodes import (
-    Node, Expression, MypyFile, FuncDef, ClassDef, AssignmentStmt, NameExpr, MemberExpr, Import,
+    AssertTypeExpr, Node, Expression, MypyFile, FuncDef, ClassDef, AssignmentStmt, NameExpr, MemberExpr, Import,
     ImportFrom, CallExpr, CastExpr, TypeVarExpr, TypeApplication, IndexExpr, UnaryExpr, OpExpr,
     ComparisonExpr, GeneratorExpr, DictionaryComprehension, StarExpr, PrintStmt, ForStmt, WithStmt,
     TupleExpr, OperatorAssignmentStmt, DelStmt, YieldFromExpr, Decorator, Block,
@@ -684,6 +684,10 @@ class DependencyVisitor(TraverserVisitor):
 
     def visit_cast_expr(self, e: CastExpr) -> None:
         super().visit_cast_expr(e)
+        self.add_type_dependencies(e.type)
+
+    def visit_assert_type_expr(self, e: AssertTypeExpr) -> None:
+        super().visit_assert_type_expr(e)
         self.add_type_dependencies(e.type)
 
     def visit_type_application(self, e: TypeApplication) -> None:

--- a/mypy/server/subexpr.py
+++ b/mypy/server/subexpr.py
@@ -3,11 +3,11 @@
 from typing import List
 
 from mypy.nodes import (
-    AssertTypeExpr, Expression, Node, MemberExpr, YieldFromExpr, YieldExpr, CallExpr, OpExpr, ComparisonExpr,
+    Expression, Node, MemberExpr, YieldFromExpr, YieldExpr, CallExpr, OpExpr, ComparisonExpr,
     SliceExpr, CastExpr, RevealExpr, UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr,
     IndexExpr, GeneratorExpr, ListComprehension, SetComprehension, DictionaryComprehension,
     ConditionalExpr, TypeApplication, LambdaExpr, StarExpr, BackquoteExpr, AwaitExpr,
-    AssignmentExpr,
+    AssignmentExpr, AssertTypeExpr,
 )
 from mypy.traverser import TraverserVisitor
 

--- a/mypy/server/subexpr.py
+++ b/mypy/server/subexpr.py
@@ -3,7 +3,7 @@
 from typing import List
 
 from mypy.nodes import (
-    Expression, Node, MemberExpr, YieldFromExpr, YieldExpr, CallExpr, OpExpr, ComparisonExpr,
+    AssertTypeExpr, Expression, Node, MemberExpr, YieldFromExpr, YieldExpr, CallExpr, OpExpr, ComparisonExpr,
     SliceExpr, CastExpr, RevealExpr, UnaryExpr, ListExpr, TupleExpr, DictExpr, SetExpr,
     IndexExpr, GeneratorExpr, ListComprehension, SetComprehension, DictionaryComprehension,
     ConditionalExpr, TypeApplication, LambdaExpr, StarExpr, BackquoteExpr, AwaitExpr,
@@ -98,6 +98,10 @@ class SubexpressionFinder(TraverserVisitor):
     def visit_cast_expr(self, e: CastExpr) -> None:
         self.add(e)
         super().visit_cast_expr(e)
+
+    def visit_assert_type_expr(self, e: AssertTypeExpr) -> None:
+        self.add(e)
+        super().visit_assert_type_expr(e)
 
     def visit_reveal_expr(self, e: RevealExpr) -> None:
         self.add(e)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -431,6 +431,9 @@ class StrConv(NodeVisitor[str]):
     def visit_cast_expr(self, o: 'mypy.nodes.CastExpr') -> str:
         return self.dump([o.expr, o.type], o)
 
+    def visit_assert_type_expr(self, o: 'mypy.nodes.AssertTypeExpr') -> str:
+        return self.dump([o.expr, o.type], o)
+
     def visit_reveal_expr(self, o: 'mypy.nodes.RevealExpr') -> str:
         if o.kind == mypy.nodes.REVEAL_TYPE:
             return self.dump([o.expr], o)

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -9,7 +9,7 @@ from mypy.patterns import (
 )
 from mypy.visitor import NodeVisitor
 from mypy.nodes import (
-    Block, MypyFile, FuncBase, FuncItem, CallExpr, ClassDef, Decorator, FuncDef,
+    AssertTypeExpr, Block, MypyFile, FuncBase, FuncItem, CallExpr, ClassDef, Decorator, FuncDef,
     ExpressionStmt, AssignmentStmt, OperatorAssignmentStmt, WhileStmt,
     ForStmt, ReturnStmt, AssertStmt, DelStmt, IfStmt, RaiseStmt,
     TryStmt, WithStmt, MatchStmt, NameExpr, MemberExpr, OpExpr, SliceExpr, CastExpr,
@@ -203,6 +203,9 @@ class TraverserVisitor(NodeVisitor[None]):
             o.stride.accept(self)
 
     def visit_cast_expr(self, o: CastExpr) -> None:
+        o.expr.accept(self)
+
+    def visit_assert_type_expr(self, o: AssertTypeExpr) -> None:
         o.expr.accept(self)
 
     def visit_reveal_expr(self, o: RevealExpr) -> None:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -6,7 +6,7 @@ Subclass TransformVisitor to perform non-trivial transformations.
 from typing import List, Dict, cast, Optional, Iterable
 
 from mypy.nodes import (
-    MypyFile, Import, Node, ImportAll, ImportFrom, FuncItem, FuncDef,
+    AssertTypeExpr, MypyFile, Import, Node, ImportAll, ImportFrom, FuncItem, FuncDef,
     OverloadedFuncDef, ClassDef, Decorator, Block, Var,
     OperatorAssignmentStmt, ExpressionStmt, AssignmentStmt, ReturnStmt,
     RaiseStmt, AssertStmt, DelStmt, BreakStmt, ContinueStmt,
@@ -406,6 +406,9 @@ class TransformVisitor(NodeVisitor[Node]):
     def visit_cast_expr(self, node: CastExpr) -> CastExpr:
         return CastExpr(self.expr(node.expr),
                         self.type(node.type))
+
+    def visit_assert_type_expr(self, node: AssertTypeExpr) -> AssertTypeExpr:
+        return AssertTypeExpr(self.expr(node.expr), self.type(node.type))
 
     def visit_reveal_expr(self, node: RevealExpr) -> RevealExpr:
         if node.kind == REVEAL_TYPE:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -134,7 +134,7 @@ REVEAL_TYPE_NAMES: Final = (
 
 ASSERT_TYPE_NAMES: Final = (
     'typing.assert_type',
-    'typing_extensions.assert_Type',
+    'typing_extensions.assert_type',
 )
 
 # Attributes that can optionally be defined in the body of a subclass of

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -132,6 +132,11 @@ REVEAL_TYPE_NAMES: Final = (
     'typing_extensions.reveal_type',
 )
 
+ASSERT_TYPE_NAMES: Final = (
+    'typing.assert_type',
+    'typing_extensions.assert_Type',
+)
+
 # Attributes that can optionally be defined in the body of a subclass of
 # enum.Enum but are removed from the class __dict__ by EnumMeta.
 ENUM_REMOVED_PROPS: Final = (

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -82,6 +82,10 @@ class ExpressionVisitor(Generic[T]):
         pass
 
     @abstractmethod
+    def visit_assert_type_expr(self, o: 'mypy.nodes.AssertTypeExpr') -> T:
+        pass
+
+    @abstractmethod
     def visit_reveal_expr(self, o: 'mypy.nodes.RevealExpr') -> T:
         pass
 
@@ -521,6 +525,9 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T], Pattern
         pass
 
     def visit_cast_expr(self, o: 'mypy.nodes.CastExpr') -> T:
+        pass
+
+    def visit_assert_type_expr(self, o: 'mypy.nodes.AssertTypeExpr') -> T:
         pass
 
     def visit_reveal_expr(self, o: 'mypy.nodes.RevealExpr') -> T:

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -7,7 +7,7 @@ and mypyc.irbuild.builder.
 from typing import List, Optional, Union, Callable, cast
 
 from mypy.nodes import (
-    Expression, NameExpr, MemberExpr, SuperExpr, CallExpr, UnaryExpr, OpExpr, IndexExpr,
+    AssertTypeExpr, Expression, NameExpr, MemberExpr, SuperExpr, CallExpr, UnaryExpr, OpExpr, IndexExpr,
     ConditionalExpr, ComparisonExpr, IntExpr, FloatExpr, ComplexExpr, StrExpr,
     BytesExpr, EllipsisExpr, ListExpr, TupleExpr, DictExpr, SetExpr, ListComprehension,
     SetComprehension, DictionaryComprehension, SliceExpr, GeneratorExpr, CastExpr, StarExpr,
@@ -203,6 +203,9 @@ def transform_super_expr(builder: IRBuilder, o: SuperExpr) -> Value:
 def transform_call_expr(builder: IRBuilder, expr: CallExpr) -> Value:
     if isinstance(expr.analyzed, CastExpr):
         return translate_cast_expr(builder, expr.analyzed)
+    elif isinstance(expr.analyzed, AssertTypeExpr):
+        # Compile to a no-op.
+        return builder.accept(expr.analyzed.expr)
 
     callee = expr.callee
     if isinstance(callee, IndexExpr) and isinstance(callee.analyzed, TypeApplication):

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -7,11 +7,11 @@ and mypyc.irbuild.builder.
 from typing import List, Optional, Union, Callable, cast
 
 from mypy.nodes import (
-    AssertTypeExpr, Expression, NameExpr, MemberExpr, SuperExpr, CallExpr, UnaryExpr, OpExpr, IndexExpr,
+    Expression, NameExpr, MemberExpr, SuperExpr, CallExpr, UnaryExpr, OpExpr, IndexExpr,
     ConditionalExpr, ComparisonExpr, IntExpr, FloatExpr, ComplexExpr, StrExpr,
     BytesExpr, EllipsisExpr, ListExpr, TupleExpr, DictExpr, SetExpr, ListComprehension,
     SetComprehension, DictionaryComprehension, SliceExpr, GeneratorExpr, CastExpr, StarExpr,
-    AssignmentExpr,
+    AssignmentExpr, AssertTypeExpr,
     Var, RefExpr, MypyFile, TypeInfo, TypeApplication, LDEF, ARG_POS
 )
 from mypy.types import TupleType, Instance, TypeType, ProperType, get_proper_type

--- a/mypyc/irbuild/visitor.py
+++ b/mypyc/irbuild/visitor.py
@@ -6,7 +6,7 @@ mypyc.irbuild.builder and mypyc.irbuild.main are closely related.
 from typing_extensions import NoReturn
 
 from mypy.nodes import (
-    MypyFile, FuncDef, ReturnStmt, AssignmentStmt, OpExpr,
+    AssertTypeExpr, MypyFile, FuncDef, ReturnStmt, AssignmentStmt, OpExpr,
     IntExpr, NameExpr, Var, IfStmt, UnaryExpr, ComparisonExpr, WhileStmt, CallExpr,
     IndexExpr, Block, ListExpr, ExpressionStmt, MemberExpr, ForStmt,
     BreakStmt, ContinueStmt, ConditionalExpr, OperatorAssignmentStmt, TupleExpr, ClassDef,
@@ -326,6 +326,9 @@ class IRBuilderVisitor(IRVisitor):
 
     def visit_cast_expr(self, o: CastExpr) -> Value:
         assert False, "CastExpr should have been handled in CallExpr"
+
+    def visit_assert_type_expr(self, o: AssertTypeExpr) -> Value:
+        assert False, "AssertTypeExpr should have been handled in CallExpr"
 
     def visit_star_expr(self, o: StarExpr) -> Value:
         assert False, "should have been handled in Tuple/List/Set/DictExpr or CallExpr"

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -876,6 +876,17 @@ L0:
     o = r3
     return 1
 
+[case testAssertType]
+from typing import assert_type
+def f(x: int) -> None:
+    y = assert_type(x, int)
+[out]
+def f(x):
+    x, y :: int
+L0:
+    y = x
+    return 1
+
 [case testDownCast]
 from typing import cast, List, Tuple
 class A: pass

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1036,6 +1036,18 @@ class B: pass
 [out]
 main:3: error: "A" not callable
 
+-- assert_type()
+
+[case testAssertType]
+from typing import assert_type, Any
+from typing_extensions import Literal
+a: int = 1
+returned = assert_type(a, int)
+reveal_type(returned)  # N: Revealed type is "builtins.int"
+assert_type(a, str)  # E: Expression is of type "int", not "str"
+assert_type(a, Any)  # E: Expression is of type "int", not "Any"
+assert_type(a, Literal[1])  # E: Expression is of type "int", not "Literal[1]"
+[builtins fixtures/tuple.pyi]
 
 -- None return type
 -- ----------------

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -11,6 +11,7 @@ from abc import abstractmethod, ABCMeta
 class GenericMeta(type): pass
 
 def cast(t, o): ...
+def assert_type(o, t): ...
 overload = 0
 Any = 0
 Union = 0

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -9,6 +9,7 @@
 # the stubs under fixtures/.
 
 cast = 0
+assert_type = 0
 overload = 0
 Any = 0
 Union = 0

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -839,6 +839,15 @@ cast(str, *None) # E: "cast" must be called with 2 positional arguments
 cast(str, target=None) # E: "cast" must be called with 2 positional arguments
 [out]
 
+[case testInvalidAssertType]
+from typing import assert_type
+assert_type(1, type=int) # E: "assert_type" must be called with 2 positional arguments
+assert_type(1, *int) # E: "assert_type" must be called with 2 positional arguments
+assert_type() # E: "assert_type" expects 2 arguments
+assert_type(1, int, "hello") # E: "assert_type" expects 2 arguments
+assert_type(int, 1)  # E: Invalid type: try using Literal[1] instead?
+assert_type(1, int[int])  # E: "int" expects no type arguments, but 1 given
+
 [case testInvalidAnyCall]
 from typing import Any
 Any(str, None)  # E: Any(...) is no longer supported. Use cast(Any, ...) instead

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -390,6 +390,17 @@ MypyFile:1(
       IntExpr(1)
       builtins.int)))
 
+[case testAssertType]
+from typing import assert_type
+assert_type(1, int)
+[out]
+MypyFile:1(
+  ImportFrom:1(typing, [assert_type])
+  ExpressionStmt:2(
+    AssertTypeExpr:2(
+      IntExpr(1)
+      builtins.int)))
+
 [case testFunctionTypeVariable]
 from typing import TypeVar
 t = TypeVar('t')

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -101,6 +101,25 @@ NameExpr(8) : B
 CastExpr(9) : B
 NameExpr(9) : B
 
+[case testAssertTypeExpr]
+## AssertTypeExpr|[a-z]
+from typing import Any, assert_type
+d = None # type: Any
+a = None # type: A
+b = None # type: B
+class A: pass
+class B(A): pass
+assert_type(d, Any)
+assert_type(a, A)
+assert_type(b, B)
+[out]
+AssertTypeExpr(8) : Any
+NameExpr(8) : Any
+AssertTypeExpr(9) : A
+NameExpr(9) : A
+AssertTypeExpr(10) : B
+NameExpr(10) : B
+
 [case testArithmeticOps]
 ## OpExpr
 import typing


### PR DESCRIPTION
See python/cpython#30843.

The implementation mostly follows that of cast(). It relies on
`mypy.sametypes.is_same_type()`.
