### PR TITLE
[use before def] handle class and function definitions

### DIFF
--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -7,6 +7,7 @@ from mypy.nodes import (
     AssignmentExpr,
     AssignmentStmt,
     BreakStmt,
+    ClassDef,
     Context,
     ContinueStmt,
     DictionaryComprehension,
@@ -258,13 +259,16 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         if self.msg.errors.is_error_code_enabled(errorcodes.PARTIALLY_DEFINED):
             self.msg.variable_may_be_undefined(name, context)
 
+    def process_definition(self, name: str) -> None:
+        # Was this name previously used? If yes, it's a use-before-definition error.
+        refs = self.tracker.pop_undefined_ref(name)
+        for ref in refs:
+            self.var_used_before_def(name, ref)
+        self.tracker.record_definition(name)
+
     def process_lvalue(self, lvalue: Lvalue | None) -> None:
         if isinstance(lvalue, NameExpr):
-            # Was this name previously used? If yes, it's a use-before-definition error.
-            refs = self.tracker.pop_undefined_ref(lvalue.name)
-            for ref in refs:
-                self.var_used_before_def(lvalue.name, ref)
-            self.tracker.record_definition(lvalue.name)
+            self.process_definition(lvalue.name)
         elif isinstance(lvalue, StarExpr):
             self.process_lvalue(lvalue.expr)
         elif isinstance(lvalue, (ListExpr, TupleExpr)):
@@ -434,6 +438,10 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
             expr.accept(self)
             self.process_lvalue(idx)
         o.body.accept(self)
+
+    def visit_class_def(self, o: ClassDef) -> None:
+        self.process_definition(o.name)
+        super().visit_class_def(o)
 
     def visit_import(self, o: Import) -> None:
         for mod, alias in o.ids:

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -318,7 +318,7 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         self.tracker.end_branch_statement()
 
     def visit_func_def(self, o: FuncDef) -> None:
-        self.tracker.record_definition(o.name)
+        self.process_definition(o.name)
         self.tracker.enter_scope()
         super().visit_func_def(o)
         self.tracker.exit_scope()

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -482,7 +482,9 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
 
     def visit_class_def(self, o: ClassDef) -> None:
         self.process_definition(o.name)
+        self.tracker.enter_scope()
         super().visit_class_def(o)
+        self.tracker.exit_scope()
 
     def visit_import(self, o: Import) -> None:
         for mod, alias in o.ids:

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -147,6 +147,18 @@ def f(x: A):  # No error here.
 y = A()  # E: Name "A" is used before definition
 class A: pass
 
+[case testClassScope]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+class C:
+    def f0(self) -> None: pass
+
+    def f2(self) -> None:
+        f0()  # No error.
+        self.f0()  # No error.
+
+f0()  # E: Name "f0" is used before definition
+def f0() -> None: pass
+
 [case testUseBeforeDefFunc]
 # flags: --enable-error-code partially-defined --enable-error-code use-before-def
 foo() # E: Name "foo" is used before definition

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -142,12 +142,15 @@ def f0(b: bool) -> None:
 
 [case testUseBeforeDefClass]
 # flags: --enable-error-code partially-defined --enable-error-code use-before-def
-def f(x: A):
+def f(x: A):  # No error here.
     pass
-
 y = A()  # E: Name "A" is used before definition
-
 class A: pass
+
+[case testUseBeforeDefFunc]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+foo() # E: Name "foo" is used before definition
+def foo(): pass
 [case testGenerator]
 # flags: --enable-error-code partially-defined
 if int():

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -150,6 +150,7 @@ class A: pass
 [case testClassScope]
 # flags: --enable-error-code partially-defined --enable-error-code use-before-def
 class C:
+    x = 0
     def f0(self) -> None: pass
 
     def f2(self) -> None:
@@ -158,6 +159,16 @@ class C:
 
 f0()  # E: Name "f0" is used before definition
 def f0() -> None: pass
+y = x  # E: Name "x" is used before definition
+x = 1
+
+[case testClassInsideFunction]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+def f() -> None:
+    class C: pass
+
+c = C()  # E: Name "C" is used before definition
+class C: pass
 
 [case testUseBeforeDefFunc]
 # flags: --enable-error-code partially-defined --enable-error-code use-before-def

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -140,6 +140,14 @@ def f0(b: bool) -> None:
         fn = lambda: 2
     y = fn   # E: Name "fn" may be undefined
 
+[case testUseBeforeDefClass]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+def f(x: A):
+    pass
+
+y = A()  # E: Name "A" is used before definition
+
+class A: pass
 [case testGenerator]
 # flags: --enable-error-code partially-defined
 if int():


### PR DESCRIPTION
Previously, we would ignore any class definitions and would fail to detect undefined classes and functions. This updates the logic to handle them.

Closes #686