### PR TITLE
Fix bug in constraints solver regarding `ParamSpec` upper bounds

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -571,6 +571,8 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             if not actual.values:
                 return infer_constraints(template, actual.upper_bound, self.direction)
             return []
+        elif isinstance(actual, ParamSpecType):
+            return infer_constraints(template, actual.upper_bound, self.direction)
         else:
             return []
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1066,15 +1066,20 @@ def run_job(job: Job[...]) -> T: ...
 [builtins fixtures/tuple.pyi]
 
 [case testTupleAndDictOperationsOnParamSpecArgsAndKwargs]
-from typing import Callable
+from typing import Callable, Iterator, Iterable, TypeVar, Tuple
 from typing_extensions import ParamSpec
 
 P = ParamSpec('P')
+T = TypeVar('T')
+def enumerate(x: Iterable[T]) -> Iterator[Tuple[int, T]]: ...
 
 def func(callback: Callable[P, str]) -> Callable[P, str]:
     def inner(*args: P.args, **kwargs: P.kwargs) -> str:
         reveal_type(args[5])  # N: Revealed type is "builtins.object"
         for a in args:
+            reveal_type(a)  # N: Revealed type is "builtins.object"
+        for idx, a in enumerate(args):
+            reveal_type(idx)  # N: Revealed type is "builtins.int"
             reveal_type(a)  # N: Revealed type is "builtins.object"
         b = 'foo' in args
         reveal_type(b)  # N: Revealed type is "builtins.bool"


### PR DESCRIPTION
### Description

Fixes #12930.

Currently, mypy erroneously emits two errors on this snippet:

```python
from typing_extensions import ParamSpec
from typing import Callable, TypeVar, Iterator, Iterable, Tuple

P = ParamSpec("P")
T = TypeVar("T")

def enumerate(x: Iterable[T]) -> Iterator[Tuple[int, T]]: ...

def foo(func: Callable[P, T]) -> Callable[P, T]:
    def _inner(*args: P.args, **kwargs: P.kwargs) -> T:
        y = enumerate(args)  # E: Need type annotation for "y"  # E: Argument 1 to "enumerate" has incompatible type "P.args"; expected "Iterable[<nothing>]"
        return func(*args, **kwargs)
    return _inner
```

This is because of a bug in `constraints.py`: `ParamSpecArgs` and `ParamSpecKwargs` have upper bounds following #12668 (`tuple[object, ...]` and `dict[str, object]` respectively), but the constraints solver isn't currently aware of that fact. This PR fixes that bug. 

## Test Plan

I added a test to one of the existing test cases.
