### PR TITLE
Give TypeVarTupleType a fallback

### DIFF
--- a/mypy/copytype.py
+++ b/mypy/copytype.py
@@ -94,7 +94,7 @@ class TypeShallowCopier(TypeVisitor[ProperType]):
         return self.copy_common(t, dup)
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> ProperType:
-        dup = TypeVarTupleType(t.name, t.fullname, t.id, t.upper_bound)
+        dup = TypeVarTupleType(t.name, t.fullname, t.id, t.upper_bound, t.tuple_fallback)
         return self.copy_common(t, dup)
 
     def visit_unpack_type(self, t: UnpackType) -> ProperType:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2506,9 +2506,22 @@ class ParamSpecExpr(TypeVarLikeExpr):
 class TypeVarTupleExpr(TypeVarLikeExpr):
     """Type variable tuple expression TypeVarTuple(...)."""
 
-    __slots__ = ()
+    __slots__ = "tuple_fallback"
+
+    tuple_fallback: mypy.types.Instance
 
     __match_args__ = ("name", "upper_bound")
+
+    def __init__(
+        self,
+        name: str,
+        fullname: str,
+        upper_bound: mypy.types.Type,
+        tuple_fallback: mypy.types.Instance,
+        variance: int = INVARIANT,
+    ) -> None:
+        super().__init__(name, fullname, upper_bound, variance)
+        self.tuple_fallback = tuple_fallback
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_type_var_tuple_expr(self)
@@ -2519,6 +2532,7 @@ class TypeVarTupleExpr(TypeVarLikeExpr):
             "name": self._name,
             "fullname": self._fullname,
             "upper_bound": self.upper_bound.serialize(),
+            "tuple_fallback": self.tuple_fallback.serialize(),
             "variance": self.variance,
         }
 
@@ -2529,6 +2543,7 @@ class TypeVarTupleExpr(TypeVarLikeExpr):
             data["name"],
             data["fullname"],
             mypy.types.deserialize_type(data["upper_bound"]),
+            mypy.types.Instance.deserialize(data["tuple_fallback"]),
             data["variance"],
         )
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4067,8 +4067,9 @@ class SemanticAnalyzer(
 
         # PEP 646 does not specify the behavior of variance, constraints, or bounds.
         if not call.analyzed:
+            tuple_fallback = self.named_type("builtins.tuple", [self.object_type()])
             typevartuple_var = TypeVarTupleExpr(
-                name, self.qualified_name(name), self.object_type(), INVARIANT
+                name, self.qualified_name(name), self.object_type(), tuple_fallback, INVARIANT
             )
             typevartuple_var.line = call.line
             call.analyzed = typevartuple_var

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -56,9 +56,6 @@ class TypeFixture:
         ) -> TypeVarType:
             return TypeVarType(name, name, id, values, upper_bound, variance)
 
-        def make_type_var_tuple(name: str, id: int, upper_bound: Type) -> TypeVarTupleType:
-            return TypeVarTupleType(name, name, id, upper_bound)
-
         self.t = make_type_var("T", 1, [], self.o, variance)  # T`1 (type variable)
         self.tf = make_type_var("T", -1, [], self.o, variance)  # T`-1 (type variable)
         self.tf2 = make_type_var("T", -2, [], self.o, variance)  # T`-2 (type variable)
@@ -67,10 +64,6 @@ class TypeFixture:
         self.sf = make_type_var("S", -2, [], self.o, variance)  # S`-2 (type variable)
         self.sf1 = make_type_var("S", -1, [], self.o, variance)  # S`-1 (type variable)
         self.u = make_type_var("U", 3, [], self.o, variance)  # U`3 (type variable)
-
-        self.ts = make_type_var_tuple("Ts", 1, self.o)  # Ts`1 (type var tuple)
-        self.ss = make_type_var_tuple("Ss", 2, self.o)  # Ss`2 (type var tuple)
-        self.us = make_type_var_tuple("Us", 3, self.o)  # Us`3 (type var tuple)
 
         # Simple types
         self.anyt = AnyType(TypeOfAny.special_form)
@@ -133,10 +126,6 @@ class TypeFixture:
             bases=[Instance(self.gi, [self.s1])],
         )
 
-        self.gvi = self.make_type_info("GV", mro=[self.oi], typevars=["Ts"], typevar_tuple_index=0)
-        self.gv2i = self.make_type_info(
-            "GV2", mro=[self.oi], typevars=["T", "Ts", "S"], typevar_tuple_index=1
-        )
         # list[T]
         self.std_listi = self.make_type_info(
             "builtins.list", mro=[self.oi], typevars=["T"], variances=[variance]
@@ -218,6 +207,18 @@ class TypeFixture:
         self._add_bool_dunder(self.bool_type_info)
         self._add_bool_dunder(self.ai)
 
+        def make_type_var_tuple(name: str, id: int, upper_bound: Type) -> TypeVarTupleType:
+            return TypeVarTupleType(name, name, id, upper_bound, self.std_tuple)
+
+        self.ts = make_type_var_tuple("Ts", 1, self.o)  # Ts`1 (type var tuple)
+        self.ss = make_type_var_tuple("Ss", 2, self.o)  # Ss`2 (type var tuple)
+        self.us = make_type_var_tuple("Us", 3, self.o)  # Us`3 (type var tuple)
+
+        self.gvi = self.make_type_info("GV", mro=[self.oi], typevars=["Ts"], typevar_tuple_index=0)
+        self.gv2i = self.make_type_info(
+            "GV2", mro=[self.oi], typevars=["T", "Ts", "S"], typevar_tuple_index=1
+        )
+
     def _add_bool_dunder(self, type_info: TypeInfo) -> None:
         signature = CallableType([], [], [], Instance(self.bool_type_info, []), self.function)
         bool_func = FuncDef("__bool__", [], Block([]))
@@ -296,7 +297,7 @@ class TypeFixture:
             v: list[TypeVarLikeType] = []
             for id, n in enumerate(typevars, 1):
                 if typevar_tuple_index is not None and id - 1 == typevar_tuple_index:
-                    v.append(TypeVarTupleType(n, n, id, self.o))
+                    v.append(TypeVarTupleType(n, n, id, self.o, self.std_tuple))
                 else:
                     if variances:
                         variance = variances[id - 1]

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -648,7 +648,11 @@ class TransformVisitor(NodeVisitor[Node]):
 
     def visit_type_var_tuple_expr(self, node: TypeVarTupleExpr) -> TypeVarTupleExpr:
         return TypeVarTupleExpr(
-            node.name, node.fullname, self.type(node.upper_bound), variance=node.variance
+            node.name,
+            node.fullname,
+            self.type(node.upper_bound),
+            node.tuple_fallback,
+            variance=node.variance,
         )
 
     def visit_type_alias_expr(self, node: TypeAliasExpr) -> TypeAliasExpr:

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -115,6 +115,7 @@ class TypeVarLikeScope:
                 tvar_expr.fullname,
                 i,
                 upper_bound=tvar_expr.upper_bound,
+                tuple_fallback=tvar_expr.tuple_fallback,
                 line=tvar_expr.line,
                 column=tvar_expr.column,
             )

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -346,12 +346,14 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     self.fail(
                         f'Type variable "{t.name}" used with arguments', t, code=codes.VALID_TYPE
                     )
+
                 # Change the line number
                 return TypeVarTupleType(
                     tvar_def.name,
                     tvar_def.fullname,
                     tvar_def.id,
                     tvar_def.upper_bound,
+                    sym.node.tuple_fallback,
                     line=t.line,
                     column=t.column,
                 )

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -706,6 +706,20 @@ class TypeVarTupleType(TypeVarLikeType):
     See PEP646 for more information.
     """
 
+    def __init__(
+        self,
+        name: str,
+        fullname: str,
+        id: TypeVarId | int,
+        upper_bound: Type,
+        tuple_fallback: Instance,
+        *,
+        line: int = -1,
+        column: int = -1,
+    ) -> None:
+        super().__init__(name, fullname, id, upper_bound, line=line, column=column)
+        self.tuple_fallback = tuple_fallback
+
     def serialize(self) -> JsonDict:
         assert not self.id.is_meta_var()
         return {
@@ -714,13 +728,18 @@ class TypeVarTupleType(TypeVarLikeType):
             "fullname": self.fullname,
             "id": self.id.raw_id,
             "upper_bound": self.upper_bound.serialize(),
+            "tuple_fallback": self.tuple_fallback.serialize(),
         }
 
     @classmethod
     def deserialize(cls, data: JsonDict) -> TypeVarTupleType:
         assert data[".class"] == "TypeVarTupleType"
         return TypeVarTupleType(
-            data["name"], data["fullname"], data["id"], deserialize_type(data["upper_bound"])
+            data["name"],
+            data["fullname"],
+            data["id"],
+            deserialize_type(data["upper_bound"]),
+            Instance.deserialize(data["tuple_fallback"]),
         )
 
     def accept(self, visitor: TypeVisitor[T]) -> T:
@@ -745,6 +764,7 @@ class TypeVarTupleType(TypeVarLikeType):
             self.fullname,
             self.id if id is _dummy else id,
             self.upper_bound,
+            self.tuple_fallback,
             line=self.line,
             column=self.column,
         )

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -39,7 +39,15 @@ def fill_typevars(typ: TypeInfo) -> Instance | TupleType:
             )
         elif isinstance(tv, TypeVarTupleType):
             tv = UnpackType(
-                TypeVarTupleType(tv.name, tv.fullname, tv.id, tv.upper_bound, line=-1, column=-1)
+                TypeVarTupleType(
+                    tv.name,
+                    tv.fullname,
+                    tv.id,
+                    tv.upper_bound,
+                    tv.tuple_fallback,
+                    line=-1,
+                    column=-1,
+                )
             )
         else:
             assert isinstance(tv, ParamSpecType)

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1474,3 +1474,4 @@ y: Unpack[TVariadic]  # E: TypeVarTuple "TVariadic" is unbound
 
 class Variadic(Generic[Unpack[TVariadic], Unpack[TVariadic2]]):  # E: Can only use one type var tuple in a class def
     pass
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1558,3 +1558,4 @@ MypyFile:1(
   AssignmentStmt:2(
     NameExpr(TV* [__main__.TV])
     TypeVarTupleExpr:2()))
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
We want to eventually decomission the use of TypeList for constraints/expanded values of TypeVarTupleTypes. In order to do that we will need a reference to the tuple fallback. All the places we currently construct these TypeLists for the use in variadic generics have access to a TypeVarTupleType, so putting the tuple fallback into the typevar type is a reasonable way to make that information accessible where we need it.

In order to get it into the type, we first put it into the expr by making a symbol table lookup in semanal.