### PR TITLE
Correctly support self types in callable ClassVar

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3236,12 +3236,11 @@ def replace_alias_tvars(
 
 
 class HasTypeVars(TypeQuery[bool]):
-    def __init__(self, exclude: TypeVarId | None = None) -> None:
+    def __init__(self) -> None:
         super().__init__(any)
-        self.exclude = exclude
 
     def visit_type_var(self, t: TypeVarType) -> bool:
-        return t.id != self.exclude
+        return True
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> bool:
         return True
@@ -3250,9 +3249,9 @@ class HasTypeVars(TypeQuery[bool]):
         return True
 
 
-def has_type_vars(typ: Type, exclude: TypeVarId | None = None) -> bool:
+def has_type_vars(typ: Type) -> bool:
     """Check if a type contains any type variables (recursively)."""
-    return typ.accept(HasTypeVars(exclude))
+    return typ.accept(HasTypeVars())
 
 
 class HasRecursiveType(TypeQuery[bool]):

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -1750,3 +1750,25 @@ from typing import Self, final
 class C:
     def meth(self) -> Self:
         return C()  # OK for final classes
+
+[case testTypingSelfCallableClassVar]
+from typing import Self, ClassVar, Callable, TypeVar
+
+class C:
+    f: ClassVar[Callable[[Self], Self]]
+class D(C): ...
+
+reveal_type(D.f)  # N: Revealed type is "def (__main__.D) -> __main__.D"
+reveal_type(D().f)  # N: Revealed type is "def () -> __main__.D"
+
+[case testSelfTypeCallableClassVarOldStyle]
+from typing import ClassVar, Callable, TypeVar
+
+T = TypeVar("T")
+class C:
+    f: ClassVar[Callable[[T], T]]
+
+class D(C): ...
+
+reveal_type(D.f)  # N: Revealed type is "def [T] (T`-1) -> T`-1"
+reveal_type(D().f)  # N: Revealed type is "def () -> __main__.D"


### PR DESCRIPTION
Fixes #14108 

This fixes both new and old style of working with self types. After all I fixed the new style by simply expanding self type, then `bind_self()` does its job, so effect on the instance will be the same.

I had two options fixing this, other one (that I didn't go with) is making the callable generic in new style, if it appears in `ClassVar`. This however has two downsides: implementation is tricky, and this adds and edge case to an existing edge case. So instead I choose internal consistency within the new style, rather than similarity between old and new style.