### PR TITLE
Update flake8 to 5.0.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,10 @@ exclude =
 #   B006: use of mutable defaults in function signatures
 #   B007: Loop control variable not used within the loop body.
 #   B011: Don't use assert False
+#   B023: Function definition does not bind loop variable
 #   F821: Name not defined (generates false positives with error codes)
 #   E741: Ambiguous variable name
-extend-ignore = E128,E203,E501,W601,E701,E704,E402,B3,B006,B007,B011,F821,E741
+extend-ignore = E128,E203,E501,W601,E701,E704,E402,B3,B006,B007,B011,B023,F821,E741
 
 [coverage:run]
 branch = true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,9 +4,9 @@ attrs>=18.0
 black==22.6.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0,<3.4.2; python_version<'3.7'
 filelock>=3.3.0; python_version>='3.7'
-flake8==3.9.2
-flake8-bugbear==22.3.20
-flake8-pyi>=20.5
+flake8==5.0.4
+flake8-bugbear==22.7.1
+flake8-pyi>=22.8.1
 isort[colors]==5.10.1  # must match version in .pre-commit-config.yaml
 lxml>=4.4.0; python_version<'3.11'
 psutil>=4.0


### PR DESCRIPTION
### Description
Update `flake8` to the latest version. Testing locally, I'm seeing roughly a 35-40% runtime improvement.

#### Changelogs
Flake8: https://flake8.pycqa.org/en/latest/release-notes/index.html
Flake8-pyi: https://github.com/PyCQA/flake8-pyi/blob/master/CHANGELOG.md#2281
Flake8-bugbear: https://github.com/PyCQA/flake8-bugbear#2271

#### New ignore -> B023

Warning description from [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear#list-of-warnings):
> B023: Functions defined inside a loop must not use variables redefined in the loop,
> because [late-binding closures are a classic gotcha](https://docs.python-guide.org/writing/gotchas/#late-binding-closures).

Creates too many false positives ATM
```
./mypyc/irbuild/ll_builder.py:342:52: B023 Function definition does not bind loop variable 'class_ir'.
./mypyc/irbuild/ll_builder.py:344:75: B023 Function definition does not bind loop variable 'ret'.
./mypyc/irbuild/ll_builder.py:375:66: B023 Function definition does not bind loop variable 'c'.
./mypyc/irbuild/ll_builder.py:377:75: B023 Function definition does not bind loop variable 'ret'.
./mypyc/irbuild/builder.py:1257:24: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1260:32: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1261:43: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1266:51: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1267:55: B023 Function definition does not bind loop variable 'target'.
./mypyc/irbuild/builder.py:1268:51: B023 Function definition does not bind loop variable 'target'.
./mypyc/irbuild/builder.py:1270:28: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1271:74: B023 Function definition does not bind loop variable 'target'.
./mypyc/irbuild/builder.py:1273:80: B023 Function definition does not bind loop variable 'arg'.
./mypy/checker.py:5249:34: B023 Function definition does not bind loop variable 'member_name'.
./mypy/checker.py:5251:37: B023 Function definition does not bind loop variable 'parent_expr'.
./mypy/checker.py:5263:32: B023 Function definition does not bind loop variable 'member_type'.
./mypy/checker.py:5282:36: B023 Function definition does not bind loop variable 'str_literals'.
./mypy/checker.py:5283:83: B023 Function definition does not bind loop variable 'str_literals'.
./mypy/checker.py:5296:40: B023 Function definition does not bind loop variable 'int_literals'.
./mypy/checker.py:5297:87: B023 Function definition does not bind loop variable 'int_literals'.
./mypy/test/testmerge.py:235:82: B023 Function definition does not bind loop variable 'type_map'.
./mypy/test/helpers.py:427:50: B023 Function definition does not bind loop variable 'path'.
```


## Test Plan
--