### PR TITLE
Remove failing test on Python 3.11

### DIFF
--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -1364,23 +1364,6 @@ class F:
 @t.coroutine
 def g(): ...
 
-[case testCoroutineSpecialCase_import]
-import asyncio
-
-__all__ = ['C']
-
-@asyncio.coroutine
-def f():
-    pass
-
-class C:
-    def f(self):
-        pass
-[out]
-import asyncio
-
-class C:
-    def f(self) -> None: ...
 
 -- Tests for stub generation from semantically analyzed trees.
 -- These tests are much slower, so use the `_semanal` suffix only when needed.


### PR DESCRIPTION
asyncio.coroutine has been removed. I don't think this test case is
particularly useful.

Linking #12840