### PR TITLE
stubtest: add error summary, other output nits

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -42,7 +42,7 @@ from mypy.subtypes import (
 )
 from mypy.sametypes import is_same_type
 from mypy.typeops import separate_union_literals
-from mypy.util import unmangle
+from mypy.util import unmangle, plural_s as plural_s
 from mypy.errorcodes import ErrorCode
 from mypy import message_registry, errorcodes as codes
 
@@ -2108,14 +2108,6 @@ def strip_quotes(s: str) -> str:
     s = re.sub('^"', '', s)
     s = re.sub('"$', '', s)
     return s
-
-
-def plural_s(s: Union[int, Sequence[Any]]) -> str:
-    count = s if isinstance(s, int) else len(s)
-    if count > 1:
-        return 's'
-    else:
-        return ''
 
 
 def format_string_list(lst: List[str]) -> str:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -42,7 +42,7 @@ from mypy.subtypes import (
 )
 from mypy.sametypes import is_same_type
 from mypy.typeops import separate_union_literals
-from mypy.util import unmangle, plural_s as plural_s
+from mypy.util import unmangle, plural_s
 from mypy.errorcodes import ErrorCode
 from mypy import message_registry, errorcodes as codes
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1259,15 +1259,16 @@ def build_stubs(modules: List[str], options: Options, find_submodules: bool = Fa
             sources.extend(found_sources)
             all_modules.extend(s.module for s in found_sources if s.module not in all_modules)
 
-    try:
-        res = mypy.build.build(sources=sources, options=options)
-    except mypy.errors.CompileError as e:
-        raise StubtestFailure(f"failed mypy compile:\n{e}") from e
-    if res.errors:
-        raise StubtestFailure("mypy build errors:\n" + "\n".join(res.errors))
+    if sources:
+        try:
+            res = mypy.build.build(sources=sources, options=options)
+        except mypy.errors.CompileError as e:
+            raise StubtestFailure(f"failed mypy compile:\n{e}") from e
+        if res.errors:
+            raise StubtestFailure("mypy build errors:\n" + "\n".join(res.errors))
 
-    global _all_stubs
-    _all_stubs = res.files
+        global _all_stubs
+        _all_stubs = res.files
 
     return all_modules
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1165,7 +1165,11 @@ class StubtestMiscUnit(unittest.TestCase):
         output = io.StringIO()
         with contextlib.redirect_stdout(output):
             test_stubs(parse_options(["not_a_module"]))
-        assert "error: not_a_module failed to find stubs" in remove_color_code(output.getvalue())
+        assert remove_color_code(output.getvalue()) == (
+            "error: not_a_module failed to find stubs\n"
+            "Stub:\nMISSING\nRuntime:\nN/A\n\n"
+            "Found 1 error (checked 1 module)\n"
+        )
 
     def test_get_typeshed_stdlib_modules(self) -> None:
         stdlib = mypy.stubtest.get_typeshed_stdlib_modules(None, (3, 6))
@@ -1218,14 +1222,4 @@ class StubtestMiscUnit(unittest.TestCase):
             test_stubs(parse_options(["--check-typeshed", "some_module"]))
         assert remove_color_code(output.getvalue()) == (
             "error: cannot pass both --check-typeshed and a list of modules\n"
-        )
-
-    def test_no_sources(self) -> None:
-        output = io.StringIO()
-        with contextlib.redirect_stdout(output):
-            test_stubs(parse_options(["missing"]))
-        assert remove_color_code(output.getvalue()) == (
-            "error: missing failed to find stubs\n"
-            "Stub:\nMISSING\nRuntime:\nN/A\n\n"
-            "Found 1 error (checked 1 module)\n"
         )

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1219,3 +1219,13 @@ class StubtestMiscUnit(unittest.TestCase):
         assert remove_color_code(output.getvalue()) == (
             "error: cannot pass both --check-typeshed and a list of modules\n"
         )
+
+    def test_no_sources(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            test_stubs(parse_options(["missing"]))
+        assert remove_color_code(output.getvalue()) == (
+            "error: missing failed to find stubs\n"
+            "Stub:\nMISSING\nRuntime:\nN/A\n\n"
+            "Found 1 error (checked 1 module)\n"
+        )

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1055,8 +1055,9 @@ class StubtestMiscUnit(unittest.TestCase):
             options=[],
         )
         expected = (
-            f'error: {TEST_MODULE_NAME}.bad is inconsistent, stub argument "number" differs from runtime '
-            'argument "num"\nStub: at line 1\ndef (number: builtins.int, text: builtins.str)\n'
+            f'error: {TEST_MODULE_NAME}.bad is inconsistent, stub argument "number" differs '
+            'from runtime argument "num"\n'
+            'Stub: at line 1\ndef (number: builtins.int, text: builtins.str)\n'
             f"Runtime: at line 1 in file {TEST_MODULE_NAME}.py\ndef (num, text)\n\n"
             'Found 1 error (checked 1 module)\n'
         )

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -11,7 +11,7 @@ import shutil
 import time
 
 from typing import (
-    TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable, Container, IO, Callable
+    TypeVar, List, Tuple, Optional, Dict, Sequence, Iterable, Container, IO, Callable, Union, Sized
 )
 from typing_extensions import Final, Type, Literal
 
@@ -724,8 +724,7 @@ class FancyFormatter:
         n_sources is total number of files passed directly on command line,
         i.e. excluding stubs and followed imports.
         """
-        msg = 'Success: no issues found in {}' \
-              ' source file{}'.format(n_sources, 's' if n_sources != 1 else '')
+        msg = f'Success: no issues found in {n_sources} source file{plural_s(n_sources)}'
         if not use_color:
             return msg
         return self.style(msg, 'green', bold=True)
@@ -735,15 +734,11 @@ class FancyFormatter:
         blockers: bool = False, use_color: bool = True
     ) -> str:
         """Format a short summary in case of errors."""
-
-        msg = 'Found {} error{} in {} file{}'.format(
-            n_errors, 's' if n_errors != 1 else '',
-            n_files, 's' if n_files != 1 else ''
-        )
+        msg = f'Found {n_errors} error{plural_s(n_errors)} in {n_files} file{plural_s(n_files)}'
         if blockers:
             msg += ' (errors prevented further checking)'
         else:
-            msg += f" (checked {n_sources} source file{'s' if n_sources != 1 else ''})"
+            msg += f" (checked {n_sources} source file{plural_s(n_sources)})"
         if not use_color:
             return msg
         return self.style(msg, 'red', bold=True)
@@ -773,3 +768,11 @@ time_ref = time.perf_counter
 
 def time_spent_us(t0: float) -> int:
     return int((time.perf_counter() - t0) * 1e6)
+
+
+def plural_s(s: Union[int, Sized]) -> str:
+    count = s if isinstance(s, int) else len(s)
+    if count > 1:
+        return 's'
+    else:
+        return ''


### PR DESCRIPTION
- error summary
- fix issue where module is presented as a stub
- handle loading modules that output or raise `BaseException`
- output formatted messages instead of tracebacks
- add some more tests

Also:
- move plural_s from messages to util
- use plural_s in summary functions

## Test Plan

I added some tests


resolves #12547