### PR TITLE
Ensure instances of `CallableType` can always be hashed

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -14,7 +14,7 @@ from mypy.backports import OrderedDict
 import mypy.nodes
 from mypy.state import state
 from mypy.nodes import (
-    INVARIANT, SymbolNode, FuncDef,
+    INVARIANT, SymbolNode, FuncDef, FakeInfo,
     ArgKind, ARG_POS, ARG_STAR, ARG_STAR2,
 )
 from mypy.util import IdMapper
@@ -1766,7 +1766,12 @@ class CallableType(FunctionLike):
                                       variables=[*variables, *self.variables])
 
     def __hash__(self) -> int:
-        return hash((self.ret_type, self.is_type_obj(),
+        # self.is_type_obj() will fail if self.fallback.type is a FakeInfo
+        if isinstance(self.fallback.type, FakeInfo):
+            is_type_obj = 2
+        else:
+            is_type_obj = self.is_type_obj()
+        return hash((self.ret_type, is_type_obj,
                      self.is_ellipsis_args, self.name,
                     tuple(self.arg_types), tuple(self.arg_names), tuple(self.arg_kinds)))
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -221,6 +221,17 @@ reveal_type(d)  # N: Revealed type is "TypedDict('__main__.D', {'y': builtins.in
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictWithClassmethodAlternativeConstructorDoesNotCrash]
+# https://github.com/python/mypy/issues/5653
+from typing import TypedDict
+
+class Foo(TypedDict):
+    bar: str
+    @classmethod  # E: Invalid statement in TypedDict definition; expected "field_name: field_type"
+    def baz(cls) -> "Foo": ...
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testCanCreateTypedDictTypeWithUnderscoreItemName]
 from mypy_extensions import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int, '_fallback': object})


### PR DESCRIPTION
### Description

Trying to hash an instance of `mypy.types.CallableType` will crash if `self.fallback.type` is a `FakeInfo`. Apparently this is the case if the `CallableType` represents a classmethod alternative constructor on a `TypedDict`. Such alternative-constructor methods aren't currently supported by mypy, but mypy also shouldn't crash if it comes across them.

Fixes #5653 (though I'm not 100% sure if this is the best solution).

## Test Plan

Test case added to `check-typeddict.test`.
