### PR TITLE
support propertied decorators

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -846,6 +846,8 @@ class SemanticAnalyzer(NodeVisitor[None],
                         # that.
                         non_overload_indexes.append(i)
                 else:
+                    if item.var.is_property:
+                        self.fail("Decorated property not supported", item)
                     item.func.is_overload = True
                     types.append(callable)
             elif isinstance(item, FuncDef):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -957,7 +957,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         deleted_items = []
         for i, item in enumerate(items[1:]):
             if isinstance(item, Decorator):
-                if len(item.decorators) == 1:
+                if len(item.decorators) >= 1:
                     node = item.decorators[0]
                     if isinstance(node, MemberExpr):
                         if node.name == 'setter':
@@ -965,8 +965,8 @@ class SemanticAnalyzer(NodeVisitor[None],
                             first_item.var.is_settable_property = True
                             # Get abstractness from the original definition.
                             item.func.is_abstract = first_item.func.is_abstract
-                else:
-                    self.fail("Decorated property not supported", item)
+                    else:
+                        self.fail("Decorated property not supported", item)
                 item.func.accept(self)
             else:
                 self.fail(f'Unexpected definition for property "{first_item.func.name}"',

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1231,7 +1231,7 @@ from typing import overload
 class A:
     @overload  # E: An overloaded function outside a stub file must have an implementation
     def f(self) -> int: pass
-    @property  # E: Decorated property not supported
+    @property
     @overload
     def f(self) -> int: pass
 [builtins fixtures/property.pyi]
@@ -1244,7 +1244,7 @@ class A:
     @dec  # E: Decorated property not supported
     @property
     def f(self) -> int: pass
-    @property  # E: Decorated property not supported
+    @property
     @dec
     def g(self) -> int: pass
 [builtins fixtures/property.pyi]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1231,7 +1231,7 @@ from typing import overload
 class A:
     @overload  # E: An overloaded function outside a stub file must have an implementation
     def f(self) -> int: pass
-    @property
+    @property  # E: Decorated property not supported
     @overload
     def f(self) -> int: pass
 [builtins fixtures/property.pyi]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1250,6 +1250,22 @@ class A:
 [builtins fixtures/property.pyi]
 [out]
 
+[case testDecoratedPropertySetter]
+import typing
+def dec(f): pass
+class A:
+    @property
+    @dec
+    def f(self) -> int: pass
+    @f.setter
+    @dec
+    def f(self, v: int) -> None: pass
+    @dec # E: Decorated property not supported
+    @f.setter
+    def f(self, v: int) -> None: pass
+[builtins fixtures/property.pyi]
+[out]
+
 [case testImportTwoModulesWithSameNameInFunction]
 import typing
 def f() -> None:


### PR DESCRIPTION
### Description
Fixes #1362 (well not really it fixes propertied decorator support not decorated properties)

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

test case is here, but I don't know how best to integrate it in CI:

```python
from collections.abc import Callable
from typing import ParamSpec, TypeVar

P = ParamSpec("P")
T = TypeVar("T")

import functools

def some_decorator(f: Callable[P, int]) -> Callable[P, str]:
    @functools.wraps(f)
    def decorator(*args: P.args, **kwargs: P.kwargs) -> str:
        return f"{f(*args, **kwargs)}"
        
    return decorator
    
    
def some_decorator2(p: property) -> property:
    return p

class Foo:
    
    # this is a propertied decorator and fairly normal
    @property  # type: ignore[misc]
    @some_decorator
    def foo(self) -> int:
        pass
    

    # this is a decorated property and an unusual construct 
    @some_decorator2
    @property
    def bar(self) -> int:
        pass
    
    
f = Foo()
reveal_type(f.foo)
```
