### PR TITLE
Tool to compare performance of any number of mypy commits/branches

### DIFF
--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -1,15 +1,15 @@
-"""Compare performance of mypyc-compiled mypy between two or more commits/branches.
+"""Compare performance of mypyc-compiled mypy between one or more commits/branches.
 
 Simple usage:
 
-  python misc/perf_compare.py my-branch master
+  python misc/perf_compare.py my-branch master ...
 
 What this does:
 
  * Create a temp clone of the mypy repo for each target commit
  * Checkout a target commit in each of the clones
- * Compile mypyc in each of the clones in parallel
- * Create another temp clone of the mypy repo as the code to self check
+ * Compile mypyc in each of the clones *in parallel*
+ * Create another temp clone of the mypy repo as the code to check
  * Self check with each of the compiled mypys N times
  * Report the average runtimes and relative performance
 """
@@ -92,6 +92,7 @@ def main() -> None:
     clone(self_check_dir, None)
 
     heading("Compiling mypy")
+    print("(This will take a while...)")
 
     for t in build_threads:
         t.join()

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -132,8 +132,8 @@ def main() -> None:
             delta = "0.0%"
             first = tt
         else:
-            d = 100 * ((tt / first) - 1)
-            delta = f"{d:+.1f}%"
+            d = (tt / first) - 1
+            delta = f"{d:+.1%}"
         print(f"{commit:<25} {tt:.3f}s ({delta})")
 
     shutil.rmtree(self_check_dir)

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -1,0 +1,101 @@
+"""Compare performance of mypyc-compiled mypy between two or more commits/branches.
+
+Simple usage:
+
+  python misc/perf_compare.py my-branch master
+
+What this does:
+
+ * Create a temp clone of the mypy repo for each target commit
+ * Checkout a target commit in each of the clones
+ * Compile mypyc in each of the clones in parallel
+ * Create another temp clone of the mypy repo as the code to self check
+ * Self check with each of the compiled mypys N times
+ * Report the average runtimes and relative performance
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import threading
+import time
+
+
+def build_mypy(target_dir: str) -> None:
+    env = os.environ.copy()
+    env["CC"] = "clang"
+    env["MYPYC_OPT_LEVEL"] = "2"
+    cmd = ["python3", "setup.py", "--use-mypyc", "build_ext", "--inplace"]
+    subprocess.run(cmd, env=env, check=True, cwd=target_dir)
+
+
+def clone(target_dir: str, commit: str | None) -> None:
+    repo_dir = os.getcwd()
+    if os.path.isdir(target_dir):
+        print(f"{target_dir} exists: deleting")
+        input()
+        shutil.rmtree(target_dir)
+    print(f"cloning mypy to {target_dir}")
+    subprocess.run(["git", "clone", repo_dir, target_dir], check=True)
+    if commit:
+        subprocess.run(["git", "checkout", commit], check=True, cwd=target_dir)
+
+
+def run_benchmark(compiled_dir: str, check_dir: str) -> float:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.path.abspath(compiled_dir)
+    cmd = ["python3", "-m", "mypy", "--config-file", "mypy_self_check.ini"]
+    cmd += glob.glob("mypy/*.py", root_dir=check_dir)
+    cmd += glob.glob("mypy/*/*.py", root_dir=check_dir)
+    t0 = time.time()
+    subprocess.run(cmd, cwd=check_dir, env=env)
+    return time.time() - t0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("commit", nargs="+")
+    args = parser.parse_args()
+    commits = args.commit
+    num_bench = 2
+
+    if not os.path.isdir(".git") or not os.path.isdir("mypyc"):
+        sys.exit("error: Run this the mypy repo root")
+
+    build_threads = []
+    target_dirs = []
+    for i, commit in enumerate(commits):
+        target_dir = f"mypy.{i}.tmpdir"
+        target_dirs.append(target_dir)
+        clone(target_dir, commit)
+        t = threading.Thread(target=lambda: build_mypy(target_dir))
+        t.start()
+        build_threads.append(t)
+
+    self_check_dir = "mypy.self.tmpdir"
+    clone(self_check_dir, None)
+
+    for t in build_threads:
+        t.join()
+
+    print(f"built mypy at {len(commits)} commits")
+
+    results: dict[str, list[float]] = {}
+    for i in range(num_bench):
+        for i, commit in enumerate(commits):
+            tt = run_benchmark(target_dirs[i], self_check_dir)
+            results.setdefault(commit, []).append(tt)
+
+    for commit in commits:
+        tt = statistics.mean(results[commit])
+        print(f"commit: {tt:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -6,7 +6,7 @@ Simple usage:
 
 What this does:
 
- * Create a temp clone of the mypy repo for each target commit
+ * Create a temp clone of the mypy repo for each target commit to measure
  * Checkout a target commit in each of the clones
  * Compile mypyc in each of the clones *in parallel*
  * Create another temp clone of the mypy repo as the code to check
@@ -73,7 +73,7 @@ def main() -> None:
     parser.add_argument("commit", nargs="+")
     args = parser.parse_args()
     commits = args.commit
-    num_runs = 11
+    num_runs = 16
 
     if not os.path.isdir(".git") or not os.path.isdir("mypyc"):
         sys.exit("error: Run this the mypy repo root")
@@ -128,6 +128,10 @@ def main() -> None:
             d = 100 * ((tt / first) - 1)
             delta = f"{d:+.1f}%"
         print(f"{commit:<25} {tt:.3f}s ({delta})")
+
+    shutil.rmtree(self_check_dir)
+    for target_dir in target_dirs:
+        shutil.rmtree(target_dir)
 
 
 if __name__ == "__main__":

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -12,6 +12,7 @@ What this does:
  * Create another temp clone of the mypy repo as the code to check
  * Self check with each of the compiled mypys N times
  * Report the average runtimes and relative performance
+ * Remove the temp clones
 """
 
 from __future__ import annotations

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -61,7 +61,7 @@ def run_benchmark(compiled_dir: str, check_dir: str) -> float:
     env = os.environ.copy()
     env["PYTHONPATH"] = os.path.abspath(compiled_dir)
     abschk = os.path.abspath(check_dir)
-    cmd = ["python3", "-m", "mypy", "--config-file", os.path.join(abschk, "mypy_self_check.ini")]
+    cmd = [sys.executable, "-m", "mypy", "--config-file", os.path.join(abschk, "mypy_self_check.ini")]
     cmd += glob.glob(os.path.join(abschk, "mypy/*.py"))
     cmd += glob.glob(os.path.join(abschk, "mypy/*/*.py"))
     t0 = time.time()

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -71,6 +71,7 @@ def run_benchmark(compiled_dir: str, check_dir: str) -> float:
     cmd += glob.glob(os.path.join(abschk, "mypy/*.py"))
     cmd += glob.glob(os.path.join(abschk, "mypy/*/*.py"))
     t0 = time.time()
+    # Ignore errors, since some commits being measured may generate additional errors.
     subprocess.run(cmd, cwd=compiled_dir, env=env)
     return time.time() - t0
 

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -37,7 +37,7 @@ def heading(s: str) -> None:
 def build_mypy(target_dir: str) -> None:
     env = os.environ.copy()
     env["CC"] = "clang"
-    env["MYPYC_OPT_LEVEL"] = "0"
+    env["MYPYC_OPT_LEVEL"] = "2"
     cmd = ["python3", "setup.py", "--use-mypyc", "build_ext", "--inplace"]
     subprocess.run(cmd, env=env, check=True, cwd=target_dir)
 

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -39,7 +39,7 @@ def build_mypy(target_dir: str) -> None:
     env = os.environ.copy()
     env["CC"] = "clang"
     env["MYPYC_OPT_LEVEL"] = "2"
-    cmd = ["python3", "setup.py", "--use-mypyc", "build_ext", "--inplace"]
+    cmd = [sys.executable, "setup.py", "--use-mypyc", "build_ext", "--inplace"]
     subprocess.run(cmd, env=env, check=True, cwd=target_dir)
 
 

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -54,16 +54,17 @@ def clone(target_dir: str, commit: str | None) -> None:
 
 
 def run_benchmark(compiled_dir: str, check_dir: str) -> float:
-    cache_dir = os.path.join(check_dir, ".mypy_cache")
+    cache_dir = os.path.join(compiled_dir, ".mypy_cache")
     if os.path.isdir(cache_dir):
         shutil.rmtree(cache_dir)
     env = os.environ.copy()
     env["PYTHONPATH"] = os.path.abspath(compiled_dir)
-    cmd = ["python3", "-m", "mypy", "--config-file", "mypy_self_check.ini"]
-    cmd += glob.glob("mypy/*.py", root_dir=check_dir)
-    cmd += glob.glob("mypy/*/*.py", root_dir=check_dir)
+    abschk = os.path.abspath(check_dir)
+    cmd = ["python3", "-m", "mypy", "--config-file", os.path.join(abschk, "mypy_self_check.ini")]
+    cmd += glob.glob(os.path.join(abschk, "mypy/*.py"))
+    cmd += glob.glob(os.path.join(abschk, "mypy/*/*.py"))
     t0 = time.time()
-    subprocess.run(cmd, cwd=check_dir, env=env)
+    subprocess.run(cmd, cwd=compiled_dir, env=env)
     return time.time() - t0
 
 
@@ -125,7 +126,7 @@ def main() -> None:
         else:
             d = 100 * ((tt / first) - 1)
             delta = f"{d:+.1f}%"
-        print(f"{commit:<25}: {tt:.3f}s ({delta})")
+        print(f"{commit:<25} {tt:.3f}s ({delta})")
 
 
 if __name__ == "__main__":

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -89,7 +89,7 @@ def main() -> None:
         build_threads.append(t)
 
     self_check_dir = "mypy.self.tmpdir"
-    clone(self_check_dir, None)
+    clone(self_check_dir, commits[0])
 
     heading("Compiling mypy")
     print("(This will take a while...)")

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -61,7 +61,13 @@ def run_benchmark(compiled_dir: str, check_dir: str) -> float:
     env = os.environ.copy()
     env["PYTHONPATH"] = os.path.abspath(compiled_dir)
     abschk = os.path.abspath(check_dir)
-    cmd = [sys.executable, "-m", "mypy", "--config-file", os.path.join(abschk, "mypy_self_check.ini")]
+    cmd = [
+        sys.executable,
+        "-m",
+        "mypy",
+        "--config-file",
+        os.path.join(abschk, "mypy_self_check.ini"),
+    ]
     cmd += glob.glob(os.path.join(abschk, "mypy/*.py"))
     cmd += glob.glob(os.path.join(abschk, "mypy/*/*.py"))
     t0 = time.time()

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -76,7 +76,7 @@ def main() -> None:
     commits = args.commit
     num_runs = 16
 
-    if not os.path.isdir(".git") or not os.path.isdir("mypyc"):
+    if not (os.path.isdir(".git") and os.path.isdir("mypyc")):
         sys.exit("error: Run this the mypy repo root")
 
     build_threads = []


### PR DESCRIPTION
The script compiles some mypy commits in parallel and then measures how long each version takes to self-check a specific mypy commit. It measures the performance 15 times for each commit and takes the average.

Based on some experiments, the noise floor on my Linux desktop is about 0.5% to 1.0%. Any difference above 1.0% is likely significant, I believe. For differences between 0.5% and 1.0% it makes sense to repeat the measurement a few times.

The interesting part of the output looks something like this:
```
...
=== Results ===

145d8a41b17ab1ba8707589be9cb5d56bbebd0ea 8.207s (0.0%)
145d8a41b17ab1ba8707589be9cb5d56bbebd0ea~1 8.105s (-1.2%)
```