### PR TITLE
Use Python 3.7 as default in tests, drop 3.6 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"
         - name: mypyc runtime tests with py37-debug-build-ubuntu
-          python: '3.7'
+          python: '3.7.13'
           arch: x64
           os: ubuntu-latest
           toxenv: py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,27 +31,27 @@ jobs:
           arch: x64
           os: windows-latest
           toxenv: py37
-        - name: Test suite with py37-ubuntu
-          python: '3.7'
-          arch: x64
-          os: ubuntu-latest
-          toxenv: py
-          tox_extra_args: "-n 2"
         - name: Test suite with py38-ubuntu
           python: '3.8'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
-        - name: Test suite with py36-ubuntu, mypyc-compiled
-          python: '3.6'
+        - name: Test suite with py39-ubuntu
+          python: '3.9'
+          arch: x64
+          os: ubuntu-latest
+          toxenv: py
+          tox_extra_args: "-n 2"
+        - name: Test suite with py37-ubuntu, mypyc-compiled
+          python: '3.7'
           arch: x64
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
           test_mypyc: true
-        - name: Test suite with py39-ubuntu, mypyc-compiled
-          python: '3.9'
+        - name: Test suite with py310-ubuntu, mypyc-compiled
+          python: '3.10'
           arch: x64
           os: ubuntu-latest
           toxenv: py
@@ -63,17 +63,17 @@ jobs:
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
-        - name: mypyc runtime tests with py36-macos
-          python: '3.6'
+        - name: mypyc runtime tests with py37-macos
+          python: '3.7'
           arch: x64
           os: macos-latest
           toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"
-        - name: mypyc runtime tests with py36-debug-build-ubuntu
-          python: '3.6.8'
+        - name: mypyc runtime tests with py37-debug-build-ubuntu
+          python: '3.7'
           arch: x64
           os: ubuntu-latest
-          toxenv: py36
+          toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"
           debug_build: true
         - name: Type check our own code (py37-ubuntu)

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -3,8 +3,16 @@ import os
 from typing_extensions import Final
 
 PYTHON2_VERSION: Final = (2, 7)
+
+# Earliest fully supported Python 3.x version. Used as the default Python
+# version in tests. Mypy wheels should be built starting with this version,
+# and CI tests should be run on this version (and later versions).
 PYTHON3_VERSION: Final = (3, 7)
+
+# Earliest Python 3.x version supported via --python-version 3.x. To run
+# mypy, at least version PYTHON3_VERSION is needed.
 PYTHON3_VERSION_MIN: Final = (3, 4)
+
 CACHE_DIR: Final = ".mypy_cache"
 CONFIG_FILE: Final = ["mypy.ini", ".mypy.ini"]
 PYPROJECT_CONFIG_FILES: Final = [

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -3,7 +3,7 @@ import os
 from typing_extensions import Final
 
 PYTHON2_VERSION: Final = (2, 7)
-PYTHON3_VERSION: Final = (3, 6)
+PYTHON3_VERSION: Final = (3, 7)
 PYTHON3_VERSION_MIN: Final = (3, 4)
 CACHE_DIR: Final = ".mypy_cache"
 CONFIG_FILE: Final = ["mypy.ini", ".mypy.ini"]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3744,7 +3744,7 @@ import b
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
 -- the proto deps file with something with mtime mismatches.
-[file ../.mypy_cache/3.6/@deps.meta.json.2]
+[file ../.mypy_cache/3.7/@deps.meta.json.2]
 {"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@root": {"path": "@root.deps.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
 [file ../.mypy_cache/.gitignore]
 # Another hack to not trigger a .gitignore creation failure "false positive"
@@ -3779,7 +3779,7 @@ import b
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by deleting
 -- the proto deps file.
-[delete ../.mypy_cache/3.6/@deps.meta.json.2]
+[delete ../.mypy_cache/3.7/@deps.meta.json.2]
 [file b.py.2]
 # uh
 -- Every file should get reloaded, since the cache was invalidated

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -202,7 +202,7 @@ a.py:8: note:     x: expected "int", got "str"
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
 -- the proto deps file with something with mtime mismatches.
-[file ../.mypy_cache/3.6/@deps.meta.json.2]
+[file ../.mypy_cache/3.7/@deps.meta.json.2]
 {"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@root": {"path": "@root.deps.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
 
 [file b.py.2]
@@ -234,8 +234,8 @@ x = 10
 [file p/c.py]
 class C: pass
 
-[delete ../.mypy_cache/3.6/b.meta.json.2]
-[delete ../.mypy_cache/3.6/p/c.meta.json.2]
+[delete ../.mypy_cache/3.7/b.meta.json.2]
+[delete ../.mypy_cache/3.7/p/c.meta.json.2]
 
 [out]
 ==

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2198,11 +2198,11 @@ import waitress
 [file a.py.3]
 import requests
 [out]
-a.py:1: error: Library stubs not installed for "waitress" (or incompatible with Python 3.6)
+a.py:1: error: Library stubs not installed for "waitress" (or incompatible with Python 3.7)
 a.py:1: note: Hint: "python3 -m pip install types-waitress"
 a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
 ==
-a.py:1: error: Library stubs not installed for "requests" (or incompatible with Python 3.6)
+a.py:1: error: Library stubs not installed for "requests" (or incompatible with Python 3.7)
 a.py:1: note: Hint: "python3 -m pip install types-requests"
 a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1553,7 +1553,7 @@ from scribe import x
 import maxminddb  # Python 3 stubs available for maxminddb
 import foobar_asdf
 [out]
-_testIgnoreImportIfNoPython3StubAvailable.py:4: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.6)
+_testIgnoreImportIfNoPython3StubAvailable.py:4: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.7)
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: Hint: "python3 -m pip install types-maxminddb"
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: (or run "mypy --install-types" to install all missing stub packages)
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
@@ -1565,7 +1565,7 @@ import maxminddb
 [out]
 _testNoPython3StubAvailable.py:1: error: Cannot find implementation or library stub for module named "scribe"
 _testNoPython3StubAvailable.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-_testNoPython3StubAvailable.py:3: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.6)
+_testNoPython3StubAvailable.py:3: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.7)
 _testNoPython3StubAvailable.py:3: note: Hint: "python3 -m pip install types-maxminddb"
 _testNoPython3StubAvailable.py:3: note: (or run "mypy --install-types" to install all missing stub packages)
 


### PR DESCRIPTION
This is work on dropping support for Python 3.6. 

Typeshed already dropped 3.6 support: https://github.com/python/typeshed/pull/8269

DO NOT MERGE YET! Let's wait until 0.970 is out.