### PR TITLE
stubtest: catch SyntaxError from inspect.getsourcelines

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -136,7 +136,7 @@ class Error:
         if not isinstance(self.runtime_object, Missing):
             try:
                 runtime_line = inspect.getsourcelines(self.runtime_object)[1]
-            except (OSError, TypeError):
+            except (OSError, TypeError, SyntaxError):
                 pass
             try:
                 runtime_file = inspect.getsourcefile(self.runtime_object)


### PR DESCRIPTION
Fixes #13822