### PR TITLE
Implementation for validation checks on functions that can only be called on dataclasses

### DIFF
--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -37,12 +37,15 @@ class DefaultPlugin(Plugin):
     """Type checker plugin that is enabled by default."""
 
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
-        from mypy.plugins import ctypes, singledispatch
+        from mypy.plugins import ctypes, singledispatch, dataclasses
 
         if fullname == "ctypes.Array":
             return ctypes.array_constructor_callback
         elif fullname == "functools.singledispatch":
             return singledispatch.create_singledispatch_function_callback
+        #these functions should only be called on dataclass instances
+        elif fullname == "dataclasses.replace" or fullname == "dataclasses.field":
+            return dataclasses.dataclass_check_type_callback
         return None
 
     def get_method_signature_hook(

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1,3 +1,48 @@
+[case testNoCrashOnReplace]
+def replace(__obj: _T, **changes: Any) -> _T: ...
+# flags: --python-version 3.7
+from dataclasses import dataclass
+from dataclasses import replace
+@dataclass
+class D:
+    pass
+class C:
+    pass
+
+replace(C())  # E: replace() should be called on dataclass instances
+[builtins fixtures/dataclasses.pyi]
+
+
+[case testNoCrashOnAstuple]
+def replace(__obj: _T, **changes: Any) -> _T: ...
+# flags: --python-version 3.7
+from dataclasses import dataclass
+from dataclasses import astuple
+
+@dataclass
+class D:
+    pass
+class C:
+    pass
+
+astuple(C())  # E: astuple() should be called on dataclass instances
+[builtins fixtures/dataclasses.pyi]
+
+[case testNoCrashOnFields]
+def replace(__obj: _T, **changes: Any) -> _T: ...
+# flags: --python-version 3.7
+from dataclasses import dataclass
+from dataclasses import fields
+
+@dataclass
+class D:
+    pass
+class C:
+    pass
+
+fields(C())   # E: astuple() should be called on dataclass instances
+[builtins fixtures/dataclasses.pyi]
+
 [case testDataclassesBasic]
 # flags: --python-version 3.7
 from dataclasses import dataclass

--- a/test-data/unit/lib-stub/dataclasses.pyi
+++ b/test-data/unit/lib-stub/dataclasses.pyi
@@ -30,5 +30,7 @@ def field(*,
     init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ...,
     metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...,) -> Any: ...
 
+@overload 
+def replace(obj: _T, **changes: Any) -> _T: ...
 
 class Field(Generic[_T]): pass


### PR DESCRIPTION
Fixes #14215 
**Description:** 
As mentioned in the issue, methods such as replace() and field() should only be called on dataclass instances. In this implementation, I added a callback to detect such issues. 

**Testing:**
I did not edit the test file in this commit - one of my teammates will in the near future. 
For local testing, when I tested my implementation against 
```
[[case testNoCrashOnReplace]
from dataclasses import dataclass
from dataclasses import replace

@dataclass
class D:
    pass
class C:
    pass

replace(D())
[builtins fixtures/dataclasses.pyi]]
```
I got the output of: 
![image](https://user-images.githubusercontent.com/79778718/207164718-bded506a-1eb9-402d-87ad-85ab4f90c0b0.png)

When I tested my implementation against

```
[case testNoCrashOnReplace]
from dataclasses import dataclass
from dataclasses import replace

@dataclass
class D:
    pass
class C:
    pass

replace(C())  # replace() should be called on dataclass instances
[builtins fixtures/dataclasses.pyi]
```

I got this output, as desired:
![image](https://user-images.githubusercontent.com/79778718/207165755-fd29b6ed-8921-4e63-a7ee-579d67bc0527.png)


<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
