### PR TITLE
Update doc readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ What's this?
 
 This directory contains the source code for Mypy documentation (under `source/`)
 and build scripts. The documentation uses Sphinx and reStructuredText. We use
-`sphinx-rtd-theme` as the documentation theme.
+`furo` as the documentation theme.
 
 Building the documentation
 --------------------------

--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -10,9 +10,6 @@ import os
 import sys
 import sysconfig
 
-if __name__ == '__main__':
-    sys.path = sys.path[1:]  # we don't want to pick up mypy.types
-
 MYPY = False
 if MYPY:
     from typing import List
@@ -29,10 +26,17 @@ def getsearchdirs():
     )
     stdlib = sysconfig.get_path("stdlib")
     stdlib_ext = os.path.join(stdlib, "lib-dynload")
-    cwd = os.path.abspath(os.getcwd())
-    excludes = set([cwd, stdlib_zip, stdlib, stdlib_ext])
+    excludes = set([stdlib_zip, stdlib, stdlib_ext])
 
-    abs_sys_path = (os.path.abspath(p) for p in sys.path)
+    # Drop the first entry of sys.path
+    # - If pyinfo.py is executed as a script (in a subprocess), this is the directory
+    #   containing pyinfo.py
+    # - Otherwise, if mypy launched via console script, this is the directory of the script
+    # - Otherwise, if mypy launched via python -m mypy, this is the current directory
+    # In all cases, this is safe to drop
+    # Note that mypy adds the cwd to SearchPaths.python_path, so we still find things on the
+    # cwd consistently (the return value here sets SearchPaths.package_path)
+    abs_sys_path = (os.path.abspath(p) for p in sys.path[1:])
     return [p for p in abs_sys_path if p not in excludes]
 
 

--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -14,6 +14,15 @@ MYPY = False
 if MYPY:
     from typing import List
 
+if __name__ == '__main__':
+    # HACK: We don't want to pick up mypy.types as the top-level types
+    #       module. This could happen if this file is run as a script.
+    #       This workaround fixes it.
+    old_sys_path = sys.path
+    sys.path = sys.path[1:]
+    import types  # noqa
+    sys.path = old_sys_path
+
 
 def getsearchdirs():
     # type: () -> List[str]

--- a/mypy/typeshed/stdlib/typing_extensions.pyi
+++ b/mypy/typeshed/stdlib/typing_extensions.pyi
@@ -1,6 +1,8 @@
 import abc
+import collections
 import sys
 from _typeshed import IdentityFunction, Self as TypeshedSelf  # see #6932 for why the Self alias cannot have a leading underscore
+from collections.abc import Iterable
 from typing import (  # noqa: Y022,Y027,Y039
     TYPE_CHECKING as TYPE_CHECKING,
     Any,
@@ -52,6 +54,7 @@ __all__ = [
     "Counter",
     "Deque",
     "DefaultDict",
+    "NamedTuple",
     "OrderedDict",
     "TypedDict",
     "SupportsIndex",
@@ -189,9 +192,11 @@ else:
     def is_typeddict(tp: object) -> bool: ...
 
 # New things in 3.11
+# NamedTuples are not new, but the ability to create generic NamedTuples is new in 3.11
 if sys.version_info >= (3, 11):
     from typing import (
         LiteralString as LiteralString,
+        NamedTuple as NamedTuple,
         Never as Never,
         NotRequired as NotRequired,
         Required as Required,
@@ -233,3 +238,24 @@ else:
         field_specifiers: tuple[type[Any] | Callable[..., Any], ...] = ...,
         **kwargs: object,
     ) -> IdentityFunction: ...
+
+    class NamedTuple(tuple[Any, ...]):
+        if sys.version_info < (3, 8):
+            _field_types: collections.OrderedDict[str, type]
+        elif sys.version_info < (3, 9):
+            _field_types: dict[str, type]
+        _field_defaults: dict[str, Any]
+        _fields: tuple[str, ...]
+        _source: str
+        @overload
+        def __init__(self, typename: str, fields: Iterable[tuple[str, Any]] = ...) -> None: ...
+        @overload
+        def __init__(self, typename: str, fields: None = ..., **kwargs: Any) -> None: ...
+        @classmethod
+        def _make(cls: type[TypeshedSelf], iterable: Iterable[Any]) -> TypeshedSelf: ...
+        if sys.version_info >= (3, 8):
+            def _asdict(self) -> dict[str, Any]: ...
+        else:
+            def _asdict(self) -> collections.OrderedDict[str, Any]: ...
+
+        def _replace(self: TypeshedSelf, **kwargs: Any) -> TypeshedSelf: ...

--- a/mypy/version.py
+++ b/mypy/version.py
@@ -5,7 +5,7 @@ from mypy import git
 # - Release versions have the form "0.NNN".
 # - Dev versions have the form "0.NNN+dev" (PLUS sign to conform to PEP 440).
 # - For 1.0 we'll switch back to 1.2.3 form.
-__version__ = '0.970+dev'
+__version__ = '0.970'
 base_version = __version__
 
 mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))

--- a/mypy/version.py
+++ b/mypy/version.py
@@ -5,7 +5,7 @@ from mypy import git
 # - Release versions have the form "0.NNN".
 # - Dev versions have the form "0.NNN+dev" (PLUS sign to conform to PEP 440).
 # - For 1.0 we'll switch back to 1.2.3 form.
-__version__ = '0.970'
+__version__ = '0.971+dev'
 base_version = __version__
 
 mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))

--- a/mypy/version.py
+++ b/mypy/version.py
@@ -5,7 +5,7 @@ from mypy import git
 # - Release versions have the form "0.NNN".
 # - Dev versions have the form "0.NNN+dev" (PLUS sign to conform to PEP 440).
 # - For 1.0 we'll switch back to 1.2.3 form.
-__version__ = '0.971+dev'
+__version__ = '0.971'
 base_version = __version__
 
 mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -136,6 +136,7 @@ def transform_operator_assignment_stmt(builder: IRBuilder, stmt: OperatorAssignm
     # usually operator assignments are done in-place
     # but when target doesn't support that we need to manually assign
     builder.assign(target, res, res.line)
+    builder.flush_keep_alives()
 
 
 def transform_import(builder: IRBuilder, node: Import) -> None:

--- a/mypyc/primitives/float_ops.py
+++ b/mypyc/primitives/float_ops.py
@@ -2,11 +2,17 @@
 
 from mypyc.ir.ops import ERR_MAGIC
 from mypyc.ir.rtypes import (
-    str_rprimitive, float_rprimitive
+    str_rprimitive, float_rprimitive, object_rprimitive
 )
 from mypyc.primitives.registry import (
-    function_op
+    load_address_op, function_op
 )
+
+# Get the 'builtins.float' type object.
+load_address_op(
+    name='builtins.float',
+    type=object_rprimitive,
+    src='PyFloat_Type')
 
 # float(str)
 function_op(

--- a/mypyc/primitives/tuple_ops.py
+++ b/mypyc/primitives/tuple_ops.py
@@ -9,8 +9,13 @@ from mypyc.ir.rtypes import (
     tuple_rprimitive, int_rprimitive, list_rprimitive, object_rprimitive,
     c_pyssize_t_rprimitive, bit_rprimitive
 )
-from mypyc.primitives.registry import method_op, function_op, custom_op
+from mypyc.primitives.registry import load_address_op, method_op, function_op, custom_op
 
+# Get the 'builtins.tuple' type object.
+load_address_op(
+    name='builtins.tuple',
+    type=object_rprimitive,
+    src='PyTuple_Type')
 
 # tuple[index] (for an int index)
 tuple_get_item_op = method_op(

--- a/mypyc/test-data/irbuild-dunders.test
+++ b/mypyc/test-data/irbuild-dunders.test
@@ -175,16 +175,13 @@ L0:
 def f(c):
     c :: __main__.C
     r0, r1 :: int
-    r2, r3, r4 :: object
-    r5 :: str
-    r6, r7 :: object
+    r2, r3, r4, r5 :: object
 L0:
     r0 = c.__neg__()
     r1 = c.__invert__()
     r2 = load_address PyLong_Type
     r3 = PyObject_CallFunctionObjArgs(r2, c, 0)
-    r4 = builtins :: module
-    r5 = 'float'
-    r6 = CPyObject_GetAttr(r4, r5)
-    r7 = PyObject_CallFunctionObjArgs(r6, c, 0)
+    r4 = load_address PyFloat_Type
+    r5 = PyObject_CallFunctionObjArgs(r4, c, 0)
     return 1
+

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -595,3 +595,15 @@ class C:
         self.foo.flag = True
         yield
         self.foo.flag = False
+
+[case testGeneratorEarlyReturnWithBorrows]
+from typing import Iterator
+class Bar:
+    bar = 0
+class Foo:
+    bar = Bar()
+    def f(self) -> Iterator[int]:
+        if self:
+            self.bar.bar += 1
+            return
+        yield 0

--- a/mypyc/test-data/run-python37.test
+++ b/mypyc/test-data/run-python37.test
@@ -70,6 +70,7 @@ class Person4:
 
 @dataclass
 class Person5:
+    weight: float
     friends: Set[str] = field(default_factory=set)
     parents: FrozenSet[str] = frozenset()
 
@@ -122,7 +123,8 @@ assert i8 > i9
 
 assert Person1.__annotations__ == {'age': int, 'name': str}
 assert Person2.__annotations__ == {'age': int, 'name': str}
-assert Person5.__annotations__ == {'friends': set, 'parents': frozenset}
+assert Person5.__annotations__ == {'weight': float, 'friends': set,
+                                       'parents': frozenset}
 
 [file driver.py]
 import sys

--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -95,6 +95,49 @@ class Sub(NT):
     pass
 assert f(Sub(3, 2)) == 3
 
+-- Ref: https://github.com/mypyc/mypyc/issues/924
+[case testNamedTupleClassSyntax]
+from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+
+class ClassIR: pass
+
+class FuncIR: pass
+
+StealsDescription = Union[bool, List[bool]]
+
+class Record(NamedTuple):
+    st_mtime: float
+    st_size: int
+    is_borrowed: bool
+    hash: str
+    python_path: Tuple[str, ...]
+    type: 'ClassIR'
+    method: FuncIR
+    shadow_method: Optional[FuncIR]
+    classes: Dict[str, 'ClassIR']
+    steals: StealsDescription
+    ordering: Optional[List[int]]
+    extra_int_constants: List[Tuple[int]]
+
+[file driver.py]
+from typing import Optional
+from native import ClassIR, FuncIR, Record
+
+assert Record.__annotations__ == {
+    'st_mtime': float,
+    'st_size': int,
+    'is_borrowed': bool,
+    'hash': str,
+    'python_path': tuple,
+    'type': ClassIR,
+    'method': FuncIR,
+    'shadow_method': type,
+    'classes': dict,
+    'steals': type,
+    'ordering': type,
+    'extra_int_constants': list,
+}, Record.__annotations__
+
 [case testTupleOps]
 from typing import Tuple, List, Any, Optional
 from typing_extensions import Final


### PR DESCRIPTION
### Description

Updates the readme for the sphinx docs which says the docs use `sphinx_rtd_theme` when they now use `furo`.

Does not affect any code. Only a documentation change in the readme for the docs folder.

## Test Plan


Rebuild the docs [(link to instructions)](https://github.com/python/mypy/tree/1f08cf44c7ec3dc4111aaf817958f7a51018ba38/docs) and review the changed pages for markup errors. Minimal changes so errors shouldn't cascade.
