### PR TITLE
Remove typed_ast tests requirement

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,6 +16,5 @@ pytest-xdist>=1.34.0
 pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0
 py>=1.5.2
-typed_ast>=1.5.4,<2; python_version>='3.8'
 setuptools!=50
 six


### PR DESCRIPTION
`typed_ast` is not directly used in tests, and is never imported on Python 3.8+.
Its requirement should be defined as a regular one (for Python < 3.8).

Saw it's installed while trying 3.11 wheels build and thought it's odd :P