### PR TITLE
stubtest: ignore `__vectorcalloffset__`

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1204,6 +1204,7 @@ IGNORABLE_CLASS_DUNDERS = frozenset(
         "__hash__",
         "__getattr__",  # resulting behaviour might be typed explicitly
         "__setattr__",  # defining this on a class can cause worse type checking
+        "__vectorcalloffset__",  # undocumented implementation detail of the vectorcall protocol
         # isinstance/issubclass hooks that type-checkers don't usually care about
         "__instancecheck__",
         "__subclasshook__",


### PR DESCRIPTION
Typeshed currently has 6 allowlist entries relating to `__vectorcalloffset__` attributes in 3.10 and 3.11. I don't think there's value in adding any of these to the stub: as far as I can tell, it seems to be an undocumented, CPython-specific implementation detail of the [vectorcall protocol](https://peps.python.org/pep-0590/)