### PR TITLE
[partially defined] use correct error code in nested if statements

### DIFF
--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -108,11 +108,9 @@ class BranchStatement:
         branch = self.branches[-1]
         return name not in branch.may_be_defined and name not in branch.must_be_defined
 
-    def is_defined_in_different_branch(self, name: str) -> bool:
+    def is_defined_in_a_branch(self, name: str) -> bool:
         assert len(self.branches) > 0
-        if not self.is_undefined(name):
-            return False
-        for b in self.branches[: len(self.branches) - 1]:
+        for b in self.branches:
             if name in b.must_be_defined or name in b.may_be_defined:
                 return True
         return False
@@ -212,7 +210,13 @@ class DefinedVariableTracker:
     def is_defined_in_different_branch(self, name: str) -> bool:
         """This will return true if a variable is defined in a branch that's not the current branch."""
         assert len(self._scope().branch_stmts) > 0
-        return self._scope().branch_stmts[-1].is_defined_in_different_branch(name)
+        stmt = self._scope().branch_stmts[-1]
+        if not stmt.is_undefined(name):
+            return False
+        for stmt in self._scope().branch_stmts:
+            if stmt.is_defined_in_a_branch(name):
+                return True
+        return False
 
     def is_undefined(self, name: str) -> bool:
         assert len(self._scope().branch_stmts) > 0

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -285,7 +285,7 @@ def f1() -> None:
     else:
         y = x  # No error.
 
-def f2():
+def f2() -> None:
     if int():
         x = 0
     elif int():

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -269,10 +269,14 @@ def f0() -> None:
         if first_iter:
             first_iter = False
             x = 0
-        else:
+        elif int():
             # This is technically a false positive but mypy isn't smart enough for this yet.
             y = x  # E: Name "x" may be undefined
+        else:
+            y = x  # E: Name "x" may be undefined
             z = x  # E: Name "x" may be undefined
+            x = 1
+            w = x
 
 
 def f1() -> None:

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -285,6 +285,19 @@ def f1() -> None:
     else:
         y = x  # No error.
 
+def f2():
+    if int():
+        x = 0
+    elif int():
+        y = x  # E: Name "x" is used before definition
+    else:
+        y = x  # E: Name "x" is used before definition
+        if int():
+            z = x  # E: Name "x" is used before definition
+            x = 1
+        else:
+            x = 2
+        w = x  # No error.
 
 [case testDefinedDifferentBranchPartiallyDefined]
 # flags: --enable-error-code partially-defined --enable-error-code use-before-def
@@ -300,10 +313,12 @@ def f0() -> None:
             y = x  # E: Name "x" may be undefined
         else:
             y = x  # E: Name "x" may be undefined
-            z = x  # E: Name "x" may be undefined
-            x = 1
-            w = x
-
+            if int():
+                z = x  # E: Name "x" may be undefined
+                x = 1
+            else:
+                x = 2
+            w = x  # No error.
 
 def f1() -> None:
     while True:


### PR DESCRIPTION
In order to know to use `partially-defined` code vs `use-before-def`, we had to check if a variable is defined in any branches, not just in the current one.
This would cause an error to be reported as a `use-before-def` and not `partially-defined` code.