### PR TITLE
Enable `--check-untyped-defs` by default

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -605,7 +605,7 @@ def process_options(args: List[str],
     add_invertible_flag('--disallow-incomplete-defs', default=False, strict_flag=True,
                         help="Disallow defining functions with incomplete type annotations",
                         group=untyped_group)
-    add_invertible_flag('--check-untyped-defs', default=False, strict_flag=True,
+    add_invertible_flag('--check-untyped-defs', default=True, strict_flag=True,
                         help="Type check the interior of functions without type annotations",
                         group=untyped_group)
     add_invertible_flag('--disallow-untyped-decorators', default=False, strict_flag=True,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -605,8 +605,9 @@ def process_options(args: List[str],
     add_invertible_flag('--disallow-incomplete-defs', default=False, strict_flag=True,
                         help="Disallow defining functions with incomplete type annotations",
                         group=untyped_group)
-    add_invertible_flag('--check-untyped-defs', default=True, strict_flag=True,
-                        help="Type check the interior of functions without type annotations",
+    add_invertible_flag('--no-check-untyped-defs', default=True, strict_flag=True,
+                        dest='check_untyped_defs',
+                        help="Don't type check the interior of functions without type annotations",
                         group=untyped_group)
     add_invertible_flag('--disallow-untyped-decorators', default=False, strict_flag=True,
                         help="Disallow decorating typed functions with untyped decorators",

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -588,12 +588,13 @@ def process_options(args: List[str],
                         help="Disallow subclassing values of type 'Any' when defining classes",
                         group=disallow_any_group)
 
+    # TODO: is the Note really helpful if --check-untyped-defs is enabled by default? (Maybe
+    # reword it to emphasize that mypy doesn't infer return types?)
     untyped_group = parser.add_argument_group(
         title='Untyped definitions and calls',
         description="Configure how untyped definitions and calls are handled. "
-                    "Note: by default, mypy ignores any untyped function definitions "
-                    "and assumes any calls to such functions have a return "
-                    "type of 'Any'.")
+                    "Note: by default, mypy assumes any calls to untyped "
+                    "functions have a return type of 'Any'.")
     add_invertible_flag('--disallow-untyped-calls', default=False, strict_flag=True,
                         help="Disallow calling functions without type annotations"
                         " from functions with type annotations",
@@ -605,7 +606,7 @@ def process_options(args: List[str],
     add_invertible_flag('--disallow-incomplete-defs', default=False, strict_flag=True,
                         help="Disallow defining functions with incomplete type annotations",
                         group=untyped_group)
-    add_invertible_flag('--no-check-untyped-defs', default=True, strict_flag=True,
+    add_invertible_flag('--no-check-untyped-defs', default=True,
                         dest='check_untyped_defs',
                         help="Don't type check the interior of functions without type annotations",
                         group=untyped_group)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -120,7 +120,7 @@ class Options:
         self.disallow_incomplete_defs = False
 
         # Type check unannotated functions
-        self.check_untyped_defs = False
+        self.check_untyped_defs = True
 
         # Disallow decorating typed functions with untyped decorators
         self.disallow_untyped_decorators = False


### PR DESCRIPTION
Having `--check-untyped-defs` off by default is rather surprising behavior, since most people don't expect whether a function is annotated to change whether mypy checks that function. See #11201 and https://github.com/python/mypy/issues/3948#issuecomment-890060233 for previous discussions of this.

I'm mainly creating this to see what mypy_primer says about the impact of changing the default and if there are other changes we can make to reduce the number of new errors. I haven't looked at whether the test suite passes yet.

### Test Plan

I made sure `mypy --check-untyped-defs`, `mypy --no-check-untyped-defs`, and `mypy --strict` all behaved the same as before, and mypy with no options reported errors in untyped functions. I also looked at the `mypy --help` output and made sure it seemed reasonable.