### PR TITLE
[undefined vars] fix per-module error code override bug

### DIFF
--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -662,7 +662,7 @@ def update_module_isolated(
     state.type_checker().reset()
     state.type_check_first_pass()
     state.type_check_second_pass()
-    state.detect_possibly_undefined_vars(state.type_map())
+    state.detect_possibly_undefined_vars()
     t2 = time.time()
     state.finish_passes()
     t3 = time.time()

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2110,7 +2110,7 @@ if foo: ...  # E: Function "Callable[[], int]" could always be true in boolean c
 42 + "no"  # type: ignore
 [file mypy.ini]
 \[mypy]
-enable_error_code = ignore-without-code, truthy-bool
+enable_error_code = ignore-without-code, truthy-bool, used-before-def
 
 \[mypy-tests.*]
 disable_error_code = ignore-without-code


### PR DESCRIPTION
This one would occur because we set the errors module with global options, instead of per-module override ones.
It only mattered for checks that happened after the partially undefined checks, which (I believe) is only the unused `type: ignore` checks.

This was discovered when updating tests for #14166.

I've also cleaned up the function signature a little.