### PR TITLE
Allow stubtest to ignore python2 only magic methods

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1142,6 +1142,11 @@ IGNORABLE_CLASS_DUNDERS = frozenset(
         "__instancecheck__",
         "__subclasshook__",
         "__subclasscheck__",
+        # python2 only magic methods:
+        "__cmp__",
+        "__nonzero__",
+        "__unicode__",
+        "__div__",
         # Pickle methods
         "__setstate__",
         "__getstate__",


### PR DESCRIPTION
CC @JelleZijlstra @AlexWaygood 
Refs https://github.com/python/typeshed/pull/8443
Refs https://github.com/python/mypy/issues/12237

I will examine and remove other python2-only magic methods from `typeshed` later 🙂 