### PR TITLE
Use GitHub's zipball as alternative to 'git+https'

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ Mypy can be installed using pip:
 
     python3 -m pip install -U mypy
 
-If you want to run the latest version of the code, you can install from git:
+If you want to run the latest version of the code, you can install from the
+repo directly:
 
     python3 -m pip install -U git+https://github.com/python/mypy.git
-
+    # or if you don't have 'git' installed
+    python3 -m pip install -U https://github.com/python/mypy/zipball/master
 
 Now you can type-check the [statically typed parts] of a program like this:
 


### PR DESCRIPTION
### Description

Use the available [`zipball`](https://docs.github.com/en/rest/repos/contents#download-a-repository-archive-zip) option for the latest installation to prevent issues when a user might not have `git` present on the system or if the installation of `git` isn't an option e.g. by having size restrictions in the environment such as Docker image.

## Test Plan

```
$ docker run -it python:alpine sh
/ # pip install -U pip
Requirement already satisfied: pip in /usr/local/lib/python3.9/site-packages (21.0)
Collecting pip
  Downloading pip-22.1.2-py3-none-any.whl (2.1 MB)
     |████████████████████████████████| 2.1 MB 8.4 MB/s 
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 21.0
    Uninstalling pip-21.0:
      Successfully uninstalled pip-21.0
Successfully installed pip-22.1.2
/ # python3 -m pip install -U git+https://github.com/python/mypy.git
Collecting git+https://github.com/python/mypy.git
  Cloning https://github.com/python/mypy.git to /tmp/pip-req-build-dg300zw9
  ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git version
ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?

# ^^^ no git, no installation, but with a zipball:

/ # python3 -m pip install -U https://github.com/python/mypy/zipball/master
Collecting https://github.com/python/mypy/zipball/master
  Downloading https://github.com/python/mypy/zipball/master
     | 3.5 MB 6.3 MB/s 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting mypy-extensions>=0.4.3
  Downloading mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
Collecting tomli>=1.1.0
  Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
Collecting typing-extensions>=3.10
  Downloading typing_extensions-4.3.0-py3-none-any.whl (25 kB)
Building wheels for collected packages: mypy
  Building wheel for mypy (pyproject.toml) ... done
  Created wheel for mypy: filename=mypy-0.980+dev-py3-none-any.whl size=2557162 sha256=6fa1a9cace43a5a8a7769402bf9afc3e334a58cbf39d0ffe5b54c5ef6d8ca2c6
  Stored in directory: /tmp/pip-ephem-wheel-cache-kemoonnn/wheels/87/5b/17/83d763085eb17df0d0a66b20ef24cab4a68fc0cf94a730fafb
Successfully built mypy
Installing collected packages: mypy-extensions, typing-extensions, tomli, mypy
Successfully installed mypy-0.980+dev mypy-extensions-0.4.3 tomli-2.0.1 typing-extensions-4.3.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
/ # 
```