### PR TITLE
[partially defined] rework handling of else in loops

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2349,6 +2349,9 @@ class State:
 
     def detect_partially_defined_vars(self, type_map: dict[Expression, Type]) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
+        if self.tree.is_stub:
+            # We skip stub files because they aren't actually executed.
+            return
         manager = self.manager
         if manager.errors.is_error_code_enabled(
             codes.PARTIALLY_DEFINED

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -223,6 +223,11 @@ def refers_to_builtin(o: RefExpr) -> bool:
     return o.fullname is not None and o.fullname.startswith("builtins.")
 
 
+class Loop:
+    def __init__(self):
+        self.has_break = False
+
+
 class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
     """Detects the following cases:
     - A variable that's defined only part of the time.
@@ -244,7 +249,7 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
     def __init__(self, msg: MessageBuilder, type_map: dict[Expression, Type]) -> None:
         self.msg = msg
         self.type_map = type_map
-        self.loop_depth = 0
+        self.loops: list[Loop] = []
         self.tracker = DefinedVariableTracker()
         for name in implicit_module_attrs:
             self.tracker.record_definition(name)
@@ -335,13 +340,23 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         self.process_lvalue(o.index)
         o.index.accept(self)
         self.tracker.start_branch_statement()
-        self.loop_depth += 1
+        loop = Loop()
+        self.loops.append(loop)
         o.body.accept(self)
         self.tracker.next_branch()
-        if o.else_body:
-            o.else_body.accept(self)
-        self.loop_depth -= 1
         self.tracker.end_branch_statement()
+        if o.else_body is not None:
+            # If the loop has a `break` inside, `else` is executed conditionally.
+            # If the loop doesn't have a `break` either the function will return or
+            # execute the `else`.
+            has_break = loop.has_break
+            if has_break:
+                self.tracker.start_branch_statement()
+                self.tracker.next_branch()
+            o.else_body.accept(self)
+            if has_break:
+                self.tracker.end_branch_statement()
+        self.loops.pop()
 
     def visit_return_stmt(self, o: ReturnStmt) -> None:
         super().visit_return_stmt(o)
@@ -367,6 +382,8 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
 
     def visit_break_stmt(self, o: BreakStmt) -> None:
         super().visit_break_stmt(o)
+        if len(self.loops) > 0:
+            self.loops[-1].has_break = True
         self.tracker.skip_branch()
 
     def visit_expression_stmt(self, o: ExpressionStmt) -> None:
@@ -377,14 +394,28 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
     def visit_while_stmt(self, o: WhileStmt) -> None:
         o.expr.accept(self)
         self.tracker.start_branch_statement()
-        self.loop_depth += 1
+        loop = Loop()
+        self.loops.append(loop)
         o.body.accept(self)
+        has_break = loop.has_break
         if not checker.is_true_literal(o.expr):
+            # If this is a loop like `while True`, we can consider the body to be
+            # a single branch statement (we're guaranteed that the body is executed at least once).
+            # If not, call next_branch() to make all variables defined there conditional.
             self.tracker.next_branch()
+        self.tracker.end_branch_statement()
+        if o.else_body is not None:
+            # If the loop has a `break` inside, `else` is executed conditionally.
+            # If the loop doesn't have a `break` either the function will return or
+            # execute the `else`.
+            if has_break:
+                self.tracker.start_branch_statement()
+                self.tracker.next_branch()
             if o.else_body:
                 o.else_body.accept(self)
-        self.loop_depth -= 1
-        self.tracker.end_branch_statement()
+            if has_break:
+                self.tracker.end_branch_statement()
+        self.loops.pop()
 
     def visit_as_pattern(self, o: AsPattern) -> None:
         if o.name is not None:
@@ -407,7 +438,7 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
             self.tracker.record_definition(o.name)
         elif self.tracker.is_defined_in_different_branch(o.name):
             # A variable is defined in one branch but used in a different branch.
-            if self.loop_depth > 0:
+            if len(self.loops) > 0:
                 self.msg.variable_may_be_undefined(o.name, o)
             else:
                 self.msg.var_used_before_def(o.name, o)

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -391,7 +391,7 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
 
     def visit_break_stmt(self, o: BreakStmt) -> None:
         super().visit_break_stmt(o)
-        if len(self.loops) > 0:
+        if self.loops:
             self.loops[-1].has_break = True
         self.tracker.skip_branch()
 

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -379,11 +379,11 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         self.tracker.start_branch_statement()
         self.loop_depth += 1
         o.body.accept(self)
-        self.loop_depth -= 1
         if not checker.is_true_literal(o.expr):
             self.tracker.next_branch()
             if o.else_body:
                 o.else_body.accept(self)
+        self.loop_depth -= 1
         self.tracker.end_branch_statement()
 
     def visit_as_pattern(self, o: AsPattern) -> None:

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -224,7 +224,7 @@ def refers_to_builtin(o: RefExpr) -> bool:
 
 
 class Loop:
-    def __init__(self):
+    def __init__(self) -> None:
         self.has_break = False
 
 

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -90,6 +90,16 @@ else:
 a = y + x  # E: Name "x" may be undefined
 a = y + z  # E: Name "z" may be undefined
 
+[case testIndexExpr]
+# flags: --enable-error-code partially-defined
+
+if int():
+    *x, y = (1, 2)
+else:
+    x = [1, 2]
+a = x  # No error.
+b = y  # E: Name "y" may be undefined
+
 [case testRedefined]
 # flags: --enable-error-code partially-defined
 y = 3
@@ -103,6 +113,32 @@ else:
     x = y + 2
 
 x = y + 2
+
+[case testFunction]
+# flags: --enable-error-code partially-defined
+def f0() -> None:
+    if int():
+        def some_func() -> None:
+            pass
+
+    some_func()  # E: Name "some_func" may be undefined
+
+def f1() -> None:
+    if int():
+        def some_func() -> None:
+            pass
+    else:
+        def some_func() -> None:
+            pass
+
+    some_func()  # No error.
+
+[case testLambda]
+# flags: --enable-error-code partially-defined
+def f0(b: bool) -> None:
+    if b:
+        fn = lambda: 2
+    y = fn   # E: Name "fn" may be undefined
 
 [case testGenerator]
 # flags: --enable-error-code partially-defined
@@ -460,3 +496,88 @@ def f4() -> None:
         y = z  # E: Name "z" is used before definition
         x = z  # E: Name "z" is used before definition
     z: int = 2
+
+[case testUseBeforeDefImportsBasic]
+# flags: --enable-error-code use-before-def
+import foo  # type: ignore
+import x.y  # type: ignore
+
+def f0() -> None:
+    a = foo  # No error.
+    foo: int = 1
+
+def f1() -> None:
+    a = y  # E: Name "y" is used before definition
+    y: int = 1
+
+def f2() -> None:
+    a = x  # No error.
+    x: int = 1
+
+def f3() -> None:
+    a = x.y  # No error.
+    x: int = 1
+
+[case testUseBeforeDefImportBasicRename]
+# flags: --enable-error-code use-before-def
+import x.y as z  # type: ignore
+from typing import Any
+
+def f0() -> None:
+    a = z  # No error.
+    z: int = 1
+
+def f1() -> None:
+    a = x  # E: Name "x" is used before definition
+    x: int = 1
+
+def f2() -> None:
+    a = x.y  # E: Name "x" is used before definition
+    x: Any = 1
+
+def f3() -> None:
+    a = y  # E: Name "y" is used before definition
+    y: int = 1
+
+[case testUseBeforeDefImportFrom]
+# flags: --enable-error-code use-before-def
+from foo import x  # type: ignore
+
+def f0() -> None:
+    a = x  # No error.
+    x: int = 1
+
+[case testUseBeforeDefImportFromRename]
+# flags: --enable-error-code use-before-def
+from foo import x as y  # type: ignore
+
+def f0() -> None:
+    a = y  # No error.
+    y: int = 1
+
+def f1() -> None:
+    a = x  # E: Name "x" is used before definition
+    x: int = 1
+
+[case testUseBeforeDefFunctionDeclarations]
+# flags: --enable-error-code use-before-def
+
+def f0() -> None:
+    def inner() -> None:
+        pass
+
+    inner()  # No error.
+    inner = lambda: None
+
+[case testUseBeforeDefBuiltins]
+# flags: --enable-error-code use-before-def
+
+def f0() -> None:
+    s = type(123)
+    type = "abc"
+    a = type
+
+[case testUseBeforeDefImplicitModuleAttrs]
+# flags: --enable-error-code use-before-def
+a = __name__  # No error.
+__name__ = "abc"

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -283,6 +283,17 @@ def f1() -> None:
             y = x  # E: Name "x" may be undefined
             z = x  # E: Name "x" may be undefined
 
+def f2() -> None:
+    for i in [0, 1]:
+        x = i
+    else:
+        y = x  # E: Name "x" may be undefined
+
+def f3() -> None:
+    while int():
+        x = 1
+    else:
+        y = x  # E: Name "x" may be undefined
 
 [case testAssert]
 # flags: --enable-error-code partially-defined

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -167,22 +167,49 @@ def foo(a: int) -> None:
 [case testWhile]
 # flags: --enable-error-code partially-defined
 while int():
-    x = 1
+    a = 1
 
-y = x  # E: Name "x" may be undefined
+x = a  # E: Name "a" may be undefined
 
 while int():
-    z = 1
+    b = 1
 else:
-    z = 2
+    b = 2
 
-y = z  # No error.
+y = b  # No error.
 
 while True:
-    k = 1
+    c = 1
     if int():
         break
-y = k # No error.
+y = c  # No error.
+
+# This while loop doesn't have a `break` inside, so we know that the else must always get executed.
+while int():
+    pass
+else:
+    d = 1
+y = d  # No error.
+
+while int():
+    if int():
+        break
+else:
+    e = 1
+# If a while loop has a `break`, it's possible that the else didn't get executed.
+y = e  # E: Name "e" may be undefined
+
+while int():
+    while int():
+        if int():
+            break
+    else:
+        f = 1
+else:
+    g = 2
+
+y = f  # E: Name "f" may be undefined
+y = g
 
 [case testForLoop]
 # flags: --enable-error-code partially-defined
@@ -190,7 +217,6 @@ for x in [1, 2, 3]:
     if x:
         x = 1
     y = x
-    z = 1
 else:
     z = 2
 
@@ -349,16 +375,12 @@ def f2() -> int:
     while int():
         if int():
             x = 1
-            z = 1
         elif int():
             pass
         else:
             continue
         y = x  # E: Name "x" may be undefined
-    else:
-        x = 2
-        z = 2
-    return z  # E: Name "z" may be undefined
+    return x  # E: Name "x" may be undefined
 
 def f3() -> None:
     while True:


### PR DESCRIPTION
`else` in loops is executed if the loop didn't exit via a raise, return, or a break. Therefore, we should treat it execution as unconditional if there is not a break statement.

This PR also improves error messages in `else`, reporting them as "may be undefined" instead of "used before definition"

Fixes #14097