### PR TITLE
[mypyc] Properly support native int argument defaults

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -8,7 +8,7 @@ from typing_extensions import Final
 
 from mypyc.codegen.literals import Literals
 from mypyc.common import (
-    ATTR_BITMAP_BITS,
+    BITMAP_BITS,
     ATTR_PREFIX,
     FAST_ISINSTANCE_MAX_SUBCLASSES,
     NATIVE_PREFIX,
@@ -332,7 +332,7 @@ class Emitter:
 
     def bitmap_field(self, index: int) -> str:
         """Return C field name used for attribute bitmap."""
-        n = index // ATTR_BITMAP_BITS
+        n = index // BITMAP_BITS
         if n == 0:
             return "bitmap"
         return f"bitmap{n + 1}"
@@ -366,7 +366,7 @@ class Emitter:
         if value:
             self.emit_line(f"if (unlikely({value} == {self.c_undefined_value(rtype)})) {{")
         index = cl.bitmap_attrs.index(attr)
-        mask = 1 << (index & (ATTR_BITMAP_BITS - 1))
+        mask = 1 << (index & (BITMAP_BITS - 1))
         bitmap = self.attr_bitmap_expr(obj, cl, index)
         if clear:
             self.emit_line(f"{bitmap} &= ~{mask};")
@@ -400,7 +400,7 @@ class Emitter:
             check = f"unlikely({check})"
         if is_fixed_width_rtype(rtype):
             index = cl.bitmap_attrs.index(attr)
-            bit = 1 << (index & (ATTR_BITMAP_BITS - 1))
+            bit = 1 << (index & (BITMAP_BITS - 1))
             attr = self.bitmap_field(index)
             obj_expr = f"({cl.struct_name(self.names)} *){obj}"
             check = f"{check} && !(({obj_expr})->{attr} & {bit})"

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -8,8 +8,8 @@ from typing_extensions import Final
 
 from mypyc.codegen.literals import Literals
 from mypyc.common import (
-    BITMAP_BITS,
     ATTR_PREFIX,
+    BITMAP_BITS,
     FAST_ISINSTANCE_MAX_SUBCLASSES,
     NATIVE_PREFIX,
     REG_PREFIX,

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -986,7 +986,11 @@ class Emitter:
 
     def emit_error_check(self, value: str, rtype: RType, failure: str) -> None:
         """Emit code for checking a native function return value for uncaught exception."""
-        if not isinstance(rtype, RTuple):
+        if is_fixed_width_rtype(rtype):
+            # The error value is also valid as a normal value, so we need to also check
+            # for a raised exception.
+            self.emit_line(f"if ({value} == {self.c_error_value(rtype)} && PyErr_Occurred()) {{")
+        elif not isinstance(rtype, RTuple):
             self.emit_line(f"if ({value} == {self.c_error_value(rtype)}) {{")
         else:
             if len(rtype.types) == 0:

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -18,8 +18,8 @@ from mypyc.codegen.emitwrapper import (
     generate_set_del_item_wrapper,
 )
 from mypyc.common import (
-    ATTR_BITMAP_BITS,
-    ATTR_BITMAP_TYPE,
+    BITMAP_BITS,
+    BITMAP_TYPE,
     NATIVE_PREFIX,
     PREFIX,
     REG_PREFIX,
@@ -385,10 +385,10 @@ def generate_object_struct(cl: ClassIR, emitter: Emitter) -> None:
             if base.bitmap_attrs:
                 # Do we need another attribute bitmap field?
                 if emitter.bitmap_field(len(base.bitmap_attrs) - 1) not in bitmap_attrs:
-                    for i in range(0, len(base.bitmap_attrs), ATTR_BITMAP_BITS):
+                    for i in range(0, len(base.bitmap_attrs), BITMAP_BITS):
                         attr = emitter.bitmap_field(i)
                         if attr not in bitmap_attrs:
-                            lines.append(f"{ATTR_BITMAP_TYPE} {attr};")
+                            lines.append(f"{BITMAP_TYPE} {attr};")
                             bitmap_attrs.append(attr)
             for attr, rtype in base.attributes.items():
                 if (attr, rtype) not in seen_attrs:
@@ -567,7 +567,7 @@ def generate_setup_for_class(
         emitter.emit_line("}")
     else:
         emitter.emit_line(f"self->vtable = {vtable_name};")
-    for i in range(0, len(cl.bitmap_attrs), ATTR_BITMAP_BITS):
+    for i in range(0, len(cl.bitmap_attrs), BITMAP_BITS):
         field = emitter.bitmap_field(i)
         emitter.emit_line(f"self->{field} = 0;")
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -17,14 +17,7 @@ from mypyc.codegen.emitwrapper import (
     generate_richcompare_wrapper,
     generate_set_del_item_wrapper,
 )
-from mypyc.common import (
-    BITMAP_BITS,
-    BITMAP_TYPE,
-    NATIVE_PREFIX,
-    PREFIX,
-    REG_PREFIX,
-    use_fastcall,
-)
+from mypyc.common import BITMAP_BITS, BITMAP_TYPE, NATIVE_PREFIX, PREFIX, REG_PREFIX, use_fastcall
 from mypyc.ir.class_ir import ClassIR, VTableEntries
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD, FuncDecl, FuncIR
 from mypyc.ir.rtypes import RTuple, RType, is_fixed_width_rtype, object_rprimitive

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -230,7 +230,7 @@ def generate_legacy_wrapper_function(
     # If fn is a method, then the first argument is a self param
     real_args = list(fn.args)
     if fn.sig.num_bitmap_args:
-        real_args = real_args[:-fn.sig.num_bitmap_args]
+        real_args = real_args[: -fn.sig.num_bitmap_args]
     if fn.class_name and not fn.decl.kind == FUNC_STATICMETHOD:
         arg = real_args.pop(0)
         emitter.emit_line(f"PyObject *obj_{arg.name} = self;")

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -17,13 +17,14 @@ from typing import Sequence
 from mypy.nodes import ARG_NAMED, ARG_NAMED_OPT, ARG_OPT, ARG_POS, ARG_STAR, ARG_STAR2, ArgKind
 from mypy.operators import op_methods_to_symbols, reverse_op_method_names, reverse_op_methods
 from mypyc.codegen.emit import AssignHandler, Emitter, ErrorHandler, GotoHandler, ReturnHandler
-from mypyc.common import DUNDER_PREFIX, NATIVE_PREFIX, PREFIX, use_vectorcall
+from mypyc.common import DUNDER_PREFIX, NATIVE_PREFIX, PREFIX, bitmap_name, use_vectorcall
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FUNC_STATICMETHOD, FuncIR, RuntimeArg
 from mypyc.ir.rtypes import (
     RInstance,
     RType,
     is_bool_rprimitive,
+    is_fixed_width_rtype,
     is_int_rprimitive,
     is_object_rprimitive,
     object_rprimitive,
@@ -135,6 +136,8 @@ def generate_wrapper_function(
 
     # If fn is a method, then the first argument is a self param
     real_args = list(fn.args)
+    if fn.sig.num_bitmap_args:
+        real_args = real_args[: -fn.sig.num_bitmap_args]
     if fn.class_name and not fn.decl.kind == FUNC_STATICMETHOD:
         arg = real_args.pop(0)
         emitter.emit_line(f"PyObject *obj_{arg.name} = self;")
@@ -185,6 +188,9 @@ def generate_wrapper_function(
         "return NULL;",
         "}",
     )
+    for i in range(fn.sig.num_bitmap_args):
+        name = bitmap_name(i)
+        emitter.emit_line(f"uint32_t {name} = 0;")
     traceback_code = generate_traceback_code(fn, emitter, source_path, module_name)
     generate_wrapper_core(
         fn,
@@ -669,7 +675,8 @@ def generate_wrapper_core(
     """
     gen = WrapperGenerator(None, emitter)
     gen.set_target(fn)
-    gen.arg_names = arg_names or [arg.name for arg in fn.args]
+    if arg_names:
+        gen.arg_names = arg_names
     gen.cleanups = cleanups or []
     gen.optional_args = optional_args or []
     gen.traceback_code = traceback_code or ""
@@ -688,6 +695,7 @@ def generate_arg_check(
     *,
     optional: bool = False,
     raise_exception: bool = True,
+    bitmap_arg_index: int = 0,
 ) -> None:
     """Insert a runtime check for argument and unbox if necessary.
 
@@ -697,17 +705,34 @@ def generate_arg_check(
     """
     error = error or AssignHandler()
     if typ.is_unboxed:
-        # Borrow when unboxing to avoid reference count manipulation.
-        emitter.emit_unbox(
-            f"obj_{name}",
-            f"arg_{name}",
-            typ,
-            declare_dest=True,
-            raise_exception=raise_exception,
-            error=error,
-            borrow=True,
-            optional=optional,
-        )
+        if is_fixed_width_rtype(typ) and optional:
+            # Update bitmap is value is provided.
+            emitter.emit_line(f"{emitter.ctype(typ)} arg_{name} = 0;")
+            emitter.emit_line(f"if (obj_{name} != NULL) {{")
+            bitmap = bitmap_name(bitmap_arg_index // 32)
+            emitter.emit_line(f"{bitmap} |= 1 << {bitmap_arg_index & 31};")
+            emitter.emit_unbox(
+                f"obj_{name}",
+                f"arg_{name}",
+                typ,
+                declare_dest=False,
+                raise_exception=raise_exception,
+                error=error,
+                borrow=True,
+            )
+            emitter.emit_line("}")
+        else:
+            # Borrow when unboxing to avoid reference count manipulation.
+            emitter.emit_unbox(
+                f"obj_{name}",
+                f"arg_{name}",
+                typ,
+                declare_dest=True,
+                raise_exception=raise_exception,
+                error=error,
+                borrow=True,
+                optional=optional,
+            )
     elif is_object_rprimitive(typ):
         # Object is trivial since any object is valid
         if optional:
@@ -749,8 +774,12 @@ class WrapperGenerator:
         """
         self.target_name = fn.name
         self.target_cname = fn.cname(self.emitter.names)
-        self.arg_names = [arg.name for arg in fn.args]
-        self.args = fn.args[:]
+        self.num_bitmap_args = fn.sig.num_bitmap_args
+        if self.num_bitmap_args:
+            self.args = fn.args[: -self.num_bitmap_args]
+        else:
+            self.args = fn.args
+        self.arg_names = [arg.name for arg in self.args]
         self.ret_type = fn.ret_type
 
     def wrapper_name(self) -> str:
@@ -779,17 +808,22 @@ class WrapperGenerator:
     ) -> None:
         """Emit validation and unboxing of arguments."""
         error = error or self.error()
+        bitmap_arg_index = 0
         for arg_name, arg in zip(self.arg_names, self.args):
             # Suppress the argument check for *args/**kwargs, since we know it must be right.
             typ = arg.type if arg.kind not in (ARG_STAR, ARG_STAR2) else object_rprimitive
+            optional = arg in self.optional_args
             generate_arg_check(
                 arg_name,
                 typ,
                 self.emitter,
                 error,
                 raise_exception=raise_exception,
-                optional=arg in self.optional_args,
+                optional=optional,
+                bitmap_arg_index=bitmap_arg_index,
             )
+            if optional and is_fixed_width_rtype(typ):
+                bitmap_arg_index += 1
 
     def emit_call(self, not_implemented_handler: str = "") -> None:
         """Emit call to the wrapper function.
@@ -798,6 +832,12 @@ class WrapperGenerator:
         a NotImplemented return value (if it's possible based on the return type).
         """
         native_args = ", ".join(f"arg_{arg}" for arg in self.arg_names)
+        if self.num_bitmap_args:
+            bitmap_args = ", ".join(
+                [bitmap_name(i) for i in reversed(range(self.num_bitmap_args))]
+            )
+            native_args = f"{native_args}, {bitmap_args}"
+
         ret_type = self.ret_type
         emitter = self.emitter
         if ret_type.is_unboxed or self.use_goto():

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -17,7 +17,15 @@ from typing import Sequence
 from mypy.nodes import ARG_NAMED, ARG_NAMED_OPT, ARG_OPT, ARG_POS, ARG_STAR, ARG_STAR2, ArgKind
 from mypy.operators import op_methods_to_symbols, reverse_op_method_names, reverse_op_methods
 from mypyc.codegen.emit import AssignHandler, Emitter, ErrorHandler, GotoHandler, ReturnHandler
-from mypyc.common import DUNDER_PREFIX, NATIVE_PREFIX, PREFIX, bitmap_name, use_vectorcall, BITMAP_TYPE, BITMAP_BITS
+from mypyc.common import (
+    BITMAP_BITS,
+    BITMAP_TYPE,
+    DUNDER_PREFIX,
+    NATIVE_PREFIX,
+    PREFIX,
+    bitmap_name,
+    use_vectorcall,
+)
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FUNC_STATICMETHOD, FuncIR, RuntimeArg
 from mypyc.ir.rtypes import (

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -229,6 +229,8 @@ def generate_legacy_wrapper_function(
 
     # If fn is a method, then the first argument is a self param
     real_args = list(fn.args)
+    if fn.sig.num_bitmap_args:
+        real_args = real_args[:-fn.sig.num_bitmap_args]
     if fn.class_name and not fn.decl.kind == FUNC_STATICMETHOD:
         arg = real_args.pop(0)
         emitter.emit_line(f"PyObject *obj_{arg.name} = self;")
@@ -260,6 +262,9 @@ def generate_legacy_wrapper_function(
         "return NULL;",
         "}",
     )
+    for i in range(fn.sig.num_bitmap_args):
+        name = bitmap_name(i)
+        emitter.emit_line(f"uint32_t {name} = 0;")
     traceback_code = generate_traceback_code(fn, emitter, source_path, module_name)
     generate_wrapper_core(
         fn,

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -53,10 +53,12 @@ MIN_SHORT_INT: Final = -(sys.maxsize >> 1) - 1
 MAX_LITERAL_SHORT_INT: Final = sys.maxsize >> 1 if not IS_MIXED_32_64_BIT_BUILD else 2**30 - 1
 MIN_LITERAL_SHORT_INT: Final = -MAX_LITERAL_SHORT_INT - 1
 
-# Decription of the C type used to track definedness of attributes
-# that have types with overlapping error values
-ATTR_BITMAP_TYPE: Final = "uint32_t"
-ATTR_BITMAP_BITS: Final = 32
+# Decription of the C type used to track the definedness of attributes and
+# the presence of argument default values that have types with overlapping
+# error values. Each tracked attribute/argument has a dedicated bit in the
+# relevant bitmap.
+BITMAP_TYPE: Final = "uint32_t"
+BITMAP_BITS: Final = 32
 
 # Runtime C library files
 RUNTIME_C_FILES: Final = [

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -128,3 +128,9 @@ def short_id_from_name(func_name: str, shortname: str, line: int | None) -> str:
     else:
         partial_name = shortname
     return partial_name
+
+
+def bitmap_name(index: int) -> str:
+    if index == 0:
+        return "__bitmap"
+    return f"__bitmap{index + 1}"

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -6,7 +6,7 @@ from typing import Sequence
 from typing_extensions import Final
 
 from mypy.nodes import ARG_POS, ArgKind, Block, FuncDef
-from mypyc.common import JsonDict, get_id_from_name, short_id_from_name
+from mypyc.common import JsonDict, bitmap_name, get_id_from_name, short_id_from_name
 from mypyc.ir.ops import (
     Assign,
     AssignMulti,
@@ -17,7 +17,7 @@ from mypyc.ir.ops import (
     Register,
     Value,
 )
-from mypyc.ir.rtypes import RType, deserialize_type
+from mypyc.ir.rtypes import RType, deserialize_type, is_fixed_width_rtype, uint32_rprimitive
 from mypyc.namegen import NameGenerator
 
 
@@ -70,12 +70,29 @@ class FuncSignature:
     def __init__(self, args: Sequence[RuntimeArg], ret_type: RType) -> None:
         self.args = tuple(args)
         self.ret_type = ret_type
+        self.num_bitmap_args = num_bitmap_args(self.args)
+        if self.num_bitmap_args:
+            extra = [
+                RuntimeArg(bitmap_name(i), uint32_rprimitive, pos_only=True)
+                for i in range(self.num_bitmap_args)
+            ]
+            self.args = self.args + tuple(reversed(extra))
+
+    def bound_sig(self) -> "FuncSignature":
+        if self.num_bitmap_args:
+            return FuncSignature(self.args[1 : -self.num_bitmap_args], self.ret_type)
+        else:
+            return FuncSignature(self.args[1:], self.ret_type)
 
     def __repr__(self) -> str:
         return f"FuncSignature(args={self.args!r}, ret={self.ret_type!r})"
 
     def serialize(self) -> JsonDict:
-        return {"args": [t.serialize() for t in self.args], "ret_type": self.ret_type.serialize()}
+        if self.num_bitmap_args:
+            args = self.args[: -self.num_bitmap_args]
+        else:
+            args = self.args
+        return {"args": [t.serialize() for t in args], "ret_type": self.ret_type.serialize()}
 
     @classmethod
     def deserialize(cls, data: JsonDict, ctx: DeserMaps) -> FuncSignature:
@@ -83,6 +100,14 @@ class FuncSignature:
             [RuntimeArg.deserialize(arg, ctx) for arg in data["args"]],
             deserialize_type(data["ret_type"], ctx),
         )
+
+
+def num_bitmap_args(args: tuple[RuntimeArg, ...]) -> int:
+    n = 0
+    for arg in args:
+        if is_fixed_width_rtype(arg.type) and arg.kind.is_optional():
+            n += 1
+    return (n + 31) // 32
 
 
 FUNC_NORMAL: Final = 0
@@ -120,7 +145,7 @@ class FuncDecl:
             if kind == FUNC_STATICMETHOD:
                 self.bound_sig = sig
             else:
-                self.bound_sig = FuncSignature(sig.args[1:], sig.ret_type)
+                self.bound_sig = sig.bound_sig()
 
         # this is optional because this will be set to the line number when the corresponding
         # FuncIR is created

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -6,7 +6,7 @@ from typing import Sequence
 from typing_extensions import Final
 
 from mypy.nodes import ARG_POS, ArgKind, Block, FuncDef
-from mypyc.common import JsonDict, bitmap_name, get_id_from_name, short_id_from_name, BITMAP_BITS
+from mypyc.common import BITMAP_BITS, JsonDict, bitmap_name, get_id_from_name, short_id_from_name
 from mypyc.ir.ops import (
     Assign,
     AssignMulti,
@@ -17,7 +17,7 @@ from mypyc.ir.ops import (
     Register,
     Value,
 )
-from mypyc.ir.rtypes import RType, deserialize_type, is_fixed_width_rtype, bitmap_rprimitive
+from mypyc.ir.rtypes import RType, bitmap_rprimitive, deserialize_type, is_fixed_width_rtype
 from mypyc.namegen import NameGenerator
 
 

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -6,7 +6,7 @@ from typing import Sequence
 from typing_extensions import Final
 
 from mypy.nodes import ARG_POS, ArgKind, Block, FuncDef
-from mypyc.common import JsonDict, bitmap_name, get_id_from_name, short_id_from_name
+from mypyc.common import JsonDict, bitmap_name, get_id_from_name, short_id_from_name, BITMAP_BITS
 from mypyc.ir.ops import (
     Assign,
     AssignMulti,
@@ -107,7 +107,7 @@ def num_bitmap_args(args: tuple[RuntimeArg, ...]) -> int:
     for arg in args:
         if is_fixed_width_rtype(arg.type) and arg.kind.is_optional():
             n += 1
-    return (n + 31) // 32
+    return (n + (BITMAP_BITS - 1)) // BITMAP_BITS
 
 
 FUNC_NORMAL: Final = 0

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -17,7 +17,7 @@ from mypyc.ir.ops import (
     Register,
     Value,
 )
-from mypyc.ir.rtypes import RType, deserialize_type, is_fixed_width_rtype, uint32_rprimitive
+from mypyc.ir.rtypes import RType, deserialize_type, is_fixed_width_rtype, bitmap_rprimitive
 from mypyc.namegen import NameGenerator
 
 
@@ -73,7 +73,7 @@ class FuncSignature:
         self.num_bitmap_args = num_bitmap_args(self.args)
         if self.num_bitmap_args:
             extra = [
-                RuntimeArg(bitmap_name(i), uint32_rprimitive, pos_only=True)
+                RuntimeArg(bitmap_name(i), bitmap_rprimitive, pos_only=True)
                 for i in range(self.num_bitmap_args)
             ]
             self.args = self.args + tuple(reversed(extra))

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -361,6 +361,9 @@ c_pointer_rprimitive: Final = RPrimitive(
     "c_ptr", is_unboxed=False, is_refcounted=False, ctype="void *"
 )
 
+# The type corresponding to mypyc.common.BITMAP_TYPE
+bitmap_rprimitive: Final = uint32_rprimitive
+
 # Floats are represent as 'float' PyObject * values. (In the future
 # we'll likely switch to a more efficient, unboxed representation.)
 float_rprimitive: Final = RPrimitive("builtins.float", is_unboxed=False, is_refcounted=True)

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -97,7 +97,7 @@ from mypyc.ir.rtypes import (
     none_rprimitive,
     object_rprimitive,
     str_rprimitive,
-    uint32_rprimitive,
+    bitmap_rprimitive,
 )
 from mypyc.irbuild.context import FuncInfo, ImplicitClass
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder
@@ -464,13 +464,13 @@ class IRBuilder:
     ) -> None:
         error_block, body_block = BasicBlock(), BasicBlock()
         o = self.int_op(
-            uint32_rprimitive,
+            bitmap_rprimitive,
             self.builder.args[-1 - index // BITMAP_BITS],
-            Integer(1 << (index & (BITMAP_BITS - 1)), uint32_rprimitive),
+            Integer(1 << (index & (BITMAP_BITS - 1)), bitmap_rprimitive),
             IntOp.AND,
             line,
         )
-        b = self.add(ComparisonOp(o, Integer(0, uint32_rprimitive), ComparisonOp.EQ))
+        b = self.add(ComparisonOp(o, Integer(0, bitmap_rprimitive), ComparisonOp.EQ))
         self.add(Branch(b, error_block, body_block, Branch.BOOL))
         self.activate_block(error_block)
         self.add(Assign(target, self.coerce(get_val(), target.type, line)))

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -57,7 +57,7 @@ from mypy.types import (
 )
 from mypy.util import split_target
 from mypy.visitor import ExpressionVisitor, StatementVisitor
-from mypyc.common import SELF_NAME, TEMP_ATTR_NAME, BITMAP_BITS
+from mypyc.common import BITMAP_BITS, SELF_NAME, TEMP_ATTR_NAME
 from mypyc.crash import catch_errors
 from mypyc.errors import Errors
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
@@ -85,6 +85,7 @@ from mypyc.ir.rtypes import (
     RInstance,
     RTuple,
     RType,
+    bitmap_rprimitive,
     c_int_rprimitive,
     c_pyssize_t_rprimitive,
     dict_rprimitive,
@@ -97,7 +98,6 @@ from mypyc.ir.rtypes import (
     none_rprimitive,
     object_rprimitive,
     str_rprimitive,
-    bitmap_rprimitive,
 )
 from mypyc.irbuild.context import FuncInfo, ImplicitClass
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -57,7 +57,7 @@ from mypy.types import (
 )
 from mypy.util import split_target
 from mypy.visitor import ExpressionVisitor, StatementVisitor
-from mypyc.common import SELF_NAME, TEMP_ATTR_NAME
+from mypyc.common import SELF_NAME, TEMP_ATTR_NAME, BITMAP_BITS
 from mypyc.crash import catch_errors
 from mypyc.errors import Errors
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
@@ -465,8 +465,8 @@ class IRBuilder:
         error_block, body_block = BasicBlock(), BasicBlock()
         o = self.int_op(
             uint32_rprimitive,
-            self.builder.args[-1 - index // 32],
-            Integer(1 << (index & 31), uint32_rprimitive),
+            self.builder.args[-1 - index // BITMAP_BITS],
+            Integer(1 << (index & (BITMAP_BITS - 1)), uint32_rprimitive),
             IntOp.AND,
             line,
         )

--- a/mypyc/irbuild/callable_class.py
+++ b/mypyc/irbuild/callable_class.py
@@ -92,7 +92,10 @@ def add_call_to_callable_class(
     given callable class, used to represent that function.
     """
     # Since we create a method, we also add a 'self' parameter.
-    sig = FuncSignature((RuntimeArg(SELF_NAME, object_rprimitive),) + sig.args, sig.ret_type)
+    nargs = len(sig.args) - sig.num_bitmap_args
+    sig = FuncSignature(
+        (RuntimeArg(SELF_NAME, object_rprimitive),) + sig.args[:nargs], sig.ret_type
+    )
     call_fn_decl = FuncDecl("__call__", fn_info.callable_class.ir.name, builder.module_name, sig)
     call_fn_ir = FuncIR(
         call_fn_decl, args, blocks, fn_info.fitem.line, traceback_name=fn_info.fitem.name

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -17,11 +17,11 @@ non-locals is via an instance of an environment class. Example:
 
 from __future__ import annotations
 
-from mypy.nodes import FuncDef, SymbolNode
-from mypyc.common import ENV_ATTR_NAME, SELF_NAME
+from mypy.nodes import Argument, FuncDef, SymbolNode, Var
+from mypyc.common import ENV_ATTR_NAME, SELF_NAME, bitmap_name
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.ops import Call, GetAttr, SetAttr, Value
-from mypyc.ir.rtypes import RInstance, object_rprimitive
+from mypyc.ir.rtypes import RInstance, is_fixed_width_rtype, object_rprimitive, uint32_rprimitive
 from mypyc.irbuild.builder import IRBuilder, SymbolTarget
 from mypyc.irbuild.context import FuncInfo, GeneratorClass, ImplicitClass
 from mypyc.irbuild.targets import AssignmentTargetAttr
@@ -159,6 +159,15 @@ def load_outer_envs(builder: IRBuilder, base: ImplicitClass) -> None:
         index -= 1
 
 
+def num_bitmap_args(builder: IRBuilder, args: list[Argument]) -> int:
+    n = 0
+    for arg in args:
+        t = builder.type_to_rtype(arg.variable.type)
+        if is_fixed_width_rtype(t) and arg.kind.is_optional():
+            n += 1
+    return (n + 31) // 32
+
+
 def add_args_to_env(
     builder: IRBuilder,
     local: bool = True,
@@ -166,12 +175,16 @@ def add_args_to_env(
     reassign: bool = True,
 ) -> None:
     fn_info = builder.fn_info
+    args = fn_info.fitem.arguments
+    nb = num_bitmap_args(builder, args)
     if local:
-        for arg in fn_info.fitem.arguments:
+        for arg in args:
             rtype = builder.type_to_rtype(arg.variable.type)
             builder.add_local_reg(arg.variable, rtype, is_arg=True)
+        for i in reversed(range(nb)):
+            builder.add_local_reg(Var(bitmap_name(i)), uint32_rprimitive, is_arg=True)
     else:
-        for arg in fn_info.fitem.arguments:
+        for arg in args:
             if is_free_variable(builder, arg.variable) or fn_info.is_generator:
                 rtype = builder.type_to_rtype(arg.variable.type)
                 assert base is not None, "base cannot be None for adding nonlocal args"

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -18,7 +18,7 @@ non-locals is via an instance of an environment class. Example:
 from __future__ import annotations
 
 from mypy.nodes import Argument, FuncDef, SymbolNode, Var
-from mypyc.common import ENV_ATTR_NAME, SELF_NAME, bitmap_name
+from mypyc.common import ENV_ATTR_NAME, SELF_NAME, bitmap_name, BITMAP_BITS
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.ops import Call, GetAttr, SetAttr, Value
 from mypyc.ir.rtypes import RInstance, is_fixed_width_rtype, object_rprimitive, uint32_rprimitive
@@ -165,7 +165,7 @@ def num_bitmap_args(builder: IRBuilder, args: list[Argument]) -> int:
         t = builder.type_to_rtype(arg.variable.type)
         if is_fixed_width_rtype(t) and arg.kind.is_optional():
             n += 1
-    return (n + 31) // 32
+    return (n + (BITMAP_BITS - 1)) // BITMAP_BITS
 
 
 def add_args_to_env(

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -18,10 +18,10 @@ non-locals is via an instance of an environment class. Example:
 from __future__ import annotations
 
 from mypy.nodes import Argument, FuncDef, SymbolNode, Var
-from mypyc.common import ENV_ATTR_NAME, SELF_NAME, bitmap_name, BITMAP_BITS
+from mypyc.common import BITMAP_BITS, ENV_ATTR_NAME, SELF_NAME, bitmap_name
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.ops import Call, GetAttr, SetAttr, Value
-from mypyc.ir.rtypes import RInstance, is_fixed_width_rtype, object_rprimitive, bitmap_rprimitive
+from mypyc.ir.rtypes import RInstance, bitmap_rprimitive, is_fixed_width_rtype, object_rprimitive
 from mypyc.irbuild.builder import IRBuilder, SymbolTarget
 from mypyc.irbuild.context import FuncInfo, GeneratorClass, ImplicitClass
 from mypyc.irbuild.targets import AssignmentTargetAttr

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -21,7 +21,7 @@ from mypy.nodes import Argument, FuncDef, SymbolNode, Var
 from mypyc.common import ENV_ATTR_NAME, SELF_NAME, bitmap_name, BITMAP_BITS
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.ops import Call, GetAttr, SetAttr, Value
-from mypyc.ir.rtypes import RInstance, is_fixed_width_rtype, object_rprimitive, uint32_rprimitive
+from mypyc.ir.rtypes import RInstance, is_fixed_width_rtype, object_rprimitive, bitmap_rprimitive
 from mypyc.irbuild.builder import IRBuilder, SymbolTarget
 from mypyc.irbuild.context import FuncInfo, GeneratorClass, ImplicitClass
 from mypyc.irbuild.targets import AssignmentTargetAttr
@@ -182,7 +182,7 @@ def add_args_to_env(
             rtype = builder.type_to_rtype(arg.variable.type)
             builder.add_local_reg(arg.variable, rtype, is_arg=True)
         for i in reversed(range(nb)):
-            builder.add_local_reg(Var(bitmap_name(i)), uint32_rprimitive, is_arg=True)
+            builder.add_local_reg(Var(bitmap_name(i)), bitmap_rprimitive, is_arg=True)
     else:
         for arg in args:
             if is_free_variable(builder, arg.variable) or fn_info.is_generator:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -990,7 +990,7 @@ class LowLevelIRBuilder:
         # Flatten out the arguments, loading error values for default
         # arguments, constructing tuples/dicts for star args, and
         # coercing everything to the expected type.
-        output_args: List[Value] = []
+        output_args: list[Value] = []
         for lst, arg in zip(formal_to_actual, sig_args):
             if arg.kind == ARG_STAR:
                 assert star_arg

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -113,7 +113,7 @@ from mypyc.ir.rtypes import (
     pointer_rprimitive,
     short_int_rprimitive,
     str_rprimitive,
-    uint32_rprimitive,
+    bitmap_rprimitive,
 )
 from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.util import concrete_arg_kind
@@ -1023,7 +1023,7 @@ class LowLevelIRBuilder:
                         if lst:
                             bitmap |= 1 << (c & (BITMAP_BITS - 1))
                     c += 1
-            output_args.append(Integer(bitmap, uint32_rprimitive))
+            output_args.append(Integer(bitmap, bitmap_rprimitive))
 
         return output_args
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -26,6 +26,7 @@ from mypyc.common import (
     PLATFORM_SIZE,
     use_method_vectorcall,
     use_vectorcall,
+    BITMAP_BITS,
 )
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
@@ -1018,9 +1019,9 @@ class LowLevelIRBuilder:
             c = 0
             for lst, arg in zip(formal_to_actual, sig_args):
                 if arg.kind.is_optional() and is_fixed_width_rtype(arg.type):
-                    if i * 32 <= c < (i + 1) * 32:
+                    if i * BITMAP_BITS <= c < (i + 1) * BITMAP_BITS:
                         if lst:
-                            bitmap |= 1 << (c & 31)
+                            bitmap |= 1 << (c & (BITMAP_BITS - 1))
                     c += 1
             output_args.append(Integer(bitmap, uint32_rprimitive))
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -18,6 +18,7 @@ from mypy.nodes import ARG_POS, ARG_STAR, ARG_STAR2, ArgKind
 from mypy.operators import op_methods
 from mypy.types import AnyType, TypeOfAny
 from mypyc.common import (
+    BITMAP_BITS,
     FAST_ISINSTANCE_MAX_SUBCLASSES,
     MAX_LITERAL_SHORT_INT,
     MAX_SHORT_INT,
@@ -26,7 +27,6 @@ from mypyc.common import (
     PLATFORM_SIZE,
     use_method_vectorcall,
     use_vectorcall,
-    BITMAP_BITS,
 )
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
@@ -81,6 +81,7 @@ from mypyc.ir.rtypes import (
     RType,
     RUnion,
     bit_rprimitive,
+    bitmap_rprimitive,
     bool_rprimitive,
     bytes_rprimitive,
     c_int_rprimitive,
@@ -113,7 +114,6 @@ from mypyc.ir.rtypes import (
     pointer_rprimitive,
     short_int_rprimitive,
     str_rprimitive,
-    bitmap_rprimitive,
 )
 from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.util import concrete_arg_kind

--- a/mypyc/test-data/irbuild-i64.test
+++ b/mypyc/test-data/irbuild-i64.test
@@ -1392,3 +1392,118 @@ L1:
 L2:
     r2 = unbox(int64, x)
     return r2
+
+[case testI64DefaultValueSingle]
+from mypy_extensions import i64
+
+def f(x: i64, y: i64 = 0) -> i64:
+    return x + y
+
+def g() -> i64:
+    return f(7) + f(8, 9)
+[out]
+def f(x, y, __bitmap):
+    x, y :: int64
+    __bitmap, r0 :: uint32
+    r1 :: bit
+    r2 :: int64
+L0:
+    r0 = __bitmap & 1
+    r1 = r0 == 0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    y = 0
+L2:
+    r2 = x + y
+    return r2
+def g():
+    r0, r1, r2 :: int64
+L0:
+    r0 = f(7, 0, 0)
+    r1 = f(8, 9, 1)
+    r2 = r0 + r1
+    return r2
+
+[case testI64DefaultValueWithMultipleArgs]
+from mypy_extensions import i64
+
+def f(a: i64, b: i64 = 1, c: int = 2, d: i64 = 3) -> i64:
+    return 0
+
+def g() -> i64:
+    return f(7) + f(8, 9) + f(1, 2, 3) + f(4, 5, 6, 7)
+[out]
+def f(a, b, c, d, __bitmap):
+    a, b :: int64
+    c :: int
+    d :: int64
+    __bitmap, r0 :: uint32
+    r1 :: bit
+    r2 :: uint32
+    r3 :: bit
+L0:
+    r0 = __bitmap & 1
+    r1 = r0 == 0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    b = 1
+L2:
+    if is_error(c) goto L3 else goto L4
+L3:
+    c = 4
+L4:
+    r2 = __bitmap & 2
+    r3 = r2 == 0
+    if r3 goto L5 else goto L6 :: bool
+L5:
+    d = 3
+L6:
+    return 0
+def g():
+    r0 :: int
+    r1 :: int64
+    r2 :: int
+    r3, r4, r5, r6, r7, r8 :: int64
+L0:
+    r0 = <error> :: int
+    r1 = f(7, 0, r0, 0, 0)
+    r2 = <error> :: int
+    r3 = f(8, 9, r2, 0, 1)
+    r4 = r1 + r3
+    r5 = f(1, 2, 6, 0, 1)
+    r6 = r4 + r5
+    r7 = f(4, 5, 12, 7, 3)
+    r8 = r6 + r7
+    return r8
+
+[case testI64MethodDefaultValue]
+from mypy_extensions import i64
+
+class C:
+    def m(self, x: i64 = 5) -> None:
+        pass
+
+def f(c: C) -> None:
+    c.m()
+    c.m(6)
+[out]
+def C.m(self, x, __bitmap):
+    self :: __main__.C
+    x :: int64
+    __bitmap, r0 :: uint32
+    r1 :: bit
+L0:
+    r0 = __bitmap & 1
+    r1 = r0 == 0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    x = 5
+L2:
+    return 1
+def f(c):
+    c :: __main__.C
+    r0, r1 :: None
+L0:
+    r0 = c.m(0, 0)
+    r1 = c.m(6, 1)
+    return 1

--- a/mypyc/test-data/run-functions.test
+++ b/mypyc/test-data/run-functions.test
@@ -430,9 +430,11 @@ def nested_funcs(n: int) -> List[Callable[..., Any]]:
         ls.append(f)
     return ls
 
+def bool_default(x: bool = False, y: bool = True) -> str:
+    return str(x) + '-' + str(y)
 
 [file driver.py]
-from native import f, g, h, same, nested_funcs, a_lambda
+from native import f, g, h, same, nested_funcs, a_lambda, bool_default
 g()
 assert f(2) == (5, "test")
 assert f(s = "123", x = -2) == (1, "123")
@@ -446,6 +448,10 @@ assert [f() for f in nested_funcs(10)] == list(range(10))
 
 assert a_lambda(10) == 10
 assert a_lambda() == 20
+
+assert bool_default() == 'False-True'
+assert bool_default(True) == 'True-True'
+assert bool_default(True, False) == 'True-False'
 
 [case testMethodCallWithDefaultArgs]
 from typing import Tuple, List

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -673,3 +673,250 @@ def test_del() -> None:
     del o.x
     with assertRaises(AttributeError):
         o.x
+
+[case testI64DefaultArgValues]
+from typing import Any, Iterator
+from typing_extensions import Final
+
+MAGIC: Final = -113
+
+MYPY = False
+if MYPY:
+    from mypy_extensions import i64
+
+def f(x: i64, y: i64 = 5) -> i64:
+    return x + y
+
+def test_simple_default_arg() -> None:
+    assert f(3) == 8
+    assert f(4, 9) == 13
+    assert f(5, MAGIC) == -108
+    for i in range(-1000, 1000):
+        assert f(1, i) == 1 + i
+    f2: Any = f
+    assert f2(3) == 8
+    assert f2(4, 9) == 13
+    assert f2(5, MAGIC) == -108
+
+def g(a: i64, b: i64 = 1, c: int = 2, d: i64 = 3) -> i64:
+    return a + b + c + d
+
+def test_two_default_args() -> None:
+    assert g(10) == 16
+    assert g(10, 2) == 17
+    assert g(10, 2, 3) == 18
+    assert g(10, 2, 3, 4) == 19
+    g2: Any = g
+    assert g2(10) == 16
+    assert g2(10, 2) == 17
+    assert g2(10, 2, 3) == 18
+    assert g2(10, 2, 3, 4) == 19
+
+class C:
+    def __init__(self) -> None:
+        self.i: i64 = 1
+
+    def m(self, a: i64, b: i64 = 1, c: int = 2, d: i64 = 3) -> i64:
+        return self.i + a + b + c + d
+
+class D(C):
+    def m(self, a: i64, b: i64 = 2, c: int = 3, d: i64 = 4) -> i64:
+        return self.i + a + b + c + d
+
+    def mm(self, a: i64 = 2, b: i64 = 1) -> i64:
+        return self.i + a + b
+
+    @staticmethod
+    def s(a: i64 = 2, b: i64 = 1) -> i64:
+        return a + b
+
+    @classmethod
+    def c(cls, a: i64 = 2, b: i64 = 3) -> i64:
+        assert cls is D
+        return a + b
+
+def test_method_default_args() -> None:
+    a = [C(), D()]
+    assert a[0].m(4) == 11
+    d = D()
+    assert d.mm() == 4
+    assert d.mm(5) == 7
+    assert d.mm(MAGIC) == MAGIC + 2
+    assert d.mm(b=5) == 8
+    assert D.mm(d) == 4
+    assert D.mm(d, 6) == 8
+    assert D.mm(d, MAGIC) == MAGIC + 2
+    assert D.mm(d, b=6) == 9
+    dd: Any = d
+    assert dd.mm() == 4
+    assert dd.mm(5) == 7
+    assert dd.mm(MAGIC) == MAGIC + 2
+    assert dd.mm(b=5) == 8
+
+def test_static_method_default_args() -> None:
+    d = D()
+    assert d.s() == 3
+    assert d.s(5) == 6
+    assert d.s(MAGIC) == MAGIC + 1
+    assert d.s(5, 6) == 11
+    assert D.s() == 3
+    assert D.s(5) == 6
+    assert D.s(MAGIC) == MAGIC + 1
+    assert D.s(5, 6) == 11
+    dd: Any = d
+    assert dd.s() == 3
+    assert dd.s(5) == 6
+    assert dd.s(MAGIC) == MAGIC + 1
+    assert dd.s(5, 6) == 11
+
+def test_class_method_default_args() -> None:
+    d = D()
+    assert d.c() == 5
+    assert d.c(5) == 8
+    assert d.c(MAGIC) == MAGIC + 3
+    assert d.c(b=5) == 7
+    assert D.c() == 5
+    assert D.c(5) == 8
+    assert D.c(MAGIC) == MAGIC + 3
+    assert D.c(b=5) == 7
+    dd: Any = d
+    assert dd.c() == 5
+    assert dd.c(5) == 8
+    assert dd.c(MAGIC) == MAGIC + 3
+    assert dd.c(b=5) == 7
+
+def kw_only(*, a: i64 = 1, b: int = 2, c: i64 = 3) -> i64:
+    return a + b + c * 2
+
+def test_kw_only_default_args() -> None:
+    assert kw_only() == 9
+    assert kw_only(a=2) == 10
+    assert kw_only(b=4) == 11
+    assert kw_only(c=11) == 25
+    assert kw_only(a=2, c=4) == 12
+    assert kw_only(c=4, a=2) == 12
+    kw_only2: Any = kw_only
+    assert kw_only2() == 9
+    assert kw_only2(a=2) == 10
+    assert kw_only2(b=4) == 11
+    assert kw_only2(c=11) == 25
+    assert kw_only2(a=2, c=4) == 12
+    assert kw_only2(c=4, a=2) == 12
+
+def many_args(
+    a1: i64 = 0,
+    a2: i64 = 1,
+    a3: i64 = 2,
+    a4: i64 = 3,
+    a5: i64 = 4,
+    a6: i64 = 5,
+    a7: i64 = 6,
+    a8: i64 = 7,
+    a9: i64 = 8,
+    a10: i64 = 9,
+    a11: i64 = 10,
+    a12: i64 = 11,
+    a13: i64 = 12,
+    a14: i64 = 13,
+    a15: i64 = 14,
+    a16: i64 = 15,
+    a17: i64 = 16,
+    a18: i64 = 17,
+    a19: i64 = 18,
+    a20: i64 = 19,
+    a21: i64 = 20,
+    a22: i64 = 21,
+    a23: i64 = 22,
+    a24: i64 = 23,
+    a25: i64 = 24,
+    a26: i64 = 25,
+    a27: i64 = 26,
+    a28: i64 = 27,
+    a29: i64 = 28,
+    a30: i64 = 29,
+    a31: i64 = 30,
+    a32: i64 = 31,
+    a33: i64 = 32,
+    a34: i64 = 33,
+) -> i64:
+    return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19 + a20 + a21 + a22 + a23 + a24 + a25 + a26 + a27 + a28 + a29 + a30 + a31 + a32 + a33 + a34
+
+def test_many_args() -> None:
+    assert many_args() == 561
+    assert many_args(a1=100) == 661
+    assert many_args(a2=101) == 661
+    assert many_args(a15=114) == 661
+    assert many_args(a31=130) == 661
+    assert many_args(a32=131) == 661
+    assert many_args(a33=232) == 761
+    assert many_args(a34=333) == 861
+    assert many_args(a1=100, a33=232) == 861
+    f: Any = many_args
+    assert f() == 561
+    assert f(a1=100) == 661
+    assert f(a2=101) == 661
+    assert f(a15=114) == 661
+    assert f(a31=130) == 661
+    assert f(a32=131) == 661
+    assert f(a33=232) == 761
+    assert f(a34=333) == 861
+    assert f(a1=100, a33=232) == 861
+
+def test_nested_function_defaults() -> None:
+    a: i64 = 1
+
+    def nested(x: i64 = 2, y: i64 = 3) -> i64:
+        return a + x + y
+
+    assert nested() == 6
+    assert nested(3) == 7
+    assert nested(y=5) == 8
+    assert nested(MAGIC) == MAGIC + 4
+    a = 11
+    assert nested() == 16
+
+
+def test_nested_function_defaults_via_any() -> None:
+    a: i64 = 1
+
+    def nested_native(x: i64 = 2, y: i64 = 3) -> i64:
+        return a + x + y
+
+    nested: Any = nested_native
+
+    assert nested() == 6
+    assert nested(3) == 7
+    assert nested(y=5) == 8
+    assert nested(MAGIC) == MAGIC + 4
+    a = 11
+    assert nested() == 16
+
+def gen(x: i64 = 1, y: i64 = 2) -> Iterator[i64]:
+    yield x + y
+
+def test_generator() -> None:
+    g = gen()
+    assert next(g) == 3
+    g = gen(2)
+    assert next(g) == 4
+    g = gen(2, 3)
+    assert next(g) == 5
+    a: Any = gen
+    g = a()
+    assert next(g) == 3
+    g = a(2)
+    assert next(g) == 4
+    g = a(2, 3)
+    assert next(g) == 5
+
+def magic_default(x: i64 = MAGIC) -> i64:
+    return x
+
+def test_magic_default() -> None:
+    assert magic_default() == MAGIC
+    assert magic_default(1) == 1
+    assert magic_default(MAGIC) == MAGIC
+    a: Any = magic_default
+    assert a() == MAGIC
+    assert a(1) == 1
+    assert a(MAGIC) == MAGIC


### PR DESCRIPTION
Since native ints can't have a dedicated reserved value to mark a
missing argument, use extra bitmap arguments that are used to indicate
whether default values should be used for particular arguments. The
bitmap arguments are implicitly added at the end of a signature. They
are not visible to user code and are just an implementation detail.

This is analogous to how we track definedness of native int attributes
using bitmaps.

If a function accepts no arguments with a native int type and a default
value, the bitmap arguments won't be generated.

This doesn't handle inheritance properly. I'll fix inheritance in a
follow-up PR.

Work on https://github.com/mypyc/mypyc/issues/837.