### PR TITLE
stubtest: Fallback to `getattr_static` if an attribute can't be found on a class at runtime

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -364,7 +364,10 @@ def verify_typeinfo(
         stub_to_verify = next((t.names[entry].node for t in stub.mro if entry in t.names), MISSING)
         assert stub_to_verify is not None
         try:
-            runtime_attr = getattr(runtime, mangled_entry, MISSING)
+            try:
+                runtime_attr = getattr(runtime, mangled_entry)
+            except AttributeError:
+                runtime_attr = inspect.getattr_static(runtime, mangled_entry, MISSING)
         except Exception:
             # Catch all exceptions in case the runtime raises an unexpected exception
             # from __getattr__ or similar.

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -615,16 +615,12 @@ class StubtestUnit(unittest.TestCase):
         )
         yield Case(
             stub="""
-            class EvilDescriptor:
-                def __get__(self, instance: object, ownerclass: type | None = ...) -> int: ...
-                def __set__(self, instance: object, value: int) -> None: ...
-
             class FineAndDandy:
                 @property
                 def attr(self) -> int: ...
             """,
             runtime="""
-            class EvilDescriptor:
+            class _EvilDescriptor:
                 def __get__(self, instance, ownerclass=None):
                     if instance is None:
                         raise AttributeError('no')
@@ -633,7 +629,7 @@ class StubtestUnit(unittest.TestCase):
                     raise AttributeError('no')
 
             class FineAndDandy:
-                attr = EvilDescriptor()
+                attr = _EvilDescriptor()
             """,
             error=None,
         )

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -613,6 +613,30 @@ class StubtestUnit(unittest.TestCase):
             """,
             error=None,
         )
+        yield Case(
+            stub="""
+            class EvilDescriptor:
+                def __get__(self, instance: object, ownerclass: type | None = ...) -> int: ...
+                def __set__(self, instance: object, value: int) -> None: ...
+
+            class FineAndDandy:
+                @property
+                def attr(self) -> int: ...
+            """,
+            runtime="""
+            class EvilDescriptor:
+                def __get__(self, instance, ownerclass=None):
+                    if instance is None:
+                        raise AttributeError('no')
+                    return 42
+                def __set__(self, instance, value):
+                    raise AttributeError('no')
+
+            class FineAndDandy:
+                attr = EvilDescriptor()
+            """,
+            error=None
+        )
 
     @collect_cases
     def test_var(self) -> Iterator[Case]:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -635,7 +635,7 @@ class StubtestUnit(unittest.TestCase):
             class FineAndDandy:
                 attr = EvilDescriptor()
             """,
-            error=None
+            error=None,
         )
 
     @collect_cases


### PR DESCRIPTION
### Description

Stubtest currently emits false-positive errors on most of the stdlib enums in typeshed, due to this behaviour:

```python
>>> from enum import Enum
>>> class Foo(Enum):
...     BAR = 1
...
>>> Foo.BAR.value
1
>>> Foo.BAR.value = 5
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\types.py", line 187, in __set__
    raise AttributeError("can't set attribute")
AttributeError: can't set attribute
>>> Foo.value
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\alexw\AppData\Local\Programs\Python\Python310\lib\enum.py", line 437, in __getattr__
    raise AttributeError(name) from None
AttributeError: value
```

The `value` property exists on `enum` classes, but stubtest can't see it due to some magic the `enum` module does to make `value` raise an `AttributeError` if you try to access it on the class itself, rather than on an enum member. We can avoid these false-positive errors by falling back to `getattr_static` if the attribute can't be found using `getattr`.

Output from running typeshed's `stubtest_stdlib.py`, with this patch checked out, relative to running the same test with mypy `master` checked out:

```diff
+ note: unused allowlist entry enum.Enum.name
+ note: unused allowlist entry enum.Enum.value
+ note: unused allowlist entry enum.Flag.name
+ note: unused allowlist entry enum.Flag.value
+ note: unused allowlist entry enum.IntEnum.value
```

## Test Plan

I added a test.
