### PR TITLE
Forbid unpacking multiple times in tuples

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -976,6 +976,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             if t.partial_fallback.type
             else self.named_type("builtins.tuple", [any_type])
         )
+        items = self.anal_array(t.items)
         return TupleType(self.anal_array(t.items), fallback, t.line)
 
     def visit_typeddict_type(self, t: TypedDictType) -> Type:
@@ -1389,7 +1390,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         res: list[Type] = []
         for t in a:
             res.append(self.anal_type(t, nested, allow_param_spec=allow_param_spec))
-        return res
+        return self.check_unpacks_in_list(res)
 
     def anal_type(self, t: Type, nested: bool = True, *, allow_param_spec: bool = False) -> Type:
         if nested:
@@ -1448,9 +1449,29 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         node = self.lookup_fqn_func(fully_qualified_name)
         assert isinstance(node.node, TypeInfo)
         any_type = AnyType(TypeOfAny.special_form)
+        if args is not None:
+            args = self.check_unpacks_in_list(args)
         return Instance(
             node.node, args or [any_type] * len(node.node.defn.type_vars), line=line, column=column
         )
+
+    def check_unpacks_in_list(self, items: list[Type]) -> list[Type]:
+        new_items: list[Type] = []
+        num_unpacks = 0
+        final_unpack = None
+        for item in items:
+            if isinstance(item, UnpackType):
+                if not num_unpacks:
+                    new_items.append(item)
+                num_unpacks += 1
+                final_unpack = item
+            else:
+                new_items.append(item)
+
+        if num_unpacks > 1:
+            assert final_unpack is not None
+            self.fail("More than one Unpack in a type is not allowed", final_unpack)
+        return new_items
 
     def tuple_type(self, items: list[Type]) -> TupleType:
         any_type = AnyType(TypeOfAny.special_form)

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -95,7 +95,7 @@ reveal_type(h(args))  # N: Revealed type is "Tuple[builtins.str, builtins.str, b
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarTupleGenericClassDefn]
-from typing import Generic, TypeVar, Tuple
+from typing import Generic, TypeVar, Tuple, Union
 from typing_extensions import TypeVarTuple, Unpack
 
 T = TypeVar("T")
@@ -119,6 +119,13 @@ reveal_type(variadic_single)  # N: Revealed type is "__main__.Variadic[builtins.
 empty: Variadic[()]
 # TODO: fix pretty printer to be better.
 reveal_type(empty)  # N: Revealed type is "__main__.Variadic"
+
+bad: Variadic[Unpack[Tuple[int, ...]], str, Unpack[Tuple[bool, ...]]]  # E: More than one Unpack in a type is not allowed
+reveal_type(bad)  # N: Revealed type is "__main__.Variadic[Unpack[builtins.tuple[builtins.int, ...]], builtins.str]"
+
+# TODO: This is tricky to fix because we need typeanal to know whether the current
+# location is valid for an Unpack or not.
+# bad2: Unpack[Tuple[int, ...]]
 
 m1: Mixed1[int, str, bool]
 reveal_type(m1)  # N: Revealed type is "__main__.Mixed1[builtins.int, builtins.str, builtins.bool]"
@@ -344,6 +351,18 @@ def expect_variadic_array_2(
 
 expect_variadic_array(u)
 expect_variadic_array_2(u)
+
+Ts = TypeVarTuple("Ts")
+Ts2 = TypeVarTuple("Ts2")
+
+def bad(x: Tuple[int, Unpack[Ts], str, Unpack[Ts2]]) -> None: # E: More than one Unpack in a type is not allowed
+
+    ...
+reveal_type(bad)  # N: Revealed type is "def [Ts, Ts2] (x: Tuple[builtins.int, Unpack[Ts`-1], builtins.str])"
+
+def bad2(x: Tuple[int, Unpack[Tuple[int, ...]], str, Unpack[Tuple[str, ...]]]) -> None:  # E: More than one Unpack in a type is not allowed
+    ...
+reveal_type(bad2)  # N: Revealed type is "def (x: Tuple[builtins.int, Unpack[builtins.tuple[builtins.int, ...]], builtins.str])"
 
 
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
This covers some cases from the PEP646 documentation which says we should error when there are multiple unpacks:

x: Tuple[int, *Ts, str, *Ts2]  # Error
y: Tuple[int, *Tuple[int, ...], str, *Tuple[str, ...]]  # Error

We handle it gracefully and include only one of the unpacks so that type checking can still continue somewhat.