### PR TITLE
Correctly handle Enum name on Python 3.11

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1448,7 +1448,13 @@ class SemanticAnalyzer(
                 dec.var.is_classmethod = True
                 self.check_decorated_function_is_method("classmethod", dec)
             elif refers_to_fullname(
-                d, ("builtins.property", "abc.abstractproperty", "functools.cached_property")
+                d,
+                (
+                    "builtins.property",
+                    "abc.abstractproperty",
+                    "functools.cached_property",
+                    "enum.property",
+                ),
             ):
                 removed.append(i)
                 dec.func.is_property = True

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1712,3 +1712,20 @@ A = Type[int] | str
 B: TypeAlias = Type[int] | str
 [out]
 m.pyi:5: note: Revealed type is "typing._SpecialForm"
+
+[case testEnumNameWorkCorrectlyOn311]
+# flags: --python-version 3.11
+from enum import Enum
+
+class E(Enum):
+    X = 1
+    Y = 2
+
+e: E
+reveal_type(e.name)
+reveal_type(e.value)
+reveal_type(E.X.name)
+[out]
+_testEnumNameWorkCorrectlyOn311.py:9: note: Revealed type is "builtins.str"
+_testEnumNameWorkCorrectlyOn311.py:10: note: Revealed type is "Union[Literal[1]?, Literal[2]?]"
+_testEnumNameWorkCorrectlyOn311.py:11: note: Revealed type is "Literal['X']?"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1730,8 +1730,8 @@ reveal_type(E.X.name)
 reveal_type(e.foo)
 reveal_type(E.Y.foo)
 [out]
-_testEnumNameWorkCorrectlyOn311.py:9: note: Revealed type is "builtins.str"
-_testEnumNameWorkCorrectlyOn311.py:10: note: Revealed type is "Union[Literal[1]?, Literal[2]?]"
-_testEnumNameWorkCorrectlyOn311.py:11: note: Revealed type is "Literal['X']?"
+_testEnumNameWorkCorrectlyOn311.py:11: note: Revealed type is "builtins.str"
+_testEnumNameWorkCorrectlyOn311.py:12: note: Revealed type is "Union[Literal[1]?, Literal[2]?]"
+_testEnumNameWorkCorrectlyOn311.py:13: note: Revealed type is "Literal['X']?"
 _testEnumNameWorkCorrectlyOn311.py:14: note: Revealed type is "builtins.int"
 _testEnumNameWorkCorrectlyOn311.py:15: note: Revealed type is "builtins.int"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1715,17 +1715,23 @@ m.pyi:5: note: Revealed type is "typing._SpecialForm"
 
 [case testEnumNameWorkCorrectlyOn311]
 # flags: --python-version 3.11
-from enum import Enum
+import enum
 
-class E(Enum):
+class E(enum.Enum):
     X = 1
     Y = 2
+    @enum.property
+    def foo(self) -> int: ...
 
 e: E
 reveal_type(e.name)
 reveal_type(e.value)
 reveal_type(E.X.name)
+reveal_type(e.foo)
+reveal_type(E.Y.foo)
 [out]
 _testEnumNameWorkCorrectlyOn311.py:9: note: Revealed type is "builtins.str"
 _testEnumNameWorkCorrectlyOn311.py:10: note: Revealed type is "Union[Literal[1]?, Literal[2]?]"
 _testEnumNameWorkCorrectlyOn311.py:11: note: Revealed type is "Literal['X']?"
+_testEnumNameWorkCorrectlyOn311.py:14: note: Revealed type is "builtins.int"
+_testEnumNameWorkCorrectlyOn311.py:15: note: Revealed type is "builtins.int"


### PR DESCRIPTION
Fixes #12483
Fixes https://github.com/python/typeshed/issues/7564
Ref #12841

The fix is straightforward. I can't use a unit test for this because there are some builtins fixtures that don't have tuple, so I can't do version check.