### PR TITLE
Revert "[mypyc] Use tabs instead of spaces in emitted C code (#14016)"

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -176,10 +176,10 @@ class Emitter:
     # Low-level operations
 
     def indent(self) -> None:
-        self._indent += 1
+        self._indent += 4
 
     def dedent(self) -> None:
-        self._indent -= 1
+        self._indent -= 4
         assert self._indent >= 0
 
     def label(self, label: BasicBlock) -> str:
@@ -194,7 +194,7 @@ class Emitter:
     def emit_line(self, line: str = "") -> None:
         if line.startswith("}"):
             self.dedent()
-        self.fragments.append(self._indent * "\t" + line + "\n")
+        self.fragments.append(self._indent * " " + line + "\n")
         if line.endswith("{"):
             self.indent()
 

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -28,4 +28,4 @@ class TestEmitter(unittest.TestCase):
         emitter.emit_line("a {")
         emitter.emit_line("f();")
         emitter.emit_line("}")
-        assert emitter.fragments == ["line;\n", "a {\n", "\tf();\n", "}\n"]
+        assert emitter.fragments == ["line;\n", "a {\n", "    f();\n", "}\n"]

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -833,7 +833,7 @@ else {
 
         op.accept(visitor)
         frags = declarations.fragments + emitter.fragments
-        actual_lines = [line.strip(" \t") for line in frags]
+        actual_lines = [line.strip(" ") for line in frags]
         assert all(line.endswith("\n") for line in actual_lines)
         actual_lines = [line.rstrip("\n") for line in actual_lines]
         if not expected.strip():
@@ -900,7 +900,7 @@ class TestGenerateFunction(unittest.TestCase):
                 "    return cpy_r_arg;\n",
                 "}\n",
             ],
-            [line.replace("\t", 4 * " ") for line in result],
+            result,
             msg="Generated code invalid",
         )
 
@@ -927,6 +927,6 @@ class TestGenerateFunction(unittest.TestCase):
                 "    CPy_Unreachable();\n",
                 "}\n",
             ],
-            [line.replace("\t", 4 * " ") for line in result],
+            result,
             msg="Generated code invalid",
         )

--- a/mypyc/test/test_emitwrapper.py
+++ b/mypyc/test/test_emitwrapper.py
@@ -56,6 +56,5 @@ class TestArgCheck(unittest.TestCase):
         )
 
     def assert_lines(self, expected: list[str], actual: list[str]) -> None:
-        actual = [line.rstrip("\n").replace(4 * " ", "\t") for line in actual]
-        expected = [line.replace(4 * " ", "\t") for line in expected]
+        actual = [line.rstrip("\n") for line in actual]
         assert_string_arrays_equal(expected, actual, "Invalid output")


### PR DESCRIPTION
This reverts commit dbcbb3f5c3ef791c98088da0bd1dfa6cbf51f301.

The indentation in generated code is now inconsistent if using 4-space tabs. We should either use tabs or spaces consistently everywhere, since we can't expect everybody to have the same tab width.

The broken indentation can be seen by compiling a hello world program and opening it in an editor configured to use 4-space tabs.

Since there is a lot of code in mypyc that assumes a 4-space indentation, fixing it all is probably only feasible by normalizing the indentation during the emit phase. However, the normalization step might actually slow down compilation slightly, whereas the intent of the original change to improve efficiency, so this change may ultimately be impractical. In the future we should make it possible to normalize tabs without any significant cost, but I'm not sure if that's possible right now.