### PR TITLE
[partially defined] respect check-untyped-defs flag

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2359,7 +2359,7 @@ class State:
             manager.errors.set_file(self.xpath, self.tree.fullname, options=manager.options)
             self.tree.accept(
                 PartiallyDefinedVariableVisitor(
-                    MessageBuilder(manager.errors, manager.modules), type_map
+                    MessageBuilder(manager.errors, manager.modules), type_map, manager.options
                 )
             )
 

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -33,6 +33,7 @@ from mypy.nodes import (
     WithStmt,
     implicit_module_attrs,
 )
+from mypy.options import Options
 from mypy.patterns import AsPattern, StarredPattern
 from mypy.reachability import ALWAYS_TRUE, infer_pattern_value
 from mypy.traverser import ExtendedTraverserVisitor
@@ -247,9 +248,12 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
     handled by the semantic analyzer.
     """
 
-    def __init__(self, msg: MessageBuilder, type_map: dict[Expression, Type]) -> None:
+    def __init__(
+        self, msg: MessageBuilder, type_map: dict[Expression, Type], options: Options
+    ) -> None:
         self.msg = msg
         self.type_map = type_map
+        self.options = options
         self.loops: list[Loop] = []
         self.tracker = DefinedVariableTracker()
         for name in implicit_module_attrs:
@@ -325,6 +329,8 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         self.tracker.exit_scope()
 
     def visit_func(self, o: FuncItem) -> None:
+        if o.is_dynamic() and not self.options.check_untyped_defs:
+            return
         if o.arguments is not None:
             for arg in o.arguments:
                 self.tracker.record_definition(arg.variable.name)

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -614,3 +614,21 @@ def f0() -> None:
 # flags: --enable-error-code use-before-def
 a = __name__  # No error.
 __name__ = "abc"
+
+[case testUntypedDef]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+
+def f():
+    if int():
+        x = 0
+    z = y  # No use-before-def error because def is untyped.
+    y = x  # No partially-defined error because def is untyped.
+
+[case testUntypedDefCheckUntypedDefs]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def --check-untyped-defs
+
+def f():
+    if int():
+        x = 0
+    z = y  # E: Name "y" is used before definition
+    y: int = x  # E: Name "x" may be undefined


### PR DESCRIPTION
We should not check untyped functions unless --check-untyped-defs is set.

This is part of the reason why #14166 saw so many new errors reported in open source projects.