### PR TITLE
Typeshed branch 'master' was renamed to 'main'

### DIFF
--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -134,7 +134,7 @@ def main() -> None:
     parser.add_argument(
         "--commit",
         default=None,
-        help="Typeshed commit (default to latest master if using a repository clone)",
+        help="Typeshed commit (default to latest main if using a repository clone)",
     )
     parser.add_argument(
         "--typeshed-dir",

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4580,7 +4580,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # exceptions or not. We determine this using a heuristic based on the
             # return type of the __exit__ method -- see the discussion in
             # https://github.com/python/mypy/issues/7214 and the section about context managers
-            # in https://github.com/python/typeshed/blob/master/CONTRIBUTING.md#conventions
+            # in https://github.com/python/typeshed/blob/main/CONTRIBUTING.md#conventions
             # for more details.
 
             exit_ret_type = get_proper_type(exit_ret_type)


### PR DESCRIPTION
There aren't really any big changes required over on mypy's side (I was worried there would be more breakage, but I think mypy should be fine). Cf. https://github.com/python/typeshed/issues/8956.