### PR TITLE
Fix formatting error in command_line.rst as well as docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.7'
       - name: Install tox
         run: pip install --upgrade 'setuptools!=50' 'virtualenv>=20.6.0' tox==3.24.5
       - name: Setup tox environment

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -216,7 +216,7 @@ imports.
 
     The default logic used to scan through search paths to resolve imports has a
     quadratic worse-case behavior in some cases, which is for instance triggered
-    by a large number of folders sharing a top-level namespace as in:
+    by a large number of folders sharing a top-level namespace as in::
 
         foo/
             company/
@@ -230,7 +230,7 @@ imports.
             company/
                 baz/
                     c.py
-       ...
+        ...
 
     If you are in this situation, you can enable an experimental fast path by
     setting the :option:`--fast-module-lookup` option.


### PR DESCRIPTION
### Description

There is a minor block formatting error in `docs/source/command_line.rst`, as committed in https://github.com/python/mypy/commit/a6166b2f7e8e4cf9d176107277da223e45c3a6a1:

https://github.com/python/mypy/blob/2051024c07cd361352e081884db0a061221a9aab/docs/source/command_line.rst#L217-L236

I noticed this during a local tox build, and then wondered why this wasn't flagged in CI.

It turns out that the `docs` github workflow wants to run the build on Python 3.10, as of commit https://github.com/python/mypy/commit/fec532028dcb7def7af4356e529fffb38c4afcea:

https://github.com/python/mypy/blob/2051024c07cd361352e081884db0a061221a9aab/.github/workflows/docs.yml#L19-L25

This fails, however, because `tox.ini` specifies Python 3.7 for the `docs` build:

https://github.com/python/mypy/blob/2051024c07cd361352e081884db0a061221a9aab/tox.ini#L56-L58

Subsequently, though, this failure is ignored, and the CI passes, because `skip_missing_interpreters` is enabled:

https://github.com/python/mypy/blob/2051024c07cd361352e081884db0a061221a9aab/tox.ini#L3

## Test Plan

With these changes, the `docs` workflow gets Python 3.7, and the docs are actually built successfully. I'm not sure why the author of the theme change thought it had to be 3.10...
