### PR TITLE
Advertise typing status via classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Topic :: Software Development",
+    "Typing :: Typed",
 ]
 
 setup(


### PR DESCRIPTION

### Description

The package advertises its typing status to typing tools via `py.typed` file.
Adding the Trove Classifier helps advertise its typing status to PyPI browsers.

Without the classifier, this package will not appear in a scoped search:
https://pypi.org/search/?q=mypy&o=&c=Typing+%3A%3A+Typed

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

Post-build/release/push to pypi.org, search for `mypy` when scoped to "Typing: Typed"
