### PR TITLE
Replace TypeList in constraints with TupleType

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -135,7 +135,7 @@ def infer_constraints_for_callable(
 
             unpacked_type = get_proper_type(unpack_type.type)
             if isinstance(unpacked_type, TypeVarTupleType):
-                constraints.append(Constraint(unpacked_type, SUPERTYPE_OF, TypeList(actual_types)))
+                constraints.append(Constraint(unpacked_type, SUPERTYPE_OF, TupleType(actual_types, unpacked_type.tuple_fallback)))
             elif isinstance(unpacked_type, TupleType):
                 # Prefixes get converted to positional args, so technically the only case we
                 # should have here is like Tuple[Unpack[Ts], Y1, Y2, Y3]. If this turns out
@@ -147,12 +147,11 @@ def infer_constraints_for_callable(
                 suffix_len = len(unpacked_type.items) - 1
                 constraints.append(
                     Constraint(
-                        inner_unpacked_type, SUPERTYPE_OF, TypeList(actual_types[:-suffix_len])
+                        inner_unpacked_type, SUPERTYPE_OF, TupleType(actual_types[:-suffix_len], inner_unpacked_type.tuple_fallback)
                     )
                 )
             else:
                 assert False, "mypy bug: unhandled constraint inference case"
-
         else:
             for actual in actuals:
                 actual_arg_type = arg_types[actual]
@@ -640,7 +639,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         if isinstance(instance_unpack, TypeVarTupleType):
                             res.append(
                                 Constraint(
-                                    instance_unpack, SUBTYPE_OF, TypeList(list(mapped_middle))
+                                    instance_unpack, SUBTYPE_OF, TupleType(list(mapped_middle), instance_unpack.tuple_fallback)
                                 )
                             )
                         elif (
@@ -742,7 +741,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         if isinstance(template_unpack, TypeVarTupleType):
                             res.append(
                                 Constraint(
-                                    template_unpack, SUPERTYPE_OF, TypeList(list(mapped_middle))
+                                    template_unpack, SUPERTYPE_OF, TupleType(list(mapped_middle), template_unpack.tuple_fallback)
                                 )
                             )
                         elif (

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -29,7 +29,6 @@ from mypy.types import (
     Type,
     TypeAliasType,
     TypedDictType,
-    TypeList,
     TypeOfAny,
     TypeQuery,
     TypeType,

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -134,7 +134,13 @@ def infer_constraints_for_callable(
 
             unpacked_type = get_proper_type(unpack_type.type)
             if isinstance(unpacked_type, TypeVarTupleType):
-                constraints.append(Constraint(unpacked_type, SUPERTYPE_OF, TupleType(actual_types, unpacked_type.tuple_fallback)))
+                constraints.append(
+                    Constraint(
+                        unpacked_type,
+                        SUPERTYPE_OF,
+                        TupleType(actual_types, unpacked_type.tuple_fallback),
+                    )
+                )
             elif isinstance(unpacked_type, TupleType):
                 # Prefixes get converted to positional args, so technically the only case we
                 # should have here is like Tuple[Unpack[Ts], Y1, Y2, Y3]. If this turns out
@@ -146,7 +152,9 @@ def infer_constraints_for_callable(
                 suffix_len = len(unpacked_type.items) - 1
                 constraints.append(
                     Constraint(
-                        inner_unpacked_type, SUPERTYPE_OF, TupleType(actual_types[:-suffix_len], inner_unpacked_type.tuple_fallback)
+                        inner_unpacked_type,
+                        SUPERTYPE_OF,
+                        TupleType(actual_types[:-suffix_len], inner_unpacked_type.tuple_fallback),
                     )
                 )
             else:
@@ -638,7 +646,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         if isinstance(instance_unpack, TypeVarTupleType):
                             res.append(
                                 Constraint(
-                                    instance_unpack, SUBTYPE_OF, TupleType(list(mapped_middle), instance_unpack.tuple_fallback)
+                                    instance_unpack,
+                                    SUBTYPE_OF,
+                                    TupleType(list(mapped_middle), instance_unpack.tuple_fallback),
                                 )
                             )
                         elif (
@@ -740,7 +750,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         if isinstance(template_unpack, TypeVarTupleType):
                             res.append(
                                 Constraint(
-                                    template_unpack, SUPERTYPE_OF, TupleType(list(mapped_middle), template_unpack.tuple_fallback)
+                                    template_unpack,
+                                    SUPERTYPE_OF,
+                                    TupleType(list(mapped_middle), template_unpack.tuple_fallback),
                                 )
                             )
                         elif (

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -94,7 +94,9 @@ def expand_type_by_instance(typ: Type, instance: Instance) -> Type:
                 instance.type.type_var_tuple_prefix,
                 instance.type.type_var_tuple_suffix,
             )
-            variables = {tvars_middle[0].id: TupleType(list(args_middle), tvars_middle[0].tuple_fallback)}
+            tvar = tvars_middle[0]
+            assert isinstance(tvar, TypeVarTupleType)
+            variables = {tvar.id: TupleType(list(args_middle), tvar.tuple_fallback)}
             instance_args = args_prefix + args_suffix
             tvars = tvars_prefix + tvars_suffix
         else:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -22,7 +22,6 @@ from mypy.types import (
     Type,
     TypeAliasType,
     TypedDictType,
-    TypeList,
     TypeType,
     TypeVarId,
     TypeVarLikeType,
@@ -95,7 +94,7 @@ def expand_type_by_instance(typ: Type, instance: Instance) -> Type:
                 instance.type.type_var_tuple_prefix,
                 instance.type.type_var_tuple_suffix,
             )
-            variables = {tvars_middle[0].id: TypeList(list(args_middle))}
+            variables = {tvars_middle[0].id: TupleType(list(args_middle), tvars_middle[0].tuple_fallback)}
             instance_args = args_prefix + args_suffix
             tvars = tvars_prefix + tvars_suffix
         else:
@@ -446,8 +445,6 @@ def expand_unpack_with_variables(
     if isinstance(t.type, TypeVarTupleType):
         repl = get_proper_type(variables.get(t.type.id, t))
         if isinstance(repl, TupleType):
-            return repl.items
-        if isinstance(repl, TypeList):
             return repl.items
         elif isinstance(repl, Instance) and repl.type.fullname == "builtins.tuple":
             return repl

--- a/mypy/test/testconstraints.py
+++ b/mypy/test/testconstraints.py
@@ -27,13 +27,19 @@ class ConstraintsSuite(Suite):
         fx = self.fx
         assert infer_constraints(
             Instance(fx.gvi, [UnpackType(fx.ts)]), Instance(fx.gvi, [fx.a, fx.b]), SUBTYPE_OF
-        ) == [Constraint(type_var=fx.ts, op=SUBTYPE_OF, target=TupleType([fx.a, fx.b], fx.std_tuple))]
+        ) == [
+            Constraint(type_var=fx.ts, op=SUBTYPE_OF, target=TupleType([fx.a, fx.b], fx.std_tuple))
+        ]
 
     def test_basic_type_var_tuple(self) -> None:
         fx = self.fx
         assert infer_constraints(
             Instance(fx.gvi, [UnpackType(fx.ts)]), Instance(fx.gvi, [fx.a, fx.b]), SUPERTYPE_OF
-        ) == [Constraint(type_var=fx.ts, op=SUPERTYPE_OF, target=TupleType([fx.a, fx.b], fx.std_tuple))]
+        ) == [
+            Constraint(
+                type_var=fx.ts, op=SUPERTYPE_OF, target=TupleType([fx.a, fx.b], fx.std_tuple)
+            )
+        ]
 
     def test_type_var_tuple_with_prefix_and_suffix(self) -> None:
         fx = self.fx
@@ -45,7 +51,9 @@ class ConstraintsSuite(Suite):
             )
         ) == {
             Constraint(type_var=fx.t, op=SUPERTYPE_OF, target=fx.a),
-            Constraint(type_var=fx.ts, op=SUPERTYPE_OF, target=TupleType([fx.b, fx.c], fx.std_tuple)),
+            Constraint(
+                type_var=fx.ts, op=SUPERTYPE_OF, target=TupleType([fx.b, fx.c], fx.std_tuple)
+            ),
             Constraint(type_var=fx.s, op=SUPERTYPE_OF, target=fx.d),
         }
 

--- a/mypy/test/testconstraints.py
+++ b/mypy/test/testconstraints.py
@@ -5,7 +5,7 @@ import pytest
 from mypy.constraints import SUBTYPE_OF, SUPERTYPE_OF, Constraint, infer_constraints
 from mypy.test.helpers import Suite
 from mypy.test.typefixture import TypeFixture
-from mypy.types import Instance, TupleType, TypeList, UnpackType
+from mypy.types import Instance, TupleType, UnpackType
 
 
 class ConstraintsSuite(Suite):
@@ -27,13 +27,13 @@ class ConstraintsSuite(Suite):
         fx = self.fx
         assert infer_constraints(
             Instance(fx.gvi, [UnpackType(fx.ts)]), Instance(fx.gvi, [fx.a, fx.b]), SUBTYPE_OF
-        ) == [Constraint(type_var=fx.ts, op=SUBTYPE_OF, target=TypeList([fx.a, fx.b]))]
+        ) == [Constraint(type_var=fx.ts, op=SUBTYPE_OF, target=TupleType([fx.a, fx.b], fx.std_tuple))]
 
     def test_basic_type_var_tuple(self) -> None:
         fx = self.fx
         assert infer_constraints(
             Instance(fx.gvi, [UnpackType(fx.ts)]), Instance(fx.gvi, [fx.a, fx.b]), SUPERTYPE_OF
-        ) == [Constraint(type_var=fx.ts, op=SUPERTYPE_OF, target=TypeList([fx.a, fx.b]))]
+        ) == [Constraint(type_var=fx.ts, op=SUPERTYPE_OF, target=TupleType([fx.a, fx.b], fx.std_tuple))]
 
     def test_type_var_tuple_with_prefix_and_suffix(self) -> None:
         fx = self.fx
@@ -45,7 +45,7 @@ class ConstraintsSuite(Suite):
             )
         ) == {
             Constraint(type_var=fx.t, op=SUPERTYPE_OF, target=fx.a),
-            Constraint(type_var=fx.ts, op=SUPERTYPE_OF, target=TypeList([fx.b, fx.c])),
+            Constraint(type_var=fx.ts, op=SUPERTYPE_OF, target=TupleType([fx.b, fx.c], fx.std_tuple)),
             Constraint(type_var=fx.s, op=SUPERTYPE_OF, target=fx.d),
         }
 


### PR DESCRIPTION
Now that the fallback is available, we can construct TupleTypes instead of TypeLists which will simplify constraint solving as it won't need to know to match TupleTypes with TypeLists.