### PR TITLE
error message: move star prefix to Argument

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -522,10 +522,6 @@ class MessageBuilder:
                 expected_type = callee.arg_types[-1]
             arg_type_str, expected_type_str = format_type_distinctly(
                 arg_type, expected_type, bare=True)
-            if arg_kind == ARG_STAR:
-                arg_type_str = '*' + arg_type_str
-            elif arg_kind == ARG_STAR2:
-                arg_type_str = '**' + arg_type_str
 
             # For function calls with keyword arguments, display the argument name rather than the
             # number.
@@ -551,8 +547,15 @@ class MessageBuilder:
                     outer_context.index.value, quote_type_string(arg_type_str),
                     quote_type_string(expected_type_str))
             else:
-                msg = 'Argument {} {}has incompatible type {}; expected {}'.format(
-                    arg_label, target, quote_type_string(arg_type_str),
+                if arg_kind == ARG_STAR:
+                    star_prefix = "*"
+                elif arg_kind == ARG_STAR2:
+                    star_prefix = "**"
+                else:
+                    star_prefix = ""
+
+                msg = '{}Argument {} {}has incompatible type {}; expected {}'.format(
+                    star_prefix, arg_label, target, quote_type_string(arg_type_str),
                     quote_type_string(expected_type_str))
             object_type = get_proper_type(object_type)
             if isinstance(object_type, TypedDictType):

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -70,9 +70,9 @@ def f(*x: int) -> None: pass
 def g(**x: int) -> None: pass
 
 a = ['']
-f(*a)  # E:4: Argument 1 to "f" has incompatible type "*List[str]"; expected "int"
+f(*a)  # E:4: *Argument 1 to "f" has incompatible type "List[str]"; expected "int"
 b = {'x': 'y'}
-g(**b) # E:5: Argument 1 to "g" has incompatible type "**Dict[str, str]"; expected "int"
+g(**b) # E:5: **Argument 1 to "g" has incompatible type "Dict[str, str]"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testColumnsMultipleStatementsPerLine]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1704,7 +1704,7 @@ kw2 = {'x': ''}
 d2 = dict(it, **kw2)
 d2() # E: "Dict[str, object]" not callable
 
-d3 = dict(it, **kw2) # type: Dict[str, int] # E: Argument 2 to "dict" has incompatible type "**Dict[str, str]"; expected "int"
+d3 = dict(it, **kw2) # type: Dict[str, int] # E: **Argument 2 to "dict" has incompatible type "Dict[str, str]"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testDictFromIterableAndStarStarArgs2]

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -988,7 +988,7 @@ func_with_kwargs(**x1)
 main:12: note: Revealed type is "typing.Iterator[builtins.int]"
 main:13: note: Revealed type is "builtins.dict[builtins.int, builtins.str]"
 main:14: error: Keywords must be strings
-main:14: error: Argument 1 to "func_with_kwargs" has incompatible type "**X1[str, int]"; expected "int"
+main:14: error: **Argument 1 to "func_with_kwargs" has incompatible type "X1[str, int]"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testSubtypingMappingUnpacking3]

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -299,9 +299,9 @@ d = None # type: Dict[str, A]
 f(**d)
 f(x=A(), **d)
 d2 = None # type: Dict[str, B]
-f(**d2)         # E: Argument 1 to "f" has incompatible type "**Dict[str, B]"; expected "A"
-f(x=A(), **d2)  # E: Argument 2 to "f" has incompatible type "**Dict[str, B]"; expected "A"
-f(**{'x': B()}) # E: Argument 1 to "f" has incompatible type "**Dict[str, B]"; expected "A"
+f(**d2)         # E: **Argument 1 to "f" has incompatible type "Dict[str, B]"; expected "A"
+f(x=A(), **d2)  # E: **Argument 2 to "f" has incompatible type "Dict[str, B]"; expected "A"
+f(**{'x': B()}) # E: **Argument 1 to "f" has incompatible type "Dict[str, B]"; expected "A"
 class A: pass
 class B: pass
 [builtins fixtures/dict.pyi]
@@ -367,7 +367,7 @@ def f(a: 'A', b: 'B') -> None: pass
 d = None # type: Dict[str, Any]
 f(**d)
 d2 = None # type: Dict[str, A]
-f(**d2) # E: Argument 1 to "f" has incompatible type "**Dict[str, A]"; expected "B"
+f(**d2) # E: **Argument 1 to "f" has incompatible type "Dict[str, A]"; expected "B"
 class A: pass
 class B: pass
 [builtins fixtures/dict.pyi]
@@ -436,7 +436,7 @@ def f(a: int) -> None:
     pass
 
 s = ('',)
-f(*s) # E: Argument 1 to "f" has incompatible type "*Tuple[str]"; expected "int"
+f(*s) # E: *Argument 1 to "f" has incompatible type "Tuple[str]"; expected "int"
 
 a = {'': 0}
 f(a) # E: Argument 1 to "f" has incompatible type "Dict[str, int]"; expected "int"
@@ -444,7 +444,7 @@ f(**a) # okay
 
 b = {'': ''}
 f(b) # E: Argument 1 to "f" has incompatible type "Dict[str, str]"; expected "int"
-f(**b) # E: Argument 1 to "f" has incompatible type "**Dict[str, str]"; expected "int"
+f(**b) # E: **Argument 1 to "f" has incompatible type "Dict[str, str]"; expected "int"
 
 c = {0: 0}
 f(**c) # E: Keywords must be strings
@@ -489,11 +489,11 @@ def g(arg: int = 0, **kwargs: object) -> None:
 
 d = {} # type: Dict[str, object]
 f(**d)
-g(**d)  # E: Argument 1 to "g" has incompatible type "**Dict[str, object]"; expected "int"
+g(**d)  # E: **Argument 1 to "g" has incompatible type "Dict[str, object]"; expected "int"
 
 m = {} # type: Mapping[str, object]
 f(**m)
-g(**m)  # E: Argument 1 to "g" has incompatible type "**Mapping[str, object]"; expected "int"
+g(**m)  # E: **Argument 1 to "g" has incompatible type "Mapping[str, object]"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testPassingEmptyDictWithStars]
@@ -551,9 +551,9 @@ foo(**good1)
 foo(**good2)
 foo(**good3)
 [out]
-main:29: error: Argument 1 to "foo" has incompatible type "**A[str, str]"; expected "float"
-main:30: error: Argument 1 to "foo" has incompatible type "**B[str, str]"; expected "float"
+main:29: error: **Argument 1 to "foo" has incompatible type "A[str, str]"; expected "float"
+main:30: error: **Argument 1 to "foo" has incompatible type "B[str, str]"; expected "float"
 main:31: error: Argument after ** must be a mapping, not "C[str, float]"
 main:32: error: Argument after ** must be a mapping, not "D"
-main:33: error: Argument 1 to "foo" has incompatible type "**Dict[str, str]"; expected "float"
+main:33: error: **Argument 1 to "foo" has incompatible type "Dict[str, str]"; expected "float"
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -367,17 +367,17 @@ P2 = ParamSpec('P2')
 class C(Generic[P, P2]):
     def m1(self, *args: P.args, **kwargs: P.kwargs) -> None:
         self.m1(*args, **kwargs)
-        self.m2(*args, **kwargs)  # E: Argument 1 to "m2" of "C" has incompatible type "*P.args"; expected "P2.args" \
-            # E: Argument 2 to "m2" of "C" has incompatible type "**P.kwargs"; expected "P2.kwargs"
-        self.m1(*kwargs, **args)  # E: Argument 1 to "m1" of "C" has incompatible type "*P.kwargs"; expected "P.args" \
-            # E: Argument 2 to "m1" of "C" has incompatible type "**P.args"; expected "P.kwargs"
-        self.m3(*args, **kwargs)  # E: Argument 1 to "m3" of "C" has incompatible type "*P.args"; expected "int" \
-            # E: Argument 2 to "m3" of "C" has incompatible type "**P.kwargs"; expected "int"
-        self.m4(*args, **kwargs)  # E: Argument 1 to "m4" of "C" has incompatible type "*P.args"; expected "int" \
-            # E: Argument 2 to "m4" of "C" has incompatible type "**P.kwargs"; expected "int"
+        self.m2(*args, **kwargs)  # E: *Argument 1 to "m2" of "C" has incompatible type "P.args"; expected "P2.args" \
+            # E: **Argument 2 to "m2" of "C" has incompatible type "P.kwargs"; expected "P2.kwargs"
+        self.m1(*kwargs, **args)  # E: *Argument 1 to "m1" of "C" has incompatible type "P.kwargs"; expected "P.args" \
+            # E: **Argument 2 to "m1" of "C" has incompatible type "P.args"; expected "P.kwargs"
+        self.m3(*args, **kwargs)  # E: *Argument 1 to "m3" of "C" has incompatible type "P.args"; expected "int" \
+            # E: **Argument 2 to "m3" of "C" has incompatible type "P.kwargs"; expected "int"
+        self.m4(*args, **kwargs)  # E: *Argument 1 to "m4" of "C" has incompatible type "P.args"; expected "int" \
+            # E: **Argument 2 to "m4" of "C" has incompatible type "P.kwargs"; expected "int"
 
-        self.m1(*args, **args)  # E: Argument 2 to "m1" of "C" has incompatible type "**P.args"; expected "P.kwargs"
-        self.m1(*kwargs, **kwargs)  # E: Argument 1 to "m1" of "C" has incompatible type "*P.kwargs"; expected "P.args"
+        self.m1(*args, **args)  # E: **Argument 2 to "m1" of "C" has incompatible type "P.args"; expected "P.kwargs"
+        self.m1(*kwargs, **kwargs)  # E: *Argument 1 to "m1" of "C" has incompatible type "P.kwargs"; expected "P.args"
 
     def m2(self, *args: P2.args, **kwargs: P2.kwargs) -> None:
         pass

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1551,8 +1551,8 @@ def f6(x: int, z: str) -> None: pass
 
 a: A
 f1(**a)
-f2(**a) # E: Argument "y" to "f2" has incompatible type "str"; expected "int"
-f3(**a) # E: Argument "x" to "f3" has incompatible type "int"; expected "B"
+f2(**a) # E: **Argument "y" to "f2" has incompatible type "str"; expected "int"
+f3(**a) # E: **Argument "x" to "f3" has incompatible type "int"; expected "B"
 f4(**a) # E: Extra argument "y" from **args for "f4"
 f5(**a) # E: Missing positional arguments "y", "z" in call to "f5"
 f6(**a) # E: Extra argument "y" from **args for "f6"
@@ -1583,13 +1583,13 @@ def g(x: int, **kwargs: str) -> None: ...
 
 a: A
 b: B
-f(**a) # E: Argument 1 to "f" has incompatible type "**A"; expected "str"
+f(**a) # E: **Argument 1 to "f" has incompatible type "A"; expected "str"
 f(**b)
 g(**a)
-g(**b) # E: Argument "x" to "g" has incompatible type "str"; expected "int"
+g(**b) # E: **Argument "x" to "g" has incompatible type "str"; expected "int"
 g(1, **a) # E: "g" gets multiple values for keyword argument "x"
 g(1, **b) # E: "g" gets multiple values for keyword argument "x" \
-          # E: Argument "x" to "g" has incompatible type "str"; expected "int"
+          # E: **Argument "x" to "g" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
 
 [case testTypedDictAsStarStarTwice]
@@ -1608,13 +1608,13 @@ b: B
 c: C
 f1(**a, **b)
 f1(**b, **a)
-f2(**a, **b) # E: Argument "y" to "f2" has incompatible type "str"; expected "float"
-f3(**a, **b) # E: Argument "z" to "f3" has incompatible type "bytes"; expected "float"
-f3(**b, **a) # E: Argument "z" to "f3" has incompatible type "bytes"; expected "float"
+f2(**a, **b) # E: **Argument "y" to "f2" has incompatible type "str"; expected "float"
+f3(**a, **b) # E: **Argument "z" to "f3" has incompatible type "bytes"; expected "float"
+f3(**b, **a) # E: **Argument "z" to "f3" has incompatible type "bytes"; expected "float"
 f1(**a, **c) # E: "f1" gets multiple values for keyword argument "x" \
-             # E: Argument "x" to "f1" has incompatible type "str"; expected "int"
+             # E: **Argument "x" to "f1" has incompatible type "str"; expected "int"
 f1(**c, **a) # E: "f1" gets multiple values for keyword argument "x" \
-             # E: Argument "x" to "f1" has incompatible type "str"; expected "int"
+             # E: **Argument "x" to "f1" has incompatible type "str"; expected "int"
 [builtins fixtures/tuple.pyi]
 
 [case testTypedDictAsStarStarAndDictAsStarStar]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -109,7 +109,7 @@ it1 = None  # type: Iterable[int]
 it2 = None  # type: Iterable[str]
 def f(*x: int) -> None: pass
 f(*it1)
-f(*it2) # E: Argument 1 to "f" has incompatible type "*Iterable[str]"; expected "int"
+f(*it2) # E: *Argument 1 to "f" has incompatible type "Iterable[str]"; expected "int"
 [builtins fixtures/for.pyi]
 
 [case testCallVarargsFunctionWithTwoTupleStarArgs]
@@ -143,7 +143,7 @@ it1 = (1, 2)
 it2 = ('',)
 f(*it1, 1, 2)
 f(*it1, 1, *it1, 2)
-f(*it1, 1, *it2, 2)  # E: Argument 3 to "f" has incompatible type "*Tuple[str]"; expected "int"
+f(*it1, 1, *it2, 2)  # E: *Argument 3 to "f" has incompatible type "Tuple[str]"; expected "int"
 f(*it1, '') # E: Argument 2 to "f" has incompatible type "str"; expected "int"
 [builtins fixtures/for.pyi]
 
@@ -241,7 +241,7 @@ class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
 [out]
-main:7: error: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
+main:7: error: *Argument 1 to "f" has incompatible type "List[A]"; expected "B"
 
 [case testCallingWithTupleVarArgs]
 
@@ -250,9 +250,9 @@ b = None # type: B
 c = None # type: C
 cc = None # type: CC
 
-f(*(a, b, b)) # E: Argument 1 to "f" has incompatible type "*Tuple[A, B, B]"; expected "C"
-f(*(b, b, c)) # E: Argument 1 to "f" has incompatible type "*Tuple[B, B, C]"; expected "A"
-f(a, *(b, b)) # E: Argument 2 to "f" has incompatible type "*Tuple[B, B]"; expected "C"
+f(*(a, b, b)) # E: *Argument 1 to "f" has incompatible type "Tuple[A, B, B]"; expected "C"
+f(*(b, b, c)) # E: *Argument 1 to "f" has incompatible type "Tuple[B, B, C]"; expected "A"
+f(a, *(b, b)) # E: *Argument 2 to "f" has incompatible type "Tuple[B, B]"; expected "C"
 f(b, *(b, c)) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 f(*(a, b))    # E: Missing positional arguments "b", "c" in call to "f"
 f(*(a, b, c, c)) # E: Too many arguments for "f"
@@ -310,26 +310,26 @@ class A: pass
 class B: pass
 [builtins fixtures/list.pyi]
 [out]
-main:3: error: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
-main:4: error: Argument 2 to "f" has incompatible type "*List[A]"; expected "B"
+main:3: error: *Argument 1 to "f" has incompatible type "List[A]"; expected "B"
+main:4: error: *Argument 2 to "f" has incompatible type "List[A]"; expected "B"
 main:5: error: Argument 1 to "f" has incompatible type "B"; expected "A"
 main:6: error: Argument 2 to "f" has incompatible type "A"; expected "B"
-main:7: error: Argument 3 to "f" has incompatible type "*List[A]"; expected "B"
+main:7: error: *Argument 3 to "f" has incompatible type "List[A]"; expected "B"
 main:8: error: Argument 1 to "f" has incompatible type "B"; expected "A"
-main:9: error: Argument 1 to "g" has incompatible type "*List[B]"; expected "A"
+main:9: error: *Argument 1 to "g" has incompatible type "List[B]"; expected "A"
 
 [case testCallingVarArgsFunctionWithTupleVarArgs]
 
 a, b, c, cc = None, None, None, None # type: (A, B, C, CC)
 
-f(*(b, b, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[B, B, B]"; expected "A"
-f(*(a, a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, A, B]"; expected "B"
-f(*(a, b, a))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B, A]"; expected "B"
-f(a, *(a, b))   # E: Argument 2 to "f" has incompatible type "*Tuple[A, B]"; expected "B"
+f(*(b, b, b))   # E: *Argument 1 to "f" has incompatible type "Tuple[B, B, B]"; expected "A"
+f(*(a, a, b))   # E: *Argument 1 to "f" has incompatible type "Tuple[A, A, B]"; expected "B"
+f(*(a, b, a))   # E: *Argument 1 to "f" has incompatible type "Tuple[A, B, A]"; expected "B"
+f(a, *(a, b))   # E: *Argument 2 to "f" has incompatible type "Tuple[A, B]"; expected "B"
 f(b, *(b, b))   # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 f(b, b, *(b,))  # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 f(a, a, *(b,))  # E: Argument 2 to "f" has incompatible type "A"; expected "B"
-f(a, b, *(a,))  # E: Argument 3 to "f" has incompatible type "*Tuple[A]"; expected "B"
+f(a, b, *(a,))  # E: *Argument 3 to "f" has incompatible type "Tuple[A]"; expected "B"
 f(*())          # E: Too few arguments for "f"
 f(*(a, b, b))
 f(a, *(b, b))
@@ -372,7 +372,7 @@ from typing import List
 aa = None # type: List[A]
 ab = None # type: List[B]
 
-g(*aa) # E: Argument 1 to "g" has incompatible type "*List[A]"; expected "B"
+g(*aa) # E: *Argument 1 to "g" has incompatible type "List[A]"; expected "B"
 f(*aa)
 f(*ab)
 g(*ab)
@@ -409,10 +409,10 @@ class B: pass
 [builtins fixtures/list.pyi]
 [out]
 main:3: error: Too few arguments for "f"
-main:4: error: Argument 2 to "f" has incompatible type "*List[A]"; expected "Optional[B]"
-main:4: error: Argument 2 to "f" has incompatible type "*List[A]"; expected "B"
-main:5: error: Argument 3 to "f" has incompatible type "*List[A]"; expected "B"
-main:6: error: Argument 1 to "f" has incompatible type "*Tuple[A, A, B]"; expected "Optional[B]"
+main:4: error: *Argument 2 to "f" has incompatible type "List[A]"; expected "Optional[B]"
+main:4: error: *Argument 2 to "f" has incompatible type "List[A]"; expected "B"
+main:5: error: *Argument 3 to "f" has incompatible type "List[A]"; expected "B"
+main:6: error: *Argument 1 to "f" has incompatible type "Tuple[A, A, B]"; expected "Optional[B]"
 
 [case testVarArgsAfterKeywordArgInCall1]
 # see: mypy issue #2729
@@ -421,7 +421,7 @@ f(x=1, *[2])
 [builtins fixtures/list.pyi]
 [out]
 main:3: error: "f" gets multiple values for keyword argument "x"
-main:3: error: Argument 1 to "f" has incompatible type "*List[int]"; expected "str"
+main:3: error: *Argument 1 to "f" has incompatible type "List[int]"; expected "str"
 
 [case testVarArgsAfterKeywordArgInCall2]
 # see: mypy issue #2729
@@ -430,7 +430,7 @@ f(y='x', *[1])
 [builtins fixtures/list.pyi]
 [out]
 main:3: error: "f" gets multiple values for keyword argument "y"
-main:3: error: Argument 1 to "f" has incompatible type "*List[int]"; expected "str"
+main:3: error: *Argument 1 to "f" has incompatible type "List[int]"; expected "str"
 
 [case testVarArgsAfterKeywordArgInCall3]
 def f(x: int, y: str) -> None: pass
@@ -534,15 +534,15 @@ T = TypeVar('T')
 a, b, aa = None, None, None # type: (A, B, List[A])
 
 if int():
-    a, b = f(*aa)    # E: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
+    a, b = f(*aa)    # E: *Argument 1 to "f" has incompatible type "List[A]"; expected "B"
 if int():
-    b, b = f(*aa)    # E: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
+    b, b = f(*aa)    # E: *Argument 1 to "f" has incompatible type "List[A]"; expected "B"
 if int():
     a, a = f(b, *aa) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 if int():
-    b, b = f(b, *aa) # E: Argument 2 to "f" has incompatible type "*List[A]"; expected "B"
+    b, b = f(b, *aa) # E: *Argument 2 to "f" has incompatible type "List[A]"; expected "B"
 if int():
-    b, b = f(b, b, *aa) # E: Argument 3 to "f" has incompatible type "*List[A]"; expected "B"
+    b, b = f(b, b, *aa) # E: *Argument 3 to "f" has incompatible type "List[A]"; expected "B"
 if int():
     a, b = f(a, *a)  # E: List or tuple expected as variadic arguments
 if int():
@@ -569,11 +569,11 @@ T = TypeVar('T')
 a, b = None, None # type: (A, B)
 
 if int():
-    a, a = f(*(a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B]"; expected "A"
+    a, a = f(*(a, b))   # E: *Argument 1 to "f" has incompatible type "Tuple[A, B]"; expected "A"
 if int():
     b, b = f(a, *(b,))  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
 if int():
-    a, a = f(*(a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B]"; expected "A"
+    a, a = f(*(a, b))   # E: *Argument 1 to "f" has incompatible type "Tuple[A, B]"; expected "A"
 if int():
     b, b = f(a, *(b,))  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
 if int():
@@ -612,7 +612,7 @@ if int():
       # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]") \
       # N: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance \
       # N: Consider using "Sequence" instead, which is covariant \
-      # E: Argument 1 to "f" of "G" has incompatible type "*List[A]"; expected "B"
+      # E: *Argument 1 to "f" of "G" has incompatible type "List[A]"; expected "B"
 
 if int():
     ao, ao = G().f(*[a]) \
@@ -757,6 +757,6 @@ bad2: Bad[float]
 bar(*good1)
 bar(*good2)
 bar(*good3)
-bar(*bad1)  # E: Argument 1 to "bar" has incompatible type "*I[str]"; expected "float"
+bar(*bad1)  # E: *Argument 1 to "bar" has incompatible type "I[str]"; expected "float"
 bar(*bad2)  # E: List or tuple expected as variadic arguments
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7376,7 +7376,7 @@ def t() -> Tuple[str]: pass
 [builtins fixtures/set.pyi]
 [out]
 ==
-main:5: error: Argument 2 to <set> has incompatible type "*Tuple[str]"; expected "int"
+main:5: error: *Argument 2 to <set> has incompatible type "Tuple[str]"; expected "int"
 
 [case testUnpackInExpression3-only_when_nocache]
 from typing import Dict


### PR DESCRIPTION
Move * or ** prefix from argument type to "Argument".

Example
------------

Before:

```
Argument 1 to "g" has incompatible type "**Dict[str, object]"
```

After:

```
**Argument 1 to "g" has incompatible type "Dict[str, object]"
```

### Description

This is the 1st step to fix #8874  :

Move * or ** prefix from argument type to "Argument".

Further possible steps:

1) Include the kwargs variable name (if any) in the error message

```
test.py:6: error: **Argument 2 ("json_kwargs") to "dumps" has incompatible type "Dict[str, int]"; expected "bool"
```

2) Include the expected argument's name

```
test.py:6: error: **Argument 2 to "dumps" has incompatible type "Dict[str, int]"; expected "bool" for "skipkeys"
```

3) Squash all error messages related to the same argument into one error message.

## Test Plan

* No new tests added.
* Updated existing tests.
