### PR TITLE
Increase get_package_properties timeout

### DIFF
--- a/mypy/moduleinspect.py
+++ b/mypy/moduleinspect.py
@@ -157,7 +157,7 @@ class ModuleInspect:
 
         Return the value read from the queue, or None if the process unexpectedly died.
         """
-        max_iter = 100
+        max_iter = 600
         n = 0
         while True:
             if n == max_iter:


### PR DESCRIPTION
### Description

Some packages may take a very long time to import, which can spuriously trip the timeout in `ModuleInspect`. To make this less likely, increase the timeout from 5s to 30s.

## Test Plan

I could use some help with how to write an appropriate test, as it doesn't seem to obviously match any existing tests (somewhat pep561.test though it's unclear how that handles the test package). I think the general idea is to write a test that simply tries to inspect a test package whose `__init__.py` looks like:
```python
import time
time.sleep(7)
```

This works to reproduce the failure by attempting to run `stubgen` on the above.

An example of this failure occurring "in the wild" can be seen [here](https://drake-cdash.csail.mit.edu/test/776657767).