### PR TITLE
Make `None` compatible with `SupportsStr` protocol

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -239,7 +239,9 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 members = self.right.type.protocol_members
                 # None is compatible with Hashable (and other similar protocols). This is
                 # slightly sloppy since we don't check the signature of "__hash__".
-                return not members or members == ["__hash__"]
+                # None is also compatible with `SupportsStr` protocol.
+                supported_members = frozenset(("__hash__", "__str__"))
+                return not members or all(member in supported_members for member in members)
             return False
         else:
             return True

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -240,7 +240,6 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 # None is compatible with Hashable (and other similar protocols). This is
                 # slightly sloppy since we don't check the signature of "__hash__".
                 # None is also compatible with `SupportsStr` protocol.
-                supported_members = frozenset(("__hash__", "__str__"))
                 return not members or all(member in supported_members for member in members)
             return False
         else:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -240,7 +240,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 # None is compatible with Hashable (and other similar protocols). This is
                 # slightly sloppy since we don't check the signature of "__hash__".
                 # None is also compatible with `SupportsStr` protocol.
-                return not members or all(member in supported_members for member in members)
+                return not members or all(member in ("__hash__", "__str__") for member in members)
             return False
         else:
             return True

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2731,6 +2731,20 @@ class EmptyProto(Protocol): ...
 
 def hh(h: EmptyProto) -> None: pass
 hh(None)
+
+# See https://github.com/python/mypy/issues/13081
+class SupportsStr(Protocol):
+    def __str__(self) -> str: ...
+
+def ss(s: SupportsStr) -> None: pass
+ss(None)
+
+class HashableStr(Protocol):
+    def __str__(self) -> str: ...
+    def __hash__(self) -> int: ...
+
+def hs(n: HashableStr) -> None: pass
+hs(None)
 [builtins fixtures/tuple.pyi]
 
 


### PR DESCRIPTION
Previously we had a special case for `None` and `__hash__`, but it can be extened for `__str__` as well.

```python
>>> str(None)
'None'
```

In the future we can change all our `None` hacks to use `NoneType`, but not today :)

Closes #13081