### PR TITLE
Fix crash on bare Final in dataclass

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -407,6 +407,10 @@ class SemanticAnalyzerPluginInterface:
     def is_stub_file(self) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
+    def analyze_simple_literal_type(self, rvalue: Expression, is_final: bool) -> Type | None:
+        raise NotImplementedError
+
 
 # A context for querying for configuration data about a module for
 # cache invalidation purposes.

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1796,3 +1796,21 @@ t: Two
 reveal_type(t.__match_args__)  # E: "Two" has no attribute "__match_args__" \
                                # N: Revealed type is "Any"
 [builtins fixtures/dataclasses.pyi]
+
+[case testFinalInDataclass]
+from dataclasses import dataclass
+from typing import Final
+
+@dataclass
+class FirstClass:
+    FIRST_CONST: Final = 3  # OK
+
+@dataclass
+class SecondClass:
+    SECOND_CONST: Final = FirstClass.FIRST_CONST  # E: Need type argument for Final[...] with non-literal default in dataclass
+
+reveal_type(FirstClass().FIRST_CONST)  # N: Revealed type is "Literal[3]?"
+FirstClass().FIRST_CONST = 42  # E: Cannot assign to final attribute "FIRST_CONST"
+reveal_type(SecondClass().SECOND_CONST)  # N: Revealed type is "Literal[3]?"
+SecondClass().SECOND_CONST = 42  # E: Cannot assign to final attribute "SECOND_CONST"
+[builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
Fixes #10090 

Unfortunately we cannot fully support this use case. Mypy requires explicit type annotations to generate methods for dataclasses before type checking. While type inference for bare `Final` happens during type checking. I still try to infer type if the default is a literal, otherwise give an error, and use `Any` for generated methods.

cc @AlexWaygood @JukkaL 