### PR TITLE
Warn when abstract or protocol type is assigned to a callable

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2431,10 +2431,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if (isinstance(rvalue_type, CallableType) and rvalue_type.is_type_obj() and
                         (rvalue_type.type_object().is_abstract or
                          rvalue_type.type_object().is_protocol) and
-                        isinstance(lvalue_type, TypeType) and
-                        isinstance(lvalue_type.item, Instance) and
-                        (lvalue_type.item.type.is_abstract or
-                         lvalue_type.item.type.is_protocol)):
+                        ((isinstance(lvalue_type, TypeType) and
+                          isinstance(lvalue_type.item, Instance) and
+                          (lvalue_type.item.type.is_abstract or
+                           lvalue_type.item.type.is_protocol)) or
+                         (isinstance(lvalue_type, CallableType) and
+                          isinstance(lvalue_type.ret_type, Instance) and
+                          (lvalue_type.ret_type.type.is_abstract or
+                           lvalue_type.ret_type.type.is_protocol)))):
                     self.msg.concrete_only_assign(lvalue_type, rvalue)
                     return
                 if rvalue_type and infer_lvalue_type and not isinstance(lvalue_type, PartialType):

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -250,6 +250,25 @@ if int():
     var_old = C # OK
 [out]
 
+[case testInstantiationAbstractsWithCallables]
+from typing import Callable, Type
+from abc import abstractmethod
+
+class A:
+    @abstractmethod
+    def m(self) -> None: pass
+class B(A): pass
+class C(B):
+    def m(self) -> None:
+        pass
+
+var: Callable[[], A]
+var()   # OK
+
+var = A # E: Can only assign concrete classes to a variable of type "Callable[[], A]"
+var = B # E: Can only assign concrete classes to a variable of type "Callable[[], A]"
+var = C # OK
+
 [case testInstantiationAbstractsInTypeForClassMethods]
 from typing import Type
 from abc import abstractmethod

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1619,6 +1619,23 @@ if int():
     var_old = B # OK
     var_old = C # OK
 
+[case testInstantiationProtocolWithCallables]
+from typing import Callable, Protocol
+
+class P(Protocol):
+    def m(self) -> None: pass
+class B(P): pass
+class C:
+    def m(self) -> None:
+        pass
+
+var: Callable[[], P]
+var()   # OK
+
+var = P # E: Can only assign concrete classes to a variable of type "Callable[[], P]"
+var = B # OK
+var = C # OK
+
 [case testInstantiationProtocolInTypeForClassMethods]
 from typing import Type, Protocol
 


### PR DESCRIPTION
Now `Callable[[], AbstractOrProtocol]` has the same semantics as `Type[AbstractOrProtocol]`.
I don't think we need to test for `@overload` here, because you cannot have inline `@overload` annotation.

Closes #13171