### PR TITLE
Fix tests on Python 3.10.0

### DIFF
--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -154,6 +154,6 @@ reveal_type(f'{1}') # N: Revealed type is "builtins.str"
 
 [case testFeatureVersionSuggestion]
 # flags: --python-version 3.99
-this is what future python looks like public static void main String[] args await goto exit
+x *** x this is what future python looks like public static void main String[] args await goto exit
 [out]
 main:2: error: invalid syntax; you likely need to run mypy using Python 3.99 or newer


### PR DESCRIPTION
Syntax error was changed in a micro version; wheel builds use 3.10.0