### PR TITLE
Opt out from the managed dict for compiled classes on Python 3.11

### DIFF
--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -3,6 +3,7 @@
 // These are registered in mypyc.primitives.misc_ops.
 
 #include <Python.h>
+#include <patchlevel.h>
 #include "CPy.h"
 
 PyObject *CPy_GetCoro(PyObject *obj)
@@ -285,6 +286,9 @@ PyObject *CPyType_FromTemplate(PyObject *template,
 
     Py_XDECREF(dummy_class);
 
+#if PY_MINOR_VERSION >= 11
+    t->ht_type.tp_flags &= ~Py_TPFLAGS_MANAGED_DICT;
+#endif
     return (PyObject *)t;
 
 error:

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -286,7 +286,9 @@ PyObject *CPyType_FromTemplate(PyObject *template,
 
     Py_XDECREF(dummy_class);
 
-#if PY_MINOR_VERSION >= 11
+#if PY_MINOR_VERSION == 11
+    // This is a hack. Python 3.11 doesn't include good public APIs to work with managed
+    // dicts, which are the default for heap types. So we try to opt-out until Python 3.12.
     t->ht_type.tp_flags &= ~Py_TPFLAGS_MANAGED_DICT;
 #endif
     return (PyObject *)t;


### PR DESCRIPTION
Hopefully this will fix the last failing test on Python 3.11

cc @JukkaL @msullivan @hauntsaninja 