### PR TITLE
stubgen: Allow aliases below the top level

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -995,8 +995,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
                 self.process_namedtuple(lvalue, o.rvalue)
                 continue
             if (
-                self.is_top_level()
-                and isinstance(lvalue, NameExpr)
+                isinstance(lvalue, NameExpr)
                 and not self.is_private_name(lvalue.name)
                 and
                 # it is never an alias with explicit annotation
@@ -1114,7 +1113,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
 
     def process_typealias(self, lvalue: NameExpr, rvalue: Expression) -> None:
         p = AliasPrinter(self)
-        self.add(f"{lvalue.name} = {rvalue.accept(p)}\n")
+        self.add(f"{self._indent}{lvalue.name} = {rvalue.accept(p)}\n")
         self.record_name(lvalue.name)
         self._vars[-1].append(lvalue.name)
 

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -977,7 +977,7 @@ class A:
         self.self_var = arg
 
     def meth(self) -> None:
-        pass
+        func_value = int_value
 
     alias_meth = meth
     alias_func = func

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -947,16 +947,6 @@ from typing import Any
 
 alias = Container[Any]
 
-[case testAliasOnlyToplevel]
-class Foo:
-    alias = str
-
-[out]
-from _typeshed import Incomplete
-
-class Foo:
-    alias: Incomplete
-
 [case testAliasExceptions]
 noalias1 = None
 noalias2 = ...
@@ -968,6 +958,56 @@ from _typeshed import Incomplete
 noalias1: Incomplete
 noalias2: Incomplete
 noalias3: bool
+
+[case testComplexAlias]
+# modules: main a
+
+from a import valid
+
+def func() -> int:
+    return 2
+
+aliased_func = func
+int_value = 1
+
+class A:
+    cls_var = valid
+
+    def __init__(self, arg: str) -> None:
+        self.self_var = arg
+
+    def meth(self) -> None:
+        pass
+
+    alias_meth = meth
+    alias_func = func
+    alias_alias_func = aliased_func
+    int_value = int_value
+
+[file a.py]
+valid : list[int] = [1, 2, 3]
+
+
+[out]
+# main.pyi
+from _typeshed import Incomplete
+from a import valid
+
+def func() -> int: ...
+aliased_func = func
+int_value: int
+
+class A:
+    cls_var = valid
+    self_var: Incomplete
+    def __init__(self, arg: str) -> None: ...
+    def meth(self) -> None: ...
+    alias_meth = meth
+    alias_func = func
+    alias_alias_func = aliased_func
+    int_value = int_value
+# a.pyi
+valid: list[int]
 
 -- More features/fixes:
 --   do not export deleted names


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->

stubgen currently allows a variable to be an alias to another, but only at the module level.

For example: 

```python
def func() -> int:
    return 2

aliased_func = func

class Foo:
    def meth() -> int:
        return 2
    
    aliased_meth = meth
```

produces:

```python
def func() -> int: ...
aliased_func = func

class Foo:
    def meth() -> int: ...
    aliased_meth: Incomplete   # <--- should be  `aliased_meth = meth`
```

At the class level, these aliased variables are marked as `Incomplete`.   

In my experience, enabling aliases below the top level produces better stubs.  

I'm not sure what the original reservations were around use of these aliases.  If the concerns about class-level aliases are still valid, I can add an option to enable them. 

