### PR TITLE
Bump `flake8` test dependencies; remove `importlib_metadata` as a test dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,9 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2  # must match test-requirements.txt
+    rev: 5.0.4  # must match test-requirements.txt
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear==22.7.1  # must match test-requirements.txt
-          - flake8-noqa==1.2.8      # must match test-requirements.txt
+          - flake8-bugbear==22.8.23  # must match test-requirements.txt
+          - flake8-noqa==1.2.9       # must match test-requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,9 +4,9 @@ attrs>=18.0
 black==22.6.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0,<3.4.2; python_version<'3.7'
 filelock>=3.3.0; python_version>='3.7'
-flake8==3.9.2           # must match version in .pre-commit-config.yaml
-flake8-bugbear==22.7.1  # must match version in .pre-commit-config.yaml
-flake8-noqa==1.2.8      # must match version in .pre-commit-config.yaml
+flake8==5.0.4           # must match version in .pre-commit-config.yaml
+flake8-bugbear==22.8.23 # must match version in .pre-commit-config.yaml
+flake8-noqa==1.2.9      # must match version in .pre-commit-config.yaml
 isort[colors]==5.10.1   # must match version in .pre-commit-config.yaml
 lxml>=4.4.0; python_version<'3.11'
 psutil>=4.0
@@ -19,4 +19,3 @@ py>=1.5.2
 typed_ast>=1.5.4,<2; python_version>='3.8'
 setuptools!=50
 six
-importlib-metadata>=4.6.1,<5.0.0


### PR DESCRIPTION
- Bump `flake8` from 3.9.2 to 5.0.4. As pointed out by @cdce8p in #13368, this has significant performance improvements.
- Bump `flake8-bugbear` from 22.7.1 to 22.8.23
- Bump `flake8-noqa` from 1.2.8 to 1.2.9
- Drop `importlib_metadata` as a test requirement. The whole test suite seems to pass without it, and it conflicts with flake8 >= 5.0.0.
