### PR TITLE
Refactoring: make the type of fullname str instead of Bogus[str]

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2178,7 +2178,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     temp = self.temp_node(sig, context=decorator)
                     fullname = None
                     if isinstance(decorator, RefExpr):
-                        fullname = decorator.fullname
+                        fullname = decorator.fullname or None
 
                     # TODO: Figure out how to have clearer error messages.
                     # (e.g. "class decorator must be a function that accepts a type."
@@ -4598,7 +4598,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             temp = self.temp_node(sig, context=e)
             fullname = None
             if isinstance(d, RefExpr):
-                fullname = d.fullname
+                fullname = d.fullname or None
             # if this is a expression like @b.a where b is an object, get the type of b
             # so we can pass it the method hook in the plugins
             object_type: Type | None = None

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -536,7 +536,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             #   get_method_hook() and get_method_signature_hook() will
             #   be invoked for these.
             if (
-                fullname is None
+                not fullname
                 and isinstance(e.callee, MemberExpr)
                 and self.chk.has_type(e.callee.expr)
             ):
@@ -605,7 +605,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif isinstance(object_type, TupleType):
             type_name = tuple_fallback(object_type).type.fullname
 
-        if type_name is not None:
+        if type_name:
             return f"{type_name}.{method_name}"
         else:
             return None

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -216,8 +216,8 @@ def extract_refexpr_names(expr: RefExpr) -> set[str]:
     Note that currently, the only two subclasses of RefExpr are NameExpr and
     MemberExpr."""
     output: set[str] = set()
-    while isinstance(expr.node, MypyFile) or expr.fullname is not None:
-        if isinstance(expr.node, MypyFile) and expr.fullname is not None:
+    while isinstance(expr.node, MypyFile) or expr.fullname:
+        if isinstance(expr.node, MypyFile) and expr.fullname:
             # If it's None, something's wrong (perhaps due to an
             # import cycle or a suppressed error).  For now we just
             # skip it.
@@ -228,7 +228,7 @@ def extract_refexpr_names(expr: RefExpr) -> set[str]:
             if isinstance(expr.node, TypeInfo):
                 # Reference to a class or a nested class
                 output.update(split_module_names(expr.node.module_name))
-            elif expr.fullname is not None and "." in expr.fullname and not is_suppressed_import:
+            elif "." in expr.fullname and not is_suppressed_import:
                 # Everything else (that is not a silenced import within a class)
                 output.add(expr.fullname.rsplit(".", 1)[0])
             break
@@ -526,7 +526,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # There are two special cases where plugins might act:
             # * A "static" reference/alias to a class or function;
             #   get_function_hook() will be invoked for these.
-            fullname = e.callee.fullname
+            fullname = e.callee.fullname or None
             if isinstance(e.callee.node, TypeAlias):
                 target = get_proper_type(e.callee.node.target)
                 if isinstance(target, Instance):
@@ -5489,7 +5489,7 @@ def type_info_from_type(typ: Type) -> TypeInfo | None:
 
 
 def is_operator_method(fullname: str | None) -> bool:
-    if fullname is None:
+    if not fullname:
         return False
     short_name = fullname.split(".")[-1]
     return (

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -287,7 +287,7 @@ class DefinedVariableTracker:
 
 
 def refers_to_builtin(o: RefExpr) -> bool:
-    return o.fullname is not None and o.fullname.startswith("builtins.")
+    return o.fullname.startswith("builtins.")
 
 
 class Loop:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3022,13 +3022,13 @@ class SemanticAnalyzer(
     def apply_dynamic_class_hook(self, s: AssignmentStmt) -> None:
         if not isinstance(s.rvalue, CallExpr):
             return
-        fname = None
+        fname = ""
         call = s.rvalue
         while True:
             if isinstance(call.callee, RefExpr):
                 fname = call.callee.fullname
             # check if method call
-            if fname is None and isinstance(call.callee, MemberExpr):
+            if not fname and isinstance(call.callee, MemberExpr):
                 callee_expr = call.callee.expr
                 if isinstance(callee_expr, RefExpr) and callee_expr.fullname:
                     method_name = call.callee.name
@@ -4624,7 +4624,7 @@ class SemanticAnalyzer(
         else:
             expr.kind = sym.kind
             expr.node = sym.node
-            expr.fullname = sym.fullname
+            expr.fullname = sym.fullname or ""
 
     def visit_super_expr(self, expr: SuperExpr) -> None:
         if not self.type and not expr.call.args:
@@ -4849,7 +4849,7 @@ class SemanticAnalyzer(
                     self.process_placeholder(expr.name, "attribute", expr)
                     return
                 expr.kind = sym.kind
-                expr.fullname = sym.fullname
+                expr.fullname = sym.fullname or ""
                 expr.node = sym.node
         elif isinstance(base, RefExpr):
             # This branch handles the case C.bar (or cls.bar or self.bar inside
@@ -4881,7 +4881,7 @@ class SemanticAnalyzer(
                     if not n:
                         return
                     expr.kind = n.kind
-                    expr.fullname = n.fullname
+                    expr.fullname = n.fullname or ""
                     expr.node = n.node
 
     def visit_op_expr(self, expr: OpExpr) -> None:
@@ -5341,7 +5341,7 @@ class SemanticAnalyzer(
         return False
 
     def is_defined_in_current_module(self, fullname: str | None) -> bool:
-        if fullname is None:
+        if not fullname:
             return False
         return module_prefix(self.modules, fullname) == self.cur_mod_id
 

--- a/mypy/server/aststrip.py
+++ b/mypy/server/aststrip.py
@@ -230,7 +230,7 @@ class NodeStripVisitor(TraverserVisitor):
     def strip_ref_expr(self, node: RefExpr) -> None:
         node.kind = None
         node.node = None
-        node.fullname = None
+        node.fullname = ""
         node.is_new_def = False
         node.is_inferred_def = False
 

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -289,13 +289,9 @@ class DependencyVisitor(TraverserVisitor):
             # all call sites, making them all `Any`.
             for d in o.decorators:
                 tname: str | None = None
-                if isinstance(d, RefExpr) and d.fullname is not None:
+                if isinstance(d, RefExpr) and d.fullname:
                     tname = d.fullname
-                if (
-                    isinstance(d, CallExpr)
-                    and isinstance(d.callee, RefExpr)
-                    and d.callee.fullname is not None
-                ):
+                if isinstance(d, CallExpr) and isinstance(d.callee, RefExpr) and d.callee.fullname:
                     tname = d.callee.fullname
                 if tname is not None:
                     self.add_dependency(make_trigger(tname), make_trigger(o.func.fullname))
@@ -500,7 +496,7 @@ class DependencyVisitor(TraverserVisitor):
             if (
                 isinstance(rvalue, CallExpr)
                 and isinstance(rvalue.callee, RefExpr)
-                and rvalue.callee.fullname is not None
+                and rvalue.callee.fullname
             ):
                 fname: str | None = None
                 if isinstance(rvalue.callee.node, TypeInfo):
@@ -638,7 +634,7 @@ class DependencyVisitor(TraverserVisitor):
     # Expressions
 
     def process_global_ref_expr(self, o: RefExpr) -> None:
-        if o.fullname is not None:
+        if o.fullname:
             self.add_dependency(make_trigger(o.fullname))
 
         # If this is a reference to a type, generate a dependency to its

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -506,7 +506,7 @@ class DependencyVisitor(TraverserVisitor):
                         fname = init.node.fullname
                 else:
                     fname = rvalue.callee.fullname
-                if fname is None:
+                if not fname:
                     return
                 for lv in o.lvalues:
                     if isinstance(lv, RefExpr) and lv.fullname and lv.is_new_def:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -367,7 +367,7 @@ class StrConv(NodeVisitor[str]):
             id = ""
         if isinstance(target_node, mypy.nodes.MypyFile) and name == fullname:
             n += id
-        elif kind == mypy.nodes.GDEF or (fullname != name and fullname is not None):
+        elif kind == mypy.nodes.GDEF or (fullname != name and fullname):
             # Append fully qualified name for global references.
             n += f" [{fullname}{id}]"
         elif kind == mypy.nodes.LDEF:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1147,7 +1147,7 @@ def _resolve_funcitem_from_decorator(dec: nodes.OverloadPart) -> nodes.FuncItem 
     ) -> nodes.FuncItem | None:
         if not isinstance(decorator, nodes.RefExpr):
             return None
-        if decorator.fullname is None:
+        if not decorator.fullname:
             # Happens with namedtuple
             return None
         if (

--- a/mypy/test/testsemanal.py
+++ b/mypy/test/testsemanal.py
@@ -202,7 +202,7 @@ class SemAnalTypeInfoSuite(DataSuite):
             for f in result.files.values():
                 for n in f.names.values():
                     if isinstance(n.node, TypeInfo):
-                        assert n.fullname is not None
+                        assert n.fullname
                         typeinfos[n.fullname] = n.node
 
             # The output is the symbol table converted into a string.

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -129,7 +129,7 @@ class TypeVarLikeScope:
 
     def get_binding(self, item: str | SymbolTableNode) -> TypeVarLikeType | None:
         fullname = item.fullname if isinstance(item, SymbolTableNode) else item
-        assert fullname is not None
+        assert fullname
         if fullname in self.scope:
             return self.scope[fullname]
         elif self.parent is not None:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1123,7 +1123,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         return TypeType.make_normalized(self.anal_type(t.item), line=t.line)
 
     def visit_placeholder_type(self, t: PlaceholderType) -> Type:
-        n = None if t.fullname is None else self.api.lookup_fully_qualified(t.fullname)
+        n = None if not t.fullname else self.api.lookup_fully_qualified(t.fullname)
         if not n or isinstance(n.node, PlaceholderNode):
             self.api.defer()  # Still incomplete
             return t

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1240,7 +1240,7 @@ class IRBuilder:
             and isinstance(expr.node, TypeInfo)
             and not self.is_synthetic_type(expr.node)
         ):
-            assert expr.fullname is not None
+            assert expr.fullname
             return self.load_native_type_object(expr.fullname)
         return self.load_global_str(expr.name, expr.line)
 

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1001,7 +1001,7 @@ class IRBuilder:
     ) -> Value:
 
         # Handle data-driven special-cased primitive call ops.
-        if callee.fullname is not None and expr.arg_kinds == [ARG_POS] * len(arg_values):
+        if callee.fullname and expr.arg_kinds == [ARG_POS] * len(arg_values):
             call_c_ops_candidates = function_ops.get(callee.fullname, [])
             target = self.builder.matching_call_c(
                 call_c_ops_candidates, arg_values, expr.line, self.node_type(expr)
@@ -1026,7 +1026,7 @@ class IRBuilder:
             callee_node = callee_node.func
         if (
             callee_node is not None
-            and callee.fullname is not None
+            and callee.fullname
             and callee_node in self.mapper.func_to_decl
             and all(kind in (ARG_POS, ARG_NAMED) for kind in expr.arg_kinds)
         ):

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -789,7 +789,7 @@ def load_type(builder: IRBuilder, typ: TypeInfo, line: int) -> Value:
 
 
 def load_func(builder: IRBuilder, func_name: str, fullname: str | None, line: int) -> Value:
-    if fullname is not None and not fullname.startswith(builder.current_module):
+    if fullname and not fullname.startswith(builder.current_module):
         # we're calling a function in a different module
 
         # We can't use load_module_attr_by_fullname here because we need to load the function using

--- a/test-data/unit/plugins/customentry.py
+++ b/test-data/unit/plugins/customentry.py
@@ -4,7 +4,7 @@ class MyPlugin(Plugin):
     def get_function_hook(self, fullname):
         if fullname == '__main__.f':
             return my_hook
-        assert fullname is not None
+        assert fullname
         return None
 
 def my_hook(ctx):


### PR DESCRIPTION
The type Bogus[X] is treated as Any when the code is compiled with mypyc, while it's equivalent to X when only type checking. They are sometimes used when X is not actually the real type of a value, but changing it to the correct type would be complicated.

Bogus[str] types are pretty awkward, since we are lying to the type checker and mypyc only sees Any types.

An empty fullname is now represented by "" instead of None, so we no longer need a Bogus[str] type.

This might break some plugins, so we should document this in release notes and the relevant issue that tracks plugin incompatibilities.

(Various small optimizations, including this, together netted a 6% performance improvement in self check.)