### PR TITLE
Remove `get_line()` and `get_column()` functions

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -231,8 +231,8 @@ class MessageBuilder:
         else:
             origin_span = None
         self.errors.report(
-            context.get_line() if context else -1,
-            context.get_column() if context else -1,
+            context.line if context else -1,
+            context.column if context else -1,
             msg,
             severity=severity,
             file=file,

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -71,14 +71,6 @@ class Context:
         if end_column is not None:
             self.end_column = end_column
 
-    def get_line(self) -> int:
-        """Don't use. Use x.line."""
-        return self.line
-
-    def get_column(self) -> int:
-        """Don't use. Use x.column."""
-        return self.column
-
 
 if TYPE_CHECKING:
     # break import cycle only needed for mypy

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -353,7 +353,7 @@ class LineCoverageVisitor(TraverserVisitor):
         return None
 
     def visit_func_def(self, defn: FuncDef) -> None:
-        start_line = defn.get_line() - 1
+        start_line = defn.line - 1
         start_indent = None
         # When a function is decorated, sometimes the start line will point to
         # whitespace or comments between the decorator and the function, so

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6031,12 +6031,12 @@ class SemanticAnalyzer(
             return
         # In case it's a bug and we don't really have context
         assert ctx is not None, msg
-        self.errors.report(ctx.get_line(), ctx.get_column(), msg, blocker=blocker, code=code)
+        self.errors.report(ctx.line, ctx.column, msg, blocker=blocker, code=code)
 
     def note(self, msg: str, ctx: Context, code: ErrorCode | None = None) -> None:
         if not self.in_checked_function():
             return
-        self.errors.report(ctx.get_line(), ctx.get_column(), msg, severity="note", code=code)
+        self.errors.report(ctx.line, ctx.column, msg, severity="note", code=code)
 
     def incomplete_feature_enabled(self, feature: str, ctx: Context) -> bool:
         if feature not in self.options.enable_incomplete_feature:

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -164,4 +164,4 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
                     )
 
     def fail(self, msg: str, context: Context, *, code: ErrorCode | None = None) -> None:
-        self.errors.report(context.get_line(), context.get_column(), msg, code=code)
+        self.errors.report(context.line, context.column, msg, code=code)

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -149,7 +149,7 @@ class StatisticsVisitor(TraverserVisitor):
                 if o in o.expanded:
                     print(
                         "{}:{}: ERROR: cycle in function expansion; skipping".format(
-                            self.filename, o.get_line()
+                            self.filename, o.line
                         )
                     )
                     return

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -50,7 +50,7 @@ class StrConv(NodeVisitor[str]):
         number. See mypy.util.dump_tagged for a description of the nodes
         argument.
         """
-        tag = short_type(obj) + ":" + str(obj.get_line())
+        tag = short_type(obj) + ":" + str(obj.line)
         if self.show_ids:
             assert self.id_mapper is not None
             tag += f"<{self.get_id(obj)}>"


### PR DESCRIPTION
When I was working on a different PR for Mypy, I came across these functions:

```python
    def get_line(self) -> int:
        """Don't use. Use x.line."""
        return self.line

    def get_column(self) -> int:
        """Don't use. Use x.column."""
        return self.column
```

So I just went ahead and removed them.