### PR TITLE
Warn on module level type ignore with error code

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -187,7 +187,11 @@ Ignoring a whole file
 ---------------------
 
 A ``# type: ignore`` comment at the top of a module (before any statements,
-including imports or docstrings) has the effect of ignoring the *entire* module.
+including imports or docstrings) has the effect of ignoring the entire contents of the module.
+
+To only ignore errors, use a top-level ``# mypy: ignore-errors`` comment instead.
+To only ignore errors with a specific error code, use a top-level
+``# mypy: disable-error-code=...`` comment.
 
 .. code-block:: python
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -192,6 +192,8 @@ including imports or docstrings) has the effect of ignoring the entire contents 
 To only ignore errors, use a top-level ``# mypy: ignore-errors`` comment instead.
 To only ignore errors with a specific error code, use a top-level
 ``# mypy: disable-error-code=...`` comment.
+To replace the contents of the module with ``Any``, use a per-module ``follow_imports = skip``.
+See :ref:`Following imports <follow-imports>` for details.
 
 .. code-block:: python
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -485,7 +485,7 @@ class ASTConverter:
             if self.type_ignores[min(self.type_ignores)]:
                 self.fail(
                     (
-                        "type ignore with error code is not supported at module level; "
+                        "type ignore with error code is not supported for modules; "
                         "use `# mypy: disable-error-code=...`"
                     ),
                     line=min(self.type_ignores),

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -482,6 +482,16 @@ class ASTConverter:
             and self.type_ignores
             and min(self.type_ignores) < self.get_lineno(stmts[0])
         ):
+            if self.type_ignores[min(self.type_ignores)]:
+                self.fail(
+                    (
+                        "type ignore with error code is not supported at module level; "
+                        "use `# mypy: disable-error-code=...`"
+                    ),
+                    line=min(self.type_ignores),
+                    column=0,
+                    blocker=False,
+                )
             self.errors.used_ignored_lines[self.errors.file][min(self.type_ignores)].append(
                 codes.FILE.code
             )

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -919,5 +919,5 @@ def f(d: D, s: str) -> None:
 
 
 [case testRecommendErrorCode]
-# type: ignore[whatever]  # E: type ignore with error code is not supported at module level; use `# mypy: disable-error-code=...`  [syntax]
+# type: ignore[whatever]  # E: type ignore with error code is not supported for modules; use `# mypy: disable-error-code=...`  [syntax]
 1 + "asdf"

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -916,3 +916,8 @@ def f(d: D, s: str) -> None:
     d[s]  # type: ignore[literal-required]
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+
+[case testRecommendErrorCode]
+# type: ignore[whatever]  # E: type ignore with error code is not supported at module level; use `# mypy: disable-error-code=...`  [syntax]
+1 + "asdf"


### PR DESCRIPTION
Per-module error codes were added in #13502, let's recommend using them.

The existing type ignore behaviour is pretty unintuitive; I think most
people actually want `# mypy: ignore-errors`. There are probably people
depending on the current behaviour of `# type: ignore` though.

Fixes #13435, fixes #12076, fixes #11999, fixes #11027, fixes #9318,
fixes #7839