### PR TITLE
Make handling of `FORCE_COLOR` environment variable match the emerging standard

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -520,7 +520,9 @@ def parse_gray_color(cup: bytes) -> str:
 
 
 def should_force_color() -> bool:
-    return bool(int(os.getenv("MYPY_FORCE_COLOR", os.getenv("FORCE_COLOR", "0"))))
+    if "MYPY_FORCE_COLOR" in os.environ:
+        return bool(int(os.environ["MYPY_FORCE_COLOR"]))
+    return "FORCE_COLOR" in os.environ
 
 
 class FancyFormatter:


### PR DESCRIPTION
See the conversation in https://github.com/python/mypy/pull/13814/files#r990652344: the emerging standard for this is to treat the presence of the `FORCE_COLOR` environment variable as indicating that color is desired, _even if_ the variable is set to `"0"` or `"False"`. This PR makes mypy's behaviour here match the behaviour of `pytest`, `nox`, `rich` and `pypa/build` in how they all handle this environment variable.

(It doesn't match the behaviour of `tox`, but `tox` seems to be on its own here.)
