### PR TITLE
Add initial `LiteralString` support

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2212,6 +2212,8 @@ def format_type_inner(
             if itype.extra_attrs and itype.extra_attrs.mod_name and module_names:
                 return f"{base_str} {itype.extra_attrs.mod_name}"
             return base_str
+        elif itype.type.fullname == "builtins.str" and itype.literal_string:
+            return "LiteralString"
         if verbosity >= 2 or (fullnames and itype.type.fullname in fullnames):
             base_str = itype.type.fullname
         else:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -138,8 +138,6 @@ type_aliases: Final = {
     "typing.DefaultDict": "collections.defaultdict",
     "typing.Deque": "collections.deque",
     "typing.OrderedDict": "collections.OrderedDict",
-    # HACK: a lie in lieu of actual support for PEP 675
-    "typing.LiteralString": "builtins.str",
 }
 
 # This keeps track of the oldest supported Python version where the corresponding
@@ -154,15 +152,12 @@ type_aliases_source_versions: Final = {
     "typing.DefaultDict": (2, 7),
     "typing.Deque": (2, 7),
     "typing.OrderedDict": (3, 7),
-    "typing.LiteralString": (3, 11),
 }
 
 # This keeps track of aliases in `typing_extensions`, which we treat specially.
 typing_extensions_aliases: Final = {
     # See: https://github.com/python/mypy/issues/11528
     "typing_extensions.OrderedDict": "collections.OrderedDict",
-    # HACK: a lie in lieu of actual support for PEP 675
-    "typing_extensions.LiteralString": "builtins.str",
 }
 
 reverse_builtin_aliases: Final = {
@@ -176,8 +171,6 @@ _nongen_builtins: Final = {"builtins.tuple": "typing.Tuple", "builtins.enumerate
 _nongen_builtins.update((name, alias) for alias, name in type_aliases.items())
 # Drop OrderedDict from this for backward compatibility
 del _nongen_builtins["collections.OrderedDict"]
-# HACK: consequence of hackily treating LiteralString as an alias for str
-del _nongen_builtins["builtins.str"]
 
 
 def get_nongen_builtins(python_version: tuple[int, int]) -> dict[str, str]:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -463,7 +463,16 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 # and we can't have circular promotions.
                 if left.type.alt_promote is right.type:
                     return True
+
             rname = right.type.fullname
+
+            # Check `LiteralString` special case:
+            if rname == "builtins.str" and right.literal_string:
+                return left.literal_string or (
+                    left.last_known_value is not None
+                    and isinstance(left.last_known_value.value, str)
+                )
+
             # Always try a nominal check if possible,
             # there might be errors that a user wants to silence *once*.
             # NamedTuples are a special case, because `NamedTuple` is not listed

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -574,6 +574,16 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 self.fail('"Unpack" is not supported yet, use --enable-incomplete-features', t)
                 return AnyType(TypeOfAny.from_error)
             return UnpackType(self.anal_type(t.args[0]), line=t.line, column=t.column)
+        elif fullname in ("typing.LiteralString", "typing_extensions.LiteralString"):
+            inst = self.named_type("builtins.str")
+            if not self.options.enable_incomplete_features:
+                self.fail(
+                    '"LiteralString" is not fully supported yet, use --enable-incomplete-features',
+                    t,
+                )
+            else:
+                inst.literal_string = True
+            return inst
         return None
 
     def get_omitted_any(self, typ: Type, fullname: str | None = None) -> AnyType:

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -141,6 +141,8 @@ class TypeState:
             # will be an unbounded number of potential types to cache,
             # making caching less effective.
             return False
+        if left.literal_string or right.literal_string:
+            return False
         info = right.type
         cache = TypeState._subtype_caches.get(info)
         if cache is None:

--- a/test-data/unit/check-literal-string.test
+++ b/test-data/unit/check-literal-string.test
@@ -1,0 +1,104 @@
+-- LiteralString tests
+-- See https://peps.python.org/pep-0675/
+
+[case testLiteralStringInference]
+from typing_extensions import LiteralString
+
+x: LiteralString = 'a'
+raw_str: str = x   # Ok, can be narrowed
+
+some_str: str
+y: LiteralString = some_str  # E: Incompatible types in assignment (expression has type "str", variable has type "LiteralString")
+
+z: LiteralString = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "LiteralString")
+[builtins fixtures/literal_string.pyi]
+
+
+[case testLiteralTypeAndLiteralString]
+from typing_extensions import LiteralString, Literal
+
+l1: Literal['a']
+l2: Literal[1]
+
+ls1: LiteralString = l1
+ls2: LiteralString = l2  # E: Incompatible types in assignment (expression has type "Literal[1]", variable has type "LiteralString")
+
+ls3: LiteralString
+l3: Literal['a'] = ls3  # E: Incompatible types in assignment (expression has type "LiteralString", variable has type "Literal['a']")
+
+def expects_literal_string(x: LiteralString): ...
+def expects_literal_a(x: Literal['a']): ...
+
+expects_literal_string(l1)
+expects_literal_string(ls1)
+
+expects_literal_a(l1)
+expects_literal_a(ls1)  # E: Argument 1 to "expects_literal_a" has incompatible type "LiteralString"; expected "Literal['a']"
+[builtins fixtures/literal_string.pyi]
+
+
+[case testLiteralStringFallbackToString]
+from typing_extensions import LiteralString
+def expects_literal_string(x: LiteralString): ...
+
+x: LiteralString
+expects_literal_string(x.format(1))  # E: Argument 1 to "expects_literal_string" has incompatible type "str"; expected "LiteralString"
+[builtins fixtures/literal_string.pyi]
+
+
+-- TODO: this is not supported yet
+-- All cases here must pass
+-- But, we need literal type math for this
+[case testLiteralStringTypeMath-skip]
+from typing_extensions import LiteralString
+def expects_literal_string(x: LiteralString): ...
+
+expects_literal_string('a')
+expects_literal_string('a' + 'b')
+expects_literal_string('a' * 2)
+[builtins fixtures/literal_string.pyi]
+
+
+[case testLiteralStringBoundTypeVar]
+from typing_extensions import LiteralString
+from typing import TypeVar
+
+T = TypeVar('T', bound=LiteralString)
+def expects_literal_string(x: T): ...
+
+expects_literal_string('a')
+
+x: LiteralString
+y: str
+expects_literal_string(x)
+expects_literal_string(y)  # E: Value of type variable "T" of "expects_literal_string" cannot be "str"
+[builtins fixtures/literal_string.pyi]
+
+
+[case testLiteralStringAsMethodSig]
+from typing_extensions import LiteralString
+
+class Base:
+    def method1(self, arg: LiteralString) -> str: ...
+    def method2(self, arg: str) -> LiteralString: ...
+    def method3(self, arg: LiteralString) -> LiteralString: ...
+    def method4(self, arg: str) -> str: ...
+
+class Correct(Base):
+    def method1(self, arg: str) -> LiteralString: ...
+    def method3(self, arg: str) -> LiteralString: ...
+    def method4(self, arg: str) -> LiteralString: ...
+
+class Wrong(Base):
+    def method2(self, arg: LiteralString) -> str: ...
+    def method3(self, arg: str) -> str: ...
+    def method4(self, arg: LiteralString) -> LiteralString: ...
+[out]
+main:15: error: Return type "str" of "method2" incompatible with return type "LiteralString" in supertype "Base"
+main:16: error: Return type "str" of "method3" incompatible with return type "LiteralString" in supertype "Base"
+main:17: error: Signature of "method4" incompatible with supertype "Base"
+main:17: note:      Superclass:
+main:17: note:          def method4(self, arg: str) -> str
+main:17: note:      Subclass:
+main:17: note:          def method4(self, arg: LiteralString) -> LiteralString
+[builtins fixtures/literal_string.pyi]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10031,3 +10031,29 @@ class C(B): ...
 ==
 ==
 main.py:4: note: Revealed type is "def () -> builtins.str"
+
+[case testLiteralStringCache]
+import main
+[file main.py]
+from typing_extensions import LiteralString
+
+def some(x: LiteralString) -> LiteralString:
+    return x
+
+x: LiteralString = 'a'
+some(x)
+some('b')
+[file main.py.2]
+from typing_extensions import LiteralString
+
+def some(x: LiteralString) -> str:
+    return x
+
+x: str
+some(x)  # error
+some('b')
+[builtins fixtures/tuple.pyi]
+[out]
+==
+==
+main.py:7: error: Argument 1 to "some" has incompatible type "str"; expected "LiteralString"

--- a/test-data/unit/fixtures/literal_string.pyi
+++ b/test-data/unit/fixtures/literal_string.pyi
@@ -1,0 +1,55 @@
+# Builtins stub used in tuple-related test cases.
+
+from typing import Iterable, Iterator, TypeVar, Generic, Sequence, Any, overload, Tuple, Type
+
+T = TypeVar("T")
+Tco = TypeVar('Tco', covariant=True)
+
+class object:
+    def __init__(self) -> None: pass
+
+class type:
+    def __init__(self, *a: object) -> None: pass
+    def __call__(self, *a: object) -> object: pass
+class tuple(Sequence[Tco], Generic[Tco]):
+    def __new__(cls: Type[T], iterable: Iterable[Tco] = ...) -> T: ...
+    def __iter__(self) -> Iterator[Tco]: pass
+    def __contains__(self, item: object) -> bool: pass
+    @overload
+    def __getitem__(self, x: int) -> Tco: pass
+    @overload
+    def __getitem__(self, x: slice) -> Tuple[Tco, ...]: ...
+    def __mul__(self, n: int) -> Tuple[Tco, ...]: pass
+    def __rmul__(self, n: int) -> Tuple[Tco, ...]: pass
+    def __add__(self, x: Tuple[Tco, ...]) -> Tuple[Tco, ...]: pass
+    def count(self, obj: object) -> int: pass
+class function: pass
+class ellipsis: pass
+class classmethod: pass
+
+# We need int and slice for indexing tuples.
+class int:
+    def __neg__(self) -> 'int': pass
+class float: pass
+class slice: pass
+class bool(int): pass
+class str:
+    def __add__(self, __other: str) -> str: pass
+    def __mul__(self, __num: int) -> str: pass
+    def format(self, *args: Any) -> str: pass
+class bytes: pass
+class unicode: pass
+
+class list(Sequence[T], Generic[T]):
+    @overload
+    def __getitem__(self, i: int) -> T: ...
+    @overload
+    def __getitem__(self, s: slice) -> list[T]: ...
+    def __contains__(self, item: object) -> bool: ...
+    def __iter__(self) -> Iterator[T]: ...
+
+def isinstance(x: object, t: type) -> bool: pass
+
+def sum(iterable: Iterable[T], start: T = None) -> T: pass
+
+class BaseException: pass

--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -33,6 +33,8 @@ Never: _SpecialForm
 TypeVarTuple: _SpecialForm
 Unpack: _SpecialForm
 
+LiteralString: _SpecialForm
+
 # Fallback type for all typed dicts (does not exist at runtime).
 class _TypedDict(Mapping[str, object]):
     # Needed to make this class non-abstract. It is explicitly declared abstract in


### PR DESCRIPTION
I went for the smallest possible diff in this feature.
There are couple of other options I did not want to go with:
- `class LiteralStringType` and using it in `last_known_value`. There are lots of places where `.last_known_value` is used for literal context checking. In this case we would also need to add new visitor methods to every type visitor, which is way harder

TODO in the next PRs:
- Literal type math: https://github.com/python/mypy/issues/11990 This will allow us to automatically support things like `x: LiteralString = 'a' + 'b'`
- More tests and use-cases 
- Removing `--enable-incomplete-features` flag from this feature

Refs https://github.com/python/mypy/issues/12554