### PR TITLE
Fix checking multiple assignments based on tuple unpacking involving partially initialised variables (Fixes #12915).

### DIFF
--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -168,9 +168,8 @@ if int():
     ab, ao = f(b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 if int():
     ao, ab = f(b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-
 if int():
-    ao, ao = f(b)
+    ao, ao = f(b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 if int():
     ab, ab = f(b)
 if int():
@@ -199,11 +198,10 @@ if int():
     ao, ab, ab, ab = h(b, b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 if int():
     ab, ab, ao, ab = h(b, b) # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
-
 if int():
-    ao, ab, ab = f(b, b)
+    ao, ab, ab = f(b, b)     # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 if int():
-    ab, ab, ao = g(b, b)
+    ab, ab, ao = g(b, b)     # E: Incompatible types in assignment (expression has type "A[B]", variable has type "A[object]")
 if int():
     ab, ab, ab, ab = h(b, b)
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1919,6 +1919,54 @@ class C:
         a = 42
 [out]
 
+[case testDefinePartiallyInitialisedVariableDuringTupleUnpacking]
+# flags: --strict-optional
+from typing import Tuple, Union
+
+t1: Union[Tuple[None], Tuple[str]]
+x1 = None
+x1, = t1
+reveal_type(x1)  # N: Revealed type is "Union[None, builtins.str]"
+
+t2: Union[Tuple[str], Tuple[None]]
+x2 = None
+x2, = t2
+reveal_type(x2)  # N: Revealed type is "Union[builtins.str, None]"
+
+t3: Union[Tuple[int], Tuple[str]]
+x3 = None
+x3, = t3
+reveal_type(x3)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def f() -> Union[
+    Tuple[None, None, None, int, int, int, int, int, int],
+    Tuple[None, None, None, int, int, int, str, str, str]
+    ]: ...
+a1 = None
+b1 = None
+c1 = None
+a2: object
+b2: object
+c2: object
+a1, a2, a3, b1, b2, b3, c1, c2, c3 = f()
+reveal_type(a1)  # N: Revealed type is "None"
+reveal_type(a2)  # N: Revealed type is "None"
+reveal_type(a3)  # N: Revealed type is "None"
+reveal_type(b1)  # N: Revealed type is "builtins.int"
+reveal_type(b2)  # N: Revealed type is "builtins.int"
+reveal_type(b3)  # N: Revealed type is "builtins.int"
+reveal_type(c1)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+reveal_type(c2)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+reveal_type(c3)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+tt: Tuple[Union[Tuple[None], Tuple[str], Tuple[int]]]
+z = None
+z, = tt[0]
+reveal_type(z)  # N: Revealed type is "Union[None, builtins.str, builtins.int]"
+
+[builtins fixtures/tuple.pyi]
+
+
 -- More partial type errors
 -- ------------------------
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1054,7 +1054,8 @@ def g(x: T) -> Tuple[T, T]:
     return (x, x)
 
 z = 1
-x, y = g(z) # E: Argument 1 to "g" has incompatible type "int"; expected "Tuple[B1, B2]"
+x, y = g(z) # E: Incompatible types in assignment (expression has type "int", variable has type "Tuple[A, ...]") \
+            # E: Incompatible types in assignment (expression has type "int", variable has type "Tuple[Union[B1, C], Union[B2, C]]")
 [builtins fixtures/tuple.pyi]
 [out]
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -619,7 +619,7 @@ from typing import Union, Tuple
 a: Union[Tuple[int, int], Tuple[int, float]]
 a1: object
 a2: int
-(a1, a2) = a  # E: Incompatible types in assignment (expression has type "float", variable has type "int")
+(a1, a2) = a  # E: Incompatible types in assignment (expression has type "Union[int, float]", variable has type "int")
 
 b: Union[Tuple[float, int], Tuple[int, int]]
 b1: object
@@ -721,10 +721,11 @@ reveal_type(d) # N: Revealed type is "builtins.list[builtins.int]"
 from typing import Union
 bad: Union[int, str]
 
-x, y = bad # E: "int" object is not iterable \
-           # E: Unpacking a string is disallowed
-reveal_type(x) # N: Revealed type is "Any"
-reveal_type(y) # N: Revealed type is "Any"
+x, y = bad     # E: "int" object is not iterable
+reveal_type(x) # E: Cannot determine type of "x" \
+               # N: Revealed type is "Any"
+reveal_type(y) # E: Cannot determine type of "y" \
+               # N: Revealed type is "Any"
 [out]
 
 [case testStringDisallowedUnpacking]
@@ -746,8 +747,10 @@ from typing import Union, Tuple
 bad: Union[Tuple[int, int, int], Tuple[str, str, str]]
 
 x, y = bad # E: Too many values to unpack (2 expected, 3 provided)
-reveal_type(x) # N: Revealed type is "Any"
-reveal_type(y) # N: Revealed type is "Any"
+reveal_type(x) # E: Cannot determine type of "x" \
+               # N: Revealed type is "Any"
+reveal_type(y) # E: Cannot determine type of "y" \
+               # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -756,10 +759,14 @@ from typing import Union, Tuple
 bad: Union[Tuple[int, int, int], Tuple[str, str, str]]
 
 x, y, z, w = bad # E: Need more than 3 values to unpack (4 expected)
-reveal_type(x) # N: Revealed type is "Any"
-reveal_type(y) # N: Revealed type is "Any"
-reveal_type(z) # N: Revealed type is "Any"
-reveal_type(w) # N: Revealed type is "Any"
+reveal_type(x) # E: Cannot determine type of "x" \
+               # N: Revealed type is "Any"
+reveal_type(y) # E: Cannot determine type of "y" \
+               # N: Revealed type is "Any"
+reveal_type(z) # E: Cannot determine type of "z" \
+               # N: Revealed type is "Any"
+reveal_type(w) # E: Cannot determine type of "w" \
+               # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -819,6 +826,125 @@ reveal_type(z) # N: Revealed type is "Union[builtins.int, builtins.str]"
 reveal_type(lst) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.str]]"
 [builtins fixtures/list.pyi]
 [out]
+
+[case testUnionUnpackingIncludingListPackingSameItemTypes]
+from typing import Tuple, Union
+t: Union[Tuple[int, int], Tuple[float, float, float], Tuple[str, str, str, str]]
+
+a1, = t          # E: Too many values to unpack (1 expected, 2 provided)
+reveal_type(a1)  # E: Cannot determine type of "a1" \
+                 # N: Revealed type is "Any"
+*b2, = t
+reveal_type(b2)  # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.float], builtins.list[builtins.str]]"
+a1, b2 = t       # E: Too many values to unpack (2 expected, 3 provided)
+*c2, d2 = t
+reveal_type(c2)  # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.float], builtins.list[builtins.str]]"
+reveal_type(d2)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+e2, *h2 = t
+reveal_type(e2)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+reveal_type(h2)  # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.float], builtins.list[builtins.str]]"
+
+a3, b3, c3 = t   # E: Need more than 2 values to unpack (3 expected)
+
+*e3, f3, g3 = t
+reveal_type(e3)  # N: Revealed type is "Union[builtins.list[builtins.float], builtins.list[builtins.str]]"
+reveal_type(f3)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+reveal_type(g3)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+
+h3, *i3, j3 = t
+reveal_type(h3)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+reveal_type(i3)  # N: Revealed type is "Union[builtins.list[builtins.float], builtins.list[builtins.str]]"
+reveal_type(g3)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+
+k3, l3, *m3 = t
+reveal_type(k3)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+reveal_type(l3)  # N: Revealed type is "Union[builtins.int, builtins.float, builtins.str]"
+reveal_type(m3)  # N: Revealed type is "Union[builtins.list[builtins.float], builtins.list[builtins.str]]"
+
+a4, b4, c4, d4 = t  # E: Need more than 2 values to unpack (4 expected)
+
+*e4, f4, g4, h4 = t   # E: Need more than 2 values to unpack (3 expected)
+
+[builtins fixtures/tuple.pyi]
+
+[case testUnionUnpackingIncludingListPackingDifferentItemTypes]
+from typing import Tuple, Union
+
+class A1: ...
+class B1: ...
+class C1: ...
+class D1: ...
+class A2: ...
+class B2: ...
+class C2: ...
+class D2: ...
+
+t: Union[Tuple[A1, B1, C1, D1], Tuple[A2, B2, C2, D2]]
+
+a1, b1, c1, d1 = t
+reveal_type(a1)  # N: Revealed type is "Union[__main__.A1, __main__.A2]"
+reveal_type(b1)  # N: Revealed type is "Union[__main__.B1, __main__.B2]"
+reveal_type(c1)  # N: Revealed type is "Union[__main__.C1, __main__.C2]"
+reveal_type(d1)  # N: Revealed type is "Union[__main__.D1, __main__.D2]"
+
+a2, *bc2, d2 = t
+reveal_type(a2)   # N: Revealed type is "Union[__main__.A1, __main__.A2]"
+reveal_type(bc2)  # N: Revealed type is "Union[builtins.list[Union[__main__.B1, __main__.C1]], builtins.list[Union[__main__.B2, __main__.C2]]]"
+reveal_type(d2)   # N: Revealed type is "Union[__main__.D1, __main__.D2]"
+
+*abc3, d3 = t
+reveal_type(abc3)  # N: Revealed type is "Union[builtins.list[Union[__main__.A1, __main__.B1, __main__.C1]], builtins.list[Union[__main__.A2, __main__.B2, __main__.C2]]]"
+reveal_type(d3)    # N: Revealed type is "Union[__main__.D1, __main__.D2]"
+
+a4, *bcd4 = t
+reveal_type(a4)    # N: Revealed type is "Union[__main__.A1, __main__.A2]"
+reveal_type(bcd4)  # N: Revealed type is "Union[builtins.list[Union[__main__.B1, __main__.C1, __main__.D1]], builtins.list[Union[__main__.B2, __main__.C2, __main__.D2]]]"
+
+*abcd5, = t
+reveal_type(abcd5)  # N: Revealed type is "Union[builtins.list[Union[__main__.A1, __main__.B1, __main__.C1, __main__.D1]], builtins.list[Union[__main__.A2, __main__.B2, __main__.C2, __main__.D2]]]"
+
+[builtins fixtures/tuple.pyi]
+
+[case testUnionUnpackingIncludingListPackingForVariousItemTypes]
+from typing import Any, List, Tuple, Union
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+
+t1: Union[Tuple[A, B]]
+a1, b1, *c1 = t1  # E: Need type annotation for "c1" (hint: "c1: List[<type>] = ...")
+reveal_type(a1)   # N: Revealed type is "__main__.A"
+reveal_type(b1)   # N: Revealed type is "__main__.B"
+reveal_type(c1)   # N: Revealed type is "builtins.list[Any]"
+
+t2: Union[Tuple[A, B], List[D]]
+a2, b2, *c2 = t2
+reveal_type(a2)   # N: Revealed type is "Union[__main__.A, __main__.D]"
+reveal_type(b2)   # N: Revealed type is "Union[__main__.B, __main__.D]"
+reveal_type(c2)   # N: Revealed type is "builtins.list[__main__.D]"
+
+t3: Union[Tuple[A, B, C], List[D]]
+a3, b3, *c3 = t3
+reveal_type(a3)   # N: Revealed type is "Union[__main__.A, __main__.D]"
+reveal_type(b3)   # N: Revealed type is "Union[__main__.B, __main__.D]"
+reveal_type(c3)   # N: Revealed type is "Union[builtins.list[__main__.C], builtins.list[__main__.D]]"
+
+t4: Union[Tuple[A, B, C], List[D], Any]
+a4, b4, *c4 = t4
+reveal_type(a4)   # N: Revealed type is "Union[__main__.A, __main__.D, Any]"
+reveal_type(b4)   # N: Revealed type is "Union[__main__.B, __main__.D, Any]"
+reveal_type(c4)   # N: Revealed type is "Union[builtins.list[__main__.C], builtins.list[__main__.D], builtins.list[Any]]"
+
+t5: Union[Tuple[A, B, C], str]
+a5, b5, *c5 = t5  # E: Unpacking a string is disallowed
+
+t6: Union[Tuple[A, B, C], D]
+a6, b6, *c6 = t6  # E: "D" object is not iterable
+
+[builtins fixtures/tuple.pyi]
+
 
 [case testUnionUnpackingInForTuple]
 from typing import Union, Tuple, NamedTuple
@@ -977,8 +1103,9 @@ from typing import Dict, Tuple, List, Any
 
 a: Any
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
-x, _ = d.get(a, ([], []))
-reveal_type(x) # N: Revealed type is "Union[builtins.list[Tuple[builtins.str, builtins.str]], builtins.list[<nothing>]]"
+x, _ = d.get(a, ([], []))  # E: Need type annotation for "x" \
+                           # E: Need type annotation for "_"
+reveal_type(x) # N: Revealed type is "Union[builtins.list[Tuple[builtins.str, builtins.str]], builtins.list[Any]]"
 
 for y in x: pass
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -531,19 +531,19 @@ T = TypeVar('T')
 a, b, aa = None, None, None # type: (A, B, List[A])
 
 if int():
-    a, b = f(*aa)    # E: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
+    a, b = f(*aa)       # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 if int():
-    b, b = f(*aa)    # E: Argument 1 to "f" has incompatible type "*List[A]"; expected "B"
+    b, b = f(*aa)       # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 if int():
-    a, a = f(b, *aa) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
+    a, a = f(b, *aa)    # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 if int():
-    b, b = f(b, *aa) # E: Argument 2 to "f" has incompatible type "*List[A]"; expected "B"
+    b, b = f(b, *aa)    # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 if int():
-    b, b = f(b, b, *aa) # E: Argument 3 to "f" has incompatible type "*List[A]"; expected "B"
+    b, b = f(b, b, *aa) # E: Incompatible types in assignment (expression has type "object", variable has type "B")
 if int():
-    a, b = f(a, *a)  # E: List or tuple expected as variadic arguments
+    a, b = f(a, *a)     # E: List or tuple expected as variadic arguments
 if int():
-    a, b = f(*a)     # E: List or tuple expected as variadic arguments
+    a, b = f(*a)        # E: List or tuple expected as variadic arguments
 
 if int():
     a, a = f(*aa)
@@ -566,13 +566,13 @@ T = TypeVar('T')
 a, b = None, None # type: (A, B)
 
 if int():
-    a, a = f(*(a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B]"; expected "A"
+    a, a = f(*(a, b))   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 if int():
-    b, b = f(a, *(b,))  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
+    b, b = f(a, *(b,))  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 if int():
-    a, a = f(*(a, b))   # E: Argument 1 to "f" has incompatible type "*Tuple[A, B]"; expected "A"
+    a, a = f(*(a, b))   # E: Incompatible types in assignment (expression has type "B", variable has type "A")
 if int():
-    b, b = f(a, *(b,))  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
+    b, b = f(a, *(b,))  # E: Incompatible types in assignment (expression has type "A", variable has type "B")
 if int():
     a, b = f(*(a, b, b)) # E: Too many arguments for "f"
 if int():
@@ -606,16 +606,18 @@ if int():
     aa, a = G().f(*[a]) # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "A")
 if int():
     ab, aa = G().f(*[a]) \
+      # E: Incompatible types in assignment (expression has type "List[A]", variable has type "List[B]") \
       # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]") \
       # N: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance \
-      # N: Consider using "Sequence" instead, which is covariant \
-      # E: Argument 1 to "f" of "G" has incompatible type "*List[A]"; expected "B"
+      # N: Consider using "Sequence" instead, which is covariant
 
 if int():
     ao, ao = G().f(*[a]) \
-      # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[object]") \
+      # E: Incompatible types in assignment (expression has type "List[A]", variable has type "List[object]") \
       # N: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance \
-      # N: Consider using "Sequence" instead, which is covariant
+      # N: Consider using "Sequence" instead, which is covariant \
+      # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[object]")
+
 if int():
     aa, aa = G().f(*[a]) \
       # E: Incompatible types in assignment (expression has type "List[<nothing>]", variable has type "List[A]") \


### PR DESCRIPTION
Fix checking multiple assignments based on tuple unpacking involving partially initialised variables (Fixes #12915).

This proposal is an alternative to #14423.  Similar to #14423, the main idea is to convert unions of tuples to tuples of (simplified) unions during multi-assignment checks.  In addition, it extends this idea to other iterable types, which allows removing the `undefined_rvalue` logic and the `no_partial_types` logic.  Hence, the problem reported in #12915 with partially initialised variables should be fixed for unions that combine, for example, tuples and lists, as well.

Besides the new test case also provided by #14423 (`testDefinePartiallyInitialisedVariableDuringTupleUnpacking`), this commit also adds the test cases `testUnionUnpackingIncludingListPackingSameItemTypes`, `testUnionUnpackingIncludingListPackingDifferentItemTypes`, and `testUnionUnpackingIncludingListPackingForVariousItemTypes`.
