### PR TITLE
Fix recursive TypedDicts/NamedTuples defined with call syntax

### DIFF
--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -880,3 +880,20 @@ class InListRecurse(Generic[T], List[InList[T]]): ...
 def list_thing(transforming: InList[T]) -> T:
     ...
 reveal_type(list_thing([5]))  # N: Revealed type is "builtins.list[builtins.int]"
+
+[case testRecursiveTypedDictWithList]
+from typing import List
+from typing_extensions import TypedDict
+
+Example = TypedDict("Example", {"rec": List["Example"]})
+e: Example
+reveal_type(e)  # N: Revealed type is "TypedDict('__main__.Example', {'rec': builtins.list[...]})"
+[builtins fixtures/dict.pyi]
+
+[case testRecursiveNamedTupleWithList]
+from typing import List, NamedTuple
+
+Example = NamedTuple("Example", [("rec", List["Example"])])
+e: Example
+reveal_type(e)  # N: Revealed type is "Tuple[builtins.list[...], fallback=__main__.Example]"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #14460

Recursive TypedDicts/NamedTuples defined with call syntax that have item types that look like type applications suffer the same chicken-and-egg problem that recursive type aliases. Fortunately, there is a very simple way to distinguish them without fully analyzing rvalues, this is what this PR does.
