### PR TITLE
Update `extending_mypy.rst` docs

### DIFF
--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -155,23 +155,9 @@ When analyzing this code, mypy will call ``get_type_analyze_hook("lib.Vector")``
 so the plugin can return some valid type for each variable.
 
 **get_function_hook()** is used to adjust the return type of a function call.
-This is a good choice if the return type of some function depends on *values*
-of some arguments that can't be expressed using literal types (for example
-a function may return an ``int`` for positive arguments and a ``float`` for
-negative arguments). This hook will be also called for instantiation of classes.
-For example:
-
-.. code-block:: python
-
-   from contextlib import contextmanager
-   from typing import TypeVar, Callable
-
-   T = TypeVar('T')
-
-   @contextmanager  # built-in plugin can infer a precise type here
-   def stopwatch(timer: Callable[[], T]) -> Iterator[T]:
-       ...
-       yield timer()
+This hook will be also called for instantiation of classes.
+This is a good choice if the return type is too complex
+to be expressed by regular python typing.
 
 **get_function_signature_hook** is used to adjust the signature of a function.
 
@@ -251,31 +237,3 @@ mypy's cache for that module so that it can be rechecked. This hook
 should be used to report to mypy any relevant configuration data,
 so that mypy knows to recheck the module if the configuration changes.
 The hooks should return data encodable as JSON.
-
-Notes about the semantic analyzer
-*********************************
-
-Mypy 0.710 introduced a new semantic analyzer, and the old semantic
-analyzer was removed in mypy 0.730. Support for the new semantic analyzer
-required some changes to existing plugins. Here is a short summary of the
-most important changes:
-
-* The order of processing AST nodes is different. Code outside
-  functions is processed first, and functions and methods are
-  processed afterwards.
-
-* Each AST node can be processed multiple times to resolve forward
-  references.  The same plugin hook may be called multiple times, so
-  they need to be idempotent.
-
-* The ``anal_type()`` API method returns ``None`` if some part of
-  the type is not available yet due to forward references, for example.
-
-* When looking up symbols, you may encounter *placeholder nodes* that
-  are used for names that haven't been fully processed yet. You'll
-  generally want to request another semantic analysis iteration by
-  *deferring* in that case.
-
-See the docstring at the top of
-`mypy/plugin.py <https://github.com/python/mypy/blob/master/mypy/plugin.py>`_
-for more details.


### PR DESCRIPTION
Changes:
- Removes notes about old semantic analyzer, it is long gone
- Removes outdated `contextlib` example, see https://github.com/python/mypy/pull/13923
- Changes `get_function_hook` wording. Because we cannot promise that we do track exact values in all cases