### PR TITLE
Disallow undesirable implicit reexport with ImportFrom

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1901,7 +1901,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             or fullname not in self.modules
             # but given `from somewhere import random_unrelated_module` we should hide
             # random_unrelated_module
-            or not fullname.startswith(self.cur_mod_id)
+            or not fullname.startswith(self.cur_mod_id + ".")
         )
 
         if isinstance(node.node, PlaceholderNode):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1894,10 +1894,14 @@ class SemanticAnalyzer(NodeVisitor[None],
                                 fullname: str,
                                 module_public: bool,
                                 context: ImportBase) -> None:
-        module_hidden = not module_public and not (
-            # `from package import module` should work regardless of whether package
-            # re-exports module
-            isinstance(node.node, MypyFile) and fullname in self.modules
+        module_hidden = not module_public and (
+            # `from package import submodule` should work regardless of whether package
+            # re-exports submodule, so we shouldn't hide it
+            not isinstance(node.node, MypyFile)
+            or fullname not in self.modules
+            # but given `from somewhere import random_unrelated_module` we should hide
+            # random_unrelated_module
+            or not fullname.startswith(self.cur_mod_id)
         )
 
         if isinstance(node.node, PlaceholderNode):

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1929,6 +1929,19 @@ from package import mod as mod
 from package import mod as internal_detail
 [builtins fixtures/module.pyi]
 
+[case testNoReExportUnrelatedModule]
+from mod2 import unrelated  # E: Module "mod2" has no attribute "unrelated"
+
+[file mod1/__init__.pyi]
+
+[file mod1/unrelated.pyi]
+x: int
+
+[file mod2.pyi]
+from mod1 import unrelated
+
+[builtins fixtures/module.pyi]
+
 [case testNoReExportChildStubs]
 import mod
 from mod import C, D  # E: Module "mod" has no attribute "C"

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1933,13 +1933,22 @@ from package import mod as internal_detail
 from mod2 import unrelated  # E: Module "mod2" has no attribute "unrelated"
 
 [file mod1/__init__.pyi]
-
 [file mod1/unrelated.pyi]
 x: int
 
 [file mod2.pyi]
 from mod1 import unrelated
+[builtins fixtures/module.pyi]
 
+[case testNoReExportUnrelatedSiblingPrefix]
+from pkg.unrel import unrelated  # E: Module "pkg.unrel" has no attribute "unrelated"
+
+[file pkg/__init__.pyi]
+[file pkg/unrelated.pyi]
+x: int
+
+[file pkg/unrel.pyi]
+from pkg import unrelated
 [builtins fixtures/module.pyi]
 
 [case testNoReExportChildStubs]


### PR DESCRIPTION
Fixes #12689

We always hid e.g. `import concurrent`, but looks like mypy
never hid `from concurrent import futures`. It's possible this fix is
pretty breaking for users, let's see what primer thinks.

I last touched this logic in #11707, which fixed cases involving
implicitly reexported symbols that shared the name of a module