### PR TITLE
Treat generators with await as async.

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -14,6 +14,7 @@ from mypy.typeanal import (
     make_optional_type,
 )
 from mypy.semanal_enum import ENUM_BASES
+from mypy.traverser import has_await_expression
 from mypy.types import (
     Type, AnyType, CallableType, Overloaded, NoneType, TypeVarType,
     TupleType, TypedDictType, Instance, ErasedType, UnionType,
@@ -3798,8 +3799,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def visit_generator_expr(self, e: GeneratorExpr) -> Type:
         # If any of the comprehensions use async for, the expression will return an async generator
-        # object
-        if any(e.is_async):
+        # object, or if the left-side expression uses await.
+        if any(e.is_async) or has_await_expression(e.left_expr):
             typ = 'typing.AsyncGenerator'
             # received type is always None in async generator expressions
             additional_args: List[Type] = [NoneType()]

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -383,7 +383,7 @@ class FuncCollectorBase(TraverserVisitor):
             self.inside_func = False
 
 
-class YieldSeeker(FuncCollectorBase):
+class YieldSeeker(TraverserVisitor):
     def __init__(self) -> None:
         super().__init__()
         self.found = False

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -383,7 +383,7 @@ class FuncCollectorBase(TraverserVisitor):
             self.inside_func = False
 
 
-class YieldSeeker(TraverserVisitor):
+class YieldSeeker(FuncCollectorBase):
     def __init__(self) -> None:
         super().__init__()
         self.found = False
@@ -398,7 +398,7 @@ def has_yield_expression(fdef: FuncBase) -> bool:
     return seeker.found
 
 
-class AwaitSeeker(FuncCollectorBase):
+class AwaitSeeker(TraverserVisitor):
     def __init__(self) -> None:
         super().__init__()
         self.found = False

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -18,6 +18,7 @@ from mypy.nodes import (
     ConditionalExpr, TypeApplication, ExecStmt, Import, ImportFrom,
     LambdaExpr, ComparisonExpr, OverloadedFuncDef, YieldFromExpr,
     YieldExpr, StarExpr, BackquoteExpr, AwaitExpr, PrintStmt, SuperExpr, Node, REVEAL_TYPE,
+    Expression,
 )
 
 
@@ -394,6 +395,21 @@ class YieldSeeker(FuncCollectorBase):
 def has_yield_expression(fdef: FuncBase) -> bool:
     seeker = YieldSeeker()
     fdef.accept(seeker)
+    return seeker.found
+
+
+class AwaitSeeker(FuncCollectorBase):
+    def __init__(self) -> None:
+        super().__init__()
+        self.found = False
+
+    def visit_await_expr(self, o: AwaitExpr) -> None:
+        self.found = True
+
+
+def has_await_expression(expr: Expression) -> bool:
+    seeker = AwaitSeeker()
+    expr.accept(seeker)
     return seeker.found
 
 

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -864,3 +864,14 @@ async with C() as x: # E: "async with" outside async function
 
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
+
+[case testAsyncGeneratorExpressionAwait]
+from typing import AsyncGenerator
+
+async def f() -> AsyncGenerator[int, None]:
+    async def g(x: int) -> int:
+        return x
+
+    return (await g(x) for x in [1, 2, 3])
+
+[typing fixtures/typing-async.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/12924 by using a traverser to find `await` expressions within a generator and then treat it as async if it is found.

A test is added. The test fails without this patch because the function has type `Generator` inferred, not `AsyncGenerator`.