### PR TITLE
[mypyc] Infer more precise error kinds for some ops

### DIFF
--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -119,6 +119,7 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
     def visit_set_attr(self, op: SetAttr) -> str:
         if op.is_init:
             assert op.error_kind == ERR_NEVER
+        if op.error_kind == ERR_NEVER:
             # Initialization and direct struct access can never fail
             return self.format("%r.%s = %r", op.obj, op.attr, op.src)
         else:

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -545,6 +545,31 @@ L3:
     r3 = <error> :: int64
     return r3
 
+[case testExceptionWithNativeAttributeGetAndSet]
+class C:
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+def foo(c: C, x: int) -> None:
+    c.x = x - c.x
+[out]
+def C.__init__(self, x):
+    self :: __main__.C
+    x :: int
+L0:
+    inc_ref x :: int
+    self.x = x
+    return 1
+def foo(c, x):
+    c :: __main__.C
+    x, r0, r1 :: int
+    r2 :: bool
+L0:
+    r0 = borrow c.x
+    r1 = CPyTagged_Subtract(x, r0)
+    c.x = r1
+    return 1
+
 [case testExceptionWithLowLevelIntAttribute]
 from mypy_extensions import i32, i64
 

--- a/mypyc/transform/exceptions.py
+++ b/mypyc/transform/exceptions.py
@@ -23,10 +23,12 @@ from mypyc.ir.ops import (
     Branch,
     CallC,
     ComparisonOp,
+    GetAttr,
     Integer,
     LoadErrorValue,
     RegisterOp,
     Return,
+    SetAttr,
     Value,
 )
 from mypyc.ir.rtypes import bool_rprimitive
@@ -40,6 +42,7 @@ def insert_exception_handling(ir: FuncIR) -> None:
     # block. The block just returns an error value.
     error_label = None
     for block in ir.blocks:
+        adjust_error_kinds(block)
         can_raise = any(op.can_raise() for op in block.ops)
         if can_raise:
             error_label = add_handler_block(ir)
@@ -141,3 +144,18 @@ def primitive_call(desc: CFunctionDescription, args: list[Value], line: int) -> 
         desc.error_kind,
         line,
     )
+
+
+def adjust_error_kinds(block: BasicBlock) -> None:
+    """Infer more precise error_kind attributes for ops.
+
+    We have access here to more information than what was available
+    when the IR was initially built.
+    """
+    for op in block.ops:
+        if isinstance(op, GetAttr):
+            if op.class_type.class_ir.is_always_defined(op.attr):
+                op.error_kind = ERR_NEVER
+        if isinstance(op, SetAttr):
+            if op.class_type.class_ir.is_always_defined(op.attr):
+                op.error_kind = ERR_NEVER


### PR DESCRIPTION
During the error handling transform we have access to always
defined attributes, which allows us to infer that certain
attribute operations will never fail.

This can improve performance and reduce the size of the generated
code.