### PR TITLE
Add hidden options to disable bytes promotion

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1121,6 +1121,12 @@ def process_options(
     parser.add_argument(
         "--enable-incomplete-features", action="store_true", help=argparse.SUPPRESS
     )
+    parser.add_argument(
+        "--_disable-bytearray-promotion", action="store_true", help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        "--_disable-memoryview-promotion", action="store_true", help=argparse.SUPPRESS
+    )
 
     # options specifying code to check
     code_group = parser.add_argument_group(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1122,10 +1122,10 @@ def process_options(
         "--enable-incomplete-features", action="store_true", help=argparse.SUPPRESS
     )
     parser.add_argument(
-        "--_disable-bytearray-promotion", action="store_true", help=argparse.SUPPRESS
+        "--disable-bytearray-promotion", action="store_true", help=argparse.SUPPRESS
     )
     parser.add_argument(
-        "--_disable-memoryview-promotion", action="store_true", help=argparse.SUPPRESS
+        "--disable-memoryview-promotion", action="store_true", help=argparse.SUPPRESS
     )
 
     # options specifying code to check

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -62,8 +62,8 @@ OPTIONS_AFFECTING_CACHE: Final = (
         "platform",
         "bazel",
         "plugins",
-        "_disable_bytearray_promotion",
-        "_disable_memoryview_promotion",
+        "disable_bytearray_promotion",
+        "disable_memoryview_promotion",
     }
 ) - {"debug_cache"}
 
@@ -336,8 +336,8 @@ class Options:
         # Deprecated reverse version of the above, do not use.
         self.enable_recursive_aliases = False
 
-        self._disable_bytearray_promotion = False
-        self._disable_memoryview_promotion = False
+        self.disable_bytearray_promotion = False
+        self.disable_memoryview_promotion = False
 
     # To avoid breaking plugin compatibility, keep providing new_semantic_analyzer
     @property

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -56,9 +56,16 @@ PER_MODULE_OPTIONS: Final = {
     "warn_unused_ignores",
 }
 
-OPTIONS_AFFECTING_CACHE: Final = (PER_MODULE_OPTIONS | {"platform", "bazel", "plugins"}) - {
-    "debug_cache"
-}
+OPTIONS_AFFECTING_CACHE: Final = (
+    PER_MODULE_OPTIONS
+    | {
+        "platform",
+        "bazel",
+        "plugins",
+        "_disable_bytearray_promotion",
+        "_disable_memoryview_promotion",
+    }
+) - {"debug_cache"}
 
 # Features that are currently incomplete/experimental
 TYPE_VAR_TUPLE: Final = "TypeVarTuple"
@@ -328,6 +335,9 @@ class Options:
         self.disable_recursive_aliases = False
         # Deprecated reverse version of the above, do not use.
         self.enable_recursive_aliases = False
+
+        self._disable_bytearray_promotion = False
+        self._disable_memoryview_promotion = False
 
     # To avoid breaking plugin compatibility, keep providing new_semantic_analyzer
     @property

--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -165,15 +165,9 @@ def add_type_promotion(
     if not promote_targets:
         if defn.fullname in TYPE_PROMOTIONS:
             target_sym = module_names.get(TYPE_PROMOTIONS[defn.fullname])
-            if (
-                defn.fullname == "builtins.bytearray"
-                and options.disable_bytearray_promotion
-            ):
+            if defn.fullname == "builtins.bytearray" and options.disable_bytearray_promotion:
                 target_sym = None
-            elif (
-                defn.fullname == "builtins.memoryview"
-                and options.disable_memoryview_promotion
-            ):
+            elif defn.fullname == "builtins.memoryview" and options.disable_memoryview_promotion:
                 target_sym = None
             # With test stubs, the target may not exist.
             if target_sym:

--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -165,6 +165,16 @@ def add_type_promotion(
     if not promote_targets:
         if defn.fullname in TYPE_PROMOTIONS:
             target_sym = module_names.get(TYPE_PROMOTIONS[defn.fullname])
+            if (
+                defn.fullname == "builtins.bytearray"
+                and options._disable_bytearray_promotion
+            ):
+                target_sym = None
+            elif (
+                defn.fullname == "builtins.memoryview"
+                and options._disable_memoryview_promotion
+            ):
+                target_sym = None
             # With test stubs, the target may not exist.
             if target_sym:
                 target_info = target_sym.node

--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -167,12 +167,12 @@ def add_type_promotion(
             target_sym = module_names.get(TYPE_PROMOTIONS[defn.fullname])
             if (
                 defn.fullname == "builtins.bytearray"
-                and options._disable_bytearray_promotion
+                and options.disable_bytearray_promotion
             ):
                 target_sym = None
             elif (
                 defn.fullname == "builtins.memoryview"
-                and options._disable_memoryview_promotion
+                and options.disable_memoryview_promotion
             ):
                 target_sym = None
             # With test stubs, the target may not exist.

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2134,10 +2134,12 @@ Ts = TypeVarTuple("Ts")  # OK
 # flags: --disable-bytearray-promotion
 def f(x: bytes) -> None: ...
 f(bytearray(b"asdf"))  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
+f(memoryview(b"asdf"))
 [builtins fixtures/primitives.pyi]
 
 [case testDisableMemoryviewPromotion]
 # flags: --disable-memoryview-promotion
 def f(x: bytes) -> None: ...
+f(bytearray(b"asdf"))
 f(memoryview(b"asdf"))  # E: Argument 1 to "f" has incompatible type "memoryview"; expected "bytes"
 [builtins fixtures/primitives.pyi]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2128,3 +2128,16 @@ Ts = TypeVarTuple("Ts")  # E: "TypeVarTuple" support is experimental, use --enab
 from typing_extensions import TypeVarTuple
 Ts = TypeVarTuple("Ts")  # OK
 [builtins fixtures/tuple.pyi]
+
+
+[case testDisableBytearrayPromotion]
+# flags: --disable-bytearray-promotion
+def f(x: bytes) -> None: ...
+f(bytearray(b"asdf"))  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
+[builtins fixtures/primitives.pyi]
+
+[case testDisableMemoryviewPromotion]
+# flags: --disable-memoryview-promotion
+def f(x: bytes) -> None: ...
+f(memoryview(b"asdf"))  # E: Argument 1 to "f" has incompatible type "memoryview"; expected "bytes"
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
It might be useful to run mypy_primer without promotions in typeshed. This would give us more confidence in changes stemming from https://github.com/python/typeshed/issues/9001