### PR TITLE
Support ParamSpec variables in type aliases

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -916,9 +916,5 @@ defeating the purpose of using aliases.  Example:
 
     OIntVec = Optional[Vec[int]]
 
-.. note::
-
-    A type alias does not define a new type. For generic type aliases
-    this means that variance of type variables used for alias definition does not
-    apply to aliases. A parameterized generic alias is treated simply as an original
-    type with the corresponding type variables substituted.
+Using type variable bounds or values in generic aliases, has the same effect
+as in generic classes/functions.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7091,7 +7091,7 @@ class SetNothingToAny(TypeTranslator):
         return t
 
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:
-        # Target of the alias cannot by an ambiguous <nothing>, so we just
+        # Target of the alias cannot be an ambiguous <nothing>, so we just
         # replace the arguments.
         return t.copy_modified(args=[a.accept(self) for a in t.args])
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3842,10 +3842,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         There are two different options here, depending on whether expr refers
         to a type alias or directly to a generic class. In the first case we need
-        to use a dedicated function typeanal.expand_type_aliases. This
-        is due to the fact that currently type aliases machinery uses
-        unbound type variables, while normal generics use bound ones;
-        see TypeAlias docstring for more details.
+        to use a dedicated function typeanal.expand_type_alias(). This
+        is due to some differences in how type arguments are applied and checked.
         """
         if isinstance(tapp.expr, RefExpr) and isinstance(tapp.expr.node, TypeAlias):
             # Subscription of a (generic) alias in runtime context, expand the alias.

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -176,8 +176,8 @@ class TypeVarEraser(TypeTranslator):
         return t
 
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:
-        # Type alias target can't contain bound type variables, so
-        # it is safe to just erase the arguments.
+        # Type alias target can't contain bound type variables (not bound by the type
+        # alias itself), so it is safe to just erase the arguments.
         return t.copy_modified(args=[a.accept(self) for a in t.args])
 
 

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -446,8 +446,8 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
         return TypeType.make_normalized(item)
 
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:
-        # Target of the type alias cannot contain type variables,
-        # so we just expand the arguments.
+        # Target of the type alias cannot contain type variables (not bound by the type
+        # alias itself), so we just expand the arguments.
         return t.copy_modified(args=self.expand_types(t.args))
 
     def expand_types(self, types: Iterable[Type]) -> list[Type]:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -15,7 +15,6 @@ from mypy.types import (
     NoneType,
     Overloaded,
     Parameters,
-    ParamSpecFlavor,
     ParamSpecType,
     PartialType,
     ProperType,
@@ -34,6 +33,7 @@ from mypy.types import (
     UninhabitedType,
     UnionType,
     UnpackType,
+    expand_param_spec,
     get_proper_type,
 )
 from mypy.typevartuples import (
@@ -212,32 +212,8 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
             # TODO: what does prefix mean in this case?
             # TODO: why does this case even happen? Instances aren't plural.
             return repl
-        elif isinstance(repl, ParamSpecType):
-            return repl.copy_modified(
-                flavor=t.flavor,
-                prefix=t.prefix.copy_modified(
-                    arg_types=t.prefix.arg_types + repl.prefix.arg_types,
-                    arg_kinds=t.prefix.arg_kinds + repl.prefix.arg_kinds,
-                    arg_names=t.prefix.arg_names + repl.prefix.arg_names,
-                ),
-            )
-        elif isinstance(repl, Parameters) or isinstance(repl, CallableType):
-            # if the paramspec is *P.args or **P.kwargs:
-            if t.flavor != ParamSpecFlavor.BARE:
-                assert isinstance(repl, CallableType), "Should not be able to get here."
-                # Is this always the right thing to do?
-                param_spec = repl.param_spec()
-                if param_spec:
-                    return param_spec.with_flavor(t.flavor)
-                else:
-                    return repl
-            else:
-                return Parameters(
-                    t.prefix.arg_types + repl.arg_types,
-                    t.prefix.arg_kinds + repl.arg_kinds,
-                    t.prefix.arg_names + repl.arg_names,
-                    variables=[*t.prefix.variables, *repl.variables],
-                )
+        elif isinstance(repl, (ParamSpecType, Parameters, CallableType)):
+            return expand_param_spec(t, repl)
         else:
             # TODO: should this branch be removed? better not to fail silently
             return repl

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -180,6 +180,8 @@ class NodeFixer(NodeVisitor[None]):
 
     def visit_type_alias(self, a: TypeAlias) -> None:
         a.target.accept(self.type_fixer)
+        for v in a.alias_tvars:
+            v.accept(self.type_fixer)
 
 
 class TypeFixer(TypeVisitor[None]):

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -25,6 +25,9 @@ from mypy.typetraverser import TypeTraverserVisitor
 class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
     """Recursive traversal of both Node and Type objects."""
 
+    def __init__(self) -> None:
+        self.in_type_alias_expr = False
+
     # Symbol nodes
 
     def visit_var(self, var: Var) -> None:
@@ -45,7 +48,9 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
 
     def visit_type_alias_expr(self, o: TypeAliasExpr) -> None:
         super().visit_type_alias_expr(o)
+        self.in_type_alias_expr = True
         o.type.accept(self)
+        self.in_type_alias_expr = False
 
     def visit_type_var_expr(self, o: TypeVarExpr) -> None:
         super().visit_type_var_expr(o)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3445,6 +3445,10 @@ class TypeAlias(SymbolNode):
     def fullname(self) -> str:
         return self._fullname
 
+    @property
+    def has_param_spec_type(self) -> bool:
+        return any(isinstance(v, mypy.types.ParamSpecType) for v in self.alias_tvars)
+
     def serialize(self) -> JsonDict:
         data: JsonDict = {
             ".class": "TypeAlias",

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -12,6 +12,7 @@ from typing import (
     Callable,
     Dict,
     Iterator,
+    List,
     Optional,
     Sequence,
     Tuple,
@@ -3481,7 +3482,7 @@ class TypeAlias(SymbolNode):
             fullname,
             line,
             column,
-            alias_tvars=cast(list[mypy.types.TypeVarLikeType], alias_tvars),
+            alias_tvars=cast(List[mypy.types.TypeVarLikeType], alias_tvars),
             no_args=no_args,
             normalized=normalized,
         )

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1777,8 +1777,7 @@ class SemanticAnalyzer(
         for i, base_expr in enumerate(base_type_exprs):
             if isinstance(base_expr, StarExpr):
                 base_expr.valid = True
-            with self.allow_unbound_tvars_set():
-                self.analyze_type_expr(base_expr)
+            self.analyze_type_expr(base_expr)
 
             try:
                 base = self.expr_to_unanalyzed_type(base_expr)
@@ -6217,7 +6216,7 @@ class SemanticAnalyzer(
         # them semantically analyzed, however, if they need to treat it as an expression
         # and not a type. (Which is to say, mypyc needs to do this.) Do the analysis
         # in a fresh tvar scope in order to suppress any errors about using type variables.
-        with self.tvar_scope_frame(TypeVarLikeScope()):
+        with self.tvar_scope_frame(TypeVarLikeScope()), self.allow_unbound_tvars_set():
             expr.accept(self)
 
     def type_analyzer(

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -459,6 +459,9 @@ class SemanticAnalyzer(
         # rvalues while temporarily setting this to True.
         self.basic_type_applications = False
 
+        # Used to temporarily enable unbound type variables in some contexts. Namely,
+        # in base class expressions, and in right hand sides of type aliases. Do not add
+        # new uses of this, as this may cause leaking `UnboundType`s to type checking.
         self.allow_unbound_tvars = False
 
     # mypyc doesn't properly handle implementing an abstractproperty

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -7,12 +7,14 @@ operations, including subtype checks.
 
 from __future__ import annotations
 
+from typing import Sequence
+
 from mypy import errorcodes as codes, message_registry
 from mypy.errorcodes import ErrorCode
 from mypy.errors import Errors
 from mypy.messages import format_type
 from mypy.mixedtraverser import MixedTraverserVisitor
-from mypy.nodes import Block, ClassDef, Context, FakeInfo, FuncItem, MypyFile, TypeInfo
+from mypy.nodes import Block, ClassDef, Context, FakeInfo, FuncItem, MypyFile
 from mypy.options import Options
 from mypy.scope import Scope
 from mypy.subtypes import is_same_type, is_subtype
@@ -24,6 +26,7 @@ from mypy.types import (
     Type,
     TypeAliasType,
     TypeOfAny,
+    TypeVarLikeType,
     TypeVarTupleType,
     TypeVarType,
     UnboundType,
@@ -35,6 +38,7 @@ from mypy.types import (
 
 class TypeArgumentAnalyzer(MixedTraverserVisitor):
     def __init__(self, errors: Errors, options: Options, is_typeshed_file: bool) -> None:
+        super().__init__()
         self.errors = errors
         self.options = options
         self.is_typeshed_file = is_typeshed_file
@@ -77,7 +81,12 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
         # correct aliases.
         if t.alias and len(t.args) != len(t.alias.alias_tvars):
             t.args = [AnyType(TypeOfAny.from_error) for _ in t.alias.alias_tvars]
-        get_proper_type(t).accept(self)
+        assert t.alias is not None, f"Unfixed type alias {t.type_ref}"
+        is_error = self.validate_args(t.alias.name, t.args, t.alias.alias_tvars, t)
+        if not is_error:
+            # If there was already an error for the alias itself, there is no point in checking
+            # the expansion, most likely it will result in the same kind of error.
+            get_proper_type(t).accept(self)
 
     def visit_instance(self, t: Instance) -> None:
         # Type argument counts were checked in the main semantic analyzer pass. We assume
@@ -85,36 +94,53 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
         info = t.type
         if isinstance(info, FakeInfo):
             return  # https://github.com/python/mypy/issues/11079
-        for (i, arg), tvar in zip(enumerate(t.args), info.defn.type_vars):
+        self.validate_args(info.name, t.args, info.defn.type_vars, t)
+        super().visit_instance(t)
+
+    def validate_args(
+        self, name: str, args: Sequence[Type], type_vars: list[TypeVarLikeType], ctx: Context
+    ) -> bool:
+        is_error = False
+        for (i, arg), tvar in zip(enumerate(args), type_vars):
             if isinstance(tvar, TypeVarType):
                 if isinstance(arg, ParamSpecType):
                     # TODO: Better message
-                    self.fail(f'Invalid location for ParamSpec "{arg.name}"', t)
+                    is_error = True
+                    self.fail(f'Invalid location for ParamSpec "{arg.name}"', ctx)
                     continue
                 if tvar.values:
                     if isinstance(arg, TypeVarType):
+                        if self.in_type_alias_expr:
+                            # Type aliases are allowed to use unconstrained type variables
+                            # error will be checked at substitution point.
+                            continue
                         arg_values = arg.values
                         if not arg_values:
+                            is_error = True
                             self.fail(
-                                message_registry.INVALID_TYPEVAR_AS_TYPEARG.format(
-                                    arg.name, info.name
-                                ),
-                                t,
+                                message_registry.INVALID_TYPEVAR_AS_TYPEARG.format(arg.name, name),
+                                ctx,
                                 code=codes.TYPE_VAR,
                             )
                             continue
                     else:
                         arg_values = [arg]
-                    self.check_type_var_values(info, arg_values, tvar.name, tvar.values, i + 1, t)
+                    if self.check_type_var_values(name, arg_values, tvar.name, tvar.values, ctx):
+                        is_error = True
                 if not is_subtype(arg, tvar.upper_bound):
+                    if self.in_type_alias_expr and isinstance(arg, TypeVarType):
+                        # Type aliases are allowed to use unconstrained type variables
+                        # error will be checked at substitution point.
+                        continue
+                    is_error = True
                     self.fail(
                         message_registry.INVALID_TYPEVAR_ARG_BOUND.format(
-                            format_type(arg), info.name, format_type(tvar.upper_bound)
+                            format_type(arg), name, format_type(tvar.upper_bound)
                         ),
-                        t,
+                        ctx,
                         code=codes.TYPE_VAR,
                     )
-        super().visit_instance(t)
+        return is_error
 
     def visit_unpack_type(self, typ: UnpackType) -> None:
         proper_type = get_proper_type(typ.type)
@@ -132,28 +158,25 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
         self.fail(message_registry.INVALID_UNPACK.format(proper_type), typ)
 
     def check_type_var_values(
-        self,
-        type: TypeInfo,
-        actuals: list[Type],
-        arg_name: str,
-        valids: list[Type],
-        arg_number: int,
-        context: Context,
-    ) -> None:
+        self, name: str, actuals: list[Type], arg_name: str, valids: list[Type], context: Context
+    ) -> bool:
+        is_error = False
         for actual in get_proper_types(actuals):
-            # TODO: bind type variables in class bases/alias targets
-            # so we can safely check this, currently we miss some errors.
+            # We skip UnboundType here, since they may appear in defn.bases,
+            # the error will be caught when visiting info.bases, tht have bound type
+            # variables.
             if not isinstance(actual, (AnyType, UnboundType)) and not any(
                 is_same_type(actual, value) for value in valids
             ):
+                is_error = True
                 if len(actuals) > 1 or not isinstance(actual, Instance):
                     self.fail(
-                        message_registry.INVALID_TYPEVAR_ARG_VALUE.format(type.name),
+                        message_registry.INVALID_TYPEVAR_ARG_VALUE.format(name),
                         context,
                         code=codes.TYPE_VAR,
                     )
                 else:
-                    class_name = f'"{type.name}"'
+                    class_name = f'"{name}"'
                     actual_type_name = f'"{actual.type.name}"'
                     self.fail(
                         message_registry.INCOMPATIBLE_TYPEVAR_VALUE.format(
@@ -162,6 +185,7 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
                         context,
                         code=codes.TYPE_VAR,
                     )
+        return is_error
 
     def fail(self, msg: str, context: Context, *, code: ErrorCode | None = None) -> None:
         self.errors.report(context.line, context.column, msg, code=code)

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -168,7 +168,7 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
         is_error = False
         for actual in get_proper_types(actuals):
             # We skip UnboundType here, since they may appear in defn.bases,
-            # the error will be caught when visiting info.bases, tht have bound type
+            # the error will be caught when visiting info.bases, that have bound type
             # variables.
             if not isinstance(actual, (AnyType, UnboundType)) and not any(
                 is_same_type(actual, value) for value in valids

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -147,7 +147,9 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
                         code=codes.TYPE_VAR,
                     )
             elif isinstance(tvar, ParamSpecType):
-                if not isinstance(arg, (ParamSpecType, Parameters, AnyType, UnboundType)):
+                if not isinstance(
+                    get_proper_type(arg), (ParamSpecType, Parameters, AnyType, UnboundType)
+                ):
                     self.fail(
                         "Can only replace ParamSpec with a parameter types list or"
                         f" another ParamSpec, got {format_type(arg)}",

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -21,6 +21,7 @@ from mypy.subtypes import is_same_type, is_subtype
 from mypy.types import (
     AnyType,
     Instance,
+    Parameters,
     ParamSpecType,
     TupleType,
     Type,
@@ -144,6 +145,13 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
                         ),
                         ctx,
                         code=codes.TYPE_VAR,
+                    )
+            elif isinstance(tvar, ParamSpecType):
+                if not isinstance(arg, (ParamSpecType, Parameters, AnyType, UnboundType)):
+                    self.fail(
+                        "Can only replace ParamSpec with a parameter types list or"
+                        f" another ParamSpec, got {format_type(arg)}",
+                        ctx,
                     )
         return is_error
 

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -107,6 +107,11 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
                     # TODO: Better message
                     is_error = True
                     self.fail(f'Invalid location for ParamSpec "{arg.name}"', ctx)
+                    self.note(
+                        "You can use ParamSpec as the first argument to Callable, e.g., "
+                        "'Callable[{}, int]'".format(arg.name),
+                        ctx,
+                    )
                     continue
                 if tvar.values:
                     if isinstance(arg, TypeVarType):
@@ -189,3 +194,6 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
 
     def fail(self, msg: str, context: Context, *, code: ErrorCode | None = None) -> None:
         self.errors.report(context.line, context.column, msg, code=code)
+
+    def note(self, msg: str, context: Context, *, code: ErrorCode | None = None) -> None:
+        self.errors.report(context.line, context.column, msg, severity="note", code=code)

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -189,7 +189,7 @@ class TypedDictAnalyzer:
         valid_items = base_items.copy()
 
         # Always fix invalid bases to avoid crashes.
-        tvars = info.type_vars
+        tvars = info.defn.type_vars
         if len(base_args) != len(tvars):
             any_kind = TypeOfAny.from_omitted_generics
             if base_args:
@@ -235,7 +235,7 @@ class TypedDictAnalyzer:
         return base_args
 
     def map_items_to_base(
-        self, valid_items: dict[str, Type], tvars: list[str], base_args: list[Type]
+        self, valid_items: dict[str, Type], tvars: list[TypeVarLikeType], base_args: list[Type]
     ) -> dict[str, Type]:
         """Map item types to how they would look in their base with type arguments applied.
 

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -187,7 +187,7 @@ def snapshot_symbol_table(name_prefix: str, table: SymbolTable) -> dict[str, Sna
         elif isinstance(node, TypeAlias):
             result[name] = (
                 "TypeAlias",
-                node.alias_tvars,
+                snapshot_types(node.alias_tvars),
                 node.normalized,
                 node.no_args,
                 snapshot_optional_type(node.target),

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -331,6 +331,8 @@ class NodeReplaceVisitor(TraverserVisitor):
 
     def visit_type_alias(self, node: TypeAlias) -> None:
         self.fixup_type(node.target)
+        for v in node.alias_tvars:
+            self.fixup_type(v)
         super().visit_type_alias(node)
 
     # Helpers

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -160,7 +160,8 @@ class TypesSuite(Suite):
 
     def test_recursive_nested_in_non_recursive(self) -> None:
         A, _ = self.fx.def_alias_1(self.fx.a)
-        NA = self.fx.non_rec_alias(Instance(self.fx.gi, [UnboundType("T")]), ["T"], [A])
+        T = TypeVarType("T", "T", -1, [], self.fx.o)
+        NA = self.fx.non_rec_alias(Instance(self.fx.gi, [T]), [T], [A])
         assert not NA.is_recursive
         assert has_recursive_types(NA)
 

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -340,7 +340,10 @@ class TypeFixture:
         return A, target
 
     def non_rec_alias(
-        self, target: Type, alias_tvars: list[str] | None = None, args: list[Type] | None = None
+        self,
+        target: Type,
+        alias_tvars: list[TypeVarLikeType] | None = None,
+        args: list[Type] | None = None,
     ) -> TypeAliasType:
         AN = TypeAlias(target, "__main__.A", -1, -1, alias_tvars=alias_tvars)
         if args is None:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -427,7 +427,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def pack_paramspec_args(self, an_args: Sequence[Type]) -> list[Type]:
         # "Aesthetic" ParamSpec literals for single ParamSpec: C[int, str] -> C[[int, str]].
-        # TODO: support arbitrary ParamSpec/TypeVar combinations.
         # These do not support mypy_extensions VarArgs, etc. as they were already analyzed
         # TODO: should these be re-analyzed to get rid of this inconsistency?
         count = len(an_args)

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -131,6 +131,9 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
         pass
 
     def visit_type_alias_type(self, t: TypeAliasType) -> None:
+        # TODO: sometimes we want to traverse target as well
+        # We need to find a way to indicate explicitly the intent,
+        # maybe make this method abstract (like for TypeTranslator)?
         self.traverse_types(t.args)
 
     def visit_unpack_type(self, t: UnpackType) -> None:

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1031,8 +1031,9 @@ IntNode[int](1, 1)
 IntNode[int](1, 'a')  # E: Argument 2 to "Node" has incompatible type "str"; expected "int"
 
 SameNode = Node[T, T]
-# TODO: fix https://github.com/python/mypy/issues/7084.
-ff = SameNode[T](1, 1)
+ff = SameNode[T](1, 1)  # E: Type variable "__main__.T" is unbound \
+        # N: (Hint: Use "Generic[T]" or "Protocol[T]" base class to bind "T" inside a class) \
+        # N: (Hint: Use "T" in function signature to bind "T" inside a function)
 a = SameNode(1, 'x')
 reveal_type(a) # N: Revealed type is "__main__.Node[Any, Any]"
 b = SameNode[int](1, 1)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -655,7 +655,7 @@ a: other.Array[float]
 reveal_type(a) # N: Revealed type is "other.array[Any, other.dtype[builtins.float]]"
 
 [out]
-main:3: error: Type argument "float" of "dtype" must be a subtype of "generic"  [type-var]
+main:3: error: Type argument "float" of "Array" must be a subtype of "generic"  [type-var]
     a: other.Array[float]
        ^
 [file other.py]
@@ -1101,13 +1101,12 @@ BadA = A[str, T]  # One error here
 SameA = A[T, T]
 
 x = None # type: SameA[int]
-y = None # type: SameA[str] # Two errors here, for both args of A
+y = None # type: SameA[str] # Another error here
 
 [builtins fixtures/list.pyi]
 [out]
 main:9:8: error: Value of type variable "T" of "A" cannot be "str"
-main:13:1: error: Value of type variable "T" of "A" cannot be "str"
-main:13:1: error: Value of type variable "S" of "A" cannot be "str"
+main:13:1: error: Value of type variable "T" of "SameA" cannot be "str"
 
 [case testGenericTypeAliasesIgnoredPotentialAlias]
 class A: ...

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2645,3 +2645,21 @@ class C(Generic[T]):
 
 def foo(x: C[T]) -> T:
     return x.x(42).y  # OK
+
+[case testNestedGenericFunctionTypeApplication]
+from typing import TypeVar, Generic, List
+
+A = TypeVar("A")
+B = TypeVar("B")
+
+class C(Generic[A]):
+    x: A
+
+def foo(x: A) -> A:
+    def bar() -> List[A]:
+        y = C[List[A]]()
+        z = C[List[B]]()  # E: Type variable "__main__.B" is unbound \
+                # N: (Hint: Use "Generic[B]" or "Protocol[B]" base class to bind "B" inside a class) \
+                # N: (Hint: Use "B" in function signature to bind "B" inside a function)
+        return y.x
+    return bar()[0]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1750,11 +1750,8 @@ def f(cls: Type[object]) -> None:
 [case testIsinstanceTypeArgs]
 from typing import Iterable, TypeVar
 x = 1
-T = TypeVar('T')
-
 isinstance(x, Iterable)
 isinstance(x, Iterable[int])  # E: Parameterized generics cannot be used with class or instance checks
-isinstance(x, Iterable[T])  # E: Parameterized generics cannot be used with class or instance checks
 isinstance(x, (int, Iterable[int]))  # E: Parameterized generics cannot be used with class or instance checks
 isinstance(x, (int, (str, Iterable[int])))  # E: Parameterized generics cannot be used with class or instance checks
 [builtins fixtures/isinstancelist.pyi]
@@ -1783,10 +1780,8 @@ isinstance(x, It2)  # E: Parameterized generics cannot be used with class or ins
 [case testIssubclassTypeArgs]
 from typing import Iterable, TypeVar
 x = int
-T = TypeVar('T')
 issubclass(x, Iterable)
 issubclass(x, Iterable[int])  # E: Parameterized generics cannot be used with class or instance checks
-issubclass(x, Iterable[T])  # E: Parameterized generics cannot be used with class or instance checks
 issubclass(x, (int, Iterable[int]))  # E: Parameterized generics cannot be used with class or instance checks
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2437,23 +2437,10 @@ b: Final = 3
 c: Final[Literal[3]] = 3
 d: Literal[3]
 
-# TODO: Consider if we want to support cases 'b' and 'd' or not.
-# Probably not: we want to mostly keep the 'types' and 'value' worlds distinct.
-# However, according to final semantics, we ought to be able to substitute "b" with
-# "3" wherever it's used and get the same behavior -- so maybe we do need to support
-# at least case "b" for consistency?
-a_wrap: Literal[4, a]  # E: Parameter 2 of Literal[...] is invalid \
-                       # E: Variable "__main__.a" is not valid as a type \
-                       # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-b_wrap: Literal[4, b]  # E: Parameter 2 of Literal[...] is invalid \
-                       # E: Variable "__main__.b" is not valid as a type \
-                       # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-c_wrap: Literal[4, c]  # E: Parameter 2 of Literal[...] is invalid \
-                       # E: Variable "__main__.c" is not valid as a type \
-                       # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
-d_wrap: Literal[4, d]  # E: Parameter 2 of Literal[...] is invalid \
-                       # E: Variable "__main__.d" is not valid as a type \
-                       # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+a_wrap: Literal[4, a]  # E: Parameter 2 of Literal[...] is invalid
+b_wrap: Literal[4, b]  # E: Parameter 2 of Literal[...] is invalid
+c_wrap: Literal[4, c]  # E: Parameter 2 of Literal[...] is invalid
+d_wrap: Literal[4, d]  # E: Parameter 2 of Literal[...] is invalid
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -2517,9 +2504,7 @@ r: Literal[Color.RED]
 g: Literal[Color.GREEN]
 b: Literal[Color.BLUE]
 bad1: Literal[Color]         # E: Parameter 1 of Literal[...] is invalid
-bad2: Literal[Color.func]    # E: Function "__main__.Color.func" is not valid as a type \
-                             # N: Perhaps you need "Callable[...]" or a callback protocol? \
-                             # E: Parameter 1 of Literal[...] is invalid
+bad2: Literal[Color.func]    # E: Parameter 1 of Literal[...] is invalid
 bad3: Literal[Color.func()]  # E: Invalid type: Literal[...] cannot contain arbitrary expressions
 
 def expects_color(x: Color) -> None: pass

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -429,7 +429,6 @@ class Z(Generic[P]): ...
 # literals can be applied
 n: Z[[int]]
 
-# TODO: type aliases too
 nt1 = Z[[int]]
 nt2: TypeAlias = Z[[int]]
 
@@ -844,9 +843,7 @@ class A:
         ...
 
 reveal_type(A.func)  # N: Revealed type is "def [_P, _R] (self: __main__.A, action: def (*_P.args, **_P.kwargs) -> _R`-2, *_P.args, **_P.kwargs) -> _R`-2"
-
-# TODO: _R`<n> keeps flip-flopping between 5 (?), 13, 14, 15. Spooky.
-# reveal_type(A().func)  $ N: Revealed type is "def [_P, _R] (action: def (*_P.args, **_P.kwargs) -> _R`13, *_P.args, **_P.kwargs) -> _R`13"
+reveal_type(A().func)  # N: Revealed type is "def [_P, _R] (action: def (*_P.args, **_P.kwargs) -> _R`5, *_P.args, **_P.kwargs) -> _R`5"
 
 def f(x: int) -> int:
     ...
@@ -879,8 +876,7 @@ class A:
         ...
 
 reveal_type(A.func)  # N: Revealed type is "def [_P] (self: __main__.A, action: __main__.Job[_P`-1, None]) -> __main__.Job[_P`-1, None]"
-# TODO: flakey, _P`4 alternates around.
-# reveal_type(A().func)  $ N: Revealed type is "def [_P] (action: __main__.Job[_P`4, None]) -> __main__.Job[_P`4, None]"
+reveal_type(A().func)  # N: Revealed type is "def [_P] (action: __main__.Job[_P`3, None]) -> __main__.Job[_P`3, None]"
 reveal_type(A().func(Job(lambda x: x)))  # N: Revealed type is "__main__.Job[[x: Any], None]"
 
 def f(x: int, y: int) -> None: ...
@@ -1370,4 +1366,36 @@ x: C[[int, str]]
 reveal_type(x)  # N: Revealed type is "def (builtins.int, builtins.str) -> Union[builtins.int, ...]"
 y: C[int, str]
 reveal_type(y)  # N: Revealed type is "def (builtins.int, builtins.str) -> Union[builtins.int, ...]"
+[builtins fixtures/paramspec.pyi]
+
+[case testParamSpecAliasInRuntimeContext]
+from typing import ParamSpec, Generic
+
+P = ParamSpec("P")
+class C(Generic[P]): ...
+
+c = C[int, str]()
+reveal_type(c)  # N: Revealed type is "__main__.C[[builtins.int, builtins.str]]"
+
+A = C[P]
+a = A[int, str]()
+reveal_type(a)  # N: Revealed type is "__main__.C[[builtins.int, builtins.str]]"
+[builtins fixtures/paramspec.pyi]
+
+[case testParamSpecAliasInvalidLocations]
+from typing import ParamSpec, Generic, List, TypeVar, Callable
+
+P = ParamSpec("P")
+T = TypeVar("T")
+A = List[T]
+def f(x: A[[int, str]]) -> None: ...  # E: Bracketed expression "[...]" is not valid as a type \
+                                      # N: Did you mean "List[...]"?
+def g(x: A[P]) -> None: ...  # E: Invalid location for ParamSpec "P" \
+                             # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
+
+C = Callable[P, T]
+x: C[int]  # E: Bad number of arguments for type alias, expected: 2, given: 1
+# TODO: this should be rejected
+y: C[int, str]
+z: C[int, str, bytes]  # E: Bad number of arguments for type alias, expected: 2, given: 3
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1315,6 +1315,38 @@ y: C[int, str]
 reveal_type(y)  # N: Revealed type is "def (builtins.int, builtins.str) -> builtins.int"
 [builtins fixtures/paramspec.pyi]
 
+[case testParamSpecInTypeAliasConcatenate]
+from typing import ParamSpec, Callable
+from typing_extensions import Concatenate
+
+P = ParamSpec("P")
+C = Callable[Concatenate[int, P], int]
+def f(n: C[P]) -> C[P]: ...
+
+@f  # E: Argument 1 to "f" has incompatible type "Callable[[], int]"; expected "Callable[[int], int]"
+def bad() -> int: ...
+
+@f
+def bar(x: int) -> int: ...
+
+@f
+def bar2(x: int, y: str) -> int: ...
+reveal_type(bar2)  # N: Revealed type is "def (builtins.int, y: builtins.str) -> builtins.int"
+
+@f  # E: Argument 1 to "f" has incompatible type "Callable[[int], str]"; expected "Callable[[int], int]" \
+    # N: This is likely because "foo" has named arguments: "x". Consider marking them positional-only
+def foo(x: int) -> str: ...
+
+@f  # E: Argument 1 to "f" has incompatible type "Callable[[str, int], int]"; expected "Callable[[int, int], int]" \
+    # N: This is likely because "foo2" has named arguments: "x". Consider marking them positional-only
+def foo2(x: str, y: int) -> int: ...
+
+x: C[[int, str]]
+reveal_type(x)  # N: Revealed type is "def (builtins.int, builtins.int, builtins.str) -> builtins.int"
+y: C[int, str]
+reveal_type(y)  # N: Revealed type is "def (builtins.int, builtins.int, builtins.str) -> builtins.int"
+[builtins fixtures/paramspec.pyi]
+
 [case testParamSpecInTypeAliasRecursive]
 from typing import ParamSpec, Callable, Union
 
@@ -1325,7 +1357,6 @@ def f(n: C[P]) -> C[P]: ...
 @f
 def bar(x: int) -> int: ...
 
-# TODO: mismatch because of arg name is hard to debug, give a note on this.
 @f
 def bar2(__x: int) -> Callable[[int], int]: ...
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1413,3 +1413,22 @@ def foo(f: Callable[P, int]) -> None:
     x1: C[int, Concatenate[int, str, P], str]
     x = x1  # OK
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecAliasNested]
+from typing import ParamSpec, Callable, List, TypeVar, Generic
+from typing_extensions import Concatenate
+
+P = ParamSpec("P")
+A = List[Callable[P, None]]
+B = List[Callable[Concatenate[int, P], None]]
+
+fs: A[int, str]
+reveal_type(fs)  # N: Revealed type is "builtins.list[def (builtins.int, builtins.str)]"
+gs: B[int, str]
+reveal_type(gs)  # N: Revealed type is "builtins.list[def (builtins.int, builtins.int, builtins.str)]"
+
+T = TypeVar("T")
+class C(Generic[T]): ...
+C[Callable[P, int]]()  # E: The first argument to Callable must be a list of types, parameter specification, or "..." \
+                       # N: See https://mypy.readthedocs.io/en/stable/kinds_of_types.html#callable-types-and-lambdas
+[builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -505,8 +505,7 @@ def f2(x: X[int, Concatenate[int, P_2]]) -> str: ...  # Accepted
 def f3(x: X[int, [int, bool]]) -> str: ...            # Accepted
 # ellipsis only show up here, but I can assume it works like Callable[..., R]
 def f4(x: X[int, ...]) -> str: ...                    # Accepted
-# TODO: this is not rejected:
-# def f5(x: X[int, int]) -> str: ...                    # Rejected
+def f5(x: X[int, int]) -> str: ...  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "int"
 
 # CASE 3
 def bar(x: int, *args: bool) -> int: ...
@@ -1395,7 +1394,6 @@ def g(x: A[P]) -> None: ...  # E: Invalid location for ParamSpec "P" \
 
 C = Callable[P, T]
 x: C[int]  # E: Bad number of arguments for type alias, expected: 2, given: 1
-# TODO: this should be rejected
-y: C[int, str]
+y: C[int, str]  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "int"
 z: C[int, str, bytes]  # E: Bad number of arguments for type alias, expected: 2, given: 3
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1397,3 +1397,19 @@ x: C[int]  # E: Bad number of arguments for type alias, expected: 2, given: 1
 y: C[int, str]  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "int"
 z: C[int, str, bytes]  # E: Bad number of arguments for type alias, expected: 2, given: 3
 [builtins fixtures/paramspec.pyi]
+
+[case testTrivialParametersHandledCorrectly]
+from typing import ParamSpec, Generic, TypeVar, Callable, Any
+from typing_extensions import Concatenate
+
+P = ParamSpec("P")
+T = TypeVar("T")
+S = TypeVar("S")
+
+class C(Generic[S, P, T]): ...
+
+def foo(f: Callable[P, int]) -> None:
+    x: C[Any, ..., Any]
+    x1: C[int, Concatenate[int, str, P], str]
+    x = x1  # OK
+[builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1296,3 +1296,47 @@ class C(Generic[P]):
 
 reveal_type(bar(C(fn=foo, x=1)))  # N: Revealed type is "__main__.C[[x: builtins.int]]"
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecInTypeAliasBasic]
+from typing import ParamSpec, Callable
+
+P = ParamSpec("P")
+C = Callable[P, int]
+def f(n: C[P]) -> C[P]: ...
+
+@f
+def bar(x: int) -> int: ...
+@f    # E: Argument 1 to "f" has incompatible type "Callable[[int], str]"; expected "Callable[[int], int]"
+def foo(x: int) -> str: ...
+
+x: C[[int, str]]
+reveal_type(x)  # N: Revealed type is "def (builtins.int, builtins.str) -> builtins.int"
+y: C[int, str]
+reveal_type(y)  # N: Revealed type is "def (builtins.int, builtins.str) -> builtins.int"
+[builtins fixtures/paramspec.pyi]
+
+[case testParamSpecInTypeAliasRecursive]
+from typing import ParamSpec, Callable, Union
+
+P = ParamSpec("P")
+C = Callable[P, Union[int, C[P]]]
+def f(n: C[P]) -> C[P]: ...
+
+@f
+def bar(x: int) -> int: ...
+
+# TODO: mismatch because of arg name is hard to debug, give a note on this.
+@f
+def bar2(__x: int) -> Callable[[int], int]: ...
+
+@f  # E: Argument 1 to "f" has incompatible type "Callable[[int], str]"; expected "C[[int]]"
+def foo(x: int) -> str: ...
+
+@f  # E: Argument 1 to "f" has incompatible type "Callable[[int], Callable[[int], str]]"; expected "C[[int]]"
+def foo2(__x: int) -> Callable[[int], str]: ...
+
+x: C[[int, str]]
+reveal_type(x)  # N: Revealed type is "def (builtins.int, builtins.str) -> Union[builtins.int, ...]"
+y: C[int, str]
+reveal_type(y)  # N: Revealed type is "def (builtins.int, builtins.str) -> Union[builtins.int, ...]"
+[builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -947,3 +947,38 @@ c.SpecialImplicit = 4
 c.SpecialExplicit = 4
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-medium.pyi]
+
+[case testValidTypeAliasValues]
+from typing import TypeVar, Generic, List
+
+T = TypeVar("T", int, str)
+S = TypeVar("S", int, bytes)
+
+class C(Generic[T]): ...
+class D(C[S]): ...  # E: Invalid type argument value for "C"
+
+U = TypeVar("U")
+A = List[C[U]]
+x: A[bytes]  # E: Value of type variable "T" of "C" cannot be "bytes"
+
+V = TypeVar("V", bound=int)
+class E(Generic[V]): ...
+B = List[E[U]]
+y: B[str]  # E: Type argument "str" of "E" must be a subtype of "int"
+
+[case testValidTypeAliasValuesMoreRestrictive]
+from typing import TypeVar, Generic, List
+
+T = TypeVar("T")
+S = TypeVar("S", int, str)
+U = TypeVar("U", bound=int)
+
+class C(Generic[T]): ...
+
+A = List[C[S]]
+x: A[int]
+x_bad: A[bytes]  # E: Value of type variable "S" of "A" cannot be "bytes"
+
+B = List[C[U]]
+y: B[int]
+y_bad: B[str]  # E: Type argument "str" of "B" must be a subtype of "int"


### PR DESCRIPTION
Fixes #11855 
Fixes #7084
Fixes #10445
Should fix #4987

After thinking about this for some time, it looks like the best way to implement this is by switching type aliases from unbound to bound type variables. Then I can essentially simply share (or copy in one small place, to avoid cyclic imports) all the logic that currently exists for `ParamSpec` and `Concatenate` in `expand_type()` etc.

This will also address a big piece of tech debt, and will get some benefits (almost) for free, such as checking bounds/values for alias type variables, and much tighter handling of unbound type variables.

Note that in this PR I change logic for emitting some errors, I try to avoid showing multiple errors for the same location/reason. But this is not an essential part of this PR (it is just some test cases would otherwise fail with even more error messages), I can reconsider if there are objections.