### PR TITLE
Don't install lxml on Windows on Python 3.11

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ flake8==5.0.4           # must match version in .pre-commit-config.yaml
 flake8-bugbear==22.9.23 # must match version in .pre-commit-config.yaml
 flake8-noqa==1.2.9      # must match version in .pre-commit-config.yaml
 isort[colors]==5.10.1   # must match version in .pre-commit-config.yaml
-lxml>=4.9.1
+lxml>=4.9.1; python_version<'3.11' or sys_platform!='win32'
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10
 pytest>=6.2.4


### PR DESCRIPTION
Windows wheels for Python 3.11 are not included in the release, and `cibuildwheels` cannot build them, this causes mypy wheel build failure on Windows for Python 3.11, see e.g. https://github.com/mypyc/mypy_mypyc-wheels/actions/runs/3527396237/jobs/5916408981

We need to do this until https://github.com/lxml/lxml/pull/360 is released (hopefully in next few weeks).

cc @hauntsaninja @JukkaL 