### PR TITLE
stubgenc: Introduce an object-oriented system for extracting function signatures

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -10,8 +10,9 @@ import importlib
 import inspect
 import os.path
 import re
+from abc import abstractmethod
 from types import ModuleType
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 from typing_extensions import Final
 
 from mypy.moduleinspect import is_c_module
@@ -40,16 +41,119 @@ _DEFAULT_TYPING_IMPORTS: Final = (
 )
 
 
+class SignatureGenerator:
+    """Abstract base class for extracting a list of FunctionSigs for each function."""
+
+    @abstractmethod
+    def get_function_sig(
+        self, func: object, module_name: str, name: str
+    ) -> list[FunctionSig] | None:
+        pass
+
+    @abstractmethod
+    def get_method_sig(
+        self, func: object, module_name: str, class_name: str, name: str, self_var: str
+    ) -> list[FunctionSig] | None:
+        pass
+
+
+class ExternalSignatureGenerator(SignatureGenerator):
+    def __init__(
+        self, func_sigs: dict[str, str] | None = None, class_sigs: dict[str, str] | None = None
+    ):
+        """
+        Takes a mapping of function/method names to signatures and class name to
+        class signatures (usually corresponds to __init__).
+        """
+        self.func_sigs = func_sigs or {}
+        self.class_sigs = class_sigs or {}
+
+    def get_function_sig(
+        self, func: object, module_name: str, name: str
+    ) -> list[FunctionSig] | None:
+        if name in self.func_sigs:
+            return [
+                FunctionSig(
+                    name=name,
+                    args=infer_arg_sig_from_anon_docstring(self.func_sigs[name]),
+                    ret_type="Any",
+                )
+            ]
+        else:
+            return None
+
+    def get_method_sig(
+        self, func: object, module_name: str, class_name: str, name: str, self_var: str
+    ) -> list[FunctionSig] | None:
+        if (
+            name in ("__new__", "__init__")
+            and name not in self.func_sigs
+            and class_name in self.class_sigs
+        ):
+            return [
+                FunctionSig(
+                    name=name,
+                    args=infer_arg_sig_from_anon_docstring(self.class_sigs[class_name]),
+                    ret_type="None" if name == "__init__" else "Any",
+                )
+            ]
+        return self.get_function_sig(func, module_name, name)
+
+
+class DocstringSignatureGenerator(SignatureGenerator):
+    def get_function_sig(
+        self, func: object, module_name: str, name: str
+    ) -> list[FunctionSig] | None:
+        docstr = getattr(func, "__doc__", None)
+        inferred = infer_sig_from_docstring(docstr, name)
+        if inferred:
+            assert docstr is not None
+            if is_pybind11_overloaded_function_docstring(docstr, name):
+                # Remove pybind11 umbrella (*args, **kwargs) for overloaded functions
+                del inferred[-1]
+        return inferred
+
+    def get_method_sig(
+        self, func: object, module_name: str, class_name: str, name: str, self_var: str
+    ) -> list[FunctionSig] | None:
+        return self.get_function_sig(func, module_name, name)
+
+
+class FallbackSignatureGenerator(SignatureGenerator):
+    def get_function_sig(
+        self, func: object, module_name: str, name: str
+    ) -> list[FunctionSig] | None:
+        return [
+            FunctionSig(
+                name=name,
+                args=infer_arg_sig_from_anon_docstring("(*args, **kwargs)"),
+                ret_type="Any",
+            )
+        ]
+
+    def get_method_sig(
+        self, func: object, module_name: str, class_name: str, name: str, self_var: str
+    ) -> list[FunctionSig] | None:
+        return [
+            FunctionSig(
+                name=name,
+                args=infer_method_sig(name, self_var),
+                ret_type="None" if name == "__init__" else "Any",
+            )
+        ]
+
+
 def generate_stub_for_c_module(
-    module_name: str,
-    target: str,
-    sigs: dict[str, str] | None = None,
-    class_sigs: dict[str, str] | None = None,
+    module_name: str, target: str, sig_generators: Iterable[SignatureGenerator]
 ) -> None:
     """Generate stub for C module.
 
-    This combines simple runtime introspection (looking for docstrings and attributes
-    with simple builtin types) and signatures inferred from .rst documentation (if given).
+    Signature generators are called in order until a list of signatures is returned.  The order
+    is:
+    - signatures inferred from .rst documentation (if given)
+    - simple runtime introspection (looking for docstrings and attributes
+      with simple builtin types)
+    - fallback based special method names or "(*args, **kwargs)"
 
     If directory for target doesn't exist it will be created. Existing stub
     will be overwritten.
@@ -65,7 +169,9 @@ def generate_stub_for_c_module(
     items = sorted(module.__dict__.items(), key=lambda x: x[0])
     for name, obj in items:
         if is_c_function(obj):
-            generate_c_function_stub(module, name, obj, functions, imports=imports, sigs=sigs)
+            generate_c_function_stub(
+                module, name, obj, functions, imports=imports, sig_generators=sig_generators
+            )
             done.add(name)
     types: list[str] = []
     for name, obj in items:
@@ -73,7 +179,7 @@ def generate_stub_for_c_module(
             continue
         if is_c_type(obj):
             generate_c_type_stub(
-                module, name, obj, types, imports=imports, sigs=sigs, class_sigs=class_sigs
+                module, name, obj, types, imports=imports, sig_generators=sig_generators
             )
             done.add(name)
     variables = []
@@ -153,10 +259,9 @@ def generate_c_function_stub(
     obj: object,
     output: list[str],
     imports: list[str],
+    sig_generators: Iterable[SignatureGenerator],
     self_var: str | None = None,
-    sigs: dict[str, str] | None = None,
     class_name: str | None = None,
-    class_sigs: dict[str, str] | None = None,
 ) -> None:
     """Generate stub for a single function or method.
 
@@ -165,60 +270,37 @@ def generate_c_function_stub(
     The 'class_name' is used to find signature of __init__ or __new__ in
     'class_sigs'.
     """
-    if sigs is None:
-        sigs = {}
-    if class_sigs is None:
-        class_sigs = {}
-
-    ret_type = "None" if name == "__init__" and class_name else "Any"
-
-    if (
-        name in ("__new__", "__init__")
-        and name not in sigs
-        and class_name
-        and class_name in class_sigs
-    ):
-        inferred: list[FunctionSig] | None = [
-            FunctionSig(
-                name=name,
-                args=infer_arg_sig_from_anon_docstring(class_sigs[class_name]),
-                ret_type=ret_type,
-            )
-        ]
+    inferred: list[FunctionSig] | None = None
+    if class_name:
+        # method:
+        assert self_var is not None, "self_var should be provided for methods"
+        for sig_gen in sig_generators:
+            inferred = sig_gen.get_method_sig(obj, module.__name__, class_name, name, self_var)
+            if inferred:
+                # add self/cls var, if not present
+                args = inferred[0].args
+                if not args or args[0].name != self_var:
+                    args.insert(0, ArgSig(name=self_var))
+                break
     else:
-        docstr = getattr(obj, "__doc__", None)
-        inferred = infer_sig_from_docstring(docstr, name)
-        if inferred:
-            assert docstr is not None
-            if is_pybind11_overloaded_function_docstring(docstr, name):
-                # Remove pybind11 umbrella (*args, **kwargs) for overloaded functions
-                del inferred[-1]
-        if not inferred:
-            if class_name and name not in sigs:
-                inferred = [
-                    FunctionSig(name, args=infer_method_sig(name, self_var), ret_type=ret_type)
-                ]
-            else:
-                inferred = [
-                    FunctionSig(
-                        name=name,
-                        args=infer_arg_sig_from_anon_docstring(
-                            sigs.get(name, "(*args, **kwargs)")
-                        ),
-                        ret_type=ret_type,
-                    )
-                ]
-        elif class_name and self_var:
-            args = inferred[0].args
-            if not args or args[0].name != self_var:
-                args.insert(0, ArgSig(name=self_var))
+        # function:
+        for sig_gen in sig_generators:
+            inferred = sig_gen.get_function_sig(obj, module.__name__, name)
+            if inferred:
+                break
+
+    if not inferred:
+        raise ValueError(
+            "No signature was found. This should never happen "
+            "if FallbackSignatureGenerator is provided"
+        )
 
     is_overloaded = len(inferred) > 1 if inferred else False
     if is_overloaded:
         imports.append("from typing import overload")
     if inferred:
         for signature in inferred:
-            sig = []
+            args: list[str] = []
             for arg in signature.args:
                 if arg.name == self_var:
                     arg_def = self_var
@@ -233,14 +315,14 @@ def generate_c_function_stub(
                     if arg.default:
                         arg_def += " = ..."
 
-                sig.append(arg_def)
+                args.append(arg_def)
 
             if is_overloaded:
                 output.append("@overload")
             output.append(
                 "def {function}({args}) -> {ret}: ...".format(
                     function=name,
-                    args=", ".join(sig),
+                    args=", ".join(args),
                     ret=strip_or_import(signature.ret_type, module, imports),
                 )
             )
@@ -338,8 +420,7 @@ def generate_c_type_stub(
     obj: type,
     output: list[str],
     imports: list[str],
-    sigs: dict[str, str] | None = None,
-    class_sigs: dict[str, str] | None = None,
+    sig_generators: Iterable[SignatureGenerator],
 ) -> None:
     """Generate stub for a single class using runtime introspection.
 
@@ -380,9 +461,8 @@ def generate_c_type_stub(
                     methods,
                     imports=imports,
                     self_var=self_var,
-                    sigs=sigs,
                     class_name=class_name,
-                    class_sigs=class_sigs,
+                    sig_generators=sig_generators,
                 )
         elif is_c_property(value):
             done.add(attr)
@@ -398,7 +478,7 @@ def generate_c_type_stub(
             )
         elif is_c_type(value):
             generate_c_type_stub(
-                module, attr, value, types, imports=imports, sigs=sigs, class_sigs=class_sigs
+                module, attr, value, types, imports=imports, sig_generators=sig_generators
             )
             done.add(attr)
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -28,6 +28,7 @@ from mypy.stubgen import (
     Options,
     collect_build_targets,
     generate_stubs,
+    get_sig_generators,
     is_blacklisted_path,
     is_non_library_module,
     mypy_options,
@@ -803,7 +804,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         mod = ModuleType("module", "")  # any module is fine
         imports: list[str] = []
-        generate_c_type_stub(mod, "alias", object, output, imports)
+        generate_c_type_stub(
+            mod,
+            "alias",
+            object,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(imports, [])
         assert_equal(output[0], "class alias:")
 
@@ -815,7 +823,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType("module", "")  # any module is fine
-        generate_c_type_stub(mod, "C", TestClassVariableCls, output, imports)
+        generate_c_type_stub(
+            mod,
+            "C",
+            TestClassVariableCls,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(imports, [])
         assert_equal(output, ["class C:", "    x: ClassVar[int] = ..."])
 
@@ -826,7 +841,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType("module, ")
-        generate_c_type_stub(mod, "C", TestClass, output, imports)
+        generate_c_type_stub(
+            mod,
+            "C",
+            TestClass,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(output, ["class C(KeyError): ..."])
         assert_equal(imports, [])
 
@@ -834,7 +856,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType(TestBaseClass.__module__, "")
-        generate_c_type_stub(mod, "C", TestClass, output, imports)
+        generate_c_type_stub(
+            mod,
+            "C",
+            TestClass,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(output, ["class C(TestBaseClass): ..."])
         assert_equal(imports, [])
 
@@ -847,7 +876,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType("module", "")
-        generate_c_type_stub(mod, "C", TestClass, output, imports)
+        generate_c_type_stub(
+            mod,
+            "C",
+            TestClass,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(output, ["class C(argparse.Action): ..."])
         assert_equal(imports, ["import argparse"])
 
@@ -858,7 +894,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType("module", "")
-        generate_c_type_stub(mod, "C", TestClass, output, imports)
+        generate_c_type_stub(
+            mod,
+            "C",
+            TestClass,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(output, ["class C(type): ..."])
         assert_equal(imports, [])
 
@@ -873,7 +916,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="self", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="self",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: int) -> Any: ..."])
         assert_equal(imports, [])
@@ -889,7 +939,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="self", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="self",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: int) -> Any: ..."])
         assert_equal(imports, [])
@@ -904,7 +961,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="cls", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="cls",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(cls, *args, **kwargs) -> Any: ..."])
         assert_equal(imports, [])
@@ -920,7 +984,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="self", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="self",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: str = ...) -> Any: ..."])
         assert_equal(imports, [])
@@ -937,7 +1008,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType(self.__module__, "")
-        generate_c_function_stub(mod, "test", test, output, imports)
+        generate_c_function_stub(
+            mod,
+            "test",
+            test,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(output, ["def test(arg0: argparse.Action) -> Any: ..."])
         assert_equal(imports, ["import argparse"])
 
@@ -955,7 +1033,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType("argparse", "")
-        generate_c_function_stub(mod, "test", test, output, imports)
+        generate_c_function_stub(
+            mod,
+            "test",
+            test,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(output, ["def test(arg0: Action) -> Any: ..."])
         assert_equal(imports, [])
 
@@ -970,7 +1055,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType(self.__module__, "")
-        generate_c_function_stub(mod, "test", test, output, imports)
+        generate_c_function_stub(
+            mod,
+            "test",
+            test,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(output, ["def test(arg0: str) -> argparse.Action: ..."])
         assert_equal(imports, ["import argparse"])
 
@@ -987,7 +1079,14 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         imports: list[str] = []
         mod = ModuleType("argparse", "")
-        generate_c_function_stub(mod, "test", test, output, imports)
+        generate_c_function_stub(
+            mod,
+            "test",
+            test,
+            output,
+            imports,
+            sig_generators=get_sig_generators(parse_options([])),
+        )
         assert_equal(output, ["def test(arg0: str) -> Action: ..."])
         assert_equal(imports, [])
 
@@ -1052,7 +1151,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="self", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="self",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: List[int]) -> Any: ..."])
         assert_equal(imports, [])
@@ -1068,7 +1174,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="self", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="self",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: Dict[str,int]) -> Any: ..."])
         assert_equal(imports, [])
@@ -1084,7 +1197,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="self", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="self",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: Dict[str,List[int]]) -> Any: ..."])
         assert_equal(imports, [])
@@ -1100,7 +1220,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="self", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="self",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: Dict[argparse.Action,int]) -> Any: ..."])
         assert_equal(imports, ["import argparse"])
@@ -1116,7 +1243,14 @@ class StubgencSuite(unittest.TestCase):
         imports: list[str] = []
         mod = ModuleType(TestClass.__module__, "")
         generate_c_function_stub(
-            mod, "test", TestClass.test, output, imports, self_var="self", class_name="TestClass"
+            mod,
+            "test",
+            TestClass.test,
+            output,
+            imports,
+            self_var="self",
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: Dict[str,argparse.Action]) -> Any: ..."])
         assert_equal(imports, ["import argparse"])
@@ -1144,6 +1278,7 @@ class StubgencSuite(unittest.TestCase):
             imports,
             self_var="self",
             class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(
             output,


### PR DESCRIPTION

### Description

<!--
If this pull request closes or fixes an issue, write Closes #NNN" or "Fixes #NNN" in that exact
format.
-->

Note: This change is part of a series of upcoming MRs to improve `stubgenc`. 

`stubgenc` tries 3 approaches to infer signatures for a function.  There are two problems with the current design:

1. the logic for how these approaches are applied is somewhat convoluted, to the point that it's not even clear at first that there are 3 distinct approaches (from rst files, from docstrings, fallback guess).
2. there's not a clear path for how a developer would create a new approach.  

Here's the heart of the current logic (comments added for clarity):

```python
    if (
        name in ("__new__", "__init__")
        and name not in sigs
        and class_name
        and class_name in class_sigs
    ): 
        # get from rst (only works classes)
        inferred: Optional[List[FunctionSig]] = [
            FunctionSig(
                name=name,
                args=infer_arg_sig_from_anon_docstring(class_sigs[class_name]),
                ret_type=ret_type,
            )
        ]
    else:
        docstr = getattr(obj, '__doc__', None)
        # get from docstring
        inferred = infer_sig_from_docstring(docstr, name)
        if inferred:
            assert docstr is not None
            if is_pybind11_overloaded_function_docstring(docstr, name):
                del inferred[-1]
        if not inferred:
            if class_name and name not in sigs:
                # fall back to using a list of known special methods
                inferred = [FunctionSig(name, args=infer_method_sig(name, self_var),
                                        ret_type=ret_type)]
            else:
                # fall back to a catchall signature
                inferred = [FunctionSig(name=name,
                                        args=infer_arg_sig_from_anon_docstring(
                                            sigs.get(name, '(*args, **kwargs)')),
                                        ret_type=ret_type)]
        elif class_name and self_var:
            # why do we only fix self var for docstring signatures and not rst signatures?
            args = inferred[0].args
            if not args or args[0].name != self_var:
                args.insert(0, ArgSig(name=self_var))
```

And after my changes:

```python
    inferred: Optional[List[FunctionSig]] = None
    if class_name:
        # method:
        assert self_var is not None, "self_var should be provided for methods"
        for sig_gen in sig_generators:
            inferred = sig_gen.get_method_sig(obj, module.__name__, class_name, name, self_var)
            if inferred:
                args = inferred[0].args
                if not args or args[0].name != self_var:
                    args.insert(0, ArgSig(name=self_var))
                break
    else:
        # function:
        for sig_gen in sig_generators:
            inferred = sig_gen.get_function_sig(obj, module.__name__, name)
            if inferred:
                break
```

This clarifies the logic and opens up the possibility for future expansion and customization.


## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

This MR has two commits: 
1. implement the object-oriented inference system: this change is designed to preserve the current behavior so required no changes to test behavior
2. fix a bug where `@classmethod` and self-var fixes were not applied to every overload.  tests have been updated and a new test added to reflect the change. 

