### PR TITLE
Fix overload overlap check for UninhabitedType

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -747,14 +747,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
                 # Is the overload alternative's arguments subtypes of the implementation's?
                 if not is_callable_compatible(
-                    impl, sig1, is_compat=is_subtype_no_promote, ignore_return=True
+                    impl, sig1, is_compat=is_subtype, ignore_return=True
                 ):
                     self.msg.overloaded_signatures_arg_specific(i + 1, defn.impl)
 
                 # Is the overload alternative's return type a subtype of the implementation's?
                 if not (
-                    is_subtype_no_promote(sig1.ret_type, impl.ret_type)
-                    or is_subtype_no_promote(impl.ret_type, sig1.ret_type)
+                    is_subtype(sig1.ret_type, impl.ret_type)
+                    or is_subtype(impl.ret_type, sig1.ret_type)
                 ):
                     self.msg.overloaded_signatures_ret_specific(i + 1, defn.impl)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6484,7 +6484,7 @@ def is_unsafe_overlapping_overload_signatures(
     return is_callable_compatible(
         signature,
         other,
-        is_compat=is_overlapping_types_no_promote,
+        is_compat=is_overlapping_types_no_promote_no_uninhabited,
         is_compat_return=lambda l, r: not is_subtype_no_promote(l, r),
         ignore_return=False,
         check_args_covariantly=True,
@@ -6492,7 +6492,7 @@ def is_unsafe_overlapping_overload_signatures(
     ) or is_callable_compatible(
         other,
         signature,
-        is_compat=is_overlapping_types_no_promote,
+        is_compat=is_overlapping_types_no_promote_no_uninhabited,
         is_compat_return=lambda l, r: not is_subtype_no_promote(r, l),
         ignore_return=False,
         check_args_covariantly=False,
@@ -6976,8 +6976,12 @@ def is_subtype_no_promote(left: Type, right: Type) -> bool:
     return is_subtype(left, right, ignore_promotions=True)
 
 
-def is_overlapping_types_no_promote(left: Type, right: Type) -> bool:
-    return is_overlapping_types(left, right, ignore_promotions=True)
+def is_overlapping_types_no_promote_no_uninhabited(left: Type, right: Type) -> bool:
+    # For the purpose of unsafe overload checks we consider list[<nothing>] and list[int]
+    # non-overlapping. This is consistent with how we treat list[int] and list[str] as
+    # non-overlapping, despite [] belongs to both. Also this will prevent false positives
+    # for failed type inference during unification.
+    return is_overlapping_types(left, right, ignore_promotions=True, ignore_uninhabited=True)
 
 
 def is_private(node_name: str) -> bool:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -473,7 +473,7 @@ def is_overlapping_types(
     # Note: it's unclear however, whether returning False is the right thing
     # to do when inferring reachability -- see  https://github.com/python/mypy/issues/5529
 
-    assert type(left) != type(right)
+    assert type(left) != type(right), f"{type(left)} vs {type(right)}"
     return False
 
 

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -211,6 +211,7 @@ def is_overlapping_types(
     right: Type,
     ignore_promotions: bool = False,
     prohibit_none_typevar_overlap: bool = False,
+    ignore_uninhabited: bool = False,
 ) -> bool:
     """Can a value of type 'left' also be of type 'right' or vice-versa?
 
@@ -235,6 +236,7 @@ def is_overlapping_types(
             right,
             ignore_promotions=ignore_promotions,
             prohibit_none_typevar_overlap=prohibit_none_typevar_overlap,
+            ignore_uninhabited=ignore_uninhabited,
         )
 
     # We should never encounter this type.
@@ -282,8 +284,10 @@ def is_overlapping_types(
     ):
         return True
 
-    if is_proper_subtype(left, right, ignore_promotions=ignore_promotions) or is_proper_subtype(
-        right, left, ignore_promotions=ignore_promotions
+    if is_proper_subtype(
+        left, right, ignore_promotions=ignore_promotions, ignore_uninhabited=ignore_uninhabited
+    ) or is_proper_subtype(
+        right, left, ignore_promotions=ignore_promotions, ignore_uninhabited=ignore_uninhabited
     ):
         return True
 
@@ -425,8 +429,10 @@ def is_overlapping_types(
     if isinstance(left, Instance) and isinstance(right, Instance):
         # First we need to handle promotions and structural compatibility for instances
         # that came as fallbacks, so simply call is_subtype() to avoid code duplication.
-        if is_subtype(left, right, ignore_promotions=ignore_promotions) or is_subtype(
-            right, left, ignore_promotions=ignore_promotions
+        if is_subtype(
+            left, right, ignore_promotions=ignore_promotions, ignore_uninhabited=ignore_uninhabited
+        ) or is_subtype(
+            right, left, ignore_promotions=ignore_promotions, ignore_uninhabited=ignore_uninhabited
         ):
             return True
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -418,6 +418,8 @@ class SubtypeVisitor(TypeVisitor[bool]):
     def visit_uninhabited_type(self, left: UninhabitedType) -> bool:
         # We ignore this for unsafe overload checks, so that and empty list and
         # a list of int will be considered non-overlapping.
+        if isinstance(self.right, UninhabitedType):
+            return True
         return not self.subtype_context.ignore_uninhabited
 
     def visit_erased_type(self, left: ErasedType) -> bool:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -67,7 +67,7 @@ IS_SETTABLE: Final = 1
 IS_CLASSVAR: Final = 2
 IS_CLASS_OR_STATIC: Final = 3
 
-TypeParameterChecker: _TypeAlias = Callable[[Type, Type, int, bool], bool]
+TypeParameterChecker: _TypeAlias = Callable[[Type, Type, int, bool, "SubtypeContext"], bool]
 
 
 class SubtypeContext:
@@ -80,6 +80,7 @@ class SubtypeContext:
         ignore_declared_variance: bool = False,
         # Supported for both proper and non-proper
         ignore_promotions: bool = False,
+        ignore_uninhabited: bool = False,
         # Proper subtype flags
         erase_instances: bool = False,
         keep_erased_types: bool = False,
@@ -89,6 +90,7 @@ class SubtypeContext:
         self.ignore_pos_arg_names = ignore_pos_arg_names
         self.ignore_declared_variance = ignore_declared_variance
         self.ignore_promotions = ignore_promotions
+        self.ignore_uninhabited = ignore_uninhabited
         self.erase_instances = erase_instances
         self.keep_erased_types = keep_erased_types
         self.options = options
@@ -115,6 +117,7 @@ def is_subtype(
     ignore_pos_arg_names: bool = False,
     ignore_declared_variance: bool = False,
     ignore_promotions: bool = False,
+    ignore_uninhabited: bool = False,
     options: Options | None = None,
 ) -> bool:
     """Is 'left' subtype of 'right'?
@@ -134,6 +137,7 @@ def is_subtype(
             ignore_pos_arg_names=ignore_pos_arg_names,
             ignore_declared_variance=ignore_declared_variance,
             ignore_promotions=ignore_promotions,
+            ignore_uninhabited=ignore_uninhabited,
             options=options,
         )
     else:
@@ -143,6 +147,7 @@ def is_subtype(
                 ignore_pos_arg_names,
                 ignore_declared_variance,
                 ignore_promotions,
+                ignore_uninhabited,
                 options,
             }
         ), "Don't pass both context and individual flags"
@@ -177,6 +182,7 @@ def is_proper_subtype(
     *,
     subtype_context: SubtypeContext | None = None,
     ignore_promotions: bool = False,
+    ignore_uninhabited: bool = False,
     erase_instances: bool = False,
     keep_erased_types: bool = False,
 ) -> bool:
@@ -192,12 +198,19 @@ def is_proper_subtype(
     if subtype_context is None:
         subtype_context = SubtypeContext(
             ignore_promotions=ignore_promotions,
+            ignore_uninhabited=ignore_uninhabited,
             erase_instances=erase_instances,
             keep_erased_types=keep_erased_types,
         )
     else:
         assert not any(
-            {ignore_promotions, erase_instances, keep_erased_types}
+            {
+                ignore_promotions,
+                ignore_uninhabited,
+                erase_instances,
+                keep_erased_types,
+                ignore_uninhabited,
+            }
         ), "Don't pass both context and individual flags"
     if TypeState.is_assumed_proper_subtype(left, right):
         return True
@@ -215,6 +228,7 @@ def is_equivalent(
     ignore_type_params: bool = False,
     ignore_pos_arg_names: bool = False,
     options: Options | None = None,
+    subtype_context: SubtypeContext | None = None,
 ) -> bool:
     return is_subtype(
         a,
@@ -222,16 +236,20 @@ def is_equivalent(
         ignore_type_params=ignore_type_params,
         ignore_pos_arg_names=ignore_pos_arg_names,
         options=options,
+        subtype_context=subtype_context,
     ) and is_subtype(
         b,
         a,
         ignore_type_params=ignore_type_params,
         ignore_pos_arg_names=ignore_pos_arg_names,
         options=options,
+        subtype_context=subtype_context,
     )
 
 
-def is_same_type(a: Type, b: Type, ignore_promotions: bool = True) -> bool:
+def is_same_type(
+    a: Type, b: Type, ignore_promotions: bool = True, subtype_context: SubtypeContext | None = None
+) -> bool:
     """Are these types proper subtypes of each other?
 
     This means types may have different representation (e.g. an alias, or
@@ -241,8 +259,10 @@ def is_same_type(a: Type, b: Type, ignore_promotions: bool = True) -> bool:
     # considered not the same type (which is the case at runtime).
     # Also Union[bool, int] (if it wasn't simplified before) will be different
     # from plain int, etc.
-    return is_proper_subtype(a, b, ignore_promotions=ignore_promotions) and is_proper_subtype(
-        b, a, ignore_promotions=ignore_promotions
+    return is_proper_subtype(
+        a, b, ignore_promotions=ignore_promotions, subtype_context=subtype_context
+    ) and is_proper_subtype(
+        b, a, ignore_promotions=ignore_promotions, subtype_context=subtype_context
     )
 
 
@@ -306,11 +326,15 @@ def _is_subtype(
     return left.accept(SubtypeVisitor(orig_right, subtype_context, proper_subtype))
 
 
-# TODO: should we pass on the original flags here and in couple other places?
-# This seems logical but was never done in the past for some reasons.
-def check_type_parameter(lefta: Type, righta: Type, variance: int, proper_subtype: bool) -> bool:
+def check_type_parameter(
+    lefta: Type, righta: Type, variance: int, proper_subtype: bool, subtype_context: SubtypeContext
+) -> bool:
     def check(left: Type, right: Type) -> bool:
-        return is_proper_subtype(left, right) if proper_subtype else is_subtype(left, right)
+        return (
+            is_proper_subtype(left, right, subtype_context=subtype_context)
+            if proper_subtype
+            else is_subtype(left, right, subtype_context=subtype_context)
+        )
 
     if variance == COVARIANT:
         return check(lefta, righta)
@@ -318,11 +342,18 @@ def check_type_parameter(lefta: Type, righta: Type, variance: int, proper_subtyp
         return check(righta, lefta)
     else:
         if proper_subtype:
-            return is_same_type(lefta, righta)
-        return is_equivalent(lefta, righta)
+            # We pass ignore_promotions=False because it is a default for subtype checks.
+            # The actual value will be taken from the subtype_context, and it is whatever
+            # the original caller passed.
+            return is_same_type(
+                lefta, righta, ignore_promotions=False, subtype_context=subtype_context
+            )
+        return is_equivalent(lefta, righta, subtype_context=subtype_context)
 
 
-def ignore_type_parameter(lefta: Type, righta: Type, variance: int, proper_subtype: bool) -> bool:
+def ignore_type_parameter(
+    lefta: Type, righta: Type, variance: int, proper_subtype: bool, subtype_context: SubtypeContext
+) -> bool:
     return True
 
 
@@ -385,7 +416,9 @@ class SubtypeVisitor(TypeVisitor[bool]):
             return True
 
     def visit_uninhabited_type(self, left: UninhabitedType) -> bool:
-        return True
+        # We ignore this for unsafe overload checks, so that and empty list and
+        # a list of int will be considered non-overlapping.
+        return not self.subtype_context.ignore_uninhabited
 
     def visit_erased_type(self, left: ErasedType) -> bool:
         # This may be encountered during type inference. The result probably doesn't
@@ -521,12 +554,12 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 for lefta, righta, tvar in type_params:
                     if isinstance(tvar, TypeVarType):
                         if not self.check_type_parameter(
-                            lefta, righta, tvar.variance, self.proper_subtype
+                            lefta, righta, tvar.variance, self.proper_subtype, self.subtype_context
                         ):
                             nominal = False
                     else:
                         if not self.check_type_parameter(
-                            lefta, righta, COVARIANT, self.proper_subtype
+                            lefta, righta, COVARIANT, self.proper_subtype, self.subtype_context
                         ):
                             nominal = False
                 if nominal:
@@ -694,6 +727,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
             if not left.names_are_wider_than(right):
                 return False
             for name, l, r in left.zip(right):
+                # TODO: should we pass on the full subtype_context here and below?
                 if self.proper_subtype:
                     check = is_same_type(l, r)
                 else:

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6467,3 +6467,29 @@ spam: Callable[..., str] = lambda x, y: 'baz'
 reveal_type(func(spam))  # N: Revealed type is "def (*Any, **Any) -> builtins.str"
 
 [builtins fixtures/paramspec.pyi]
+
+[case testGenericOverloadOverlapWithType]
+import m
+
+[file m.pyi]
+from typing import TypeVar, Type, overload, Callable
+
+T = TypeVar("T", bound=str)
+@overload
+def foo(x: Type[T] | int) -> int: ...
+@overload
+def foo(x: Callable[[int], bool]) -> str: ...
+
+[case testGenericOverloadOverlapWithCollection]
+import m
+
+[file m.pyi]
+from typing import TypeVar, Sequence, overload, List
+
+T = TypeVar("T", bound=str)
+
+@overload
+def foo(x: List[T]) -> str: ...
+@overload
+def foo(x: Sequence[int]) -> int: ...
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
The issue was exposed by merge of subtype visitors. Fix is actually trivial, but the diff is big because I need to add and pass the new flag everywhere (`is_subtype()`, `is_proper_subtype()`, `is_equivalent()`, `is_same_type()` can call each other).

cc @Michael0x2a 