### PR TITLE
Enable recursive type aliases behind a flag

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3678,7 +3678,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.check_subtype(
                     # Preserve original aliases for error messages when possible.
                     orig_rvalue,
-                    orig_lvalue,
+                    orig_lvalue or lvalue_type,
                     context,
                     msg,
                     f"{rvalue_name} has type",

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3662,11 +3662,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # '...' is always a valid initializer in a stub.
             return AnyType(TypeOfAny.special_form)
         else:
+            orig_lvalue = lvalue_type
             lvalue_type = get_proper_type(lvalue_type)
             always_allow_any = lvalue_type is not None and not isinstance(lvalue_type, AnyType)
             rvalue_type = self.expr_checker.accept(
                 rvalue, lvalue_type, always_allow_any=always_allow_any
             )
+            orig_rvalue = rvalue_type
             rvalue_type = get_proper_type(rvalue_type)
             if isinstance(rvalue_type, DeletedType):
                 self.msg.deleted_as_rvalue(rvalue_type, context)
@@ -3674,8 +3676,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.msg.deleted_as_lvalue(lvalue_type, context)
             elif lvalue_type:
                 self.check_subtype(
-                    rvalue_type,
-                    lvalue_type,
+                    # Preserve original aliases for error messages when possible.
+                    orig_rvalue,
+                    orig_lvalue,
                     context,
                     msg,
                     f"{rvalue_name} has type",
@@ -5568,7 +5571,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             code = msg.code
         else:
             msg_text = msg
+        orig_subtype = subtype
         subtype = get_proper_type(subtype)
+        orig_supertype = supertype
         supertype = get_proper_type(supertype)
         if self.msg.try_report_long_tuple_assignment_error(
             subtype, supertype, context, msg_text, subtype_label, supertype_label, code=code
@@ -5580,7 +5585,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         note_msg = ""
         notes: List[str] = []
         if subtype_label is not None or supertype_label is not None:
-            subtype_str, supertype_str = format_type_distinctly(subtype, supertype)
+            subtype_str, supertype_str = format_type_distinctly(orig_subtype, orig_supertype)
             if subtype_label is not None:
                 extra_info.append(subtype_label + " " + subtype_str)
             if supertype_label is not None:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -138,7 +138,6 @@ from mypy.types import (
     StarType,
     TupleType,
     Type,
-    TypeAliasType,
     TypedDictType,
     TypeOfAny,
     TypeType,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -138,6 +138,7 @@ from mypy.types import (
     StarType,
     TupleType,
     Type,
+    TypeAliasType,
     TypedDictType,
     TypeOfAny,
     TypeType,
@@ -147,6 +148,7 @@ from mypy.types import (
     flatten_nested_unions,
     get_proper_type,
     get_proper_types,
+    has_recursive_types,
     is_generic_instance,
     is_named_instance,
     is_optional,
@@ -1534,6 +1536,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 else:
                     pass1_args.append(arg)
 
+            # This is a hack to better support inference for recursive types.
+            # When the outer context for a function call is known to be recursive,
+            # we solve type constraints inferred from arguments using unions instead
+            # of joins. This is a bit arbitrary, but in practice it works for most
+            # cases. A cleaner alternative would be to switch to single bin type
+            # inference, but this is a lot of work.
+            ctx = self.type_context[-1]
+            if ctx and has_recursive_types(ctx):
+                infer_unions = True
+            else:
+                infer_unions = False
             inferred_args = infer_function_type_arguments(
                 callee_type,
                 pass1_args,
@@ -1541,6 +1554,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 formal_to_actual,
                 context=self.argument_infer_context(),
                 strict=self.chk.in_checked_function(),
+                infer_unions=infer_unions,
             )
 
             if 2 in arg_pass_nums:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -293,7 +293,8 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
                 else:
                     items.extend(unpacked_items)
             else:
-                items.append(proper_item.accept(self))
+                # Must preserve original aliases when possible.
+                items.append(item.accept(self))
         return items
 
     def visit_tuple_type(self, t: TupleType) -> Type:

--- a/mypy/infer.py
+++ b/mypy/infer.py
@@ -34,6 +34,7 @@ def infer_function_type_arguments(
     formal_to_actual: List[List[int]],
     context: ArgumentInferContext,
     strict: bool = True,
+    infer_unions: bool = False,
 ) -> List[Optional[Type]]:
     """Infer the type arguments of a generic function.
 
@@ -55,7 +56,7 @@ def infer_function_type_arguments(
 
     # Solve constraints.
     type_vars = callee_type.type_var_ids()
-    return solve_constraints(type_vars, constraints, strict)
+    return solve_constraints(type_vars, constraints, strict, infer_unions=infer_unions)
 
 
 def infer_type_arguments(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -978,6 +978,11 @@ def process_options(
         help="Use a custom typing module",
     )
     internals_group.add_argument(
+        "--enable-recursive-aliases",
+        action="store_true",
+        help="Experimental support for recursive type aliases",
+    )
+    internals_group.add_argument(
         "--custom-typeshed-dir", metavar="DIR", help="Use the custom typeshed in DIR"
     )
     add_invertible_flag(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -87,6 +87,7 @@ from mypy.types import (
     ProperType,
     TupleType,
     Type,
+    TypeAliasType,
     TypedDictType,
     TypeOfAny,
     TypeType,
@@ -2128,7 +2129,17 @@ def format_type_inner(typ: Type, verbosity: int, fullnames: Optional[Set[str]]) 
         else:
             return typ.value_repr()
 
-    # TODO: show type alias names in errors.
+    if isinstance(typ, TypeAliasType) and typ.is_recursive:
+        # TODO: find balance here, str(typ) doesn't support custom verbosity, and may be
+        # too verbose for user messages, OTOH it nicely shows structure of recursive types.
+        if verbosity < 2:
+            type_str = typ.alias.name if typ.alias else "<alias (unfixed)>"
+            if typ.args:
+                type_str += f"[{format_list(typ.args)}]"
+            return type_str
+        return str(typ)
+
+    # TODO: always mention type alias names in errors.
     typ = get_proper_type(typ)
 
     if isinstance(typ, Instance):

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -315,6 +315,8 @@ class Options:
         # skip most errors after this many messages have been reported.
         # -1 means unlimited.
         self.many_errors_threshold = defaults.MANY_ERRORS_THRESHOLD
+        # Enable recursive type aliases (currently experimental)
+        self.enable_recursive_aliases = False
 
     # To avoid breaking plugin compatibility, keep providing new_semantic_analyzer
     @property

--- a/mypy/sametypes.py
+++ b/mypy/sametypes.py
@@ -33,6 +33,10 @@ from mypy.types import (
 def is_same_type(left: Type, right: Type) -> bool:
     """Is 'left' the same type as 'right'?"""
 
+    if isinstance(left, TypeAliasType) and isinstance(right, TypeAliasType):
+        if left.is_recursive and right.is_recursive:
+            return left.alias == right.alias and left.args == right.args
+
     left = get_proper_type(left)
     right = get_proper_type(right)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4555,7 +4555,7 @@ class SemanticAnalyzer(
         if self.found_incomplete_ref(tag):
             return None
         if self.basic_type_applications:
-            # Postpone the rest until we are sure this is not a r.h.s. of a type alias.
+            # Postpone the rest until we have more information (for r.h.s. of an assignment)
             return None
         types: List[Type] = []
         if isinstance(index, TupleExpr):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -105,13 +105,15 @@ def is_subtype(
     if TypeState.is_assumed_subtype(left, right):
         return True
     if (
+        # TODO: recursive instances like `class str(Sequence[str])` can also cause
+        # issues, so we also need to include them in the assumptions stack
         isinstance(left, TypeAliasType)
         and isinstance(right, TypeAliasType)
         and left.is_recursive
         and right.is_recursive
     ):
         # This case requires special care because it may cause infinite recursion.
-        # Our view on recursive types is known under a fancy name of equirecursive mu-types.
+        # Our view on recursive types is known under a fancy name of iso-recursive mu-types.
         # Roughly this means that a recursive type is defined as an alias where right hand side
         # can refer to the type as a whole, for example:
         #     A = Union[int, Tuple[A, ...]]

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -362,7 +362,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 if (
                     isinstance(res, Instance)  # type: ignore[misc]
                     and len(res.args) != len(res.type.type_vars)
-                    and (not self.defining_alias or self.nesting_level)
+                    and not self.defining_alias
                 ):
                     fix_instance(
                         res,

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -362,7 +362,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 if (
                     isinstance(res, Instance)  # type: ignore[misc]
                     and len(res.args) != len(res.type.type_vars)
-                    and not self.defining_alias
+                    and (not self.defining_alias or self.nesting_level)
                 ):
                     fix_instance(
                         res,

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -441,7 +441,7 @@ def make_simplified_union(
     items = flatten_nested_unions(items, handle_type_alias_type=True)
 
     # Step 2: remove redundant unions
-    simplified_set = _remove_redundant_union_items(items, keep_erased)
+    simplified_set: Sequence[Type] = _remove_redundant_union_items(items, keep_erased)
 
     # Step 3: If more than one literal exists in the union, try to simplify
     if (

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -55,6 +55,7 @@ from mypy.types import (
     UninhabitedType,
     UnionType,
     UnpackType,
+    flatten_nested_unions,
     get_proper_type,
     get_proper_types,
 )
@@ -436,17 +437,8 @@ def make_simplified_union(
     back into a sum type. Set it to False when called by try_expanding_sum_type_
     to_union().
     """
-    items = get_proper_types(items)
-
     # Step 1: expand all nested unions
-    while any(isinstance(typ, UnionType) for typ in items):
-        all_items: List[ProperType] = []
-        for typ in items:
-            if isinstance(typ, UnionType):
-                all_items.extend(get_proper_types(typ.items))
-            else:
-                all_items.append(typ)
-        items = all_items
+    items = cast(List[ProperType], flatten_nested_unions(items, handle_type_alias_type=True))
 
     # Step 2: remove redundant unions
     simplified_set = _remove_redundant_union_items(items, keep_erased)

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3229,3 +3229,8 @@ class b:
     T = Union[Any]
 
 [builtins fixtures/tuple.pyi]
+
+[case testSelfReferentialSubscriptExpression]
+x = x[1]  # E: Cannot resolve name "x" (possible cyclic definition)
+y = 1[y]  # E: Value of type "int" is not indexable \
+          # E: Cannot determine type of "y"

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -57,3 +57,18 @@ class Bad: ...
 x: Nested[int] = [1, [2, [3]]]
 x = [1, [Bad()]]  # E: List item 0 has incompatible type "Bad"; expected "Union[int, Nested[int]]"
 [builtins fixtures/isinstancelist.pyi]
+
+[case testRecursiveAliasNewStyleSupported]
+# flags: --enable-recursive-aliases
+from test import A
+
+x: A
+if isinstance(x, list):
+    reveal_type(x[0])  # N: Revealed type is "Union[builtins.int, builtins.list[Union[builtins.int, builtins.list[...]]]]"
+else:
+    reveal_type(x)  # N: Revealed type is "builtins.int"
+
+[file test.pyi]
+A = int | list[A]
+
+[builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -1,3 +1,5 @@
+-- Tests checking that basic functionality works
+
 [case testRecursiveAliasBasic]
 # flags: --enable-recursive-aliases
 from typing import Dict, List, Union, TypeVar, Sequence
@@ -70,5 +72,123 @@ else:
 
 [file test.pyi]
 A = int | list[A]
+[builtins fixtures/isinstancelist.pyi]
 
+-- Tests duplicating some existing tests with recursive aliases enabled
+
+[case testRecursiveAliasesMutual]
+# flags: --enable-recursive-aliases
+from typing import Type, Callable, Union
+
+A = Union[B, int]
+B = Callable[[C], int]
+C = Type[A]
+x: A
+reveal_type(x)  # N: Revealed type is "Union[def (Union[Type[def (...) -> builtins.int], Type[builtins.int]]) -> builtins.int, builtins.int]"
+
+[case testRecursiveAliasesProhibited-skip]
+# flags: --enable-recursive-aliases
+from typing import Type, Callable, Union
+
+A = Union[B, int]
+B = Union[A, int]
+C = Type[C]
+
+[case testRecursiveAliasImported]
+# flags: --enable-recursive-aliases
+import lib
+x: lib.A
+reveal_type(x)  # N: Revealed type is "builtins.list[builtins.list[...]]"
+
+[file lib.pyi]
+from typing import List
+from other import B
+A = List[B]
+
+[file other.pyi]
+from typing import List
+from lib import A
+B = List[A]
+[builtins fixtures/list.pyi]
+
+[case testRecursiveAliasViaBaseClass]
+# flags: --enable-recursive-aliases
+from typing import List
+
+x: B
+B = List[C]
+class C(B): pass
+
+reveal_type(x)  # N: Revealed type is "builtins.list[__main__.C]"
+reveal_type(x[0][0])  # N: Revealed type is "__main__.C"
+[builtins fixtures/list.pyi]
+
+[case testRecursiveAliasViaBaseClass2]
+# flags: --enable-recursive-aliases
+from typing import NewType, List
+
+x: D
+reveal_type(x[0][0])  # N: Revealed type is "__main__.C"
+
+D = List[C]
+C = NewType('C', B)
+
+class B(D):
+    pass
+[builtins fixtures/list.pyi]
+
+[case testRecursiveAliasViaBaseClass3]
+# flags: --enable-recursive-aliases
+from typing import List, Generic, TypeVar, NamedTuple
+T = TypeVar('T')
+
+class C(A, B):
+    pass
+class G(Generic[T]): pass
+A = G[C]
+class B(NamedTuple):
+    x: int
+
+y: C
+reveal_type(y.x)  # N: Revealed type is "builtins.int"
+reveal_type(y[0])  # N: Revealed type is "builtins.int"
+x: A
+reveal_type(x)  # N: Revealed type is "__main__.G[Tuple[builtins.int, fallback=__main__.C]]"
+[builtins fixtures/list.pyi]
+
+[case testRecursiveAliasViaBaseClassImported]
+# flags: --enable-recursive-aliases
+import a
+[file a.py]
+from typing import List
+from b import D
+
+def f(x: B) -> List[B]: ...
+B = List[C]
+class C(B): pass
+
+[file b.py]
+from a import f
+class D: ...
+reveal_type(f)  # N: Revealed type is "def (x: builtins.list[a.C]) -> builtins.list[builtins.list[a.C]]"
+[builtins fixtures/list.pyi]
+
+[case testRecursiveAliasViaNamedTuple]
+# flags: --enable-recursive-aliases
+from typing import List, NamedTuple, Union
+
+Exp = Union['A', 'B']
+class A(NamedTuple('A', [('attr', List[Exp])])): pass
+class B(NamedTuple('B', [('val', object)])): pass
+
+def my_eval(exp: Exp) -> int:
+    reveal_type(exp) # N: Revealed type is "Union[Tuple[builtins.list[...], fallback=__main__.A], Tuple[builtins.object, fallback=__main__.B]]"
+    if isinstance(exp, A):
+        my_eval(exp[0][0])
+        return my_eval(exp.attr[0])
+    if isinstance(exp, B):
+        return exp.val  # E: Incompatible return value type (got "object", expected "int")
+    return 0
+
+my_eval(A([B(1), B(2)]))
 [builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -1,0 +1,59 @@
+[case testRecursiveAliasBasic]
+# flags: --enable-recursive-aliases
+from typing import Dict, List, Union, TypeVar, Sequence
+
+JSON = Union[str, List[JSON], Dict[str, JSON]]
+
+x: JSON = ["foo", {"bar": "baz"}]
+
+reveal_type(x)  # N: Revealed type is "Union[builtins.str, builtins.list[...], builtins.dict[builtins.str, ...]]"
+if isinstance(x, list):
+    x = x[0]
+
+class Bad: ...
+x = ["foo", {"bar": [Bad()]}]  # E: List item 0 has incompatible type "Bad"; expected "Union[str, List[JSON], Dict[str, JSON]]"
+[builtins fixtures/isinstancelist.pyi]
+
+[case testRecursiveAliasBasicGenericSubtype]
+# flags: --enable-recursive-aliases
+from typing import Union, TypeVar, Sequence, List
+
+T = TypeVar("T")
+
+Nested = Sequence[Union[T, Nested[T]]]
+
+class Bad: ...
+x: Nested[int]
+y: Nested[Bad]
+x = y  # E: Incompatible types in assignment (expression has type "Nested[Bad]", variable has type "Nested[int]")
+
+NestedOther = Sequence[Union[T, Nested[T]]]
+
+xx: Nested[int]
+yy: NestedOther[bool]
+xx = yy  # OK
+[builtins fixtures/isinstancelist.pyi]
+
+[case testRecursiveAliasBasicGenericInference]
+# flags: --enable-recursive-aliases
+from typing import Union, TypeVar, Sequence, List
+
+T = TypeVar("T")
+
+Nested = Sequence[Union[T, Nested[T]]]
+
+def flatten(arg: Nested[T]) -> List[T]:
+    res: List[T] = []
+    for item in arg:
+        if isinstance(item, Sequence):
+            res.extend(flatten(item))
+        else:
+            res.append(item)
+    return res
+
+reveal_type(flatten([1, [2, [3]]]))  # N: Revealed type is "builtins.list[builtins.int]"
+
+class Bad: ...
+x: Nested[int] = [1, [2, [3]]]
+x = [1, [Bad()]]  # E: List item 0 has incompatible type "Bad"; expected "Union[int, Nested[int]]"
+[builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/fixtures/isinstancelist.pyi
+++ b/test-data/unit/fixtures/isinstancelist.pyi
@@ -41,6 +41,8 @@ class list(Sequence[T]):
     def __getitem__(self, x: int) -> T: pass
     def __add__(self, x: List[T]) -> T: pass
     def __contains__(self, item: object) -> bool: pass
+    def append(self, x: T) -> None: pass
+    def extend(self, x: Iterable[T]) -> None: pass
 
 class dict(Mapping[KT, VT]):
     @overload


### PR DESCRIPTION
This PR exposes recursive type aliases that were secretly there for last ~3 years. For now they will still be behind an opt-in flag, because they are not production ready.

As we discussed with @JukkaL during PyCon, I use couple hacks to make them minimally usable, as proper solutions will take time. I may clean up some of them in near future (or may not).

You can see few added test cases to get an idea of what is supported, example:
```python
Nested = Sequence[Union[T, Nested[T]]]

def flatten(seq: Nested[T]) -> List[T]:
    flat: List[T] = []
    for item in seq:
        if isinstance(item, Sequence):
            res.extend(flatten(item))
        else:
            res.append(item)
    return flat

reveal_type(flatten([1, [2, [3]]]))  # N: Revealed type is "builtins.list[builtins.int]"
```

There are several known issues, missing features, etc. Some comments:
* People use `get_proper_type()` too much (I also used to do this). This can cause giant error messages, infinite recursion, and even performance issues. We should try to avoid expanding unless necessary, and always pass on original type when possible.
* We should fail gracefully on invalid aliases `A = Union[A, ...]` and `B = Type[B]` (first is theoretically meaningless, second is technically valid, but hard to support)
* We need a better formatting for recursive types. Currently it is just two verbosity levels: deep unroll with full names or just `Name[Arg, ...]`.
* Local (function level) recursive aliases may need to be prohibited (or we can store them in global namespace, like we do with local named tuples etc).
* Recursive classes (most notably `class str(Sequence[str]): ...`) can interfere with recursive aliases causing infinite recursion. I will likely fix this soon (should be easy unless I am missing something).
* Recursive named tuples and typed dicts are still not supported (unless you use dirty `NT = Union[_NT, _NT]` trick). Btw supporting recursive _and_ generic named tuples/typed dicts should be quite easy if we agree to store them internally as type aliases (or maybe we can introduce couple other non-proper types).
* We should get rid of `is_same_type()` altogether, replacing with either equality or (proper) equivalence call by call. Also I am probably going to unify (proper) subtype visitors.