### PR TITLE
Support recursive named tuples

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -563,6 +563,7 @@ def analyze_descriptor_access(descriptor_type: Type, mx: MemberContext) -> Type:
         The return type of the appropriate ``__get__`` overload for the descriptor.
     """
     instance_type = get_proper_type(mx.original_type)
+    orig_descriptor_type = descriptor_type
     descriptor_type = get_proper_type(descriptor_type)
 
     if isinstance(descriptor_type, UnionType):
@@ -571,10 +572,10 @@ def analyze_descriptor_access(descriptor_type: Type, mx: MemberContext) -> Type:
             [analyze_descriptor_access(typ, mx) for typ in descriptor_type.items]
         )
     elif not isinstance(descriptor_type, Instance):
-        return descriptor_type
+        return orig_descriptor_type
 
     if not descriptor_type.type.has_readable_member("__get__"):
-        return descriptor_type
+        return orig_descriptor_type
 
     dunder_get = descriptor_type.type.get_method("__get__")
     if dunder_get is None:

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -75,6 +75,7 @@ class NodeFixer(NodeVisitor[None]):
                     p.accept(self.type_fixer)
             if info.tuple_type:
                 info.tuple_type.accept(self.type_fixer)
+                info.update_tuple_type(info.tuple_type)
             if info.typeddict_type:
                 info.typeddict_type.accept(self.type_fixer)
             if info.declared_metaclass:

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -339,6 +339,8 @@ def lookup_fully_qualified_alias(
     if isinstance(node, TypeAlias):
         return node
     elif isinstance(node, TypeInfo):
+        if node.tuple_alias:
+            return node.tuple_alias
         alias = TypeAlias.from_tuple_type(node)
         node.tuple_alias = alias
         return alias

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -338,9 +338,7 @@ def lookup_fully_qualified_alias(
     if isinstance(node, TypeAlias):
         return node
     elif isinstance(node, TypeInfo):
-        assert node.tuple_type
-        target = node.tuple_type.copy_modified(fallback=Instance(node, []))
-        alias = TypeAlias(target, node.fullname, node.line, node.column)
+        alias = TypeAlias.from_tuple_type(node)
         node.tuple_alias = alias
         return alias
     else:

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -337,6 +337,12 @@ def lookup_fully_qualified_alias(
     node = stnode.node if stnode else None
     if isinstance(node, TypeAlias):
         return node
+    elif isinstance(node, TypeInfo):
+        assert node.tuple_type
+        target = node.tuple_type.copy_modified(fallback=Instance(node, []))
+        alias = TypeAlias(target, node.fullname, node.line, node.column)
+        node.tuple_alias = alias
+        return alias
     else:
         # Looks like a missing TypeAlias during an initial daemon load, put something there
         assert (

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2292,6 +2292,11 @@ class CollectAllInstancesQuery(TypeTraverserVisitor):
         self.instances.append(t)
         super().visit_instance(t)
 
+    def visit_type_alias_type(self, t: TypeAliasType) -> None:
+        if t.alias and not t.is_recursive:
+            t.alias.target.accept(self)
+        super().visit_type_alias_type(t)
+
 
 def find_type_overlaps(*types: Type) -> Set[str]:
     """Return a set of fullnames that share a short name and appear in either type.

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3258,6 +3258,17 @@ class TypeAlias(SymbolNode):
         self.eager = eager
         super().__init__(line, column)
 
+    @classmethod
+    def from_tuple_type(cls, info: TypeInfo) -> "TypeAlias":
+        return TypeAlias(
+            info.tuple_type.copy_modified(
+                fallback=mypy.types.Instance(info, [])
+            ),
+            info.fullname,
+            info.line,
+            info.column,
+        )
+
     @property
     def name(self) -> str:
         return self._fullname.split(".")[-1]

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2970,6 +2970,15 @@ class TypeInfo(SymbolNode):
         """
         return [base.type for base in self.bases]
 
+    def update_tuple_type(self, typ: "mypy.types.TupleType") -> None:
+        """Update tuple_type and tuple_alias as needed."""
+        self.tuple_type = typ
+        alias = TypeAlias.from_tuple_type(self)
+        if not self.tuple_alias:
+            self.tuple_alias = alias
+        else:
+            self.tuple_alias.target = alias.target
+
     def __str__(self) -> str:
         """Return a string representation of the type.
 
@@ -3260,6 +3269,7 @@ class TypeAlias(SymbolNode):
 
     @classmethod
     def from_tuple_type(cls, info: TypeInfo) -> "TypeAlias":
+        """Generate an alias to the tuple type described by a given TypeInfo."""
         assert info.tuple_type
         return TypeAlias(
             info.tuple_type.copy_modified(fallback=mypy.types.Instance(info, [])),

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3260,10 +3260,9 @@ class TypeAlias(SymbolNode):
 
     @classmethod
     def from_tuple_type(cls, info: TypeInfo) -> "TypeAlias":
+        assert info.tuple_type
         return TypeAlias(
-            info.tuple_type.copy_modified(
-                fallback=mypy.types.Instance(info, [])
-            ),
+            info.tuple_type.copy_modified(fallback=mypy.types.Instance(info, [])),
             info.fullname,
             info.line,
             info.column,

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2651,6 +2651,7 @@ class TypeInfo(SymbolNode):
         "bases",
         "_promote",
         "tuple_type",
+        "tuple_alias",
         "is_named_tuple",
         "typeddict_type",
         "is_newtype",
@@ -2789,6 +2790,9 @@ class TypeInfo(SymbolNode):
     # It is useful for plugins to add their data to save in the cache.
     metadata: Dict[str, JsonDict]
 
+    # Store type alias representing this type (for named tuples).
+    tuple_alias: Optional["TypeAlias"]
+
     FLAGS: Final = [
         "is_abstract",
         "is_enum",
@@ -2835,6 +2839,7 @@ class TypeInfo(SymbolNode):
         self._promote = []
         self.alt_promote = None
         self.tuple_type = None
+        self.tuple_alias = None
         self.is_named_tuple = False
         self.typeddict_type = None
         self.is_newtype = False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1841,13 +1841,13 @@ class SemanticAnalyzer(
             self.fail("Class has two incompatible bases derived from tuple", defn)
             defn.has_incompatible_baseclass = True
         info.tuple_type = base
-        target = base.copy_modified(fallback=Instance(info, []))
+        alias = TypeAlias.from_tuple_type(info)
         if not info.tuple_alias:
-            info.tuple_alias = TypeAlias(target, info.fullname, info.line, info.column)
+            info.tuple_alias = alias
         else:
             if has_placeholder(info.tuple_alias.target):
                 self.defer(force_progress=True)
-            info.tuple_alias.target = target
+            info.tuple_alias.target = alias.target
 
         if base.partial_fallback.type.fullname == "builtins.tuple":
             # Fallback can only be safely calculated after semantic analysis, since base

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1441,8 +1441,6 @@ class SemanticAnalyzer(
             if info is None:
                 self.mark_incomplete(defn.name, defn)
             else:
-                if info.tuple_type and has_placeholder(info.tuple_type):
-                    self.defer(force_progress=True)
                 self.prepare_class_def(defn, info)
                 with self.scope.class_scope(defn.info):
                     with self.named_tuple_analyzer.save_namedtuple_body(info):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1787,7 +1787,6 @@ class SemanticAnalyzer(
         base_types: List[Instance] = []
         info = defn.info
 
-        info.tuple_type = None
         for base, base_expr in bases:
             if isinstance(base, TupleType):
                 actual_base = self.configure_tuple_base_class(defn, base)
@@ -1838,14 +1837,14 @@ class SemanticAnalyzer(
 
         # There may be an existing valid tuple type from previous semanal iterations.
         # Use equality to check if it is the case.
-        if info.tuple_type and info.tuple_type != base:
+        if info.tuple_type and info.tuple_type != base and not has_placeholder(info.tuple_type):
             self.fail("Class has two incompatible bases derived from tuple", defn)
             defn.has_incompatible_baseclass = True
         if info.tuple_alias and has_placeholder(info.tuple_alias.target):
             self.defer(force_progress=True)
         info.update_tuple_type(base)
 
-        if base.partial_fallback.type.fullname == "builtins.tuple":
+        if base.partial_fallback.type.fullname == "builtins.tuple" and not has_placeholder(base):
             # Fallback can only be safely calculated after semantic analysis, since base
             # classes may be incomplete. Postpone the calculation.
             self.schedule_patch(PRIORITY_FALLBACKS, lambda: calculate_tuple_fallback(base))

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1840,14 +1840,9 @@ class SemanticAnalyzer(
         if info.tuple_type and info.tuple_type != base:
             self.fail("Class has two incompatible bases derived from tuple", defn)
             defn.has_incompatible_baseclass = True
-        info.tuple_type = base
-        alias = TypeAlias.from_tuple_type(info)
-        if not info.tuple_alias:
-            info.tuple_alias = alias
-        else:
-            if has_placeholder(info.tuple_alias.target):
-                self.defer(force_progress=True)
-            info.tuple_alias.target = alias.target
+        if info.tuple_alias and has_placeholder(info.tuple_alias.target):
+            self.defer(force_progress=True)
+        info.update_tuple_type(base)
 
         if base.partial_fallback.type.fullname == "builtins.tuple":
             # Fallback can only be safely calculated after semantic analysis, since base

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1841,6 +1841,13 @@ class SemanticAnalyzer(
             self.fail("Class has two incompatible bases derived from tuple", defn)
             defn.has_incompatible_baseclass = True
         info.tuple_type = base
+        target = base.copy_modified(fallback=Instance(info, []))
+        if not info.tuple_alias:
+            info.tuple_alias = TypeAlias(target, info.fullname, info.line, info.column)
+        else:
+            if has_placeholder(info.tuple_alias.target):
+                self.defer(force_progress=True)
+            info.tuple_alias.target = target
 
         if base.partial_fallback.type.fullname == "builtins.tuple":
             # Fallback can only be safely calculated after semantic analysis, since base

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -480,11 +480,11 @@ class NamedTupleAnalyzer:
         if existing_info:
             old_tuple_type = existing_info.tuple_type
         info.tuple_type = tuple_base
-        target = tuple_base.copy_modified(fallback=Instance(info, []))
+        alias = TypeAlias.from_tuple_type(info)
         if not info.tuple_alias:
-            info.tuple_alias = TypeAlias(target, info.fullname, info.line, info.column)
+            info.tuple_alias = alias
         else:
-            info.tuple_alias.target = target
+            info.tuple_alias.target = alias.target
         info.line = line
         # For use by mypyc.
         info.metadata["namedtuple"] = {"fields": items.copy()}

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -93,6 +93,7 @@ class NewTypeAnalyzer:
                 name, old_type, old_type.partial_fallback, s.line
             )
             newtype_class_info.tuple_type = old_type
+            newtype_class_info.tuple_alias = old_type.partial_fallback.type.tuple_alias
         elif isinstance(old_type, Instance):
             if old_type.type.is_protocol:
                 self.fail("NewType cannot be used with protocol classes", s)

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -24,11 +24,12 @@ from mypy.nodes import (
     RefExpr,
     StrExpr,
     SymbolTableNode,
+    TypeAlias,
     TypeInfo,
     Var,
 )
 from mypy.options import Options
-from mypy.semanal_shared import SemanticAnalyzerInterface
+from mypy.semanal_shared import SemanticAnalyzerInterface, has_placeholder
 from mypy.typeanal import check_for_explicit_any, has_any_from_unimported_type
 from mypy.types import (
     AnyType,
@@ -90,14 +91,20 @@ class NewTypeAnalyzer:
         # Create the corresponding class definition if the aliased type is subtypeable
         if isinstance(old_type, TupleType):
             newtype_class_info = self.build_newtype_typeinfo(
-                name, old_type, old_type.partial_fallback, s.line
+                name, old_type, old_type.partial_fallback, s.line, call.analyzed.info
             )
             newtype_class_info.tuple_type = old_type
-            newtype_class_info.tuple_alias = old_type.partial_fallback.type.tuple_alias
+            alias = TypeAlias.from_tuple_type(newtype_class_info)
+            if not newtype_class_info.tuple_alias:
+                newtype_class_info.tuple_alias = alias
+            else:
+                newtype_class_info.tuple_alias.target = alias.target
         elif isinstance(old_type, Instance):
             if old_type.type.is_protocol:
                 self.fail("NewType cannot be used with protocol classes", s)
-            newtype_class_info = self.build_newtype_typeinfo(name, old_type, old_type, s.line)
+            newtype_class_info = self.build_newtype_typeinfo(
+                name, old_type, old_type, s.line, call.analyzed.info
+            )
         else:
             if old_type is not None:
                 message = "Argument 2 to NewType(...) must be subclassable (got {})"
@@ -105,7 +112,9 @@ class NewTypeAnalyzer:
             # Otherwise the error was already reported.
             old_type = AnyType(TypeOfAny.from_error)
             object_type = self.api.named_type("builtins.object")
-            newtype_class_info = self.build_newtype_typeinfo(name, old_type, object_type, s.line)
+            newtype_class_info = self.build_newtype_typeinfo(
+                name, old_type, object_type, s.line, call.analyzed.info
+            )
             newtype_class_info.fallback_to_any = True
 
         check_for_explicit_any(
@@ -195,9 +204,18 @@ class NewTypeAnalyzer:
 
         # We want to use our custom error message (see above), so we suppress
         # the default error message for invalid types here.
-        old_type = get_proper_type(self.api.anal_type(unanalyzed_type, report_invalid_types=False))
+        old_type = get_proper_type(
+            self.api.anal_type(
+                unanalyzed_type,
+                report_invalid_types=False,
+                allow_placeholder=self.options.enable_recursive_aliases
+                and not self.api.is_func_scope(),
+            )
+        )
         should_defer = False
-        if old_type is None or isinstance(old_type, PlaceholderType):
+        if isinstance(old_type, PlaceholderType):
+            old_type = None
+        if old_type is None:
             should_defer = True
 
         # The caller of this function assumes that if we return a Type, it's always
@@ -209,9 +227,14 @@ class NewTypeAnalyzer:
         return None if has_failed else old_type, should_defer
 
     def build_newtype_typeinfo(
-        self, name: str, old_type: Type, base_type: Instance, line: int
+        self,
+        name: str,
+        old_type: Type,
+        base_type: Instance,
+        line: int,
+        existing_info: Optional[TypeInfo],
     ) -> TypeInfo:
-        info = self.api.basic_new_typeinfo(name, base_type, line)
+        info = existing_info or self.api.basic_new_typeinfo(name, base_type, line)
         info.is_newtype = True
 
         # Add __init__ method
@@ -232,6 +255,8 @@ class NewTypeAnalyzer:
         init_func._fullname = info.fullname + ".__init__"
         info.names["__init__"] = SymbolTableNode(MDEF, init_func)
 
+        if info.tuple_type and has_placeholder(info.tuple_type):
+            self.api.defer(force_progress=True)
         return info
 
     # Helpers

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -24,7 +24,6 @@ from mypy.nodes import (
     RefExpr,
     StrExpr,
     SymbolTableNode,
-    TypeAlias,
     TypeInfo,
     Var,
 )
@@ -94,12 +93,7 @@ class NewTypeAnalyzer:
             newtype_class_info = self.build_newtype_typeinfo(
                 name, old_type, old_type.partial_fallback, s.line, call.analyzed.info
             )
-            newtype_class_info.tuple_type = old_type
-            alias = TypeAlias.from_tuple_type(newtype_class_info)
-            if not newtype_class_info.tuple_alias:
-                newtype_class_info.tuple_alias = alias
-            else:
-                newtype_class_info.tuple_alias.target = alias.target
+            newtype_class_info.update_tuple_type(old_type)
         elif isinstance(old_type, Instance):
             if old_type.type.is_protocol:
                 self.fail("NewType cannot be used with protocol classes", s)

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -89,6 +89,7 @@ class NewTypeAnalyzer:
                 return True
 
         # Create the corresponding class definition if the aliased type is subtypeable
+        assert isinstance(call.analyzed, NewTypeExpr)
         if isinstance(old_type, TupleType):
             newtype_class_info = self.build_newtype_typeinfo(
                 name, old_type, old_type.partial_fallback, s.line, call.analyzed.info

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -19,6 +19,7 @@ from mypy.nodes import (
     TypeInfo,
 )
 from mypy.tvar_scope import TypeVarLikeScope
+from mypy.type_visitor import TypeQuery
 from mypy.types import (
     TPDICT_FB_NAMES,
     FunctionLike,
@@ -26,6 +27,7 @@ from mypy.types import (
     Parameters,
     ParamSpecFlavor,
     ParamSpecType,
+    PlaceholderType,
     ProperType,
     TupleType,
     Type,
@@ -82,7 +84,7 @@ class SemanticAnalyzerCoreInterface:
         raise NotImplementedError
 
     @abstractmethod
-    def defer(self) -> None:
+    def defer(self, debug_context: Optional[Context] = ..., force_progress: bool = ...) -> None:
         raise NotImplementedError
 
     @abstractmethod
@@ -147,6 +149,7 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
         allow_tuple_literal: bool = False,
         allow_unbound_tvars: bool = False,
         allow_required: bool = False,
+        allow_placeholder: bool = False,
         report_invalid_types: bool = True,
     ) -> Optional[Type]:
         raise NotImplementedError
@@ -297,3 +300,16 @@ def paramspec_kwargs(
         column=column,
         prefix=prefix,
     )
+
+
+class HasPlaceholders(TypeQuery[bool]):
+    def __init__(self) -> None:
+        super().__init__(any)
+
+    def visit_placeholder_type(self, t: PlaceholderType) -> bool:
+        return True
+
+
+def has_placeholder(typ: Type) -> bool:
+    """Check if a type contains any placeholder types (recursively)."""
+    return typ.accept(HasPlaceholders())

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -108,6 +108,10 @@ class SemanticAnalyzerCoreInterface:
     def is_stub_file(self) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
+    def is_func_scope(self) -> bool:
+        raise NotImplementedError
+
 
 @trait
 class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
@@ -209,10 +213,6 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
     @property
     @abstractmethod
     def is_typeshed_stub_file(self) -> bool:
-        raise NotImplementedError
-
-    @abstractmethod
-    def is_func_scope(self) -> bool:
         raise NotImplementedError
 
 

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -84,7 +84,7 @@ class SemanticAnalyzerCoreInterface:
         raise NotImplementedError
 
     @abstractmethod
-    def defer(self, debug_context: Optional[Context] = ..., force_progress: bool = ...) -> None:
+    def defer(self, debug_context: Optional[Context] = None, force_progress: bool = False) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -349,6 +349,9 @@ class NodeReplaceVisitor(TraverserVisitor):
             # old MRO.
             new = cast(TypeInfo, self.replacements[node])
             TypeState.reset_all_subtype_caches_for(new)
+            # Special case: tuple_alias is not exposed in symbol tables, but may appear
+            # in external types (e.g. named tuples), so we need to update it manually.
+            replace_object_state(new.tuple_alias, node.tuple_alias)
         return self.fixup(node)
 
     def fixup_type(self, typ: Optional[Type]) -> None:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -364,6 +364,8 @@ class NodeReplaceVisitor(TraverserVisitor):
             self.fixup_type(target)
         self.fixup_type(info.tuple_type)
         self.fixup_type(info.typeddict_type)
+        if info.tuple_alias:
+            self.fixup_type(info.tuple_alias.target)
         info.defn.info = self.fixup(info)
         replace_nodes_in_symbol_table(info.names, self.replacements)
         for i, item in enumerate(info.mro):

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -45,7 +45,7 @@ Discussion of some notable special cases:
 See the main entry point merge_asts for more details.
 """
 
-from typing import Dict, List, Optional, TypeVar, cast
+from typing import Dict, List, Optional, Tuple, TypeVar, cast
 
 from mypy.nodes import (
     MDEF,
@@ -172,6 +172,8 @@ def replacement_map_from_symbol_table(
                         node.node.names, new_node.node.names, prefix
                     )
                     replacements.update(type_repl)
+                    if node.node.tuple_alias and new_node.node.tuple_alias:
+                        replacements[new_node.node.tuple_alias] = node.node.tuple_alias
     return replacements
 
 
@@ -334,7 +336,13 @@ class NodeReplaceVisitor(TraverserVisitor):
     def fixup(self, node: SN) -> SN:
         if node in self.replacements:
             new = self.replacements[node]
-            replace_object_state(new, node)
+            skip_slots: Tuple[str, ...] = ()
+            if isinstance(node, TypeInfo) and isinstance(new, TypeInfo):
+                # Special case: tuple_alias is not exposed in symbol tables, but may appear
+                # in external types (e.g. named tuples), so we need to update it manually.
+                skip_slots = ("tuple_alias",)
+                replace_object_state(new.tuple_alias, node.tuple_alias)
+            replace_object_state(new, node, skip_slots=skip_slots)
             return cast(SN, new)
         return node
 
@@ -349,9 +357,6 @@ class NodeReplaceVisitor(TraverserVisitor):
             # old MRO.
             new = cast(TypeInfo, self.replacements[node])
             TypeState.reset_all_subtype_caches_for(new)
-            # Special case: tuple_alias is not exposed in symbol tables, but may appear
-            # in external types (e.g. named tuples), so we need to update it manually.
-            replace_object_state(new.tuple_alias, node.tuple_alias)
         return self.fixup(node)
 
     def fixup_type(self, typ: Optional[Type]) -> None:
@@ -541,7 +546,8 @@ def replace_nodes_in_symbol_table(
             if node.node in replacements:
                 new = replacements[node.node]
                 old = node.node
-                replace_object_state(new, old)
+                # Needed for TypeInfo, see comment in fixup() above.
+                replace_object_state(new, old, skip_slots=("tuple_alias",))
                 node.node = new
             if isinstance(node.node, (Var, TypeAlias)):
                 # Handle them here just in case these aren't exposed through the AST.

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -140,6 +140,7 @@ class NodeStripVisitor(TraverserVisitor):
         TypeState.reset_subtype_caches_for(node.info)
         # Kill the TypeInfo, since there is none before semantic analysis.
         node.info = CLASSDEF_NO_INFO
+        # TODO: Should we also do node.analyzed = None here?
 
     def save_implicit_attributes(self, node: ClassDef) -> None:
         """Produce callbacks that re-add attributes defined on self."""

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -140,7 +140,7 @@ class NodeStripVisitor(TraverserVisitor):
         TypeState.reset_subtype_caches_for(node.info)
         # Kill the TypeInfo, since there is none before semantic analysis.
         node.info = CLASSDEF_NO_INFO
-        # TODO: Should we also do node.analyzed = None here?
+        node.analyzed = None
 
     def save_implicit_attributes(self, node: ClassDef) -> None:
         """Produce callbacks that re-add attributes defined on self."""

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -941,18 +941,23 @@ class DependencyVisitor(TraverserVisitor):
         return get_type_triggers(typ, self.use_logical_deps())
 
 
-def get_type_triggers(typ: Type, use_logical_deps: bool) -> List[str]:
+def get_type_triggers(
+    typ: Type, use_logical_deps: bool, seen_aliases: Optional[Set[TypeAliasType]] = None
+) -> List[str]:
     """Return all triggers that correspond to a type becoming stale."""
-    return typ.accept(TypeTriggersVisitor(use_logical_deps))
+    return typ.accept(TypeTriggersVisitor(use_logical_deps, seen_aliases))
 
 
 class TypeTriggersVisitor(TypeVisitor[List[str]]):
-    def __init__(self, use_logical_deps: bool) -> None:
+    def __init__(
+        self, use_logical_deps: bool, seen_aliases: Optional[Set[TypeAliasType]] = None
+    ) -> None:
         self.deps: List[str] = []
+        self.seen_aliases: Set[TypeAliasType] = seen_aliases or set()
         self.use_logical_deps = use_logical_deps
 
     def get_type_triggers(self, typ: Type) -> List[str]:
-        return get_type_triggers(typ, self.use_logical_deps)
+        return get_type_triggers(typ, self.use_logical_deps, self.seen_aliases)
 
     def visit_instance(self, typ: Instance) -> List[str]:
         trigger = make_trigger(typ.type.fullname)
@@ -964,14 +969,16 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         return triggers
 
     def visit_type_alias_type(self, typ: TypeAliasType) -> List[str]:
+        if typ in self.seen_aliases:
+            return []
+        self.seen_aliases.add(typ)
         assert typ.alias is not None
         trigger = make_trigger(typ.alias.fullname)
         triggers = [trigger]
         for arg in typ.args:
             triggers.extend(self.get_type_triggers(arg))
-        # TODO: Add guard for infinite recursion here. Moreover, now that type aliases
-        # are its own kind of types we can simplify the logic to rely on intermediate
-        # dependencies (like for instance types).
+        # TODO: Now that type aliases are its own kind of types we can simplify
+        # the logic to rely on intermediate dependencies (like for instance types).
         triggers.extend(self.get_type_triggers(typ.alias.target))
         return triggers
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -393,6 +393,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         #       need access to MessageBuilder here. Also move the similar
         #       message generation logic in semanal.py.
         self.api.fail(f'Cannot resolve name "{t.name}" (possible cyclic definition)', t)
+        if self.options.enable_recursive_aliases and self.api.is_func_scope():
+            self.note("Recursive types are not allowed at function scope", t)
 
     def apply_concatenate_operator(self, t: UnboundType) -> Type:
         if len(t.args) == 0:
@@ -611,6 +613,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 self.fail("Generic tuple types not supported", ctx)
                 return AnyType(TypeOfAny.from_error)
             if info.tuple_alias:
+                # We don't support generic tuple types yet.
                 return TypeAliasType(info.tuple_alias, [])
             return tup.copy_modified(items=self.anal_array(tup.items), fallback=instance)
         td = info.typeddict_type

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -610,6 +610,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             if args:
                 self.fail("Generic tuple types not supported", ctx)
                 return AnyType(TypeOfAny.from_error)
+            if info.tuple_alias:
+                return TypeAliasType(info.tuple_alias, [])
             return tup.copy_modified(items=self.anal_array(tup.items), fallback=instance)
         td = info.typeddict_type
         if td is not None:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -359,7 +359,9 @@ def get_class_descriptors(cls: "Type[object]") -> Sequence[str]:
     return fields_cache[cls]
 
 
-def replace_object_state(new: object, old: object, copy_dict: bool = False) -> None:
+def replace_object_state(
+    new: object, old: object, copy_dict: bool = False, skip_slots: Tuple[str, ...] = ()
+) -> None:
     """Copy state of old node to the new node.
 
     This handles cases where there is __dict__ and/or attribute descriptors
@@ -374,6 +376,8 @@ def replace_object_state(new: object, old: object, copy_dict: bool = False) -> N
             new.__dict__ = old.__dict__
 
     for attr in get_class_descriptors(old.__class__):
+        if attr in skip_slots:
+            continue
         try:
             if hasattr(old, attr):
                 setattr(new, attr, getattr(old, attr))

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5750,6 +5750,7 @@ from typing import NamedTuple, Optional
 class N(NamedTuple):
     r: Optional[M]
     x: int
+n: N
 [file b.py]
 from a import N
 from typing import NamedTuple
@@ -5773,12 +5774,15 @@ def f(x: a.N) -> None:
     if x.r is not None and x.r.r is not None and x.r.r.r is not None:
         reveal_type(x)
         s: int = x.r.r.r.r
+f(a.n)
+reveal_type(a.n)
 [builtins fixtures/tuple.pyi]
 [out]
 [out2]
 [out3]
 tmp/c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 tmp/c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
+tmp/c.py:7: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 
 [case testTupleTypeUpdateNonRecursiveToRecursiveCoarse]
 # flags: --enable-recursive-aliases

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5740,3 +5740,108 @@ class C:
         nt2: NT2 = NT2(x=1)
 
 [builtins fixtures/tuple.pyi]
+
+[case testNamedTupleUpdateNonRecursiveToRecursiveCoarse]
+# flags: --enable-recursive-aliases
+import c
+[file a.py]
+from b import M
+from typing import NamedTuple, Optional
+class N(NamedTuple):
+    r: Optional[M]
+    x: int
+[file b.py]
+from a import N
+from typing import NamedTuple
+class M(NamedTuple):
+    r: None
+    x: int
+[file b.py.2]
+from a import N
+from typing import NamedTuple, Optional
+class M(NamedTuple):
+    r: Optional[N]
+    x: int
+[file c.py]
+import a
+def f(x: a.N) -> None:
+    if x.r is not None:
+        s: int = x.r.x
+[file c.py.3]
+import a
+def f(x: a.N) -> None:
+    if x.r is not None and x.r.r is not None and x.r.r.r is not None:
+        reveal_type(x)
+        s: int = x.r.r.r.r
+[builtins fixtures/tuple.pyi]
+[out]
+[out2]
+[out3]
+tmp/c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
+tmp/c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
+
+[case testTupleTypeUpdateNonRecursiveToRecursiveCoarse]
+# flags: --enable-recursive-aliases
+import c
+[file a.py]
+from b import M
+from typing import Tuple, Optional
+class N(Tuple[Optional[M], int]): ...
+[file b.py]
+from a import N
+from typing import Tuple
+class M(Tuple[None, int]): ...
+[file b.py.2]
+from a import N
+from typing import Tuple, Optional
+class M(Tuple[Optional[N], int]): ...
+[file c.py]
+import a
+def f(x: a.N) -> None:
+    if x[0] is not None:
+        s: int = x[0][1]
+[file c.py.3]
+import a
+def f(x: a.N) -> None:
+    if x[0] is not None and x[0][0] is not None and x[0][0][0] is not None:
+        reveal_type(x)
+        s: int = x[0][0][0][0]
+[builtins fixtures/tuple.pyi]
+[out]
+[out2]
+[out3]
+tmp/c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
+tmp/c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
+
+[case testTypeAliasUpdateNonRecursiveToRecursiveCoarse]
+# flags: --enable-recursive-aliases
+import c
+[file a.py]
+from b import M
+from typing import Tuple, Optional
+N = Tuple[Optional[M], int]
+[file b.py]
+from a import N
+from typing import Tuple
+M = Tuple[None, int]
+[file b.py.2]
+from a import N
+from typing import Tuple, Optional
+M = Tuple[Optional[N], int]
+[file c.py]
+import a
+def f(x: a.N) -> None:
+    if x[0] is not None:
+        s: int = x[0][1]
+[file c.py.3]
+import a
+def f(x: a.N) -> None:
+    if x[0] is not None and x[0][0] is not None and x[0][0][0] is not None:
+        reveal_type(x)
+        s: int = x[0][0][0][0]
+[builtins fixtures/tuple.pyi]
+[out]
+[out2]
+[out3]
+tmp/c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int], None], builtins.int]"
+tmp/c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -90,7 +90,7 @@ else:
 A = int | list[A]
 [builtins fixtures/isinstancelist.pyi]
 
--- Tests duplicating some existing tests with recursive aliases enabled
+-- Tests duplicating some type alias existing tests with recursive aliases enabled
 
 [case testRecursiveAliasesMutual]
 # flags: --enable-recursive-aliases
@@ -426,3 +426,62 @@ U = Type[Union[int, U]]  # E: Type[...] cannot contain another Type[...]
 x: U
 reveal_type(x)  # N: Revealed type is "Type[Any]"
 [builtins fixtures/isinstancelist.pyi]
+
+[case testBasicNamedTuple]
+# flags: --enable-recursive-aliases
+from typing import NamedTuple, Optional
+
+NT = NamedTuple("NT", [("x", Optional[NT]), ("y", int)])
+nt: NT
+reveal_type(nt)  # N: Revealed type is "Tuple[Union[..., None], builtins.int, fallback=__main__.NT]"
+reveal_type(nt.x)  # N: Revealed type is "Union[Tuple[Union[..., None], builtins.int, fallback=__main__.NT], None]"
+reveal_type(nt[0])  # N: Revealed type is "Union[Tuple[Union[..., None], builtins.int, fallback=__main__.NT], None]"
+y: str
+if nt.x is not None:
+    y = nt.x[0]  # E: Incompatible types in assignment (expression has type "Optional[NT]", variable has type "str")
+[builtins fixtures/tuple.pyi]
+
+[case testBasicNamedTupleSpecial]
+# flags: --enable-recursive-aliases
+from typing import NamedTuple
+
+NT = NamedTuple("NT", [("x", NT), ("y", int)])
+nt: NT
+reveal_type(nt)  # N: Revealed type is "Tuple[..., builtins.int, fallback=__main__.NT]"
+reveal_type(nt.x)  # N: Revealed type is "Tuple[Tuple[..., builtins.int, fallback=__main__.NT], builtins.int, fallback=__main__.NT]"
+reveal_type(nt[0])  # N: Revealed type is "Tuple[Tuple[..., builtins.int, fallback=__main__.NT], builtins.int, fallback=__main__.NT]"
+y: str
+if nt.x is not None:
+    y = nt.x[0]  # E: Incompatible types in assignment (expression has type "NT", variable has type "str")
+# XXX check join no infinite recursion on fallbacks
+[builtins fixtures/tuple.pyi]
+
+[case testBasicNamedTupleClass]
+# flags: --enable-recursive-aliases
+from typing import NamedTuple, Optional
+
+class NT(NamedTuple):
+    x: Optional[NT]
+    y: int
+
+nt: NT
+reveal_type(nt)  # N: Revealed type is "Tuple[Union[..., None], builtins.int, fallback=__main__.NT]"
+reveal_type(nt.x)  # N: Revealed type is "Union[Tuple[Union[..., None], builtins.int, fallback=__main__.NT], None]"
+reveal_type(nt[0])  # N: Revealed type is "Union[Tuple[Union[..., None], builtins.int, fallback=__main__.NT], None]"
+y: str
+if nt.x is not None:
+    y = nt.x[0]  # E: Incompatible types in assignment (expression has type "Optional[NT]", variable has type "str")
+[builtins fixtures/tuple.pyi]
+
+[case testBasicRegularTupleClass]
+# flags: --enable-recursive-aliases
+[builtins fixtures/tuple.pyi]
+
+[case testBasicTupleClassesNewType]
+# flags: --enable-recursive-aliases
+# check both regular and named
+[builtins fixtures/tuple.pyi]
+
+-- Add fine-grained tests
+
+-- Tests duplicating some named tuple existing tests with recursive aliases enabled

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -482,7 +482,7 @@ class B(Tuple[B, int]):
     x: int
 
 b, _ = x
-reveal_type(b.x)  # N:Revealed type is "builtins.int"
+reveal_type(b.x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testBasicTupleClassesNewType]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -90,7 +90,7 @@ else:
 A = int | list[A]
 [builtins fixtures/isinstancelist.pyi]
 
--- Tests duplicating some type alias existing tests with recursive aliases enabled
+-- Tests duplicating some existing type alias tests with recursive aliases enabled
 
 [case testRecursiveAliasesMutual]
 # flags: --enable-recursive-aliases
@@ -427,7 +427,7 @@ x: U
 reveal_type(x)  # N: Revealed type is "Type[Any]"
 [builtins fixtures/isinstancelist.pyi]
 
-[case testBasicNamedTuple]
+[case testBasicRecursiveNamedTuple]
 # flags: --enable-recursive-aliases
 from typing import NamedTuple, Optional
 
@@ -441,9 +441,9 @@ if nt.x is not None:
     y = nt.x[0]  # E: Incompatible types in assignment (expression has type "Optional[NT]", variable has type "str")
 [builtins fixtures/tuple.pyi]
 
-[case testBasicNamedTupleSpecial]
+[case testBasicRecursiveNamedTupleSpecial]
 # flags: --enable-recursive-aliases
-from typing import NamedTuple
+from typing import NamedTuple, TypeVar, Tuple
 
 NT = NamedTuple("NT", [("x", NT), ("y", int)])
 nt: NT
@@ -453,10 +453,17 @@ reveal_type(nt[0])  # N: Revealed type is "Tuple[Tuple[..., builtins.int, fallba
 y: str
 if nt.x is not None:
     y = nt.x[0]  # E: Incompatible types in assignment (expression has type "NT", variable has type "str")
-# XXX check join no infinite recursion on fallbacks
+
+T = TypeVar("T")
+def f(a: T, b: T) -> T: ...
+tnt: Tuple[NT]
+
+# Should these be tuple[object] instead?
+reveal_type(f(nt, tnt))  # N: Revealed type is "builtins.tuple[Any, ...]"
+reveal_type(f(tnt, nt))  # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/tuple.pyi]
 
-[case testBasicNamedTupleClass]
+[case testBasicRecursiveNamedTupleClass]
 # flags: --enable-recursive-aliases
 from typing import NamedTuple, Optional
 
@@ -473,7 +480,7 @@ if nt.x is not None:
     y = nt.x[0]  # E: Incompatible types in assignment (expression has type "Optional[NT]", variable has type "str")
 [builtins fixtures/tuple.pyi]
 
-[case testBasicRegularTupleClass]
+[case testRecursiveRegularTupleClass]
 # flags: --enable-recursive-aliases
 from typing import Tuple
 
@@ -485,7 +492,7 @@ b, _ = x
 reveal_type(b.x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
-[case testBasicTupleClassesNewType]
+[case testRecursiveTupleClassesNewType]
 # flags: --enable-recursive-aliases
 from typing import Tuple, NamedTuple, NewType
 
@@ -506,6 +513,78 @@ bnt, _ = y
 reveal_type(bnt.y)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
--- TODO: Add more fine-grained tests for various kinds of recursive types
+-- Tests duplicating some existing named tuple tests with recursive aliases enabled
 
--- Tests duplicating some named tuple existing tests with recursive aliases enabled
+[case testMutuallyRecursiveNamedTuples]
+# flags: --enable-recursive-aliases
+from typing import Tuple, NamedTuple, TypeVar, Union
+
+A = NamedTuple('A', [('x', str), ('y', Tuple[B, ...])])
+class B(NamedTuple):
+    x: A
+    y: int
+
+n: A
+reveal_type(n) # N: Revealed type is "Tuple[builtins.str, builtins.tuple[Tuple[..., builtins.int, fallback=__main__.B], ...], fallback=__main__.A]"
+
+T = TypeVar("T")
+S = TypeVar("S")
+def foo(arg: Tuple[T, S]) -> Union[T, S]: ...
+x = foo(n)
+y: str = x  # E: Incompatible types in assignment (expression has type "Union[str, Tuple[B, ...]]", variable has type "str")
+[builtins fixtures/tuple.pyi]
+
+[case testMutuallyRecursiveNamedTuplesJoin]
+# flags: --enable-recursive-aliases
+from typing import NamedTuple, Tuple
+
+class B(NamedTuple):
+    x: Tuple[A, int]
+    y: int
+
+A = NamedTuple('A', [('x', str), ('y', B)])
+n: B
+m: A
+reveal_type(n.x) # N: Revealed type is "Tuple[Tuple[builtins.str, Tuple[Tuple[..., builtins.int], builtins.int, fallback=__main__.B], fallback=__main__.A], builtins.int]"
+reveal_type(m[0]) # N: Revealed type is "builtins.str"
+lst = [m, n]
+reveal_type(lst[0]) # N: Revealed type is "Tuple[builtins.object, builtins.object]"
+[builtins fixtures/tuple.pyi]
+
+[case testMutuallyRecursiveNamedTuplesClasses]
+# flags: --enable-recursive-aliases
+from typing import NamedTuple, Tuple
+
+class B(NamedTuple):
+    x: A
+    y: int
+class A(NamedTuple):
+    x: str
+    y: B
+
+n: A
+reveal_type(n.y[0]) # N: Revealed type is "Tuple[builtins.str, Tuple[Tuple[builtins.str, ..., fallback=__main__.A], builtins.int, fallback=__main__.B], fallback=__main__.A]"
+
+m: B
+n = m.x
+n = n.y.x
+
+t: Tuple[str, B]
+t = n
+t = m  # E: Incompatible types in assignment (expression has type "B", variable has type "Tuple[str, B]")
+[builtins fixtures/tuple.pyi]
+
+[case testMutuallyRecursiveNamedTuplesCalls]
+# flags: --enable-recursive-aliases
+from typing import NamedTuple
+
+B = NamedTuple('B', [('x', A), ('y', int)])
+A = NamedTuple('A', [('x', str), ('y', 'B')])
+n: A
+def f(m: B) -> None: pass
+reveal_type(n) # N: Revealed type is "Tuple[builtins.str, Tuple[..., builtins.int, fallback=__main__.B], fallback=__main__.A]"
+reveal_type(f) # N: Revealed type is "def (m: Tuple[Tuple[builtins.str, ..., fallback=__main__.A], builtins.int, fallback=__main__.B])"
+f(n)  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
+[builtins fixtures/tuple.pyi]
+
+-- TODO: Add more fine-grained tests for various kinds of recursive types

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -482,7 +482,7 @@ class B(Tuple[B, int]):
     x: int
 
 b, _ = x
-reveal_type(b.x)
+reveal_type(b.x)  # N:Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testBasicTupleClassesNewType]
@@ -492,17 +492,18 @@ from typing import Tuple, NamedTuple, NewType
 x: C
 class B(Tuple[B, int]):
     x: int
-C = NewType(B)
+C = NewType("C", B)
 b, _ = x
-reveal_type(b.x)
+reveal_type(b)  # N: Revealed type is "Tuple[..., builtins.int, fallback=__main__.B]"
+reveal_type(b.x)  # N: Revealed type is "builtins.int"
 
-y: BNT
+y: CNT
 class BNT(NamedTuple):
-    x: BNT
+    x: CNT
     y: int
-CNT = NewType(BNT)
+CNT = NewType("CNT", BNT)
 bnt, _ = y
-reveal_type(bnt.y)
+reveal_type(bnt.y)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 -- TODO: Add more fine-grained tests for various kinds of recursive types

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -475,13 +475,36 @@ if nt.x is not None:
 
 [case testBasicRegularTupleClass]
 # flags: --enable-recursive-aliases
+from typing import Tuple
+
+x: B
+class B(Tuple[B, int]):
+    x: int
+
+b, _ = x
+reveal_type(b.x)
 [builtins fixtures/tuple.pyi]
 
 [case testBasicTupleClassesNewType]
 # flags: --enable-recursive-aliases
-# check both regular and named
+from typing import Tuple, NamedTuple, NewType
+
+x: C
+class B(Tuple[B, int]):
+    x: int
+C = NewType(B)
+b, _ = x
+reveal_type(b.x)
+
+y: BNT
+class BNT(NamedTuple):
+    x: BNT
+    y: int
+CNT = NewType(BNT)
+bnt, _ = y
+reveal_type(bnt.y)
 [builtins fixtures/tuple.pyi]
 
--- Add fine-grained tests
+-- TODO: Add more fine-grained tests for various kinds of recursive types
 
 -- Tests duplicating some named tuple existing tests with recursive aliases enabled

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -545,7 +545,7 @@ class B(NamedTuple):
 A = NamedTuple('A', [('x', str), ('y', B)])
 n: B
 m: A
-reveal_type(n.x) # N: Revealed type is "Tuple[Tuple[builtins.str, Tuple[Tuple[..., builtins.int], builtins.int, fallback=__main__.B], fallback=__main__.A], builtins.int]"
+s: str = n.x  # E: Incompatible types in assignment (expression has type "Tuple[A, int]", variable has type "str")
 reveal_type(m[0]) # N: Revealed type is "builtins.str"
 lst = [m, n]
 reveal_type(lst[0]) # N: Revealed type is "Tuple[builtins.object, builtins.object]"
@@ -563,7 +563,7 @@ class A(NamedTuple):
     y: B
 
 n: A
-reveal_type(n.y[0]) # N: Revealed type is "Tuple[builtins.str, Tuple[Tuple[builtins.str, ..., fallback=__main__.A], builtins.int, fallback=__main__.B], fallback=__main__.A]"
+s: str = n.y[0]  # E: Incompatible types in assignment (expression has type "A", variable has type "str")
 
 m: B
 n = m.x
@@ -585,6 +585,18 @@ def f(m: B) -> None: pass
 reveal_type(n) # N: Revealed type is "Tuple[builtins.str, Tuple[..., builtins.int, fallback=__main__.B], fallback=__main__.A]"
 reveal_type(f) # N: Revealed type is "def (m: Tuple[Tuple[builtins.str, ..., fallback=__main__.A], builtins.int, fallback=__main__.B])"
 f(n)  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
+[builtins fixtures/tuple.pyi]
+
+[case testNoRecursiveTuplesAtFunctionScope]
+# flags: --enable-recursive-aliases
+from typing import NamedTuple, Tuple
+def foo() -> None:
+    class B(NamedTuple):
+        x: B  # E: Cannot resolve name "B" (possible cyclic definition) \
+              # N: Recursive types are not allowed at function scope
+        y: int
+    b: B
+    reveal_type(b)  # N: Revealed type is "Tuple[Any, builtins.int, fallback=__main__.B@4]"
 [builtins fixtures/tuple.pyi]
 
 -- TODO: Add more fine-grained tests for various kinds of recursive types

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -470,7 +470,7 @@ T = TypeVar("T")
 def f(a: T, b: T) -> T: ...
 tnt: Tuple[NT]
 
-# Should these be tuple[object] instead?
+# TODO: these should be tuple[object] instead.
 reveal_type(f(nt, tnt))  # N: Revealed type is "builtins.tuple[Any, ...]"
 reveal_type(f(tnt, nt))  # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -610,5 +610,3 @@ def foo() -> None:
     b: B
     reveal_type(b)  # N: Revealed type is "Tuple[Any, builtins.int, fallback=__main__.B@4]"
 [builtins fixtures/tuple.pyi]
-
--- TODO: Add more fine-grained tests for various kinds of recursive types

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3472,6 +3472,111 @@ f(a.x)
 [out]
 ==
 
+[case testNamedTupleUpdateNonRecursiveToRecursiveFine]
+# flags: --enable-recursive-aliases
+import c
+[file a.py]
+from b import M
+from typing import NamedTuple, Optional
+class N(NamedTuple):
+    r: Optional[M]
+    x: int
+[file b.py]
+from a import N
+from typing import NamedTuple
+class M(NamedTuple):
+    r: None
+    x: int
+[file b.py.2]
+from a import N
+from typing import NamedTuple, Optional
+class M(NamedTuple):
+    r: Optional[N]
+    x: int
+[file c.py]
+import a
+def f(x: a.N) -> None:
+    if x.r is not None:
+        s: int = x.r.x
+[file c.py.3]
+import a
+def f(x: a.N) -> None:
+    if x.r is not None and x.r.r is not None and x.r.r.r is not None:
+        reveal_type(x)
+        s: int = x.r.r.r.r
+[builtins fixtures/tuple.pyi]
+[out]
+==
+==
+c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
+c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
+
+[case testTupleTypeUpdateNonRecursiveToRecursiveFine]
+# flags: --enable-recursive-aliases
+import c
+[file a.py]
+from b import M
+from typing import Tuple, Optional
+class N(Tuple[Optional[M], int]): ...
+[file b.py]
+from a import N
+from typing import Tuple
+class M(Tuple[None, int]): ...
+[file b.py.2]
+from a import N
+from typing import Tuple, Optional
+class M(Tuple[Optional[N], int]): ...
+[file c.py]
+import a
+def f(x: a.N) -> None:
+    if x[0] is not None:
+        s: int = x[0][1]
+[file c.py.3]
+import a
+def f(x: a.N) -> None:
+    if x[0] is not None and x[0][0] is not None and x[0][0][0] is not None:
+        reveal_type(x)
+        s: int = x[0][0][0][0]
+[builtins fixtures/tuple.pyi]
+[out]
+==
+==
+c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int], None], builtins.int]"
+c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
+
+[case testTypeAliasUpdateNonRecursiveToRecursiveFine]
+# flags: --enable-recursive-aliases
+import c
+[file a.py]
+from b import M
+from typing import Tuple, Optional
+N = Tuple[Optional[M], int]
+[file b.py]
+from a import N
+from typing import Tuple
+M = Tuple[None, int]
+[file b.py.2]
+from a import N
+from typing import Tuple, Optional
+M = Tuple[Optional[N], int]
+[file c.py]
+import a
+def f(x: a.N) -> None:
+    if x[0] is not None:
+        s: int = x[0][1]
+[file c.py.3]
+import a
+def f(x: a.N) -> None:
+    if x[0] is not None and x[0][0] is not None and x[0][0][0] is not None:
+        reveal_type(x)
+        s: int = x[0][0][0][0]
+[builtins fixtures/tuple.pyi]
+[out]
+==
+==
+.c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int], None], builtins.int]"
+c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
+
 [case testTypedDictRefresh]
 [builtins fixtures/dict.pyi]
 import a

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3448,6 +3448,30 @@ f(a.x)
 [out]
 ==
 
+[case testNamedTupleUpdate5]
+# flags: --enable-recursive-aliases
+import b
+[file a.py]
+from typing import NamedTuple, Optional
+class N(NamedTuple):
+    r: Optional[N]
+    x: int
+x = N(None, 1)
+[file a.py.2]
+from typing import NamedTuple, Optional
+class N(NamedTuple):
+    r: Optional[N]
+    x: str
+x = N(None, 'hi')
+[file b.py]
+import a
+def f(x: a.N) -> None:
+    pass
+f(a.x)
+[builtins fixtures/tuple.pyi]
+[out]
+==
+
 [case testTypedDictRefresh]
 [builtins fixtures/dict.pyi]
 import a

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3481,6 +3481,7 @@ from typing import NamedTuple, Optional
 class N(NamedTuple):
     r: Optional[M]
     x: int
+n: N
 [file b.py]
 from a import N
 from typing import NamedTuple
@@ -3504,12 +3505,15 @@ def f(x: a.N) -> None:
     if x.r is not None and x.r.r is not None and x.r.r.r is not None:
         reveal_type(x)
         s: int = x.r.r.r.r
+f(a.n)
+reveal_type(a.n)
 [builtins fixtures/tuple.pyi]
 [out]
 ==
 ==
 c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
+c.py:7: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 
 [case testTupleTypeUpdateNonRecursiveToRecursiveFine]
 # flags: --enable-recursive-aliases
@@ -3541,7 +3545,7 @@ def f(x: a.N) -> None:
 [out]
 ==
 ==
-c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int], None], builtins.int]"
+c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
 
 [case testTypeAliasUpdateNonRecursiveToRecursiveFine]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3578,7 +3578,7 @@ def f(x: a.N) -> None:
 [out]
 ==
 ==
-.c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int], None], builtins.int]"
+c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int], None], builtins.int]"
 c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
 
 [case testTypedDictRefresh]


### PR DESCRIPTION
This is a continuation of #13297 

The main change here is that although named tuples are still stored in symbol tables as `TypeInfo`s, when type analyzer sees them, it creates a `TypeAliasType` targeting what it would return before (a `TupleType` with a fallback to an instance of that `TypeInfo`). Although it is a significant change, IMO this is the simplest but still clean way to support recursive named tuples.

Also it is very simple to extend to TypedDicts, but I wanted to make the latter in a separate PR, to minimize the scope of changes.
It would be great if someone can take a look at this PR soon.

The most code changes are to make named tuples semantic analysis idempotent, previously they were analyzed "for real" only once, when all types were ready. It is not possible anymore if we want them to be recursive. So I pass in `existing_info` everywhere, and update it instead of creating a new one every time.

cc @JukkaL 