### PR TITLE
[mypyc] Borrow even more things

### DIFF
--- a/mypyc/irbuild/ast_helpers.py
+++ b/mypyc/irbuild/ast_helpers.py
@@ -1,0 +1,94 @@
+"""IRBuilder AST transform helpers shared between expressions and statements.
+
+Shared code that is tightly coupled to mypy ASTs can be put here instead of
+making mypyc.irbuild.builder larger.
+"""
+
+from mypy.nodes import (
+    Expression, MemberExpr, Var, IntExpr, FloatExpr, StrExpr, BytesExpr, NameExpr, OpExpr,
+    UnaryExpr, ComparisonExpr, LDEF
+)
+from mypyc.ir.ops import BasicBlock
+from mypyc.ir.rtypes import is_tagged
+from mypyc.irbuild.builder import IRBuilder
+from mypyc.irbuild.constant_fold import constant_fold_expr
+
+
+def process_conditional(self: IRBuilder, e: Expression, true: BasicBlock,
+                        false: BasicBlock) -> None:
+    if isinstance(e, OpExpr) and e.op in ['and', 'or']:
+        if e.op == 'and':
+            # Short circuit 'and' in a conditional context.
+            new = BasicBlock()
+            process_conditional(self, e.left, new, false)
+            self.activate_block(new)
+            process_conditional(self, e.right, true, false)
+        else:
+            # Short circuit 'or' in a conditional context.
+            new = BasicBlock()
+            process_conditional(self, e.left, true, new)
+            self.activate_block(new)
+            process_conditional(self, e.right, true, false)
+    elif isinstance(e, UnaryExpr) and e.op == 'not':
+        process_conditional(self, e.expr, false, true)
+    else:
+        res = maybe_process_conditional_comparison(self, e, true, false)
+        if res:
+            return
+        # Catch-all for arbitrary expressions.
+        reg = self.accept(e)
+        self.add_bool_branch(reg, true, false)
+
+
+def maybe_process_conditional_comparison(self: IRBuilder,
+                                         e: Expression,
+                                         true: BasicBlock,
+                                         false: BasicBlock) -> bool:
+    """Transform simple tagged integer comparisons in a conditional context.
+
+    Return True if the operation is supported (and was transformed). Otherwise,
+    do nothing and return False.
+
+    Args:
+        e: Arbitrary expression
+        true: Branch target if comparison is true
+        false: Branch target if comparison is false
+    """
+    if not isinstance(e, ComparisonExpr) or len(e.operands) != 2:
+        return False
+    ltype = self.node_type(e.operands[0])
+    rtype = self.node_type(e.operands[1])
+    if not is_tagged(ltype) or not is_tagged(rtype):
+        return False
+    op = e.operators[0]
+    if op not in ('==', '!=', '<', '<=', '>', '>='):
+        return False
+    left_expr = e.operands[0]
+    right_expr = e.operands[1]
+    borrow_left = is_borrow_friendly_expr(self, right_expr)
+    left = self.accept(left_expr, can_borrow=borrow_left)
+    right = self.accept(right_expr, can_borrow=True)
+    # "left op right" for two tagged integers
+    self.builder.compare_tagged_condition(left, right, op, true, false, e.line)
+    return True
+
+
+def is_borrow_friendly_expr(self: IRBuilder, expr: Expression) -> bool:
+    """Can the result of the expression borrowed temporarily?
+
+    Borrowing means keeping a reference without incrementing the reference count.
+    """
+    if isinstance(expr, (IntExpr, FloatExpr, StrExpr, BytesExpr)):
+        # Literals are immportal and can always be borrowed
+        return True
+    if (isinstance(expr, (UnaryExpr, OpExpr, NameExpr, MemberExpr)) and
+            constant_fold_expr(self, expr) is not None):
+        # Literal expressions are similar to literals
+        return True
+    if isinstance(expr, NameExpr):
+        if isinstance(expr.node, Var) and expr.kind == LDEF:
+            # Local variable reference can be borrowed
+            return True
+    if isinstance(expr, MemberExpr) and self.is_native_attr_ref(expr):
+        return True
+    return False

--- a/mypyc/irbuild/ast_helpers.py
+++ b/mypyc/irbuild/ast_helpers.py
@@ -79,7 +79,7 @@ def is_borrow_friendly_expr(self: IRBuilder, expr: Expression) -> bool:
     Borrowing means keeping a reference without incrementing the reference count.
     """
     if isinstance(expr, (IntExpr, FloatExpr, StrExpr, BytesExpr)):
-        # Literals are immportal and can always be borrowed
+        # Literals are immortal and can always be borrowed
         return True
     if (isinstance(expr, (UnaryExpr, OpExpr, NameExpr, MemberExpr)) and
             constant_fold_expr(self, expr) is not None):

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -21,8 +21,8 @@ from mypy.build import Graph
 from mypy.nodes import (
     MypyFile, SymbolNode, Statement, OpExpr, IntExpr, NameExpr, LDEF, Var, UnaryExpr,
     CallExpr, IndexExpr, Expression, MemberExpr, RefExpr, Lvalue, TupleExpr,
-    TypeInfo, Decorator, OverloadedFuncDef, StarExpr, ComparisonExpr, FloatExpr, StrExpr,
-    BytesExpr, GDEF, ArgKind, ARG_POS, ARG_NAMED, FuncDef,
+    TypeInfo, Decorator, OverloadedFuncDef, StarExpr,
+    GDEF, ArgKind, ARG_POS, ARG_NAMED, FuncDef,
 )
 from mypy.types import (
     Type, Instance, TupleType, UninhabitedType, get_proper_type
@@ -40,7 +40,7 @@ from mypyc.ir.ops import (
 from mypyc.ir.rtypes import (
     RType, RTuple, RInstance, c_int_rprimitive, int_rprimitive, dict_rprimitive,
     none_rprimitive, is_none_rprimitive, object_rprimitive, is_object_rprimitive,
-    str_rprimitive, is_tagged, is_list_rprimitive, is_tuple_rprimitive, c_pyssize_t_rprimitive
+    str_rprimitive, is_list_rprimitive, is_tuple_rprimitive, c_pyssize_t_rprimitive
 )
 from mypyc.ir.func_ir import FuncIR, INVALID_FUNC_DEF, RuntimeArg, FuncSignature, FuncDecl
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -21,8 +21,8 @@ from mypy.build import Graph
 from mypy.nodes import (
     MypyFile, SymbolNode, Statement, OpExpr, IntExpr, NameExpr, LDEF, Var, UnaryExpr,
     CallExpr, IndexExpr, Expression, MemberExpr, RefExpr, Lvalue, TupleExpr,
-    TypeInfo, Decorator, OverloadedFuncDef, StarExpr, ComparisonExpr, GDEF,
-    ArgKind, ARG_POS, ARG_NAMED, FuncDef,
+    TypeInfo, Decorator, OverloadedFuncDef, StarExpr, ComparisonExpr, FloatExpr, StrExpr,
+    BytesExpr, GDEF, ArgKind, ARG_POS, ARG_NAMED, FuncDef,
 )
 from mypy.types import (
     Type, Instance, TupleType, UninhabitedType, get_proper_type
@@ -914,61 +914,6 @@ class IRBuilder:
             lambda: self.accept(expr.right),
             expr.line
         )
-
-    # Conditional expressions
-
-    def process_conditional(self, e: Expression, true: BasicBlock, false: BasicBlock) -> None:
-        if isinstance(e, OpExpr) and e.op in ['and', 'or']:
-            if e.op == 'and':
-                # Short circuit 'and' in a conditional context.
-                new = BasicBlock()
-                self.process_conditional(e.left, new, false)
-                self.activate_block(new)
-                self.process_conditional(e.right, true, false)
-            else:
-                # Short circuit 'or' in a conditional context.
-                new = BasicBlock()
-                self.process_conditional(e.left, true, new)
-                self.activate_block(new)
-                self.process_conditional(e.right, true, false)
-        elif isinstance(e, UnaryExpr) and e.op == 'not':
-            self.process_conditional(e.expr, false, true)
-        else:
-            res = self.maybe_process_conditional_comparison(e, true, false)
-            if res:
-                return
-            # Catch-all for arbitrary expressions.
-            reg = self.accept(e)
-            self.add_bool_branch(reg, true, false)
-
-    def maybe_process_conditional_comparison(self,
-                                             e: Expression,
-                                             true: BasicBlock,
-                                             false: BasicBlock) -> bool:
-        """Transform simple tagged integer comparisons in a conditional context.
-
-        Return True if the operation is supported (and was transformed). Otherwise,
-        do nothing and return False.
-
-        Args:
-            e: Arbitrary expression
-            true: Branch target if comparison is true
-            false: Branch target if comparison is false
-        """
-        if not isinstance(e, ComparisonExpr) or len(e.operands) != 2:
-            return False
-        ltype = self.node_type(e.operands[0])
-        rtype = self.node_type(e.operands[1])
-        if not is_tagged(ltype) or not is_tagged(rtype):
-            return False
-        op = e.operators[0]
-        if op not in ('==', '!=', '<', '<=', '>', '>='):
-            return False
-        left = self.accept(e.operands[0])
-        right = self.accept(e.operands[1])
-        # "left op right" for two tagged integers
-        self.builder.compare_tagged_condition(left, right, op, true, false, e.line)
-        return True
 
     # Basic helpers
 

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -292,7 +292,7 @@ class IRBuilder:
                         arg_kinds: Optional[List[ArgKind]] = None,
                         arg_names: Optional[List[Optional[str]]] = None) -> Value:
         return self.builder.gen_method_call(
-            base, name, arg_values, result_type, line, arg_kinds, arg_names
+            base, name, arg_values, result_type, line, arg_kinds, arg_names, self.can_borrow
         )
 
     def load_module(self, name: str) -> Value:

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -5,7 +5,6 @@ and mypyc.irbuild.builder.
 """
 
 from typing import List, Optional, Union, Callable, cast
-from typing_extensions import Final
 
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, SuperExpr, CallExpr, UnaryExpr, OpExpr, IndexExpr,
@@ -41,7 +40,7 @@ from mypyc.primitives.set_ops import set_add_op, set_update_op
 from mypyc.primitives.str_ops import str_slice_op
 from mypyc.primitives.int_ops import int_comparison_op_mapping
 from mypyc.irbuild.specialize import apply_function_specialization, apply_method_specialization
-from mypyc.irbuild.builder import IRBuilder
+from mypyc.irbuild.builder import IRBuilder, int_borrow_friendly_op
 from mypyc.irbuild.for_helpers import (
     translate_list_comprehension, translate_set_comprehension,
     comprehension_helper
@@ -515,11 +514,6 @@ def transform_conditional_expr(builder: IRBuilder, expr: ConditionalExpr) -> Val
     builder.activate_block(next_block)
 
     return target
-
-
-# These int binary operations can borrow their operands safely, since the
-# primitives take this into consideration.
-int_borrow_friendly_op: Final = {'+', '-', '==', '!=', '<', '<=', '>', '>='}
 
 
 def transform_comparison_expr(builder: IRBuilder, e: ComparisonExpr) -> Value:

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -5,6 +5,7 @@ and mypyc.irbuild.builder.
 """
 
 from typing import List, Optional, Union, Callable, cast
+from typing_extensions import Final
 
 from mypy.nodes import (
     Expression, NameExpr, MemberExpr, SuperExpr, CallExpr, UnaryExpr, OpExpr, IndexExpr,
@@ -46,6 +47,7 @@ from mypyc.irbuild.for_helpers import (
     comprehension_helper
 )
 from mypyc.irbuild.constant_fold import constant_fold_expr
+from mypyc.irbuild.ast_helpers import is_borrow_friendly_expr, process_conditional
 
 
 # Name and attribute references
@@ -404,6 +406,15 @@ def transform_op_expr(builder: IRBuilder, expr: OpExpr) -> Value:
     if folded:
         return folded
 
+    # Special case some int ops to allow borrowing operands.
+    if (is_int_rprimitive(builder.node_type(expr.left))
+            and is_int_rprimitive(builder.node_type(expr.right))):
+        if expr.op in int_borrow_friendly_op:
+            borrow_left = is_borrow_friendly_expr(builder, expr.right)
+            left = builder.accept(expr.left, can_borrow=borrow_left)
+            right = builder.accept(expr.right, can_borrow=True)
+            return builder.binary_op(left, right, expr.op, expr.line)
+
     return builder.binary_op(
         builder.accept(expr.left), builder.accept(expr.right), expr.op, expr.line
     )
@@ -428,26 +439,6 @@ def transform_index_expr(builder: IRBuilder, expr: IndexExpr) -> Value:
     index_reg = builder.accept(expr.index, can_borrow=is_list)
     return builder.gen_method_call(
         base, '__getitem__', [index_reg], builder.node_type(expr), expr.line)
-
-
-def is_borrow_friendly_expr(builder: IRBuilder, expr: Expression) -> bool:
-    """Can the result of the expression borrowed temporarily?
-
-    Borrowing means keeping a reference without incrementing the reference count.
-    """
-    if isinstance(expr, (IntExpr, FloatExpr, StrExpr, BytesExpr)):
-        # Literals are immportal and can always be borrowed
-        return True
-    if isinstance(expr, (UnaryExpr, OpExpr)) and constant_fold_expr(builder, expr) is not None:
-        # Literal expressions are similar to literals
-        return True
-    if isinstance(expr, NameExpr):
-        if isinstance(expr.node, Var) and expr.kind == LDEF:
-            # Local variable reference can be borrowed
-            return True
-    if isinstance(expr, MemberExpr) and builder.is_native_attr_ref(expr):
-        return True
-    return False
 
 
 def try_constant_fold(builder: IRBuilder, expr: Expression) -> Optional[Value]:
@@ -504,7 +495,7 @@ def try_gen_slice_op(builder: IRBuilder, base: Value, index: SliceExpr) -> Optio
 def transform_conditional_expr(builder: IRBuilder, expr: ConditionalExpr) -> Value:
     if_body, else_body, next_block = BasicBlock(), BasicBlock(), BasicBlock()
 
-    builder.process_conditional(expr.cond, if_body, else_body)
+    process_conditional(builder, expr.cond, if_body, else_body)
     expr_type = builder.node_type(expr)
     # Having actual Phi nodes would be really nice here!
     target = Register(expr_type)
@@ -524,6 +515,11 @@ def transform_conditional_expr(builder: IRBuilder, expr: ConditionalExpr) -> Val
     builder.activate_block(next_block)
 
     return target
+
+
+# These int binary operations can borrow their operands safely, since the
+# primitives take this into consideration.
+int_borrow_friendly_op: Final = {'+', '-', '==', '!=', '<', '<=', '>', '>='}
 
 
 def transform_comparison_expr(builder: IRBuilder, e: ComparisonExpr) -> Value:
@@ -577,11 +573,22 @@ def transform_comparison_expr(builder: IRBuilder, e: ComparisonExpr) -> Value:
             else:
                 return builder.true()
 
-    if first_op in ('is', 'is not') and len(e.operators) == 1:
-        right = e.operands[1]
-        if isinstance(right, NameExpr) and right.fullname == 'builtins.None':
-            # Special case 'is None' / 'is not None'.
-            return translate_is_none(builder, e.operands[0], negated=first_op != 'is')
+    if len(e.operators) == 1:
+        # Special some common simple cases
+        if first_op in ('is', 'is not'):
+            right_expr = e.operands[1]
+            if isinstance(right_expr, NameExpr) and right_expr.fullname == 'builtins.None':
+                # Special case 'is None' / 'is not None'.
+                return translate_is_none(builder, e.operands[0], negated=first_op != 'is')
+        left_expr = e.operands[0]
+        if is_int_rprimitive(builder.node_type(left_expr)):
+            right_expr = e.operands[1]
+            if is_int_rprimitive(builder.node_type(right_expr)):
+                if first_op in int_borrow_friendly_op:
+                    borrow_left = is_borrow_friendly_expr(builder, right_expr)
+                    left = builder.accept(left_expr, can_borrow=borrow_left)
+                    right = builder.accept(right_expr, can_borrow=True)
+                    return builder.compare_tagged(left, right, first_op, e.line)
 
     # TODO: Don't produce an expression when used in conditional context
     # All of the trickiness here is due to support for chained conditionals

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1315,6 +1315,13 @@ class LowLevelIRBuilder:
             error_kind = ERR_NEVER
         target = self.add(CallC(desc.c_function_name, coerced, desc.return_type, desc.steals,
                                 desc.is_borrowed, error_kind, line, var_arg_idx))
+        if desc.is_borrowed:
+            # If the result is borrowed, force the arguments to be
+            # kept alive afterwards, as otherwise the result might be
+            # immediately freed, at the risk of a dangling pointer.
+            for arg in coerced:
+                if not isinstance(arg, (Integer, LoadLiteral)):
+                    self.keep_alives.append(arg)
         if desc.error_kind == ERR_NEG_INT:
             comp = ComparisonOp(target,
                                 Integer(0, desc.return_type, line),

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -36,6 +36,7 @@ from mypyc.irbuild.nonlocalcontrol import (
 )
 from mypyc.irbuild.for_helpers import for_loop_helper
 from mypyc.irbuild.builder import IRBuilder
+from mypyc.irbuild.ast_helpers import process_conditional
 
 GenFunc = Callable[[], None]
 
@@ -207,7 +208,7 @@ def transform_if_stmt(builder: IRBuilder, stmt: IfStmt) -> None:
     # If statements are normalized
     assert len(stmt.expr) == 1
 
-    builder.process_conditional(stmt.expr[0], if_body, else_body)
+    process_conditional(builder, stmt.expr[0], if_body, else_body)
     builder.activate_block(if_body)
     builder.accept(stmt.body[0])
     builder.goto(next)
@@ -226,7 +227,7 @@ def transform_while_stmt(builder: IRBuilder, s: WhileStmt) -> None:
 
     # Split block so that we get a handle to the top of the loop.
     builder.goto_and_activate(top)
-    builder.process_conditional(s.expr, body, normal_loop_exit)
+    process_conditional(builder, s.expr, body, normal_loop_exit)
 
     builder.activate_block(body)
     builder.accept(s.body)

--- a/mypyc/irbuild/targets.py
+++ b/mypyc/irbuild/targets.py
@@ -35,9 +35,10 @@ class AssignmentTargetIndex(AssignmentTarget):
 class AssignmentTargetAttr(AssignmentTarget):
     """obj.attr as assignment target"""
 
-    def __init__(self, obj: Value, attr: str) -> None:
+    def __init__(self, obj: Value, attr: str, can_borrow: bool = False) -> None:
         self.obj = obj
         self.attr = attr
+        self.can_borrow = can_borrow
         if isinstance(obj.type, RInstance) and obj.type.class_ir.has_attr(attr):
             # Native attribute reference
             self.obj_type: RType = obj.type

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -340,6 +340,8 @@ PyObject *CPyList_Build(Py_ssize_t len, ...);
 PyObject *CPyList_GetItem(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemUnsafe(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemShort(PyObject *list, CPyTagged index);
+PyObject *CPyList_GetItemBorrow(PyObject *list, CPyTagged index);
+PyObject *CPyList_GetItemShortBorrow(PyObject *list, CPyTagged index);
 bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value);
 bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value);
 PyObject *CPyList_PopLast(PyObject *obj);

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -250,8 +250,11 @@ bool CPyTagged_IsEq_(CPyTagged left, CPyTagged right) {
     if (CPyTagged_CheckShort(right)) {
         return false;
     } else {
-        int result = PyObject_RichCompareBool(CPyTagged_LongAsObject(left),
-                                              CPyTagged_LongAsObject(right), Py_EQ);
+        PyObject *left_obj = CPyTagged_AsObject(left);
+        PyObject *right_obj = CPyTagged_AsObject(right);
+        int result = PyObject_RichCompareBool(left_obj, right_obj, Py_EQ);
+        Py_DECREF(left_obj);
+        Py_DECREF(right_obj);
         if (result == -1) {
             CPyError_OutOfMemory();
         }

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -52,6 +52,24 @@ PyObject *CPyList_GetItemShort(PyObject *list, CPyTagged index) {
     return result;
 }
 
+PyObject *CPyList_GetItemShortBorrow(PyObject *list, CPyTagged index) {
+    Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
+    Py_ssize_t size = PyList_GET_SIZE(list);
+    if (n >= 0) {
+        if (n >= size) {
+            PyErr_SetString(PyExc_IndexError, "list index out of range");
+            return NULL;
+        }
+    } else {
+        n += size;
+        if (n < 0) {
+            PyErr_SetString(PyExc_IndexError, "list index out of range");
+            return NULL;
+        }
+    }
+    return PyList_GET_ITEM(list, n);
+}
+
 PyObject *CPyList_GetItem(PyObject *list, CPyTagged index) {
     if (CPyTagged_CheckShort(index)) {
         Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
@@ -71,6 +89,29 @@ PyObject *CPyList_GetItem(PyObject *list, CPyTagged index) {
         PyObject *result = PyList_GET_ITEM(list, n);
         Py_INCREF(result);
         return result;
+    } else {
+        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
+        return NULL;
+    }
+}
+
+PyObject *CPyList_GetItemBorrow(PyObject *list, CPyTagged index) {
+    if (CPyTagged_CheckShort(index)) {
+        Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
+        Py_ssize_t size = PyList_GET_SIZE(list);
+        if (n >= 0) {
+            if (n >= size) {
+                PyErr_SetString(PyExc_IndexError, "list index out of range");
+                return NULL;
+            }
+        } else {
+            n += size;
+            if (n < 0) {
+                PyErr_SetString(PyExc_IndexError, "list index out of range");
+                return NULL;
+            }
+        }
+        return PyList_GET_ITEM(list, n);
     } else {
         PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
         return NULL;

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -55,7 +55,7 @@ list_get_item_op = method_op(
     c_function_name='CPyList_GetItem',
     error_kind=ERR_MAGIC)
 
-# Version with no int bounds check for when it is known to be short
+# list[index] version with no int bounds check for when it is known to be short
 method_op(
     name='__getitem__',
     arg_types=[list_rprimitive, short_int_rprimitive],
@@ -63,6 +63,26 @@ method_op(
     c_function_name='CPyList_GetItemShort',
     error_kind=ERR_MAGIC,
     priority=2)
+
+# list[index] that produces a borrowed result
+method_op(
+    name='__getitem__',
+    arg_types=[list_rprimitive, int_rprimitive],
+    return_type=object_rprimitive,
+    c_function_name='CPyList_GetItemBorrow',
+    error_kind=ERR_MAGIC,
+    is_borrowed=True,
+    priority=3)
+
+# list[index] that produces a borrowed result and index is known to be short
+method_op(
+    name='__getitem__',
+    arg_types=[list_rprimitive, short_int_rprimitive],
+    return_type=object_rprimitive,
+    c_function_name='CPyList_GetItemShortBorrow',
+    error_kind=ERR_MAGIC,
+    is_borrowed=True,
+    priority=4)
 
 # This is unsafe because it assumes that the index is a non-negative short integer
 # that is in-bounds for the list.

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -135,11 +135,10 @@ L4:
     r5 = i < l :: signed
     if r5 goto L5 else goto L10 :: bool
 L5:
-    r6 = CPyList_GetItem(a, i)
+    r6 = CPyList_GetItemBorrow(a, i)
     if is_error(r6) goto L11 (error at sum:6) else goto L6
 L6:
     r7 = unbox(int, r6)
-    dec_ref r6
     if is_error(r7) goto L11 (error at sum:6) else goto L7
 L7:
     r8 = CPyTagged_Add(sum, r7)

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2197,14 +2197,14 @@ L0:
     r0 = self.is_add
     if r0 goto L1 else goto L2 :: bool
 L1:
-    r1 = self.left
-    r2 = self.right
+    r1 = borrow self.left
+    r2 = borrow self.right
     r3 = CPyTagged_Add(r1, r2)
     r4 = r3
     goto L3
 L2:
-    r5 = self.left
-    r6 = self.right
+    r5 = borrow self.left
+    r6 = borrow self.right
     r7 = CPyTagged_Subtract(r5, r6)
     r4 = r7
 L3:
@@ -2292,7 +2292,7 @@ def BaseProperty.next(self):
     r0, r1 :: int
     r2 :: __main__.BaseProperty
 L0:
-    r0 = self._incrementer
+    r0 = borrow self._incrementer
     r1 = CPyTagged_Add(r0, 2)
     r2 = BaseProperty(r1)
     return r2
@@ -2483,7 +2483,7 @@ def g(a, b, c):
     r2, r3 :: int
 L0:
     r0 = a.__getitem__(c)
-    r1 = CPyList_GetItem(b, c)
+    r1 = CPyList_GetItemBorrow(b, c)
     r2 = unbox(int, r1)
     r3 = CPyTagged_Add(r0, r2)
     return r3

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2489,6 +2489,7 @@ L0:
     r1 = CPyList_GetItemBorrow(b, c)
     r2 = unbox(int, r1)
     r3 = CPyTagged_Add(r0, r2)
+    keep_alive b, c
     return r3
 
 [case testTypeAlias_toplevel]

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2200,12 +2200,14 @@ L1:
     r1 = borrow self.left
     r2 = borrow self.right
     r3 = CPyTagged_Add(r1, r2)
+    keep_alive self, self
     r4 = r3
     goto L3
 L2:
     r5 = borrow self.left
     r6 = borrow self.right
     r7 = CPyTagged_Subtract(r5, r6)
+    keep_alive self, self
     r4 = r7
 L3:
     return r4
@@ -2294,6 +2296,7 @@ def BaseProperty.next(self):
 L0:
     r0 = borrow self._incrementer
     r1 = CPyTagged_Add(r0, 2)
+    keep_alive self
     r2 = BaseProperty(r1)
     return r2
 def BaseProperty.__init__(self, value):

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -61,6 +61,7 @@ L0:
     d = r6
     r7 = borrow d.x
     r8 = CPyTagged_Add(r7, 2)
+    keep_alive d
     return r8
 
 [case testMethodCall]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -59,7 +59,7 @@ L0:
     r5 = CPyList_GetItemShort(a, 0)
     r6 = cast(__main__.C, r5)
     d = r6
-    r7 = d.x
+    r7 = borrow d.x
     r8 = CPyTagged_Add(r7, 2)
     return r8
 

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1289,3 +1289,47 @@ L0:
     r1 = r0.e
     r2 = r1.x
     return r2
+
+[case testBorrowResultOfCustomGetItemInIfStatement]
+from typing import List
+
+class C:
+    def __getitem__(self, x: int) -> List[int]:
+        return []
+
+def f(x: C) -> None:
+    # In this case the keep_alive must come before the branch, as otherwise
+    # reference count transform will get confused.
+    if x[1][0] == 2:
+        y = 1
+    else:
+        y = 2
+[out]
+def C.__getitem__(self, x):
+    self :: __main__.C
+    x :: int
+    r0 :: list
+L0:
+    r0 = PyList_New(0)
+    return r0
+def f(x):
+    x :: __main__.C
+    r0 :: list
+    r1 :: object
+    r2 :: int
+    r3 :: bit
+    y :: int
+L0:
+    r0 = x.__getitem__(2)
+    r1 = CPyList_GetItemShortBorrow(r0, 0)
+    r2 = unbox(int, r1)
+    r3 = r2 == 4
+    keep_alive r0
+    if r3 goto L1 else goto L2 :: bool
+L1:
+    y = 2
+    goto L3
+L2:
+    y = 4
+L3:
+    return 1

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -175,7 +175,7 @@ def increment(o):
     r0, r1 :: int
     r2 :: bool
 L0:
-    r0 = o.x
+    r0 = borrow o.x
     r1 = CPyTagged_Add(r0, 2)
     o.x = r1; r2 = is_error
     return o

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -65,6 +65,7 @@ L0:
     r3 = borrow c.x
     r4 = unbox(int, r3)
     r5 = CPyTagged_Add(4, r4)
+    keep_alive c
     return 1
 
 [case testGenericMethod]

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -62,7 +62,7 @@ L0:
     c = r0
     r1 = object 1
     c.x = r1; r2 = is_error
-    r3 = c.x
+    r3 = borrow c.x
     r4 = unbox(int, r3)
     r5 = CPyTagged_Add(4, r4)
     return 1

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -42,6 +42,7 @@ L0:
     r1 = borrow cast(list, r0)
     r2 = CPyList_GetItemShort(r1, 2)
     r3 = unbox(int, r2)
+    keep_alive x, r0
     return r3
 
 [case testListSet]

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -38,8 +38,8 @@ def f(x):
     r2 :: object
     r3 :: int
 L0:
-    r0 = CPyList_GetItemShort(x, 0)
-    r1 = cast(list, r0)
+    r0 = CPyList_GetItemShortBorrow(x, 0)
+    r1 = borrow cast(list, r0)
     r2 = CPyList_GetItemShort(r1, 2)
     r3 = unbox(int, r2)
     return r3

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -1153,14 +1153,20 @@ L0:
 [case testBorrowListGetItem2]
 from typing import List
 
-def attr_index(x: C) -> str:
+def attr_before_index(x: C) -> str:
     return x.a[x.n]
+
+def attr_after_index(a: List[C], i: int) -> int:
+    return a[i].n
+
+def attr_after_index_literal(a: List[C]) -> int:
+    return a[0].n
 
 class C:
     a: List[str]
     n: int
 [out]
-def attr_index(x):
+def attr_before_index(x):
     x :: __main__.C
     r0 :: list
     r1 :: int
@@ -1172,6 +1178,27 @@ L0:
     r2 = CPyList_GetItem(r0, r1)
     r3 = cast(str, r2)
     return r3
+def attr_after_index(a, i):
+    a :: list
+    i :: int
+    r0 :: object
+    r1 :: __main__.C
+    r2 :: int
+L0:
+    r0 = CPyList_GetItemBorrow(a, i)
+    r1 = borrow cast(__main__.C, r0)
+    r2 = r1.n
+    return r2
+def attr_after_index_literal(a):
+    a :: list
+    r0 :: object
+    r1 :: __main__.C
+    r2 :: int
+L0:
+    r0 = CPyList_GetItemShortBorrow(a, 0)
+    r1 = borrow cast(__main__.C, r0)
+    r2 = r1.n
+    return r2
 
 [case testCannotBorrowListGetItem]
 from typing import List

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -1241,3 +1241,163 @@ L0:
     r0 = borrow x.c
     r0.b = 0; r1 = is_error
     return 1
+
+[case testBorrowIntEquality]
+def add(c: C) -> bool:
+    return c.x == c.y
+
+class C:
+    x: int
+    y: int
+[out]
+def add(c):
+    c :: __main__.C
+    r0, r1 :: int
+    r2 :: native_int
+    r3, r4 :: bit
+    r5 :: bool
+    r6 :: bit
+L0:
+    r0 = borrow c.x
+    r1 = borrow c.y
+    r2 = r0 & 1
+    r3 = r2 == 0
+    if r3 goto L1 else goto L2 :: bool
+L1:
+    r4 = r0 == r1
+    r5 = r4
+    goto L3
+L2:
+    r6 = CPyTagged_IsEq_(r0, r1)
+    r5 = r6
+L3:
+    return r5
+
+[case testBorrowIntLessThan]
+def add(c: C) -> bool:
+    return c.x < c.y
+
+class C:
+    x: int
+    y: int
+[out]
+def add(c):
+    c :: __main__.C
+    r0, r1 :: int
+    r2 :: native_int
+    r3 :: bit
+    r4 :: native_int
+    r5, r6, r7 :: bit
+    r8 :: bool
+    r9 :: bit
+L0:
+    r0 = borrow c.x
+    r1 = borrow c.y
+    r2 = r0 & 1
+    r3 = r2 == 0
+    r4 = r1 & 1
+    r5 = r4 == 0
+    r6 = r3 & r5
+    if r6 goto L1 else goto L2 :: bool
+L1:
+    r7 = r0 < r1 :: signed
+    r8 = r7
+    goto L3
+L2:
+    r9 = CPyTagged_IsLt_(r0, r1)
+    r8 = r9
+L3:
+    return r8
+
+[case testBorrowIntCompareFinal]
+from typing_extensions import Final
+
+X: Final = 10
+
+def add(c: C) -> bool:
+    return c.x == X
+
+class C:
+    x: int
+[out]
+def add(c):
+    c :: __main__.C
+    r0 :: int
+    r1 :: native_int
+    r2, r3 :: bit
+    r4 :: bool
+    r5 :: bit
+L0:
+    r0 = borrow c.x
+    r1 = r0 & 1
+    r2 = r1 == 0
+    if r2 goto L1 else goto L2 :: bool
+L1:
+    r3 = r0 == 20
+    r4 = r3
+    goto L3
+L2:
+    r5 = CPyTagged_IsEq_(r0, 20)
+    r4 = r5
+L3:
+    return r4
+
+[case testBorrowIntArithmetic]
+def add(c: C) -> int:
+    return c.x + c.y
+
+def sub(c: C) -> int:
+    return c.x - c.y
+
+class C:
+    x: int
+    y: int
+[out]
+def add(c):
+    c :: __main__.C
+    r0, r1, r2 :: int
+L0:
+    r0 = borrow c.x
+    r1 = borrow c.y
+    r2 = CPyTagged_Add(r0, r1)
+    return r2
+def sub(c):
+    c :: __main__.C
+    r0, r1, r2 :: int
+L0:
+    r0 = borrow c.x
+    r1 = borrow c.y
+    r2 = CPyTagged_Subtract(r0, r1)
+    return r2
+
+[case testBorrowIntComparisonInIf]
+def add(c: C, n: int) -> bool:
+    if c.x == c.y:
+        return True
+    return False
+
+class C:
+    x: int
+    y: int
+[out]
+def add(c, n):
+    c :: __main__.C
+    n, r0, r1 :: int
+    r2 :: native_int
+    r3, r4, r5 :: bit
+L0:
+    r0 = borrow c.x
+    r1 = borrow c.y
+    r2 = r0 & 1
+    r3 = r2 != 0
+    if r3 goto L1 else goto L2 :: bool
+L1:
+    r4 = CPyTagged_IsEq_(r0, r1)
+    if r4 goto L3 else goto L4 :: bool
+L2:
+    r5 = r0 == r1
+    if r5 goto L3 else goto L4 :: bool
+L3:
+    return 1
+L4:
+    return 0

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -1401,3 +1401,34 @@ L3:
     return 1
 L4:
     return 0
+
+[case testBorrowIntInPlaceOp]
+def add(c: C, n: int) -> None:
+    c.x += n
+
+def sub(c: C, n: int) -> None:
+    c.x -= c.y
+
+class C:
+    x: int
+    y: int
+[out]
+def add(c, n):
+    c :: __main__.C
+    n, r0, r1 :: int
+    r2 :: bool
+L0:
+    r0 = borrow c.x
+    r1 = CPyTagged_Add(r0, n)
+    c.x = r1; r2 = is_error
+    return 1
+def sub(c, n):
+    c :: __main__.C
+    n, r0, r1, r2 :: int
+    r3 :: bool
+L0:
+    r0 = borrow c.x
+    r1 = borrow c.y
+    r2 = CPyTagged_Subtract(r0, r1)
+    c.x = r2; r3 = is_error
+    return 1

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -1229,6 +1229,37 @@ def f():
 L0:
     return 0
 
+[case testBorrowListGetItemKeepAlive]
+from typing import List
+
+def f() -> str:
+    a = [C()]
+    return a[0].s
+
+class C:
+    s: str
+[out]
+def f():
+    r0 :: __main__.C
+    r1 :: list
+    r2, r3 :: ptr
+    a :: list
+    r4 :: object
+    r5 :: __main__.C
+    r6 :: str
+L0:
+    r0 = C()
+    r1 = PyList_New(1)
+    r2 = get_element_ptr r1 ob_item :: PyListObject
+    r3 = load_mem r2 :: ptr*
+    set_mem r3, r0 :: builtins.object*
+    a = r1
+    r4 = CPyList_GetItemShortBorrow(a, 0)
+    r5 = borrow cast(__main__.C, r4)
+    r6 = r5.s
+    dec_ref a
+    return r6
+
 [case testBorrowSetAttrObject]
 from typing import Optional
 

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -379,8 +379,33 @@ def test() -> None:
     source_str = "abcd"
     f = list("str:" + x for x in source_str)
     assert f == ["str:a", "str:b", "str:c", "str:d"]
+
 [case testNextBug]
 from typing import List, Optional
 
 def test(x: List[int]) -> None:
     res = next((i for i in x), None)
+
+[case testListGetItemWithBorrow]
+from typing import List
+
+class D:
+    def __init__(self, n: int) -> None:
+        self.n = n
+
+class C:
+    def __init__(self, d: D) -> None:
+        self.d = d
+
+def test_index_with_literal() -> None:
+    d1 = D(1)
+    d2 = D(2)
+    a = [C(d1), C(d2)]
+    d = a[0].d
+    assert d is d1
+    d = a[1].d
+    assert d is d2
+    d = a[-1].d
+    assert d is d2
+    d = a[-2].d
+    assert d is d1


### PR DESCRIPTION
Borrow operands of tagged integer operations to reduce the number of
incref/decref operations (when it's safe to do so).

Borrow the results in list get item operations, similar to what we've been
doing with get attribute operations.