### PR TITLE
Remove all `builtins.unicode` references

### DIFF
--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -228,11 +228,6 @@ command.
    Only allow some fraction of types in the suggested signature to be ``Any`` types.
    The fraction ranges from ``0`` (same as ``--no-any``) to ``1``.
 
-.. option:: --try-text
-
-   Try also using ``unicode`` wherever ``str`` is inferred. This flag may be useful
-   for annotating Python 2/3 straddling code.
-
 .. option:: --callsites
 
    Only find call sites for a given function instead of suggesting a type.

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -162,9 +162,6 @@ p.add_argument(
     help="Allow anys in types if they go above a certain score (scores are from 0-1)",
 )
 p.add_argument(
-    "--try-text", action="store_true", help="Try using unicode wherever str is inferred"
-)
-p.add_argument(
     "--callsites", action="store_true", help="Find callsites instead of suggesting a type"
 )
 p.add_argument(
@@ -525,7 +522,6 @@ def do_suggest(args: argparse.Namespace) -> None:
         no_errors=args.no_errors,
         no_any=args.no_any,
         flex_any=args.flex_any,
-        try_text=args.try_text,
         use_fixme=args.use_fixme,
         max_guesses=args.max_guesses,
     )

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -168,13 +168,9 @@ def expr_to_unanalyzed_type(
             column=expr.column,
         )
     elif isinstance(expr, StrExpr):
-        return parse_type_string(
-            expr.value, "builtins.str", expr.line, expr.column
-        )
+        return parse_type_string(expr.value, "builtins.str", expr.line, expr.column)
     elif isinstance(expr, BytesExpr):
-        return parse_type_string(
-            expr.value, "builtins.bytes", expr.line, expr.column
-        )
+        return parse_type_string(expr.value, "builtins.bytes", expr.line, expr.column)
     elif isinstance(expr, UnaryExpr):
         typ = expr_to_unanalyzed_type(expr.expr, options, allow_new_syntax)
         if isinstance(typ, RawExpressionType):

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -169,11 +169,11 @@ def expr_to_unanalyzed_type(
         )
     elif isinstance(expr, StrExpr):
         return parse_type_string(
-            expr.value, "builtins.str", expr.line, expr.column, assume_str_is_unicode=True
+            expr.value, "builtins.str", expr.line, expr.column
         )
     elif isinstance(expr, BytesExpr):
         return parse_type_string(
-            expr.value, "builtins.bytes", expr.line, expr.column, assume_str_is_unicode=False
+            expr.value, "builtins.bytes", expr.line, expr.column
         )
     elif isinstance(expr, UnaryExpr):
         typ = expr_to_unanalyzed_type(expr.expr, options, allow_new_syntax)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1946,12 +1946,6 @@ class TypeConverter:
 
     # Str(string s)
     def visit_Str(self, n: Str) -> Type:
-        # Do a getattr because the field doesn't exist in 3.8 (where
-        # this method doesn't actually ever run.) We can't just do
-        # an attribute access with a `# type: ignore` because it would be
-        # unused on < 3.8.
-        kind: str = getattr(n, "kind")  # noqa
-
         return parse_type_string(n.s, "builtins.str", self.line, n.col_offset)
 
     # Bytes(bytes s)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -331,10 +331,7 @@ def parse_type_ignore_tag(tag: Optional[str]) -> Optional[List[str]]:
 
 
 def parse_type_comment(
-    type_comment: str,
-    line: int,
-    column: int,
-    errors: Optional[Errors],
+    type_comment: str, line: int, column: int, errors: Optional[Errors]
 ) -> Tuple[Optional[List[str]], Optional[ProperType]]:
     """Parse type portion of a type comment (+ optional type ignore).
 
@@ -365,19 +362,13 @@ def parse_type_comment(
             ignored = None
         assert isinstance(typ, ast3_Expression)
         converted = TypeConverter(
-            errors,
-            line=line,
-            override_column=column,
-            is_evaluated=False,
+            errors, line=line, override_column=column, is_evaluated=False
         ).visit(typ.body)
         return ignored, converted
 
 
 def parse_type_string(
-    expr_string: str,
-    expr_fallback_name: str,
-    line: int,
-    column: int,
+    expr_string: str, expr_fallback_name: str, line: int, column: int
 ) -> ProperType:
     """Parses a type that was originally present inside of an explicit string.
 
@@ -385,12 +376,7 @@ def parse_type_string(
     string expression "blah" using this function.
     """
     try:
-        _, node = parse_type_comment(
-            expr_string.strip(),
-            line=line,
-            column=column,
-            errors=None,
-        )
+        _, node = parse_type_comment(expr_string.strip(), line=line, column=column, errors=None)
         if isinstance(node, UnboundType) and node.original_str_expr is None:
             node.original_str_expr = expr_string
             node.original_str_fallback = expr_fallback_name
@@ -1906,12 +1892,7 @@ class TypeConverter:
             return UnboundType("None", line=self.line)
         if isinstance(val, str):
             # Parse forward reference.
-            return parse_type_string(
-                n.s,
-                "builtins.str",
-                self.line,
-                n.col_offset,
-            )
+            return parse_type_string(n.s, "builtins.str", self.line, n.col_offset)
         if val is Ellipsis:
             # '...' is valid in some types.
             return EllipsisType(line=self.line)
@@ -1971,12 +1952,7 @@ class TypeConverter:
         # unused on < 3.8.
         kind: str = getattr(n, "kind")  # noqa
 
-        return parse_type_string(
-            n.s,
-            "builtins.str",
-            self.line,
-            n.col_offset,
-        )
+        return parse_type_string(n.s, "builtins.str", self.line, n.col_offset)
 
     # Bytes(bytes s)
     def visit_Bytes(self, n: Bytes) -> Type:

--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -23,26 +23,6 @@ from mypy.types import (
 )
 
 
-def _get_bytes_type(api: "mypy.plugin.CheckerPluginInterface") -> Instance:
-    """Return the type corresponding to bytes on the current Python version.
-
-    This is bytes in Python 3, and str in Python 2.
-    """
-    return api.named_generic_type(
-        "builtins.bytes" if api.options.python_version >= (3,) else "builtins.str", []
-    )
-
-
-def _get_text_type(api: "mypy.plugin.CheckerPluginInterface") -> Instance:
-    """Return the type corresponding to Text on the current Python version.
-
-    This is str in Python 3, and unicode in Python 2.
-    """
-    return api.named_generic_type(
-        "builtins.str" if api.options.python_version >= (3,) else "builtins.unicode", []
-    )
-
-
 def _find_simplecdata_base_arg(
     tp: Instance, api: "mypy.plugin.CheckerPluginInterface"
 ) -> Optional[ProperType]:
@@ -221,9 +201,9 @@ def array_value_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
             if isinstance(tp, AnyType):
                 types.append(AnyType(TypeOfAny.from_another_any, source_any=tp))
             elif isinstance(tp, Instance) and tp.type.fullname == "ctypes.c_char":
-                types.append(_get_bytes_type(ctx.api))
+                types.append(ctx.api.named_generic_type("builtins.bytes"))
             elif isinstance(tp, Instance) and tp.type.fullname == "ctypes.c_wchar":
-                types.append(_get_text_type(ctx.api))
+                types.append(ctx.api.named_generic_type("builtins.str"))
             else:
                 ctx.api.msg.fail(
                     'Array attribute "value" is only available'
@@ -245,7 +225,7 @@ def array_raw_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
                 or isinstance(tp, Instance)
                 and tp.type.fullname == "ctypes.c_char"
             ):
-                types.append(_get_bytes_type(ctx.api))
+                types.append(ctx.api.named_generic_type("builtins.bytes"))
             else:
                 ctx.api.msg.fail(
                     'Array attribute "raw" is only available'

--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -201,9 +201,9 @@ def array_value_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
             if isinstance(tp, AnyType):
                 types.append(AnyType(TypeOfAny.from_another_any, source_any=tp))
             elif isinstance(tp, Instance) and tp.type.fullname == "ctypes.c_char":
-                types.append(ctx.api.named_generic_type("builtins.bytes"))
+                types.append(ctx.api.named_generic_type("builtins.bytes", []))
             elif isinstance(tp, Instance) and tp.type.fullname == "ctypes.c_wchar":
-                types.append(ctx.api.named_generic_type("builtins.str"))
+                types.append(ctx.api.named_generic_type("builtins.str", []))
             else:
                 ctx.api.msg.fail(
                     'Array attribute "value" is only available'
@@ -225,7 +225,7 @@ def array_raw_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
                 or isinstance(tp, Instance)
                 and tp.type.fullname == "ctypes.c_char"
             ):
-                types.append(ctx.api.named_generic_type("builtins.bytes"))
+                types.append(ctx.api.named_generic_type("builtins.bytes", []))
             else:
                 ctx.api.msg.fail(
                     'Array attribute "raw" is only available'

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -308,11 +308,10 @@ class AnnotationPrinter(TypeStrVisitor):
         The main difference from list_str is the preservation of quotes for string
         arguments
         """
-        types = ["builtins.bytes", "builtins.unicode"]
         res = []
         for arg in args:
             arg_str = arg.accept(self)
-            if isinstance(arg, UnboundType) and arg.original_str_fallback in types:
+            if isinstance(arg, UnboundType) and arg.original_str_fallback == "builtins.bytes":
                 res.append(f"'{arg_str}'")
             else:
                 res.append(arg_str)

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -308,10 +308,11 @@ class AnnotationPrinter(TypeStrVisitor):
         The main difference from list_str is the preservation of quotes for string
         arguments
         """
+        types = ["builtins.bytes", "builtins.str"]
         res = []
         for arg in args:
             arg_str = arg.accept(self)
-            if isinstance(arg, UnboundType) and arg.original_str_fallback == "builtins.bytes":
+            if isinstance(arg, UnboundType) and arg.original_str_fallback in types:
                 res.append(f"'{arg_str}'")
             else:
                 res.append(arg_str)

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -249,7 +249,6 @@ class SuggestionEngine:
         json: bool,
         no_errors: bool = False,
         no_any: bool = False,
-        try_text: bool = False,
         flex_any: Optional[float] = None,
         use_fixme: Optional[str] = None,
         max_guesses: Optional[int] = None,
@@ -262,7 +261,6 @@ class SuggestionEngine:
 
         self.give_json = json
         self.no_errors = no_errors
-        self.try_text = try_text
         self.flex_any = flex_any
         if no_any:
             self.flex_any = 1.0
@@ -768,8 +766,6 @@ class SuggestionEngine:
                 return 10
         if isinstance(t, CallableType) and (has_any_type(t) or is_tricky_callable(t)):
             return 10
-        if self.try_text and isinstance(t, Instance) and t.type.fullname == "builtins.str":
-            return 1
         return 0
 
     def score_callable(self, t: CallableType) -> int:

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -292,7 +292,6 @@ class FineGrainedSuite(DataSuite):
             callsites = "--callsites" in flags
             no_any = "--no-any" in flags
             no_errors = "--no-errors" in flags
-            try_text = "--try-text" in flags
             m = re.match("--flex-any=([0-9.]+)", flags)
             flex_any = float(m.group(1)) if m else None
             m = re.match(r"--use-fixme=(\w+)", flags)
@@ -304,7 +303,6 @@ class FineGrainedSuite(DataSuite):
                 json=json,
                 no_any=no_any,
                 no_errors=no_errors,
-                try_text=try_text,
                 flex_any=flex_any,
                 use_fixme=use_fixme,
                 callsites=callsites,

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1162,7 +1162,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             return [
                 LiteralType(
                     value=arg.original_str_expr,
-                    fallback=self.named_type_with_normalized_str(arg.original_str_fallback),
+                    fallback=self.named_type(arg.original_str_fallback),
                     line=arg.line,
                     column=arg.column,
                 )
@@ -1210,7 +1210,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 return None
 
             # Remap bytes and unicode into the appropriate type for the correct Python version
-            fallback = self.named_type_with_normalized_str(arg.base_type_name)
+            fallback = self.named_type(arg.base_type_name)
             assert isinstance(fallback, Instance)
             return [LiteralType(arg.literal_value, fallback, line=arg.line, column=arg.column)]
         elif isinstance(arg, (NoneType, LiteralType)):
@@ -1356,17 +1356,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def anal_var_defs(self, var_defs: Sequence[TypeVarLikeType]) -> List[TypeVarLikeType]:
         return [self.anal_var_def(vd) for vd in var_defs]
-
-    def named_type_with_normalized_str(self, fully_qualified_name: str) -> Instance:
-        """Does almost the same thing as `named_type`, except that we immediately
-        unalias `builtins.bytes` and `builtins.unicode` to `builtins.str` as appropriate.
-        """
-        python_version = self.options.python_version
-        if python_version[0] == 2 and fully_qualified_name == "builtins.bytes":
-            fully_qualified_name = "builtins.str"
-        if python_version[0] >= 3 and fully_qualified_name == "builtins.unicode":
-            fully_qualified_name = "builtins.str"
-        return self.named_type(fully_qualified_name)
 
     def named_type(
         self,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2406,10 +2406,6 @@ class LiteralType(ProperType):
             # Note: 'builtins.bytes' only appears in Python 3, so we want to
             # explicitly prefix with a "b"
             return "b" + raw
-        elif fallback_name == "builtins.unicode":
-            # Similarly, 'builtins.unicode' only appears in Python 2, where we also
-            # want to explicitly prefix
-            return "u" + raw
         else:
             # 'builtins.str' could mean either depending on context, but either way
             # we don't prefix: it's the "native" string. And of course, if value is


### PR DESCRIPTION
Refs https://github.com/python/mypy/issues/12237
Should be merged after https://github.com/python/mypy/pull/13264 since `checkexpr` is using `unicode` as well.