### PR TITLE
Treat `ABCMeta` subtypes as abstract metaclasses

### DIFF
--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -95,7 +95,7 @@ def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: E
     # implement some methods.
     typ.abstract_attributes = sorted(abstract)
     if is_stub_file:
-        if typ.declared_metaclass and typ.declared_metaclass.type.fullname == "abc.ABCMeta":
+        if typ.declared_metaclass and typ.declared_metaclass.type.has_base("abc.ABCMeta"):
             return
         if typ.is_protocol:
             return

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5497,6 +5497,13 @@ class E(Protocol):  # OK, is a protocol
 class F(E, Protocol):  # OK, is a protocol
     pass
 
+# Custom metaclass subclassing `ABCMeta`, see #13561
+class CustomMeta(ABCMeta):
+    pass
+
+class G(A, metaclass=CustomMeta):  # Ok, has CustomMeta as a metaclass
+    pass
+
 [file b.py]
 # All of these are OK because this is not a stub file.
 from abc import ABCMeta, abstractmethod
@@ -5523,6 +5530,12 @@ class E(Protocol):
         pass
 
 class F(E, Protocol):
+    pass
+
+class CustomMeta(ABCMeta):
+    pass
+
+class G(A, metaclass=CustomMeta):
     pass
 
 [case testClassMethodOverride]


### PR DESCRIPTION
Closes #13561