### PR TITLE
refactor: use contextlib.suppress instead of `except Exception: pass`

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -533,7 +533,7 @@ def find_config_file_line_number(path: str, section: str, setting_name: str) -> 
     Return -1 if can't determine the line unambiguously.
     """
     in_desired_section = False
-    try:
+    with contextlib.suppress(OSError):
         results = []
         with open(path, encoding="UTF-8") as f:
             for i, line in enumerate(f):
@@ -545,8 +545,6 @@ def find_config_file_line_number(path: str, section: str, setting_name: str) -> 
                     results.append(i + 1)
         if len(results) == 1:
             return results[0]
-    except OSError:
-        pass
     return -1
 
 
@@ -1189,12 +1187,10 @@ def add_catch_all_gitignore(target_dir: str) -> None:
     No-op if the .gitignore already exists.
     """
     gitignore = os.path.join(target_dir, ".gitignore")
-    try:
+    with contextlib.suppress(FileExistsError):
         with open(gitignore, "x") as f:
             print("# Automatically created by mypy", file=f)
             print("*", file=f)
-    except FileExistsError:
-        pass
 
 
 def exclude_from_backups(target_dir: str) -> None:
@@ -1203,7 +1199,7 @@ def exclude_from_backups(target_dir: str) -> None:
     If the CACHEDIR.TAG file exists the function is a no-op.
     """
     cachedir_tag = os.path.join(target_dir, "CACHEDIR.TAG")
-    try:
+    with contextlib.suppress(FileExistsError):
         with open(cachedir_tag, "x") as f:
             f.write(
                 """Signature: 8a477f597d28d172789f06886806bc55
@@ -1211,8 +1207,6 @@ def exclude_from_backups(target_dir: str) -> None:
 # For information about cache directory tags see https://bford.info/cachedir/
 """
             )
-    except FileExistsError:
-        pass
 
 
 def create_metastore(options: Options) -> MetadataStore:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import itertools
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from typing import Callable, ClassVar, Iterator, List, Optional, Sequence, cast
 from typing_extensions import Final, TypeAlias as _TypeAlias, overload
 
@@ -415,9 +415,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             for typ in mypy.checker.flatten(e.args[1]):
                 node = None
                 if isinstance(typ, NameExpr):
-                    with suppress(KeyError):
-                        # Undefined names should already be reported in semantic analysis.
+                    try:
                         node = self.chk.lookup_qualified(typ.name)
+                    except KeyError:
+                        # Undefined names should already be reported in semantic analysis.
+                        pass
                 if is_expr_literal_type(typ):
                     self.msg.cannot_use_function_with_type(e.callee.name, "Literal", e)
                     continue

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import itertools
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import Callable, ClassVar, Iterator, List, Optional, Sequence, cast
 from typing_extensions import Final, TypeAlias as _TypeAlias, overload
 
@@ -415,11 +415,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             for typ in mypy.checker.flatten(e.args[1]):
                 node = None
                 if isinstance(typ, NameExpr):
-                    try:
-                        node = self.chk.lookup_qualified(typ.name)
-                    except KeyError:
+                    with suppress(KeyError):
                         # Undefined names should already be reported in semantic analysis.
-                        pass
+                        node = self.chk.lookup_qualified(typ.name)
                 if is_expr_literal_type(typ):
                     self.msg.cannot_use_function_with_type(e.callee.name, "Literal", e)
                     continue

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -14,6 +14,7 @@ import pickle
 import sys
 import time
 import traceback
+from contextlib import suppress
 from typing import Any, Callable, Mapping, NoReturn
 
 from mypy.dmypy_os import alive, kill
@@ -336,11 +337,9 @@ def do_restart(args: argparse.Namespace) -> None:
 
 def restart_server(args: argparse.Namespace, allow_sources: bool = False) -> None:
     """Restart daemon (it may or may not be running; but not hanging)."""
-    try:
+    with suppress(BadStatus):
+        # Suppressed: Bad or missing status file or dead process; good to start.
         do_stop(args)
-    except BadStatus:
-        # Bad or missing status file or dead process; good to start.
-        pass
     start_server(args, allow_sources)
 
 

--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -30,6 +30,7 @@ advantage of the benefits.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import stat
 
@@ -71,10 +72,8 @@ class FileSystemCache:
             st = os.stat(path)
         except OSError as err:
             if self.init_under_package_root(path):
-                try:
+                with contextlib.suppress(OSError):
                     return self._fake_init(path)
-                except OSError:
-                    pass
             # Take a copy to get rid of associated traceback and frame objects.
             # Just assigning to __traceback__ doesn't free them.
             self.stat_error_cache[path] = copy_os_error(err)

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -14,6 +14,7 @@ import binascii
 import os
 import time
 from abc import abstractmethod
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Iterable
 
 if TYPE_CHECKING:
@@ -153,10 +154,8 @@ def connect_db(db_file: str) -> sqlite3.Connection:
     db = sqlite3.dbapi2.connect(db_file)
     db.executescript(SCHEMA)
     for migr in MIGRATIONS:
-        try:
+        with suppress(sqlite3.OperationalError):
             db.executescript(migr)
-        except sqlite3.OperationalError:
-            pass
     return db
 
 

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -12,6 +12,7 @@ import time
 import tokenize
 import typing
 from abc import ABCMeta, abstractmethod
+from contextlib import suppress
 from operator import attrgetter
 from typing import Any, Callable, Dict, Iterator, Tuple, cast
 from typing_extensions import Final, TypeAlias as _TypeAlias
@@ -61,10 +62,8 @@ class Reports:
             self.add_report(report_type, report_dir)
 
     def add_report(self, report_type: str, report_dir: str) -> AbstractReporter:
-        try:
+        with suppress(KeyError):
             return self.named_reporters[report_type]
-        except KeyError:
-            pass
         reporter_cls, needs_lxml = reporter_classes[report_type]
         if needs_lxml and not LXML_INSTALLED:
             print(

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import types
 import weakref
 from collections.abc import Iterable
+from contextlib import suppress
 from typing import Iterator, Mapping
 from typing_extensions import Final
 
@@ -43,13 +44,11 @@ def get_edge_candidates(o: object) -> Iterator[tuple[object, object]]:
         return
     if type(o) not in COLLECTION_TYPE_BLACKLIST:
         for attr in dir(o):
-            try:
+            with suppress(AssertionError):
                 if attr not in ATTR_BLACKLIST and hasattr(o, attr) and not isproperty(o, attr):
                     e = getattr(o, attr)
                     if not type(e) in ATOMIC_TYPE_BLACKLIST:
                         yield attr, e
-            except AssertionError:
-                pass
     if isinstance(o, Mapping):
         yield from o.items()
     elif isinstance(o, Iterable) and not isinstance(o, str):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -21,7 +21,7 @@ import types
 import typing
 import typing_extensions
 import warnings
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout, suppress
 from functools import singledispatch
 from pathlib import Path
 from typing import Any, Generic, Iterator, TypeVar, Union, cast
@@ -1427,15 +1427,13 @@ def build_stubs(modules: list[str], options: Options, find_submodules: bool = Fa
             # find submodules via mypy
             all_modules.extend(s.module for s in found_sources if s.module not in all_modules)
             # find submodules via pkgutil
-            try:
+            with suppress(Exception):
                 runtime = silent_import_module(module)
                 all_modules.extend(
                     m.name
                     for m in pkgutil.walk_packages(runtime.__path__, runtime.__name__ + ".")
                     if m.name not in all_modules
                 )
-            except Exception:
-                pass
 
     if sources:
         try:

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import sys
 import time
+from contextlib import suppress
 from importlib import resources as importlib_resources
 from typing import IO, Callable, Container, Iterable, Sequence, Sized, TypeVar
 from typing_extensions import Final, Literal
@@ -366,17 +367,15 @@ def replace_object_state(
     for attr in get_class_descriptors(old.__class__):
         if attr in skip_slots:
             continue
-        try:
+        with suppress(AttributeError):
+            # There is no way to distinguish getsetdescriptors that allow
+            # writes from ones that don't (I think?), so we just ignore
+            # AttributeErrors if we need to.
+            # TODO: What about getsetdescriptors that act like properties???
             if hasattr(old, attr):
                 setattr(new, attr, getattr(old, attr))
             elif hasattr(new, attr):
                 delattr(new, attr)
-        # There is no way to distinguish getsetdescriptors that allow
-        # writes from ones that don't (I think?), so we just ignore
-        # AttributeErrors if we need to.
-        # TODO: What about getsetdescriptors that act like properties???
-        except AttributeError:
-            pass
 
 
 def is_sub_path(path1: str, path2: str) -> bool:

--- a/mypyc/__main__.py
+++ b/mypyc/__main__.py
@@ -12,6 +12,7 @@ mypycify, suitable for prototyping and testing.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import os.path
 import subprocess
@@ -31,10 +32,8 @@ setup(name='mypyc_output',
 
 def main() -> None:
     build_dir = "build"  # can this be overridden??
-    try:
+    with contextlib.suppress(FileExistsError):
         os.mkdir(build_dir)
-    except FileExistsError:
-        pass
 
     opt_level = os.getenv("MYPYC_OPT_LEVEL", "3")
     debug_level = os.getenv("MYPYC_DEBUG_LEVEL", "1")


### PR DESCRIPTION
### Description

The Mypy application currently requires Python 3.7+ per https://github.com/python/mypy/blob/master/setup.py#L10

`contextlib.suppress` was added in Python 3.4:
https://docs.python.org/3/library/contextlib.html#contextlib.suppress

The context manager slightly shortens the code and significantly clarifies the author's intention to ignore the specific errors. The standard library feature was introduced following a [discussion](https://bugs.python.org/issue15806), where the consensus was that

> A key benefit here is in the priming effect for readers... The with statement form makes it clear before you start reading the code that certain exceptions won't propagate.

## Test Plan

N/A
