### PR TITLE
[mypyc] Generate smaller code for casts

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -2,6 +2,8 @@
 
 from mypy.backports import OrderedDict
 from typing import List, Set, Dict, Optional, Callable, Union, Tuple
+from typing_extensions import Final
+
 import sys
 
 from mypyc.common import (
@@ -22,6 +24,10 @@ from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.namegen import NameGenerator, exported_name
 from mypyc.sametype import is_same_type
 from mypyc.codegen.literals import Literals
+
+# Whether to insert debug asserts for all error handling, to quickly
+# catch errors propagating without exceptions set.
+DEBUG_ERRORS: Final = False
 
 
 class HeaderDeclaration:
@@ -102,6 +108,20 @@ class GotoHandler(ErrorHandler):
 
     def __init__(self, label: str) -> None:
         self.label = label
+
+
+class TracebackAndGotoHandler(ErrorHandler):
+    """Add traceback item and goto label on error."""
+
+    def __init__(self,
+                 label: str,
+                 source_path: str,
+                 module_name: str,
+                 traceback_entry: Tuple[str, int]) -> None:
+        self.label = label
+        self.source_path = source_path
+        self.module_name = module_name
+        self.traceback_entry = traceback_entry
 
 
 class ReturnHandler(ErrorHandler):
@@ -439,18 +459,6 @@ class Emitter:
             likely: If the cast is likely to succeed (can be False for unions)
         """
         error = error or AssignHandler()
-        if isinstance(error, AssignHandler):
-            handle_error = '%s = NULL;' % dest
-        elif isinstance(error, GotoHandler):
-            handle_error = 'goto %s;' % error.label
-        else:
-            assert isinstance(error, ReturnHandler)
-            handle_error = 'return %s;' % error.value
-        if raise_exception:
-            raise_exc = f'CPy_TypeError("{self.pretty_name(typ)}", {src}); '
-            err = raise_exc + handle_error
-        else:
-            err = handle_error
 
         # Special case casting *from* optional
         if src_type and is_optional_type(src_type) and not is_object_rprimitive(typ):
@@ -465,9 +473,9 @@ class Emitter:
                 self.emit_arg_check(src, dest, typ, check.format(src), optional)
                 self.emit_lines(
                     f'    {dest} = {src};',
-                    'else {',
-                    err,
-                    '}')
+                    'else {')
+                self.emit_cast_error_handler(error, src, dest, typ, raise_exception)
+                self.emit_line('}')
                 return
 
         # TODO: Verify refcount handling.
@@ -500,9 +508,9 @@ class Emitter:
             self.emit_arg_check(src, dest, typ, check.format(prefix, src), optional)
             self.emit_lines(
                 f'    {dest} = {src};',
-                'else {',
-                err,
-                '}')
+                'else {')
+            self.emit_cast_error_handler(error, src, dest, typ, raise_exception)
+            self.emit_line('}')
         elif is_bytes_rprimitive(typ):
             if declare_dest:
                 self.emit_line(f'PyObject *{dest};')
@@ -512,9 +520,9 @@ class Emitter:
             self.emit_arg_check(src, dest, typ, check.format(src, src), optional)
             self.emit_lines(
                 f'    {dest} = {src};',
-                'else {',
-                err,
-                '}')
+                'else {')
+            self.emit_cast_error_handler(error, src, dest, typ, raise_exception)
+            self.emit_line('}')
         elif is_tuple_rprimitive(typ):
             if declare_dest:
                 self.emit_line(f'{self.ctype(typ)} {dest};')
@@ -525,9 +533,9 @@ class Emitter:
                                 check.format(src), optional)
             self.emit_lines(
                 f'    {dest} = {src};',
-                'else {',
-                err,
-                '}')
+                'else {')
+            self.emit_cast_error_handler(error, src, dest, typ, raise_exception)
+            self.emit_line('}')
         elif isinstance(typ, RInstance):
             if declare_dest:
                 self.emit_line(f'PyObject *{dest};')
@@ -551,10 +559,10 @@ class Emitter:
                 check = f'(likely{check})'
             self.emit_arg_check(src, dest, typ, check, optional)
             self.emit_lines(
-                f'    {dest} = {src};',
-                'else {',
-                err,
-                '}')
+                f'    {dest} = {src};'.format(dest, src),
+                'else {')
+            self.emit_cast_error_handler(error, src, dest, typ, raise_exception)
+            self.emit_line('}')
         elif is_none_rprimitive(typ):
             if declare_dest:
                 self.emit_line(f'PyObject *{dest};')
@@ -565,9 +573,9 @@ class Emitter:
                                 check.format(src), optional)
             self.emit_lines(
                 f'    {dest} = {src};',
-                'else {',
-                err,
-                '}')
+                'else {')
+            self.emit_cast_error_handler(error, src, dest, typ, raise_exception)
+            self.emit_line('}')
         elif is_object_rprimitive(typ):
             if declare_dest:
                 self.emit_line(f'PyObject *{dest};')
@@ -576,21 +584,43 @@ class Emitter:
             if optional:
                 self.emit_line('}')
         elif isinstance(typ, RUnion):
-            self.emit_union_cast(src, dest, typ, declare_dest, err, optional, src_type)
+            self.emit_union_cast(src, dest, typ, declare_dest, error, optional, src_type,
+                                 raise_exception)
         elif isinstance(typ, RTuple):
             assert not optional
-            self.emit_tuple_cast(src, dest, typ, declare_dest, err, src_type)
+            self.emit_tuple_cast(src, dest, typ, declare_dest, error, src_type)
         else:
             assert False, 'Cast not implemented: %s' % typ
+
+    def emit_cast_error_handler(self,
+                                error: ErrorHandler,
+                                src: str,
+                                dest: str,
+                                typ: RType,
+                                raise_exception: bool) -> None:
+        if raise_exception:
+            self.emit_line('CPy_TypeError("{}", {}); '.format(self.pretty_name(typ), src))
+        if isinstance(error, AssignHandler):
+            self.emit_line('%s = NULL;' % dest)
+        elif isinstance(error, GotoHandler):
+            self.emit_line('goto %s;' % error.label)
+        elif isinstance(error, TracebackAndGotoHandler):
+            self.emit_line('%s = NULL;' % dest)
+            self.emit_traceback(error.source_path, error.module_name, error.traceback_entry)
+            self.emit_line('goto %s;' % error.label)
+        else:
+            assert isinstance(error, ReturnHandler)
+            self.emit_line('return %s;' % error.value)
 
     def emit_union_cast(self,
                         src: str,
                         dest: str,
                         typ: RUnion,
                         declare_dest: bool,
-                        err: str,
+                        error: ErrorHandler,
                         optional: bool,
-                        src_type: Optional[RType]) -> None:
+                        src_type: Optional[RType],
+                        raise_exception: bool) -> None:
         """Emit cast to a union type.
 
         The arguments are similar to emit_cast.
@@ -613,11 +643,11 @@ class Emitter:
                            likely=False)
             self.emit_line(f'if ({dest} != NULL) goto {good_label};')
         # Handle cast failure.
-        self.emit_line(err)
+        self.emit_cast_error_handler(error, src, dest, typ, raise_exception)
         self.emit_label(good_label)
 
     def emit_tuple_cast(self, src: str, dest: str, typ: RTuple, declare_dest: bool,
-                        err: str, src_type: Optional[RType]) -> None:
+                        error: ErrorHandler, src_type: Optional[RType]) -> None:
         """Emit cast to a tuple type.
 
         The arguments are similar to emit_cast.
@@ -740,7 +770,8 @@ class Emitter:
                 self.emit_line('} else {')
 
             cast_temp = self.temp_name()
-            self.emit_tuple_cast(src, cast_temp, typ, declare_dest=True, err='', src_type=None)
+            self.emit_tuple_cast(src, cast_temp, typ, declare_dest=True, error=error,
+                                 src_type=None)
             self.emit_line(f'if (unlikely({cast_temp} == NULL)) {{')
 
             # self.emit_arg_check(src, dest, typ,
@@ -886,3 +917,16 @@ class Emitter:
             self.emit_line(f'Py_CLEAR({target});')
         else:
             assert False, 'emit_gc_clear() not implemented for %s' % repr(rtype)
+
+    def emit_traceback(self,
+                       source_path: str,
+                       module_name: str,
+                       traceback_entry: Tuple[str, int]) -> None:
+        globals_static = self.static_name('globals', module_name)
+        self.emit_line('CPy_AddTraceback("%s", "%s", %d, %s);' % (
+            source_path.replace("\\", "\\\\"),
+            traceback_entry[0],
+            traceback_entry[1],
+            globals_static))
+        if DEBUG_ERRORS:
+            self.emit_line('assert(PyErr_Occurred() != NULL && "failure w/o err!");')

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -498,6 +498,8 @@ void _CPy_GetExcInfo(PyObject **p_type, PyObject **p_value, PyObject **p_traceba
 void CPyError_OutOfMemory(void);
 void CPy_TypeError(const char *expected, PyObject *value);
 void CPy_AddTraceback(const char *filename, const char *funcname, int line, PyObject *globals);
+void CPy_TypeErrorTraceback(const char *filename, const char *funcname, int line,
+                            PyObject *globals, const char *expected, PyObject *value);
 void CPy_AttributeError(const char *filename, const char *funcname, const char *classname,
                         const char *attrname, int line, PyObject *globals);
 

--- a/mypyc/lib-rt/exc_ops.c
+++ b/mypyc/lib-rt/exc_ops.c
@@ -226,6 +226,13 @@ error:
     _PyErr_ChainExceptions(exc, val, tb);
 }
 
+CPy_NOINLINE
+void CPy_TypeErrorTraceback(const char *filename, const char *funcname, int line,
+                            PyObject *globals, const char *expected, PyObject *value) {
+    CPy_TypeError(expected, value);
+    CPy_AddTraceback(filename, funcname, line, globals);
+}
+
 void CPy_AttributeError(const char *filename, const char *funcname, const char *classname,
                         const char *attrname, int line, PyObject *globals) {
     char buf[500];

--- a/mypyc/test-data/run-functions.test
+++ b/mypyc/test-data/run-functions.test
@@ -1220,3 +1220,18 @@ def sub(s: str, f: Callable[[str], str]) -> str: ...
 def sub(s: bytes, f: Callable[[bytes], bytes]) -> bytes: ...
 def sub(s, f):
     return f(s)
+
+[case testContextManagerSpecialCase]
+from typing import Generator, Callable, Iterator
+from contextlib import contextmanager
+
+@contextmanager
+def f() -> Iterator[None]:
+    yield
+
+def g() -> None:
+    a = ['']
+    with f():
+        a.pop()
+
+g()

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -453,9 +453,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             if (likely(PyDict_Check(cpy_r_r)))
                 cpy_r_r0 = cpy_r_r;
             else {
-                CPy_TypeError("dict", cpy_r_r);
-                cpy_r_r0 = NULL;
-                CPy_AddTraceback("prog.py", "foobar", 123, CPyStatic_prog___globals);
+                CPy_TypeErrorTraceback("prog.py", "foobar", 123, CPyStatic_prog___globals, "dict", cpy_r_r);
                 goto CPyL8;
             }
             """,

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -450,13 +450,13 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(
             op,
             """\
-            if (likely(PyDict_Check(cpy_r_r)))
-                cpy_r_r0 = cpy_r_r;
-            else {
-                CPy_TypeErrorTraceback("prog.py", "foobar", 123, CPyStatic_prog___globals, "dict", cpy_r_r);
-                goto CPyL8;
-            }
-            """,
+if (likely(PyDict_Check(cpy_r_r)))
+    cpy_r_r0 = cpy_r_r;
+else {
+    CPy_TypeErrorTraceback("prog.py", "foobar", 123, CPyStatic_prog___globals, "dict", cpy_r_r);
+    goto CPyL8;
+}
+""",
             next_block=next_block,
             next_branch=branch,
             skip_next=True,

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -9,7 +9,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     BasicBlock, Goto, Return, Integer, Assign, AssignMulti, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, SetAttr, Op, Value, CallC, IntOp, LoadMem,
-    GetElementPtr, LoadAddress, ComparisonOp, SetMem, Register, Unreachable
+    GetElementPtr, LoadAddress, ComparisonOp, SetMem, Register, Unreachable, Cast
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, RType, RArray, int_rprimitive, bool_rprimitive, list_rprimitive,
@@ -312,7 +312,9 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             CPyTagged_INCREF(cpy_r_r0);
             goto CPyL9;
             """,
-            next_branch=branch)
+            next_branch=branch,
+            skip_next=True,
+        )
 
     def test_set_attr(self) -> None:
         self.assert_emit(
@@ -440,13 +442,112 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(Assign(a, Integer(-(1 << 31), int64_rprimitive)),
                          """cpy_r_a = -2147483648LL;""")
 
+    def test_cast_and_branch_merge(self) -> None:
+        op = Cast(self.r, dict_rprimitive, 1)
+        next_block = BasicBlock(9)
+        branch = Branch(op, BasicBlock(8), next_block, Branch.IS_ERROR)
+        branch.traceback_entry = ('foobar', 123)
+        self.assert_emit(
+            op,
+            """\
+            if (likely(PyDict_Check(cpy_r_r)))
+                cpy_r_r0 = cpy_r_r;
+            else {
+                CPy_TypeError("dict", cpy_r_r);
+                cpy_r_r0 = NULL;
+                CPy_AddTraceback("prog.py", "foobar", 123, CPyStatic_prog___globals);
+                goto CPyL8;
+            }
+            """,
+            next_block=next_block,
+            next_branch=branch,
+            skip_next=True,
+        )
+
+    def test_cast_and_branch_no_merge_1(self) -> None:
+        op = Cast(self.r, dict_rprimitive, 1)
+        branch = Branch(op, BasicBlock(8), BasicBlock(9), Branch.IS_ERROR)
+        branch.traceback_entry = ('foobar', 123)
+        self.assert_emit(
+            op,
+            """\
+            if (likely(PyDict_Check(cpy_r_r)))
+                cpy_r_r0 = cpy_r_r;
+            else {
+                CPy_TypeError("dict", cpy_r_r);
+                cpy_r_r0 = NULL;
+            }
+            """,
+            next_block=BasicBlock(10),
+            next_branch=branch,
+            skip_next=False,
+        )
+
+    def test_cast_and_branch_no_merge_2(self) -> None:
+        op = Cast(self.r, dict_rprimitive, 1)
+        next_block = BasicBlock(9)
+        branch = Branch(op, BasicBlock(8), next_block, Branch.IS_ERROR)
+        branch.negated = True
+        branch.traceback_entry = ('foobar', 123)
+        self.assert_emit(
+            op,
+            """\
+            if (likely(PyDict_Check(cpy_r_r)))
+                cpy_r_r0 = cpy_r_r;
+            else {
+                CPy_TypeError("dict", cpy_r_r);
+                cpy_r_r0 = NULL;
+            }
+            """,
+            next_block=next_block,
+            next_branch=branch,
+        )
+
+    def test_cast_and_branch_no_merge_3(self) -> None:
+        op = Cast(self.r, dict_rprimitive, 1)
+        next_block = BasicBlock(9)
+        branch = Branch(op, BasicBlock(8), next_block, Branch.BOOL)
+        branch.traceback_entry = ('foobar', 123)
+        self.assert_emit(
+            op,
+            """\
+            if (likely(PyDict_Check(cpy_r_r)))
+                cpy_r_r0 = cpy_r_r;
+            else {
+                CPy_TypeError("dict", cpy_r_r);
+                cpy_r_r0 = NULL;
+            }
+            """,
+            next_block=next_block,
+            next_branch=branch,
+        )
+
+    def test_cast_and_branch_no_merge_4(self) -> None:
+        op = Cast(self.r, dict_rprimitive, 1)
+        next_block = BasicBlock(9)
+        branch = Branch(op, BasicBlock(8), next_block, Branch.IS_ERROR)
+        self.assert_emit(
+            op,
+            """\
+            if (likely(PyDict_Check(cpy_r_r)))
+                cpy_r_r0 = cpy_r_r;
+            else {
+                CPy_TypeError("dict", cpy_r_r);
+                cpy_r_r0 = NULL;
+            }
+            """,
+            next_block=next_block,
+            next_branch=branch,
+        )
+
     def assert_emit(self,
                     op: Op,
                     expected: str,
                     next_block: Optional[BasicBlock] = None,
                     *,
                     rare: bool = False,
-                    next_branch: Optional[Branch] = None) -> None:
+                    next_branch: Optional[Branch] = None,
+                    skip_next: bool = False) -> None:
         block = BasicBlock(0)
         block.ops.append(op)
         value_names = generate_names_for_ir(self.registers, [block])
@@ -476,6 +577,10 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         expected_lines = [line.strip(' ') for line in expected_lines]
         assert_string_arrays_equal(expected_lines, actual_lines,
                                    msg='Generated code unexpected')
+        if skip_next:
+            assert visitor.op_index == 1
+        else:
+            assert visitor.op_index == 0
 
     def assert_emit_binary_op(self,
                               op: str,

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -22,7 +22,8 @@ class TestArgCheck(unittest.TestCase):
             'if (likely(PyList_Check(obj_x)))',
             '    arg_x = obj_x;',
             'else {',
-            '    CPy_TypeError("list", obj_x); return NULL;',
+            '    CPy_TypeError("list", obj_x);',
+            '    return NULL;',
             '}',
         ], lines)
 


### PR DESCRIPTION
Merge a cast op followed by a branch that does an error check and adds a
traceback entry. Since casts are very common, this reduces the size of 
the generated code a fair amount.

Old code generated for a cast:
```
    if (likely(PyUnicode_Check(cpy_r_x)))
        cpy_r_r0 = cpy_r_x;
    else {
        CPy_TypeError("str", cpy_r_x);
        cpy_r_r0 = NULL;
    }
    if (unlikely(cpy_r_r0 == NULL)) {
        CPy_AddTraceback("t/t.py", "foo", 2, CPyStatic_globals);
        goto CPyL2;
    }
```

New code:
```
    if (likely(PyUnicode_Check(cpy_r_x)))
        cpy_r_r0 = cpy_r_x;
    else {
        CPy_TypeErrorTraceback("t/t.py", "foo", 2, CPyStatic_globals, "str", cpy_r_x);
        goto CPyL2;
    }
```

The generated assembly is the same in the successful case, but assembly for the 
error handler is more compact, reducing the size of binaries.

We could also do a similar thing to unbox ops in the future.