### PR TITLE
Fix isort skip config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ line_length = 99
 combine_as_imports = true
 skip_gitignore = true
 extra_standard_library = ["typing_extensions"]
-skip = [
-    "mypy/typeshed",
-    "mypyc/test-data",
-    "test-data",
+skip_glob = [
+    "mypy/typeshed/*",
+    "mypyc/test-data/*",
+    "test-data/*",
 ]


### PR DESCRIPTION
Our current isort config doesn't fully work for the pre-commit hook. Whereas in tox isort is called with the global `.` path, pre-commit passes all filenames individually.

E.g. running this command will also reformat the `mypy/typeshed` directory:
```
pre-commit run isort --all-files
```

Using `skip_glob` instead of `skip` will resolve the issue.
https://pycqa.github.io/isort/docs/configuration/options.html#skip-glob

Followup to https://github.com/python/mypy/pull/13832#issuecomment-1272552104
/CC: @hauntsaninja 