### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,6 +5,9 @@ on:
     branches: [master, 'release*']
     tags: ['*']
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     if: github.repository == 'python/mypy'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ on:
     - CREDITS
     - LICENSE
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -15,6 +15,9 @@ on:
     - 'mypy/test/**'
     - 'test-data/**'
 
+permissions:
+  contents: read
+
 jobs:
   mypy_primer:
     name: Run mypy_primer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -12,6 +12,9 @@ on:
     - 'mypy/stubdoc.py'
     - 'test-data/stubgen/**'
 
+permissions:
+  contents: read
+
 jobs:
   stubgenc:
     # Check stub file generation for a small pybind11 project


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflow runs:
https://github.com/python/mypy/runs/8253080028?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- build_wheels.yml
- docs.yml
- mypy_primer.yml
- test.yml
- test_stubgenc.yml

The following workflow already has the least privileged token permission set:

- mypy_primer_comment.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>
