### PR TITLE
stubtest: Use `module_name` for error reporting

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -116,10 +116,14 @@ class Error:
             return _style(self.object_desc, bold=True) + " " + self.message
 
         stub_line = None
-        stub_file: None = None
+        stub_file = None
         if not isinstance(self.stub_object, Missing):
             stub_line = self.stub_object.line
-        # TODO: Find a way of getting the stub file
+        # TODO: find out how we can get filenames from other nodes:
+        if isinstance(self.stub_object, nodes.TypeInfo):
+            stub_file = os.path.abspath(
+                self.stub_object.module_name.replace(".", os.path.sep) + ".pyi"
+            )
 
         stub_loc_str = ""
         if stub_line:


### PR DESCRIPTION
There was a `TODO` item for this. 
My solution is not 100% complete, but it is something.
Getting path from `FuncDef` / etc is pretty hard.

Showcase:
<img width="752" alt="Снимок экрана 2022-08-06 в 11 39 36" src="https://user-images.githubusercontent.com/4660275/183241753-ee9b8d07-2f71-42f6-9103-ecbf87842311.png">
<img width="752" alt="Снимок экрана 2022-08-06 в 11 36 57" src="https://user-images.githubusercontent.com/4660275/183241757-00d6f260-80e0-415c-8dc3-27cc1a036ea1.png">
