### PR TITLE
Replace unsafe PY_*_VERSION comparisons to fix for Python 4.0

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1529,9 +1529,6 @@ def get_typeshed_stdlib_modules(
     stdlib_py_versions = mypy.modulefinder.load_stdlib_py_versions(custom_typeshed_dir)
     if version_info is None:
         version_info = sys.version_info[0:2]
-    # Typeshed's minimum supported Python 3 is Python 3.7
-    if sys.version_info < (3, 7):
-        version_info = (3, 7)
 
     def exists_in_version(module: str) -> bool:
         assert version_info is not None

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -44,13 +44,6 @@ IS_32_BIT_PLATFORM: Final = int(SIZEOF_SIZE_T) == 4
 
 PLATFORM_SIZE = 4 if IS_32_BIT_PLATFORM else 8
 
-# Python 3.5 on macOS uses a hybrid 32/64-bit build that requires some workarounds.
-# The same generated C will be compiled in both 32 and 64 bit modes when building mypy
-# wheels (for an unknown reason).
-#
-# Note that we use "in ['darwin']" because of https://github.com/mypyc/mypyc/issues/761.
-IS_MIXED_32_64_BIT_BUILD: Final = sys.platform in ["darwin"] and sys.version_info < (3, 6)
-
 # Maximum value for a short tagged integer.
 MAX_SHORT_INT: Final = 2 ** (8 * int(SIZEOF_SIZE_T) - 2) - 1
 
@@ -59,9 +52,8 @@ MIN_SHORT_INT: Final = -(MAX_SHORT_INT) - 1
 
 # Maximum value for a short tagged integer represented as a C integer literal.
 #
-# Note: Assume that the compiled code uses the same bit width as mypyc, except for
-#       Python 3.5 on macOS.
-MAX_LITERAL_SHORT_INT: Final = MAX_SHORT_INT if not IS_MIXED_32_64_BIT_BUILD else 2**30 - 1
+# Note: Assume that the compiled code uses the same bit width as mypyc
+MAX_LITERAL_SHORT_INT: Final = MAX_SHORT_INT
 MIN_LITERAL_SHORT_INT: Final = -MAX_LITERAL_SHORT_INT - 1
 
 # Decription of the C type used to track the definedness of attributes and

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -499,13 +499,8 @@ static inline bool CPy_KeepPropagating(void) {
 }
 // We want to avoid the public PyErr_GetExcInfo API for these because
 // it requires a bunch of spurious refcount traffic on the parts of
-// the triple we don't care about. Unfortunately the layout of the
-// data structure changed in 3.7 so we need to handle that.
-#if PY_VERSION_HEX >= 0x03070000
+// the triple we don't care about.
 #define CPy_ExcState() PyThreadState_GET()->exc_info
-#else
-#define CPy_ExcState() PyThreadState_GET()
-#endif
 
 void CPy_Raise(PyObject *exc);
 void CPy_Reraise(void);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -501,7 +501,7 @@ static inline bool CPy_KeepPropagating(void) {
 // it requires a bunch of spurious refcount traffic on the parts of
 // the triple we don't care about. Unfortunately the layout of the
 // data structure changed in 3.7 so we need to handle that.
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
+#if PY_VERSION_HEX >= 0x03070000
 #define CPy_ExcState() PyThreadState_GET()->exc_info
 #else
 #define CPy_ExcState() PyThreadState_GET()
@@ -527,7 +527,7 @@ void CPy_AttributeError(const char *filename, const char *funcname, const char *
 
 // Misc operations
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 8
+#if PY_VERSION_HEX >= 0x03080000
 #define CPy_TRASHCAN_BEGIN(op, dealloc) Py_TRASHCAN_BEGIN(op, dealloc)
 #define CPy_TRASHCAN_END(op) Py_TRASHCAN_END
 #else

--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -18,9 +18,6 @@
 #include <Python.h>
 #include "CPy.h"
 
-/* None of this is supported on Python 3.6 or earlier */
-#if PY_VERSION_HEX >= 0x03070000
-
 #define PARSER_INITED(parser) ((parser)->kwtuple != NULL)
 
 /* Forward */
@@ -570,5 +567,3 @@ skipitem_fast(const char **p_format, va_list *p_va)
 
     *p_format = format;
 }
-
-#endif

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -22,7 +22,7 @@ extern "C" {
 
 /////////////////////////////////////////
 // Adapted from bltinmodule.c in Python 3.7.0
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
+#if PY_VERSION_HEX >= 0x03070000
 _Py_IDENTIFIER(__mro_entries__);
 static PyObject*
 update_bases(PyObject *bases)
@@ -105,7 +105,7 @@ update_bases(PyObject *bases)
 #endif
 
 // From Python 3.7's typeobject.c
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 6
+#if PY_VERSION_HEX >= 0x03060000
 _Py_IDENTIFIER(__init_subclass__);
 static int
 init_subclass(PyTypeObject *type, PyObject *kwds)
@@ -306,7 +306,7 @@ list_count(PyListObject *self, PyObject *value)
     return CPyTagged_ShortFromSsize_t(count);
 }
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION < 8
+#if PY_VERSION_HEX < 0x03080000
 static PyObject *
 _PyDict_GetItemStringWithError(PyObject *v, const char *key)
 {
@@ -321,11 +321,11 @@ _PyDict_GetItemStringWithError(PyObject *v, const char *key)
 }
 #endif
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION < 6
+#if PY_VERSION_HEX < 0x03060000
 /* _PyUnicode_EqualToASCIIString got added in 3.5.3 (argh!) so we can't actually know
  * whether it will be present at runtime, so we just assume we don't have it in 3.5. */
 #define CPyUnicode_EqualToASCIIString(x, y) (PyUnicode_CompareWithASCIIString((x), (y)) == 0)
-#elif PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 6
+#elif PY_VERSION_HEX >= 0x03060000
 #define CPyUnicode_EqualToASCIIString(x, y) _PyUnicode_EqualToASCIIString(x, y)
 #endif
 
@@ -390,7 +390,7 @@ _CPyDictView_New(PyObject *dict, PyTypeObject *type)
 }
 #endif
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >=10
+#if PY_VERSION_HEX >= 0x030A0000  // 3.10
 static int
 _CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
     PyObject *tmp = NULL;
@@ -404,7 +404,7 @@ _CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
 #define _CPyObject_HasAttrId _PyObject_HasAttrId
 #endif
 
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION < 9
+#if PY_VERSION_HEX < 0x03090000
 // OneArgs and NoArgs functions got added in 3.9
 #define _PyObject_CallMethodIdNoArgs(self, name) \
     _PyObject_CallMethodIdObjArgs((self), (name), NULL)

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -22,7 +22,6 @@ extern "C" {
 
 /////////////////////////////////////////
 // Adapted from bltinmodule.c in Python 3.7.0
-#if PY_VERSION_HEX >= 0x03070000
 _Py_IDENTIFIER(__mro_entries__);
 static PyObject*
 update_bases(PyObject *bases)
@@ -96,16 +95,8 @@ error:
     Py_XDECREF(new_bases);
     return NULL;
 }
-#else
-static PyObject*
-update_bases(PyObject *bases)
-{
-    return bases;
-}
-#endif
 
 // From Python 3.7's typeobject.c
-#if PY_VERSION_HEX >= 0x03060000
 _Py_IDENTIFIER(__init_subclass__);
 static int
 init_subclass(PyTypeObject *type, PyObject *kwds)
@@ -133,14 +124,6 @@ init_subclass(PyTypeObject *type, PyObject *kwds)
     Py_DECREF(result);
     return 0;
 }
-
-#else
-static int
-init_subclass(PyTypeObject *type, PyObject *kwds)
-{
-    return 0;
-}
-#endif
 
 // Adapted from longobject.c in Python 3.7.0
 
@@ -321,13 +304,7 @@ _PyDict_GetItemStringWithError(PyObject *v, const char *key)
 }
 #endif
 
-#if PY_VERSION_HEX < 0x03060000
-/* _PyUnicode_EqualToASCIIString got added in 3.5.3 (argh!) so we can't actually know
- * whether it will be present at runtime, so we just assume we don't have it in 3.5. */
-#define CPyUnicode_EqualToASCIIString(x, y) (PyUnicode_CompareWithASCIIString((x), (y)) == 0)
-#elif PY_VERSION_HEX >= 0x03060000
 #define CPyUnicode_EqualToASCIIString(x, y) _PyUnicode_EqualToASCIIString(x, y)
-#endif
 
 // Adapted from genobject.c in Python 3.7.2
 // Copied because it wasn't in 3.5.2 and it is undocumented anyways.


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

## Replace unsafe `PY_*_VERSION` comparisons to fix for Python 4

`#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7`

For example, this is true for Python 3.7-3.11 but also true for Python 4.7-4.11. Instead, `PY_VERSION_HEX` should be used.

https://docs.python.org/3.11/c-api/apiabiversion.html

```c
/* Version as a single 4-byte hex number, e.g. 0x010502B2 == 1.5.2b2.
   Use this for numeric comparisons, e.g. #if PY_VERSION_HEX >= ... */
```

https://github.com/python/cpython/blob/2e279e85fece187b6058718ac7e82d1692461e26/Include/patchlevel.h#L29-L30

---

## Remove redundant version checks

Remove compatibility code that only applied to EOL and unsupported Python versions (<= 3.6).	


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->


