### PR TITLE
introduce per-file timing-stats

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1810,8 +1810,8 @@ class State:
 
     fine_grained_deps_loaded = False
 
-    # Cumulative time spent on this file (for profiling stats)
-    time_spent: int = 0
+    # Cumulative time spent on this file, in microseconds (for profiling stats)
+    time_spent_us: int = 0
 
     def __init__(self,
                  id: Optional[str],
@@ -2039,7 +2039,7 @@ class State:
         else:
             manager.log("Using cached AST for %s (%s)" % (self.xpath, self.id))
 
-        t0 = time.perf_counter_ns()
+        t0 = time.perf_counter()
 
         with self.wrap_context():
             source = self.source
@@ -2086,7 +2086,7 @@ class State:
                     self.tree.ignored_lines,
                     self.ignore_all or self.options.ignore_errors)
 
-        self.time_spent += time.perf_counter_ns() - t0
+        self.time_spent_us += int((time.perf_counter() - t0) * 1e6)
 
         if not cached:
             # Make a copy of any errors produced during parse time so that
@@ -2123,7 +2123,7 @@ class State:
         options = self.options
         assert self.tree is not None
 
-        t0 = time.perf_counter_ns()
+        t0 = time.perf_counter()
 
         # Do the first pass of semantic analysis: analyze the reachability
         # of blocks and import statements. We must do this before
@@ -2143,7 +2143,7 @@ class State:
             if options.allow_redefinition:
                 # Perform more renaming across the AST to allow variable redefinitions
                 self.tree.accept(VariableRenameVisitor())
-        self.time_spent += time.perf_counter_ns() - t0
+        self.time_spent_us += int((time.perf_counter() - t0) * 1e6)
 
     def add_dependency(self, dep: str) -> None:
         if dep not in self.dependencies_set:
@@ -2201,10 +2201,10 @@ class State:
     def type_check_first_pass(self) -> None:
         if self.options.semantic_analysis_only:
             return
-        t0 = time.perf_counter_ns()
+        t0 = time.perf_counter()
         with self.wrap_context():
             self.type_checker().check_first_pass()
-        self.time_spent += time.perf_counter_ns() - t0
+        self.time_spent_us += int((time.perf_counter() - t0) * 1e6)
 
     def type_checker(self) -> TypeChecker:
         if not self._type_checker:
@@ -2222,17 +2222,17 @@ class State:
     def type_check_second_pass(self) -> bool:
         if self.options.semantic_analysis_only:
             return False
-        t0 = time.perf_counter_ns()
+        t0 = time.perf_counter()
         with self.wrap_context():
             return self.type_checker().check_second_pass()
-        self.time_spent += time.perf_counter_ns() - t0
+        self.time_spent_us += int((time.perf_counter() - t0) * 1e6)
 
     def finish_passes(self) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
         manager = self.manager
         if self.options.semantic_analysis_only:
             return
-        t0 = time.perf_counter_ns()
+        t0 = time.perf_counter()
         with self.wrap_context():
             # Some tests (and tools) want to look at the set of all types.
             options = manager.options
@@ -2255,7 +2255,7 @@ class State:
             self.free_state()
             if not manager.options.fine_grained_incremental and not manager.options.preserve_asts:
                 free_tree(self.tree)
-        self.time_spent += time.perf_counter_ns() - t0
+        self.time_spent_us += int((time.perf_counter() - t0) * 1e6)
 
     def free_state(self) -> None:
         if self._type_checker:
@@ -2797,7 +2797,7 @@ def dump_timing_stats(path: str, graph: Graph) -> None:
     with open(path, 'w') as f:
         for k in sorted(graph.keys()):
             v = graph[k]
-            f.write('{} {}\n'.format(v.id, v.time_spent))
+            f.write('{} {}\n'.format(v.id, v.time_spent_us))
 
 
 def dump_graph(graph: Graph, stdout: Optional[TextIO] = None) -> None:
@@ -3118,8 +3118,6 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
         manager.trace(str(fresh_scc_queue))
     else:
         manager.log("No fresh SCCs left in queue")
-
-
 
 
 def order_ascc(graph: Graph, ascc: AbstractSet[str], pri_max: int = PRI_ALL) -> List[str]:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -256,6 +256,8 @@ def _build(sources: List[BuildSource],
         graph = dispatch(sources, manager, stdout)
         if not options.fine_grained_incremental:
             TypeState.reset_all_subtype_caches()
+        if options.timing_stats is not None:
+            dump_timing_stats(options.timing_stats, graph)
         return BuildResult(manager, graph)
     finally:
         t0 = time.time()
@@ -1808,6 +1810,9 @@ class State:
 
     fine_grained_deps_loaded = False
 
+    # Cumulative time spent on this file (for profiling stats)
+    time_spent: int = 0
+
     def __init__(self,
                  id: Optional[str],
                  path: Optional[str],
@@ -2034,6 +2039,8 @@ class State:
         else:
             manager.log("Using cached AST for %s (%s)" % (self.xpath, self.id))
 
+        t0 = time.perf_counter_ns()
+
         with self.wrap_context():
             source = self.source
             self.source = None  # We won't need it again.
@@ -2079,6 +2086,8 @@ class State:
                     self.tree.ignored_lines,
                     self.ignore_all or self.options.ignore_errors)
 
+        self.time_spent += time.perf_counter_ns() - t0
+
         if not cached:
             # Make a copy of any errors produced during parse time so that
             # fine-grained mode can repeat them when the module is
@@ -2113,6 +2122,9 @@ class State:
         """
         options = self.options
         assert self.tree is not None
+
+        t0 = time.perf_counter_ns()
+
         # Do the first pass of semantic analysis: analyze the reachability
         # of blocks and import statements. We must do this before
         # processing imports, since this may mark some import statements as
@@ -2131,6 +2143,7 @@ class State:
             if options.allow_redefinition:
                 # Perform more renaming across the AST to allow variable redefinitions
                 self.tree.accept(VariableRenameVisitor())
+        self.time_spent += time.perf_counter_ns() - t0
 
     def add_dependency(self, dep: str) -> None:
         if dep not in self.dependencies_set:
@@ -2188,8 +2201,10 @@ class State:
     def type_check_first_pass(self) -> None:
         if self.options.semantic_analysis_only:
             return
+        t0 = time.perf_counter_ns()
         with self.wrap_context():
             self.type_checker().check_first_pass()
+        self.time_spent += time.perf_counter_ns() - t0
 
     def type_checker(self) -> TypeChecker:
         if not self._type_checker:
@@ -2207,14 +2222,17 @@ class State:
     def type_check_second_pass(self) -> bool:
         if self.options.semantic_analysis_only:
             return False
+        t0 = time.perf_counter_ns()
         with self.wrap_context():
             return self.type_checker().check_second_pass()
+        self.time_spent += time.perf_counter_ns() - t0
 
     def finish_passes(self) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
         manager = self.manager
         if self.options.semantic_analysis_only:
             return
+        t0 = time.perf_counter_ns()
         with self.wrap_context():
             # Some tests (and tools) want to look at the set of all types.
             options = manager.options
@@ -2237,6 +2255,7 @@ class State:
             self.free_state()
             if not manager.options.fine_grained_incremental and not manager.options.preserve_asts:
                 free_tree(self.tree)
+        self.time_spent += time.perf_counter_ns() - t0
 
     def free_state(self) -> None:
         if self._type_checker:
@@ -2771,6 +2790,16 @@ class NodeInfo:
                                                      json.dumps(self.deps))
 
 
+def dump_timing_stats(path: str, graph: Graph) -> None:
+    """
+    Dump timing stats for each file in the given graph
+    """
+    with open(path, 'w') as f:
+        for k in sorted(graph.keys()):
+            v = graph[k]
+            f.write('{} {}\n'.format(v.id, v.time_spent))
+
+
 def dump_graph(graph: Graph, stdout: Optional[TextIO] = None) -> None:
     """Dump the graph as a JSON string to stdout.
 
@@ -3089,6 +3118,8 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
         manager.trace(str(fresh_scc_queue))
     else:
         manager.log("No fresh SCCs left in queue")
+
+
 
 
 def order_ascc(graph: Graph, ascc: AbstractSet[str], pri_max: int = PRI_ALL) -> List[str]:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -835,6 +835,9 @@ def process_options(args: List[str],
     parser.add_argument(
         '--dump-build-stats', action='store_true',
         help=argparse.SUPPRESS)
+    # dump timing  stats for each processed file into the given output file
+    parser.add_argument(
+        '--timing-stats', dest='timing_stats', help=argparse.SUPPRESS)
     # --debug-cache will disable any cache-related compressions/optimizations,
     # which will make the cache writing process output pretty-printed JSON (which
     # is easier to debug).

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -263,6 +263,7 @@ class Options:
         self.dump_inference_stats = False
         self.dump_build_stats = False
         self.enable_incomplete_features = False
+        self.timing_stats: Optional[str] = None
 
         # -- test options --
         # Stop after the semantic analysis phase

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -464,8 +464,8 @@ def check_test_output_files(testcase: DataDrivenTestCase,
             if expected_content.fullmatch(actual_output_content) is not None:
                 continue
             raise AssertionError(
-                'Output file {} did not match its expected output pattern\n---\n{}\n---\n{}\n---'.format(
-                    path, actual_output_content, expected_content)
+                'Output file {} did not match its expected output pattern\n---\n{}\n---'.format(
+                    path, actual_output_content)
             )
 
         normalized_output = normalize_file_output(actual_output_content.splitlines(),

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -5,7 +5,7 @@ import time
 import shutil
 import contextlib
 
-from typing import List, Iterable, Dict, Tuple, Callable, Any, Iterator, Union
+from typing import List, Iterable, Dict, Tuple, Callable, Any, Iterator, Union, Pattern
 
 from mypy import defaults
 import mypy.api as api
@@ -458,8 +458,17 @@ def check_test_output_files(testcase: DataDrivenTestCase,
                 'Expected file {} was not produced by test case{}'.format(
                     path, ' on step %d' % step if testcase.output2 else ''))
         with open(path, 'r', encoding='utf8') as output_file:
-            actual_output_content = output_file.read().splitlines()
-        normalized_output = normalize_file_output(actual_output_content,
+            actual_output_content = output_file.read()
+
+        if isinstance(expected_content, Pattern):
+            if expected_content.fullmatch(actual_output_content) is not None:
+                continue
+            raise AssertionError(
+                'Output file {} did not match its expected output pattern\n---\n{}\n---\n{}\n---'.format(
+                    path, actual_output_content, expected_content)
+            )
+
+        normalized_output = normalize_file_output(actual_output_content.splitlines(),
                                                   os.path.abspath(test_temp_dir))
         # We always normalize things like timestamp, but only handle operating-system
         # specific things if requested.

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -8,6 +8,7 @@ import sys
 import hashlib
 import io
 import shutil
+import time
 
 from typing import (
     TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable, Container, IO, Callable
@@ -763,3 +764,12 @@ def is_stub_package_file(file: str) -> bool:
 
 def unnamed_function(name: Optional[str]) -> bool:
     return name is not None and name == "_"
+
+
+# TODO: replace with uses of perf_counter_ns when support for py3.6 is dropped
+# (or when mypy properly handles alternate definitions based on python version check
+time_ref = time.perf_counter
+
+
+def time_spent_us(t0: float) -> int:
+    return int((time.perf_counter() - t0) * 1e6)

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1373,3 +1373,15 @@ exclude = (?x)(
 1()
 [out]
 c/cpkg.py:1: error: "int" not callable
+
+
+[case testCmdlineTimingStats]
+# cmd: mypy --timing-stats timing.txt .
+[file b/__init__.py]
+[file b/c.py]
+class C: pass
+[outfile-re timing.txt]
+.*
+b \d+
+b\.c \d+
+.*


### PR DESCRIPTION
When profiling mypy over a large codebase, it can be useful
to know which files are slowest to typecheck.

Gather per-file timing stats and expose them through a new
(hidden) command line switch