### PR TITLE
refactor: prefer f-strings to .format in docs

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -276,7 +276,7 @@ See :ref:`async-and-await` for the full detail on typing coroutines and asynchro
    # A coroutine is typed like a normal function
    async def countdown35(tag: str, count: int) -> str:
        while count > 0:
-           print('T-minus {} ({})'.format(count, tag))
+           print(f'T-minus {count} ({tag})')
            await asyncio.sleep(0.1)
            count -= 1
        return "Blastoff!"

--- a/docs/source/final_attrs.rst
+++ b/docs/source/final_attrs.rst
@@ -33,7 +33,7 @@ further assignments to final names in type-checked code:
 
    from typing import Final
 
-   RATE: Final = 3000
+   RATE: Final = 3_000
 
    class Base:
        DEFAULT_ID: Final = 0

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -159,7 +159,7 @@ non-generic. For example:
 
    class StrDict(dict[str, str]):  # This is a non-generic subclass of dict
        def __str__(self) -> str:
-           return 'StrDict({})'.format(super().__str__())
+           return f'StrDict({super().__str__()})'
 
    data: StrDict[int, int]  # Error! StrDict is not generic
    data2: StrDict  # OK

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -129,7 +129,7 @@ Arguments with default values can be annotated like so:
 .. code-block:: python
 
    def greeting(name: str, excited: bool = False) -> str:
-       message = 'Hello, {}'.format(name)
+       message = f'Hello, {name}'
        if excited:
            message += '!!!'
        return message
@@ -213,7 +213,7 @@ ints or strings, but no other types. You can express this using the :py:data:`~t
 
    def normalize_id(user_id: Union[int, str]) -> str:
        if isinstance(user_id, int):
-           return 'user-{}'.format(100000 + user_id)
+           return f'user-{100_000 + user_id}'
        else:
            return user_id
 

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -452,7 +452,7 @@ but it's not obvious from its signature:
 
     def greeting(name: str) -> str:
         if name:
-            return 'Hello, {}'.format(name)
+            return f'Hello, {name}'
         else:
             return 'Hello, stranger'
 
@@ -469,7 +469,7 @@ enabled:
 
     def greeting(name: Optional[str]) -> str:
         if name:
-            return 'Hello, {}'.format(name)
+            return f'Hello, {name}'
         else:
             return 'Hello, stranger'
 

--- a/docs/source/literal_types.rst
+++ b/docs/source/literal_types.rst
@@ -446,7 +446,7 @@ Let's start with a definition:
 
   def assert_never(value: NoReturn) -> NoReturn:
       # This also works in runtime as well:
-      assert False, 'This code should never be reached, got: {0}'.format(value)
+      assert False, f'This code should never be reached, got: {value}'
 
   class Direction(Enum):
       up = 'up'

--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -840,7 +840,7 @@ expect to get back when ``await``-ing the coroutine.
    import asyncio
 
    async def format_string(tag: str, count: int) -> str:
-       return 'T-minus {} ({})'.format(count, tag)
+       return f'T-minus {count} ({tag})'
 
    async def countdown_1(tag: str, count: int) -> str:
        while count > 0:
@@ -882,7 +882,7 @@ You may also choose to create a subclass of :py:class:`~typing.Awaitable` instea
 
        def __await__(self) -> Generator[Any, None, str]:
            for i in range(n, 0, -1):
-               print('T-minus {} ({})'.format(i, tag))
+               print(f'T-minus {i} ({tag})')
                yield from asyncio.sleep(0.1)
            return "Blastoff!"
 
@@ -919,7 +919,7 @@ To create an iterable coroutine, subclass :py:class:`~typing.AsyncIterator`:
 
    async def countdown_4(tag: str, n: int) -> str:
        async for i in arange(n, 0, -1):
-           print('T-minus {} ({})'.format(i, tag))
+           print(f'T-minus {i} ({tag})')
            await asyncio.sleep(0.1)
        return "Blastoff!"
 
@@ -941,7 +941,7 @@ generator type as the return type:
    @asyncio.coroutine
    def countdown_2(tag: str, count: int) -> Generator[Any, None, str]:
        while count > 0:
-           print('T-minus {} ({})'.format(count, tag))
+           print(f'T-minus {count} ({tag})')
            yield from asyncio.sleep(0.1)
            count -= 1
        return "Blastoff!"
@@ -1045,7 +1045,7 @@ a subtype of (that is, compatible with) ``Mapping[str, object]``, since
 
    def print_typed_dict(obj: Mapping[str, object]) -> None:
        for key, value in obj.items():
-           print('{}: {}'.format(key, value))
+           print(f'{key}: {value}')
 
    print_typed_dict(Movie(name='Toy Story', year=1995))  # OK
 

--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -177,7 +177,7 @@ In this example, the function ``format_id()`` has no annotation:
 .. code-block:: python
 
    def format_id(user):
-       return "User: {}".format(user)
+       return f"User: {user}"
 
    root = format_id(0)
 


### PR DESCRIPTION
### Description

Because Mypy currently requires 3.6+, this merge request begins the process of refactoring the use of various format styles such as `.format`,  with the use of f-strings. This intentionally leaves behind certain formatting examples which are being used to demonstrate errors, such as:

```
    def foo(a):
        return '(' + a.split() + ')'  # No error!
```

Python added f-strings in version 3.6, with [PEP 498](https://www.python.org/dev/peps/pep-0498/). F-strings are a flexible and powerful way to concatenate strings. They make the code shorter and more readable, since the code now looks more like the output. Finally, there is also a performance benefit to using f-strings, which is an additional reason to advocate for their usage in examples.

Finally, this also leverages [PEP515](https://peps.python.org/pep-0515/), underscores in numeric literals, in two locations, to improve legibility while reading numbers larger than 999 that are not years.
## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
