### PR TITLE
Optimization: "visit_UnaryOp"

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1255,8 +1255,7 @@ class ASTConverter:
             op = '+'
         elif isinstance(n.op, ast3.USub):
             op = '-'
-
-        if op is None:
+        else:
             raise RuntimeError('cannot translate UnaryOp ' + str(type(n.op)))
 
         e = UnaryExpr(op, self.visit(n.operand))

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -844,8 +844,7 @@ class ASTConverter:
             op = '+'
         elif isinstance(n.op, ast27.USub):
             op = '-'
-
-        if op is None:
+        else:
             raise RuntimeError('cannot translate UnaryOp ' + str(type(n.op)))
 
         e = UnaryExpr(op, self.visit(n.operand))


### PR DESCRIPTION
The function "visit_UnaryOp" in files "fastparse.py" and "fastparse2.py" contains a superfluous condition.