### PR TITLE
Fix typevar tuple handling to expect unpack in class def

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -583,6 +583,57 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             if self.direction == SUBTYPE_OF and template.type.has_base(instance.type.fullname):
                 mapped = map_instance_to_supertype(template, instance.type)
                 tvars = mapped.type.defn.type_vars
+
+                if instance.type.has_type_var_tuple_type:
+                    mapped_prefix, mapped_middle, mapped_suffix = split_with_instance(mapped)
+                    instance_prefix, instance_middle, instance_suffix = split_with_instance(
+                        instance
+                    )
+
+                    # Add a constraint for the type var tuple, and then
+                    # remove it for the case below.
+                    instance_unpack = extract_unpack(instance_middle)
+                    if instance_unpack is not None:
+                        if isinstance(instance_unpack, TypeVarTupleType):
+                            res.append(
+                                Constraint(
+                                    instance_unpack.id, SUBTYPE_OF, TypeList(list(mapped_middle))
+                                )
+                            )
+                        elif (
+                            isinstance(instance_unpack, Instance)
+                            and instance_unpack.type.fullname == "builtins.tuple"
+                        ):
+                            for item in mapped_middle:
+                                res.extend(
+                                    infer_constraints(
+                                        instance_unpack.args[0], item, self.direction
+                                    )
+                                )
+                        elif isinstance(instance_unpack, TupleType):
+                            if len(instance_unpack.items) == len(mapped_middle):
+                                for instance_arg, item in zip(
+                                    instance_unpack.items, mapped_middle
+                                ):
+                                    res.extend(
+                                        infer_constraints(instance_arg, item, self.direction)
+                                    )
+
+                    mapped_args = mapped_prefix + mapped_suffix
+                    instance_args = instance_prefix + instance_suffix
+
+                    assert instance.type.type_var_tuple_prefix is not None
+                    assert instance.type.type_var_tuple_suffix is not None
+                    tvars_prefix, _, tvars_suffix = split_with_prefix_and_suffix(
+                        tuple(tvars),
+                        instance.type.type_var_tuple_prefix,
+                        instance.type.type_var_tuple_suffix,
+                    )
+                    tvars = list(tvars_prefix + tvars_suffix)
+                else:
+                    mapped_args = mapped.args
+                    instance_args = instance.args
+
                 # N.B: We use zip instead of indexing because the lengths might have
                 # mismatches during daemon reprocessing.
                 for tvar, mapped_arg, instance_arg in zip(tvars, mapped.args, instance.args):
@@ -617,8 +668,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                             res.append(Constraint(mapped_arg, SUPERTYPE_OF, suffix))
                         elif isinstance(suffix, ParamSpecType):
                             res.append(Constraint(mapped_arg, SUPERTYPE_OF, suffix))
-                    elif isinstance(tvar, TypeVarTupleType):
-                        raise NotImplementedError
+                    else:
+                        # This case should have been handled above.
+                        assert not isinstance(tvar, TypeVarTupleType)
 
                 return res
             elif self.direction == SUPERTYPE_OF and instance.type.has_base(template.type.fullname):
@@ -710,6 +762,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                             res.append(Constraint(template_arg, SUPERTYPE_OF, suffix))
                         elif isinstance(suffix, ParamSpecType):
                             res.append(Constraint(template_arg, SUPERTYPE_OF, suffix))
+                    else:
+                        # This case should have been handled above.
+                        assert not isinstance(tvar, TypeVarTupleType)
                 return res
             if (
                 template.type.is_protocol

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -636,7 +636,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
 
                 # N.B: We use zip instead of indexing because the lengths might have
                 # mismatches during daemon reprocessing.
-                for tvar, mapped_arg, instance_arg in zip(tvars, mapped.args, instance.args):
+                for tvar, mapped_arg, instance_arg in zip(tvars, mapped_args, instance_args):
                     # TODO(PEP612): More ParamSpec work (or is Parameters the only thing accepted)
                     if isinstance(tvar, TypeVarType):
                         # The constraints for generic type parameters depend on variance.

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -597,7 +597,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         if isinstance(instance_unpack, TypeVarTupleType):
                             res.append(
                                 Constraint(
-                                    instance_unpack.id, SUBTYPE_OF, TypeList(list(mapped_middle))
+                                    instance_unpack, SUBTYPE_OF, TypeList(list(mapped_middle))
                                 )
                             )
                         elif (

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2858,6 +2858,7 @@ class TypeInfo(SymbolNode):
         self.metadata = {}
 
     def add_type_vars(self) -> None:
+        self.has_type_var_tuple_type = False
         if self.defn.type_vars:
             for i, vd in enumerate(self.defn.type_vars):
                 if isinstance(vd, mypy.types.ParamSpecType):

--- a/mypy/test/testconstraints.py
+++ b/mypy/test/testconstraints.py
@@ -22,6 +22,7 @@ class ConstraintsSuite(Suite):
                 Constraint(type_var=fx.t, op=direction, target=fx.a)
             ]
 
+    @pytest.mark.xfail
     def test_basic_type_var_tuple_subtype(self) -> None:
         fx = self.fx
         assert infer_constraints(

--- a/mypy/test/testconstraints.py
+++ b/mypy/test/testconstraints.py
@@ -22,7 +22,6 @@ class ConstraintsSuite(Suite):
                 Constraint(type_var=fx.t, op=direction, target=fx.a)
             ]
 
-    @pytest.mark.xfail
     def test_basic_type_var_tuple_subtype(self) -> None:
         fx = self.fx
         assert infer_constraints(

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -96,18 +96,18 @@ reveal_type(h(args))  # N: Revealed type is "Tuple[builtins.str, builtins.str, b
 
 [case testTypeVarTupleGenericClassDefn]
 from typing import Generic, TypeVar, Tuple
-from typing_extensions import TypeVarTuple
+from typing_extensions import TypeVarTuple, Unpack
 
 T = TypeVar("T")
 Ts = TypeVarTuple("Ts")
 
-class Variadic(Generic[Ts]):
+class Variadic(Generic[Unpack[Ts]]):
     pass
 
-class Mixed1(Generic[T, Ts]):
+class Mixed1(Generic[T, Unpack[Ts]]):
     pass
 
-class Mixed2(Generic[Ts, T]):
+class Mixed2(Generic[Unpack[Ts], T]):
     pass
 
 variadic: Variadic[int, str]
@@ -133,7 +133,7 @@ Ts = TypeVarTuple("Ts")
 T = TypeVar("T")
 S = TypeVar("S")
 
-class Variadic(Generic[T, Ts, S]):
+class Variadic(Generic[T, Unpack[Ts], S]):
     pass
 
 def foo(t: Variadic[int, Unpack[Ts], object]) -> Tuple[int, Unpack[Ts]]:
@@ -152,7 +152,7 @@ Ts = TypeVarTuple("Ts")
 T = TypeVar("T")
 S = TypeVar("S")
 
-class Variadic(Generic[T, Ts, S]):
+class Variadic(Generic[T, Unpack[Ts], S]):
     def __init__(self, t: Tuple[Unpack[Ts]]) -> None:
         ...
 
@@ -169,4 +169,91 @@ from typing_extensions import TypeVarTuple
 
 Ts = TypeVarTuple("Ts")
 B = Ts  # E: Type variable "__main__.Ts" is invalid as target for type alias
+[builtins fixtures/tuple.pyi]
+
+[case testPep646ArrayExample]
+from typing import Generic, Tuple, TypeVar, Protocol, NewType
+from typing_extensions import TypeVarTuple, Unpack
+
+Shape = TypeVarTuple('Shape')
+
+Height = NewType('Height', int)
+Width = NewType('Width', int)
+
+T_co = TypeVar("T_co", covariant=True)
+T = TypeVar("T")
+
+class SupportsAbs(Protocol[T_co]):
+    def __abs__(self) -> T_co: pass
+
+def abs(a: SupportsAbs[T]) -> T:
+    ...
+
+class Array(Generic[Unpack[Shape]]):
+    def __init__(self, shape: Tuple[Unpack[Shape]]):
+        self._shape: Tuple[Unpack[Shape]] = shape
+
+    def get_shape(self) -> Tuple[Unpack[Shape]]:
+        return self._shape
+    
+    def __abs__(self) -> Array[Unpack[Shape]]: ...
+
+    def __add__(self, other: Array[Unpack[Shape]]) -> Array[Unpack[Shape]]: ...
+
+shape = (Height(480), Width(640))
+x: Array[Height, Width] = Array(shape)
+reveal_type(abs(x))  # N: Revealed type is "__main__.Array[__main__.Height, __main__.Width]"
+reveal_type(x + x)  # N: Revealed type is "__main__.Array[__main__.Height, __main__.Width]"
+
+[builtins fixtures/tuple.pyi]
+[case testPep646ArrayExampleWithDType]
+from typing import Generic, Tuple, TypeVar, Protocol, NewType
+from typing_extensions import TypeVarTuple, Unpack
+
+DType = TypeVar("DType")
+Shape = TypeVarTuple('Shape')
+
+Height = NewType('Height', int)
+Width = NewType('Width', int)
+
+T_co = TypeVar("T_co", covariant=True)
+T = TypeVar("T")
+
+class SupportsAbs(Protocol[T_co]):
+    def __abs__(self) -> T_co: pass
+
+def abs(a: SupportsAbs[T]) -> T:
+    ...
+
+class Array(Generic[DType, Unpack[Shape]]):
+    def __init__(self, shape: Tuple[Unpack[Shape]]):
+        self._shape: Tuple[Unpack[Shape]] = shape
+
+    def get_shape(self) -> Tuple[Unpack[Shape]]:
+        return self._shape
+    
+    def __abs__(self) -> Array[DType, Unpack[Shape]]: ...
+
+    def __add__(self, other: Array[DType, Unpack[Shape]]) -> Array[DType, Unpack[Shape]]: ...
+
+shape = (Height(480), Width(640))
+x: Array[float, Height, Width] = Array(shape)
+reveal_type(abs(x))  # N: Revealed type is "__main__.Array[builtins.float, __main__.Height, __main__.Width]"
+reveal_type(x + x)  # N: Revealed type is "__main__.Array[builtins.float, __main__.Height, __main__.Width]"
+
+[builtins fixtures/tuple.pyi]
+
+[case testPep646ArrayExampleInfer]
+from typing import Generic, Tuple, TypeVar, NewType
+from typing_extensions import TypeVarTuple, Unpack
+
+Shape = TypeVarTuple('Shape')
+
+Height = NewType('Height', int)
+Width = NewType('Width', int)
+
+class Array(Generic[Unpack[Shape]]):
+    pass
+
+x: Array[float, Height, Width] = Array()
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1456,9 +1456,11 @@ bad: Tuple[Unpack[int]]  # E: builtins.int cannot be unpacked (must be tuple or 
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarTuple]
+from typing import Generic
 from typing_extensions import TypeVarTuple, Unpack
 
 TVariadic = TypeVarTuple('TVariadic')
+TVariadic2 = TypeVarTuple('TVariadic2')
 TP = TypeVarTuple('?')  # E: String argument 1 "?" to TypeVarTuple(...) does not match variable name "TP"
 TP2: int = TypeVarTuple('TP2')  # E: Cannot declare the type of a TypeVar or similar construct
 TP3 = TypeVarTuple()  # E: Too few arguments for TypeVarTuple()
@@ -1467,3 +1469,7 @@ TP5 = TypeVarTuple(t='TP5')  # E: TypeVarTuple() expects a string literal as fir
 
 x: TVariadic  # E: TypeVarTuple "TVariadic" is unbound
 y: Unpack[TVariadic]  # E: TypeVarTuple "TVariadic" is unbound
+
+
+class Variadic(Generic[Unpack[TVariadic], Unpack[TVariadic2]]):  # E: Can only use one type var tuple in a class def
+    pass


### PR DESCRIPTION
Originally this PR was intended to add some test cases from PEP646. However it became immediately apparent that there was a major bug in the implementation where we expected the definition to look like:

```
class Foo(Generic[Ts])
```

When it is supposed to be

```
class Foo(Generic[Unpack[Ts]])
```

This fixes that.