### PR TITLE
Enable generic NamedTuples

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3640,6 +3640,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if isinstance(item, Instance):
                 tp = type_object_type(item.type, self.named_type)
                 return self.apply_type_arguments_to_callable(tp, item.args, tapp)
+            elif isinstance(item, TupleType) and item.partial_fallback.type.is_named_tuple:
+                tp = type_object_type(item.partial_fallback.type, self.named_type)
+                return self.apply_type_arguments_to_callable(tp, item.partial_fallback.args, tapp)
             else:
                 self.chk.fail(message_registry.ONLY_CLASS_APPLICATION, tapp)
                 return AnyType(TypeOfAny.from_error)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -880,6 +880,14 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                     ]
 
         if isinstance(actual, TupleType) and len(actual.items) == len(template.items):
+            if (
+                actual.partial_fallback.type.is_named_tuple
+                and template.partial_fallback.type.is_named_tuple
+            ):
+                # For named tuples using just the fallbacks usually gives better results.
+                return infer_constraints(
+                    template.partial_fallback, actual.partial_fallback, self.direction
+                )
             res: List[Constraint] = []
             for i in range(len(template.items)):
                 res.extend(infer_constraints(template.items[i], actual.items[i], self.direction))

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -296,7 +296,11 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
     def visit_tuple_type(self, t: TupleType) -> Type:
         items = self.expand_types_with_unpack(t.items)
         if isinstance(items, list):
-            return t.copy_modified(items=items)
+            fallback = t.partial_fallback.accept(self)
+            fallback = get_proper_type(fallback)
+            if not isinstance(fallback, Instance):
+                fallback = t.partial_fallback
+            return t.copy_modified(items=items, fallback=fallback)
         else:
             return items
 

--- a/mypy/maptype.py
+++ b/mypy/maptype.py
@@ -1,8 +1,19 @@
 from typing import Dict, List
 
+import mypy.typeops
 from mypy.expandtype import expand_type
 from mypy.nodes import TypeInfo
-from mypy.types import AnyType, Instance, ProperType, Type, TypeOfAny, TypeVarId
+from mypy.types import (
+    AnyType,
+    Instance,
+    ProperType,
+    TupleType,
+    Type,
+    TypeOfAny,
+    TypeVarId,
+    get_proper_type,
+    has_type_vars,
+)
 
 
 def map_instance_to_supertype(instance: Instance, superclass: TypeInfo) -> Instance:
@@ -15,6 +26,20 @@ def map_instance_to_supertype(instance: Instance, superclass: TypeInfo) -> Insta
     if instance.type == superclass:
         # Fast path: `instance` already belongs to `superclass`.
         return instance
+
+    if superclass.fullname == "builtins.tuple" and instance.type.tuple_type:
+        if has_type_vars(instance.type.tuple_type):
+            # We special case mapping generic tuple types to tuple base, because for
+            # such tuples fallback can't be calculated before applying type arguments.
+            alias = instance.type.special_alias
+            assert alias is not None
+            if not alias._is_recursive:
+                # Unfortunately we can't support this for generic recursive tuples.
+                # If we skip this special casing we will fall back to tuple[Any, ...].
+                env = instance_to_type_environment(instance)
+                tuple_type = get_proper_type(expand_type(instance.type.tuple_type, env))
+                if isinstance(tuple_type, TupleType):
+                    return mypy.typeops.tuple_fallback(tuple_type)
 
     if not superclass.type_vars:
         # Fast path: `superclass` has no type variables to map to.

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3294,7 +3294,7 @@ class TypeAlias(SymbolNode):
         """Generate an alias to the tuple type described by a given TypeInfo."""
         assert info.tuple_type
         return TypeAlias(
-            info.tuple_type.copy_modified(fallback=mypy.types.Instance(info, [])),
+            info.tuple_type.copy_modified(fallback=mypy.types.Instance(info, info.defn.type_vars)),
             info.fullname,
             info.line,
             info.column,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1381,10 +1381,7 @@ class SemanticAnalyzer(
         if self.analyze_typeddict_classdef(defn):
             return
 
-        if self.analyze_namedtuple_classdef(defn):
-            if defn.info:
-                self.setup_type_vars(defn, tvar_defs)
-                self.setup_alias_type_vars(defn)
+        if self.analyze_namedtuple_classdef(defn, tvar_defs):
             return
 
         # Create TypeInfo for class now that base classes and the MRO can be calculated.
@@ -1447,7 +1444,9 @@ class SemanticAnalyzer(
             return True
         return False
 
-    def analyze_namedtuple_classdef(self, defn: ClassDef) -> bool:
+    def analyze_namedtuple_classdef(
+        self, defn: ClassDef, tvar_defs: List[TypeVarLikeType]
+    ) -> bool:
         """Check if this class can define a named tuple."""
         if (
             defn.info
@@ -1467,6 +1466,8 @@ class SemanticAnalyzer(
                 self.mark_incomplete(defn.name, defn)
             else:
                 self.prepare_class_def(defn, info, custom_names=True)
+                self.setup_type_vars(defn, tvar_defs)
+                self.setup_alias_type_vars(defn)
                 with self.scope.class_scope(defn.info):
                     with self.named_tuple_analyzer.save_namedtuple_body(info):
                         self.analyze_class_body_common(defn)

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -58,6 +58,7 @@ from mypy.types import (
     TypeType,
     TypeVarType,
     UnboundType,
+    has_type_vars,
 )
 from mypy.util import get_unique_redefinition_name
 
@@ -487,7 +488,7 @@ class NamedTupleAnalyzer:
         # We can't calculate the complete fallback type until after semantic
         # analysis, since otherwise base classes might be incomplete. Postpone a
         # callback function that patches the fallback.
-        if not has_placeholder(tuple_base):
+        if not has_placeholder(tuple_base) and not has_type_vars(tuple_base):
             self.api.schedule_patch(
                 PRIORITY_FALLBACKS, lambda: calculate_tuple_fallback(tuple_base)
             )

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -116,7 +116,6 @@ class NamedTupleAnalyzer:
                     info = self.build_namedtuple_typeinfo(
                         defn.name, items, types, default_items, defn.line, existing_info
                     )
-                    defn.info = info
                     defn.analyzed = NamedTupleExpr(info, is_typed=True)
                     defn.analyzed.line = defn.line
                     defn.analyzed.column = defn.column

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -32,6 +32,7 @@ from mypy.types import (
     TupleType,
     Type,
     TypeVarId,
+    TypeVarLikeType,
     get_proper_type,
 )
 
@@ -124,6 +125,8 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
     * Less need to pass around callback functions
     """
 
+    tvar_scope: TypeVarLikeScope
+
     @abstractmethod
     def lookup(
         self, name: str, ctx: Context, suppress_errors: bool = False
@@ -156,6 +159,10 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
         allow_placeholder: bool = False,
         report_invalid_types: bool = True,
     ) -> Optional[Type]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_and_bind_all_tvars(self, type_exprs: List[Expression]) -> List[TypeVarLikeType]:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -73,6 +73,11 @@ class TypeVarLikeScope:
         """A new scope frame for binding a class. Prohibits *this* class's tvars"""
         return TypeVarLikeScope(self.get_function_scope(), True, self, namespace=namespace)
 
+    def new_unique_func_id(self) -> int:
+        """Used by plugin-like code that needs to make synthetic generic functions."""
+        self.func_id -= 1
+        return self.func_id
+
     def bind_new(self, name: str, tvar_expr: TypeVarLikeExpr) -> TypeVarLikeType:
         if self.is_class_scope:
             self.class_id += 1

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -610,12 +610,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         if tup is not None:
             # The class has a Tuple[...] base class so it will be
             # represented as a tuple type.
-            if args:
-                self.fail("Generic tuple types not supported", ctx)
-                return AnyType(TypeOfAny.from_error)
             if info.special_alias:
-                # We don't support generic tuple types yet.
-                return TypeAliasType(info.special_alias, [])
+                return TypeAliasType(info.special_alias, self.anal_array(args))
             return tup.copy_modified(items=self.anal_array(tup.items), fallback=instance)
         td = info.typeddict_type
         if td is not None:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7329,3 +7329,13 @@ a: int = child.foo(1)
 b: str = child.bar("abc")
 c: float = child.baz(3.4)
 d: bool = child.foobar()
+
+[case testGenericTupleTypeCreation]
+from typing import Generic, Tuple, TypeVar
+
+[builtins fixtures/tuple.pyi]
+
+[case testGenericTupleTypeSubclassing]
+from typing import Generic, Tuple, TypeVar
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7333,9 +7333,26 @@ d: bool = child.foobar()
 [case testGenericTupleTypeCreation]
 from typing import Generic, Tuple, TypeVar
 
+T = TypeVar("T")
+S = TypeVar("S")
+class C(Tuple[T, S]):
+    def __init__(self, x: T, y: S) -> None: ...
+    def foo(self, arg: T) -> S: ...
+
+cis: C[int, str]
+reveal_type(cis)  # N: Revealed type is "Tuple[builtins.int, builtins.str, fallback=__main__.C[builtins.int, builtins.str]]"
+cii = C(0, 1)
+reveal_type(cii)  # N: Revealed type is "Tuple[builtins.int, builtins.int, fallback=__main__.C[builtins.int, builtins.int]]"
+reveal_type(cis.foo)  # N: Revealed type is "def (arg: builtins.int) -> builtins.str"
 [builtins fixtures/tuple.pyi]
 
 [case testGenericTupleTypeSubclassing]
-from typing import Generic, Tuple, TypeVar
+from typing import Generic, Tuple, TypeVar, List
 
+T = TypeVar("T")
+class C(Tuple[T, T]): ...
+class D(C[List[T]]): ...
+
+di: D[int]
+reveal_type(di)  # N: Revealed type is "Tuple[builtins.list[builtins.int], builtins.list[builtins.int], fallback=__main__.D[builtins.int]]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5893,3 +5893,26 @@ reveal_type(a.n)
 tmp/c.py:4: note: Revealed type is "TypedDict('a.N', {'r': Union[TypedDict('b.M', {'r': Union[..., None], 'x': builtins.int}), None], 'x': builtins.int})"
 tmp/c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
 tmp/c.py:7: note: Revealed type is "TypedDict('a.N', {'r': Union[TypedDict('b.M', {'r': Union[..., None], 'x': builtins.int}), None], 'x': builtins.int})"
+
+[case testGenericNamedTupleSerialization]
+import b
+[file a.py]
+from typing import NamedTuple, Generic, TypeVar
+
+T = TypeVar("T")
+class NT(NamedTuple, Generic[T]):
+    key: int
+    value: T
+
+[file b.py]
+from a import NT
+nt = NT(key=0, value="yes")
+s: str = nt.value
+[file b.py.2]
+from a import NT
+nt = NT(key=0, value=42)
+s: str = nt.value
+[builtins fixtures/tuple.pyi]
+[out]
+[out2]
+tmp/b.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1278,3 +1278,31 @@ reveal_type(foo(x, nti))  # N: Revealed type is "builtins.tuple[builtins.int, ..
 reveal_type(foo(x, nts))  # N: Revealed type is "builtins.tuple[builtins.object, ...]"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
+
+[case testGenericNamedTupleCallSyntax]
+from typing import NamedTuple, TypeVar
+
+T = TypeVar("T")
+NT = NamedTuple("NT", [("key", int), ("value", T)])
+reveal_type(NT)  # N: Revealed type is "def [T] (key: builtins.int, value: T`-1) -> Tuple[builtins.int, T`-1, fallback=__main__.NT[T`-1]]"
+
+nts: NT[str]
+reveal_type(nts)  # N: Revealed type is "Tuple[builtins.int, builtins.str, fallback=__main__.NT[builtins.str]]"
+
+nti = NT(key=0, value=0)
+reveal_type(nti)  # N: Revealed type is "Tuple[builtins.int, builtins.int, fallback=__main__.NT[builtins.int]]"
+NT[str](key=0, value=0)  # E: Argument "value" to "NT" has incompatible type "int"; expected "str"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
+
+[case testGenericNamedTupleNoLegacySyntax]
+from typing import TypeVar, NamedTuple
+
+T = TypeVar("T")
+class C(
+    NamedTuple("_C", [("x", int), ("y", T)])  # E: Generic named tuples are not supported for legacy class syntax \
+                                              # N: Use either Python 3 class syntax, or the assignment syntax
+): ...
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1240,7 +1240,7 @@ foo(nts)  # E: Argument 1 to "foo" has incompatible type "NT[str]"; expected "Tu
 [case testGenericNamedTupleJoin]
 from typing import Generic, NamedTuple, TypeVar, Tuple
 
-T = TypeVar("T")
+T = TypeVar("T", covariant=True)
 class NT(NamedTuple, Generic[T]):
     key: int
     value: T
@@ -1249,12 +1249,12 @@ nts: NT[str]
 nti: NT[int]
 x: Tuple[int, ...]
 
-def foo(x: T, y: T) -> T: ...
+S = TypeVar("S")
+def foo(x: S, y: S) -> S: ...
 reveal_type(foo(nti, nti))  # N: Revealed type is "Tuple[builtins.int, builtins.int, fallback=__main__.NT[builtins.int]]"
 
-# Here fallbacks are object because named tuples are invariant.
-reveal_type(foo(nti, nts))  # N: Revealed type is "Tuple[builtins.int, builtins.object, fallback=builtins.object]"
-reveal_type(foo(nts, nti))  # N: Revealed type is "Tuple[builtins.int, builtins.object, fallback=builtins.object]"
+reveal_type(foo(nti, nts))  # N: Revealed type is "Tuple[builtins.int, builtins.object, fallback=__main__.NT[builtins.object]]"
+reveal_type(foo(nts, nti))  # N: Revealed type is "Tuple[builtins.int, builtins.object, fallback=__main__.NT[builtins.object]]"
 
 reveal_type(foo(nti, x))  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 reveal_type(foo(nts, x))  # N: Revealed type is "builtins.tuple[builtins.object, ...]"

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1162,3 +1162,47 @@ NT5 = NamedTuple(b'NT5', [('x', int), ('y', int)])  # E: "NamedTuple()" expects 
 
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
+
+[case testGenericNamedTupleCreation]
+from typing import Generic, NamedTuple, TypeVar
+
+T = TypeVar("T")
+class NT(NamedTuple, Generic[T]):
+    key: int
+    value: T
+
+nts: NT[str]
+reveal_type(nts)  # N: Revealed type is "Tuple[builtins.int, builtins.str, fallback=__main__.NT[builtins.str]]"
+reveal_type(nts.value)  # N: Revealed type is "builtins.str"
+
+nti = NT(key=0, value=0)
+reveal_type(nti)  # N: Revealed type is "Tuple[builtins.int, builtins.int, fallback=__main__.NT[builtins.int]]"
+reveal_type(nti.value)  # N: Revealed type is "builtins.int"
+
+NT[str](key=0, value=0)  # E: Argument "value" to "NT" has incompatible type "int"; expected "str"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
+
+[case testGenericNamedTupleMethods]
+from typing import Generic, NamedTuple, TypeVar
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
+
+[case testGenericNamedTupleCustomMethods]
+from typing import Generic, NamedTuple, TypeVar
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
+
+[case testGenericNamedTupleSubtyping]
+from typing import Generic, NamedTuple, TypeVar
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
+
+[case testGenericNamedTupleJoin]
+from typing import Generic, NamedTuple, TypeVar
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1183,6 +1183,22 @@ NT[str](key=0, value=0)  # E: Argument "value" to "NT" has incompatible type "in
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
 
+[case testGenericNamedTupleAlias]
+from typing import NamedTuple, Generic, TypeVar, List
+
+T = TypeVar("T")
+class NT(NamedTuple, Generic[T]):
+    key: int
+    value: T
+
+Alias = NT[List[T]]
+
+an: Alias[str]
+reveal_type(an)  # N: Revealed type is "Tuple[builtins.int, builtins.list[builtins.str], fallback=__main__.NT[builtins.list[builtins.str]]]"
+Alias[str](key=0, value=0)  # E: Argument "value" to "NT" has incompatible type "int"; expected "List[str]"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
+
 [case testGenericNamedTupleMethods]
 from typing import Generic, NamedTuple, TypeVar
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1186,23 +1186,79 @@ NT[str](key=0, value=0)  # E: Argument "value" to "NT" has incompatible type "in
 [case testGenericNamedTupleMethods]
 from typing import Generic, NamedTuple, TypeVar
 
+T = TypeVar("T")
+class NT(NamedTuple, Generic[T]):
+    key: int
+    value: T
+x: int
+
+nti: NT[int]
+reveal_type(nti * x)  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
+
+nts: NT[str]
+reveal_type(nts * x)  # N: Revealed type is "builtins.tuple[builtins.object, ...]"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
 
 [case testGenericNamedTupleCustomMethods]
 from typing import Generic, NamedTuple, TypeVar
 
+T = TypeVar("T")
+class NT(NamedTuple, Generic[T]):
+    key: int
+    value: T
+    def foo(self) -> T: ...
+    @classmethod
+    def from_value(cls, value: T) -> NT[T]: ...
+
+nts: NT[str]
+reveal_type(nts.foo())  # N: Revealed type is "builtins.str"
+
+nti = NT.from_value(1)
+reveal_type(nti)  # N: Revealed type is "Tuple[builtins.int, builtins.int, fallback=__main__.NT[builtins.int]]"
+NT[str].from_value(1)  # E: Argument 1 to "from_value" of "NT" has incompatible type "int"; expected "str"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
 
 [case testGenericNamedTupleSubtyping]
-from typing import Generic, NamedTuple, TypeVar
+from typing import Generic, NamedTuple, TypeVar, Tuple
 
+T = TypeVar("T")
+class NT(NamedTuple, Generic[T]):
+    key: int
+    value: T
+
+nts: NT[str]
+nti: NT[int]
+
+def foo(x: Tuple[int, ...]) -> None: ...
+foo(nti)
+foo(nts)  # E: Argument 1 to "foo" has incompatible type "NT[str]"; expected "Tuple[int, ...]"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
 
 [case testGenericNamedTupleJoin]
-from typing import Generic, NamedTuple, TypeVar
+from typing import Generic, NamedTuple, TypeVar, Tuple
 
+T = TypeVar("T")
+class NT(NamedTuple, Generic[T]):
+    key: int
+    value: T
+
+nts: NT[str]
+nti: NT[int]
+x: Tuple[int, ...]
+
+def foo(x: T, y: T) -> T: ...
+reveal_type(foo(nti, nti))  # N: Revealed type is "Tuple[builtins.int, builtins.int, fallback=__main__.NT[builtins.int]]"
+
+# Here fallbacks are object because named tuples are invariant.
+reveal_type(foo(nti, nts))  # N: Revealed type is "Tuple[builtins.int, builtins.object, fallback=builtins.object]"
+reveal_type(foo(nts, nti))  # N: Revealed type is "Tuple[builtins.int, builtins.object, fallback=builtins.object]"
+
+reveal_type(foo(nti, x))  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
+reveal_type(foo(nts, x))  # N: Revealed type is "builtins.tuple[builtins.object, ...]"
+reveal_type(foo(x, nti))  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
+reveal_type(foo(x, nts))  # N: Revealed type is "builtins.tuple[builtins.object, ...]"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -611,6 +611,30 @@ def foo() -> None:
     reveal_type(b)  # N: Revealed type is "Tuple[Any, builtins.int, fallback=__main__.B@4]"
 [builtins fixtures/tuple.pyi]
 
+[case testBasicRecursiveGenericNamedTuple]
+# flags: --enable-recursive-aliases
+from typing import Generic, NamedTuple, TypeVar, Union
+
+T = TypeVar("T", covariant=True)
+class NT(NamedTuple, Generic[T]):
+    key: int
+    value: Union[T, NT[T]]
+
+class A: ...
+class B(A): ...
+
+nti: NT[int] = NT(key=0, value=NT(key=1, value=A()))  # E: Argument "value" to "NT" has incompatible type "A"; expected "Union[int, NT[int]]"
+reveal_type(nti)  # N: Revealed type is "Tuple[builtins.int, Union[builtins.int, ...], fallback=__main__.NT[builtins.int]]"
+
+nta: NT[A]
+ntb: NT[B]
+nta = ntb  # OK, covariance
+ntb = nti  # E: Incompatible types in assignment (expression has type "NT[int]", variable has type "NT[B]")
+
+def last(arg: NT[T]) -> T: ...
+reveal_type(last(ntb))  # N: Revealed type is "__main__.B"
+[builtins fixtures/tuple.pyi]
+
 [case testBasicRecursiveTypedDictClass]
 # flags: --enable-recursive-aliases
 from typing import TypedDict

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -883,9 +883,9 @@ from typing import TypeVar, Generic, Tuple
 T = TypeVar('T')
 class Test(Generic[T], Tuple[T]): pass
 x = Test() # type: Test[int]
+reveal_type(x)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.Test[builtins.int]]"
 [builtins fixtures/tuple.pyi]
 [out]
-main:4: error: Generic tuple types not supported
 
 
 -- Variable-length tuples (Tuple[t, ...] with literal '...')

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3472,6 +3472,36 @@ f(a.x)
 [out]
 ==
 
+[case testNamedTupleUpdateGeneric]
+import b
+[file a.py]
+from typing import NamedTuple
+class Point(NamedTuple):
+    x: int
+    y: int
+[file a.py.2]
+from typing import Generic, TypeVar, NamedTuple
+
+T = TypeVar("T")
+class Point(NamedTuple, Generic[T]):
+    x: int
+    y: T
+[file b.py]
+from a import Point
+def foo() -> None:
+    p = Point(x=0, y=1)
+    i: int = p.y
+[file b.py.3]
+from a import Point
+def foo() -> None:
+    p = Point(x=0, y="no")
+    i: int = p.y
+[builtins fixtures/tuple.pyi]
+[out]
+==
+==
+b.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
 [case testNamedTupleUpdateNonRecursiveToRecursiveFine]
 # flags: --enable-recursive-aliases
 import c

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -25,6 +25,7 @@ class tuple(Sequence[Tco], Generic[Tco]):
     def count(self, obj: object) -> int: pass
 class function: pass
 class ellipsis: pass
+class classmethod: pass
 
 # We need int and slice for indexing tuples.
 class int:


### PR DESCRIPTION
Fixes #685

This builds on top of some infra I added for recursive types (Ref https://github.com/python/mypy/pull/13297). Implementation is based on the idea in https://github.com/python/mypy/pull/13297#issuecomment-1211317009. Generally it works well, but there are actually some problems for named tuples that are recursive. Special-casing them in `maptype.py` is a bit ugly, but I think this is best we can get at the moment.

An important note on runtime support for this: IIUC this should work in Python 3.11, and should work soon with `typing_extensions` on earlier versions. I didn't add any version checks here. If someone is interested in adding those, please do this.