### PR TITLE
Fix --fast-exit argument

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1008,7 +1008,10 @@ def process_options(
         help="When encountering SOURCE_FILE, read and type check "
         "the contents of SHADOW_FILE instead.",
     )
-    add_invertible_flag("--fast-exit", default=True, help=argparse.SUPPRESS, group=internals_group)
+    internals_group.add_argument("--fast-exit", action="store_true", help=argparse.SUPPRESS)
+    internals_group.add_argument(
+        "--no-fast-exit", action="store_false", dest="fast_exit", help=argparse.SUPPRESS
+    )
     # This flag is useful for mypy tests, where function bodies may be omitted. Plugin developers
     # may want to use this as well in their tests.
     add_invertible_flag(


### PR DESCRIPTION
Previously --fast-exit would actually disable the fast_exit option. Now it behaves as expected (a no-op, since fast exit is enabled by default).