### PR TITLE
Fix sidebar logo not loading in HTML docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="http://mypy-lang.org/static/mypy_light.svg" alt="mypy logo" width="300px"/>
+<img src="docs/source/mypy_light.svg" alt="mypy logo" width="300px"/>
 
 Mypy: Static Typing for Python
 =======================================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,7 +122,7 @@ html_theme = "furo"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = "http://mypy-lang.org/static/mypy_light.svg"
+html_logo = "mypy_light.svg"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/docs/source/mypy_light.svg
+++ b/docs/source/mypy_light.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   height="175.94801"
+   width="873.66284"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="mypy_light.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1680"
+     inkscape:window-height="1001"
+     id="namedview4260"
+     showgrid="false"
+     inkscape:zoom="1.0737884"
+     inkscape:cx="473.10057"
+     inkscape:cy="55.723359"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     inkscape:connector-curvature="0"
+     id="path8615"
+     d="m 87.796991,0 c -44.90034,0 -42.09648,19.4715 -42.09648,19.4715 l 0.05,20.17227 42.8473,0 0,6.05668 -59.866091,0 c 0,0 -28.73172,-3.25844 -28.73172,42.04643 0,45.30485 25.07769,43.69824 25.07769,43.69824 l 14.966521,0 0,-21.02321 c 0,0 -0.80673,-25.07769 24.67724,-25.07769 25.48398,0 42.496919,0 42.496919,0 0,0 23.87636,0.38596 23.87636,-23.07547 0,-23.46144 0,-38.79283 0,-38.79283 0,0 3.62509,-23.47592 -43.297799,-23.47592 z m -23.62608,13.56498 c 4.26299,0 7.70851,3.44551 7.70851,7.70851 0,4.26299 -3.44552,7.70851 -7.70851,7.70851 -4.263,0 -7.70851,-3.44552 -7.70851,-7.70851 0,-4.263 3.44551,-7.70851 7.70851,-7.70851 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#2a6db2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     inkscape:connector-curvature="0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#505050;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     d="m 89.072161,175.94801 c 44.900349,0 42.096469,-19.47149 42.096469,-19.47149 l -0.05,-20.17228 -42.847309,0 0,-6.05668 59.866099,0 c 0,0 28.73172,3.25843 28.73172,-42.04644 2e-5,-45.30485 -25.07769,-43.69824 -25.07769,-43.69824 l -14.96652,0 0,21.02321 c 0,0 0.80675,25.07768 -24.67725,25.07768 -25.483969,0 -42.496909,0 -42.496909,0 0,0 -23.87636,-0.38596 -23.87636,23.0755 0,23.46142 0,38.79282 0,38.79282 0,0 -3.62509,23.47592 43.2978,23.47592 z m 23.626079,-13.56497 c -4.26299,0 -7.70851,-3.44552 -7.70851,-7.70851 0,-4.263 3.44552,-7.70851 7.70851,-7.70851 4.263,0 7.70851,3.44551 7.70851,7.70851 2e-5,4.26299 -3.44551,7.70851 -7.70851,7.70851 z"
+     id="path8620" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3890"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:102.68504333px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#505050;fill-opacity:1;stroke:none"
+     d="m 211.33512,110.31397 16.94571,0 0,20.39908 -16.94571,0 0,-20.39908 m 0,-64.65064 16.94571,0 0,20.39908 -16.94571,0 0,-20.39908" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3892"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:102.68504333px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#2a6db2;fill-opacity:1;stroke:none"
+     d="m 385.53045,56.03127 c 3.69422,-6.63898 7.57434,-9.86018 12.71435,-13.01919 5.13983,-3.15881 11.72695,-4.41606 18.68739,-4.41616 9.36953,1e-4 16.59754,3.29285 21.68407,9.8783 5.08624,6.53208 7.62943,15.84819 7.62957,27.94836 l 0,54.29047 -14.8576,0 0,-53.80861 c -1.3e-4,-8.62001 -1.52605,-15.01815 -4.57774,-19.19441 -3.05196,-4.17611 -7.71002,-6.26421 -13.97418,-6.26429 -7.65645,8e-5 -13.70657,2.54327 -18.15038,7.62958 -4.44397,5.08646 -6.66592,12.02 -6.66584,20.80064 l 0,50.83709 -14.8576,0 0,-53.80861 c -6e-5,-8.67356 -1.52599,-15.07169 -4.57774,-19.19441 -3.0519,-4.17611 -7.7635,-6.26421 -14.13481,-6.26429 -7.54931,8e-5 -13.54588,2.57004 -17.98973,7.70989 -4.44393,5.08646 -6.66587,11.99322 -6.66584,20.72033 l 0,50.83709 -14.8576,0 0,-89.94872 14.8576,0 0,11.97418 c 3.37304,-5.51463 6.87835,-8.01335 11.58999,-10.63695 4.71155,-2.62341 10.8436,-3.50554 17.32209,-3.50564 6.53193,1e-4 12.07341,1.65987 16.62445,4.97931 4.60445,3.31962 8.00428,6.1383 10.19955,12.45604" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3894"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:102.68504333px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#2a6db2;fill-opacity:1;stroke:none"
+     d="m 513.22549,139.06544 c -4.17622,10.70815 -8.24534,17.69524 -12.20731,20.96125 -3.96207,3.26597 -9.26261,4.89896 -15.90166,4.89899 l -11.80577,0 0,-12.36794 8.67363,0 c 4.06908,-2e-5 7.22799,-0.96375 9.47675,-2.89121 2.24867,-1.92749 4.73833,-6.47846 7.46895,-13.65293 l 2.65027,-6.74615 -36.38105,-88.50312 15.66072,0 28.10898,70.35275 28.10897,-70.35275 15.66072,0 -39.5132,98.30111" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3896"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:102.68504333px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#505050;fill-opacity:1;stroke:none"
+     d="m 571.77248,5.74859 34.05203,0 0,11.48452 -19.27474,0 0,123.67949 19.27474,0 0,11.48452 -34.05203,0 0,-146.64853" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3898"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:102.68504333px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#2a6db2;fill-opacity:1;stroke:none"
+     d="m 651.68231,117.22074 0,47.70494 -14.85761,0 0,-124.16135 14.85761,0 0,13.65293 c 3.10535,-5.354 7.01382,-9.31603 11.72545,-11.88608 4.7651,-2.62341 10.44043,-3.93516 17.02602,-3.93526 10.92226,1e-4 19.78328,4.3369 26.58306,13.01045 6.85313,8.6737 10.27975,20.07789 10.27984,34.21263 -9e-5,14.13484 -3.42671,25.53903 -10.27984,34.21264 -6.79978,8.67364 -15.6608,13.01044 -26.58306,13.01044 -6.58559,0 -12.26092,-1.28498 -17.02602,-3.85494 -4.71163,-2.62351 -8.6201,-6.61229 -11.72545,-11.9664 m 45.52876,-56.94075 c -4.44396,-6.21066 -10.5744,-9.31603 -18.39131,-9.31611 -7.81702,8e-5 -13.97422,3.10545 -18.47161,9.31611 -4.44392,6.15728 -6.66588,14.67026 -6.66584,25.53901 -4e-5,10.86883 2.22192,19.40861 6.66584,25.61933 4.49739,6.15721 10.65459,9.23581 18.47161,9.23581 7.81691,0 13.94735,-3.0786 18.39131,-9.23581 4.49735,-6.21072 6.74615,-14.7505 6.74615,-25.61933 0,-10.86875 -2.2488,-19.38173 -6.74615,-25.53901 z" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3900"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:102.68504333px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#2a6db2;fill-opacity:1;stroke:none"
+     d="m 779.21669,139.06544 c -4.17622,10.70815 -8.24534,17.69524 -12.20731,20.96125 -3.96207,3.26597 -9.26261,4.89896 -15.90166,4.89899 l -11.80577,0 0,-12.36794 8.67363,0 c 4.06908,-2e-5 7.22799,-0.96375 9.47675,-2.89121 2.24867,-1.92749 4.73832,-6.47846 7.46895,-13.65293 l 2.65027,-6.74615 -36.38105,-88.50312 15.66072,0 28.10898,70.35275 28.10897,-70.35275 15.66071,0 -39.51319,98.30111" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3902"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:102.68504333px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;letter-spacing:0px;word-spacing:0px;fill:#505050;fill-opacity:1;stroke:none"
+     d="m 873.66285,5.74859 0,146.64853 -34.052,0 0,-11.48452 19.1944,0 0,-123.67949 -19.1944,0 0,-11.48452 34.052,0" />
+</svg>


### PR DESCRIPTION
### Description

The mypy logo wasn't loading on https://mypy.readthedocs.io/ because
it's referenced via an http:// (not https) URL. The logo's URL is
http://mypy-lang.org/static/mypy_light.svg; that server is not
accessible via https, so I've moved mypy_light.svg into docs/source and
referenced it from there.

The project README also referenced the logo via the same URL, so for
consistency, the README now points at the same logo file in docs/source.
(Although the README's logo did load because GitHub proxies external
resources referenced in markdown files).


## Test Plan

I've rebuilt the HTML docs after this change, and verified the HTML correctly references the logo file via a relative path. So it should load correctly on readthedocs, as the logo will be available via https from their server, alongside the HTML.
