### PR TITLE
Running dataclass transform in a later pass to fix crashes

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -692,7 +692,8 @@ class Plugin(CommonPluginApi):
 
         The plugin can modify a TypeInfo _in place_ (for example add some generated
         methods to the symbol table). This hook is called after the class body was
-        semantically analyzed, but *there may still be placeholders*.
+        semantically analyzed, but *there may still be placeholders* (typically
+        caused by forward references).
 
         NOTE: Usually get_class_decorator_hook_2 is the better option, since it
               guarantees that there are no placeholders.

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -692,14 +692,33 @@ class Plugin(CommonPluginApi):
 
         The plugin can modify a TypeInfo _in place_ (for example add some generated
         methods to the symbol table). This hook is called after the class body was
-        semantically analyzed.
+        semantically analyzed, but *there may still be placeholders*.
 
-        The hook is called with full names of all class decorators, for example
+        NOTE: Usually get_class_decorator_hook_2 is the better option, since it
+              guarantees that there are no placeholders.
+
+        The hook is called with full names of all class decorators.
+
+        The hook can be called multiple times per class, so it must be
+        idempotent.
         """
         return None
 
     def get_class_decorator_hook_2(self, fullname: str
                                    ) -> Optional[Callable[[ClassDefContext], bool]]:
+        """Update class definition for given class decorators.
+
+        Similar to get_class_decorator_hook, but this runs in a later pass when
+        placeholders have been resolved.
+
+        The hook can return False if some base class hasn't been
+        processed yet using class hooks. It causes all class hooks
+        (that are run in this same pass) to be invoked another time for
+        the file(s) currently being processed.
+
+        The hook can be called multiple times per class, so it must be
+        idempotent.
+        """
         return None
 
     def get_metaclass_hook(self, fullname: str

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -820,7 +820,7 @@ class ChainedPlugin(Plugin):
         return self._find_hook(lambda plugin: plugin.get_class_decorator_hook(fullname))
 
     def get_class_decorator_hook_2(self, fullname: str
-                                  ) -> Optional[Callable[[ClassDefContext], None]]:
+                                   ) -> Optional[Callable[[ClassDefContext], None]]:
         return self._find_hook(lambda plugin: plugin.get_class_decorator_hook_2(fullname))
 
     def get_metaclass_hook(self, fullname: str

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -819,6 +819,10 @@ class ChainedPlugin(Plugin):
                                  ) -> Optional[Callable[[ClassDefContext], None]]:
         return self._find_hook(lambda plugin: plugin.get_class_decorator_hook(fullname))
 
+    def get_class_decorator_hook_2(self, fullname: str
+                                  ) -> Optional[Callable[[ClassDefContext], None]]:
+        return self._find_hook(lambda plugin: plugin.get_class_decorator_hook_2(fullname))
+
     def get_metaclass_hook(self, fullname: str
                            ) -> Optional[Callable[[ClassDefContext], None]]:
         return self._find_hook(lambda plugin: plugin.get_metaclass_hook(fullname))

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -698,6 +698,10 @@ class Plugin(CommonPluginApi):
         """
         return None
 
+    def get_class_decorator_hook_2(self, fullname: str
+                                   ) -> Optional[Callable[[ClassDefContext], None]]:
+        return None
+
     def get_metaclass_hook(self, fullname: str
                            ) -> Optional[Callable[[ClassDefContext], None]]:
         """Update class definition for given declared metaclasses.

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -699,7 +699,7 @@ class Plugin(CommonPluginApi):
         return None
 
     def get_class_decorator_hook_2(self, fullname: str
-                                   ) -> Optional[Callable[[ClassDefContext], None]]:
+                                   ) -> Optional[Callable[[ClassDefContext], bool]]:
         return None
 
     def get_metaclass_hook(self, fullname: str
@@ -820,7 +820,7 @@ class ChainedPlugin(Plugin):
         return self._find_hook(lambda plugin: plugin.get_class_decorator_hook(fullname))
 
     def get_class_decorator_hook_2(self, fullname: str
-                                   ) -> Optional[Callable[[ClassDefContext], None]]:
+                                   ) -> Optional[Callable[[ClassDefContext], bool]]:
         return self._find_hook(lambda plugin: plugin.get_class_decorator_hook_2(fullname))
 
     def get_metaclass_hook(self, fullname: str

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -304,6 +304,9 @@ class DataclassTransformer:
           b: SomeOtherType = ...
 
         are collected.
+
+        Return None if some dataclass base class hasn't been processed
+        yet and thus we'll need to ask for another pass.
         """
         # First, collect attributes belonging to the current class.
         ctx = self._ctx

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -107,6 +107,15 @@ class DataclassAttribute:
 
 
 class DataclassTransformer:
+    """Implement the behavior of @dataclass.
+
+    Note that this may be executed multiple times on the same class, so
+    everything here must be idempotent.
+
+    This runs after the main semantic analysis pass, so you can assume that
+    there are no placeholders.
+    """
+
     def __init__(self, ctx: ClassDefContext) -> None:
         self._ctx = ctx
 
@@ -119,7 +128,7 @@ class DataclassTransformer:
         info = self._ctx.cls.info
         attributes = self.collect_attributes()
         if attributes is None:
-            # Some definitions are not ready. we need another pass.
+            # Some definitions are not ready. We need another pass.
             return False
         for attr in attributes:
             if attr.type is None:

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -115,8 +115,6 @@ class DefaultPlugin(Plugin):
                 attrs.attr_class_maker_callback,
                 auto_attribs_default=None,
             )
-        #elif fullname in dataclasses.dataclass_makers:
-        #    return dataclasses.dataclass_class_maker_callback
         elif fullname in functools.functools_total_ordering_makers:
             return functools.functools_total_ordering_maker_callback
 

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -95,7 +95,6 @@ class DefaultPlugin(Plugin):
     def get_class_decorator_hook(self, fullname: str
                                  ) -> Optional[Callable[[ClassDefContext], None]]:
         from mypy.plugins import attrs
-        from mypy.plugins import dataclasses
         from mypy.plugins import functools
 
         if fullname in attrs.attr_class_makers:
@@ -116,10 +115,19 @@ class DefaultPlugin(Plugin):
                 attrs.attr_class_maker_callback,
                 auto_attribs_default=None,
             )
-        elif fullname in dataclasses.dataclass_makers:
-            return dataclasses.dataclass_class_maker_callback
+        #elif fullname in dataclasses.dataclass_makers:
+        #    return dataclasses.dataclass_class_maker_callback
         elif fullname in functools.functools_total_ordering_makers:
             return functools.functools_total_ordering_maker_callback
+
+        return None
+
+    def get_class_decorator_hook_2(self, fullname: str
+                                   ) -> Optional[Callable[[ClassDefContext], None]]:
+        from mypy.plugins import dataclasses
+
+        if fullname in dataclasses.dataclass_makers:
+            return dataclasses.dataclass_class_maker_callback
 
         return None
 

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -95,6 +95,7 @@ class DefaultPlugin(Plugin):
     def get_class_decorator_hook(self, fullname: str
                                  ) -> Optional[Callable[[ClassDefContext], None]]:
         from mypy.plugins import attrs
+        from mypy.plugins import dataclasses
         from mypy.plugins import functools
 
         if fullname in attrs.attr_class_makers:
@@ -115,13 +116,15 @@ class DefaultPlugin(Plugin):
                 attrs.attr_class_maker_callback,
                 auto_attribs_default=None,
             )
+        elif fullname in dataclasses.dataclass_makers:
+            return dataclasses.dataclass_tag_callback
         elif fullname in functools.functools_total_ordering_makers:
             return functools.functools_total_ordering_maker_callback
 
         return None
 
     def get_class_decorator_hook_2(self, fullname: str
-                                   ) -> Optional[Callable[[ClassDefContext], None]]:
+                                   ) -> Optional[Callable[[ClassDefContext], bool]]:
         from mypy.plugins import dataclasses
 
         if fullname in dataclasses.dataclass_makers:

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -402,7 +402,7 @@ def apply_class_plugin_hooks(graph: 'Graph', scc: List[str], errors: Errors) -> 
     # If we encounter a base class that has not been processed, we'll run another
     # pass. This should eventually reach a fixed point.
     while incomplete:
-        assert num_passes < 5, "Internal error: too many class plugin hook passes"
+        assert num_passes < 10, "Internal error: too many class plugin hook passes"
         num_passes += 1
         incomplete = False
         for module in scc:

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -436,7 +436,7 @@ def apply_hooks_to_class(self: SemanticAnalyzer,
             if decorator_name:
                 hook = self.plugin.get_class_decorator_hook_2(decorator_name)
                 if hook:
-                        hook(ClassDefContext(defn, decorator, self))
+                    hook(ClassDefContext(defn, decorator, self))
     return True
 
 

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -431,12 +431,12 @@ def apply_hooks_to_class(self: SemanticAnalyzer,
     saved = (module, info, None)  # module, class, function
     defn = info.defn
     for decorator in defn.decorators:
-        decorator_name = get_fullname(decorator)
-        if decorator_name:
-            hook = self.plugin.get_class_decorator_hook_2(decorator_name)
-            if hook:
-                with self.file_context(file_node, options, info):
-                    hook(ClassDefContext(defn, decorator, self))
+        with self.file_context(file_node, options, info):
+            decorator_name = get_fullname(decorator)
+            if decorator_name:
+                hook = self.plugin.get_class_decorator_hook_2(decorator_name)
+                if hook:
+                        hook(ClassDefContext(defn, decorator, self))
     return True
 
 

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -135,6 +135,7 @@ def semantic_analysis_for_targets(
 
     check_type_arguments_in_targets(nodes, state, state.manager.errors)
     calculate_class_properties(graph, [state.id], state.manager.errors)
+    apply_class_decorator_hooks(graph, [state.id], state.manager.errors)
 
 
 def restore_saved_attrs(saved_attrs: SavedAttributes) -> None:

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -428,7 +428,6 @@ def apply_hooks_to_class(self: SemanticAnalyzer,
                 return sym.fullname
         return None
 
-    saved = (module, info, None)  # module, class, function
     defn = info.defn
     for decorator in defn.decorators:
         with self.file_context(file_node, options, info):

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -46,6 +46,7 @@ from mypy.checker import FineGrainedDeferredNode
 from mypy.server.aststrip import SavedAttributes
 from mypy.util import is_typeshed_file
 from mypy.options import Options
+from mypy.plugin import ClassDefContext
 import mypy.build
 
 if TYPE_CHECKING:
@@ -384,10 +385,6 @@ def check_type_arguments_in_targets(targets: List[FineGrainedDeferredNode], stat
                 with errors.scope.saved_scope(saved) if errors.scope else nullcontext():
                     analyzer.recurse_into_functions = func is not None
                     target.node.accept(analyzer)
-
-
-from mypy.nodes import Expression, CallExpr, IndexExpr, RefExpr
-from mypy.plugin import ClassDefContext
 
 
 def apply_class_plugin_hooks(graph: 'Graph', scc: List[str], errors: Errors) -> None:

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -442,12 +442,12 @@ def apply_hooks_to_class(self: SemanticAnalyzer,
 
 def calculate_class_properties(graph: 'Graph', scc: List[str], errors: Errors) -> None:
     for module in scc:
-        tree = graph[module].tree
+        state = graph[module]
+        tree = state.tree
         assert tree
         for _, node, _ in tree.local_definitions():
             if isinstance(node.node, TypeInfo):
-                saved = (module, node.node, None)  # module, class, function
-                with errors.scope.saved_scope(saved) if errors.scope else nullcontext():
+                with state.manager.semantic_analyzer.file_context(tree, state.options, node.node):
                     calculate_class_abstract_status(node.node, tree.is_stub, errors)
                     check_protocol_status(node.node, errors)
                     calculate_class_vars(node.node)

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -411,27 +411,10 @@ def apply_hooks_to_class(self: SemanticAnalyzer,
                          options: Options,
                          file_node: MypyFile,
                          errors: Errors) -> bool:
-
-    def get_fullname(expr: Expression) -> Optional[str]:
-        if isinstance(expr, CallExpr):
-            return get_fullname(expr.callee)
-        elif isinstance(expr, IndexExpr):
-            return get_fullname(expr.base)
-        elif isinstance(expr, RefExpr):
-            if expr.fullname:
-                return expr.fullname
-            # If we don't have a fullname look it up. This happens because base classes are
-            # analyzed in a different manner (see exprtotype.py) and therefore those AST
-            # nodes will not have full names.
-            sym = self.lookup_type_node(expr)
-            if sym:
-                return sym.fullname
-        return None
-
     defn = info.defn
     for decorator in defn.decorators:
         with self.file_context(file_node, options, info):
-            decorator_name = get_fullname(decorator)
+            decorator_name = self.get_fullname_for_hook(decorator)
             if decorator_name:
                 hook = self.plugin.get_class_decorator_hook_2(decorator_name)
                 if hook:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1620,20 +1620,52 @@ Child(x='', y=1)
 Child(x=None, y=None)
 [builtins fixtures/dataclasses.pyi]
 
-[case testDataclassGenericInheritanceSpecialCase]
+[case testDataclassGenericInheritanceSpecialCase1]
 # flags: --python-version 3.7
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, List
 
 T = TypeVar("T")
 
 @dataclass
 class Parent(Generic[T]):
-    key: str
+    x: List[T]
 
 @dataclass
 class Child1(Parent["Child2"]): ...
 
 @dataclass
 class Child2(Parent["Child1"]): ...
+
+def f(c: Child2) -> None:
+    reveal_type(Child1([c]).x)  # N: Revealed type is "builtins.list[__main__.Child2]"
+
+def g(c: Child1) -> None:
+    reveal_type(Child2([c]).x)  # N: Revealed type is "builtins.list[__main__.Child1]"
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassGenericInheritanceSpecialCase2]
+# flags: --python-version 3.7
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+# A subclass might be analyzed before base in import cycles.  They are
+# defined here in reversed order to simulate this.
+
+@dataclass
+class Child1(Parent["Child2"]):
+    x: int
+
+@dataclass
+class Child2(Parent["Child1"]):
+    y: int
+
+@dataclass
+class Parent(Generic[T]):
+    key: str
+
+Child1(x=1, key='')
+Child2(y=1, key='')
 [builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1619,3 +1619,21 @@ Child(x='', y='')  # E: Argument "y" to "Child" has incompatible type "str"; exp
 Child(x='', y=1)
 Child(x=None, y=None)
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassGenericInheritanceSpecialCase]
+# flags: --python-version 3.7
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+@dataclass
+class Parent(Generic[T]):
+    key: str
+
+@dataclass
+class Child1(Parent["Child2"]): ...
+
+@dataclass
+class Child2(Parent["Child1"]): ...
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1669,3 +1669,19 @@ class Parent(Generic[T]):
 Child1(x=1, key='')
 Child2(y=1, key='')
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassGenericWithBound]
+# flags: --python-version 3.7
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound="C")
+
+@dataclass
+class C(Generic[T]):
+    x: int
+
+c: C[C]
+d: C[str]  # E: Type argument "str" of "C" must be a subtype of "C[Any]"
+C(x=2)
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1207,7 +1207,7 @@ class A2:
 from dataclasses import dataclass
 
 @dataclass
-class A:  # E: Name "x" already defined (possibly by an import)
+class A:
     x: int = 0
     x: int = 0  # E: Name "x" already defined on line 7
 


### PR DESCRIPTION
The dataclass plugin could crash if it encountered a placeholder. Fix the issue by
running the plugin after the main semantic analysis pass, when all placeholders have 
been resolved.

Also add a new hook called `get_class_decorator_hook_2` that is used by the
dataclass plugin.

We may want to do a similar change to the attrs plugin, but let's change one thing
at a time.

Fix #12685.