### PR TITLE
(🐞) fix `util.plural_s` for zero and negative

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -816,7 +816,7 @@ def time_spent_us(t0: int) -> int:
 
 def plural_s(s: int | Sized) -> str:
     count = s if isinstance(s, int) else len(s)
-    if count > 1:
+    if count != 1:
         return "s"
     else:
         return ""


### PR DESCRIPTION
While this doesn't currently appear anywhere in usages, it would be incorrect to say

`0 error found` or `-4 line earlier`
