### PR TITLE
Set metaclass in `make_fake_typeinfo`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4613,7 +4613,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         cdef.info = info
         info.bases = bases
         calculate_mro(info)
-        info.calculate_metaclass_type()
+        info.metaclass_type = info.calculate_metaclass_type()
         return cdef, info
 
     def intersect_instances(


### PR DESCRIPTION
`calculate_metaclass_info()` does not mutate `info`, it returns a value.
It was never used.

Since `make_fake_typeinfo` is only used in a couple of places, we haven't noticed it.
