### PR TITLE
Some semantic analyzer micro-optimizations

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1915,7 +1915,7 @@ class SemanticAnalyzer(
                 except TypeTranslationError:
                     # This error will be caught later.
                     continue
-                base_tvars = base.accept(TypeVarLikeQuery(self.lookup_qualified, self.tvar_scope))
+                base_tvars = base.accept(TypeVarLikeQuery(self, self.tvar_scope))
                 tvars.extend(base_tvars)
         return remove_dups(tvars)
 
@@ -1933,7 +1933,7 @@ class SemanticAnalyzer(
             except TypeTranslationError:
                 # This error will be caught later.
                 continue
-            base_tvars = base.accept(TypeVarLikeQuery(self.lookup_qualified, self.tvar_scope))
+            base_tvars = base.accept(TypeVarLikeQuery(self, self.tvar_scope))
             tvars.extend(base_tvars)
         tvars = remove_dups(tvars)  # Variables are defined in order of textual appearance.
         tvar_defs = []
@@ -3294,7 +3294,7 @@ class SemanticAnalyzer(
             )
             return None, [], set(), []
 
-        found_type_vars = typ.accept(TypeVarLikeQuery(self.lookup_qualified, self.tvar_scope))
+        found_type_vars = typ.accept(TypeVarLikeQuery(self, self.tvar_scope))
         tvar_defs: list[TypeVarLikeType] = []
         namespace = self.qualified_name(name)
         with self.tvar_scope_frame(self.tvar_scope.class_frame(namespace)):

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -315,7 +315,7 @@ class TypeQuery(SyntheticTypeVisitor[T]):
     # TODO: check that we don't have existing violations of this rule.
     """
 
-    def __init__(self, strategy: Callable[[Iterable[T]], T]) -> None:
+    def __init__(self, strategy: Callable[[list[T]], T]) -> None:
         self.strategy = strategy
         # Keep track of the type aliases already visited. This is needed to avoid
         # infinite recursion on types like A = Union[int, List[A]].


### PR DESCRIPTION
The biggest change is replacing some calls to bound methods with trait method calls, which are faster when compiled.

Also remove an unused argument to TypeVarLikeQuery and make a few misc tweaks.

(Various small optimizations, including these, together netted a 6% performance improvement in self check.)