### PR TITLE
Fix false positive on generic base class with six

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2181,7 +2181,7 @@ class SemanticAnalyzer(
         if len(defn.base_type_exprs) == 1:
             base_expr = defn.base_type_exprs[0]
             if isinstance(base_expr, CallExpr) and isinstance(base_expr.callee, RefExpr):
-                base_expr.accept(self)
+                self.analyze_type_expr(base_expr)
                 if (
                     base_expr.callee.fullname
                     in {

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5293,6 +5293,19 @@ class F(six.with_metaclass(t.M)): pass
 class G: pass
 [builtins fixtures/tuple.pyi]
 
+[case testSixMetaclassGenericBase]
+import six
+import abc
+from typing import TypeVar, Generic
+
+T = TypeVar("T")
+
+class C(six.with_metaclass(abc.ABCMeta, Generic[T])):
+    pass
+class D(six.with_metaclass(abc.ABCMeta, C[T])):
+    pass
+[builtins fixtures/tuple.pyi]
+
 -- Special support for future.utils
 -- --------------------------------
 


### PR DESCRIPTION
Fixes #14475

The fix is straightforward. We need to use the "guarded accept" at this stage, similar to e.g. `clean_up_bases_and_infer_type_variables()`.