### PR TITLE
Add better support for debugging mypyc runtests

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -11,10 +11,16 @@ import sys
 
 import pytest
 from typing import List, Tuple, Set, Optional, Iterator, Any, Dict, NamedTuple, Union, Pattern
+from typing_extensions import Final
 
 from mypy.test.config import test_data_prefix, test_temp_dir, PREFIX
 
 root_dir = os.path.normpath(PREFIX)
+
+# Debuggers that we support for debugging mypyc run tests
+# implementation of using each of these debuggers is in test_run.py
+# TODO: support more debuggers
+SUPPORTED_DEBUGGERS: Final = ["gdb", "lldb"]
 
 
 # File modify/create operation: copy module contents from source_path.
@@ -549,6 +555,13 @@ def pytest_addoption(parser: Any) -> None:
                     help='Set the verbose flag when creating mypy Options')
     group.addoption('--mypyc-showc', action='store_true', default=False,
                     help='Display C code on mypyc test failures')
+    group.addoption(
+        "--mypyc-debug",
+        default=None,
+        dest="debugger",
+        choices=SUPPORTED_DEBUGGERS,
+        help="Run the first mypyc run test with the specified debugger",
+    )
 
 
 # This function name is special to pytest.  See

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -3,7 +3,6 @@
 import ast
 import glob
 import os.path
-import platform
 import re
 import subprocess
 import contextlib
@@ -276,19 +275,20 @@ class TestRun(MypycDataSuite):
         env = os.environ.copy()
         env['MYPYC_RUN_BENCH'] = '1' if bench else '0'
 
-        # XXX: This is an ugly hack.
-        if 'MYPYC_RUN_GDB' in os.environ:
-            if platform.system() == 'Darwin':
+        debugger = testcase.config.getoption('debugger')
+        if debugger:
+            if debugger == 'lldb':
                 subprocess.check_call(['lldb', '--', sys.executable, driver_path], env=env)
-                assert False, ("Test can't pass in lldb mode. (And remember to pass -s to "
-                               "pytest)")
-            elif platform.system() == 'Linux':
+            elif debugger == 'gdb':
                 subprocess.check_call(['gdb', '--args', sys.executable, driver_path], env=env)
-                assert False, ("Test can't pass in gdb mode. (And remember to pass -s to "
-                               "pytest)")
             else:
-                assert False, 'Unsupported OS'
-
+                assert False, 'Unsupported debugger'
+            # TODO: find a way to automatically disable capturing
+            # stdin/stdout when in debugging mode
+            assert False, (
+                "Test can't pass in debugging mode. "
+                "(Make sure to pass -s to pytest to interact with the debugger)"
+            )
         proc = subprocess.Popen([sys.executable, driver_path], stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT, env=env)
         output = proc.communicate()[0].decode('utf8')


### PR DESCRIPTION
### Description

Add a `--mypyc-debug` option to pytest that compiles a test normally and then runs the resulting binary in the debugger specified.

The support for debugging runtests was already there previously, so this PR just cleans it up and adds a pytest option to use it.

## Test Plan

I ran a mypyc test using various combinations of `--mypyc-debug` and `-s` and everything seemed to work fine.