### PR TITLE
Stubtest: Improve heuristics for determining whether global-namespace names are imported

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -295,11 +295,10 @@ def _get_imported_symbol_names(runtime: types.ModuleType) -> frozenset[str] | No
     it won't include names imported via `from foo import *` imports.
     """
     try:
-        sourcelines = inspect.getsourcelines(runtime)[0]
+        source = inspect.getsource(runtime)
     except (OSError, TypeError, SyntaxError):
         return None
 
-    source = "".join(sourcelines)
     if not source.strip():
         return None
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -15,6 +15,7 @@ import inspect
 import os
 import pkgutil
 import re
+import symtable
 import sys
 import traceback
 import types
@@ -281,6 +282,35 @@ def _verify_exported_names(
     )
 
 
+def _get_imported_symbol_names(runtime: types.ModuleType) -> frozenset[str] | None:
+    """Retrieve the names in the global namespace which are known to be imported.
+
+    1). Use inspect to retrieve the source code of the module
+    2). Use symtable to parse the source and retrieve names that are known to be imported
+        from other modules.
+
+    If either of the above steps fails, return `None`.
+
+    Note that if a set of names is returned,
+    it won't include names imported via `from foo import *` imports.
+    """
+    try:
+        sourcelines = inspect.getsourcelines(runtime)[0]
+    except (OSError, TypeError, SyntaxError):
+        return None
+
+    source = "".join(sourcelines)
+    if not source.strip():
+        return None
+
+    try:
+        module_symtable = symtable.symtable(source, runtime.__name__, "exec")
+    except SyntaxError:
+        return None
+
+    return frozenset(sym.get_name() for sym in module_symtable.get_symbols() if sym.is_imported())
+
+
 @verify.register(nodes.MypyFile)
 def verify_mypyfile(
     stub: nodes.MypyFile, runtime: MaybeMissing[types.ModuleType], object_path: list[str]
@@ -310,15 +340,22 @@ def verify_mypyfile(
         if not o.module_hidden and (not is_probably_private(m) or hasattr(runtime, m))
     }
 
+    imported_symbols = _get_imported_symbol_names(runtime)
+
     def _belongs_to_runtime(r: types.ModuleType, attr: str) -> bool:
         obj = getattr(r, attr)
-        try:
-            obj_mod = getattr(obj, "__module__", None)
-        except Exception:
+        if isinstance(obj, types.ModuleType):
             return False
-        if obj_mod is not None:
-            return bool(obj_mod == r.__name__)
-        return not isinstance(obj, types.ModuleType)
+        if callable(obj):
+            try:
+                obj_mod = getattr(obj, "__module__", None)
+            except Exception:
+                return False
+            if obj_mod is not None:
+                return bool(obj_mod == r.__name__)
+        if imported_symbols is not None:
+            return attr not in imported_symbols
+        return True
 
     runtime_public_contents = (
         runtime_all_as_set

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -300,7 +300,9 @@ def _get_imported_symbol_names(runtime: types.ModuleType) -> frozenset[str] | No
         return None
 
     if not source.strip():
-        return None
+        # The source code for the module was an empty file,
+        # no point in parsing it with symtable
+        return frozenset()
 
     try:
         module_symtable = symtable.symtable(source, runtime.__name__, "exec")

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1082,6 +1082,9 @@ class StubtestUnit(unittest.TestCase):
         yield Case(stub="", runtime="import sys", error=None)
         yield Case(stub="", runtime="def g(): ...", error="g")
         yield Case(stub="", runtime="CONSTANT = 0", error="CONSTANT")
+        yield Case(stub="", runtime="import re; constant = re.compile('foo')", error="constant")
+        yield Case(stub="", runtime="from json.scanner import NUMBER_RE", error=None)
+        yield Case(stub="", runtime="from string import ascii_letters", error=None)
 
     @collect_cases
     def test_non_public_1(self) -> Iterator[Case]:


### PR DESCRIPTION
## The problem

Stubtest currently has both false-positives and false-negatives when it comes to verifying constants in the global namespace of a module.

### False positive

The import of `string.ascii_letters` is an implementation detail, but stubtest will complain about it missing from the stub:

```python
# STUB: empty file

# RUNTIME
from string import ascii_letters
```

### False negative

`IMPORTANT_REGEX` is defined in the module, but stubtest will erroneously conclude (on Python 3.10+) that the constant has been imported from another module, due to the fact that `IMPORTANT_REGEX.__module__` is `"re"`:

```python
# STUB: empty file

# RUNTIME
import re
IMPORTANT_REGEX = re.compile("foo")
```

## Solution

This PR fixes the false positive by using `inspect.getsourcelines()` to dynamically retrieve the module source code. It then uses `symtable` to analyse that source code to gather a list of names which are known to be imported.

The PR fixes the false negative by only using the `__module__` heuristic on objects which are callable. The vast majority of callable objects will be types or functions. For these objects, the `__module__` attribute will give a good indication of whether the object originates from another module or not; for other objects, it's less useful.

## Impact on typeshed

This PR has the following impact on typeshed (all diffs are relative to stubtest as it exists on mypy `master`, when run on Python 3.10.7; the stdlib diff is based on running stubtest on a Windows machine):

<details>

`Stdlib`:

```diff
+error: lib2to3.pygram.python_grammar_no_print_and_exec_statement is not present in stub
+Stub: in file ..\typeshed\stdlib\lib2to3\pygram.pyi
+MISSING
+Runtime:
+<lib2to3.pgen2.grammar.Grammar object at 0x000001279D810FA0>
+ 
+error: venv.logger is not present in stub
+Stub: in file ..\typeshed\stdlib\venv\__init__.pyi
+MISSING
+Runtime:
+<Logger venv (WARNING)>
+ 
+note: unused allowlist entry asyncore\.E[A-Z]+
+note: unused allowlist entry asyncore.errorcode
+note: unused allowlist entry email._header_value_parser.hexdigits
+note: unused allowlist entry logging.handlers.ST_[A-Z]+
+note: unused allowlist entry xml.dom.expatbuilder.EMPTY_NAMESPACE
+note: unused allowlist entry xml.dom.expatbuilder.EMPTY_PREFIX
+note: unused allowlist entry xml.dom.expatbuilder.XMLNS_NAMESPACE
+note: unused allowlist entry xml.dom.minidom.EMPTY_NAMESPACE
+note: unused allowlist entry xml.dom.minidom.EMPTY_PREFIX
+note: unused allowlist entry xml.dom.minidom.XMLNS_NAMESPACE
+note: unused allowlist entry distutils.command.bdist_rpm.DEBUG
+note: unused allowlist entry distutils.command.build_ext.USER_BASE
+note: unused allowlist entry distutils.command.build_scripts.ST_MODE
+note: unused allowlist entry distutils.command.install_scripts.ST_MODE
+note: unused allowlist entry distutils.dist.DEBUG
+note: unused allowlist entry distutils.spawn.DEBUG
+note: unused allowlist entry distutils.core.DEBUG
+note: unused allowlist entry distutils.archive_util.getgrnam
+note: unused allowlist entry distutils.archive_util.getpwnam
+note: unused allowlist entry xmlrpc.server.fcntl
-Found 6 errors (checked 482 modules)
+Found 28 errors (checked 482 modules)
```

`cffi`:

```diff
+note: unused allowlist entry cffi.cparser.COMMON_TYPES
+note: unused allowlist entry cffi.verifier.__version_verifier_modules__
-Found 1 error (checked 17 modules)
+Found 3 errors (checked 17 modules)
```

`chevron`:

```diff
+note: unused allowlist entry chevron.main.version
+note: unused allowlist entry chevron.renderer.linesep
+Found 2 errors (checked 5 modules)
```

`colorama`:

```diff
+note: unused allowlist entry colorama.ansitowin32.BEL
+note: unused allowlist entry colorama.ansitowin32.windll
+Found 2 errors (checked 13 modules)
```

`croniter`

```diff
+error: croniter.croniter.hash_expression_re is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/croniter/croniter/croniter.pyi
+MISSING
+Runtime:
+re.compile('^(?P<hash_type>h|r)(\\((?P<range_begin>\\d+)-(?P<range_end>\\d+)\\))?(\\/(?P<divisor>...
+ 
+error: croniter.croniter.only_int_re is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/croniter/croniter/croniter.pyi
+MISSING
+Runtime:
+re.compile('^\\d+$')
+ 
+error: croniter.croniter.special_weekday_re is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/croniter/croniter/croniter.pyi
+MISSING
+Runtime:
+re.compile('^(\\w+)#(\\d+)|l(\\d+)$')
+ 
+error: croniter.croniter.star_or_int_re is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/croniter/croniter/croniter.pyi
+MISSING
+Runtime:
+re.compile('^(\\d+|\\*)$')
+ 
+error: croniter.croniter.step_search_re is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/croniter/croniter/croniter.pyi
+MISSING
+Runtime:
+re.compile('^([^-]+)-([^-/]+)(/(\\d+))?$')
+ 
+Found 5 errors (checked 2 modules)
```

`crontab`

```diff
+note: unused allowlist entry crontabs.X_OK
+Found 1 error (checked 3 modules)
```

`dateparser`:

```diff
+note: unused allowlist entry dateparser.conf.date_order_chart
+note: unused allowlist entry dateparser.conf.language_order
+note: unused allowlist entry dateparser.languages.loader.language_locale_dict
+note: unused allowlist entry dateparser.languages.loader.language_order
+note: unused allowlist entry dateparser.languages.locale.ALWAYS_KEEP_TOKENS
+note: unused allowlist entry dateparser.custom_language_detection.language_mapping.language_map
+note: unused allowlist entry dateparser.custom_language_detection.fasttext.dateparser_model_home
+note: unused allowlist entry dateparser.timezone_parser.timezone_info_list
+Found 8 errors (checked 238 modules)
```

`decorator`:

```diff
+error: decorator.POS is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/decorator/decorator.pyi
+MISSING
+Runtime:
+<_ParameterKind.POSITIONAL_OR_KEYWORD: 1>
+ 
+Found 1 error (checked 1 module)
```

`dockerfile-parse`:

```diff
+error: dockerfile_parse.parser.logger is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/dockerfile-parse/dockerfile_parse/parser.pyi
+MISSING
+Runtime:
+<Logger dockerfile_parse.parser (WARNING)>
+ 
+note: unused allowlist entry dockerfile_parse.constants.version_info
+note: unused allowlist entry dockerfile_parse.parser.string_types
+note: unused allowlist entry dockerfile_parse.parser.DOCKERFILE_FILENAME
+note: unused allowlist entry dockerfile_parse.parser.COMMENT_INSTRUCTION
+note: unused allowlist entry dockerfile_parse.util.PY2
+Found 6 errors (checked 4 modules)
```

`fpdf`:

```diff
+error: fpdf.image_parsing.RESAMPLE is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/fpdf2/fpdf/image_parsing.pyi
+MISSING
+Runtime:
+<Resampling.LANCZOS: 1>
+ 
+note: unused allowlist entry fpdf.syntax.BOM_UTF16_BE
+note: unused allowlist entry fpdf.linearization.signer
+note: unused allowlist entry fpdf.output.signer
+Found 4 errors (checked 25 modules)
```

`parsimonious`

```diff
+note: unused allowlist entry parsimonious.nodes.version_info
+Found 1 error (checked 13 modules)
```

`pika`

```diff
+note: unused allowlist entry pika.data.PY2
+note: unused allowlist entry pika.data.basestring
+note: unused allowlist entry pika.spec.str_or_bytes
+note: unused allowlist entry pika.validators.basestring
-Found 2 errors (checked 30 modules)
+Found 6 errors (checked 30 modules)
```

`playsound`:

```diff
+error: playsound.logger is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/playsound/playsound.pyi
+MISSING
+Runtime:
+<Logger playsound (WARNING)>
+ 
+Found 1 error (checked 1 module)
```

`pyinstaller`:

```diff
+error: PyInstaller.__main__.logger is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/pyinstaller/PyInstaller/__main__.pyi
+MISSING
+Runtime:
+<Logger PyInstaller.__main__ (INFO)>
+ 
+error: PyInstaller.utils.hooks.logger is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/pyinstaller/PyInstaller/utils/hooks/__init__.pyi
+MISSING
+Runtime:
+<Logger PyInstaller.utils.hooks (INFO)>
+ 
+Found 2 errors (checked 151 modules)
```

`pyscreeze`:

```diff
+error: pyscreeze.whichProc is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/PyScreeze/pyscreeze/__init__.pyi
+MISSING
+Runtime:
+<Popen: returncode: 1 args: ['which', 'scrot']>
+ 
+Found 1 error (checked 1 module)
```

`requests`:

```diff
+note: unused allowlist entry requests.adapters.basestring
+note: unused allowlist entry requests.auth.basestring
+note: unused allowlist entry requests.utils.basestring
+note: unused allowlist entry requests.utils.integer_types
+note: unused allowlist entry requests.models.basestring
+note: unused allowlist entry requests.help.requests_version
+note: unused allowlist entry requests.sessions.DEFAULT_PORTS
+note: unused allowlist entry requests.help.chardet
+note: unused allowlist entry requests.help.cryptography
+note: unused allowlist entry requests.help.pyopenssl
+note: unused allowlist entry requests.help.OpenSSL
+note: unused allowlist entry requests.charset_normalizer_version
+note: unused allowlist entry requests.chardet_version
+note: unused allowlist entry requests.utils.HEADER_VALIDATORS
-Found 2 errors (checked 18 modules)
+Found 16 errors (checked 18 modules)
```

`retry`:

```diff
+error: retry.api.logging_logger is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/retry/retry/api.pyi
+MISSING
+Runtime:
+<Logger retry.api (WARNING)>
+ 
+Found 1 error (checked 5 modules)
```

`toml`:

```diff
+note: unused allowlist entry toml.decoder.linesep
+Found 1 error (checked 5 modules)
```

`vobject`:

```diff
+error: vobject.base.formatter is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/vobject/vobject/base.pyi
+MISSING
+Runtime:
+<logging.Formatter object at 0x7f8bb3d737f0>
+ 
+error: vobject.base.handler is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/vobject/vobject/base.pyi
+MISSING
+Runtime:
+<StreamHandler /dev/null (NOTSET)>
+ 
+error: vobject.base.logger is not present in stub
+Stub: in file /home/runner/work/typeshed/typeshed/stubs/vobject/vobject/base.pyi
+MISSING
+Runtime:
+<Logger vobject.base (ERROR)>
+ 
+note: unused allowlist entry vobject.change_tz.PyICU
+note: unused allowlist entry vobject.hcalendar.CRLF
+Found 5 errors (checked 9 modules)
```

`Xlib`:

```diff
+note: unused allowlist entry Xlib.ext.randr.W
+note: unused allowlist entry Xlib.ext.xinput.integer_types
+note: unused allowlist entry Xlib.protocol.display.PY3
+note: unused allowlist entry Xlib.protocol.rq.PY3
+Found 4 errors (checked 66 modules)
```

`zxcvbn`:

```diff
+note: unused allowlist entry zxcvbn.scoring.ADJACENCY_GRAPHS
+note: unused allowlist entry zxcvbn.matching.FREQUENCY_LISTS 
+Found 2 errors (checked 8 modules)
```