### PR TITLE
If attrs doesn't generate __init__, it generates __attrs_init__ instead

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -324,8 +324,8 @@ def attr_class_maker_callback(
     }
 
     adder = MethodAdder(ctx)
-    if init:
-        _add_init(ctx, attributes, adder)
+    # If  __init__ is not being generated, attrs still generates it as __attrs_init__ instead.
+    _add_init(ctx, attributes, adder, "__init__" if init else "__attrs_init__")
     if order:
         _add_order(ctx, adder)
     if frozen:
@@ -749,7 +749,10 @@ def _make_frozen(ctx: mypy.plugin.ClassDefContext, attributes: list[Attribute]) 
 
 
 def _add_init(
-    ctx: mypy.plugin.ClassDefContext, attributes: list[Attribute], adder: MethodAdder
+    ctx: mypy.plugin.ClassDefContext,
+    attributes: list[Attribute],
+    adder: MethodAdder,
+    method_name: str,
 ) -> None:
     """Generate an __init__ method for the attributes and add it to the class."""
     # Convert attributes to arguments with kw_only arguments at the  end of
@@ -777,7 +780,7 @@ def _add_init(
         for a in args:
             a.variable.type = AnyType(TypeOfAny.implementation_artifact)
             a.type_annotation = AnyType(TypeOfAny.implementation_artifact)
-    adder.add_method("__init__", args, NoneType())
+    adder.add_method(method_name, args, NoneType())
 
 
 def _add_attrs_magic_attribute(

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1498,6 +1498,25 @@ takes_attrs_cls(A(1, ""))  # E: Argument 1 to "takes_attrs_cls" has incompatible
 takes_attrs_instance(A)  # E: Argument 1 to "takes_attrs_instance" has incompatible type "Type[A]"; expected "AttrsInstance" # N: ClassVar protocol member AttrsInstance.__attrs_attrs__ can never be matched by a class object
 [builtins fixtures/attr.pyi]
 
+[case testAttrsInitMethodAlwaysGenerates]
+from typing import Tuple
+import attr
+
+@attr.define(init=False)
+class A:
+    b: int
+    c: str
+    def __init__(self, bc: Tuple[int, str]) -> None:
+        b, c = bc
+        self.__attrs_init__(b, c)
+
+reveal_type(A)  # N: Revealed type is "def (bc: Tuple[builtins.int, builtins.str]) -> __main__.A"
+reveal_type(A.__init__)  # N: Revealed type is "def (self: __main__.A, bc: Tuple[builtins.int, builtins.str])"
+reveal_type(A.__attrs_init__)  # N: Revealed type is "def (self: __main__.A, b: builtins.int, c: builtins.str)"
+
+[builtins fixtures/tuple.pyi]
+[builtins fixtures/attr.pyi]
+
 [case testAttrsClassWithSlots]
 import attr
 


### PR DESCRIPTION
If an `attrs` class does not generate the `__init__` method for whatever reason, the method is still actually generated, under the name `__attrs_init__`. This is intended to allow a user `__init__` to then delegate to the `attrs` implementation to do the assignment (especially useful with frozen classes). This PR makes Mypy typecheck this method in this situation.