### PR TITLE
Fix crash during ParamSpec inference

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1404,6 +1404,18 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             )
             callee = freshen_function_type_vars(callee)
             callee = self.infer_function_type_arguments_using_context(callee, context)
+            if need_refresh:
+                # Argument kinds etc. may have changed due to
+                # ParamSpec variables being replaced with an arbitrary
+                # number of arguments; recalculate actual-to-formal map
+                formal_to_actual = map_actuals_to_formals(
+                    arg_kinds,
+                    arg_names,
+                    callee.arg_kinds,
+                    callee.arg_names,
+                    lambda i: self.accept(args[i]),
+                )
+
             callee = self.infer_function_type_arguments(
                 callee, args, arg_kinds, formal_to_actual, context
             )

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1281,3 +1281,18 @@ class Some(Generic[P]):
 # TODO: this probably should be reported.
 def call(*args: P.args, **kwargs: P.kwargs): ...
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecInferenceCrash]
+from typing import Callable, Generic, ParamSpec, TypeVar
+
+def foo(x: int) -> int: ...
+T = TypeVar("T")
+def bar(x: T) -> T: ...
+
+P = ParamSpec("P")
+
+class C(Generic[P]):
+    def __init__(self, fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs): ...
+
+reveal_type(bar(C(fn=foo, x=1)))  # N: Revealed type is "__main__.C[[x: builtins.int]]"
+[builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
Fixes #13903 

The fix is straightforward, the formal to actual map needs to be refreshed twice, after both using external _and_ internal type context.