### PR TITLE
Skip tests that depend on lxml if not installed

### DIFF
--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -21,6 +21,12 @@ from mypy.test.helpers import (
 from mypy.errors import CompileError
 from mypy.semanal_main import core_modules
 
+try:
+    import lxml  # type: ignore
+except ImportError:
+    lxml = None
+
+import pytest
 
 # List of files that contain test case descriptions.
 typecheck_files = [
@@ -117,6 +123,8 @@ class TypeCheckSuite(DataSuite):
     files = typecheck_files
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
+        if lxml is None and os.path.basename(testcase.file) == 'check-reports.test':
+            pytest.skip("Cannot import lxml. Is it installed?")
         incremental = ('incremental' in testcase.name.lower()
                        or 'incremental' in testcase.file
                        or 'serialize' in testcase.file)

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -18,6 +18,13 @@ from mypy.test.helpers import (
     assert_string_arrays_equal, normalize_error_messages, check_test_output_files
 )
 
+try:
+    import lxml  # type: ignore
+except ImportError:
+    lxml = None
+
+import pytest
+
 # Path to Python 3 interpreter
 python3_path = sys.executable
 
@@ -35,6 +42,8 @@ class PythonCmdlineSuite(DataSuite):
     native_sep = True
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
+        if lxml is None and os.path.basename(testcase.file) == 'reports.test':
+            pytest.skip("Cannot import lxml. Is it installed?")
         for step in [1] + sorted(testcase.output2):
             test_python_cmdline(testcase, step)
 

--- a/mypy/test/testreports.py
+++ b/mypy/test/testreports.py
@@ -5,11 +5,21 @@ from mypy.test.helpers import Suite, assert_equal
 from mypy.report import CoberturaPackage, get_line_rate
 
 
+try:
+    import lxml  # type: ignore
+except ImportError:
+    lxml = None
+
+import pytest
+
+
 class CoberturaReportSuite(Suite):
+    @pytest.mark.skipif(lxml is None, reason="Cannot import lxml. Is it installed?")
     def test_get_line_rate(self) -> None:
         assert_equal('1.0', get_line_rate(0, 0))
         assert_equal('0.3333', get_line_rate(1, 3))
 
+    @pytest.mark.skipif(lxml is None, reason="Cannot import lxml. Is it installed?")
     def test_as_xml(self) -> None:
         import lxml.etree as etree  # type: ignore
 


### PR DESCRIPTION
### Description

Detect if `lxml` is importable in the test suite, if it is not, then skip the report tests which depend on it.

## Test Plan

To test this I uninstalled `lxml` and was able to see `pytest mypy/test/testcheck.py::TypeCheckSuite::check-reports.test` skip all the tests.