### PR TITLE
Delete Python 2 specific AST nodes

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -33,7 +33,6 @@ from mypy.nodes import (
     AssertTypeExpr,
     AssignmentExpr,
     AwaitExpr,
-    BackquoteExpr,
     BytesExpr,
     CallExpr,
     CastExpr,
@@ -84,7 +83,6 @@ from mypy.nodes import (
     TypeVarExpr,
     TypeVarTupleExpr,
     UnaryExpr,
-    UnicodeExpr,
     Var,
     YieldExpr,
     YieldFromExpr,
@@ -509,7 +507,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """More precise type checking for str.format() calls on literals."""
         assert isinstance(e.callee, MemberExpr)
         format_value = None
-        if isinstance(e.callee.expr, (StrExpr, UnicodeExpr)):
+        if isinstance(e.callee.expr, StrExpr):
             format_value = e.callee.expr.value
         elif self.chk.has_type(e.callee.expr):
             base_typ = try_getting_literal(self.chk.lookup_type(e.callee.expr))
@@ -2553,10 +2551,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Type check a bytes literal (trivial)."""
         return self.infer_literal_expr_type(e.value, "builtins.bytes")
 
-    def visit_unicode_expr(self, e: UnicodeExpr) -> Type:
-        """Type check a unicode literal (trivial)."""
-        return self.infer_literal_expr_type(e.value, "builtins.unicode")
-
     def visit_float_expr(self, e: FloatExpr) -> Type:
         """Type check a float literal (trivial)."""
         return self.named_type("builtins.float")
@@ -3511,7 +3505,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return union
 
     def visit_typeddict_index_expr(self, td_type: TypedDictType, index: Expression) -> Type:
-        if isinstance(index, (StrExpr, UnicodeExpr)):
+        if isinstance(index, StrExpr):
             key_names = [index.value]
         else:
             typ = get_proper_type(self.accept(index))
@@ -4459,10 +4453,6 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return UninhabitedType()
             self.chk.push_type_map(map)
             return self.accept(node, type_context=context, allow_none_return=allow_none_return)
-
-    def visit_backquote_expr(self, e: BackquoteExpr) -> Type:
-        self.accept(e.expr)
-        return self.named_type("builtins.str")
 
     #
     # Helpers

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -20,7 +20,6 @@ from mypy.nodes import (
     StrExpr,
     TupleExpr,
     UnaryExpr,
-    UnicodeExpr,
     get_member_expr_fullname,
 )
 from mypy.options import Options
@@ -47,8 +46,6 @@ def _extract_argument_name(expr: Expression) -> Optional[str]:
     if isinstance(expr, NameExpr) and expr.name == "None":
         return None
     elif isinstance(expr, StrExpr):
-        return expr.value
-    elif isinstance(expr, UnicodeExpr):
         return expr.value
     else:
         raise TypeTranslationError()
@@ -181,10 +178,6 @@ def expr_to_unanalyzed_type(
     elif isinstance(expr, BytesExpr):
         return parse_type_string(
             expr.value, "builtins.bytes", expr.line, expr.column, assume_str_is_unicode=False
-        )
-    elif isinstance(expr, UnicodeExpr):
-        return parse_type_string(
-            expr.value, "builtins.unicode", expr.line, expr.column, assume_str_is_unicode=True
         )
     elif isinstance(expr, UnaryExpr):
         typ = expr_to_unanalyzed_type(expr.expr, options, allow_new_syntax)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -79,7 +79,6 @@ from mypy.nodes import (
     TryStmt,
     TupleExpr,
     UnaryExpr,
-    UnicodeExpr,
     Var,
     WhileStmt,
     WithStmt,
@@ -1546,13 +1545,7 @@ class ASTConverter:
         return self.set_line(e, n)
 
     # Str(string s)
-    def visit_Str(self, n: Str) -> Union[UnicodeExpr, StrExpr]:
-        # Hack: assume all string literals in Python 2 stubs are normal
-        # strs (i.e. not unicode).  All stubs are parsed with the Python 3
-        # parser, which causes unprefixed string literals to be interpreted
-        # as unicode instead of bytes.  This hack is generally okay,
-        # because mypy considers str literals to be compatible with
-        # unicode.
+    def visit_Str(self, n: Str) -> StrExpr:
         e = StrExpr(n.s)
         return self.set_line(e, n)
 

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -9,7 +9,6 @@ from mypy.nodes import (
     AssertTypeExpr,
     AssignmentExpr,
     AwaitExpr,
-    BackquoteExpr,
     BytesExpr,
     CallExpr,
     CastExpr,
@@ -50,7 +49,6 @@ from mypy.nodes import (
     TypeVarExpr,
     TypeVarTupleExpr,
     UnaryExpr,
-    UnicodeExpr,
     YieldExpr,
     YieldFromExpr,
 )
@@ -117,7 +115,7 @@ def literal(e: Expression) -> int:
     elif isinstance(e, NameExpr):
         return LITERAL_TYPE
 
-    if isinstance(e, (IntExpr, FloatExpr, ComplexExpr, StrExpr, BytesExpr, UnicodeExpr)):
+    if isinstance(e, (IntExpr, FloatExpr, ComplexExpr, StrExpr, BytesExpr)):
         return LITERAL_YES
 
     if literal_hash(e):
@@ -145,9 +143,6 @@ class _Hasher(ExpressionVisitor[Optional[Key]]):
         return ("Literal", e.value, e.from_python_3)
 
     def visit_bytes_expr(self, e: BytesExpr) -> Key:
-        return ("Literal", e.value)
-
-    def visit_unicode_expr(self, e: UnicodeExpr) -> Key:
         return ("Literal", e.value)
 
     def visit_float_expr(self, e: FloatExpr) -> Key:
@@ -256,9 +251,6 @@ class _Hasher(ExpressionVisitor[Optional[Key]]):
         return None
 
     def visit_generator_expr(self, e: GeneratorExpr) -> None:
-        return None
-
-    def visit_backquote_expr(self, e: BackquoteExpr) -> None:
         return None
 
     def visit_type_var_expr(self, e: TypeVarExpr) -> None:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1541,49 +1541,6 @@ class MatchStmt(Statement):
         return visitor.visit_match_stmt(self)
 
 
-class PrintStmt(Statement):
-    """Python 2 print statement"""
-
-    __slots__ = ("args", "newline", "target")
-
-    args: List[Expression]
-    newline: bool
-    # The file-like target object (given using >>).
-    target: Optional[Expression]
-
-    def __init__(
-        self, args: List[Expression], newline: bool, target: Optional[Expression] = None
-    ) -> None:
-        super().__init__()
-        self.args = args
-        self.newline = newline
-        self.target = target
-
-    def accept(self, visitor: StatementVisitor[T]) -> T:
-        return visitor.visit_print_stmt(self)
-
-
-class ExecStmt(Statement):
-    """Python 2 exec statement"""
-
-    __slots__ = ("expr", "globals", "locals")
-
-    expr: Expression
-    globals: Optional[Expression]
-    locals: Optional[Expression]
-
-    def __init__(
-        self, expr: Expression, globals: Optional[Expression], locals: Optional[Expression]
-    ) -> None:
-        super().__init__()
-        self.expr = expr
-        self.globals = globals
-        self.locals = locals
-
-    def accept(self, visitor: StatementVisitor[T]) -> T:
-        return visitor.visit_exec_stmt(self)
-
-
 # Expressions
 
 
@@ -1603,15 +1560,9 @@ class IntExpr(Expression):
 
 
 # How mypy uses StrExpr, BytesExpr, and UnicodeExpr:
-# In Python 2 mode:
-# b'x', 'x' -> StrExpr
-# u'x' -> UnicodeExpr
-# BytesExpr is unused
 #
-# In Python 3 mode:
 # b'x' -> BytesExpr
 # 'x', u'x' -> StrExpr
-# UnicodeExpr is unused
 
 
 class StrExpr(Expression):
@@ -1666,21 +1617,6 @@ class BytesExpr(Expression):
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_bytes_expr(self)
-
-
-class UnicodeExpr(Expression):
-    """Unicode literal (Python 2.x)"""
-
-    __slots__ = ("value",)
-
-    value: str
-
-    def __init__(self, value: str) -> None:
-        super().__init__()
-        self.value = value
-
-    def accept(self, visitor: ExpressionVisitor[T]) -> T:
-        return visitor.visit_unicode_expr(self)
 
 
 class FloatExpr(Expression):
@@ -2327,21 +2263,6 @@ class ConditionalExpr(Expression):
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_conditional_expr(self)
-
-
-class BackquoteExpr(Expression):
-    """Python 2 expression `...`."""
-
-    __slots__ = ("expr",)
-
-    expr: Expression
-
-    def __init__(self, expr: Expression) -> None:
-        super().__init__()
-        self.expr = expr
-
-    def accept(self, visitor: ExpressionVisitor[T]) -> T:
-        return visitor.visit_backquote_expr(self)
 
 
 class TypeApplication(Expression):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1559,7 +1559,7 @@ class IntExpr(Expression):
         return visitor.visit_int_expr(self)
 
 
-# How mypy uses StrExpr, BytesExpr, and UnicodeExpr:
+# How mypy uses StrExpr and BytesExpr:
 #
 # b'x' -> BytesExpr
 # 'x', u'x' -> StrExpr

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -26,7 +26,6 @@ from mypy.nodes import (
     StrExpr,
     TupleExpr,
     UnaryExpr,
-    UnicodeExpr,
 )
 from mypy.options import Options
 from mypy.patterns import AsPattern, OrPattern, Pattern
@@ -234,13 +233,13 @@ def consider_sys_platform(expr: Expression, platform: str) -> int:
         if not is_sys_attr(expr.operands[0], "platform"):
             return TRUTH_VALUE_UNKNOWN
         right = expr.operands[1]
-        if not isinstance(right, (StrExpr, UnicodeExpr)):
+        if not isinstance(right, StrExpr):
             return TRUTH_VALUE_UNKNOWN
         return fixed_comparison(platform, op, right.value)
     elif isinstance(expr, CallExpr):
         if not isinstance(expr.callee, MemberExpr):
             return TRUTH_VALUE_UNKNOWN
-        if len(expr.args) != 1 or not isinstance(expr.args[0], (StrExpr, UnicodeExpr)):
+        if len(expr.args) != 1 or not isinstance(expr.args[0], StrExpr):
             return TRUTH_VALUE_UNKNOWN
         if not is_sys_attr(expr.callee.expr, "platform"):
             return TRUTH_VALUE_UNKNOWN

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -39,7 +39,6 @@ from mypy.nodes import (
     TupleExpr,
     TypeInfo,
     TypeVarExpr,
-    UnicodeExpr,
     Var,
 )
 from mypy.options import Options
@@ -339,15 +338,13 @@ class NamedTupleAnalyzer:
         if call.arg_kinds[:2] != [ARG_POS, ARG_POS]:
             self.fail(f'Unexpected arguments to "{type_name}()"', call)
             return None
-        if not isinstance(args[0], (StrExpr, BytesExpr, UnicodeExpr)):
+        if not isinstance(args[0], (StrExpr, BytesExpr)):
             self.fail(f'"{type_name}()" expects a string literal as the first argument', call)
             return None
-        typename = cast(Union[StrExpr, BytesExpr, UnicodeExpr], call.args[0]).value
+        typename = cast(Union[StrExpr, BytesExpr], call.args[0]).value
         types: List[Type] = []
         if not isinstance(args[1], (ListExpr, TupleExpr)):
-            if fullname == "collections.namedtuple" and isinstance(
-                args[1], (StrExpr, BytesExpr, UnicodeExpr)
-            ):
+            if fullname == "collections.namedtuple" and isinstance(args[1], (StrExpr, BytesExpr)):
                 str_expr = args[1]
                 items = str_expr.value.replace(",", " ").split()
             else:
@@ -362,16 +359,10 @@ class NamedTupleAnalyzer:
             listexpr = args[1]
             if fullname == "collections.namedtuple":
                 # The fields argument contains just names, with implicit Any types.
-                if any(
-                    not isinstance(item, (StrExpr, BytesExpr, UnicodeExpr))
-                    for item in listexpr.items
-                ):
+                if any(not isinstance(item, (StrExpr, BytesExpr)) for item in listexpr.items):
                     self.fail('String literal expected as "namedtuple()" item', call)
                     return None
-                items = [
-                    cast(Union[StrExpr, BytesExpr, UnicodeExpr], item).value
-                    for item in listexpr.items
-                ]
+                items = [cast(Union[StrExpr, BytesExpr], item).value for item in listexpr.items]
             else:
                 # The fields argument contains (name, type) tuples.
                 result = self.parse_namedtuple_fields_with_types(listexpr.items, call)
@@ -410,7 +401,7 @@ class NamedTupleAnalyzer:
                     self.fail('Invalid "NamedTuple()" field definition', item)
                     return None
                 name, type_node = item.items
-                if isinstance(name, (StrExpr, BytesExpr, UnicodeExpr)):
+                if isinstance(name, (StrExpr, BytesExpr)):
                     items.append(name.value)
                 else:
                     self.fail('Invalid "NamedTuple()" field name', item)

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -26,7 +26,6 @@ from mypy.nodes import (
     StrExpr,
     SymbolTableNode,
     TypeInfo,
-    UnicodeExpr,
     Var,
 )
 from mypy.options import Options
@@ -178,7 +177,7 @@ class NewTypeAnalyzer:
             return None, False
 
         # Check first argument
-        if not isinstance(args[0], (StrExpr, BytesExpr, UnicodeExpr)):
+        if not isinstance(args[0], (StrExpr, BytesExpr)):
             self.fail("Argument 1 to NewType(...) must be a string literal", context)
             has_failed = True
         elif args[0].value != name:

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -28,7 +28,6 @@ from mypy.nodes import (
     TempNode,
     TypedDictExpr,
     TypeInfo,
-    UnicodeExpr,
 )
 from mypy.options import Options
 from mypy.semanal_shared import SemanticAnalyzerInterface
@@ -294,7 +293,7 @@ class TypedDictAnalyzer:
             return self.fail_typeddict_arg(
                 f'Unexpected keyword argument "{call.arg_names[2]}" for "TypedDict"', call
             )
-        if not isinstance(args[0], (StrExpr, BytesExpr, UnicodeExpr)):
+        if not isinstance(args[0], (StrExpr, BytesExpr)):
             return self.fail_typeddict_arg(
                 "TypedDict() expects a string literal as the first argument", call
             )
@@ -338,7 +337,7 @@ class TypedDictAnalyzer:
         items: List[str] = []
         types: List[Type] = []
         for (field_name_expr, field_type_expr) in dict_items:
-            if isinstance(field_name_expr, (StrExpr, BytesExpr, UnicodeExpr)):
+            if isinstance(field_name_expr, (StrExpr, BytesExpr)):
                 key = field_name_expr.value
                 items.append(key)
                 if key in seen_keys:

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -118,7 +118,6 @@ from mypy.nodes import (
     OperatorAssignmentStmt,
     OpExpr,
     OverloadedFuncDef,
-    PrintStmt,
     RefExpr,
     StarExpr,
     SuperExpr,
@@ -636,11 +635,6 @@ class DependencyVisitor(TraverserVisitor):
                 self.add_attribute_dependency_for_expr(e, "__aexit__")
         for typ in o.analyzed_types:
             self.add_type_dependencies(typ)
-
-    def visit_print_stmt(self, o: PrintStmt) -> None:
-        super().visit_print_stmt(o)
-        if o.target:
-            self.add_attribute_dependency_for_expr(o.target, "write")
 
     def visit_del_stmt(self, o: DelStmt) -> None:
         super().visit_del_stmt(o)

--- a/mypy/server/subexpr.py
+++ b/mypy/server/subexpr.py
@@ -6,7 +6,6 @@ from mypy.nodes import (
     AssertTypeExpr,
     AssignmentExpr,
     AwaitExpr,
-    BackquoteExpr,
     CallExpr,
     CastExpr,
     ComparisonExpr,
@@ -190,10 +189,6 @@ class SubexpressionFinder(TraverserVisitor):
     def visit_star_expr(self, e: StarExpr) -> None:
         self.add(e)
         super().visit_star_expr(e)
-
-    def visit_backquote_expr(self, e: BackquoteExpr) -> None:
-        self.add(e)
-        super().visit_backquote_expr(e)
 
     def visit_await_expr(self, e: AwaitExpr) -> None:
         self.add(e)

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -40,7 +40,6 @@ from mypy.nodes import (
     StrExpr,
     TypeApplication,
     UnaryExpr,
-    UnicodeExpr,
     YieldFromExpr,
 )
 from mypy.traverser import TraverserVisitor
@@ -218,7 +217,7 @@ class StatisticsVisitor(TraverserVisitor):
         super().visit_assignment_stmt(o)
 
     def visit_expression_stmt(self, o: ExpressionStmt) -> None:
-        if isinstance(o.expr, (StrExpr, UnicodeExpr, BytesExpr)):
+        if isinstance(o.expr, (StrExpr, BytesExpr)):
             # Docstring
             self.record_line(o.line, TYPE_EMPTY)
         else:
@@ -315,9 +314,6 @@ class StatisticsVisitor(TraverserVisitor):
         super().visit_unary_expr(o)
 
     def visit_str_expr(self, o: StrExpr) -> None:
-        self.record_precise_if_checked_scope(o)
-
-    def visit_unicode_expr(self, o: UnicodeExpr) -> None:
         self.record_precise_if_checked_scope(o)
 
     def visit_bytes_expr(self, o: BytesExpr) -> None:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -302,17 +302,6 @@ class StrConv(NodeVisitor[str]):
             a.append(o.unanalyzed_type)
         return self.dump(a + [o.body], o)
 
-    def visit_print_stmt(self, o: "mypy.nodes.PrintStmt") -> str:
-        a: List[Any] = o.args[:]
-        if o.target:
-            a.append(("Target", [o.target]))
-        if o.newline:
-            a.append("Newline")
-        return self.dump(a, o)
-
-    def visit_exec_stmt(self, o: "mypy.nodes.ExecStmt") -> str:
-        return self.dump([o.expr, o.globals, o.locals], o)
-
     def visit_match_stmt(self, o: "mypy.nodes.MatchStmt") -> str:
         a: List[Any] = [o.subject]
         for i in range(len(o.patterns)):
@@ -334,9 +323,6 @@ class StrConv(NodeVisitor[str]):
 
     def visit_bytes_expr(self, o: "mypy.nodes.BytesExpr") -> str:
         return f"BytesExpr({self.str_repr(o.value)})"
-
-    def visit_unicode_expr(self, o: "mypy.nodes.UnicodeExpr") -> str:
-        return f"UnicodeExpr({self.str_repr(o.value)})"
 
     def str_repr(self, s: str) -> str:
         s = re.sub(r"\\u[0-9a-fA-F]{4}", lambda m: "\\" + m.group(0), s)
@@ -556,9 +542,6 @@ class StrConv(NodeVisitor[str]):
         if not a[1]:
             a[1] = "<empty>"
         return self.dump(a, o)
-
-    def visit_backquote_expr(self, o: "mypy.nodes.BackquoteExpr") -> str:
-        return self.dump([o.expr], o)
 
     def visit_temp_node(self, o: "mypy.nodes.TempNode") -> str:
         return self.dump([o.type], o)

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -11,7 +11,6 @@ from mypy.nodes import (
     AssignmentExpr,
     AssignmentStmt,
     AwaitExpr,
-    BackquoteExpr,
     Block,
     BreakStmt,
     BytesExpr,
@@ -28,7 +27,6 @@ from mypy.nodes import (
     DictionaryComprehension,
     EllipsisExpr,
     EnumCallExpr,
-    ExecStmt,
     Expression,
     ExpressionStmt,
     FloatExpr,
@@ -60,7 +58,6 @@ from mypy.nodes import (
     OverloadedFuncDef,
     ParamSpecExpr,
     PassStmt,
-    PrintStmt,
     RaiseStmt,
     ReturnStmt,
     RevealExpr,
@@ -79,7 +76,6 @@ from mypy.nodes import (
     TypeVarExpr,
     TypeVarTupleExpr,
     UnaryExpr,
-    UnicodeExpr,
     WhileStmt,
     WithStmt,
     YieldExpr,
@@ -361,9 +357,6 @@ class TraverserVisitor(NodeVisitor[None]):
     def visit_star_expr(self, o: StarExpr) -> None:
         o.expr.accept(self)
 
-    def visit_backquote_expr(self, o: BackquoteExpr) -> None:
-        o.expr.accept(self)
-
     def visit_await_expr(self, o: AwaitExpr) -> None:
         o.expr.accept(self)
 
@@ -413,17 +406,6 @@ class TraverserVisitor(NodeVisitor[None]):
     def visit_import_from(self, o: ImportFrom) -> None:
         for a in o.assignments:
             a.accept(self)
-
-    def visit_print_stmt(self, o: PrintStmt) -> None:
-        for arg in o.args:
-            arg.accept(self)
-
-    def visit_exec_stmt(self, o: ExecStmt) -> None:
-        o.expr.accept(self)
-        if o.globals:
-            o.globals.accept(self)
-        if o.locals:
-            o.locals.accept(self)
 
 
 class ExtendedTraverserVisitor(TraverserVisitor):
@@ -583,16 +565,6 @@ class ExtendedTraverserVisitor(TraverserVisitor):
             return
         super().visit_with_stmt(o)
 
-    def visit_print_stmt(self, o: PrintStmt) -> None:
-        if not self.visit(o):
-            return
-        super().visit_print_stmt(o)
-
-    def visit_exec_stmt(self, o: ExecStmt) -> None:
-        if not self.visit(o):
-            return
-        super().visit_exec_stmt(o)
-
     def visit_match_stmt(self, o: MatchStmt) -> None:
         if not self.visit(o):
             return
@@ -614,11 +586,6 @@ class ExtendedTraverserVisitor(TraverserVisitor):
         if not self.visit(o):
             return
         super().visit_bytes_expr(o)
-
-    def visit_unicode_expr(self, o: UnicodeExpr) -> None:
-        if not self.visit(o):
-            return
-        super().visit_unicode_expr(o)
 
     def visit_float_expr(self, o: FloatExpr) -> None:
         if not self.visit(o):
@@ -769,11 +736,6 @@ class ExtendedTraverserVisitor(TraverserVisitor):
         if not self.visit(o):
             return
         super().visit_conditional_expr(o)
-
-    def visit_backquote_expr(self, o: BackquoteExpr) -> None:
-        if not self.visit(o):
-            return
-        super().visit_backquote_expr(o)
 
     def visit_type_var_expr(self, o: TypeVarExpr) -> None:
         if not self.visit(o):

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -14,7 +14,6 @@ from mypy.nodes import (
     AssignmentExpr,
     AssignmentStmt,
     AwaitExpr,
-    BackquoteExpr,
     Block,
     BreakStmt,
     BytesExpr,
@@ -31,7 +30,6 @@ from mypy.nodes import (
     DictionaryComprehension,
     EllipsisExpr,
     EnumCallExpr,
-    ExecStmt,
     Expression,
     ExpressionStmt,
     FloatExpr,
@@ -62,7 +60,6 @@ from mypy.nodes import (
     OverloadPart,
     ParamSpecExpr,
     PassStmt,
-    PrintStmt,
     PromoteExpr,
     RaiseStmt,
     RefExpr,
@@ -85,7 +82,6 @@ from mypy.nodes import (
     TypeVarExpr,
     TypeVarTupleExpr,
     UnaryExpr,
-    UnicodeExpr,
     Var,
     WhileStmt,
     WithStmt,
@@ -383,16 +379,6 @@ class TransformVisitor(NodeVisitor[Node]):
         new.analyzed_types = [self.type(typ) for typ in node.analyzed_types]
         return new
 
-    def visit_print_stmt(self, node: PrintStmt) -> PrintStmt:
-        return PrintStmt(
-            self.expressions(node.args), node.newline, self.optional_expr(node.target)
-        )
-
-    def visit_exec_stmt(self, node: ExecStmt) -> ExecStmt:
-        return ExecStmt(
-            self.expr(node.expr), self.optional_expr(node.globals), self.optional_expr(node.locals)
-        )
-
     def visit_star_expr(self, node: StarExpr) -> StarExpr:
         return StarExpr(node.expr)
 
@@ -404,9 +390,6 @@ class TransformVisitor(NodeVisitor[Node]):
 
     def visit_bytes_expr(self, node: BytesExpr) -> BytesExpr:
         return BytesExpr(node.value)
-
-    def visit_unicode_expr(self, node: UnicodeExpr) -> UnicodeExpr:
-        return UnicodeExpr(node.value)
 
     def visit_float_expr(self, node: FloatExpr) -> FloatExpr:
         return FloatExpr(node.value)
@@ -586,9 +569,6 @@ class TransformVisitor(NodeVisitor[Node]):
         return ConditionalExpr(
             self.expr(node.cond), self.expr(node.if_expr), self.expr(node.else_expr)
         )
-
-    def visit_backquote_expr(self, node: BackquoteExpr) -> BackquoteExpr:
-        return BackquoteExpr(self.expr(node.expr))
 
     def visit_type_var_expr(self, node: TypeVarExpr) -> TypeVarExpr:
         return TypeVarExpr(

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -31,10 +31,6 @@ class ExpressionVisitor(Generic[T]):
         pass
 
     @abstractmethod
-    def visit_unicode_expr(self, o: "mypy.nodes.UnicodeExpr") -> T:
-        pass
-
-    @abstractmethod
     def visit_float_expr(self, o: "mypy.nodes.FloatExpr") -> T:
         pass
 
@@ -152,10 +148,6 @@ class ExpressionVisitor(Generic[T]):
 
     @abstractmethod
     def visit_conditional_expr(self, o: "mypy.nodes.ConditionalExpr") -> T:
-        pass
-
-    @abstractmethod
-    def visit_backquote_expr(self, o: "mypy.nodes.BackquoteExpr") -> T:
         pass
 
     @abstractmethod
@@ -313,14 +305,6 @@ class StatementVisitor(Generic[T]):
         pass
 
     @abstractmethod
-    def visit_print_stmt(self, o: "mypy.nodes.PrintStmt") -> T:
-        pass
-
-    @abstractmethod
-    def visit_exec_stmt(self, o: "mypy.nodes.ExecStmt") -> T:
-        pass
-
-    @abstractmethod
     def visit_match_stmt(self, o: "mypy.nodes.MatchStmt") -> T:
         pass
 
@@ -471,12 +455,6 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T], Pattern
     def visit_with_stmt(self, o: "mypy.nodes.WithStmt") -> T:
         pass
 
-    def visit_print_stmt(self, o: "mypy.nodes.PrintStmt") -> T:
-        pass
-
-    def visit_exec_stmt(self, o: "mypy.nodes.ExecStmt") -> T:
-        pass
-
     def visit_match_stmt(self, o: "mypy.nodes.MatchStmt") -> T:
         pass
 
@@ -489,9 +467,6 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T], Pattern
         pass
 
     def visit_bytes_expr(self, o: "mypy.nodes.BytesExpr") -> T:
-        pass
-
-    def visit_unicode_expr(self, o: "mypy.nodes.UnicodeExpr") -> T:
         pass
 
     def visit_float_expr(self, o: "mypy.nodes.FloatExpr") -> T:
@@ -582,9 +557,6 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T], Pattern
         pass
 
     def visit_conditional_expr(self, o: "mypy.nodes.ConditionalExpr") -> T:
-        pass
-
-    def visit_backquote_expr(self, o: "mypy.nodes.BackquoteExpr") -> T:
         pass
 
     def visit_type_var_expr(self, o: "mypy.nodes.TypeVarExpr") -> T:

--- a/mypyc/irbuild/visitor.py
+++ b/mypyc/irbuild/visitor.py
@@ -11,7 +11,6 @@ from mypy.nodes import (
     AssignmentExpr,
     AssignmentStmt,
     AwaitExpr,
-    BackquoteExpr,
     Block,
     BreakStmt,
     BytesExpr,
@@ -28,7 +27,6 @@ from mypy.nodes import (
     DictionaryComprehension,
     EllipsisExpr,
     EnumCallExpr,
-    ExecStmt,
     ExpressionStmt,
     FloatExpr,
     ForStmt,
@@ -56,7 +54,6 @@ from mypy.nodes import (
     OverloadedFuncDef,
     ParamSpecExpr,
     PassStmt,
-    PrintStmt,
     PromoteExpr,
     RaiseStmt,
     ReturnStmt,
@@ -76,7 +73,6 @@ from mypy.nodes import (
     TypeVarExpr,
     TypeVarTupleExpr,
     UnaryExpr,
-    UnicodeExpr,
     Var,
     WhileStmt,
     WithStmt,
@@ -334,20 +330,6 @@ class IRBuilderVisitor(IRVisitor):
 
     def visit_assignment_expr(self, o: AssignmentExpr) -> Value:
         return transform_assignment_expr(self.builder, o)
-
-    # Unimplemented constructs that shouldn't come up because they are py2 only
-
-    def visit_backquote_expr(self, o: BackquoteExpr) -> Value:
-        self.bail("Python 2 features are unsupported", o.line)
-
-    def visit_exec_stmt(self, o: ExecStmt) -> None:
-        self.bail("Python 2 features are unsupported", o.line)
-
-    def visit_print_stmt(self, o: PrintStmt) -> None:
-        self.bail("Python 2 features are unsupported", o.line)
-
-    def visit_unicode_expr(self, o: UnicodeExpr) -> Value:
-        self.bail("Python 2 features are unsupported", o.line)
 
     # Constructs that shouldn't ever show up
 


### PR DESCRIPTION
Ref #12237 

This includes `UnicodeExpr`, `BackquoteExpr`, `PrintStmt`, and `ExecStmt`.