### PR TITLE
Support additinal attributes in callback protocols

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5875,7 +5875,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if (
             isinstance(supertype, Instance)
             and supertype.type.is_protocol
-            and isinstance(subtype, (Instance, TupleType, TypedDictType))
+            and isinstance(subtype, (CallableType, Instance, TupleType, TypedDictType))
         ):
             self.msg.report_protocol_problems(subtype, supertype, context, code=msg.code)
         if isinstance(supertype, CallableType) and isinstance(subtype, Instance):
@@ -5883,10 +5883,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if call:
                 self.msg.note_call(subtype, call, context, code=msg.code)
         if isinstance(subtype, (CallableType, Overloaded)) and isinstance(supertype, Instance):
-            if supertype.type.is_protocol and supertype.type.protocol_members == ["__call__"]:
+            if supertype.type.is_protocol and "__call__" in supertype.type.protocol_members:
                 call = find_member("__call__", supertype, subtype, is_operator=True)
                 assert call is not None
-                self.msg.note_call(supertype, call, context, code=msg.code)
+                if not is_subtype(subtype, call, options=self.options):
+                    self.msg.note_call(supertype, call, context, code=msg.code)
         self.check_possible_missing_await(subtype, supertype, context)
         return False
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -553,7 +553,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         original_actual = actual = self.actual
         res: list[Constraint] = []
         if isinstance(actual, (CallableType, Overloaded)) and template.type.is_protocol:
-            if template.type.protocol_members == ["__call__"]:
+            if "__call__" in template.type.protocol_members:
                 # Special case: a generic callback protocol
                 if not any(template == t for t in template.type.inferring):
                     template.type.inferring.append(template)
@@ -565,7 +565,6 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         subres = infer_constraints(call, actual, self.direction)
                         res.extend(subres)
                     template.type.inferring.pop()
-                    return res
         if isinstance(actual, CallableType) and actual.fallback is not None:
             if actual.is_type_obj() and template.type.is_protocol:
                 ret_type = get_proper_type(actual.ret_type)
@@ -815,7 +814,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                 # because some type may be considered a subtype of a protocol
                 # due to _promote, but still not implement the protocol.
                 not any(template == t for t in reversed(template.type.inferring))
-                and mypy.subtypes.is_protocol_implementation(instance, erased)
+                and mypy.subtypes.is_protocol_implementation(instance, erased, skip=["__call__"])
             ):
                 template.type.inferring.append(template)
                 res.extend(
@@ -831,7 +830,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                 and
                 # We avoid infinite recursion for structural subtypes also here.
                 not any(instance == i for i in reversed(instance.type.inferring))
-                and mypy.subtypes.is_protocol_implementation(erased, instance)
+                and mypy.subtypes.is_protocol_implementation(erased, instance, skip=["__call__"])
             ):
                 instance.type.inferring.append(instance)
                 res.extend(
@@ -887,6 +886,8 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             inst = mypy.subtypes.find_member(member, instance, subtype, class_obj=class_obj)
             temp = mypy.subtypes.find_member(member, template, subtype)
             if inst is None or temp is None:
+                if member == "__call__":
+                    continue
                 return []  # See #11020
             # The above is safe since at this point we know that 'instance' is a subtype
             # of (erased) 'template', therefore it defines all protocol members

--- a/mypy/test/testtypegen.py
+++ b/mypy/test/testtypegen.py
@@ -7,7 +7,7 @@ import re
 from mypy import build
 from mypy.errors import CompileError
 from mypy.modulefinder import BuildSource
-from mypy.nodes import NameExpr
+from mypy.nodes import NameExpr, TempNode
 from mypy.options import Options
 from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase, DataSuite
@@ -54,6 +54,8 @@ class TypeExportSuite(DataSuite):
             # Filter nodes that should be included in the output.
             keys = []
             for node in nodes:
+                if isinstance(node, TempNode):
+                    continue
                 if node.line != -1 and map[node]:
                     if ignore_node(node) or node in ignored:
                         continue

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2642,6 +2642,43 @@ reveal_type([b, a])  # N: Revealed type is "builtins.list[def (x: def (__main__.
 [builtins fixtures/list.pyi]
 [out]
 
+[case testCallbackProtocolFunctionAttributesSubtyping]
+from typing import Protocol
+
+class A(Protocol):
+    __name__: str
+    def __call__(self) -> str: ...
+
+class B1(Protocol):
+    __name__: int
+    def __call__(self) -> str: ...
+
+class B2(Protocol):
+    __name__: str
+    def __call__(self) -> int: ...
+
+def f() -> str: ...
+
+reveal_type(f.__name__)  # N: Revealed type is "builtins.str"
+a: A = f  # OK
+b1: B1 = f  # E: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "B1")
+b2: B2 = f  # E: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "B2") \
+            # N: "B2.__call__" has type "Callable[[], int]"
+
+[case testCallbackProtocolFunctionAttributesInference]
+from typing import Protocol, TypeVar, Generic, Tuple
+
+T = TypeVar("T")
+S = TypeVar("S", covariant=True)
+class A(Protocol[T, S]):
+    __name__: T
+    def __call__(self) -> S: ...
+
+def f() -> int: ...
+def test(func: A[T, S]) -> Tuple[T, S]: ...
+reveal_type(test(f))  # N: Revealed type is "Tuple[builtins.str, builtins.int]"
+[builtins fixtures/tuple.pyi]
+
 [case testProtocolsAlwaysABCs]
 from typing import Protocol
 

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2657,13 +2657,23 @@ class B2(Protocol):
     __name__: str
     def __call__(self) -> int: ...
 
+class B3(Protocol):
+    __name__: str
+    extra_stuff: int
+    def __call__(self) -> str: ...
+
 def f() -> str: ...
 
 reveal_type(f.__name__)  # N: Revealed type is "builtins.str"
 a: A = f  # OK
-b1: B1 = f  # E: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "B1")
+b1: B1 = f  # E: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "B1") \
+            # N: Following member(s) of "function" have conflicts: \
+            # N:     __name__: expected "int", got "str"
 b2: B2 = f  # E: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "B2") \
             # N: "B2.__call__" has type "Callable[[], int]"
+b3: B3 = f  # E: Incompatible types in assignment (expression has type "Callable[[], str]", variable has type "B3") \
+            # N: "function" is missing following "B3" protocol member: \
+            # N:     extra_stuff
 
 [case testCallbackProtocolFunctionAttributesInference]
 from typing import Protocol, TypeVar, Generic, Tuple

--- a/test-data/unit/fine-grained-inspect.test
+++ b/test-data/unit/fine-grained-inspect.test
@@ -52,8 +52,8 @@ class Meta(type):
 ==
 {"C": ["meth", "x"]}
 {"C": ["meth", "x"], "Meta": ["y"], "type": ["__init__"]}
-{}
-{"object": ["__init__"]}
+{"function": ["__name__"]}
+{"function": ["__name__"], "object": ["__init__"]}
 
 [case testInspectDefBasic]
 # inspect2: --show=definition foo.py:5:5

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -23,7 +23,8 @@ class tuple(Sequence[Tco], Generic[Tco]):
     def __rmul__(self, n: int) -> Tuple[Tco, ...]: pass
     def __add__(self, x: Tuple[Tco, ...]) -> Tuple[Tco, ...]: pass
     def count(self, obj: object) -> int: pass
-class function: pass
+class function:
+    __name__: str
 class ellipsis: pass
 class classmethod: pass
 

--- a/test-data/unit/lib-stub/builtins.pyi
+++ b/test-data/unit/lib-stub/builtins.pyi
@@ -17,7 +17,8 @@ class float: pass
 class str: pass
 class bytes: pass
 
-class function: pass
+class function:
+    __name__: str
 class ellipsis: pass
 
 from typing import Generic, Sequence, TypeVar


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/10976
Fixes https://github.com/python/mypy/issues/10403

This is quite straightforward. Note that we will not allow _arbitrary_ attributes on functions, only those that are defined in `types.FunctionType` (or more precisely `builtins.function` that is identical). We have a separate issue for arbitrary attributes https://github.com/python/mypy/issues/2087