### PR TITLE
Silence errors from third party packages in daemon

### DIFF
--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -963,9 +963,10 @@ def reprocess_nodes(
 
     nodes = sorted(nodeset, key=key)
 
-    options = graph[module_id].options
+    state = graph[module_id]
+    options = state.options
     manager.errors.set_file_ignored_lines(
-        file_node.path, file_node.ignored_lines, options.ignore_errors
+        file_node.path, file_node.ignored_lines, options.ignore_errors or state.ignore_all
     )
 
     targets = set()

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2207,7 +2207,7 @@ a.py:1: error: Library stubs not installed for "jack"
 a.py:1: note: Hint: "python3 -m pip install types-JACK-Client"
 a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 
-[case testXXX]
+[case testIgnoreErrorsFromTypeshed]
 # flags: --custom-typeshed-dir tmp/ts --follow-imports=normal
 # cmd1: mypy a.py
 # cmd2: mypy a.py
@@ -2229,7 +2229,9 @@ def cast(x): ...
 [file ts/stubs/mypy_extensions/mypy_extensions.pyi]
 
 [file ts/stdlib/foobar.pyi.2]
-# We report no errors from typeshed
+# We report no errors from typeshed. It would be better to test ignoring
+# errors from PEP 561 packages, but it's harder to test and uses the
+# same code paths, so we are using typeshed instead.
 import baz
 import zar
 undefined

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2209,6 +2209,10 @@ a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missin
 
 [case testXXX]
 # flags: --custom-typeshed-dir tmp/ts --follow-imports=normal
+# cmd1: mypy a.py
+# cmd2: mypy a.py
+
+[file a.py]
 import foobar
 
 [file ts/stdlib/abc.pyi]
@@ -2235,6 +2239,6 @@ import whatever
 undefined
 
 [out]
-main:2: error: Cannot find implementation or library stub for module named "foobar"
-main:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+a.py:1: error: Cannot find implementation or library stub for module named "foobar"
+a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2206,3 +2206,35 @@ a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missin
 a.py:1: error: Library stubs not installed for "jack"
 a.py:1: note: Hint: "python3 -m pip install types-JACK-Client"
 a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+
+[case testXXX]
+# flags: --custom-typeshed-dir tmp/ts --follow-imports=normal
+import foobar
+
+[file ts/stdlib/abc.pyi]
+[file ts/stdlib/builtins.pyi]
+class object: pass
+class str: pass
+class ellipsis: pass
+[file ts/stdlib/sys.pyi]
+[file ts/stdlib/types.pyi]
+[file ts/stdlib/typing.pyi]
+def cast(x): ...
+[file ts/stdlib/typing_extensions.pyi]
+[file ts/stdlib/VERSIONS]
+[file ts/stubs/mypy_extensions/mypy_extensions.pyi]
+
+[file ts/stdlib/foobar.pyi.2]
+# We report no errors from typeshed
+import baz
+import zar
+undefined
+
+[file ts/stdlib/baz.pyi.2]
+import whatever
+undefined
+
+[out]
+main:2: error: Cannot find implementation or library stub for module named "foobar"
+main:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+==


### PR DESCRIPTION
If daemon was running and additional third party code was installed, mypy
daemon would report errors from the code. This was inconsistent with 
non-daemon mypy and the initial daemon run. If mypy was run with strict
options, this could results lots of errors being generated.

The same code is used to silence errors from typeshed. I'm using typeshed in 
the test case since it was easier to do.

I also manually verified that this works with pytest, aiohttp and some typeshed
stub packages.

Fixes #13140.