### PR TITLE
Remove slots already defined in base class

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3091,7 +3091,7 @@ class TypeAlias(SymbolNode):
         within functions that can't be looked up from the symbol table)
     """
     __slots__ = ('target', '_fullname', 'alias_tvars', 'no_args', 'normalized',
-                 'line', 'column', '_is_recursive', 'eager')
+                 '_is_recursive', 'eager')
 
     def __init__(self, target: 'mypy.types.Type', fullname: str, line: int, column: int,
                  *,
@@ -3199,7 +3199,7 @@ class PlaceholderNode(SymbolNode):
     something that can support general recursive types.
     """
 
-    __slots__ = ('_fullname', 'node', 'line', 'becomes_typeinfo')
+    __slots__ = ('_fullname', 'node',  'becomes_typeinfo')
 
     def __init__(self, fullname: str, node: Node, line: int, *,
                  becomes_typeinfo: bool = False) -> None:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3199,7 +3199,7 @@ class PlaceholderNode(SymbolNode):
     something that can support general recursive types.
     """
 
-    __slots__ = ('_fullname', 'node',  'becomes_typeinfo')
+    __slots__ = ('_fullname', 'node', 'becomes_typeinfo')
 
     def __init__(self, fullname: str, node: Node, line: int, *,
                  becomes_typeinfo: bool = False) -> None:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -258,7 +258,7 @@ class TypeAliasType(Type):
     can be represented in a tree-like manner.
     """
 
-    __slots__ = ('alias', 'args', 'line', 'column', 'type_ref')
+    __slots__ = ('alias', 'args', 'type_ref')
 
     def __init__(self, alias: Optional[mypy.nodes.TypeAlias], args: List[Type],
                  line: int = -1, column: int = -1) -> None:
@@ -1838,7 +1838,7 @@ class Overloaded(FunctionLike):
     implementation.
     """
 
-    __slots__ = ('_items', 'fallback')
+    __slots__ = ('_items',)
 
     _items: List[CallableType]  # Must not be empty
 


### PR DESCRIPTION
### Description

Remove redefining base class slots.
`nodes.TypeAlias.line` slot is defined in `nodes.Context`
`nodes.TypeAlias.column` slot is defined in `nodes.Context`
`nodes.PlaceholderNode.line` slot is defined in `nodes.Context`
`types.TypeAliasType.line` slot is defined in `nodes.Context`
`types.TypeAliasType.column` slot is defined in `nodes.Context`
`types.Overloaded.fallback` slot is defined in `types.FunctionLike`


## Test Plan
No additional tests required.