### PR TITLE
Implement basic *args support for variadic generics

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -202,6 +202,7 @@ from mypy.types import (
     UnboundType,
     UninhabitedType,
     UnionType,
+    UnpackType,
     flatten_nested_unions,
     get_proper_type,
     get_proper_types,
@@ -1170,7 +1171,16 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                 ctx = typ
                             self.fail(message_registry.FUNCTION_PARAMETER_CANNOT_BE_COVARIANT, ctx)
                     if typ.arg_kinds[i] == nodes.ARG_STAR:
-                        if not isinstance(arg_type, ParamSpecType):
+                        if isinstance(arg_type, ParamSpecType):
+                            pass
+                        elif isinstance(arg_type, UnpackType):
+                            arg_type = TupleType(
+                                [arg_type],
+                                fallback=self.named_generic_type(
+                                    "builtins.tuple", [self.named_type("builtins.object")]
+                                ),
+                            )
+                        else:
                             # builtins.tuple[T] is typing.Tuple[T, ...]
                             arg_type = self.named_generic_type("builtins.tuple", [arg_type])
                     elif typ.arg_kinds[i] == nodes.ARG_STAR2:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -145,6 +145,7 @@ from mypy.types import (
     TypedDictType,
     TypeOfAny,
     TypeType,
+    TypeVarTupleType,
     TypeVarType,
     UninhabitedType,
     UnionType,
@@ -1397,7 +1398,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         )
 
         if callee.is_generic():
-            need_refresh = any(isinstance(v, ParamSpecType) for v in callee.variables)
+            need_refresh = any(
+                isinstance(v, (ParamSpecType, TypeVarTupleType)) for v in callee.variables
+            )
             callee = freshen_function_type_vars(callee)
             callee = self.infer_function_type_arguments_using_context(callee, context)
             callee = self.infer_function_type_arguments(

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -134,9 +134,7 @@ def infer_constraints_for_callable(
                 )
 
             assert isinstance(unpack_type.type, TypeVarTupleType)
-            constraints.append(
-                Constraint(unpack_type.type, SUPERTYPE_OF, TypeList(actual_types))
-            )
+            constraints.append(Constraint(unpack_type.type, SUPERTYPE_OF, TypeList(actual_types)))
         else:
             for actual in actuals:
                 actual_arg_type = arg_types[actual]

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -111,16 +111,43 @@ def infer_constraints_for_callable(
     mapper = ArgTypeExpander(context)
 
     for i, actuals in enumerate(formal_to_actual):
-        for actual in actuals:
-            actual_arg_type = arg_types[actual]
-            if actual_arg_type is None:
-                continue
+        if isinstance(callee.arg_types[i], UnpackType):
+            unpack_type = callee.arg_types[i]
+            assert isinstance(unpack_type, UnpackType)
 
-            actual_type = mapper.expand_actual_type(
-                actual_arg_type, arg_kinds[actual], callee.arg_names[i], callee.arg_kinds[i]
+            # In this case we are binding all of the actuals to *args
+            # and we want a constraint that the typevar tuple being unpacked
+            # is equal to a type list of all the actuals.
+            actual_types = []
+            for actual in actuals:
+                actual_arg_type = arg_types[actual]
+                if actual_arg_type is None:
+                    continue
+
+                actual_types.append(
+                    mapper.expand_actual_type(
+                        actual_arg_type,
+                        arg_kinds[actual],
+                        callee.arg_names[i],
+                        callee.arg_kinds[i],
+                    )
+                )
+
+            assert isinstance(unpack_type.type, TypeVarTupleType)
+            constraints.append(
+                Constraint(unpack_type.type, SUPERTYPE_OF, TypeList(actual_types))
             )
-            c = infer_constraints(callee.arg_types[i], actual_type, SUPERTYPE_OF)
-            constraints.extend(c)
+        else:
+            for actual in actuals:
+                actual_arg_type = arg_types[actual]
+                if actual_arg_type is None:
+                    continue
+
+                actual_type = mapper.expand_actual_type(
+                    actual_arg_type, arg_kinds[actual], callee.arg_names[i], callee.arg_kinds[i]
+                )
+                c = infer_constraints(callee.arg_types[i], actual_type, SUPERTYPE_OF)
+                constraints.extend(c)
 
     return constraints
 
@@ -165,7 +192,6 @@ def infer_constraints(template: Type, actual: Type, direction: int) -> list[Cons
 
 
 def _infer_constraints(template: Type, actual: Type, direction: int) -> list[Constraint]:
-
     orig_template = template
     template = get_proper_type(template)
     actual = get_proper_type(actual)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -80,6 +80,7 @@ from mypy.types import (
     TypedDictType,
     TypeOfAny,
     TypeType,
+    TypeVarTupleType,
     TypeVarType,
     UnboundType,
     UninhabitedType,
@@ -2261,6 +2262,9 @@ def format_type_inner(
     elif isinstance(typ, UnpackType):
         return f"Unpack[{format(typ.type)}]"
     elif isinstance(typ, TypeVarType):
+        # This is similar to non-generic instance types.
+        return typ.name
+    elif isinstance(typ, TypeVarTupleType):
         # This is similar to non-generic instance types.
         return typ.name
     elif isinstance(typ, ParamSpecType):

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -347,3 +347,19 @@ expect_variadic_array_2(u)
 
 
 [builtins fixtures/tuple.pyi]
+
+[case testPep646TypeVarStarArgs]
+from typing import Tuple
+from typing_extensions import TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+
+# TODO: add less trivial tests with prefix/suffix etc.
+# TODO: add tests that call with a type var tuple instead of just args.
+def args_to_tuple(*args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
+    reveal_type(args)  # N: Revealed type is "Tuple[Unpack[Ts`-1]]"
+    return args
+
+reveal_type(args_to_tuple(1, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, Literal['a']?]"
+
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
This implements the most basic support for the *args feature but various edge cases are not handled in this PR because of the large volume of places that needed to be modified to support this.

In particular, we need to special handle the ARG_STAR argument in several places for the case where the type is a UnpackType. Finally when we actually check a function we need to construct a TupleType instead of a builtins.tuple.