### PR TITLE
Enable Final instance attributes for attrs

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Iterable, List, cast
-from typing_extensions import Final
+from typing_extensions import Final, Literal
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.exprtotype import TypeTranslationError, expr_to_unanalyzed_type
@@ -756,10 +756,10 @@ def _add_init(
     ctx: mypy.plugin.ClassDefContext,
     attributes: list[Attribute],
     adder: MethodAdder,
-    method_name: str,
+    method_name: Literal["__init__", "__attrs_init__"],
 ) -> None:
     """Generate an __init__ method for the attributes and add it to the class."""
-    # Convert attributes to arguments with kw_only arguments at the  end of
+    # Convert attributes to arguments with kw_only arguments at the end of
     # the argument list
     pos_args = []
     kw_only_args = []
@@ -770,6 +770,16 @@ def _add_init(
             kw_only_args.append(attribute.argument(ctx))
         else:
             pos_args.append(attribute.argument(ctx))
+
+        # If the attribute is Final, present in `__init__` and has
+        # no default, make sure it doesn't error later.
+        if not attribute.has_default:
+            for ti in ctx.cls.info.mro:
+                if attribute.name in ti.names:
+                    sym_node = ti.names[attribute.name].node
+                    if isinstance(sym_node, Var) and sym_node.is_final:
+                        sym_node.final_set_in_init = True
+                        break
     args = pos_args + kw_only_args
     if all(
         # We use getattr rather than instance checks because the variable.type

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -1834,3 +1834,17 @@ class Sub(Base):
 # This matches runtime semantics
 reveal_type(Sub)  # N: Revealed type is "def (*, name: builtins.str, first_name: builtins.str, last_name: builtins.str) -> __main__.Sub"
 [builtins fixtures/property.pyi]
+
+[case testFinalInstanceAttribute]
+from attrs import define
+from typing import Final
+
+@define
+class C:
+    a: Final[int]
+
+reveal_type(C) # N: Revealed type is "def (a: builtins.int) -> __main__.C"
+
+C(1).a = 2 # E: Cannot assign to final attribute "a"
+
+[builtins fixtures/property.pyi]


### PR DESCRIPTION
A quick patch to enable the following scenario:

```python
@define
class C:
    a: Final[int]  # `a` is a final instance attribute
```

There are some edge cases I haven't covered here that would be complex to handle and not add much value IMO, so I think this will be useful like this. 

For example:

```python
@define
class C:
    a: Final[int] = field(init=False)
```
This is technically not sound, but there might be an `__attrs_post_init__` on the class or one of its ancestors and that function might set it.