### PR TITLE
[mypyc] flush keepalives on operator assignment statements

### DIFF
--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -136,6 +136,7 @@ def transform_operator_assignment_stmt(builder: IRBuilder, stmt: OperatorAssignm
     # usually operator assignments are done in-place
     # but when target doesn't support that we need to manually assign
     builder.assign(target, res, res.line)
+    builder.flush_keep_alives()
 
 
 def transform_import(builder: IRBuilder, node: Import) -> None:

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -595,3 +595,15 @@ class C:
         self.foo.flag = True
         yield
         self.foo.flag = False
+
+[case testGeneratorEarlyReturnWithBorrows]
+from typing import Iterator
+class Bar:
+    bar = 0
+class Foo:
+    bar = Bar()
+    def f(self) -> Iterator[int]:
+        if self:
+            self.bar.bar += 1
+            return
+        yield 0


### PR DESCRIPTION
### Description

This PR makes mypyc flush keepalives on operator assignment statements, to prevent accessing undefined variables in the generated C code.

Fixes mypyc/mypyc#941.

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

- [x] Write a test case
