### PR TITLE
stubtest: fix broken error message for async/sync mismatch

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -862,7 +862,7 @@ def verify_funcitem(
         stub_sig = Signature.from_funcitem(stub)
         runtime_sig = Signature.from_inspect_signature(signature)
         runtime_sig_desc = f'{"async " if runtime_is_coroutine else ""}def {signature}'
-        stub_desc = f"def {stub_sig!r}"
+        stub_desc = str(stub_sig)
     else:
         runtime_sig_desc, stub_desc = None, None
 


### PR DESCRIPTION
For an example of how the error message here is currently broken, see https://github.com/python/typeshed/runs/7405140240?check_suite_focus=true