### PR TITLE
[partially defined] fix false positive with global/nonlocal vars

### DIFF
--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -17,6 +17,7 @@ from mypy.nodes import (
     FuncDef,
     FuncItem,
     GeneratorExpr,
+    GlobalDecl,
     IfStmt,
     Import,
     ImportFrom,
@@ -25,6 +26,7 @@ from mypy.nodes import (
     Lvalue,
     MatchStmt,
     NameExpr,
+    NonlocalDecl,
     RaiseStmt,
     RefExpr,
     ReturnStmt,
@@ -278,6 +280,16 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
         for ref in refs:
             self.var_used_before_def(name, ref)
         self.tracker.record_definition(name)
+
+    def visit_global_decl(self, o: GlobalDecl) -> None:
+        for name in o.names:
+            self.process_definition(name)
+        super().visit_global_decl(o)
+
+    def visit_nonlocal_decl(self, o: NonlocalDecl) -> None:
+        for name in o.names:
+            self.process_definition(name)
+        super().visit_nonlocal_decl(o)
 
     def process_lvalue(self, lvalue: Lvalue | None) -> None:
         if isinstance(lvalue, NameExpr):

--- a/test-data/unit/check-partially-defined.test
+++ b/test-data/unit/check-partially-defined.test
@@ -191,6 +191,49 @@ if int():
     y = 3
 x = y  # E: Name "y" may be undefined
 
+[case testVarDefinedInOuterScopeUpdated]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+def f0() -> None:
+    global x
+    y = x
+    x = 1  # No error.
+
+x = 2
+
+[case testNonlocalVar]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+def f0() -> None:
+    x = 2
+
+    def inner() -> None:
+        nonlocal x
+        y = x
+        x = 1  # No error.
+
+
+[case testGlobalDeclarationAfterUsage]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+def f0() -> None:
+    y = x  # E: Name "x" is used before definition
+    global x
+    x = 1  # No error.
+
+x = 2
+[case testVarDefinedInOuterScope]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+def f0() -> None:
+  global x
+  y = x  # We do not detect such errors right now.
+
+f0()
+x = 1
+[case testDefinedInOuterScopeNoError]
+# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+def foo() -> None:
+    bar()
+
+def bar() -> None:
+    foo()
 [case testFuncParams]
 # flags: --enable-error-code partially-defined
 def foo(a: int) -> None:


### PR DESCRIPTION
This is a workaround until we implement better handling for variables undefined in global scope (see #14213).

We treat `global/nonlocal` as a variable declaration. I've included test cases that should fail in the future once we implement the check properly.