### PR TITLE
Allow using super() in methods with self-types

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4280,7 +4280,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # checking super() we will still get an error. So to be consistent, we also
             # allow such imprecise annotations for use with super(), where we fall back
             # to the current class MRO instead.
-            if is_self_type_like(instance_type, method.is_class):
+            if is_self_type_like(instance_type, is_classmethod=method.is_class):
                 if e.info and type_info in e.info.mro:
                     mro = e.info.mro
                     index = mro.index(type_info)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -153,6 +153,7 @@ from mypy.types import (
     is_generic_instance,
     is_named_instance,
     is_optional,
+    is_self_type_like,
     remove_optional,
 )
 from mypy.typestate import TypeState
@@ -4268,9 +4269,22 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         # The base is the first MRO entry *after* type_info that has a member
         # with the right name
-        try:
+        index = None
+        if type_info in mro:
             index = mro.index(type_info)
-        except ValueError:
+        else:
+            method = self.chk.scope.top_function()
+            assert method is not None
+            # Mypy explicitly allows supertype upper bounds (and no upper bound at all)
+            # for annotating self-types. However, if such an annotation is used for
+            # checking super() we will still get an error. So to be consistent, we also
+            # allow such imprecise annotations for use with super(), where we fall back
+            # to the current class MRO instead.
+            if is_self_type_like(instance_type, method.is_class):
+                if e.info and type_info in e.info.mro:
+                    mro = e.info.mro
+                    index = mro.index(type_info)
+        if index is None:
             self.chk.fail(message_registry.SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1, e)
             return AnyType(TypeOfAny.from_error)
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3313,6 +3313,16 @@ def is_literal_type(typ: ProperType, fallback_fullname: str, value: LiteralValue
     return typ.value == value
 
 
+def is_self_type_like(typ: Type, is_class: bool) -> bool:
+    """Does this look like a self-type annotation?"""
+    typ = get_proper_type(typ)
+    if not is_class:
+        return isinstance(typ, TypeVarType)
+    if not isinstance(typ, TypeType):
+        return False
+    return isinstance(typ.item, TypeVarType)
+
+
 names: Final = globals().copy()
 names.pop("NOT_READY", None)
 deserialize_map: Final = {

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3313,10 +3313,10 @@ def is_literal_type(typ: ProperType, fallback_fullname: str, value: LiteralValue
     return typ.value == value
 
 
-def is_self_type_like(typ: Type, is_class: bool) -> bool:
+def is_self_type_like(typ: Type, *, is_classmethod: bool) -> bool:
     """Does this look like a self-type annotation?"""
     typ = get_proper_type(typ)
-    if not is_class:
+    if not is_classmethod:
         return isinstance(typ, TypeVarType)
     if not isinstance(typ, TypeType):
         return False

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -380,3 +380,32 @@ class A:
 class B(A):
     def h(self, t: Type[None]) -> None:
         super(t, self).f # E: Unsupported argument 1 for "super"
+
+[case testSuperSelfTypeInstanceMethod]
+from typing import TypeVar, Type
+
+T = TypeVar("T", bound="A")
+
+class A:
+    def foo(self: T) -> T: ...
+
+class B(A):
+    def foo(self: T) -> T:
+        reveal_type(super().foo())  # N: Revealed type is "T`-1"
+        return super().foo()
+
+[case testSuperSelfTypeClassMethod]
+from typing import TypeVar, Type
+
+T = TypeVar("T", bound="A")
+
+class A:
+    @classmethod
+    def foo(cls: Type[T]) -> T: ...
+
+class B(A):
+    @classmethod
+    def foo(cls: Type[T]) -> T:
+        reveal_type(super().foo())  # N: Revealed type is "T`-1"
+        return super().foo()
+[builtins fixtures/classmethod.pyi]


### PR DESCRIPTION
Fixes #9282 

It looks like `super()` checking is too strict for methods with self-types. Mypy explicitly allows self-type annotation to be a supertype of current class, so to be consistent, I relax the check for `super()` as well.