### PR TITLE
Handle interactions between recursive aliases and recursive instances

### DIFF
--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -80,10 +80,10 @@ class TypeState:
     # recursive type aliases. Normally, one would pass type assumptions as an additional
     # arguments to is_subtype(), but this would mean updating dozens of related functions
     # threading this through all callsites (see also comment for TypeInfo.assuming).
-    _assuming: Final[List[Tuple[TypeAliasType, TypeAliasType]]] = []
-    _assuming_proper: Final[List[Tuple[TypeAliasType, TypeAliasType]]] = []
+    _assuming: Final[List[Tuple[Type, Type]]] = []
+    _assuming_proper: Final[List[Tuple[Type, Type]]] = []
     # Ditto for inference of generic constraints against recursive type aliases.
-    _inferring: Final[List[TypeAliasType]] = []
+    inferring: Final[List[TypeAliasType]] = []
 
     # N.B: We do all of the accesses to these properties through
     # TypeState, instead of making these classmethods and accessing
@@ -109,7 +109,7 @@ class TypeState:
         return False
 
     @staticmethod
-    def get_assumptions(is_proper: bool) -> List[Tuple[TypeAliasType, TypeAliasType]]:
+    def get_assumptions(is_proper: bool) -> List[Tuple[Type, Type]]:
         if is_proper:
             return TypeState._assuming_proper
         return TypeState._assuming

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -278,3 +278,57 @@ if isinstance(b[0], Sequence):
     a = b[0]
     x = a  # E: Incompatible types in assignment (expression has type "Sequence[Union[B, NestedB]]", variable has type "int")
 [builtins fixtures/isinstancelist.pyi]
+
+[case testRecursiveAliasWithRecursiveInstance]
+# flags: --enable-recursive-aliases
+from typing import Sequence, Union, TypeVar
+
+class A: ...
+T = TypeVar("T")
+Nested = Sequence[Union[T, Nested[T]]]
+class B(Sequence[B]): ...
+
+a: Nested[A]
+aa: Nested[A]
+b: B
+a = b  # OK
+a = [[b]]  # OK
+b = aa  # E: Incompatible types in assignment (expression has type "Nested[A]", variable has type "B")
+
+def join(a: T, b: T) -> T: ...
+reveal_type(join(a, b))  # N: Revealed type is "typing.Sequence[Union[__main__.A, typing.Sequence[Union[__main__.A, ...]]]]"
+reveal_type(join(b, a))  # N: Revealed type is "typing.Sequence[Union[__main__.A, typing.Sequence[Union[__main__.A, ...]]]]"
+[builtins fixtures/isinstancelist.pyi]
+
+[case testRecursiveAliasWithRecursiveInstanceInference]
+# flags: --enable-recursive-aliases
+from typing import Sequence, Union, TypeVar, List
+
+class A: ...
+T = TypeVar("T", bound=B)
+Nested = List[Union[T, Nested[T]]]
+class B(Sequence[B]): ...
+
+nb: Nested[B] = [B(), [B(), [B()]]]
+
+def foo(x: Nested[T]) -> T: ...
+reveal_type(foo([B(), [B(), [B()]]]))  # N: Revealed type is "__main__.B"
+[builtins fixtures/isinstancelist.pyi]
+
+[case testRecursiveAliasTopUnion]
+# flags: --enable-recursive-aliases
+from typing import Sequence, Union, TypeVar, Generic
+
+class A: ...
+class B(A): ...
+
+T = TypeVar("T")
+PlainNested = Union[T, Sequence[PlainNested[T]]]
+
+x: PlainNested[A]
+y: PlainNested[B]
+x = y  # OK
+
+xx: PlainNested[B]
+yy: PlainNested[A]
+xx = yy  # E: Incompatible types in assignment (expression has type "PlainNested[A]", variable has type "PlainNested[B]")


### PR DESCRIPTION
This is a follow-up for #13297 

The fix for infinite recursion is kind of simple, but it is hard to make inference infer something useful. Currently we handle all most common cases, but it is quite fragile (I however have few tricks left if people will complain about inference).

Btw a curious thing: it looks like `"hm..."` is a valid value for `Nested = Sequence[Union[int, Nested]]`.

cc @JukkaL 