### PR TITLE
Improve handling of overloads with `ParamSpec`

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -6,7 +6,7 @@ from mypy.types import (
     TupleType, TypedDictType, ErasedType, UnionType, PartialType, DeletedType,
     UninhabitedType, TypeType, TypeOfAny, Overloaded, FunctionLike, LiteralType,
     ProperType, get_proper_type, get_proper_types, TypeAliasType, TypeGuardedType,
-    ParamSpecType, Parameters, UnpackType, TypeVarTupleType,
+    ParamSpecType, Parameters, UnpackType, TypeVarTupleType, TypeVarLikeType
 )
 from mypy.subtypes import is_equivalent, is_subtype, is_callable_compatible, is_proper_subtype
 from mypy.erasetype import erase_type
@@ -134,6 +134,8 @@ def get_possible_variants(typ: Type) -> List[Type]:
             return typ.values
         else:
             return [typ.upper_bound]
+    elif isinstance(typ, ParamSpecType):
+        return [typ.upper_bound]
     elif isinstance(typ, UnionType):
         return list(typ.items)
     elif isinstance(typ, Overloaded):
@@ -255,14 +257,14 @@ def is_overlapping_types(left: Type,
 
     def is_none_typevar_overlap(t1: Type, t2: Type) -> bool:
         t1, t2 = get_proper_types((t1, t2))
-        return isinstance(t1, NoneType) and isinstance(t2, TypeVarType)
+        return isinstance(t1, NoneType) and isinstance(t2, TypeVarLikeType)
 
     if prohibit_none_typevar_overlap:
         if is_none_typevar_overlap(left, right) or is_none_typevar_overlap(right, left):
             return False
 
     if (len(left_possible) > 1 or len(right_possible) > 1
-            or isinstance(left, TypeVarType) or isinstance(right, TypeVarType)):
+            or isinstance(left, TypeVarLikeType) or isinstance(right, TypeVarLikeType)):
         for l in left_possible:
             for r in right_possible:
                 if _is_overlapping_types(l, r):

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6506,3 +6506,33 @@ if True:
         @overload
         def f3(g: D) -> D: ...
 def f3(g): ...  # E: Name "f3" already defined on line 32
+
+[case testOverloadingWithParamSpec]
+from typing import TypeVar, Callable, Any, overload
+from typing_extensions import ParamSpec, Concatenate
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+@overload
+def func(x: Callable[Concatenate[Any, P], R]) -> Callable[P, R]: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+@overload
+def func(x: Callable[P, R]) -> Callable[Concatenate[str, P], R]: ...
+def func(x: Callable[..., R]) -> Callable[..., R]: ...
+
+def foo(arg1: str, arg2: int) -> bytes: ...
+reveal_type(func(foo))  # N: Revealed type is "def (arg2: builtins.int) -> builtins.bytes"
+
+def bar() -> int: ...
+reveal_type(func(bar))  # N: Revealed type is "def (builtins.str) -> builtins.int"
+
+baz: Callable[[str, str], str] = lambda x, y: 'baz'
+reveal_type(func(baz))  # N: Revealed type is "def (builtins.str) -> builtins.str"
+
+eggs = lambda: 'eggs'
+reveal_type(func(eggs))  # N: Revealed type is "def (builtins.str) -> builtins.str"
+
+spam: Callable[..., str] = lambda x, y: 'baz'
+reveal_type(func(spam))  # N: Revealed type is "def (*Any, **Any) -> Any"
+
+[builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
### Description

Fixes #12922 (a crash report).

Mypy's logic for overlapping overloads currently doesn't account for the existence of `ParamSpec`s. This PR fixes that.

## Test Plan

I added a test that ensures that the crash report in #12922 is fixed, and that ensures that basic type inference works as expected.
I'm not 100% confident I've covered all edge cases, but I think this is better than the status quo, anyway.