### PR TITLE
Ensure builtin modules are from typeshed sooner

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,2 +1,3 @@
 -r mypy-requirements.txt
+types-setuptools
 types-typed-ast>=1.5.0,<1.6.0

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,5 @@
 typing_extensions>=3.10
 mypy_extensions>=0.4.3
+importlib_resources; python_version<'3.7'
 typed_ast>=1.4.0,<2; python_version<'3.8'
 tomli>=1.1.0; python_version<'3.11'

--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -41,6 +41,7 @@ class GraphSuite(Suite):
     def _make_manager(self) -> BuildManager:
         errors = Errors()
         options = Options()
+        options.use_builtins_fixtures = True
         fscache = FileSystemCache()
         search_paths = SearchPaths((), (), (), ())
         manager = BuildManager(

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 try:
     # Import setuptools so that it monkey-patch overrides distutils
-    import setuptools  # type: ignore  # noqa
+    import setuptools  # noqa
 except ImportError:
     if sys.version_info >= (3, 12):
         # Raise on Python 3.12, since distutils will go away forever
@@ -61,7 +61,7 @@ def get_extension() -> Type["Extension"]:
     if not use_setuptools:
         from distutils.core import Extension
     else:
-        from setuptools import Extension  # type: ignore  # noqa
+        from setuptools import Extension  # noqa
 
     return Extension
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1439,3 +1439,29 @@ b\.c \d+
 # cmd: mypy --enable-incomplete-features a.py
 [file a.py]
 pass
+
+[case testShadowTypingModuleEarlyLoad]
+# cmd: mypy dir
+[file dir/__init__.py]
+from typing import Union
+
+def foo(a: Union[int, str]) -> str:
+    return str
+[file typing.py]
+# Since this file will be picked by mypy itself, we need it to be a fully-working typing
+# A bare minimum would be NamedTuple and TypedDict, which are used in runtime,
+# everything else technically can be just mocked.
+import sys
+import os
+del sys.modules["typing"]
+path = sys.path
+try:
+    sys.path.remove(os.getcwd())
+except ValueError:
+    sys.path.remove("")  # python 3.6
+from typing import *
+sys.path = path
+[out]
+mypy: "typing.py" shadows library module "typing"
+note: A user-defined top-level module with name "typing" is not supported
+== Return code: 2


### PR DESCRIPTION
It should work now with `custom-typeshed-dir` and `use_builtins_fixtures`.

Fixes #1876