### PR TITLE
stubtest: reduce false-positive errors for attributes on enum members

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -362,6 +362,10 @@ def verify_typeinfo(
                 runtime_attr = getattr(runtime, mangled_entry)
             except AttributeError:
                 runtime_attr = inspect.getattr_static(runtime, mangled_entry, MISSING)
+            if runtime_attr is MISSING and issubclass(runtime, enum.Enum):
+                members = getattr(runtime, "__members__", [])
+                if members:
+                    runtime_attr = getattr(members[0], mangled_entry, MISSING)
         except Exception:
             # Catch all exceptions in case the runtime raises an unexpected exception
             # from __getattr__ or similar.

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -929,6 +929,26 @@ class StubtestUnit(unittest.TestCase):
             """,
             error="X.c",
         )
+        yield Case(
+            stub="""
+            import enum
+            class Z(enum.IntEnum):
+                foo: int
+                @property
+                def spam(self) -> str: ...
+            """,
+            runtime="""
+            import enum
+            class Z(enum.IntEnum):
+                def __new__(cls, val, spam):
+                    obj = int.__new__(cls, val)
+                    obj._value_ = val
+                    obj.spam = spam
+                    return obj
+                foo = 1, 'foo'
+            """,
+            error=None,
+        )
 
     @collect_cases
     def test_decorator(self) -> Iterator[Case]:


### PR DESCRIPTION
### Description

The following pattern is fairly common for specialised enum classes that provide additional attributes on enum members. It's used for `http.HTTPStatus` in the stdlib, and in 3.11, it's also used for `http.HTTPMethod`:

```python
from enum import IntEnum

class HTTPStatus(IntEnum):
    def __new__(cls, value, phrase, description=''):
        obj = int.__new__(cls, value)
        obj._value_ = value

        obj.phrase = phrase
        obj.description = description
        return obj

    CONTINUE = 100, 'Continue', 'Request received, please continue'
    SWITCHING_PROTOCOLS = 101, 'Switching Protocols', 'Switching to new protocol; obey Upgrade header'
    # etc.
```

The only reasonable way to write a stub for this is as follows:

```python
from enum import IntEnum

class HTTPStatus(IntEnum):
    @property
    def phrase(self) -> str: ...
    @property
    def description(self) -> str: ...
    CONTINUE: int
    SWITCHING_PROTOCOLS: int
```

However, stubtest will emit false-positive errors on the `phrase` and `description` properties, since it can't find them on the enum class itself; they only exist on the enum members.

This PR teaches stubtest to look for properties on enum members if it can't find them on the enum class. Running stubtest on typeshed (on my Windows machine, with Python 3.10) with this patch applied, here is the additional output from stubtest, relative to the master branch:

```diff
+ note: unused allowlist entry http.HTTPStatus.description
+ note: unused allowlist entry http.HTTPStatus.phrase
```

If I were running on Python 3.11, I'm pretty sure the allowlist entry for `http.HTTPMethod.description` would also be flagged as unused.

## Test Plan

I added a test.
