### PR TITLE
Avoid slow error message logic if errors not shown to user

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5936,6 +5936,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if isinstance(msg, str):
             msg = ErrorMessage(msg, code=code)
 
+        if self.msg.prefer_simple_messages():
+            self.fail(msg, context)  # Fast path -- skip all fancy logic
+            return False
+
         orig_subtype = subtype
         subtype = get_proper_type(subtype)
         orig_supertype = supertype
@@ -5983,8 +5987,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 assert call is not None
                 if not is_subtype(subtype, call, options=self.options):
                     self.msg.note_call(supertype, call, context, code=msg.code)
-        if not self.msg.prefer_simple_messages():
-            self.check_possible_missing_await(subtype, supertype, context)
+        self.check_possible_missing_await(subtype, supertype, context)
         return False
 
     def get_precise_awaitable_type(self, typ: Type, local_errors: ErrorWatcher) -> Type | None:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5983,7 +5983,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 assert call is not None
                 if not is_subtype(subtype, call, options=self.options):
                     self.msg.note_call(supertype, call, context, code=msg.code)
-        self.check_possible_missing_await(subtype, supertype, context)
+        if not self.msg.prefer_simple_messages():
+            self.check_possible_missing_await(subtype, supertype, context)
         return False
 
     def get_precise_awaitable_type(self, typ: Type, local_errors: ErrorWatcher) -> Type | None:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2157,7 +2157,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.msg.incompatible_argument_note(
                 original_caller_type, callee_type, context, code=code
             )
-            self.chk.check_possible_missing_await(caller_type, callee_type, context)
+            if not self.msg.prefer_simple_messages():
+                self.chk.check_possible_missing_await(caller_type, callee_type, context)
 
     def check_overload_call(
         self,

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -272,8 +272,9 @@ def report_missing_attribute(
     override_info: TypeInfo | None = None,
 ) -> Type:
     res_type = mx.msg.has_no_attr(original_type, typ, name, mx.context, mx.module_symbol_table)
-    if may_be_awaitable_attribute(name, typ, mx, override_info):
-        mx.msg.possible_missing_await(mx.context)
+    if not mx.msg.prefer_simple_messages():
+        if may_be_awaitable_attribute(name, typ, mx, override_info):
+            mx.msg.possible_missing_await(mx.context)
     return res_type
 
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -737,6 +737,24 @@ class Errors:
         """Are there any errors for the given file?"""
         return file in self.error_info_map
 
+    def prefer_simple_messages(self) -> bool:
+        """Should we generate simple/fast error messages?
+
+        Return True if errors are not shown to user, i.e. errors are ignored
+        or they are collected for internal use only.
+
+        If True, we should prefer to generate a simple message quickly.
+        All normal errors should still be reported.
+        """
+        if self.file in self.ignored_files:
+            # Errors ignored, so no point generating fancy messages
+            return True
+        for _watcher in self._watchers:
+            if _watcher._filter == True and _watcher._filtered is None:
+                # Errors are filtered
+                return True
+        return False
+
     def raise_error(self, use_stdout: bool = True) -> NoReturn:
         """Raise a CompileError with the generated messages.
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -750,7 +750,7 @@ class Errors:
             # Errors ignored, so no point generating fancy messages
             return True
         for _watcher in self._watchers:
-            if _watcher._filter == True and _watcher._filtered is None:
+            if _watcher._filter is True and _watcher._filtered is None:
                 # Errors are filtered
                 return True
         return False

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -191,6 +191,10 @@ class MessageBuilder:
     def are_type_names_disabled(self) -> bool:
         return len(self._disable_type_names) > 0 and self._disable_type_names[-1]
 
+    def prefer_simple_messages(self) -> bool:
+        """Should we generate simple/fast error messages?"""
+        return self.errors.prefer_simple_messages()
+
     def report(
         self,
         msg: str,

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -334,10 +334,6 @@ class MessageBuilder:
         If member corresponds to an operator, use the corresponding operator
         name in the messages. Return type Any.
         """
-        if self.prefer_simple_messages():
-            self.fail("Attribute not defined", context)
-            return AnyType(TypeOfAny.from_error)
-
         original_type = get_proper_type(original_type)
         typ = get_proper_type(typ)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -192,7 +192,11 @@ class MessageBuilder:
         return len(self._disable_type_names) > 0 and self._disable_type_names[-1]
 
     def prefer_simple_messages(self) -> bool:
-        """Should we generate simple/fast error messages?"""
+        """Should we generate simple/fast error messages?
+
+        If errors aren't shown to the user, we don't want to waste cyles producing
+        complex error messages.
+        """
         return self.errors.prefer_simple_messages()
 
     def report(
@@ -330,6 +334,10 @@ class MessageBuilder:
         If member corresponds to an operator, use the corresponding operator
         name in the messages. Return type Any.
         """
+        if self.prefer_simple_messages():
+            self.fail("Attribute not defined", context)
+            return AnyType(TypeOfAny.from_error)
+
         original_type = get_proper_type(original_type)
         typ = get_proper_type(typ)
 
@@ -689,64 +697,69 @@ class MessageBuilder:
                 actual_type_str, expected_type_str
             )
         else:
-            try:
-                expected_type = callee.arg_types[m - 1]
-            except IndexError:  # Varargs callees
-                expected_type = callee.arg_types[-1]
-            arg_type_str, expected_type_str = format_type_distinctly(
-                arg_type, expected_type, bare=True
-            )
-            if arg_kind == ARG_STAR:
-                arg_type_str = "*" + arg_type_str
-            elif arg_kind == ARG_STAR2:
-                arg_type_str = "**" + arg_type_str
-
-            # For function calls with keyword arguments, display the argument name rather than the
-            # number.
-            arg_label = str(n)
-            if isinstance(outer_context, CallExpr) and len(outer_context.arg_names) >= n:
-                arg_name = outer_context.arg_names[n - 1]
-                if arg_name is not None:
-                    arg_label = f'"{arg_name}"'
-            if (
-                arg_kind == ARG_STAR2
-                and isinstance(arg_type, TypedDictType)
-                and m <= len(callee.arg_names)
-                and callee.arg_names[m - 1] is not None
-                and callee.arg_kinds[m - 1] != ARG_STAR2
-            ):
-                arg_name = callee.arg_names[m - 1]
-                assert arg_name is not None
-                arg_type_str, expected_type_str = format_type_distinctly(
-                    arg_type.items[arg_name], expected_type, bare=True
-                )
-                arg_label = f'"{arg_name}"'
-            if isinstance(outer_context, IndexExpr) and isinstance(outer_context.index, StrExpr):
-                msg = 'Value of "{}" has incompatible type {}; expected {}'.format(
-                    outer_context.index.value,
-                    quote_type_string(arg_type_str),
-                    quote_type_string(expected_type_str),
-                )
+            if self.prefer_simple_messages():
+                msg = "Argument has incompatible type"
             else:
-                msg = "Argument {} {}has incompatible type {}; expected {}".format(
-                    arg_label,
-                    target,
-                    quote_type_string(arg_type_str),
-                    quote_type_string(expected_type_str),
+                try:
+                    expected_type = callee.arg_types[m - 1]
+                except IndexError:  # Varargs callees
+                    expected_type = callee.arg_types[-1]
+                arg_type_str, expected_type_str = format_type_distinctly(
+                    arg_type, expected_type, bare=True
                 )
+                if arg_kind == ARG_STAR:
+                    arg_type_str = "*" + arg_type_str
+                elif arg_kind == ARG_STAR2:
+                    arg_type_str = "**" + arg_type_str
+
+                # For function calls with keyword arguments, display the argument name rather
+                # than the number.
+                arg_label = str(n)
+                if isinstance(outer_context, CallExpr) and len(outer_context.arg_names) >= n:
+                    arg_name = outer_context.arg_names[n - 1]
+                    if arg_name is not None:
+                        arg_label = f'"{arg_name}"'
+                if (
+                    arg_kind == ARG_STAR2
+                    and isinstance(arg_type, TypedDictType)
+                    and m <= len(callee.arg_names)
+                    and callee.arg_names[m - 1] is not None
+                    and callee.arg_kinds[m - 1] != ARG_STAR2
+                ):
+                    arg_name = callee.arg_names[m - 1]
+                    assert arg_name is not None
+                    arg_type_str, expected_type_str = format_type_distinctly(
+                        arg_type.items[arg_name], expected_type, bare=True
+                    )
+                    arg_label = f'"{arg_name}"'
+                if isinstance(outer_context, IndexExpr) and isinstance(
+                    outer_context.index, StrExpr
+                ):
+                    msg = 'Value of "{}" has incompatible type {}; expected {}'.format(
+                        outer_context.index.value,
+                        quote_type_string(arg_type_str),
+                        quote_type_string(expected_type_str),
+                    )
+                else:
+                    msg = "Argument {} {}has incompatible type {}; expected {}".format(
+                        arg_label,
+                        target,
+                        quote_type_string(arg_type_str),
+                        quote_type_string(expected_type_str),
+                    )
+                expected_type = get_proper_type(expected_type)
+                if isinstance(expected_type, UnionType):
+                    expected_types = list(expected_type.items)
+                else:
+                    expected_types = [expected_type]
+                for type in get_proper_types(expected_types):
+                    if isinstance(arg_type, Instance) and isinstance(type, Instance):
+                        notes = append_invariance_notes(notes, arg_type, type)
             object_type = get_proper_type(object_type)
             if isinstance(object_type, TypedDictType):
                 code = codes.TYPEDDICT_ITEM
             else:
                 code = codes.ARG_TYPE
-            expected_type = get_proper_type(expected_type)
-            if isinstance(expected_type, UnionType):
-                expected_types = list(expected_type.items)
-            else:
-                expected_types = [expected_type]
-            for type in get_proper_types(expected_types):
-                if isinstance(arg_type, Instance) and isinstance(type, Instance):
-                    notes = append_invariance_notes(notes, arg_type, type)
         self.fail(msg, context, code=code)
         if notes:
             for note_msg in notes:
@@ -760,6 +773,8 @@ class MessageBuilder:
         context: Context,
         code: ErrorCode | None,
     ) -> None:
+        if self.prefer_simple_messages():
+            return
         if isinstance(
             original_caller_type, (Instance, TupleType, TypedDictType, TypeType, CallableType)
         ):
@@ -836,7 +851,9 @@ class MessageBuilder:
     def too_few_arguments(
         self, callee: CallableType, context: Context, argument_names: Sequence[str | None] | None
     ) -> None:
-        if argument_names is not None:
+        if self.prefer_simple_messages():
+            msg = "Too few arguments"
+        elif argument_names is not None:
             num_positional_args = sum(k is None for k in argument_names)
             arguments_left = callee.arg_names[num_positional_args : callee.min_args]
             diff = [k for k in arguments_left if k not in argument_names]
@@ -860,7 +877,10 @@ class MessageBuilder:
         self.fail(msg, context, code=codes.CALL_ARG)
 
     def too_many_arguments(self, callee: CallableType, context: Context) -> None:
-        msg = "Too many arguments" + for_function(callee)
+        if self.prefer_simple_messages():
+            msg = "Too many arguments"
+        else:
+            msg = "Too many arguments" + for_function(callee)
         self.fail(msg, context, code=codes.CALL_ARG)
         self.maybe_note_about_special_args(callee, context)
 
@@ -878,11 +898,16 @@ class MessageBuilder:
         self.fail(msg, context)
 
     def too_many_positional_arguments(self, callee: CallableType, context: Context) -> None:
-        msg = "Too many positional arguments" + for_function(callee)
+        if self.prefer_simple_messages():
+            msg = "Too many positional arguments"
+        else:
+            msg = "Too many positional arguments" + for_function(callee)
         self.fail(msg, context)
         self.maybe_note_about_special_args(callee, context)
 
     def maybe_note_about_special_args(self, callee: CallableType, context: Context) -> None:
+        if self.prefer_simple_messages():
+            return
         # https://github.com/python/mypy/issues/11309
         first_arg = callee.def_extras.get("first_arg")
         if first_arg and first_arg not in {"self", "cls", "mcs"}:


### PR DESCRIPTION
This helps with await-related errors introduced in #12958, in particular, which are expensive to generate. If errors are ignored (e.g. in third-party libraries) or we don't care about the error message, use simpler error message logic. We also often filter out error messages temporarily, so any effort in constructing a nice error message is wasted.

We could skip even more logic, but this should cover many of the important code paths.

This speeds up self check by about 2%.