### PR TITLE
Add option for `strict-error-codes`

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -618,6 +618,14 @@ of the above sections.
 
        assert text is not None  # OK, check against None is allowed as a special case.
 
+.. option:: --strict-error-codes
+
+    Enable additional error codes, disabled by default. You can see the list
+    of codes enabled by this flag in the full :option:`mypy --help` output.
+
+    Note: the exact list of codes enabled by running :option:`--strict-error-codes`
+    may change over time.
+
 .. option:: --strict
 
     This flag mode enables all optional error checking flags.  You can see the

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -679,6 +679,17 @@ section of the command line docs.
    Prohibit equality checks, identity checks, and container checks between
    non-overlapping types.
 
+.. confval:: strict_error_codes
+
+    :type: boolean
+    :default: False
+
+   Enable additional error codes, disabled by default. You can see the list
+   of codes enabled by this flag in the full :option:`mypy --help` output.
+
+   Note: the exact list of codes enabled by running :confval:`strict_error_codes`
+   may change over time.
+
 .. confval:: strict
 
     :type: boolean

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -12,12 +12,19 @@ error_codes: dict[str, ErrorCode] = {}
 
 class ErrorCode:
     def __init__(
-        self, code: str, description: str, category: str, default_enabled: bool = True
+        self,
+        code: str,
+        description: str,
+        category: str,
+        default_enabled: bool = True,
+        *,
+        strict_enabled: bool = False,
     ) -> None:
         self.code = code
         self.description = description
         self.category = category
         self.default_enabled = default_enabled
+        self.strict_enabled = strict_enabled
         error_codes[code] = self
 
     def __str__(self) -> str:
@@ -144,6 +151,7 @@ IGNORE_WITHOUT_CODE: Final = ErrorCode(
     "Warn about '# type: ignore' comments which do not have error codes",
     "General",
     default_enabled=False,
+    strict_enabled=True,
 )
 UNUSED_AWAITABLE: Final = ErrorCode(
     "unused-awaitable",

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -590,13 +590,17 @@ class Errors:
         if self.options:
             current_mod_disabled = self.options.disabled_error_codes
             current_mod_enabled = self.options.enabled_error_codes
+            strict_error_codes = self.options.strict_error_codes
         else:
             current_mod_disabled = set()
             current_mod_enabled = set()
+            strict_error_codes = False
 
         if error_code in current_mod_disabled:
             return False
         elif error_code in current_mod_enabled:
+            return True
+        elif strict_error_codes and error_code.strict_enabled:
             return True
         else:
             return error_code.default_enabled

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -824,6 +824,20 @@ def process_options(
         group=strictness_group,
     )
 
+    strict_error_code_names = [name for name, code in error_codes.items() if code.strict_enabled]
+    strict_error_codes_help = (
+        "Enable additional error codes, disabled by default; "
+        f"enables the following codes: {', '.join(strict_error_code_names)}"
+    )
+
+    add_invertible_flag(
+        "--strict-error-codes",
+        default=False,
+        strict_flag=True,
+        help=strict_error_codes_help,
+        group=strictness_group,
+    )
+
     strict_help = "Strict mode; enables the following flags: {}".format(
         ", ".join(strict_flag_names)
     )

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -190,6 +190,8 @@ class Options:
         # Variable names considered False
         self.always_false: list[str] = []
 
+        self.strict_error_codes = False
+
         # Error codes to disable
         self.disable_error_code: list[str] = []
         self.disabled_error_codes: set[ErrorCode] = set()

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -925,3 +925,7 @@ def f(d: D, s: str) -> None:
 [case testRecommendErrorCode]
 # type: ignore[whatever]  # E: type ignore with error code is not supported for modules; use `# mypy: disable-error-code=...`  [syntax]
 1 + "asdf"
+
+[case testStrictErrorCodes]
+# flags: --strict-error-codes
+var: bool = 1  # type: ignore  # E: "type: ignore" comment without error code (consider "type: ignore[assignment]" instead)  [ignore-without-code]


### PR DESCRIPTION
### Description
This PR adds a `--strict-error-codes` option which will enable the `ignore-without-code` error code in strict mode. Additional error codes may be added in the future. However, I don't believe any of the other once currently disabled by default are suitable (`redundant-expr`, `truthy-bool`, `unused-awaitable`).

### Rational
Since the release, `ignore-without-code` has been added to an increasing number of repos by default and even mypy itself recently #13534. I believe it's beneficial for everyone if we try to nudge users into providing more specific type ignores instead of the bare one.