### PR TITLE
Add pip to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,7 @@ setup(
         "dmypy": "psutil >= 4.0",
         "python2": "typed_ast >= 1.4.0, < 2",
         "reports": "lxml",
+        "install-types": "pip",
     },
     python_requires=">=3.7",
     include_package_data=True,


### PR DESCRIPTION
setup.py:
Change `setup()` call to include pip in the list of dependencies passed to `install_requires`.
Pip is required for the `mypy --install-types` feature. Without specifically adding it, minimal environments (e.g. venvs) will not have pip installed and therefore have no way of installing required types (e.g. for tests).

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #13580 

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
