### PR TITLE
Ensure we always infer a valid fallback type for lambda callables

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4230,6 +4230,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         callable_ctx = get_proper_type(replace_meta_vars(ctx, ErasedType()))
         assert isinstance(callable_ctx, CallableType)
 
+        # The callable_ctx may have a fallback of builtins.type if the context
+        # is a constructor -- but this fallback doesn't make sense for lambdas.
+        callable_ctx = callable_ctx.copy_modified(fallback=self.named_type("builtins.function"))
+
         if callable_ctx.type_guard is not None:
             # Lambda's return type cannot be treated as a `TypeGuard`,
             # because it is implicit. And `TypeGuard`s must be explicit.

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1276,6 +1276,21 @@ class A:
 def h(x: Callable[[], int]) -> None:
     pass
 
+[case testLambdaJoinWithDynamicConstructor]
+from typing import Any, Union
+
+class Wrapper:
+    def __init__(self, x: Any) -> None: ...
+
+def f(cond: bool) -> Any:
+    f = Wrapper if cond else lambda x: x
+    reveal_type(f)  # N: Revealed type is "def (x: Any) -> Any"
+    return f(3)
+
+def g(cond: bool) -> Any:
+    f = lambda x: x if cond else Wrapper
+    reveal_type(f)  # N: Revealed type is "def (x: Any) -> Any"
+    return f(3)
 
 -- Boolean operators
 -- -----------------


### PR DESCRIPTION
Fixes #9234

This diff fixes a bug in `infer_lambda_type_using_context` where it blindly trusted and reused whatever fallback the context callable was using.

This causes mypy to crash in the case where the context was a dynamic constructor. This is because...

1.  The constructor has a fallback of `builtins.type`
2.  The Callable object `infer_lambda_type_using_context` returns uses this fallback as-is.
3.  The join of the LHS and RHS of the ternary ends up being a `def (Any) -> Any` with a fallback of `builtins.type`. See: https://github.com/python/mypy/blob/7ffaf230a3984faaf848fe314cf275b854a0cdb0/mypy/join.py#L578
4.  Later, we call `CallableType.is_type_obj()` and `CallableType.type_object()`. The former ends up succeeding due to the fallback, but the latter fails an assert because the return type is Any, not an Instance: https://github.com/python/mypy/blob/7ffaf230a3984faaf848fe314cf275b854a0cdb0/mypy/types.py#L1771

I opted to fix this by modifying `infer_lambda_type_using_context` so it overrides the fallback to always be `builtins.function` -- I don't think it makes sense for it to be anything else.