### PR TITLE
Fix __set__ to __get__ in messages

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -627,7 +627,7 @@ def analyze_descriptor_access(descriptor_type: Type, mx: MemberContext) -> Type:
         itype=descriptor_type,
         info=descriptor_type.type,
         self_type=descriptor_type,
-        name="__set__",
+        name="__get__",
         mx=mx,
     )
 


### PR DESCRIPTION
We're dealing with the get descriptor here but calling it `__set__`, probably a copy-paste from similar code elsewhere. I think this only affects messages.