### PR TITLE
[stubtest] Error related to `__all__` must have it in the error path

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -261,7 +261,7 @@ def _verify_exported_names(
     if not (names_in_runtime_not_stub or names_in_stub_not_runtime):
         return
     yield Error(
-        object_path,
+        object_path + ["__all__"],
         (
             "names exported from the stub do not correspond to the names exported at runtime. "
             "This is probably due to an inaccurate `__all__` in the stub or things being missing from the stub."

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -264,7 +264,7 @@ def _verify_exported_names(
         object_path + ["__all__"],
         (
             "names exported from the stub do not correspond to the names exported at runtime. "
-            "This is probably due to an inaccurate `__all__` in the stub or things being missing from the stub."
+            "This is probably due to things being missing from the stub, or if present, an inaccurate `__all__` in the stub"
         ),
         # Pass in MISSING instead of the stub and runtime objects, as the line numbers aren't very
         # relevant here, and it makes for a prettier error message

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1028,7 +1028,7 @@ class StubtestUnit(unittest.TestCase):
 
     @collect_cases
     def test_all_in_stub_different_to_all_at_runtime(self) -> Iterator[Case]:
-        # We *should* emit an error with the module name itself,
+        # We *should* emit an error with the module name itself + __all__,
         # if the stub *does* define __all__,
         # but the stub's __all__ is inconsistent with the runtime's __all__
         yield Case(
@@ -1040,7 +1040,7 @@ class StubtestUnit(unittest.TestCase):
             __all__ = []
             foo = 'foo'
             """,
-            error="",
+            error="__all__",
         )
 
     @collect_cases


### PR DESCRIPTION
Right now `stubtest` gives this error for `__all__`:

```
error: passlib.handlers.oracle names exported from the stub do not correspond to the names exported at runtime. This is probably due to an inaccurate `__all__` in the stub or things being missing from the stub.
Stub: in file /Users/sobolev/Desktop/typeshed/stubs/passlib/passlib/handlers/oracle.pyi
Names exported in the stub but not at runtime: ['oracle10', 'oracle11']
Runtime:
Names exported at runtime but not in the stub: ['oracle10g', 'oracle11g']
```

(Context: there's a real error in `__all__`: https://foss.heptapod.net/python-libs/passlib/-/blob/branch/stable/passlib/handlers/oracle.py#L18)

The only way to ignore it is to ignore the whole module. This is not right.
We need to be able to ignore just `some_module.__all__`.