### PR TITLE
[mypyc] Use tabs instead of spaces in emitted C code

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -176,10 +176,10 @@ class Emitter:
     # Low-level operations
 
     def indent(self) -> None:
-        self._indent += 4
+        self._indent += 1
 
     def dedent(self) -> None:
-        self._indent -= 4
+        self._indent -= 1
         assert self._indent >= 0
 
     def label(self, label: BasicBlock) -> str:
@@ -194,7 +194,7 @@ class Emitter:
     def emit_line(self, line: str = "") -> None:
         if line.startswith("}"):
             self.dedent()
-        self.fragments.append(self._indent * " " + line + "\n")
+        self.fragments.append(self._indent * "\t" + line + "\n")
         if line.endswith("{"):
             self.indent()
 

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -28,4 +28,4 @@ class TestEmitter(unittest.TestCase):
         emitter.emit_line("a {")
         emitter.emit_line("f();")
         emitter.emit_line("}")
-        assert emitter.fragments == ["line;\n", "a {\n", "    f();\n", "}\n"]
+        assert emitter.fragments == ["line;\n", "a {\n", "\tf();\n", "}\n"]

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -833,7 +833,7 @@ else {
 
         op.accept(visitor)
         frags = declarations.fragments + emitter.fragments
-        actual_lines = [line.strip(" ") for line in frags]
+        actual_lines = [line.strip(" \t") for line in frags]
         assert all(line.endswith("\n") for line in actual_lines)
         actual_lines = [line.rstrip("\n") for line in actual_lines]
         if not expected.strip():
@@ -900,7 +900,7 @@ class TestGenerateFunction(unittest.TestCase):
                 "    return cpy_r_arg;\n",
                 "}\n",
             ],
-            result,
+            [line.replace("\t", 4 * " ") for line in result],
             msg="Generated code invalid",
         )
 
@@ -927,6 +927,6 @@ class TestGenerateFunction(unittest.TestCase):
                 "    CPy_Unreachable();\n",
                 "}\n",
             ],
-            result,
+            [line.replace("\t", 4 * " ") for line in result],
             msg="Generated code invalid",
         )

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -56,5 +56,6 @@ class TestArgCheck(unittest.TestCase):
         )
 
     def assert_lines(self, expected: list[str], actual: list[str]) -> None:
-        actual = [line.rstrip("\n") for line in actual]
+        actual = [line.rstrip("\n").replace(4 * " ", "\t") for line in actual]
+        expected = [line.replace(4 * " ", "\t") for line in expected]
         assert_string_arrays_equal(expected, actual, "Invalid output")


### PR DESCRIPTION
By using tabs instead of spaces for indentation in the emitted C code we are able to reduce the file size by almost 9%:

| File | Size |
|------|------|
| `build/__native_74cdc94b2b24dafac2a2.c` (spaces) | 86.5MB |
| `build/__native_74cdc94b2b24dafac2a2.c` (tabs)   | 79.6MB |

For this particular file we save about 6.9MB, or 8.7%.

I checked, and this has no effect on the compilation speed, which is to be expected. At the very least opening these auto generated files inside an editor will be faster, even if the compilation isn't any faster.

I am interested in making mypy/mypyc faster, and this seemed like a low-hanging fruit that could be beneficial.