### PR TITLE
[stubtest] Add `__warningregistry__` to the list of ignored module dunders

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1243,12 +1243,12 @@ IGNORED_MODULE_DUNDERS: typing_extensions.Final = frozenset(
         "__annotations__",
         "__path__",  # mypy adds __path__ to packages, but C packages don't have it
         "__getattr__",  # resulting behaviour might be typed explicitly
+        # Created by `warnings.warn`, does not make much sense to have in stubs:
+        "__warningregistry__",
         # TODO: remove the following from this list
         "__author__",
         "__version__",
         "__copyright__",
-        # Created by `warnings.warn`, does not make much sense to have in stubs:
-        "__warningregistry__",
     }
 )
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1247,6 +1247,8 @@ IGNORED_MODULE_DUNDERS: typing_extensions.Final = frozenset(
         "__author__",
         "__version__",
         "__copyright__",
+        # Created by `warnings.warn`, does not make much sense to have in stubs:
+        "__warningregistry__",
     }
 )
 


### PR DESCRIPTION
We have multiple of these in `typeshed`: https://github.com/python/typeshed/search?q=__warningregistry__