### PR TITLE
Fix Unpack imported from typing

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1881,7 +1881,7 @@ class SemanticAnalyzer(
                 # It's bound by our type variable scope
                 return None
             return unbound.name, sym.node
-        if sym and sym.fullname in {"typing.Unpack", "typing_extensions.Unpack"}:
+        if sym and sym.fullname in ("typing.Unpack", "typing_extensions.Unpack"):
             inner_t = unbound.args[0]
             if not isinstance(inner_t, UnboundType):
                 return None

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1881,7 +1881,7 @@ class SemanticAnalyzer(
                 # It's bound by our type variable scope
                 return None
             return unbound.name, sym.node
-        if sym and sym.fullname == "typing_extensions.Unpack":
+        if sym and sym.fullname in {"typing.Unpack", "typing_extensions.Unpack"}:
             inner_t = unbound.args[0]
             if not isinstance(inner_t, UnboundType):
                 return None

--- a/test-data/unit/check-python311.test
+++ b/test-data/unit/check-python311.test
@@ -51,3 +51,15 @@ try:
 except* (RuntimeError, ExceptionGroup) as e:  # E: Exception type in except* cannot derive from BaseExceptionGroup
     reveal_type(e)  # N: Revealed type is "builtins.ExceptionGroup[Union[builtins.RuntimeError, Any]]"
 [builtins fixtures/exception.pyi]
+
+[case testBasicTypeVarTupleGeneric]
+from typing import Generic, TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+
+class Variadic(Generic[Unpack[Ts]]):
+    ...
+
+variadic: Variadic[int, str]
+reveal_type(variadic)  # N: Revealed type is "__main__.Variadic[builtins.int, builtins.str]"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -27,6 +27,8 @@ NoReturn = 0
 Never = 0
 NewType = 0
 ParamSpec = 0
+TypeVarTuple = 0
+Unpack = 0
 Self = 0
 TYPE_CHECKING = 0
 


### PR DESCRIPTION
Add missing check for `typing.Unpack` to fix running with `--python 3.11`.