### PR TITLE
[mypyc] Fix clang warning on different signs integer

### DIFF
--- a/mypyc/lib-rt/int_ops.c
+++ b/mypyc/lib-rt/int_ops.c
@@ -346,10 +346,10 @@ static digit *GetIntDigits(CPyTagged n, Py_ssize_t *size, digit *buf) {
             val = -val;
         }
         buf[0] = val & PyLong_MASK;
-        if (val > PyLong_MASK) {
+        if (val > (Py_ssize_t)PyLong_MASK) {
             val >>= PyLong_SHIFT;
             buf[1] = val & PyLong_MASK;
-            if (val > PyLong_MASK) {
+            if (val > (Py_ssize_t)PyLong_MASK) {
                 buf[2] = val >> PyLong_SHIFT;
                 len = 3;
             } else {


### PR DESCRIPTION
when building a module for web assembly with pygame-web ready to use toolchain (clang 15 based and python-wasm 3.11b4). Two warnings on different signs integer comparison would make the build fail.

