### PR TITLE
DEP: Avoid using the deprecated `importlib.resources.path` function

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -25,11 +25,14 @@ except ImportError:
 
 T = TypeVar("T")
 
-with importlib_resources.path(
-    "mypy",  # mypy-c doesn't support __package__
-    "py.typed",  # a marker file for type information, we assume typeshed to live in the same dir
-) as _resource:
-    TYPESHED_DIR: Final = str(_resource.parent / "typeshed")
+if sys.version_info >= (3, 9):
+    TYPESHED_DIR: Final = str(importlib_resources.files("mypy") / "typeshed")
+else:
+    with importlib_resources.path(
+        "mypy",  # mypy-c doesn't support __package__
+        "py.typed",  # a marker file for type information, we assume typeshed to live in the same dir
+    ) as _resource:
+        TYPESHED_DIR = str(_resource.parent / "typeshed")
 
 
 ENCODING_RE: Final = re.compile(rb"([ \t\v]*#.*(\r\n?|\n))??[ \t\v]*#.*coding[:=][ \t]*([-\w.]+)")


### PR DESCRIPTION
The `importlib.resources.path` function is deprecated as of Python 3.11; substitute it with `importlib.resources.files`.