### PR TITLE
[0.980 backport] Update pos-only unit tests for Python 3.10.7 (#13660)

### DIFF
--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -573,7 +573,7 @@ reveal_type(f(n))  # N: Revealed type is "def (builtins.int, builtins.bytes) -> 
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecConcatenateNamedArgs]
-# flags: --strict-concatenate
+# flags: --python-version 3.8 --strict-concatenate
 # this is one noticeable deviation from PEP but I believe it is for the better
 from typing_extensions import ParamSpec, Concatenate
 from typing import Callable, TypeVar
@@ -595,12 +595,14 @@ def f2(c: Callable[P, R]) -> Callable[Concatenate[int, P], R]:
 f2(lambda x: 42)(42, x=42)
 [builtins fixtures/paramspec.pyi]
 [out]
-main:10: error: invalid syntax
+main:10: error: invalid syntax; you likely need to run mypy using Python 3.8 or newer
 [out version>=3.8]
 main:17: error: Incompatible return value type (got "Callable[[Arg(int, 'x'), **P], R]", expected "Callable[[int, **P], R]")
 main:17: note: This may be because "result" has arguments named: "x"
 
 [case testNonStrictParamSpecConcatenateNamedArgs]
+# flags: --python-version 3.8
+
 # this is one noticeable deviation from PEP but I believe it is for the better
 from typing_extensions import ParamSpec, Concatenate
 from typing import Callable, TypeVar
@@ -622,7 +624,7 @@ def f2(c: Callable[P, R]) -> Callable[Concatenate[int, P], R]:
 f2(lambda x: 42)(42, x=42)
 [builtins fixtures/paramspec.pyi]
 [out]
-main:9: error: invalid syntax
+main:11: error: invalid syntax; you likely need to run mypy using Python 3.8 or newer
 [out version>=3.8]
 
 [case testParamSpecConcatenateWithTypeVar]
@@ -644,6 +646,8 @@ reveal_type(n(42))  # N: Revealed type is "None"
 [builtins fixtures/paramspec.pyi]
 
 [case testCallablesAsParameters]
+# flags: --python-version 3.8
+
 # credits to https://github.com/microsoft/pyright/issues/2705
 from typing_extensions import ParamSpec, Concatenate
 from typing import Generic, Callable, Any
@@ -661,9 +665,9 @@ reveal_type(abc)
 bar(abc)
 [builtins fixtures/paramspec.pyi]
 [out]
-main:11: error: invalid syntax
+main:13: error: invalid syntax; you likely need to run mypy using Python 3.8 or newer
 [out version>=3.8]
-main:14: note: Revealed type is "__main__.Foo[[builtins.int, b: builtins.str]]"
+main:16: note: Revealed type is "__main__.Foo[[builtins.int, b: builtins.str]]"
 
 [case testSolveParamSpecWithSelfType]
 from typing_extensions import ParamSpec, Concatenate

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -115,21 +115,25 @@ def g(x: int): ...
 )  # type: ignore  # E: Unused "type: ignore" comment
 
 [case testPEP570ArgTypesMissing]
-# flags: --disallow-untyped-defs
+# flags: --python-version 3.8 --disallow-untyped-defs
 def f(arg, /) -> None: ...  # E: Function is missing a type annotation for one or more arguments
 
 [case testPEP570ArgTypesBadDefault]
+# flags: --python-version 3.8
 def f(arg: int = "ERROR", /) -> None: ...  # E: Incompatible default for argument "arg" (default has type "str", argument has type "int")
 
 [case testPEP570ArgTypesDefault]
+# flags: --python-version 3.8
 def f(arg: int = 0, /) -> None:
     reveal_type(arg)  # N: Revealed type is "builtins.int"
 
 [case testPEP570ArgTypesRequired]
+# flags: --python-version 3.8
 def f(arg: int, /) -> None:
     reveal_type(arg)  # N: Revealed type is "builtins.int"
 
 [case testPEP570Required]
+# flags: --python-version 3.8
 def f(arg: int, /) -> None: ...  # N: "f" defined here
 f(1)
 f("ERROR")  # E: Argument 1 to "f" has incompatible type "str"; expected "int"
@@ -137,6 +141,7 @@ f(arg=1)  # E: Unexpected keyword argument "arg" for "f"
 f(arg="ERROR")  # E: Unexpected keyword argument "arg" for "f"
 
 [case testPEP570Default]
+# flags: --python-version 3.8
 def f(arg: int = 0, /) -> None: ...  # N: "f" defined here
 f()
 f(1)
@@ -145,6 +150,7 @@ f(arg=1)  # E: Unexpected keyword argument "arg" for "f"
 f(arg="ERROR")  # E: Unexpected keyword argument "arg" for "f"
 
 [case testPEP570Calls]
+# flags: --python-version 3.8 --no-strict-optional
 from typing import Any, Dict
 def f(p, /, p_or_kw, *, kw) -> None: ...  # N: "f" defined here
 d = None # type: Dict[Any, Any]
@@ -157,6 +163,7 @@ f(**d)  # E: Missing positional argument "p_or_kw" in call to "f"
 [builtins fixtures/dict.pyi]
 
 [case testPEP570Signatures1]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float, /, p_or_kw: int, *, kw: str) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
@@ -164,6 +171,7 @@ def f(p1: bytes, p2: float, /, p_or_kw: int, *, kw: str) -> None:
     reveal_type(kw)  # N: Revealed type is "builtins.str"
 
 [case testPEP570Signatures2]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float = 0.0, /, p_or_kw: int = 0, *, kw: str) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
@@ -171,28 +179,33 @@ def f(p1: bytes, p2: float = 0.0, /, p_or_kw: int = 0, *, kw: str) -> None:
     reveal_type(kw)  # N: Revealed type is "builtins.str"
 
 [case testPEP570Signatures3]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float = 0.0, /, *, kw: int) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
     reveal_type(kw)  # N: Revealed type is "builtins.int"
 
 [case testPEP570Signatures4]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: int = 0, /) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.int"
 
 [case testPEP570Signatures5]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float, /, p_or_kw: int) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
     reveal_type(p_or_kw)  # N: Revealed type is "builtins.int"
 
 [case testPEP570Signatures6]
+# flags: --python-version 3.8
 def f(p1: bytes, p2: float, /) -> None:
     reveal_type(p1)  # N: Revealed type is "builtins.bytes"
     reveal_type(p2)  # N: Revealed type is "builtins.float"
 
 [case testPEP570Unannotated]
+# flags: --python-version 3.8
 def f(arg, /): ...  # N: "f" defined here
 g = lambda arg, /: arg
 def h(arg=0, /): ...  # N: "h" defined here
@@ -554,6 +567,7 @@ def foo() -> None:
 [builtins fixtures/dict.pyi]
 
 [case testOverloadWithPositionalOnlySelf]
+# flags: --python-version 3.8
 from typing import overload, Optional
 
 class Foo:
@@ -578,6 +592,7 @@ class Bar:
 [builtins fixtures/bool.pyi]
 
 [case testUnpackWithDuplicateNamePositionalOnly]
+# flags: --python-version 3.8
 from typing_extensions import Unpack, TypedDict
 
 class Person(TypedDict):


### PR DESCRIPTION
Backport #13660 to fix test issues with Python 3.10.7.
https://github.com/python/mypy/actions/runs/3046723692/jobs/4909887963