### PR TITLE
Fix forward references and generic inheritance in attrs classes

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -2,12 +2,11 @@
 
 from mypy.backports import OrderedDict
 
-from typing import Optional, Dict, List, cast, Tuple, Iterable, Union
+from typing import Optional, Dict, List, cast, Tuple, Iterable
 from typing_extensions import Final
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.exprtotype import expr_to_unanalyzed_type, TypeTranslationError
-from mypy.lookup import lookup_fully_qualified
 from mypy.nodes import (
     Context, Argument, Var, ARG_OPT, ARG_POS, TypeInfo, AssignmentStmt,
     TupleExpr, ListExpr, NameExpr, CallExpr, RefExpr, FuncDef,
@@ -23,7 +22,7 @@ from mypy.plugins.common import (
 from mypy.types import (
     TupleType, Type, AnyType, TypeOfAny, CallableType, NoneType, TypeVarType,
     Overloaded, UnionType, FunctionLike, Instance, get_proper_type,
-    LiteralType, deserialize_type
+    LiteralType
 )
 from mypy.typeops import make_simplified_union, map_type_from_supertype
 from mypy.typevars import fill_typevars

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -96,7 +96,7 @@ class Attribute:
             init_type = None
             converter_type = get_proper_type(converter_type)
             if isinstance(converter_type, CallableType) and converter_type.arg_types:
-                init_type = ctx.api.anal_type(converter_type.arg_types[0])
+                init_type = converter_type.arg_types[0]
             elif isinstance(converter_type, Overloaded):
                 types: List[Type] = []
                 for item in converter_type.items:

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -180,7 +180,10 @@ class Attribute:
     def expand_typevar_from_subtype(self, sub_type: TypeInfo) -> None:
         """Expands type vars in the context of a subtype when an attribute is inherited
         from a generic super type."""
-        self.init_type = map_type_from_supertype(self.init_type, sub_type, self.info)
+        if self.init_type:
+            self.init_type = map_type_from_supertype(self.init_type, sub_type, self.info)
+        else:
+            self.init_type = None
 
 
 def _determine_eq_order(ctx: 'mypy.plugin.ClassDefContext') -> bool:

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -292,11 +292,7 @@ def attr_class_maker_callback(ctx: 'mypy.plugin.ClassDefContext',
             ctx.api.fail(KW_ONLY_PYTHON_2_UNSUPPORTED, ctx.reason)
             early_fail = True
     if early_fail:
-        # Add empty metadata to mark that we've finished processing this class.
-        ctx.cls.info.metadata['attrs'] = {
-            'attributes': [],
-            'frozen': False,
-        }
+        _add_empty_metadata(info)
         return True
 
     for super_info in ctx.cls.info.mro[1:-1]:
@@ -312,6 +308,7 @@ def attr_class_maker_callback(ctx: 'mypy.plugin.ClassDefContext',
         if node is None:
             # This name is likely blocked by some semantic analysis error that
             # should have been reported already.
+            _add_empty_metadata(info)
             return True
 
     _add_attrs_magic_attribute(ctx, [(attr.name, info[attr.name].type) for attr in attributes])
@@ -429,6 +426,14 @@ def _analyze_class(ctx: 'mypy.plugin.ClassDefContext',
         last_default |= attribute.has_default
 
     return attributes
+
+
+def _add_empty_metadata(info: TypeInfo) -> None:
+    """Add empty metadata to mark that we've finished processing this class."""
+    info.metadata['attrs'] = {
+        'attributes': [],
+        'frozen': False,
+    }
 
 
 def _detect_auto_attribs(ctx: 'mypy.plugin.ClassDefContext') -> bool:

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -300,7 +300,7 @@ def attr_class_maker_callback(ctx: 'mypy.plugin.ClassDefContext',
     # Check if attribute types are ready.
     for attr in attributes:
         node = info.get(attr.name)
-        if node is None or node.type is None:
+        if node is None:
             # This name is likely blocked by some semantic analysis error that
             # should have been reported already.
             return True

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -22,7 +22,7 @@ from mypy.plugins.common import (
 from mypy.types import (
     TupleType, Type, AnyType, TypeOfAny, CallableType, NoneType, TypeVarType,
     Overloaded, UnionType, FunctionLike, Instance, get_proper_type,
-    LiteralType
+    LiteralType,
 )
 from mypy.typeops import make_simplified_union, map_type_from_supertype
 from mypy.typevars import fill_typevars

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -180,9 +180,6 @@ class Attribute:
     def expand_typevar_from_subtype(self, sub_type: TypeInfo) -> None:
         """Expands type vars in the context of a subtype when an attribute is inherited
         from a generic super type."""
-        if not isinstance(self.init_type, TypeVarType):
-            return
-
         self.init_type = map_type_from_supertype(self.init_type, sub_type, self.info)
 
 

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -109,8 +109,7 @@ class Attribute:
                     types.append(item.arg_types[0])
                 # Make a union of all the valid types.
                 if types:
-                    args = make_simplified_union(types)
-                    init_type = ctx.api.anal_type(args)
+                    init_type = make_simplified_union(types)
 
             if self.converter.is_attr_converters_optional and init_type:
                 # If the converter was attr.converter.optional(type) then add None to

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -95,9 +95,19 @@ class DefaultPlugin(Plugin):
     def get_class_decorator_hook(self, fullname: str
                                  ) -> Optional[Callable[[ClassDefContext], None]]:
         from mypy.plugins import dataclasses
+        from mypy.plugins import attrs
 
+        # These dataclass and attrs hooks run in the main semantic analysis pass
+        # and only tag known dataclasses/attrs classes, so that the second
+        # hooks (in get_class_decorator_hook_2) can detect dataclasses/attrs classes
+        # in the MRO.
         if fullname in dataclasses.dataclass_makers:
             return dataclasses.dataclass_tag_callback
+        if (fullname in attrs.attr_class_makers
+                or fullname in attrs.attr_dataclass_makers
+                or fullname in attrs.attr_frozen_makers
+                or fullname in attrs.attr_define_makers):
+            return attrs.attr_tag_callback
 
         return None
 

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -94,10 +94,24 @@ class DefaultPlugin(Plugin):
 
     def get_class_decorator_hook(self, fullname: str
                                  ) -> Optional[Callable[[ClassDefContext], None]]:
-        from mypy.plugins import attrs
         from mypy.plugins import dataclasses
 
-        if fullname in attrs.attr_class_makers:
+        if fullname in dataclasses.dataclass_makers:
+            return dataclasses.dataclass_tag_callback
+
+        return None
+
+    def get_class_decorator_hook_2(self, fullname: str
+                                   ) -> Optional[Callable[[ClassDefContext], bool]]:
+        from mypy.plugins import dataclasses
+        from mypy.plugins import functools
+        from mypy.plugins import attrs
+
+        if fullname in dataclasses.dataclass_makers:
+            return dataclasses.dataclass_class_maker_callback
+        elif fullname in functools.functools_total_ordering_makers:
+            return functools.functools_total_ordering_maker_callback
+        elif fullname in attrs.attr_class_makers:
             return attrs.attr_class_maker_callback
         elif fullname in attrs.attr_dataclass_makers:
             return partial(
@@ -115,20 +129,6 @@ class DefaultPlugin(Plugin):
                 attrs.attr_class_maker_callback,
                 auto_attribs_default=None,
             )
-        elif fullname in dataclasses.dataclass_makers:
-            return dataclasses.dataclass_tag_callback
-
-        return None
-
-    def get_class_decorator_hook_2(self, fullname: str
-                                   ) -> Optional[Callable[[ClassDefContext], bool]]:
-        from mypy.plugins import dataclasses
-        from mypy.plugins import functools
-
-        if fullname in dataclasses.dataclass_makers:
-            return dataclasses.dataclass_class_maker_callback
-        elif fullname in functools.functools_total_ordering_makers:
-            return functools.functools_total_ordering_maker_callback
 
         return None
 

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -544,6 +544,37 @@ reveal_type(sub.three)  # N: Revealed type is "builtins.float"
 [builtins fixtures/bool.pyi]
 
 
+[case testAttrsGenericInheritance3]
+import attr
+from typing import Any, Callable, Generic, TypeVar, List
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+@attr.s(auto_attribs=True)
+class Parent(Generic[T]):
+    f: Callable[[T], Any]
+
+@attr.s(auto_attribs=True)
+class Child(Parent[T]): ...
+
+class A: ...
+def func(obj: A) -> bool: ...
+
+reveal_type(Child[A](func).f)  # N: Revealed type is "def (__main__.A) -> Any"
+
+@attr.s(auto_attribs=True)
+class Parent2(Generic[T]):
+    a: List[T]
+
+@attr.s(auto_attribs=True)
+class Child2(Generic[T, S], Parent2[S]):
+    b: List[T]
+
+reveal_type(Child2([A()], [1]).a)  # N: Revealed type is "builtins.list[__main__.A]"
+reveal_type(Child2[int, A]([A()], [1]).b)  # N: Revealed type is "builtins.list[builtins.int]"
+[builtins fixtures/list.pyi]
+
 [case testAttrsMultiGenericInheritance]
 from typing import Generic, TypeVar
 import attr

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1718,3 +1718,19 @@ class Parent(Generic[T]):
 Child1(x=1, key='')
 Child2(y=1, key='')
 [builtins fixtures/list.pyi]
+
+[case testAttrsUnsupportedConverterWithDisallowUntypedDefs]
+# flags: --disallow-untyped-defs
+import attr
+from typing import Mapping, Any, Union
+
+def default_if_none(factory: Any) -> Any: pass
+
+@attr.s(slots=True, frozen=True)
+class C:
+    name: Union[str, None] = attr.ib(default=None)
+    options: Mapping[str, Mapping[str, Any]] = attr.ib(
+        default=None, converter=default_if_none(factory=dict) \
+        # E: Unsupported converter, only named functions and types are currently supported
+    )
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1591,3 +1591,17 @@ class B:
 class AB(A, B):
     pass
 [builtins fixtures/attr.pyi]
+
+[case testAttrsForwardReferenceInTypeVarBound]
+from typing import TypeVar, Generic
+import attr
+
+T = TypeVar("T", bound="C")
+
+@attr.define
+class D(Generic[T]):
+    x: int
+
+class C:
+    pass
+[builtins fixtures/attr.pyi]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1667,3 +1667,51 @@ class D:
 tmp/b.py:8: error: Value of type "int" is not indexable
 tmp/a.py:7: error: Name "Lst" is not defined
 tmp/a.py:10: error: Value of type "int" is not indexable
+
+[case testAttrsGenericInheritanceSpecialCase1]
+import attr
+from typing import Generic, TypeVar, List
+
+T = TypeVar("T")
+
+@attr.define
+class Parent(Generic[T]):
+    x: List[T]
+
+@attr.define
+class Child1(Parent["Child2"]): ...
+
+@attr.define
+class Child2(Parent["Child1"]): ...
+
+def f(c: Child2) -> None:
+    reveal_type(Child1([c]).x)  # N: Revealed type is "builtins.list[__main__.Child2]"
+
+def g(c: Child1) -> None:
+    reveal_type(Child2([c]).x)  # N: Revealed type is "builtins.list[__main__.Child1]"
+[builtins fixtures/list.pyi]
+
+[case testAttrsGenericInheritanceSpecialCase2]
+import attr
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+# A subclass might be analyzed before base in import cycles.  They are
+# defined here in reversed order to simulate this.
+
+@attr.define
+class Child1(Parent["Child2"]):
+    x: int
+
+@attr.define
+class Child2(Parent["Child1"]):
+    y: int
+
+@attr.define
+class Parent(Generic[T]):
+    key: str
+
+Child1(x=1, key='')
+Child2(y=1, key='')
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1041,6 +1041,9 @@ class Good(object):
 @attr.s
 class Bad:  # E: attrs only works with new-style classes
     pass
+@attr.s
+class SubclassOfBad(Bad):
+    pass
 [builtins_py2 fixtures/bool.pyi]
 
 [case testAttrsAutoAttribsPy2]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1605,3 +1605,34 @@ class D(Generic[T]):
 class C:
     pass
 [builtins fixtures/attr.pyi]
+
+[case testComplexTypeInAttrIb]
+import a
+
+[file a.py]
+import attr
+import b
+from typing import Callable
+
+@attr.s
+class C:
+    a = attr.ib(type=Lst[int])
+    # Note that for this test, the 'Value of type "int" is not indexable' errors are silly,
+    # and a consequence of Callable etc. being set to an int in the test stub.
+    b = attr.ib(type=Callable[[], C])
+[builtins fixtures/bool.pyi]
+
+[file b.py]
+import attr
+import a
+from typing import List as Lst, Optional
+
+@attr.s
+class D:
+    a = attr.ib(type=Lst[int])
+    b = attr.ib(type=Optional[int])
+[builtins fixtures/list.pyi]
+[out]
+tmp/b.py:8: error: Value of type "int" is not indexable
+tmp/a.py:7: error: Name "Lst" is not defined
+tmp/a.py:10: error: Value of type "int" is not indexable

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -34,7 +34,7 @@ class dict(Mapping[KT, VT]):
 class int: # for convenience
     def __add__(self, x: Union[int, complex]) -> int: pass
     def __sub__(self, x: Union[int, complex]) -> int: pass
-    def __neg__(self): pass
+    def __neg__(self) -> int: pass
     real: int
     imag: int
 


### PR DESCRIPTION
Move the attrs plugin to a later pass, so that we won't have placeholders. Fix
various issues related to forward references and generic inheritance, including 
some crashes.

This is follow-up to #12762 and related to #12656 and #12633.