### PR TITLE
Allow generic decorators on abstarct classes

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1914,6 +1914,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             and (caller_type.type_object().is_abstract or caller_type.type_object().is_protocol)
             and isinstance(callee_type.item, Instance)
             and (callee_type.item.type.is_abstract or callee_type.item.type.is_protocol)
+            and not self.chk.allow_abstract_call
         ):
             self.msg.concrete_only_call(callee_type, context)
         elif not is_subtype(caller_type, callee_type, options=self.chk.options):

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -1018,3 +1018,15 @@ d = my_abstract_types['B']()  # E: Cannot instantiate abstract class "MyAbstract
 d.do()
 
 [builtins fixtures/dict.pyi]
+
+[case testAbstractClassesWorkWithGenericDecorators]
+from abc import abstractmethod, ABCMeta
+from typing import Type, TypeVar
+
+T = TypeVar("T")
+def deco(cls: Type[T]) -> Type[T]: ...
+
+@deco
+class A(metaclass=ABCMeta):
+    @abstractmethod
+    def foo(self, x: int) -> None: ...


### PR DESCRIPTION
Fixes #5374 

As discussed in the issue, we should allow this common use case, although it may be technically unsafe (e.g. if one would instantiate a class in a class decorator body).