### PR TITLE
Run `pyupgrade` on the source code

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Dict, Iterator, List, Optional, Set, Tuple, Union, cast
+from typing import DefaultDict, Dict, Iterator, List, Optional, Set, Tuple, Union, cast
 
-from typing_extensions import DefaultDict, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
 
 from mypy.erasetype import remove_instance_last_known_values
 from mypy.join import join_simple

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -22,15 +22,18 @@ import sys
 import time
 import types
 from typing import (
+    TYPE_CHECKING,
     AbstractSet,
     Any,
     Callable,
+    ClassVar,
     Dict,
     Iterable,
     Iterator,
     List,
     Mapping,
     NamedTuple,
+    NoReturn,
     Optional,
     Sequence,
     Set,
@@ -41,7 +44,7 @@ from typing import (
 )
 
 from mypy_extensions import TypedDict
-from typing_extensions import TYPE_CHECKING, ClassVar, Final, NoReturn, TypeAlias as _TypeAlias
+from typing_extensions import Final, TypeAlias as _TypeAlias
 
 import mypy.semanal_main
 from mypy.checker import TypeChecker
@@ -1068,9 +1071,7 @@ def read_plugins_snapshot(manager: BuildManager) -> Optional[Dict[str, str]]:
     if snapshot is None:
         return None
     if not isinstance(snapshot, dict):
-        manager.log(
-            "Could not load plugins snapshot: cache is not a dict: {}".format(type(snapshot))
-        )
+        manager.log(f"Could not load plugins snapshot: cache is not a dict: {type(snapshot)}")
         return None
     return snapshot
 
@@ -1284,9 +1285,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> Optional[Cache
     if meta is None:
         return None
     if not isinstance(meta, dict):
-        manager.log(
-            "Could not load cache for {}: meta cache is not a dict: {}".format(id, repr(meta))
-        )
+        manager.log(f"Could not load cache for {id}: meta cache is not a dict: {repr(meta)}")
         return None
     m = cache_meta_from_dict(meta, data_json)
     t2 = time.time()
@@ -1459,9 +1458,7 @@ def validate_meta(
                 manager.log(f"Using stale metadata for {id}: file {path}")
                 return meta
             else:
-                manager.log(
-                    "Metadata abandoned for {}: file {} has different hash".format(id, path)
-                )
+                manager.log(f"Metadata abandoned for {id}: file {path} has different hash")
                 return None
         else:
             t0 = time.time()

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2,9 +2,21 @@
 
 import itertools
 from contextlib import contextmanager
-from typing import Callable, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union, cast
+from typing import (
+    Callable,
+    ClassVar,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
-from typing_extensions import ClassVar, Final, TypeAlias as _TypeAlias, overload
+from typing_extensions import Final, TypeAlias as _TypeAlias, overload
 
 import mypy.checker
 import mypy.errorcodes as codes

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1,8 +1,6 @@
 """Type checking of attribute access"""
 
-from typing import Callable, Optional, Sequence, Union, cast
-
-from typing_extensions import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Optional, Sequence, Union, cast
 
 from mypy import meet, message_registry, subtypes
 from mypy.erasetype import erase_typevars
@@ -836,7 +834,7 @@ def analyze_class_attribute_access(
     if override_info:
         info = override_info
 
-    fullname = "{}.{}".format(info.fullname, name)
+    fullname = f"{info.fullname}.{name}"
     hook = mx.chk.plugin.get_class_attribute_hook(fullname)
 
     node = info.get(name)

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -11,9 +11,21 @@ implementation simple.
 """
 
 import re
-from typing import Callable, Dict, List, Match, Optional, Pattern, Set, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    Match,
+    Optional,
+    Pattern,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
-from typing_extensions import TYPE_CHECKING, Final, TypeAlias as _TypeAlias
+from typing_extensions import Final, TypeAlias as _TypeAlias
 
 import mypy.errorcodes as codes
 from mypy.errors import Errors

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -46,7 +46,7 @@ def parse_version(v: Union[str, float]) -> Tuple[int, int]:
         pass  # Error raised elsewhere
     elif major == 3:
         if minor < defaults.PYTHON3_VERSION_MIN[1]:
-            msg = "Python 3.{0} is not supported (must be {1}.{2} or higher)".format(
+            msg = "Python 3.{} is not supported (must be {}.{} or higher)".format(
                 minor, *defaults.PYTHON3_VERSION_MIN
             )
 

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -12,9 +12,7 @@ import pickle
 import sys
 import time
 import traceback
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
-
-from typing_extensions import NoReturn
+from typing import Any, Callable, Dict, List, Mapping, NoReturn, Optional, Tuple
 
 from mypy.dmypy_os import alive, kill
 from mypy.dmypy_util import DEFAULT_STATUS_FILE, receive

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -2,9 +2,9 @@ import os.path
 import sys
 import traceback
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Set, TextIO, Tuple, TypeVar, Union
+from typing import Callable, Dict, List, NoReturn, Optional, Set, TextIO, Tuple, TypeVar, Union
 
-from typing_extensions import Final, Literal, NoReturn
+from typing_extensions import Final, Literal
 
 from mypy import errorcodes as codes
 from mypy.errorcodes import IMPORT, ErrorCode
@@ -884,7 +884,7 @@ class Errors:
                                 -1,
                                 -1,
                                 "note",
-                                'In class "{}":'.format(e.type),
+                                f'In class "{e.type}":',
                                 e.allow_dups,
                                 None,
                             )
@@ -899,7 +899,7 @@ class Errors:
                                 -1,
                                 -1,
                                 "note",
-                                'In function "{}":'.format(e.function_or_member),
+                                f'In function "{e.function_or_member}":',
                                 e.allow_dups,
                                 None,
                             )

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1855,9 +1855,7 @@ class TypeConverter:
         elif isinstance(n, NameConstant) and str(n.value) == "None":
             return None
         self.fail(
-            "Expected string literal for argument name, got {}".format(type(n).__name__),
-            self.line,
-            0,
+            f"Expected string literal for argument name, got {type(n).__name__}", self.line, 0
         )
         return None
 

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -10,9 +10,9 @@ import shutil
 import sys
 import tempfile
 from types import TracebackType
-from typing import Callable, Optional
+from typing import Callable, Optional, Type
 
-from typing_extensions import Final, Type
+from typing_extensions import Final
 
 if sys.platform == "win32":
     # This may be private, but it is needed for IPC on Windows, and is basically stable

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -6,9 +6,9 @@ import subprocess
 import sys
 import time
 from gettext import gettext
-from typing import IO, Any, Dict, List, Optional, Sequence, TextIO, Tuple, Union
+from typing import IO, Any, Dict, List, NoReturn, Optional, Sequence, TextIO, Tuple, Union
 
-from typing_extensions import Final, NoReturn
+from typing_extensions import Final
 
 from mypy import build, defaults, state, util
 from mypy.config_parser import get_config_module_names, parse_config_file, parse_version

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -337,7 +337,7 @@ class MessageBuilder:
             self.fail(f'Member "{member}" is not assignable', context)
         elif member == "__contains__":
             self.fail(
-                "Unsupported right operand type for in ({})".format(format_type(original_type)),
+                f"Unsupported right operand type for in ({format_type(original_type)})",
                 context,
                 code=codes.OPERATOR,
             )
@@ -350,19 +350,19 @@ class MessageBuilder:
                     break
         elif member == "__neg__":
             self.fail(
-                "Unsupported operand type for unary - ({})".format(format_type(original_type)),
+                f"Unsupported operand type for unary - ({format_type(original_type)})",
                 context,
                 code=codes.OPERATOR,
             )
         elif member == "__pos__":
             self.fail(
-                "Unsupported operand type for unary + ({})".format(format_type(original_type)),
+                f"Unsupported operand type for unary + ({format_type(original_type)})",
                 context,
                 code=codes.OPERATOR,
             )
         elif member == "__invert__":
             self.fail(
-                "Unsupported operand type for ~ ({})".format(format_type(original_type)),
+                f"Unsupported operand type for ~ ({format_type(original_type)})",
                 context,
                 code=codes.OPERATOR,
             )
@@ -378,7 +378,7 @@ class MessageBuilder:
                 )
             else:
                 self.fail(
-                    "Value of type {} is not indexable".format(format_type(original_type)),
+                    f"Value of type {format_type(original_type)} is not indexable",
                     context,
                     code=codes.INDEX,
                 )
@@ -986,13 +986,13 @@ class MessageBuilder:
             )
         elif num_args == 1:
             self.fail(
-                "No overload variant{} matches argument type {}".format(name_str, arg_types_str),
+                f"No overload variant{name_str} matches argument type {arg_types_str}",
                 context,
                 code=code,
             )
         else:
             self.fail(
-                "No overload variant{} matches argument types {}".format(name_str, arg_types_str),
+                f"No overload variant{name_str} matches argument types {arg_types_str}",
                 context,
                 code=code,
             )
@@ -1009,13 +1009,11 @@ class MessageBuilder:
                 self.fail(f"Need more than 1 value to unpack ({expected} expected)", context)
             else:
                 self.fail(
-                    "Need more than {} values to unpack ({} expected)".format(provided, expected),
-                    context,
+                    f"Need more than {provided} values to unpack ({expected} expected)", context
                 )
         elif provided > expected:
             self.fail(
-                "Too many values to unpack ({} expected, {} provided)".format(expected, provided),
-                context,
+                f"Too many values to unpack ({expected} expected, {provided} provided)", context
             )
 
     def unpacking_strings_disallowed(self, context: Context) -> None:
@@ -1035,9 +1033,7 @@ class MessageBuilder:
     ) -> None:
         target = self.override_target(name, name_in_super, supertype)
         self.fail(
-            'Signature of "{}" incompatible with {}'.format(name, target),
-            context,
-            code=codes.OVERRIDE,
+            f'Signature of "{name}" incompatible with {target}', context, code=codes.OVERRIDE
         )
 
         note_template = 'Overload variants must be defined in the same order as they are in "{}"'
@@ -1054,9 +1050,7 @@ class MessageBuilder:
     ) -> None:
         code = codes.OVERRIDE
         target = self.override_target(name, name_in_super, supertype)
-        self.fail(
-            'Signature of "{}" incompatible with {}'.format(name, target), context, code=code
-        )
+        self.fail(f'Signature of "{name}" incompatible with {target}', context, code=code)
 
         INCLUDE_DECORATOR = True  # Include @classmethod and @staticmethod decorators, if any
         ALLOW_DUPS = True  # Allow duplicate notes, needed when signatures are duplicates
@@ -1197,13 +1191,11 @@ class MessageBuilder:
             self.fail("Type application targets a non-generic function or class", context)
         elif actual_arg_count > expected_arg_count:
             self.fail(
-                "Type application has too many types ({} expected)".format(expected_arg_count),
-                context,
+                f"Type application has too many types ({expected_arg_count} expected)", context
             )
         else:
             self.fail(
-                "Type application has too few types ({} expected)".format(expected_arg_count),
-                context,
+                f"Type application has too few types ({expected_arg_count} expected)", context
             )
 
     def could_not_infer_type_arguments(
@@ -1487,9 +1479,7 @@ class MessageBuilder:
         self.fail(f'Forward operator "{forward_method}" is not callable', context)
 
     def signatures_incompatible(self, method: str, other_method: str, context: Context) -> None:
-        self.fail(
-            'Signatures of "{}" and "{}" are incompatible'.format(method, other_method), context
-        )
+        self.fail(f'Signatures of "{method}" and "{other_method}" are incompatible', context)
 
     def yield_from_invalid_operand_type(self, expr: Type, context: Context) -> Type:
         text = format_type(expr) if format_type(expr) != "object" else expr
@@ -1641,7 +1631,7 @@ class MessageBuilder:
             )
         else:
             self.fail(
-                'TypedDict {} has no key "{}"'.format(format_type(typ), item_name),
+                f'TypedDict {format_type(typ)} has no key "{item_name}"',
                 context,
                 code=codes.TYPEDDICT_ITEM,
             )
@@ -1655,9 +1645,7 @@ class MessageBuilder:
 
     def typeddict_context_ambiguous(self, types: List[TypedDictType], context: Context) -> None:
         formatted_types = ", ".join(list(format_type_distinctly(*types)))
-        self.fail(
-            "Type of TypedDict is ambiguous, could be any of ({})".format(formatted_types), context
-        )
+        self.fail(f"Type of TypedDict is ambiguous, could be any of ({formatted_types})", context)
 
     def typeddict_key_cannot_be_deleted(
         self, typ: TypedDictType, item_name: str, context: Context
@@ -1666,8 +1654,7 @@ class MessageBuilder:
             self.fail(f'TypedDict key "{item_name}" cannot be deleted', context)
         else:
             self.fail(
-                'Key "{}" of TypedDict {} cannot be deleted'.format(item_name, format_type(typ)),
-                context,
+                f'Key "{item_name}" of TypedDict {format_type(typ)} cannot be deleted', context
             )
 
     def typeddict_setdefault_arguments_inconsistent(
@@ -1719,8 +1706,7 @@ class MessageBuilder:
             self.fail("Function is untyped after decorator transformation", context)
         else:
             self.fail(
-                'Type of decorated function contains type "Any" ({})'.format(format_type(typ)),
-                context,
+                f'Type of decorated function contains type "Any" ({format_type(typ)})', context
             )
 
     def typed_function_untyped_decorator(self, func_name: str, context: Context) -> None:
@@ -1739,14 +1725,12 @@ class MessageBuilder:
 
     def concrete_only_assign(self, typ: Type, context: Context) -> None:
         self.fail(
-            "Can only assign concrete classes to a variable of type {}".format(format_type(typ)),
-            context,
+            f"Can only assign concrete classes to a variable of type {format_type(typ)}", context
         )
 
     def concrete_only_call(self, typ: Type, context: Context) -> None:
         self.fail(
-            "Only concrete class can be given where {} is expected".format(format_type(typ)),
-            context,
+            f"Only concrete class can be given where {format_type(typ)} is expected", context
         )
 
     def cannot_use_function_with_type(
@@ -1763,7 +1747,7 @@ class MessageBuilder:
         )
         if len(members) < 3:
             attrs = ", ".join(members)
-            self.note('Protocol "{}" has non-method member(s): {}'.format(tp.name, attrs), context)
+            self.note(f'Protocol "{tp.name}" has non-method member(s): {attrs}', context)
 
     def note_call(
         self, subtype: Type, call: Type, context: Context, *, code: Optional[ErrorCode]
@@ -2117,9 +2101,7 @@ def format_callable_args(
             if arg_kind.is_star() or arg_name is None:
                 arg_strings.append(f"{constructor}({format(arg_type)})")
             else:
-                arg_strings.append(
-                    "{}({}, {})".format(constructor, format(arg_type), repr(arg_name))
-                )
+                arg_strings.append(f"{constructor}({format(arg_type)}, {repr(arg_name)})")
 
     return ", ".join(arg_strings)
 

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -12,9 +12,7 @@ import binascii
 import os
 import time
 from abc import abstractmethod
-from typing import Any, Iterable, List, Optional
-
-from typing_extensions import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional
 
 if TYPE_CHECKING:
     # We avoid importing sqlite3 unless we are using it so we can mostly work

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -5,8 +5,10 @@ from abc import abstractmethod
 from collections import defaultdict
 from enum import Enum, unique
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
+    DefaultDict,
     Dict,
     Iterator,
     List,
@@ -20,7 +22,7 @@ from typing import (
 )
 
 from mypy_extensions import trait
-from typing_extensions import TYPE_CHECKING, DefaultDict, Final, TypeAlias as _TypeAlias
+from typing_extensions import Final, TypeAlias as _TypeAlias
 
 import mypy.strconv
 from mypy.bogus_type import Bogus

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,9 +1,9 @@
 import pprint
 import re
 import sys
-from typing import Any, Callable, Dict, List, Mapping, Optional, Pattern, Set, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Pattern, Set, Tuple
 
-from typing_extensions import TYPE_CHECKING, Final
+from typing_extensions import Final
 
 from mypy import defaults
 from mypy.util import get_class_descriptors, replace_object_state

--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 """Utilities to find the site and prefix information of a Python executable, which may be Python 2.
 
 This file MUST remain compatible with Python 2. Since we cannot make any assumptions about the
@@ -49,11 +47,11 @@ def getsyspath():
     stdlib_zip = os.path.join(
         sys.base_exec_prefix,
         getattr(sys, "platlibdir", "lib"),
-        "python{}{}.zip".format(sys.version_info.major, sys.version_info.minor),
+        f"python{sys.version_info.major}{sys.version_info.minor}.zip",
     )
     stdlib = sysconfig.get_path("stdlib")
     stdlib_ext = os.path.join(stdlib, "lib-dynload")
-    excludes = set([stdlib_zip, stdlib, stdlib_ext])
+    excludes = {stdlib_zip, stdlib, stdlib_ext}
 
     # Drop the first entry of sys.path
     # - If pyinfo.py is executed as a script (in a subprocess), this is the directory

--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 """Utilities to find the site and prefix information of a Python executable, which may be Python 2.
 
 This file MUST remain compatible with Python 2. Since we cannot make any assumptions about the
@@ -47,11 +49,11 @@ def getsyspath():
     stdlib_zip = os.path.join(
         sys.base_exec_prefix,
         getattr(sys, "platlibdir", "lib"),
-        f"python{sys.version_info.major}{sys.version_info.minor}.zip",
+        "python{}{}.zip".format(sys.version_info.major, sys.version_info.minor),
     )
     stdlib = sysconfig.get_path("stdlib")
     stdlib_ext = os.path.join(stdlib, "lib-dynload")
-    excludes = {stdlib_zip, stdlib, stdlib_ext}
+    excludes = set([stdlib_zip, stdlib, stdlib_ext])
 
     # Drop the first entry of sys.path
     # - If pyinfo.py is executed as a script (in a subprocess), this is the directory

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2546,9 +2546,7 @@ class SemanticAnalyzer(
         if not isinstance(rv, RefExpr):
             return False
         if isinstance(rv.node, TypeVarLikeExpr):
-            self.fail(
-                'Type variable "{}" is invalid as target for type alias'.format(rv.fullname), rv
-            )
+            self.fail(f'Type variable "{rv.fullname}" is invalid as target for type alias', rv)
             return False
 
         if bare:
@@ -3654,8 +3652,7 @@ class SemanticAnalyzer(
                 return None
             else:
                 self.fail(
-                    '{}: "{}"'.format(message_registry.TYPEVAR_UNEXPECTED_ARGUMENT, param_name),
-                    context,
+                    f'{message_registry.TYPEVAR_UNEXPECTED_ARGUMENT}: "{param_name}"', context
                 )
                 return None
 
@@ -4466,9 +4463,7 @@ class SemanticAnalyzer(
             self.fail('"%s" expects %d argument%s' % (name, numargs, s), expr)
             return False
         if expr.arg_kinds != [ARG_POS] * numargs:
-            self.fail(
-                '"%s" must be called with %s positional argument%s' % (name, numargs, s), expr
-            )
+            self.fail(f'"{name}" must be called with {numargs} positional argument{s}', expr)
             return False
         return True
 

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -25,9 +25,9 @@ will be incomplete.
 """
 
 from contextlib import nullcontext
-from typing import Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 
-from typing_extensions import TYPE_CHECKING, Final, TypeAlias as _TypeAlias
+from typing_extensions import Final, TypeAlias as _TypeAlias
 
 import mypy.build
 import mypy.state

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -173,8 +173,7 @@ class NamedTupleAnalyzer:
                 # ...despite possible minor failures that allow further analyzis.
                 if name.startswith("_"):
                     self.fail(
-                        "NamedTuple field name cannot start with an underscore: {}".format(name),
-                        stmt,
+                        f"NamedTuple field name cannot start with an underscore: {name}", stmt
                     )
                 if stmt.type is None or hasattr(stmt, "new_syntax") and not stmt.new_syntax:
                     self.fail(NAMEDTUP_CLASS_ERROR, stmt)

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -117,9 +117,7 @@ class TypedDictAnalyzer:
                 valid_items = base_items.copy()
                 for key in base_items:
                     if key in keys:
-                        self.fail(
-                            'Overwriting TypedDict field "{}" while merging'.format(key), defn
-                        )
+                        self.fail(f'Overwriting TypedDict field "{key}" while merging', defn)
                 keys.extend(valid_items.keys())
                 types.extend(valid_items.values())
                 required_keys.update(base_typed_dict.required_keys)
@@ -167,9 +165,7 @@ class TypedDictAnalyzer:
             else:
                 name = stmt.lvalues[0].name
                 if name in (oldfields or []):
-                    self.fail(
-                        'Overwriting TypedDict field "{}" while extending'.format(name), stmt
-                    )
+                    self.fail(f'Overwriting TypedDict field "{name}" while extending', stmt)
                 if name in fields:
                     self.fail(f'Duplicate TypedDict key "{name}"', stmt)
                     continue

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -79,9 +79,7 @@ dependency map significantly without significant benefit.
 Test cases for this module live in 'test-data/unit/deps*.test'.
 """
 
-from typing import Dict, List, Optional, Set, Tuple
-
-from typing_extensions import DefaultDict
+from typing import DefaultDict, Dict, List, Optional, Set, Tuple
 
 from mypy.nodes import (
     GDEF,
@@ -527,9 +525,7 @@ class DependencyVisitor(TraverserVisitor):
                 # global variable.
                 lvalue_type = self.get_non_partial_lvalue_type(lvalue)
                 type_triggers = self.get_type_triggers(lvalue_type)
-                attr_trigger = make_trigger(
-                    "{}.{}".format(self.scope.current_full_target(), lvalue.name)
-                )
+                attr_trigger = make_trigger(f"{self.scope.current_full_target()}.{lvalue.name}")
                 for type_trigger in type_triggers:
                     self.add_dependency(type_trigger, attr_trigger)
         elif isinstance(lvalue, MemberExpr):
@@ -922,7 +918,7 @@ class DependencyVisitor(TraverserVisitor):
             triggers = self.attribute_triggers(typ.item, name)
             if isinstance(typ.item, Instance) and typ.item.type.metaclass_type is not None:
                 triggers.append(
-                    make_trigger("%s.%s" % (typ.item.type.metaclass_type.type.fullname, name))
+                    make_trigger(f"{typ.item.type.metaclass_type.type.fullname}.{name}")
                 )
             return triggers
         else:

--- a/mypy/server/mergecheck.py
+++ b/mypy/server/mergecheck.py
@@ -51,9 +51,7 @@ def check_consistency(o: object) -> None:
         path2 = get_path(sym2, seen, parents)
 
         if fn in m:
-            print(
-                "\nDuplicate {!r} nodes with fullname {!r} found:".format(type(sym).__name__, fn)
-            )
+            print(f"\nDuplicate {type(sym).__name__!r} nodes with fullname {fn!r} found:")
             print("[1] %d: %s" % (id(sym1), path_to_str(path1)))
             print("[2] %d: %s" % (id(sym2), path_to_str(path2)))
 

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -2,9 +2,7 @@
 
 import os
 import re
-from typing import Any, List, Optional, Sequence, Tuple, Union
-
-from typing_extensions import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
 
 import mypy.nodes
 from mypy.util import IdMapper, short_type

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -874,7 +874,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             ):
                 self.add_coroutine_decorator(
                     context.func,
-                    "%s.coroutines.coroutine" % (expr.expr.expr.name,),
+                    f"{expr.expr.expr.name}.coroutines.coroutine",
                     expr.expr.expr.name,
                 )
             elif isinstance(expr.expr, NameExpr) and (

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -21,10 +21,23 @@ import warnings
 from contextlib import redirect_stderr, redirect_stdout
 from functools import singledispatch
 from pathlib import Path
-from typing import Any, Dict, Generic, Iterator, List, Optional, Set, Tuple, TypeVar, Union, cast
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import typing_extensions
-from typing_extensions import Type, get_origin
+from typing_extensions import get_origin
 
 import mypy.build
 import mypy.modulefinder
@@ -985,7 +998,7 @@ def verify_paramspecexpr(
         getattr(typing, "ParamSpec", None),
         getattr(typing_extensions, "ParamSpec", None),
     )
-    paramspec_types = tuple([t for t in maybe_paramspec_types if t is not None])
+    paramspec_types = tuple(t for t in maybe_paramspec_types if t is not None)
     if not paramspec_types or not isinstance(runtime, paramspec_types):
         yield Error(object_path, "is not a ParamSpec", stub, runtime)
         return

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -592,12 +592,12 @@ class SuggestionEngine:
         for i, component in enumerate(components[:-1]):
             if component not in names:
                 raise SuggestionFailure(
-                    "Unknown class %s.%s" % (modname, ".".join(components[: i + 1]))
+                    "Unknown class {}.{}".format(modname, ".".join(components[: i + 1]))
                 )
             node: Optional[SymbolNode] = names[component].node
             if not isinstance(node, TypeInfo):
                 raise SuggestionFailure(
-                    "Object %s.%s is not a class" % (modname, ".".join(components[: i + 1]))
+                    "Object {}.{} is not a class".format(modname, ".".join(components[: i + 1]))
                 )
             names = node.names
 
@@ -606,7 +606,7 @@ class SuggestionEngine:
         if funcname not in names:
             key = modname + "." + tail
             raise SuggestionFailure(
-                "Unknown %s %s" % ("method" if len(components) > 1 else "function", key)
+                "Unknown {} {}".format("method" if len(components) > 1 else "function", key)
             )
         return names[funcname].node
 

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -346,9 +346,7 @@ def typename(t: type) -> str:
 def assert_type(typ: type, value: object) -> None:
     __tracebackhide__ = True
     if type(value) != typ:
-        raise AssertionError(
-            "Invalid type {}, expected {}".format(typename(type(value)), typename(typ))
-        )
+        raise AssertionError(f"Invalid type {typename(type(value))}, expected {typename(typ)}")
 
 
 def parse_options(

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -162,7 +162,7 @@ class TypeCheckSuite(DataSuite):
             output = testcase.output
         elif incremental_step > 1:
             msg = (
-                "Unexpected type checker output in incremental, run {}".format(incremental_step)
+                f"Unexpected type checker output in incremental, run {incremental_step}"
                 + " ({}, line {})"
             )
             output = testcase.output2.get(incremental_step, [])
@@ -227,7 +227,7 @@ class TypeCheckSuite(DataSuite):
         # just notes attached to other errors.
         assert error_paths or not busted_paths, "Some modules reported error despite no errors"
         if not missing_paths == busted_paths:
-            raise AssertionError("cache data discrepancy %s != %s" % (missing_paths, busted_paths))
+            raise AssertionError(f"cache data discrepancy {missing_paths} != {busted_paths}")
         assert os.path.isfile(os.path.join(manager.options.cache_dir, ".gitignore"))
         cachedir_tag = os.path.join(manager.options.cache_dir, "CACHEDIR.TAG")
         assert os.path.isfile(cachedir_tag)

--- a/mypy/test/testdaemon.py
+++ b/mypy/test/testdaemon.py
@@ -88,12 +88,7 @@ def run_cmd(input: str) -> Tuple[int, str]:
     env["PYTHONPATH"] = PREFIX
     try:
         output = subprocess.check_output(
-            input,
-            shell=True,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-            cwd=test_temp_dir,
-            env=env,
+            input, shell=True, stderr=subprocess.STDOUT, text=True, cwd=test_temp_dir, env=env
         )
         return 0, output
     except subprocess.CalledProcessError as err:

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -2,9 +2,7 @@
 
 import os
 from collections import defaultdict
-from typing import Dict, List, Optional, Set, Tuple
-
-from typing_extensions import DefaultDict
+from typing import DefaultDict, Dict, List, Optional, Set, Tuple
 
 from mypy import build
 from mypy.errors import CompileError

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -40,7 +40,5 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
         assert e.messages == []
 
     assert_string_arrays_equal(
-        testcase.output,
-        logged_messages,
-        "Invalid output ({}, line {})".format(testcase.file, testcase.line),
+        testcase.output, logged_messages, f"Invalid output ({testcase.file}, line {testcase.line})"
     )

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -48,9 +48,7 @@ def test_parser(testcase: DataDrivenTestCase) -> None:
     except CompileError as e:
         a = e.messages
     assert_string_arrays_equal(
-        testcase.output,
-        a,
-        "Invalid parser output ({}, line {})".format(testcase.file, testcase.line),
+        testcase.output, a, f"Invalid parser output ({testcase.file}, line {testcase.line})"
     )
 
 

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager
-from subprocess import PIPE
 from typing import Iterator, List, Tuple
 
 import filelock

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -34,7 +34,7 @@ def virtualenv(python_executable: str = sys.executable) -> Iterator[Tuple[str, s
     """
     with tempfile.TemporaryDirectory() as venv_dir:
         proc = subprocess.run(
-            [python_executable, "-m", "venv", venv_dir], cwd=os.getcwd(), stdout=PIPE, stderr=PIPE
+            [python_executable, "-m", "venv", venv_dir], cwd=os.getcwd(), capture_output=True
         )
         if proc.returncode != 0:
             err = proc.stdout.decode("utf-8") + proc.stderr.decode("utf-8")
@@ -69,11 +69,9 @@ def install_package(
         env.update(os.environ)
         try:
             with filelock.FileLock(pip_lock, timeout=pip_timeout):
-                proc = subprocess.run(
-                    install_cmd, cwd=working_dir, stdout=PIPE, stderr=PIPE, env=env
-                )
+                proc = subprocess.run(install_cmd, cwd=working_dir, capture_output=True, env=env)
         except filelock.Timeout as err:
-            raise Exception("Failed to acquire {}".format(pip_lock)) from err
+            raise Exception(f"Failed to acquire {pip_lock}") from err
     if proc.returncode != 0:
         raise Exception(proc.stdout.decode("utf-8") + proc.stderr.decode("utf-8"))
 
@@ -137,7 +135,7 @@ def test_pep561(testcase: DataDrivenTestCase) -> None:
             assert_string_arrays_equal(
                 expected,
                 output,
-                "Invalid output ({}, line {}){}".format(testcase.file, testcase.line, iter_count),
+                f"Invalid output ({testcase.file}, line {testcase.line}){iter_count}",
             )
 
         if has_program:

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -82,7 +82,7 @@ def test_python_evaluation(testcase: DataDrivenTestCase, cache_dir: str) -> None
     if returncode == 0:
         # Execute the program.
         proc = subprocess.run(
-            [interpreter, "-Wignore", program], cwd=test_temp_dir, stdout=PIPE, stderr=PIPE
+            [interpreter, "-Wignore", program], cwd=test_temp_dir, capture_output=True
         )
         output.extend(split_lines(proc.stdout, proc.stderr))
     # Remove temp file.
@@ -91,9 +91,7 @@ def test_python_evaluation(testcase: DataDrivenTestCase, cache_dir: str) -> None
         if os.path.sep + "typeshed" + os.path.sep in line:
             output[i] = line.split(os.path.sep)[-1]
     assert_string_arrays_equal(
-        adapt_output(testcase),
-        output,
-        "Invalid output ({}, line {})".format(testcase.file, testcase.line),
+        adapt_output(testcase), output, f"Invalid output ({testcase.file}, line {testcase.line})"
     )
 
 

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -15,7 +15,6 @@ import os.path
 import re
 import subprocess
 import sys
-from subprocess import PIPE
 from tempfile import TemporaryDirectory
 from typing import List
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -709,9 +709,7 @@ class StubgenPythonSuite(DataSuite):
             except CompileError as e:
                 a = e.messages
             assert_string_arrays_equal(
-                testcase.output,
-                a,
-                "Invalid output ({}, line {})".format(testcase.file, testcase.line),
+                testcase.output, a, f"Invalid output ({testcase.file}, line {testcase.line})"
             )
         finally:
             for mod in mods:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1130,9 +1130,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     kind = ARG_KINDS_BY_CONSTRUCTOR[found.fullname]
                     kinds.append(kind)
                     if arg.name is not None and kind.is_star():
-                        self.fail(
-                            "{} arguments should not have names".format(arg.constructor), arg
-                        )
+                        self.fail(f"{arg.constructor} arguments should not have names", arg)
                         return None
             else:
                 args.append(arg)
@@ -1540,10 +1538,7 @@ def expand_type_alias(
         tp.column = ctx.column
         return tp
     if act_len != exp_len:
-        fail(
-            "Bad number of arguments for type alias, expected: %s, given: %s" % (exp_len, act_len),
-            ctx,
-        )
+        fail(f"Bad number of arguments for type alias, expected: {exp_len}, given: {act_len}", ctx)
         return set_any_tvars(node, ctx.line, ctx.column, from_error=True)
     typ = TypeAliasType(node, args, ctx.line, ctx.column)
     assert typ.alias is not None

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -7,9 +7,20 @@ NOTE: These must not be accessed from mypy.nodes or mypy.types to avoid import
 
 import itertools
 import sys
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, TypeVar, Union, cast
-
-from typing_extensions import Type as TypingType
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type as TypingType,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from mypy.copytype import copy_type
 from mypy.expandtype import expand_type, expand_type_by_instance

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3,7 +3,9 @@
 import sys
 from abc import abstractmethod
 from typing import (
+    TYPE_CHECKING,
     Any,
+    ClassVar,
     Dict,
     Iterable,
     List,
@@ -17,7 +19,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import TYPE_CHECKING, ClassVar, Final, TypeAlias as _TypeAlias, overload
+from typing_extensions import Final, TypeAlias as _TypeAlias, overload
 
 import mypy.nodes
 from mypy.bogus_type import Bogus

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -3,9 +3,9 @@ A shared state for all TypeInfos that holds global cache and dependency informat
 and potentially other mutable TypeInfo state. This module contains mutable global state.
 """
 
-from typing import Dict, List, Optional, Set, Tuple
+from typing import ClassVar, Dict, List, Optional, Set, Tuple
 
-from typing_extensions import ClassVar, Final, TypeAlias as _TypeAlias
+from typing_extensions import Final, TypeAlias as _TypeAlias
 
 from mypy.nodes import TypeInfo
 from mypy.server.trigger import make_trigger

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -20,11 +20,12 @@ from typing import (
     Sequence,
     Sized,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
 
-from typing_extensions import Final, Literal, Type
+from typing_extensions import Final, Literal
 
 try:
     import curses

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -1,10 +1,9 @@
 """Generic abstract syntax tree node visitor"""
 
 from abc import abstractmethod
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from mypy_extensions import mypyc_attr, trait
-from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # break import cycle only needed for mypy


### PR DESCRIPTION
I ran `pyupgrade` on all `mypy/*` files.
Command: `pyupgrade --py37-plus mypy/**/*.py`, but I had to do it twice, because `pyugrade` changes `%s` to `.format` first, then to `f` strings.

Basically, it does several things:
1. Normalizes `typing` imports
2. Uses `f` strings where possible
3. Uses different `subprocess.run` signature

Refs https://github.com/python/mypy/pull/12711

I will address `pyinfo.py` in a separate PR. 