### PR TITLE
Enable support for decorated properties where possible

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4310,6 +4310,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         e.var.type = sig
         e.var.is_ready = True
         if e.func.is_property:
+            if isinstance(sig, CallableType):
+                if len([k for k in sig.arg_kinds if k.is_required()]) > 1:
+                    self.msg.fail("Too many arguments for @property", e)
             self.check_incompatible_property_override(e)
         if e.func.info and not e.func.is_dynamic():
             self.check_method_override(e)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4312,7 +4312,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if e.func.is_property:
             if isinstance(sig, CallableType):
                 if len([k for k in sig.arg_kinds if k.is_required()]) > 1:
-                    self.msg.fail("Too many arguments for @property", e)
+                    self.msg.fail("Too many arguments for property", e)
             self.check_incompatible_property_override(e)
         if e.func.info and not e.func.is_dynamic():
             self.check_method_override(e)

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -1030,3 +1030,23 @@ def deco(cls: Type[T]) -> Type[T]: ...
 class A(metaclass=ABCMeta):
     @abstractmethod
     def foo(self, x: int) -> None: ...
+
+[case testAbstractPropertiesAllowed]
+from abc import abstractmethod
+
+class B:
+    @property
+    @abstractmethod
+    def x(self) -> int: ...
+    @property
+    @abstractmethod
+    def y(self) -> int: ...
+    @y.setter
+    @abstractmethod
+    def y(self, value: int) -> None: ...
+
+B()  # E: Cannot instantiate abstract class "B" with abstract attributes "x" and "y"
+b: B
+b.x = 1  # E: Property "x" defined in "B" is read-only
+b.y = 1
+[builtins fixtures/property.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7006,8 +7006,8 @@ class A:
     def y(self) -> int: ...
     @y.setter
     def y(self, value: int) -> None: ...
-    @dec
-    def y(self) -> None: ...  # TODO: This should generate an error
+    @dec  # E: Only supported top decorator is @y.setter
+    def y(self) -> None: ...
 
 reveal_type(A().y)  # N: Revealed type is "builtins.int"
 [builtins fixtures/property.pyi]
@@ -7044,7 +7044,7 @@ reveal_type(D1() + 0.5)  # N: Revealed type is "__main__.D1"
 [builtins fixtures/primitives.pyi]
 
 [case testRefMethodWithDecorator]
-from typing import Type
+from typing import Type, final
 
 class A:
     pass
@@ -7058,7 +7058,7 @@ class B:
         return A
 
 class C:
-    @property
+    @final
     @staticmethod
     def A() -> Type[A]:
         return A

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2589,3 +2589,88 @@ def a(b: any): pass # E: Function "builtins.any" is not valid as a type \
 def a(b: callable): pass # E: Function "builtins.callable" is not valid as a type \
                          # N: Perhaps you meant "typing.Callable" instead of "callable"?
 [builtins fixtures/callable.pyi]
+
+[case testDecoratedProperty]
+from typing import TypeVar, Callable, final
+
+T = TypeVar("T")
+
+def dec(f: Callable[[T], int]) -> Callable[[T], str]: ...
+def dec2(f: T) -> T: ...
+
+class A:
+    @property
+    @dec
+    def f(self) -> int: pass
+    @property
+    @dec2
+    def g(self) -> int: pass
+reveal_type(A().f)  # N: Revealed type is "builtins.str"
+reveal_type(A().g)  # N: Revealed type is "builtins.int"
+
+class B:
+    @final
+    @property
+    @dec
+    def f(self) -> int: pass
+reveal_type(B().f)  # N: Revealed type is "builtins.str"
+
+class C:
+    @property  # E: Only instance methods can be decorated with @property
+    @classmethod
+    def f(cls) -> int: pass
+reveal_type(C().f)  # N: Revealed type is "builtins.int"
+[builtins fixtures/property.pyi]
+[out]
+
+[case testDecoratedPropertySetter]
+from typing import TypeVar, Callable, final
+
+T = TypeVar("T")
+def dec(f: T) -> T: ...
+
+class A:
+    @property
+    @dec
+    def f(self) -> int: pass
+    @f.setter
+    @dec
+    def f(self, v: int) -> None: pass
+reveal_type(A().f)  # N: Revealed type is "builtins.int"
+
+class B:
+    @property
+    @dec
+    def f(self) -> int: pass
+    @dec # E: Only supported top decorator is @f.setter
+    @f.setter
+    def f(self, v: int) -> None: pass
+
+class C:
+    @dec  # E: Decorators on top of @property are not supported
+    @property
+    def f(self) -> int: pass
+    @f.setter
+    @dec
+    def f(self, v: int) -> None: pass
+[builtins fixtures/property.pyi]
+[out]
+
+[case testInvalidArgCountForProperty]
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+def dec(f: Callable[[T], int]) -> Callable[[T, int], int]: ...
+
+class A:
+    @property  # E: Too many arguments for @property
+    def f(self, x) -> int: pass
+    @property  # E: Too many arguments for @property
+    @dec
+    def e(self) -> int: pass
+    @property
+    def g() -> int: pass   # E: Method must have at least one argument
+    @property
+    def h(self, *args, **kwargs) -> int: pass   # OK
+[builtins fixtures/property.pyi]
+[out]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2663,9 +2663,9 @@ T = TypeVar("T")
 def dec(f: Callable[[T], int]) -> Callable[[T, int], int]: ...
 
 class A:
-    @property  # E: Too many arguments for @property
+    @property  # E: Too many arguments for property
     def f(self, x) -> int: pass
-    @property  # E: Too many arguments for @property
+    @property  # E: Too many arguments for property
     @dec
     def e(self) -> int: pass
     @property

--- a/test-data/unit/check-functools.test
+++ b/test-data/unit/check-functools.test
@@ -119,8 +119,8 @@ class Child(Parent):
     def f(self) -> str: pass
     @cached_property
     def g(self) -> int: pass
-    @cached_property
-    def h(self, arg) -> int: pass  # E: Too many arguments
+    @cached_property  # E: Too many arguments for property
+    def h(self, arg) -> int: pass
 reveal_type(Parent().f)  # N: Revealed type is "builtins.str"
 reveal_type(Child().f)  # N: Revealed type is "builtins.str"
 reveal_type(Child().g)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/fixtures/property.pyi
+++ b/test-data/unit/fixtures/property.pyi
@@ -11,6 +11,7 @@ class type:
 class function: pass
 
 property = object()  # Dummy definition
+class classmethod: pass
 
 class dict: pass
 class int: pass

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1205,23 +1205,13 @@ def f() -> int: pass
 [builtins fixtures/property.pyi]
 [out]
 
-[case testInvalidArgCountForProperty]
-import typing
-class A:
-    @property
-    def f(self, x) -> int: pass  # E: Too many arguments
-    @property
-    def g() -> int: pass   # E: Method must have at least one argument
-[builtins fixtures/property.pyi]
-[out]
-
 [case testOverloadedProperty]
 from typing import overload
 class A:
-    @overload  # E: Decorated property not supported
+    @overload  # E: Decorators on top of @property are not supported
     @property
     def f(self) -> int: pass
-    @property  # E: Decorated property not supported
+    @property  # E: Only supported top decorator is @f.setter
     @overload
     def f(self) -> int: pass
 [builtins fixtures/property.pyi]
@@ -1232,7 +1222,7 @@ from typing import overload
 class A:
     @overload  # E: An overloaded function outside a stub file must have an implementation
     def f(self) -> int: pass
-    @property  # E: Decorated property not supported
+    @property  # E: An overload can not be a property
     @overload
     def f(self) -> int: pass
 [builtins fixtures/property.pyi]
@@ -1242,10 +1232,10 @@ class A:
 import typing
 def dec(f): pass
 class A:
-    @dec  # E: Decorated property not supported
+    @dec  # E: Decorators on top of @property are not supported
     @property
     def f(self) -> int: pass
-    @property  # E: Decorated property not supported
+    @property  # OK
     @dec
     def g(self) -> int: pass
 [builtins fixtures/property.pyi]


### PR DESCRIPTION
Fixes #1362

This is based on the original idea by @graingert. I delete the old cryptic error message and instead:
* Enable the situations that we can already handle (cover 95% of what was discussed in the issue)
* For the rest give more precise error messages