### PR TITLE
Remove unnecessary comment line

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -409,7 +409,6 @@ def compile_modules_to_c(
         compiler_options: The compilation options
         errors: Where to report any errors encountered
         groups: The groups that we are compiling. See documentation of Groups type above.
-        ops: Optionally, where to dump stringified ops for debugging.
 
     Returns the IR of the modules and a list containing the generated files for each group.
     """


### PR DESCRIPTION
Signed-off-by: jinzewu <294843472@qq.com>

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Remove unnecessary comment line since the `compile_modules_to_c` function has no `ops` argument.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
