### PR TITLE
Fail gracefully on invalid and/or unsupported recursive type aliases

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3120,6 +3120,8 @@ class SemanticAnalyzer(
             no_args=no_args,
             eager=eager,
         )
+        if invalid_recursive_alias({alias_node}, alias_node.target):
+            self.fail("Invalid recursive alias: a union item of itself", rvalue)
         if isinstance(s.rvalue, (IndexExpr, CallExpr)):  # CallExpr is for `void = type(None)`
             s.rvalue.analyzed = TypeAliasExpr(alias_node)
             s.rvalue.analyzed.line = s.line
@@ -3155,8 +3157,6 @@ class SemanticAnalyzer(
             self.add_symbol(lvalue.name, alias_node, s)
         if isinstance(rvalue, RefExpr) and isinstance(rvalue.node, TypeAlias):
             alias_node.normalized = rvalue.node.normalized
-        if invalid_recursive_alias(alias_node.target):
-            self.fail("Invalid recursive alias: a union item of itself", rvalue)
         return True
 
     def analyze_lvalue(

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -73,11 +73,11 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
             # types, since errors there have already been reported.
             return
         self.seen_aliases.add(t)
-        if invalid_recursive_alias(t):
+        assert t.alias is not None, f"Unfixed type alias {t.type_ref}"
+        if invalid_recursive_alias({t.alias}, t.alias.target):
             # Fix type arguments for invalid aliases (error is already reported).
             t.args = []
-            if t.alias is not None:
-                t.alias.target = AnyType(TypeOfAny.from_error)
+            t.alias.target = AnyType(TypeOfAny.from_error)
             return
         get_proper_type(t).accept(self)
 

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -30,6 +30,7 @@ from mypy.types import (
     UnpackType,
     get_proper_type,
     get_proper_types,
+    invalid_recursive_alias,
 )
 
 
@@ -68,10 +69,16 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
         super().visit_type_alias_type(t)
         if t in self.seen_aliases:
             # Avoid infinite recursion on recursive type aliases.
-            # Note: it is fine to skip the aliases we have already seen in non-recursive types,
-            # since errors there have already already reported.
+            # Note: it is fine to skip the aliases we have already seen in non-recursive
+            # types, since errors there have already been reported.
             return
         self.seen_aliases.add(t)
+        if invalid_recursive_alias(t):
+            # Fix type arguments for invalid aliases (error is already reported).
+            t.args = []
+            if t.alias is not None:
+                t.alias.target = AnyType(TypeOfAny.from_error)
+            return
         get_proper_type(t).accept(self)
 
     def visit_instance(self, t: Instance) -> None:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -236,8 +236,6 @@ class Type(mypy.nodes.Context):
 class TypeAliasType(Type):
     """A type alias to another type.
 
-    NOTE: this is not being used yet, and the implementation is still incomplete.
-
     To support recursive type aliases we don't immediately expand a type alias
     during semantic analysis, but create an instance of this type that records the target alias
     definition node (mypy.nodes.TypeAlias) and type arguments (for generic aliases).
@@ -3195,6 +3193,50 @@ def union_items(typ: Type) -> List[ProperType]:
         return items
     else:
         return [typ]
+
+
+def invalid_recursive_alias(target: Type) -> bool:
+    """Flag aliases like A = Union[int, A] (and similar mutual aliases).
+
+    Such aliases don't make much sense, and cause problems in later phases.
+    """
+    target = get_proper_type(target)
+    if not isinstance(target, UnionType):
+        return False
+    seen_aliases: Set[TypeAliasType] = set()
+
+    def try_flatten_unions(typ: Type) -> bool:
+        if isinstance(typ, TypeAliasType):
+            if typ in seen_aliases:
+                return True
+            seen_aliases.add(typ)
+        typ = get_proper_type(typ)
+        if isinstance(typ, UnionType):
+            for item in typ.items:
+                recursed = try_flatten_unions(item)
+                if recursed:
+                    return True
+        return False
+
+    return try_flatten_unions(target)
+
+
+def bad_type_type_item(item: Type) -> bool:
+    """Prohibit types like Type[Type[...]].
+
+    Such types are explicitly prohibited by PEP 484. Also they cause problems
+    with recursive types like T = Type[T], because internal representation of
+    TypeType item is normalized (i.e. always a proper type).
+    """
+    item = get_proper_type(item)
+    if isinstance(item, TypeType):
+        return True
+    if isinstance(item, UnionType):
+        return any(
+            isinstance(get_proper_type(i), TypeType)
+            for i in flatten_nested_unions(item.items, handle_type_alias_type=True)
+        )
+    return False
 
 
 def is_union_with_any(tp: Type) -> bool:

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -389,15 +389,23 @@ reveal_type(bar(lla))  # N: Revealed type is "__main__.A"
 reveal_type(bar(llla))  # N: Revealed type is "__main__.A"
 [builtins fixtures/isinstancelist.pyi]
 
-[case testProhibitBadAliases]
+[case testRecursiveAliasesProhibitBadAliases]
 # flags: --enable-recursive-aliases
-from typing import Union, Type, List, Type
+from typing import Union, Type, List, TypeVar
+
+NR = List[int]
+NR2 = Union[NR, NR]
+NR3 = Union[NR, Union[NR2, NR2]]
 
 A = Union[B, int]  # E: Invalid recursive alias: a union item of itself
 B = Union[int, A]  # E: Invalid recursive alias: a union item of itself
-
 def f() -> A: ...
 reveal_type(f())  # N: Revealed type is "Union[Any, builtins.int]"
+
+T = TypeVar("T")
+G = Union[T, G[T]]  # E: Invalid recursive alias: a union item of itself
+def g() -> G[int]: ...
+reveal_type(g())  # N: Revealed type is "Any"
 
 def local() -> None:
     L = List[Union[int, L]]  # E: Cannot resolve name "L" (possible cyclic definition) \
@@ -405,7 +413,8 @@ def local() -> None:
     x: L
     reveal_type(x)  # N: Revealed type is "builtins.list[Union[builtins.int, Any]]"
 
-T = Type[T]  # E: Type[...] cannot contain another Type[...]
+S = Type[S]  # E: Type[...] cannot contain another Type[...]
 U = Type[Union[int, U]]  # E: Type[...] cannot contain another Type[...]
 x: U
 reveal_type(x)  # N: Revealed type is "Type[Any]"
+[builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -388,3 +388,24 @@ reveal_type(bar(la))  # N: Revealed type is "__main__.A"
 reveal_type(bar(lla))  # N: Revealed type is "__main__.A"
 reveal_type(bar(llla))  # N: Revealed type is "__main__.A"
 [builtins fixtures/isinstancelist.pyi]
+
+[case testProhibitBadAliases]
+# flags: --enable-recursive-aliases
+from typing import Union, Type, List, Type
+
+A = Union[B, int]  # E: Invalid recursive alias: a union item of itself
+B = Union[int, A]  # E: Invalid recursive alias: a union item of itself
+
+def f() -> A: ...
+reveal_type(f())  # N: Revealed type is "Union[Any, builtins.int]"
+
+def local() -> None:
+    L = List[Union[int, L]]  # E: Cannot resolve name "L" (possible cyclic definition) \
+                             # N: Recursive types are not allowed at function scope
+    x: L
+    reveal_type(x)  # N: Revealed type is "builtins.list[Union[builtins.int, Any]]"
+
+T = Type[T]  # E: Type[...] cannot contain another Type[...]
+U = Type[Union[int, U]]  # E: Type[...] cannot contain another Type[...]
+x: U
+reveal_type(x)  # N: Revealed type is "Type[Any]"


### PR DESCRIPTION
This is a follow up for #13297.

See some motivation in the original PR (also in the docstrings).

cc @JukkaL 