### PR TITLE
(🎁) canwecolor🚀

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,16 @@ jobs:
     name: ${{ matrix.name }}
     env:
       TOX_SKIP_MISSING_INTERPRETERS: False
+      # Rich (pip)
+      FORCE_COLOR: 1
+      # Tox
+      PY_COLORS: 1
+      # Mypy (see https://github.com/python/mypy/issues/7771)
+      TERM: xterm-color
+      MYPY_FORCE_COLOR: 1
+      MYPY_FORCE_TERMINAL_WIDTH: 200
+      # Pytest
+      PYTEST_ADDOPTS: --color=yes
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 minversion = 3.8.0
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 envlist =
-    py36,
     py37,
     py38,
     py39,
@@ -14,7 +13,7 @@ isolated_build = true
 
 [testenv]
 description = run the test driver with {basepython}
-passenv = PYTEST_XDIST_WORKER_COUNT PROGRAMDATA PROGRAMFILES(X86)
+passenv = PYTEST_XDIST_WORKER_COUNT PROGRAMDATA PROGRAMFILES(X86) PYTEST_ADDOPTS
 deps = -rtest-requirements.txt
 commands = python -m pytest {posargs}
 
@@ -27,6 +26,7 @@ commands =
 
 [testenv:type]
 description = type check ourselves
+passenv = TERM MYPY_FORCE_COLOR MYPY_FORCE_TERMINAL_WIDTH
 commands =
     python -m mypy --config-file mypy_self_check.ini -p mypy -p mypyc
     python -m mypy --config-file mypy_self_check.ini misc --exclude misc/fix_annotate.py --exclude misc/async_matrix.py --exclude misc/sync-typeshed.py


### PR DESCRIPTION
Last time i checked it wasn't the 1960's. So I think the CI could be colorized.

Configured pytest, tox, mypy(#7771) and pip¹ (I already already colorized black and isort when I initially added them)


1: Pip doesn't work yet https://github.com/pypa/pip/issues/10909, so this is just a placedholder for when it (hopefully) soon will.