### PR TITLE
Add test case for fixed dataclass-classmethod crash

### DIFF
--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -495,6 +495,19 @@ reveal_type(A.foo("foo"))  # N: Revealed type is "builtins.str"
 
 [builtins fixtures/dataclasses.pyi]
 
+[case testClassmethodShadowingFieldDoesNotCrash]
+# flags: --python-version 3.7
+from dataclasses import dataclass
+
+# This used to crash -- see #6217
+@dataclass
+class Foo:
+    bar: str
+    @classmethod  # E: Name "bar" already defined on line 7
+    def bar(cls) -> "Foo":
+        return cls('asdf')
+[builtins fixtures/dataclasses.pyi]
+
 [case testDataclassesClassVars]
 # flags: --python-version 3.7
 from dataclasses import dataclass


### PR DESCRIPTION
### Description

Closes #6217. This crash seems to have been fixed a while ago (I [can't reproduce on mypy 0.720+](https://mypy-play.net/?mypy=0.720&python=3.10&gist=324738b3c7b491e47ad2a95521c5688d)), but it doesn't seem like a regression test was ever added.