### PR TITLE
Fix ParamSpec constraint for types as callable

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -954,7 +954,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                                 arg_types=cactual.arg_types[prefix_len:],
                                 arg_kinds=cactual.arg_kinds[prefix_len:],
                                 arg_names=cactual.arg_names[prefix_len:],
-                                ret_type=NoneType(),
+                                ret_type=UninhabitedType(),
                             ),
                         )
                     )

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1298,6 +1298,7 @@ reveal_type(bar(C(fn=foo, x=1)))  # N: Revealed type is "__main__.C[[x: builtins
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecClassConstructor]
+# flags: --strict-optional
 from typing import ParamSpec, Callable
 
 P = ParamSpec("P")
@@ -1316,6 +1317,6 @@ def wrong_constructor(a: bool) -> SomeClass:
     return SomeClass("a")
 
 func(SomeClass, constructor)
-func(SomeClass, wrong_constructor)  # E: Argument 1 to "func" has incompatible type "Type[SomeClass]"; expected "Callable[[VarArg(None), KwArg(None)], SomeClass]" \
-				    # E: Argument 2 to "func" has incompatible type "Callable[[bool], SomeClass]"; expected "Callable[[VarArg(None), KwArg(None)], SomeClass]"
+func(SomeClass, wrong_constructor)  # E: Argument 1 to "func" has incompatible type "Type[SomeClass]"; expected "Callable[[VarArg(<nothing>), KwArg(<nothing>)], SomeClass]" \
+				    # E: Argument 2 to "func" has incompatible type "Callable[[bool], SomeClass]"; expected "Callable[[VarArg(<nothing>), KwArg(<nothing>)], SomeClass]"
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1296,3 +1296,26 @@ class C(Generic[P]):
 
 reveal_type(bar(C(fn=foo, x=1)))  # N: Revealed type is "__main__.C[[x: builtins.int]]"
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecClassConstructor]
+from typing import ParamSpec, Callable
+
+P = ParamSpec("P")
+
+class SomeClass:
+    def __init__(self, a: str) -> None:
+        pass
+
+def func(t: Callable[P, SomeClass], val: Callable[P, SomeClass]) -> None:
+    pass
+
+def constructor(a: str) -> SomeClass:
+    return SomeClass(a)
+
+def wrong_constructor(a: bool) -> SomeClass:
+    return SomeClass("a")
+
+func(SomeClass, constructor)
+func(SomeClass, wrong_constructor)  # E: Argument 1 to "func" has incompatible type "Type[SomeClass]"; expected "Callable[[VarArg(None), KwArg(None)], SomeClass]" \
+				    # E: Argument 2 to "func" has incompatible type "Callable[[bool], SomeClass]"; expected "Callable[[VarArg(None), KwArg(None)], SomeClass]"
+[builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
Most types can be considered as callables, constructing the type itself. When a constraint was created for a ParamSpec variable, the return type would be set to NoneType, which conflicts with assumptions that CallableType makes when it is the constructor of another type, crashing mypy. This patch replaces the return type by UninhabitedType instead, which stops CallableType from considering itself as a constructor.