### PR TITLE
Avoid using `isinstance()` checks with `FuncBase` for type narrowing

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -70,6 +70,7 @@ from mypy.nodes import (
     LDEF,
     LITERAL_TYPE,
     MDEF,
+    SYMBOL_FUNCBASE_TYPES,
     AssertStmt,
     AssignmentExpr,
     AssignmentStmt,
@@ -2292,7 +2293,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def determine_type_of_member(self, sym: SymbolTableNode) -> Type | None:
         if sym.type is not None:
             return sym.type
-        if isinstance(sym.node, FuncBase):
+        if isinstance(sym.node, SYMBOL_FUNCBASE_TYPES):
             return self.function_type(sym.node)
         if isinstance(sym.node, TypeInfo):
             if sym.node.typeddict_type:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -951,7 +951,7 @@ def analyze_class_attribute_access(
             t = erase_typevars(expand_type_by_instance(t, isuper))
 
         is_classmethod = (is_decorated and cast(Decorator, node.node).func.is_class) or (
-            isinstance(node.node, FuncBase) and node.node.is_class
+            isinstance(node.node, SYMBOL_FUNCBASE_TYPES) and node.node.is_class
         )
         t = get_proper_type(t)
         if isinstance(t, FunctionLike) and is_classmethod:
@@ -993,7 +993,7 @@ def analyze_class_attribute_access(
             mx.not_ready_callback(name, mx.context)
             return AnyType(TypeOfAny.from_error)
     else:
-        assert isinstance(node.node, FuncBase)
+        assert isinstance(node.node, SYMBOL_FUNCBASE_TYPES)
         typ = function_type(node.node, mx.named_type("builtins.function"))
         # Note: if we are accessing class method on class object, the cls argument is bound.
         # Annotated and/or explicit class methods go through other code paths above, for
@@ -1226,7 +1226,7 @@ def is_valid_constructor(n: SymbolNode | None) -> bool:
     This includes normal functions, overloaded functions, and decorators
     that return a callable type.
     """
-    if isinstance(n, FuncBase):
+    if isinstance(n, SYMBOL_FUNCBASE_TYPES):
         return True
     if isinstance(n, Decorator):
         return isinstance(get_proper_type(n.type), FunctionLike)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2936,7 +2936,7 @@ class TypeInfo(SymbolNode):
         for cls in self.mro:
             if name in cls.names:
                 node = cls.names[name].node
-                if isinstance(node, FuncBase):
+                if isinstance(node, SYMBOL_FUNCBASE_TYPES):
                     return node
                 elif isinstance(node, Decorator):  # Two `if`s make `mypyc` happy
                     return node

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -57,9 +57,9 @@ from typing_extensions import TypeAlias as _TypeAlias
 
 from mypy.expandtype import expand_type
 from mypy.nodes import (
+    SYMBOL_FUNCBASE_TYPES,
     UNBOUND_IMPORTED,
     Decorator,
-    FuncBase,
     FuncItem,
     MypyFile,
     OverloadedFuncDef,
@@ -211,7 +211,7 @@ def snapshot_definition(node: SymbolNode | None, common: tuple[object, ...]) -> 
     The representation is nested tuples and dicts. Only externally
     visible attributes are included.
     """
-    if isinstance(node, FuncBase):
+    if isinstance(node, SYMBOL_FUNCBASE_TYPES):
         # TODO: info
         if node.type:
             signature = snapshot_type(node.type)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -88,6 +88,7 @@ from mypy.nodes import (
     GDEF,
     LDEF,
     MDEF,
+    SYMBOL_FUNCBASE_TYPES,
     AssertTypeExpr,
     AssignmentStmt,
     AwaitExpr,
@@ -506,7 +507,7 @@ class DependencyVisitor(TraverserVisitor):
                 if isinstance(rvalue.callee.node, TypeInfo):
                     # use actual __init__ as a dependency source
                     init = rvalue.callee.node.get("__init__")
-                    if init and isinstance(init.node, FuncBase):
+                    if init and isinstance(init.node, SYMBOL_FUNCBASE_TYPES):
                         fname = init.node.fullname
                 else:
                     fname = rvalue.callee.fullname


### PR DESCRIPTION
This PR improves mypy's understanding of the mypy codebase, and reduces the number of false positives if you run the selfcheck with `--warn-unreachable`.

---

As stated in this docstring here, mypy doesn't understand type narrowing very well if you use an `isinstance()` check with `FuncBase`:

https://github.com/python/mypy/blob/130e1a4e6fc5b14fda625495e25abd177af61bbb/mypy/nodes.py#L528-L536

Instead, it tends to view blocks of code beneath an `if isinstance(foo, FuncBase)` guard as unreachable, leading to a lot of false positives if you run the selfcheck with `--warn-unreachable`.