### PR TITLE
Add test case for missing TypedDict TypeVar scope frame

### DIFF
--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2545,6 +2545,22 @@ Alias(key=0, value=0)  # E: Missing type parameters for generic type "Alias" \
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testGenericTypedDictMultipleGenerics]
+# See https://github.com/python/mypy/issues/13755
+from typing import Generic, TypeVar, TypedDict
+
+T = TypeVar("T")
+Foo = TypedDict("Foo", {"bar": T})
+class Stack(Generic[T]): pass
+
+a = Foo[str]
+b = Foo[int]
+reveal_type(a)  # N: Revealed type is "def (*, bar: builtins.str) -> TypedDict('__main__.Foo', {'bar': builtins.str})"
+reveal_type(b)  # N: Revealed type is "def (*, bar: builtins.int) -> TypedDict('__main__.Foo', {'bar': builtins.int})"
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testGenericTypedDictCallSyntax]
 from typing import TypedDict, TypeVar
 


### PR DESCRIPTION
This is a small follow-up to #13678 and #13755.

In the former diff, I added a TypeVar scope frame around TypedDict creation. However, I had really no good reason for doing this at the time: I wasn't able to find a bug due to the missing frame and added it purely speculatively, out of a desire for symmetry.

It turns out this missing frame does legitimately cause some issues, which were reported in the latter.

So, this diff encodes one of the reported bugs as a test case to make sure we don't regress.