### PR TITLE
Update pos-only unit tests for Python 3.10.7

### DIFF
--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -595,7 +595,7 @@ def f2(c: Callable[P, R]) -> Callable[Concatenate[int, P], R]:
 f2(lambda x: 42)(42, x=42)
 [builtins fixtures/paramspec.pyi]
 [out]
-main:10: error: invalid syntax
+main:10: error: invalid syntax; you likely need to run mypy using Python 3.8 or newer
 [out version>=3.8]
 main:17: error: Incompatible return value type (got "Callable[[Arg(int, 'x'), **P], R]", expected "Callable[[int, **P], R]")
 main:17: note: This may be because "result" has arguments named: "x"
@@ -624,7 +624,7 @@ def f2(c: Callable[P, R]) -> Callable[Concatenate[int, P], R]:
 f2(lambda x: 42)(42, x=42)
 [builtins fixtures/paramspec.pyi]
 [out]
-main:9: error: invalid syntax
+main:11: error: invalid syntax; you likely need to run mypy using Python 3.8 or newer
 [out version>=3.8]
 
 [case testParamSpecConcatenateWithTypeVar]
@@ -665,7 +665,7 @@ reveal_type(abc)
 bar(abc)
 [builtins fixtures/paramspec.pyi]
 [out]
-main:11: error: invalid syntax
+main:13: error: invalid syntax; you likely need to run mypy using Python 3.8 or newer
 [out version>=3.8]
 main:16: note: Revealed type is "__main__.Foo[[builtins.int, b: builtins.str]]"
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -573,7 +573,7 @@ reveal_type(f(n))  # N: Revealed type is "def (builtins.int, builtins.bytes) -> 
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecConcatenateNamedArgs]
-# flags: --strict-concatenate
+# flags: --python-version 3.8 --strict-concatenate
 # this is one noticeable deviation from PEP but I believe it is for the better
 from typing_extensions import ParamSpec, Concatenate
 from typing import Callable, TypeVar
@@ -601,6 +601,8 @@ main:17: error: Incompatible return value type (got "Callable[[Arg(int, 'x'), **
 main:17: note: This may be because "result" has arguments named: "x"
 
 [case testNonStrictParamSpecConcatenateNamedArgs]
+# flags: --python-version 3.8
+
 # this is one noticeable deviation from PEP but I believe it is for the better
 from typing_extensions import ParamSpec, Concatenate
 from typing import Callable, TypeVar
@@ -644,6 +646,8 @@ reveal_type(n(42))  # N: Revealed type is "None"
 [builtins fixtures/paramspec.pyi]
 
 [case testCallablesAsParameters]
+# flags: --python-version 3.8
+
 # credits to https://github.com/microsoft/pyright/issues/2705
 from typing_extensions import ParamSpec, Concatenate
 from typing import Generic, Callable, Any
@@ -663,7 +667,7 @@ bar(abc)
 [out]
 main:11: error: invalid syntax
 [out version>=3.8]
-main:14: note: Revealed type is "__main__.Foo[[builtins.int, b: builtins.str]]"
+main:16: note: Revealed type is "__main__.Foo[[builtins.int, b: builtins.str]]"
 
 [case testSolveParamSpecWithSelfType]
 from typing_extensions import ParamSpec, Concatenate

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -185,8 +185,9 @@ def f(p1: bytes, p2: float = 0.0, /, *, kw: int) -> None:
     reveal_type(p2)  # N: Revealed type is "builtins.float"
     reveal_type(kw)  # N: Revealed type is "builtins.int"
 
-# flags: --python-version 3.8
 [case testPEP570Signatures4]
+# flags: --python-version 3.8
+
 def f(p1: bytes, p2: int = 0, /) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.int"
@@ -599,6 +600,7 @@ class Bar:
 [builtins fixtures/bool.pyi]
 
 [case testOverloadPositionalOnlyErrorMessage]
+# flags: --python-version 3.8
 from typing import overload
 
 @overload
@@ -609,12 +611,13 @@ def foo(a): ...
 
 foo(a=1)
 [out]
-main:9: error: No overload variant of "foo" matches argument type "int"
-main:9: note: Possible overload variants:
-main:9: note:     def foo(int, /) -> Any
-main:9: note:     def foo(a: str) -> Any
+main:10: error: No overload variant of "foo" matches argument type "int"
+main:10: note: Possible overload variants:
+main:10: note:     def foo(int, /) -> Any
+main:10: note:     def foo(a: str) -> Any
 
 [case testOverloadPositionalOnlyErrorMessageAllTypes]
+# flags: --python-version 3.8
 from typing import overload
 
 @overload
@@ -625,12 +628,13 @@ def foo(a, b, *, c): ...
 
 foo(a=1)
 [out]
-main:9: error: No overload variant of "foo" matches argument type "int"
-main:9: note: Possible overload variants:
-main:9: note:     def foo(int, /, b: int, *, c: int) -> Any
-main:9: note:     def foo(a: str, b: int, *, c: int) -> Any
+main:10: error: No overload variant of "foo" matches argument type "int"
+main:10: note: Possible overload variants:
+main:10: note:     def foo(int, /, b: int, *, c: int) -> Any
+main:10: note:     def foo(a: str, b: int, *, c: int) -> Any
 
 [case testOverloadPositionalOnlyErrorMessageMultiplePosArgs]
+# flags: --python-version 3.8
 from typing import overload
 
 @overload
@@ -641,12 +645,13 @@ def foo(a, b, c, d): ...
 
 foo(a=1)
 [out]
-main:9: error: No overload variant of "foo" matches argument type "int"
-main:9: note: Possible overload variants:
-main:9: note:     def foo(int, int, int, /, d: str) -> Any
-main:9: note:     def foo(a: str, b: int, c: int, d: str) -> Any
+main:10: error: No overload variant of "foo" matches argument type "int"
+main:10: note: Possible overload variants:
+main:10: note:     def foo(int, int, int, /, d: str) -> Any
+main:10: note:     def foo(a: str, b: int, c: int, d: str) -> Any
 
 [case testOverloadPositionalOnlyErrorMessageMethod]
+# flags: --python-version 3.8
 from typing import overload
 
 class Some:
@@ -660,13 +665,14 @@ class Some:
 
 Some().foo(a=1)
 [out]
-main:12: error: No overload variant of "foo" of "Some" matches argument type "int"
-main:12: note: Possible overload variants:
-main:12: note:     def foo(self, int, /) -> Any
-main:12: note:     def foo(self, float, /) -> Any
-main:12: note:     def foo(self, a: str) -> Any
+main:13: error: No overload variant of "foo" of "Some" matches argument type "int"
+main:13: note: Possible overload variants:
+main:13: note:     def foo(self, int, /) -> Any
+main:13: note:     def foo(self, float, /) -> Any
+main:13: note:     def foo(self, a: str) -> Any
 
 [case testOverloadPositionalOnlyErrorMessageClassMethod]
+# flags: --python-version 3.8
 from typing import overload
 
 class Some:
@@ -685,11 +691,11 @@ class Some:
 Some.foo(a=1)
 [builtins fixtures/classmethod.pyi]
 [out]
-main:16: error: No overload variant of "foo" of "Some" matches argument type "int"
-main:16: note: Possible overload variants:
-main:16: note:     def foo(cls, int, /) -> Any
-main:16: note:     def foo(cls, float, /) -> Any
-main:16: note:     def foo(cls, a: str) -> Any
+main:17: error: No overload variant of "foo" of "Some" matches argument type "int"
+main:17: note: Possible overload variants:
+main:17: note:     def foo(cls, int, /) -> Any
+main:17: note:     def foo(cls, float, /) -> Any
+main:17: note:     def foo(cls, a: str) -> Any
 
 [case testUnpackWithDuplicateNamePositionalOnly]
 # flags: --python-version 3.8

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -115,21 +115,25 @@ def g(x: int): ...
 )  # type: ignore  # E: Unused "type: ignore" comment
 
 [case testPEP570ArgTypesMissing]
-# flags: --disallow-untyped-defs
+# flags: --python-version 3.8 --disallow-untyped-defs
 def f(arg, /) -> None: ...  # E: Function is missing a type annotation for one or more arguments
 
 [case testPEP570ArgTypesBadDefault]
+# flags: --python-version 3.8
 def f(arg: int = "ERROR", /) -> None: ...  # E: Incompatible default for argument "arg" (default has type "str", argument has type "int")
 
 [case testPEP570ArgTypesDefault]
+# flags: --python-version 3.8
 def f(arg: int = 0, /) -> None:
     reveal_type(arg)  # N: Revealed type is "builtins.int"
 
 [case testPEP570ArgTypesRequired]
+# flags: --python-version 3.8
 def f(arg: int, /) -> None:
     reveal_type(arg)  # N: Revealed type is "builtins.int"
 
 [case testPEP570Required]
+# flags: --python-version 3.8
 def f(arg: int, /) -> None: ...  # N: "f" defined here
 f(1)
 f("ERROR")  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
@@ -137,6 +141,7 @@ f(arg=1)  # E: Unexpected keyword argument "arg" for "f"
 f(arg="ERROR")  # E: Unexpected keyword argument "arg" for "f"
 
 [case testPEP570Default]
+# flags: --python-version 3.8
 def f(arg: int = 0, /) -> None: ...  # N: "f" defined here
 f()
 f(1)
@@ -145,6 +150,7 @@ f(arg=1)  # E: Unexpected keyword argument "arg" for "f"
 f(arg="ERROR")  # E: Unexpected keyword argument "arg" for "f"
 
 [case testPEP570Calls]
+# flags: --python-version 3.8 --no-strict-optional
 from typing import Any, Dict
 def f(p, /, p_or_kw, *, kw) -> None: ...  # N: "f" defined here
 d = None # type: Dict[Any, Any]
@@ -157,6 +163,7 @@ f(**d)  # E: Missing positional argument "p_or_kw" in call to "f"
 [builtins fixtures/dict.pyi]
 
 [case testPEP570Signatures1]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float, /, p_or_kw: int, *, kw: str) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
@@ -164,6 +171,7 @@ def f(p1: bytes, p2: float, /, p_or_kw: int, *, kw: str) -> None:
     reveal_type(kw)  # N: Revealed type is "builtins.str"
 
 [case testPEP570Signatures2]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float = 0.0, /, p_or_kw: int = 0, *, kw: str) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
@@ -171,28 +179,33 @@ def f(p1: bytes, p2: float = 0.0, /, p_or_kw: int = 0, *, kw: str) -> None:
     reveal_type(kw)  # N: Revealed type is "builtins.str"
 
 [case testPEP570Signatures3]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float = 0.0, /, *, kw: int) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
     reveal_type(kw)  # N: Revealed type is "builtins.int"
 
+# flags: --python-version 3.8
 [case testPEP570Signatures4]
 def f(p1: bytes, p2: int = 0, /) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.int"
 
 [case testPEP570Signatures5]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float, /, p_or_kw: int) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
     reveal_type(p_or_kw)  # N: Revealed type is "builtins.int"
 
 [case testPEP570Signatures6]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float, /) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
 
 [case testPEP570Unannotated]
+# flags: --python-version 3.8
 def f(arg, /): ...  # N: "f" defined here
 g = lambda arg, /: arg
 def h(arg=0, /): ...  # N: "h" defined here
@@ -561,6 +574,7 @@ def foo() -> None:
 [builtins fixtures/dict.pyi]
 
 [case testOverloadWithPositionalOnlySelf]
+# flags: --python-version 3.8
 from typing import overload, Optional
 
 class Foo:
@@ -678,6 +692,7 @@ main:16: note:     def foo(cls, float, /) -> Any
 main:16: note:     def foo(cls, a: str) -> Any
 
 [case testUnpackWithDuplicateNamePositionalOnly]
+# flags: --python-version 3.8
 from typing_extensions import Unpack, TypedDict
 
 class Person(TypedDict):

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -187,7 +187,6 @@ def f(p1: bytes, p2: float = 0.0, /, *, kw: int) -> None:
 
 [case testPEP570Signatures4]
 # flags: --python-version 3.8
-
 def f(p1: bytes, p2: int = 0, /) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.int"


### PR DESCRIPTION
### Description

The CI has started to sporadically fail depending on whether 3.10.6 is picked up by GitHub Actions (okay) or 3.10.7 (not okay). For example:

- https://github.com/python/mypy/actions/runs/3046671132/jobs/4909772702
- https://github.com/python/mypy/actions/runs/3046723692/jobs/4909887963

 On Python 3.10.7 (but not on Python 3.10.6), mypy correctly rejects using PEP 570 syntax unless `--python-version` is set to 3.8 or higher (this is due to https://github.com/python/cpython/pull/95935). However, this makes several unit tests fail.

This PR updates those unit tests so that the CI passes on both 3.10.6 and 3.10.7