### PR TITLE
Exposes `end_col_offset` attr from python AST

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -373,6 +373,8 @@ class ASTConverter:
         node.line = n.lineno
         node.column = n.col_offset
         node.end_line = getattr(n, "end_lineno", None) if isinstance(n, ast3.expr) else None
+        node.end_column = getattr(n, "end_col_offset", None) if isinstance(n, ast3.expr) else None
+
         return node
 
     def translate_opt_expr_list(self, l: Sequence[Optional[AST]]) -> List[Optional[Expression]]:

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -599,7 +599,7 @@ class ASTConverter:
         cdef.line = n.lineno + len(n.decorator_list)
         cdef.column = n.col_offset
         cdef.end_line = n.lineno
-        cdef.end_column = n.col_offset
+        cdef.end_column = None
         self.class_and_function_stack.pop()
         return cdef
 

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -599,6 +599,7 @@ class ASTConverter:
         cdef.line = n.lineno + len(n.decorator_list)
         cdef.column = n.col_offset
         cdef.end_line = n.lineno
+        cdef.end_column = n.col_offset
         self.class_and_function_stack.pop()
         return cdef
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 class Context:
     """Base type for objects that are valid as error message locations."""
-    __slots__ = ('line', 'column', 'end_line', "end_column")
+    __slots__ = ('line', 'column', 'end_line', 'end_column')
 
     def __init__(self, line: int = -1, column: int = -1) -> None:
         self.line = line

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -34,7 +34,8 @@ class Context:
     def set_line(self,
                  target: Union['Context', int],
                  column: Optional[int] = None,
-                 end_line: Optional[int] = None) -> None:
+                 end_line: Optional[int] = None,
+                 end_column: Optional[int] = None) -> None:
         """If target is a node, pull line (and column) information
         into this node. If column is specified, this will override any column
         information coming from a node.
@@ -45,12 +46,16 @@ class Context:
             self.line = target.line
             self.column = target.column
             self.end_line = target.end_line
+            self.end_column = target.end_column
 
         if column is not None:
             self.column = column
 
         if end_line is not None:
             self.end_line = end_line
+
+        if end_column is not None:
+            self.end_column = end_column
 
     def get_line(self) -> int:
         """Don't use. Use x.line."""
@@ -632,13 +637,16 @@ class Argument(Node):
     def set_line(self,
                  target: Union[Context, int],
                  column: Optional[int] = None,
-                 end_line: Optional[int] = None) -> None:
-        super().set_line(target, column, end_line)
+                 end_line: Optional[int] = None,
+                 end_column: Optional[int] = None) -> None:
+        super().set_line(target, column, end_line, end_column)
 
         if self.initializer and self.initializer.line < 0:
-            self.initializer.set_line(self.line, self.column, self.end_line)
+            self.initializer.set_line(
+                self.line, self.column, self.end_line, self.end_column)
 
-        self.variable.set_line(self.line, self.column, self.end_line)
+        self.variable.set_line(
+            self.line, self.column, self.end_line, self.end_column)
 
 
 FUNCITEM_FLAGS: Final = FUNCBASE_FLAGS + [
@@ -699,10 +707,12 @@ class FuncItem(FuncBase):
     def set_line(self,
                  target: Union[Context, int],
                  column: Optional[int] = None,
-                 end_line: Optional[int] = None) -> None:
-        super().set_line(target, column, end_line)
+                 end_line: Optional[int] = None,
+                 end_column: Optional[int] = None) -> None:
+        super().set_line(target, column, end_line, end_column)
         for arg in self.arguments:
-            arg.set_line(self.line, self.column, self.end_line)
+            arg.set_line(
+                self.line, self.column, self.end_line, end_column)
 
     def is_dynamic(self) -> bool:
         return self.type is None

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -711,8 +711,7 @@ class FuncItem(FuncBase):
                  end_column: Optional[int] = None) -> None:
         super().set_line(target, column, end_line, end_column)
         for arg in self.arguments:
-            arg.set_line(
-                self.line, self.column, self.end_line, end_column)
+            arg.set_line(self.line, self.column, self.end_line, end_column)
 
     def is_dynamic(self) -> bool:
         return self.type is None

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -23,12 +23,13 @@ if TYPE_CHECKING:
 
 class Context:
     """Base type for objects that are valid as error message locations."""
-    __slots__ = ('line', 'column', 'end_line')
+    __slots__ = ('line', 'column', 'end_line', "end_column")
 
     def __init__(self, line: int = -1, column: int = -1) -> None:
         self.line = line
         self.column = column
         self.end_line: Optional[int] = None
+        self.end_column: Optional[int] = None
 
     def set_line(self,
                  target: Union['Context', int],


### PR DESCRIPTION
### Description

Closes #12940

The AST nodes from python versions greater than 3.7 provide the `end_col_offset` attribute. This attribute can be used to solve some issues in mypy.

https://github.com/python/mypy/issues/12288
https://github.com/python/mypy/issues/4868
https://github.com/python/mypy/issues/12513

The AST nodes will have an optional[int] type for `end_col_offset` attributre. 

For python<3.8 this attribute will be None, following the approach already been used in mypy
https://github.com/python/mypy/blob/9ccd081550010700341a46f0e08b8954e5beef70/mypy/fastparse.py#L375


## Test Plan

Currently, the `end_line` attribute is not being tested in mypy so I believe there is no reason to create a test for `end_col_offset`.


