### PR TITLE
Assert original type exists during function redefinition

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -959,11 +959,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 # Function definition overrides a variable initialized via assignment or a
                 # decorated function.
                 orig_type = defn.original_def.type
-                if orig_type is None:
-                    # XXX This can be None, as happens in
-                    # test_testcheck_TypeCheckSuite.testRedefinedFunctionInTryWithElse
-                    self.msg.note("Internal mypy error checking function redefinition", defn)
-                    return
+                assert orig_type is not None, f"Error checking function redefinition {defn}"
                 if isinstance(orig_type, PartialType):
                     if orig_type.type is None:
                         # Ah this is a partial type. Give it the type of the function.


### PR DESCRIPTION
The code involved is really old. The mentioned test case does not
trigger any errors. I cannot find any mention of this error message in
any non-ancient mypy issues