### PR TITLE
Fix crash when using decorator in class scope

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4927,7 +4927,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         # when it can also be a FuncBase. Once fixed, `f` in the following can be removed.
         # See also https://github.com/mypyc/mypyc/issues/892
         f = cast(Any, lambda x: x)
-        if isinstance(f(symbol_node), (FuncBase, Var)):
+        if isinstance(f(symbol_node), (Decorator, FuncBase, Var)):
             # For imports in class scope, we construct a new node to represent the symbol and
             # set its `info` attribute to `self.type`.
             existing = self.current_symbol_table().get(name)
@@ -4935,7 +4935,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 # The redefinition checks in `add_symbol_table_node` don't work for our
                 # constructed Var / FuncBase, so check for possible redefinitions here.
                 existing is not None
-                and isinstance(f(existing.node), (FuncBase, Var))
+                and isinstance(f(existing.node), (Decorator, FuncBase, Var))
                 and (
                     isinstance(f(existing.type), f(AnyType))
                     or f(existing.type) == f(symbol_node).type
@@ -4944,7 +4944,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 return existing.node
 
             # Construct the new node
-            if isinstance(f(symbol_node), FuncBase):
+            if isinstance(f(symbol_node), (FuncBase, Decorator)):
                 # In theory we could construct a new node here as well, but in practice
                 # it doesn't work well, see #12197
                 typ: Optional[Type] = AnyType(TypeOfAny.from_error)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7284,3 +7284,19 @@ def meth1(self: Any, y: str) -> str: ...
 
 T = TypeVar("T")
 def meth2(self: Any, y: T) -> T: ...
+
+[case testClassScopeImportWithWrapperAndError]
+class Foo:
+    from mod import foo # E: Unsupported class scoped import
+
+[file mod.py]
+from typing import Any, Callable, TypeVar
+
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+def identity_wrapper(func: FuncT) -> FuncT:
+    return func
+
+@identity_wrapper
+def foo(self: Any) -> str:
+    return ""
+


### PR DESCRIPTION
### Description

Fixes #12474 
<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->
Fix INTERNAL_ERROR when using a decorated function within class scope.

## Test Plan

Add unit test

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
Run unit tests
