### PR TITLE
Handle AssignmentExpr when checking for partially defined vars

### DIFF
--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -4,6 +4,7 @@ from mypy import checker
 from mypy.messages import MessageBuilder
 from mypy.nodes import (
     AssertStmt,
+    AssignmentExpr,
     AssignmentStmt,
     BreakStmt,
     ContinueStmt,
@@ -179,6 +180,10 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         for lvalue in o.lvalues:
             self.process_lvalue(lvalue)
         super().visit_assignment_stmt(o)
+
+    def visit_assignment_expr(self, o: AssignmentExpr) -> None:
+        self.process_lvalue(o.target)
+        return super().visit_assignment_expr(o)
 
     def visit_if_stmt(self, o: IfStmt) -> None:
         for e in o.expr:

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -319,3 +319,13 @@ def f() -> None:
         fail()
     z = y  # E: Name "y" may be undefined
     z = x
+
+[case testAssignmentExpr]
+# flags: --python-version 3.8 --enable-error-code partially-defined
+def f1() -> None:
+    d = {0: 1}
+    if (x := d.get(1)) is None:
+        z = x
+        x = 2
+    z = x
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
### Description
Adds support for `AssignmentExpr` nodes for the partially defined check.
/CC: @ilinum 