### PR TITLE
checker: simplify check_simple_assignment error handling

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1252,10 +1252,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 arg.variable.type,
                 arg.initializer,
                 context=arg.initializer,
-                msg=msg,
+                msg=ErrorMessage(msg, code=codes.ASSIGNMENT),
                 lvalue_name="argument",
                 rvalue_name="default",
-                code=codes.ASSIGNMENT,
             )
 
     def is_forward_op_method(self, method_name: str) -> bool:
@@ -2396,8 +2395,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if lvalue_type is None:
                 # TODO: This is broken.
                 lvalue_type = AnyType(TypeOfAny.special_form)
-            message = '{} "{}"'.format(
-                message_registry.INCOMPATIBLE_IMPORT_OF, cast(NameExpr, assign.rvalue).name
+            message = message_registry.INCOMPATIBLE_IMPORT_OF.format(
+                cast(NameExpr, assign.rvalue).name
             )
             self.check_simple_assignment(
                 lvalue_type,
@@ -2660,9 +2659,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             lvalue_type = make_optional_type(lvalue_type)
                             self.set_inferred_type(lvalue.node, lvalue, lvalue_type)
 
-                    rvalue_type = self.check_simple_assignment(
-                        lvalue_type, rvalue, context=rvalue, code=codes.ASSIGNMENT
-                    )
+                    rvalue_type = self.check_simple_assignment(lvalue_type, rvalue, context=rvalue)
 
                 # Special case: only non-abstract non-protocol classes can be assigned to
                 # variables with explicit type Type[A], where A is protocol or abstract.
@@ -2895,7 +2892,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
                 "expression has type",
                 f'base class "{base.name}" defined the type as',
-                code=codes.ASSIGNMENT,
             )
         return True
 
@@ -3683,11 +3679,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         lvalue_type: Type | None,
         rvalue: Expression,
         context: Context,
-        msg: str = message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
+        msg: ErrorMessage = message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
         lvalue_name: str = "variable",
         rvalue_name: str = "expression",
-        *,
-        code: ErrorCode | None = None,
     ) -> Type:
         if self.is_stub and isinstance(rvalue, EllipsisExpr):
             # '...' is always a valid initializer in a stub.
@@ -3712,7 +3706,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     msg,
                     f"{rvalue_name} has type",
                     f"{lvalue_name} has type",
-                    code=code,
                 )
             return rvalue_type
 
@@ -3736,16 +3729,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if (isinstance(instance_type, FunctionLike) and instance_type.is_type_obj()) or isinstance(
             instance_type, TypeType
         ):
-            rvalue_type = self.check_simple_assignment(
-                attribute_type, rvalue, context, code=codes.ASSIGNMENT
-            )
+            rvalue_type = self.check_simple_assignment(attribute_type, rvalue, context)
             return rvalue_type, attribute_type, True
 
         if not isinstance(attribute_type, Instance):
             # TODO: support __set__() for union types.
-            rvalue_type = self.check_simple_assignment(
-                attribute_type, rvalue, context, code=codes.ASSIGNMENT
-            )
+            rvalue_type = self.check_simple_assignment(attribute_type, rvalue, context)
             return rvalue_type, attribute_type, True
 
         mx = MemberContext(
@@ -3764,9 +3753,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # the return type of __get__. This doesn't match the python semantics,
             # (which allow you to override the descriptor with any value), but preserves
             # the type of accessing the attribute (even after the override).
-            rvalue_type = self.check_simple_assignment(
-                get_type, rvalue, context, code=codes.ASSIGNMENT
-            )
+            rvalue_type = self.check_simple_assignment(get_type, rvalue, context)
             return rvalue_type, get_type, True
 
         dunder_set = attribute_type.type.get_method("__set__")
@@ -3833,9 +3820,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # and '__get__' type is narrower than '__set__', then we invoke the binder to narrow type
         # by this assignment. Technically, this is not safe, but in practice this is
         # what a user expects.
-        rvalue_type = self.check_simple_assignment(
-            set_type, rvalue, context, code=codes.ASSIGNMENT
-        )
+        rvalue_type = self.check_simple_assignment(set_type, rvalue, context)
         infer = is_subtype(rvalue_type, get_type) and is_subtype(get_type, set_type)
         return rvalue_type if infer else set_type, get_type, infer
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -819,10 +819,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     lvalue_type=item_expected_type,
                     rvalue=item_value,
                     context=item_value,
-                    msg=message_registry.INCOMPATIBLE_TYPES.value,
+                    msg=ErrorMessage(
+                        message_registry.INCOMPATIBLE_TYPES.value, code=codes.TYPEDDICT_ITEM
+                    ),
                     lvalue_name=f'TypedDict item "{item_name}"',
                     rvalue_name="expression",
-                    code=codes.TYPEDDICT_ITEM,
                 )
 
         return orig_ret_type

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -46,7 +46,7 @@ RETURN: Final[ErrorCode] = ErrorCode(
 RETURN_VALUE: Final[ErrorCode] = ErrorCode(
     "return-value", "Check that return value is compatible with signature", "General"
 )
-ASSIGNMENT: Final = ErrorCode(
+ASSIGNMENT: Final[ErrorCode] = ErrorCode(
     "assignment", "Check that assigned value is compatible with target", "General"
 )
 TYPE_ARG: Final = ErrorCode("type-arg", "Check that generic type arguments are present", "General")

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -99,7 +99,7 @@ RETURN_TYPE_CANNOT_BE_CONTRAVARIANT: Final = ErrorMessage(
 FUNCTION_PARAMETER_CANNOT_BE_COVARIANT: Final = ErrorMessage(
     "Cannot use a covariant type variable as a parameter"
 )
-INCOMPATIBLE_IMPORT_OF: Final = ErrorMessage("Incompatible import of {}", code=codes.ASSIGNMENT)
+INCOMPATIBLE_IMPORT_OF: Final = ErrorMessage('Incompatible import of "{}"', code=codes.ASSIGNMENT)
 FUNCTION_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a type annotation", codes.NO_UNTYPED_DEF
 )

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -51,7 +51,9 @@ INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR: Final = ErrorMessage(
 )
 YIELD_VALUE_EXPECTED: Final = ErrorMessage("Yield value expected")
 INCOMPATIBLE_TYPES: Final = ErrorMessage("Incompatible types")
-INCOMPATIBLE_TYPES_IN_ASSIGNMENT: Final = "Incompatible types in assignment"
+INCOMPATIBLE_TYPES_IN_ASSIGNMENT: Final = ErrorMessage(
+    "Incompatible types in assignment", code=codes.ASSIGNMENT
+)
 INCOMPATIBLE_TYPES_IN_AWAIT: Final = ErrorMessage('Incompatible types in "await"')
 INCOMPATIBLE_REDEFINITION: Final = ErrorMessage("Incompatible redefinition")
 INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER: Final = (
@@ -97,7 +99,7 @@ RETURN_TYPE_CANNOT_BE_CONTRAVARIANT: Final = ErrorMessage(
 FUNCTION_PARAMETER_CANNOT_BE_COVARIANT: Final = ErrorMessage(
     "Cannot use a covariant type variable as a parameter"
 )
-INCOMPATIBLE_IMPORT_OF: Final = "Incompatible import of"
+INCOMPATIBLE_IMPORT_OF: Final = ErrorMessage("Incompatible import of {}", code=codes.ASSIGNMENT)
 FUNCTION_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a type annotation", codes.NO_UNTYPED_DEF
 )

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -582,20 +582,18 @@ class MessageBuilder:
                     )
                     return codes.INDEX
                 else:
-                    msg = "{} (expression has type {}, target has type {})"
                     arg_type_str, callee_type_str = format_type_distinctly(
                         arg_type, callee.arg_types[n - 1]
                     )
-                    self.fail(
-                        msg.format(
-                            message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT,
-                            arg_type_str,
-                            callee_type_str,
-                        ),
-                        context,
-                        code=codes.ASSIGNMENT,
+                    info = (
+                        f" (expression has type {arg_type_str}, "
+                        f"target has type {callee_type_str})"
                     )
-                    return codes.ASSIGNMENT
+                    msg = message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT.with_additional_msg(
+                        info
+                    )
+                    self.fail(msg.value, context, code=msg.code)
+                    return msg.code
 
             target = f"to {name} "
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -589,11 +589,11 @@ class MessageBuilder:
                         f" (expression has type {arg_type_str}, "
                         f"target has type {callee_type_str})"
                     )
-                    msg = message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT.with_additional_msg(
-                        info
+                    error_msg = (
+                        message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT.with_additional_msg(info)
                     )
-                    self.fail(msg.value, context, code=msg.code)
-                    return msg.code
+                    self.fail(error_msg.value, context, code=error_msg.code)
+                    return error_msg.code
 
             target = f"to {name} "
 


### PR DESCRIPTION
Let it only take an ErrorMessage. The default error now gets an error
code as well, which closes up some code paths where we were getting code
"misc".