### PR TITLE
Fix nested namedtuple crash in incremental mode

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1484,10 +1484,8 @@ class SemanticAnalyzer(NodeVisitor[None],
             else:
                 # Preserve name from previous fine-grained incremental run.
                 local_name = defn.info.name
-            print('here2', defn.info._fullname, local_name)
             defn.fullname = defn.info._fullname
             if defn.info.is_named_tuple:
-                print('[add_symbol_skip_local]', local_name)
                 self.add_symbol_skip_local(local_name, defn.info)
             else:
                 self.globals[local_name] = SymbolTableNode(GDEF, defn.info)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1462,7 +1462,10 @@ class SemanticAnalyzer(NodeVisitor[None],
                 info._fullname = self.qualified_name(defn.name)
             else:
                 info._fullname = info.name
-        self.add_symbol(defn.name, defn.info, defn)
+        n = defn.name
+        if '@' in n:
+            n = n[:n.index('@')]
+        self.add_symbol(n, defn.info, defn)
         if self.is_nested_within_func_scope():
             # We need to preserve local classes, let's store them
             # in globals under mangled unique names
@@ -1484,6 +1487,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             print('here2', defn.info._fullname, local_name)
             defn.fullname = defn.info._fullname
             if defn.info.is_named_tuple:
+                print('[add_symbol_skip_local]', local_name)
                 self.add_symbol_skip_local(local_name, defn.info)
             else:
                 self.globals[local_name] = SymbolTableNode(GDEF, defn.info)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1475,11 +1475,11 @@ class SemanticAnalyzer(NodeVisitor[None],
             #       ad-hoc and needs to be removed/refactored.
             if '@' not in defn.info._fullname:
                 local_name = defn.info.name + '@' + str(defn.line)
-                #defn.name = local_name
-                #if defn.info.is_named_tuple and False:
-                #    # Module is already correctly set in _fullname for named tuples.
-                #    defn.info._fullname += '@' + str(defn.line)
-                #else:
+                # defn.name = local_name
+                # if defn.info.is_named_tuple and False:
+                #     # Module is already correctly set in _fullname for named tuples.
+                #     defn.info._fullname += '@' + str(defn.line)
+                # else:
                 defn.info._fullname = self.cur_mod_id + '.' + local_name
             else:
                 # Preserve name from previous fine-grained incremental run.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1481,6 +1481,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 global_name = defn.info.name
             defn.fullname = defn.info._fullname
             if defn.info.is_named_tuple:
+                # Named tuple nested within a class is stored in the class symbol table.
                 self.add_symbol_skip_local(global_name, defn.info)
             else:
                 self.globals[global_name] = SymbolTableNode(GDEF, defn.info)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1475,7 +1475,7 @@ class SemanticAnalyzer(NodeVisitor[None],
             #       ad-hoc and needs to be removed/refactored.
             if '@' not in defn.info._fullname:
                 global_name = defn.info.name + '@' + str(defn.line)
-                defn.info._fullname = self.cur_mod_id + '.' + local_name
+                defn.info._fullname = self.cur_mod_id + '.' + global_name
             else:
                 # Preserve name from previous fine-grained incremental run.
                 global_name = defn.info.name

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1462,10 +1462,10 @@ class SemanticAnalyzer(NodeVisitor[None],
                 info._fullname = self.qualified_name(defn.name)
             else:
                 info._fullname = info.name
-        n = defn.name
-        if '@' in n:
-            n = n[:n.index('@')]
-        self.add_symbol(n, defn.info, defn)
+        local_name = defn.name
+        if '@' in local_name:
+            local_name = local_name.split('@')[0]
+        self.add_symbol(local_name, defn.info, defn)
         if self.is_nested_within_func_scope():
             # We need to preserve local classes, let's store them
             # in globals under mangled unique names
@@ -1474,21 +1474,16 @@ class SemanticAnalyzer(NodeVisitor[None],
             #       incremental mode and we should avoid it. In general, this logic is too
             #       ad-hoc and needs to be removed/refactored.
             if '@' not in defn.info._fullname:
-                local_name = defn.info.name + '@' + str(defn.line)
-                # defn.name = local_name
-                # if defn.info.is_named_tuple and False:
-                #     # Module is already correctly set in _fullname for named tuples.
-                #     defn.info._fullname += '@' + str(defn.line)
-                # else:
+                global_name = defn.info.name + '@' + str(defn.line)
                 defn.info._fullname = self.cur_mod_id + '.' + local_name
             else:
                 # Preserve name from previous fine-grained incremental run.
-                local_name = defn.info.name
+                global_name = defn.info.name
             defn.fullname = defn.info._fullname
             if defn.info.is_named_tuple:
-                self.add_symbol_skip_local(local_name, defn.info)
+                self.add_symbol_skip_local(global_name, defn.info)
             else:
-                self.globals[local_name] = SymbolTableNode(GDEF, defn.info)
+                self.globals[global_name] = SymbolTableNode(GDEF, defn.info)
 
     def make_empty_type_info(self, defn: ClassDef) -> TypeInfo:
         if (self.is_module_scope()

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -66,7 +66,6 @@ class NamedTupleAnalyzer:
             if isinstance(base_expr, RefExpr):
                 self.api.accept(base_expr)
                 if base_expr.fullname == 'typing.NamedTuple':
-                    print([1], is_func_scope)
                     result = self.check_namedtuple_classdef(defn, is_stub_file)
                     if result is None:
                         # This is a valid named tuple, but some types are incomplete.
@@ -180,7 +179,6 @@ class NamedTupleAnalyzer:
             is_typed = True
         else:
             return None, None
-        print('[old-style namedtuple]')
         result = self.parse_namedtuple_args(call, fullname)
         if result:
             items, types, defaults, typename, ok = result
@@ -243,14 +241,12 @@ class NamedTupleAnalyzer:
         #     there is no var_name (but it still needs to be serialized
         #     since it is in MRO of some class).
         if name != var_name or is_func_scope:
-            print('here', name, var_name, is_func_scope)
             # NOTE: we skip local namespaces since they are not serialized.
             self.api.add_symbol_skip_local(name, info)
         return typename, info
 
     def store_namedtuple_info(self, info: TypeInfo, name: str,
                               call: CallExpr, is_typed: bool) -> None:
-        print('[store_namedtuple_info]', name)
         self.api.add_symbol(name, info, call)
         call.analyzed = NamedTupleExpr(info, is_typed=is_typed)
         call.analyzed.set_line(call.line, call.column)
@@ -391,7 +387,6 @@ class NamedTupleAnalyzer:
                                   types: List[Type],
                                   default_items: Mapping[str, Expression],
                                   line: int) -> TypeInfo:
-        print('[build]', name)
         strtype = self.api.named_type('builtins.str')
         implicit_any = AnyType(TypeOfAny.special_form)
         basetuple_type = self.api.named_type('builtins.tuple', [implicit_any])
@@ -410,7 +405,6 @@ class NamedTupleAnalyzer:
         match_args_type = TupleType(literals, basetuple_type)
 
         info = self.api.basic_new_typeinfo(name, fallback, line)
-        print([2], info.fullname)
         info.is_named_tuple = True
         tuple_base = TupleType(types, fallback)
         info.tuple_type = tuple_base
@@ -450,7 +444,6 @@ class NamedTupleAnalyzer:
         add_field(Var('__doc__', strtype), is_initialized_in_class=True)
         add_field(Var('__match_args__', match_args_type), is_initialized_in_class=True)
 
-        print('_NT', info.fullname)
         tvd = TypeVarType(SELF_TVAR_NAME, info.fullname + '.' + SELF_TVAR_NAME,
                          -1, [], info.tuple_type)
         selftype = tvd

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -169,7 +169,6 @@ class NamedTupleAnalyzer:
         """
         if not isinstance(node, CallExpr):
             return None, None
-        print('[old-style namedtuple]')
         call = node
         callee = call.callee
         if not isinstance(callee, RefExpr):
@@ -181,6 +180,7 @@ class NamedTupleAnalyzer:
             is_typed = True
         else:
             return None, None
+        print('[old-style namedtuple]')
         result = self.parse_namedtuple_args(call, fullname)
         if result:
             items, types, defaults, typename, ok = result
@@ -250,6 +250,7 @@ class NamedTupleAnalyzer:
 
     def store_namedtuple_info(self, info: TypeInfo, name: str,
                               call: CallExpr, is_typed: bool) -> None:
+        print('[store_namedtuple_info]', name)
         self.api.add_symbol(name, info, call)
         call.analyzed = NamedTupleExpr(info, is_typed=is_typed)
         call.analyzed.set_line(call.line, call.column)
@@ -449,6 +450,7 @@ class NamedTupleAnalyzer:
         add_field(Var('__doc__', strtype), is_initialized_in_class=True)
         add_field(Var('__match_args__', match_args_type), is_initialized_in_class=True)
 
+        print('_NT', info.fullname)
         tvd = TypeVarType(SELF_TVAR_NAME, info.fullname + '.' + SELF_TVAR_NAME,
                          -1, [], info.tuple_type)
         selftype = tvd

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5535,7 +5535,6 @@ def g() -> None:
 
 [builtins fixtures/tuple.pyi]
 
-
 [case testIncrementalNestedTypeAlias]
 import a
 
@@ -5673,8 +5672,8 @@ import b
 b.xyz
 
 [file b.py]
-from typing_extensions import TypedDict
 from typing import NamedTuple
+from typing_extensions import TypedDict, TypeAlias
 from enum import Enum
 from dataclasses import dataclass
 
@@ -5693,6 +5692,7 @@ class C:
         @dataclass
         class DC:
             c: int
+        Alias: TypeAlias = NT1
         c: C = C()
         nt1: NT1 = NT1(c=1)
         nt2: NT2 = NT2(c=1)
@@ -5700,6 +5700,7 @@ class C:
         td2: TD2 = TD2(c=1)
         e: E = E.X
         dc: DC = DC(c=1)
+        al: Alias = Alias(c=1)
 
 [builtins fixtures/dict.pyi]
 [out2]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5684,6 +5684,8 @@ class C:
         class NT1(NamedTuple):
             c: int
         NT2 = NamedTuple("NT2", [("c", int)])
+        class NT3(NT1):
+            pass
         class TD(TypedDict):
             c: int
         TD2 = TypedDict("TD2", {"c": int})
@@ -5698,6 +5700,7 @@ class C:
         c: C = C()
         nt1: NT1 = NT1(c=1)
         nt2: NT2 = NT2(c=1)
+        nt3: NT3 = NT3(c=1)
         td: TD = TD(c=1)
         td2: TD2 = TD2(c=1)
         e: E = E.X

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5658,3 +5658,97 @@ class D(C):
 [out]
 [out2]
 tmp/a.py:9: error: Trying to assign name "z" that is not in "__slots__" of type "a.D"
+
+[case testXXX]
+# IncrementalNamedTupleClassNestedInMethod]
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+import b
+b.xyz
+
+[file b.py]
+from typing import NamedTuple
+
+class C:
+    def f(self) -> None:
+        class NT(NamedTuple):
+            c: int
+
+[builtins fixtures/tuple.pyi]
+
+[case testYYY]
+# IncrementalNamedTupleClassNestedInMethod]
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+import b
+b.xyz
+
+[file b.py]
+class C:
+    def f(self) -> None:
+        class NT:
+            c: int
+
+[builtins fixtures/tuple.pyi]
+
+[case testZZZ]
+# IncrementalNamedTupleClassNestedInMethod]
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+import b
+b.xyz
+
+[file b.py]
+from typing import NamedTuple
+
+class C:
+    def f(self) -> None:
+        NT = NamedTuple('NT', [('c', int)])
+
+[builtins fixtures/tuple.pyi]
+
+[case testIncrementalWithDifferentKindsOfNestedTypes]
+# flags: --python-version 3.7
+
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+import b
+b.xyz
+
+[file b.py]
+from typing_extensions import TypedDict
+from typing import NamedTuple
+from enum import Enum
+from dataclasses import dataclass
+
+class C:
+    def f(self) -> None:
+        class C:
+            c: int
+        NT = NamedTuple("NT", [("c", int)])
+        class TD(TypedDict):
+            c: int
+        TD2 = TypedDict("TD2", {"c": int})
+        class E(Enum):
+            X = 1
+        @dataclass
+        class DC:
+            c: int
+
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5660,68 +5660,6 @@ class D(C):
 [out2]
 tmp/a.py:9: error: Trying to assign name "z" that is not in "__slots__" of type "a.D"
 
-[case testXXX]
-# IncrementalNamedTupleClassNestedInMethod]
-import a
-
-[file a.py]
-import b
-
-[file a.py.2]
-import b
-b.xyz
-
-[file b.py]
-from typing import NamedTuple
-
-class C:
-    def f(self) -> None:
-        class NT(NamedTuple):
-            c: int
-        nt: NT = NT(c=1)
-
-[builtins fixtures/tuple.pyi]
-
-[case testYYY]
-# IncrementalNamedTupleClassNestedInMethod]
-import a
-
-[file a.py]
-import b
-
-[file a.py.2]
-import b
-b.xyz
-
-[file b.py]
-class C:
-    def f(self) -> None:
-        class NT:
-            c: int
-        nt: NT = NT()
-
-[builtins fixtures/tuple.pyi]
-
-[case testZZZ]
-# IncrementalNamedTupleClassNestedInMethod]
-import a
-
-[file a.py]
-import b
-
-[file a.py.2]
-import b
-b.xyz
-
-[file b.py]
-from typing import NamedTuple
-
-class C:
-    def f(self) -> None:
-        NT = NamedTuple('NT', [('c', int)])
-
-[builtins fixtures/tuple.pyi]
-
 [case testIncrementalWithDifferentKindsOfNestedTypes]
 # flags: --python-version 3.7
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5535,6 +5535,7 @@ def g() -> None:
 
 [builtins fixtures/tuple.pyi]
 
+
 [case testIncrementalNestedTypeAlias]
 import a
 
@@ -5677,6 +5678,7 @@ class C:
     def f(self) -> None:
         class NT(NamedTuple):
             c: int
+        nt: NT = NT(c=1)
 
 [builtins fixtures/tuple.pyi]
 
@@ -5696,6 +5698,7 @@ class C:
     def f(self) -> None:
         class NT:
             c: int
+        nt: NT = NT()
 
 [builtins fixtures/tuple.pyi]
 
@@ -5750,5 +5753,11 @@ class C:
         @dataclass
         class DC:
             c: int
+        c: C = C()
+        nt: NT = NT(c=1)
+        td: TD = TD(c=1)
+        td2: TD2 = TD2(c=1)
+        e: E = E.X
+        dc: DC = DC(c=1)
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5744,7 +5744,9 @@ class C:
     def f(self) -> None:
         class C:
             c: int
-        NT = NamedTuple("NT", [("c", int)])
+        class NT1(NamedTuple):
+            c: int
+        NT2 = NamedTuple("NT2", [("c", int)])
         class TD(TypedDict):
             c: int
         TD2 = TypedDict("TD2", {"c": int})
@@ -5754,10 +5756,13 @@ class C:
         class DC:
             c: int
         c: C = C()
-        nt: NT = NT(c=1)
+        nt1: NT1 = NT1(c=1)
+        nt2: NT2 = NT2(c=1)
         td: TD = TD(c=1)
         td2: TD2 = TD2(c=1)
         e: E = E.X
         dc: DC = DC(c=1)
 
 [builtins fixtures/dict.pyi]
+[out2]
+tmp/a.py:2: error: "object" has no attribute "xyz"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5659,7 +5659,7 @@ class D(C):
 [out2]
 tmp/a.py:9: error: Trying to assign name "z" that is not in "__slots__" of type "a.D"
 
-[case testIncrementalWithDifferentKindsOfNestedTypes]
+[case testIncrementalWithDifferentKindsOfNestedTypesWithinMethod]
 # flags: --python-version 3.7
 
 import a
@@ -5672,7 +5672,7 @@ import b
 b.xyz
 
 [file b.py]
-from typing import NamedTuple
+from typing import NamedTuple, NewType
 from typing_extensions import TypedDict, TypeAlias
 from enum import Enum
 from dataclasses import dataclass
@@ -5693,6 +5693,8 @@ class C:
         class DC:
             c: int
         Alias: TypeAlias = NT1
+        N = NewType("N", NT1)
+
         c: C = C()
         nt1: NT1 = NT1(c=1)
         nt2: NT2 = NT2(c=1)
@@ -5701,6 +5703,7 @@ class C:
         e: E = E.X
         dc: DC = DC(c=1)
         al: Alias = Alias(c=1)
+        n: N = N(NT1(c=1))
 
 [builtins fixtures/dict.pyi]
 [out2]


### PR DESCRIPTION
Make sure the fullname of a named tuple defined within a method matches 
the nesting of the definition in the symbol table. Otherwise we'll have a
crash during deserialization.

In particular, a named tuple defined within a method will now be always 
stored in the symbol table of the surrounding class, instead of the global 
symbol table. Previously there was an inconsistency between old-style 
and new-style syntax.

Fix #10913.