### PR TITLE
Allow passing arguments to stubgen.main

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1704,14 +1704,14 @@ def parse_options(args: List[str]) -> Options:
                    export_less=ns.export_less)
 
 
-def main() -> None:
+def main(args: Optional[List[str]] = None) -> None:
     mypy.util.check_python_version('stubgen')
     # Make sure that the current directory is in sys.path so that
     # stubgen can be run on packages in the current directory.
     if not ('' in sys.path or '.' in sys.path):
         sys.path.insert(0, '')
 
-    options = parse_options(sys.argv[1:])
+    options = parse_options(sys.argv[1:] if args is None else args)
     generate_stubs(options)
 
 


### PR DESCRIPTION
Modify signature of `stubgen.main` to accept a user-provided list of arguments. This allows users to supply their own argument list without monkeying about with `sys.argv`, which improves the usefulness of embedding `stubgen` into other projects.