### PR TITLE
Add test case for fixed generic-dataclass crash

### DIFF
--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1685,3 +1685,15 @@ c: C[C]
 d: C[str]  # E: Type argument "str" of "C" must be a subtype of "C[Any]"
 C(x=2)
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassGenericBoundToInvalidTypeVarDoesNotCrash]
+# flags: --python-version 3.7
+import dataclasses
+from typing import Generic, TypeVar
+
+T = TypeVar("T", bound="NotDefined")  # E: Name "NotDefined" is not defined
+
+@dataclasses.dataclass
+class C(Generic[T]):
+    x: float
+[builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
Adds a test case for a crash that was fixed by https://github.com/python/mypy/pull/12762. Closes #12527.
