### PR TITLE
fix: incorrect type in `misc/test_case_to_actual.py:produce_chunks` test case

### DIFF
--- a/misc/test_case_to_actual.py
+++ b/misc/test_case_to_actual.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import os.path
 import sys
-from typing import Iterator, Optional
+from typing import Iterator
 
 
 class Chunk:

--- a/misc/test_case_to_actual.py
+++ b/misc/test_case_to_actual.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import os.path
 import sys
-from typing import Iterator
+from typing import Iterator, Optional
 
 
 class Chunk:
@@ -22,7 +22,7 @@ def normalize(lines: Iterator[str]) -> Iterator[str]:
 
 
 def produce_chunks(lines: Iterator[str]) -> Iterator[Chunk]:
-    current_chunk: Chunk = None
+    current_chunk: Optional[Chunk] = None
     for line in normalize(lines):
         if is_header(line):
             if current_chunk is not None:
@@ -30,7 +30,7 @@ def produce_chunks(lines: Iterator[str]) -> Iterator[Chunk]:
             parts = line[1:-1].split(" ", 1)
             args = parts[1] if len(parts) > 1 else ""
             current_chunk = Chunk(parts[0], args)
-        else:
+        elif current_chunk is not None:
             current_chunk.lines.append(line)
     if current_chunk is not None:
         yield current_chunk

--- a/misc/test_case_to_actual.py
+++ b/misc/test_case_to_actual.py
@@ -22,7 +22,7 @@ def normalize(lines: Iterator[str]) -> Iterator[str]:
 
 
 def produce_chunks(lines: Iterator[str]) -> Iterator[Chunk]:
-    current_chunk: Optional[Chunk] = None
+    current_chunk: Chunk | None = None
     for line in normalize(lines):
         if is_header(line):
             if current_chunk is not None:


### PR DESCRIPTION
### Description

This pull request updates the `produce_chunks` method which included an incorrectly annotated type. By updating this test, the intent is to provide greater type safety of the `produce_chunks` method. Technically, the use of `Iterator` could also be changed to a `Generator`, but this was not a true "error", but rather dependent on intent as I understood it.

## Test Plan

N/A
