### PR TITLE
Fix function argument inference for constrained type variables within unions (Fixes #3644).

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -421,10 +421,8 @@ def filter_satisfiable(option: list[Constraint] | None) -> list[Constraint] | No
     satisfiable = []
     for c in option:
         if isinstance(c.origin_type_var, TypeVarType) and c.origin_type_var.values:
-            for value in c.origin_type_var.values:
-                if mypy.subtypes.is_subtype(c.target, value):
-                    satisfiable.append(c)
-                    break
+            if any(mypy.subtypes.is_subtype(c.target, value) for value in c.origin_type_var.values):
+                satisfiable.append(c)
         elif mypy.subtypes.is_subtype(c.target, c.origin_type_var.upper_bound):
             satisfiable.append(c)
     if not satisfiable:

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -421,7 +421,9 @@ def filter_satisfiable(option: list[Constraint] | None) -> list[Constraint] | No
     satisfiable = []
     for c in option:
         if isinstance(c.origin_type_var, TypeVarType) and c.origin_type_var.values:
-            if any(mypy.subtypes.is_subtype(c.target, value) for value in c.origin_type_var.values):
+            if any(
+                mypy.subtypes.is_subtype(c.target, value) for value in c.origin_type_var.values
+            ):
                 satisfiable.append(c)
         elif mypy.subtypes.is_subtype(c.target, c.origin_type_var.upper_bound):
             satisfiable.append(c)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -420,8 +420,12 @@ def filter_satisfiable(option: list[Constraint] | None) -> list[Constraint] | No
         return option
     satisfiable = []
     for c in option:
-        # TODO: add similar logic for TypeVar values (also in various other places)?
-        if mypy.subtypes.is_subtype(c.target, c.origin_type_var.upper_bound):
+        if isinstance(c.origin_type_var, TypeVarType) and c.origin_type_var.values:
+            for value in c.origin_type_var.values:
+                if mypy.subtypes.is_subtype(c.target, value):
+                    satisfiable.append(c)
+                    break
+        elif mypy.subtypes.is_subtype(c.target, c.origin_type_var.upper_bound):
             satisfiable.append(c)
     if not satisfiable:
         return None

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -1171,6 +1171,25 @@ def foo(
 foo([1])
 [builtins fixtures/list.pyi]
 
+[case testGenericUnionMemberWithTypeVarConstraints]
+
+from typing import Generic, TypeVar, Union
+
+T = TypeVar('T', str, int)
+
+class C(Generic[T]): ...
+
+def f(s: Union[T, C[T]]) -> T:  ...
+
+ci: C[int]
+cs: C[str]
+
+reveal_type(f(1))  # N: Revealed type is "builtins.int"
+reveal_type(f(''))  # N: Revealed type is "builtins.str"
+reveal_type(f(ci))  # N: Revealed type is "builtins.int"
+reveal_type(f(cs))  # N: Revealed type is "builtins.str"
+
+
 [case testNestedInstanceTypeAliasUnsimplifiedUnion]
 from typing import TypeVar, Union, Iterator, List, Any
 T = TypeVar("T")


### PR DESCRIPTION
Fix function argument inference for constrained type variables within unions (Fixes #3644).

Handling of constrained type variables of function `filter_satisfiable` of module `constraints` was missing (as was indicated by a removed ToDo).
