### PR TITLE
Nitpicky change - remove duplicate word

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -205,7 +205,7 @@ will continue to be of type ``Any``.
 1.  To suppress a *single* missing import error, add a ``# type: ignore`` at the end of the
     line containing the import.
 
-2.  To suppress *all* missing import imports errors from a single library, add
+2.  To suppress *all* missing import errors from a single library, add
     a section to your :ref:`mypy config file <config-file>` for that library setting
     :confval:`ignore_missing_imports` to True. For example, suppose your codebase
     makes heavy use of an (untyped) library named ``foobar``. You can silence


### PR DESCRIPTION
### Description

This PR does not change mypy. It doesn't even change the documentation in a meaningful way. It makes a nitpicky change by removing what looks like a duplicate word in the docs.

## Test Plan

Nothing meaningful to test here apart from looking at the diff.