### PR TITLE
Basic support for `typing_extensions.NamedTuple`

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2417,7 +2417,7 @@ class NamedTupleExpr(Expression):
     # The class representation of this named tuple (its tuple_type attribute contains
     # the tuple item types)
     info: "TypeInfo"
-    is_typed: bool  # whether this class was created with typing.NamedTuple
+    is_typed: bool  # whether this class was created with typing(_extensions).NamedTuple
 
     def __init__(self, info: 'TypeInfo', is_typed: bool = False) -> None:
         super().__init__()

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -99,7 +99,7 @@ from mypy.types import (
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
     get_proper_type, get_proper_types, TypeAliasType, TypeVarLikeType, Parameters, ParamSpecType,
     PROTOCOL_NAMES, TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES, FINAL_DECORATOR_NAMES, REVEAL_TYPE_NAMES,
-    ASSERT_TYPE_NAMES, OVERLOAD_NAMES, is_named_instance,
+    ASSERT_TYPE_NAMES, OVERLOAD_NAMES, TYPED_NAMEDTUPLE_NAMES, is_named_instance,
 )
 from mypy.typeops import function_type, get_type_vars
 from mypy.type_visitor import TypeQuery
@@ -1529,7 +1529,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         bases = []
         for base_expr in base_type_exprs:
             if (isinstance(base_expr, RefExpr) and
-                    base_expr.fullname in ('typing.NamedTuple',) + TPDICT_NAMES):
+                    base_expr.fullname in TYPED_NAMEDTUPLE_NAMES + TPDICT_NAMES):
                 # Ignore magic bases for now.
                 continue
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -8,7 +8,7 @@ from mypy.types import (
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
     FunctionLike, TypeOfAny, LiteralType, get_proper_type, TypeAliasType, ParamSpecType,
-    Parameters, UnpackType, TUPLE_LIKE_INSTANCE_NAMES, TypeVarTupleType,
+    Parameters, UnpackType, TUPLE_LIKE_INSTANCE_NAMES, TYPED_NAMEDTUPLE_NAMES, TypeVarTupleType,
 )
 import mypy.applytype
 import mypy.constraints
@@ -286,7 +286,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
             # in `TypeInfo.mro`, so when `(a: NamedTuple) -> None` is used,
             # we need to check for `is_named_tuple` property
             if ((left.type.has_base(rname) or rname == 'builtins.object'
-                    or (rname == 'typing.NamedTuple'
+                    or (rname in TYPED_NAMEDTUPLE_NAMES
                         and any(l.is_named_tuple for l in left.type.mro)))
                     and not self.ignore_declared_variance):
                 # Map left type to corresponding right instances.

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -66,6 +66,11 @@ if TYPE_CHECKING:
         SyntheticTypeVisitor as SyntheticTypeVisitor,
     )
 
+TYPED_NAMEDTUPLE_NAMES: Final = (
+    "typing.NamedTuple",
+    "typing_extensions.NamedTuple"
+)
+
 # Supported names of TypedDict type constructors.
 TPDICT_NAMES: Final = (
     "typing.TypedDict",

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -709,3 +709,21 @@ class HasStaticMethod(NamedTuple):
         return 4
 
 [builtins fixtures/property.pyi]
+
+[case testTypingExtensionsNamedTuple]
+from typing_extensions import NamedTuple
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+bad_point = Point('foo') # E: Missing positional argument "y" in call to "Point" \
+                         # E: Argument 1 to "Point" has incompatible type "str"; expected "int"
+point = Point(1, 2)
+x, y = point
+x = point.x
+reveal_type(x) # N: Revealed type is "builtins.int"
+reveal_type(y) # N: Revealed type is "builtins.int"
+point.y = 6 # E: Property "y" defined in "Point" is read-only
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -10,6 +10,7 @@ class _SpecialForm:
     def __getitem__(self, typeargs: Any) -> Any:
         pass
 
+NamedTuple = 0
 Protocol: _SpecialForm = ...
 def runtime_checkable(x: _T) -> _T: pass
 runtime = runtime_checkable


### PR DESCRIPTION
### Description

This PR adds basic support for `typing_extensions.NamedTuple`, added to the `typing_extensions` runtime in https://github.com/python/typing_extensions/commit/7c28357e412cef215a7d66c0ef69b568b316678b and added to the typeshed stub in https://github.com/python/typeshed/commit/10f3238998737fa7c73a1005b61b5c717cc9c429.

This PR doesn't add support for _generic_ `NamedTuple`s: that'll have to come later. For now, it just teaches mypy that `typing_extensions.NamedTuple` should be treated much the same as `typing.NamedTuple` in nearly all circumstances.

I haven't cherry-picked the typeshed change in this PR (which was cherry-picked to the `0.970` branch in #13149, but doesn't exist on `master` yet). It turned out I didn't need to do the cherry-pick in order for the tests to pass. I'm happy to do the cherry-pick as part of this PR if it's desirable, but I assume this PR comes too late to make it into release 0.970, and I assume there'll be another typeshed sync before release 0.980 comes out.

## Test Plan

I added a test making sure that all the basics work as expected, but didn't try to duplicate all tests relating to `typing.NamedTuple` (a similar approach to the one taken in #12602 for `typing_extensions.overload`).
