### PR TITLE
[Docs] Add missing type hint

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -119,7 +119,7 @@ Python 3 supports an annotation syntax for function declarations.
                   sender: str,
                   cc: Optional[list[str]],
                   bcc: Optional[list[str]],
-                  subject='',
+                  subject: str = '',
                   body: Optional[list[str]] = None
                   ) -> bool:
        ...


### PR DESCRIPTION
### Description
In the cheat sheet there was a missing type hint:

`subject='',`  -> `subject: str = '',`


## Test Plan

Documentation change. I verified that the output looks OK.
