### PR TITLE
stubtest: ignore __pyx_vtable__

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1184,6 +1184,8 @@ IGNORABLE_CLASS_DUNDERS = frozenset(
         "__nonzero__",
         "__unicode__",
         "__div__",
+        # cython methods
+        "__pyx_vtable__",
         # Pickle methods
         "__setstate__",
         "__getstate__",


### PR DESCRIPTION
I also considered ignoring the module level `__pyx_capi__`, but that seems less troublesome and may have potential uses. Maybe someone more familiar with Cython knows for sure