### PR TITLE
Add support for jump statements in partially defined vars check

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2337,7 +2337,7 @@ class State:
         self.time_spent_us += time_spent_us(t0)
         return result
 
-    def detect_partially_defined_vars(self, type_map: Dict[Expression, Type]) -> None:
+    def detect_partially_defined_vars(self, type_map: dict[Expression, Type]) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
         manager = self.manager
         if manager.errors.is_error_code_enabled(codes.PARTIALLY_DEFINED):

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2343,7 +2343,9 @@ class State:
         if manager.errors.is_error_code_enabled(codes.PARTIALLY_DEFINED):
             manager.errors.set_file(self.xpath, self.tree.fullname, options=manager.options)
             self.tree.accept(
-                PartiallyDefinedVariableVisitor(MessageBuilder(manager.errors, manager.modules), type_map)
+                PartiallyDefinedVariableVisitor(
+                    MessageBuilder(manager.errors, manager.modules), type_map
+                )
             )
 
     def finish_passes(self) -> None:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2337,13 +2337,13 @@ class State:
         self.time_spent_us += time_spent_us(t0)
         return result
 
-    def detect_partially_defined_vars(self) -> None:
+    def detect_partially_defined_vars(self, type_map: Dict[Expression, Type]) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
         manager = self.manager
         if manager.errors.is_error_code_enabled(codes.PARTIALLY_DEFINED):
             manager.errors.set_file(self.xpath, self.tree.fullname, options=manager.options)
             self.tree.accept(
-                PartiallyDefinedVariableVisitor(MessageBuilder(manager.errors, manager.modules))
+                PartiallyDefinedVariableVisitor(MessageBuilder(manager.errors, manager.modules), type_map)
             )
 
     def finish_passes(self) -> None:
@@ -3375,7 +3375,7 @@ def process_stale_scc(graph: Graph, scc: list[str], manager: BuildManager) -> No
         graph[id].type_check_first_pass()
         if not graph[id].type_checker().deferred_nodes:
             unfinished_modules.discard(id)
-            graph[id].detect_partially_defined_vars()
+            graph[id].detect_partially_defined_vars(graph[id].type_map())
             graph[id].finish_passes()
 
     while unfinished_modules:
@@ -3384,7 +3384,7 @@ def process_stale_scc(graph: Graph, scc: list[str], manager: BuildManager) -> No
                 continue
             if not graph[id].type_check_second_pass():
                 unfinished_modules.discard(id)
-                graph[id].detect_partially_defined_vars()
+                graph[id].detect_partially_defined_vars(graph[id].type_map())
                 graph[id].finish_passes()
     for id in stale:
         graph[id].generate_unused_ignore_notes()

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -165,8 +165,8 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
 
     def __init__(self, msg: MessageBuilder, type_map: dict[Expression, Type]) -> None:
         self.msg = msg
-        self.tracker = DefinedVariableTracker()
         self.type_map = type_map
+        self.tracker = DefinedVariableTracker()
 
     def process_lvalue(self, lvalue: Lvalue) -> None:
         if isinstance(lvalue, NameExpr):
@@ -250,9 +250,10 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         o.expr.accept(self)
         self.tracker.start_branch_statement()
         o.body.accept(self)
-        self.tracker.next_branch()
-        if o.else_body:
-            o.else_body.accept(self)
+        if not checker.is_true_literal(o.expr):
+            self.tracker.next_branch()
+            if o.else_body:
+                o.else_body.accept(self)
         self.tracker.end_branch_statement()
 
     def visit_name_expr(self, o: NameExpr) -> None:

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
+from mypy import checker
 from mypy.messages import MessageBuilder
 from mypy.nodes import (
+    AssertStmt,
     AssignmentStmt,
+    BreakStmt,
+    ContinueStmt,
     ForStmt,
     FuncDef,
     FuncItem,
@@ -12,10 +16,13 @@ from mypy.nodes import (
     ListExpr,
     Lvalue,
     NameExpr,
+    RaiseStmt,
+    ReturnStmt,
     TupleExpr,
-    WhileStmt,
+    WhileStmt, ExpressionStmt, Expression, Block, GeneratorExpr,
 )
-from mypy.traverser import TraverserVisitor
+from mypy.traverser import ExtendedTraverserVisitor
+from mypy.types import Type, UninhabitedType
 
 
 class DefinedVars(NamedTuple):
@@ -30,52 +37,58 @@ class DefinedVars(NamedTuple):
     must_be_defined: set[str]
 
 
+class BranchState:
+    def __init__(self, already_defined: DefinedVars) -> None:
+        self.vars = DefinedVars(
+            may_be_defined=set(), must_be_defined=set(already_defined.must_be_defined)
+        )
+        self.skipped = False
+
+
 class BranchStatement:
     def __init__(self, already_defined: DefinedVars) -> None:
         self.already_defined = already_defined
-        self.defined_by_branch: list[DefinedVars] = [
-            DefinedVars(may_be_defined=set(), must_be_defined=set(already_defined.must_be_defined))
-        ]
+        self.branches: list[BranchState] = [BranchState(self.already_defined)]
 
     def next_branch(self) -> None:
-        self.defined_by_branch.append(
-            DefinedVars(
-                may_be_defined=set(), must_be_defined=set(self.already_defined.must_be_defined)
-            )
-        )
+        self.branches.append(BranchState(self.already_defined))
 
     def record_definition(self, name: str) -> None:
-        assert len(self.defined_by_branch) > 0
-        self.defined_by_branch[-1].must_be_defined.add(name)
-        self.defined_by_branch[-1].may_be_defined.discard(name)
+        assert len(self.branches) > 0
+        self.branches[-1].vars.must_be_defined.add(name)
+        self.branches[-1].vars.may_be_defined.discard(name)
 
     def record_nested_branch(self, vars: DefinedVars) -> None:
-        assert len(self.defined_by_branch) > 0
-        current_branch = self.defined_by_branch[-1]
-        current_branch.must_be_defined.update(vars.must_be_defined)
-        current_branch.may_be_defined.update(vars.may_be_defined)
-        current_branch.may_be_defined.difference_update(current_branch.must_be_defined)
+        assert len(self.branches) > 0
+        current_branch = self.branches[-1]
+        current_branch.vars.must_be_defined.update(vars.must_be_defined)
+        current_branch.vars.may_be_defined.update(vars.may_be_defined)
+        current_branch.vars.may_be_defined.difference_update(current_branch.vars.must_be_defined)
+
+    def skip_branch(self) -> None:
+        assert len(self.branches) > 0
+        self.branches[-1].skipped = True
 
     def is_possibly_undefined(self, name: str) -> bool:
-        assert len(self.defined_by_branch) > 0
-        return name in self.defined_by_branch[-1].may_be_defined
+        assert len(self.branches) > 0
+        return name in self.branches[-1].vars.may_be_defined
 
     def done(self) -> DefinedVars:
-        assert len(self.defined_by_branch) > 0
-        if len(self.defined_by_branch) == 1:
-            # If there's only one branch, then we just return current.
-            # Note that this case is a different case when an empty branch is omitted (e.g. `if` without `else`).
-            return self.defined_by_branch[0]
+        branch_vars = [b.vars for b in self.branches if not b.skipped]
+        if len(branch_vars) == 0:
+            return DefinedVars(must_be_defined=set(), may_be_defined=set())
+        if len(branch_vars) == 1:
+            return branch_vars[0]
 
         # must_be_defined is a union of must_be_defined of all branches.
-        must_be_defined = set(self.defined_by_branch[0].must_be_defined)
-        for branch_vars in self.defined_by_branch[1:]:
-            must_be_defined.intersection_update(branch_vars.must_be_defined)
+        must_be_defined = set(branch_vars[0].must_be_defined)
+        for vars in branch_vars[1:]:
+            must_be_defined.intersection_update(vars.must_be_defined)
         # may_be_defined are all variables that are not must be defined.
         all_vars = set()
-        for branch_vars in self.defined_by_branch:
-            all_vars.update(branch_vars.may_be_defined)
-            all_vars.update(branch_vars.must_be_defined)
+        for vars in branch_vars:
+            all_vars.update(vars.may_be_defined)
+            all_vars.update(vars.must_be_defined)
         may_be_defined = all_vars.difference(must_be_defined)
         return DefinedVars(may_be_defined=may_be_defined, must_be_defined=must_be_defined)
 
@@ -95,14 +108,14 @@ class DefinedVariableTracker:
 
     def enter_scope(self) -> None:
         assert len(self._scope()) > 0
-        self.scopes.append([BranchStatement(self._scope()[-1].defined_by_branch[-1])])
+        self.scopes.append([BranchStatement(self._scope()[-1].branches[-1].vars)])
 
     def exit_scope(self) -> None:
         self.scopes.pop()
 
     def start_branch_statement(self) -> None:
         assert len(self._scope()) > 0
-        self._scope().append(BranchStatement(self._scope()[-1].defined_by_branch[-1]))
+        self._scope().append(BranchStatement(self._scope()[-1].branches[-1].vars))
 
     def next_branch(self) -> None:
         assert len(self._scope()) > 1
@@ -112,6 +125,11 @@ class DefinedVariableTracker:
         assert len(self._scope()) > 1
         result = self._scope().pop().done()
         self._scope()[-1].record_nested_branch(result)
+
+    def skip_branch(self) -> None:
+        # Only skip branch if we're outside of "root" branch statement.
+        if len(self._scope()) > 1:
+            self._scope()[-1].skip_branch()
 
     def record_declaration(self, name: str) -> None:
         assert len(self.scopes) > 0
@@ -125,7 +143,7 @@ class DefinedVariableTracker:
         return self._scope()[-1].is_possibly_undefined(name)
 
 
-class PartiallyDefinedVariableVisitor(TraverserVisitor):
+class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
     """Detect variables that are defined only part of the time.
 
     This visitor detects the following case:
@@ -137,9 +155,10 @@ class PartiallyDefinedVariableVisitor(TraverserVisitor):
     handled by the semantic analyzer.
     """
 
-    def __init__(self, msg: MessageBuilder) -> None:
+    def __init__(self, msg: MessageBuilder, type_map: dict[Expression, Type]) -> None:
         self.msg = msg
         self.tracker = DefinedVariableTracker()
+        self.type_map = type_map
 
     def process_lvalue(self, lvalue: Lvalue) -> None:
         if isinstance(lvalue, NameExpr):
@@ -185,6 +204,32 @@ class PartiallyDefinedVariableVisitor(TraverserVisitor):
         if o.else_body:
             o.else_body.accept(self)
         self.tracker.end_branch_statement()
+
+    def visit_return_stmt(self, o: ReturnStmt) -> None:
+        super().visit_return_stmt(o)
+        self.tracker.skip_branch()
+
+    def visit_assert_stmt(self, o: AssertStmt) -> None:
+        super().visit_assert_stmt(o)
+        if checker.is_false_literal(o.expr):
+            self.tracker.skip_branch()
+
+    def visit_raise_stmt(self, o: RaiseStmt) -> None:
+        super().visit_raise_stmt(o)
+        self.tracker.skip_branch()
+
+    def visit_continue_stmt(self, o: ContinueStmt) -> None:
+        super().visit_continue_stmt(o)
+        self.tracker.skip_branch()
+
+    def visit_break_stmt(self, o: BreakStmt) -> None:
+        super().visit_break_stmt(o)
+        self.tracker.skip_branch()
+
+    def visit_expression_stmt(self, o: ExpressionStmt) -> None:
+        if isinstance(self.type_map.get(o.expr, None), UninhabitedType):
+            self.tracker.skip_branch()
+        super().visit_expression_stmt(o)
 
     def visit_while_stmt(self, o: WhileStmt) -> None:
         o.expr.accept(self)

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -38,8 +38,8 @@ class BranchState:
 
     def __init__(
         self,
-        must_be_defined: Optional[set[str]] = None,
-        may_be_defined: Optional[set[str]] = None,
+        must_be_defined: set[str] | None = None,
+        may_be_defined: set[str] | None = None,
         skipped: bool = False,
     ) -> None:
         if may_be_defined is None:

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -7,11 +7,15 @@ from mypy.messages import MessageBuilder
 from mypy.nodes import (
     AssertStmt,
     AssignmentStmt,
+    Block,
     BreakStmt,
     ContinueStmt,
+    Expression,
+    ExpressionStmt,
     ForStmt,
     FuncDef,
     FuncItem,
+    GeneratorExpr,
     IfStmt,
     ListExpr,
     Lvalue,
@@ -19,7 +23,7 @@ from mypy.nodes import (
     RaiseStmt,
     ReturnStmt,
     TupleExpr,
-    WhileStmt, ExpressionStmt, Expression, Block, GeneratorExpr,
+    WhileStmt,
 )
 from mypy.traverser import ExtendedTraverserVisitor
 from mypy.types import Type, UninhabitedType
@@ -193,6 +197,13 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
             for arg in o.arguments:
                 self.tracker.record_declaration(arg.variable.name)
         super().visit_func(o)
+
+    def visit_generator_expr(self, o: GeneratorExpr) -> None:
+        self.tracker.enter_scope()
+        for idx in o.indices:
+            self.process_lvalue(idx)
+        super().visit_generator_expr(o)
+        self.tracker.exit_scope()
 
     def visit_for_stmt(self, o: ForStmt) -> None:
         o.expr.accept(self)

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from mypy import checker
 from mypy.messages import MessageBuilder
 from mypy.nodes import (

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -651,7 +651,7 @@ def update_module_isolated(
     state.type_checker().reset()
     state.type_check_first_pass()
     state.type_check_second_pass()
-    state.detect_partially_defined_vars()
+    state.detect_partially_defined_vars(state.type_map())
     t2 = time.time()
     state.finish_passes()
     t3 = time.time()

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -137,3 +137,148 @@ else:
     z = 2
 
 a = z + y  # E: Name "y" may be undefined
+[case testReturn]
+# flags: --enable-error-code partially-defined
+def f1() -> int:
+    if int():
+        x = 1
+    else:
+        return 0
+    return x
+
+def f2() -> int:
+    if int():
+        x = 1
+    elif int():
+        return 0
+    else:
+        x = 2
+    return x
+
+def f3() -> int:
+    if int():
+        x = 1
+    elif int():
+        return 0
+    else:
+        y = 2
+    return x  # E: Name "x" may be undefined
+
+def f4() -> int:
+    if int():
+        x = 1
+    elif int():
+        return 0
+    else:
+        y = 2
+    return x  # E: Name "x" may be undefined
+
+def f5() -> int:
+    # This is a test against crashes.
+    if int():
+        return 1
+    if int():
+        return 2
+    else:
+        return 3
+    return 1
+[case testAssert]
+# flags: --enable-error-code partially-defined
+def f1() -> int:
+    if int():
+        x = 1
+    else:
+        assert False, "something something"
+    return x
+
+def f2() -> int:
+    if int():
+        x = 1
+    elif int():
+        assert False
+    else:
+        y = 2
+    return x  # E: Name "x" may be undefined
+[case testRaise]
+# flags: --enable-error-code partially-defined
+def f1() -> int:
+    if int():
+        x = 1
+    else:
+        raise BaseException("something something")
+    return x
+
+def f2() -> int:
+    if int():
+        x = 1
+    elif int():
+        raise BaseException("something something")
+    else:
+        y = 2
+    return x  # E: Name "x" may be undefined
+[builtins fixtures/exception.pyi]
+
+[case testContinue]
+# flags: --enable-error-code partially-defined
+def f1() -> int:
+    while int():
+        if int():
+            x = 1
+        else:
+            continue
+        y = x
+    else:
+        x = 2
+    return x
+
+def f2() -> int:
+    while int():
+        if int():
+            x = 1
+        elif int():
+            pass
+        else:
+            continue
+        y = x  # E: Name "x" may be undefined
+    else:
+        x = 2
+    return x  # E: Name "x" may be undefined
+
+[case testBreak]
+# flags: --enable-error-code partially-defined
+def f1() -> None:
+    while int():
+        if int():
+            x = 1
+        else:
+            break
+        y = x  # No error -- x is always defined.
+
+def f2() -> None:
+    while int():
+        if int():
+            x = 1
+        elif int():
+            pass
+        else:
+            break
+        y = x  # E: Name "x" may be undefined
+
+[case testNoReturn]
+# flags: --enable-error-code partially-defined
+
+from typing import NoReturn
+def fail() -> NoReturn:
+    assert False
+
+def f() -> None:
+    if int():
+        x = 1
+    elif int():
+        x = 2
+        y = 3
+    else:
+        # This has a NoReturn type, so we can skip it.
+        fail()
+    z = y  # E: Name "y" may be undefined
+    z = x

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -251,6 +251,16 @@ def f2() -> int:
         x = 2
     return x  # E: Name "x" may be undefined
 
+def f3() -> None:
+    while True:
+        if int():
+            x = 2
+        elif int():
+            continue
+        else:
+            continue
+        y = x
+
 [case testBreak]
 # flags: --enable-error-code partially-defined
 def f1() -> None:

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -133,6 +133,12 @@ else:
 
 y = z  # No error.
 
+while True:
+    k = 1
+    if int():
+        break
+y = k # No error.
+
 [case testForLoop]
 # flags: --enable-error-code partially-defined
 for x in [1, 2, 3]:
@@ -144,6 +150,7 @@ else:
     z = 2
 
 a = z + y  # E: Name "y" may be undefined
+
 [case testReturn]
 # flags: --enable-error-code partially-defined
 def f1() -> int:
@@ -177,8 +184,8 @@ def f4() -> int:
     elif int():
         return 0
     else:
-        y = 2
-    return x  # E: Name "x" may be undefined
+        return 0
+    return x
 
 def f5() -> int:
     # This is a test against crashes.
@@ -189,6 +196,7 @@ def f5() -> int:
     else:
         return 3
     return 1
+
 [case testAssert]
 # flags: --enable-error-code partially-defined
 def f1() -> int:
@@ -206,6 +214,7 @@ def f2() -> int:
     else:
         y = 2
     return x  # E: Name "x" may be undefined
+
 [case testRaise]
 # flags: --enable-error-code partially-defined
 def f1() -> int:
@@ -280,6 +289,17 @@ def f2() -> None:
         else:
             break
         y = x  # E: Name "x" may be undefined
+
+def f3() -> None:
+    while int():
+        x = 1
+        while int():
+            if int():
+                x = 2
+            else:
+                break
+        y = x
+    z = x  # E: Name "x" may be undefined
 
 [case testNoReturn]
 # flags: --enable-error-code partially-defined

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -95,6 +95,13 @@ else:
 
 x = y + 2
 
+[case testGenerator]
+# flags: --enable-error-code partially-defined
+if int():
+    a = 3
+s = [a + 1 for a in [1, 2, 3]]
+x = a  # E: Name "a" may be undefined
+
 [case testScope]
 # flags: --enable-error-code partially-defined
 def foo() -> None:


### PR DESCRIPTION
### Description

This builds on #13601 to add support for statements like `continue`, `break`, `return`, `raise` in partially defined variables check. The simplest example is:
```python
def f1() -> int:
    if int():
        x = 1
    else:
        return 0
    return x
```

Previously, mypy would generate a false positive on the last line of example. See test cases for more details.

Adding this support was relatively simple, given all the already existing code. 

Things that aren't supported yet: `match`, `with`, and detecting unreachable blocks.

After this PR, when enabling this check on mypy itself, it generates 18 errors, all of them are potential bugs.
## Test Plan

Tests added.