### PR TITLE
Better errors for missing imports

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -436,7 +436,7 @@ often suggest the name of the stub distribution:
 
 .. code-block:: text
 
-  prog.py:1: error: Library stubs not installed for "yaml" (or incompatible with Python 3.8)
+  prog.py:1: error: Library stubs not installed for "yaml"
   prog.py:1: note: Hint: "python3 -m pip install types-PyYAML"
   ...
 

--- a/docs/source/installed_packages.rst
+++ b/docs/source/installed_packages.rst
@@ -57,10 +57,10 @@ stubs.)
 If you have installed typed packages in another Python installation or
 environment, mypy won't automatically find them. One option is to
 install another copy of those packages in the environment in which you
-use to run mypy. Alternatively, you can use the
+installed mypy. Alternatively, you can use the
 :option:`--python-executable <mypy --python-executable>` flag to point
-to the target Python executable, and mypy will find packages installed
-for that Python executable.
+to the Python executable for another environment, and mypy will find
+packages installed for that Python executable.
 
 Note that mypy does not support some more advanced import features,
 such as zip imports and custom import hooks.

--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -138,7 +138,7 @@ the import. This can cause errors that look like the following:
 .. code-block:: text
 
     main.py:1: error: Skipping analyzing 'django': module is installed, but missing library stubs or py.typed marker
-    main.py:2: error: Library stubs not installed for "requests" (or incompatible with Python 3.8)
+    main.py:2: error: Library stubs not installed for "requests"
     main.py:3: error: Cannot find implementation or library stub for module named "this_module_does_not_exist"
 
 If you get any of these errors on an import, mypy will assume the type of that
@@ -243,7 +243,7 @@ the library, you will get a message like this:
 
 .. code-block:: text
 
-    main.py:1: error: Library stubs not installed for "yaml" (or incompatible with Python 3.8)
+    main.py:1: error: Library stubs not installed for "yaml"
     main.py:1: note: Hint: "python3 -m pip install types-PyYAML"
     main.py:1: note: (or run "mypy --install-types" to install all missing stub packages)
 
@@ -275,6 +275,11 @@ explicitly installing stubs before running mypy, since it may type
 check your code twice -- the first time to find the missing stubs, and
 the second time to type check your code properly after mypy has
 installed the stubs.
+
+If you've already installed the relevant third-party libraries in an environment
+other than the one mypy is running in, you can use :option:`--python-executable
+<mypy --python-executable>` flag to point to the Python executable for that
+environment, and mypy will find packages installed for that Python executable.
 
 .. _missing-type-hints-for-third-party-library:
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2731,8 +2731,7 @@ def module_not_found(
     else:
         daemon = manager.options.fine_grained_incremental
         msg, notes = reason.error_message_templates(daemon)
-        pyver = "%d.%d" % manager.options.python_version
-        errors.report(line, 0, msg.format(module=target, pyver=pyver), code=codes.IMPORT)
+        errors.report(line, 0, msg.format(module=target), code=codes.IMPORT)
         top_level, second_level = get_top_two_prefixes(target)
         if second_level in legacy_bundled_packages:
             top_level = second_level

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -89,9 +89,7 @@ class ModuleNotFoundReason(Enum):
             )
             notes = [doc_link]
         elif self is ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED:
-            msg = (
-                'Library stubs not installed for "{module}" (or incompatible with Python {pyver})'
-            )
+            msg = 'Library stubs not installed for "{module}"'
             notes = ['Hint: "python3 -m pip install {stub_dist}"']
             if not daemon:
                 notes.append(

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2198,11 +2198,11 @@ import waitress
 [file a.py.3]
 import requests
 [out]
-a.py:1: error: Library stubs not installed for "waitress" (or incompatible with Python 3.7)
+a.py:1: error: Library stubs not installed for "waitress"
 a.py:1: note: Hint: "python3 -m pip install types-waitress"
 a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
 ==
-a.py:1: error: Library stubs not installed for "requests" (or incompatible with Python 3.7)
+a.py:1: error: Library stubs not installed for "requests"
 a.py:1: note: Hint: "python3 -m pip install types-requests"
 a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1562,7 +1562,7 @@ from scribe import x
 import maxminddb  # Python 3 stubs available for maxminddb
 import foobar_asdf
 [out]
-_testIgnoreImportIfNoPython3StubAvailable.py:4: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.7)
+_testIgnoreImportIfNoPython3StubAvailable.py:4: error: Library stubs not installed for "maxminddb"
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: Hint: "python3 -m pip install types-maxminddb"
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: (or run "mypy --install-types" to install all missing stub packages)
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
@@ -1574,7 +1574,7 @@ import maxminddb
 [out]
 _testNoPython3StubAvailable.py:1: error: Cannot find implementation or library stub for module named "scribe"
 _testNoPython3StubAvailable.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-_testNoPython3StubAvailable.py:3: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.7)
+_testNoPython3StubAvailable.py:3: error: Library stubs not installed for "maxminddb"
 _testNoPython3StubAvailable.py:3: note: Hint: "python3 -m pip install types-maxminddb"
 _testNoPython3StubAvailable.py:3: note: (or run "mypy --install-types" to install all missing stub packages)
 


### PR DESCRIPTION
Fixes #13633

- Incompatible stubs aren't really a thing (that is visible to mypy at module find time) now that Python 2 support is dead.
- Adjust some documentation wording to clarify use of `--python-executable`