### PR TITLE
Fix docs build

### DIFF
--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -177,7 +177,7 @@ Caveats/Known Issues
   will complain about not understanding the argument and the type annotation in
   :py:meth:`__init__ <object.__init__>` will be replaced by ``Any``.
 
-* :ref:`Validator decorators <attrs:examples_validators>`
+* :ref:`Validator decorators <attrs:examples-validators>`
   and `default decorators <http://www.attrs.org/en/stable/examples.html#defaults>`_
   are not type-checked against the attribute they are setting/validating.
 


### PR DESCRIPTION
The docs build is currently failing on `master`: see e.g. https://github.com/python/mypy/actions/runs/3748461486/jobs/6365827914.

It looks like it was broken by the release of `attrs` 22.2.0 earlier today. Specifically, it looks like https://github.com/python-attrs/attrs/commit/1bb28648248e1bed63c1c6b077e7fe4b8260efc8 broke mypy's docs build.

I think this fixes things.