### PR TITLE
Fix crash on partial type inference within a lambda

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7031,6 +7031,9 @@ def is_valid_inferred_type(typ: Type, is_lvalue_final: bool = False) -> bool:
         return is_lvalue_final
     elif isinstance(proper_type, UninhabitedType):
         return False
+    elif mypy.checkexpr.has_erased_component(typ):
+        # This can happen inside a lambda.
+        return False
     return not typ.accept(NothingSeeker())
 
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -178,6 +178,7 @@ from mypy.types import (
     AnyType,
     CallableType,
     DeletedType,
+    ErasedType,
     FunctionLike,
     Instance,
     LiteralType,
@@ -7031,20 +7032,25 @@ def is_valid_inferred_type(typ: Type, is_lvalue_final: bool = False) -> bool:
         return is_lvalue_final
     elif isinstance(proper_type, UninhabitedType):
         return False
-    elif mypy.checkexpr.has_erased_component(typ):
-        # This can happen inside a lambda.
-        return False
-    return not typ.accept(NothingSeeker())
+    return not typ.accept(InvalidInferredTypes())
 
 
-class NothingSeeker(TypeQuery[bool]):
-    """Find any <nothing> types resulting from failed (ambiguous) type inference."""
+class InvalidInferredTypes(TypeQuery[bool]):
+    """Find type components that are not valid for an inferred type.
+
+    These include <Erased> type, and any <nothing> types resulting from failed
+    (ambiguous) type inference.
+    """
 
     def __init__(self) -> None:
         super().__init__(any)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return t.ambiguous
+
+    def visit_erased_type(self, t: ErasedType) -> bool:
+        # This can happen inside a lambda.
+        return True
 
 
 class SetNothingToAny(TypeTranslator):

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6288,6 +6288,8 @@ class C: ...
 [out3]
 
 [case testNoCrashOnPartialLambdaInference]
+import m
+[file m.py]
 from typing import TypeVar, Callable
 
 V = TypeVar("V")
@@ -6296,6 +6298,17 @@ def apply(val: V, func: Callable[[V], None]) -> None:
 
 xs = []
 apply(0, lambda a: xs.append(a))
+[file m.py.2]
+from typing import TypeVar, Callable
+
+V = TypeVar("V")
+def apply(val: V, func: Callable[[V], None]) -> None:
+    return func(val)
+
+xs = []
+apply(0, lambda a: xs.append(a))
+reveal_type(xs)
 [builtins fixtures/list.pyi]
 [out]
 [out2]
+tmp/m.py:9: note: Revealed type is "builtins.list[builtins.int]"

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6286,3 +6286,16 @@ class C: ...
 [out]
 [out2]
 [out3]
+
+[case testNoCrashOnPartialLambdaInference]
+from typing import TypeVar, Callable
+
+V = TypeVar("V")
+def apply(val: V, func: Callable[[V], None]) -> None:
+    return func(val)
+
+xs = []
+apply(0, lambda a: xs.append(a))
+[builtins fixtures/list.pyi]
+[out]
+[out2]


### PR DESCRIPTION
Fixes #9654

Seems to be quite straightforward. Erased types should never be stored on variables, it is just a temporary thing for nested generic calls.