### PR TITLE
Add back workaround to avoid confusing mypy.types and types in pyinfo

### DIFF
--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -14,6 +14,15 @@ MYPY = False
 if MYPY:
     from typing import List
 
+if __name__ == '__main__':
+    # HACK: We don't want to pick up mypy.types as the top-level types
+    #       module. This could happen if this file is run as a script.
+    #       This workaround fixes it.
+    old_sys_path = sys.path
+    sys.path = sys.path[1:]
+    import types  # noqa
+    sys.path = old_sys_path
+
 
 def getsearchdirs():
     # type: () -> List[str]


### PR DESCRIPTION
We run mypy/pyinfo.py as a script, and this means that mypy/types.py
could be picked up instead of the stdlib `types` module, which clearly
doesn't work. This seems to happen at least on macOS, and it broke
PEP 561 tests.

The workaround was accidentally removed as part of #13161.

This should fix #13174 and help with the wheel builds.