### PR TITLE
Fixes no error thrown for Final fields declared with init=False and not assigned inside __init__

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1402,6 +1402,9 @@ class MessageBuilder:
         kind = "attribute" if attr_assign else "name"
         self.fail(f'Cannot assign to final {kind} "{unmangle(name)}"', ctx)
 
+    def final_field_not_set_in_init(self, name: str, ctx: Context) -> None:
+        self.fail(f'Final field "{name}" not set', ctx)
+
     def protocol_members_cant_be_final(self, ctx: Context) -> None:
         self.fail("Protocol member cannot be final", ctx)
 

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2027,3 +2027,53 @@ class Bar:
         self.b = 1
 
 [builtins fixtures/dataclasses.pyi]
+
+[case testErrorFinalFieldInitNoArgumentPassed]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Foo:
+    a: Final[int] = field() 
+
+Foo().a # E: Missing positional argument "a" in call to "Foo"
+[builtins fixtures/dataclasses.pyi]
+
+[case testFinalFieldGeneratedInitArgumentPassed]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Foo:
+    a: Final[int] = field() 
+
+Foo(1).a 
+[builtins fixtures/dataclasses.pyi]
+
+[case testFinalFieldInit]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Foo:
+    a: Final[int] = field(init=False)
+
+    def __init__(self):
+        self.a = 1
+
+Foo().a 
+[builtins fixtures/dataclasses.pyi]
+
+[case testFinalFieldPostInit]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Foo:
+    a: Final[int] = field(init=False)
+
+    def __post_init__(self):
+        self.a = 1
+
+Foo().a 
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2002,14 +2002,12 @@ e: Element[Bar]
 reveal_type(e.elements)  # N: Revealed type is "typing.Sequence[__main__.Element[__main__.Bar]]"
 [builtins fixtures/dataclasses.pyi]
 
-
-
 [case testErrorFinalFieldNoInitNoArgumentPassed]
 from typing import Final
 from dataclasses import dataclass, field
 @dataclass
 class Foo:
-    a: Final[int] = field(init=False)
+    a: Final[int] = field(init=False) # E: Final name must be initialized with a value
 Foo().a # E: Final field "a" not set
 [builtins fixtures/dataclasses.pyi]
 
@@ -2023,7 +2021,7 @@ class Bar:
     b: Final[int]
 
     def __init__(self) -> None:
-        self.a = 1
+        self.a = 1 
         self.b = 1
 
 [builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2001,3 +2001,29 @@ class Bar(Foo): ...
 e: Element[Bar]
 reveal_type(e.elements)  # N: Revealed type is "typing.Sequence[__main__.Element[__main__.Bar]]"
 [builtins fixtures/dataclasses.pyi]
+
+
+
+[case testErrorFinalFieldNoInitNoArgumentPassed]
+from typing import Final
+from dataclasses import dataclass, field
+@dataclass
+class Foo:
+    a: Final[int] = field(init=False)
+Foo().a # E: Final field "a" not set
+[builtins fixtures/dataclasses.pyi]
+
+[case testNoErrorFinalFieldDelayedInit]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Bar:
+    a: Final[int] = field()
+    b: Final[int]
+
+    def __init__(self) -> None:
+        self.a = 1
+        self.b = 1
+
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -210,10 +210,10 @@ class C:
     y: Final[int]  # E: Final name must be initialized with a value
     def __init__(self) -> None:
         self.z: Final  # E: Type in Final[...] can only be omitted if there is an initializer
-reveal_type(x)  # N: Revealed type is "Any"
+reveal_type(x)  # N: Revealed type is "Any" 
 reveal_type(y)  # N: Revealed type is "builtins.int"
-reveal_type(C().x)  # N: Revealed type is "Any"
-reveal_type(C().y)  # N: Revealed type is "builtins.int"
+reveal_type(C().x)  # E: Final field "x" not set # N: Revealed type is "Any" 
+reveal_type(C().y)  # E: Final field "y" not set # N: Revealed type is "builtins.int"
 reveal_type(C().z)  # N: Revealed type is "Any"
 [out]
 


### PR DESCRIPTION
Fixes #13119

For all final field assignments to class variables in a dataclass i.e. `x: Final[int] = field()`, this PR checks whether this field is being properly assigned in the `__init__` or `__post_init__` methods. In the case where the field has the argument `init=True`, no error is thrown if the field is assigned inside `__init__` or `__post_init__` which was previously a false positive. This addresses the last example given in the issue thread.

In the case where the field has the argument `init=False` and it is not being assigned in `__init__` or `__post_init__`, on the line where it is a declared, the error "Final name must be initialized with a value" is now thrown. A new error was added and is thrown if that same field is accessed through the class "Final field "a" not set". This addresses the original false negative given in the issue thread. 

Tests Added (all in `check-dataclasses.test`): 
testErrorFinalFieldNoInitNoArgumentPassed
testNoErrorFinalFieldDelayedInit 
testErrorFinalFieldInitNoArgumentPassed
testFinalFieldGeneratedInitArgumentPassed
testFinalFieldInit
testFinalFieldPostInit

testFinalDefiningNoRhs in `check-final.test` was modified to now throw the new error when an unset final attribute is accessed