### PR TITLE
Fix TypeError with hidden enable-incomplete-features flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -869,7 +869,7 @@ def process_options(args: List[str],
     # Must be followed by another flag or by '--' (and then only file args may follow).
     parser.add_argument('--cache-map', nargs='+', dest='special-opts:cache_map',
                         help=argparse.SUPPRESS)
-    parser.add_argument('--enable-incomplete-features', default=False,
+    parser.add_argument('--enable-incomplete-features', action='store_true',
                         help=argparse.SUPPRESS)
 
     # options specifying code to check

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1394,3 +1394,8 @@ class C: pass
 b \d+
 b\.c \d+
 .*
+
+[case testCmdlineEnableIncompleteFeatures]
+# cmd: mypy --enable-incomplete-features a.py
+[file a.py]
+pass


### PR DESCRIPTION
### Description

This fixes an issue with the `enable-incomplete-features` flag if the compiled version of mypy is used.
Since the default is a `bool` and no type cast is specified, any string argument will result in a TypeError.
```
mypy --enable-incomplete-features True
```
```
Traceback (most recent call last):
  File "/.../bin/mypy", line 8, in <module>
    sys.exit(console_entry())
  File "/.../lib/python3.10/site-packages/mypy/__main__.py", line 12, in console_entry
    main(None, sys.stdout, sys.stderr)
  File "mypy/main.py", line 70, in main
  File "mypy/main.py", line 945, in process_options
  File "/.../3.10/lib/python3.10/argparse.py", line 1825, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/.../3.10/lib/python3.10/argparse.py", line 1858, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/.../3.10/lib/python3.10/argparse.py", line 2067, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/.../3.10/lib/python3.10/argparse.py", line 2007, in consume_optional
    take_action(action, args, option_string)
  File "/.../3.10/lib/python3.10/argparse.py", line 1935, in take_action
    action(self, namespace, argument_values, option_string)
  File "/.../3.10/lib/python3.10/argparse.py", line 935, in __call__
    setattr(namespace, self.dest, values)
  File "/.../lib/python3.10/site-packages/mypy/split_namespace.py", line 28, in __setattr__
    setattr(self._standard_namespace, name, value)
TypeError: bool object expected; got str
```

As this is only meant to be a hidden command line flag anyway, the easiest solution would be to use `action=store_true`. This changes the cli flag slightly, since it's no longer necessary / possible to pass `True` explicitly.


## Test Plan
Added a simple test case to make sure mypy doesn't raise an exception.