### PR TITLE
CI: Add `workflow_dispatch` as a trigger for several workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Check documentation build
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, 'release*']
     tags: ['*']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, 'release*']
     tags: ['*']

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -1,6 +1,7 @@
 name: Test stubgenc on pybind11-mypy-demo
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, 'release*']
     tags: ['*']


### PR DESCRIPTION
Adding `workflow_dispatch` as a workflow trigger means that contributors are able to manually trigger workflow runs from their mypy forks on GitHub without having to open a PR first.