### PR TITLE
Improve performance for errors on class with many attributes

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2798,7 +2798,7 @@ def find_defining_module(modules: dict[str, MypyFile], typ: CallableType) -> Myp
 COMMON_MISTAKES: Final[dict[str, Sequence[str]]] = {"add": ("append", "extend")}
 
 
-def real_quick_ratio(a, b):
+def _real_quick_ratio(a: str, b: str) -> float:
     # this is an upper bound on difflib.SequenceMatcher.ratio
     # similar to difflib.SequenceMatcher.real_quick_ratio, but faster since we don't instantiate
     al = len(a)
@@ -2809,7 +2809,7 @@ def real_quick_ratio(a, b):
 def best_matches(current: str, options: Collection[str], n: int) -> list[str]:
     # narrow down options cheaply
     assert current
-    options = [o for o in options if real_quick_ratio(current, o) > 0.75]
+    options = [o for o in options if _real_quick_ratio(current, o) > 0.75]
     if len(options) >= 50:
         options = [o for o in options if abs(len(o) - len(current)) <= 1]
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2809,13 +2809,13 @@ def real_quick_ratio(a, b):
 def best_matches(current: str, options: Collection[str], n: int) -> list[str]:
     # narrow down options cheaply
     assert current
-    options = [o for o in options if real_quick_ratio(current, o) >= 0.75]
+    options = [o for o in options if real_quick_ratio(current, o) > 0.75]
     if len(options) >= 50:
         options = [o for o in options if abs(len(o) - len(current)) <= 1]
 
     ratios = {option: difflib.SequenceMatcher(a=current, b=option).ratio() for option in options}
-    options = [option for option, ratio in ratios.items() if ratio >= 0.75]
-    return sorted(options, reverse=True, key=lambda v: ratios[v])[:n]
+    options = [option for option, ratio in ratios.items() if ratio > 0.75]
+    return sorted(options, key=lambda v: (-ratios[v], v))[:n]
 
 
 def pretty_seq(args: Sequence[str], conjunction: str) -> str:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2531,7 +2531,7 @@ class SemanticAnalyzer(
                 )
             else:
                 alternatives = set(module.names.keys()).difference({source_id})
-                matches = best_matches(source_id, alternatives)[:3]
+                matches = best_matches(source_id, alternatives, n=3)
                 if matches:
                     suggestion = f"; maybe {pretty_seq(matches, 'or')}?"
                     message += f"{suggestion}"

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -87,7 +87,7 @@ class A: pass
 
 [case testMultipleKeywordsForMisspelling]
 def f(thing : 'A', other: 'A', atter: 'A', btter: 'B') -> None: pass # N: "f" defined here
-f(otter=A()) # E: Unexpected keyword argument "otter" for "f"; did you mean "other" or "atter"?
+f(otter=A()) # E: Unexpected keyword argument "otter" for "f"; did you mean "atter" or "other"?
 class A: pass
 class B: pass
 
@@ -99,7 +99,7 @@ class B: pass
 
 [case testKeywordMisspellingInheritance]
 def f(atter: 'A', btter: 'B', ctter: 'C') -> None: pass # N: "f" defined here
-f(otter=B()) # E: Unexpected keyword argument "otter" for "f"; did you mean "btter" or "atter"?
+f(otter=B()) # E: Unexpected keyword argument "otter" for "f"; did you mean "atter" or "btter"?
 class A: pass
 class B(A): pass
 class C: pass
@@ -107,7 +107,7 @@ class C: pass
 [case testKeywordMisspellingFloatInt]
 def f(atter: float, btter: int) -> None: pass # N: "f" defined here
 x: int = 5
-f(otter=x) # E: Unexpected keyword argument "otter" for "f"; did you mean "btter" or "atter"?
+f(otter=x) # E: Unexpected keyword argument "otter" for "f"; did you mean "atter" or "btter"?
 
 [case testKeywordMisspellingVarArgs]
 def f(other: 'A', *atter: 'A') -> None: pass # N: "f" defined here

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2871,7 +2871,7 @@ aaaaa: int
 
 [case testModuleAttributeThreeSuggestions]
 import m
-m.aaaaa # E: Module has no attribute "aaaaa"; maybe "aabaa", "aaaba", or "aaaab"?
+m.aaaaa # E: Module has no attribute "aaaaa"; maybe "aaaab", "aaaba", or "aabaa"?
 
 [file m.py]
 aaaab: int

--- a/test-data/unit/semanal-modules.test
+++ b/test-data/unit/semanal-modules.test
@@ -814,7 +814,7 @@ def somef_unction():
 [file f.py]
 from m.x import somefunction
 [out]
-tmp/f.py:1: error: Module "m.x" has no attribute "somefunction"; maybe "somef_unction" or "some_function"?
+tmp/f.py:1: error: Module "m.x" has no attribute "somefunction"; maybe "some_function" or "somef_unction"?
 
 [case testImportMisspellingMultipleCandidatesTruncated]
 import f
@@ -831,7 +831,7 @@ def somefun_ction():
 [file f.py]
 from m.x import somefunction
 [out]
-tmp/f.py:1: error: Module "m.x" has no attribute "somefunction"; maybe "somefun_ction", "somefu_nction", or "somef_unction"?
+tmp/f.py:1: error: Module "m.x" has no attribute "somefunction"; maybe "some_function", "somef_unction", or "somefu_nction"?
 
 [case testFromImportAsInStub]
 from m import *


### PR DESCRIPTION
When checking manticore with `--check-untyped-defs`, this is a 4x total speedup from master, from ~320s to ~80s (uncompiled).

I looked into this because of https://github.com/python/typeshed/pull/9443#issuecomment-1369120219