### PR TITLE
Begin unifying logic for constraint building

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1157,7 +1157,7 @@ def find_matching_overload_items(
 def find_and_build_constraints_for_unpack(
     mapped: tuple[Type, ...], template: tuple[Type, ...], direction: int
 ) -> tuple[list[Constraint], tuple[Type, ...], tuple[Type, ...]]:
-    mapped_prefix_len = find_unpack_in_list(mapped)
+    mapped_prefix_len: int | None = find_unpack_in_list(mapped)
     if mapped_prefix_len is not None:
         mapped_suffix_len = len(mapped) - mapped_prefix_len - 1
     else:

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1157,9 +1157,9 @@ def find_matching_overload_items(
 def find_and_build_constraints_for_unpack(
     mapped: tuple[Type, ...], template: tuple[Type, ...], direction: int
 ) -> tuple[list[Constraint], tuple[Type, ...], tuple[Type, ...]]:
-    mapped_prefix_len: int | None = find_unpack_in_list(mapped)
+    mapped_prefix_len = find_unpack_in_list(mapped)
     if mapped_prefix_len is not None:
-        mapped_suffix_len = len(mapped) - mapped_prefix_len - 1
+        mapped_suffix_len: int | None = len(mapped) - mapped_prefix_len - 1
     else:
         mapped_suffix_len = None
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -52,7 +52,6 @@ from mypy.typestate import type_state
 from mypy.typevartuples import (
     extract_unpack,
     find_unpack_in_list,
-    split_with_instance,
     split_with_mapped_and_template,
     split_with_prefix_and_suffix,
 )
@@ -566,7 +565,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         raise NotImplementedError
 
     def visit_unpack_type(self, template: UnpackType) -> list[Constraint]:
-        raise NotImplementedError
+        raise RuntimeError("Mypy bug: unpack should be handled at a higher level.")
 
     def visit_parameters(self, template: Parameters) -> list[Constraint]:
         # constraining Any against C[P] turns into infer_against_any([P], Any)
@@ -638,47 +637,22 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                 tvars = mapped.type.defn.type_vars
 
                 if instance.type.has_type_var_tuple_type:
-                    mapped_prefix, mapped_middle, mapped_suffix = split_with_instance(mapped)
-                    instance_prefix, instance_middle, instance_suffix = split_with_instance(
-                        instance
-                    )
-
-                    # Add a constraint for the type var tuple, and then
-                    # remove it for the case below.
-                    instance_unpack = extract_unpack(instance_middle)
-                    if instance_unpack is not None:
-                        if isinstance(instance_unpack, TypeVarTupleType):
-                            res.append(
-                                Constraint(
-                                    instance_unpack,
-                                    SUBTYPE_OF,
-                                    TupleType(list(mapped_middle), instance_unpack.tuple_fallback),
-                                )
-                            )
-                        elif (
-                            isinstance(instance_unpack, Instance)
-                            and instance_unpack.type.fullname == "builtins.tuple"
-                        ):
-                            for item in mapped_middle:
-                                res.extend(
-                                    infer_constraints(
-                                        instance_unpack.args[0], item, self.direction
-                                    )
-                                )
-                        elif isinstance(instance_unpack, TupleType):
-                            if len(instance_unpack.items) == len(mapped_middle):
-                                for instance_arg, item in zip(
-                                    instance_unpack.items, mapped_middle
-                                ):
-                                    res.extend(
-                                        infer_constraints(instance_arg, item, self.direction)
-                                    )
-
-                    mapped_args = mapped_prefix + mapped_suffix
-                    instance_args = instance_prefix + instance_suffix
-
                     assert instance.type.type_var_tuple_prefix is not None
                     assert instance.type.type_var_tuple_suffix is not None
+                    assert mapped.type.type_var_tuple_prefix is not None
+                    assert mapped.type.type_var_tuple_suffix is not None
+
+                    unpack_constraints, mapped_args, instance_args = build_constraints_for_unpack(
+                        mapped.args,
+                        mapped.type.type_var_tuple_prefix,
+                        mapped.type.type_var_tuple_suffix,
+                        instance.args,
+                        instance.type.type_var_tuple_prefix,
+                        instance.type.type_var_tuple_suffix,
+                        self.direction,
+                    )
+                    res.extend(unpack_constraints)
+
                     tvars_prefix, _, tvars_suffix = split_with_prefix_and_suffix(
                         tuple(tvars),
                         instance.type.type_var_tuple_prefix,
@@ -732,57 +706,22 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                 mapped = map_instance_to_supertype(instance, template.type)
                 tvars = template.type.defn.type_vars
                 if template.type.has_type_var_tuple_type:
-                    mapped_prefix, mapped_middle, mapped_suffix = split_with_instance(mapped)
-                    template_prefix, template_middle, template_suffix = split_with_instance(
-                        template
-                    )
-                    split_result = split_with_mapped_and_template(mapped, template)
-                    assert split_result is not None
-                    (
-                        mapped_prefix,
-                        mapped_middle,
-                        mapped_suffix,
-                        template_prefix,
-                        template_middle,
-                        template_suffix,
-                    ) = split_result
-
-                    # Add a constraint for the type var tuple, and then
-                    # remove it for the case below.
-                    template_unpack = extract_unpack(template_middle)
-                    if template_unpack is not None:
-                        if isinstance(template_unpack, TypeVarTupleType):
-                            res.append(
-                                Constraint(
-                                    template_unpack,
-                                    SUPERTYPE_OF,
-                                    TupleType(list(mapped_middle), template_unpack.tuple_fallback),
-                                )
-                            )
-                        elif (
-                            isinstance(template_unpack, Instance)
-                            and template_unpack.type.fullname == "builtins.tuple"
-                        ):
-                            for item in mapped_middle:
-                                res.extend(
-                                    infer_constraints(
-                                        template_unpack.args[0], item, self.direction
-                                    )
-                                )
-                        elif isinstance(template_unpack, TupleType):
-                            if len(template_unpack.items) == len(mapped_middle):
-                                for template_arg, item in zip(
-                                    template_unpack.items, mapped_middle
-                                ):
-                                    res.extend(
-                                        infer_constraints(template_arg, item, self.direction)
-                                    )
-
-                    mapped_args = mapped_prefix + mapped_suffix
-                    template_args = template_prefix + template_suffix
-
+                    assert mapped.type.type_var_tuple_prefix is not None
+                    assert mapped.type.type_var_tuple_suffix is not None
                     assert template.type.type_var_tuple_prefix is not None
                     assert template.type.type_var_tuple_suffix is not None
+
+                    unpack_constraints, mapped_args, template_args = build_constraints_for_unpack(
+                        mapped.args,
+                        mapped.type.type_var_tuple_prefix,
+                        mapped.type.type_var_tuple_suffix,
+                        template.args,
+                        template.type.type_var_tuple_prefix,
+                        template.type.type_var_tuple_suffix,
+                        self.direction,
+                    )
+                    res.extend(unpack_constraints)
+
                     tvars_prefix, _, tvars_suffix = split_with_prefix_and_suffix(
                         tuple(tvars),
                         template.type.type_var_tuple_prefix,
@@ -945,12 +884,28 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                 # We can't infer constraints from arguments if the template is Callable[..., T]
                 # (with literal '...').
                 if not template.is_ellipsis_args:
+                    if find_unpack_in_list(template.arg_types) is not None:
+                        (
+                            unpack_constraints,
+                            cactual_args_t,
+                            template_args_t,
+                        ) = find_and_build_constraints_for_unpack(
+                            tuple(cactual.arg_types), tuple(template.arg_types), self.direction
+                        )
+                        template_args = list(template_args_t)
+                        cactual_args = list(cactual_args_t)
+                        res.extend(unpack_constraints)
+                        assert len(template_args) == len(cactual_args)
+                    else:
+                        template_args = template.arg_types
+                        cactual_args = cactual.arg_types
                     # The lengths should match, but don't crash (it will error elsewhere).
-                    for t, a in zip(template.arg_types, cactual.arg_types):
+                    for t, a in zip(template_args, cactual_args):
                         # Negate direction due to function argument type contravariance.
                         res.extend(infer_constraints(t, a, neg_op(self.direction)))
             else:
                 # sometimes, it appears we try to get constraints between two paramspec callables?
+
                 # TODO: Direction
                 # TODO: check the prefixes match
                 prefix = param_spec.prefix
@@ -1197,3 +1152,80 @@ def find_matching_overload_items(
         # it maintains backward compatibility.
         res = items[:]
     return res
+
+
+def find_and_build_constraints_for_unpack(
+    mapped: tuple[Type, ...], template: tuple[Type, ...], direction: int
+) -> tuple[list[Constraint], tuple[Type, ...], tuple[Type, ...]]:
+    mapped_prefix_len = find_unpack_in_list(mapped)
+    if mapped_prefix_len is not None:
+        mapped_suffix_len = len(mapped) - mapped_prefix_len - 1
+    else:
+        mapped_suffix_len = None
+
+    template_prefix_len = find_unpack_in_list(template)
+    assert template_prefix_len is not None
+    template_suffix_len = len(template) - template_prefix_len - 1
+
+    return build_constraints_for_unpack(
+        mapped,
+        mapped_prefix_len,
+        mapped_suffix_len,
+        template,
+        template_prefix_len,
+        template_suffix_len,
+        direction,
+    )
+
+
+def build_constraints_for_unpack(
+    mapped: tuple[Type, ...],
+    mapped_prefix_len: int | None,
+    mapped_suffix_len: int | None,
+    template: tuple[Type, ...],
+    template_prefix_len: int,
+    template_suffix_len: int,
+    direction: int,
+) -> tuple[list[Constraint], tuple[Type, ...], tuple[Type, ...]]:
+    split_result = split_with_mapped_and_template(
+        mapped,
+        mapped_prefix_len,
+        mapped_suffix_len,
+        template,
+        template_prefix_len,
+        template_suffix_len,
+    )
+    assert split_result is not None
+    (
+        mapped_prefix,
+        mapped_middle,
+        mapped_suffix,
+        template_prefix,
+        template_middle,
+        template_suffix,
+    ) = split_result
+
+    template_unpack = extract_unpack(template_middle)
+    res = []
+
+    if template_unpack is not None:
+        if isinstance(template_unpack, TypeVarTupleType):
+            res.append(
+                Constraint(
+                    template_unpack,
+                    direction,
+                    TupleType(list(mapped_middle), template_unpack.tuple_fallback),
+                )
+            )
+        elif (
+            isinstance(template_unpack, Instance)
+            and template_unpack.type.fullname == "builtins.tuple"
+        ):
+            for item in mapped_middle:
+                res.extend(infer_constraints(template_unpack.args[0], item, direction))
+
+        elif isinstance(template_unpack, TupleType):
+            if len(template_unpack.items) == len(mapped_middle):
+                for template_arg, item in zip(template_unpack.items, mapped_middle):
+                    res.extend(infer_constraints(template_arg, item, direction))
+    return (res, mapped_prefix + mapped_suffix, template_prefix + template_suffix)

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -482,7 +482,18 @@ class SubtypeVisitor(TypeVisitor[bool]):
                     t = erased
                 nominal = True
                 if right.type.has_type_var_tuple_type:
-                    split_result = fully_split_with_mapped_and_template(left, right)
+                    assert left.type.type_var_tuple_prefix is not None
+                    assert left.type.type_var_tuple_suffix is not None
+                    assert right.type.type_var_tuple_prefix is not None
+                    assert right.type.type_var_tuple_suffix is not None
+                    split_result = fully_split_with_mapped_and_template(
+                        left.args,
+                        left.type.type_var_tuple_prefix,
+                        left.type.type_var_tuple_suffix,
+                        right.args,
+                        right.type.type_var_tuple_prefix,
+                        right.type.type_var_tuple_suffix,
+                    )
                     if split_result is None:
                         return False
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3568,10 +3568,16 @@ def store_argument_type(
         if isinstance(arg_type, ParamSpecType):
             pass
         elif isinstance(arg_type, UnpackType):
-            if isinstance(get_proper_type(arg_type.type), TupleType):
+            unpacked_type = get_proper_type(arg_type.type)
+            if isinstance(unpacked_type, TupleType):
                 # Instead of using Tuple[Unpack[Tuple[...]]], just use
                 # Tuple[...]
-                arg_type = arg_type.type
+                arg_type = unpacked_type
+            elif (
+                isinstance(unpacked_type, Instance)
+                and unpacked_type.type.fullname == "builtins.tuple"
+            ):
+                arg_type = unpacked_type
             else:
                 arg_type = TupleType(
                     [arg_type],

--- a/mypy/typevartuples.py
+++ b/mypy/typevartuples.py
@@ -46,7 +46,12 @@ def split_with_instance(
 
 
 def split_with_mapped_and_template(
-    mapped: Instance, template: Instance
+    mapped: tuple[Type, ...],
+    mapped_prefix_len: int | None,
+    mapped_suffix_len: int | None,
+    template: tuple[Type, ...],
+    template_prefix_len: int,
+    template_suffix_len: int,
 ) -> tuple[
     tuple[Type, ...],
     tuple[Type, ...],
@@ -55,7 +60,14 @@ def split_with_mapped_and_template(
     tuple[Type, ...],
     tuple[Type, ...],
 ] | None:
-    split_result = fully_split_with_mapped_and_template(mapped, template)
+    split_result = fully_split_with_mapped_and_template(
+        mapped,
+        mapped_prefix_len,
+        mapped_suffix_len,
+        template,
+        template_prefix_len,
+        template_suffix_len,
+    )
     if split_result is None:
         return None
 
@@ -83,7 +95,12 @@ def split_with_mapped_and_template(
 
 
 def fully_split_with_mapped_and_template(
-    mapped: Instance, template: Instance
+    mapped: tuple[Type, ...],
+    mapped_prefix_len: int | None,
+    mapped_suffix_len: int | None,
+    template: tuple[Type, ...],
+    template_prefix_len: int,
+    template_suffix_len: int,
 ) -> tuple[
     tuple[Type, ...],
     tuple[Type, ...],
@@ -96,8 +113,19 @@ def fully_split_with_mapped_and_template(
     tuple[Type, ...],
     tuple[Type, ...],
 ] | None:
-    mapped_prefix, mapped_middle, mapped_suffix = split_with_instance(mapped)
-    template_prefix, template_middle, template_suffix = split_with_instance(template)
+    if mapped_prefix_len is not None:
+        assert mapped_suffix_len is not None
+        mapped_prefix, mapped_middle, mapped_suffix = split_with_prefix_and_suffix(
+            tuple(mapped), mapped_prefix_len, mapped_suffix_len
+        )
+    else:
+        mapped_prefix = tuple()
+        mapped_suffix = tuple()
+        mapped_middle = mapped
+
+    template_prefix, template_middle, template_suffix = split_with_prefix_and_suffix(
+        tuple(template), template_prefix_len, template_suffix_len
+    )
 
     unpack_prefix = find_unpack_in_list(template_middle)
     if unpack_prefix is None:

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -178,7 +178,7 @@ Ts = TypeVarTuple("Ts")
 B = Ts  # E: Type variable "__main__.Ts" is invalid as target for type alias
 [builtins fixtures/tuple.pyi]
 
-[case testPep646ArrayExample]
+[case testTypeVarTuplePep646ArrayExample]
 from typing import Generic, Tuple, TypeVar, Protocol, NewType
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -213,7 +213,7 @@ reveal_type(abs(x))  # N: Revealed type is "__main__.Array[__main__.Height, __ma
 reveal_type(x + x)  # N: Revealed type is "__main__.Array[__main__.Height, __main__.Width]"
 
 [builtins fixtures/tuple.pyi]
-[case testPep646ArrayExampleWithDType]
+[case testTypeVarTuplePep646ArrayExampleWithDType]
 from typing import Generic, Tuple, TypeVar, Protocol, NewType
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -250,7 +250,7 @@ reveal_type(x + x)  # N: Revealed type is "__main__.Array[builtins.float, __main
 
 [builtins fixtures/tuple.pyi]
 
-[case testPep646ArrayExampleInfer]
+[case testTypeVarTuplePep646ArrayExampleInfer]
 from typing import Generic, Tuple, TypeVar, NewType
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -265,7 +265,7 @@ class Array(Generic[Unpack[Shape]]):
 x: Array[float, Height, Width] = Array()
 [builtins fixtures/tuple.pyi]
 
-[case testPep646TypeConcatenation]
+[case testTypeVarTuplePep646TypeConcatenation]
 from typing import Generic, TypeVar, NewType
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -295,7 +295,7 @@ d = add_batch_channels(a)
 reveal_type(d)  # N: Revealed type is "__main__.Array[__main__.Batch, __main__.Height, __main__.Width, __main__.Channels]"
 
 [builtins fixtures/tuple.pyi]
-[case testPep646TypeVarConcatenation]
+[case testTypeVarTuplePep646TypeVarConcatenation]
 from typing import Generic, TypeVar, NewType, Tuple
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -311,7 +311,7 @@ def prefix_tuple(
 z = prefix_tuple(x=0, y=(True, 'a'))
 reveal_type(z)  # N: Revealed type is "Tuple[builtins.int, builtins.bool, builtins.str]"
 [builtins fixtures/tuple.pyi]
-[case testPep646TypeVarTupleUnpacking]
+[case testTypeVarTuplePep646TypeVarTupleUnpacking]
 from typing import Generic, TypeVar, NewType, Any, Tuple
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -367,7 +367,7 @@ reveal_type(bad2)  # N: Revealed type is "def (x: Tuple[builtins.int, Unpack[bui
 
 [builtins fixtures/tuple.pyi]
 
-[case testPep646TypeVarStarArgs]
+[case testTypeVarTuplePep646TypeVarStarArgsBasic]
 from typing import Tuple
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -380,6 +380,13 @@ def args_to_tuple(*args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
     return args
 
 reveal_type(args_to_tuple(1, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, Literal['a']?]"
+
+[builtins fixtures/tuple.pyi]
+[case testTypeVarTuplePep646TypeVarStarArgs]
+from typing import Tuple
+from typing_extensions import TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
 
 def with_prefix_suffix(*args: Unpack[Tuple[bool, str, Unpack[Ts], int]]) -> Tuple[bool, str, Unpack[Ts], int]:
     reveal_type(args)  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Unpack[Ts`-1], builtins.int]"
@@ -404,14 +411,69 @@ with_prefix_suffix(*bad_t)  # E: Too few arguments for "with_prefix_suffix"
 def foo(*args: Unpack[Ts]) -> None:
     reveal_type(with_prefix_suffix(True, "bar", *args, 5))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Unpack[Ts`-1], builtins.int]"
 
-def concrete(*args: Unpack[Tuple[int, str]]) -> None:
+
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTuplePep646TypeVarStarArgsFixedLengthTuple]
+from typing import Tuple
+from typing_extensions import Unpack
+
+def foo(*args: Unpack[Tuple[int, str]]) -> None:
     reveal_type(args)  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
 
-concrete(0, "foo")
-concrete(0, 1)  # E: Argument 2 to "concrete" has incompatible type "int"; expected "Unpack[Tuple[int, str]]"
-concrete("foo", "bar")  # E: Argument 1 to "concrete" has incompatible type "str"; expected "Unpack[Tuple[int, str]]"
-concrete(0, "foo", 1)  # E: Invalid number of arguments
-concrete(0)  # E: Invalid number of arguments
-concrete()  # E: Invalid number of arguments
+foo(0, "foo")
+foo(0, 1)  # E: Argument 2 to "foo" has incompatible type "int"; expected "Unpack[Tuple[int, str]]"
+foo("foo", "bar")  # E: Argument 1 to "foo" has incompatible type "str"; expected "Unpack[Tuple[int, str]]"
+foo(0, "foo", 1)  # E: Invalid number of arguments
+foo(0)  # E: Invalid number of arguments
+foo()  # E: Invalid number of arguments
+foo(*(0, "foo"))
 
+# TODO: fix this case to do something sensible.
+#def foo2(*args: Unpack[Tuple[bool, Unpack[Tuple[int, str]], bool]]) -> None:
+#    reveal_type(args)
+
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTuplePep646TypeVarStarArgsVariableLengthTuple]
+from typing import Tuple
+from typing_extensions import Unpack
+
+def foo(*args: Unpack[Tuple[int, ...]]) -> None:
+    reveal_type(args)  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
+
+foo(0, 1, 2)
+# TODO: this should say 'expected "int"' rather than the unpack
+foo(0, 1, "bar")  # E: Argument 3 to "foo" has incompatible type "str"; expected "Unpack[Tuple[int, ...]]" 
+
+
+def foo2(*args: Unpack[Tuple[str, Unpack[Tuple[int, ...]], bool, bool]]) -> None:
+    reveal_type(args)  # N: Revealed type is "Tuple[builtins.str, Unpack[builtins.tuple[builtins.int, ...]], builtins.bool, builtins.bool]"
+    # TODO: generate an error
+    # reveal_type(args[1])
+
+foo2("bar", 1, 2, 3, False, True)
+foo2(0, 1, 2, 3, False, True)  # E: Argument 1 to "foo2" has incompatible type "int"; expected "Unpack[Tuple[str, Unpack[Tuple[int, ...]], bool, bool]]"
+foo2("bar", "bar", 2, 3, False, True)  # E: Argument 2 to "foo2" has incompatible type "str"; expected "Unpack[Tuple[str, Unpack[Tuple[int, ...]], bool, bool]]"
+foo2("bar", 1, 2, 3, 4, True)  # E: Argument 5 to "foo2" has incompatible type "int"; expected "Unpack[Tuple[str, Unpack[Tuple[int, ...]], bool, bool]]"
+foo2(*("bar", 1, 2, 3, False, True))
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTuplePep646Callable]
+from typing import Tuple, Callable
+from typing_extensions import Unpack, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+def call(
+    target: Callable[[ Unpack[Ts]], None],
+    args: Tuple[Unpack[Ts]],
+) -> None:
+    pass
+
+def func(arg1: int, arg2: str) -> None: ...
+
+call(target=func, args=(0, 'foo'))  # Valid
+#call(target=func, args=(True, 'foo', 0))  # Error
+#call(target=func, args=(0, 0, 'foo'))  # Error
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1474,4 +1474,12 @@ y: Unpack[TVariadic]  # E: TypeVarTuple "TVariadic" is unbound
 
 class Variadic(Generic[Unpack[TVariadic], Unpack[TVariadic2]]):  # E: Can only use one type var tuple in a class def
     pass
-[builtins fixtures/tuple.pyi]
+
+# TODO: this should generate an error
+#def bad_args(*args: TVariadic):
+#    pass
+
+def bad_kwargs(**kwargs: Unpack[TVariadic]):  # E: Unpack item in ** argument must be a TypedDict
+    pass
+
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1560,4 +1560,29 @@ MypyFile:1(
   AssignmentStmt:2(
     NameExpr(TV* [__main__.TV])
     TypeVarTupleExpr:2()))
+
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleCallable]
+from typing_extensions import TypeVarTuple, Unpack
+from typing import Callable
+Ts = TypeVarTuple("Ts")
+
+def foo(x: Callable[[Unpack[Ts]], None]) -> None:
+    pass
+[out]
+MypyFile:1(
+  ImportFrom:1(typing_extensions, [TypeVarTuple, Unpack])
+  ImportFrom:2(typing, [Callable])
+  AssignmentStmt:3(
+    NameExpr(Ts* [__main__.Ts])
+    TypeVarTupleExpr:3())
+  FuncDef:5(
+    foo
+    Args(
+      Var(x))
+    def [Ts] (x: def (*Unpack[Ts`-1]))
+    Block:5(
+      PassStmt:6())))
+
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Implements support for unpacking varlength tuples from *args, but because it became apparent that several parts of constraints building were doing nearly the same thing for typevar tuples, we begin extracting out some of the logic for re-use. Some existing callsites still should be switched to the new helpers but it is defered to future PRs.