### PR TITLE
Support debug prints in mypy daemon

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -665,6 +665,10 @@ def request(
         return {"error": str(err)}
     # TODO: Other errors, e.g. ValueError, UnicodeError
     else:
+        # Display debugging output written to stdout in the server process for convenience.
+        stdout = response.get("stdout")
+        if stdout:
+            sys.stdout.write(stdout)
         return response
 
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -214,6 +214,8 @@ class Server:
             while True:
                 with server:
                     data = receive(server)
+                    debug_stdout = io.StringIO()
+                    sys.stdout = debug_stdout
                     resp: dict[str, Any] = {}
                     if "command" not in data:
                         resp = {"error": "No command found in request"}
@@ -230,8 +232,10 @@ class Server:
                                 tb = traceback.format_exception(*sys.exc_info())
                                 resp = {"error": "Daemon crashed!\n" + "".join(tb)}
                                 resp.update(self._response_metadata())
+                                resp["stdout"] = debug_stdout.getvalue()
                                 server.write(json.dumps(resp).encode("utf8"))
                                 raise
+                    resp["stdout"] = debug_stdout.getvalue()
                     try:
                         resp.update(self._response_metadata())
                         server.write(json.dumps(resp).encode("utf8"))


### PR DESCRIPTION
Capture stdout in daemon and display it in the client. This makes it possible to use debug prints in 
the daemon when doing end-to-end testing. They previously only worked in daemon test cases.