### PR TITLE
Treating NoneType as None and warning against using NoneType.

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -508,6 +508,11 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             # Create a named TypedDictType
             return td.copy_modified(item_types=self.anal_array(list(td.items.values())),
                                     fallback=instance)
+
+        if info.fullname == 'types.NoneType':
+            self.fail("NoneType should not be used as a type, please use None instead", ctx)
+            return NoneType(ctx.line, ctx.column)
+
         return instance
 
     def analyze_unbound_type_without_type_info(self, t: UnboundType, sym: SymbolTableNode,

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1591,3 +1591,12 @@ def test_func(test_str: str) -> str:
             return "special"
         case _:
             return "other"
+
+
+[case testNoneTypeWarning]
+from types import NoneType
+
+def foo(x: NoneType): # E: NoneType should not be used as a type, please use None instead
+    reveal_type(x) # N: Revealed type is "None"
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/lib-stub/types.pyi
+++ b/test-data/unit/lib-stub/types.pyi
@@ -11,3 +11,6 @@ class ModuleType:
 if sys.version_info >= (3, 10):
     class Union:
         def __or__(self, x) -> Union: ...
+
+    class NoneType:
+        ...


### PR DESCRIPTION
### Description

Fixes #11288

Warns people to not use `NoneType` as a type annotation, as requested in #11288.

### Example

**Before**

```python
from types import NoneType

def f(x: NoneType) -> None:
    pass

f(None) # E: Argument 1 to "f" has incompatible type "None"; expected "NoneType"
```

**After**

```python
from types import NoneType

def f(x: NoneType) -> None: # E: NoneType should not be used as a type, please use None instead 
    pass

f(None)
```

Had to edit `test-data/unit/lib-stub/types.pyi` to allow NoneType type annotation.
