### PR TITLE
Fix quotes for upload-pypi version check

### DIFF
--- a/misc/upload-pypi.py
+++ b/misc/upload-pypi.py
@@ -70,7 +70,7 @@ def check_sdist(dist: Path, version: str) -> None:
         hashless_version = match.group(1) if match else version
 
         assert (
-            f"'{hashless_version}'" in version_py_contents
+            f'"{hashless_version}"' in version_py_contents
         ), "Version does not match version.py in sdist"
 
 


### PR DESCRIPTION
After we started using black upload-pypi broke because we switched the style of quotes. This remedies that.