### PR TITLE
Run tests on Python 3.11 as required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,12 @@ jobs:
           os: ubuntu-latest
           toxenv: py
           tox_extra_args: "-n 2"
+        - name: Test suite with py311-ubuntu
+          python: '3.11'
+          arch: x64
+          os: ubuntu-latest
+          toxenv: py
+          tox_extra_args: "-n 2"
         - name: mypyc runtime tests with py37-macos
           python: '3.7'
           arch: x64
@@ -128,7 +134,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11-dev'
+        python-version: '3.12-dev'
     - name: Install tox
       run: pip install --upgrade 'setuptools!=50' tox==3.24.5
     - name: Setup tox environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           toxenv: py
           tox_extra_args: "-n 2"
         - name: Test suite with py311-ubuntu
-          python: '3.11'
+          python: '3.11-dev'
           arch: x64
           os: ubuntu-latest
           toxenv: py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,21 +126,3 @@ jobs:
       run: tox -e ${{ matrix.toxenv }} --notest
     - name: Test
       run: tox -e ${{ matrix.toxenv }} --skip-pkg-install -- ${{ matrix.tox_extra_args }}
-
-  python-nightly:
-    runs-on: ubuntu-latest
-    name: Test suite with Python nightly
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.12-dev'
-    - name: Install tox
-      run: pip install --upgrade 'setuptools!=50' tox==3.24.5
-    - name: Setup tox environment
-      run: tox -e py --notest
-    - name: Test
-      run: tox -e py --skip-pkg-install -- "-n 2"
-      continue-on-error: true
-    - name: Mark as a success
-      run: exit 0


### PR DESCRIPTION
For now we run non-compiled version. (I tried compiling mypy locally and it failed with couple errors, some deprecation error, and a weird pointer type mismatch)

I also ass Python 3.12 that will always pass, just to be prepared for the next version