### PR TITLE
Add import Union to stub file (#12929)

### DIFF
--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -909,13 +909,13 @@ alias = Dict[str, List[str]]
 alias = Dict[str, List[str]]
 
 [case testDeepGenericTypeAliasPreserved]
-from typing import TypeVar
+from typing import List, TypeVar, Union
 
 T = TypeVar('T')
 alias = Union[T, List[T]]
 
 [out]
-from typing import TypeVar
+from typing import List, TypeVar, Union
 
 T = TypeVar('T')
 alias = Union[T, List[T]]

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -2705,3 +2705,28 @@ def f():
     return 0
 [out]
 def f(): ...
+
+[case testAddUnionImportForArgument]
+def foo(a: str | None):
+    pass
+[out]
+from typing import Union
+
+def foo(a: Union[str, None]): ...
+
+[case testAddUnionImportForReturn]
+def foo() -> str | None:
+    pass
+[out]
+from typing import Union
+
+def foo() -> Union[str, None]: ...
+
+[case testAddUnionImportForClassAttribute]
+class A:
+    a: int | str
+[out]
+from typing import Union
+
+class A:
+    a: Union[int, str]


### PR DESCRIPTION
Fixes #12929

Stubs generated from files with new format of Union typing will include importing Union from typing.

## Test Plan

I've added 3 new tests while making sure they pass locally.
