### PR TITLE
Refactor TypeState into a singleton class

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -100,7 +100,7 @@ from mypy.stubinfo import (
     stub_package_name,
 )
 from mypy.types import Type
-from mypy.typestate import TypeState, reset_global_state
+from mypy.typestate import reset_global_state, type_state
 from mypy.version import __version__
 
 # Switch to True to produce debug output related to fine-grained incremental
@@ -276,7 +276,7 @@ def _build(
     try:
         graph = dispatch(sources, manager, stdout)
         if not options.fine_grained_incremental:
-            TypeState.reset_all_subtype_caches()
+            type_state.reset_all_subtype_caches()
         if options.timing_stats is not None:
             dump_timing_stats(options.timing_stats, graph)
         if options.line_checking_stats is not None:
@@ -2459,7 +2459,7 @@ class State:
             from mypy.server.deps import merge_dependencies  # Lazy import to speed up startup
 
             merge_dependencies(self.compute_fine_grained_deps(), deps)
-            TypeState.update_protocol_deps(deps)
+            type_state.update_protocol_deps(deps)
 
     def valid_references(self) -> set[str]:
         assert self.ancestors is not None
@@ -2926,7 +2926,7 @@ def dispatch(sources: list[BuildSource], manager: BuildManager, stdout: TextIO) 
             # then we need to collect fine grained protocol dependencies.
             # Since these are a global property of the program, they are calculated after we
             # processed the whole graph.
-            TypeState.add_all_protocol_deps(manager.fg_deps)
+            type_state.add_all_protocol_deps(manager.fg_deps)
             if not manager.options.fine_grained_incremental:
                 rdeps = generate_deps_for_cache(manager, graph)
                 write_deps_cache(rdeps, manager, graph)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -162,7 +162,7 @@ from mypy.types import (
     is_self_type_like,
     remove_optional,
 )
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 from mypy.typevars import fill_typevars
 from mypy.util import split_module_names
 from mypy.visitor import ExpressionVisitor
@@ -1591,13 +1591,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # of joins. This is a bit arbitrary, but in practice it works for most
         # cases. A cleaner alternative would be to switch to single bin type
         # inference, but this is a lot of work.
-        old = TypeState.infer_unions
+        old = type_state.infer_unions
         if has_recursive_types(type_context):
-            TypeState.infer_unions = True
+            type_state.infer_unions = True
         try:
             yield
         finally:
-            TypeState.infer_unions = old
+            type_state.infer_unions = old
 
     def infer_arg_types_in_context(
         self,

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -48,7 +48,7 @@ from mypy.types import (
     is_named_instance,
     is_union_with_any,
 )
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 from mypy.typevartuples import (
     extract_unpack,
     find_unpack_in_list,
@@ -198,7 +198,7 @@ def infer_constraints(template: Type, actual: Type, direction: int) -> list[Cons
     if any(
         get_proper_type(template) == get_proper_type(t)
         and get_proper_type(actual) == get_proper_type(a)
-        for (t, a) in reversed(TypeState.inferring)
+        for (t, a) in reversed(type_state.inferring)
     ):
         return []
     if has_recursive_types(template) or isinstance(get_proper_type(template), Instance):
@@ -207,9 +207,9 @@ def infer_constraints(template: Type, actual: Type, direction: int) -> list[Cons
         if not has_type_vars(template):
             # Return early on an empty branch.
             return []
-        TypeState.inferring.append((template, actual))
+        type_state.inferring.append((template, actual))
         res = _infer_constraints(template, actual, direction)
-        TypeState.inferring.pop()
+        type_state.inferring.pop()
         return res
     return _infer_constraints(template, actual, direction)
 

--- a/mypy/mro.py
+++ b/mypy/mro.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from mypy.nodes import TypeInfo
 from mypy.types import Instance
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 
 
 def calculate_mro(info: TypeInfo, obj_type: Callable[[], Instance] | None = None) -> None:
@@ -17,7 +17,7 @@ def calculate_mro(info: TypeInfo, obj_type: Callable[[], Instance] | None = None
     info.mro = mro
     # The property of falling back to Any is inherited.
     info.fallback_to_any = any(baseinfo.fallback_to_any for baseinfo in info.mro)
-    TypeState.reset_all_subtype_caches_for(info)
+    type_state.reset_all_subtype_caches_for(info)
 
 
 class MroError(Exception):

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -110,7 +110,7 @@ from mypy.types import (
     UnionType,
     UnpackType,
 )
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 from mypy.util import get_prefix, replace_object_state
 
 
@@ -360,7 +360,7 @@ class NodeReplaceVisitor(TraverserVisitor):
             # The subclass relationships may change, so reset all caches relevant to the
             # old MRO.
             new = cast(TypeInfo, self.replacements[node])
-            TypeState.reset_all_subtype_caches_for(new)
+            type_state.reset_all_subtype_caches_for(new)
         return self.fixup(node)
 
     def fixup_type(self, typ: Type | None) -> None:

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -66,7 +66,7 @@ from mypy.nodes import (
 )
 from mypy.traverser import TraverserVisitor
 from mypy.types import CallableType
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 
 SavedAttributes: _TypeAlias = Dict[Tuple[ClassDef, str], SymbolTableNode]
 
@@ -143,7 +143,7 @@ class NodeStripVisitor(TraverserVisitor):
             super().visit_class_def(node)
         node.defs.body.extend(node.removed_statements)
         node.removed_statements = []
-        TypeState.reset_subtype_caches_for(node.info)
+        type_state.reset_subtype_caches_for(node.info)
         # Kill the TypeInfo, since there is none before semantic analysis.
         node.info = CLASSDEF_NO_INFO
         node.analyzed = None

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -172,7 +172,7 @@ from mypy.types import (
     UnpackType,
     get_proper_type,
 )
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 from mypy.util import correct_relative_import
 
 
@@ -344,7 +344,7 @@ class DependencyVisitor(TraverserVisitor):
                 self.add_dependency(
                     make_wildcard_trigger(base_info.fullname), target=make_trigger(target)
                 )
-                # More protocol dependencies are collected in TypeState._snapshot_protocol_deps
+                # More protocol dependencies are collected in type_state._snapshot_protocol_deps
                 # after a full run or update is finished.
 
         self.add_type_alias_deps(self.scope.current_target())
@@ -1123,7 +1123,7 @@ def dump_all_dependencies(
         deps = get_dependencies(node, type_map, python_version, options)
         for trigger, targets in deps.items():
             all_deps.setdefault(trigger, set()).update(targets)
-    TypeState.add_all_protocol_deps(all_deps)
+    type_state.add_all_protocol_deps(all_deps)
 
     for trigger, targets in sorted(all_deps.items(), key=lambda x: x[0]):
         print(trigger)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -157,7 +157,7 @@ from mypy.server.aststrip import SavedAttributes, strip_target
 from mypy.server.deps import get_dependencies_of_target, merge_dependencies
 from mypy.server.target import trigger_to_target
 from mypy.server.trigger import WILDCARD_TAG, make_trigger
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 from mypy.util import module_prefix, split_target
 
 MAX_ITER: Final = 1000
@@ -869,7 +869,7 @@ def propagate_changes_using_dependencies(
         # We need to do this to avoid false negatives if the protocol itself is
         # unchanged, but was marked stale because its sub- (or super-) type changed.
         for info in stale_protos:
-            TypeState.reset_subtype_caches_for(info)
+            type_state.reset_subtype_caches_for(info)
         # Then fully reprocess all targets.
         # TODO: Preserve order (set is not optimal)
         for id, nodes in sorted(todo.items(), key=lambda x: x[0]):
@@ -1081,7 +1081,7 @@ def update_deps(
         for trigger, targets in new_deps.items():
             deps.setdefault(trigger, set()).update(targets)
     # Merge also the newly added protocol deps (if any).
-    TypeState.update_protocol_deps(deps)
+    type_state.update_protocol_deps(deps)
 
 
 def lookup_target(

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -18,7 +18,7 @@ from mypy.types import (
     UnionType,
     get_proper_type,
 )
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 
 
 def solve_constraints(
@@ -54,7 +54,7 @@ def solve_constraints(
                 if bottom is None:
                     bottom = c.target
                 else:
-                    if TypeState.infer_unions:
+                    if type_state.infer_unions:
                         # This deviates from the general mypy semantics because
                         # recursive types are union-heavy in 95% of cases.
                         bottom = UnionType.make_union([bottom, c.target])

--- a/mypy/test/testdeps.py
+++ b/mypy/test/testdeps.py
@@ -15,7 +15,7 @@ from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase, DataSuite
 from mypy.test.helpers import assert_string_arrays_equal, find_test_files, parse_options
 from mypy.types import Type
-from mypy.typestate import TypeState
+from mypy.typestate import type_state
 
 # Only dependencies in these modules are dumped
 dumped_modules = ["__main__", "pkg", "pkg.mod"]
@@ -54,7 +54,7 @@ class GetDependenciesSuite(DataSuite):
                     for source in new_deps:
                         deps[source].update(new_deps[source])
 
-            TypeState.add_all_protocol_deps(deps)
+            type_state.add_all_protocol_deps(deps)
 
             for source, targets in sorted(deps.items()):
                 if source.startswith(("<enum", "<typing", "<mypy")):

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -5,7 +5,7 @@ and potentially other mutable TypeInfo state. This module contains mutable globa
 
 from __future__ import annotations
 
-from typing import ClassVar, Dict, Set, Tuple
+from typing import Dict, Set, Tuple
 from typing_extensions import Final, TypeAlias as _TypeAlias
 
 from mypy.nodes import TypeInfo
@@ -40,7 +40,7 @@ class TypeState:
     # was done in strict optional mode and of the specific *kind* of subtyping relationship,
     # which we represent as an arbitrary hashable tuple.
     # We need the caches, since subtype checks for structural types are very slow.
-    _subtype_caches: Final[SubtypeCache] = {}
+    _subtype_caches: Final[SubtypeCache]
 
     # This contains protocol dependencies generated after running a full build,
     # or after an update. These dependencies are special because:
@@ -53,7 +53,7 @@ class TypeState:
     # A blocking error will be generated in this case, since we can't proceed safely.
     # For the description of kinds of protocol dependencies and corresponding examples,
     # see _snapshot_protocol_deps.
-    proto_deps: ClassVar[dict[str, set[str]] | None] = {}
+    proto_deps: dict[str, set[str]] | None
 
     # Protocols (full names) a given class attempted to implement.
     # Used to calculate fine grained protocol dependencies and optimize protocol
@@ -61,13 +61,13 @@ class TypeState:
     # of type a.A to a function expecting something compatible with protocol p.P,
     # we'd have 'a.A' -> {'p.P', ...} in the map. This map is flushed after every incremental
     # update.
-    _attempted_protocols: Final[dict[str, set[str]]] = {}
+    _attempted_protocols: Final[dict[str, set[str]]]
     # We also snapshot protocol members of the above protocols. For example, if we pass
     # a value of type a.A to a function expecting something compatible with Iterable, we'd have
     # 'a.A' -> {'__iter__', ...} in the map. This map is also flushed after every incremental
     # update. This map is needed to only generate dependencies like <a.A.__iter__> -> <a.A>
     # instead of a wildcard to avoid unnecessarily invalidating classes.
-    _checked_against_members: Final[dict[str, set[str]]] = {}
+    _checked_against_members: Final[dict[str, set[str]]]
     # TypeInfos that appeared as a left type (subtype) in a subtype check since latest
     # dependency snapshot update. This is an optimisation for fine grained mode; during a full
     # run we only take a dependency snapshot at the very end, so this set will contain all
@@ -75,74 +75,78 @@ class TypeState:
     # dependencies generated from (typically) few TypeInfos that were subtype-checked
     # (i.e. appeared as r.h.s. in an assignment or an argument in a function call in
     # a re-checked target) during the update.
-    _rechecked_types: Final[set[TypeInfo]] = set()
+    _rechecked_types: Final[set[TypeInfo]]
 
     # The two attributes below are assumption stacks for subtyping relationships between
     # recursive type aliases. Normally, one would pass type assumptions as an additional
     # arguments to is_subtype(), but this would mean updating dozens of related functions
     # threading this through all callsites (see also comment for TypeInfo.assuming).
-    _assuming: Final[list[tuple[Type, Type]]] = []
-    _assuming_proper: Final[list[tuple[Type, Type]]] = []
+    _assuming: Final[list[tuple[Type, Type]]]
+    _assuming_proper: Final[list[tuple[Type, Type]]]
     # Ditto for inference of generic constraints against recursive type aliases.
-    inferring: Final[list[tuple[Type, Type]]] = []
+    inferring: Final[list[tuple[Type, Type]]]
     # Whether to use joins or unions when solving constraints, see checkexpr.py for details.
-    infer_unions: ClassVar = False
+    infer_unions: bool
 
     # N.B: We do all of the accesses to these properties through
     # TypeState, instead of making these classmethods and accessing
     # via the cls parameter, since mypyc can optimize accesses to
     # Final attributes of a directly referenced type.
 
-    @staticmethod
-    def is_assumed_subtype(left: Type, right: Type) -> bool:
-        for (l, r) in reversed(TypeState._assuming):
+    def __init__(self) -> None:
+        self._subtype_caches = {}
+        self.proto_deps = {}
+        self._attempted_protocols = {}
+        self._checked_against_members = {}
+        self._rechecked_types = set()
+        self._assuming = []
+        self._assuming_proper = []
+        self.inferring = []
+        self.infer_unions = False
+
+    def is_assumed_subtype(self, left: Type, right: Type) -> bool:
+        for (l, r) in reversed(self._assuming):
             if get_proper_type(l) == get_proper_type(left) and get_proper_type(
                 r
             ) == get_proper_type(right):
                 return True
         return False
 
-    @staticmethod
-    def is_assumed_proper_subtype(left: Type, right: Type) -> bool:
-        for (l, r) in reversed(TypeState._assuming_proper):
+    def is_assumed_proper_subtype(self, left: Type, right: Type) -> bool:
+        for (l, r) in reversed(self._assuming_proper):
             if get_proper_type(l) == get_proper_type(left) and get_proper_type(
                 r
             ) == get_proper_type(right):
                 return True
         return False
 
-    @staticmethod
-    def get_assumptions(is_proper: bool) -> list[tuple[Type, Type]]:
+    def get_assumptions(self, is_proper: bool) -> list[tuple[Type, Type]]:
         if is_proper:
-            return TypeState._assuming_proper
-        return TypeState._assuming
+            return self._assuming_proper
+        return self._assuming
 
-    @staticmethod
-    def reset_all_subtype_caches() -> None:
+    def reset_all_subtype_caches(self) -> None:
         """Completely reset all known subtype caches."""
-        TypeState._subtype_caches.clear()
+        self._subtype_caches.clear()
 
-    @staticmethod
-    def reset_subtype_caches_for(info: TypeInfo) -> None:
+    def reset_subtype_caches_for(self, info: TypeInfo) -> None:
         """Reset subtype caches (if any) for a given supertype TypeInfo."""
-        if info in TypeState._subtype_caches:
-            TypeState._subtype_caches[info].clear()
+        if info in self._subtype_caches:
+            self._subtype_caches[info].clear()
 
-    @staticmethod
-    def reset_all_subtype_caches_for(info: TypeInfo) -> None:
+    def reset_all_subtype_caches_for(self, info: TypeInfo) -> None:
         """Reset subtype caches (if any) for a given supertype TypeInfo and its MRO."""
         for item in info.mro:
-            TypeState.reset_subtype_caches_for(item)
+            self.reset_subtype_caches_for(item)
 
-    @staticmethod
-    def is_cached_subtype_check(kind: SubtypeKind, left: Instance, right: Instance) -> bool:
+    def is_cached_subtype_check(self, kind: SubtypeKind, left: Instance, right: Instance) -> bool:
         if left.last_known_value is not None or right.last_known_value is not None:
             # If there is a literal last known value, give up. There
             # will be an unbounded number of potential types to cache,
             # making caching less effective.
             return False
         info = right.type
-        cache = TypeState._subtype_caches.get(info)
+        cache = self._subtype_caches.get(info)
         if cache is None:
             return False
         subcache = cache.get(kind)
@@ -150,36 +154,32 @@ class TypeState:
             return False
         return (left, right) in subcache
 
-    @staticmethod
-    def record_subtype_cache_entry(kind: SubtypeKind, left: Instance, right: Instance) -> None:
+    def record_subtype_cache_entry(
+        self, kind: SubtypeKind, left: Instance, right: Instance
+    ) -> None:
         if left.last_known_value is not None or right.last_known_value is not None:
             # These are unlikely to match, due to the large space of
             # possible values.  Avoid uselessly increasing cache sizes.
             return
-        cache = TypeState._subtype_caches.setdefault(right.type, dict())
+        cache = self._subtype_caches.setdefault(right.type, dict())
         cache.setdefault(kind, set()).add((left, right))
 
-    @staticmethod
-    def reset_protocol_deps() -> None:
+    def reset_protocol_deps(self) -> None:
         """Reset dependencies after a full run or before a daemon shutdown."""
-        TypeState.proto_deps = {}
-        TypeState._attempted_protocols.clear()
-        TypeState._checked_against_members.clear()
-        TypeState._rechecked_types.clear()
+        self.proto_deps = {}
+        self._attempted_protocols.clear()
+        self._checked_against_members.clear()
+        self._rechecked_types.clear()
 
-    @staticmethod
-    def record_protocol_subtype_check(left_type: TypeInfo, right_type: TypeInfo) -> None:
+    def record_protocol_subtype_check(self, left_type: TypeInfo, right_type: TypeInfo) -> None:
         assert right_type.is_protocol
-        TypeState._rechecked_types.add(left_type)
-        TypeState._attempted_protocols.setdefault(left_type.fullname, set()).add(
-            right_type.fullname
-        )
-        TypeState._checked_against_members.setdefault(left_type.fullname, set()).update(
+        self._rechecked_types.add(left_type)
+        self._attempted_protocols.setdefault(left_type.fullname, set()).add(right_type.fullname)
+        self._checked_against_members.setdefault(left_type.fullname, set()).update(
             right_type.protocol_members
         )
 
-    @staticmethod
-    def _snapshot_protocol_deps() -> dict[str, set[str]]:
+    def _snapshot_protocol_deps(self) -> dict[str, set[str]]:
         """Collect protocol attribute dependencies found so far from registered subtype checks.
 
         There are three kinds of protocol dependencies. For example, after a subtype check:
@@ -209,8 +209,8 @@ class TypeState:
         'subtypes.is_protocol_implementation').
         """
         deps: dict[str, set[str]] = {}
-        for info in TypeState._rechecked_types:
-            for attr in TypeState._checked_against_members[info.fullname]:
+        for info in self._rechecked_types:
+            for attr in self._checked_against_members[info.fullname]:
                 # The need for full MRO here is subtle, during an update, base classes of
                 # a concrete class may not be reprocessed, so not all <B.x> -> <C.x> deps
                 # are added.
@@ -220,7 +220,7 @@ class TypeState:
                         # TODO: avoid everything from typeshed
                         continue
                     deps.setdefault(trigger, set()).add(make_trigger(info.fullname))
-            for proto in TypeState._attempted_protocols[info.fullname]:
+            for proto in self._attempted_protocols[info.fullname]:
                 trigger = make_trigger(info.fullname)
                 if "typing" in trigger or "builtins" in trigger:
                     continue
@@ -233,38 +233,37 @@ class TypeState:
                 deps.setdefault(trigger, set()).add(proto)
         return deps
 
-    @staticmethod
-    def update_protocol_deps(second_map: dict[str, set[str]] | None = None) -> None:
+    def update_protocol_deps(self, second_map: dict[str, set[str]] | None = None) -> None:
         """Update global protocol dependency map.
 
         We update the global map incrementally, using a snapshot only from recently
         type checked types. If second_map is given, update it as well. This is currently used
         by FineGrainedBuildManager that maintains normal (non-protocol) dependencies.
         """
-        assert (
-            TypeState.proto_deps is not None
-        ), "This should not be called after failed cache load"
-        new_deps = TypeState._snapshot_protocol_deps()
+        assert self.proto_deps is not None, "This should not be called after failed cache load"
+        new_deps = self._snapshot_protocol_deps()
         for trigger, targets in new_deps.items():
-            TypeState.proto_deps.setdefault(trigger, set()).update(targets)
+            self.proto_deps.setdefault(trigger, set()).update(targets)
         if second_map is not None:
             for trigger, targets in new_deps.items():
                 second_map.setdefault(trigger, set()).update(targets)
-        TypeState._rechecked_types.clear()
-        TypeState._attempted_protocols.clear()
-        TypeState._checked_against_members.clear()
+        self._rechecked_types.clear()
+        self._attempted_protocols.clear()
+        self._checked_against_members.clear()
 
-    @staticmethod
-    def add_all_protocol_deps(deps: dict[str, set[str]]) -> None:
+    def add_all_protocol_deps(self, deps: dict[str, set[str]]) -> None:
         """Add all known protocol dependencies to deps.
 
         This is used by tests and debug output, and also when collecting
         all collected or loaded dependencies as part of build.
         """
-        TypeState.update_protocol_deps()  # just in case
-        if TypeState.proto_deps is not None:
-            for trigger, targets in TypeState.proto_deps.items():
+        self.update_protocol_deps()  # just in case
+        if self.proto_deps is not None:
+            for trigger, targets in self.proto_deps.items():
                 deps.setdefault(trigger, set()).update(targets)
+
+
+type_state: Final = TypeState()
 
 
 def reset_global_state() -> None:
@@ -273,6 +272,6 @@ def reset_global_state() -> None:
     Currently most of it is in this module. Few exceptions are strict optional status and
     and functools.lru_cache.
     """
-    TypeState.reset_all_subtype_caches()
-    TypeState.reset_protocol_deps()
+    type_state.reset_all_subtype_caches()
+    type_state.reset_protocol_deps()
     TypeVarId.next_raw_id = 1


### PR DESCRIPTION
This helps mypyc, since accessing mutable attributes of singleton instances is faster than accessing class variables. The implementation is also arguably a bit cleaner.

This seems performance-neutral or a very minor optimization, but if we continue to add attributes to TypeState, this can help.