### PR TITLE
update theme used from sphinx_rtd_them to furo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ What's this?
 
 This directory contains the source code for Mypy documentation (under `source/`)
 and build scripts. The documentation uses Sphinx and reStructuredText. We use
-`sphinx-rtd-theme` as the documentation theme.
+`furo` as the documentation theme.
 
 Building the documentation
 --------------------------


### PR DESCRIPTION
### Description

Updates the readme for the sphinx docs which says the docs use `sphinx_rtd_theme` when they now use `furo`.

Does not affect any code. Only a documentation change in the readme for the docs folder.

## Test Plan

Rebuild the docs [(link to instructions)](https://github.com/python/mypy/tree/1f08cf44c7ec3dc4111aaf817958f7a51018ba38/docs) and review the changed pages for markup errors. Minimal changes so errors shouldn't cascade.
