### PR TITLE
Remove python2 specific logic for `raise` keyword check

### DIFF
--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -767,21 +767,18 @@ class ASTConverter:
 
     # 'raise' [test [',' test [',' test]]]
     def visit_Raise(self, n: ast27.Raise) -> RaiseStmt:
-        legacy_mode = False
         if n.type is None:
             e = None
         else:
             if n.inst is None:
                 e = self.visit(n.type)
             else:
-                legacy_mode = True
                 if n.tback is None:
                     e = TupleExpr([self.visit(n.type), self.visit(n.inst)])
                 else:
                     e = TupleExpr([self.visit(n.type), self.visit(n.inst), self.visit(n.tback)])
 
         stmt = RaiseStmt(e, None)
-        stmt.legacy_mode = legacy_mode
         return self.set_line(stmt, n)
 
     # TryExcept(stmt* body, excepthandler* handlers, stmt* orelse)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1424,19 +1424,16 @@ class IfStmt(Statement):
 
 
 class RaiseStmt(Statement):
-    __slots__ = ("expr", "from_expr", "legacy_mode")
+    __slots__ = ("expr", "from_expr")
 
     # Plain 'raise' is a valid statement.
     expr: Optional[Expression]
     from_expr: Optional[Expression]
-    # Is set when python2 has `raise exc, msg, traceback`.
-    legacy_mode: bool
 
     def __init__(self, expr: Optional[Expression], from_expr: Optional[Expression]) -> None:
         super().__init__()
         self.expr = expr
         self.from_expr = from_expr
-        self.legacy_mode = False
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_raise_stmt(self)


### PR DESCRIPTION
After #13135 is merged, I think it is safe to say that we can now remove all python2-specific artifacts.

This is one of them. 
Originally introduced in https://github.com/python/mypy/pull/11289

Refs https://github.com/python/mypy/issues/12237