### PR TITLE
Improve typeshed sync scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: ^mypy/typeshed/
 repos:
   - repo: https://github.com/psf/black
     rev: 22.6.0  # must match test-requirements.txt

--- a/misc/cherry-pick-typeshed.py
+++ b/misc/cherry-pick-typeshed.py
@@ -58,6 +58,10 @@ def main() -> None:
             check=True,
         )
 
+        print("Commit typeshed changes? [yN]", end="")
+        answer = input()
+        if answer.lower() != "y":
+            sys.exit("Aborting")
         title = parse_commit_title(out.stdout)
         subprocess.run(["git", "commit", "-m", f"Typeshed cherry-pick: {title}"], check=True)
 

--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -104,6 +104,10 @@ def main() -> None:
             commit=commit
         )
     )
+    print("Commit typeshed changes? [yN]", end="")
+    answer = input()
+    if answer.lower() != "y":
+        sys.exit("Aborting")
     subprocess.run(["git", "add", "--all", os.path.join("mypy", "typeshed")], check=True)
     subprocess.run(["git", "commit", "-m", message], check=True)
     print("Created typeshed sync commit.")


### PR DESCRIPTION
**Pause before commit**
Allow user to view `git diff` before committing.

**Don't run pre-commit hooks for mypy/typeshed**
Formatting is done in the `typeshed` repo. Prevent errors during with the sync script if pre-commit hooks are installed. Both repos use different `line_length` settings which would trigger a reformatting and subsequent commit failure.