### PR TITLE
Fix crash overriding partial-type attribute with method

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1575,7 +1575,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # it can be checked for compatibility.
             original_type = get_proper_type(base_attr.type)
             original_node = base_attr.node
-            if original_type is None:
+            # `original_type` can be partial if (e.g.) it is originally an
+            # instance variable from an `__init__` block that becomes deferred.
+            if original_type is None or isinstance(original_type, PartialType):
                 if self.pass_num < self.last_pass:
                     # If there are passes left, defer this node until next pass,
                     # otherwise try reconstructing the method type from available information.

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -151,6 +151,24 @@ class Derived(Base):
     __hash__ = 1  # E: Incompatible types in assignment (expression has type "int", base class "Base" defined the type as "Callable[[Base], int]")
 
 
+[case testOverridePartialAttributeWithMethod]
+# This was crashing: https://github.com/python/mypy/issues/11686.
+class Base:
+    def __init__(self, arg: int):
+        self.partial_type = []  # E: Need type annotation for "partial_type" (hint: "partial_type: List[<type>] = ...")
+        self.force_deferral = []
+
+    # Force inference of the `force_deferral` attribute in `__init__` to be
+    # deferred to a later pass by providing a definition in another context,
+    # which means `partial_type` remains only partially inferred.
+    force_deferral = []  # E: Need type annotation for "force_deferral" (hint: "force_deferral: List[<type>] = ...")
+
+
+class Derived(Base):
+    def partial_type(self) -> int:  # E: Signature of "partial_type" incompatible with supertype "Base"
+        ...
+
+
 -- Attributes
 -- ----------
 


### PR DESCRIPTION
### Description

Attributes can still be partially typed (e.g. `<partial list[?]>`) after
a parent-class definition if the block they are declared in is deferred.
The first pass for child classes might then encounter this type when
considering method overrides, which could cause a crash when attempting
to determine subtype compatibility.

This patch causes the subtype checker to defer the override test if the original type is still partial, avoiding the crash.  The correct error messages are still reported after this.  This is the same approach as suggested by https://github.com/python/mypy/issues/11686#issuecomment-989115227, but the test case is different to the original issue.  The original reproducer involved `@property`, which runs afoul of #4125, and a full fix there is likely better part of #7724.  The behaviour is not caused by `@property` itself, though, but any method overriding a value with partially inferred type.

Fixes #11686
Fixes #11981

## Test Plan

Added test case to `check-classes.test`.
