### PR TITLE
[mypyc] Support inheriting native int attributes from traits

### DIFF
--- a/mypyc/analysis/attrdefined.py
+++ b/mypyc/analysis/attrdefined.py
@@ -415,6 +415,9 @@ def update_always_defined_attrs_using_subclasses(cl: ClassIR, seen: set[ClassIR]
 
 
 def detect_undefined_bitmap(cl: ClassIR, seen: Set[ClassIR]) -> None:
+    if cl.is_trait:
+        return
+
     if cl in seen:
         return
     seen.add(cl)
@@ -426,3 +429,9 @@ def detect_undefined_bitmap(cl: ClassIR, seen: Set[ClassIR]) -> None:
     for n, t in cl.attributes.items():
         if t.error_overlap and not cl.is_always_defined(n):
             cl.bitmap_attrs.append(n)
+
+    for base in cl.mro[1:]:
+        if base.is_trait:
+            for n, t in base.attributes.items():
+                if t.error_overlap and not cl.is_always_defined(n) and n not in cl.bitmap_attrs:
+                    cl.bitmap_attrs.append(n)

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -330,7 +330,8 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         rtype = op.class_type
         cl = rtype.class_ir
         attr_rtype, decl_cl = cl.attr_details(op.attr)
-        if cl.get_method(op.attr):
+        prefer_method = cl.is_trait and attr_rtype.error_overlap
+        if cl.get_method(op.attr, prefer_method=prefer_method):
             # Properties are essentially methods, so use vtable access for them.
             version = "_TRAIT" if cl.is_trait else ""
             self.emit_line(

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -294,9 +294,12 @@ class ClassIR:
 
         return None
 
-    def get_method(self, name: str) -> FuncIR | None:
-        res = self.get_method_and_class(name)
+    def get_method(self, name: str, *, prefer_method: bool = False) -> FuncIR | None:
+        res = self.get_method_and_class(name, prefer_method=prefer_method)
         return res[0] if res else None
+
+    def has_method_decl(self, name: str) -> bool:
+        return any(name in ir.method_decls for ir in self.mro)
 
     def subclasses(self) -> set[ClassIR] | None:
         """Return all subclasses of this class, both direct and indirect.

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -161,14 +161,16 @@ def transform_class_def(builder: IRBuilder, cdef: ClassDef) -> None:
     # Generate implicit property setters/getters
     for name, decl in ir.method_decls.items():
         if decl.implicit and decl.is_prop_getter:
-            getter_ir = gen_property_getter_ir(builder, decl, cdef)
+            getter_ir = gen_property_getter_ir(builder, decl, cdef, ir.is_trait)
             builder.functions.append(getter_ir)
             ir.methods[getter_ir.decl.name] = getter_ir
 
             setter_ir = None
             setter_name = PROPSET_PREFIX + name
             if setter_name in ir.method_decls:
-                setter_ir = gen_property_setter_ir(builder, ir.method_decls[setter_name], cdef)
+                setter_ir = gen_property_setter_ir(
+                    builder, ir.method_decls[setter_name], cdef, ir.is_trait
+                )
                 builder.functions.append(setter_ir)
                 ir.methods[setter_name] = setter_ir
 

--- a/mypyc/irbuild/vtable.py
+++ b/mypyc/irbuild/vtable.py
@@ -40,7 +40,7 @@ def compute_vtable(cls: ClassIR) -> None:
     for t in [cls] + cls.traits:
         for fn in itertools.chain(t.methods.values()):
             # TODO: don't generate a new entry when we overload without changing the type
-            if fn == cls.get_method(fn.name):
+            if fn == cls.get_method(fn.name, prefer_method=True):
                 cls.vtable[fn.name] = len(entries)
                 # If the class contains a glue method referring to itself, that is a
                 # shadow glue method to support interpreted subclasses.
@@ -60,7 +60,7 @@ def specialize_parent_vtable(cls: ClassIR, parent: ClassIR) -> VTableEntries:
     for entry in parent.vtable_entries:
         # Find the original method corresponding to this vtable entry.
         # (This may not be the method in the entry, if it was overridden.)
-        orig_parent_method = entry.cls.get_method(entry.name)
+        orig_parent_method = entry.cls.get_method(entry.name, prefer_method=True)
         assert orig_parent_method
         method_cls = cls.get_method_and_class(entry.name, prefer_method=True)
         if method_cls:

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -1371,3 +1371,65 @@ def test_read_only_property_in_trait_implemented_as_property() -> None:
     assert t.x == 6
     with assertRaises(TypeError):
         t.y
+
+@trait
+class T2:
+    x: i64
+    y: i64
+
+class C2(T2):
+    pass
+
+def test_inherit_trait_attribute() -> None:
+    c = C2()
+    c.x = 5
+    assert c.x == 5
+    c.x = MAGIC
+    assert c.x == MAGIC
+    with assertRaises(AttributeError):
+        c.y
+    c.y = 6
+    assert c.y == 6
+    t: T2 = C2()
+    with assertRaises(AttributeError):
+        t.y
+    t = c
+    assert t.x == MAGIC
+    c.x = 55
+    assert t.x == 55
+    assert t.y == 6
+    a: Any = c
+    assert a.x == 55
+    assert a.y == 6
+    a.x = 7
+    a.y = 8
+    assert a.x == 7
+    assert a.y == 8
+
+class D2(T2):
+    x: i64
+    y: i64 = 4
+
+def test_implement_trait_attribute() -> None:
+    d = D2()
+    d.x = 5
+    assert d.x == 5
+    d.x = MAGIC
+    assert d.x == MAGIC
+    assert d.y == 4
+    d.y = 6
+    assert d.y == 6
+    t: T2 = D2()
+    assert t.y == 4
+    t = d
+    assert t.x == MAGIC
+    d.x = 55
+    assert t.x == 55
+    assert t.y == 6
+    a: Any = d
+    assert a.x == 55
+    assert a.y == 6
+    a.x = 7
+    a.y = 8
+    assert a.x == 7
+    assert a.y == 8


### PR DESCRIPTION
Regular trait attributes are accessed via looking up the field offset from a vtable. This doesn't work with native ints, since they may also require access to a defined attributes bitmap, and also looking that up from a vtable would be too complicated.

Work around this may always accessing trait native int attributes using accessor methods. These can raise an exception if an attribute is undefined.

Add empty accessor methods in traits for each attribute with overlapping error values. Also synthesize real accessors in each concrete subclass.

When accessing the attribute using a concrete subclass, still prefer direct field and bitmap access. Only attribute access through a trait type requires accessors to be used.

Work on mypyc/mypyc#837.