### PR TITLE
Allow type application on `Union`, `Callable`, `Tuple`, refs #13337

### DIFF
--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -419,6 +419,53 @@ def f(x: T) -> T: pass
 y = f[int]  # E: Type application is only supported for generic classes
 [out]
 
+[case testAllowTypeApplicationUnionOfInstances]
+from typing import TypeVar, Generic, Union
+from typing_extensions import TypeAlias
+
+T = TypeVar("T")
+class A(Generic[T]): ...
+class B(Generic[T]): ...
+
+AorB: TypeAlias = Union[A[T], B[T]]
+AorB[int]  # ok
+[builtins fixtures/list.pyi]
+[out]
+
+[case testAllowTypeApplicationOptional]
+from typing import TypeVar, Optional
+from typing_extensions import TypeAlias
+T = TypeVar("T")
+OptionalT: TypeAlias = Optional[T]
+OptionalT[int]  # ok
+[builtins fixtures/list.pyi]
+[out]
+
+[case testAllowTypeApplicationToUnionOfGenericFunctions]
+from typing import TypeVar, Union, Callable
+T = TypeVar('T')
+A = Union[Callable[[T], T], Callable[[T, T], T]]
+A[int]
+[builtins fixtures/list.pyi]
+[out]
+
+[case testAllowTypeApplicationTuple]
+from typing import TypeVar, Tuple
+from typing_extensions import TypeAlias
+
+T = TypeVar("T")
+TT: TypeAlias = Tuple[T, T]
+TT[int]  # ok
+[builtins fixtures/tuple.pyi]
+[out]
+
+[case testProhibitTypeApplicationToNoneType]
+from typing_extensions import TypeAlias
+A: TypeAlias = None
+A[int]  # E: Bad number of arguments for type alias, expected: 0, given: 1
+[builtins fixtures/tuple.pyi]
+[out]
+
 
 -- Generic types in expressions
 -- ----------------------------
@@ -966,7 +1013,7 @@ reveal_type(x)  # N: Revealed type is "Union[builtins.int, None]"
 reveal_type(y)  # N: Revealed type is "builtins.int"
 
 U[int]  # E: Type application targets a non-generic function or class
-O[int]  # E: Bad number of arguments for type alias, expected: 0, given: 1  # E: Type application is only supported for generic classes
+O[int]  # E: Bad number of arguments for type alias, expected: 0, given: 1
 [out]
 
 [case testAliasesInClassBodyNormalVsSubscripted]
@@ -1034,9 +1081,9 @@ reveal_type(ts) # N: Revealed type is "Any"
 us = UA.x # E: "object" has no attribute "x"
 reveal_type(us) # N: Revealed type is "Any"
 
-xx = CA[str] + 1  # E: Type application is only supported for generic classes
-yy = TA[str]()  # E: Type application is only supported for generic classes
-zz = UA[str].x  # E: Type application is only supported for generic classes
+xx = CA[str]
+yy = TA[str]
+zz = UA[str]
 [builtins fixtures/tuple.pyi]
 
 [out]


### PR DESCRIPTION
This looks a bit messy. Suggestions on implementation are welcome.

All python versions starting from 3.7 allow runtime subscription of `Union`, `Tuple`, `Callable` types (probably something else).

So, I think that it is a good idea to remove this errors from types that can be subscribed.