### PR TITLE
Remove Optional[...] special-casing during semantic analysis

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2524,7 +2524,7 @@ class UnionType(ProperType):
         if state.strict_optional:
             return self.items
         else:
-            return [i for i in get_proper_types(self.items) if not isinstance(i, NoneType)]
+            return [i for i in self.items if not isinstance(get_proper_type(i), NoneType)]
 
     def serialize(self) -> JsonDict:
         return {".class": "UnionType", "items": [t.serialize() for t in self.items]}
@@ -3176,21 +3176,6 @@ def flatten_nested_unions(
             # Must preserve original aliases when possible.
             flat_items.append(t)
     return flat_items
-
-
-def union_items(typ: Type) -> List[ProperType]:
-    """Return the flattened items of a union type.
-
-    For non-union types, return a list containing just the argument.
-    """
-    typ = get_proper_type(typ)
-    if isinstance(typ, UnionType):
-        items = []
-        for item in typ.items:
-            items.extend(union_items(item))
-        return items
-    else:
-        return [typ]
 
 
 def invalid_recursive_alias(seen_nodes: Set[mypy.nodes.TypeAlias], target: Type) -> bool:

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -389,6 +389,14 @@ reveal_type(bar(lla))  # N: Revealed type is "__main__.A"
 reveal_type(bar(llla))  # N: Revealed type is "__main__.A"
 [builtins fixtures/isinstancelist.pyi]
 
+[case testRecursiveAliasesWithOptional]
+# flags: --enable-recursive-aliases
+from typing import Optional, Sequence
+
+A = Sequence[Optional[A]]
+x: A
+y: str = x[0]  # E: Incompatible types in assignment (expression has type "Optional[A]", variable has type "str")
+
 [case testRecursiveAliasesProhibitBadAliases]
 # flags: --enable-recursive-aliases
 from typing import Union, Type, List, TypeVar

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -421,7 +421,7 @@ def foobar(items: List[object]):
     c: List[Bar] = [x for x in items if is_foo(x)]  # E: List comprehension has incompatible type List[Foo]; expected List[Bar]
 [builtins fixtures/tuple.pyi]
 
-[case testTypeGuardNestedRestrictionUnionIsInstance-xfail]
+[case testTypeGuardNestedRestrictionUnionIsInstance]
 from typing_extensions import TypeGuard
 from typing import Any, List
 


### PR DESCRIPTION
This is another fix for recursive aliases. Ref #13297 

Previously this special casing caused `Optional[...]` to fail with infinite recursion, where `Union[..., None]` worked. I also delete a duplicate helper, and replace it with another existing one that handles type aliases properly.

(I have no idea why some TypeGuard test started passing, but we have `xfail-strict` so I am re-enabling this test.)

cc @JukkaL 