### PR TITLE
selfcheck: enable the `ignore-without-code` error code

### DIFF
--- a/misc/proper_plugin.py
+++ b/misc/proper_plugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+from mypy.checker import TypeChecker
 from mypy.nodes import TypeInfo
 from mypy.plugin import FunctionContext, Plugin
 from mypy.subtypes import is_proper_subtype
@@ -155,7 +156,9 @@ def proper_types_hook(ctx: FunctionContext) -> Type:
 
 
 def get_proper_type_instance(ctx: FunctionContext) -> Instance:
-    types = ctx.api.modules["mypy.types"]  # type: ignore
+    checker = ctx.api
+    assert isinstance(checker, TypeChecker)
+    types = checker.modules["mypy.types"]
     proper_type_info = types.names["ProperType"]
     assert isinstance(proper_type_info.node, TypeInfo)
     return Instance(proper_type_info.node, [])

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5704,7 +5704,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         sym = self.lookup_qualified(name)
         node = sym.node
         if isinstance(node, TypeAlias):
-            assert isinstance(node.target, Instance)  # type: ignore
+            assert isinstance(node.target, Instance)  # type: ignore[misc]
             node = node.target.type
         assert isinstance(node, TypeInfo)
         any_type = AnyType(TypeOfAny.from_omitted_generics)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -319,7 +319,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 result = self.typeddict_callable(node)
             else:
                 result = type_object_type(node, self.named_type)
-            if isinstance(result, CallableType) and isinstance(  # type: ignore
+            if isinstance(result, CallableType) and isinstance(  # type: ignore[misc]
                 result.ret_type, Instance
             ):
                 # We need to set correct line and column
@@ -3805,7 +3805,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             x = A()
             y = cast(A, ...)
         """
-        if isinstance(alias.target, Instance) and alias.target.invalid:  # type: ignore
+        if isinstance(alias.target, Instance) and alias.target.invalid:  # type: ignore[misc]
             # An invalid alias, error already has been reported
             return AnyType(TypeOfAny.from_error)
         # If this is a generic alias, we set all variables to `Any`.

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -577,7 +577,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         if isinstance(actual, Instance):
             instance = actual
             erased = erase_typevars(template)
-            assert isinstance(erased, Instance)  # type: ignore
+            assert isinstance(erased, Instance)  # type: ignore[misc]
             # We always try nominal inference if possible,
             # it is much faster than the structural one.
             if self.direction == SUBTYPE_OF and template.type.has_base(instance.type.fullname):

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1990,9 +1990,10 @@ class TypeConverter:
             for s in dims:
                 if getattr(s, "col_offset", None) is None:
                     if isinstance(s, ast3.Index):
-                        s.col_offset = s.value.col_offset  # type: ignore
+                        s.col_offset = s.value.col_offset  # type: ignore[attr-defined]
                     elif isinstance(s, ast3.Slice):
-                        s.col_offset = s.lower.col_offset  # type: ignore
+                        assert s.lower is not None
+                        s.col_offset = s.lower.col_offset  # type: ignore[attr-defined]
             sliceval = ast3.Tuple(dims, n.ctx)
 
         empty_tuple_index = False

--- a/mypy/memprofile.py
+++ b/mypy/memprofile.py
@@ -35,7 +35,7 @@ def collect_memory_stats() -> tuple[dict[str, int], dict[str, int]]:
         if hasattr(obj, "__dict__"):
             # Keep track of which class a particular __dict__ is associated with.
             inferred[id(obj.__dict__)] = f"{n} (__dict__)"
-        if isinstance(obj, (Node, Type)):  # type: ignore
+        if isinstance(obj, (Node, Type)):  # type: ignore[misc]
             if hasattr(obj, "__dict__"):
                 for x in obj.__dict__.values():
                     if isinstance(x, list):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1113,7 +1113,7 @@ class ClassDef(Statement):
     ) -> None:
         super().__init__()
         self.name = name
-        self.fullname = None  # type: ignore
+        self.fullname = None  # type: ignore[assignment]
         self.defs = defs
         self.type_vars = type_vars or []
         self.base_type_exprs = base_type_exprs or []

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -40,7 +40,7 @@ SINGLEDISPATCH_CALLABLE_CALL_METHOD: Final = f"{SINGLEDISPATCH_TYPE}.__call__"
 
 def get_singledispatch_info(typ: Instance) -> SingledispatchTypeVars | None:
     if len(typ.args) == 2:
-        return SingledispatchTypeVars(*typ.args)  # type: ignore
+        return SingledispatchTypeVars(*typ.args)  # type: ignore[arg-type]
     return None
 
 
@@ -200,7 +200,7 @@ def call_singledispatch_function_after_register_argument(ctx: MethodContext) -> 
     """Called on the function after passing a type to register"""
     register_callable = ctx.type
     if isinstance(register_callable, Instance):
-        type_args = RegisterCallableInfo(*register_callable.args)  # type: ignore
+        type_args = RegisterCallableInfo(*register_callable.args)  # type: ignore[arg-type]
         func = get_first_arg(ctx.arg_types)
         if func is not None:
             register_function(ctx, type_args.singledispatch_obj, func, type_args.register_type)

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -25,7 +25,7 @@ from mypy.types import Type, TypeOfAny
 from mypy.version import __version__
 
 try:
-    from lxml import etree  # type: ignore
+    from lxml import etree  # type: ignore[import]
 
     LXML_INSTALLED = True
 except ImportError:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5291,7 +5291,7 @@ class SemanticAnalyzer(
             return None
         node = sym.node
         if isinstance(node, TypeAlias):
-            assert isinstance(node.target, Instance)  # type: ignore
+            assert isinstance(node.target, Instance)  # type: ignore[misc]
             node = node.target.type
         assert isinstance(node, TypeInfo), node
         if args is not None:

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -64,11 +64,11 @@ def get_edges(o: object) -> Iterator[tuple[object, object]]:
             # in closures and self pointers to other objects
 
             if hasattr(e, "__closure__"):
-                yield (s, "__closure__"), e.__closure__  # type: ignore
+                yield (s, "__closure__"), e.__closure__  # type: ignore[union-attr]
             if hasattr(e, "__self__"):
-                se = e.__self__  # type: ignore
+                se = e.__self__  # type: ignore[union-attr]
                 if se is not o and se is not type(o) and hasattr(s, "__self__"):
-                    yield s.__self__, se  # type: ignore
+                    yield s.__self__, se  # type: ignore[attr-defined]
         else:
             if not type(e) in TYPE_BLACKLIST:
                 yield s, e

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -985,7 +985,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
                 continue
             if isinstance(lvalue, TupleExpr) or isinstance(lvalue, ListExpr):
                 items = lvalue.items
-                if isinstance(o.unanalyzed_type, TupleType):  # type: ignore
+                if isinstance(o.unanalyzed_type, TupleType):  # type: ignore[misc]
                     annotations: Iterable[Type | None] = o.unanalyzed_type.items
                 else:
                     annotations = [None] * len(items)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -354,7 +354,7 @@ def _verify_final(
 ) -> Iterator[Error]:
     try:
 
-        class SubClass(runtime):  # type: ignore
+        class SubClass(runtime):  # type: ignore[misc,valid-type]
             pass
 
     except TypeError:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -26,7 +26,7 @@ from mypy.test.helpers import (
 )
 
 try:
-    import lxml  # type: ignore
+    import lxml  # type: ignore[import]
 except ImportError:
     lxml = None
 

--- a/mypy/test/testcmdline.py
+++ b/mypy/test/testcmdline.py
@@ -20,7 +20,7 @@ from mypy.test.helpers import (
 )
 
 try:
-    import lxml  # type: ignore
+    import lxml  # type: ignore[import]
 except ImportError:
     lxml = None
 

--- a/mypy/test/testreports.py
+++ b/mypy/test/testreports.py
@@ -7,7 +7,7 @@ from mypy.report import CoberturaPackage, get_line_rate
 from mypy.test.helpers import Suite, assert_equal
 
 try:
-    import lxml  # type: ignore
+    import lxml  # type: ignore[import]
 except ImportError:
     lxml = None
 
@@ -22,7 +22,7 @@ class CoberturaReportSuite(Suite):
 
     @pytest.mark.skipif(lxml is None, reason="Cannot import lxml. Is it installed?")
     def test_as_xml(self) -> None:
-        import lxml.etree as etree  # type: ignore
+        import lxml.etree as etree  # type: ignore[import]
 
         cobertura_package = CoberturaPackage("foobar")
         cobertura_package.covered_lines = 21

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -209,7 +209,7 @@ class TypeTranslator(TypeVisitor[Type]):
         last_known_value: LiteralType | None = None
         if t.last_known_value is not None:
             raw_last_known_value = t.last_known_value.accept(self)
-            assert isinstance(raw_last_known_value, LiteralType)  # type: ignore
+            assert isinstance(raw_last_known_value, LiteralType)  # type: ignore[misc]
             last_known_value = raw_last_known_value
         return Instance(
             typ=t.type,
@@ -266,7 +266,7 @@ class TypeTranslator(TypeVisitor[Type]):
 
     def visit_literal_type(self, t: LiteralType) -> Type:
         fallback = t.fallback.accept(self)
-        assert isinstance(fallback, Instance)  # type: ignore
+        assert isinstance(fallback, Instance)  # type: ignore[misc]
         return LiteralType(value=t.value, fallback=fallback, line=t.line, column=t.column)
 
     def visit_union_type(self, t: UnionType) -> Type:
@@ -284,7 +284,7 @@ class TypeTranslator(TypeVisitor[Type]):
         items: list[CallableType] = []
         for item in t.items:
             new = item.accept(self)
-            assert isinstance(new, CallableType)  # type: ignore
+            assert isinstance(new, CallableType)  # type: ignore[misc]
             items.append(new)
         return Overloaded(items=items)
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1550,7 +1550,7 @@ def expand_type_alias(
     assert typ.alias is not None
     # HACK: Implement FlexibleAlias[T, typ] by expanding it to typ here.
     if (
-        isinstance(typ.alias.target, Instance)  # type: ignore
+        isinstance(typ.alias.target, Instance)  # type: ignore[misc]
         and typ.alias.target.type.fullname == "mypy_extensions.FlexibleAlias"
     ):
         exp = get_proper_type(typ)

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -11,3 +11,4 @@ always_false = MYPYC
 plugins = misc/proper_plugin.py
 python_version = 3.7
 exclude = mypy/typeshed/|mypyc/test-data/|mypyc/lib-rt/
+enable_error_code = ignore-without-code


### PR DESCRIPTION
This PR makes mypy's self-check stricter by enforcing the use of error codes for `type: ignore` comments.