### PR TITLE
stubtest: improve signature checking

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -288,6 +288,11 @@ class StubtestUnit(unittest.TestCase):
                 runtime="def runtime_posonly(number, /, text): pass",
                 error="runtime_posonly",
             )
+            yield Case(
+                stub="def stub_posonly_570(number: int, /, text: str) -> None: ...",
+                runtime="def stub_posonly_570(number, text): pass",
+                error="stub_posonly_570",
+            )
 
     @collect_cases
     def test_default_value(self) -> Iterator[Case]:


### PR DESCRIPTION
Avoid issuing duplicate errors for keyword-only mismatches.
Fixes #13305

Fix cases where PEP 570 is used in the stub