### PR TITLE
Remove python2 from `build.py` and `reachability.py`

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2547,18 +2547,7 @@ def find_module_and_diagnose(
 
     Returns a tuple containing (file path, target's effective follow_imports setting)
     """
-    file_id = id
-    if id == "builtins" and options.python_version[0] == 2:
-        # The __builtin__ module is called internally by mypy
-        # 'builtins' in Python 2 mode (similar to Python 3),
-        # but the stub file is __builtin__.pyi.  The reason is
-        # that a lot of code hard-codes 'builtins.x' and it's
-        # easier to work it around like this.  It also means
-        # that the implementation can mostly ignore the
-        # difference and just assume 'builtins' everywhere,
-        # which simplifies code.
-        file_id = "__builtin__"
-    result = find_module_with_reason(file_id, manager)
+    result = find_module_with_reason(id, manager)
     if isinstance(result, str):
         # For non-stubs, look at options.follow_imports:
         # - normal (default) -> fully analyze
@@ -2614,7 +2603,7 @@ def find_module_and_diagnose(
         # search path or the module has not been installed.
 
         ignore_missing_imports = options.ignore_missing_imports
-        top_level, second_level = get_top_two_prefixes(file_id)
+        top_level, second_level = get_top_two_prefixes(id)
         # Don't honor a global (not per-module) ignore_missing_imports
         # setting for modules that used to have bundled stubs, as
         # otherwise updating mypy can silently result in new false

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -147,7 +147,7 @@ def infer_condition_value(expr: Expression, options: Options) -> int:
         if name == "PY2":
             result = ALWAYS_FALSE
         elif name == "PY3":
-            result = ALWAYS_TRUE if pyversion[0] == 3 else ALWAYS_FALSE
+            result = ALWAYS_TRUE
         elif name == "MYPY" or name == "TYPE_CHECKING":
             result = MYPY_TRUE
         elif name in options.always_true:

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -145,7 +145,7 @@ def infer_condition_value(expr: Expression, options: Options) -> int:
             result = consider_sys_platform(expr, options.platform)
     if result == TRUTH_VALUE_UNKNOWN:
         if name == "PY2":
-            result = ALWAYS_TRUE if pyversion[0] == 2 else ALWAYS_FALSE
+            result = ALWAYS_FALSE
         elif name == "PY3":
             result = ALWAYS_TRUE if pyversion[0] == 3 else ALWAYS_FALSE
         elif name == "MYPY" or name == "TYPE_CHECKING":


### PR DESCRIPTION
The one in `reachability.py` made me think 🤔 
I guess it is a right thing to keep `PY2` as always false.

Refs https://github.com/python/mypy/issues/12237