### PR TITLE
Don't type check most function bodies if ignoring errors

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -842,9 +842,9 @@ class BuildManager:
         Raise CompileError if there is a parse error.
         """
         t0 = time.time()
-        #if ignore_errors:
-        #    print('ignore_errors', path)
-        #    self.errors.ignored_files.add(path)
+        if ignore_errors:
+            #print('ignore_errors', path)
+            self.errors.ignored_files.add(path)
         tree = parse(source, path, id, self.errors, options=options)
         tree._fullname = id
         self.add_stats(

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -843,7 +843,6 @@ class BuildManager:
         """
         t0 = time.time()
         if ignore_errors:
-            #print('ignore_errors', path)
             self.errors.ignored_files.add(path)
         tree = parse(source, path, id, self.errors, options=options)
         tree._fullname = id

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -842,6 +842,9 @@ class BuildManager:
         Raise CompileError if there is a parse error.
         """
         t0 = time.time()
+        #if ignore_errors:
+        #    print('ignore_errors', path)
+        #    self.errors.ignored_files.add(path)
         tree = parse(source, path, id, self.errors, options=options)
         tree._fullname = id
         self.add_stats(

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -529,10 +529,7 @@ def split_directive(s: str) -> tuple[list[str], list[str]]:
 
 
 def mypy_comments_to_config_map(line: str, template: Options) -> tuple[dict[str, str], list[str]]:
-    """Rewrite the mypy comment syntax into ini file syntax.
-
-    Returns
-    """
+    """Rewrite the mypy comment syntax into ini file syntax."""
     options = {}
     entries, errors = split_directive(line)
     for entry in entries:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -2133,7 +2133,6 @@ class FindAttributeAssign(TraverserVisitor):
         pass
 
     def visit_member_expr(self, e: MemberExpr) -> None:
-        print(e, self.lvalue)
         if self.lvalue:
             self.found = True
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -262,11 +262,9 @@ def parse(
     Return the parse tree. If errors is not provided, raise ParseError
     on failure. Otherwise, use the errors object to report parse errors.
     """
-    if int():
-        1 + ''
-    ignore_errors = options.ignore_errors or (errors and fnam in errors.ignored_files)
-    if ignore_errors:
-        print(fnam, fnam in errors.ignored_files, len(errors.ignored_files))
+    ignore_errors = (options is not None and options.ignore_errors) or (errors is not None and fnam in errors.ignored_files)
+    #if ignore_errors:
+    #    print(fnam, fnam in errors.ignored_files, len(errors.ignored_files))
     raise_on_error = False
     if options is None:
         options = Options()
@@ -288,7 +286,8 @@ def parse(
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             ast = ast3_parse(source, fnam, "exec", feature_version=feature_version)
 
-        tree = ASTConverter(options=options, is_stub=is_stub_file, errors=errors, ignore_errors=ignore_errors).visit(ast)
+        tree = ASTConverter(options=options, is_stub=is_stub_file, errors=errors,
+                            ignore_errors=ignore_errors).visit(ast)
         tree.path = fnam
         tree.is_stub = is_stub_file
     except SyntaxError as e:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -263,8 +263,6 @@ def parse(
     on failure. Otherwise, use the errors object to report parse errors.
     """
     ignore_errors = (options is not None and options.ignore_errors) or (errors is not None and fnam in errors.ignored_files)
-    #if ignore_errors:
-    #    print(fnam, fnam in errors.ignored_files, len(errors.ignored_files))
     raise_on_error = False
     if options is None:
         options = Options()

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -262,7 +262,9 @@ def parse(
     Return the parse tree. If errors is not provided, raise ParseError
     on failure. Otherwise, use the errors object to report parse errors.
     """
-    ignore_errors = (options is not None and options.ignore_errors) or (errors is not None and fnam in errors.ignored_files)
+    ignore_errors = (options is not None and options.ignore_errors) or (
+        errors is not None and fnam in errors.ignored_files
+    )
     raise_on_error = False
     if options is None:
         options = Options()
@@ -284,8 +286,9 @@ def parse(
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             ast = ast3_parse(source, fnam, "exec", feature_version=feature_version)
 
-        tree = ASTConverter(options=options, is_stub=is_stub_file, errors=errors,
-                            ignore_errors=ignore_errors).visit(ast)
+        tree = ASTConverter(
+            options=options, is_stub=is_stub_file, errors=errors, ignore_errors=ignore_errors
+        ).visit(ast)
         tree.path = fnam
         tree.is_stub = is_stub_file
     except SyntaxError as e:
@@ -405,7 +408,9 @@ def is_no_type_check_decorator(expr: ast3.expr) -> bool:
 
 
 class ASTConverter:
-    def __init__(self, options: Options, is_stub: bool, errors: Errors, ignore_errors: bool) -> None:
+    def __init__(
+        self, options: Options, is_stub: bool, errors: Errors, ignore_errors: bool
+    ) -> None:
         # 'C' for class, 'F' for function, 'L' for lambda
         self.class_and_function_stack: list[Literal["C", "F", "L"]] = []
         self.imports: list[ImportBase] = []
@@ -481,7 +486,7 @@ class ASTConverter:
         return node.lineno
 
     def translate_stmt_list(
-            self, stmts: Sequence[ast3.stmt], *, ismodule: bool = False, can_strip: bool = False
+        self, stmts: Sequence[ast3.stmt], *, ismodule: bool = False, can_strip: bool = False
     ) -> list[Statement]:
         # A "# type: ignore" comment before the first statement of a module
         # ignores the whole module:
@@ -517,7 +522,13 @@ class ASTConverter:
             node = self.visit(stmt)
             res.append(node)
 
-        if (self.ignore_errors and can_strip and len(stack) == 2 and stack[-2:] == ["C", "F"] and not is_possible_trivial_body(res)):
+        if (
+            self.ignore_errors
+            and can_strip
+            and len(stack) == 2
+            and stack[-2:] == ["C", "F"]
+            and not is_possible_trivial_body(res)
+        ):
             v = FindAttributeAssign()
             for n in res:
                 n.accept(v)
@@ -589,9 +600,13 @@ class ASTConverter:
             b.set_line(lineno)
         return b
 
-    def as_required_block(self, stmts: list[ast3.stmt], lineno: int, *, can_strip: bool = False) -> Block:
+    def as_required_block(
+        self, stmts: list[ast3.stmt], lineno: int, *, can_strip: bool = False
+    ) -> Block:
         assert stmts  # must be non-empty
-        b = Block(self.fix_function_overloads(self.translate_stmt_list(stmts, can_strip=can_strip)))
+        b = Block(
+            self.fix_function_overloads(self.translate_stmt_list(stmts, can_strip=can_strip))
+        )
         # TODO: in most call sites line is wrong (includes first line of enclosing statement)
         # TODO: also we need to set the column, and the end position here.
         b.set_line(lineno)
@@ -2153,5 +2168,6 @@ def is_possible_trivial_body(s: list[Statement]) -> bool:
     if l > i + 1:
         return False
     stmt = s[i]
-    return isinstance(stmt, (PassStmt, RaiseStmt)) or (isinstance(stmt, ExpressionStmt) and
-                                          isinstance(stmt.expr, EllipsisExpr))
+    return isinstance(stmt, (PassStmt, RaiseStmt)) or (
+        isinstance(stmt, ExpressionStmt) and isinstance(stmt.expr, EllipsisExpr)
+    )

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -2109,6 +2109,8 @@ def stringify_name(n: AST) -> str | None:
 
 
 class FindAttributeAssign(TraverserVisitor):
+    """Check if an AST contains attribute assignments (e.g. self.x = 0)."""
+
     def __init__(self) -> None:
         self.lvalue = False
         self.found = False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6391,7 +6391,7 @@ def is_trivial_body(block: Block) -> bool:
     "..." (ellipsis), or "raise NotImplementedError()". A trivial body may also
     start with a statement containing just a string (e.g. a docstring).
 
-    Note: functions that raise other kinds of exceptions do not count as
+    Note: Functions that raise other kinds of exceptions do not count as
     "trivial". We use this function to help us determine when it's ok to
     relax certain checks on body, but functions that raise arbitrary exceptions
     are more likely to do non-trivial work. For example:
@@ -6401,11 +6401,18 @@ def is_trivial_body(block: Block) -> bool:
 
     A function that raises just NotImplementedError is much less likely to be
     this complex.
+
+    Note: If you update this, you may also need to update
+    mypy.fastparse.is_possible_trivial_body!
     """
     body = block.body
+    if not body:
+        # Functions have empty bodies only if the body is stripped or the function is
+        # generated or deserialized. In these cases the body is unknown.
+        return False
 
     # Skip a docstring
-    if body and isinstance(body[0], ExpressionStmt) and isinstance(body[0].expr, StrExpr):
+    if isinstance(body[0], ExpressionStmt) and isinstance(body[0].expr, StrExpr):
         body = block.body[1:]
 
     if len(body) == 0:

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1568,6 +1568,7 @@ def mypy_options(stubgen_options: Options) -> MypyOptions:
     options.python_version = stubgen_options.pyversion
     options.show_traceback = True
     options.transform_source = remove_misplaced_type_comments
+    options.preserve_asts = True
     return options
 
 

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -7,13 +7,13 @@ import sys
 from pytest import skip
 
 from mypy import defaults
+from mypy.config_parser import parse_mypy_comments
 from mypy.errors import CompileError
 from mypy.options import Options
 from mypy.parse import parse
-from mypy.util import get_mypy_comments
-from mypy.config_parser import parse_mypy_comments
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal, find_test_files, parse_options
+from mypy.util import get_mypy_comments
 
 
 class ParserSuite(DataSuite):

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -50,11 +50,7 @@ def test_parser(testcase: DataDrivenTestCase) -> None:
 
     try:
         n = parse(
-            bytes(source, "ascii"),
-            fnam="main",
-            module="__main__",
-            errors=None,
-            options=options,
+            bytes(source, "ascii"), fnam="main", module="__main__", errors=None, options=options
         )
         a = str(n).split("\n")
     except CompileError as e:

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -10,6 +10,8 @@ from mypy import defaults
 from mypy.errors import CompileError
 from mypy.options import Options
 from mypy.parse import parse
+from mypy.util import get_mypy_comments
+from mypy.config_parser import parse_mypy_comments
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal, find_test_files, parse_options
 
@@ -39,9 +41,16 @@ def test_parser(testcase: DataDrivenTestCase) -> None:
     else:
         options.python_version = defaults.PYTHON3_VERSION
 
+    source = "\n".join(testcase.input)
+
+    # Apply mypy: comments to options.
+    comments = get_mypy_comments(source)
+    changes, _ = parse_mypy_comments(comments, options)
+    options = options.apply_changes(changes)
+
     try:
         n = parse(
-            bytes("\n".join(testcase.input), "ascii"),
+            bytes(source, "ascii"),
             fnam="main",
             module="__main__",
             errors=None,

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -520,3 +520,33 @@ class A:
 
 [file test.py]
 def foo(s: str) -> None: ...
+
+[case testXXX]
+# mypy: ignore-errors=True
+
+def f() -> None:
+    while 1():
+        pass
+
+[case testXXX2]
+from m import C
+c = C()
+reveal_type(c.x)  # N: Revealed type is "builtins.int"
+
+[file m.py]
+# mypy: ignore-errors=True
+
+class C:
+    def f(self) -> None:
+        self.x = 1
+
+[case testXXX3]
+# mypy: ignore-errors=True
+
+def f(self, x=lambda: 1) -> None:
+    pass
+
+class C:
+    def f(self) -> None:
+        l = lambda: 1
+        self.x = 1

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -520,33 +520,3 @@ class A:
 
 [file test.py]
 def foo(s: str) -> None: ...
-
-[case testXXX]
-# mypy: ignore-errors=True
-
-def f() -> None:
-    while 1():
-        pass
-
-[case testXXX2]
-from m import C
-c = C()
-reveal_type(c.x)  # N: Revealed type is "builtins.int"
-
-[file m.py]
-# mypy: ignore-errors=True
-
-class C:
-    def f(self) -> None:
-        self.x = 1
-
-[case testXXX3]
-# mypy: ignore-errors=True
-
-def f(self, x=lambda: 1) -> None:
-    pass
-
-class C:
-    def f(self) -> None:
-        l = lambda: 1
-        self.x = 1

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -259,6 +259,7 @@ class D(C):
             # E: Call to abstract method "m5" of "C" with trivial body via super() is unsafe
         super().m6() \
             # E: Call to abstract method "m6" of "C" with trivial body via super() is unsafe
+        super().m7()
 
     def m1(self) -> int:
         return 0
@@ -307,5 +308,10 @@ class C:
     @abc.abstractmethod
     def m6(self) -> int:
         raise NotImplementedError()
+
+    @abc.abstractmethod
+    def m7(self) -> int:
+        raise NotImplementedError()
+        pass
 
 [builtins fixtures/exception.pyi]

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -210,3 +210,33 @@ enable_error_code = ignore-without-code, truthy-bool
 
 \[mypy-tests.*]
 disable_error_code = ignore-without-code
+
+[case testIgnoreErrorsSimple]
+# mypy: ignore-errors=True
+
+def f() -> None:
+    while 1():
+        pass
+
+[case testIgnoreErrorsInImportedModule]
+from m import C
+c = C()
+reveal_type(c.x)  # N: Revealed type is "builtins.int"
+
+[file m.py]
+# mypy: ignore-errors=True
+
+class C:
+    def f(self) -> None:
+        self.x = 1
+
+[case testIgnoreErrorsWithLambda]
+# mypy: ignore-errors=True
+
+def f(self, x=lambda: 1) -> None:
+    pass
+
+class C:
+    def f(self) -> None:
+        l = lambda: 1
+        self.x = 1

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -255,6 +255,8 @@ class D(C):
             # E: Call to abstract method "m3" of "C" with trivial body via super() is unsafe
         super().m4() \
             # E: Call to abstract method "m4" of "C" with trivial body via super() is unsafe
+        super().m5() \
+            # E: Call to abstract method "m5" of "C" with trivial body via super() is unsafe
 
     def m1(self) -> int:
         return 0
@@ -268,6 +270,9 @@ class D(C):
     def m4(self) -> int:
         return 0
 
+    def m5(self) -> int:
+        return 0
+
 [file m.py]
 # mypy: ignore-errors=True
 import abc
@@ -275,6 +280,7 @@ import abc
 class C:
     @abc.abstractmethod
     def m1(self) -> int:
+        """x"""
         return 0
 
     @abc.abstractmethod
@@ -287,3 +293,8 @@ class C:
 
     @abc.abstractmethod
     def m4(self) -> int: ...
+
+    @abc.abstractmethod
+    def m5(self) -> int:
+        """doc"""
+        ...

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -240,3 +240,50 @@ class C:
     def f(self) -> None:
         l = lambda: 1
         self.x = 1
+
+[case testIgnoreErrorsWithUnsafeSuperCall_no_empty]
+# flags: --strict-optional
+
+from m import C
+
+class D(C):
+    def m(self) -> None:
+        super().m1()
+        super().m2() \
+            # E: Call to abstract method "m2" of "C" with trivial body via super() is unsafe
+        super().m3() \
+            # E: Call to abstract method "m3" of "C" with trivial body via super() is unsafe
+        super().m4() \
+            # E: Call to abstract method "m4" of "C" with trivial body via super() is unsafe
+
+    def m1(self) -> int:
+        return 0
+
+    def m2(self) -> int:
+        return 0
+
+    def m3(self) -> int:
+        return 0
+
+    def m4(self) -> int:
+        return 0
+
+[file m.py]
+# mypy: ignore-errors=True
+import abc
+
+class C:
+    @abc.abstractmethod
+    def m1(self) -> int:
+        return 0
+
+    @abc.abstractmethod
+    def m2(self) -> int:
+        """doc"""
+
+    @abc.abstractmethod
+    def m3(self) -> int:
+        pass
+
+    @abc.abstractmethod
+    def m4(self) -> int: ...

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -257,6 +257,8 @@ class D(C):
             # E: Call to abstract method "m4" of "C" with trivial body via super() is unsafe
         super().m5() \
             # E: Call to abstract method "m5" of "C" with trivial body via super() is unsafe
+        super().m6() \
+            # E: Call to abstract method "m6" of "C" with trivial body via super() is unsafe
 
     def m1(self) -> int:
         return 0
@@ -271,6 +273,9 @@ class D(C):
         return 0
 
     def m5(self) -> int:
+        return 0
+
+    def m6(self) -> int:
         return 0
 
 [file m.py]
@@ -298,3 +303,9 @@ class C:
     def m5(self) -> int:
         """doc"""
         ...
+
+    @abc.abstractmethod
+    def m6(self) -> int:
+        raise NotImplementedError()
+
+[builtins fixtures/exception.pyi]

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -3665,3 +3665,129 @@ MypyFile:1(
             y)
           NameExpr(x)
           Block:7())))))
+
+[case testStripDecoratedFunctionOrMethod]
+# mypy: ignore-errors=True
+@deco
+def f():
+    x = 0
+
+class C:
+    @deco
+    def m1(self):
+        x = 0
+
+    @deco
+    def m2(self):
+        self.x = 0
+[out]
+MypyFile:1(
+  Decorator:2(
+    Var(f)
+    NameExpr(deco)
+    FuncDef:3(
+      f
+      Block:3()))
+  ClassDef:6(
+    C
+    Decorator:7(
+      Var(m1)
+      NameExpr(deco)
+      FuncDef:8(
+        m1
+        Args(
+          Var(self))
+        Block:8()))
+    Decorator:11(
+      Var(m2)
+      NameExpr(deco)
+      FuncDef:12(
+        m2
+        Args(
+          Var(self))
+        Block:12(
+          AssignmentStmt:13(
+            MemberExpr:13(
+              NameExpr(self)
+              x)
+            IntExpr(0)))))))
+
+[case testStripOverloadedMethod]
+# mypy: ignore-errors=True
+class C:
+    @overload
+    def m1(self, x: int) -> None: ...
+    @overload
+    def m1(self, x: str) -> None: ...
+    def m1(self, x):
+        x = 0
+
+    @overload
+    def m2(self, x: int) -> None: ...
+    @overload
+    def m2(self, x: str) -> None: ...
+    def m2(self, x):
+        self.x = 0
+[out]
+MypyFile:1(
+  ClassDef:2(
+    C
+    OverloadedFuncDef:3(
+      Decorator:3(
+        Var(m1)
+        NameExpr(overload)
+        FuncDef:4(
+          m1
+          Args(
+            Var(self)
+            Var(x))
+          def (self: Any, x: int?) -> None?
+          Block:4()))
+      Decorator:5(
+        Var(m1)
+        NameExpr(overload)
+        FuncDef:6(
+          m1
+          Args(
+            Var(self)
+            Var(x))
+          def (self: Any, x: str?) -> None?
+          Block:6()))
+      FuncDef:7(
+        m1
+        Args(
+          Var(self)
+          Var(x))
+        Block:7()))
+    OverloadedFuncDef:10(
+      Decorator:10(
+        Var(m2)
+        NameExpr(overload)
+        FuncDef:11(
+          m2
+          Args(
+            Var(self)
+            Var(x))
+          def (self: Any, x: int?) -> None?
+          Block:11()))
+      Decorator:12(
+        Var(m2)
+        NameExpr(overload)
+        FuncDef:13(
+          m2
+          Args(
+            Var(self)
+            Var(x))
+          def (self: Any, x: str?) -> None?
+          Block:13()))
+      FuncDef:14(
+        m2
+        Args(
+          Var(self)
+          Var(x))
+        Block:14(
+          AssignmentStmt:15(
+            MemberExpr:15(
+              NameExpr(self)
+              x)
+            IntExpr(0)))))))

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -3807,3 +3807,33 @@ MypyFile:1(
               NameExpr(self)
               x)
             IntExpr(0)))))))
+
+[case testStripMethodInNestedClass]
+# mypy: ignore-errors=True
+class C:
+    class D:
+        def m1(self):
+             self.x = 1
+        def m2(self):
+             return self.x
+[out]
+MypyFile:1(
+  ClassDef:2(
+    C
+    ClassDef:3(
+      D
+      FuncDef:4(
+        m1
+        Args(
+          Var(self))
+        Block:4(
+          AssignmentStmt:5(
+            MemberExpr:5(
+              NameExpr(self)
+              x)
+            IntExpr(1))))
+      FuncDef:6(
+        m2
+        Args(
+          Var(self))
+        Block:6()))))

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -3581,6 +3581,8 @@ class C:
     def m3(self):
         if x:
             self.y = 0
+        else:
+            x = 4
 [out]
 MypyFile:1(
   ClassDef:2(
@@ -3626,7 +3628,11 @@ MypyFile:1(
               MemberExpr:11(
                 NameExpr(self)
                 y)
-              IntExpr(0))))))))
+              IntExpr(0)))
+          Else(
+            AssignmentStmt:13(
+              NameExpr(x)
+              IntExpr(4))))))))
 
 [case testDoNotStripMethodThatDefinesAttributeWithoutAssignment]
 # mypy: ignore-errors=True
@@ -3653,7 +3659,8 @@ MypyFile:1(
             MemberExpr:4(
               NameExpr(self)
               x))
-          Block:4())))
+          Block:4(
+            PassStmt:5()))))
     FuncDef:6(
       m2
       Args(
@@ -3664,7 +3671,8 @@ MypyFile:1(
             NameExpr(self)
             y)
           NameExpr(x)
-          Block:7())))))
+          Block:7(
+            PassStmt:8()))))))
 
 [case testStripDecoratedFunctionOrMethod]
 # mypy: ignore-errors=True
@@ -3742,7 +3750,9 @@ MypyFile:1(
             Var(self)
             Var(x))
           def (self: Any, x: int?) -> None?
-          Block:4()))
+          Block:4(
+            ExpressionStmt:4(
+              Ellipsis))))
       Decorator:5(
         Var(m1)
         NameExpr(overload)
@@ -3752,7 +3762,9 @@ MypyFile:1(
             Var(self)
             Var(x))
           def (self: Any, x: str?) -> None?
-          Block:6()))
+          Block:6(
+            ExpressionStmt:6(
+              Ellipsis))))
       FuncDef:7(
         m1
         Args(
@@ -3769,7 +3781,9 @@ MypyFile:1(
             Var(self)
             Var(x))
           def (self: Any, x: int?) -> None?
-          Block:11()))
+          Block:11(
+            ExpressionStmt:11(
+              Ellipsis))))
       Decorator:12(
         Var(m2)
         NameExpr(overload)
@@ -3779,7 +3793,9 @@ MypyFile:1(
             Var(self)
             Var(x))
           def (self: Any, x: str?) -> None?
-          Block:13()))
+          Block:13(
+            ExpressionStmt:13(
+              Ellipsis))))
       FuncDef:14(
         m2
         Args(

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -95,7 +95,6 @@ MypyFile:1(
     StrExpr(x\n\'))
   ExpressionStmt:2(
     StrExpr(x\n\")))
---" fix syntax highlight
 
 [case testBytes]
 b'foo'
@@ -128,7 +127,6 @@ MypyFile:1(
 MypyFile:1(
   ExpressionStmt:1(
     StrExpr(')))
---'
 
 [case testOctalEscapes]
 '\0\1\177\1234'
@@ -3484,3 +3482,81 @@ MypyFile:1(
                           NameExpr(y)
                           NameExpr(y))
                         StrExpr()))))))))))))
+
+[case testStripFunctionBodiesIfIgnoringErrors]
+# mypy: ignore-errors=True
+def f():
+    return 1
+[out]
+MypyFile:1(
+  FuncDef:2(
+    f
+    Block:2()))
+
+[case testStripMethodBodiesIfIgnoringErrors]
+# mypy: ignore-errors=True
+class C:
+    def f(self):
+        x = self.x
+        while foo():
+            bah()
+[out]
+MypyFile:1(
+  ClassDef:2(
+    C
+    FuncDef:3(
+      f
+      Args(
+        Var(self))
+      Block:3())))
+
+[case testDoNotStripModuleTopLevelOrClassBody]
+# mypy: ignore-errors=True
+f()
+class C:
+    x = 5
+[out]
+MypyFile:1(
+  ExpressionStmt:2(
+    CallExpr:2(
+      NameExpr(f)
+      Args()))
+  ClassDef:3(
+    C
+    AssignmentStmt:4(
+      NameExpr(x)
+      IntExpr(5))))
+
+[case testDoNotStripMethodThatAssignsToAnAttribute]
+# mypy: ignore-errors=True
+class C:
+    def m1(self):
+        self.x = 0
+    def m2(self):
+        a, self.y = 0
+[out]
+MypyFile:1(
+  ClassDef:2(
+    C
+    FuncDef:3(
+      m1
+      Args(
+        Var(self))
+      Block:3(
+        AssignmentStmt:4(
+          MemberExpr:4(
+            NameExpr(self)
+            x)
+          IntExpr(0))))
+    FuncDef:5(
+      m2
+      Args(
+        Var(self))
+      Block:5(
+        AssignmentStmt:6(
+          TupleExpr:6(
+            NameExpr(a)
+            MemberExpr:6(
+              NameExpr(self)
+              y))
+          IntExpr(0))))))

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -3498,8 +3498,13 @@ MypyFile:1(
 class C:
     def f(self):
         x = self.x
-        while foo():
-            bah()
+        for x in y:
+            pass
+        with a as y:
+            pass
+        while self.foo():
+            self.bah()
+            a[self.x] = 1
 [out]
 MypyFile:1(
   ClassDef:2(
@@ -3527,7 +3532,7 @@ MypyFile:1(
       NameExpr(x)
       IntExpr(5))))
 
-[case testDoNotStripMethodThatAssignsToAnAttribute]
+[case testDoNotStripMethodThatAssignsToAttribute]
 # mypy: ignore-errors=True
 class C:
     def m1(self):
@@ -3560,3 +3565,100 @@ MypyFile:1(
               NameExpr(self)
               y))
           IntExpr(0))))))
+
+[case testDoNotStripMethodThatAssignsToAttributeWithinStatement]
+# mypy: ignore-errors=True
+class C:
+    def m1(self):
+        for x in y:
+            self.x = 0
+    def m2(self):
+        with x:
+            self.y = 0
+    def m3(self):
+        if x:
+            self.y = 0
+[out]
+MypyFile:1(
+  ClassDef:2(
+    C
+    FuncDef:3(
+      m1
+      Args(
+        Var(self))
+      Block:3(
+        ForStmt:4(
+          NameExpr(x)
+          NameExpr(y)
+          Block:4(
+            AssignmentStmt:5(
+              MemberExpr:5(
+                NameExpr(self)
+                x)
+              IntExpr(0))))))
+    FuncDef:6(
+      m2
+      Args(
+        Var(self))
+      Block:6(
+        WithStmt:7(
+          Expr(
+            NameExpr(x))
+          Block:7(
+            AssignmentStmt:8(
+              MemberExpr:8(
+                NameExpr(self)
+                y)
+              IntExpr(0))))))
+    FuncDef:9(
+      m3
+      Args(
+        Var(self))
+      Block:9(
+        IfStmt:10(
+          If(
+            NameExpr(x))
+          Then(
+            AssignmentStmt:11(
+              MemberExpr:11(
+                NameExpr(self)
+                y)
+              IntExpr(0))))))))
+
+[case testDoNotStripMethodThatDefinesAttributeWithoutAssignment]
+# mypy: ignore-errors=True
+class C:
+    def m1(self):
+        with y as self.x:
+            pass
+    def m2(self):
+        for self.y in x:
+            pass
+[out]
+MypyFile:1(
+  ClassDef:2(
+    C
+    FuncDef:3(
+      m1
+      Args(
+        Var(self))
+      Block:3(
+        WithStmt:4(
+          Expr(
+            NameExpr(y))
+          Target(
+            MemberExpr:4(
+              NameExpr(self)
+              x))
+          Block:4())))
+    FuncDef:6(
+      m2
+      Args(
+        Var(self))
+      Block:6(
+        ForStmt:7(
+          MemberExpr:7(
+            NameExpr(self)
+            y)
+          NameExpr(x)
+          Block:7())))))

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -3485,12 +3485,15 @@ MypyFile:1(
 
 [case testStripFunctionBodiesIfIgnoringErrors]
 # mypy: ignore-errors=True
-def f():
+def f(self):
+    self.x = 1  # Cannot define an attribute
     return 1
 [out]
 MypyFile:1(
   FuncDef:2(
     f
+    Args(
+      Var(self))
     Block:2()))
 
 [case testStripMethodBodiesIfIgnoringErrors]


### PR DESCRIPTION
If errors are ignored, type checking function bodies often can have no effect. Remove function bodies after parsing to speed up type checking.

Methods that define attributes have an externally visible effect even if errors are ignored. The body of any method that assigns to any attribute is preserved to deal with this (even if it doesn't actually define a new attribute). Most methods don't assign to an attribute, so stripping bodies is still effective for methods.

There are a couple of additional interesting things in the implementation:

1. We need to know whether an abstract method has a trivial body (e.g. just `...`) to check `super()` method calls. The approach here is to preserve such trivial bodies and treat them differently from no body at all.
2. Stubgen analyzes the bodies of functions to e.g. infer some return types. As a workaround, explicitly preserve full ASTs when using stubgen.

The main benefit is faster type checking when using installed packages with inline type information (PEP 561). Errors are ignored in this case, and it's common to have a large number of third-party code to type check. For example, a self check (code under `mypy/`) is now about **20% faster**, with a compiled mypy on Python 3.11.

Another, more subtle benefit is improved reliability. A third-party library may have some code that triggers a mypy crash or an invalid blocking error. If bodies are stripped, often the error will no longer be triggered, since the amount code to type check is much lower.