### PR TITLE
Union types: Support narrowing to `Ellipsis` (`...`) cases of `Unions`

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -732,8 +732,8 @@ def is_singleton_type(typ: Type) -> bool:
     'is_singleton_type(t)' returns True if and only if the expression 'a is b' is
     always true.
 
-    Currently, this returns True when given NoneTypes, enum LiteralTypes and
-    enum types with a single value.
+    Currently, this returns True when given NoneTypes, enum LiteralTypes,
+    enum types with a single value and ... (Ellipses).
 
     Note that other kinds of LiteralTypes cannot count as singleton types. For
     example, suppose we do 'a = 100000 + 1' and 'b = 100001'. It is not guaranteed
@@ -742,12 +742,14 @@ def is_singleton_type(typ: Type) -> bool:
     """
     typ = get_proper_type(typ)
     # TODO:
-    # Also make this return True if the type corresponds to ... (ellipsis) or NotImplemented?
+    # Also make this return True if the type corresponds to NotImplemented?
     return (
             isinstance(typ, NoneType)
             or (isinstance(typ, LiteralType)
                 and (typ.is_enum_literal() or isinstance(typ.value, bool)))
-            or (isinstance(typ, Instance) and typ.type.is_enum and len(get_enum_values(typ)) == 1)
+            or (isinstance(typ, Instance) and (
+                typ.type.is_enum and len(get_enum_values(typ)) == 1
+                or typ.type.fullname == 'builtins.ellipsis'))
     )
 
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -137,6 +137,16 @@ def f() -> Union[int, None]: pass
 x = 1
 x = f()
 
+[case testUnionWithEllipsis]
+from typing import Union
+def f(x: Union[int, EllipsisType]) -> int:
+    if x is Ellipsis:
+        reveal_type(x) # N: Revealed type is "builtins.ellipsis"
+        x = 1
+    reveal_type(x) # N: Revealed type is "builtins.int"
+    return x
+[builtins fixtures/isinstancelist.pyi]
+
 [case testOptional]
 from typing import Optional
 def f(x: Optional[int]) -> None: pass

--- a/test-data/unit/fixtures/isinstancelist.pyi
+++ b/test-data/unit/fixtures/isinstancelist.pyi
@@ -10,8 +10,11 @@ class type:
     def __init__(self, x) -> None: pass
 
 class function: pass
-class ellipsis: pass
 class classmethod: pass
+
+class ellipsis: pass
+EllipsisType = ellipsis
+Ellipsis = ellipsis()
 
 def isinstance(x: object, t: Union[type, Tuple]) -> bool: pass
 def issubclass(x: object, t: Union[type, Tuple]) -> bool: pass


### PR DESCRIPTION
After this change, narrowing to `Ellipsis` works similarly with
regards to narrowing as `None` in `Optional`s

It would be a good followup refactor to delegate some of the logic
from `is_singleton_type` to the actual mypy types so they could decide
for themselves if they are representing singleton objects

Fixes: #13117
Co-authored-by: Zsolt Cserna <cserna.zsolt@gmail.com>
