### PR TITLE
Show error codes for some notes

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -17,6 +17,9 @@ from mypy.version import __version__ as mypy_version
 
 T = TypeVar("T")
 
+# Show error codes for some note-level messages (these usually appear alone
+# and not as a comment for a previous error-level message).
+SHOW_NOTE_CODES: Final = {codes.ANNOTATION_UNCHECKED}
 allowed_duplicates: Final = ["@overload", "Got:", "Expected:"]
 
 # Keep track of the original error code when the error code of a message is changed.
@@ -782,7 +785,11 @@ class Errors:
                 s = f"{srcloc}: {severity}: {message}"
             else:
                 s = message
-            if not self.hide_error_codes and code and severity != "note":
+            if (
+                not self.hide_error_codes
+                and code
+                and (severity != "note" or code in SHOW_NOTE_CODES)
+            ):
                 # If note has an error code, it is related to a previous error. Avoid
                 # displaying duplicate error codes.
                 s = f"{s}  [{code.code}]"

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -966,6 +966,10 @@ T = TypeVar("T")
 def test(tp: Type[T]) -> T: ...
 test(C)  # E: Only concrete class can be given where "Type[C]" is expected  [type-abstract]
 
+[case testUncheckedAnnotationCodeShown]
+def f():
+    x: int = "no"  # N: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
+
 [case testUncheckedAnnotationSuppressed]
 # flags: --disable-error-code=annotation-unchecked
 def f():


### PR DESCRIPTION
This will hint people affected by #13851 what to do to silence this. I am not doing it for all notes as this will cause too much noise (especially for some nicely formatted multi-line notes like possible overloads, incompatible overrides, or protocol mismatches), instead we can select specific codes that we want to show.

cc @svalentin 