### PR TITLE
Remove unnecessary `max` call for python version in test_run.py

### DIFF
--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -174,11 +174,7 @@ class TestRun(MypycDataSuite):
         options.use_builtins_fixtures = True
         options.show_traceback = True
         options.strict_optional = True
-        # N.B: We try to (and ought to!) run with the current
-        # version of python, since we are going to link and run
-        # against the current version of python.
-        # But a lot of the tests use type annotations so we can't say it is 3.5.
-        options.python_version = max(sys.version_info[:2], (3, 6))
+        options.python_version = sys.version_info[:2]
         options.export_types = True
         options.preserve_asts = True
         options.incremental = self.separate


### PR DESCRIPTION
### Description

We don't support running on Python 3.5 or lower anymore, so the `max` call is unnecessary because the current version will always be greater than or equal to 3.6.

## Test Plan

This seems minor enough to rely on the current CI passing.