### PR TITLE
Implement some constraints tests for typevar tuples.

### DIFF
--- a/mypy/test/testconstraints.py
+++ b/mypy/test/testconstraints.py
@@ -27,7 +27,7 @@ class ConstraintsSuite(Suite):
         fx = self.fx
         assert infer_constraints(
             Instance(fx.gvi, [UnpackType(fx.ts)]), Instance(fx.gvi, [fx.a, fx.b]), SUBTYPE_OF
-        ) == [Constraint(type_var=fx.ts.id, op=SUPERTYPE_OF, target=TypeList([fx.a, fx.b]))]
+        ) == [Constraint(type_var=fx.ts.id, op=SUBTYPE_OF, target=TypeList([fx.a, fx.b]))]
 
     def test_basic_type_var_tuple(self) -> None:
         fx = self.fx

--- a/mypy/test/testconstraints.py
+++ b/mypy/test/testconstraints.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
 from mypy.constraints import SUBTYPE_OF, SUPERTYPE_OF, Constraint, infer_constraints
 from mypy.test.helpers import Suite
 from mypy.test.typefixture import TypeFixture
+from mypy.types import Instance, TypeList, UnpackType
 
 
 class ConstraintsSuite(Suite):
@@ -18,3 +21,30 @@ class ConstraintsSuite(Suite):
             assert infer_constraints(fx.gt, fx.ga, direction) == [
                 Constraint(type_var=fx.t.id, op=direction, target=fx.a)
             ]
+
+    @pytest.mark.xfail
+    def test_basic_type_var_tuple_subtype(self) -> None:
+        fx = self.fx
+        assert infer_constraints(
+            Instance(fx.gvi, [UnpackType(fx.ts)]), Instance(fx.gvi, [fx.a, fx.b]), SUBTYPE_OF
+        ) == [Constraint(type_var=fx.ts.id, op=SUPERTYPE_OF, target=TypeList([fx.a, fx.b]))]
+
+    def test_basic_type_var_tuple(self) -> None:
+        fx = self.fx
+        assert infer_constraints(
+            Instance(fx.gvi, [UnpackType(fx.ts)]), Instance(fx.gvi, [fx.a, fx.b]), SUPERTYPE_OF
+        ) == [Constraint(type_var=fx.ts.id, op=SUPERTYPE_OF, target=TypeList([fx.a, fx.b]))]
+
+    def test_type_var_tuple_with_prefix_and_suffix(self) -> None:
+        fx = self.fx
+        assert set(
+            infer_constraints(
+                Instance(fx.gv2i, [fx.t, UnpackType(fx.ts), fx.s]),
+                Instance(fx.gv2i, [fx.a, fx.b, fx.c, fx.d]),
+                SUPERTYPE_OF,
+            )
+        ) == {
+            Constraint(type_var=fx.t.id, op=SUPERTYPE_OF, target=fx.a),
+            Constraint(type_var=fx.ts.id, op=SUPERTYPE_OF, target=TypeList([fx.b, fx.c])),
+            Constraint(type_var=fx.s.id, op=SUPERTYPE_OF, target=fx.d),
+        }

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -135,6 +135,9 @@ class TypeFixture:
         )
 
         self.gvi = self.make_type_info("GV", mro=[self.oi], typevars=["Ts"], typevar_tuple_index=0)
+        self.gv2i = self.make_type_info(
+            "GV2", mro=[self.oi], typevars=["T", "Ts", "S"], typevar_tuple_index=1
+        )
         # list[T]
         self.std_listi = self.make_type_info(
             "builtins.list", mro=[self.oi], typevars=["T"], variances=[variance]

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -891,7 +891,7 @@ class TypeList(ProperType):
 
     def __init__(self, items: List[Type], line: int = -1, column: int = -1) -> None:
         super().__init__(line, column)
-        self.items = tuple(items)
+        self.items = items
 
     def accept(self, visitor: "TypeVisitor[T]") -> T:
         assert isinstance(visitor, SyntheticTypeVisitor)
@@ -901,7 +901,7 @@ class TypeList(ProperType):
         assert False, "Synthetic types don't serialize"
 
     def __hash__(self) -> int:
-        return hash(self.items)
+        return hash(tuple(self.items))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TypeList):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -891,7 +891,7 @@ class TypeList(ProperType):
 
     def __init__(self, items: List[Type], line: int = -1, column: int = -1) -> None:
         super().__init__(line, column)
-        self.items = items
+        self.items = tuple(items)
 
     def accept(self, visitor: "TypeVisitor[T]") -> T:
         assert isinstance(visitor, SyntheticTypeVisitor)
@@ -899,6 +899,14 @@ class TypeList(ProperType):
 
     def serialize(self) -> JsonDict:
         assert False, "Synthetic types don't serialize"
+
+    def __hash__(self) -> int:
+        return hash(self.items)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TypeList):
+            return False
+        return self.items == other.items
 
 
 class UnpackType(ProperType):


### PR DESCRIPTION
This implements some constraint tests for type var tuples. We only test SUPERTYPE_OF right now because the SUBTYPE_OF path doesn't actually seem to work yet. We also have to make `TypeList` support hash and eq in order to compare the sets.