### PR TITLE
Remove Python 3.6 specific filelock requirement

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,8 +2,7 @@
 -r build-requirements.txt
 attrs>=18.0
 black==22.6.0  # must match version in .pre-commit-config.yaml
-filelock>=3.3.0,<3.4.2; python_version<'3.7'
-filelock>=3.3.0; python_version>='3.7'
+filelock>=3.3.0
 flake8==5.0.4           # must match version in .pre-commit-config.yaml
 flake8-bugbear==22.8.23 # must match version in .pre-commit-config.yaml
 flake8-noqa==1.2.9      # must match version in .pre-commit-config.yaml


### PR DESCRIPTION
We no longer support Python 3.6.