### PR TITLE
[mypyc] Fix command-line tests on Python 3.11

### DIFF
--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -43,6 +43,9 @@ class TestCommandLine(MypycDataSuite):
         with open(program_path, "w") as f:
             f.write(text)
 
+        env = os.environ.copy()
+        env["PYTHONPATH"] = base_path
+
         out = b""
         try:
             # Compile program
@@ -51,6 +54,7 @@ class TestCommandLine(MypycDataSuite):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 cwd="tmp",
+                env=env,
             )
             if "ErrorOutput" in testcase.name or cmd.returncode != 0:
                 out += cmd.stdout


### PR DESCRIPTION
This fixes the testErrorOutput and testCompileMypyc test cases by setting up the module search path explicitly.