### PR TITLE
Delete unused symbol node

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -490,43 +490,6 @@ class ImportAll(ImportBase):
         return visitor.visit_import_all(self)
 
 
-class ImportedName(SymbolNode):
-    """Indirect reference to a fullname stored in symbol table.
-
-    This node is not present in the original program as such. This is
-    just a temporary artifact in binding imported names. After semantic
-    analysis pass 2, these references should be replaced with direct
-    reference to a real AST node.
-
-    Note that this is neither a Statement nor an Expression so this
-    can't be visited.
-    """
-
-    __slots__ = ("target_fullname",)
-
-    def __init__(self, target_fullname: str) -> None:
-        super().__init__()
-        self.target_fullname = target_fullname
-
-    @property
-    def name(self) -> str:
-        return self.target_fullname.split(".")[-1]
-
-    @property
-    def fullname(self) -> str:
-        return self.target_fullname
-
-    def serialize(self) -> JsonDict:
-        assert False, "ImportedName leaked from semantic analysis"
-
-    @classmethod
-    def deserialize(cls, data: JsonDict) -> ImportedName:
-        assert False, "ImportedName should never be serialized"
-
-    def __str__(self) -> str:
-        return f"ImportedName({self.target_fullname})"
-
-
 FUNCBASE_FLAGS: Final = ["is_property", "is_class", "is_static", "is_final"]
 
 


### PR DESCRIPTION
IIRC `ImportedName` was used by old semantic analyzer, that is long gone now.

cc @JukkaL 