### PR TITLE
[mypyc] Foundational work to help support native ints

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -9,7 +9,7 @@ from mypyc.ir.ops import (
     BasicBlock, OpVisitor, Assign, AssignMulti, Integer, LoadErrorValue, RegisterOp, Goto, Branch,
     Return, Call, Box, Unbox, Cast, Op, Unreachable, TupleGet, TupleSet, GetAttr, SetAttr,
     LoadLiteral, LoadStatic, InitStatic, MethodCall, RaiseStandardError, CallC, LoadGlobal,
-    Truncate, IntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem, KeepAlive
+    Truncate, IntOp, LoadMem, GetElementPtr, LoadAddress, ComparisonOp, SetMem, KeepAlive, Extend
 )
 from mypyc.ir.func_ir import all_values
 
@@ -197,6 +197,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill[T]]):
         return self.visit_register_op(op)
 
     def visit_truncate(self, op: Truncate) -> GenAndKill[T]:
+        return self.visit_register_op(op)
+
+    def visit_extend(self, op: Extend) -> GenAndKill[T]:
         return self.visit_register_op(op)
 
     def visit_load_global(self, op: LoadGlobal) -> GenAndKill[T]:

--- a/mypyc/analysis/ircheck.py
+++ b/mypyc/analysis/ircheck.py
@@ -7,7 +7,7 @@ from mypyc.ir.ops import (
     InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast,
     Box, Unbox, RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp,
     LoadMem, SetMem, GetElementPtr, LoadAddress, KeepAlive, Register, Integer,
-    BaseAssign
+    BaseAssign, Extend
 )
 from mypyc.ir.rtypes import (
     RType, RPrimitive, RUnion, is_object_rprimitive, RInstance, RArray,
@@ -324,6 +324,9 @@ class OpChecker(OpVisitor[None]):
         pass
 
     def visit_truncate(self, op: Truncate) -> None:
+        pass
+
+    def visit_extend(self, op: Extend) -> None:
         pass
 
     def visit_load_global(self, op: LoadGlobal) -> None:

--- a/mypyc/analysis/selfleaks.py
+++ b/mypyc/analysis/selfleaks.py
@@ -4,7 +4,8 @@ from mypyc.ir.ops import (
     OpVisitor, Register, Goto, Assign, AssignMulti, SetMem, Call, MethodCall, LoadErrorValue,
     LoadLiteral, GetAttr, SetAttr, LoadStatic, InitStatic, TupleGet, TupleSet, Box, Unbox,
     Cast, RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp, LoadMem,
-    GetElementPtr, LoadAddress, KeepAlive, Branch, Return, Unreachable, RegisterOp, BasicBlock
+    GetElementPtr, LoadAddress, KeepAlive, Branch, Return, Unreachable, RegisterOp, BasicBlock,
+    Extend
 )
 from mypyc.ir.rtypes import RInstance
 from mypyc.analysis.dataflow import MAYBE_ANALYSIS, run_analysis, AnalysisResult, CFG
@@ -113,6 +114,9 @@ class SelfLeakedVisitor(OpVisitor[GenAndKill]):
         return self.check_register_op(op)
 
     def visit_truncate(self, op: Truncate) -> GenAndKill:
+        return CLEAN
+
+    def visit_extend(self, op: Extend) -> GenAndKill:
         return CLEAN
 
     def visit_load_global(self, op: LoadGlobal) -> GenAndKill:

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -765,6 +765,13 @@ class Emitter:
             self.emit_line(failure)
             self.emit_line('} else')
             self.emit_line(f'    {dest} = 1;')
+        elif is_int64_rprimitive(typ):
+            # Whether we are borrowing or not makes no difference.
+            if declare_dest:
+                self.emit_line(f'int64_t {dest};')
+            self.emit_line(f'{dest} = CPyLong_AsInt64({src});')
+            # TODO: Handle 'optional'
+            # TODO: Handle 'failure'
         elif isinstance(typ, RTuple):
             self.declare_tuple_struct(typ)
             if declare_dest:

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -781,6 +781,13 @@ class Emitter:
             self.emit_line(f'{dest} = CPyLong_AsInt64({src});')
             # TODO: Handle 'optional'
             # TODO: Handle 'failure'
+        elif is_int32_rprimitive(typ):
+            # Whether we are borrowing or not makes no difference.
+            if declare_dest:
+                self.emit_line('int32_t {};'.format(dest))
+            self.emit_line('{} = CPyLong_AsInt32({});'.format(dest, src))
+            # TODO: Handle 'optional'
+            # TODO: Handle 'failure'
         elif isinstance(typ, RTuple):
             self.declare_tuple_struct(typ)
             if declare_dest:

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -17,7 +17,8 @@ from mypyc.ir.rtypes import (
     is_list_rprimitive, is_dict_rprimitive, is_set_rprimitive, is_tuple_rprimitive,
     is_none_rprimitive, is_object_rprimitive, object_rprimitive, is_str_rprimitive,
     int_rprimitive, is_optional_type, optional_value_type, is_int32_rprimitive,
-    is_int64_rprimitive, is_bit_rprimitive, is_range_rprimitive, is_bytes_rprimitive
+    is_int64_rprimitive, is_bit_rprimitive, is_range_rprimitive, is_bytes_rprimitive,
+    is_fixed_width_rtype
 )
 from mypyc.ir.func_ir import FuncDecl
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -479,9 +480,16 @@ class Emitter:
                 return
 
         # TODO: Verify refcount handling.
-        if (is_list_rprimitive(typ) or is_dict_rprimitive(typ) or is_set_rprimitive(typ)
-                or is_str_rprimitive(typ) or is_range_rprimitive(typ) or is_float_rprimitive(typ)
-                or is_int_rprimitive(typ) or is_bool_rprimitive(typ) or is_bit_rprimitive(typ)):
+        if (is_list_rprimitive(typ)
+                or is_dict_rprimitive(typ)
+                or is_set_rprimitive(typ)
+                or is_str_rprimitive(typ)
+                or is_range_rprimitive(typ)
+                or is_float_rprimitive(typ)
+                or is_int_rprimitive(typ)
+                or is_bool_rprimitive(typ)
+                or is_bit_rprimitive(typ)
+                or is_fixed_width_rtype(typ)):
             if declare_dest:
                 self.emit_line(f'PyObject *{dest};')
             if is_list_rprimitive(typ):
@@ -496,12 +504,13 @@ class Emitter:
                 prefix = 'PyRange'
             elif is_float_rprimitive(typ):
                 prefix = 'CPyFloat'
-            elif is_int_rprimitive(typ):
+            elif is_int_rprimitive(typ) or is_fixed_width_rtype(typ):
+                # TODO: Range check for fixed-width types?
                 prefix = 'PyLong'
             elif is_bool_rprimitive(typ) or is_bit_rprimitive(typ):
                 prefix = 'PyBool'
             else:
-                assert False, 'unexpected primitive type'
+                assert False, f'unexpected primitive type: {typ}'
             check = '({}_Check({}))'
             if likely:
                 check = f'(likely{check})'

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -641,7 +641,10 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             s = str(val)
             if val >= (1 << 31):
                 # Avoid overflowing signed 32-bit int
-                s += 'ULL'
+                if val >= (1 << 63):
+                    s += 'ULL'
+                else:
+                    s += 'LL'
             elif val == -(1 << 63):
                 # Avoid overflowing C integer literal
                 s = '(-9223372036854775807LL - 1)'

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -614,9 +614,9 @@ class GetAttr(RegisterOp):
         self.attr = attr
         assert isinstance(obj.type, RInstance), 'Attribute access not supported: %s' % obj.type
         self.class_type = obj.type
-        typ = obj.type.attr_type(attr)
-        self.type = typ
-        if is_fixed_width_rtype(typ):
+        attr_type = obj.type.attr_type(attr)
+        self.type = attr_type
+        if is_fixed_width_rtype(attr_type):
             self.error_kind = ERR_NEVER
         self.is_borrowed = borrow
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -21,7 +21,7 @@ from mypyc.ir.rtypes import (
     RType, RInstance, RTuple, RArray, RVoid, is_bool_rprimitive, is_int_rprimitive,
     is_short_int_rprimitive, is_none_rprimitive, object_rprimitive, bool_rprimitive,
     short_int_rprimitive, int_rprimitive, void_rtype, pointer_rprimitive, is_pointer_rprimitive,
-    bit_rprimitive, is_bit_rprimitive
+    bit_rprimitive, is_bit_rprimitive, is_fixed_width_rtype
 )
 
 if TYPE_CHECKING:
@@ -614,7 +614,10 @@ class GetAttr(RegisterOp):
         self.attr = attr
         assert isinstance(obj.type, RInstance), 'Attribute access not supported: %s' % obj.type
         self.class_type = obj.type
-        self.type = obj.type.attr_type(attr)
+        typ = obj.type.attr_type(attr)
+        self.type = typ
+        if is_fixed_width_rtype(typ):
+            self.error_kind = ERR_NEVER
         self.is_borrowed = borrow
 
     def sources(self) -> List[Value]:

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1068,8 +1068,6 @@ class IntOp(RegisterOp):
         RIGHT_SHIFT: '>>',
     }
 
-    op_to_id = {op: op_id for op_id, op in op_str.items()}  # type: Final
-
     def __init__(self, type: RType, lhs: Value, rhs: Value, op: int, line: int = -1) -> None:
         super().__init__(line)
         self.type = type
@@ -1082,6 +1080,11 @@ class IntOp(RegisterOp):
 
     def accept(self, visitor: 'OpVisitor[T]') -> T:
         return visitor.visit_int_op(self)
+
+
+# We can't have this in the IntOp class body, because of
+# https://github.com/mypyc/mypyc/issues/932.
+int_op_to_id: Final = {op: op_id for op_id, op in IntOp.op_str.items()}
 
 
 class ComparisonOp(RegisterOp):

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1092,14 +1092,14 @@ class ComparisonOp(RegisterOp):
         UGE: '>=',
     }
 
-    signed_ops = {
+    signed_ops: Final = {
         '==': EQ,
         '!=': NEQ,
         '<': SLT,
         '>': SGT,
         '<=': SLE,
         '>=': SGE,
-    }  # type: Final
+    }
 
     def __init__(self, lhs: Value, rhs: Value, op: int, line: int = -1) -> None:
         super().__init__(line)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -938,22 +938,20 @@ class Truncate(RegisterOp):
 
     Truncate a value from type with more bits to type with less bits.
 
-    Both src_type and dst_type should be non-reference counted integer
-    types or bool. Note that int_rprimitive is reference counted so
-    it should never be used here.
+    dst_type should be a native integer type or bool.
+    src_type can also be a short tagged integer.
     """
 
     error_kind = ERR_NEVER
 
     def __init__(self,
                  src: Value,
-                 src_type: RType,
                  dst_type: RType,
                  line: int = -1) -> None:
         super().__init__(line)
         self.src = src
-        self.src_type = src_type
         self.type = dst_type
+        self.src_type = src.type
 
     def sources(self) -> List[Value]:
         return [self.src]

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -618,7 +618,7 @@ class GetAttr(RegisterOp):
         self.type = attr_type
         if is_fixed_width_rtype(attr_type):
             self.error_kind = ERR_NEVER
-        self.is_borrowed = borrow
+        self.is_borrowed = borrow and attr_type.is_refcounted
 
     def sources(self) -> List[Value]:
         return [self.obj]

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1076,6 +1076,15 @@ class ComparisonOp(RegisterOp):
         UGE: '>=',
     }
 
+    signed_ops = {
+        '==': EQ,
+        '!=': NEQ,
+        '<': SLT,
+        '>': SGT,
+        '<=': SLE,
+        '>=': SGE,
+    }  # type: Final
+
     def __init__(self, lhs: Value, rhs: Value, op: int, line: int = -1) -> None:
         super().__init__(line)
         self.type = bit_rprimitive

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1021,6 +1021,8 @@ class IntOp(RegisterOp):
         RIGHT_SHIFT: '>>',
     }
 
+    op_to_id = {op: op_id for op_id, op in op_str.items()}  # type: Final
+
     def __init__(self, type: RType, lhs: Value, rhs: Value, op: int, line: int = -1) -> None:
         super().__init__(line)
         self.type = type

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -11,7 +11,7 @@ from mypyc.ir.ops import (
     LoadStatic, InitStatic, TupleGet, TupleSet, IncRef, DecRef, Call, MethodCall, Cast, Box, Unbox,
     RaiseStandardError, CallC, Truncate, LoadGlobal, IntOp, ComparisonOp, LoadMem, SetMem,
     GetElementPtr, LoadAddress, Register, Value, OpVisitor, BasicBlock, ControlOp, LoadLiteral,
-    AssignMulti, KeepAlive, Op, ERR_NEVER
+    AssignMulti, KeepAlive, Op, Extend, ERR_NEVER
 )
 from mypyc.ir.func_ir import FuncIR, all_values_full
 from mypyc.ir.module_ir import ModuleIRs
@@ -171,6 +171,13 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
 
     def visit_truncate(self, op: Truncate) -> str:
         return self.format("%r = truncate %r: %t to %t", op, op.src, op.src_type, op.type)
+
+    def visit_extend(self, op: Extend) -> str:
+        if op.signed:
+            extra = ' signed'
+        else:
+            extra = ''
+        return self.format("%r = extend%s %r: %t to %t", op, extra, op.src, op.src_type, op.type)
 
     def visit_load_global(self, op: LoadGlobal) -> str:
         ann = f'  ({repr(op.ann)})' if op.ann else ''

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -52,9 +52,13 @@ class RType:
     is_refcounted = True
     # C type; use Emitter.ctype() to access
     _ctype: str
-    # If True, error/undefined value overlaps with a valid value. To detect
-    # an exception, PyErr_Occurred() must be used in addition to checking for
-    # error value.
+    # If True, error/undefined value overlaps with a valid value. To
+    # detect an exception, PyErr_Occurred() must be used in addition
+    # to checking for error value as the return value of a function.
+    #
+    # For example, no i64 value can be reserved for error value, so we
+    # pick an arbitrary value (e.g. -113) to signal error, but this is
+    # also a valid non-error value.
     error_overlap = False
 
     @abstractmethod

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -182,6 +182,8 @@ class RPrimitive(RType):
                  *,
                  is_unboxed: bool,
                  is_refcounted: bool,
+                 is_native_int: bool = False,
+                 is_signed: bool = False,
                  ctype: str = 'PyObject *',
                  size: int = PLATFORM_SIZE,
                  error_overlap: bool = False) -> None:
@@ -189,8 +191,10 @@ class RPrimitive(RType):
 
         self.name = name
         self.is_unboxed = is_unboxed
-        self._ctype = ctype
         self.is_refcounted = is_refcounted
+        self.is_native_int = is_native_int
+        self.is_signed = is_signed
+        self._ctype = ctype
         self.size = size
         self.error_overlap = error_overlap
         if ctype == 'CPyTagged':
@@ -278,16 +282,42 @@ short_int_rprimitive: Final = RPrimitive(
 # Low level integer types (correspond to C integer types)
 
 int32_rprimitive: Final = RPrimitive(
-    "int32", is_unboxed=True, is_refcounted=False, ctype="int32_t", size=4, error_overlap=True
+    "int32",
+    is_unboxed=True,
+    is_refcounted=False,
+    is_native_int=True,
+    is_signed=True,
+    ctype="int32_t",
+    size=4,
+    error_overlap=True,
 )
 int64_rprimitive: Final = RPrimitive(
-    "int64", is_unboxed=True, is_refcounted=False, ctype="int64_t", size=8, error_overlap=True
+    "int64",
+    is_unboxed=True,
+    is_refcounted=False,
+    is_native_int=True,
+    is_signed=True,
+    ctype="int64_t",
+    size=8,
+    error_overlap=True,
 )
 uint32_rprimitive: Final = RPrimitive(
-    "uint32", is_unboxed=True, is_refcounted=False, ctype="uint32_t", size=4
+    "uint32",
+    is_unboxed=True,
+    is_refcounted=False,
+    is_native_int=True,
+    is_signed=False,
+    ctype="uint32_t",
+    size=4,
 )
 uint64_rprimitive: Final = RPrimitive(
-    "uint64", is_unboxed=True, is_refcounted=False, ctype="uint64_t", size=8
+    "uint64",
+    is_unboxed=True,
+    is_refcounted=False,
+    is_native_int=True,
+    is_signed=False,
+    ctype="uint64_t",
+    size=8,
 )
 
 # The C 'int' type
@@ -295,12 +325,26 @@ c_int_rprimitive = int32_rprimitive
 
 if IS_32_BIT_PLATFORM:
     c_size_t_rprimitive = uint32_rprimitive
-    c_pyssize_t_rprimitive = RPrimitive('native_int', is_unboxed=True, is_refcounted=False,
-                                        ctype='int32_t', size=4)
+    c_pyssize_t_rprimitive = RPrimitive(
+        'native_int',
+        is_unboxed=True,
+        is_refcounted=False,
+        is_native_int=True,
+        is_signed=True,
+        ctype='int32_t',
+        size=4,
+    )
 else:
     c_size_t_rprimitive = uint64_rprimitive
-    c_pyssize_t_rprimitive = RPrimitive('native_int', is_unboxed=True, is_refcounted=False,
-                                        ctype='int64_t', size=8)
+    c_pyssize_t_rprimitive = RPrimitive(
+        'native_int',
+        is_unboxed=True,
+        is_refcounted=False,
+        is_native_int=True,
+        is_signed=True,
+        ctype='int64_t',
+        size=8,
+    )
 
 # Untyped pointer, represented as integer in the C backend
 pointer_rprimitive: Final = RPrimitive("ptr", is_unboxed=True, is_refcounted=False, ctype="CPyPtr")

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -45,6 +45,8 @@ class RType:
     is_unboxed = False
     # This is the C undefined value for this type. It's used for initialization
     # if there's no value yet, and for function return value on error/exception.
+    #
+    # TODO: This shouldn't be specific to C or a string
     c_undefined: str
     # If unboxed: does the unboxed version use reference counting?
     is_refcounted = True
@@ -196,7 +198,7 @@ class RPrimitive(RType):
         elif ctype in ('int32_t', 'int64_t'):
             # This is basically an arbitrary value that is pretty
             # unlikely to overlap with a real value.
-            self.c_undefined = -113
+            self.c_undefined = '-113'
         elif ctype in ('CPyPtr', 'uint32_t', 'uint64_t'):
             # TODO: For low-level integers, we need to invent an overlapping
             #       error value, similar to int64_t above.

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -374,6 +374,10 @@ def is_int64_rprimitive(rtype: RType) -> bool:
             (rtype is c_pyssize_t_rprimitive and rtype._ctype == 'int64_t'))
 
 
+def is_fixed_width_rtype(rtype: RType) -> bool:
+    return is_int32_rprimitive(rtype) or is_int64_rprimitive(rtype)
+
+
 def is_uint32_rprimitive(rtype: RType) -> bool:
     return rtype is uint32_rprimitive
 

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -208,7 +208,7 @@ class RPrimitive(RType):
             self.c_undefined = 'NULL'
         elif ctype == 'char':
             self.c_undefined = '2'
-        elif ctype == 'PyObject **':
+        elif ctype in ('PyObject **', 'void *'):
             self.c_undefined = 'NULL'
         else:
             assert False, 'Unrecognized ctype: %r' % ctype
@@ -302,8 +302,12 @@ else:
     c_pyssize_t_rprimitive = RPrimitive('native_int', is_unboxed=True, is_refcounted=False,
                                         ctype='int64_t', size=8)
 
-# Low level pointer, represented as integer in C backends
+# Untyped pointer, represented as integer in the C backend
 pointer_rprimitive: Final = RPrimitive("ptr", is_unboxed=True, is_refcounted=False, ctype="CPyPtr")
+
+# Untyped pointer, represented as void * in the C backend
+c_pointer_rprimitive: Final = RPrimitive("c_ptr", is_unboxed=False, is_refcounted=False,
+                                         ctype="void *")
 
 # Floats are represent as 'float' PyObject * values. (In the future
 # we'll likely switch to a more efficient, unboxed representation.)

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -513,7 +513,7 @@ class TupleNameVisitor(RTypeVisitor[str]):
         elif t._ctype == 'int64_t':
             return '8'  # "8 byte integer"
         elif t._ctype == 'int32_t':
-            return '8'  # "4 byte integer"
+            return '4'  # "4 byte integer"
         assert not t.is_unboxed, f"{t} unexpected unboxed type"
         return 'O'
 

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -466,6 +466,10 @@ class TupleNameVisitor(RTypeVisitor[str]):
             return 'I'
         elif t._ctype == 'char':
             return 'C'
+        elif t._ctype == 'int64_t':
+            return '8'  # "8 byte integer"
+        elif t._ctype == 'int32_t':
+            return '8'  # "4 byte integer"
         assert not t.is_unboxed, f"{t} unexpected unboxed type"
         return 'O'
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1337,7 +1337,7 @@ class LowLevelIRBuilder:
         if desc.truncated_type is None:
             result = target
         else:
-            truncate = self.add(Truncate(target, desc.return_type, desc.truncated_type))
+            truncate = self.add(Truncate(target, desc.truncated_type))
             result = truncate
         if result_type and not is_runtime_subtype(result.type, result_type):
             if is_none_rprimitive(result_type):

--- a/mypyc/subtype.py
+++ b/mypyc/subtype.py
@@ -3,7 +3,7 @@
 from mypyc.ir.rtypes import (
     RType, RInstance, RPrimitive, RTuple, RVoid, RTypeVisitor, RUnion, RStruct, RArray,
     is_bool_rprimitive, is_int_rprimitive, is_tuple_rprimitive, is_short_int_rprimitive,
-    is_object_rprimitive, is_bit_rprimitive
+    is_object_rprimitive, is_bit_rprimitive, is_tagged, is_fixed_width_rtype
 )
 
 
@@ -43,12 +43,15 @@ class SubtypeVisitor(RTypeVisitor[bool]):
     def visit_rprimitive(self, left: RPrimitive) -> bool:
         right = self.right
         if is_bool_rprimitive(left):
-            if is_int_rprimitive(right):
+            if is_tagged(right) or is_fixed_width_rtype(right):
                 return True
         elif is_bit_rprimitive(left):
-            if is_bool_rprimitive(right) or is_int_rprimitive(right):
+            if is_bool_rprimitive(right) or is_tagged(right) or is_fixed_width_rtype(right):
                 return True
         elif is_short_int_rprimitive(left):
+            if is_int_rprimitive(right):
+                return True
+        elif is_fixed_width_rtype(left):
             if is_int_rprimitive(right):
                 return True
         return left is right

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -556,11 +556,10 @@ else {
         self.assert_emit(Extend(a, int64_rprimitive, signed=False),
                          """cpy_r_r0 = (uint32_t)cpy_r_a;""")
         if PLATFORM_SIZE == 4:
-            b = Register(int_rprimitive, 'b')
-            self.assert_emit(Extend(b, int64_rprimitive, signed=True),
-                             """cpy_r_r0 = (Py_ssize_t)cpy_r_b;""")
-            self.assert_emit(Extend(b, int64_rprimitive, signed=False),
-                             """cpy_r_r0 = cpy_r_b;""")
+            self.assert_emit(Extend(self.n, int64_rprimitive, signed=True),
+                             """cpy_r_r0 = (Py_ssize_t)cpy_r_n;""")
+            self.assert_emit(Extend(self.n, int64_rprimitive, signed=False),
+                             """cpy_r_r0 = cpy_r_n;""")
         if PLATFORM_SIZE == 8:
             self.assert_emit(Extend(a, int_rprimitive, signed=True),
                              """cpy_r_r0 = cpy_r_a;""")

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -442,7 +442,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_long_unsigned(self) -> None:
         a = Register(int64_rprimitive, 'a')
         self.assert_emit(Assign(a, Integer(1 << 31, int64_rprimitive)),
-                         """cpy_r_a = 2147483648ULL;""")
+                         """cpy_r_a = 2147483648LL;""")
         self.assert_emit(Assign(a, Integer((1 << 31) - 1, int64_rprimitive)),
                          """cpy_r_a = 2147483647;""")
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -383,7 +383,9 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.LEFT_SHIFT, 1),
                          """cpy_r_r0 = cpy_r_s1 << cpy_r_s2;""")
         self.assert_emit(IntOp(short_int_rprimitive, self.s1, self.s2, IntOp.RIGHT_SHIFT, 1),
-                         """cpy_r_r0 = cpy_r_s1 >> cpy_r_s2;""")
+                         """cpy_r_r0 = (Py_ssize_t)cpy_r_s1 >> (Py_ssize_t)cpy_r_s2;""")
+        self.assert_emit(IntOp(short_int_rprimitive, self.i64, self.i64_1, IntOp.RIGHT_SHIFT, 1),
+                         """cpy_r_r0 = cpy_r_i64 >> cpy_r_i64_1;""")
 
     def test_comparison_op(self) -> None:
         # signed

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -9,7 +9,7 @@ from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.ir.ops import (
     BasicBlock, Goto, Return, Integer, Assign, AssignMulti, IncRef, DecRef, Branch,
     Call, Unbox, Box, TupleGet, GetAttr, SetAttr, Op, Value, CallC, IntOp, LoadMem,
-    GetElementPtr, LoadAddress, ComparisonOp, SetMem, Register, Unreachable, Cast
+    GetElementPtr, LoadAddress, ComparisonOp, SetMem, Register, Unreachable, Cast, Extend
 )
 from mypyc.ir.rtypes import (
     RTuple, RInstance, RType, RArray, int_rprimitive, bool_rprimitive, list_rprimitive,
@@ -31,6 +31,7 @@ from mypyc.primitives.dict_ops import (
 from mypyc.primitives.int_ops import int_neg_op
 from mypyc.subtype import is_subtype
 from mypyc.namegen import NameGenerator
+from mypyc.common import PLATFORM_SIZE
 
 
 class TestFunctionEmitterVisitor(unittest.TestCase):
@@ -452,6 +453,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(Assign(a, Integer(-(1 << 31), int64_rprimitive)),
                          """cpy_r_a = -2147483648LL;""")
 
+<<<<<<< HEAD
     def test_cast_and_branch_merge(self) -> None:
         op = Cast(self.r, dict_rprimitive, 1)
         next_block = BasicBlock(9)
@@ -548,6 +550,27 @@ else {
             next_branch=branch,
         )
 
+||||||| constructed merge base
+=======
+    def test_extend(self) -> None:
+        a = Register(int32_rprimitive, 'a')
+        self.assert_emit(Extend(a, int64_rprimitive, signed=True),
+                         """cpy_r_r0 = cpy_r_a;""")
+        self.assert_emit(Extend(a, int64_rprimitive, signed=False),
+                         """cpy_r_r0 = (uint32_t)cpy_r_a;""")
+        if PLATFORM_SIZE == 4:
+            b = Register(int_rprimitive, 'b')
+            self.assert_emit(Extend(b, int64_rprimitive, signed=True),
+                             """cpy_r_r0 = (Py_ssize_t)cpy_r_b;""")
+            self.assert_emit(Extend(b, int64_rprimitive, signed=False),
+                             """cpy_r_r0 = cpy_r_b;""")
+        if PLATFORM_SIZE == 8:
+            self.assert_emit(Extend(a, int_rprimitive, signed=True),
+                             """cpy_r_r0 = cpy_r_a;""")
+            self.assert_emit(Extend(a, int_rprimitive, signed=False),
+                             """cpy_r_r0 = (uint32_t)cpy_r_a;""")
+
+>>>>>>> Add Extend op
     def assert_emit(self,
                     op: Op,
                     expected: str,

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -258,11 +258,11 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                                list_set_item_op.is_borrowed, list_set_item_op.error_kind, 55),
                          """cpy_r_r0 = CPyList_SetItem(cpy_r_l, cpy_r_n, cpy_r_o);""")
 
-    def test_box(self) -> None:
+    def test_box_int(self) -> None:
         self.assert_emit(Box(self.n),
                          """cpy_r_r0 = CPyTagged_StealAsObject(cpy_r_n);""")
 
-    def test_unbox(self) -> None:
+    def test_unbox_int(self) -> None:
         self.assert_emit(Unbox(self.m, int_rprimitive, 55),
                          """if (likely(PyLong_Check(cpy_r_m)))
                                 cpy_r_r0 = CPyTagged_FromObject(cpy_r_m);
@@ -270,6 +270,14 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
                                 CPy_TypeError("int", cpy_r_m); cpy_r_r0 = CPY_INT_TAG;
                             }
                          """)
+
+    def test_box_i64(self) -> None:
+        self.assert_emit(Box(self.i64),
+                         """cpy_r_r0 = PyLong_FromLongLong(cpy_r_i64);""")
+
+    def test_unbox_i64(self) -> None:
+        self.assert_emit(Unbox(self.o, int64_rprimitive, 55),
+                         """cpy_r_r0 = CPyLong_AsInt64(cpy_r_o);""")
 
     def test_list_append(self) -> None:
         self.assert_emit(CallC(list_append_op.c_function_name, [self.l, self.o],

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -453,7 +453,6 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.assert_emit(Assign(a, Integer(-(1 << 31), int64_rprimitive)),
                          """cpy_r_a = -2147483648LL;""")
 
-<<<<<<< HEAD
     def test_cast_and_branch_merge(self) -> None:
         op = Cast(self.r, dict_rprimitive, 1)
         next_block = BasicBlock(9)
@@ -550,8 +549,6 @@ else {
             next_branch=branch,
         )
 
-||||||| constructed merge base
-=======
     def test_extend(self) -> None:
         a = Register(int32_rprimitive, 'a')
         self.assert_emit(Extend(a, int64_rprimitive, signed=True),
@@ -570,7 +567,6 @@ else {
             self.assert_emit(Extend(a, int_rprimitive, signed=False),
                              """cpy_r_r0 = (uint32_t)cpy_r_a;""")
 
->>>>>>> Add Extend op
     def assert_emit(self,
                     op: Op,
                     expected: str,

--- a/mypyc/test/test_subtype.py
+++ b/mypyc/test/test_subtype.py
@@ -2,7 +2,10 @@
 
 import unittest
 
-from mypyc.ir.rtypes import bit_rprimitive, bool_rprimitive, int_rprimitive
+from mypyc.ir.rtypes import (
+    bit_rprimitive, bool_rprimitive, int_rprimitive, int64_rprimitive, int32_rprimitive,
+    short_int_rprimitive
+)
 from mypyc.subtype import is_subtype
 from mypyc.rt_subtype import is_runtime_subtype
 
@@ -11,10 +14,26 @@ class TestSubtype(unittest.TestCase):
     def test_bit(self) -> None:
         assert is_subtype(bit_rprimitive, bool_rprimitive)
         assert is_subtype(bit_rprimitive, int_rprimitive)
+        assert is_subtype(bit_rprimitive, short_int_rprimitive)
+        assert is_subtype(bit_rprimitive, int64_rprimitive)
+        assert is_subtype(bit_rprimitive, int32_rprimitive)
 
     def test_bool(self) -> None:
         assert not is_subtype(bool_rprimitive, bit_rprimitive)
         assert is_subtype(bool_rprimitive, int_rprimitive)
+        assert is_subtype(bool_rprimitive, short_int_rprimitive)
+        assert is_subtype(bool_rprimitive, int64_rprimitive)
+        assert is_subtype(bool_rprimitive, int32_rprimitive)
+
+    def test_int64(self) -> None:
+        assert is_subtype(int64_rprimitive, int_rprimitive)
+        assert not is_subtype(int64_rprimitive, short_int_rprimitive)
+        assert not is_subtype(int64_rprimitive, int32_rprimitive)
+
+    def test_int32(self) -> None:
+        assert is_subtype(int32_rprimitive, int_rprimitive)
+        assert not is_subtype(int32_rprimitive, short_int_rprimitive)
+        assert not is_subtype(int32_rprimitive, int64_rprimitive)
 
 
 class TestRuntimeSubtype(unittest.TestCase):

--- a/mypyc/transform/exceptions.py
+++ b/mypyc/transform/exceptions.py
@@ -12,11 +12,14 @@ only be placed at the end of a basic block.
 from typing import List, Optional
 
 from mypyc.ir.ops import (
-    Value, BasicBlock, LoadErrorValue, Return, Branch, RegisterOp, Integer, ERR_NEVER, ERR_MAGIC,
-    ERR_FALSE, ERR_ALWAYS, NO_TRACEBACK_LINE_NO
+    Value, BasicBlock, LoadErrorValue, Return, Branch, RegisterOp, ComparisonOp, CallC,
+    Integer, ERR_NEVER, ERR_MAGIC, ERR_FALSE, ERR_ALWAYS, ERR_MAGIC_OVERLAPPING,
+    NO_TRACEBACK_LINE_NO
 )
 from mypyc.ir.func_ir import FuncIR
 from mypyc.ir.rtypes import bool_rprimitive
+from mypyc.primitives.registry import CFunctionDescription
+from mypyc.primitives.exc_ops import err_occurred_op
 
 
 def insert_exception_handling(ir: FuncIR) -> None:
@@ -81,6 +84,20 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                     # this is a hack to represent the always fail
                     # semantics, using a temporary bool with value false
                     target = Integer(0, bool_rprimitive)
+                elif op.error_kind == ERR_MAGIC_OVERLAPPING:
+                    errvalue = Integer(target.type.c_undefined, rtype=op.type)
+                    comp = ComparisonOp(target, errvalue, ComparisonOp.EQ)
+                    cur_block.ops.append(comp)
+                    new_block2 = BasicBlock()
+                    new_blocks.append(new_block2)
+                    branch = Branch(comp, true_label=new_block2, false_label=new_block,
+                                    op=Branch.BOOL)
+                    cur_block.ops.append(branch)
+                    cur_block = new_block2
+                    target = primitive_call(err_occurred_op, [], target.line)
+                    cur_block.ops.append(target)
+                    variant = Branch.IS_ERROR
+                    negated = True
                 else:
                     assert False, 'unknown error kind %d' % op.error_kind
 
@@ -101,3 +118,15 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                 cur_block = new_block
 
     return new_blocks
+
+
+def primitive_call(desc: CFunctionDescription, args: List[Value], line: int) -> CallC:
+    return CallC(
+        desc.c_function_name,
+        [],
+        desc.return_type,
+        desc.steals,
+        desc.is_borrowed,
+        desc.error_kind,
+        line,
+    )

--- a/mypyc/transform/exceptions.py
+++ b/mypyc/transform/exceptions.py
@@ -85,7 +85,7 @@ def split_blocks_at_errors(blocks: List[BasicBlock],
                     # semantics, using a temporary bool with value false
                     target = Integer(0, bool_rprimitive)
                 elif op.error_kind == ERR_MAGIC_OVERLAPPING:
-                    errvalue = Integer(target.type.c_undefined, rtype=op.type)
+                    errvalue = Integer(int(target.type.c_undefined), rtype=op.type)
                     comp = ComparisonOp(target, errvalue, ComparisonOp.EQ)
                     cur_block.ops.append(comp)
                     new_block2 = BasicBlock()


### PR DESCRIPTION
Some IR and codegen changes that help with native int support.

This was split off from a branch with a working implementation of
native ints to make reviewing easier. Some tests and primitives 
are missing here and I will include them in follow-up PRs.

Summary of major changes below.

1) Allow ambiguous error returns from functions. Since all values
of `i64` values are valid return values, none can be reserved for 
errors. The approach here is to have the error value overlap a 
valid value, and use `PyErr_Occurred()` as a secondary check 
to make sure it actually was an error.

2) Add `Extend` op which extends a value to a larger integer
type with either zero or sign extension.

3) Improve subtype checking with native int types.

4) Fill in other minor gaps in IR and codegen support for native 
ints.

Work on mypyc/mypyc#837.