### PR TITLE
protocols.rst: fix documentation

### DIFF
--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -475,7 +475,7 @@ member:
                             # different name and kind in the callback
 
 Callback protocols and :py:data:`~typing.Callable` types can be used interchangeably.
-Keyword argument names in :py:meth:`__call__ <object.__call__>` methods must be identical, unless
+Argument names in :py:meth:`__call__ <object.__call__>` methods must be identical, unless
 a double underscore prefix is used. For example:
 
 .. code-block:: python


### PR DESCRIPTION
The documentation is not referring to keyword arguments, but to arguments in general.

Fixes #8805.
