### PR TITLE
Don't run test suite on 32bit Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Test suite with py37-windows-32
-          python: '3.7'
-          arch: x86
-          os: windows-latest
-          toxenv: py37
         - name: Test suite with py37-windows-64
           python: '3.7'
           arch: x64


### PR DESCRIPTION
I don't think testing the different architecture gains us anything, and [we don't build mypyc compiled wheels for win32 anyway](https://github.com/mypyc/mypy_mypyc-wheels/blob/aabe075c7abe8baa0b212cc14e7ab607dffa6934/build_wheel.py#L35), so there shouldn't be a difference between the two. This should provide a nice speedup to the test suite as well.

These tests were initially introduced in https://github.com/python/mypy/pull/8327.

