### PR TITLE
tox: Remove outdate coverage targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,16 @@ python3 runtests.py
 You can also use `tox` to run tests (`tox` handles setting up the test environment for you):
 ```
 tox -e py
+
+# Or some specific python version:
+tox -e py39
+
+# Or some specific command:
+tox -e lint
 ```
 
 Some useful commands for running specific tests include:
-```
+```bash
 # Use mypy to check mypy's own code
 python3 runtests.py self
 # or equivalently:
@@ -74,6 +80,12 @@ flake8
 
 # Run formatters
 black . && isort .
+```
+
+To run tests with coverage:
+
+```bash
+python -m pytest --durations 100 --cov mypy --cov-config setup.cfg  --cov-report=term-missing:skip-covered --cov-report=html
 ```
 
 For an in-depth guide on running and writing tests,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,12 +82,6 @@ flake8
 black . && isort .
 ```
 
-To run tests with coverage:
-
-```bash
-python -m pytest --durations 100 --cov mypy --cov-config setup.cfg  --cov-report=term-missing:skip-covered --cov-report=html
-```
-
 For an in-depth guide on running and writing tests,
 see [the README in the test-data directory](test-data/unit/README.md).
 

--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -176,6 +176,10 @@ full builtins and library stubs instead of minimal ones. Run them using
 Note that running more processes than logical cores is likely to
 significantly decrease performance.
 
+To run tests with coverage:
+
+    python3 -m pytest --durations 100 --cov mypy --cov-config setup.cfg  --cov-report=term-missing:skip-covered --cov-report=html
+
 
 Debugging
 ---------

--- a/tox.ini
+++ b/tox.ini
@@ -14,36 +14,9 @@ isolated_build = true
 
 [testenv]
 description = run the test driver with {basepython}
-setenv = cov: COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 passenv = PYTEST_XDIST_WORKER_COUNT PROGRAMDATA PROGRAMFILES(X86)
 deps = -rtest-requirements.txt
 commands = python -m pytest --durations 100 {posargs}
-           cov: python -m pytest --durations 100 {posargs: --cov mypy --cov-config setup.cfg}
-
-
-[testenv:coverage]
-description = [run locally after tests]: combine coverage data and create report
-deps =
-    coverage >= 4.5.1, < 5
-    diff_cover >= 1.0.5, <2
-skip_install = True
-passenv =
-    {[testenv]passenv}
-    DIFF_AGAINST
-setenv = COVERAGE_FILE={toxworkdir}/.coverage
-commands =
-    coverage combine --rcfile setup.cfg
-    coverage report -m --rcfile setup.cfg
-    coverage xml -o {toxworkdir}/coverage.xml --rcfile setup.cfg
-    coverage html -d {toxworkdir}/htmlcov --rcfile setup.cfg
-    diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
-depends =
-    py36,
-    py37,
-    py38,
-    py39,
-    py310,
-parallel_show_output = True
 
 [testenv:lint]
 description = check the code style


### PR DESCRIPTION
There were so many things from with this:
1. `cov` command (the second one after `pytest`) was never executed, since you needed to call it explicitly with `tox -e py38-cov`. But, in this case it was generated after the initial test run. So, basically you had two test runs to get coverage
2. `coverage` environment was just broken. For example, all packages are very outdated `diff-cover` is at [`6.5` right now](https://pypi.org/project/diff-cover/#history), while we had it pinned to `<2`. It tried to make it work, but no luck. After all, I don't think that we really need this undocumented and unused way of getting coverage
3. I've also added a working way to get coverage into the `CONTRIBUTING.md` file