### PR TITLE
[mypyc] Always emit warnings

### DIFF
--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -223,3 +223,9 @@ def h(arg: str) -> None:
 @a.register
 def i(arg: Foo) -> None:
     pass
+
+[case testOnlyWarningOutput]
+# cmd: test.py
+
+[file test.py]
+names = (str(v) for v in [1, 2, 3])  # W: Treating generator comprehension as list

--- a/mypyc/test/test_commandline.py
+++ b/mypyc/test/test_commandline.py
@@ -58,6 +58,11 @@ class TestCommandLine(MypycDataSuite):
             )
             if "ErrorOutput" in testcase.name or cmd.returncode != 0:
                 out += cmd.stdout
+            elif "WarningOutput" in testcase.name:
+                # Strip out setuptools build related output since we're only
+                # interested in the messages emitted during compilation.
+                messages, _, _ = cmd.stdout.partition(b"running build_ext")
+                out += messages
 
             if cmd.returncode == 0:
                 # Run main program


### PR DESCRIPTION
For example the warning for "treating generator comprehension as list" doesn't get printed unless there were errors too. This was due to the fact mypyc/build.py was only checking errors.num_errors to decide whether to print messages to STDOUT.

To be honest, the generate_c() logic was pretty messy, so I broke out the message printing logic into a separate helper function and made liberal use of early exits.

Fixes https://github.com/mypyc/mypyc/issues/873#issuecomment-871055474.
