### PR TITLE
Move truthy-function docs from “optional checks” to “enabled by default”

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -764,6 +764,19 @@ the provided type.
 
    assert_type([1], list[str])  # Error
 
+Check that function isn't used in boolean context [truthy-function]
+-------------------------------------------------------------------
+
+Functions will always evaluate to true in boolean contexts.
+
+.. code-block:: python
+
+    def f():
+        ...
+
+    if f:  # Error: Function "Callable[[], Any]" could always be true in boolean context  [truthy-function]
+        pass
+
 Report syntax errors [syntax]
 -----------------------------
 

--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -256,19 +256,6 @@ what the author might have intended. Of course it's possible that ``transform`` 
 and so there is no error in practice. In such case, it is recommended to annotate ``items: Collection[int]``.
 
 
-Check that function isn't used in boolean context [truthy-function]
--------------------------------------------------------------------
-
-Functions will always evaluate to true in boolean contexts.
-
-.. code-block:: python
-
-    def f():
-        ...
-
-    if f:  # Error: Function "Callable[[], Any]" could always be true in boolean context  [truthy-function]
-        pass
-
 .. _ignore-without-code:
 
 Check that ``# type: ignore`` include an error code [ignore-without-code]


### PR DESCRIPTION
This error was enabled by default since its introduction (#13686); document it in the correct section.