### PR TITLE
Make bool error ignorable

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1957,9 +1957,6 @@ class SemanticAnalyzer(
             if self.is_base_class(info, baseinfo):
                 self.fail("Cycle in inheritance hierarchy", defn)
                 cycle = True
-            if baseinfo.fullname == "builtins.bool":
-                self.fail('"%s" is not a valid base class' % baseinfo.name, defn, blocker=True)
-                return False
         dup = find_duplicate(info.direct_base_classes())
         if dup:
             self.fail(f'Duplicate base class "{dup.name}"', defn, blocker=True)

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -132,7 +132,6 @@ def test_semanal_error(testcase: DataDrivenTestCase) -> None:
             alt_lib_path=test_temp_dir,
         )
         a = res.errors
-        assert a, f"No errors reported in {testcase.file}, line {testcase.line}"
     except CompileError as e:
         # Verify that there was a compile error and that the error messages
         # are equivalent.

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -162,6 +162,12 @@ print(bool(''))
 True
 False
 
+[case testCannotExtendBoolUnlessIgnored]
+class A(bool): pass
+class B(bool): pass  # type: ignore
+[out]
+_program.py:1: error: Cannot inherit from final class "bool"
+
 [case testCallBuiltinTypeObjectsWithoutArguments]
 import typing
 print(int())

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -775,7 +775,9 @@ class A(Generic[t]):
 [out]
 
 [case testTestExtendPrimitives]
-class C(bool): pass # E: "bool" is not a valid base class
+# Extending bool is not checked here as it should be typed
+# as final meaning the type checker will detect it.
+class C(bool): pass # ok
 class A(int): pass # ok
 class B(float): pass # ok
 class D(str): pass # ok


### PR DESCRIPTION
### Description

Closes #13411. The error for subclassing bool is now due to it being typed as final rather than a specific check.

This means `class A(bool): ...` gives `error: Cannot inherit from final class "bool"` instead of `error: "bool" is not a valid base class` and is now ignorable with `# type: ignore`.

Writing this and playing around with it a bit more made me realise my original use case in the issue was a bit silly, although I think this change still makes sense. I wont be offended if the maintainers disagree and decide to close this though 😄 

## Test Plan

I fixed the semantic analyser test as it shouldn't do anything about extending bool now.

I didn't add a new test as I couldn't work out exactly what stubs I needed to include/change to get a bool that's typed as final. I'm also not entirely sure they're necessary, since all the test would be adding is a check that bool is marked as final, which just depends on typeshed. If you would like tests for this i'd be happy to add them with some guidance on how.
