### PR TITLE
Remove useless parameter script_path of main()

### DIFF
--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -9,7 +9,7 @@ from mypy.util import FancyFormatter
 
 def console_entry() -> None:
     try:
-        main(sys.stdout, sys.stderr)
+        main()
         sys.stdout.flush()
         sys.stderr.flush()
     except BrokenPipeError:

--- a/mypy/__main__.py
+++ b/mypy/__main__.py
@@ -9,7 +9,7 @@ from mypy.util import FancyFormatter
 
 def console_entry() -> None:
     try:
-        main(None, sys.stdout, sys.stderr)
+        main(sys.stdout, sys.stderr)
         sys.stdout.flush()
         sys.stderr.flush()
     except BrokenPipeError:

--- a/mypy/api.py
+++ b/mypy/api.py
@@ -67,7 +67,7 @@ def run(args: List[str]) -> Tuple[str, str, int]:
     from mypy.main import main
 
     return _run(
-        lambda stdout, stderr: main(None, args=args, stdout=stdout, stderr=stderr, clean_exit=True)
+        lambda stdout, stderr: main(args=args, stdout=stdout, stderr=stderr, clean_exit=True)
     )
 
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -39,7 +39,6 @@ def stat_proxy(path: str) -> os.stat_result:
 
 
 def main(
-    script_path: Optional[str],
     stdout: TextIO,
     stderr: TextIO,
     args: Optional[List[str]] = None,
@@ -48,7 +47,6 @@ def main(
     """Main entry point to the type checker.
 
     Args:
-        script_path: Path to the 'mypy' script (used for finding data files).
         args: Custom command-line arguments.  If not given, sys.argv[1:] will
             be used.
         clean_exit: Don't hard kill the process on exit. This allows catching

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -39,9 +39,10 @@ def stat_proxy(path: str) -> os.stat_result:
 
 
 def main(
-    stdout: TextIO,
-    stderr: TextIO,
+    *,
     args: Optional[List[str]] = None,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
     clean_exit: bool = False,
 ) -> None:
     """Main entry point to the type checker.


### PR DESCRIPTION
`script_path` was entirely useless since `bin_dir` had been dropped long time ago by https://github.com/python/mypy/pull/5690 