### PR TITLE
add depth parameter to git clone command

### DIFF
--- a/misc/trigger_wheel_build.sh
+++ b/misc/trigger_wheel_build.sh
@@ -14,7 +14,7 @@ pip install -r mypy-requirements.txt
 V=$(python3 -m mypy --version)
 V=$(echo "$V" | cut -d" " -f2)
 
-git clone https://${WHEELS_PUSH_TOKEN}@github.com/mypyc/mypy_mypyc-wheels.git build
+git clone --depth 1 https://${WHEELS_PUSH_TOKEN}@github.com/mypyc/mypy_mypyc-wheels.git build
 cd build
 echo $COMMIT > mypy_commit
 git commit -am "Build wheels for mypy $V"


### PR DESCRIPTION
### Description

With depth=1 only the last commit is retrieved hence the command takes less time to clone the repository.

Reference
1. https://git-scm.com/docs/git-clone

