### PR TITLE
provide more verbosity for mismatched type types

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -749,6 +749,14 @@ class MessageBuilder:
                 self.report_protocol_problems(
                     original_caller_type, callee_type, context, code=code
                 )
+            if (
+                isinstance(callee_type, TypeType)
+                and isinstance(original_caller_type, CallableType)
+                and callee_type.item.type.is_protocol
+            ):
+                self.report_protocol_problems(
+                    original_caller_type.ret_type, callee_type.item, context, code=code
+                )
             if isinstance(callee_type, UnionType):
                 for item in callee_type.items:
                     item = get_proper_type(item)


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

When assigning to a protocol hinted name or attribute invalid values are clearly described as
to how they do not satisfy the hinted protocol.  This is presently not the case for `Type[]`
hints.  This PR enables the verbosity and clarity for the `Type[]` hints as well.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->

Draft for:
- [ ] Consideration of other implications
- [ ] Consideration of handling more cases
