### PR TITLE
[mypyc] Add irbuild test case for cast(i64, ...)

### DIFF
--- a/mypyc/test-data/irbuild-i64.test
+++ b/mypyc/test-data/irbuild-i64.test
@@ -1730,3 +1730,44 @@ L0:
 def f5():
 L0:
     return 4
+
+[case testI64Cast]
+from typing import cast
+from mypy_extensions import i64
+
+def cast_object(o: object) -> i64:
+    return cast(i64, o)
+
+def cast_int(x: int) -> i64:
+    return cast(i64, x)
+[out]
+def cast_object(o):
+    o :: object
+    r0 :: int64
+L0:
+    r0 = unbox(int64, o)
+    return r0
+def cast_int(x):
+    x :: int
+    r0 :: native_int
+    r1 :: bit
+    r2, r3 :: int64
+    r4 :: ptr
+    r5 :: c_ptr
+    r6 :: int64
+L0:
+    r0 = x & 1
+    r1 = r0 == 0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    r2 = x >> 1
+    r3 = r2
+    goto L3
+L2:
+    r4 = x ^ 1
+    r5 = r4
+    r6 = CPyLong_AsInt64(r5)
+    r3 = r6
+    keep_alive x
+L3:
+    return r3


### PR DESCRIPTION
This tests already supported functionality to detect regressions.