### PR TITLE
[mypyc] Support tuples of native ints

### DIFF
--- a/mypyc/analysis/attrdefined.py
+++ b/mypyc/analysis/attrdefined.py
@@ -91,7 +91,7 @@ from mypyc.ir.ops import (
     SetMem,
     Unreachable,
 )
-from mypyc.ir.rtypes import RInstance, is_fixed_width_rtype
+from mypyc.ir.rtypes import RInstance
 
 # If True, print out all always-defined attributes of native classes (to aid
 # debugging and testing)
@@ -424,5 +424,6 @@ def detect_undefined_bitmap(cl: ClassIR, seen: Set[ClassIR]) -> None:
     if len(cl.base_mro) > 1:
         cl.bitmap_attrs.extend(cl.base_mro[1].bitmap_attrs)
     for n, t in cl.attributes.items():
-        if is_fixed_width_rtype(t) and not cl.is_always_defined(n):
+        if t.error_overlap and not cl.is_always_defined(n):
             cl.bitmap_attrs.append(n)
+            print('!', n)

--- a/mypyc/analysis/attrdefined.py
+++ b/mypyc/analysis/attrdefined.py
@@ -426,4 +426,3 @@ def detect_undefined_bitmap(cl: ClassIR, seen: Set[ClassIR]) -> None:
     for n, t in cl.attributes.items():
         if t.error_overlap and not cl.is_always_defined(n):
             cl.bitmap_attrs.append(n)
-            print('!', n)

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -403,7 +403,9 @@ class Emitter:
 
     def error_value_check(self, rtype: RType, value: str, compare: str) -> str:
         if isinstance(rtype, RTuple):
-            return self.tuple_undefined_check_cond(rtype, value, self.c_error_value, compare, check_exception=False)
+            return self.tuple_undefined_check_cond(
+                rtype, value, self.c_error_value, compare, check_exception=False
+            )
         else:
             return f"{value} {compare} {self.c_error_value(rtype)}"
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -20,7 +20,7 @@ from mypyc.codegen.emitwrapper import (
 from mypyc.common import BITMAP_BITS, BITMAP_TYPE, NATIVE_PREFIX, PREFIX, REG_PREFIX, use_fastcall
 from mypyc.ir.class_ir import ClassIR, VTableEntries
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD, FuncDecl, FuncIR
-from mypyc.ir.rtypes import RTuple, RType, is_fixed_width_rtype, object_rprimitive
+from mypyc.ir.rtypes import RTuple, RType, object_rprimitive
 from mypyc.namegen import NameGenerator
 from mypyc.sametype import is_same_type
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -960,13 +960,13 @@ def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
         emitter.emit_lines("if (!tmp)", "    return -1;")
     emitter.emit_inc_ref("tmp", rtype)
     emitter.emit_line(f"self->{attr_field} = tmp;")
-    if is_fixed_width_rtype(rtype) and not always_defined:
+    if rtype.error_overlap and not always_defined:
         emitter.emit_attr_bitmap_set("tmp", "self", rtype, cl, attr)
 
     if deletable:
         emitter.emit_line("} else")
         emitter.emit_line(f"    self->{attr_field} = {emitter.c_undefined_value(rtype)};")
-        if is_fixed_width_rtype(rtype):
+        if rtype.error_overlap:
             emitter.emit_attr_bitmap_clear("self", rtype, cl, attr)
     emitter.emit_line("return 0;")
     emitter.emit_line("}")

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -442,7 +442,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                 self.emitter.emit_dec_ref(attr_expr, attr_rtype)
                 if not always_defined:
                     self.emitter.emit_line("}")
-            elif is_fixed_width_rtype(attr_rtype) and not cl.is_always_defined(op.attr):
+            elif attr_rtype.error_overlap and not cl.is_always_defined(op.attr):
                 # If there is overlap with the error value, update bitmap to mark
                 # attribute as defined.
                 self.emitter.emit_attr_bitmap_set(src, obj, attr_rtype, cl, op.attr)

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -60,7 +60,6 @@ from mypyc.ir.rtypes import (
     RStruct,
     RTuple,
     RType,
-    is_fixed_width_rtype,
     is_int32_rprimitive,
     is_int64_rprimitive,
     is_int_rprimitive,

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -17,7 +17,7 @@ from mypyc.ir.ops import (
     Register,
     Value,
 )
-from mypyc.ir.rtypes import RType, bitmap_rprimitive, deserialize_type, is_fixed_width_rtype
+from mypyc.ir.rtypes import RType, bitmap_rprimitive, deserialize_type
 from mypyc.namegen import NameGenerator
 
 
@@ -113,7 +113,7 @@ class FuncSignature:
 def num_bitmap_args(args: tuple[RuntimeArg, ...]) -> int:
     n = 0
     for arg in args:
-        if is_fixed_width_rtype(arg.type) and arg.kind.is_optional():
+        if arg.type.error_overlap and arg.kind.is_optional():
             n += 1
     return (n + (BITMAP_BITS - 1)) // BITMAP_BITS
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -28,7 +28,6 @@ from mypyc.ir.rtypes import (
     int_rprimitive,
     is_bit_rprimitive,
     is_bool_rprimitive,
-    is_fixed_width_rtype,
     is_int_rprimitive,
     is_none_rprimitive,
     is_pointer_rprimitive,
@@ -632,7 +631,7 @@ class GetAttr(RegisterOp):
         self.class_type = obj.type
         attr_type = obj.type.attr_type(attr)
         self.type = attr_type
-        if is_fixed_width_rtype(attr_type):
+        if attr_type.error_overlap:
             self.error_kind = ERR_MAGIC_OVERLAPPING
         self.is_borrowed = borrow and attr_type.is_refcounted
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -785,7 +785,7 @@ class TupleGet(RegisterOp):
 
     error_kind = ERR_NEVER
 
-    def __init__(self, src: Value, index: int, line: int) -> None:
+    def __init__(self, src: Value, index: int, line: int = -1) -> None:
         super().__init__(line)
         self.src = src
         self.index = index

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -572,6 +572,7 @@ class RTuple(RType):
         # Nominally the max c length is 31 chars, but I'm not honestly worried about this.
         self.struct_name = f"tuple_{self.unique_id}"
         self._ctype = f"{self.struct_name}"
+        self.error_overlap = all(t.error_overlap for t in self.types) and bool(self.types)
 
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rtuple(self)

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1308,7 +1308,7 @@ def gen_arg_defaults(builder: IRBuilder) -> None:
 
             assert isinstance(target, AssignmentTargetRegister)
             reg = target.register
-            if not is_fixed_width_rtype(reg.type):
+            if not reg.type.error_overlap:
                 builder.assign_if_null(target.register, get_default, arg.initializer.line)
             else:
                 builder.assign_if_bitmap_unset(

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -90,7 +90,6 @@ from mypyc.ir.rtypes import (
     c_pyssize_t_rprimitive,
     dict_rprimitive,
     int_rprimitive,
-    is_fixed_width_rtype,
     is_list_rprimitive,
     is_none_rprimitive,
     is_object_rprimitive,

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -21,7 +21,7 @@ from mypy.nodes import Argument, FuncDef, SymbolNode, Var
 from mypyc.common import BITMAP_BITS, ENV_ATTR_NAME, SELF_NAME, bitmap_name
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.ops import Call, GetAttr, SetAttr, Value
-from mypyc.ir.rtypes import RInstance, bitmap_rprimitive, is_fixed_width_rtype, object_rprimitive
+from mypyc.ir.rtypes import RInstance, bitmap_rprimitive, object_rprimitive
 from mypyc.irbuild.builder import IRBuilder, SymbolTarget
 from mypyc.irbuild.context import FuncInfo, GeneratorClass, ImplicitClass
 from mypyc.irbuild.targets import AssignmentTargetAttr
@@ -163,7 +163,7 @@ def num_bitmap_args(builder: IRBuilder, args: list[Argument]) -> int:
     n = 0
     for arg in args:
         t = builder.type_to_rtype(arg.variable.type)
-        if is_fixed_width_rtype(t) and arg.kind.is_optional():
+        if t.error_overlap and arg.kind.is_optional():
             n += 1
     return (n + (BITMAP_BITS - 1)) // BITMAP_BITS
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1034,7 +1034,7 @@ class LowLevelIRBuilder:
             bitmap = 0
             c = 0
             for lst, arg in zip(formal_to_actual, sig_args):
-                if arg.kind.is_optional() and is_fixed_width_rtype(arg.type):
+                if arg.kind.is_optional() and arg.type.error_overlap:
                     if i * BITMAP_BITS <= c < (i + 1) * BITMAP_BITS:
                         if lst:
                             bitmap |= 1 << (c & (BITMAP_BITS - 1))

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -755,6 +755,21 @@ def test_del() -> None:
     with assertRaises(AttributeError):
         o.x
 
+class UndefinedTuple:
+    def __init__(self, x: i64, y: i64) -> None:
+        if x != 0:
+            self.t = (x, y)
+
+def test_undefined_native_int_tuple() -> None:
+    o = UndefinedTuple(MAGIC, MAGIC)
+    assert o.t[0] == MAGIC
+    assert o.t[1] == MAGIC
+    o = UndefinedTuple(0, 0)
+    with assertRaises(AttributeError):
+        o.t
+    o = UndefinedTuple(-13, 45)
+    assert o.t == (-13, 45)
+
 [case testI64DefaultArgValues]
 from typing import Any, Iterator
 from typing_extensions import Final

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -771,7 +771,7 @@ def test_undefined_native_int_tuple() -> None:
     assert o.t == (-13, 45)
 
 [case testI64DefaultArgValues]
-from typing import Any, Iterator
+from typing import Any, Iterator, Tuple
 from typing_extensions import Final
 
 MAGIC: Final = -113
@@ -929,6 +929,18 @@ def test_kw_only_default_args() -> None:
     assert kw_only2(c=11) == 25
     assert kw_only2(a=2, c=4) == 12
     assert kw_only2(c=4, a=2) == 12
+
+def tuples(t: Tuple[i64, i64] = (MAGIC, MAGIC)) -> i64:
+    return t[0] + t[1]
+
+def test_tuple_arg_defaults() -> None:
+    assert tuples() == 2 * MAGIC
+    assert tuples((1, 2)) == 3
+    assert tuples((MAGIC, MAGIC)) == 2 * MAGIC
+    tuples2: Any = tuples
+    assert tuples2() == 2 * MAGIC
+    assert tuples2((1, 2)) == 3
+    assert tuples2((MAGIC, MAGIC)) == 2 * MAGIC
 
 def many_args(
     a1: i64 = 0,

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -770,6 +770,17 @@ def test_undefined_native_int_tuple() -> None:
     o = UndefinedTuple(-13, 45)
     assert o.t == (-13, 45)
 
+def test_undefined_native_int_tuple_via_any() -> None:
+    cls: Any = UndefinedTuple
+    o: Any = cls(MAGIC, MAGIC)
+    assert o.t[0] == MAGIC
+    assert o.t[1] == MAGIC
+    o = cls(0, 0)
+    with assertRaises(AttributeError):
+        o.t
+    o = UndefinedTuple(-13, 45)
+    assert o.t == (-13, 45)
+
 [case testI64DefaultArgValues]
 from typing import Any, Iterator, Tuple
 from typing_extensions import Final

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -1097,6 +1097,24 @@ def test_assign_error_value_conditionally() -> None:
     assert y == MAGIC
     assert z == MAGIC
 
+def tuple_case(x: i64, y: i64) -> None:
+    if not int():
+        t = (x, y)
+    assert t == (x, y)
+    if int():
+        t2 = (x, y)
+    try:
+        print(t2)
+    except NameError as e:
+        assert str(e) == 'local variable "t2" referenced before assignment'
+    else:
+        assert False
+
+def test_conditionally_undefined_tuple() -> None:
+    tuple_case(2, 3)
+    tuple_case(-2, -3)
+    tuple_case(MAGIC, MAGIC)
+
 def test_many_locals() -> None:
     x = int()
     if x:

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -958,6 +958,19 @@ def test_tuple_arg_defaults() -> None:
     assert tuples2((1, 2)) == 3
     assert tuples2((MAGIC, MAGIC)) == 2 * MAGIC
 
+class TupleInit:
+    def __init__(self, t: Tuple[i64, i64] = (MAGIC, MAGIC)) -> None:
+        self.t = t[0] + t[1]
+
+def test_tuple_init_arg_defaults() -> None:
+    assert TupleInit().t == 2 * MAGIC
+    assert TupleInit((1, 2)).t == 3
+    assert TupleInit((MAGIC, MAGIC)).t == 2 * MAGIC
+    o: Any = TupleInit
+    assert o().t == 2 * MAGIC
+    assert o((1, 2)).t == 3
+    assert o((MAGIC, MAGIC)).t == 2 * MAGIC
+
 def many_args(
     a1: i64 = 0,
     a2: i64 = 1,

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -440,6 +440,11 @@ def test_tuple_error_value() -> None:
         assert maybe_raise_tuple(i, False) == (i, i + 1)
     with assertRaises(ValueError):
         maybe_raise_tuple(0, True)
+    f: Any = maybe_raise_tuple
+    for i in range(-1000, 1000):
+        assert f(i, False) == (i, i + 1)
+    with assertRaises(ValueError):
+        f(0, True)
 
 def maybe_raise_tuple2(n: i64, error: bool) -> Tuple[i64, int]:
     if error:

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -395,7 +395,7 @@ def test_for_loop() -> None:
     assert sum([x * x for x in range(i64(4 + int()))]) == 1 + 4 + 9
 
 [case testI64ErrorValuesAndUndefined]
-from typing import Any
+from typing import Any, Tuple
 import sys
 
 from mypy_extensions import mypyc_attr
@@ -429,6 +429,28 @@ def test_method_error_value() -> None:
         assert C().maybe_raise(i, False) == i
     with assertRaises(ValueError):
         C().maybe_raise(0, True)
+
+def maybe_raise_tuple(n: i64, error: bool) -> Tuple[i64, i64]:
+    if error:
+        raise ValueError()
+    return n, n+ 1
+
+def test_tuple_error_value() -> None:
+    for i in range(-1000, 1000):
+        assert maybe_raise_tuple(i, False) == (i, i + 1)
+    with assertRaises(ValueError):
+        maybe_raise_tuple(0, True)
+
+def maybe_raise_tuple2(n: i64, error: bool) -> Tuple[i64, int]:
+    if error:
+        raise ValueError()
+    return n, n+ 1
+
+def test_tuple_error_value_2() -> None:
+    for i in range(-1000, 1000):
+        assert maybe_raise_tuple2(i, False) == (i, i + 1)
+    with assertRaises(ValueError):
+        maybe_raise_tuple(0, True)
 
 def test_unbox_int() -> None:
     for i in list(range(-1000, 1000)) + [-(1 << 63), (1 << 63) - 1]:

--- a/mypyc/transform/exceptions.py
+++ b/mypyc/transform/exceptions.py
@@ -31,6 +31,7 @@ from mypyc.ir.ops import (
     SetAttr,
     Value,
     TupleGet,
+    Op,
 )
 from mypyc.ir.rtypes import bool_rprimitive, RTuple
 from mypyc.primitives.exc_ops import err_occurred_op

--- a/mypyc/transform/exceptions.py
+++ b/mypyc/transform/exceptions.py
@@ -26,14 +26,14 @@ from mypyc.ir.ops import (
     GetAttr,
     Integer,
     LoadErrorValue,
+    Op,
     RegisterOp,
     Return,
     SetAttr,
-    Value,
     TupleGet,
-    Op,
+    Value,
 )
-from mypyc.ir.rtypes import bool_rprimitive, RTuple
+from mypyc.ir.rtypes import RTuple, bool_rprimitive
 from mypyc.primitives.exc_ops import err_occurred_op
 from mypyc.primitives.registry import CFunctionDescription
 

--- a/mypyc/transform/uninit.py
+++ b/mypyc/transform/uninit.py
@@ -20,7 +20,7 @@ from mypyc.ir.ops import (
     Unreachable,
     Value,
 )
-from mypyc.ir.rtypes import bitmap_rprimitive, is_fixed_width_rtype
+from mypyc.ir.rtypes import bitmap_rprimitive
 
 
 def insert_uninit_checks(ir: FuncIR) -> None:
@@ -77,7 +77,7 @@ def split_blocks_at_uninits(
                         init_registers.append(src)
                         init_registers_set.add(src)
 
-                    if not is_fixed_width_rtype(src.type):
+                    if not src.type.error_overlap:
                         cur_block.ops.append(
                             Branch(
                                 src,


### PR DESCRIPTION
A tuple such as `tuple[i64, i64]` can't have a dedicated error value, so use overlapping error values, similarly to how we support plain native integers such as `i64`.

For a heterogeneous tuple such as as `tuple[i64, str]` we attempt to store the error value in the smallest item index where the value type supports error values (1 in this example).

This affects error returns, undefined attributes, default arguments and undefined locals.