### PR TITLE
Add TypeVarTupleType type node

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -8,7 +8,7 @@ from mypy.types import (
     TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeVarId, TypeQuery, is_named_instance, TypeOfAny, LiteralType,
     ProperType, ParamSpecType, get_proper_type, TypeAliasType, is_union_with_any,
-    UnpackType, callable_with_ellipsis, Parameters, TUPLE_LIKE_INSTANCE_NAMES,
+    UnpackType, callable_with_ellipsis, Parameters, TUPLE_LIKE_INSTANCE_NAMES, TypeVarTupleType,
 )
 from mypy.maptype import map_instance_to_supertype
 import mypy.subtypes
@@ -402,6 +402,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
     def visit_param_spec(self, template: ParamSpecType) -> List[Constraint]:
         # Can't infer ParamSpecs from component values (only via Callable[P, T]).
         return []
+
+    def visit_type_var_tuple(self, template: TypeVarTupleType) -> List[Constraint]:
+        raise NotImplementedError
 
     def visit_unpack_type(self, template: UnpackType) -> List[Constraint]:
         raise NotImplementedError

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -4,7 +4,8 @@ from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneType, TypeVarId, Instance, TypeVarType,
     CallableType, TupleType, TypedDictType, UnionType, Overloaded, ErasedType, PartialType,
     DeletedType, TypeTranslator, UninhabitedType, TypeType, TypeOfAny, LiteralType, ProperType,
-    get_proper_type, get_proper_types, TypeAliasType, ParamSpecType, Parameters, UnpackType
+    get_proper_type, get_proper_types, TypeAliasType, ParamSpecType, Parameters, UnpackType,
+    TypeVarTupleType
 )
 from mypy.nodes import ARG_STAR, ARG_STAR2
 
@@ -62,8 +63,11 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
     def visit_parameters(self, t: Parameters) -> ProperType:
         raise RuntimeError("Parameters should have been bound to a class")
 
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> ProperType:
+        return AnyType(TypeOfAny.special_form)
+
     def visit_unpack_type(self, t: UnpackType) -> ProperType:
-        raise NotImplementedError
+        return AnyType(TypeOfAny.special_form)
 
     def visit_callable_type(self, t: CallableType) -> ProperType:
         # We must preserve the fallback type for overload resolution to work.

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -6,7 +6,7 @@ from mypy.types import (
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, TypeVarId,
     FunctionLike, TypeVarType, LiteralType, get_proper_type, ProperType,
     TypeAliasType, ParamSpecType, TypeVarLikeType, Parameters, ParamSpecFlavor,
-    UnpackType
+    UnpackType, TypeVarTupleType
 )
 
 
@@ -130,6 +130,9 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
         else:
             # TODO: should this branch be removed? better not to fail silently
             return repl
+
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> Type:
+        raise NotImplementedError
 
     def visit_unpack_type(self, t: UnpackType) -> Type:
         raise NotImplementedError

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -11,7 +11,7 @@ from mypy.types import (
     CallableType, Instance, Overloaded, TupleType, TypedDictType,
     TypeVarType, UnboundType, UnionType, TypeVisitor, LiteralType,
     TypeType, NOT_READY, TypeAliasType, AnyType, TypeOfAny, ParamSpecType,
-    Parameters, UnpackType,
+    Parameters, UnpackType, TypeVarTupleType
 )
 from mypy.visitor import NodeVisitor
 from mypy.lookup import lookup_fully_qualified
@@ -251,6 +251,9 @@ class TypeFixer(TypeVisitor[None]):
 
     def visit_param_spec(self, p: ParamSpecType) -> None:
         p.upper_bound.accept(self)
+
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> None:
+        t.upper_bound.accept(self)
 
     def visit_unpack_type(self, u: UnpackType) -> None:
         u.type.accept(self)

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -67,6 +67,9 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
     def visit_param_spec(self, t: types.ParamSpecType) -> Set[str]:
         return set()
 
+    def visit_type_var_tuple(self, t: types.TypeVarTupleType) -> Set[str]:
+        return self._visit(t.upper_bound)
+
     def visit_unpack_type(self, t: types.UnpackType) -> Set[str]:
         return t.type.accept(self)
 

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -8,7 +8,7 @@ from mypy.types import (
     TupleType, TypedDictType, ErasedType, UnionType, FunctionLike, Overloaded, LiteralType,
     PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, get_proper_type,
     ProperType, get_proper_types, TypeAliasType, PlaceholderType, ParamSpecType, Parameters,
-    UnpackType
+    UnpackType, TypeVarTupleType,
 )
 from mypy.maptype import map_instance_to_supertype
 from mypy.subtypes import (
@@ -253,6 +253,11 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             return self.default(self.s)
 
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
+        if self.s == t:
+            return t
+        return self.default(self.s)
+
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> ProperType:
         if self.s == t:
             return t
         return self.default(self.s)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -6,7 +6,7 @@ from mypy.types import (
     TupleType, TypedDictType, ErasedType, UnionType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike, LiteralType,
     ProperType, get_proper_type, get_proper_types, TypeAliasType, TypeGuardedType,
-    ParamSpecType, Parameters, UnpackType,
+    ParamSpecType, Parameters, UnpackType, TypeVarTupleType,
 )
 from mypy.subtypes import is_equivalent, is_subtype, is_callable_compatible, is_proper_subtype
 from mypy.erasetype import erase_type
@@ -531,6 +531,12 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
             return self.default(self.s)
 
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
+        if self.s == t:
+            return self.s
+        else:
+            return self.default(self.s)
+
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> ProperType:
         if self.s == t:
             return self.s
         else:

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -4,7 +4,8 @@ from mypy.types import (
     Type, UnboundType, AnyType, NoneType, TupleType, TypedDictType,
     UnionType, CallableType, TypeVarType, Instance, TypeVisitor, ErasedType,
     Overloaded, PartialType, DeletedType, UninhabitedType, TypeType, LiteralType,
-    ProperType, get_proper_type, TypeAliasType, ParamSpecType, Parameters, UnpackType
+    ProperType, get_proper_type, TypeAliasType, ParamSpecType, Parameters,
+    UnpackType, TypeVarTupleType,
 )
 from mypy.typeops import tuple_fallback, make_simplified_union, is_simple_literal
 
@@ -117,6 +118,10 @@ class SameTypeVisitor(TypeVisitor[bool]):
         # Ignore upper bound since it's derived from flavor.
         return (isinstance(self.right, ParamSpecType) and
                 left.id == self.right.id and left.flavor == self.right.flavor)
+
+    def visit_type_var_tuple(self, left: TypeVarTupleType) -> bool:
+        return (isinstance(self.right, TypeVarTupleType) and
+                left.id == self.right.id)
 
     def visit_unpack_type(self, left: UnpackType) -> bool:
         return (isinstance(self.right, UnpackType) and

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -60,7 +60,7 @@ from mypy.types import (
     Type, TypeVisitor, UnboundType, AnyType, NoneType, UninhabitedType,
     ErasedType, DeletedType, Instance, TypeVarType, CallableType, TupleType, TypedDictType,
     UnionType, Overloaded, PartialType, TypeType, LiteralType, TypeAliasType, ParamSpecType,
-    Parameters, UnpackType,
+    Parameters, UnpackType, TypeVarTupleType,
 )
 from mypy.util import get_prefix
 
@@ -316,6 +316,12 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
                 typ.id.raw_id,
                 typ.id.meta_level,
                 typ.flavor,
+                snapshot_type(typ.upper_bound))
+
+    def visit_type_var_tuple(self, typ: TypeVarTupleType) -> SnapshotItem:
+        return ('TypeVarTupleType',
+                typ.id.raw_id,
+                typ.id.meta_level,
                 snapshot_type(typ.upper_bound))
 
     def visit_unpack_type(self, typ: UnpackType) -> SnapshotItem:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -60,7 +60,7 @@ from mypy.types import (
     TupleType, TypeType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     Overloaded, TypeVarType, TypeList, CallableArgument, EllipsisType, StarType, LiteralType,
     RawExpressionType, PartialType, PlaceholderType, TypeAliasType, ParamSpecType, Parameters,
-    UnpackType
+    UnpackType, TypeVarTupleType,
 )
 from mypy.util import get_prefix, replace_object_state
 from mypy.typestate import TypeState
@@ -415,6 +415,9 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
 
     def visit_param_spec(self, typ: ParamSpecType) -> None:
         pass
+
+    def visit_type_var_tuple(self, typ: TypeVarTupleType) -> None:
+        typ.upper_bound.accept(self)
 
     def visit_unpack_type(self, typ: UnpackType) -> None:
         typ.type.accept(self)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -100,7 +100,7 @@ from mypy.types import (
     Type, Instance, AnyType, NoneType, TypeVisitor, CallableType, DeletedType, PartialType,
     TupleType, TypeType, TypeVarType, TypedDictType, UnboundType, UninhabitedType, UnionType,
     FunctionLike, Overloaded, TypeOfAny, LiteralType, ErasedType, get_proper_type, ProperType,
-    TypeAliasType, ParamSpecType, Parameters, UnpackType
+    TypeAliasType, ParamSpecType, Parameters, UnpackType, TypeVarTupleType,
 )
 from mypy.server.trigger import make_trigger, make_wildcard_trigger
 from mypy.util import correct_relative_import
@@ -960,6 +960,13 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         return triggers
 
     def visit_param_spec(self, typ: ParamSpecType) -> List[str]:
+        triggers = []
+        if typ.fullname:
+            triggers.append(make_trigger(typ.fullname))
+        triggers.extend(self.get_type_triggers(typ.upper_bound))
+        return triggers
+
+    def visit_type_var_tuple(self, typ: TypeVarTupleType) -> List[str]:
         triggers = []
         if typ.fullname:
             triggers.append(make_trigger(typ.fullname))

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -8,7 +8,7 @@ from mypy.types import (
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
     FunctionLike, TypeOfAny, LiteralType, get_proper_type, TypeAliasType, ParamSpecType,
-    Parameters, UnpackType, TUPLE_LIKE_INSTANCE_NAMES,
+    Parameters, UnpackType, TUPLE_LIKE_INSTANCE_NAMES, TypeVarTupleType,
 )
 import mypy.applytype
 import mypy.constraints
@@ -336,6 +336,15 @@ class SubtypeVisitor(TypeVisitor[bool]):
             isinstance(right, ParamSpecType)
             and right.id == left.id
             and right.flavor == left.flavor
+        ):
+            return True
+        return self._is_subtype(left.upper_bound, self.right)
+
+    def visit_type_var_tuple(self, left: TypeVarTupleType) -> bool:
+        right = self.right
+        if (
+            isinstance(right, TypeVarTupleType)
+            and right.id == left.id
         ):
             return True
         return self._is_subtype(left.upper_bound, self.right)
@@ -1459,6 +1468,15 @@ class ProperSubtypeVisitor(TypeVisitor[bool]):
             isinstance(right, ParamSpecType)
             and right.id == left.id
             and right.flavor == left.flavor
+        ):
+            return True
+        return self._is_proper_subtype(left.upper_bound, self.right)
+
+    def visit_type_var_tuple(self, left: TypeVarTupleType) -> bool:
+        right = self.right
+        if (
+            isinstance(right, TypeVarTupleType)
+            and right.id == left.id
         ):
             return True
         return self._is_proper_subtype(left.upper_bound, self.right)

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -1,6 +1,10 @@
 from typing import Optional, Dict, Union
-from mypy.types import TypeVarLikeType, TypeVarType, ParamSpecType, ParamSpecFlavor, TypeVarId
-from mypy.nodes import ParamSpecExpr, TypeVarExpr, TypeVarLikeExpr, SymbolTableNode
+from mypy.types import (
+    TypeVarLikeType, TypeVarType, ParamSpecType, ParamSpecFlavor, TypeVarId, TypeVarTupleType,
+)
+from mypy.nodes import (
+    ParamSpecExpr, TypeVarExpr, TypeVarLikeExpr, SymbolTableNode, TypeVarTupleExpr,
+)
 
 
 class TypeVarLikeScope:
@@ -84,6 +88,15 @@ class TypeVarLikeScope:
                 tvar_expr.fullname,
                 i,
                 flavor=ParamSpecFlavor.BARE,
+                upper_bound=tvar_expr.upper_bound,
+                line=tvar_expr.line,
+                column=tvar_expr.column
+            )
+        elif isinstance(tvar_expr, TypeVarTupleExpr):
+            tvar_def = TypeVarTupleType(
+                name,
+                tvar_expr.fullname,
+                i,
                 upper_bound=tvar_expr.upper_bound,
                 line=tvar_expr.line,
                 column=tvar_expr.column

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -23,7 +23,8 @@ from mypy.types import (
     Parameters, RawExpressionType, Instance, NoneType, TypeType,
     UnionType, TypeVarType, PartialType, DeletedType, UninhabitedType, TypeVarLikeType,
     UnboundType, ErasedType, StarType, EllipsisType, TypeList, CallableArgument,
-    PlaceholderType, TypeAliasType, ParamSpecType, UnpackType, get_proper_type
+    PlaceholderType, TypeAliasType, ParamSpecType, UnpackType, TypeVarTupleType,
+    get_proper_type
 )
 
 
@@ -69,6 +70,10 @@ class TypeVisitor(Generic[T]):
 
     @abstractmethod
     def visit_parameters(self, t: Parameters) -> T:
+        pass
+
+    @abstractmethod
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> T:
         pass
 
     @abstractmethod
@@ -197,6 +202,9 @@ class TypeTranslator(TypeVisitor[Type]):
     def visit_parameters(self, t: Parameters) -> Type:
         return t.copy_modified(arg_types=self.translate_types(t.arg_types))
 
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> Type:
+        return t
+
     def visit_partial_type(self, t: PartialType) -> Type:
         return t
 
@@ -313,6 +321,9 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return self.query_types([t.upper_bound] + t.values)
 
     def visit_param_spec(self, t: ParamSpecType) -> T:
+        return self.strategy([])
+
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> T:
         return self.strategy([])
 
     def visit_unpack_type(self, t: UnpackType) -> T:

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -7,7 +7,7 @@ from mypy.types import (
     TypeVarType, LiteralType, Instance, CallableType, TupleType, TypedDictType, UnionType,
     Overloaded, TypeType, CallableArgument, UnboundType, TypeList, StarType, EllipsisType,
     PlaceholderType, PartialType, RawExpressionType, TypeAliasType, ParamSpecType, Parameters,
-    UnpackType
+    UnpackType, TypeVarTupleType,
 )
 
 
@@ -43,6 +43,9 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
 
     def visit_parameters(self, t: Parameters) -> None:
         self.traverse_types(t.arg_types)
+
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> None:
+        pass
 
     def visit_literal_type(self, t: LiteralType) -> None:
         t.fallback.accept(self)

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1462,7 +1462,7 @@ bad: Tuple[Unpack[int]]  # E: builtins.int cannot be unpacked (must be tuple or 
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarTuple]
-from typing_extensions import TypeVarTuple
+from typing_extensions import TypeVarTuple, Unpack
 
 TVariadic = TypeVarTuple('TVariadic')
 TP = TypeVarTuple('?')  # E: String argument 1 "?" to TypeVarTuple(...) does not match variable name "TP"
@@ -1470,3 +1470,6 @@ TP2: int = TypeVarTuple('TP2')  # E: Cannot declare the type of a TypeVar or sim
 TP3 = TypeVarTuple()  # E: Too few arguments for TypeVarTuple()
 TP4 = TypeVarTuple('TP4', 'TP4')  # E: Only the first argument to TypeVarTuple has defined semantics
 TP5 = TypeVarTuple(t='TP5')  # E: TypeVarTuple() expects a string literal as first argument
+
+x: TVariadic  # E: TypeVarTuple "TVariadic" is unbound
+y: Unpack[TVariadic]  # E: TypeVarTuple "TVariadic" is unbound


### PR DESCRIPTION
This adds the TypeVarTupleType type node and basic semanal/glue.

Type checking involving it will be added in a subsequent PR to keep each PR smaller.

This PR is mostly consisting of modifying all the visitors, but not all of them are implemented.