### PR TITLE
Stubtest: clean up the `_belongs_to_runtime` function

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -346,7 +346,7 @@ def verify_mypyfile(
     imported_symbols = _get_imported_symbol_names(runtime)
 
     def _belongs_to_runtime(r: types.ModuleType, attr: str) -> bool:
-        """Use various heuristics to determine whether a global name originates from an import."""
+        """Heuristics to determine whether a name originates from another module."""
         obj = getattr(r, attr)
         if isinstance(obj, types.ModuleType):
             return False
@@ -371,9 +371,8 @@ def verify_mypyfile(
             m
             for m in dir(runtime)
             if not is_probably_private(m)
-            # Do our best to filter out objects that originate from different modules,
-            # since in the absence of __all__,
-            # we don't have a sure-fire way to detect re-exports at runtime
+            # Filter out objects that originate from other modules (best effort). Note that in the
+            # absence of __all__, we don't have a way to detect re-exports at runtime
             and _belongs_to_runtime(runtime, m)
         }
     )

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -372,7 +372,7 @@ def verify_mypyfile(
             for m in dir(runtime)
             if not is_probably_private(m)
             # Filter out objects that originate from other modules (best effort). Note that in the
-            # absence of __all__, we don't have a way to detect re-exports at runtime
+            # absence of __all__, we don't have a way to detect explicit re-exports at runtime
             and _belongs_to_runtime(runtime, m)
         }
     )

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -370,7 +370,11 @@ def verify_mypyfile(
         else {
             m
             for m in dir(runtime)
-            if not is_probably_private(m) and _belongs_to_runtime(runtime, m)
+            if not is_probably_private(m)
+            # Do our best to filter out objects that originate from different modules,
+            # since in the absence of __all__,
+            # we don't have a sure-fire way to detect re-exports at runtime
+            and _belongs_to_runtime(runtime, m)
         }
     )
     # Check all things declared in module's __all__, falling back to our best guess

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -372,7 +372,8 @@ def verify_mypyfile(
             for m in dir(runtime)
             if not is_probably_private(m)
             # Filter out objects that originate from other modules (best effort). Note that in the
-            # absence of __all__, we don't have a way to detect explicit re-exports at runtime
+            # absence of __all__, we don't have a way to detect explicit / intentional re-exports
+            # at runtime
             and _belongs_to_runtime(runtime, m)
         }
     )


### PR DESCRIPTION
There's a small semantic change in this PR (instead of returning `False` if trying to access the `__module__` attribute raises an exception, we now just move on to the next heuristic). But the main purpose of this PR is to make the code more readable, as this function was getting quite hard to understand.