### PR TITLE
(🔼) update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0  # must match test-requirements.txt
+    rev: 22.12.0  # must match test-requirements.txt
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1  # must match test-requirements.txt
+    rev: 5.11.4  # must match test-requirements.txt
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8
@@ -12,5 +12,5 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear==22.9.23  # must match test-requirements.txt
-          - flake8-noqa==1.2.9       # must match test-requirements.txt
+          - flake8-bugbear==22.12.6  # must match test-requirements.txt
+          - flake8-noqa==1.3.0       # must match test-requirements.txt

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,12 +1,12 @@
 -r mypy-requirements.txt
 -r build-requirements.txt
 attrs>=18.0
-black==22.10.0  # must match version in .pre-commit-config.yaml
+black==22.12.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
 flake8==5.0.4           # must match version in .pre-commit-config.yaml
-flake8-bugbear==22.9.23 # must match version in .pre-commit-config.yaml
-flake8-noqa==1.2.9      # must match version in .pre-commit-config.yaml
-isort[colors]==5.10.1   # must match version in .pre-commit-config.yaml
+flake8-bugbear==22.12.6 # must match version in .pre-commit-config.yaml
+flake8-noqa==1.3.0      # must match version in .pre-commit-config.yaml
+isort[colors]==5.11.4   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10


### PR DESCRIPTION
update black and isort, but not flake8, it requires python 3.8