### PR TITLE
runtests: Remove unused tasks and targets

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -8,8 +8,6 @@ from sys import argv, executable, exit
 
 # Slow test suites
 CMDLINE = "PythonCmdline"
-SAMPLES = "SamplesSuite"
-TYPESHED = "TypeshedSuite"
 PEP561 = "PEP561Suite"
 EVALUATION = "PythonEvaluation"
 DAEMON = "testdaemon"
@@ -24,8 +22,6 @@ ERROR_STREAM = "ErrorStreamSuite"
 
 ALL_NON_FAST = [
     CMDLINE,
-    SAMPLES,
-    TYPESHED,
     PEP561,
     EVALUATION,
     DAEMON,
@@ -71,12 +67,10 @@ cmds = {
         "pytest",
         "-q",
         "-k",
-        " or ".join([SAMPLES, TYPESHED, DAEMON, MYPYC_EXTERNAL, MYPYC_COMMAND_LINE, ERROR_STREAM]),
+        " or ".join([DAEMON, MYPYC_EXTERNAL, MYPYC_COMMAND_LINE, ERROR_STREAM]),
     ],
     # Test cases that might take minutes to run
     "pytest-extra": ["pytest", "-q", "-k", " or ".join(PYTEST_OPT_IN)],
-    # Test cases to run in typeshed CI
-    "typeshed-ci": ["pytest", "-q", "-k", " or ".join([CMDLINE, EVALUATION, SAMPLES, TYPESHED])],
     # Mypyc tests that aren't run by default, since they are slow and rarely
     # fail for commits that don't touch mypyc
     "mypyc-extra": ["pytest", "-q", "-k", " or ".join(MYPYC_OPT_IN)],
@@ -85,7 +79,7 @@ cmds = {
 # Stop run immediately if these commands fail
 FAST_FAIL = ["self", "lint"]
 
-EXTRA_COMMANDS = ("pytest-extra", "mypyc-extra", "typeshed-ci")
+EXTRA_COMMANDS = ("pytest-extra", "mypyc-extra")
 DEFAULT_COMMANDS = [cmd for cmd in cmds if cmd not in EXTRA_COMMANDS]
 
 assert all(cmd in cmds for cmd in FAST_FAIL)


### PR DESCRIPTION
- `typeshed-ci` is not used in `typeshed` itself, moreover, `TypeshedSuite` does not exist anymore
- `SAMPLES` is also pointing to non-existant `SamplesSuite`

It is time to remove them.