### PR TITLE
[mypyc] Infer native int index type from range over native int

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4286,6 +4286,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         iterable = get_proper_type(echk.accept(expr))
         iterator = echk.check_method_call_by_name("__iter__", iterable, [], [], expr)[0]
 
+        int_type = self.analyze_range_native_int_type(expr)
+        if int_type:
+            return iterator, int_type
+
         if isinstance(iterable, TupleType):
             joined: Type = UninhabitedType()
             for item in iterable.items:
@@ -4294,6 +4298,36 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         else:
             # Non-tuple iterable.
             return iterator, echk.check_method_call_by_name("__next__", iterator, [], [], expr)[0]
+
+    def analyze_range_native_int_type(self, expr: Expression) -> Type | None:
+        """Try to infer native int item type from arguments to range(...).
+
+        For example, return i64 if the expression is "range(0, i64(n))".
+
+        Return None if unsuccessful.
+        """
+        if (
+            isinstance(expr, CallExpr)
+            and isinstance(expr.callee, RefExpr)
+            and expr.callee.fullname == "builtins.range"
+            and 1 <= len(expr.args) <= 3
+            and all(kind == ARG_POS for kind in expr.arg_kinds)
+        ):
+            native_int = None
+            ok = True
+            for arg in expr.args:
+                argt = get_proper_type(self.lookup_type(arg))
+                if isinstance(argt, Instance) and argt.type.fullname in (
+                    "mypy_extensions.i64",
+                    "mypy_extensions.i32",
+                ):
+                    if native_int is None:
+                        native_int = argt
+                    elif argt != native_int:
+                        ok = False
+            if ok and native_int:
+                return native_int
+        return None
 
     def analyze_container_item_type(self, typ: Type) -> Type | None:
         """Check if a type is a nominal container of a union of such.

--- a/mypyc/test-data/irbuild-i64.test
+++ b/mypyc/test-data/irbuild-i64.test
@@ -1574,3 +1574,57 @@ L0:
     y = 11
     z = -3
     return 1
+
+[case testI64ForLoopOverRange]
+from mypy_extensions import i64
+
+def f() -> None:
+    for x in range(i64(4)):
+        y = x
+[out]
+def f():
+    r0, x :: int64
+    r1 :: bit
+    y, r2 :: int64
+L0:
+    r0 = 0
+    x = r0
+L1:
+    r1 = r0 < 4 :: signed
+    if r1 goto L2 else goto L4 :: bool
+L2:
+    y = x
+L3:
+    r2 = r0 + 1
+    r0 = r2
+    x = r2
+    goto L1
+L4:
+    return 1
+
+[case testI64ForLoopOverRange2]
+from mypy_extensions import i64
+
+def f() -> None:
+    for x in range(0, i64(4)):
+        y = x
+[out]
+def f():
+    r0, x :: int64
+    r1 :: bit
+    y, r2 :: int64
+L0:
+    r0 = 0
+    x = r0
+L1:
+    r1 = r0 < 4 :: signed
+    if r1 goto L2 else goto L4 :: bool
+L2:
+    y = x
+L3:
+    r2 = r0 + 1
+    r0 = r2
+    x = r2
+    goto L1
+L4:
+    return 1

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -375,6 +375,25 @@ def test_mixed_arithmetic_and_bitwise_ops() -> None:
     with assertRaises(OverflowError):
         assert int_too_small & i64_3
 
+def test_for_loop() -> None:
+    n: i64 = 0
+    for i in range(i64(5 + int())):
+        n += i
+    assert n == 10
+    n = 0
+    for i in range(i64(5)):
+        n += i
+    assert n == 10
+    n = 0
+    for i in range(i64(2 + int()), 5 + int()):
+        n += i
+    assert n == 9
+    n = 0
+    for i in range(2, i64(5 + int())):
+        n += i
+    assert n == 9
+    assert sum([x * x for x in range(i64(4 + int()))]) == 1 + 4 + 9
+
 [case testI64ErrorValuesAndUndefined]
 from typing import Any
 import sys

--- a/test-data/unit/check-native-int.test
+++ b/test-data/unit/check-native-int.test
@@ -151,3 +151,36 @@ def fi32(x: i32) -> None: pass
 reveal_type(meet(ff, fi32))  # N: Revealed type is "<nothing>"
 reveal_type(meet(fi32, ff))  # N: Revealed type is "<nothing>"
 [builtins fixtures/dict.pyi]
+
+[case testNativeIntForLoopRange]
+from mypy_extensions import i64, i32
+
+for a in range(i64(5)):
+    reveal_type(a)  # N: Revealed type is "mypy_extensions.i64"
+
+for b in range(0, i32(5)):
+    reveal_type(b)  # N: Revealed type is "mypy_extensions.i32"
+
+for c in range(i64(0), 5):
+    reveal_type(c)  # N: Revealed type is "mypy_extensions.i64"
+
+for d in range(i64(0), i64(5)):
+    reveal_type(d)  # N: Revealed type is "mypy_extensions.i64"
+
+for e in range(i64(0), i32(5)):
+    reveal_type(e)  # N: Revealed type is "builtins.int"
+
+for f in range(0, i64(3), 2):
+    reveal_type(f)  # N: Revealed type is "mypy_extensions.i64"
+
+n = 5
+for g in range(0, n, i64(2)):
+    reveal_type(g)  # N: Revealed type is "mypy_extensions.i64"
+[builtins fixtures/range.pyi]
+
+[case testNativeIntComprehensionRange]
+from mypy_extensions import i64, i32
+
+reveal_type([a for a in range(i64(5))])  # N: Revealed type is "builtins.list[mypy_extensions.i64]"
+[reveal_type(a) for a in range(0, i32(5))]  # N: Revealed type is "mypy_extensions.i32"
+[builtins fixtures/range.pyi]


### PR DESCRIPTION
Previously the for index variable would always be inferred a plain `int` when iterating over range. Now we infer a native int type if one of the range arguments is a native int.

Example:
```
for x in range(i64(5)):
    # type of x is i64
    ...
```

This also works in comprehensions. This is particularly useful since there's no way to annotate the index variables in comprehensions, as they are in an inner scope.

This is a convenience feature that makes it easier to avoid implicit conversions between int and native int types.

Work on mypyc/mypyc#837.