### PR TITLE
Replace hard crash with typecheck error when subclass method has the same name as type alias

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1600,7 +1600,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     else:
                         original_type = NoneType()
                 else:
-                    assert False, str(base_attr.node)
+                    # Will always fail to typecheck below, since we know the node is a method
+                    original_type = NoneType()
             if isinstance(original_node, (FuncDef, OverloadedFuncDef)):
                 original_class_or_static = original_node.is_class or original_node.is_static
             elif isinstance(original_node, Decorator):

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7300,3 +7300,31 @@ def identity_wrapper(func: FuncT) -> FuncT:
 def foo(self: Any) -> str:
     return ""
 
+[case testParentClassWithTypeAliasAndSubclassWithMethod]
+from typing import Any, Callable, TypeVar
+
+class Parent:
+    foo = Callable[..., int] 
+    class bar:
+        pass
+    import typing as baz
+    foobar = TypeVar("foobar")
+
+class Child(Parent):
+    def foo(self, val: int) -> int:  # E: Signature of "foo" incompatible with supertype "Parent"
+        return val
+    def bar(self, val: str) -> str:  # E: Signature of "bar" incompatible with supertype "Parent"
+        return val
+    def baz(self, val: float) -> float:  # E: Signature of "baz" incompatible with supertype "Parent"
+        return val
+    def foobar(self) -> bool:  # E: Signature of "foobar" incompatible with supertype "Parent"
+        return False
+
+x: Parent.foo = lambda: 5
+y: Parent.bar = Parent.bar()
+z: Parent.baz.Any = 1
+child = Child()
+a: int = child.foo(1)
+b: str = child.bar("abc")
+c: float = child.baz(3.4)
+d: bool = child.foobar()


### PR DESCRIPTION
### Description

Fixes #5425.

Typechecking for method overrides ended in an `assert False` for any AST nodes other than `FuncDef`, `OverloadedFuncDef`, `Decorator`, and `Var`. This PR replaces this with a typecheck error for any unrecognized AST nodes instead.

## Test Plan

Added a new test case to `check-classes.test` covering the original bug report from the example, as well as some [extra cases that Jukka mentioned](https://github.com/python/mypy/issues/5425#issuecomment-423993232) in the comments.