### PR TITLE
Handle DictComp when checking for partially defined vars

### DIFF
--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -7,6 +7,7 @@ from mypy.nodes import (
     AssignmentStmt,
     BreakStmt,
     ContinueStmt,
+    DictionaryComprehension,
     Expression,
     ExpressionStmt,
     ForStmt,
@@ -207,6 +208,13 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         for idx in o.indices:
             self.process_lvalue(idx)
         super().visit_generator_expr(o)
+        self.tracker.exit_scope()
+
+    def visit_dictionary_comprehension(self, o: DictionaryComprehension) -> None:
+        self.tracker.enter_scope()
+        for idx in o.indices:
+            self.process_lvalue(idx)
+        super().visit_dictionary_comprehension(o)
         self.tracker.exit_scope()
 
     def visit_for_stmt(self, o: ForStmt) -> None:

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -319,3 +319,20 @@ def f() -> None:
         fail()
     z = y  # E: Name "y" may be undefined
     z = x
+
+[case testDictComprehension]
+# flags: --enable-error-code partially-defined
+
+def f() -> None:
+    for _ in some_iterator():  # type: ignore[name-defined]
+        key = 2
+        val = 2
+
+    x = (
+        key,  # E: Name "key" may be undefined
+        val,  # E: Name "val" may be undefined
+    )
+
+    d = [(0, "a"), (1, "b")]
+    {val: key for key, val in d}
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -324,7 +324,7 @@ def f() -> None:
 # flags: --enable-error-code partially-defined
 
 def f() -> None:
-    for _ in some_iterator():  # type: ignore[name-defined]
+    for _ in [1, 2]:
         key = 2
         val = 2
 


### PR DESCRIPTION
Description

Adds support for `DictionaryComprehension` nodes for the partially defined check.
/CC: @ilinum