### PR TITLE
Remove quotes from annotations

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -108,7 +108,7 @@ class Attribute:
         self.context = context
         self.init_type = init_type
 
-    def argument(self, ctx: "mypy.plugin.ClassDefContext") -> Argument:
+    def argument(self, ctx: mypy.plugin.ClassDefContext) -> Argument:
         """Return this attribute as an argument to __init__."""
         assert self.init
 
@@ -169,7 +169,7 @@ class Attribute:
     @classmethod
     def deserialize(
         cls, info: TypeInfo, data: JsonDict, api: SemanticAnalyzerPluginInterface
-    ) -> "Attribute":
+    ) -> Attribute:
         """Return the Attribute that was serialized."""
         raw_init_type = data["init_type"]
         init_type = deserialize_and_fixup_type(raw_init_type, api) if raw_init_type else None
@@ -200,7 +200,7 @@ class Attribute:
             self.init_type = None
 
 
-def _determine_eq_order(ctx: "mypy.plugin.ClassDefContext") -> bool:
+def _determine_eq_order(ctx: mypy.plugin.ClassDefContext) -> bool:
     """
     Validate the combination of *cmp*, *eq*, and *order*. Derive the effective
     value of order.
@@ -230,7 +230,7 @@ def _determine_eq_order(ctx: "mypy.plugin.ClassDefContext") -> bool:
 
 
 def _get_decorator_optional_bool_argument(
-    ctx: "mypy.plugin.ClassDefContext", name: str, default: Optional[bool] = None
+    ctx: mypy.plugin.ClassDefContext, name: str, default: Optional[bool] = None
 ) -> Optional[bool]:
     """Return the Optional[bool] argument for the decorator.
 
@@ -253,7 +253,7 @@ def _get_decorator_optional_bool_argument(
         return default
 
 
-def attr_tag_callback(ctx: "mypy.plugin.ClassDefContext") -> None:
+def attr_tag_callback(ctx: mypy.plugin.ClassDefContext) -> None:
     """Record that we have an attrs class in the main semantic analysis pass.
 
     The later pass implemented by attr_class_maker_callback will use this
@@ -264,7 +264,7 @@ def attr_tag_callback(ctx: "mypy.plugin.ClassDefContext") -> None:
 
 
 def attr_class_maker_callback(
-    ctx: "mypy.plugin.ClassDefContext",
+    ctx: mypy.plugin.ClassDefContext,
     auto_attribs_default: Optional[bool] = False,
     frozen_default: bool = False,
 ) -> bool:
@@ -334,7 +334,7 @@ def attr_class_maker_callback(
     return True
 
 
-def _get_frozen(ctx: "mypy.plugin.ClassDefContext", frozen_default: bool) -> bool:
+def _get_frozen(ctx: mypy.plugin.ClassDefContext, frozen_default: bool) -> bool:
     """Return whether this class is frozen."""
     if _get_decorator_bool_argument(ctx, "frozen", frozen_default):
         return True
@@ -346,7 +346,7 @@ def _get_frozen(ctx: "mypy.plugin.ClassDefContext", frozen_default: bool) -> boo
 
 
 def _analyze_class(
-    ctx: "mypy.plugin.ClassDefContext", auto_attribs: Optional[bool], kw_only: bool
+    ctx: mypy.plugin.ClassDefContext, auto_attribs: Optional[bool], kw_only: bool
 ) -> List[Attribute]:
     """Analyze the class body of an attr maker, its parents, and return the Attributes found.
 
@@ -429,7 +429,7 @@ def _add_empty_metadata(info: TypeInfo) -> None:
     info.metadata["attrs"] = {"attributes": [], "frozen": False}
 
 
-def _detect_auto_attribs(ctx: "mypy.plugin.ClassDefContext") -> bool:
+def _detect_auto_attribs(ctx: mypy.plugin.ClassDefContext) -> bool:
     """Return whether auto_attribs should be enabled or disabled.
 
     It's disabled if there are any unannotated attribs()
@@ -459,7 +459,7 @@ def _detect_auto_attribs(ctx: "mypy.plugin.ClassDefContext") -> bool:
 
 
 def _attributes_from_assignment(
-    ctx: "mypy.plugin.ClassDefContext", stmt: AssignmentStmt, auto_attribs: bool, kw_only: bool
+    ctx: mypy.plugin.ClassDefContext, stmt: AssignmentStmt, auto_attribs: bool, kw_only: bool
 ) -> Iterable[Attribute]:
     """Return Attribute objects that are created by this assignment.
 
@@ -525,7 +525,7 @@ def _cleanup_decorator(stmt: Decorator, attr_map: Dict[str, Attribute]) -> None:
 
 
 def _attribute_from_auto_attrib(
-    ctx: "mypy.plugin.ClassDefContext",
+    ctx: mypy.plugin.ClassDefContext,
     kw_only: bool,
     lhs: NameExpr,
     rvalue: Expression,
@@ -541,7 +541,7 @@ def _attribute_from_auto_attrib(
 
 
 def _attribute_from_attrib_maker(
-    ctx: "mypy.plugin.ClassDefContext",
+    ctx: mypy.plugin.ClassDefContext,
     auto_attribs: bool,
     kw_only: bool,
     lhs: NameExpr,
@@ -608,7 +608,7 @@ def _attribute_from_attrib_maker(
 
 
 def _parse_converter(
-    ctx: "mypy.plugin.ClassDefContext", converter_expr: Optional[Expression]
+    ctx: mypy.plugin.ClassDefContext, converter_expr: Optional[Expression]
 ) -> Optional[Converter]:
     """Return the Converter object from an Expression."""
     # TODO: Support complex converters, e.g. lambdas, calls, etc.
@@ -709,7 +709,7 @@ def _parse_assignments(
     return lvalues, rvalues
 
 
-def _add_order(ctx: "mypy.plugin.ClassDefContext", adder: "MethodAdder") -> None:
+def _add_order(ctx: mypy.plugin.ClassDefContext, adder: MethodAdder) -> None:
     """Generate all the ordering methods for this class."""
     bool_type = ctx.api.named_type("builtins.bool")
     object_type = ctx.api.named_type("builtins.object")
@@ -730,7 +730,7 @@ def _add_order(ctx: "mypy.plugin.ClassDefContext", adder: "MethodAdder") -> None
         adder.add_method(method, args, bool_type, self_type=tvd, tvd=tvd)
 
 
-def _make_frozen(ctx: "mypy.plugin.ClassDefContext", attributes: List[Attribute]) -> None:
+def _make_frozen(ctx: mypy.plugin.ClassDefContext, attributes: List[Attribute]) -> None:
     """Turn all the attributes into properties to simulate frozen classes."""
     for attribute in attributes:
         if attribute.name in ctx.cls.info.names:
@@ -749,7 +749,7 @@ def _make_frozen(ctx: "mypy.plugin.ClassDefContext", attributes: List[Attribute]
 
 
 def _add_init(
-    ctx: "mypy.plugin.ClassDefContext", attributes: List[Attribute], adder: "MethodAdder"
+    ctx: mypy.plugin.ClassDefContext, attributes: List[Attribute], adder: MethodAdder
 ) -> None:
     """Generate an __init__ method for the attributes and add it to the class."""
     # Convert attributes to arguments with kw_only arguments at the  end of
@@ -781,10 +781,10 @@ def _add_init(
 
 
 def _add_attrs_magic_attribute(
-    ctx: "mypy.plugin.ClassDefContext", attrs: "List[Tuple[str, Optional[Type]]]"
+    ctx: mypy.plugin.ClassDefContext, attrs: List[Tuple[str, Optional[Type]]]
 ) -> None:
     any_type = AnyType(TypeOfAny.explicit)
-    attributes_types: "List[Type]" = [
+    attributes_types: List[Type] = [
         ctx.api.named_type_or_none("attr.Attribute", [attr_type or any_type]) or any_type
         for _, attr_type in attrs
     ]
@@ -814,12 +814,12 @@ def _add_attrs_magic_attribute(
     )
 
 
-def _add_slots(ctx: "mypy.plugin.ClassDefContext", attributes: List[Attribute]) -> None:
+def _add_slots(ctx: mypy.plugin.ClassDefContext, attributes: List[Attribute]) -> None:
     # Unlike `@dataclasses.dataclass`, `__slots__` is rewritten here.
     ctx.cls.info.slots = {attr.name for attr in attributes}
 
 
-def _add_match_args(ctx: "mypy.plugin.ClassDefContext", attributes: List[Attribute]) -> None:
+def _add_match_args(ctx: mypy.plugin.ClassDefContext, attributes: List[Attribute]) -> None:
     if (
         "__match_args__" not in ctx.cls.info.names
         or ctx.cls.info.names["__match_args__"].plugin_generated
@@ -844,7 +844,7 @@ class MethodAdder:
 
     # TODO: Combine this with the code build_namedtuple_typeinfo to support both.
 
-    def __init__(self, ctx: "mypy.plugin.ClassDefContext") -> None:
+    def __init__(self, ctx: mypy.plugin.ClassDefContext) -> None:
         self.ctx = ctx
         self.self_type = fill_typevars(ctx.cls.info)
 

--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -26,7 +26,7 @@ from mypy.types import (
 
 
 def _find_simplecdata_base_arg(
-    tp: Instance, api: "mypy.plugin.CheckerPluginInterface"
+    tp: Instance, api: mypy.plugin.CheckerPluginInterface
 ) -> Optional[ProperType]:
     """Try to find a parametrized _SimpleCData in tp's bases and return its single type argument.
 
@@ -42,7 +42,7 @@ def _find_simplecdata_base_arg(
     return None
 
 
-def _autoconvertible_to_cdata(tp: Type, api: "mypy.plugin.CheckerPluginInterface") -> Type:
+def _autoconvertible_to_cdata(tp: Type, api: mypy.plugin.CheckerPluginInterface) -> Type:
     """Get a type that is compatible with all types that can be implicitly converted to the given
     CData type.
 
@@ -110,7 +110,7 @@ def _get_array_element_type(tp: Type) -> Optional[ProperType]:
     return None
 
 
-def array_constructor_callback(ctx: "mypy.plugin.FunctionContext") -> Type:
+def array_constructor_callback(ctx: mypy.plugin.FunctionContext) -> Type:
     """Callback to provide an accurate signature for the ctypes.Array constructor."""
     # Extract the element type from the constructor's return type, i. e. the type of the array
     # being constructed.
@@ -144,7 +144,7 @@ def array_constructor_callback(ctx: "mypy.plugin.FunctionContext") -> Type:
     return ctx.default_return_type
 
 
-def array_getitem_callback(ctx: "mypy.plugin.MethodContext") -> Type:
+def array_getitem_callback(ctx: mypy.plugin.MethodContext) -> Type:
     """Callback to provide an accurate return type for ctypes.Array.__getitem__."""
     et = _get_array_element_type(ctx.type)
     if et is not None:
@@ -164,7 +164,7 @@ def array_getitem_callback(ctx: "mypy.plugin.MethodContext") -> Type:
     return ctx.default_return_type
 
 
-def array_setitem_callback(ctx: "mypy.plugin.MethodSigContext") -> CallableType:
+def array_setitem_callback(ctx: mypy.plugin.MethodSigContext) -> CallableType:
     """Callback to provide an accurate signature for ctypes.Array.__setitem__."""
     et = _get_array_element_type(ctx.type)
     if et is not None:
@@ -186,7 +186,7 @@ def array_setitem_callback(ctx: "mypy.plugin.MethodSigContext") -> CallableType:
     return ctx.default_signature
 
 
-def array_iter_callback(ctx: "mypy.plugin.MethodContext") -> Type:
+def array_iter_callback(ctx: mypy.plugin.MethodContext) -> Type:
     """Callback to provide an accurate return type for ctypes.Array.__iter__."""
     et = _get_array_element_type(ctx.type)
     if et is not None:
@@ -195,7 +195,7 @@ def array_iter_callback(ctx: "mypy.plugin.MethodContext") -> Type:
     return ctx.default_return_type
 
 
-def array_value_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
+def array_value_callback(ctx: mypy.plugin.AttributeContext) -> Type:
     """Callback to provide an accurate type for ctypes.Array.value."""
     et = _get_array_element_type(ctx.type)
     if et is not None:
@@ -218,7 +218,7 @@ def array_value_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
     return ctx.default_attr_type
 
 
-def array_raw_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
+def array_raw_callback(ctx: mypy.plugin.AttributeContext) -> Type:
     """Callback to provide an accurate type for ctypes.Array.raw."""
     et = _get_array_element_type(ctx.type)
     if et is not None:

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -115,7 +115,7 @@ class DataclassAttribute:
     @classmethod
     def deserialize(
         cls, info: TypeInfo, data: JsonDict, api: SemanticAnalyzerPluginInterface
-    ) -> "DataclassAttribute":
+    ) -> DataclassAttribute:
         data = data.copy()
         if data.get("kw_only") is None:
             data["kw_only"] = False

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -30,7 +30,7 @@ ENUM_VALUE_ACCESS: Final = {f"{prefix}.value" for prefix in ENUM_BASES} | {
 }
 
 
-def enum_name_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
+def enum_name_callback(ctx: mypy.plugin.AttributeContext) -> Type:
     """This plugin refines the 'name' attribute in enums to act as if
     they were declared to be final.
 
@@ -68,7 +68,7 @@ def _first(it: Iterable[_T]) -> Optional[_T]:
 
 
 def _infer_value_type_with_auto_fallback(
-    ctx: "mypy.plugin.AttributeContext", proper_type: Optional[ProperType]
+    ctx: mypy.plugin.AttributeContext, proper_type: Optional[ProperType]
 ) -> Optional[Type]:
     """Figure out the type of an enum value accounting for `auto()`.
 
@@ -117,7 +117,7 @@ def _implements_new(info: TypeInfo) -> bool:
     return type_with_new.fullname not in ("enum.Enum", "enum.IntEnum", "enum.StrEnum")
 
 
-def enum_value_callback(ctx: "mypy.plugin.AttributeContext") -> Type:
+def enum_value_callback(ctx: mypy.plugin.AttributeContext) -> Type:
     """This plugin refines the 'value' attribute in enums to refer to
     the original underlying value. For example, suppose we have the
     following:

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -220,7 +220,7 @@ class DependencyVisitor(TraverserVisitor):
         self,
         type_map: Dict[Expression, Type],
         python_version: Tuple[int, int],
-        alias_deps: "DefaultDict[str, Set[str]]",
+        alias_deps: DefaultDict[str, Set[str]],
         options: Optional[Options] = None,
     ) -> None:
         self.scope = Scope()

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -41,7 +41,7 @@ class DeleteFile(NamedTuple):
 FileOperation = Union[UpdateFile, DeleteFile]
 
 
-def parse_test_case(case: "DataDrivenTestCase") -> None:
+def parse_test_case(case: DataDrivenTestCase) -> None:
     """Parse and prepare a single case from suite with test case descriptions.
 
     This method is part of the setup phase, just before the test case is run.
@@ -216,7 +216,7 @@ class DataDrivenTestCase(pytest.Item):
     """Holds parsed data-driven test cases, and handles directory setup and teardown."""
 
     # Override parent member type
-    parent: "DataSuiteCollector"
+    parent: DataSuiteCollector
 
     input: List[str]
     output: List[str]  # Output for the first pass
@@ -244,8 +244,8 @@ class DataDrivenTestCase(pytest.Item):
 
     def __init__(
         self,
-        parent: "DataSuiteCollector",
-        suite: "DataSuite",
+        parent: DataSuiteCollector,
+        suite: DataSuite,
         file: str,
         name: str,
         writescache: bool,
@@ -583,7 +583,7 @@ def pytest_addoption(parser: Any) -> None:
 
 # This function name is special to pytest.  See
 # http://doc.pytest.org/en/latest/writing_plugins.html#collection-hooks
-def pytest_pycollect_makeitem(collector: Any, name: str, obj: object) -> "Optional[Any]":
+def pytest_pycollect_makeitem(collector: Any, name: str, obj: object) -> Optional[Any]:
     """Called by pytest on each object in modules configured in conftest.py files.
 
     collector is pytest.Collector, returns Optional[pytest.Class]
@@ -601,8 +601,8 @@ def pytest_pycollect_makeitem(collector: Any, name: str, obj: object) -> "Option
 
 
 def split_test_cases(
-    parent: "DataFileCollector", suite: "DataSuite", file: str
-) -> Iterator["DataDrivenTestCase"]:
+    parent: DataFileCollector, suite: DataSuite, file: str
+) -> Iterator[DataDrivenTestCase]:
     """Iterate over raw test cases in file, at collection time, ignoring sub items.
 
     The collection phase is slow, so any heavy processing should be deferred to after
@@ -654,7 +654,7 @@ def split_test_cases(
 
 
 class DataSuiteCollector(pytest.Class):
-    def collect(self) -> Iterator["DataFileCollector"]:
+    def collect(self) -> Iterator[DataFileCollector]:
         """Called by pytest on each of the object returned from pytest_pycollect_makeitem"""
 
         # obj is the object for which pytest_pycollect_makeitem returned self.
@@ -679,10 +679,10 @@ class DataFileCollector(pytest.Collector):
     @classmethod  # We have to fight with pytest here:
     def from_parent(  # type: ignore[override]
         cls, parent: DataSuiteCollector, *, name: str
-    ) -> "DataFileCollector":
+    ) -> DataFileCollector:
         return super().from_parent(parent, name=name)
 
-    def collect(self) -> Iterator["DataDrivenTestCase"]:
+    def collect(self) -> Iterator[DataDrivenTestCase]:
         yield from split_test_cases(
             parent=self,
             suite=self.parent.obj,

--- a/mypy/test/testipc.py
+++ b/mypy/test/testipc.py
@@ -12,7 +12,7 @@ from mypy.ipc import IPCClient, IPCServer
 CONNECTION_NAME = "dmypy-test-ipc"
 
 
-def server(msg: str, q: "Queue[str]") -> None:
+def server(msg: str, q: Queue[str]) -> None:
     server = IPCServer(CONNECTION_NAME)
     q.put(server.connection_name)
     data = b""

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -157,7 +157,7 @@ AnalysisDict = Dict[Tuple[BasicBlock, int], Set[T]]
 
 
 class AnalysisResult(Generic[T]):
-    def __init__(self, before: "AnalysisDict[T]", after: "AnalysisDict[T]") -> None:
+    def __init__(self, before: AnalysisDict[T], after: AnalysisDict[T]) -> None:
         self.before = before
         self.after = after
 

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -209,7 +209,7 @@ class Emitter:
         # Extra semicolon prevents an error when the next line declares a tempvar
         self.fragments.append(f"{text}: ;\n")
 
-    def emit_from_emitter(self, emitter: "Emitter") -> None:
+    def emit_from_emitter(self, emitter: Emitter) -> None:
         self.fragments.extend(emitter.fragments)
 
     def emit_printf(self, fmt: str, *args: str) -> None:

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -313,7 +313,7 @@ def generate_bin_op_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
 
 
 def generate_bin_op_forward_only_wrapper(
-    fn: FuncIR, emitter: Emitter, gen: "WrapperGenerator"
+    fn: FuncIR, emitter: Emitter, gen: WrapperGenerator
 ) -> None:
     gen.emit_arg_processing(error=GotoHandler("typefail"), raise_exception=False)
     gen.emit_call(not_implemented_handler="goto typefail;")
@@ -344,7 +344,7 @@ def generate_bin_op_forward_only_wrapper(
     gen.finish()
 
 
-def generate_bin_op_reverse_only_wrapper(emitter: Emitter, gen: "WrapperGenerator") -> None:
+def generate_bin_op_reverse_only_wrapper(emitter: Emitter, gen: WrapperGenerator) -> None:
     gen.arg_names = ["right", "left"]
     gen.emit_arg_processing(error=GotoHandler("typefail"), raise_exception=False)
     gen.emit_call()
@@ -356,7 +356,7 @@ def generate_bin_op_reverse_only_wrapper(emitter: Emitter, gen: "WrapperGenerato
 
 
 def generate_bin_op_both_wrappers(
-    cl: ClassIR, fn: FuncIR, fn_rev: FuncIR, emitter: Emitter, gen: "WrapperGenerator"
+    cl: ClassIR, fn: FuncIR, fn_rev: FuncIR, emitter: Emitter, gen: WrapperGenerator
 ) -> None:
     # There's both a forward and a reverse operator method. First
     # check if we should try calling the forward one. If the

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -197,7 +197,7 @@ class ClassIR:
     def fullname(self) -> str:
         return f"{self.module_name}.{self.name}"
 
-    def real_base(self) -> Optional["ClassIR"]:
+    def real_base(self) -> Optional[ClassIR]:
         """Return the actual concrete base class, if there is one."""
         if len(self.mro) > 1 and not self.mro[1].is_trait:
             return self.mro[1]
@@ -208,7 +208,7 @@ class ClassIR:
         assert name in self.vtable, f"{self.name!r} has no attribute {name!r}"
         return self.vtable[name]
 
-    def attr_details(self, name: str) -> Tuple[RType, "ClassIR"]:
+    def attr_details(self, name: str) -> Tuple[RType, ClassIR]:
         for ir in self.mro:
             if name in ir.attributes:
                 return ir.attributes[name], ir
@@ -274,7 +274,7 @@ class ClassIR:
     def struct_name(self, names: NameGenerator) -> str:
         return f"{exported_name(self.fullname)}Object"
 
-    def get_method_and_class(self, name: str) -> Optional[Tuple[FuncIR, "ClassIR"]]:
+    def get_method_and_class(self, name: str) -> Optional[Tuple[FuncIR, ClassIR]]:
         for ir in self.mro:
             if name in ir.methods:
                 return ir.methods[name], ir
@@ -285,7 +285,7 @@ class ClassIR:
         res = self.get_method_and_class(name)
         return res[0] if res else None
 
-    def subclasses(self) -> Optional[Set["ClassIR"]]:
+    def subclasses(self) -> Optional[Set[ClassIR]]:
         """Return all subclasses of this class, both direct and indirect.
 
         Return None if it is impossible to identify all subclasses, for example
@@ -302,7 +302,7 @@ class ClassIR:
                 result.update(child_subs)
         return result
 
-    def concrete_subclasses(self) -> Optional[List["ClassIR"]]:
+    def concrete_subclasses(self) -> Optional[List[ClassIR]]:
         """Return all concrete (i.e. non-trait and non-abstract) subclasses.
 
         Include both direct and indirect subclasses. Place classes with no children first.
@@ -373,7 +373,7 @@ class ClassIR:
         }
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: "DeserMaps") -> "ClassIR":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> ClassIR:
         fullname = data["module_name"] + "." + data["name"]
         assert fullname in ctx.classes, "Class %s not in deser class map" % fullname
         ir = ctx.classes[fullname]
@@ -453,7 +453,7 @@ def serialize_vtable(vtable: VTableEntries) -> List[JsonDict]:
     return [serialize_vtable_entry(v) for v in vtable]
 
 
-def deserialize_vtable_entry(data: JsonDict, ctx: "DeserMaps") -> VTableMethod:
+def deserialize_vtable_entry(data: JsonDict, ctx: DeserMaps) -> VTableMethod:
     if data[".class"] == "VTableMethod":
         return VTableMethod(
             ctx.classes[data["cls"]],
@@ -464,7 +464,7 @@ def deserialize_vtable_entry(data: JsonDict, ctx: "DeserMaps") -> VTableMethod:
     assert False, "Bogus vtable .class: %s" % data[".class"]
 
 
-def deserialize_vtable(data: List[JsonDict], ctx: "DeserMaps") -> VTableEntries:
+def deserialize_vtable(data: List[JsonDict], ctx: DeserMaps) -> VTableEntries:
     return [deserialize_vtable_entry(x, ctx) for x in data]
 
 

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -53,7 +53,7 @@ class RuntimeArg:
         }
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> "RuntimeArg":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> RuntimeArg:
         return RuntimeArg(
             data["name"],
             deserialize_type(data["type"], ctx),
@@ -78,7 +78,7 @@ class FuncSignature:
         return {"args": [t.serialize() for t in self.args], "ret_type": self.ret_type.serialize()}
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> "FuncSignature":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> FuncSignature:
         return FuncSignature(
             [RuntimeArg.deserialize(arg, ctx) for arg in data["args"]],
             deserialize_type(data["ret_type"], ctx),
@@ -177,7 +177,7 @@ class FuncDecl:
         return get_id_from_name(decl["name"], fullname, func_ir["line"])
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> "FuncDecl":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> FuncDecl:
         return FuncDecl(
             data["name"],
             data["class_name"],
@@ -265,7 +265,7 @@ class FuncIR:
         }
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> "FuncIR":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> FuncIR:
         return FuncIR(
             FuncDecl.deserialize(data["decl"], ctx), [], [], data["line"], data["traceback_name"]
         )

--- a/mypyc/ir/module_ir.py
+++ b/mypyc/ir/module_ir.py
@@ -38,7 +38,7 @@ class ModuleIR:
         }
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> "ModuleIR":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> ModuleIR:
         return ModuleIR(
             data["fullname"],
             data["imports"],

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -102,7 +102,7 @@ class BasicBlock:
         return bool(self.ops) and isinstance(self.ops[-1], ControlOp)
 
     @property
-    def terminator(self) -> "ControlOp":
+    def terminator(self) -> ControlOp:
         """The terminator operation of the block."""
         assert bool(self.ops) and isinstance(self.ops[-1], ControlOp)
         return self.ops[-1]
@@ -239,7 +239,7 @@ class Op(Value):
         return result
 
     @abstractmethod
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         pass
 
 
@@ -266,7 +266,7 @@ class Assign(BaseAssign):
     def stolen(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_assign(self)
 
 
@@ -296,7 +296,7 @@ class AssignMulti(BaseAssign):
     def stolen(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_assign_multi(self)
 
 
@@ -334,7 +334,7 @@ class Goto(ControlOp):
     def sources(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_goto(self)
 
 
@@ -397,7 +397,7 @@ class Branch(ControlOp):
     def invert(self) -> None:
         self.negated = not self.negated
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_branch(self)
 
 
@@ -416,7 +416,7 @@ class Return(ControlOp):
     def stolen(self) -> List[Value]:
         return [self.value]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_return(self)
 
 
@@ -444,7 +444,7 @@ class Unreachable(ControlOp):
     def sources(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_unreachable(self)
 
 
@@ -486,7 +486,7 @@ class IncRef(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_inc_ref(self)
 
 
@@ -511,7 +511,7 @@ class DecRef(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_dec_ref(self)
 
 
@@ -521,7 +521,7 @@ class Call(RegisterOp):
     The call target can be a module-level function or a class.
     """
 
-    def __init__(self, fn: "FuncDecl", args: Sequence[Value], line: int) -> None:
+    def __init__(self, fn: FuncDecl, args: Sequence[Value], line: int) -> None:
         self.fn = fn
         self.args = list(args)
         assert len(self.args) == len(fn.sig.args)
@@ -536,7 +536,7 @@ class Call(RegisterOp):
     def sources(self) -> List[Value]:
         return list(self.args[:])
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_call(self)
 
 
@@ -564,7 +564,7 @@ class MethodCall(RegisterOp):
     def sources(self) -> List[Value]:
         return self.args[:] + [self.obj]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_method_call(self)
 
 
@@ -591,7 +591,7 @@ class LoadErrorValue(RegisterOp):
     def sources(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_load_error_value(self)
 
 
@@ -627,7 +627,7 @@ class LoadLiteral(RegisterOp):
     def sources(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_load_literal(self)
 
 
@@ -651,7 +651,7 @@ class GetAttr(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.obj]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_get_attr(self)
 
 
@@ -686,7 +686,7 @@ class SetAttr(RegisterOp):
     def stolen(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_set_attr(self)
 
 
@@ -733,7 +733,7 @@ class LoadStatic(RegisterOp):
     def sources(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_load_static(self)
 
 
@@ -762,7 +762,7 @@ class InitStatic(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.value]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_init_static(self)
 
 
@@ -788,7 +788,7 @@ class TupleSet(RegisterOp):
     def sources(self) -> List[Value]:
         return self.items[:]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_tuple_set(self)
 
 
@@ -808,7 +808,7 @@ class TupleGet(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_tuple_get(self)
 
 
@@ -836,7 +836,7 @@ class Cast(RegisterOp):
             return []
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_cast(self)
 
 
@@ -867,7 +867,7 @@ class Box(RegisterOp):
     def stolen(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_box(self)
 
 
@@ -890,7 +890,7 @@ class Unbox(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_unbox(self)
 
 
@@ -921,7 +921,7 @@ class RaiseStandardError(RegisterOp):
     def sources(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_raise_standard_error(self)
 
 
@@ -968,7 +968,7 @@ class CallC(RegisterOp):
         else:
             return [] if not self.steals else self.sources()
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_call_c(self)
 
 
@@ -995,7 +995,7 @@ class Truncate(RegisterOp):
     def stolen(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_truncate(self)
 
 
@@ -1026,7 +1026,7 @@ class Extend(RegisterOp):
     def stolen(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_extend(self)
 
 
@@ -1050,7 +1050,7 @@ class LoadGlobal(RegisterOp):
     def sources(self) -> List[Value]:
         return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_load_global(self)
 
 
@@ -1106,7 +1106,7 @@ class IntOp(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.lhs, self.rhs]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_int_op(self)
 
 
@@ -1168,7 +1168,7 @@ class ComparisonOp(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.lhs, self.rhs]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_comparison_op(self)
 
 
@@ -1194,7 +1194,7 @@ class LoadMem(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_load_mem(self)
 
 
@@ -1222,7 +1222,7 @@ class SetMem(Op):
     def stolen(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_set_mem(self)
 
 
@@ -1245,7 +1245,7 @@ class GetElementPtr(RegisterOp):
     def sources(self) -> List[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_get_element_ptr(self)
 
 
@@ -1272,7 +1272,7 @@ class LoadAddress(RegisterOp):
         else:
             return []
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_load_address(self)
 
 
@@ -1303,7 +1303,7 @@ class KeepAlive(RegisterOp):
     def sources(self) -> List[Value]:
         return self.src[:]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_keep_alive(self)
 
 

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -63,7 +63,7 @@ class RType:
     error_overlap = False
 
     @abstractmethod
-    def accept(self, visitor: "RTypeVisitor[T]") -> T:
+    def accept(self, visitor: RTypeVisitor[T]) -> T:
         raise NotImplementedError
 
     def short_name(self) -> str:
@@ -79,7 +79,7 @@ class RType:
         raise NotImplementedError(f"Cannot serialize {self.__class__.__name__} instance")
 
 
-def deserialize_type(data: Union[JsonDict, str], ctx: "DeserMaps") -> "RType":
+def deserialize_type(data: Union[JsonDict, str], ctx: DeserMaps) -> RType:
     """Deserialize a JSON-serialized RType.
 
     Arguments:
@@ -109,31 +109,31 @@ class RTypeVisitor(Generic[T]):
     """Generic visitor over RTypes (uses the visitor design pattern)."""
 
     @abstractmethod
-    def visit_rprimitive(self, typ: "RPrimitive") -> T:
+    def visit_rprimitive(self, typ: RPrimitive) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rinstance(self, typ: "RInstance") -> T:
+    def visit_rinstance(self, typ: RInstance) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_runion(self, typ: "RUnion") -> T:
+    def visit_runion(self, typ: RUnion) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rtuple(self, typ: "RTuple") -> T:
+    def visit_rtuple(self, typ: RTuple) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rstruct(self, typ: "RStruct") -> T:
+    def visit_rstruct(self, typ: RStruct) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rarray(self, typ: "RArray") -> T:
+    def visit_rarray(self, typ: RArray) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rvoid(self, typ: "RVoid") -> T:
+    def visit_rvoid(self, typ: RVoid) -> T:
         raise NotImplementedError
 
 
@@ -148,7 +148,7 @@ class RVoid(RType):
     name = "void"
     ctype = "void"
 
-    def accept(self, visitor: "RTypeVisitor[T]") -> T:
+    def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rvoid(self)
 
     def serialize(self) -> str:
@@ -180,7 +180,7 @@ class RPrimitive(RType):
     """
 
     # Map from primitive names to primitive types and is used by deserialization
-    primitive_map: ClassVar[Dict[str, "RPrimitive"]] = {}
+    primitive_map: ClassVar[Dict[str, RPrimitive]] = {}
 
     def __init__(
         self,
@@ -224,7 +224,7 @@ class RPrimitive(RType):
         else:
             assert False, "Unrecognized ctype: %r" % ctype
 
-    def accept(self, visitor: "RTypeVisitor[T]") -> T:
+    def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rprimitive(self)
 
     def serialize(self) -> str:
@@ -509,13 +509,13 @@ def is_sequence_rprimitive(rtype: RType) -> bool:
 class TupleNameVisitor(RTypeVisitor[str]):
     """Produce a tuple name based on the concrete representations of types."""
 
-    def visit_rinstance(self, t: "RInstance") -> str:
+    def visit_rinstance(self, t: RInstance) -> str:
         return "O"
 
-    def visit_runion(self, t: "RUnion") -> str:
+    def visit_runion(self, t: RUnion) -> str:
         return "O"
 
-    def visit_rprimitive(self, t: "RPrimitive") -> str:
+    def visit_rprimitive(self, t: RPrimitive) -> str:
         if t._ctype == "CPyTagged":
             return "I"
         elif t._ctype == "char":
@@ -527,17 +527,17 @@ class TupleNameVisitor(RTypeVisitor[str]):
         assert not t.is_unboxed, f"{t} unexpected unboxed type"
         return "O"
 
-    def visit_rtuple(self, t: "RTuple") -> str:
+    def visit_rtuple(self, t: RTuple) -> str:
         parts = [elem.accept(self) for elem in t.types]
         return "T{}{}".format(len(parts), "".join(parts))
 
-    def visit_rstruct(self, t: "RStruct") -> str:
+    def visit_rstruct(self, t: RStruct) -> str:
         assert False, "RStruct not supported in tuple"
 
-    def visit_rarray(self, t: "RArray") -> str:
+    def visit_rarray(self, t: RArray) -> str:
         assert False, "RArray not supported in tuple"
 
-    def visit_rvoid(self, t: "RVoid") -> str:
+    def visit_rvoid(self, t: RVoid) -> str:
         assert False, "rvoid in tuple?"
 
 
@@ -570,7 +570,7 @@ class RTuple(RType):
         self.struct_name = f"tuple_{self.unique_id}"
         self._ctype = f"{self.struct_name}"
 
-    def accept(self, visitor: "RTypeVisitor[T]") -> T:
+    def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rtuple(self)
 
     def __str__(self) -> str:
@@ -590,7 +590,7 @@ class RTuple(RType):
         return {".class": "RTuple", "types": types}
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: "DeserMaps") -> "RTuple":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> RTuple:
         types = [deserialize_type(t, ctx) for t in data["types"]]
         return RTuple(types)
 
@@ -691,7 +691,7 @@ class RStruct(RType):
         self.offsets, self.size = compute_aligned_offsets_and_size(types)
         self._ctype = name
 
-    def accept(self, visitor: "RTypeVisitor[T]") -> T:
+    def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rstruct(self)
 
     def __str__(self) -> str:
@@ -722,7 +722,7 @@ class RStruct(RType):
         assert False
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: "DeserMaps") -> "RStruct":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> RStruct:
         assert False
 
 
@@ -744,14 +744,14 @@ class RInstance(RType):
 
     is_unboxed = False
 
-    def __init__(self, class_ir: "ClassIR") -> None:
+    def __init__(self, class_ir: ClassIR) -> None:
         # name is used for formatting the name in messages and debug output
         # so we want the fullname for precision.
         self.name = class_ir.fullname
         self.class_ir = class_ir
         self._ctype = "PyObject *"
 
-    def accept(self, visitor: "RTypeVisitor[T]") -> T:
+    def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rinstance(self)
 
     def struct_name(self, names: NameGenerator) -> str:
@@ -793,7 +793,7 @@ class RUnion(RType):
         self.items_set = frozenset(items)
         self._ctype = "PyObject *"
 
-    def accept(self, visitor: "RTypeVisitor[T]") -> T:
+    def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_runion(self)
 
     def __repr__(self) -> str:
@@ -814,7 +814,7 @@ class RUnion(RType):
         return {".class": "RUnion", "types": types}
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: "DeserMaps") -> "RUnion":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> RUnion:
         types = [deserialize_type(t, ctx) for t in data["types"]]
         return RUnion(types)
 
@@ -850,7 +850,7 @@ class RArray(RType):
         self.length = length
         self.is_refcounted = False
 
-    def accept(self, visitor: "RTypeVisitor[T]") -> T:
+    def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rarray(self)
 
     def __str__(self) -> str:
@@ -873,7 +873,7 @@ class RArray(RType):
         assert False
 
     @classmethod
-    def deserialize(cls, data: JsonDict, ctx: "DeserMaps") -> "RArray":
+    def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> RArray:
         assert False
 
 

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1115,7 +1115,7 @@ class IRBuilder:
     def lookup(self, symbol: SymbolNode) -> SymbolTarget:
         return self.symtables[-1][symbol]
 
-    def add_local(self, symbol: SymbolNode, typ: RType, is_arg: bool = False) -> "Register":
+    def add_local(self, symbol: SymbolNode, typ: RType, is_arg: bool = False) -> Register:
         """Add register that represents a symbol to the symbol table.
 
         Args:

--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -64,12 +64,12 @@ class FuncInfo:
         return self.fitem.is_coroutine
 
     @property
-    def callable_class(self) -> "ImplicitClass":
+    def callable_class(self) -> ImplicitClass:
         assert self._callable_class is not None
         return self._callable_class
 
     @callable_class.setter
-    def callable_class(self, cls: "ImplicitClass") -> None:
+    def callable_class(self, cls: ImplicitClass) -> None:
         self._callable_class = cls
 
     @property
@@ -82,12 +82,12 @@ class FuncInfo:
         self._env_class = ir
 
     @property
-    def generator_class(self) -> "GeneratorClass":
+    def generator_class(self) -> GeneratorClass:
         assert self._generator_class is not None
         return self._generator_class
 
     @generator_class.setter
-    def generator_class(self, cls: "GeneratorClass") -> None:
+    def generator_class(self, cls: GeneratorClass) -> None:
         self._generator_class = cls
 
     @property

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -320,7 +320,7 @@ def make_for_loop_generator(
     loop_exit: BasicBlock,
     line: int,
     nested: bool = False,
-) -> "ForGenerator":
+) -> ForGenerator:
     """Return helper object for generating a for loop over an iterable.
 
     If "nested" is True, this is a nested iterator such as "e" in "enumerate(e)".

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -111,7 +111,7 @@ def is_from_module(node: SymbolNode, module: MypyFile) -> bool:
     return node.fullname == module.fullname + "." + node.name
 
 
-def load_type_map(mapper: "Mapper", modules: List[MypyFile], deser_ctx: DeserMaps) -> None:
+def load_type_map(mapper: Mapper, modules: List[MypyFile], deser_ctx: DeserMaps) -> None:
     """Populate a Mapper with deserialized IR from a list of modules."""
     for module in modules:
         for name, node in module.names.items():

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -84,7 +84,7 @@ specializers: Dict[Tuple[str, Optional[RType]], List[Specializer]] = {}
 
 
 def _apply_specialization(
-    builder: "IRBuilder",
+    builder: IRBuilder,
     expr: CallExpr,
     callee: RefExpr,
     name: Optional[str],
@@ -104,14 +104,14 @@ def _apply_specialization(
 
 
 def apply_function_specialization(
-    builder: "IRBuilder", expr: CallExpr, callee: RefExpr
+    builder: IRBuilder, expr: CallExpr, callee: RefExpr
 ) -> Optional[Value]:
     """Invoke the Specializer callback for a function if one has been registered"""
     return _apply_specialization(builder, expr, callee, callee.fullname)
 
 
 def apply_method_specialization(
-    builder: "IRBuilder", expr: CallExpr, callee: MemberExpr, typ: Optional[RType] = None
+    builder: IRBuilder, expr: CallExpr, callee: MemberExpr, typ: Optional[RType] = None
 ) -> Optional[Value]:
     """Invoke the Specializer callback for a method if one has been registered"""
     name = callee.fullname if typ is None else callee.name

--- a/mypyc/transform/refcount.py
+++ b/mypyc/transform/refcount.py
@@ -92,7 +92,7 @@ def is_maybe_undefined(post_must_defined: Set[Value], src: Value) -> bool:
 
 
 def maybe_append_dec_ref(
-    ops: List[Op], dest: Value, defined: "AnalysisDict[Value]", key: Tuple[BasicBlock, int]
+    ops: List[Op], dest: Value, defined: AnalysisDict[Value], key: Tuple[BasicBlock, int]
 ) -> None:
     if dest.type.is_refcounted and not isinstance(dest, Integer):
         ops.append(DecRef(dest, is_xdec=is_maybe_undefined(defined[key], dest)))
@@ -105,10 +105,10 @@ def maybe_append_inc_ref(ops: List[Op], dest: Value) -> None:
 
 def transform_block(
     block: BasicBlock,
-    pre_live: "AnalysisDict[Value]",
-    post_live: "AnalysisDict[Value]",
-    pre_borrow: "AnalysisDict[Value]",
-    post_must_defined: "AnalysisDict[Value]",
+    pre_live: AnalysisDict[Value],
+    post_live: AnalysisDict[Value],
+    pre_borrow: AnalysisDict[Value],
+    post_must_defined: AnalysisDict[Value],
 ) -> None:
     old_ops = block.ops
     ops: List[Op] = []
@@ -158,10 +158,10 @@ def insert_branch_inc_and_decrefs(
     block: BasicBlock,
     cache: BlockCache,
     blocks: List[BasicBlock],
-    pre_live: "AnalysisDict[Value]",
-    pre_borrow: "AnalysisDict[Value]",
-    post_borrow: "AnalysisDict[Value]",
-    post_must_defined: "AnalysisDict[Value]",
+    pre_live: AnalysisDict[Value],
+    pre_borrow: AnalysisDict[Value],
+    post_borrow: AnalysisDict[Value],
+    post_must_defined: AnalysisDict[Value],
     ordering: Dict[Value, int],
 ) -> None:
     """Insert inc_refs and/or dec_refs after a branch/goto.
@@ -206,7 +206,7 @@ def insert_branch_inc_and_decrefs(
 
 def after_branch_decrefs(
     label: BasicBlock,
-    pre_live: "AnalysisDict[Value]",
+    pre_live: AnalysisDict[Value],
     source_defined: Set[Value],
     source_borrowed: Set[Value],
     source_live_regs: Set[Value],
@@ -226,8 +226,8 @@ def after_branch_decrefs(
 
 def after_branch_increfs(
     label: BasicBlock,
-    pre_live: "AnalysisDict[Value]",
-    pre_borrow: "AnalysisDict[Value]",
+    pre_live: AnalysisDict[Value],
+    pre_borrow: AnalysisDict[Value],
     source_borrowed: Set[Value],
     ordering: Dict[Value, int],
 ) -> Tuple[Value, ...]:

--- a/mypyc/transform/uninit.py
+++ b/mypyc/transform/uninit.py
@@ -34,7 +34,7 @@ def insert_uninit_checks(ir: FuncIR) -> None:
 
 
 def split_blocks_at_uninits(
-    blocks: List[BasicBlock], pre_must_defined: "AnalysisDict[Value]"
+    blocks: List[BasicBlock], pre_must_defined: AnalysisDict[Value]
 ) -> List[BasicBlock]:
     new_blocks: List[BasicBlock] = []
 


### PR DESCRIPTION
### Description
With #13391 (adding `from __future__ import annotations` everywhere), it's now possible to remove the quotes from annotations. Change generated with `pyupgrade` and excluding unrelated changes.