### PR TITLE
refactor: use constuctor call or comprehensions instead of loops

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -269,7 +269,7 @@ def any_constraints(options: List[Optional[List[Constraint]]], eager: bool) -> L
                 else:
                     merged_option = None
                 merged_options.append(merged_option)
-            return any_constraints([option for option in merged_options], eager)
+            return any_constraints(list(merged_options), eager)
     # Otherwise, there are either no valid options or multiple, inconsistent valid
     # options. Give up and deduce nothing.
     return []

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -74,9 +74,7 @@ def generate_stub_for_c_module(module_name: str,
         if name not in done and not inspect.ismodule(obj):
             type_str = strip_or_import(get_type_fullname(type(obj)), module, imports)
             variables.append(f'{name}: {type_str}')
-    output = []
-    for line in sorted(set(imports)):
-        output.append(line)
+    output = list(sorted(set(imports)))
     for line in variables:
         output.append(line)
     for line in types:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -74,7 +74,7 @@ def generate_stub_for_c_module(module_name: str,
         if name not in done and not inspect.ismodule(obj):
             type_str = strip_or_import(get_type_fullname(type(obj)), module, imports)
             variables.append(f'{name}: {type_str}')
-    output = list(sorted(set(imports)))
+    output = sorted(set(imports))
     for line in variables:
         output.append(line)
     for line in types:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -304,10 +304,7 @@ class TypeCheckSuite(DataSuite):
         return hits
 
     def find_module_files(self, manager: build.BuildManager) -> Dict[str, str]:
-        modules = {}
-        for id, module in manager.modules.items():
-            modules[id] = module.path
-        return modules
+        return {id: module.path for id, module in manager.modules.items()}
 
     def find_missing_cache_files(self, modules: Dict[str, str],
                                  manager: build.BuildManager) -> Set[str]:

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -126,9 +126,7 @@ class Literals:
            ...
         """
         values = self.tuple_literals
-        value_by_index = {}
-        for value, index in values.items():
-            value_by_index[index] = value
+        value_by_index = {index: value for value, index in values.items()}
         result = []
         num = len(values)
         result.append(str(num))
@@ -142,9 +140,7 @@ class Literals:
 
 
 def _encode_str_values(values: Dict[str, int]) -> List[bytes]:
-    value_by_index = {}
-    for value, index in values.items():
-        value_by_index[index] = value
+    value_by_index = {index: value for value, index in values.items()}
     result = []
     line: List[bytes] = []
     line_len = 0
@@ -165,9 +161,7 @@ def _encode_str_values(values: Dict[str, int]) -> List[bytes]:
 
 
 def _encode_bytes_values(values: Dict[bytes, int]) -> List[bytes]:
-    value_by_index = {}
-    for value, index in values.items():
-        value_by_index[index] = value
+    value_by_index = {index: value for value, index in values.items()}
     result = []
     line: List[bytes] = []
     line_len = 0
@@ -212,9 +206,7 @@ def _encode_int_values(values: Dict[int, int]) -> List[bytes]:
 
     Values are stored in base 10 and separated by 0 bytes.
     """
-    value_by_index = {}
-    for value, index in values.items():
-        value_by_index[index] = value
+    value_by_index = {index: value for value, index in values.items()}
     result = []
     line: List[bytes] = []
     line_len = 0
@@ -248,9 +240,7 @@ def _encode_float_values(values: Dict[float, int]) -> List[str]:
 
     The result contains the number of values followed by individual values.
     """
-    value_by_index = {}
-    for value, index in values.items():
-        value_by_index[index] = value
+    value_by_index = {index: value for value, index in values.items()}
     result = []
     num = len(values)
     result.append(str(num))
@@ -266,9 +256,7 @@ def _encode_complex_values(values: Dict[complex, int]) -> List[str]:
     The result contains the number of values followed by pairs of doubles
     representing complex numbers.
     """
-    value_by_index = {}
-    for value, index in values.items():
-        value_by_index[index] = value
+    value_by_index = {index: value for value, index in values.items()}
     result = []
     num = len(values)
     result.append(str(num))


### PR DESCRIPTION
### Description

Small refactors to simplify the codebase.

* use constructor call to avoid loops
* use comprehension in simple cases 