### PR TITLE
Describe how to annotate a function with return type depending on a flag

### DIFF
--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -307,6 +307,27 @@ redundancy, it's possible to replace default values in overload definitions with
     def get_model(model_or_pk: int | M, flag: bool = True) -> M | None:
         ...
 
+The overload that applies is chosen depending on the type of the ``model_or_pk``
+argument. On the other hand, the return type in the following example depends on
+an argument with a default value. To ensure that the overloads do not overlap,
+a default value is specified for only one of them.
+
+.. code-block:: python
+
+    from typing import overload, Literal
+
+    # This overload variant applies when "rounded" is omitted or set to False.
+    @overload
+    def pi(rounded: Literal[False] = ...) -> float: ...
+
+    # This overload variant applies only when the "rounded" argument was
+    # specified explicitly.
+    @overload
+    def pi(rounded: Literal[True]) -> int: ...
+
+    def pi(rounded=False):
+        return 3 if rounded else 3.14159
+
 
 Runtime behavior
 ----------------


### PR DESCRIPTION
I could not find how to do this in the documentation, but eventually saw the example in
https://github.com/python/mypy/issues/6580#issuecomment-586547247
Reading this helped me improve my mental model of how overloads work, and perhaps others would benefit as well.