### PR TITLE
[mypyc] Use PyObject_CallNoArgs and PyObject_CallOneArg instead of PyObject_CallFunctionObjArgs

### DIFF
--- a/mypyc/lib-rt/exc_ops.c
+++ b/mypyc/lib-rt/exc_ops.c
@@ -7,7 +7,7 @@
 
 void CPy_Raise(PyObject *exc) {
     if (PyObject_IsInstance(exc, (PyObject *)&PyType_Type)) {
-        PyObject *obj = PyObject_CallFunctionObjArgs(exc, NULL);
+        PyObject *obj = PyObject_CallNoArgs(exc);
         if (!obj)
             return;
         PyErr_SetObject(exc, obj);

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -54,7 +54,7 @@ int CPy_YieldFromErrorHandle(PyObject *iter, PyObject **outp)
     if (PyErr_GivenExceptionMatches(exc_type, PyExc_GeneratorExit)) {
         _m = _PyObject_GetAttrId(iter, &PyId_close);
         if (_m) {
-            res = PyObject_CallFunctionObjArgs(_m, NULL);
+            res = PyObject_CallNoArgs(_m);
             Py_DECREF(_m);
             if (!res)
                 return 2;
@@ -360,7 +360,7 @@ CPyDataclass_SleightOfHand(PyObject *dataclass_dec, PyObject *tp,
     }
 
     /* Run the @dataclass descriptor */
-    res = PyObject_CallFunctionObjArgs(dataclass_dec, tp, NULL);
+    res = PyObject_CallOneArg(dataclass_dec, tp);
     if (!res) {
         goto fail;
     }

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -350,7 +350,7 @@ CPyGen_SetStopIterationValue(PyObject *value)
         return 0;
     }
     /* Construct an exception instance manually with
-     * PyObject_CallFunctionObjArgs and pass it to PyErr_SetObject.
+     * PyObject_CallOneArg and pass it to PyErr_SetObject.
      *
      * We do this to handle a situation when "value" is a tuple, in which
      * case PyErr_SetObject would set the value of StopIteration to
@@ -358,7 +358,7 @@ CPyGen_SetStopIterationValue(PyObject *value)
      *
      * (See PyErr_SetObject/_PyErr_CreateException code for details.)
      */
-    e = PyObject_CallFunctionObjArgs(PyExc_StopIteration, value, NULL);
+    e = PyObject_CallOneArg(PyExc_StopIteration, value);
     if (e == NULL) {
         return -1;
     }
@@ -410,10 +410,6 @@ _CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
     _PyObject_CallMethodIdObjArgs((self), (name), NULL)
 #define _PyObject_CallMethodIdOneArg(self, name, arg) \
     _PyObject_CallMethodIdObjArgs((self), (name), (arg), NULL)
-#define PyObject_CallNoArgs(callable) \
-    PyObject_CallFunctionObjArgs((callable), NULL)
-#define PyObject_CallOneArg(callable, arg) \
-    PyObject_CallFunctionObjArgs((callable), (arg), NULL)
 #endif
 
 #endif


### PR DESCRIPTION
### Description

Use `PyObject_CallNoArgs` and `PyObject_CallOneArg` to replace `PyObject_CallFunctionObjArgs` in `lib-rt`, since the new API costs less memory according to https://github.com/python/cpython/pull/13890#issuecomment-502563443

Also remove the macro in `pythonsupport.h` since the two API are already covered by `pythoncapi_compat.h`.