### PR TITLE
[mypyc] Fix `setup` conflict when setting an attribute with name `up`

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -345,11 +345,11 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
 
 
 def getter_name(cl: ClassIR, attribute: str, names: NameGenerator) -> str:
-    return names.private_name(cl.module_name, f'{cl.name}_get{attribute}')
+    return names.private_name(cl.module_name, f'{cl.name}_get_{attribute}')
 
 
 def setter_name(cl: ClassIR, attribute: str, names: NameGenerator) -> str:
-    return names.private_name(cl.module_name, f'{cl.name}_set{attribute}')
+    return names.private_name(cl.module_name, f'{cl.name}_set_{attribute}')
 
 
 def generate_object_struct(cl: ClassIR, emitter: Emitter) -> None:

--- a/mypyc/test/test_emitclass.py
+++ b/mypyc/test/test_emitclass.py
@@ -1,6 +1,8 @@
 import unittest
 
-from mypyc.codegen.emitclass import slot_key
+from mypyc.codegen.emitclass import getter_name, setter_name, slot_key
+from mypyc.ir.class_ir import ClassIR
+from mypyc.namegen import NameGenerator
 
 
 class TestEmitClass(unittest.TestCase):
@@ -10,3 +12,16 @@ class TestEmitClass(unittest.TestCase):
         # __delitem__ and reverse methods should come last.
         assert s == [
             '__add__', '__rshift__', '__setitem__', '__delitem__', '__radd__', '__rrshift__']
+
+    def test_setter_name(self) -> None:
+        cls = ClassIR(module_name="testing", name="SomeClass")
+        generator = NameGenerator([['mod']])
+
+        # This should never be `setup`, as it will conflict with the class `setup`
+        assert setter_name(cls, "up", generator) == "testing___SomeClass_set_up"
+
+    def test_getter_name(self) -> None:
+        cls = ClassIR(module_name="testing", name="SomeClass")
+        generator = NameGenerator([['mod']])
+
+        assert getter_name(cls, "down", generator) == "testing___SomeClass_get_down"


### PR DESCRIPTION
### Description

Fixes https://github.com/mypyc/mypyc/issues/933 by preventing the conflicting `set(up)` name. `getter_name` has also been changed for consistency sake.

## Test Plan

Test cases added to `test_emitclass.py`