### PR TITLE
Put filelock around PEP 561 tests (fixes #12615)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 .mypy_cache/
 .incremental_checker_cache.json
 .cache
+test-data/packages/.pip_lock
 dmypy.json
 .dmypy.json
 

--- a/mypy/test/config.py
+++ b/mypy/test/config.py
@@ -15,3 +15,12 @@ package_path = os.path.join(PREFIX, 'test-data', 'packages')
 # This is *within* the tempfile.TemporaryDirectory that is chroot'ed per testcase.
 # It is also hard-coded in numerous places, so don't change it.
 test_temp_dir = 'tmp'
+
+# The PEP 561 tests do a bunch of pip installs which, even though they operate
+# on distinct temporary virtual environments, run into race conditions on shared
+# file-system state. To make this work reliably in parallel mode, we'll use a
+# FileLock courtesy of the tox-dev/py-filelock package.
+# Ref. https://github.com/python/mypy/issues/12615
+# Ref. mypy/test/testpep561.py
+pip_lock = os.path.join(package_path, '.pip_lock')
+pip_timeout = 60

--- a/runtests.py
+++ b/runtests.py
@@ -58,11 +58,15 @@ cmds = {
     'pytest-slow': ['pytest', '-q', '-k', ' or '.join(
         [SAMPLES,
          TYPESHED,
-         PEP561,
          DAEMON,
          MYPYC_EXTERNAL,
          MYPYC_COMMAND_LINE,
          ERROR_STREAM])],
+
+    # Test cases that might take minutes to run
+    'pytest-slower': ['pytest', '-q', '-k', ' or '.join(
+        [PEP561])],
+
     # Test cases to run in typeshed CI
     'typeshed-ci': ['pytest', '-q', '-k', ' or '.join([CMDLINE,
                                                        EVALUATION,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
 -r mypy-requirements.txt
 -r build-requirements.txt
 attrs>=18.0
+filelock>=3.0.0,<3.4.2; python_version<'3.7'
+filelock>=3.0.0; python_version>='3.7'
 flake8==3.9.2
 flake8-bugbear==22.3.20
 flake8-pyi>=20.5


### PR DESCRIPTION
### Description

Fixes #12615

As discussed in the linked issue, this  PR would put a filesystem-based lock around the pip install steps of the suite of PEP561 testcases, to address race conditions.

It introduces a test-dependency on tox-dev/py-filelock. I used 3.0.0 as a lower bound, simply because that's what the tox version mentioned in tox.ini specifies as its lower bound. However from the release history it seems that Python 3.6 support was dropped in 3.4.2, hence the second line in the requirements.

I ended up just adding the location of the lock file to .gitignore -- I guess it would be possible to try and remove it after the suite has run, e.g. with atexit.register, but I didn't want to make this complicated.

## Test Plan

No new tests, just moved the PEP561 suite from "slow" to "slower" in `runtests.py`.
