### PR TITLE
Allow `@final` on `TypedDict`

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1469,8 +1469,8 @@ class SemanticAnalyzer(
             for decorator in defn.decorators:
                 decorator.accept(self)
                 if isinstance(decorator, RefExpr):
-                    if decorator.fullname in FINAL_DECORATOR_NAMES:
-                        self.fail("@final cannot be used with TypedDict", decorator)
+                    if decorator.fullname in FINAL_DECORATOR_NAMES and info is not None:
+                        info.is_final = True
             if info is None:
                 self.mark_incomplete(defn.name, defn)
             else:

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing_extensions import Final
 
-from mypy import errorcodes as codes
+from mypy import errorcodes as codes, message_registry
 from mypy.errorcodes import ErrorCode
 from mypy.exprtotype import TypeTranslationError, expr_to_unanalyzed_type
 from mypy.messages import MessageBuilder
@@ -79,6 +79,9 @@ class TypedDictAnalyzer:
                 self.api.accept(base_expr)
                 if base_expr.fullname in TPDICT_NAMES or self.is_typeddict(base_expr):
                     possible = True
+                    if isinstance(base_expr.node, TypeInfo) and base_expr.node.is_final:
+                        err = message_registry.CANNOT_INHERIT_FROM_FINAL
+                        self.fail(err.format(base_expr.node.name).value, defn, code=err.code)
         if not possible:
             return False, None
         existing_info = None

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2012,15 +2012,34 @@ v = {bad2: 2}  # E: Extra key "bad" for TypedDict "Value"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
-[case testCannotUseFinalDecoratorWithTypedDict]
+[case testCannotSubclassFinalTypedDict]
 from typing import TypedDict
 from typing_extensions import final
 
-@final  # E: @final cannot be used with TypedDict
+@final
 class DummyTypedDict(TypedDict):
     int_val: int
     float_val: float
     str_val: str
+
+class SubType(DummyTypedDict): # E: Cannot inherit from final class "DummyTypedDict"
+    pass
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+[case testCannotSubclassFinalTypedDictWithForwardDeclarations]
+from typing import TypedDict
+from typing_extensions import final
+
+@final
+class DummyTypedDict(TypedDict):
+    forward_declared: "ForwardDeclared"
+
+class SubType(DummyTypedDict): # E: Cannot inherit from final class "DummyTypedDict"
+    pass
+
+class ForwardDeclared: pass
 
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]


### PR DESCRIPTION
Allow a `TypedDict` to be decorated with `@final`. Like a regular class, mypy will emit an error if a final `TypedDict` is subclassed.

Relates-to: #7981

### Description

Allow `@final` to be applied to a `TypedDict`, and have mypy emit an error if class is derived from a final `TypedDict`. This goes some way towards closing #7981 and closing a feature gap with pyright, though not the whole way, as #7981 also asks for additional type narrowing for a final `TypedDict`.

## Test Plan

`testCannotUseFinalDecoratorWithTypedDict` was removed, and `testCannotSubclassFinalTypedDict` added.