### PR TITLE
Allow overriding attribute with a settable property

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1786,9 +1786,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     and isinstance(defn, Decorator)
                 ):
                     # We only give an error where no other similar errors will be given.
-                    self.msg.fail(
-                        "Cannot override writeable attribute with read-only property", defn
-                    )
+                    if not isinstance(original_type, AnyType):
+                        self.msg.fail(
+                            "Cannot override writeable attribute with read-only property",
+                            # Give an error on function line to match old behaviour.
+                            defn.func,
+                            code=codes.OVERRIDE,
+                        )
 
             if isinstance(original_type, AnyType) or isinstance(typ, AnyType):
                 pass

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1774,7 +1774,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
             if isinstance(original_type, FunctionLike):
                 original_type = self.bind_and_map_method(base_attr, original_type, defn.info, base)
-                if is_property(original_node):
+                if original_node and is_property(original_node):
                     original_type = get_property_type(original_type)
 
             if isinstance(typ, FunctionLike) and is_property(defn):
@@ -1812,7 +1812,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 #
                 pass
             elif (
-                base_attr.node
+                original_node
                 and not self.is_writable_attribute(original_node)
                 and is_subtype(typ, original_type)
             ):

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -789,7 +789,7 @@ class A(metaclass=ABCMeta):
     def x(self) -> int: pass
 class B(A):
     @property
-    def x(self) -> str: pass # E: Return type "str" of "x" incompatible with return type "int" in supertype "A"
+    def x(self) -> str: pass # E: Signature of "x" incompatible with supertype "A"
 b = B()
 b.x() # E: "str" not callable
 [builtins fixtures/property.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7366,3 +7366,26 @@ class D(C[List[T]]): ...
 di: D[int]
 reveal_type(di)  # N: Revealed type is "Tuple[builtins.list[builtins.int], builtins.list[builtins.int], fallback=__main__.D[builtins.int]]"
 [builtins fixtures/tuple.pyi]
+
+[case testOverrideAttrWithSettableProperty]
+class Foo:
+    def __init__(self) -> None:
+        self.x = 42
+
+class Bar(Foo):
+    @property
+    def x(self) -> int: ...
+    @x.setter
+    def x(self, value: int) -> None: ...
+[builtins fixtures/property.pyi]
+
+[case testOverrideAttrWithSettablePropertyAnnotation]
+class Foo:
+    x: int
+
+class Bar(Foo):
+    @property
+    def x(self) -> int: ...
+    @x.setter
+    def x(self, value: int) -> None: ...
+[builtins fixtures/property.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1286,7 +1286,7 @@ class A:
 @dataclass
 class B(A):
     @property
-    def foo(self) -> int: pass  # E: Signature of "foo" incompatible with supertype "A"
+    def foo(self) -> int: pass
 
 reveal_type(B)  # N: Revealed type is "def (foo: builtins.int) -> __main__.B"
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1475,9 +1475,8 @@ class A:
         self.x = [] # E: Need type annotation for "x" (hint: "x: List[<type>] = ...")
 
 class B(A):
-    # TODO?: This error is kind of a false positive, unfortunately
     @property
-    def x(self) -> List[int]:  # E: Signature of "x" incompatible with supertype "A"
+    def x(self) -> List[int]:
         return [123]
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1475,7 +1475,7 @@ class A:
         self.x = [] # E: Need type annotation for "x" (hint: "x: List[<type>] = ...")
 
 class B(A):
-    @property
+    @property  # E: Cannot override writeable attribute with read-only property
     def x(self) -> List[int]:
         return [123]
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1475,8 +1475,8 @@ class A:
         self.x = [] # E: Need type annotation for "x" (hint: "x: List[<type>] = ...")
 
 class B(A):
-    @property  # E: Cannot override writeable attribute with read-only property
-    def x(self) -> List[int]:
+    @property
+    def x(self) -> List[int]:  # E: Cannot override writeable attribute with read-only property
         return [123]
 [builtins fixtures/list.pyi]
 


### PR DESCRIPTION
Fixes #4125

Previously the code compared the original signatures for properties. Now we compare just the return types, similar to how we do it in `checkmember.py`.

Note that we still only allow invariant overrides, which is stricter that for regular variables that where we allow (unsafe) covariance.