### PR TITLE
Handle prefix/suffix in typevartuple *args support

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -11,6 +11,7 @@ from mypy.types import (
     Parameters,
     ParamSpecType,
     PartialType,
+    TupleType,
     Type,
     TypeVarId,
     TypeVarLikeType,
@@ -19,6 +20,7 @@ from mypy.types import (
     UnpackType,
     get_proper_type,
 )
+from mypy.typevartuples import find_unpack_in_list, replace_starargs
 
 
 def get_target_type(
@@ -114,39 +116,58 @@ def apply_generic_arguments(
     # Apply arguments to argument types.
     var_arg = callable.var_arg()
     if var_arg is not None and isinstance(var_arg.typ, UnpackType):
-        expanded = expand_unpack_with_variables(var_arg.typ, id_to_type)
-        assert isinstance(expanded, list)
-        # Handle other cases later.
-        for t in expanded:
-            assert not isinstance(t, UnpackType)
         star_index = callable.arg_kinds.index(ARG_STAR)
-        arg_kinds = (
-            callable.arg_kinds[:star_index]
-            + [ARG_POS] * len(expanded)
-            + callable.arg_kinds[star_index + 1 :]
+        callable = callable.copy_modified(
+            arg_types=(
+                [
+                    expand_type(at, id_to_type, allow_erased_callables)
+                    for at in callable.arg_types[:star_index]
+                ]
+                + [callable.arg_types[star_index]]
+                + [
+                    expand_type(at, id_to_type, allow_erased_callables)
+                    for at in callable.arg_types[star_index + 1 :]
+                ]
+            )
         )
-        arg_names = (
-            callable.arg_names[:star_index]
-            + [None] * len(expanded)
-            + callable.arg_names[star_index + 1 :]
-        )
-        arg_types = (
-            [
-                expand_type(at, id_to_type, allow_erased_callables)
-                for at in callable.arg_types[:star_index]
-            ]
-            + expanded
-            + [
-                expand_type(at, id_to_type, allow_erased_callables)
-                for at in callable.arg_types[star_index + 1 :]
-            ]
-        )
+
+        unpacked_type = get_proper_type(var_arg.typ.type)
+        if isinstance(unpacked_type, TupleType):
+            # Assuming for now that because we convert prefixes to positional arguments,
+            # the first argument is always an unpack.
+            expanded_tuple = expand_type(unpacked_type, id_to_type)
+            if isinstance(expanded_tuple, TupleType):
+                # TODO: handle the case where the tuple has an unpack. This will
+                # hit an assert below.
+                expanded_unpack = find_unpack_in_list(expanded_tuple.items)
+                if expanded_unpack is not None:
+                    callable = callable.copy_modified(
+                        arg_types=(
+                            callable.arg_types[:star_index]
+                            + [expanded_tuple]
+                            + callable.arg_types[star_index + 1 :]
+                        )
+                    )
+                else:
+                    expanded = expanded_tuple.items
+                    callable = replace_starargs(callable, expanded_tuple.items)
+            else:
+                # TODO: handle the case for if we get a variable length tuple.
+                assert False, f"mypy bug: unimplemented case, {expanded_tuple}"
+        elif isinstance(unpacked_type, TypeVarTupleType):
+            expanded_tvt = expand_unpack_with_variables(var_arg.typ, id_to_type)
+            assert isinstance(expanded_tvt, list)
+            for t in expanded_tvt:
+                assert not isinstance(t, UnpackType)
+            callable = replace_starargs(callable, expanded_tvt)
+        else:
+            assert False, "mypy bug: unhandled case applying unpack"
     else:
-        arg_types = [
-            expand_type(at, id_to_type, allow_erased_callables) for at in callable.arg_types
-        ]
-        arg_kinds = callable.arg_kinds
-        arg_names = callable.arg_names
+        callable = callable.copy_modified(
+            arg_types=[
+                expand_type(at, id_to_type, allow_erased_callables) for at in callable.arg_types
+            ]
+        )
 
     # Apply arguments to TypeGuard if any.
     if callable.type_guard is not None:
@@ -158,10 +179,7 @@ def apply_generic_arguments(
     remaining_tvars = [tv for tv in tvars if tv.id not in id_to_type]
 
     return callable.copy_modified(
-        arg_types=arg_types,
         ret_type=expand_type(callable.ret_type, id_to_type, allow_erased_callables),
         variables=remaining_tvars,
         type_guard=type_guard,
-        arg_kinds=arg_kinds,
-        arg_names=arg_names,
     )

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -4,7 +4,7 @@ from typing import Callable, Sequence
 
 import mypy.subtypes
 from mypy.expandtype import expand_type, expand_unpack_with_variables
-from mypy.nodes import ARG_POS, ARG_STAR, Context
+from mypy.nodes import ARG_STAR, Context
 from mypy.types import (
     AnyType,
     CallableType,
@@ -149,7 +149,6 @@ def apply_generic_arguments(
                         )
                     )
                 else:
-                    expanded = expanded_tuple.items
                     callable = replace_starargs(callable, expanded_tuple.items)
             else:
                 # TODO: handle the case for if we get a variable length tuple.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1178,12 +1178,17 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         if isinstance(arg_type, ParamSpecType):
                             pass
                         elif isinstance(arg_type, UnpackType):
-                            arg_type = TupleType(
-                                [arg_type],
-                                fallback=self.named_generic_type(
-                                    "builtins.tuple", [self.named_type("builtins.object")]
-                                ),
-                            )
+                            if isinstance(get_proper_type(arg_type.type), TupleType):
+                                # Instead of using Tuple[Unpack[Tuple[...]]], just use
+                                # Tuple[...]
+                                arg_type = arg_type.type
+                            else:
+                                arg_type = TupleType(
+                                    [arg_type],
+                                    fallback=self.named_generic_type(
+                                        "builtins.tuple", [self.named_type("builtins.object")]
+                                    ),
+                                )
                         else:
                             # builtins.tuple[T] is typing.Tuple[T, ...]
                             arg_type = self.named_generic_type("builtins.tuple", [arg_type])

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Iterable, Mapping, Sequence, TypeVar, cast, overload
 
-from mypy.nodes import ARG_STAR, Var
+from mypy.nodes import ARG_POS, ARG_STAR, Var
 from mypy.type_visitor import TypeTranslator
 from mypy.types import (
     AnyType,
@@ -36,7 +36,11 @@ from mypy.types import (
     UnpackType,
     get_proper_type,
 )
-from mypy.typevartuples import split_with_instance, split_with_prefix_and_suffix
+from mypy.typevartuples import (
+    find_unpack_in_list,
+    split_with_instance,
+    split_with_prefix_and_suffix,
+)
 
 
 @overload
@@ -282,21 +286,84 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
 
         var_arg = t.var_arg()
         if var_arg is not None and isinstance(var_arg.typ, UnpackType):
-            expanded = self.expand_unpack(var_arg.typ)
-            # Handle other cases later.
-            assert isinstance(expanded, list)
-            assert len(expanded) == 1 and isinstance(expanded[0], UnpackType)
             star_index = t.arg_kinds.index(ARG_STAR)
-            arg_types = (
-                self.expand_types(t.arg_types[:star_index])
-                + expanded
-                + self.expand_types(t.arg_types[star_index + 1 :])
-            )
+
+            # We have something like Unpack[Tuple[X1, X2, Unpack[Ts], Y1, Y2]]
+            if isinstance(get_proper_type(var_arg.typ.type), TupleType):
+                expanded_tuple = get_proper_type(var_arg.typ.type.accept(self))
+                # TODO: handle the case that expanded_tuple is a variable length tuple.
+                assert isinstance(expanded_tuple, TupleType)
+                expanded_unpack_index = find_unpack_in_list(expanded_tuple.items)
+                # This is the case where we just have Unpack[Tuple[X1, X2, X3]]
+                # (for example if either the tuple had no unpacks, or the unpack in the
+                # tuple got fully expanded to something with fixed length)
+                if expanded_unpack_index is None:
+                    arg_names = (
+                        t.arg_names[:star_index]
+                        + [None] * len(expanded_tuple.items)
+                        + t.arg_names[star_index + 1 :]
+                    )
+                    arg_kinds = (
+                        t.arg_kinds[:star_index]
+                        + [ARG_POS] * len(expanded_tuple.items)
+                        + t.arg_kinds[star_index + 1 :]
+                    )
+                    arg_types = (
+                        self.expand_types(t.arg_types[:star_index])
+                        + expanded_tuple.items
+                        + self.expand_types(t.arg_types[star_index + 1 :])
+                    )
+                else:
+                    # If Unpack[Ts] simplest form still has an unpack or is a
+                    # homogenous tuple, then only the prefix can be represented as
+                    # positional arguments, and we pass Tuple[Unpack[Ts-1], Y1, Y2]
+                    # as the star arg, for example.
+                    expanded_unpack = expanded_tuple.items[expanded_unpack_index]
+                    prefix_len = expanded_unpack_index
+                    arg_names = (
+                        t.arg_names[:star_index] + [None] * prefix_len + t.arg_names[star_index:]
+                    )
+                    arg_kinds = (
+                        t.arg_kinds[:star_index]
+                        + [ARG_POS] * prefix_len
+                        + t.arg_kinds[star_index:]
+                    )
+                    arg_types = (
+                        self.expand_types(t.arg_types[:star_index])
+                        + expanded_tuple.items[:prefix_len]
+                        # Constructing the Unpack containing the tuple without the prefix.
+                        + [
+                            UnpackType(
+                                expanded_tuple.copy_modified(
+                                    items=expanded_tuple.items[prefix_len:]
+                                )
+                            )
+                        ]
+                        + self.expand_types(t.arg_types[star_index + 1 :])
+                    )
+            else:
+                expanded = self.expand_unpack(var_arg.typ)
+                # Handle other cases later.
+                assert isinstance(expanded, list)
+                assert len(expanded) == 1 and isinstance(expanded[0], UnpackType)
+
+                # In this case we keep the arg as ARG_STAR.
+                arg_names = t.arg_names
+                arg_kinds = t.arg_kinds
+                arg_types = (
+                    self.expand_types(t.arg_types[:star_index])
+                    + expanded
+                    + self.expand_types(t.arg_types[star_index + 1 :])
+                )
         else:
             arg_types = self.expand_types(t.arg_types)
+            arg_names = t.arg_names
+            arg_kinds = t.arg_kinds
 
         return t.copy_modified(
             arg_types=arg_types,
+            arg_names=arg_names,
+            arg_kinds=arg_kinds,
             ret_type=t.ret_type.accept(self),
             type_guard=(t.type_guard.accept(self) if t.type_guard is not None else None),
         )

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -318,7 +318,6 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
                     # homogenous tuple, then only the prefix can be represented as
                     # positional arguments, and we pass Tuple[Unpack[Ts-1], Y1, Y2]
                     # as the star arg, for example.
-                    expanded_unpack = expanded_tuple.items[expanded_unpack_index]
                     prefix_len = expanded_unpack_index
                     arg_names = (
                         t.arg_names[:star_index] + [None] * prefix_len + t.arg_names[star_index:]

--- a/mypy/typevartuples.py
+++ b/mypy/typevartuples.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Sequence, TypeVar
 
-from mypy.types import Instance, ProperType, Type, UnpackType, get_proper_type
+from mypy.nodes import ARG_POS, ARG_STAR
+from mypy.types import CallableType, Instance, ProperType, Type, UnpackType, get_proper_type
 
 
 def find_unpack_in_list(items: Sequence[Type]) -> int | None:
@@ -150,3 +151,20 @@ def extract_unpack(types: Sequence[Type]) -> ProperType | None:
         if isinstance(proper_type, UnpackType):
             return get_proper_type(proper_type.type)
     return None
+
+
+def replace_starargs(callable: CallableType, types: list[Type]) -> CallableType:
+    star_index = callable.arg_kinds.index(ARG_STAR)
+    arg_kinds = (
+        callable.arg_kinds[:star_index]
+        + [ARG_POS] * len(types)
+        + callable.arg_kinds[star_index + 1 :]
+    )
+    arg_names = (
+        callable.arg_names[:star_index]
+        + [None] * len(types)
+        + callable.arg_names[star_index + 1 :]
+    )
+    arg_types = callable.arg_types[:star_index] + types + callable.arg_types[star_index + 1 :]
+
+    return callable.copy_modified(arg_types=arg_types, arg_names=arg_names, arg_kinds=arg_kinds)

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -381,4 +381,37 @@ def args_to_tuple(*args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
 
 reveal_type(args_to_tuple(1, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, Literal['a']?]"
 
+def with_prefix_suffix(*args: Unpack[Tuple[bool, str, Unpack[Ts], int]]) -> Tuple[bool, str, Unpack[Ts], int]:
+    reveal_type(args)  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Unpack[Ts`-1], builtins.int]"
+    return args
+
+reveal_type(with_prefix_suffix(True, "bar", "foo", 5))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Literal['foo']?, builtins.int]"
+reveal_type(with_prefix_suffix(True, "bar", 5))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, builtins.int]"
+
+with_prefix_suffix(True, "bar", "foo", 1.0)  # E: Argument 4 to "with_prefix_suffix" has incompatible type "float"; expected "int"
+with_prefix_suffix(True, "bar")  # E: Too few arguments for "with_prefix_suffix"
+
+t = (True, "bar", "foo", 5)
+reveal_type(with_prefix_suffix(*t))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, builtins.str, builtins.int]"
+reveal_type(with_prefix_suffix(True, *("bar", "foo"), 5))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Literal['foo']?, builtins.int]"
+
+# TODO: handle list case
+#reveal_type(with_prefix_suffix(True, "bar", *["foo1", "foo2"], 5))
+
+bad_t = (True, "bar")
+with_prefix_suffix(*bad_t)  # E: Too few arguments for "with_prefix_suffix"
+
+def foo(*args: Unpack[Ts]) -> None:
+    reveal_type(with_prefix_suffix(True, "bar", *args, 5))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Unpack[Ts`-1], builtins.int]"
+
+def concrete(*args: Unpack[Tuple[int, str]]) -> None:
+    reveal_type(args)  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
+
+concrete(0, "foo")
+concrete(0, 1)  # E: Argument 2 to "concrete" has incompatible type "int"; expected "Unpack[Tuple[int, str]]"
+concrete("foo", "bar")  # E: Argument 1 to "concrete" has incompatible type "str"; expected "Unpack[Tuple[int, str]]"
+concrete(0, "foo", 1)  # E: Invalid number of arguments
+concrete(0)  # E: Invalid number of arguments
+concrete()  # E: Invalid number of arguments
+
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
This requires handling more cases in the various places that we previously modified to support *args in general. We also need to refresh the formals-to-actuals twice in checkexpr as now it can happen in the infer_function_type_arguments_using_context call.

The handling here is kind of asymmetric, because we can convert prefices into positional arguments, but there is no equivalent for suffices, so we represent that as a Tuple[Unpack[...], <suffix>] and handle that case separately in some spots.

We also support various edge cases like passing in a tuple without any typevartuples involved.