### PR TITLE
[mypyc] Mark magic-overlapping error handler branches as rare

### DIFF
--- a/mypyc/transform/exceptions.py
+++ b/mypyc/transform/exceptions.py
@@ -103,7 +103,11 @@ def split_blocks_at_errors(
                     new_block2 = BasicBlock()
                     new_blocks.append(new_block2)
                     branch = Branch(
-                        comp, true_label=new_block2, false_label=new_block, op=Branch.BOOL
+                        comp,
+                        true_label=new_block2,
+                        false_label=new_block,
+                        op=Branch.BOOL,
+                        rare=True,
                     )
                     cur_block.ops.append(branch)
                     cur_block = new_block2


### PR DESCRIPTION
This might slightly improve performance when using native ints,
and it's consistent with how other error handler branches are
treated as rare.

Now the generated error handling code when calling a function
that returns a native int looks something like this (the
`unlikely(...)` part is new):

```
    cpy_r_r0 = CPyDef_f();
    cpy_r_r1 = cpy_r_r0 == -113;
    if (unlikely(cpy_r_r1)) goto CPyL2;
```