### PR TITLE
Enable `--debug-serialize` for mypy_primer

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -62,6 +62,7 @@ jobs:
             --new $GITHUB_SHA --old base_commit \
             --num-shards 5 --shard-index ${{ matrix.shard-index }} \
             --debug \
+            --additional-flags="--debug-serialize" \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]


### PR DESCRIPTION
Enable the `--debug-serialize` option to help catch issues during serialization which would normally be skipped by mypy_primer.

Followup to #14155