### PR TITLE
Allow narrowing metaclasses, refs #11671

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5982,7 +5982,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             vartype = UnionType(union_list)
         elif isinstance(vartype, TypeType):
             vartype = vartype.item
-        elif isinstance(vartype, Instance) and vartype.type.fullname == "builtins.type":
+        elif isinstance(vartype, Instance) and vartype.type.is_metaclass():
             vartype = self.named_type("builtins.object")
         else:
             # Any other object whose type we don't know precisely

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1808,14 +1808,18 @@ if issubclass(fm, Bar):
 [case testIssubclassWithMetaclassesStrictOptional]
 # flags: --strict-optional
 class FooMetaclass(type): ...
+class BarMetaclass(type): ...
 class Foo(metaclass=FooMetaclass): ...
-class Bar: ...
+class Bar(metaclass=BarMetaclass): ...
+class Baz: ...
 
 fm: FooMetaclass
 reveal_type(fm)  # N: Revealed type is "__main__.FooMetaclass"
 if issubclass(fm, Foo):
     reveal_type(fm)  # N: Revealed type is "Type[__main__.Foo]"
 if issubclass(fm, Bar):
+    reveal_type(fm)  # N: Revealed type is "<nothing>"
+if issubclass(fm, Baz):
     reveal_type(fm)  # N: Revealed type is "<nothing>"
 [builtins fixtures/isinstance.pyi]
 

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1792,6 +1792,33 @@ issubclass(x, (int, Iterable[int]))  # E: Parameterized generics cannot be used 
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testIssubclassWithMetaclasses]
+class FooMetaclass(type): ...
+class Foo(metaclass=FooMetaclass): ...
+class Bar: ...
+
+fm: FooMetaclass
+reveal_type(fm)  # N: Revealed type is "__main__.FooMetaclass"
+if issubclass(fm, Foo):
+    reveal_type(fm)  # N: Revealed type is "Type[__main__.Foo]"
+if issubclass(fm, Bar):
+    reveal_type(fm)  # N: Revealed type is "None"
+[builtins fixtures/isinstance.pyi]
+
+[case testIssubclassWithMetaclassesStrictOptional]
+# flags: --strict-optional
+class FooMetaclass(type): ...
+class Foo(metaclass=FooMetaclass): ...
+class Bar: ...
+
+fm: FooMetaclass
+reveal_type(fm)  # N: Revealed type is "__main__.FooMetaclass"
+if issubclass(fm, Foo):
+    reveal_type(fm)  # N: Revealed type is "Type[__main__.Foo]"
+if issubclass(fm, Bar):
+    reveal_type(fm)  # N: Revealed type is "<nothing>"
+[builtins fixtures/isinstance.pyi]
+
 [case testIsinstanceAndNarrowTypeVariable]
 from typing import TypeVar
 


### PR DESCRIPTION
We now allow narrowing metaclasses with `issubclass`.
Closes https://github.com/python/mypy/issues/11671