### PR TITLE
Fix minor issues with keywords Unpack

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2704,6 +2704,17 @@ def for_function(callee: CallableType) -> str:
     return ""
 
 
+def wrong_type_arg_count(n: int, act: str, name: str) -> str:
+    s = f"{n} type arguments"
+    if n == 0:
+        s = "no type arguments"
+    elif n == 1:
+        s = "1 type argument"
+    if act == "0":
+        act = "none"
+    return f'"{name}" expects {s}, but {act} given'
+
+
 def find_defining_module(modules: dict[str, MypyFile], typ: CallableType) -> MypyFile | None:
     if not typ.definition:
         return None

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -1043,3 +1043,41 @@ def g(**kwargs: Unpack[Person]) -> int: ...
 
 reveal_type(g)  # N: Revealed type is "def (*, name: builtins.str, age: builtins.int) -> builtins.list[builtins.int]"
 [builtins fixtures/dict.pyi]
+
+[case testUnpackGenericTypedDictImplicitAnyEnabled]
+from typing import Generic, TypeVar
+from typing_extensions import Unpack, TypedDict
+
+T = TypeVar("T")
+class TD(TypedDict, Generic[T]):
+    key: str
+    value: T
+
+def foo(**kwds: Unpack[TD]) -> None: ...  # Same as `TD[Any]`
+foo(key="yes", value=42)
+foo(key="yes", value="ok")
+[builtins fixtures/dict.pyi]
+
+[case testUnpackGenericTypedDictImplicitAnyDisabled]
+# flags: --disallow-any-generics
+from typing import Generic, TypeVar
+from typing_extensions import Unpack, TypedDict
+
+T = TypeVar("T")
+class TD(TypedDict, Generic[T]):
+    key: str
+    value: T
+
+def foo(**kwds: Unpack[TD]) -> None: ...  # E: Missing type parameters for generic type "TD"
+foo(key="yes", value=42)
+foo(key="yes", value="ok")
+[builtins fixtures/dict.pyi]
+
+[case testUnpackNoCrashOnEmpty]
+from typing_extensions import Unpack
+
+class C:
+    def __init__(self, **kwds: Unpack) -> None: ...  # E: Unpack[...] requires exactly one type argument
+class D:
+    def __init__(self, **kwds: Unpack[int, str]) -> None: ...  # E: Unpack[...] requires exactly one type argument
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
This fixes couple issues discovered in https://github.com/python/mypy/pull/13790:
* A crash on empty `Unpack`
* Wrong behavior with implicit generic `Any`

The latter was actually caused by somewhat reckless handling of generic `TypedDict`s, wrong argument count was handled inconsistently there.