### PR TITLE
Modernize `pyinfo.py` to 3.7+

### DIFF
--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -1,20 +1,16 @@
-from __future__ import print_function
+from __future__ import annotations
 
-"""Utilities to find the site and prefix information of a Python executable, which may be Python 2.
+"""Utilities to find the site and prefix information of a Python executable.
 
-This file MUST remain compatible with Python 2. Since we cannot make any assumptions about the
+This file MUST remain compatible with all Python 3.7+ versions. Since we cannot make any assumptions about the
 Python being executed, this module should not use *any* dependencies outside of the standard
-library found in Python 2. This file is run each mypy run, so it should be kept as fast as
+library found in Python 3.7. This file is run each mypy run, so it should be kept as fast as
 possible.
 """
 import os
 import site
 import sys
 import sysconfig
-
-MYPY = False
-if MYPY:
-    from typing import List, Tuple
 
 if __name__ == "__main__":
     # HACK: We don't want to pick up mypy.types as the top-level types
@@ -27,8 +23,7 @@ if __name__ == "__main__":
     sys.path = old_sys_path
 
 
-def getsitepackages():
-    # type: () -> List[str]
+def getsitepackages() -> list[str]:
     res = []
     if hasattr(site, "getsitepackages"):
         res.extend(site.getsitepackages())
@@ -42,18 +37,17 @@ def getsitepackages():
     return res
 
 
-def getsyspath():
-    # type: () -> List[str]
+def getsyspath() -> list[str]:
     # Do not include things from the standard library
     # because those should come from typeshed.
     stdlib_zip = os.path.join(
         sys.base_exec_prefix,
         getattr(sys, "platlibdir", "lib"),
-        "python{}{}.zip".format(sys.version_info.major, sys.version_info.minor),
+        f"python{sys.version_info.major}{sys.version_info.minor}.zip",
     )
     stdlib = sysconfig.get_path("stdlib")
     stdlib_ext = os.path.join(stdlib, "lib-dynload")
-    excludes = set([stdlib_zip, stdlib, stdlib_ext])
+    excludes = {stdlib_zip, stdlib, stdlib_ext}
 
     # Drop the first entry of sys.path
     # - If pyinfo.py is executed as a script (in a subprocess), this is the directory
@@ -72,8 +66,7 @@ def getsyspath():
     return [p for p in abs_sys_path if p not in excludes]
 
 
-def getsearchdirs():
-    # type: () -> Tuple[List[str], List[str]]
+def getsearchdirs() -> tuple[list[str], list[str]]:
     return (getsyspath(), getsitepackages())
 
 


### PR DESCRIPTION
`pyinfo.py` can no longer be called with 2.7 and 3.6, because their support is dropped.