### PR TITLE
Unskip `testTrailingCommaParsing` test

### DIFF
--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -300,12 +300,15 @@ main:4: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "i
 main:5: error: Incompatible return value type (got "int", expected "str")
 main:6: error: Argument 1 to "f" of "A" has incompatible type "str"; expected "int"
 
-[case testTrailingCommaParsing-skip]
+[case testTrailingCommaParsing]
 x = 1
-x in 1,
-if x in 1, :
-    pass
+x in 1,  # E: Unsupported right operand type for in ("int")
+[builtins fixtures/tuple.pyi]
+
+[case testTrailingCommaInIfParsing]
+if x in 1, : pass
 [out]
+main:1: error: invalid syntax
 
 [case testInitReturnTypeError]
 class C:


### PR DESCRIPTION
The first test right now passes.

But, second one is not valid Python:

```python
>>> if x in 1, : pass
  File "<stdin>", line 1
    if x in 1, : pass
             ^
SyntaxError: invalid syntax
```

And:

```python
>>> import ast
>>> ast.dump(ast.parse('if x in 1, : pass'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sobolev/.pyenv/versions/3.8.9/lib/python3.8/ast.py", line 47, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 1
    if x in 1, : pass
             ^
SyntaxError: invalid syntax
```

So, we must raise a correct syntax error for it.