### PR TITLE
Attempt to fix issue with ParamSpec serialization

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -188,11 +188,7 @@ class TypeFixer(TypeVisitor[None]):
         if ct.ret_type is not None:
             ct.ret_type.accept(self)
         for v in ct.variables:
-            if isinstance(v, TypeVarType):
-                if v.values:
-                    for val in v.values:
-                        val.accept(self)
-                v.upper_bound.accept(self)
+            v.accept(self)
         for arg in ct.bound_args:
             if arg:
                 arg.accept(self)
@@ -262,6 +258,8 @@ class TypeFixer(TypeVisitor[None]):
         for argt in p.arg_types:
             if argt is not None:
                 argt.accept(self)
+        for var in p.variables:
+            var.accept(self)
 
     def visit_unbound_type(self, o: UnboundType) -> None:
         for a in o.args:


### PR DESCRIPTION
I've seen crashes like this, which might be caused by not
fixing up some FakeInfos:

```
  File "mypy/checkexpr.py", line 3981, in accept
  File "mypy/nodes.py", line 1753, in accept
  File "mypy/checkexpr.py", line 288, in visit_call_expr
  File "mypy/checkexpr.py", line 371, in visit_call_expr_inner
  File "mypy/checkexpr.py", line 880, in check_call_expr_with_callee_type
  File "mypy/checkexpr.py", line 940, in check_call
  File "mypy/checkexpr.py", line 1027, in check_callable_call
  File "mypy/checkexpr.py", line 1269, in infer_function_type_arguments
  File "mypy/checkexpr.py", line 1324, in infer_function_type_arguments_pass2
  File "mypy/infer.py", line 47, in infer_function_type_arguments
  File "mypy/constraints.py", line 72, in infer_constraints_for_callable
  File "mypy/constraints.py", line 108, in infer_constraints
  File "mypy/constraints.py", line 181, in _infer_constraints
  File "mypy/types.py", line 1576, in accept
  File "mypy/constraints.py", line 663, in visit_callable_type
  File "mypy/constraints.py", line 685, in infer_against_overloaded
  File "mypy/constraints.py", line 775, in find_matching_overload_item
  File "mypy/subtypes.py", line 942, in is_callable_compatible
  File "mypy/subtypes.py", line 1209, in unify_generic_callable
  File "mypy/applytype.py", line 86, in apply_generic_arguments
  File "mypy/applytype.py", line 50, in get_target_type
  File "mypy/subtypes.py", line 97, in is_subtype
  File "mypy/subtypes.py", line 158, in _is_subtype
  File "mypy/types.py", line 615, in accept
  File "mypy/subtypes.py", line 341, in visit_param_spec
  File "mypy/subtypes.py", line 217, in _is_subtype
  File "mypy/subtypes.py", line 97, in is_subtype
  File "mypy/subtypes.py", line 158, in _is_subtype
  File "mypy/types.py", line 1127, in accept
  File "mypy/subtypes.py", line 257, in visit_instance
AttributeError: attribute 'fallback_to_any' of 'TypeInfo' undefined
```

I don't have a small reproducer to I couldn't add a test case,
unfortunately.