### PR TITLE
Prevent warnings from causing dmypy to fail

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -512,7 +512,8 @@ class Server:
 
             print_memory_profile(run_gc=False)
 
-        status = 1 if messages else 0
+        __, n_notes, __ = count_stats(messages)
+        status = 1 if messages and n_notes < len(messages) else 0
         messages = self.pretty_messages(messages, len(sources), is_tty, terminal_width)
         return {"out": "".join(s + "\n" for s in messages), "err": "", "status": status}
 

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -214,7 +214,7 @@ mypy-daemon: error: Missing target module, package, files, or command.
 $ dmypy stop
 Daemon stopped
 
-[case testDaemonWarningSuccessExitCode]
+[case testDaemonWarningSuccessExitCode-posix]
 $ dmypy run -- foo.py --follow-imports=error
 Daemon started
 foo.py:2: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -214,6 +214,20 @@ mypy-daemon: error: Missing target module, package, files, or command.
 $ dmypy stop
 Daemon stopped
 
+[case testDaemonWarningSuccessExitCode]
+$ dmypy run -- foo.py --follow-imports=error
+Daemon started
+foo.py:2: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs
+Success: no issues found in 1 source file
+$ echo $?
+0
+$ dmypy stop
+Daemon stopped
+[file foo.py]
+def foo():
+    a: int = 1
+    print(a + "2")
+
 -- this is carefully constructed to be able to break if the quickstart system lets
 -- something through incorrectly. in particular, the files need to have the same size
 [case testDaemonQuickstart]


### PR DESCRIPTION
Fixes: #14101

This prevents non-error messages (e.g. warnings) from causing dmypy to return exit code 1.