### PR TITLE
(🐞) Fix CI python interpreter

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TOXENV: docs
+      TOX_SKIP_MISSING_INTERPRETERS: False
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,8 @@ jobs:
           toxenv: lint
 
     name: ${{ matrix.name }}
+    env:
+      TOX_SKIP_MISSING_INTERPRETERS: False
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -325,7 +325,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         if not fields.get('tp_vectorcall'):
             # This is just a placeholder to please CPython. It will be
             # overriden during setup.
-            fields['tp_call'] = 'PyVectorcall_Call'        
+            fields['tp_call'] = 'PyVectorcall_Call'
     fields['tp_flags'] = ' | '.join(flags)
 
     emitter.emit_line(f"static PyTypeObject {emitter.type_struct_name(cl)}_template_ = {{")

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.8.0
-skip_missing_interpreters = true
+skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 envlist =
     py36,
     py37,

--- a/tox.ini
+++ b/tox.ini
@@ -47,19 +47,16 @@ parallel_show_output = True
 
 [testenv:lint]
 description = check the code style
-basepython = python3.10
 commands = flake8 {posargs}
 
 [testenv:type]
 description = type check ourselves
-basepython = python3.10
 commands =
     python -m mypy --config-file mypy_self_check.ini -p mypy -p mypyc
     python -m mypy --config-file mypy_self_check.ini misc/proper_plugin.py
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
-basepython = python3.10
 deps = -rdocs/requirements-docs.txt
 commands =
     sphinx-build -d "{toxworkdir}/docs_doctree" docs/source "{toxworkdir}/docs_out" --color -W -bhtml {posargs}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65446343/179431198-18a2db98-6cd8-4cdc-9bd8-cc67898fa824.png)
:trollface: 


This change will mean that `tox -e type` will use your current interpreter instead of 3.7, this could be good or bad depending on how you look at it.

Also added an override in CI to not skip missing interpreters.
