### PR TITLE
feat: stubgen warn some modules are ignored

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1406,10 +1406,13 @@ def get_qualified_name(o: Expression) -> str:
         return ERROR_MARKER
 
 
-def remove_blacklisted_modules(modules: list[StubSource]) -> list[StubSource]:
-    return [
+def remove_blacklisted_modules(
+    modules: list[StubSource],
+) -> tuple[list[StubSource], list[StubSource]]:
+    blacklisted_removed = [
         module for module in modules if module.path is None or not is_blacklisted_path(module.path)
     ]
+    return blacklisted_removed, list(set(modules) - set(blacklisted_removed))
 
 
 def is_blacklisted_path(path: str) -> bool:
@@ -1424,7 +1427,7 @@ def normalize_path_separators(path: str) -> str:
 
 def collect_build_targets(
     options: Options, mypy_opts: MypyOptions
-) -> tuple[list[StubSource], list[StubSource]]:
+) -> tuple[list[StubSource], list[StubSource], list[StubSource]]:
     """Collect files for which we need to generate stubs.
 
     Return list of Python modules and C modules.
@@ -1449,9 +1452,9 @@ def collect_build_targets(
         py_modules = [StubSource(m.module, m.path) for m in source_list]
         c_modules = []
 
-    py_modules = remove_blacklisted_modules(py_modules)
+    py_modules, ignored_py_modules = remove_blacklisted_modules(py_modules)
 
-    return py_modules, c_modules
+    return py_modules, c_modules, ignored_py_modules
 
 
 def find_module_paths_using_imports(
@@ -1683,7 +1686,7 @@ def collect_docs_signatures(doc_dir: str) -> tuple[dict[str, str], dict[str, str
 def generate_stubs(options: Options) -> None:
     """Main entry point for the program."""
     mypy_opts = mypy_options(options)
-    py_modules, c_modules = collect_build_targets(options, mypy_opts)
+    py_modules, c_modules, ignored_py_modules = collect_build_targets(options, mypy_opts)
     sig_generators = get_sig_generators(options)
     # Use parsed sources to generate stubs for Python modules.
     generate_asts_for_modules(py_modules, options.parse_only, mypy_opts, options.verbose)
@@ -1713,12 +1716,17 @@ def generate_stubs(options: Options) -> None:
         with generate_guarded(mod.module, target, options.ignore_errors, options.verbose):
             generate_stub_for_c_module(mod.module, target, sig_generators=sig_generators)
     num_modules = len(py_modules) + len(c_modules)
-    if not options.quiet and num_modules > 0:
+    if not options.quiet and (num_modules > 0 or len(ignored_py_modules) > 0):
         print("Processed %d modules" % num_modules)
         if len(files) == 1:
             print(f"Generated {files[0]}")
         else:
             print(f"Generated files under {common_dir_prefix(files)}" + os.sep)
+        if len(ignored_py_modules):
+            print(f"Ignored {len(ignored_py_modules)} modules")
+            if options.verbose:
+                for ignored in ignored_py_modules:
+                    print(f"\tignored: {ignored.path}")
 
 
 HEADER = """%(prog)s [-h] [more options, see -h]

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -60,8 +60,10 @@ class StubgenCmdLineSuite(unittest.TestCase):
                 self.make_file("subdir", "b.py")
                 os.mkdir(os.path.join("subdir", "pack"))
                 self.make_file("subdir", "pack", "__init__.py")
+                os.mkdir(os.path.join("subdir", "vendor"))
+                self.make_file("subdir", "vendor", "a.py")
                 opts = parse_options(["subdir"])
-                py_mods, c_mods = collect_build_targets(opts, mypy_options(opts))
+                py_mods, c_mods, ignored_py_mods = collect_build_targets(opts, mypy_options(opts))
                 assert_equal(c_mods, [])
                 files = {mod.path for mod in py_mods}
                 assert_equal(
@@ -72,6 +74,8 @@ class StubgenCmdLineSuite(unittest.TestCase):
                         os.path.join("subdir", "b.py"),
                     },
                 )
+                ignored_files = {mod.path for mod in ignored_py_mods}
+                assert_equal(ignored_files, {os.path.join("subdir", "vendor", "a.py")})
             finally:
                 os.chdir(current)
 
@@ -85,8 +89,11 @@ class StubgenCmdLineSuite(unittest.TestCase):
                 self.make_file("pack", "__init__.py", content="from . import a, b")
                 self.make_file("pack", "a.py")
                 self.make_file("pack", "b.py")
+                os.mkdir(os.path.join("pack", "vendor"))
+                self.make_file("pack", "vendor", "__init__.py")
+                self.make_file("pack", "vendor", "a.py")
                 opts = parse_options(["-p", "pack"])
-                py_mods, c_mods = collect_build_targets(opts, mypy_options(opts))
+                py_mods, c_mods, ignored_py_mods = collect_build_targets(opts, mypy_options(opts))
                 assert_equal(c_mods, [])
                 files = {os.path.relpath(mod.path or "FAIL") for mod in py_mods}
                 assert_equal(
@@ -95,6 +102,14 @@ class StubgenCmdLineSuite(unittest.TestCase):
                         os.path.join("pack", "__init__.py"),
                         os.path.join("pack", "a.py"),
                         os.path.join("pack", "b.py"),
+                    },
+                )
+                ignored_files = {os.path.relpath(mod.path or "FAIL") for mod in ignored_py_mods}
+                assert_equal(
+                    ignored_files,
+                    {
+                        os.path.join("pack", "vendor", "__init__.py"),
+                        os.path.join("pack", "vendor", "a.py"),
                     },
                 )
             finally:
@@ -110,7 +125,7 @@ class StubgenCmdLineSuite(unittest.TestCase):
                 os.chdir(tmp)
                 self.make_file(tmp, "mymodule.py", content="import a")
                 opts = parse_options(["-m", "mymodule"])
-                py_mods, c_mods = collect_build_targets(opts, mypy_options(opts))
+                py_mods, c_mods, ignored_py_mods = collect_build_targets(opts, mypy_options(opts))
                 assert captured_output.getvalue() == ""
             finally:
                 sys.stdout = sys.__stdout__


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Print message how many modules ignored when some modules are blacklisted. see: #9599
There are two preceding pull requests exist but no updates since about one year ago.

Suppose these project structure, 
```
a
  __init__.py
  a.py
  vendor
    __init__.py
    a.py
```

After this change, print messages like this. (line starts with `Ignored` is added)

```
$ python -m mypy.stubgen a
Processed 2 modules
Generated files under out/a/
Ignored 2 files
```

And when specified verbose flag, print message like this. (line starts with `Ignored` and following the lines are added)

```
$ python -m mypy.stubgen a -v
Processing 2 files...
Processing a
Created out/a/__init__.pyi
Processing a.a
Created out/a/a.pyi
Processed 2 modules
Generated files under out/a/
Ignored 2 modules
        ignored: a/vendor/__init__.py
        ignored: a/vendor/a.py
```


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
