### PR TITLE
Don't skip flake8 for the `misc` directory

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -13,7 +13,6 @@ on:
     - 'mypy/stubgen.py'
     - 'mypy/stubgenc.py'
     - 'mypy/test/**'
-    - 'scripts/**'
     - 'test-data/**'
 
 jobs:

--- a/misc/async_matrix.py
+++ b/misc/async_matrix.py
@@ -70,7 +70,7 @@ def plain_host_generator(func) -> Generator[str, None, None]:
     x = 0
     f = func()
     try:
-        x = yield from f
+        x = yield from f  # noqa: F841
     finally:
         try:
             f.close()
@@ -80,7 +80,7 @@ def plain_host_generator(func) -> Generator[str, None, None]:
 
 async def plain_host_coroutine(func) -> None:
     x = 0
-    x = await func()
+    x = await func()  # noqa: F841
 
 
 @coroutine
@@ -89,7 +89,7 @@ def decorated_host_generator(func) -> Generator[str, None, None]:
     x = 0
     f = func()
     try:
-        x = yield from f
+        x = yield from f  # noqa: F841
     finally:
         try:
             f.close()
@@ -100,7 +100,7 @@ def decorated_host_generator(func) -> Generator[str, None, None]:
 @coroutine
 async def decorated_host_coroutine(func) -> None:
     x = 0
-    x = await func()
+    x = await func()  # noqa: F841
 
 
 # Main driver.

--- a/misc/cherry-pick-typeshed.py
+++ b/misc/cherry-pick-typeshed.py
@@ -37,7 +37,7 @@ def main() -> None:
         sys.exit(f"error: Invalid commit {commit!r}")
 
     if not os.path.exists("mypy") or not os.path.exists("mypyc"):
-        sys.exit(f"error: This script must be run at the mypy repository root directory")
+        sys.exit("error: This script must be run at the mypy repository root directory")
 
     with tempfile.TemporaryDirectory() as d:
         diff_file = os.path.join(d, "diff")

--- a/misc/find_type.py
+++ b/misc/find_type.py
@@ -17,7 +17,7 @@
 #   " Convert to 0-based column offsets
 #   let startcol = startcol - 1
 #   " Change this line to point to the find_type.py script.
-#   execute '!python3 /path/to/mypy/scripts/find_type.py % ' . startline . ' ' . startcol . ' ' . endline . ' ' . endcol . ' ' . mypycmd
+#   execute '!python3 /path/to/mypy/misc/find_type.py % ' . startline . ' ' . startcol . ' ' . endline . ' ' . endcol . ' ' . mypycmd
 # endfunction
 # vnoremap <Leader>t :call RevealType()<CR>
 #

--- a/misc/fix_annotate.py
+++ b/misc/fix_annotate.py
@@ -72,12 +72,12 @@ class FixAnnotate(BaseFix):
         #
         # "Compact" functions (e.g. "def foo(x, y): return max(x, y)")
         # have a different structure that isn't matched by PATTERN.
-
-        ## print('-'*60)
-        ## print(node)
-        ## for i, ch in enumerate(children):
-        ##     print(i, repr(ch.prefix), repr(ch))
-
+        #
+        #   print('-'*60)
+        #   print(node)
+        #   for i, ch in enumerate(children):
+        #       print(i, repr(ch.prefix), repr(ch))
+        #
         # Check if there's already an annotation.
         for ch in children:
             if ch.prefix.lstrip().startswith("# type:"):

--- a/misc/upload-pypi.py
+++ b/misc/upload-pypi.py
@@ -49,7 +49,7 @@ def download_asset(asset: dict[str, Any], dst: Path) -> Path:
 
 
 def download_all_release_assets(release: dict[str, Any], dst: Path) -> None:
-    print(f"Downloading assets...")
+    print("Downloading assets...")
     with ThreadPoolExecutor() as e:
         for asset in e.map(lambda asset: download_asset(asset, dst), release["assets"]):
             print(f"Downloaded {asset}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,6 @@ exclude =
   # Sphinx configuration is irrelevant
   docs/source/conf.py,
   mypyc/doc/conf.py,
-  # conflicting styles
-  misc/*,
-  # conflicting styles
-  scripts/*,
   # tests have more relaxed styling requirements
   # fixtures have their own .pyi-specific configuration
   test-data/*,


### PR DESCRIPTION
Now that we use black for the whole codebase, there's not much reason to skip flake8 for the `misc` directory, since we use a uniform style everywhere.

Also, remove a few outdated references to the deleted `scripts` directory.