### PR TITLE
[docs] Update `running_mypy.rst` - fix typo

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -250,7 +250,7 @@ If you are getting this error, try:
 1.  Upgrading the version of the library you're using, in case a newer version
     has started to include type hints.
 
-2.  Searching to see if there is a :ref:`PEP 561 compliant stub package <installed-packages>`.
+2.  Searching to see if there is a :ref:`PEP 561 compliant stub package <installed-packages>`
     corresponding to your third party library. Stub packages let you install
     type hints independently from the library itself.
 


### PR DESCRIPTION
Fix typo - remove an unneeded period

https://mypy.readthedocs.io/en/stable/running_mypy.html#ignore-missing-imports
![image](https://user-images.githubusercontent.com/36337649/204286512-34a07d28-5417-4857-87a6-f910b33fb81f.png)
