### PR TITLE
Make join of recursive types more robust

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2542,9 +2542,9 @@ class PromoteExpr(Expression):
 
     __slots__ = ("type",)
 
-    type: mypy.types.Type
+    type: mypy.types.ProperType
 
-    def __init__(self, type: mypy.types.Type) -> None:
+    def __init__(self, type: mypy.types.ProperType) -> None:
         super().__init__()
         self.type = type
 
@@ -2769,7 +2769,7 @@ class TypeInfo(SymbolNode):
     # even though it's not a subclass in Python.  The non-standard
     # `@_promote` decorator introduces this, and there are also
     # several builtin examples, in particular `int` -> `float`.
-    _promote: list[mypy.types.Type]
+    _promote: list[mypy.types.ProperType]
 
     # This is used for promoting native integer types such as 'i64' to
     # 'int'. (_promote is used for the other direction.) This only
@@ -3100,7 +3100,12 @@ class TypeInfo(SymbolNode):
         ti.type_vars = data["type_vars"]
         ti.has_param_spec_type = data["has_param_spec_type"]
         ti.bases = [mypy.types.Instance.deserialize(b) for b in data["bases"]]
-        ti._promote = [mypy.types.deserialize_type(p) for p in data["_promote"]]
+        _promote = []
+        for p in data["_promote"]:
+            t = mypy.types.deserialize_type(p)
+            assert isinstance(t, mypy.types.ProperType)
+            _promote.append(t)
+        ti._promote = _promote
         ti.declared_metaclass = (
             None
             if data["declared_metaclass"] is None

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4945,6 +4945,7 @@ class SemanticAnalyzer(
     def visit__promote_expr(self, expr: PromoteExpr) -> None:
         analyzed = self.anal_type(expr.type)
         if analyzed is not None:
+            assert isinstance(analyzed, ProperType), "Cannot use type aliases for promotions"
             expr.type = analyzed
 
     def visit_yield_expr(self, e: YieldExpr) -> None:

--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -22,7 +22,7 @@ from mypy.nodes import (
     Var,
 )
 from mypy.options import Options
-from mypy.types import Instance, Type
+from mypy.types import Instance, ProperType
 
 # Hard coded type promotions (shared between all Python versions).
 # These add extra ad-hoc edges to the subtyping relation. For example,
@@ -155,7 +155,7 @@ def add_type_promotion(
     This includes things like 'int' being compatible with 'float'.
     """
     defn = info.defn
-    promote_targets: list[Type] = []
+    promote_targets: list[ProperType] = []
     for decorator in defn.decorators:
         if isinstance(decorator, CallExpr):
             analyzed = decorator.analyzed

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -532,7 +532,14 @@ m: A
 s: str = n.x  # E: Incompatible types in assignment (expression has type "Tuple[A, int]", variable has type "str")
 reveal_type(m[0]) # N: Revealed type is "builtins.str"
 lst = [m, n]
-reveal_type(lst[0]) # N: Revealed type is "Tuple[builtins.object, builtins.object]"
+
+# Unfortunately, join of two recursive types is not very precise.
+reveal_type(lst[0]) # N: Revealed type is "builtins.object"
+
+# These just should not crash
+lst1 = [m]
+lst2 = [m, m]
+lst3 = [m, m, m]
 [builtins fixtures/tuple.pyi]
 
 [case testMutuallyRecursiveNamedTuplesClasses]
@@ -785,4 +792,19 @@ class B:
     Bar = Sequence[Foo]
 y: B.Foo
 reveal_type(y)  # N: Revealed type is "typing.Sequence[typing.Sequence[...]]"
+[builtins fixtures/tuple.pyi]
+
+[case testNoCrashOnRecursiveTupleFallback]
+from typing import Union, Tuple
+
+Tree1 = Union[str, Tuple[Tree1]]
+Tree2 = Union[str, Tuple[Tree2, Tree2]]
+Tree3 = Union[str, Tuple[Tree3, Tree3, Tree3]]
+
+def test1() -> Tree1:
+    return 42  # E: Incompatible return value type (got "int", expected "Union[str, Tuple[Tree1]]")
+def test2() -> Tree2:
+    return 42  # E: Incompatible return value type (got "int", expected "Union[str, Tuple[Tree2, Tree2]]")
+def test3() -> Tree3:
+    return 42  # E: Incompatible return value type (got "int", expected "Union[str, Tuple[Tree3, Tree3, Tree3]]")
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #13795

Calculating tuple fallbacks on the fly creates a cycle between joins and subtyping. Although IMO this is conceptually not a right thing, it is hard to get rid of (unless we want to use unions in the fallbacks, cc @JukkaL). So instead I re-worked how `join_types()` works w.r.t. `get_proper_type()`, essentially it now follows the golden rule "Always pass on the original type if possible".