### PR TITLE
Doc: Add Optional in Decorator factories

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -724,7 +724,7 @@ achieved by combining with :py:func:`@overload <typing.overload>`:
 
 .. code-block:: python
 
-    from typing import Any, Callable, TypeVar, overload
+    from typing import Any, Callable, Optional, TypeVar, overload
 
     F = TypeVar('F', bound=Callable[..., Any])
 
@@ -736,7 +736,7 @@ achieved by combining with :py:func:`@overload <typing.overload>`:
     def atomic(*, savepoint: bool = True) -> Callable[[F], F]: ...
 
     # Implementation
-    def atomic(__func: Callable[..., Any] = None, *, savepoint: bool = True):
+    def atomic(__func: Optional[Callable[..., Any]] = None, *, savepoint: bool = True):
         def decorator(func: Callable[..., Any]):
             ...  # Code goes here
         if __func is not None:


### PR DESCRIPTION
# Situation
The documentation shows an example in the ["Decorator factories"](https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories) section and it looks like this:

```python
# Implementation
def atomic(__func: Callable[..., Any] = None, *, savepoint: bool = True):
    # pruned
```

However, if you save the file and run mypy, it complains about the previous line:

    error: Incompatible default for argument "__func" (default has type "None", argument has type "Callable[..., Any]")  [assignment]
    note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True

# Proposed change
This change adds Optional around `Callable[..., Any]]` which avoids the above error message.
