### PR TITLE
Fix crash on redefined class variable annotated with `Final[<type>]`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2715,13 +2715,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if is_final_decl and self.scope.active_class():
             lv = lvs[0]
             assert isinstance(lv, RefExpr)
-            assert isinstance(lv.node, Var)
-            if (lv.node.final_unset_in_class and not lv.node.final_set_in_init and
-                    not self.is_stub and  # It is OK to skip initializer in stub files.
-                    # Avoid extra error messages, if there is no type in Final[...],
-                    # then we already reported the error about missing r.h.s.
-                    isinstance(s, AssignmentStmt) and s.type is not None):
-                self.msg.final_without_value(s)
+            if lv.node is not None:
+                assert isinstance(lv.node, Var)
+                if (lv.node.final_unset_in_class and not lv.node.final_set_in_init and
+                        not self.is_stub and  # It is OK to skip initializer in stub files.
+                        # Avoid extra error messages, if there is no type in Final[...],
+                        # then we already reported the error about missing r.h.s.
+                        isinstance(s, AssignmentStmt) and s.type is not None):
+                    self.msg.final_without_value(s)
         for lv in lvs:
             if isinstance(lv, RefExpr) and isinstance(lv.node, Var):
                 name = lv.node.name

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1109,3 +1109,11 @@ class A(ABC):
     @final # E: Method B is both abstract and final
     @abstractmethod
     def B(self) -> None: ...
+
+[case testFinalClassVariableRedefinitionDoesNotCrash]
+# This used to crash -- see #12950
+from typing import Final
+
+class MyClass:
+    a: None
+    a: Final[int] = 1  # E: Cannot redefine an existing name as final  # E: Name "a" already defined on line 5


### PR DESCRIPTION
### Description

Fixes #12950.

Mypy currently crashes on this snippet of code:

```python
from typing import Final

class MyClass:
    a: None
    a: Final[int] = 1
```

This PR fixes that.

## Test Plan

I added a test.