### PR TITLE
Simplify Union Math

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -231,9 +231,6 @@ RUNTIME_PROTOCOL_EXPECTED: Final = ErrorMessage(
     "Only @runtime_checkable protocols can be used with instance and class checks"
 )
 CANNOT_INSTANTIATE_PROTOCOL: Final = ErrorMessage('Cannot instantiate protocol class "{}"')
-TOO_MANY_UNION_COMBINATIONS: Final = ErrorMessage(
-    "Not all union combinations were tried because there are too many unions"
-)
 
 CONTIGUOUS_ITERABLE_EXPECTED: Final = ErrorMessage("Contiguous iterable with same type expected")
 ITERABLE_TYPE_EXPECTED: Final = ErrorMessage("Invalid type '{}' for *expr (iterable expected)")

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4675,7 +4675,6 @@ x: Union[int, str]
 f(x, x, x, x, x, x, x, x)
 [builtins fixtures/tuple.pyi]
 [out]
-main:11: error: Not all union combinations were tried because there are too many unions
 main:11: error: Argument 1 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 2 to "f" has incompatible type "Union[int, str]"; expected "int"
 main:11: error: Argument 3 to "f" has incompatible type "Union[int, str]"; expected "int"


### PR DESCRIPTION
While trying to understand how union matching works in Mypy, I realized that it's probably too complicated.

Recursive matching when doing Union math is not needed, because only one argument can ever be matched as a Union.

Tests remain the same, except for the limitation around recursion levels, which is no longer a limitation. I feel like this could probably be further simplified, but I'm trying to keep this change as small as possible.