### PR TITLE
Allow stubs to use newer syntax than 3.7

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -267,6 +267,8 @@ def parse(
     is_stub_file = fnam.endswith(".pyi")
     if is_stub_file:
         feature_version = defaults.PYTHON3_VERSION[1]
+        if options.python_version[0] == 3 and options.python_version[1] > feature_version:
+            feature_version = options.python_version[1]
     else:
         assert options.python_version[0] >= 3
         feature_version = options.python_version[1]


### PR DESCRIPTION
Fixes #13499

Today this code reads like "stubs should all target 3.7" and this
is indeed how typeshed operates. But authors of pyi other than typeshed
should probably be allowed to choose what Python version they're
targetting. Since typeshed runs checks against 3.7, this should not
cause testing regressions for typeshed.

This code goes back to #3000 back in the typed_ast days, when this
allowed stubs to use much newer syntax features than the base Python
version, so in some ways this is in the spirit of the original code.