### PR TITLE
[undefined vars] skip visiting unreachable else clauses

### DIFF
--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -363,9 +363,10 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
             b.accept(self)
             self.tracker.next_branch()
         if o.else_body:
-            if o.else_body.is_unreachable:
+            if not o.else_body.is_unreachable:
+                o.else_body.accept(self)
+            else:
                 self.tracker.skip_branch()
-            o.else_body.accept(self)
         self.tracker.end_branch_statement()
 
     def visit_match_stmt(self, o: MatchStmt) -> None:

--- a/test-data/unit/check-possibly-undefined.test
+++ b/test-data/unit/check-possibly-undefined.test
@@ -766,22 +766,30 @@ def f() -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testUnreachable]
-# flags: --enable-error-code possibly-undefined
+# flags: --enable-error-code possibly-undefined --enable-error-code used-before-def
 import typing
 
-if typing.TYPE_CHECKING:
-    x = 1
-elif int():
-    y = 1
-else:
-    y = 2
-a = x
+def f0() -> None:
+    if typing.TYPE_CHECKING:
+        x = 1
+    elif int():
+        y = 1
+    else:
+        y = 2
+    a = x
 
-if not typing.TYPE_CHECKING:
-    pass
-else:
-    z = 1
-a = z
+def f1() -> None:
+    if not typing.TYPE_CHECKING:
+        pass
+    else:
+        z = 1
+    a = z
+
+def f2() -> None:
+    if typing.TYPE_CHECKING:
+        x = 1
+    else:
+        y = x
 [typing fixtures/typing-medium.pyi]
 
 [case testUsedBeforeDef]


### PR DESCRIPTION
In particular, ran into an issue with an `if TYPE_CHECKING` case, so I added a test for that.