### PR TITLE
Fix crash on Any metaclass in incremental mode

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -901,7 +901,7 @@ def analyze_class_attribute_access(
             # For modules use direct symbol table lookup.
             if not itype.extra_attrs.mod_name:
                 return itype.extra_attrs.attrs[name]
-        if info.fallback_to_any:
+        if info.fallback_to_any or info.meta_fallback_to_any:
             return apply_class_attr_hook(mx, hook, AnyType(TypeOfAny.special_form))
         return None
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2800,6 +2800,7 @@ class TypeInfo(SymbolNode):
         "inferring",
         "is_enum",
         "fallback_to_any",
+        "meta_fallback_to_any",
         "type_vars",
         "has_param_spec_type",
         "bases",
@@ -2894,6 +2895,10 @@ class TypeInfo(SymbolNode):
     # (and __setattr__), but without the __getattr__ method.
     fallback_to_any: bool
 
+    # Same as above but for cases where metaclass has type Any. This will suppress
+    # all attribute errors only for *class object* access.
+    meta_fallback_to_any: bool
+
     # Information related to type annotations.
 
     # Generic type variable names (full names)
@@ -2963,6 +2968,7 @@ class TypeInfo(SymbolNode):
         "is_abstract",
         "is_enum",
         "fallback_to_any",
+        "meta_fallback_to_any",
         "is_named_tuple",
         "is_newtype",
         "is_protocol",
@@ -3002,6 +3008,7 @@ class TypeInfo(SymbolNode):
         self.is_final = False
         self.is_enum = False
         self.fallback_to_any = False
+        self.meta_fallback_to_any = False
         self._promote = []
         self.alt_promote = None
         self.tuple_type = None

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -255,6 +255,7 @@ def snapshot_definition(node: SymbolNode | None, common: tuple[object, ...]) -> 
             node.is_enum,
             node.is_protocol,
             node.fallback_to_any,
+            node.meta_fallback_to_any,
             node.is_named_tuple,
             node.is_newtype,
             # We need this to e.g. trigger metaclass calculation in subclasses.

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1167,7 +1167,7 @@ def find_member(
                     if isinstance(getattr_type, CallableType):
                         return getattr_type.ret_type
                     return getattr_type
-        if itype.type.fallback_to_any:
+        if itype.type.fallback_to_any or class_obj and itype.type.meta_fallback_to_any:
             return AnyType(TypeOfAny.special_form)
         if isinstance(v, TypeInfo):
             # PEP 544 doesn't specify anything about such use cases. So we just try

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4439,7 +4439,7 @@ def f(TB: Type[B]):
     reveal_type(TB.x)  # N: Revealed type is "builtins.int"
 
 [case testMetaclassAsAny]
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Type
 
 MyAny: Any
 class WithMeta(metaclass=MyAny):
@@ -4451,13 +4451,15 @@ reveal_type(WithMeta.x)   # N: Revealed type is "builtins.int"
 reveal_type(WithMeta().x) # N: Revealed type is "builtins.int"
 WithMeta().m              # E: "WithMeta" has no attribute "m"
 WithMeta().a              # E: "WithMeta" has no attribute "a"
+t: Type[WithMeta]
+t.unknown  # OK
 
 [case testMetaclassAsAnyWithAFlag]
 # flags: --disallow-subclassing-any
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Type
 
 MyAny: Any
-class WithMeta(metaclass=MyAny):  # E: Class cannot use "__main__.MyAny" as a metaclass (has type "Any")
+class WithMeta(metaclass=MyAny):  # E: Class cannot use "MyAny" as a metaclass (has type "Any")
     x: ClassVar[int]
 
 reveal_type(WithMeta.a)   # N: Revealed type is "Any"
@@ -4466,6 +4468,8 @@ reveal_type(WithMeta.x)   # N: Revealed type is "builtins.int"
 reveal_type(WithMeta().x) # N: Revealed type is "builtins.int"
 WithMeta().m              # E: "WithMeta" has no attribute "m"
 WithMeta().a              # E: "WithMeta" has no attribute "a"
+t: Type[WithMeta]
+t.unknown  # OK
 
 [case testMetaclassIterable]
 from typing import Iterable, Iterator

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6348,3 +6348,14 @@ class C(B):
         self.x = self.foo()
 [out]
 [out2]
+
+[case testNoCrashIncrementalMetaAny]
+import a
+[file a.py]
+from m import Foo
+[file a.py.2]
+from m import Foo
+# touch
+[file m.py]
+from missing_module import Meta  # type: ignore[import]
+class Foo(metaclass=Meta): ...

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3124,7 +3124,6 @@ whatever: int
 [out]
 ==
 b.py:2: error: Name "c.M" is not defined
-a.py:3: error: "Type[B]" has no attribute "x"
 
 [case testFixMissingMetaclass]
 import a
@@ -3143,7 +3142,6 @@ class M(type):
     x: int
 [out]
 b.py:2: error: Name "c.M" is not defined
-a.py:3: error: "Type[B]" has no attribute "x"
 ==
 
 [case testGoodMetaclassSpoiled]


### PR DESCRIPTION
Fixes #14254

This essentially re-implements https://github.com/python/mypy/pull/13605 in a simpler way that also works in incremental mode. Also I decided to set `meta_fallback_to_any` in case of errors, to match how we do this for base classes.