### PR TITLE
Support type aliases in metaclasses

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4496,6 +4496,30 @@ class E(metaclass=Explicit): ...
 class I(metaclass=Implicit): ...
 [builtins fixtures/classmethod.pyi]
 
+[case testTypeAliasWithArgsAsMetaclass]
+from typing import Generic, TypeVar
+from typing_extensions import TypeAlias
+
+T = TypeVar('T')
+class Meta(Generic[T]): ...
+
+Explicit: TypeAlias = Meta[T]
+Implicit = Meta[T]
+
+class E(metaclass=Explicit): ...  # E: Invalid metaclass "Explicit"
+class I(metaclass=Implicit): ...  # E: Invalid metaclass "Implicit"
+[builtins fixtures/classmethod.pyi]
+
+[case testTypeAliasNonTypeAsMetaclass]
+from typing_extensions import TypeAlias
+
+Explicit: TypeAlias = int
+Implicit = int
+
+class E(metaclass=Explicit): ...  # E: Metaclasses not inheriting from "type" are not supported
+class I(metaclass=Implicit): ...  # E: Metaclasses not inheriting from "type" are not supported
+[builtins fixtures/classmethod.pyi]
+
 [case testInvalidVariableAsMetaclass]
 from typing import Any
 M = 0  # type: int

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4486,6 +4486,16 @@ class A(metaclass=M):
 reveal_type(A.y) # N: Revealed type is "builtins.int"
 A.x # E: "Type[A]" has no attribute "x"
 
+[case testValidTypeAliasAsMetaclass]
+from typing_extensions import TypeAlias
+
+Explicit: TypeAlias = type
+Implicit = type
+
+class E(metaclass=Explicit): ...
+class I(metaclass=Implicit): ...
+[builtins fixtures/classmethod.pyi]
+
 [case testInvalidVariableAsMetaclass]
 from typing import Any
 M = 0  # type: int

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4496,6 +4496,23 @@ class E(metaclass=Explicit): ...
 class I(metaclass=Implicit): ...
 [builtins fixtures/classmethod.pyi]
 
+[case testValidTypeAliasOfTypeAliasAsMetaclass]
+from typing_extensions import TypeAlias
+
+Explicit: TypeAlias = type
+Implicit = type
+
+A1: TypeAlias = Explicit
+A2 = Explicit
+A3: TypeAlias = Implicit
+A4 = Implicit
+
+class C1(metaclass=A1): ...
+class C2(metaclass=A2): ...
+class C3(metaclass=A3): ...
+class C4(metaclass=A4): ...
+[builtins fixtures/classmethod.pyi]
+
 [case testTypeAliasWithArgsAsMetaclass]
 from typing import Generic, TypeVar
 from typing_extensions import TypeAlias


### PR DESCRIPTION
This is the simplest solution I found: I just expand type alias before `isinstance(type_info, Instance)`. 

I've added several tests to make sure wrong aliases are not allowed.
Should I add anything else to the test? 

Closes #13334
Refs https://github.com/python/mypy/pull/13331