### PR TITLE
Simplify callable overlap logic

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -438,18 +438,13 @@ def is_overlapping_types(
         return _type_object_overlap(left, right) or _type_object_overlap(right, left)
 
     if isinstance(left, CallableType) and isinstance(right, CallableType):
-
-        def _callable_overlap(left: CallableType, right: CallableType) -> bool:
-            return is_callable_compatible(
-                left,
-                right,
-                is_compat=_is_overlapping_types,
-                ignore_pos_arg_names=True,
-                allow_partial_overlap=True,
-            )
-
-        # Compare both directions to handle type objects.
-        return _callable_overlap(left, right) or _callable_overlap(right, left)
+        return is_callable_compatible(
+            left,
+            right,
+            is_compat=_is_overlapping_types,
+            ignore_pos_arg_names=True,
+            allow_partial_overlap=True,
+        )
     elif isinstance(left, CallableType):
         left = left.fallback
     elif isinstance(right, CallableType):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1361,7 +1361,7 @@ def is_callable_compatible(
         ignore_pos_arg_names = True
 
     # Non-type cannot be a subtype of type.
-    if right.is_type_obj() and not left.is_type_obj():
+    if right.is_type_obj() and not left.is_type_obj() and not allow_partial_overlap:
         return False
 
     # A callable L is a subtype of a generic callable R if L is a


### PR DESCRIPTION
This gives around 1% speed-up on self check, and may give even more for code that is heavy on overloads.