### PR TITLE
Fix crash on inference with recursive alias to recursive instance

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -177,8 +177,9 @@ def infer_constraints(template: Type, actual: Type, direction: int) -> list[Cons
         for (t, a) in reversed(TypeState.inferring)
     ):
         return []
-    if has_recursive_types(template):
+    if has_recursive_types(template) or isinstance(get_proper_type(template), Instance):
         # This case requires special care because it may cause infinite recursion.
+        # Note that we include Instances because the may be recursive as str(Sequence[str]).
         if not has_type_vars(template):
             # Return early on an empty branch.
             return []

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3240,6 +3240,12 @@ class HasTypeVars(TypeQuery[bool]):
     def visit_type_var(self, t: TypeVarType) -> bool:
         return True
 
+    def visit_type_var_tuple(self, t: TypeVarTupleType) -> bool:
+        return True
+
+    def visit_param_spec(self, t: ParamSpecType) -> bool:
+        return True
+
 
 def has_type_vars(typ: Type) -> bool:
     """Check if a type contains any type variables (recursively)."""

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -826,3 +826,14 @@ z = z
 x = y  # E: Incompatible types in assignment (expression has type "L", variable has type "K")
 z = x  # OK
 [builtins fixtures/tuple.pyi]
+
+[case testRecursiveInstanceInferenceNoCrash]
+from typing import Sequence, TypeVar, Union
+
+class C(Sequence[C]): ...
+
+T = TypeVar("T")
+def foo(x: T) -> C: ...
+
+Nested = Union[C, Sequence[Nested]]
+x: Nested = foo(42)


### PR DESCRIPTION
Fixes #14031 

It turns out premature optimization is the root of all evil. (It turns out this costs us less than 1% time on self-check).