### PR TITLE
Fix crash on missing indirect dependencies

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2363,7 +2363,10 @@ class State:
 
             # We should always patch indirect dependencies, even in full (non-incremental) builds,
             # because the cache still may be written, and it must be correct.
-            self._patch_indirect_dependencies(self.type_checker().module_refs, self.type_map())
+            symbol_types = {sym.type for _, sym, _ in self.tree.local_definitions()} - {None}
+            self._patch_indirect_dependencies(
+                self.type_checker().module_refs, set(self.type_map().values()) | symbol_types
+            )
 
             if self.options.dump_inference_stats:
                 dump_type_stats(
@@ -2386,10 +2389,7 @@ class State:
             self._type_checker.reset()
             self._type_checker = None
 
-    def _patch_indirect_dependencies(
-        self, module_refs: set[str], type_map: dict[Expression, Type]
-    ) -> None:
-        types = set(type_map.values())
+    def _patch_indirect_dependencies(self, module_refs: set[str], types: set[Type]) -> None:
         assert None not in types
         valid = self.valid_references()
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6113,3 +6113,175 @@ class C: ...
 [out]
 [out2]
 [out3]
+
+[case testNoCrashDoubleReexportBaseEmpty]
+import m
+
+[file m.py]
+import f
+[file m.py.3]
+import f
+# modify
+
+[file f.py]
+import c
+class D(c.C): pass
+
+[file c.py]
+from types import C
+
+[file types.py]
+import pb1
+C = pb1.C
+[file types.py.2]
+import pb1, pb2
+C = pb2.C
+
+[file pb1.py]
+class C: ...
+[file pb2.py.2]
+class C: ...
+[file pb1.py.2]
+[out]
+[out2]
+[out3]
+
+[case testNoCrashDoubleReexportMetaEmpty]
+import m
+
+[file m.py]
+import f
+[file m.py.3]
+import f
+# modify
+
+[file f.py]
+import c
+class D(metaclass=c.C): pass
+
+[file c.py]
+from types import C
+
+[file types.py]
+import pb1
+C = pb1.C
+[file types.py.2]
+import pb1, pb2
+C = pb2.C
+
+[file pb1.py]
+class C(type): ...
+[file pb2.py.2]
+class C(type): ...
+[file pb1.py.2]
+[out]
+[out2]
+[out3]
+
+[case testNoCrashDoubleReexportTypedDictEmpty]
+import m
+
+[file m.py]
+import f
+[file m.py.3]
+import f
+# modify
+
+[file f.py]
+from typing_extensions import TypedDict
+import c
+class D(TypedDict):
+    x: c.C
+
+[file c.py]
+from types import C
+
+[file types.py]
+import pb1
+C = pb1.C
+[file types.py.2]
+import pb1, pb2
+C = pb2.C
+
+[file pb1.py]
+class C: ...
+[file pb2.py.2]
+class C: ...
+[file pb1.py.2]
+[builtins fixtures/dict.pyi]
+[out]
+[out2]
+[out3]
+
+[case testNoCrashDoubleReexportTupleEmpty]
+import m
+
+[file m.py]
+import f
+[file m.py.3]
+import f
+# modify
+
+[file f.py]
+from typing import Tuple
+import c
+class D(Tuple[c.C, int]): pass
+
+[file c.py]
+from types import C
+
+[file types.py]
+import pb1
+C = pb1.C
+[file types.py.2]
+import pb1, pb2
+C = pb2.C
+
+[file pb1.py]
+class C: ...
+[file pb2.py.2]
+class C: ...
+[file pb1.py.2]
+[builtins fixtures/tuple.pyi]
+[out]
+[out2]
+[out3]
+
+[case testNoCrashDoubleReexportOverloadEmpty]
+import m
+
+[file m.py]
+import f
+[file m.py.3]
+import f
+# modify
+
+[file f.py]
+from typing import Any, overload
+import c
+
+@overload
+def foo(arg: int) -> None: ...
+@overload
+def foo(arg: c.C) -> None: ...
+def foo(arg: Any) -> None:
+    pass
+
+[file c.py]
+from types import C
+
+[file types.py]
+import pb1
+C = pb1.C
+[file types.py.2]
+import pb1, pb2
+C = pb2.C
+
+[file pb1.py]
+class C: ...
+[file pb2.py.2]
+class C: ...
+[file pb1.py.2]
+[out]
+[out2]
+[out3]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6081,3 +6081,35 @@ class Base:
 [out]
 [out2]
 main:6: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
+
+[case testNoCrashDoubleReexportFunctionEmpty]
+import m
+
+[file m.py]
+import f
+[file m.py.3]
+import f
+# modify
+
+[file f.py]
+import c
+def foo(arg: c.C) -> None: pass
+
+[file c.py]
+from types import C
+
+[file types.py]
+import pb1
+C = pb1.C
+[file types.py.2]
+import pb1, pb2
+C = pb2.C
+
+[file pb1.py]
+class C: ...
+[file pb2.py.2]
+class C: ...
+[file pb1.py.2]
+[out]
+[out2]
+[out3]


### PR DESCRIPTION
Fixes #13825

We add also types encountered in locally defined symbols, not just expressions. I think we may also need to add base-classes/metaclass for `TypeInfo`s, I will check and add if needed ~tomorrow.