### PR TITLE
Add binary files to stubgen blacklisted path

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1410,7 +1410,9 @@ def remove_blacklisted_modules(modules: list[StubSource]) -> list[StubSource]:
 
 
 def is_blacklisted_path(path: str) -> bool:
-    return any(substr in (normalize_path_separators(path) + "\n") for substr in BLACKLIST)
+    return path.endswith((".dll", ".so")) or any(
+        substr in (normalize_path_separators(path) + "\n") for substr in BLACKLIST
+    )
 
 
 def normalize_path_separators(path: str) -> str:


### PR DESCRIPTION
Add binary files to stubgen blacklisted path. `.so` for Linux and macOS. `.dll` for Windows.
Fixes #14028

References: https://github.com/python/typeshed/tree/main/stubs/pywin32 and https://github.com/python/typeshed/tree/main/stubs/tree-sitter-languages/%40tests