### PR TITLE
Cancel old test jobs in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ on:
     - CREDITS
     - LICENSE
 
+concurrency: 
+  group: test-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   main:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
     - LICENSE
 
 concurrency: 
-  group: test-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
When new commit is pushed to the CI, we can cancel old jobs for this branch.
This way we can use less CI minutes. Right now some test jobs take around 30mins.

Docs: https://docs.github.com/en/actions/using-jobs/using-concurrency