### PR TITLE
Add error for asdict, astuple, fields, and replace in dataclasses - Fixes #14215

### DIFF
--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2001,3 +2001,29 @@ class Bar(Foo): ...
 e: Element[Bar]
 reveal_type(e.elements)  # N: Revealed type is "typing.Sequence[__main__.Element[__main__.Bar]]"
 [builtins fixtures/dataclasses.pyi]
+
+[case testFuncsOnlyTakeDataclassArg]
+# flags: --python-version 3.7
+# Ensure asdict, astuple, fields, and replace methods from dataclasses module only accept
+# a dataclass instance as the first argument.
+# See mypy issue #14215
+from dataclasses import asdict, astuple, dataclass, fields, replace
+
+class Klass:
+    pass
+
+@dataclass
+class DClass:
+    pass
+
+klass = Klass()
+dclass = DClass()
+asdict(dclass)
+astuple(dclass)
+replace(dclass)
+fields(dclass)
+asdict(klass)  # E: asdict() should be called on dataclass instances
+astuple(klass)  # E: astuple() should be called on dataclass instances
+fields(klass)  # E: fields() should be called on dataclass instances
+replace(klass)  # E: replace() should be called on dataclass instances
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/lib-stub/dataclasses.pyi
+++ b/test-data/unit/lib-stub/dataclasses.pyi
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Generic, Mapping, Optional, TypeVar, overload, Type
+from typing import (
+    Any, Callable, Generic, Mapping, Optional, TypeVar, overload, Tuple,
+    Type,
+)
 
 _T = TypeVar('_T')
 
@@ -32,3 +35,19 @@ def field(*,
 
 
 class Field(Generic[_T]): pass
+
+@overload
+def asdict(obj: Any) -> dict[str, Any]: ...
+
+@overload
+def asdict(obj: Any, *, dict_factory: Callable[[list[tuple[str, Any]]], _T]) -> _T: ...
+
+@overload
+def astuple(obj: Any) -> Tuple[Any, ...]: ...
+
+@overload
+def astuple(obj: Any, *, tuple_factory: Callable[[list[Any]], _T]) -> _T: ...
+
+def replace(obj: _T, **changes: Any) -> _T: ...
+
+def fields(class_or_instance: Any) -> Tuple[Field[Any], ...]: ...


### PR DESCRIPTION
Fixes #14215

This change ensures Mypy detects an error when any of the asdict, astuple, fields, or replace methods from the dataclasses library is called on an object that is not a dataclass.
