### PR TITLE
Make invalid type ignore comments non-blocking

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -828,7 +828,7 @@ class ASTConverter:
             if parsed is not None:
                 self.type_ignores[ti.lineno] = parsed
             else:
-                self.fail(INVALID_TYPE_IGNORE, ti.lineno, -1)
+                self.fail(INVALID_TYPE_IGNORE, ti.lineno, -1, blocker=False)
         body = self.fix_function_overloads(self.translate_stmt_list(mod.body, ismodule=True))
         return MypyFile(body, self.imports, False, self.type_ignores)
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -180,7 +180,9 @@ import nostub  # type: ignore[import]
 from defusedxml import xyz  # type: ignore[import]
 
 [case testErrorCodeBadIgnore]
-import nostub # type: ignore xyz  # E: Invalid "type: ignore" comment  [syntax]
+import nostub # type: ignore xyz  # E: Invalid "type: ignore" comment  [syntax] \
+                                  # E: Cannot find implementation or library stub for module named "nostub"  [import] \
+                                  # N: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 import nostub # type: ignore[  # E: Invalid "type: ignore" comment  [syntax]
 import nostub # type: ignore[foo  # E: Invalid "type: ignore" comment  [syntax]
 import nostub # type: ignore[foo,  # E: Invalid "type: ignore" comment  [syntax]
@@ -207,6 +209,8 @@ def f(x,  # type: int  # type: ignore[
     pass
 [out]
 main:2: error: Invalid "type: ignore" comment  [syntax]
+main:2: error: Cannot find implementation or library stub for module named "nostub"  [import]
+main:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 main:3: error: Invalid "type: ignore" comment  [syntax]
 main:4: error: Invalid "type: ignore" comment  [syntax]
 main:5: error: Invalid "type: ignore" comment  [syntax]


### PR DESCRIPTION
Blocking errors are a bad user experience and there's no reason for this
one to be one / there is another code path for invalid type ignores that
is non-blocking.

Fixes half of #12299. The half it doesn't fix is that ideally users
shouldn't be getting these warnings from third party libraries.
Also see https://github.com/python/mypy/issues/12162#issuecomment-1212554729
But that's for another PR