### PR TITLE
[partially defined] handle unreachable blocks

### DIFF
--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -217,16 +217,15 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         self.tracker.start_branch_statement()
         o.subject.accept(self)
         for i in range(len(o.patterns)):
-            if o.bodies[i].is_unreachable:
-                self.tracker.skip_branch()
-                self.tracker.next_branch()
-                continue
             pattern = o.patterns[i]
             pattern.accept(self)
             guard = o.guards[i]
             if guard is not None:
                 guard.accept(self)
-            o.bodies[i].accept(self)
+            if not o.bodies[i].is_unreachable:
+                o.bodies[i].accept(self)
+            else:
+                self.tracker.skip_branch()
             is_catchall = infer_pattern_value(pattern) == ALWAYS_TRUE
             if not is_catchall:
                 self.tracker.next_branch()

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -217,6 +217,10 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         self.tracker.start_branch_statement()
         o.subject.accept(self)
         for i in range(len(o.patterns)):
+            if o.bodies[i].is_unreachable:
+                self.tracker.skip_branch()
+                self.tracker.next_branch()
+                continue
             pattern = o.patterns[i]
             pattern.accept(self)
             guard = o.guards[i]

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -203,9 +203,13 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
             e.accept(self)
         self.tracker.start_branch_statement()
         for b in o.body:
+            if b.is_unreachable:
+                continue
             b.accept(self)
             self.tracker.next_branch()
         if o.else_body:
+            if o.else_body.is_unreachable:
+                self.tracker.skip_branch()
             o.else_body.accept(self)
         self.tracker.end_branch_statement()
 

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -367,3 +367,22 @@ def f() -> None:
     d = a
     d = b
 [builtins fixtures/tuple.pyi]
+
+[case testUnreachable]
+# flags: --enable-error-code partially-defined
+import typing
+
+if typing.TYPE_CHECKING:
+    x = 1
+elif int():
+    y = 1
+else:
+    y = 2
+a = x
+
+if not typing.TYPE_CHECKING:
+    pass
+else:
+    z = 1
+a = z
+[typing fixtures/typing-medium.pyi]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1787,7 +1787,32 @@ def f6(a: object) -> None:
     match a:
         case _ if y is not None:  # E: Name "y" may be undefined
             pass
+
 [builtins fixtures/tuple.pyi]
+
+[case testPartiallyDefinedMatchUnreachable]
+# flags: --enable-error-code partially-defined
+import typing
+
+def f7(x: int) -> int:
+    match x:
+        case 1 if not typing.TYPE_CHECKING:
+            pass
+        case 2:
+            y = 2
+        case _:
+            y = 3
+    return y # No error.
+
+def f8(x: int) -> int:
+    match x:
+        case 1 if not typing.TYPE_CHECKING:
+            pass
+        case 2:
+            y = 2
+    return y  # E: Name "y" may be undefined
+
+[typing fixtures/typing-medium.pyi]
 
 [case testTypeAliasWithNewUnionSyntaxAndNoneLeftOperand]
 from typing import overload

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1794,7 +1794,7 @@ def f6(a: object) -> None:
 # flags: --enable-error-code partially-defined
 import typing
 
-def f7(x: int) -> int:
+def f0(x: int) -> int:
     match x:
         case 1 if not typing.TYPE_CHECKING:
             pass
@@ -1804,7 +1804,7 @@ def f7(x: int) -> int:
             y = 3
     return y # No error.
 
-def f8(x: int) -> int:
+def f1(x: int) -> int:
     match x:
         case 1 if not typing.TYPE_CHECKING:
             pass

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1787,7 +1787,6 @@ def f6(a: object) -> None:
     match a:
         case _ if y is not None:  # E: Name "y" may be undefined
             pass
-
 [builtins fixtures/tuple.pyi]
 
 [case testPartiallyDefinedMatchUnreachable]


### PR DESCRIPTION
This adds support for unreachable blocks in `partially-defined` check.

Currently, this only supports blocks that are detected as unreachable during semantic analysis (so mostly stuff like python version, etc.).
This doesn't support more advanced cases (see #13926 for an example what's not covered).

Closes #13929 