### PR TITLE
Flake8 updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,11 @@ repos:
     rev: 5.10.1  # must match test-requirements.txt
     hooks:
       - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.9.2  # must match test-requirements.txt
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear==22.7.1  # must match test-requirements.txt
+          - flake8-noqa==1.2.8      # must match test-requirements.txt
+          - flake8-pyi==22.8.1      # must match test-requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,3 @@ repos:
         additional_dependencies:
           - flake8-bugbear==22.7.1  # must match test-requirements.txt
           - flake8-noqa==1.2.8      # must match test-requirements.txt
-          - flake8-pyi==22.8.1      # must match test-requirements.txt

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -224,7 +224,7 @@ def _build(
     reports = None
     if options.report_dirs:
         # Import lazily to avoid slowing down startup.
-        from mypy.report import Reports  # noqa
+        from mypy.report import Reports
 
         reports = Reports(data_dir, options.report_dirs)
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1188,7 +1188,7 @@ def process_options(
 
     # Set strict flags before parsing (if strict mode enabled), so other command
     # line options can override.
-    if getattr(dummy, "special-opts:strict"):  # noqa
+    if getattr(dummy, "special-opts:strict"):
         set_strict_flags()
 
     # Override cache_dir if provided in the environment

--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     #       This workaround fixes it.
     old_sys_path = sys.path
     sys.path = sys.path[1:]
-    import types  # noqa
+    import types  # noqa: F401
 
     sys.path = old_sys_path
 

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -162,7 +162,7 @@ def replacement_map_from_symbol_table(
         ):
             new_node = new[name]
             if (
-                type(new_node.node) == type(node.node)  # noqa
+                type(new_node.node) == type(node.node)  # noqa: E721
                 and new_node.node
                 and node.node
                 and new_node.node.fullname == node.node.fullname

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -39,7 +39,7 @@ def isproperty(o: object, attr: str) -> bool:
 
 def get_edge_candidates(o: object) -> Iterator[Tuple[object, object]]:
     # use getattr because mypyc expects dict, not mappingproxy
-    if "__getattribute__" in getattr(type(o), "__dict__"):  # noqa
+    if "__getattribute__" in getattr(type(o), "__dict__"):  # noqa: B009
         return
     if type(o) not in COLLECTION_TYPE_BLACKLIST:
         for attr in dir(o):

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -346,7 +346,7 @@ def generate_c_type_stub(
     """
     # typeshed gives obj.__dict__ the not quite correct type Dict[str, Any]
     # (it could be a mappingproxy!), which makes mypyc mad, so obfuscate it.
-    obj_dict: Mapping[str, Any] = getattr(obj, "__dict__")  # noqa
+    obj_dict: Mapping[str, Any] = getattr(obj, "__dict__")  # noqa: B009
     items = sorted(obj_dict.items(), key=lambda x: method_name_sort_key(x[0]))
     methods: List[str] = []
     types: List[str] = []

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2762,7 +2762,7 @@ def get_proper_types(
 # to make it easier to gradually get modules working with mypyc.
 # Import them here, after the types are defined.
 # This is intended as a re-export also.
-from mypy.type_visitor import (  # noqa
+from mypy.type_visitor import (  # noqa: F811
     SyntheticTypeVisitor as SyntheticTypeVisitor,
     TypeQuery as TypeQuery,
     TypeTranslator as TypeTranslator,

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -29,7 +29,7 @@ from typing_extensions import Final, Literal
 try:
     import curses
 
-    import _curses  # noqa
+    import _curses  # noqa: F401
 
     CURSES_ENABLED = True
 except ImportError:

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -52,11 +52,11 @@ from mypyc.namegen import exported_name
 from mypyc.options import CompilerOptions
 
 if TYPE_CHECKING:
-    from distutils.core import Extension  # noqa
+    from distutils.core import Extension
 
 try:
     # Import setuptools so that it monkey-patch overrides distutils
-    import setuptools  # noqa
+    import setuptools  # noqa: F401
 except ImportError:
     if sys.version_info >= (3, 12):
         # Raise on Python 3.12, since distutils will go away forever
@@ -72,7 +72,7 @@ def get_extension() -> Type["Extension"]:
     if not use_setuptools:
         from distutils.core import Extension
     else:
-        from setuptools import Extension  # noqa
+        from setuptools import Extension
 
     return Extension
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -51,8 +51,8 @@ from mypyc.ir.rtypes import (
 )
 
 if TYPE_CHECKING:
-    from mypyc.ir.class_ir import ClassIR  # noqa
-    from mypyc.ir.func_ir import FuncDecl, FuncIR  # noqa
+    from mypyc.ir.class_ir import ClassIR
+    from mypyc.ir.func_ir import FuncDecl, FuncIR
 
 T = TypeVar("T")
 

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -304,13 +304,13 @@ def load_address_op(name: str, type: RType, src: str) -> LoadAddressDescription:
     return LoadAddressDescription(name, type, src)
 
 
-import mypyc.primitives.bytes_ops  # noqa
-import mypyc.primitives.dict_ops  # noqa
-import mypyc.primitives.float_ops  # noqa
+import mypyc.primitives.bytes_ops
+import mypyc.primitives.dict_ops
+import mypyc.primitives.float_ops
 
 # Import various modules that set up global state.
-import mypyc.primitives.int_ops  # noqa
-import mypyc.primitives.list_ops  # noqa
-import mypyc.primitives.misc_ops  # noqa
-import mypyc.primitives.str_ops  # noqa
-import mypyc.primitives.tuple_ops  # noqa
+import mypyc.primitives.int_ops
+import mypyc.primitives.list_ops
+import mypyc.primitives.misc_ops
+import mypyc.primitives.str_ops
+import mypyc.primitives.tuple_ops  # noqa: F401

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -86,7 +86,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         self.n = add_local("n", int_rprimitive)
         self.m = add_local("m", int_rprimitive)
         self.k = add_local("k", int_rprimitive)
-        self.l = add_local("l", list_rprimitive)  # noqa
+        self.l = add_local("l", list_rprimitive)
         self.ll = add_local("ll", list_rprimitive)
         self.o = add_local("o", object_rprimitive)
         self.o2 = add_local("o2", object_rprimitive)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 99
+noqa-require-code = True
 # typeshed and unit test fixtures have .pyi-specific flake8 configuration
 exclude =
   # from .gitignore: directories, and file patterns that intersect with *.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,21 +34,17 @@ exclude =
   .Python
 
 # Things to ignore:
-#   E128: continuation line under-indented (too noisy)
 #   E203: conflicts with black
 #   E501: conflicts with black
 #   W601: has_key() deprecated (false positives)
-#   E701: multiple statements on one line (colon) (we use this for classes with empty body)
-#   E704: multiple statements on one line (def)
 #   E402: module level import not at top of file
-#   B3??: Python 3 compatibility warnings
 #   B006: use of mutable defaults in function signatures
 #   B007: Loop control variable not used within the loop body.
 #   B011: Don't use assert False
 #   B023: Function definition does not bind loop variable
 #   F821: Name not defined (generates false positives with error codes)
 #   E741: Ambiguous variable name
-extend-ignore = E128,E203,E501,W601,E701,E704,E402,B3,B006,B007,B011,B023,F821,E741
+extend-ignore = E203,E501,W601,E402,B006,B007,B011,B023,F821,E741
 
 [coverage:run]
 branch = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,10 @@ exclude =
 #   B006: use of mutable defaults in function signatures
 #   B007: Loop control variable not used within the loop body.
 #   B011: Don't use assert False
+#   B023: Function definition does not bind loop variable
 #   F821: Name not defined (generates false positives with error codes)
 #   E741: Ambiguous variable name
-extend-ignore = E128,E203,E501,W601,E701,E704,E402,B3,B006,B007,B011,F821,E741
+extend-ignore = E128,E203,E501,W601,E701,E704,E402,B3,B006,B007,B011,B023,F821,E741
 
 [coverage:run]
 branch = true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,7 @@ filelock>=3.3.0,<3.4.2; python_version<'3.7'
 filelock>=3.3.0; python_version>='3.7'
 flake8==3.9.2
 flake8-bugbear==22.7.1
+flake8-noqa==1.2.8
 flake8-pyi==22.8.1
 isort[colors]==5.10.1  # must match version in .pre-commit-config.yaml
 lxml>=4.4.0; python_version<'3.11'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,8 +5,8 @@ black==22.6.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0,<3.4.2; python_version<'3.7'
 filelock>=3.3.0; python_version>='3.7'
 flake8==3.9.2
-flake8-bugbear==22.3.20
-flake8-pyi>=20.5
+flake8-bugbear==22.7.1
+flake8-pyi==22.8.1
 isort[colors]==5.10.1  # must match version in .pre-commit-config.yaml
 lxml>=4.4.0; python_version<'3.11'
 psutil>=4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,11 +4,11 @@ attrs>=18.0
 black==22.6.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0,<3.4.2; python_version<'3.7'
 filelock>=3.3.0; python_version>='3.7'
-flake8==3.9.2
-flake8-bugbear==22.7.1
-flake8-noqa==1.2.8
-flake8-pyi==22.8.1
-isort[colors]==5.10.1  # must match version in .pre-commit-config.yaml
+flake8==3.9.2           # must match version in .pre-commit-config.yaml
+flake8-bugbear==22.7.1  # must match version in .pre-commit-config.yaml
+flake8-noqa==1.2.8      # must match version in .pre-commit-config.yaml
+flake8-pyi==22.8.1      # must match version in .pre-commit-config.yaml
+isort[colors]==5.10.1   # must match version in .pre-commit-config.yaml
 lxml>=4.4.0; python_version<'3.11'
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,6 @@ filelock>=3.3.0; python_version>='3.7'
 flake8==3.9.2           # must match version in .pre-commit-config.yaml
 flake8-bugbear==22.7.1  # must match version in .pre-commit-config.yaml
 flake8-noqa==1.2.8      # must match version in .pre-commit-config.yaml
-flake8-pyi==22.8.1      # must match version in .pre-commit-config.yaml
 isort[colors]==5.10.1   # must match version in .pre-commit-config.yaml
 lxml>=4.4.0; python_version<'3.11'
 psutil>=4.0


### PR DESCRIPTION
### Description
Second attempt to update the Flake8 plugins (after #13368). This time without update Flake8 itself since it's blocked by a dependency conflict.

#### Changes
* ~Update and pin `flake8-pyi` to `22.8.1`: https://github.com/PyCQA/flake8-pyi/blob/master/CHANGELOG.md#2281~
**Update**: Remove `flake8-pyi`. `pyi` files aren't checked anyway.
* Update `flake8-bugbear` to `22.7.1`: https://github.com/PyCQA/flake8-bugbear#2271
* Add pre-commit config for flake8
* Remove unused ignores (after black update and move to Python 3 only)
* Add `flake8-noqa` to validate `noqa` comments: https://github.com/plinss/flake8-noqa
* Require code for `noqa`
* Remove unused `noqa` comments
* Add new ignore for `B023` (`flake8-bugbear`). This causes too many false positives ATM.
> B023: Functions defined inside a loop must not use variables redefined in the loop,
> because [late-binding closures are a classic gotcha](https://docs.python-guide.org/writing/gotchas/#late-binding-closures).
```
./mypyc/irbuild/ll_builder.py:342:52: B023 Function definition does not bind loop variable 'class_ir'.
./mypyc/irbuild/ll_builder.py:344:75: B023 Function definition does not bind loop variable 'ret'.
./mypyc/irbuild/ll_builder.py:375:66: B023 Function definition does not bind loop variable 'c'.
./mypyc/irbuild/ll_builder.py:377:75: B023 Function definition does not bind loop variable 'ret'.
./mypyc/irbuild/builder.py:1257:24: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1260:32: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1261:43: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1266:51: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1267:55: B023 Function definition does not bind loop variable 'target'.
./mypyc/irbuild/builder.py:1268:51: B023 Function definition does not bind loop variable 'target'.
./mypyc/irbuild/builder.py:1270:28: B023 Function definition does not bind loop variable 'arg'.
./mypyc/irbuild/builder.py:1271:74: B023 Function definition does not bind loop variable 'target'.
./mypyc/irbuild/builder.py:1273:80: B023 Function definition does not bind loop variable 'arg'.
./mypy/checker.py:5249:34: B023 Function definition does not bind loop variable 'member_name'.
./mypy/checker.py:5251:37: B023 Function definition does not bind loop variable 'parent_expr'.
./mypy/checker.py:5263:32: B023 Function definition does not bind loop variable 'member_type'.
./mypy/checker.py:5282:36: B023 Function definition does not bind loop variable 'str_literals'.
./mypy/checker.py:5283:83: B023 Function definition does not bind loop variable 'str_literals'.
./mypy/checker.py:5296:40: B023 Function definition does not bind loop variable 'int_literals'.
./mypy/checker.py:5297:87: B023 Function definition does not bind loop variable 'int_literals'.
./mypy/test/testmerge.py:235:82: B023 Function definition does not bind loop variable 'type_map'.
./mypy/test/helpers.py:427:50: B023 Function definition does not bind loop variable 'path'.
```

## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
