### PR TITLE
Fix crash on type alias definition inside dataclass declaration

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -338,9 +338,9 @@ class DataclassTransformer:
                 ctx.api.fail(
                     (
                         'Type aliases inside dataclass definitions '
-                        'are not supported at runtime.'
+                        'are not supported at runtime'
                     ),
-                    Context(line=node.line, column=node.column)
+                    node
                 )
                 # Now do our best to simulate the runtime,
                 # which treates a TypeAlias definition in a dataclass class
@@ -355,14 +355,9 @@ class DataclassTransformer:
                 # Something else -- fallback to Any
                 else:
                     var_type = AnyType(TypeOfAny.from_error)
-                var = Var(name=fullname, type=var_type)
+                var = Var(name=node.name, type=var_type)
                 var.info = cls.info
                 var._fullname = fullname
-                cls.info.names[fullname] = SymbolTableNode(
-                    kind=MDEF,
-                    node=var,
-                    plugin_generated=True,
-                )
                 sym.node = node = var
 
             assert isinstance(node, Var)

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -513,6 +513,36 @@ Application.COUNTER = 1
 
 [builtins fixtures/dataclasses.pyi]
 
+[case testTypeAliasInDataclassDoesNotCrash]
+# flags: --python-version 3.7
+from dataclasses import dataclass
+from typing import Callable
+from typing_extensions import TypeAlias
+
+@dataclass
+class Foo:
+    x: int
+
+@dataclass
+class One:
+    S: TypeAlias = Foo  # E: Type aliases inside dataclass definitions are not supported at runtime.
+
+a = One()
+b = One(Foo)
+reveal_type(a.S)  # N: Revealed type is "Type[__main__.Foo]"
+reveal_type(b.S)  # N: Revealed type is "Type[__main__.Foo]"
+a.S()  # E: Missing positional argument "x" in call to "Foo"
+reveal_type(a.S(5))  # N: Revealed type is "__main__.Foo"
+reveal_type(b.S(98))  # N: Revealed type is "__main__.Foo"
+
+@dataclass
+class Two:
+    S: TypeAlias = Callable[[int], str]  # E: Type aliases inside dataclass definitions are not supported at runtime.
+
+c = Two()
+reveal_type(c.S)  # N: Revealed type is "Any"
+[builtins fixtures/dataclasses.pyi]
+
 [case testDataclassOrdering]
 # flags: --python-version 3.7
 from dataclasses import dataclass

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -525,7 +525,7 @@ class Foo:
 
 @dataclass
 class One:
-    S: TypeAlias = Foo  # E: Type aliases inside dataclass definitions are not supported at runtime.
+    S: TypeAlias = Foo  # E: Type aliases inside dataclass definitions are not supported at runtime
 
 a = One()
 b = One(Foo)
@@ -537,7 +537,7 @@ reveal_type(b.S(98))  # N: Revealed type is "__main__.Foo"
 
 @dataclass
 class Two:
-    S: TypeAlias = Callable[[int], str]  # E: Type aliases inside dataclass definitions are not supported at runtime.
+    S: TypeAlias = Callable[[int], str]  # E: Type aliases inside dataclass definitions are not supported at runtime
 
 c = Two()
 reveal_type(c.S)  # N: Revealed type is "Any"

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -528,19 +528,17 @@ class One:
     S: TypeAlias = Foo  # E: Type aliases inside dataclass definitions are not supported at runtime
 
 a = One()
-b = One(Foo)
-reveal_type(a.S)  # N: Revealed type is "Type[__main__.Foo]"
-reveal_type(b.S)  # N: Revealed type is "Type[__main__.Foo]"
+reveal_type(a.S)  # N: Revealed type is "def (x: builtins.int) -> __main__.Foo"
 a.S()  # E: Missing positional argument "x" in call to "Foo"
 reveal_type(a.S(5))  # N: Revealed type is "__main__.Foo"
-reveal_type(b.S(98))  # N: Revealed type is "__main__.Foo"
 
 @dataclass
 class Two:
     S: TypeAlias = Callable[[int], str]  # E: Type aliases inside dataclass definitions are not supported at runtime
 
 c = Two()
-reveal_type(c.S)  # N: Revealed type is "Any"
+x = c.S  # E: Member "S" is not assignable
+reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassOrdering]


### PR DESCRIPTION
### Description

Fixes #12544.

At the moment, mypy crashes on the following code:

```python
from dataclasses import dataclass
from typing_extensions import TypeAlias

class Foo: ...

@dataclass
class A:
    S: TypeAlias = Foo
```

This is because mypy's `dataclasses` plugin does not currently account for the possibility of a `TypeAlias` node being inside a dataclass definition.

At runtime, [no special treatment is given](https://github.com/python/cpython/issues/91322) to fields annotated with `TypeAlias` -- they're treated just like normal instance fields with default values. As such, this PR proposes that mypy:

1. Always emits an error on encountering a `TypeAlias` node inside a dataclass definition (it probably won't have the behaviour the user expects).
2. Infers the type of the field as `type[X]` in simple cases such as `S: TypeAlias = int`.
3. Falls back to `Any` for anything more complex, such as `S: TypeAlias = Callable[[int], str]`.

## Test Plan

I added tests.
