### PR TITLE
[mypyc] Fix bad C generated for multiple assignment

### DIFF
--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -101,6 +101,7 @@ def transform_assignment_stmt(builder: IRBuilder, stmt: AssignmentStmt) -> None:
         for (left, temp) in zip(first_lvalue.items, temps):
             assignment_target = builder.get_assignment_target(left)
             builder.assign(assignment_target, temp, stmt.line)
+        builder.flush_keep_alives()
         return
 
     line = stmt.rvalue.line

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -607,3 +607,27 @@ class Foo:
             self.bar.bar += 1
             return
         yield 0
+
+[case testBorrowingInGeneratorInTupleAssignment]
+from typing import Iterator
+
+class Foo:
+    flag1: bool
+    flag2: bool
+
+class C:
+    foo: Foo
+
+    def genf(self) -> Iterator[None]:
+        self.foo.flag1, self.foo.flag2 = True, True
+        yield
+        self.foo.flag1, self.foo.flag2 = False, False
+
+def test_generator() -> None:
+    c = C()
+    c.foo = Foo()
+    gen = c.genf()
+    next(gen)
+    assert c.foo.flag1 == c.foo.flag2 == True
+    assert list(gen) == []
+    assert c.foo.flag1 == c.foo.flag2 == False


### PR DESCRIPTION
We need to flush keep alives also after a multiple assignment, as otherwise
the generated IR will be badly formed and confuse the reference count transform.

Fixes mypyc/mypyc#942.