### PR TITLE
[mypyc] Track definedness of native int attributes using a bitmap

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -17,10 +17,17 @@ from mypyc.codegen.emitwrapper import (
     generate_richcompare_wrapper,
     generate_set_del_item_wrapper,
 )
-from mypyc.common import NATIVE_PREFIX, PREFIX, REG_PREFIX, use_fastcall
+from mypyc.common import (
+    ATTR_BITMAP_BITS,
+    ATTR_BITMAP_TYPE,
+    NATIVE_PREFIX,
+    PREFIX,
+    REG_PREFIX,
+    use_fastcall,
+)
 from mypyc.ir.class_ir import ClassIR, VTableEntries
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD, FuncDecl, FuncIR
-from mypyc.ir.rtypes import RTuple, RType, object_rprimitive
+from mypyc.ir.rtypes import RTuple, RType, is_fixed_width_rtype, object_rprimitive
 from mypyc.namegen import NameGenerator
 from mypyc.sametype import is_same_type
 
@@ -367,8 +374,17 @@ def generate_object_struct(cl: ClassIR, emitter: Emitter) -> None:
     lines += ["typedef struct {", "PyObject_HEAD", "CPyVTableItem *vtable;"]
     if cl.has_method("__call__") and emitter.use_vectorcall():
         lines.append("vectorcallfunc vectorcall;")
+    bitmap_attrs = []
     for base in reversed(cl.base_mro):
         if not base.is_trait:
+            if base.bitmap_attrs:
+                # Do we need another attribute bitmap field?
+                if emitter.bitmap_field(len(base.bitmap_attrs) - 1) not in bitmap_attrs:
+                    for i in range(0, len(base.bitmap_attrs), ATTR_BITMAP_BITS):
+                        attr = emitter.bitmap_field(i)
+                        if attr not in bitmap_attrs:
+                            lines.append(f"{ATTR_BITMAP_TYPE} {attr};")
+                            bitmap_attrs.append(attr)
             for attr, rtype in base.attributes.items():
                 if (attr, rtype) not in seen_attrs:
                     lines.append(f"{emitter.ctype_spaced(rtype)}{emitter.attr(attr)};")
@@ -546,6 +562,9 @@ def generate_setup_for_class(
         emitter.emit_line("}")
     else:
         emitter.emit_line(f"self->vtable = {vtable_name};")
+    for i in range(0, len(cl.bitmap_attrs), ATTR_BITMAP_BITS):
+        field = emitter.bitmap_field(i)
+        emitter.emit_line(f"self->{field} = 0;")
 
     if cl.has_method("__call__") and emitter.use_vectorcall():
         name = cl.method_decl("__call__").cname(emitter.names)
@@ -887,7 +906,7 @@ def generate_getter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
     always_defined = cl.is_always_defined(attr) and not rtype.is_refcounted
 
     if not always_defined:
-        emitter.emit_undefined_attr_check(rtype, attr_expr, "==", unlikely=True)
+        emitter.emit_undefined_attr_check(rtype, attr_expr, "==", "self", attr, cl, unlikely=True)
         emitter.emit_line("PyErr_SetString(PyExc_AttributeError,")
         emitter.emit_line(f'    "attribute {repr(attr)} of {repr(cl.name)} undefined");')
         emitter.emit_line("return NULL;")
@@ -926,7 +945,7 @@ def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
     if rtype.is_refcounted:
         attr_expr = f"self->{attr_field}"
         if not always_defined:
-            emitter.emit_undefined_attr_check(rtype, attr_expr, "!=")
+            emitter.emit_undefined_attr_check(rtype, attr_expr, "!=", "self", attr, cl)
         emitter.emit_dec_ref(f"self->{attr_field}", rtype)
         if not always_defined:
             emitter.emit_line("}")
@@ -943,9 +962,14 @@ def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
         emitter.emit_lines("if (!tmp)", "    return -1;")
     emitter.emit_inc_ref("tmp", rtype)
     emitter.emit_line(f"self->{attr_field} = tmp;")
+    if is_fixed_width_rtype(rtype) and not always_defined:
+        emitter.emit_attr_bitmap_set("tmp", "self", rtype, cl, attr)
+
     if deletable:
         emitter.emit_line("} else")
         emitter.emit_line(f"    self->{attr_field} = {emitter.c_undefined_value(rtype)};")
+        if is_fixed_width_rtype(rtype):
+            emitter.emit_attr_bitmap_clear("self", rtype, cl, attr)
     emitter.emit_line("return 0;")
     emitter.emit_line("}")
 

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -60,6 +60,7 @@ from mypyc.ir.rtypes import (
     RStruct,
     RTuple,
     RType,
+    is_fixed_width_rtype,
     is_int32_rprimitive,
     is_int64_rprimitive,
     is_int_rprimitive,
@@ -353,7 +354,9 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             always_defined = cl.is_always_defined(op.attr)
             merged_branch = None
             if not always_defined:
-                self.emitter.emit_undefined_attr_check(attr_rtype, dest, "==", unlikely=True)
+                self.emitter.emit_undefined_attr_check(
+                    attr_rtype, dest, "==", obj, op.attr, cl, unlikely=True
+                )
                 branch = self.next_branch()
                 if branch is not None:
                     if (
@@ -433,10 +436,17 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                 # previously undefined), so decref the old value.
                 always_defined = cl.is_always_defined(op.attr)
                 if not always_defined:
-                    self.emitter.emit_undefined_attr_check(attr_rtype, attr_expr, "!=")
+                    self.emitter.emit_undefined_attr_check(
+                        attr_rtype, attr_expr, "!=", obj, op.attr, cl
+                    )
                 self.emitter.emit_dec_ref(attr_expr, attr_rtype)
                 if not always_defined:
                     self.emitter.emit_line("}")
+            elif is_fixed_width_rtype(attr_rtype) and not cl.is_always_defined(op.attr):
+                # If there is overlap with the error value, update bitmap to mark
+                # attribute as defined.
+                self.emitter.emit_attr_bitmap_set(src, obj, attr_rtype, cl, op.attr)
+
             # This steals the reference to src, so we don't need to increment the arg
             self.emitter.emit_line(f"{attr_expr} = {src};")
             if op.error_kind == ERR_FALSE:

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -53,6 +53,11 @@ MIN_SHORT_INT: Final = -(sys.maxsize >> 1) - 1
 MAX_LITERAL_SHORT_INT: Final = sys.maxsize >> 1 if not IS_MIXED_32_64_BIT_BUILD else 2**30 - 1
 MIN_LITERAL_SHORT_INT: Final = -MAX_LITERAL_SHORT_INT - 1
 
+# Decription of the C type used to track definedness of attributes
+# that have types with overlapping error values
+ATTR_BITMAP_TYPE: Final = "uint32_t"
+ATTR_BITMAP_BITS: Final = 32
+
 # Runtime C library files
 RUNTIME_C_FILES: Final = [
     "init.c",

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -130,7 +130,7 @@ class ClassIR:
         self.builtin_base: str | None = None
         # Default empty constructor
         self.ctor = FuncDecl(name, None, module_name, FuncSignature([], RInstance(self)))
-
+        # Attributes defined in the class (not inherited)
         self.attributes: dict[str, RType] = {}
         # Deletable attributes
         self.deletable: list[str] = []
@@ -183,6 +183,13 @@ class ClassIR:
 
         # If True, __init__ can make 'self' visible to unanalyzed/arbitrary code
         self.init_self_leak = False
+
+        # Definedness of these attributes is backed by a bitmap. Index in the list
+        # indicates the bit number. Includes inherited attributes. We need the
+        # bitmap for types such as native ints that can't have a dedicated error
+        # value that doesn't overlap a valid value. The bitmap is used if the
+        # value of an attribute is the same as the error value.
+        self.bitmap_attrs: List[str] = []
 
     def __repr__(self) -> str:
         return (

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -633,7 +633,7 @@ class GetAttr(RegisterOp):
         attr_type = obj.type.attr_type(attr)
         self.type = attr_type
         if is_fixed_width_rtype(attr_type):
-            self.error_kind = ERR_NEVER
+            self.error_kind = ERR_MAGIC_OVERLAPPING
         self.is_borrowed = borrow and attr_type.is_refcounted
 
     def sources(self) -> list[Value]:

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -57,7 +57,11 @@ def build_ir(
     options: CompilerOptions,
     errors: Errors,
 ) -> ModuleIRs:
-    """Build IR for a set of modules that have been type-checked by mypy."""
+    """Build basic IR for a set of modules that have been type-checked by mypy.
+
+    The returned IR is not complete and requires additional
+    transformations, such as the insertion of refcount handling.
+    """
 
     build_type_map(mapper, modules, graph, types, options, errors)
     singledispatch_info = find_singledispatch_register_impls(modules, errors)

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -335,9 +335,12 @@ def test_mixed_arithmetic_and_bitwise_ops() -> None:
     with assertRaises(OverflowError):
         assert int_too_small & i64_3
 
-[case testI64ErrorValues]
+[case testI64ErrorValuesAndUndefined]
 from typing import Any
 import sys
+
+from mypy_extensions import mypyc_attr
+from typing_extensions import Final
 
 MYPY = False
 if MYPY:
@@ -390,3 +393,283 @@ def test_unbox_int_fails() -> None:
     o3: Any = -(1 << 63 + 1)
     with assertRaises(OverflowError, "int too large to convert to i64"):
         z: i64 = o3
+
+class Uninit:
+    x: i64
+    y: i64 = 0
+    z: i64
+
+class Derived(Uninit):
+    a: i64 = 1
+    b: i64
+    c: i64 = 2
+
+class Derived2(Derived):
+    h: i64
+
+def test_uninitialized_attr() -> None:
+    o = Uninit()
+    assert o.y == 0
+    with assertRaises(AttributeError):
+        o.x
+    with assertRaises(AttributeError):
+        o.z
+    o.x = 1
+    assert o.x == 1
+    with assertRaises(AttributeError):
+        o.z
+    o.z = 2
+    assert o.z == 2
+
+# This is the error value, but it's also a valid normal value
+MAGIC: Final = -113
+
+def test_magic_value() -> None:
+    o = Uninit()
+    o.x = MAGIC
+    assert o.x == MAGIC
+    with assertRaises(AttributeError):
+        o.z
+    o.z = MAGIC
+    assert o.x == MAGIC
+    assert o.z == MAGIC
+
+def test_magic_value_via_any() -> None:
+    o: Any = Uninit()
+    with assertRaises(AttributeError):
+        o.x
+    with assertRaises(AttributeError):
+        o.z
+    o.x = MAGIC
+    assert o.x == MAGIC
+    with assertRaises(AttributeError):
+        o.z
+    o.z = MAGIC
+    assert o.z == MAGIC
+
+def test_magic_value_and_inheritance() -> None:
+    o = Derived2()
+    o.x = MAGIC
+    assert o.x == MAGIC
+    with assertRaises(AttributeError):
+        o.z
+    with assertRaises(AttributeError):
+        o.b
+    with assertRaises(AttributeError):
+        o.h
+    o.z = MAGIC
+    assert o.z == MAGIC
+    with assertRaises(AttributeError):
+        o.b
+    with assertRaises(AttributeError):
+        o.h
+    o.h = MAGIC
+    assert o.h == MAGIC
+    with assertRaises(AttributeError):
+        o.b
+    o.b = MAGIC
+    assert o.b == MAGIC
+
+@mypyc_attr(allow_interpreted_subclasses=True)
+class MagicInit:
+    x: i64 = MAGIC
+
+def test_magic_value_as_initializer() -> None:
+    o = MagicInit()
+    assert o.x == MAGIC
+
+class ManyUninit:
+    a1: i64
+    a2: i64
+    a3: i64
+    a4: i64
+    a5: i64
+    a6: i64
+    a7: i64
+    a8: i64
+    a9: i64
+    a10: i64
+    a11: i64
+    a12: i64
+    a13: i64
+    a14: i64
+    a15: i64
+    a16: i64
+    a17: i64
+    a18: i64
+    a19: i64
+    a20: i64
+    a21: i64
+    a22: i64
+    a23: i64
+    a24: i64
+    a25: i64
+    a26: i64
+    a27: i64
+    a28: i64
+    a29: i64
+    a30: i64
+    a31: i64
+    a32: i64
+    a33: i64
+    a34: i64
+    a35: i64
+    a36: i64
+    a37: i64
+    a38: i64
+    a39: i64
+    a40: i64
+    a41: i64
+    a42: i64
+    a43: i64
+    a44: i64
+    a45: i64
+    a46: i64
+    a47: i64
+    a48: i64
+    a49: i64
+    a50: i64
+    a51: i64
+    a52: i64
+    a53: i64
+    a54: i64
+    a55: i64
+    a56: i64
+    a57: i64
+    a58: i64
+    a59: i64
+    a60: i64
+    a61: i64
+    a62: i64
+    a63: i64
+    a64: i64
+    a65: i64
+    a66: i64
+    a67: i64
+    a68: i64
+    a69: i64
+    a70: i64
+    a71: i64
+    a72: i64
+    a73: i64
+    a74: i64
+    a75: i64
+    a76: i64
+    a77: i64
+    a78: i64
+    a79: i64
+    a80: i64
+    a81: i64
+    a82: i64
+    a83: i64
+    a84: i64
+    a85: i64
+    a86: i64
+    a87: i64
+    a88: i64
+    a89: i64
+    a90: i64
+    a91: i64
+    a92: i64
+    a93: i64
+    a94: i64
+    a95: i64
+    a96: i64
+    a97: i64
+    a98: i64
+    a99: i64
+    a100: i64
+
+def test_many_uninitialized_attributes() -> None:
+    o = ManyUninit()
+    with assertRaises(AttributeError):
+        o.a1
+    with assertRaises(AttributeError):
+        o.a10
+    with assertRaises(AttributeError):
+        o.a20
+    with assertRaises(AttributeError):
+        o.a30
+    with assertRaises(AttributeError):
+        o.a31
+    with assertRaises(AttributeError):
+        o.a32
+    with assertRaises(AttributeError):
+        o.a33
+    with assertRaises(AttributeError):
+        o.a40
+    with assertRaises(AttributeError):
+        o.a50
+    with assertRaises(AttributeError):
+        o.a60
+    with assertRaises(AttributeError):
+        o.a62
+    with assertRaises(AttributeError):
+        o.a63
+    with assertRaises(AttributeError):
+        o.a64
+    with assertRaises(AttributeError):
+        o.a65
+    with assertRaises(AttributeError):
+        o.a80
+    with assertRaises(AttributeError):
+        o.a100
+    o.a30 = MAGIC
+    assert o.a30 == MAGIC
+    o.a31 = MAGIC
+    assert o.a31 == MAGIC
+    o.a32 = MAGIC
+    assert o.a32 == MAGIC
+    o.a33 = MAGIC
+    assert o.a33 == MAGIC
+    with assertRaises(AttributeError):
+        o.a34
+    o.a62 = MAGIC
+    assert o.a62 == MAGIC
+    o.a63 = MAGIC
+    assert o.a63 == MAGIC
+    o.a64 = MAGIC
+    assert o.a64 == MAGIC
+    o.a65 = MAGIC
+    assert o.a65 == MAGIC
+    with assertRaises(AttributeError):
+        o.a66
+
+class BaseNoBitmap:
+    x: int = 5
+
+class DerivedBitmap(BaseNoBitmap):
+    # Subclass needs a bitmap, but base class doesn't have it.
+    y: i64
+
+def test_derived_adds_bitmap() -> None:
+    d = DerivedBitmap()
+    d.x = 643
+    b: BaseNoBitmap = d
+    assert b.x == 643
+
+class Delete:
+    __deletable__ = ['x', 'y']
+    x: i64
+    y: i64
+
+def test_del() -> None:
+    o = Delete()
+    o.x = MAGIC
+    o.y = -1
+    assert o.x == MAGIC
+    assert o.y == -1
+    del o.x
+    with assertRaises(AttributeError):
+        o.x
+    assert o.y == -1
+    del o.y
+    with assertRaises(AttributeError):
+        o.y
+    o.x = 5
+    assert o.x == 5
+    with assertRaises(AttributeError):
+        o.y
+    del o.x
+    with assertRaises(AttributeError):
+        o.x


### PR DESCRIPTION
Since native ints can't support a reserved value to mark an undefined
attribute, use a separate bitmap attribute (or attributes) to store
information about defined/undefined attributes with native int types.

The bitmap is only defined if we can't infer that an attribute is
always defined, and it's only needed for native int attributes.

We only access the bitmap if the runtime value of an attribute is
equal to the (overlapping) error value. This way the performance cost
of the bitmap is pretty low on average.

I'll add support for traits in a follow-up PR to keep this PR simple.

Work on mypyc/mypyc#837.