### PR TITLE
Fix spurious unreachable and disallow-any errors from deferred passes

### DIFF
--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -366,6 +366,22 @@ def f() -> NoReturn:  # E: Implicit return in function which does not return
   non_trivial_function = 1
 [builtins fixtures/dict.pyi]
 
+[case testNoReturnImplicitReturnCheckInDeferredNode]
+# flags: --warn-no-return
+from typing import NoReturn
+
+def exit() -> NoReturn: ...
+
+def force_forward_reference() -> int:
+    return 4
+
+def f() -> NoReturn:
+    x
+    exit()
+
+x = force_forward_reference()
+[builtins fixtures/exception.pyi]
+
 [case testNoReturnNoWarnNoReturn]
 # flags: --warn-no-return
 from mypy_extensions import NoReturn

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -945,6 +945,18 @@ x = f()
 main:10: note: Revealed type is "builtins.int"
 main:15: note: Revealed type is "builtins.str"
 
+[case testExceptionVariableWithDisallowAnyExprInDeferredNode]
+# flags: --disallow-any-expr
+def f() -> int:
+    x
+    try:
+        pass
+    except Exception as ex:
+        pass
+    return 0
+x = f()
+[builtins fixtures/exception.pyi]
+
 [case testArbitraryExpressionAsExceptionType]
 import typing
 a = BaseException

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1397,3 +1397,20 @@ a or a  # E: Right operand of "or" is never evaluated
 1 and a and 1  # E: Right operand of "and" is never evaluated
 a and a  # E: Right operand of "and" is never evaluated
 [builtins fixtures/exception.pyi]
+
+[case testUnreachableFlagWithTerminalBranchInDeferredNode]
+# flags: --warn-unreachable
+from typing import NoReturn
+
+def assert_never(x: NoReturn) -> NoReturn: ...
+
+def force_forward_ref() -> int:
+    return 4
+
+def f(value: None) -> None:
+    x
+    if value is not None:
+        assert_never(value)
+
+x = force_forward_ref()
+[builtins fixtures/exception.pyi]


### PR DESCRIPTION
This diff:

- Fixes #8129
- Fixes #13043
- Fixes #13167

For more concise repros of these various issues, see the modified test files. But in short, there were two broad categories of errors:

1.  Within the deferred pass, we tend to infer 'Any' for the types of different variables instead of the actual type. This interacts badly with our unreachable and disallow-any checks and causes spurious errors.

    Arguably, the better way of handling this error is to only collect errors during the final pass. I briefly experimented with this
    approach, but was unable to find a clean, efficient, and non-disruptive way of implementing this. So, I settled for sprinkling in a few more `not self.current_node_deferred` checks.

2.  The `self.msg.disallowed_any_type(...)` call is normally guarded behind a `not self.chk.current_node_deferred` check. However, we were bypassing this check for `except` block assignments because we were deliberately setting that flag to False to work around some bug. For more context, see #2290.

    It appears we no longer need this patch anymore. I'm not entirely sure why, but I'm guessing we tightened and fixed the underlying problem with deferred passes some time during the past half-decade.
