### PR TITLE
[mypyc] Native int primitives

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -150,6 +150,7 @@ PyObject *CPyLong_FromStrWithBase(PyObject *o, CPyTagged base);
 PyObject *CPyLong_FromStr(PyObject *o);
 PyObject *CPyLong_FromFloat(PyObject *o);
 PyObject *CPyBool_Str(bool b);
+int64_t CPyInt64_Divide(int64_t x, int64_t y);
 
 static inline int CPyTagged_CheckLong(CPyTagged x) {
     return x & CPY_INT_TAG;

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -287,7 +287,7 @@ static void CPy_DecRef(PyObject *p) {
     CPy_DECREF(p);
 }
 
-CPy_NOINLINE
+//CPy_NOINLINE
 static void CPy_XDecRef(PyObject *p) {
     CPy_XDECREF(p);
 }

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -156,6 +156,7 @@ int64_t CPyInt64_Remainder(int64_t x, int64_t y);
 int32_t CPyLong_AsInt32(PyObject *o);
 int32_t CPyInt32_Divide(int32_t x, int32_t y);
 int32_t CPyInt32_Remainder(int32_t x, int32_t y);
+void CPyInt32_Overflow(void);
 
 static inline int CPyTagged_CheckLong(CPyTagged x) {
     return x & CPY_INT_TAG;

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -122,6 +122,7 @@ static inline size_t CPy_FindAttrOffset(PyTypeObject *trait, CPyVTableItem *vtab
 
 CPyTagged CPyTagged_FromSsize_t(Py_ssize_t value);
 CPyTagged CPyTagged_FromVoidPtr(void *ptr);
+CPyTagged CPyTagged_FromInt64(int64_t value);
 CPyTagged CPyTagged_FromObject(PyObject *object);
 CPyTagged CPyTagged_StealFromObject(PyObject *object);
 CPyTagged CPyTagged_BorrowFromObject(PyObject *object);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -151,6 +151,7 @@ PyObject *CPyLong_FromStr(PyObject *o);
 PyObject *CPyLong_FromFloat(PyObject *o);
 PyObject *CPyBool_Str(bool b);
 int64_t CPyInt64_Divide(int64_t x, int64_t y);
+int64_t CPyInt64_Remainder(int64_t x, int64_t y);
 
 static inline int CPyTagged_CheckLong(CPyTagged x) {
     return x & CPY_INT_TAG;

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -287,7 +287,7 @@ static void CPy_DecRef(PyObject *p) {
     CPy_DECREF(p);
 }
 
-//CPy_NOINLINE
+CPy_NOINLINE
 static void CPy_XDecRef(PyObject *p) {
     CPy_XDECREF(p);
 }

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -152,6 +152,8 @@ PyObject *CPyLong_FromFloat(PyObject *o);
 PyObject *CPyBool_Str(bool b);
 int64_t CPyInt64_Divide(int64_t x, int64_t y);
 int64_t CPyInt64_Remainder(int64_t x, int64_t y);
+int32_t CPyInt32_Divide(int32_t x, int32_t y);
+int32_t CPyInt32_Remainder(int32_t x, int32_t y);
 
 static inline int CPyTagged_CheckLong(CPyTagged x) {
     return x & CPY_INT_TAG;
@@ -347,6 +349,7 @@ PyObject *CPyList_GetItemShortBorrow(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemInt64(PyObject *list, int64_t index);
 bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value);
 bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value);
+bool CPyList_SetItemInt64(PyObject *list, int64_t index, PyObject *value);
 PyObject *CPyList_PopLast(PyObject *obj);
 PyObject *CPyList_Pop(PyObject *obj, CPyTagged index);
 CPyTagged CPyList_Count(PyObject *obj, PyObject *value);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -357,6 +357,7 @@ PyObject *CPyList_GetItemShort(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemBorrow(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemShortBorrow(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemInt64(PyObject *list, int64_t index);
+PyObject *CPyList_GetItemInt64Borrow(PyObject *list, int64_t index);
 bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value);
 bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value);
 bool CPyList_SetItemInt64(PyObject *list, int64_t index, PyObject *value);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -201,6 +201,12 @@ static inline bool CPyTagged_TooBig(Py_ssize_t value) {
         && (value >= 0 || value < CPY_TAGGED_MIN);
 }
 
+static inline bool CPyTagged_TooBigInt64(int64_t value) {
+    // Micro-optimized for the common case where it fits.
+    return (uint64_t)value > CPY_TAGGED_MAX
+        && (value >= 0 || value < CPY_TAGGED_MIN);
+}
+
 static inline bool CPyTagged_IsAddOverflow(CPyTagged sum, CPyTagged left, CPyTagged right) {
     // This check was copied from some of my old code I believe that it works :-)
     return (Py_ssize_t)(sum ^ left) < 0 && (Py_ssize_t)(sum ^ right) < 0;

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -342,6 +342,7 @@ PyObject *CPyList_GetItemUnsafe(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemShort(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemBorrow(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemShortBorrow(PyObject *list, CPyTagged index);
+PyObject *CPyList_GetItemInt64(PyObject *list, int64_t index);
 bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value);
 bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value);
 PyObject *CPyList_PopLast(PyObject *obj);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -150,6 +150,7 @@ PyObject *CPyLong_FromStrWithBase(PyObject *o, CPyTagged base);
 PyObject *CPyLong_FromStr(PyObject *o);
 PyObject *CPyLong_FromFloat(PyObject *o);
 PyObject *CPyBool_Str(bool b);
+int64_t CPyLong_AsInt64(PyObject *o);
 int64_t CPyInt64_Divide(int64_t x, int64_t y);
 int64_t CPyInt64_Remainder(int64_t x, int64_t y);
 int32_t CPyInt32_Divide(int32_t x, int32_t y);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -153,6 +153,7 @@ PyObject *CPyBool_Str(bool b);
 int64_t CPyLong_AsInt64(PyObject *o);
 int64_t CPyInt64_Divide(int64_t x, int64_t y);
 int64_t CPyInt64_Remainder(int64_t x, int64_t y);
+int32_t CPyLong_AsInt32(PyObject *o);
 int32_t CPyInt32_Divide(int32_t x, int32_t y);
 int32_t CPyInt32_Remainder(int32_t x, int32_t y);
 

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -35,6 +35,15 @@ CPyTagged CPyTagged_FromVoidPtr(void *ptr) {
     }
 }
 
+CPyTagged CPyTagged_FromInt64(int64_t value) {
+    if (unlikely(CPyTagged_TooBig(value))) {
+        PyObject *object = PyLong_FromLongLong(value);
+        return ((CPyTagged)object) | CPY_INT_TAG;
+    } else {
+        return value << 1;
+    }
+}
+
 CPyTagged CPyTagged_FromObject(PyObject *object) {
     int overflow;
     // The overflow check knows about CPyTagged's width

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -504,3 +504,19 @@ CPyTagged CPyTagged_Lshift(CPyTagged left, CPyTagged right) {
     }
     return CPyTagged_StealFromObject(result);
 }
+
+int64_t CPyLong_AsInt64(PyObject *o) {
+    if (likely(PyLong_Check(o))) {
+        PyLongObject *lobj = (PyLongObject *)o;
+        int size = lobj->ob_base.ob_size;
+        if (size == 1) {
+            // Fast path
+            return lobj->ob_digit[0];
+        }
+    }
+    // Slow path
+    int overflow;
+    int64_t result = PyLong_AsLongLongAndOverflow(o, &overflow);
+    // TODO: Handle errors
+    return result;
+}

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -622,3 +622,7 @@ int32_t CPyInt32_Remainder(int32_t x, int32_t y) {
     }
     return d;
 }
+
+void CPyInt32_Overflow() {
+    PyErr_SetString(PyExc_OverflowError, "int too large to convert to i32");
+}

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -538,6 +538,7 @@ int64_t CPyInt64_Divide(int64_t x, int64_t y) {
         return CPY_LL_INT_ERROR;
     }
     int64_t d = x / y;
+    // Adjust for Python semantics
     if (((x < 0) != (y < 0)) && d * y != x) {
         d--;
     }
@@ -554,6 +555,41 @@ int64_t CPyInt64_Remainder(int64_t x, int64_t y) {
         return 0;
     }
     int64_t d = x % y;
+    // Adjust for Python semantics
+    if (((x < 0) != (y < 0)) && d != 0) {
+        d += y;
+    }
+    return d;
+}
+
+int32_t CPyInt32_Divide(int32_t x, int32_t y) {
+    if (y == 0) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
+        return CPY_LL_INT_ERROR;
+    }
+    if (y == -1 && x == -1LL << 31) {
+        PyErr_SetString(PyExc_OverflowError, "integer division overflow");
+        return CPY_LL_INT_ERROR;
+    }
+    int32_t d = x / y;
+    // Adjust for Python semantics
+    if (((x < 0) != (y < 0)) && d * y != x) {
+        d--;
+    }
+    return d;
+}
+
+int32_t CPyInt32_Remainder(int32_t x, int32_t y) {
+    if (y == 0) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
+        return CPY_LL_INT_ERROR;
+    }
+    // Edge case: avoid core dump
+    if (y == -1 && x == -1LL << 31) {
+        return 0;
+    }
+    int32_t d = x % y;
+    // Adjust for Python semantics
     if (((x < 0) != (y < 0)) && d != 0) {
         d += y;
     }

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -36,7 +36,7 @@ CPyTagged CPyTagged_FromVoidPtr(void *ptr) {
 }
 
 CPyTagged CPyTagged_FromInt64(int64_t value) {
-    if (unlikely(CPyTagged_TooBig(value))) {
+    if (unlikely(CPyTagged_TooBigInt64(value))) {
         PyObject *object = PyLong_FromLongLong(value);
         return ((CPyTagged)object) | CPY_INT_TAG;
     } else {

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -517,10 +517,12 @@ CPyTagged CPyTagged_Lshift(CPyTagged left, CPyTagged right) {
 int64_t CPyLong_AsInt64(PyObject *o) {
     if (likely(PyLong_Check(o))) {
         PyLongObject *lobj = (PyLongObject *)o;
-        int size = lobj->ob_base.ob_size;
-        if (size == 1) {
+        Py_ssize_t size = Py_SIZE(lobj);
+        if (likely(size == 1)) {
             // Fast path
             return lobj->ob_digit[0];
+        } else if (likely(size == 0)) {
+            return 0;
         }
     }
     // Slow path
@@ -574,10 +576,12 @@ int64_t CPyInt64_Remainder(int64_t x, int64_t y) {
 int32_t CPyLong_AsInt32(PyObject *o) {
     if (likely(PyLong_Check(o))) {
         PyLongObject *lobj = (PyLongObject *)o;
-        int size = lobj->ob_base.ob_size;
-        if (size == 1) {
+        Py_ssize_t size = lobj->ob_base.ob_size;
+        if (likely(size == 1)) {
             // Fast path
             return lobj->ob_digit[0];
+        } else if (likely(size == 0)) {
+            return 0;
         }
     }
     // Slow path

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -527,3 +527,19 @@ int64_t CPyLong_AsInt64(PyObject *o) {
     }
     return result;
 }
+
+int64_t CPyInt64_Divide(int64_t x, int64_t y) {
+    if (y == 0) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
+        return CPY_LL_INT_ERROR;
+    }
+    if (y == -1 && x == -1L << 63) {
+        PyErr_SetString(PyExc_OverflowError, "integer division overflow");
+        return CPY_LL_INT_ERROR;
+    }
+    int64_t d = x / y;
+    if (((x < 0) != (y < 0)) && d * y != x) {
+        d--;
+    }
+    return d;
+}

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -517,6 +517,13 @@ int64_t CPyLong_AsInt64(PyObject *o) {
     // Slow path
     int overflow;
     int64_t result = PyLong_AsLongLongAndOverflow(o, &overflow);
-    // TODO: Handle errors
+    if (result == -1) {
+        if (PyErr_Occurred()) {
+            return CPY_LL_INT_ERROR;
+        } else if (overflow) {
+            PyErr_SetString(PyExc_OverflowError, "int too large to convert to i64");
+            return CPY_LL_INT_ERROR;
+        }
+    }
     return result;
 }

--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -533,13 +533,29 @@ int64_t CPyInt64_Divide(int64_t x, int64_t y) {
         PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
         return CPY_LL_INT_ERROR;
     }
-    if (y == -1 && x == -1L << 63) {
+    if (y == -1 && x == -1LL << 63) {
         PyErr_SetString(PyExc_OverflowError, "integer division overflow");
         return CPY_LL_INT_ERROR;
     }
     int64_t d = x / y;
     if (((x < 0) != (y < 0)) && d * y != x) {
         d--;
+    }
+    return d;
+}
+
+int64_t CPyInt64_Remainder(int64_t x, int64_t y) {
+    if (y == 0) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
+        return CPY_LL_INT_ERROR;
+    }
+    // Edge case: avoid core dump
+    if (y == -1 && x == -1LL << 63) {
+        return 0;
+    }
+    int64_t d = x % y;
+    if (((x < 0) != (y < 0)) && d != 0) {
+        d += y;
     }
     return d;
 }

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -139,6 +139,23 @@ PyObject *CPyList_GetItemInt64(PyObject *list, int64_t index) {
     return result;
 }
 
+PyObject *CPyList_GetItemInt64Borrow(PyObject *list, int64_t index) {
+    size_t size = PyList_GET_SIZE(list);
+    if (likely((uint64_t)index < size)) {
+        return PyList_GET_ITEM(list, index);
+    }
+    if (index >= 0) {
+        PyErr_SetString(PyExc_IndexError, "list index out of range");
+        return NULL;
+    }
+    index += size;
+    if (index < 0) {
+        PyErr_SetString(PyExc_IndexError, "list index out of range");
+        return NULL;
+    }
+    return PyList_GET_ITEM(list, index);
+}
+
 bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
     if (CPyTagged_CheckShort(index)) {
         Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -118,6 +118,27 @@ PyObject *CPyList_GetItemBorrow(PyObject *list, CPyTagged index) {
     }
 }
 
+PyObject *CPyList_GetItemInt64(PyObject *list, int64_t index) {
+    size_t size = PyList_GET_SIZE(list);
+    if (likely((uint64_t)index < size)) {
+        PyObject *result = PyList_GET_ITEM(list, index);
+        Py_INCREF(result);
+        return result;
+    }
+    if (index >= 0) {
+        PyErr_SetString(PyExc_IndexError, "list index out of range");
+        return NULL;
+    }
+    index += size;
+    if (index < 0) {
+        PyErr_SetString(PyExc_IndexError, "list index out of range");
+        return NULL;
+    }
+    PyObject *result = PyList_GET_ITEM(list, index);
+    Py_INCREF(result);
+    return result;
+}
+
 bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
     if (CPyTagged_CheckShort(index)) {
         Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -166,6 +166,26 @@ bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value) {
     }
 }
 
+bool CPyList_SetItemInt64(PyObject *list, int64_t index, PyObject *value) {
+    size_t size = PyList_GET_SIZE(list);
+    if (unlikely((uint64_t)index >= size)) {
+        if (index > 0) {
+            PyErr_SetString(PyExc_IndexError, "list assignment index out of range");
+            return false;
+        }
+        index += size;
+        if (index < 0) {
+            PyErr_SetString(PyExc_IndexError, "list assignment index out of range");
+            return false;
+        }
+    }
+    // PyList_SET_ITEM doesn't decref the old element, so we do
+    Py_DECREF(PyList_GET_ITEM(list, index));
+    // N.B: Steals reference
+    PyList_SET_ITEM(list, index, value);
+    return true;
+}
+
 // This function should only be used to fill in brand new lists.
 bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value) {
     if (CPyTagged_CheckShort(index)) {

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -53,6 +53,9 @@ typedef PyObject CPyModule;
 // Tag bit used for long integers
 #define CPY_INT_TAG 1
 
+// Error value for fixed-width (low-level) integers
+#define CPY_LL_INT_ERROR -113
+
 typedef void (*CPyVTableItem)(void);
 
 static inline CPyTagged CPyTagged_ShortFromInt(int x) {

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -202,3 +202,10 @@ int64_to_int_op = custom_op(
     return_type=int_rprimitive,
     c_function_name='CPyTagged_FromSsize_t',
     error_kind=ERR_MAGIC)
+
+# Convert tagged int (as PyObject *) to i32
+int_to_int32_op = custom_op(
+    arg_types=[object_rprimitive],
+    return_type=int64_rprimitive,
+    c_function_name='CPyLong_AsInt32',
+    error_kind=ERR_MAGIC_OVERLAPPING)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -171,3 +171,9 @@ int64_divide_op = custom_op(
     return_type=int64_rprimitive,
     c_function_name='CPyInt64_Divide',
     error_kind=ERR_MAGIC_OVERLAPPING)
+
+int64_mod_op = custom_op(
+    arg_types=[int64_rprimitive, int64_rprimitive],
+    return_type=int64_rprimitive,
+    c_function_name='CPyInt64_Remainder',
+    error_kind=ERR_MAGIC_OVERLAPPING)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -189,3 +189,9 @@ int32_mod_op = custom_op(
     return_type=int32_rprimitive,
     c_function_name='CPyInt32_Remainder',
     error_kind=ERR_MAGIC_OVERLAPPING)
+
+int_to_int64_op = custom_op(
+    arg_types=[object_rprimitive],
+    return_type=int64_rprimitive,
+    c_function_name='CPyLong_AsInt64',
+    error_kind=ERR_MAGIC_OVERLAPPING)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -190,8 +190,15 @@ int32_mod_op = custom_op(
     c_function_name='CPyInt32_Remainder',
     error_kind=ERR_MAGIC_OVERLAPPING)
 
+# Convert tagged int (as PyObject *) to i64
 int_to_int64_op = custom_op(
     arg_types=[object_rprimitive],
     return_type=int64_rprimitive,
     c_function_name='CPyLong_AsInt64',
     error_kind=ERR_MAGIC_OVERLAPPING)
+
+int64_to_int_op = custom_op(
+    arg_types=[int64_rprimitive],
+    return_type=int_rprimitive,
+    c_function_name='CPyTagged_FromSsize_t',
+    error_kind=ERR_MAGIC)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -12,7 +12,7 @@ from typing import Dict, NamedTuple
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_MAGIC_OVERLAPPING, ComparisonOp
 from mypyc.ir.rtypes import (
     int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive,
-    str_rprimitive, bit_rprimitive, int64_rprimitive, RType
+    str_rprimitive, bit_rprimitive, int64_rprimitive, int32_rprimitive, RType
 )
 from mypyc.primitives.registry import (
     load_address_op, unary_op, CFunctionDescription, function_op, binary_op, custom_op
@@ -176,4 +176,16 @@ int64_mod_op = custom_op(
     arg_types=[int64_rprimitive, int64_rprimitive],
     return_type=int64_rprimitive,
     c_function_name='CPyInt64_Remainder',
+    error_kind=ERR_MAGIC_OVERLAPPING)
+
+int32_divide_op = custom_op(
+    arg_types=[int32_rprimitive, int32_rprimitive],
+    return_type=int32_rprimitive,
+    c_function_name='CPyInt32_Divide',
+    error_kind=ERR_MAGIC_OVERLAPPING)
+
+int32_mod_op = custom_op(
+    arg_types=[int32_rprimitive, int32_rprimitive],
+    return_type=int32_rprimitive,
+    c_function_name='CPyInt32_Remainder',
     error_kind=ERR_MAGIC_OVERLAPPING)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -9,10 +9,10 @@ Use mypyc.ir.ops.IntOp for operations on fixed-width/C integers.
 """
 
 from typing import Dict, NamedTuple
-from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_MAGIC_OVERLAPPING, ComparisonOp
+from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_MAGIC_OVERLAPPING, ERR_ALWAYS, ComparisonOp
 from mypyc.ir.rtypes import (
     int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive,
-    str_rprimitive, bit_rprimitive, int64_rprimitive, int32_rprimitive, RType
+    str_rprimitive, bit_rprimitive, int64_rprimitive, int32_rprimitive, void_rtype, RType
 )
 from mypyc.primitives.registry import (
     load_address_op, unary_op, CFunctionDescription, function_op, binary_op, custom_op
@@ -206,6 +206,12 @@ int64_to_int_op = custom_op(
 # Convert tagged int (as PyObject *) to i32
 int_to_int32_op = custom_op(
     arg_types=[object_rprimitive],
-    return_type=int64_rprimitive,
+    return_type=int32_rprimitive,
     c_function_name='CPyLong_AsInt32',
     error_kind=ERR_MAGIC_OVERLAPPING)
+
+int32_overflow = custom_op(
+    arg_types=[],
+    return_type=void_rtype,
+    c_function_name='CPyInt32_Overflow',
+    error_kind=ERR_ALWAYS)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -9,10 +9,10 @@ Use mypyc.ir.ops.IntOp for operations on fixed-width/C integers.
 """
 
 from typing import Dict, NamedTuple
-from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ComparisonOp
+from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_MAGIC_OVERLAPPING, ComparisonOp
 from mypyc.ir.rtypes import (
     int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive,
-    str_rprimitive, bit_rprimitive, RType
+    str_rprimitive, bit_rprimitive, int64_rprimitive, RType
 )
 from mypyc.primitives.registry import (
     load_address_op, unary_op, CFunctionDescription, function_op, binary_op, custom_op
@@ -165,3 +165,9 @@ int_comparison_op_mapping: Dict[str, IntComparisonOpDescription] = {
     '>': IntComparisonOpDescription(ComparisonOp.SGT, int_less_than_, False, True),
     '>=': IntComparisonOpDescription(ComparisonOp.SGE, int_less_than_, True, False),
 }
+
+int64_divide_op = custom_op(
+    arg_types=[int64_rprimitive, int64_rprimitive],
+    return_type=int64_rprimitive,
+    c_function_name='CPyInt64_Divide',
+    error_kind=ERR_MAGIC_OVERLAPPING)

--- a/mypyc/primitives/int_ops.py
+++ b/mypyc/primitives/int_ops.py
@@ -12,7 +12,8 @@ from typing import Dict, NamedTuple
 from mypyc.ir.ops import ERR_NEVER, ERR_MAGIC, ERR_MAGIC_OVERLAPPING, ERR_ALWAYS, ComparisonOp
 from mypyc.ir.rtypes import (
     int_rprimitive, bool_rprimitive, float_rprimitive, object_rprimitive,
-    str_rprimitive, bit_rprimitive, int64_rprimitive, int32_rprimitive, void_rtype, RType
+    str_rprimitive, bit_rprimitive, int64_rprimitive, int32_rprimitive, void_rtype, RType,
+    c_pyssize_t_rprimitive
 )
 from mypyc.primitives.registry import (
     load_address_op, unary_op, CFunctionDescription, function_op, binary_op, custom_op
@@ -197,10 +198,16 @@ int_to_int64_op = custom_op(
     c_function_name='CPyLong_AsInt64',
     error_kind=ERR_MAGIC_OVERLAPPING)
 
+ssize_t_to_int_op = custom_op(
+    arg_types=[c_pyssize_t_rprimitive],
+    return_type=int_rprimitive,
+    c_function_name='CPyTagged_FromSsize_t',
+    error_kind=ERR_MAGIC)
+
 int64_to_int_op = custom_op(
     arg_types=[int64_rprimitive],
     return_type=int_rprimitive,
-    c_function_name='CPyTagged_FromSsize_t',
+    c_function_name='CPyTagged_FromInt64',
     error_kind=ERR_MAGIC)
 
 # Convert tagged int (as PyObject *) to i32

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -93,6 +93,16 @@ method_op(
     error_kind=ERR_MAGIC,
     priority=2)
 
+# Version with native int index
+method_op(
+    name='__getitem__',
+    arg_types=[list_rprimitive, int64_rprimitive],
+    return_type=object_rprimitive,
+    c_function_name='CPyList_GetItemInt64Borrow',
+    is_borrowed=True,
+    error_kind=ERR_MAGIC,
+    priority=4)
+
 # This is unsafe because it assumes that the index is a non-negative short integer
 # that is in-bounds for the list.
 list_get_item_unsafe_op = custom_op(

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -91,7 +91,7 @@ method_op(
     return_type=object_rprimitive,
     c_function_name='CPyList_GetItemInt64',
     error_kind=ERR_MAGIC,
-    priority=2)
+    priority=5)
 
 # Version with native int index
 method_op(
@@ -101,7 +101,7 @@ method_op(
     c_function_name='CPyList_GetItemInt64Borrow',
     is_borrowed=True,
     error_kind=ERR_MAGIC,
-    priority=4)
+    priority=6)
 
 # This is unsafe because it assumes that the index is a non-negative short integer
 # that is in-bounds for the list.

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -110,6 +110,15 @@ list_set_item_op = method_op(
     error_kind=ERR_FALSE,
     steals=[False, False, True])
 
+# list[index_i64] = obj
+method_op(
+    name='__setitem__',
+    arg_types=[list_rprimitive, int64_rprimitive, object_rprimitive],
+    return_type=bit_rprimitive,
+    c_function_name='CPyList_SetItemInt64',
+    error_kind=ERR_FALSE,
+    steals=[False, False, True])
+
 # PyList_SET_ITEM does no error checking,
 # and should only be used to fill in brand new lists.
 new_list_set_item_op = custom_op(

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -3,7 +3,7 @@
 from mypyc.ir.ops import ERR_MAGIC, ERR_NEVER, ERR_FALSE
 from mypyc.ir.rtypes import (
     int_rprimitive, short_int_rprimitive, list_rprimitive, object_rprimitive,  c_int_rprimitive,
-    c_pyssize_t_rprimitive, bit_rprimitive
+    c_pyssize_t_rprimitive, bit_rprimitive, int64_rprimitive
 )
 from mypyc.primitives.registry import (
     load_address_op, function_op, binary_op, method_op, custom_op, ERR_NEG_INT
@@ -55,7 +55,7 @@ list_get_item_op = method_op(
     c_function_name='CPyList_GetItem',
     error_kind=ERR_MAGIC)
 
-# list[index] version with no int bounds check for when it is known to be short
+# list[index] version with no int tag check for when it is known to be short
 method_op(
     name='__getitem__',
     arg_types=[list_rprimitive, short_int_rprimitive],
@@ -83,6 +83,15 @@ method_op(
     error_kind=ERR_MAGIC,
     is_borrowed=True,
     priority=4)
+
+# Version with native int index
+method_op(
+    name='__getitem__',
+    arg_types=[list_rprimitive, int64_rprimitive],
+    return_type=object_rprimitive,
+    c_function_name='CPyList_GetItemInt64',
+    error_kind=ERR_MAGIC,
+    priority=2)
 
 # This is unsafe because it assumes that the index is a non-negative short integer
 # that is in-bounds for the list.

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -127,7 +127,8 @@ method_op(
     return_type=bit_rprimitive,
     c_function_name='CPyList_SetItemInt64',
     error_kind=ERR_FALSE,
-    steals=[False, False, True])
+    steals=[False, False, True],
+    priority=2)
 
 # PyList_SET_ITEM does no error checking,
 # and should only be used to fill in brand new lists.


### PR DESCRIPTION
Add various C primitives that will be used to support native ints. 

The primitives aren't used for anything yet. I'll prepare follow-up PRs 
that use the primitives and include tests. I'm splitting these into a 
separate PR to make this easier to review. All of these are tested in 
my local branch, at least to a basic level.

Most of these are fairly straightforward, but we need to jump through
some hoops to make the semantics of // and % operators compatible
with Python semantics when using negative operands.

Work on https://github.com/mypyc/mypyc/issues/837.