### PR TITLE
Rename `partially-defined` error codes

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2355,7 +2355,7 @@ class State:
         manager = self.manager
         if manager.errors.is_error_code_enabled(
             codes.POSSIBLY_UNDEFINED
-        ) or manager.errors.is_error_code_enabled(codes.USE_BEFORE_DEF):
+        ) or manager.errors.is_error_code_enabled(codes.USED_BEFORE_DEF):
             manager.errors.set_file(self.xpath, self.tree.fullname, options=manager.options)
             self.tree.accept(
                 PossiblyUndefinedVariableVisitor(

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -50,7 +50,7 @@ from mypy.errors import CompileError, ErrorInfo, Errors, report_internal_error
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.messages import MessageBuilder
 from mypy.nodes import Import, ImportAll, ImportBase, ImportFrom, MypyFile, SymbolTable, TypeInfo
-from mypy.partially_defined import PartiallyDefinedVariableVisitor
+from mypy.partially_defined import PossiblyUndefinedVariableVisitor
 from mypy.semanal import SemanticAnalyzer
 from mypy.semanal_pass1 import SemanticAnalyzerPreAnalysis
 from mypy.util import (
@@ -2347,18 +2347,18 @@ class State:
         self.time_spent_us += time_spent_us(t0)
         return result
 
-    def detect_partially_defined_vars(self, type_map: dict[Expression, Type]) -> None:
+    def detect_possibly_undefined_vars(self, type_map: dict[Expression, Type]) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
         if self.tree.is_stub:
             # We skip stub files because they aren't actually executed.
             return
         manager = self.manager
         if manager.errors.is_error_code_enabled(
-            codes.PARTIALLY_DEFINED
+            codes.POSSIBLY_UNDEFINED
         ) or manager.errors.is_error_code_enabled(codes.USE_BEFORE_DEF):
             manager.errors.set_file(self.xpath, self.tree.fullname, options=manager.options)
             self.tree.accept(
-                PartiallyDefinedVariableVisitor(
+                PossiblyUndefinedVariableVisitor(
                     MessageBuilder(manager.errors, manager.modules), type_map, manager.options
                 )
             )
@@ -3412,7 +3412,7 @@ def process_stale_scc(graph: Graph, scc: list[str], manager: BuildManager) -> No
         graph[id].type_check_first_pass()
         if not graph[id].type_checker().deferred_nodes:
             unfinished_modules.discard(id)
-            graph[id].detect_partially_defined_vars(graph[id].type_map())
+            graph[id].detect_possibly_undefined_vars(graph[id].type_map())
             graph[id].finish_passes()
 
     while unfinished_modules:
@@ -3421,7 +3421,7 @@ def process_stale_scc(graph: Graph, scc: list[str], manager: BuildManager) -> No
                 continue
             if not graph[id].type_check_second_pass():
                 unfinished_modules.discard(id)
-                graph[id].detect_partially_defined_vars(graph[id].type_map())
+                graph[id].detect_possibly_undefined_vars(graph[id].type_map())
                 graph[id].finish_passes()
     for id in stale:
         graph[id].generate_unused_ignore_notes()

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -140,8 +140,8 @@ UNREACHABLE: Final = ErrorCode(
 ANNOTATION_UNCHECKED = ErrorCode(
     "annotation-unchecked", "Notify about type annotations in unchecked functions", "General"
 )
-PARTIALLY_DEFINED: Final[ErrorCode] = ErrorCode(
-    "partially-defined",
+POSSIBLY_UNDEFINED: Final[ErrorCode] = ErrorCode(
+    "possibly-undefined",
     "Warn about variables that are defined only in some execution paths",
     "General",
     default_enabled=False,

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -192,8 +192,8 @@ REDUNDANT_SELF_TYPE = ErrorCode(
     "General",
     default_enabled=False,
 )
-USE_BEFORE_DEF: Final[ErrorCode] = ErrorCode(
-    "use-before-def",
+USED_BEFORE_DEF: Final[ErrorCode] = ErrorCode(
+    "used-before-def",
     "Warn about variables that are used before they are defined",
     "General",
     default_enabled=False,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1229,7 +1229,7 @@ class MessageBuilder:
         self.fail(f'"{member}" undefined in superclass', context)
 
     def variable_may_be_undefined(self, name: str, context: Context) -> None:
-        self.fail(f'Name "{name}" may be undefined', context, code=codes.PARTIALLY_DEFINED)
+        self.fail(f'Name "{name}" may be undefined', context, code=codes.POSSIBLY_UNDEFINED)
 
     def var_used_before_def(self, name: str, context: Context) -> None:
         self.fail(f'Name "{name}" is used before definition', context, code=codes.USE_BEFORE_DEF)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1232,7 +1232,7 @@ class MessageBuilder:
         self.fail(f'Name "{name}" may be undefined', context, code=codes.POSSIBLY_UNDEFINED)
 
     def var_used_before_def(self, name: str, context: Context) -> None:
-        self.fail(f'Name "{name}" is used before definition', context, code=codes.USE_BEFORE_DEF)
+        self.fail(f'Name "{name}" is used before definition', context, code=codes.USED_BEFORE_DEF)
 
     def first_argument_for_super_must_be_type(self, actual: Type, context: Context) -> None:
         actual = get_proper_type(actual)

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -104,7 +104,7 @@ class BranchStatement:
         assert len(self.branches) > 0
         self.branches[-1].skipped = True
 
-    def is_partially_defined(self, name: str) -> bool:
+    def is_possibly_undefined(self, name: str) -> bool:
         assert len(self.branches) > 0
         return name in self.branches[-1].may_be_defined
 
@@ -213,10 +213,10 @@ class DefinedVariableTracker:
         assert len(self.scopes) > 0
         return self._scope().pop_undefined_ref(name)
 
-    def is_partially_defined(self, name: str) -> bool:
+    def is_possibly_undefined(self, name: str) -> bool:
         assert len(self._scope().branch_stmts) > 0
         # A variable is undefined if it's in a set of `may_be_defined` but not in `must_be_defined`.
-        return self._scope().branch_stmts[-1].is_partially_defined(name)
+        return self._scope().branch_stmts[-1].is_possibly_undefined(name)
 
     def is_defined_in_different_branch(self, name: str) -> bool:
         """This will return true if a variable is defined in a branch that's not the current branch."""
@@ -243,7 +243,7 @@ class Loop:
         self.has_break = False
 
 
-class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
+class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
     """Detects the following cases:
     - A variable that's defined only part of the time.
     - If a variable is used before definition
@@ -277,7 +277,7 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
             self.msg.var_used_before_def(name, context)
 
     def variable_may_be_undefined(self, name: str, context: Context) -> None:
-        if self.msg.errors.is_error_code_enabled(errorcodes.PARTIALLY_DEFINED):
+        if self.msg.errors.is_error_code_enabled(errorcodes.POSSIBLY_UNDEFINED):
             self.msg.variable_may_be_undefined(name, context)
 
     def process_definition(self, name: str) -> None:
@@ -471,7 +471,7 @@ class PartiallyDefinedVariableVisitor(ExtendedTraverserVisitor):
     def visit_name_expr(self, o: NameExpr) -> None:
         if refers_to_builtin(o):
             return
-        if self.tracker.is_partially_defined(o.name):
+        if self.tracker.is_possibly_undefined(o.name):
             # A variable is only defined in some branches.
             self.variable_may_be_undefined(o.name, o)
             # We don't want to report the error on the same variable multiple times.

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -253,7 +253,7 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
         x = 1
     print(x)  # Error: "x" may be undefined.
 
-    Example of a use before definition:
+    Example of a used before definition:
     x = y
     y: int = 2
 
@@ -273,7 +273,7 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
             self.tracker.record_definition(name)
 
     def var_used_before_def(self, name: str, context: Context) -> None:
-        if self.msg.errors.is_error_code_enabled(errorcodes.USE_BEFORE_DEF):
+        if self.msg.errors.is_error_code_enabled(errorcodes.USED_BEFORE_DEF):
             self.msg.var_used_before_def(name, context)
 
     def variable_may_be_undefined(self, name: str, context: Context) -> None:
@@ -281,7 +281,7 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
             self.msg.variable_may_be_undefined(name, context)
 
     def process_definition(self, name: str) -> None:
-        # Was this name previously used? If yes, it's a use-before-definition error.
+        # Was this name previously used? If yes, it's a used-before-definition error.
         refs = self.tracker.pop_undefined_ref(name)
         for ref in refs:
             self.var_used_before_def(name, ref)
@@ -488,7 +488,7 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
             # 2. The variable is defined later in the code.
             # Case (1) will be caught by semantic analyzer. Case (2) is a forward ref that should
             # be caught by this visitor. Save the ref for later, so that if we see a definition,
-            # we know it's a use-before-definition scenario.
+            # we know it's a used-before-definition scenario.
             self.tracker.record_undefined_ref(o)
         super().visit_name_expr(o)
 

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -662,7 +662,7 @@ def update_module_isolated(
     state.type_checker().reset()
     state.type_check_first_pass()
     state.type_check_second_pass()
-    state.detect_partially_defined_vars(state.type_map())
+    state.detect_possibly_undefined_vars(state.type_map())
     t2 = time.time()
     state.finish_passes()
     t3 = time.time()

--- a/test-data/unit/check-possibly-undefined.test
+++ b/test-data/unit/check-possibly-undefined.test
@@ -1,5 +1,5 @@
 [case testDefinedInOneBranch]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 if int():
     a = 1
 else:
@@ -8,7 +8,7 @@ z = a + 1  # E: Name "a" may be undefined
 z = a + 1  # We only report the error on first occurrence.
 
 [case testElif]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 if int():
     a = 1
 elif int():
@@ -19,14 +19,14 @@ else:
 z = a + 1  # E: Name "a" may be undefined
 
 [case testUsedInIf]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 if int():
     y = 1
 if int():
     x = y  # E: Name "y" may be undefined
 
 [case testDefinedInAllBranches]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 if int():
     a = 1
 elif int():
@@ -36,13 +36,13 @@ else:
 z = a + 1
 
 [case testOmittedElse]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 if int():
     a = 1
 z = a + 1  # E: Name "a" may be undefined
 
 [case testUpdatedInIf]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 # Variable a is already defined. Just updating it in an "if" is acceptable.
 a = 1
 if int():
@@ -50,7 +50,7 @@ if int():
 z = a + 1
 
 [case testNestedIf]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 if int():
     if int():
         a = 1
@@ -65,7 +65,7 @@ else:
 z = a + b  # E: Name "a" may be undefined
 
 [case testVeryNestedIf]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 if int():
     if int():
         if int():
@@ -81,7 +81,7 @@ else:
 z = a + b  # E: Name "a" may be undefined
 
 [case testTupleUnpack]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 
 if int():
     (x, y) = (1, 2)
@@ -91,7 +91,7 @@ a = y + x  # E: Name "x" may be undefined
 a = y + z  # E: Name "z" may be undefined
 
 [case testIndexExpr]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 
 if int():
     *x, y = (1, 2)
@@ -101,7 +101,7 @@ a = x  # No error.
 b = y  # E: Name "y" may be undefined
 
 [case testRedefined]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 y = 3
 if int():
     if int():
@@ -115,7 +115,7 @@ else:
 x = y + 2
 
 [case testFunction]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def f0() -> None:
     if int():
         def some_func() -> None:
@@ -134,21 +134,21 @@ def f1() -> None:
     some_func()  # No error.
 
 [case testLambda]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def f0(b: bool) -> None:
     if b:
         fn = lambda: 2
     y = fn   # E: Name "fn" may be undefined
 
 [case testUseBeforeDefClass]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 def f(x: A):  # No error here.
     pass
 y = A()  # E: Name "A" is used before definition
 class A: pass
 
 [case testClassScope]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 class C:
     x = 0
     def f0(self) -> None: pass
@@ -163,7 +163,7 @@ y = x  # E: Name "x" is used before definition
 x = 1
 
 [case testClassInsideFunction]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 def f() -> None:
     class C: pass
 
@@ -171,18 +171,18 @@ c = C()  # E: Name "C" is used before definition
 class C: pass
 
 [case testUseBeforeDefFunc]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 foo() # E: Name "foo" is used before definition
 def foo(): pass
 [case testGenerator]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 if int():
     a = 3
 s = [a + 1 for a in [1, 2, 3]]
 x = a  # E: Name "a" may be undefined
 
 [case testScope]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def foo() -> None:
     if int():
         y = 2
@@ -192,7 +192,7 @@ if int():
 x = y  # E: Name "y" may be undefined
 
 [case testVarDefinedInOuterScopeUpdated]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 def f0() -> None:
     global x
     y = x
@@ -201,7 +201,7 @@ def f0() -> None:
 x = 2
 
 [case testNonlocalVar]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 def f0() -> None:
     x = 2
 
@@ -212,7 +212,7 @@ def f0() -> None:
 
 
 [case testGlobalDeclarationAfterUsage]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 def f0() -> None:
     y = x  # E: Name "x" is used before definition
     global x
@@ -220,7 +220,7 @@ def f0() -> None:
 
 x = 2
 [case testVarDefinedInOuterScope]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 def f0() -> None:
   global x
   y = x  # We do not detect such errors right now.
@@ -228,21 +228,21 @@ def f0() -> None:
 f0()
 x = 1
 [case testDefinedInOuterScopeNoError]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 def foo() -> None:
     bar()
 
 def bar() -> None:
     foo()
 [case testFuncParams]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def foo(a: int) -> None:
     if int():
         a = 2
     x = a
 
 [case testWhile]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 while int():
     a = 1
 
@@ -289,7 +289,7 @@ y = f  # E: Name "f" may be undefined
 y = g
 
 [case testForLoop]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 for x in [1, 2, 3]:
     if x:
         x = 1
@@ -300,7 +300,7 @@ else:
 a = z + y  # E: Name "y" may be undefined
 
 [case testReturn]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def f1() -> int:
     if int():
         x = 1
@@ -352,7 +352,7 @@ def f6() -> int:
     return x  # E: Name "x" may be undefined
 
 [case testDefinedDifferentBranchUseBeforeDef]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 
 def f0() -> None:
     if int():
@@ -382,8 +382,8 @@ def f2() -> None:
             x = 2
         w = x  # No error.
 
-[case testDefinedDifferentBranchPartiallyDefined]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+[case testDefinedDifferentBranchPossiblyUndefined]
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 
 def f0() -> None:
     first_iter = True
@@ -424,7 +424,7 @@ def f3() -> None:
         y = x  # E: Name "x" may be undefined
 
 [case testAssert]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def f1() -> int:
     if int():
         x = 1
@@ -442,7 +442,7 @@ def f2() -> int:
     return x  # E: Name "x" may be undefined
 
 [case testRaise]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def f1() -> int:
     if int():
         x = 1
@@ -461,7 +461,7 @@ def f2() -> int:
 [builtins fixtures/exception.pyi]
 
 [case testContinue]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def f1() -> int:
     while int():
         if int():
@@ -495,7 +495,7 @@ def f3() -> None:
         y = x
 
 [case testBreak]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 def f1() -> None:
     while int():
         if int():
@@ -526,7 +526,7 @@ def f3() -> None:
     z = x  # E: Name "x" may be undefined
 
 [case testNoReturn]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 
 from typing import NoReturn
 def fail() -> NoReturn:
@@ -545,7 +545,7 @@ def f() -> None:
     z = x
 
 [case testDictComprehension]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 
 def f() -> None:
     for _ in [1, 2]:
@@ -562,7 +562,7 @@ def f() -> None:
 [builtins fixtures/dict.pyi]
 
 [case testWithStmt]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 from contextlib import contextmanager
 
 @contextmanager
@@ -582,7 +582,7 @@ def f() -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testUnreachable]
-# flags: --enable-error-code partially-defined
+# flags: --enable-error-code possibly-undefined
 import typing
 
 if typing.TYPE_CHECKING:
@@ -718,16 +718,16 @@ a = __name__  # No error.
 __name__ = "abc"
 
 [case testUntypedDef]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
 
 def f():
     if int():
         x = 0
     z = y  # No use-before-def error because def is untyped.
-    y = x  # No partially-defined error because def is untyped.
+    y = x  # No possibly-undefined error because def is untyped.
 
 [case testUntypedDefCheckUntypedDefs]
-# flags: --enable-error-code partially-defined --enable-error-code use-before-def --check-untyped-defs
+# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def --check-untyped-defs
 
 def f():
     if int():

--- a/test-data/unit/check-possibly-undefined.test
+++ b/test-data/unit/check-possibly-undefined.test
@@ -140,15 +140,15 @@ def f0(b: bool) -> None:
         fn = lambda: 2
     y = fn   # E: Name "fn" may be undefined
 
-[case testUseBeforeDefClass]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+[case testUsedBeforeDefClass]
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 def f(x: A):  # No error here.
     pass
 y = A()  # E: Name "A" is used before definition
 class A: pass
 
 [case testClassScope]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 class C:
     x = 0
     def f0(self) -> None: pass
@@ -163,15 +163,15 @@ y = x  # E: Name "x" is used before definition
 x = 1
 
 [case testClassInsideFunction]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 def f() -> None:
     class C: pass
 
 c = C()  # E: Name "C" is used before definition
 class C: pass
 
-[case testUseBeforeDefFunc]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+[case testUsedBeforeDefFunc]
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 foo() # E: Name "foo" is used before definition
 def foo(): pass
 [case testGenerator]
@@ -192,7 +192,7 @@ if int():
 x = y  # E: Name "y" may be undefined
 
 [case testVarDefinedInOuterScopeUpdated]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 def f0() -> None:
     global x
     y = x
@@ -201,7 +201,7 @@ def f0() -> None:
 x = 2
 
 [case testNonlocalVar]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 def f0() -> None:
     x = 2
 
@@ -212,7 +212,7 @@ def f0() -> None:
 
 
 [case testGlobalDeclarationAfterUsage]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 def f0() -> None:
     y = x  # E: Name "x" is used before definition
     global x
@@ -220,7 +220,7 @@ def f0() -> None:
 
 x = 2
 [case testVarDefinedInOuterScope]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 def f0() -> None:
   global x
   y = x  # We do not detect such errors right now.
@@ -228,7 +228,7 @@ def f0() -> None:
 f0()
 x = 1
 [case testDefinedInOuterScopeNoError]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 def foo() -> None:
     bar()
 
@@ -351,8 +351,8 @@ def f6() -> int:
         return x
     return x  # E: Name "x" may be undefined
 
-[case testDefinedDifferentBranchUseBeforeDef]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+[case testDefinedDifferentBranchUsedBeforeDef]
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 
 def f0() -> None:
     if int():
@@ -383,7 +383,7 @@ def f2() -> None:
         w = x  # No error.
 
 [case testDefinedDifferentBranchPossiblyUndefined]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 
 def f0() -> None:
     first_iter = True
@@ -600,8 +600,8 @@ else:
 a = z
 [typing fixtures/typing-medium.pyi]
 
-[case testUseBeforeDef]
-# flags: --enable-error-code use-before-def
+[case testUsedBeforeDef]
+# flags: --enable-error-code used-before-def
 
 def f0() -> None:
     x = y  # E: Name "y" is used before definition
@@ -611,7 +611,7 @@ def f2() -> None:
     if int():
         pass
     else:
-        # No use-before-def error.
+        # No used-before-def error.
         y = z  # E: Name "z" is not defined
 
     def inner2() -> None:
@@ -632,8 +632,8 @@ def f4() -> None:
         x = z  # E: Name "z" is used before definition
     z: int = 2
 
-[case testUseBeforeDefImportsBasic]
-# flags: --enable-error-code use-before-def
+[case testUsedBeforeDefImportsBasic]
+# flags: --enable-error-code used-before-def
 import foo  # type: ignore
 import x.y  # type: ignore
 
@@ -653,8 +653,8 @@ def f3() -> None:
     a = x.y  # No error.
     x: int = 1
 
-[case testUseBeforeDefImportBasicRename]
-# flags: --enable-error-code use-before-def
+[case testUsedBeforeDefImportBasicRename]
+# flags: --enable-error-code used-before-def
 import x.y as z  # type: ignore
 from typing import Any
 
@@ -674,16 +674,16 @@ def f3() -> None:
     a = y  # E: Name "y" is used before definition
     y: int = 1
 
-[case testUseBeforeDefImportFrom]
-# flags: --enable-error-code use-before-def
+[case testUsedBeforeDefImportFrom]
+# flags: --enable-error-code used-before-def
 from foo import x  # type: ignore
 
 def f0() -> None:
     a = x  # No error.
     x: int = 1
 
-[case testUseBeforeDefImportFromRename]
-# flags: --enable-error-code use-before-def
+[case testUsedBeforeDefImportFromRename]
+# flags: --enable-error-code used-before-def
 from foo import x as y  # type: ignore
 
 def f0() -> None:
@@ -694,8 +694,8 @@ def f1() -> None:
     a = x  # E: Name "x" is used before definition
     x: int = 1
 
-[case testUseBeforeDefFunctionDeclarations]
-# flags: --enable-error-code use-before-def
+[case testUsedBeforeDefFunctionDeclarations]
+# flags: --enable-error-code used-before-def
 
 def f0() -> None:
     def inner() -> None:
@@ -704,30 +704,30 @@ def f0() -> None:
     inner()  # No error.
     inner = lambda: None
 
-[case testUseBeforeDefBuiltins]
-# flags: --enable-error-code use-before-def
+[case testUsedBeforeDefBuiltins]
+# flags: --enable-error-code used-before-def
 
 def f0() -> None:
     s = type(123)
     type = "abc"
     a = type
 
-[case testUseBeforeDefImplicitModuleAttrs]
-# flags: --enable-error-code use-before-def
+[case testUsedBeforeDefImplicitModuleAttrs]
+# flags: --enable-error-code used-before-def
 a = __name__  # No error.
 __name__ = "abc"
 
 [case testUntypedDef]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 
 def f():
     if int():
         x = 0
-    z = y  # No use-before-def error because def is untyped.
+    z = y  # No used-before-def error because def is untyped.
     y = x  # No possibly-undefined error because def is untyped.
 
 [case testUntypedDefCheckUntypedDefs]
-# flags: --enable-error-code possibly-undefined --enable-error-code use-before-def --check-untyped-defs
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def --check-untyped-defs
 
 def f():
     if int():

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1726,8 +1726,8 @@ def my_func(pairs: Iterable[tuple[S, S]]) -> None:
                                    # N: Revealed type is "Tuple[builtins.str, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
-[case testPartiallyDefinedMatch]
-# flags: --enable-error-code partially-defined
+[case testPossiblyUndefinedMatch]
+# flags: --enable-error-code possibly-undefined
 def f0(x: int | str) -> int:
     match x:
         case int():
@@ -1789,8 +1789,8 @@ def f6(a: object) -> None:
             pass
 [builtins fixtures/tuple.pyi]
 
-[case testPartiallyDefinedMatchUnreachable]
-# flags: --enable-error-code partially-defined
+[case testPossiblyUndefinedMatchUnreachable]
+# flags: --enable-error-code possibly-undefined
 import typing
 
 def f0(x: int) -> int:

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -707,8 +707,8 @@ def foo(name: str, /, **kwargs: Unpack[Person]) -> None:  # Allowed
     ...
 [builtins fixtures/dict.pyi]
 
-[case testPartiallyDefinedWithAssignmentExpr]
-# flags: --python-version 3.8 --enable-error-code partially-defined
+[case testPossiblyUndefinedWithAssignmentExpr]
+# flags: --python-version 3.8 --enable-error-code possibly-undefined
 def f1() -> None:
     d = {0: 1}
     if int():


### PR DESCRIPTION
Rename `partially-defined` to `possibly-undefined` and `use-before-def` to `used-before-def`.

Ref #14226