### PR TITLE
Make ValuePattern non-exhaustive

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -23,7 +23,7 @@ from mypy.subtypes import is_subtype
 from mypy.typeops import try_getting_str_literals_from_type, make_simplified_union, \
     coerce_to_literal
 from mypy.types import (
-    ProperType, AnyType, TypeOfAny, Instance, Type, UninhabitedType, get_proper_type,
+    LiteralType, ProperType, AnyType, TypeOfAny, Instance, Type, UninhabitedType, get_proper_type,
     TypedDictType, TupleType, NoneType, UnionType
 )
 from mypy.typevars import fill_typevars
@@ -183,6 +183,8 @@ class PatternChecker(PatternVisitor[PatternType]):
             o,
             default=current_type
         )
+        if not isinstance(get_proper_type(narrowed_type), (LiteralType, UninhabitedType)):
+            return PatternType(narrowed_type, UnionType.make_union([narrowed_type, rest_type]), {})
         return PatternType(narrowed_type, rest_type, {})
 
     def visit_singleton_pattern(self, o: SingletonPattern) -> PatternType:

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1576,3 +1576,18 @@ def f(x: AST) -> None:
             reveal_type(b)  # N: Revealed type is "builtins.int"
             reveal_type(c)  # N: Revealed type is "builtins.str"
 [builtins fixtures/tuple.pyi]
+
+[case testMatchReachableDottedNames]
+# flags: --warn-unreachable
+class Consts:
+    BLANK = ""
+    SPECIAL = "asdf"
+
+def test_func(test_str: str) -> str:
+    match test_str:
+        case Consts.BLANK:
+            return "blank"
+        case Consts.SPECIAL:
+            return "special"
+        case _:
+            return "other"


### PR DESCRIPTION
### Description

Changes behaviour of `PatternChecker`, so that dotted names do not cover the entire type.
Since dotted names match only one value of the type, the returned `rest_type` should also contain the type of the value.

Fixes: #12545

## Test Plan

Included code similar to the one from the issue, modified into one file.
