### PR TITLE
Note that `assert_type` always matches against any in untyped function

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3726,7 +3726,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if not is_same_type(source_type, target_type):
             if not self.chk.in_checked_function():
                 self.msg.note(
-                    "'assert_type' always outputs 'Any' in unchecked functions", expr.expr
+                    '"assert_type" expects everything to be "Any" in unchecked functions',
+                    expr.expr,
                 )
             self.msg.assert_type_fail(source_type, target_type, expr)
         return source_type

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3724,6 +3724,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         )
         target_type = expr.type
         if not is_same_type(source_type, target_type):
+            if not self.chk.in_checked_function():
+                self.msg.note(
+                    "'assert_type' always outputs 'Any' in unchecked functions", expr.expr
+                )
             self.msg.assert_type_fail(source_type, target_type, expr)
         return source_type
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -950,6 +950,14 @@ assert_type(Gen(1), Gen[int])
 # With type context, it infers Gen[Literal[1]] instead.
 y: Gen[Literal[1]] = assert_type(Gen(1), Gen[Literal[1]])
 
+[case testAssertTypeUncheckedFunction]
+def f():
+    x = 42
+    assert_type(x, Literal[42])
+[out]
+main:3: error: Expression is of type "Any", not "Literal[42]"
+main:3: note: 'assert_type' always outputs 'Any' in unchecked functions
+
 [builtins fixtures/tuple.pyi]
 
 -- None return type

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -971,8 +971,7 @@ def f():
     x = 42
     assert_type(x, Literal[42])
 [out]
-main:6: error: Expression is of type "Any", not "Literal[42]"
-main:6: note: "assert_type" expects everything to be "Any" in unchecked functions
+main:6: error: Expression is of type "int", not "Literal[42]"
 [builtins fixtures/tuple.pyi]
 
 -- None return type

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -959,8 +959,8 @@ def f():
     x = 42
     assert_type(x, Literal[42])
 [out]
-main:5 error: Expression is of type "Any", not "Literal[42]"
-main:5 note: "assert_type" expects everything to be "Any" in unchecked functions
+main:5: error: Expression is of type "Any", not "Literal[42]"
+main:5: note: "assert_type" expects everything to be "Any" in unchecked functions
 [builtins fixtures/tuple.pyi]
 
 [case testAssertTypeUncheckedFunctionWithUntypedCheck]
@@ -971,8 +971,8 @@ def f():
     x = 42
     assert_type(x, Literal[42])
 [out]
-main:6 error: Expression is of type "Any", not "Literal[42]"
-main:6 note: "assert_type" expects everything to be "Any" in unchecked functions
+main:6: error: Expression is of type "Any", not "Literal[42]"
+main:6: note: "assert_type" expects everything to be "Any" in unchecked functions
 [builtins fixtures/tuple.pyi]
 
 -- None return type

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -953,13 +953,26 @@ y: Gen[Literal[1]] = assert_type(Gen(1), Gen[Literal[1]])
 [builtins fixtures/tuple.pyi]
 
 [case testAssertTypeUncheckedFunction]
-from typing_extensions import assert_type, Literal
+from typing import assert_type
+from typing_extensions import Literal
 def f():
     x = 42
     assert_type(x, Literal[42])
 [out]
-main:4 error: Expression is of type "Any", not "Literal[42]"
-main:4 note: "assert_type" expects everything to be "Any" in unchecked functions
+main:5 error: Expression is of type "Any", not "Literal[42]"
+main:5 note: "assert_type" expects everything to be "Any" in unchecked functions
+[builtins fixtures/tuple.pyi]
+
+[case testAssertTypeUncheckedFunctionWithUntypedCheck]
+# flags: --check-untyped-defs
+from typing import assert_type
+from typing_extensions import Literal
+def f():
+    x = 42
+    assert_type(x, Literal[42])
+[out]
+main:6 error: Expression is of type "Any", not "Literal[42]"
+main:6 note: "assert_type" expects everything to be "Any" in unchecked functions
 [builtins fixtures/tuple.pyi]
 
 -- None return type

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -950,14 +950,16 @@ assert_type(Gen(1), Gen[int])
 # With type context, it infers Gen[Literal[1]] instead.
 y: Gen[Literal[1]] = assert_type(Gen(1), Gen[Literal[1]])
 
+[builtins fixtures/tuple.pyi]
+
 [case testAssertTypeUncheckedFunction]
+from typing_extensions import assert_type, Literal
 def f():
     x = 42
     assert_type(x, Literal[42])
 [out]
-main:3: error: Expression is of type "Any", not "Literal[42]"
-main:3: note: 'assert_type' always outputs 'Any' in unchecked functions
-
+main:4 error: Expression is of type "Any", not "Literal[42]"
+main:4 note: "assert_type" expects everything to be "Any" in unchecked functions
 [builtins fixtures/tuple.pyi]
 
 -- None return type


### PR DESCRIPTION
### Description

`reveal_type` provides a useful note to users that it will always reveal `Any` within an unchecked function. Similarly, `assert_type` always checks against `Any`, but does not notify the user about its behavior. 

This PR adds said note, which is displayed when `assert_type` raises an error in an unchecked function


## Test Plan

<!--
If this is a documentation change, rebuild the docs (link to instructions) and review the changed pages for markup errors.
If this is a code change, include new tests (link to the testing docs). Be sure to run the tests locally and fix any errors before submitting the PR (more instructions).
If this change cannot be tested by the CI, please explain how to verify it manually.
-->

I added a test to `test-data/unit/check-expressions.test` that is comparable to the corresponding test case for `reveal_type` in an unchecked scope.