### PR TITLE
Fix type inference in pattern matching by positional argument

### DIFF
--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -136,7 +136,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
     def visit_instance(self, t: Instance) -> Type:
         args = self.expand_types_with_unpack(list(t.args))
         if isinstance(args, list):
-            return Instance(t.type, args, t.line, t.column)
+            return t.copy_modified(args=args)
         else:
             return args
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1632,6 +1632,7 @@ match var:
 [case testMatchNamedAndKeywordsAreTheSame]
 from typing import Generic, TypeVar, Union
 from typing_extensions import Final
+from dataclasses import dataclass
 
 T = TypeVar("T")
 
@@ -1649,8 +1650,20 @@ class GenericRegular(Generic[T]):
 class GenericWithFinal(Generic[T]):
     x: T
     __match_args__: Final = ("x",)
+class RegularSubtype(GenericRegular[str]): ...
 
-input_arg: Union[Regular, ReveresedOrder, GenericRegular[str], GenericWithFinal[str]]
+@dataclass
+class GenericDataclass(Generic[T]):
+    x: T
+
+input_arg: Union[
+    Regular,
+    ReveresedOrder,
+    GenericRegular[str],
+    GenericWithFinal[str],
+    RegularSubtype,
+    GenericDataclass[str],
+]
 
 # Positional:
 match input_arg:
@@ -1658,19 +1671,27 @@ match input_arg:
         reveal_type(a)  # N: Revealed type is "builtins.str"
     case ReveresedOrder(a):
         reveal_type(a)  # N: Revealed type is "builtins.str"
+    case GenericWithFinal(a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    case RegularSubtype(a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
     case GenericRegular(a):
         reveal_type(a)  # N: Revealed type is "builtins.str"
-    case GenericWithFinal(a):
+    case GenericDataclass(a):
         reveal_type(a)  # N: Revealed type is "builtins.str"
 
 # Keywords:
 match input_arg:
     case Regular(x=a):
         reveal_type(a)  # N: Revealed type is "builtins.str"
-    case ReveresedOrder(x=b):  # note, that order is different
+    case ReveresedOrder(x=b):  # Order is different
         reveal_type(b)  # N: Revealed type is "builtins.int"
-    case GenericRegular(x=a):
-        reveal_type(a)  # N: Revealed type is "builtins.str"
     case GenericWithFinal(x=a):
         reveal_type(a)  # N: Revealed type is "builtins.str"
-[builtins fixtures/tuple.pyi]
+    case RegularSubtype(x=a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    case GenericRegular(x=a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    case GenericDataclass(x=a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1628,3 +1628,49 @@ match var:
     case ("yes", b):
         reveal_type(b)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
+
+[case testMatchNamedAndKeywordsAreTheSame]
+from typing import Generic, TypeVar, Union
+from typing_extensions import Final
+
+T = TypeVar("T")
+
+class Regular:
+    x: str
+    y: int
+    __match_args__ = ("x",)
+class ReveresedOrder:
+    x: int
+    y: str
+    __match_args__ = ("y",)
+class GenericRegular(Generic[T]):
+    x: T
+    __match_args__ = ("x",)
+class GenericWithFinal(Generic[T]):
+    x: T
+    __match_args__: Final = ("x",)
+
+input_arg: Union[Regular, ReveresedOrder, GenericRegular[str], GenericWithFinal[str]]
+
+# Positional:
+match input_arg:
+    case Regular(a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    case ReveresedOrder(a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    case GenericRegular(a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    case GenericWithFinal(a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+
+# Keywords:
+match input_arg:
+    case Regular(x=a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    case ReveresedOrder(x=b):  # note, that order is different
+        reveal_type(b)  # N: Revealed type is "builtins.int"
+    case GenericRegular(x=a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    case GenericWithFinal(x=a):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Oh, this was very interesting.
During the debug sessions I learned a lot about how pattern matching and its analysis do work.

But, the problem was that `expand_type` did not preserve `.last_known_value` for some reason.
I used `.copy_modified` to preserve everything we know about `Instance`.

However, I expect that some tests might fail now. This code even has something similar in `TODO` some lines above: 

https://github.com/python/mypy/blob/88aed94ae3de2542491f6cd65d1236c4f0cdedb1/mypy/expandtype.py#L144-L148

Let's see what will happen.

Closes https://github.com/python/mypy/issues/13612