### PR TITLE
Support match statement in partially defined check

### DIFF
--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -18,6 +18,13 @@ else:
 
 z = a + 1  # E: Name "a" may be undefined
 
+[case testUsedInIf]
+# flags: --enable-error-code partially-defined
+if int():
+    y = 1
+if int():
+    x = y  # E: Name "y" may be undefined
+
 [case testDefinedInAllBranches]
 # flags: --enable-error-code partially-defined
 if int():

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1728,6 +1728,12 @@ def my_func(pairs: Iterable[tuple[S, S]]) -> None:
 
 [case testPartiallyDefinedMatch]
 # flags: --enable-error-code partially-defined
+def f0(x: int | str) -> int:
+    match x:
+        case int():
+            y = 1
+    return y  # E: Name "y" may be undefined
+
 def f1(a: object) -> None:
     match a:
         case [y]: pass

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1725,3 +1725,63 @@ def my_func(pairs: Iterable[tuple[S, S]]) -> None:
                 reveal_type(pair)  # N: Revealed type is "Tuple[builtins.int, builtins.int]" \
                                    # N: Revealed type is "Tuple[builtins.str, builtins.str]"
 [builtins fixtures/tuple.pyi]
+
+[case testPartiallyDefinedMatch]
+# flags: --enable-error-code partially-defined
+def f1(a: object) -> None:
+    match a:
+        case [y]: pass
+        case _:
+            y = 1
+            x = 2
+    z = y
+    z = x  # E: Name "x" may be undefined
+
+def f2(a: object) -> None:
+    match a:
+        case [[y] as x]: pass
+        case {"k1": 1, "k2": x, "k3": y}: pass
+        case [0, *x]:
+            y = 2
+        case _:
+            y = 1
+            x = [2]
+    z = x
+    z = y
+
+def f3(a: object) -> None:
+    y = 1
+    match a:
+        case [x]:
+            y = 2
+        # Note the missing `case _:`
+    z = x  # E: Name "x" may be undefined
+    z = y
+
+def f4(a: object) -> None:
+    y = 1
+    match a:
+        case [x]:
+            y = 2
+        case _:
+            assert False, "unsupported"
+    z = x
+    z = y
+
+def f5(a: object) -> None:
+    match a:
+        case tuple(x): pass
+        case _:
+            return
+    y = x
+
+def f6(a: object) -> None:
+    if int():
+        y = 1
+    match a:
+        case _ if y is not None:  # E: Name "y" may be undefined
+            pass
+[builtins fixtures/primitives.pyi]
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/list.pyi]
+[builtins fixtures/type.pyi]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1781,7 +1781,4 @@ def f6(a: object) -> None:
     match a:
         case _ if y is not None:  # E: Name "y" may be undefined
             pass
-[builtins fixtures/primitives.pyi]
 [builtins fixtures/tuple.pyi]
-[builtins fixtures/list.pyi]
-[builtins fixtures/type.pyi]


### PR DESCRIPTION
This adds support for match statements for the partially-defined variables check. This should completely cover all match features. 

In addition, during testing, I found a bug in the generic branch tracking logic, which is also fixed here.

Because match is only supported in python 3.10, I had to put the tests in a separate file, which is a bit unfortunate; let me know if you have better ideas.
