### PR TITLE
Allow unpacking from TypeVars with iterable bounds

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3168,6 +3168,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # TODO: maybe elsewhere; redundant.
         rvalue_type = get_proper_type(rv_type or self.expr_checker.accept(rvalue))
 
+        if isinstance(rvalue_type, TypeVarType):
+            rvalue_type = get_proper_type(rvalue_type.upper_bound)
+
         if isinstance(rvalue_type, UnionType):
             # If this is an Optional type in non-strict Optional code, unwrap it.
             relevant_items = rvalue_type.relevant_items()

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -215,3 +215,11 @@ if int():
     b = 'a' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 twice(a) # E: Value of type variable "T" of "twice" cannot be "int"
 [builtins fixtures/args.pyi]
+
+
+[case testIterableBoundUnpacking]
+from typing import Tuple, TypeVar
+TupleT = TypeVar("TupleT", bound=Tuple[int, ...])
+def f(t: TupleT) -> None:
+    a, *b = t
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-bound.test
+++ b/test-data/unit/check-bound.test
@@ -222,4 +222,6 @@ from typing import Tuple, TypeVar
 TupleT = TypeVar("TupleT", bound=Tuple[int, ...])
 def f(t: TupleT) -> None:
     a, *b = t
+    reveal_type(a)  # N: Revealed type is "builtins.int"
+    reveal_type(b)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typevar-unbound.test
+++ b/test-data/unit/check-typevar-unbound.test
@@ -58,3 +58,9 @@ def h(a: List[Union[Callable[..., T]]]) -> T:
 def j(a: List[Union[Callable[..., Tuple[T, T]], int]]) -> T:
     ...
 [builtins fixtures/tuple.pyi]
+
+[case testUnboundedTypevarUnpacking]
+from typing import TypeVar
+T = TypeVar("T")
+def f(t: T) -> None:
+    a, *b = t  # E: "object" object is not iterable


### PR DESCRIPTION
### Description

TypeVars aren't iterable, but their bounds might be! Resolve a TypeVar to its bounds before trying to decide how to unpack one of its instances. This allows unpacking from instances of TypeVars with iterable bounds, which otherwise fails.

Fixes #13402.

## Test Plan

Added a test for a minimal reproducer.