### PR TITLE
Add error when making abstractmethod final

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1104,7 +1104,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         if dec.decorators and dec.var.is_property:
             self.fail('Decorated property not supported', dec)
         if dec.func.is_abstract and dec.func.is_final:
-            self.fail(f"Final method {dec.func.name} has abstract attributes", dec)
+            self.fail(f"Method {dec.func.name} is both abstract and final", dec)
 
     def check_decorated_function_is_method(self, decorator: str,
                                            context: Context) -> None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1103,6 +1103,8 @@ class SemanticAnalyzer(NodeVisitor[None],
             dec.func.accept(self)
         if dec.decorators and dec.var.is_property:
             self.fail('Decorated property not supported', dec)
+        if dec.func.is_abstract and dec.func.is_final:
+            self.fail(f"Final method {dec.func.name} has abstract attributes", dec)
 
     def check_decorated_function_is_method(self, decorator: str,
                                            context: Context) -> None:

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1091,3 +1091,21 @@ class A:
     b: ClassVar[Final[int]]  # E: Final can be only used as an outermost qualifier in a variable annotation
     c: ClassVar[Final] = 1  # E: Final can be only used as an outermost qualifier in a variable annotation
 [out]
+
+[case testFinalClassWithAbstractMethod]
+from typing import final
+from abc import ABC, abstractmethod
+
+@final
+class A(ABC): # E: Final class __main__.A has abstract attributes "B"
+    @abstractmethod
+    def B(self) -> None: ...
+
+[case testFinalDefiningFuncWithAbstractMethod]
+from typing import final
+from abc import ABC, abstractmethod
+
+class A(ABC):
+    @final # E: Final method B has abstract attributes
+    @abstractmethod
+    def B(self) -> None: ...

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1106,6 +1106,6 @@ from typing import final
 from abc import ABC, abstractmethod
 
 class A(ABC):
-    @final # E: Final method B has abstract attributes
+    @final # E: Method B is both abstract and final
     @abstractmethod
     def B(self) -> None: ...


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

This fixes https://github.com/python/mypy/issues/12164.
When an abstract method is tried to make as `final`, an error will be raised.

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

Added a simple test case to make sure mypy doesn't raise an exception.