### PR TITLE
[mypyc] Faster bool and integer conversions

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -326,6 +326,11 @@ class LowLevelIRBuilder:
             ):
                 # Equivalent types
                 return src
+            elif is_bool_rprimitive(src_type) and is_int_rprimitive(target_type):
+                shifted = self.int_op(
+                    bool_rprimitive, src, Integer(1, bool_rprimitive), IntOp.LEFT_SHIFT
+                )
+                return self.add(Extend(shifted, int_rprimitive, signed=False))
             else:
                 # To go from one unboxed type to another, we go through a boxed
                 # in-between value, for simplicity.
@@ -1795,7 +1800,7 @@ class LowLevelIRBuilder:
             return target
         return None
 
-    def int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int) -> Value:
+    def int_op(self, type: RType, lhs: Value, rhs: Value, op: int, line: int = -1) -> Value:
         """Generate a native integer binary op.
 
         Use native/C semantics, which sometimes differ from Python

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -326,12 +326,16 @@ class LowLevelIRBuilder:
             ):
                 # Equivalent types
                 return src
-            elif (is_bool_rprimitive(src_type) or is_bit_rprimitive(src_type)) and is_int_rprimitive(target_type):
+            elif (
+                is_bool_rprimitive(src_type) or is_bit_rprimitive(src_type)
+            ) and is_int_rprimitive(target_type):
                 shifted = self.int_op(
                     bool_rprimitive, src, Integer(1, bool_rprimitive), IntOp.LEFT_SHIFT
                 )
                 return self.add(Extend(shifted, int_rprimitive, signed=False))
-            elif (is_bool_rprimitive(src_type) or is_bit_rprimitive(src_type)) and is_fixed_width_rtype(target_type):
+            elif (
+                is_bool_rprimitive(src_type) or is_bit_rprimitive(src_type)
+            ) and is_fixed_width_rtype(target_type):
                 return self.add(Extend(src, target_type, signed=False))
             else:
                 # To go from one unboxed type to another, we go through a boxed

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -703,19 +703,5 @@ def translate_bool(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value
     arg_type = builder.node_type(arg)
     if is_int_rprimitive(arg_type):
         src = builder.accept(arg)
-        tmp = Register(bool_rprimitive)
-        b1, b2, b3 = BasicBlock(), BasicBlock(), BasicBlock()
-        chk = builder.builder.comparison_op(
-            src, Integer(0, int_rprimitive), ComparisonOp.EQ, expr.line
-        )
-        builder.flush_keep_alives()
-        builder.add(Branch(chk, b1, b2, Branch.BOOL))
-        builder.activate_block(b1)
-        builder.add(Assign(tmp, Integer(0, bool_rprimitive)))
-        builder.add(Goto(b3))
-        builder.activate_block(b2)
-        builder.add(Assign(tmp, Integer(1, bool_rprimitive)))
-        builder.add(Goto(b3))
-        builder.activate_block(b3)
-        return tmp
+        return builder.builder.bool_value(src)
     return None

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -700,8 +700,5 @@ def translate_bool(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value
     if len(expr.args) != 1 or expr.arg_kinds[0] != ARG_POS:
         return None
     arg = expr.args[0]
-    arg_type = builder.node_type(arg)
-    if is_int_rprimitive(arg_type):
-        src = builder.accept(arg)
-        return builder.builder.bool_value(src)
-    return None
+    src = builder.accept(arg)
+    return builder.builder.bool_value(src)

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -51,6 +51,8 @@ from mypyc.ir.rtypes import (
     dict_rprimitive,
     int32_rprimitive,
     int64_rprimitive,
+    int_rprimitive,
+    is_bool_rprimitive,
     is_dict_rprimitive,
     is_int32_rprimitive,
     is_int64_rprimitive,
@@ -687,6 +689,18 @@ def translate_i32(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value 
     elif is_int_rprimitive(arg_type):
         val = builder.accept(arg)
         return builder.coerce(val, int32_rprimitive, expr.line)
+    return None
+
+
+@specialize_function("builtins.int")
+def translate_bool(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
+    if len(expr.args) != 1 or expr.arg_kinds[0] != ARG_POS:
+        return None
+    arg = expr.args[0]
+    arg_type = builder.node_type(arg)
+    if is_bool_rprimitive(arg_type) or is_int_rprimitive(arg_type):
+        src = builder.accept(arg)
+        return builder.coerce(src, int_rprimitive, expr.line)
     return None
 
 

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -33,12 +33,8 @@ from mypy.nodes import (
 )
 from mypy.types import AnyType, TypeOfAny
 from mypyc.ir.ops import (
-    Assign,
     BasicBlock,
-    Branch,
-    ComparisonOp,
     Extend,
-    Goto,
     Integer,
     RaiseStandardError,
     Register,
@@ -55,7 +51,6 @@ from mypyc.ir.rtypes import (
     dict_rprimitive,
     int32_rprimitive,
     int64_rprimitive,
-    int_rprimitive,
     is_dict_rprimitive,
     is_int32_rprimitive,
     is_int64_rprimitive,

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -54,6 +54,7 @@ from mypyc.ir.rtypes import (
     int_rprimitive,
     is_bool_rprimitive,
     is_dict_rprimitive,
+    is_fixed_width_rtype,
     is_int32_rprimitive,
     is_int64_rprimitive,
     is_int_rprimitive,
@@ -693,12 +694,16 @@ def translate_i32(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value 
 
 
 @specialize_function("builtins.int")
-def translate_bool(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
+def translate_int(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
     if len(expr.args) != 1 or expr.arg_kinds[0] != ARG_POS:
         return None
     arg = expr.args[0]
     arg_type = builder.node_type(arg)
-    if is_bool_rprimitive(arg_type) or is_int_rprimitive(arg_type):
+    if (
+        is_bool_rprimitive(arg_type)
+        or is_int_rprimitive(arg_type)
+        or is_fixed_width_rtype(arg_type)
+    ):
         src = builder.accept(arg)
         return builder.coerce(src, int_rprimitive, expr.line)
     return None

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -33,8 +33,12 @@ from mypy.nodes import (
 )
 from mypy.types import AnyType, TypeOfAny
 from mypyc.ir.ops import (
+    Assign,
     BasicBlock,
+    Branch,
+    ComparisonOp,
     Extend,
+    Goto,
     Integer,
     RaiseStandardError,
     Register,
@@ -51,6 +55,7 @@ from mypyc.ir.rtypes import (
     dict_rprimitive,
     int32_rprimitive,
     int64_rprimitive,
+    int_rprimitive,
     is_dict_rprimitive,
     is_int32_rprimitive,
     is_int64_rprimitive,
@@ -687,4 +692,30 @@ def translate_i32(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value 
     elif is_int_rprimitive(arg_type):
         val = builder.accept(arg)
         return builder.coerce(val, int32_rprimitive, expr.line)
+    return None
+
+
+@specialize_function("builtins.bool")
+def translate_bool(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
+    if len(expr.args) != 1 or expr.arg_kinds[0] != ARG_POS:
+        return None
+    arg = expr.args[0]
+    arg_type = builder.node_type(arg)
+    if is_int_rprimitive(arg_type):
+        src = builder.accept(arg)
+        tmp = Register(bool_rprimitive)
+        b1, b2, b3 = BasicBlock(), BasicBlock(), BasicBlock()
+        chk = builder.builder.comparison_op(
+            src, Integer(0, int_rprimitive), ComparisonOp.EQ, expr.line
+        )
+        builder.flush_keep_alives()
+        builder.add(Branch(chk, b1, b2, Branch.BOOL))
+        builder.activate_block(b1)
+        builder.add(Assign(tmp, Integer(0, bool_rprimitive)))
+        builder.add(Goto(b3))
+        builder.activate_block(b2)
+        builder.add(Assign(tmp, Integer(1, bool_rprimitive)))
+        builder.add(Goto(b3))
+        builder.activate_block(b3)
+        return tmp
     return None

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1108,7 +1108,9 @@ L0:
     return 1
 
 [case testCallableTypes]
-from typing import Callable
+from typing import Callable, Any
+from m import f
+
 def absolute_value(x: int) -> int:
     return x if x > 0 else -x
 
@@ -1116,7 +1118,7 @@ def call_native_function(x: int) -> int:
     return absolute_value(x)
 
 def call_python_function(x: int) -> int:
-    return int(x)
+    return f(x)
 
 def return_float() -> float:
     return 5.0
@@ -1127,6 +1129,9 @@ def return_callable_type() -> Callable[[], float]:
 def call_callable_type() -> float:
     f = return_callable_type()
     return f()
+[file m.py]
+def f(x: int) -> int:
+    return x
 [out]
 def absolute_value(x):
     x :: int
@@ -1158,14 +1163,18 @@ L0:
     return r0
 def call_python_function(x):
     x :: int
-    r0, r1, r2 :: object
-    r3 :: int
+    r0 :: dict
+    r1 :: str
+    r2, r3, r4 :: object
+    r5 :: int
 L0:
-    r0 = load_address PyLong_Type
-    r1 = box(int, x)
-    r2 = PyObject_CallFunctionObjArgs(r0, r1, 0)
-    r3 = unbox(int, r2)
-    return r3
+    r0 = __main__.globals :: static
+    r1 = 'f'
+    r2 = CPyDict_GetItem(r0, r1)
+    r3 = box(int, x)
+    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
+    r5 = unbox(int, r4)
+    return r5
 def return_float():
     r0 :: float
 L0:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3075,8 +3075,7 @@ def call_sum(l, comparison):
     r1, r2 :: object
     r3, x :: int
     r4, r5 :: object
-    r6 :: bool
-    r7 :: object
+    r6, r7 :: bool
     r8, r9 :: int
     r10 :: bit
 L0:
@@ -3091,8 +3090,8 @@ L2:
     r4 = box(int, x)
     r5 = PyObject_CallFunctionObjArgs(comparison, r4, 0)
     r6 = unbox(bool, r5)
-    r7 = box(bool, r6)
-    r8 = unbox(int, r7)
+    r7 = r6 << 1
+    r8 = extend r7: builtins.bool to builtins.int
     r9 = CPyTagged_Add(r0, r8)
     r0 = r9
 L3:

--- a/mypyc/test-data/irbuild-bool.test
+++ b/mypyc/test-data/irbuild-bool.test
@@ -1,0 +1,19 @@
+[case testBoolToAndFromInt]
+def b2i(b: bool) -> int:
+    return b
+def i2b(n: int) -> bool:
+    return bool(n)
+[out]
+def b2i(b):
+    b, r0 :: bool
+    r1 :: int
+L0:
+    r0 = b << 1
+    r1 = extend r0: builtins.bool to builtins.int
+    return r1
+def i2b(n):
+    n :: int
+    r0 :: bit
+L0:
+    r0 = n != 0
+    return r0

--- a/mypyc/test-data/irbuild-bool.test
+++ b/mypyc/test-data/irbuild-bool.test
@@ -1,19 +1,144 @@
 [case testBoolToAndFromInt]
-def b2i(b: bool) -> int:
+from mypy_extensions import i64
+
+def bool_to_int(b: bool) -> int:
     return b
-def i2b(n: int) -> bool:
+def int_to_bool(n: int) -> bool:
     return bool(n)
+def bool_to_i64(b: bool) -> i64:
+    return b
+def i64_to_bool(n: i64) -> bool:
+    return bool(n)
+def bit_to_int(n1: i64, n2: i64) -> int:
+    return bool(n1 == n2)
+def bit_to_i64(n1: i64, n2: i64) -> i64:
+    return bool(n1 == n2)
 [out]
-def b2i(b):
+def bool_to_int(b):
     b, r0 :: bool
     r1 :: int
 L0:
     r0 = b << 1
     r1 = extend r0: builtins.bool to builtins.int
     return r1
-def i2b(n):
+def int_to_bool(n):
     n :: int
     r0 :: bit
 L0:
     r0 = n != 0
     return r0
+def bool_to_i64(b):
+    b :: bool
+    r0 :: int64
+L0:
+    r0 = extend b: builtins.bool to int64
+    return r0
+def i64_to_bool(n):
+    n :: int64
+    r0 :: bit
+L0:
+    r0 = n != 0
+    return r0
+def bit_to_int(n1, n2):
+    n1, n2 :: int64
+    r0 :: bit
+    r1 :: bool
+    r2 :: int
+L0:
+    r0 = n1 == n2
+    r1 = r0 << 1
+    r2 = extend r1: builtins.bool to builtins.int
+    return r2
+def bit_to_i64(n1, n2):
+    n1, n2 :: int64
+    r0 :: bit
+    r1 :: int64
+L0:
+    r0 = n1 == n2
+    r1 = extend r0: bit to int64
+    return r1
+
+[case testBoolConversions]
+from typing import List, Optional
+
+class C: pass
+class D:
+    def __bool__(self) -> bool:
+        return True
+
+def list_to_bool(l: List[str]) -> bool:
+    return bool(l)
+
+def always_truthy_instance_to_bool(o: C) -> bool:
+    return bool(o)
+
+def instance_to_bool(o: D) -> bool:
+    return bool(o)
+
+def optional_truthy_to_bool(o: Optional[C]) -> bool:
+    return bool(o)
+
+def optional_maybe_falsey_to_bool(o: Optional[D]) -> bool:
+    return bool(o)
+[out]
+def D.__bool__(self):
+    self :: __main__.D
+L0:
+    return 1
+def list_to_bool(l):
+    l :: list
+    r0 :: ptr
+    r1 :: native_int
+    r2 :: short_int
+    r3 :: bit
+L0:
+    r0 = get_element_ptr l ob_size :: PyVarObject
+    r1 = load_mem r0 :: native_int*
+    keep_alive l
+    r2 = r1 << 1
+    r3 = r2 != 0
+    return r3
+def always_truthy_instance_to_bool(o):
+    o :: __main__.C
+    r0 :: int32
+    r1 :: bit
+    r2 :: bool
+L0:
+    r0 = PyObject_IsTrue(o)
+    r1 = r0 >= 0 :: signed
+    r2 = truncate r0: int32 to builtins.bool
+    return r2
+def instance_to_bool(o):
+    o :: __main__.D
+    r0 :: bool
+L0:
+    r0 = o.__bool__()
+    return r0
+def optional_truthy_to_bool(o):
+    o :: union[__main__.C, None]
+    r0 :: object
+    r1 :: bit
+L0:
+    r0 = load_address _Py_NoneStruct
+    r1 = o != r0
+    return r1
+def optional_maybe_falsey_to_bool(o):
+    o :: union[__main__.D, None]
+    r0 :: object
+    r1 :: bit
+    r2 :: __main__.D
+    r3 :: bool
+    r4 :: bit
+L0:
+    r0 = load_address _Py_NoneStruct
+    r1 = o != r0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    r2 = cast(__main__.D, o)
+    r3 = r2.__bool__()
+    r4 = r3
+    goto L3
+L2:
+    r4 = 0
+L3:
+    return r4

--- a/mypyc/test-data/irbuild-bool.test
+++ b/mypyc/test-data/irbuild-bool.test
@@ -58,7 +58,7 @@ L0:
     r1 = extend r0: bit to int64
     return r1
 
-[case testBoolConversions]
+[case testConversionToBool]
 from typing import List, Optional
 
 class C: pass

--- a/mypyc/test-data/irbuild-i64.test
+++ b/mypyc/test-data/irbuild-i64.test
@@ -1559,6 +1559,32 @@ L2:
 L3:
     return r3
 
+[case testI64ExplicitConversionToInt_64bit]
+from mypy_extensions import i64
+
+def f(x: i64) -> int:
+    return int(x)
+[out]
+def f(x):
+    x :: int64
+    r0, r1 :: bit
+    r2, r3, r4 :: int
+L0:
+    r0 = x <= 4611686018427387903 :: signed
+    if r0 goto L1 else goto L2 :: bool
+L1:
+    r1 = x >= -4611686018427387904 :: signed
+    if r1 goto L3 else goto L2 :: bool
+L2:
+    r2 = CPyTagged_FromInt64(x)
+    r3 = r2
+    goto L4
+L3:
+    r4 = x << 1
+    r3 = r4
+L4:
+    return r3
+
 [case testI64ExplicitConversionFromLiteral]
 from mypy_extensions import i64
 

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -203,3 +203,22 @@ L0:
 def f5():
 L0:
     return -2
+
+[case testConvertIntegralToInt]
+def bool_to_int(b: bool) -> int:
+    return int(b)
+
+def int_to_int(n: int) -> int:
+    return int(n)
+[out]
+def bool_to_int(b):
+    b, r0 :: bool
+    r1 :: int
+L0:
+    r0 = b << 1
+    r1 = extend r0: builtins.bool to builtins.int
+    return r1
+def int_to_int(n):
+    n :: int
+L0:
+    return n

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -203,23 +203,3 @@ L0:
 def f5():
 L0:
     return -2
-
-[case testBoolToAndFromInt]
-def b2i(b: bool) -> int:
-    return b
-def i2b(n: int) -> bool:
-    return bool(n)
-[out]
-def b2i(b):
-    b, r0 :: bool
-    r1 :: int
-L0:
-    r0 = b << 1
-    r1 = extend r0: builtins.bool to builtins.int
-    return r1
-def i2b(n):
-    n :: int
-    r0 :: bit
-L0:
-    r0 = n != 0
-    return r0

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -220,14 +220,6 @@ L0:
 def i2b(n):
     n :: int
     r0 :: bit
-    r1 :: bool
 L0:
-    r0 = n == 0
-    if r0 goto L1 else goto L2 :: bool
-L1:
-    r1 = 0
-    goto L3
-L2:
-    r1 = 1
-L3:
-    return r1
+    r0 = n != 0
+    return r0

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -203,3 +203,31 @@ L0:
 def f5():
 L0:
     return -2
+
+[case testBoolToAndFromInt]
+def b2i(b: bool) -> int:
+    return b
+def i2b(n: int) -> bool:
+    return bool(n)
+[out]
+def b2i(b):
+    b, r0 :: bool
+    r1 :: int
+L0:
+    r0 = b << 1
+    r1 = extend r0: builtins.bool to builtins.int
+    return r1
+def i2b(n):
+    n :: int
+    r0 :: bit
+    r1 :: bool
+L0:
+    r0 = n == 0
+    if r0 goto L1 else goto L2 :: bool
+L1:
+    r1 = 0
+    goto L3
+L2:
+    r1 = 1
+L3:
+    return r1

--- a/mypyc/test-data/run-bools.test
+++ b/mypyc/test-data/run-bools.test
@@ -15,6 +15,8 @@ True
 False
 
 [case testBoolOps]
+from typing import Optional, Any
+
 def f(x: bool) -> bool:
     if x:
         return False
@@ -27,8 +29,8 @@ def test_if() -> None:
 
 def test_bitwise_and() -> None:
     # Use eval() to avoid constand folding
-    t = eval('True')  # type: bool
-    f = eval('False')  # type: bool
+    t: bool = eval('True')
+    f: bool = eval('False')
     assert t & t == True
     assert t & f == False
     assert f & t == False
@@ -40,8 +42,8 @@ def test_bitwise_and() -> None:
 
 def test_bitwise_or() -> None:
     # Use eval() to avoid constand folding
-    t = eval('True')  # type: bool
-    f = eval('False')  # type: bool
+    t: bool = eval('True')
+    f: bool = eval('False')
     assert t | t == True
     assert t | f == True
     assert f | t == True
@@ -53,8 +55,8 @@ def test_bitwise_or() -> None:
 
 def test_bitwise_xor() -> None:
     # Use eval() to avoid constand folding
-    t = eval('True')  # type: bool
-    f = eval('False')  # type: bool
+    t: bool = eval('True')
+    f: bool = eval('False')
     assert t ^ t == False
     assert t ^ f == True
     assert f ^ t == True
@@ -66,7 +68,6 @@ def test_bitwise_xor() -> None:
     f ^= f
     assert f == False
 
-[case testIsinstanceBool]
 def test_isinstance_bool() -> None:
     a = True
     b = 1.0
@@ -76,3 +77,45 @@ def test_isinstance_bool() -> None:
     assert isinstance(b, bool) == False
     assert isinstance(c, bool) == False
     assert isinstance(d, bool) == True
+
+class C: pass
+class D:
+    def __init__(self, b: bool) -> None:
+        self.b = b
+
+    def __bool__(self) -> bool:
+        return self.b
+
+class E: pass
+class F(E):
+    def __init__(self, b: bool) -> None:
+        self.b = b
+
+    def __bool__(self) -> bool:
+        return self.b
+
+def optional_to_bool1(o: Optional[C]) -> bool:
+    return bool(o)
+
+def optional_to_bool2(o: Optional[D]) -> bool:
+    return bool(o)
+
+def optional_to_bool3(o: Optional[E]) -> bool:
+    return bool(o)
+
+def test_optional_to_bool() -> None:
+    assert not optional_to_bool1(None)
+    assert optional_to_bool1(C())
+    assert not optional_to_bool2(None)
+    assert not optional_to_bool2(D(False))
+    assert optional_to_bool2(D(True))
+    assert not optional_to_bool3(None)
+    assert optional_to_bool3(E())
+    assert not optional_to_bool3(F(False))
+    assert optional_to_bool3(F(True))
+
+def test_any_to_bool() -> None:
+    a: Any = int()
+    b: Any = a + 1
+    assert not bool(a)
+    assert bool(b)

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -62,6 +62,37 @@ def test_comparisons() -> None:
     assert one != two
     assert not (one != one2)
 
+def is_true(x: i64) -> bool:
+    if x:
+        return True
+    else:
+        return False
+
+def is_true2(x: i64) -> bool:
+    return bool(x)
+
+def is_false(x: i64) -> bool:
+    if not x:
+        return True
+    else:
+        return False
+
+def test_i64_as_bool() -> None:
+    assert not is_true(0)
+    assert not is_true2(0)
+    assert is_false(0)
+    for x in 1, 55, -1, -7, 1 << 40, -(1 << 50):
+        assert is_true(x)
+        assert is_true2(x)
+        assert not is_false(x)
+
+def bool_as_i64(b: bool) -> i64:
+    return b
+
+def test_bool_as_i64() -> None:
+    assert bool_as_i64(False) == 0
+    assert bool_as_i64(True) == 1
+
 def div_by_3(x: i64) -> i64:
     return x // 3
 

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -260,6 +260,16 @@ def test_coerce_to_and_from_int() -> None:
                     m: int = x
                     assert m == n
 
+def test_coerce_to_and_from_int2() -> None:
+    for shift in range(0, 64):
+        for sign in 1, -1:
+            for delta in range(-5, 5):
+                n = sign * (1 << shift) + delta
+                if -(1 << 63) <= n < (1 << 63):
+                    x: i64 = i64(n)
+                    m: int = int(x)
+                    assert m == n
+
 def test_explicit_conversion_to_i64() -> None:
     x = i64(5)
     assert x == 5

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -353,6 +353,9 @@ def is_true(x: int) -> bool:
     else:
         return False
 
+def is_true2(x: int) -> bool:
+    return bool(x)
+
 def is_false(x: int) -> bool:
     if not x:
         return True
@@ -361,10 +364,19 @@ def is_false(x: int) -> bool:
 
 def test_int_as_bool() -> None:
     assert not is_true(0)
+    assert not is_true2(0)
     assert is_false(0)
     for x in 1, 55, -1, -7, 1 << 50, 1 << 101, -(1 << 50), -(1 << 101):
         assert is_true(x)
+        assert is_true2(x)
         assert not is_false(x)
+
+def bool_as_int(b: bool) -> int:
+    return b
+
+def test_bool_as_int() -> None:
+    assert bool_as_int(False) == 0
+    assert bool_as_int(True) == 1
 
 def test_divide() -> None:
     for x in range(-100, 100):

--- a/mypyc/test-data/run-integers.test
+++ b/mypyc/test-data/run-integers.test
@@ -374,9 +374,21 @@ def test_int_as_bool() -> None:
 def bool_as_int(b: bool) -> int:
     return b
 
+def bool_as_int2(b: bool) -> int:
+    return int(b)
+
 def test_bool_as_int() -> None:
     assert bool_as_int(False) == 0
     assert bool_as_int(True) == 1
+    assert bool_as_int2(False) == 0
+    assert bool_as_int2(True) == 1
+
+def no_op_conversion(n: int) -> int:
+    return int(n)
+
+def test_no_op_conversion() -> None:
+    for x in 1, 55, -1, -7, 1 << 50, 1 << 101, -(1 << 50), -(1 << 101):
+        assert no_op_conversion(x) == x
 
 def test_divide() -> None:
     for x in range(-100, 100):

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -136,6 +136,9 @@ def is_true(x: str) -> bool:
     else:
         return False
 
+def is_true2(x: str) -> bool:
+    return bool(x)
+
 def is_false(x: str) -> bool:
     if not x:
         return True
@@ -145,8 +148,10 @@ def is_false(x: str) -> bool:
 def test_str_to_bool() -> None:
     assert is_false('')
     assert not is_true('')
+    assert not is_true2('')
     for x in 'a', 'foo', 'bar', 'some string':
         assert is_true(x)
+        assert is_true2(x)
         assert not is_false(x)
 
 def test_str_min_max() -> None:

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -24,6 +24,7 @@ from mypyc.test.testutil import (
 files = [
     "irbuild-basic.test",
     "irbuild-int.test",
+    "irbuild-bool.test",
     "irbuild-lists.test",
     "irbuild-tuple.test",
     "irbuild-dict.test",


### PR DESCRIPTION
Speed up various conversions between bool and integer types. These cases are covered:
* `bool(x)` for various types
* `int(x)` for `bool` and integer arguments
* Implicit coercion from `bool` to an integer type

Support both regular `int` values and native int values.

(Various small optimizations, including these, together netted a 6% performance improvement in self check.)