### PR TITLE
Don't skip magic-trailing-comma [black]

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -175,7 +175,7 @@ from mypy.visitor import ExpressionVisitor
 # Type of callback user for checking individual function arguments. See
 # check_args() below for details.
 ArgChecker: _TypeAlias = Callable[
-    [Type, Type, ArgKind, Type, int, int, CallableType, Optional[Type], Context, Context], None,
+    [Type, Type, ArgKind, Type, int, int, CallableType, Optional[Type], Context, Context], None
 ]
 
 # Maximum nesting level for math union in overloads, setting this to large values

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -33,7 +33,13 @@ from mypy import defaults
 from mypy.options import PER_MODULE_OPTIONS, Options
 
 _CONFIG_VALUE_TYPES: _TypeAlias = Union[
-    str, bool, int, float, Dict[str, str], List[str], Tuple[int, int],
+    str,
+    bool,
+    int,
+    float,
+    Dict[str, str],
+    List[str],
+    Tuple[int, int],
 ]
 _INI_PARSER_CALLABLE: _TypeAlias = Callable[[Any], _CONFIG_VALUE_TYPES]
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2040,7 +2040,10 @@ class RevealExpr(Expression):
     local_nodes: Optional[List[Var]]
 
     def __init__(
-        self, kind: int, expr: Optional[Expression] = None, local_nodes: Optional[List[Var]] = None
+        self,
+        kind: int,
+        expr: Optional[Expression] = None,
+        local_nodes: Optional[List[Var]] = None,
     ) -> None:
         super().__init__()
         self.expr = expr

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -45,7 +45,7 @@ type_of_any_name_map: Final[collections.OrderedDict[int, str]] = collections.Ord
 )
 
 ReporterClasses: _TypeAlias = Dict[
-    str, Tuple[Callable[["Reports", str], "AbstractReporter"], bool],
+    str, Tuple[Callable[["Reports", str], "AbstractReporter"], bool]
 ]
 
 reporter_classes: Final[ReporterClasses] = {}

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -110,7 +110,10 @@ def cleanup_builtin_scc(state: State) -> None:
 
 
 def semantic_analysis_for_targets(
-    state: State, nodes: List[FineGrainedDeferredNode], graph: Graph, saved_attrs: SavedAttributes
+    state: State,
+    nodes: List[FineGrainedDeferredNode],
+    graph: Graph,
+    saved_attrs: SavedAttributes,
 ) -> None:
     """Semantically analyze only selected nodes in a given module.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 99
 target-version = ['py37']
-skip-magic-trailing-comma = true
 extend-exclude = '''
 ^/mypy/typeshed|
 ^/mypyc/test-data|


### PR DESCRIPTION
### Description
Follow up to discussion in https://github.com/python/mypy/pull/13412#issuecomment-1214707398

Remove black setting to `skip-maagic-trailing-comma` since in some instances it can result in better readable code. With the setting enabled, black will always choose the most compact function definition even if it isn't the best solution.
https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#the-magic-trailing-comma

Initial comment adding it: https://github.com/python/mypy/pull/12424#discussion_r926274300

## Test Plan
I've reapplied the changes suggested in https://github.com/python/mypy/pull/13412#pullrequestreview-1072120354 to show the impact of the setting change.