### PR TITLE
stubtest: don't error for a missing submodule if the submodule name is private

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -205,11 +205,7 @@ def test_module(module_name: str) -> Iterator[Error]:
     """
     stub = get_stub(module_name)
     if stub is None:
-        if "." in module_name:
-            last_part_of_module_name = module_name.split(".")[-1]
-        else:
-            last_part_of_module_name = module_name
-        if not is_probably_private(last_part_of_module_name):
+        if not is_probably_private(module_name.split(".")[-1]):
             runtime_desc = repr(sys.modules[module_name]) if module_name in sys.modules else "N/A"
             yield Error(
                 [module_name], "failed to find stubs", MISSING, None, runtime_desc=runtime_desc

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -205,10 +205,15 @@ def test_module(module_name: str) -> Iterator[Error]:
     """
     stub = get_stub(module_name)
     if stub is None:
-        runtime_desc = repr(sys.modules[module_name]) if module_name in sys.modules else "N/A"
-        yield Error(
-            [module_name], "failed to find stubs", MISSING, None, runtime_desc=runtime_desc
-        )
+        if "." in module_name:
+            last_part_of_module_name = module_name.split(".")[-1]
+        else:
+            last_part_of_module_name = module_name
+        if not is_probably_private(last_part_of_module_name):
+            runtime_desc = repr(sys.modules[module_name]) if module_name in sys.modules else "N/A"
+            yield Error(
+                [module_name], "failed to find stubs", MISSING, None, runtime_desc=runtime_desc
+            )
         return
 
     try:
@@ -1441,7 +1446,7 @@ def build_stubs(modules: List[str], options: Options, find_submodules: bool = Fa
                 all_modules.extend(
                     m.name
                     for m in pkgutil.walk_packages(runtime.__path__, runtime.__name__ + ".")
-                    if m.name not in all_modules and not is_probably_private(m.name.split(".")[-1])
+                    if m.name not in all_modules
                 )
             except Exception:
                 pass

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1441,7 +1441,7 @@ def build_stubs(modules: List[str], options: Options, find_submodules: bool = Fa
                 all_modules.extend(
                     m.name
                     for m in pkgutil.walk_packages(runtime.__path__, runtime.__name__ + ".")
-                    if m.name not in all_modules
+                    if m.name not in all_modules and not is_probably_private(m.name.split('.')[-1])
                 )
             except Exception:
                 pass

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1441,7 +1441,7 @@ def build_stubs(modules: List[str], options: Options, find_submodules: bool = Fa
                 all_modules.extend(
                     m.name
                     for m in pkgutil.walk_packages(runtime.__path__, runtime.__name__ + ".")
-                    if m.name not in all_modules and not is_probably_private(m.name.split('.')[-1])
+                    if m.name not in all_modules and not is_probably_private(m.name.split(".")[-1])
                 )
             except Exception:
                 pass


### PR DESCRIPTION
If a module name is private, the contents of that module are likely considered implementation details by the package author. Sometimes we want to include these implementation details in a stub, and sometimes we don't, but in my opinion stubtest probably shouldn't error for these submodules being missing from the stub. This is in keeping with stubtest's approach for class and module attributes, where it generally doesn't emit an error if the attribute name is private.