### PR TITLE
stubtest: Fix `TypeType` subtyping problem

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1353,10 +1353,15 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
         )
 
     # Try and look up a stub for the runtime object
-    stub = get_stub(type(runtime).__module__)
+    if isinstance(runtime, type):
+        runtime_type = runtime  # This might be a class
+    else:
+        runtime_type = type(runtime)  # Or an instance
+
+    stub = get_stub(runtime_type.__module__)
     if stub is None:
         return None
-    type_name = type(runtime).__name__
+    type_name = runtime_type.__name__
     if type_name not in stub.names:
         return None
     type_info = stub.names[type_name].node
@@ -1382,6 +1387,8 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
     elif isinstance(runtime, (bool, int, str)):
         value = runtime
     else:
+        if isinstance(runtime, type):
+            return mypy.types.TypeType(fallback)
         return fallback
 
     return mypy.types.LiteralType(value=value, fallback=fallback)

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -708,6 +708,90 @@ class StubtestUnit(unittest.TestCase):
         )
 
     @collect_cases
+    def test_class_var(self) -> Iterator[Case]:
+        # Regular classes
+        yield Case(stub="class Z: ...", runtime="class Z: ...", error=None)
+        yield Case(
+            stub="""
+            class A1:
+                a: type[Z]
+            """,
+            runtime="""
+            class A1:
+                a = Z
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class A2:
+                a: type[Z]
+            """,
+            runtime="""
+            class A2:
+                a = int
+            """,
+            error="A2.a",
+        )
+
+        # Now, with metaclasses:
+        yield Case(
+            stub="""
+            class Meta(type): ...
+            class Y(metaclass=Meta): ...
+            """,
+            runtime="""
+            class Meta(type): ...
+            class Y(metaclass=Meta): ...
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class B1:
+                a: type[Y]
+            """,
+            runtime="""
+            class B1:
+                a = Y
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class B2:
+                a: type[Y]
+            """,
+            runtime="""
+            class B2:
+                a = int
+            """,
+            error="B2.a",
+        )
+        yield Case(
+            stub="""
+            class B3:
+                a: Meta
+            """,
+            runtime="""
+            class B3:
+                a = Y
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class B4:
+                a: Meta
+            """,
+            runtime="""
+            class B4:
+                a = int
+            """,
+            error="B4.a",
+        )
+
+    @collect_cases
     def test_type_alias(self) -> Iterator[Case]:
         yield Case(
             stub="""


### PR DESCRIPTION
Now this passes:

```python
# STUB
class Meta(type): ...
class Y(metaclass=Meta): ...
class Z:
    foo: type[Y]

# RUNTIME:
class Meta(type): ...
class Y(metaclass=Meta): ...
class Z:
    foo = Y
```

Closes #13316