### PR TITLE
stubtest: emit error if a stub defines a public type alias that doesn't exist at runtime

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -83,7 +83,8 @@ class Error:
         if not stub_desc:
             obj = getattr(stub_object, "type", stub_object)
             if isinstance(obj, nodes.TypeInfo):
-                obj = obj.name  # we get very verbose, not particularly helpful, messages otherwise
+                # we get very verbose, not particularly helpful, messages otherwise
+                obj = obj.fullname
             stub_desc = str(obj)
         if typealias_node is not None:
             stub_desc = 'Type alias for: ' + stub_desc

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -55,15 +55,11 @@ class Error:
         self,
         object_path: List[str],
         message: str,
-        stub_object: MaybeMissing[Union[nodes.Node, mypy.types.ProperType]],
+        stub_object: MaybeMissing[nodes.Node],
         runtime_object: MaybeMissing[Any],
         *,
         stub_desc: Optional[str] = None,
-        runtime_desc: Optional[str] = None,
-        # Extra field that's usually None,
-        # to help us get correct line numbers
-        # when reporting errors for type aliases.
-        typealias_node: Optional[nodes.TypeAlias] = None
+        runtime_desc: Optional[str] = None
     ) -> None:
         """Represents an error found by stubtest.
 
@@ -80,23 +76,8 @@ class Error:
         self.message = message
         self.stub_object = stub_object
         self.runtime_object = runtime_object
-        if not stub_desc:
-            obj = getattr(stub_object, "type", stub_object)
-            if isinstance(obj, nodes.TypeInfo):
-                # we get very verbose, not particularly helpful, messages otherwise
-                obj = obj.fullname
-            stub_desc = str(obj)
-        if typealias_node is not None:
-            stub_desc = 'Type alias for: ' + stub_desc
-        self.stub_desc = stub_desc
+        self.stub_desc = stub_desc or str(getattr(stub_object, "type", stub_object))
         self.runtime_desc = runtime_desc or str(runtime_object)
-        self.typealias_node = typealias_node
-        if isinstance(stub_object, Missing):
-            self.stub_line: Optional[int] = None
-        elif typealias_node is None:
-            self.stub_line = stub_object.line
-        else:
-            self.stub_line = typealias_node.line
 
     def is_missing_stub(self) -> bool:
         """Whether or not the error is for something missing from the stub."""
@@ -116,8 +97,10 @@ class Error:
         if concise:
             return _style(self.object_desc, bold=True) + " " + self.message
 
-        stub_line = self.stub_line
+        stub_line = None
         stub_file: None = None
+        if not isinstance(self.stub_object, Missing):
+            stub_line = self.stub_object.line
         # TODO: Find a way of getting the stub file
 
         stub_loc_str = ""

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -959,7 +959,8 @@ def verify_typealias(
     stub_target = mypy.types.get_proper_type(stub.target)
     if isinstance(runtime, Missing):
         yield Error(
-            object_path, "is not present at runtime", stub_target, runtime, typealias_node=stub
+            object_path, "is not present at runtime", stub, runtime,
+            stub_desc=f"Type alias for {stub_target}"
         )
         return
     if isinstance(stub_target, mypy.types.Instance):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -960,7 +960,7 @@ def verify_typealias(
     if isinstance(runtime, Missing):
         yield Error(
             object_path, "is not present at runtime", stub, runtime,
-            stub_desc=f"Type alias for {stub_target}"
+            stub_desc=f"Type alias for: {stub_target}"
         )
         return
     if isinstance(stub_target, mypy.types.Instance):

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -712,6 +712,18 @@ class StubtestUnit(unittest.TestCase):
             runtime="A = (int, str)",
             error="A",
         )
+        # Error if an alias isn't present at runtime...
+        yield Case(
+            stub="B = str",
+            runtime="",
+            error="B"
+        )
+        # ... but only if the alias isn't private
+        yield Case(
+            stub="_C = int",
+            runtime="",
+            error=None
+        )
 
     @collect_cases
     def test_enum(self) -> Iterator[Case]:


### PR DESCRIPTION
### Description

A followup to https://github.com/python/typeshed/pull/7634#discussion_r851603664

Stubtest currently declines to error if a stub defines a public type alias that doesn't exist at runtime. But it should!

These are the new error reported from running stubtest on the typeshed stdlib, with this patch applied:

```
error: _threading_local.localdict is not present at runtime
Stub: at line 6
Type alias for: builtins.dict
Runtime:
MISSING

error: audioop.AdpcmState is not present at runtime
Stub: at line 3
Type alias for: Tuple[builtins.int, builtins.int]
Runtime:
MISSING

error: audioop.RatecvState is not present at runtime
Stub: at line 4
Type alias for: Tuple[builtins.int, builtins.tuple[Tuple[builtins.int, builtins.int], ...]]
Runtime:
MISSING

error: itertools.Predicate is not present at runtime
Stub: at line 14
Type alias for: def (_T?) -> builtins.object
Runtime:
MISSING

error: sqlite3.dbapi2.OptimizedUnicode is not present at runtime
Stub: at line 413
Type alias for: builtins.str
Runtime:
MISSING
```

They all look like true positives to me (or at least should be allowlisted in typeshed, rather than being ignored by stubtest altogether).

## Test Plan

Two test cases added
