### PR TITLE
`mypy/ipc.py`: Remove some typeshed-related TODOs

### DIFF
--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -89,9 +89,6 @@ class IPCBase:
         if sys.platform == "win32":
             try:
                 ov, err = _winapi.WriteFile(self.connection, data, overlapped=True)
-                # TODO: remove once typeshed supports Literal types
-                assert isinstance(ov, _winapi.Overlapped)
-                assert isinstance(err, int)
                 try:
                     if err == _winapi.ERROR_IO_PENDING:
                         timeout = int(self.timeout * 1000) if self.timeout else _winapi.INFINITE
@@ -217,8 +214,6 @@ class IPCServer(IPCBase):
             # client never connects, though this can be "solved" by killing the server
             try:
                 ov = _winapi.ConnectNamedPipe(self.connection, overlapped=True)
-                # TODO: remove once typeshed supports Literal types
-                assert isinstance(ov, _winapi.Overlapped)
             except OSError as e:
                 # Don't raise if the client already exists, or the client already connected
                 if e.winerror not in (_winapi.ERROR_PIPE_CONNECTED, _winapi.ERROR_NO_DATA):


### PR DESCRIPTION
As per the TODO comments, this PR removes some unnecessary `assert`s in `mypy/ipc.py`. When these `assert`s were added in #6148, typeshed wasn't able to use `Literal` types yet. However, nowadays, typeshed has precise `Literal` overloads for `_winapi.WriteFile` and `_winapi.ConnectNamedType`, meaning mypy is able to precisely infer the return type of these function calls without the need for the `assert`s in `mypy/ipc.py`: https://github.com/python/typeshed/blob/main/stdlib/_winapi.pyi.