### PR TITLE
Remove unnecessary build-system entries

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,4 +1,3 @@
-# NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
 -r mypy-requirements.txt
 types-psutil
 types-setuptools

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,3 @@
-# NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
 typing_extensions>=3.10
 mypy_extensions>=0.4.3
 typed_ast>=1.4.0,<2; python_version<'3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,7 @@
 [build-system]
 requires = [
-    # NOTE: this needs to be kept in sync with mypy-requirements.txt
-    # and build-requirements.txt, because those are both needed for
-    # self-typechecking :/
     "setuptools >= 40.6.2",
     "wheel >= 0.30.0",
-    # the following is from mypy-requirements.txt
-    "typing_extensions>=3.10",
-    "mypy_extensions>=0.4.3",
-    "typed_ast>=1.4.0,<2; python_version<'3.8'",
-    "tomli>=1.1.0; python_version<'3.11'",
-    # the following is from build-requirements.txt
-    "types-psutil",
-    "types-setuptools",
-    "types-typed-ast>=1.5.8,<1.6.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
pyproject.toml:
Remove all unneeded entries from the `build-system` table. The build-system entries are required for building the wheels and sdist tarballs of a project [1][2].
They should not include the test and runtime requirements of a project, which are defined either in setup.py or in in pyproject.toml (in accordance with PEP0621 [3]).
Only stating the required build system dependencies allows downstream consumers to properly build and install a project using pypa/build and pypa/installer.

{build,mypy}-requirements.txt:
Remove unnecessary note about syncing contents with pyproject.toml.

[1] https://peps.python.org/pep-0517/
[2] https://peps.python.org/pep-0518/
[3] https://peps.python.org/pep-0621/

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #14171

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
