### PR TITLE
Switch :py:func:`type` to py:class:`type` in type_narrowing.rst

### DIFF
--- a/docs/source/type_narrowing.rst
+++ b/docs/source/type_narrowing.rst
@@ -16,7 +16,7 @@ The simplest way to narrow a type is to use one of the supported expressions:
 
 - :py:func:`isinstance` like in ``isinstance(obj, float)`` will narrow ``obj`` to have ``float`` type
 - :py:func:`issubclass` like in ``issubclass(cls, MyClass)`` will narrow ``cls`` to be ``Type[MyClass]``
-- :py:func:`type` like in ``type(obj) is int`` will narrow ``obj`` to have ``int`` type
+- :py:class:`type` like in ``type(obj) is int`` will narrow ``obj`` to have ``int`` type
 - :py:func:`callable` like in ``callable(obj)`` will narrow object to callable type
 
 Type narrowing is contextual. For example, based on the condition, mypy will narrow an expression only within an ``if`` branch:


### PR DESCRIPTION
The former does not render properly in the docs

This is a tiny follow up from https://github.com/python/mypy/pull/14246#issuecomment-1336467793