### PR TITLE
[mypyc] Don't load forward ref targets while setting up non-ext __annotations__

### DIFF
--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -99,8 +99,6 @@ assert f(Sub(3, 2)) == 3
 [case testNamedTupleClassSyntax]
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union
 
-class ClassIR: pass
-
 class FuncIR: pass
 
 StealsDescription = Union[bool, List[bool]]
@@ -119,8 +117,12 @@ class Record(NamedTuple):
     ordering: Optional[List[int]]
     extra_int_constants: List[Tuple[int]]
 
+# Make sure mypyc loads the annotation string for this forward reference.
+# Ref: https://github.com/mypyc/mypyc/issues/938
+class ClassIR: pass
+
 [file driver.py]
-from typing import Optional
+from typing import ForwardRef, Optional
 from native import ClassIR, FuncIR, Record
 
 assert Record.__annotations__ == {
@@ -129,7 +131,7 @@ assert Record.__annotations__ == {
     'is_borrowed': bool,
     'hash': str,
     'python_path': tuple,
-    'type': ClassIR,
+    'type': ForwardRef('ClassIR'),
     'method': FuncIR,
     'shadow_method': type,
     'classes': dict,


### PR DESCRIPTION
Take this example:

    from typing import NamedTuple

    class VTableMethod(NamedTuple):
        cls: "ClassIR"

    class ClassIR: pass

In irbuild::classdef::add_non_ext_class_attr_ann(), mypyc tries to assign the ClassIR type object to VTableMethod's \_\_annotations\_\_. This causes a segfault as ClassIR won't be initialized and allocated until *after* the NamedTuple is set up.

Fortunately, AssignmentStmt preserves the unanalyzed type (UnboundType). If `stmt.unanalyzed_type.orginal_str_expr` is not None, then we know we're dealing with a forward ref and should just load the string instead.

Unfortunately, it seems difficult (or impossible?) to infer whether an annotation is a forward reference when the annotations future is enabled and the annotation isn't a string.

I guess this fixes https://github.com/mypyc/mypyc/issues/938?

---

Dataclasses are still broken as strings in \_\_annotations\_\_ cause dataclass's internals to lookup the module in sys.modules which fails (as the module hasn't been fully initialized and added to sys.modules yet!)