### PR TITLE
Implement miscellaneous fixes for partially-defined check

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2340,6 +2340,9 @@ class State:
 
     def detect_partially_defined_vars(self, type_map: dict[Expression, Type]) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
+        if self.tree.is_stub:
+            # We skip stub files because they aren't actually executed.
+            return
         manager = self.manager
         if manager.errors.is_error_code_enabled(
             codes.PARTIALLY_DEFINED

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -196,7 +196,6 @@ USE_BEFORE_DEF: Final[ErrorCode] = ErrorCode(
     "use-before-def",
     "Warn about variables that are used before they are defined",
     "General",
-    default_enabled=False,
 )
 
 

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -193,9 +193,7 @@ REDUNDANT_SELF_TYPE = ErrorCode(
     default_enabled=False,
 )
 USE_BEFORE_DEF: Final[ErrorCode] = ErrorCode(
-    "use-before-def",
-    "Warn about variables that are used before they are defined",
-    "General",
+    "use-before-def", "Warn about variables that are used before they are defined", "General"
 )
 
 

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -193,7 +193,10 @@ REDUNDANT_SELF_TYPE = ErrorCode(
     default_enabled=False,
 )
 USE_BEFORE_DEF: Final[ErrorCode] = ErrorCode(
-    "use-before-def", "Warn about variables that are used before they are defined", "General"
+    "use-before-def",
+    "Warn about variables that are used before they are defined",
+    "General",
+    default_enabled=False,
 )
 
 

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -27,7 +27,7 @@ from mypy.nodes import (
     ReturnStmt,
     TupleExpr,
     WhileStmt,
-    WithStmt,
+    WithStmt, StarExpr,
 )
 from mypy.patterns import AsPattern, StarredPattern
 from mypy.reachability import ALWAYS_TRUE, infer_pattern_value
@@ -250,6 +250,8 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
             for ref in refs:
                 self.msg.var_used_before_def(lvalue.name, ref)
             self.tracker.record_definition(lvalue.name)
+        elif isinstance(lvalue, StarExpr):
+            self.process_lvalue(lvalue.expr)
         elif isinstance(lvalue, (ListExpr, TupleExpr)):
             for item in lvalue.items:
                 self.process_lvalue(item)

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -421,10 +421,11 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
 
     def visit_import(self, o: Import) -> None:
         for mod, alias in o.ids:
-            name = alias
-            if name is None:
-                name = mod
-            self.tracker.record_definition(name)
+            names = mod.split(".")
+            if alias is not None:
+                names[-1] = alias
+            for name in names:
+                self.tracker.record_definition(name)
         super().visit_import(o)
 
     def visit_import_from(self, o: ImportFrom) -> None:

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -16,6 +16,8 @@ from mypy.nodes import (
     FuncItem,
     GeneratorExpr,
     IfStmt,
+    Import,
+    ImportFrom,
     ListExpr,
     Lvalue,
     MatchStmt,
@@ -396,3 +398,19 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
             expr.accept(self)
             self.process_lvalue(idx)
         o.body.accept(self)
+
+    def visit_import(self, o: Import) -> None:
+        for mod, alias in o.ids:
+            name = alias
+            if name is None:
+                name = mod
+            self.tracker.record_definition(name)
+        super().visit_import(o)
+
+    def visit_import_from(self, o: ImportFrom) -> None:
+        for mod, alias in o.names:
+            name = alias
+            if name is None:
+                name = mod
+            self.tracker.record_definition(name)
+        super().visit_import_from(o)

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -30,6 +30,7 @@ from mypy.nodes import (
     TupleExpr,
     WhileStmt,
     WithStmt,
+    implicit_module_attrs,
 )
 from mypy.patterns import AsPattern, StarredPattern
 from mypy.reachability import ALWAYS_TRUE, infer_pattern_value
@@ -244,6 +245,8 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         self.msg = msg
         self.type_map = type_map
         self.tracker = DefinedVariableTracker()
+        for name in implicit_module_attrs:
+            self.tracker.record_definition(name)
 
     def process_lvalue(self, lvalue: Lvalue | None) -> None:
         if isinstance(lvalue, NameExpr):

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -292,6 +292,7 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         self.tracker.end_branch_statement()
 
     def visit_func_def(self, o: FuncDef) -> None:
+        self.tracker.record_definition(o.name)
         self.tracker.enter_scope()
         super().visit_func_def(o)
         self.tracker.exit_scope()

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -429,11 +429,15 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
 
     def visit_import(self, o: Import) -> None:
         for mod, alias in o.ids:
-            names = mod.split(".")
             if alias is not None:
-                names[-1] = alias
-            for name in names:
-                self.tracker.record_definition(name)
+                self.tracker.record_definition(alias)
+            else:
+                # When you do `import x.y`, only `x` becomes defined.
+                names = mod.split(".")
+                if len(names) > 0:
+                    # `names` should always be nonempty, but we don't want mypy
+                    # to crash on invalid code.
+                    self.tracker.record_definition(names[0])
         super().visit_import(o)
 
     def visit_import_from(self, o: ImportFrom) -> None:

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -18,6 +18,7 @@ from mypy.nodes import (
     IfStmt,
     Import,
     ImportFrom,
+    LambdaExpr,
     ListExpr,
     Lvalue,
     MatchStmt,
@@ -25,9 +26,10 @@ from mypy.nodes import (
     RaiseStmt,
     RefExpr,
     ReturnStmt,
+    StarExpr,
     TupleExpr,
     WhileStmt,
-    WithStmt, StarExpr,
+    WithStmt,
 )
 from mypy.patterns import AsPattern, StarredPattern
 from mypy.reachability import ALWAYS_TRUE, infer_pattern_value
@@ -338,6 +340,11 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
     def visit_return_stmt(self, o: ReturnStmt) -> None:
         super().visit_return_stmt(o)
         self.tracker.skip_branch()
+
+    def visit_lambda_expr(self, o: LambdaExpr) -> None:
+        self.tracker.enter_scope()
+        super().visit_lambda_expr(o)
+        self.tracker.exit_scope()
 
     def visit_assert_stmt(self, o: AssertStmt) -> None:
         super().visit_assert_stmt(o)

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -133,6 +133,13 @@ def f1() -> None:
 
     some_func()  # No error.
 
+[case testLambda]
+# flags: --enable-error-code partially-defined
+def f0(b: bool) -> None:
+    if b:
+        fn = lambda: 2
+    y = fn   # E: Name "fn" may be undefined
+
 [case testGenerator]
 # flags: --enable-error-code partially-defined
 if int():

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -513,3 +513,8 @@ def f0() -> None:
     s = type(123)
     type = "abc"
     a = type
+
+[case testUseBeforeDefImplicitModuleAttrs]
+# flags: --enable-error-code use-before-def
+a = __name__  # No error.
+__name__ = "abc"

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -469,32 +469,54 @@ def f5() -> None:
         x = z  # E: Name "z" is used before definition
     z: int = 2
 
-[case testUseBeforeDefImports]
+[case testUseBeforeDefImportsBasic]
 # flags: --enable-error-code use-before-def
-from foo import x  # type: ignore
-from foo import abc as y  # type: ignore
-import z  # type: ignore
-import foo as f  # type: ignore
+import foo  # type: ignore
+import x.y  # type: ignore
 
 def f0() -> None:
-    a = x  # No error.
-    x = 1
+    a = foo  # No error.
+    foo: int = 1
 
 def f1() -> None:
     a = y  # No error.
-    y = 1
+    y: int = 1
 
 def f2() -> None:
-    a = z  # No error.
-    z = 1
+    a = x  # No error.
+    x: int = 1
 
-def f3() -> None:
-    a = f  # No error.
-    z = 1
+[case testUseBeforeDefImportBasicRename]
+# flags: --enable-error-code use-before-def
+import foo as bar  # type: ignore
 
-def f4() -> None:
-    a = abc  # E: Name "abc" is used before definition
-    abc: int = 1
+def f0() -> None:
+    a = bar  # No error.
+    bar: int = 1
+
+def f1() -> None:
+    a = foo  # E: Name "foo" is used before definition
+    foo: int = 1
+
+[case testUseBeforeDefImportFrom]
+# flags: --enable-error-code use-before-def
+from foo import x  # type: ignore
+
+def f0() -> None:
+    a = x  # No error.
+    x: int = 1
+
+[case testUseBeforeDefImportFromRename]
+# flags: --enable-error-code use-before-def
+from foo import x as y  # type: ignore
+
+def f0() -> None:
+    a = y  # No error.
+    y: int = 1
+
+def f1() -> None:
+    a = x  # E: Name "x" is used before definition
+    x: int = 1
 
 [case testUseBeforeDefFunctionDeclarations]
 # flags: --enable-error-code use-before-def

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -432,3 +432,30 @@ def f5() -> None:
         y = z  # E: Name "z" is used before definition
         x = z  # E: Name "z" is used before definition
     z: int = 2
+
+[case testUseBeforeDefImports]
+# flags: --enable-error-code use-before-def
+from foo import x  # type: ignore
+from foo import abc as y  # type: ignore
+import z  # type: ignore
+import foo as f  # type: ignore
+
+def f0() -> None:
+    a = x  # No error.
+    x = 1
+
+def f1() -> None:
+    a = y  # No error.
+    y = 1
+
+def f2() -> None:
+    a = z  # No error.
+    z = 1
+
+def f3() -> None:
+    a = f  # No error.
+    z = 1
+
+def f4() -> None:
+    a = abc  # E: Name "abc" is used before definition
+    abc: int = 1

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -90,6 +90,16 @@ else:
 a = y + x  # E: Name "x" may be undefined
 a = y + z  # E: Name "z" may be undefined
 
+[case testIndexExpr]
+# flags: --enable-error-code partially-defined
+
+if int():
+    *x, y = (1, 2)
+else:
+    x = [1, 2]
+a = x  # No error.
+b = y  # E: Name "y" may be undefined
+
 [case testRedefined]
 # flags: --enable-error-code partially-defined
 y = 3
@@ -479,7 +489,7 @@ def f4() -> None:
     a = abc  # E: Name "abc" is used before definition
     abc: int = 1
 
-[case testFunctionDeclarations]
+[case testUseBeforeDefFunctionDeclarations]
 # flags: --enable-error-code use-before-def
 
 def f0() -> None:
@@ -489,7 +499,7 @@ def f0() -> None:
     inner()  # No error.
     inner = lambda: None
 
-[case testBuiltins]
+[case testUseBeforeDefBuiltins]
 # flags: --enable-error-code use-before-def
 
 def f0() -> None:

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -104,6 +104,25 @@ else:
 
 x = y + 2
 
+[case testFunction]
+# flags: --enable-error-code partially-defined
+def f0() -> None:
+    if int():
+        def some_func() -> None:
+            pass
+
+    some_func()  # E: Name "some_func" may be undefined
+
+def f1() -> None:
+    if int():
+        def some_func() -> None:
+            pass
+    else:
+        def some_func() -> None:
+            pass
+
+    some_func()  # No error.
+
 [case testGenerator]
 # flags: --enable-error-code partially-defined
 if int():
@@ -459,3 +478,13 @@ def f3() -> None:
 def f4() -> None:
     a = abc  # E: Name "abc" is used before definition
     abc: int = 1
+
+[case testFunctionDeclarations]
+# flags: --enable-error-code use-before-def
+
+def f0() -> None:
+    def inner() -> None:
+        pass
+
+    inner()  # No error.
+    inner = lambda: None

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -507,24 +507,37 @@ def f0() -> None:
     foo: int = 1
 
 def f1() -> None:
-    a = y  # No error.
+    a = y  # E: Name "y" is used before definition
     y: int = 1
 
 def f2() -> None:
     a = x  # No error.
     x: int = 1
 
+def f3() -> None:
+    a = x.y  # No error.
+    x: int = 1
+
 [case testUseBeforeDefImportBasicRename]
 # flags: --enable-error-code use-before-def
-import foo as bar  # type: ignore
+import x.y as z  # type: ignore
+from typing import Any
 
 def f0() -> None:
-    a = bar  # No error.
-    bar: int = 1
+    a = z  # No error.
+    z: int = 1
 
 def f1() -> None:
-    a = foo  # E: Name "foo" is used before definition
-    foo: int = 1
+    a = x  # E: Name "x" is used before definition
+    x: int = 1
+
+def f2() -> None:
+    a = x.y  # E: Name "x" is used before definition
+    x: Any = 1
+
+def f3() -> None:
+    a = y  # E: Name "y" is used before definition
+    y: int = 1
 
 [case testUseBeforeDefImportFrom]
 # flags: --enable-error-code use-before-def

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -488,3 +488,11 @@ def f0() -> None:
 
     inner()  # No error.
     inner = lambda: None
+
+[case testBuiltins]
+# flags: --enable-error-code use-before-def
+
+def f0() -> None:
+    s = type(123)
+    type = "abc"
+    a = type


### PR DESCRIPTION
These are the issues that I've found using mypy-primer.

You should be able to review this PR commit-by-commit. Each commit includes the relevant tests:
- Process imports correctly
- Support for function names
- Skip stub files (this change has no tests)
- Handle builtins and implicit module attrs (e.g. `str` and `__doc__`)
- Improved support for lambdas.