### PR TITLE
Add scripts for running mypy and mypyc tests inside a Docker container

### DIFF
--- a/misc/docker/Dockerfile
+++ b/misc/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:latest
+
+WORKDIR /mypy
+
+RUN apt-get update
+RUN apt-get install -y python3 python3-pip clang
+
+COPY mypy-requirements.txt .
+COPY test-requirements.txt .
+COPY build-requirements.txt .
+
+RUN pip3 install -r test-requirements.txt

--- a/misc/docker/README.md
+++ b/misc/docker/README.md
@@ -22,8 +22,15 @@ Prerequisites
 
 First install Docker. On macOS, both Docker Desktop (proprietary, but
 with a free of charge subscription for some use cases) and Colima (MIT
-license) should work as runtimes. You may have to explicitly start the
-runtime.
+license) should work as runtimes.
+
+You may have to explicitly start the runtime first. Colima example
+(replace '8' with the number of CPU cores you have):
+
+```
+$ colima start -c 8
+
+```
 
 How to run tests
 ----------------
@@ -80,15 +87,15 @@ File system changes within the container are not visible to the host
 system. You can't use the container to format code using Black, for
 example.
 
-On a mac, you may want to give more CPU to the VM used to run the
-container. The default allocation may be way too low (e.g. 2 CPUs).
-For example, use the `-c` option when starting the VM if you use
-Colima:
+On a mac, you may want to give additional CPU to the VM used to run
+the container. The default allocation may be way too low (e.g. 2 CPU
+cores). For example, use the `-c` option when starting the VM if you
+use Colima:
 
 ```
 $ colima start -c 8
 ```
 
 Giving access to all available CPUs to the Linux VM tends to provide
-the best performance. This is unncessary on a Linux host, since the
+the best performance. This is not needed on a Linux host, since the
 container is not run in a VM.

--- a/misc/docker/README.md
+++ b/misc/docker/README.md
@@ -2,24 +2,31 @@ Running mypy and mypyc tests in a Docker container
 ==================================================
 
 This directory contains scripts for running mypy and mypyc tests in a
-Linux Docker container. This allows running Linux tests under a
-different operating system that supports Docker, or running tests in
-an isolated environment under a Linux host operating system.
+Linux Docker container. This allows running Linux tests on a different
+operating system that supports Docker, or running tests in an
+isolated, predictable environment on a Linux host operating system.
 
 Why use Docker?
 ---------------
 
-Mypyc tests in particular can be much faster in a Docker container
-than running on the host operating system.
+Mypyc tests can be significantly faster in a Docker container than
+running natively on macOS.
 
 Also, if it's inconvient to install the necessary dependencies on the
-host operating system, or there are issues running some tests on the
-host operating system, using a container can help.
+host operating system, or there are issues getting some tests to pass
+on the host operating system, using a container can be an easy
+workaround.
+
+Prerequisites
+-------------
+
+First install Docker. On macOS, both Docker Desktop (proprietary, but
+with a free of charge subscription for some use cases) and Colima (MIT
+license) should work as runtimes. You may have to explicitly start the
+runtime.
 
 How to run tests
 ----------------
-
-First install Docker.
 
 You need to build the container with all necessary dependencies before
 you can run tests:
@@ -54,7 +61,7 @@ $ misc/docker/run.sh pytest mypyc
 
 You can also use `-k <filter>`, `-n0`, `-q`, etc.
 
-Again, you may need to run this as root:
+Again, you may need to run `run.sh` as root:
 
 ```
 $ sudo misc/docker/run.sh pytest mypyc
@@ -65,3 +72,17 @@ You can also use `runtests.py` in the container. Example:
 ```
 $ misc/docker/run.sh ./runtests.py self lint
 ```
+
+Notes
+-----
+
+On a mac, you may want to try using different CPU allocations for the
+container. The default allocation may be quite low (e.g. 2 CPUs). For
+example, to use 4 CPUs when using Colima, use the `-c` option when
+starting the VM:
+
+```
+$ colima start -c 4
+```
+
+Giving access to all available CPUs for the VM may not be optimal.

--- a/misc/docker/README.md
+++ b/misc/docker/README.md
@@ -1,0 +1,67 @@
+Running mypy and mypyc tests in a Docker container
+==================================================
+
+This directory contains scripts for running mypy and mypyc tests in a
+Linux Docker container. This allows running Linux tests under a
+different operating system that supports Docker, or running tests in
+an isolated environment under a Linux host operating system.
+
+Why use Docker?
+---------------
+
+Mypyc tests in particular can be much faster in a Docker container
+than running on the host operating system.
+
+Also, if it's inconvient to install the necessary dependencies on the
+host operating system, or there are issues running some tests on the
+host operating system, using a container can help.
+
+How to run tests
+----------------
+
+First install Docker.
+
+You need to build the container with all necessary dependencies before
+you can run tests:
+
+```
+$ python3 misc/docker/build.py
+```
+
+This creates a `mypy-test` Docker container that you can use to run
+tests.
+
+You may need to run the script as root:
+
+```
+$ sudo python3 misc/docker/build.py
+```
+
+If you have a stale container which isn't up-to-date, use `--no-cache`
+`--pull` to force rebuilding everything:
+
+```
+$ python3 misc/docker/build.py --no-cache --pull
+```
+
+Now you can run tests by using the `misc/docker/run.sh` script. Give
+it the pytest command line you want to run as arguments. For example,
+you can run mypyc tests like this:
+
+```
+$ misc/docker/run.sh pytest mypyc
+```
+
+You can also use `-k <filter>`, `-n0`, `-q`, etc.
+
+Again, you may need to run this as root:
+
+```
+$ sudo misc/docker/run.sh pytest mypyc
+```
+
+You can also use `runtests.py` in the container. Example:
+
+```
+$ misc/docker/run.sh ./runtests.py self lint
+```

--- a/misc/docker/README.md
+++ b/misc/docker/README.md
@@ -76,6 +76,10 @@ $ misc/docker/run.sh ./runtests.py self lint
 Notes
 -----
 
+File system changes within the container are not visible to the host
+system. You can't use the container to format code using Black, for
+example.
+
 On a mac, you may want to try using different CPU allocations for the
 container. The default allocation may be quite low (e.g. 2 CPUs). For
 example, to use 4 CPUs when using Colima, use the `-c` option when

--- a/misc/docker/README.md
+++ b/misc/docker/README.md
@@ -80,13 +80,15 @@ File system changes within the container are not visible to the host
 system. You can't use the container to format code using Black, for
 example.
 
-On a mac, you may want to try using different CPU allocations for the
-container. The default allocation may be quite low (e.g. 2 CPUs). For
-example, to use 4 CPUs when using Colima, use the `-c` option when
-starting the VM:
+On a mac, you may want to give more CPU to the VM used to run the
+container. The default allocation may be way too low (e.g. 2 CPUs).
+For example, use the `-c` option when starting the VM if you use
+Colima:
 
 ```
-$ colima start -c 4
+$ colima start -c 8
 ```
 
-Giving access to all available CPUs for the VM may not be optimal.
+Giving access to all available CPUs to the Linux VM tends to provide
+the best performance. This is unncessary on a Linux host, since the
+container is not run in a VM.

--- a/misc/docker/build.py
+++ b/misc/docker/build.py
@@ -1,0 +1,46 @@
+"""Build a "mypy-test" Linux Docker container for running mypy/mypyc tests.
+
+This allows running Linux tests under a non-Linux operating system. Mypyc
+tests can also run much faster under Linux that the host OS.
+
+NOTE: You may need to run this as root (using sudo).
+
+Run with "--no-cache" to force reinstallation of mypy dependencies.
+Run with "--pull" to force update of the Linux (Ubuntu) base image.
+
+After you've built the container, use "run.sh" to run tests. Example:
+
+  misc/docker/run.sh pytest mypyc/
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="""Build a 'mypy-test' Docker container for running mypy/mypyc tests. You may
+                       need to run this as root (using sudo)."""
+    )
+    parser.add_argument("--no-cache", action="store_true", help="Force rebuilding")
+    parser.add_argument("--pull", action="store_true", help="Force pulling fresh Linux base image")
+    args = parser.parse_args()
+
+    dockerdir = os.path.dirname(os.path.abspath(__file__))
+    dockerfile = os.path.join(dockerdir, "Dockerfile")
+    rootdir = os.path.join(dockerdir, "..", "..")
+
+    cmdline = ["docker", "build", "-t", "mypy-test", "-f", dockerfile]
+    if args.no_cache:
+        cmdline.append("--no-cache")
+    if args.pull:
+        cmdline.append("--pull")
+    cmdline.append(rootdir)
+    result = subprocess.run(cmdline)
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/docker/run-wrapper.sh
+++ b/misc/docker/run-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Internal wrapper script used to run commands in a container
+
+# Copy all the files we need from the directory shared with the host to a local directory
+cp -R /repo/{mypy,mypyc,test-data,misc} .
+cp /repo/{pytest.ini,conftest.py,runtests.py,pyproject.toml,setup.cfg} .
+cp /repo/{mypy_self_check.ini,mypy_bootstrap.ini} .
+
+# Run the wrapped command
+"$@"

--- a/misc/docker/run-wrapper.sh
+++ b/misc/docker/run-wrapper.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Internal wrapper script used to run commands in a container
 
-# Copy all the files we need from the directory shared with the host to a local directory
+# Copy all the files we need from the mypy repo directory shared with
+# the host to a local directory. Accessing files using a shared
+# directory on a mac can be *very* slow.
 echo "copying files to the container..."
 cp -R /repo/{mypy,mypyc,test-data,misc} .
 cp /repo/{pytest.ini,conftest.py,runtests.py,pyproject.toml,setup.cfg} .

--- a/misc/docker/run-wrapper.sh
+++ b/misc/docker/run-wrapper.sh
@@ -2,6 +2,7 @@
 # Internal wrapper script used to run commands in a container
 
 # Copy all the files we need from the directory shared with the host to a local directory
+echo "copying files to the container..."
 cp -R /repo/{mypy,mypyc,test-data,misc} .
 cp /repo/{pytest.ini,conftest.py,runtests.py,pyproject.toml,setup.cfg} .
 cp /repo/{mypy_self_check.ini,mypy_bootstrap.ini} .

--- a/misc/docker/run.sh
+++ b/misc/docker/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Run mypy or mypyc tests in a Docker container that was built using misc/docker/build.py.
+#
+# Usage: misc/docker/run.sh <command> <arg>...
+#
+# For example, run mypyc tests like this:
+#
+#   misc/docker/run.sh pytest mypyc
+#
+# NOTE: You may need to run this as root (using sudo).
+
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+MYPY_DIR="$SCRIPT_DIR/../.."
+
+docker run -ti --rm -v "$MYPY_DIR:/repo" -w /repo mypy-test "$@"

--- a/misc/docker/run.sh
+++ b/misc/docker/run.sh
@@ -12,4 +12,4 @@
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 MYPY_DIR="$SCRIPT_DIR/../.."
 
-docker run -ti --rm -v "$MYPY_DIR:/repo" -w /repo mypy-test "$@"
+docker run -ti --rm -v "$MYPY_DIR:/repo" mypy-test /repo/misc/docker/run-wrapper.sh "$@"


### PR DESCRIPTION
This speeds up running `pytest mypyc/test/test_run.py` by over 3x on a Mac mini M1. Mypy test performance is fairly similar to running natively.

Example of how to use these on macOS:
```
$ colima start -c 8  # Start VM
$ python3 misc/docker/build.py  # Build Ubuntu container with test dependencies
$ misc/docker/run.sh pytest mypyc/test/test_run.py  # Run tests in container
```

Also add a README that documents how to use these.

Closes #14453.