### PR TITLE
(🎁) Put an overload on `checker.check_subtype`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3599,8 +3599,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         supertype=return_type,
                         context=s.expr,
                         outer_context=s,
-                        msg=message_registry.INCOMPATIBLE_RETURN_VALUE_TYPE,
-                        code=codes.RETURN_VALUE)
+                        msg=message_registry.INCOMPATIBLE_RETURN_VALUE_TYPE)
             else:
                 # Empty returns are valid in Generators with Any typed returns, but not in
                 # coroutines.
@@ -5259,6 +5258,28 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     #
     # Helpers
     #
+    @overload
+    def check_subtype(self,
+                      subtype: Type,
+                      supertype: Type,
+                      context: Context,
+                      msg: str = ...,
+                      subtype_label: Optional[str] = ...,
+                      supertype_label: Optional[str] = ...,
+                      *,
+                      code: Optional[ErrorCode] = ...,
+                      outer_context: Optional[Context] = ...) -> bool: ...
+
+    @overload
+    def check_subtype(self,
+                      subtype: Type,
+                      supertype: Type,
+                      context: Context,
+                      msg: ErrorMessage = ...,
+                      subtype_label: Optional[str] = ...,
+                      supertype_label: Optional[str] = ...,
+                      *,
+                      outer_context: Optional[Context] = ...) -> bool: ...
 
     def check_subtype(self,
                       subtype: Type,
@@ -5658,7 +5679,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
              code: Optional[ErrorCode] = None) -> None:
         """Produce an error message."""
         if isinstance(msg, ErrorMessage):
-            self.msg.fail(msg.value, context, code=msg.code)
+            self.msg.fail(msg.value, context, code=code or msg.code)
             return
         self.msg.fail(msg, context, code=code)
 


### PR DESCRIPTION
I think this is a good one, what about you?
```py
fail(message_registry.SUSSY_IMPOSTOR, code=codes.AMONGUS)  # no warning that the code will be ignored
```

unfortunately I don't want to put an overload on `fail` as that would require editing the plugin interface, so instead just update the implementation to always use the code if it's passed.

Turns out there was an existing instance of this happening.