### PR TITLE
update tox, add py38,39,310 remove py35

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,11 @@
 minversion = 3.8.0
 skip_missing_interpreters = true
 envlist =
-    py35,
     py36,
     py37,
+    py38,
+    py39,
+    py310,
     lint,
     type,
     docs,
@@ -36,26 +38,28 @@ commands =
     coverage html -d {toxworkdir}/htmlcov --rcfile setup.cfg
     diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
 depends =
-    py35,
     py36,
     py37,
+    py38,
+    py39,
+    py310,
 parallel_show_output = True
 
 [testenv:lint]
 description = check the code style
-basepython = python3.7
+basepython = python3.10
 commands = flake8 {posargs}
 
 [testenv:type]
 description = type check ourselves
-basepython = python3.7
+basepython = python3.10
 commands =
     python -m mypy --config-file mypy_self_check.ini -p mypy -p mypyc
     python -m mypy --config-file mypy_self_check.ini misc/proper_plugin.py
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
-basepython = python3.7
+basepython = python3.10
 deps = -rdocs/requirements-docs.txt
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -W -bhtml {posargs}


### PR DESCRIPTION
### Description

This PR removes the py35 test environment from tox and adds py38, 39 and 310 environments.
It also sets the basepython required for the following env below to 3.10

- [testenv:lint]
- [testenv:type]
- [testenv:docs]

