### PR TITLE
Allow `ParamSpecArgs` to be unpacked

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -194,6 +194,7 @@ from mypy.types import (
     TypeTranslator,
     TypeType,
     TypeVarId,
+    TypeVarLikeType,
     TypeVarType,
     UnboundType,
     UninhabitedType,
@@ -3161,7 +3162,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # TODO: maybe elsewhere; redundant.
         rvalue_type = get_proper_type(rv_type or self.expr_checker.accept(rvalue))
 
-        if isinstance(rvalue_type, TypeVarType):
+        if isinstance(rvalue_type, TypeVarLikeType):
             rvalue_type = get_proper_type(rvalue_type.upper_bound)
 
         if isinstance(rvalue_type, UnionType):

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1092,3 +1092,20 @@ def func(callback: Callable[P, str]) -> Callable[P, str]:
         return 'baz'
     return inner
 [builtins fixtures/paramspec.pyi]
+
+[case testUnpackingParamsSpecArgsAndKwargs]
+from typing import Callable
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+
+def func(callback: Callable[P, str]) -> Callable[P, str]:
+    def inner(*args: P.kwargs, **kwargs: P.kwargs) -> str:
+        a, *b = args
+        reveal_type(a)  # N: Revealed type is "builtins.object"
+        reveal_type(b)  # N: Revealed type is "builtins.list[builtins.object]"
+        d = {**kwargs}
+        reveal_type(d)  # N: Revealed type is "builtins.dict[builtins.str, builtins.object]"
+        return "foo"
+    return inner
+[builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1104,8 +1104,11 @@ def func(callback: Callable[P, str]) -> Callable[P, str]:
         a, *b = args
         reveal_type(a)  # N: Revealed type is "builtins.object"
         reveal_type(b)  # N: Revealed type is "builtins.list[builtins.object]"
-        d = {**kwargs}
-        reveal_type(d)  # N: Revealed type is "builtins.dict[builtins.str, builtins.object]"
+        c, *d = kwargs
+        reveal_type(c)  # N: Revealed type is "builtins.str"
+        reveal_type(d)  # N: Revealed type is "builtins.list[builtins.str]"
+        e = {**kwargs}
+        reveal_type(e)  # N: Revealed type is "builtins.dict[builtins.str, builtins.object]"
         return "foo"
     return inner
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1100,7 +1100,7 @@ from typing_extensions import ParamSpec
 P = ParamSpec("P")
 
 def func(callback: Callable[P, str]) -> Callable[P, str]:
-    def inner(*args: P.kwargs, **kwargs: P.kwargs) -> str:
+    def inner(*args: P.args, **kwargs: P.kwargs) -> str:
         a, *b = args
         reveal_type(a)  # N: Revealed type is "builtins.object"
         reveal_type(b)  # N: Revealed type is "builtins.list[builtins.object]"


### PR DESCRIPTION
### Description

If `TypeVar`s with iterable bounds can be unpacked, so can `ParamSpecArgs`! This PR is a small extension of #13425 that allows that to happen.

## Test Plan

I added a test that currently fails on `master`, but passes with this patch applied.