### PR TITLE
Allow function arguments as base classes

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -354,7 +354,7 @@ def _verify_final(
 ) -> Iterator[Error]:
     try:
 
-        class SubClass(runtime):
+        class SubClass(runtime):  # type: ignore[misc]
             pass
 
     except TypeError:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -354,7 +354,7 @@ def _verify_final(
 ) -> Iterator[Error]:
     try:
 
-        class SubClass(runtime):  # type: ignore[misc,valid-type]
+        class SubClass(runtime):
             pass
 
     except TypeError:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -550,7 +550,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return new
 
     def visit_assignment_expr(self, node: AssignmentExpr) -> AssignmentExpr:
-        return AssignmentExpr(node.target, node.value)
+        return AssignmentExpr(self.expr(node.target), self.expr(node.value))
 
     def visit_unary_expr(self, node: UnaryExpr) -> UnaryExpr:
         new = UnaryExpr(node.op, self.expr(node.expr))

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -201,6 +201,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         allow_param_spec_literals: bool = False,
         report_invalid_types: bool = True,
         prohibit_self_type: str | None = None,
+        allow_type_any: bool = False,
     ) -> None:
         self.api = api
         self.lookup_qualified = api.lookup_qualified
@@ -237,6 +238,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # Names of type aliases encountered while analysing a type will be collected here.
         self.aliases_used: set[str] = set()
         self.prohibit_self_type = prohibit_self_type
+        # Allow variables typed as Type[Any] and type (useful for base classes).
+        self.allow_type_any = allow_type_any
 
     def visit_unbound_type(self, t: UnboundType, defining_literal: bool = False) -> Type:
         typ = self.visit_unbound_type_nonoptional(t, defining_literal)
@@ -730,6 +733,11 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 return AnyType(
                     TypeOfAny.from_unimported_type, missing_import_name=typ.missing_import_name
                 )
+            elif self.allow_type_any:
+                if isinstance(typ, Instance) and typ.type.fullname == "builtins.type":
+                    return AnyType(TypeOfAny.special_form)
+                if isinstance(typ, TypeType) and isinstance(typ.item, AnyType):
+                    return AnyType(TypeOfAny.from_another_any, source_any=typ.item)
         # Option 2:
         # Unbound type variable. Currently these may be still valid,
         # for example when defining a generic type alias.

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ClassVar,
     Dict,
     Iterable,
@@ -29,6 +30,7 @@ from mypy.nodes import (
     ArgKind,
     FakeInfo,
     FuncDef,
+    FuncItem,
     SymbolNode,
 )
 from mypy.state import state
@@ -3390,3 +3392,29 @@ def callable_with_ellipsis(any_type: AnyType, ret_type: Type, fallback: Instance
         fallback=fallback,
         is_ellipsis_args=True,
     )
+
+
+def store_argument_type(
+    defn: FuncItem, i: int, typ: CallableType, named_type: Callable[[str, list[Type]], Instance]
+) -> None:
+    arg_type = typ.arg_types[i]
+    if typ.arg_kinds[i] == ARG_STAR:
+        if isinstance(arg_type, ParamSpecType):
+            pass
+        elif isinstance(arg_type, UnpackType):
+            if isinstance(get_proper_type(arg_type.type), TupleType):
+                # Instead of using Tuple[Unpack[Tuple[...]]], just use
+                # Tuple[...]
+                arg_type = arg_type.type
+            else:
+                arg_type = TupleType(
+                    [arg_type],
+                    fallback=named_type("builtins.tuple", [named_type("builtins.object", [])]),
+                )
+        else:
+            # builtins.tuple[T] is typing.Tuple[T, ...]
+            arg_type = named_type("builtins.tuple", [arg_type])
+    elif typ.arg_kinds[i] == ARG_STAR2:
+        if not isinstance(arg_type, ParamSpecType) and not typ.unpack_kwargs:
+            arg_type = named_type("builtins.dict", [named_type("builtins.str", []), arg_type])
+    defn.arguments[i].variable.type = arg_type

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7664,3 +7664,15 @@ class C(B):
     def foo(self) -> int:  # E: Signature of "foo" incompatible with supertype "B"
         ...
 [builtins fixtures/property.pyi]
+
+[case testAllowArgumentAsBaseClass]
+from typing import Any, Type
+
+def f(b: Any) -> None:
+    class D(b): ...
+
+def g(b: Type[Any]) -> None:
+    class D(b): ...
+
+def h(b: type) -> None:
+    class D(b): ...

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7668,6 +7668,9 @@ class C(B):
 [case testAllowArgumentAsBaseClass]
 from typing import Any, Type
 
+def e(b) -> None:
+    class D(b): ...
+
 def f(b: Any) -> None:
     class D(b): ...
 

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -718,3 +718,19 @@ def f1() -> None:
         y = x
     z = x
 [builtins fixtures/dict.pyi]
+
+[case testNarrowOnSelfInGeneric]
+# flags: --strict-optional
+from typing import Generic, TypeVar, Optional
+
+T = TypeVar("T", int, str)
+
+class C(Generic[T]):
+    x: Optional[T]
+    def meth(self) -> Optional[T]:
+        if (y := self.x) is not None:
+            reveal_type(y)
+        return None
+[out]
+main:10: note: Revealed type is "builtins.int"
+main:10: note: Revealed type is "builtins.str"

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -1772,3 +1772,16 @@ class D(C): ...
 
 reveal_type(D.f)  # N: Revealed type is "def [T] (T`-1) -> T`-1"
 reveal_type(D().f)  # N: Revealed type is "def () -> __main__.D"
+
+[case testTypingSelfOnSuperTypeVarValues]
+from typing import Self, Generic, TypeVar
+
+T = TypeVar("T", int, str)
+
+class B:
+    def copy(self) -> Self: ...
+class C(B, Generic[T]):
+    def copy(self) -> Self:
+        inst = super().copy()
+        reveal_type(inst)  # N: Revealed type is "Self`0"
+        return inst

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -790,6 +790,7 @@ def f(x: int) -> None: pass
 def f(*args) -> None: pass
 
 x = f
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   ImportFrom:1(typing, [overload])
@@ -1032,6 +1033,7 @@ MypyFile:1(
 
 [case testVarArgsAndKeywordArgs]
 def g(*x: int, y: str = ''): pass
+[builtins fixtures/tuple.pyi]
 [out]
 MypyFile:1(
   FuncDef:1(


### PR DESCRIPTION
Fixes #5865 

Looks quite easy and safe, unless I am missing something. Most changes in the diff are just moving stuff around.

Previously we only applied argument types before type checking, but it looks like we can totally do this in semantic analyzer. I also enable variable annotated as `type` (or equivalently `Type[Any]`), this use case was mentioned in the comments.

This PR also accidentally fixes two additional bugs, one related to type variables with values vs walrus operator, another one for type variables with values vs self types. I include test cases for those as well.