### PR TITLE
[conf] Allow trailing commas in `ini` configuration of multiline values

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -137,6 +137,15 @@ def check_follow_imports(choice: str) -> str:
     return choice
 
 
+def split_commas(value: str) -> list[str]:
+    # Uses a bit smarter technique to allow last trailing comma
+    # and to remove last `""` item from the split.
+    items = value.split(",")
+    if items and items[-1] == "":
+        items.pop(-1)
+    return items
+
+
 # For most options, the type of the default value set in options.py is
 # sufficient, and we don't have to do anything here.  This table
 # exists to specify types for values initialized to None or container
@@ -151,13 +160,13 @@ ini_config_types: Final[dict[str, _INI_PARSER_CALLABLE]] = {
     "junit_xml": expand_path,
     "follow_imports": check_follow_imports,
     "no_site_packages": bool,
-    "plugins": lambda s: [p.strip() for p in s.split(",")],
-    "always_true": lambda s: [p.strip() for p in s.split(",")],
-    "always_false": lambda s: [p.strip() for p in s.split(",")],
-    "enable_incomplete_feature": lambda s: [p.strip() for p in s.split(",")],
-    "disable_error_code": lambda s: validate_codes([p.strip() for p in s.split(",")]),
-    "enable_error_code": lambda s: validate_codes([p.strip() for p in s.split(",")]),
-    "package_root": lambda s: [p.strip() for p in s.split(",")],
+    "plugins": lambda s: [p.strip() for p in split_commas(s)],
+    "always_true": lambda s: [p.strip() for p in split_commas(s)],
+    "always_false": lambda s: [p.strip() for p in split_commas(s)],
+    "enable_incomplete_feature": lambda s: [p.strip() for p in split_commas(s)],
+    "disable_error_code": lambda s: validate_codes([p.strip() for p in split_commas(s)]),
+    "enable_error_code": lambda s: validate_codes([p.strip() for p in split_commas(s)]),
+    "package_root": lambda s: [p.strip() for p in split_commas(s)],
     "cache_dir": expand_path,
     "python_executable": expand_path,
     "strict": bool,

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -163,6 +163,15 @@ reveal_type(f())  # N: Revealed type is "builtins.int"
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/customentry.py:register
 
+[case testCustomPluginEntryPointFileTrailingComma]
+# flags: --config-file tmp/mypy.ini
+def f() -> str: ...
+reveal_type(f())  # N: Revealed type is "builtins.int"
+[file mypy.ini]
+\[mypy]
+plugins =
+    <ROOT>/test-data/unit/plugins/customentry.py:register,
+
 [case testCustomPluginEntryPoint]
 # flags: --config-file tmp/mypy.ini
 def f() -> str: ...

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1570,3 +1570,29 @@ foo.py:1: error: "int" not callable
 1()
 [out]
 foo/m.py:1: error: "int" not callable
+
+[case testCmdlineCfgEnableErrorCodeTrailingComma]
+# cmd: mypy .
+[file mypy.ini]
+\[mypy]
+enable_error_code =
+  truthy-bool,
+  redundant-expr,
+[out]
+
+[case testCmdlineCfgDisableErrorCodeTrailingComma]
+# cmd: mypy .
+[file mypy.ini]
+\[mypy]
+disable_error_code =
+  misc,
+  override,
+[out]
+
+[case testCmdlineCfgAlwaysTrueTrailingComma]
+# cmd: mypy .
+[file mypy.ini]
+\[mypy]
+always_true =
+  MY_VAR,
+[out]


### PR DESCRIPTION
Now these two samples are identical:

```ini
[mypy]
enable_error_code =
  truthy-bool,
  redundant-expr,
  unused-awaitable,
  ignore-without-code
```

and

```ini
[mypy]
enable_error_code =
  truthy-bool,
  redundant-expr,
  unused-awaitable,
  ignore-without-code,
```

I've covered some of the changed values, but not all (they are identical - no need to create so many slow tests).

I've also checked `pyproject.toml`. It does not have this problem: it uses `[]` to create arrays, so no trailing commas are used there.