### PR TITLE
Fix issues with type aliases and new style unions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2668,26 +2668,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.msg.annotation_in_unchecked_function(context=s)
 
     def check_type_alias_rvalue(self, s: AssignmentStmt) -> None:
-        if not (self.is_stub and isinstance(s.rvalue, OpExpr) and s.rvalue.op == "|"):
-            # We do this mostly for compatibility with old semantic analyzer.
-            # TODO: should we get rid of this?
-            alias_type = self.expr_checker.accept(s.rvalue)
-        else:
-            # Avoid type checking 'X | Y' in stubs, since there can be errors
-            # on older Python targets.
-            alias_type = AnyType(TypeOfAny.special_form)
-
-            def accept_items(e: Expression) -> None:
-                if isinstance(e, OpExpr) and e.op == "|":
-                    accept_items(e.left)
-                    accept_items(e.right)
-                else:
-                    # Nested union types have been converted to type context
-                    # in semantic analysis (such as in 'list[int | str]'),
-                    # so we don't need to deal with them here.
-                    self.expr_checker.accept(e)
-
-            accept_items(s.rvalue)
+        alias_type = self.expr_checker.accept(s.rvalue)
         self.store_type(s.lvalues[-1], alias_type)
 
     def check_assignment(

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2847,6 +2847,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def visit_op_expr(self, e: OpExpr) -> Type:
         """Type check a binary operator expression."""
+        if e.analyzed:
+            # It's actually a type expression X | Y.
+            return self.accept(e.analyzed)
         if e.op == "and" or e.op == "or":
             return self.check_boolean_op(e, e)
         if e.op == "*" and isinstance(e.left, ListExpr):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1994,7 +1994,7 @@ class OpExpr(Expression):
     right_always: bool
     # Per static analysis only: Is the right side unreachable?
     right_unreachable: bool
-    # Used for expressions that represent type X | Y in some contexts
+    # Used for expressions that represent a type "X | Y" in some contexts
     analyzed: TypeAliasExpr | None
 
     def __init__(self, op: str, left: Expression, right: Expression) -> None:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1968,10 +1968,20 @@ class AssignmentExpr(Expression):
 
 
 class OpExpr(Expression):
-    """Binary operation (other than . or [] or comparison operators,
-    which have specific nodes)."""
+    """Binary operation.
 
-    __slots__ = ("op", "left", "right", "method_type", "right_always", "right_unreachable")
+    The dot (.), [] and comparison operators have more specific nodes.
+    """
+
+    __slots__ = (
+        "op",
+        "left",
+        "right",
+        "method_type",
+        "right_always",
+        "right_unreachable",
+        "analyzed",
+    )
 
     __match_args__ = ("left", "op", "right")
 
@@ -1984,6 +1994,8 @@ class OpExpr(Expression):
     right_always: bool
     # Per static analysis only: Is the right side unreachable?
     right_unreachable: bool
+    # Used for expressions that represent type X | Y in some contexts
+    analyzed: TypeAliasExpr | None
 
     def __init__(self, op: str, left: Expression, right: Expression) -> None:
         super().__init__()
@@ -1993,6 +2005,7 @@ class OpExpr(Expression):
         self.method_type = None
         self.right_always = False
         self.right_unreachable = False
+        self.analyzed = None
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_op_expr(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1997,7 +1997,9 @@ class OpExpr(Expression):
     # Used for expressions that represent a type "X | Y" in some contexts
     analyzed: TypeAliasExpr | None
 
-    def __init__(self, op: str, left: Expression, right: Expression, analyzed: TypeAliasExpr | None = None) -> None:
+    def __init__(
+        self, op: str, left: Expression, right: Expression, analyzed: TypeAliasExpr | None = None
+    ) -> None:
         super().__init__()
         self.op = op
         self.left = left

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1997,7 +1997,7 @@ class OpExpr(Expression):
     # Used for expressions that represent a type "X | Y" in some contexts
     analyzed: TypeAliasExpr | None
 
-    def __init__(self, op: str, left: Expression, right: Expression) -> None:
+    def __init__(self, op: str, left: Expression, right: Expression, analyzed: TypeAliasExpr | None = None) -> None:
         super().__init__()
         self.op = op
         self.left = left
@@ -2005,7 +2005,7 @@ class OpExpr(Expression):
         self.method_type = None
         self.right_always = False
         self.right_unreachable = False
-        self.analyzed = None
+        self.analyzed = analyzed
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_op_expr(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3440,7 +3440,9 @@ class SemanticAnalyzer(
             no_args=no_args,
             eager=eager,
         )
-        if isinstance(s.rvalue, (IndexExpr, CallExpr, OpExpr)):  # CallExpr is for `void = type(None)`
+        if isinstance(
+            s.rvalue, (IndexExpr, CallExpr, OpExpr)
+        ):  # CallExpr is for `void = type(None)`
             s.rvalue.analyzed = TypeAliasExpr(alias_node)
             s.rvalue.analyzed.line = s.line
             # we use the column from resulting target, to get better location for errors

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3444,7 +3444,7 @@ class SemanticAnalyzer(
             not isinstance(rvalue, OpExpr)
             or (self.options.python_version >= (3, 10) or self.is_stub_file)
         ):
-            # Note: CallExpr is for `void = type(None)` and OpExpr is for X | Y union syntax.
+            # Note: CallExpr is for "void = type(None)" and OpExpr is for "X | Y" union syntax.
             s.rvalue.analyzed = TypeAliasExpr(alias_node)
             s.rvalue.analyzed.line = s.line
             # we use the column from resulting target, to get better location for errors

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3440,7 +3440,7 @@ class SemanticAnalyzer(
             no_args=no_args,
             eager=eager,
         )
-        if isinstance(s.rvalue, (IndexExpr, CallExpr)):  # CallExpr is for `void = type(None)`
+        if isinstance(s.rvalue, (IndexExpr, CallExpr, OpExpr)):  # CallExpr is for `void = type(None)`
             s.rvalue.analyzed = TypeAliasExpr(alias_node)
             s.rvalue.analyzed.line = s.line
             # we use the column from resulting target, to get better location for errors

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3440,9 +3440,11 @@ class SemanticAnalyzer(
             no_args=no_args,
             eager=eager,
         )
-        if isinstance(
-            s.rvalue, (IndexExpr, CallExpr, OpExpr)
-        ):  # CallExpr is for `void = type(None)`
+        if isinstance(s.rvalue, (IndexExpr, CallExpr, OpExpr)) and (
+            not isinstance(rvalue, OpExpr)
+            or (self.options.python_version >= (3, 10) or self.is_stub_file)
+        ):
+            # Note: CallExpr is for `void = type(None)` and OpExpr is for X | Y union syntax.
             s.rvalue.analyzed = TypeAliasExpr(alias_node)
             s.rvalue.analyzed.line = s.line
             # we use the column from resulting target, to get better location for errors

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -54,6 +54,7 @@ from mypy.nodes import (
     MypyFile,
     NameExpr,
     Node,
+    OpExpr,
     OverloadedFuncDef,
     RefExpr,
     StarExpr,

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -222,6 +222,10 @@ class NodeStripVisitor(TraverserVisitor):
         node.analyzed = None  # May have been an alias or type application.
         super().visit_index_expr(node)
 
+    def visit_op_expr(self, node: OpExpr) -> None:
+        node.analyzed = None  # May have been an alias
+        super().visit_op_expr(node)
+
     def strip_ref_expr(self, node: RefExpr) -> None:
         node.kind = None
         node.node = None

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -413,6 +413,8 @@ class StrConv(NodeVisitor[str]):
         return self.dump(a + extra, o)
 
     def visit_op_expr(self, o: mypy.nodes.OpExpr) -> str:
+        if o.analyzed:
+            return o.analyzed.accept(self)
         return self.dump([o.op, o.left, o.right], o)
 
     def visit_comparison_expr(self, o: mypy.nodes.ComparisonExpr) -> str:

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -262,6 +262,8 @@ class TraverserVisitor(NodeVisitor[None]):
     def visit_op_expr(self, o: OpExpr) -> None:
         o.left.accept(self)
         o.right.accept(self)
+        if o.analyzed is not None:
+            o.analyzed.accept(self)
 
     def visit_comparison_expr(self, o: ComparisonExpr) -> None:
         for operand in o.operands:

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -519,7 +519,12 @@ class TransformVisitor(NodeVisitor[Node]):
         )
 
     def visit_op_expr(self, node: OpExpr) -> OpExpr:
-        new = OpExpr(node.op, self.expr(node.left), self.expr(node.right))
+        new = OpExpr(
+            node.op,
+            self.expr(node.left),
+            self.expr(node.right),
+            cast(Optional[TypeAliasExpr], self.optional_expr(node.analyzed)),
+        )
         new.method_type = self.optional_type(node.method_type)
         return new
 

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -947,3 +947,14 @@ c.SpecialImplicit = 4
 c.SpecialExplicit = 4
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-medium.pyi]
+
+[case testNewStyleUnionInTypeAliasWithMalformedInstance]
+# flags: --python-version 3.10
+from typing import List
+
+A = List[int, str] | int  # E: "list" expects 1 type argument, but 2 given
+B = int | list[int, str]  # E: "list" expects 1 type argument, but 2 given
+a: A
+b: B
+reveal_type(a)  # N: Revealed type is "Union[builtins.list[Any], builtins.int]"
+reveal_type(b)  # N: Revealed type is "Union[builtins.int, builtins.list[Any]]"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10277,3 +10277,34 @@ A = str
 m.py:5: error: Invalid statement in TypedDict definition; expected "field_name: field_type"
 ==
 m.py:5: error: Invalid statement in TypedDict definition; expected "field_name: field_type"
+
+[case testTypeAliasWithNewStyleUnionChangedToVariable]
+# flags: --python-version 3.10
+import a
+
+[file a.py]
+from b import C, D
+A = C | D
+a: A
+reveal_type(a)
+
+[file b.py]
+C = int
+D = str
+
+[file b.py.2]
+C = "x"
+D = "y"
+
+[file b.py.3]
+C = str
+D = int
+[out]
+a.py:4: note: Revealed type is "Union[builtins.int, builtins.str]"
+==
+a.py:2: error: Unsupported left operand type for | ("str")
+a.py:3: error: Variable "a.A" is not valid as a type
+a.py:3: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+a.py:4: note: Revealed type is "A?"
+==
+a.py:4: note: Revealed type is "Union[builtins.str, builtins.int]"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1699,6 +1699,18 @@ _testTypeAliasWithNewStyleUnion.py:28: note: Revealed type is "Union[Type[builti
 [case testTypeAliasWithNewStyleUnionInStub]
 # flags: --python-version 3.7
 import m
+a: m.A
+reveal_type(a)
+b: m.B
+reveal_type(b)
+c: m.C
+reveal_type(c)
+d: m.D
+reveal_type(d)
+e: m.E
+reveal_type(e)
+f: m.F
+reveal_type(f)
 
 [file m.pyi]
 from typing import Type
@@ -1729,6 +1741,12 @@ F: TypeAlias = str | type[int]
 [out]
 m.pyi:5: note: Revealed type is "typing._SpecialForm"
 m.pyi:22: note: Revealed type is "typing._SpecialForm"
+_testTypeAliasWithNewStyleUnionInStub.py:4: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
+_testTypeAliasWithNewStyleUnionInStub.py:6: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
+_testTypeAliasWithNewStyleUnionInStub.py:8: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
+_testTypeAliasWithNewStyleUnionInStub.py:10: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
+_testTypeAliasWithNewStyleUnionInStub.py:12: note: Revealed type is "Union[builtins.str, Type[builtins.int]]"
+_testTypeAliasWithNewStyleUnionInStub.py:14: note: Revealed type is "Union[builtins.str, Type[builtins.int]]"
 
 [case testEnumNameWorkCorrectlyOn311]
 # flags: --python-version 3.11

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1713,7 +1713,7 @@ f: m.F
 reveal_type(f)
 
 [file m.pyi]
-from typing import Type
+from typing import Type, Callable
 from typing_extensions import Literal, TypeAlias
 
 Foo = Literal[1, 2]
@@ -1738,6 +1738,11 @@ reveal_type(C)
 D: TypeAlias = type[int] | str
 E = str | type[int]
 F: TypeAlias = str | type[int]
+
+CU1 = int | Callable[[], str | bool]
+CU2: TypeAlias = int | Callable[[], str | bool]
+CU3 = int | Callable[[str | bool], str]
+CU4: TypeAlias = int | Callable[[str | bool], str]
 [out]
 m.pyi:5: note: Revealed type is "typing._SpecialForm"
 m.pyi:22: note: Revealed type is "typing._SpecialForm"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1721,6 +1721,10 @@ Opt4 = float | None
 
 A = Type[int] | str
 B: TypeAlias = Type[int] | str
+C = type[int] | str
+D: TypeAlias = type[int] | str
+E = str | type[int]
+F: TypeAlias = str | type[int]
 [out]
 m.pyi:5: note: Revealed type is "typing._SpecialForm"
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1663,7 +1663,7 @@ _testNarrowTypeForDictKeys.py:16: note: Revealed type is "Union[builtins.str, No
 
 [case testTypeAliasWithNewStyleUnion]
 # flags: --python-version 3.10
-from typing import Literal, Type, TypeAlias
+from typing import Literal, Type, TypeAlias, TypeVar
 
 Foo = Literal[1, 2]
 reveal_type(Foo)
@@ -1691,6 +1691,12 @@ E: TypeAlias = type[int] | str
 y: E
 reveal_type(y)
 F = list[type[int] | str]
+
+T = TypeVar("T", int, str)
+def foo(x: T) -> T:
+    A = type[int] | str
+    a: A
+    return x
 [out]
 _testTypeAliasWithNewStyleUnion.py:5: note: Revealed type is "typing._SpecialForm"
 _testTypeAliasWithNewStyleUnion.py:25: note: Revealed type is "Union[Type[builtins.int], builtins.str]"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1738,6 +1738,8 @@ reveal_type(C)
 D: TypeAlias = type[int] | str
 E = str | type[int]
 F: TypeAlias = str | type[int]
+G = list[type[int] | str]
+H = list[str | type[int]]
 
 CU1 = int | Callable[[], str | bool]
 CU2: TypeAlias = int | Callable[[], str | bool]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1682,8 +1682,19 @@ Opt4 = float | None
 
 A = Type[int] | str
 B: TypeAlias = Type[int] | str
+C = type[int] | str
+
+D = type[int] | str
+x: D
+reveal_type(x)
+E: TypeAlias = type[int] | str
+y: E
+reveal_type(y)
+F = list[type[int] | str]
 [out]
 _testTypeAliasWithNewStyleUnion.py:5: note: Revealed type is "typing._SpecialForm"
+_testTypeAliasWithNewStyleUnion.py:24: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
+_testTypeAliasWithNewStyleUnion.py:27: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
 
 [case testTypeAliasWithNewStyleUnionInStub]
 # flags: --python-version 3.7
@@ -1735,3 +1746,20 @@ _testEnumNameWorkCorrectlyOn311.py:12: note: Revealed type is "Union[Literal[1]?
 _testEnumNameWorkCorrectlyOn311.py:13: note: Revealed type is "Literal['X']?"
 _testEnumNameWorkCorrectlyOn311.py:14: note: Revealed type is "builtins.int"
 _testEnumNameWorkCorrectlyOn311.py:15: note: Revealed type is "builtins.int"
+
+[case testTypeAliasNotSupportedWithNewStyleUnion]
+# flags: --python-version 3.9
+from typing_extensions import TypeAlias
+A = type[int] | str
+B = str | type[int]
+C = str | int
+D: TypeAlias = str | int
+[out]
+_testTypeAliasNotSupportedWithNewStyleUnion.py:3: error: Invalid type alias: expression is not a valid type
+_testTypeAliasNotSupportedWithNewStyleUnion.py:3: error: Value of type "Type[type]" is not indexable
+_testTypeAliasNotSupportedWithNewStyleUnion.py:4: error: Invalid type alias: expression is not a valid type
+_testTypeAliasNotSupportedWithNewStyleUnion.py:4: error: Value of type "Type[type]" is not indexable
+_testTypeAliasNotSupportedWithNewStyleUnion.py:5: error: Invalid type alias: expression is not a valid type
+_testTypeAliasNotSupportedWithNewStyleUnion.py:5: error: Unsupported left operand type for | ("Type[str]")
+_testTypeAliasNotSupportedWithNewStyleUnion.py:6: error: Invalid type alias: expression is not a valid type
+_testTypeAliasNotSupportedWithNewStyleUnion.py:6: error: Unsupported left operand type for | ("Type[str]")

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1693,8 +1693,8 @@ reveal_type(y)
 F = list[type[int] | str]
 [out]
 _testTypeAliasWithNewStyleUnion.py:5: note: Revealed type is "typing._SpecialForm"
-_testTypeAliasWithNewStyleUnion.py:24: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
-_testTypeAliasWithNewStyleUnion.py:27: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
+_testTypeAliasWithNewStyleUnion.py:25: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
+_testTypeAliasWithNewStyleUnion.py:28: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
 
 [case testTypeAliasWithNewStyleUnionInStub]
 # flags: --python-version 3.7

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1722,11 +1722,13 @@ Opt4 = float | None
 A = Type[int] | str
 B: TypeAlias = Type[int] | str
 C = type[int] | str
+reveal_type(C)
 D: TypeAlias = type[int] | str
 E = str | type[int]
 F: TypeAlias = str | type[int]
 [out]
 m.pyi:5: note: Revealed type is "typing._SpecialForm"
+m.pyi:22: note: Revealed type is "typing._SpecialForm"
 
 [case testEnumNameWorkCorrectlyOn311]
 # flags: --python-version 3.11


### PR DESCRIPTION
Fix aliases like this and other aliases involving new-style unions:
```
A = type[int] | str
```

Fixes #12392. Fixes #14158.