### PR TITLE
Add `--debug-serialize` option

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2465,6 +2465,12 @@ class State:
             or self.options.cache_dir == os.devnull
             or self.options.fine_grained_incremental
         ):
+            if self.options.debug_serialize:
+                try:
+                    self.tree.serialize()
+                except Exception:
+                    print(f"Error serializing {self.id}", file=self.manager.stdout)
+                    raise  # Propagate to display traceback
             return
         is_errors = self.transitive_error
         if is_errors:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1117,6 +1117,9 @@ def process_options(
     parser.add_argument(
         "--cache-map", nargs="+", dest="special-opts:cache_map", help=argparse.SUPPRESS
     )
+    # --debug-serialize will run tree.serialize() even if cache generation is disabled.
+    # Useful for mypy_primer to detect serialize errors earlier.
+    parser.add_argument("--debug-serialize", action="store_true", help=argparse.SUPPRESS)
     # This one is deprecated, but we will keep it for few releases.
     parser.add_argument(
         "--enable-incomplete-features", action="store_true", help=argparse.SUPPRESS

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -249,6 +249,9 @@ class Options:
         # Read cache files in fine-grained incremental mode (cache must include dependencies)
         self.use_fine_grained_cache = False
 
+        # Run tree.serialize() even if cache generation is disabled
+        self.debug_serialize = False
+
         # Tune certain behaviors when being used as a front-end to mypyc. Set per-module
         # in modules being compiled. Not in the config file or command line.
         self.mypyc = False


### PR DESCRIPTION
Currently, `mypy_primer` sets `--cache-dir=/dev/null` which disables cache generation. This can result in errors being missed which would normally come up during  `tree.serialize()`. Removing `--cache-dir=/dev/null` isn't practical.

This PR adds a new debug / test option `--debug-serialize` which runs `tree.serialize()` even if cache generation is disabled to help detect serialize errors earlier.

**Refs**
* #14137
* https://github.com/hauntsaninja/mypy_primer/pull/54#pullrequestreview-1187145602

cc: @hauntsaninja