### PR TITLE
Fix reporting location in aliased types.

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2760,6 +2760,7 @@ from mypy.type_visitor import (  # noqa
     TypeTranslator as TypeTranslator,
     TypeVisitor as TypeVisitor,
 )
+from mypy.typetraverser import TypeTraverserVisitor
 
 
 class TypeStrVisitor(SyntheticTypeVisitor[str]):
@@ -3122,6 +3123,18 @@ class InstantiateAliasVisitor(TrivialSyntheticTypeTranslator):
         return typ
 
 
+class LocationSetter(TypeTraverserVisitor):
+    # TODO: Should we update locations of other Type subclasses?
+    def __init__(self, line: int, column: int) -> None:
+        self.line = line
+        self.column = column
+
+    def visit_instance(self, typ: Instance) -> None:
+        typ.line = self.line
+        typ.column = self.column
+        super().visit_instance(typ)
+
+
 def replace_alias_tvars(
     tp: Type, vars: List[str], subs: List[Type], newline: int, newcolumn: int
 ) -> Type:
@@ -3130,6 +3143,7 @@ def replace_alias_tvars(
     """
     replacer = InstantiateAliasVisitor(vars, subs)
     new_tp = tp.accept(replacer)
+    new_tp.accept(LocationSetter(newline, newcolumn))
     new_tp.line = newline
     new_tp.column = newcolumn
     return new_tp

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -648,6 +648,30 @@ reveal_type(f3()) # N: Revealed type is "Union[builtins.int, __main__.Node[built
 
 [builtins fixtures/list.pyi]
 
+[case testGenericTypeAliasesWithNestedArgs]
+# flags: --pretty --show-error-codes
+import other
+a: other.Array[float]
+reveal_type(a) # N: Revealed type is "other.array[Any, other.dtype[builtins.float]]"
+
+[out]
+main:3: error: Type argument "float" of "dtype" must be a subtype of "generic"  [type-var]
+    a: other.Array[float]
+       ^
+[file other.py]
+from typing import Any, Generic, TypeVar
+
+DT = TypeVar("DT", covariant=True, bound=dtype[Any])
+DTS = TypeVar("DTS", covariant=True, bound=generic)
+S = TypeVar("S", bound=Any)
+ST = TypeVar("ST", bound=generic, covariant=True)
+
+class common: pass
+class generic(common): pass
+class dtype(Generic[DTS]): pass
+class array(common, Generic[S, DT]): pass
+Array = array[Any, dtype[ST]]
+
 [case testGenericTypeAliasesAny]
 from typing import TypeVar, Generic
 T = TypeVar('T')


### PR DESCRIPTION
### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Fixes #12678 by updating line and column not only in an alias type variable but also recursively in arguments.

The current develop output
```
python3 -m pip install numpy mypy
echo -e "import numpy.typing as npt;\na: npt.NDArray[float]" > test_ntp.py
python3 -m mypy test_ntp.py --cache-dir=/dev/null
test_ntp.py:212: error: Type argument "float" of "dtype" must be a subtype of "generic"
Found 1 error in 1 file (checked 1 source file)
python3 -m mypy test_ntp.py --cache-dir=/dev/null --pretty
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/miha/.local/lib/python3.8/site-packages/mypy/__main__.py", line 34, in <module>
    console_entry()
  File "/home/miha/.local/lib/python3.8/site-packages/mypy/__main__.py", line 12, in console_entry
    main(None, sys.stdout, sys.stderr)
  File "mypy/main.py", line 96, in main
  File "mypy/main.py", line 173, in run_build
  File "mypy/build.py", line 180, in build
  File "mypy/build.py", line 256, in _build
  File "mypy/build.py", line 2727, in dispatch
  File "mypy/build.py", line 3075, in process_graph
  File "mypy/build.py", line 3192, in process_stale_scc
  File "mypy/errors.py", line 649, in file_messages
  File "mypy/errors.py", line 622, in format_messages
IndexError: list index out of range
```

The branch output
```
python3 -m mypy test_ntp.py --cache-dir=/dev/null
test_ntp.py:2: error: Type argument "float" of "dtype" must be a subtype of "generic"
Found 1 error in 1 file (checked 1 source file)
python3 -m mypy test_ntp.py --cache-dir=/dev/null --pretty
test_ntp.py:2: error: Type argument "float" of "dtype" must be a subtype of "generic"
    a: npt.NDArray[float]
       ^
Found 1 error in 1 file (checked 1 source file)
```


## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
