### PR TITLE
Use consistent capitalization of `TypeVar`

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -172,7 +172,7 @@ TYPEVAR_BOUND_MUST_BE_TYPE: Final = 'TypeVar "bound" must be a type'
 TYPEVAR_UNEXPECTED_ARGUMENT: Final = 'Unexpected argument to "TypeVar()"'
 UNBOUND_TYPEVAR: Final = (
     "A function returning TypeVar should receive at least "
-    "one argument containing the same Typevar"
+    "one argument containing the same TypeVar"
 )
 
 # Super

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3232,7 +3232,7 @@ def error(u_c: Type[U]) -> P: # Error here, see below
     return new_pro(u_c)  # Error here, see below
 [out]
 main:11: note: Revealed type is "__main__.WizUser"
-main:12: error: A function returning TypeVar should receive at least one argument containing the same Typevar
+main:12: error: A function returning TypeVar should receive at least one argument containing the same TypeVar
 main:13: error: Value of type variable "P" of "new_pro" cannot be "U"
 main:13: error: Incompatible return value type (got "U", expected "P")
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -254,7 +254,7 @@ z: y  # E: Variable "__main__.y" is not valid as a type  [valid-type] \
 from typing import TypeVar
 
 T = TypeVar('T')
-def f() -> T: pass # E: A function returning TypeVar should receive at least one argument containing the same Typevar  [type-var]
+def f() -> T: pass # E: A function returning TypeVar should receive at least one argument containing the same TypeVar  [type-var]
 x = f()  # E: Need type annotation for "x"  [var-annotated]
 y = []  # E: Need type annotation for "y" (hint: "y: List[<type>] = ...")  [var-annotated]
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1557,9 +1557,9 @@ A = TypeVar('A')
 B = TypeVar('B')
 
 def f1(x: A) -> A: ...
-def f2(x: A) -> B: ... # E: A function returning TypeVar should receive at least one argument containing the same Typevar
+def f2(x: A) -> B: ... # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
 def f3(x: B) -> B: ...
-def f4(x: int) -> A: ... # E: A function returning TypeVar should receive at least one argument containing the same Typevar
+def f4(x: int) -> A: ... # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
 
 y1 = f1
 if int():
@@ -1608,8 +1608,8 @@ B = TypeVar('B')
 T = TypeVar('T')
 def outer(t: T) -> None:
     def f1(x: A) -> A: ...
-    def f2(x: A) -> B: ... # E: A function returning TypeVar should receive at least one argument containing the same Typevar
-    def f3(x: T) -> A: ... # E: A function returning TypeVar should receive at least one argument containing the same Typevar
+    def f2(x: A) -> B: ... # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
+    def f3(x: T) -> A: ... # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
     def f4(x: A) -> T: ...
     def f5(x: T) -> T: ...
 
@@ -1778,7 +1778,7 @@ from typing import TypeVar
 A = TypeVar('A')
 B = TypeVar('B')
 def f1(x: int, y: A) -> A: ...
-def f2(x: int, y: A) -> B: ... # E: A function returning TypeVar should receive at least one argument containing the same Typevar
+def f2(x: int, y: A) -> B: ... # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
 def f3(x: A, y: B) -> B: ...
 g = f1
 g = f2

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -448,7 +448,7 @@ g(None) # Ok
 f()     # Ok because not used to infer local variable type
 g(a)
 
-def f() -> T: pass # E: A function returning TypeVar should receive at least one argument containing the same Typevar
+def f() -> T: pass # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
 def g(a: T) -> None: pass
 [out]
 
@@ -2355,7 +2355,7 @@ def main() -> None:
 [case testDontMarkUnreachableAfterInferenceUninhabited]
 from typing import TypeVar
 T = TypeVar('T')
-def f() -> T: pass # E: A function returning TypeVar should receive at least one argument containing the same Typevar
+def f() -> T: pass # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
 
 class C:
     x = f() # E: Need type annotation for "x"

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1066,7 +1066,7 @@ def callback(func: Callable[[Any], Any]) -> None: ...
 class Job(Generic[P]): ...
 
 @callback
-def run_job(job: Job[...]) -> T: ... # E: A function returning TypeVar should receive at least one argument containing the same Typevar
+def run_job(job: Job[...]) -> T: ... # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
 [builtins fixtures/tuple.pyi]
 
 [case testTupleAndDictOperationsOnParamSpecArgsAndKwargs]

--- a/test-data/unit/check-typevar-unbound.test
+++ b/test-data/unit/check-typevar-unbound.test
@@ -4,7 +4,7 @@ from typing import TypeVar
 
 T = TypeVar('T')
 
-def f() -> T: # E: A function returning TypeVar should receive at least one argument containing the same Typevar
+def f() -> T: # E: A function returning TypeVar should receive at least one argument containing the same TypeVar
     ...
 
 f()


### PR DESCRIPTION
### Description

Changed `Typevar` -> `TypeVar` in the error message from #13166.

I was testing the mypy 0.980 pre-release builds and noticed that the error message was using inconsistent capitalization.

## Test Plan

Covered by existing tests, updated relevant test cases.
