### PR TITLE
Fix match crash on unions including tuples

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -326,7 +326,9 @@ class PatternChecker(PatternVisitor[PatternType]):
             else:
                 return None
 
-        if self.chk.type_is_iterable(t) and isinstance(t, Instance):
+        if self.chk.type_is_iterable(t) and isinstance(t, (Instance, TupleType)):
+            if isinstance(t, TupleType):
+                t = tuple_fallback(t)
             return self.chk.iterable_item_type(t)
         else:
             return None

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1600,3 +1600,29 @@ def foo(x: NoneType): # E: NoneType should not be used as a type, please use Non
     reveal_type(x) # N: Revealed type is "None"
 
 [builtins fixtures/tuple.pyi]
+
+[case testMatchTupleInstanceUnionNoCrash]
+from typing import Union
+
+def func(e: Union[str, tuple[str]]) -> None:
+    match e:
+        case (a,) if isinstance(a, str):
+            ...
+[builtins fixtures/tuple.pyi]
+
+[case testMatchTupleOptionalNoCrash]
+# flags: --strict-optional
+foo: tuple[int] | None
+match foo:
+    case x,: pass
+[builtins fixtures/tuple.pyi]
+
+[case testMatchUnionTwoTuplesNoCrash]
+var: tuple[int, int] | tuple[str, str]
+
+match var:
+    case (42, a):
+        ...
+    case ("yes", b):
+        ...
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1607,22 +1607,24 @@ from typing import Union
 def func(e: Union[str, tuple[str]]) -> None:
     match e:
         case (a,) if isinstance(a, str):
-            ...
+            reveal_type(a)  # N: Revealed type is "builtins.str"
 [builtins fixtures/tuple.pyi]
 
 [case testMatchTupleOptionalNoCrash]
 # flags: --strict-optional
 foo: tuple[int] | None
 match foo:
-    case x,: pass
+    case x,:
+        reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testMatchUnionTwoTuplesNoCrash]
 var: tuple[int, int] | tuple[str, str]
 
+# TODO: we can infer better here.
 match var:
     case (42, a):
-        ...
+        reveal_type(a)  # N: Revealed type is "Union[builtins.int, builtins.str]"
     case ("yes", b):
-        ...
+        reveal_type(b)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #12533 

The fix is trivial. I also noticed the whole procedure in that function doesn't make much sense, left a TODO about it.