### PR TITLE
Support recursive NamedTuple classes

### DIFF
--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -418,7 +418,7 @@ class NamedTupleAnalyzer:
                                   info: TypeInfo,
                                   items: List[str],
                                   types: List[Type],
-                                  default_items: Mapping[str, Expression]):
+                                  default_items: Mapping[str, Expression]) -> None:
         tuple_base = TupleType(types, info.bases[0])
         info.tuple_type = tuple_base
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5677,6 +5677,7 @@ from typing_extensions import TypedDict, TypeAlias
 from enum import Enum
 from dataclasses import dataclass
 
+reveal_type(1) # TODO: why does this prevent an error?
 class C:
     def f(self) -> None:
         class C:
@@ -5709,7 +5710,10 @@ class C:
         n: N = N(NT1(c=1))
 
 [builtins fixtures/dict.pyi]
+[out1]
+tmp/b.py:6: note: Revealed type is "Literal[1]?"
 [out2]
+tmp/b.py:6: note: Revealed type is "Literal[1]?"
 tmp/a.py:2: error: "object" has no attribute "xyz"
 
 [case testIncrementalInvalidNamedTupleInUnannotatedFunction]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -630,13 +630,13 @@ tmp/b.py:7: note: Revealed type is "Tuple[Any, fallback=a.N]"
 
 from typing import NamedTuple
 class MyNamedTuple(NamedTuple):
-    parent: 'MyNamedTuple' # E: Cannot resolve name "MyNamedTuple" (possible cyclic definition)
+    parent: 'MyNamedTuple'
 
 def bar(nt: MyNamedTuple) -> MyNamedTuple:
     return nt
 
 x: MyNamedTuple
-reveal_type(x.parent) # N: Revealed type is "Any"
+reveal_type(x.parent) # N: Revealed type is "__main__.MyNamedTuple"
 [builtins fixtures/tuple.pyi]
 
 -- Some crazy self-referential named tuples and types dicts
@@ -682,14 +682,14 @@ from typing import Tuple, NamedTuple
 
 A = NamedTuple('A', [
         ('x', str),
-        ('y', Tuple['B', ...]), # E: Cannot resolve name "B" (possible cyclic definition)
+        ('y', Tuple['B', ...]),
     ])
 class B(NamedTuple):
     x: A
     y: int
 
 n: A
-reveal_type(n) # N: Revealed type is "Tuple[builtins.str, builtins.tuple[Any, ...], fallback=__main__.A]"
+reveal_type(n) # N: Revealed type is "Tuple[builtins.str, builtins.tuple[__main__.B, ...], fallback=__main__.A]"
 [builtins fixtures/tuple.pyi]
 
 [case testSelfRefNT3]
@@ -697,7 +697,7 @@ reveal_type(n) # N: Revealed type is "Tuple[builtins.str, builtins.tuple[Any, ..
 from typing import NamedTuple, Tuple
 
 class B(NamedTuple):
-    x: Tuple[A, int] # E: Cannot resolve name "A" (possible cyclic definition)
+    x: Tuple[A, int]
     y: int
 
 A = NamedTuple('A', [
@@ -706,10 +706,10 @@ A = NamedTuple('A', [
     ])
 n: B
 m: A
-reveal_type(n.x) # N: Revealed type is "Tuple[Any, builtins.int]"
+reveal_type(n.x) # N: Revealed type is "Tuple[Tuple[builtins.str, __main__.B, fallback=__main__.A], builtins.int]"
 reveal_type(m[0]) # N: Revealed type is "builtins.str"
 lst = [m, n]
-reveal_type(lst[0]) # N: Revealed type is "Tuple[builtins.object, builtins.object]"
+reveal_type(lst[0]) # N: Revealed type is "builtins.tuple[builtins.object, ...]"
 [builtins fixtures/tuple.pyi]
 
 [case testSelfRefNT4]
@@ -717,7 +717,7 @@ reveal_type(lst[0]) # N: Revealed type is "Tuple[builtins.object, builtins.objec
 from typing import NamedTuple
 
 class B(NamedTuple):
-    x: A # E: Cannot resolve name "A" (possible cyclic definition)
+    x: A
     y: int
 
 class A(NamedTuple):
@@ -725,7 +725,7 @@ class A(NamedTuple):
     y: B
 
 n: A
-reveal_type(n.y[0]) # N: Revealed type is "Any"
+reveal_type(n.y[0]) # N: Revealed type is "builtins.object"
 [builtins fixtures/tuple.pyi]
 
 [case testSelfRefNT5]
@@ -795,13 +795,13 @@ tp = NamedTuple('tp', [('x', int)])
 from typing import List, NamedTuple
 
 class Command(NamedTuple):
-    subcommands: List['Command'] # E: Cannot resolve name "Command" (possible cyclic definition)
+    subcommands: List['Command']
 
 class HelpCommand(Command):
     pass
 
 hc = HelpCommand(subcommands=[])
-reveal_type(hc)  # N: Revealed type is "Tuple[builtins.list[Any], fallback=__main__.HelpCommand]"
+reveal_type(hc)  # N: Revealed type is "Tuple[builtins.list[__main__.Command], fallback=__main__.HelpCommand]"
 [builtins fixtures/list.pyi]
 [out]
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -879,7 +879,7 @@ class Out(NamedTuple):
     x: In
     y: Other
 
-reveal_type(o)  # N: Revealed type is "Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]"
+reveal_type(o)  # N: Revealed type is "__main__.Out"
 reveal_type(o.x)  # N: Revealed type is "Tuple[builtins.str, __main__.Other, fallback=__main__.In]"
 reveal_type(o.y)  # N: Revealed type is "__main__.Other"
 reveal_type(o.x.t)  # N: Revealed type is "__main__.Other"
@@ -916,7 +916,7 @@ from typing import NamedTuple
 o: C.Out
 i: C.In
 
-reveal_type(o)  # N: Revealed type is "Tuple[Tuple[builtins.str, __main__.C.Other, fallback=__main__.C.In], __main__.C.Other, fallback=__main__.C.Out]"
+reveal_type(o)  # N: Revealed type is "__main__.C.Out"
 reveal_type(o.x)  # N: Revealed type is "Tuple[builtins.str, __main__.C.Other, fallback=__main__.C.In]"
 reveal_type(o.y)  # N: Revealed type is "__main__.C.Other"
 reveal_type(o.x.t)  # N: Revealed type is "__main__.C.Other"
@@ -951,9 +951,9 @@ class C:
 from typing import NamedTuple
 
 c = C()
-reveal_type(c.o)  # N: Revealed type is "Tuple[Tuple[builtins.str, __main__.Other@18, fallback=__main__.C.In@15], __main__.Other@18, fallback=__main__.C.Out@11]"
-reveal_type(c.o.x)  # N: Revealed type is "Tuple[builtins.str, __main__.Other@18, fallback=__main__.C.In@15]"
-reveal_type(c.o.method())  # N: Revealed type is "Tuple[builtins.str, __main__.Other@18, fallback=__main__.C.In@15]"
+reveal_type(c.o)  # N: Revealed type is "Tuple[Tuple[builtins.str, __main__.Other@18, fallback=__main__.In@15], __main__.Other@18, fallback=__main__.Out@11]"
+reveal_type(c.o.x)  # N: Revealed type is "Tuple[builtins.str, __main__.Other@18, fallback=__main__.In@15]"
+reveal_type(c.o.method())  # N: Revealed type is "Tuple[builtins.str, __main__.Other@18, fallback=__main__.In@15]"
 
 class C:
     def get_tuple(self) -> None:


### PR DESCRIPTION
### Description

Recursive named tuple classes like this now pass:
```python
from __future__ import annotations
from typing import NamedTuple

class Node(NamedTuple):
    parent: Node | None
```
(Instead of causing a `Cannot resolve name "MyNamedTuple" (possible cyclic definition)` error.)

This is done by letting `mypy.semanal_namedtuple.analyze_namedtuple_classdef` complete recursive type references in a subsequent pass.

Fixes #9397.

## Test Plan

Tests are updated to reflect this new support. (I did not add my own use case above since the existing tests already cover this feature which previously caused the error (along with many more special cases).)

## Questions

I believe this change is good, but it raises some questions.

1. The now conditional call to `add_symbol`  in `mypy.semanal.prepare_class_def` does add to the somewhat complex situation already in there, regarding func scope nesting. I tried to make the logic clear, but would you prefer me to attempt to improve it further?

   (I did note the already present `TODO` in there. It seems hard to get at the clarity without untangling that, which I think is a separate task. I initially added a flag to avoid the double check, which I can't say made it more understandable, but rather indicated the already noted need for a refactoring.)

3. Related but distinct, an odd error cropped up in `check-incremental.test::testIncrementalWithDifferentKindsOfNestedTypesWithinMethod` which made `lookup_fully_qualified` throw an error:

       E   AssertionError: Cannot find component 'NT1@11' for 'b.NT1@11'

   Somehow this is prevented by a call to `reveal_type` (regardless of value). Did I stumble upon a separate issue, or is there an obvious mistake in this change?

4. In `check-namedtuple.test::testSelfRefNT4` it is shown that `reveal_type` for an item-accessed named tuple value now returns `builtins.object` instead of `Any`. While it is beyond the scope of this PR to fix type-inference for named tuple item access in general, would you consider the resulting semantics a regression or an improvement?

5. I used a `for ... else` in `analyze_namedtuple_classdef` since (IMHO) it's a good fit and made things clearer. But if you're adverse to that language feature I can change it (and if so reasonably also advice against it in the coding conventions).
