### PR TITLE
Properly support union of TypedDicts as dict literal context

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1705,7 +1705,9 @@ class MessageBuilder:
 
     def typeddict_context_ambiguous(self, types: list[TypedDictType], context: Context) -> None:
         formatted_types = ", ".join(list(format_type_distinctly(*types)))
-        self.fail(f"Type of TypedDict is ambiguous, could be any of ({formatted_types})", context)
+        self.fail(
+            f"Type of TypedDict is ambiguous, none of ({formatted_types}) matches cleanly", context
+        )
 
     def typeddict_key_cannot_be_deleted(
         self, typ: TypedDictType, item_name: str, context: Context

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -895,15 +895,25 @@ c: Union[A, B] = {'@type': 'a-type', 'a': 'Test'}
 reveal_type(c) # N: Revealed type is "Union[TypedDict('__main__.A', {'@type': Literal['a-type'], 'a': builtins.str}), TypedDict('__main__.B', {'@type': Literal['b-type'], 'b': builtins.int})]"
 [builtins fixtures/dict.pyi]
 
-[case testTypedDictUnionAmbiguousCase]
+[case testTypedDictUnionAmbiguousCaseBothMatch]
 from typing import Union, Mapping, Any, cast
 from typing_extensions import TypedDict, Literal
 
-A = TypedDict('A', {'@type': Literal['a-type'], 'a': str})
-B = TypedDict('B', {'@type': Literal['a-type'], 'a': str})
+A = TypedDict('A', {'@type': Literal['a-type'], 'value': str})
+B = TypedDict('B', {'@type': Literal['b-type'], 'value': str})
 
-c: Union[A, B] = {'@type': 'a-type', 'a': 'Test'} # E: Type of TypedDict is ambiguous, could be any of ("A", "B") \
-                                                  # E: Incompatible types in assignment (expression has type "Dict[str, str]", variable has type "Union[A, B]")
+c: Union[A, B] = {'@type': 'a-type', 'value': 'Test'}
+[builtins fixtures/dict.pyi]
+
+[case testTypedDictUnionAmbiguousCaseNoMatch]
+from typing import Union, Mapping, Any, cast
+from typing_extensions import TypedDict, Literal
+
+A = TypedDict('A', {'@type': Literal['a-type'], 'value': int})
+B = TypedDict('B', {'@type': Literal['b-type'], 'value': int})
+
+c: Union[A, B] = {'@type': 'a-type', 'value': 'Test'}  # E: Type of TypedDict is ambiguous, none of ("A", "B") matches cleanly \
+                                                       # E: Incompatible types in assignment (expression has type "Dict[str, str]", variable has type "Union[A, B]")
 [builtins fixtures/dict.pyi]
 
 -- Use dict literals
@@ -2784,5 +2794,81 @@ class TD(TypedDict):
     next: Optional[Self]  # E: Self type cannot be used in TypedDict item type
 TDC = TypedDict("TDC", {"val": int, "next": Optional[Self]})  # E: Self type cannot be used in TypedDict item type
 
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+[case testUnionOfEquivalentTypedDictsInferred]
+from typing import TypedDict, Dict
+
+D = TypedDict("D", {"foo": int}, total=False)
+
+def f(d: Dict[str, D]) -> None:
+    args = d["a"]
+    args.update(d.get("b", {}))  # OK
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+[case testUnionOfEquivalentTypedDictsDeclared]
+from typing import TypedDict, Union
+
+class A(TypedDict, total=False):
+    name: str
+class B(TypedDict, total=False):
+    name: str
+
+def foo(data: Union[A, B]) -> None: ...
+foo({"name": "Robert"})  # OK
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+[case testUnionOfEquivalentTypedDictsEmpty]
+from typing import TypedDict, Union
+
+class Foo(TypedDict, total=False):
+    foo: str
+class Bar(TypedDict, total=False):
+    bar: str
+
+def foo(body: Union[Foo, Bar] = {}) -> None:  # OK
+    ...
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+[case testUnionOfEquivalentTypedDictsDistinct]
+from typing import TypedDict, Union, Literal
+
+class A(TypedDict):
+    type: Literal['a']
+    value: bool
+class B(TypedDict):
+    type: Literal['b']
+    value: str
+
+Response = Union[A, B]
+def method(message: Response) -> None: ...
+
+method({'type': 'a', 'value': True})  # OK
+method({'type': 'b', 'value': 'abc'})  # OK
+method({'type': 'a', 'value': 'abc'})  # E: Type of TypedDict is ambiguous, none of ("A", "B") matches cleanly \
+                                       # E: Argument 1 to "method" has incompatible type "Dict[str, str]"; expected "Union[A, B]"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+[case testUnionOfEquivalentTypedDictsNested]
+from typing import TypedDict, Union
+
+class A(TypedDict, total=False):
+    foo: C
+class B(TypedDict, total=False):
+    foo: D
+class C(TypedDict, total=False):
+    c: str
+class D(TypedDict, total=False):
+    d: str
+
+def foo(data: Union[A, B]) -> None: ...
+foo({"foo": {"c": "foo"}})  # OK
+foo({"foo": {"e": "foo"}})  # E: Type of TypedDict is ambiguous, none of ("A", "B") matches cleanly \
+                            # E: Argument 1 to "foo" has incompatible type "Dict[str, Dict[str, str]]"; expected "Union[A, B]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -971,14 +971,14 @@ if x:
 [builtins fixtures/dict.pyi]
 [out]
 
-[case testUnpackUnionNoCrashOnPartialNoneList]
+[case testUnpackUnionNoCrashOnPartialList]
 # flags: --strict-optional
 from typing import Dict, Tuple, List, Any
 
 a: Any
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
-x, _ = d.get(a, ([], []))
-reveal_type(x) # N: Revealed type is "Union[builtins.list[Tuple[builtins.str, builtins.str]], builtins.list[<nothing>]]"
+x, _ = d.get(a, ([], ""))
+reveal_type(x) # N: Revealed type is "builtins.list[Tuple[builtins.str, builtins.str]]"
 
 for y in x: pass
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -29,7 +29,7 @@ class dict(Mapping[KT, VT]):
     @overload
     def get(self, k: KT) -> Optional[VT]: pass
     @overload
-    def get(self, k: KT, default: Union[KT, T]) -> Union[VT, T]: pass
+    def get(self, k: KT, default: Union[VT, T]) -> Union[VT, T]: pass
     def __len__(self) -> int: ...
 
 class int: # for convenience


### PR DESCRIPTION
Fixes #14481 (regression)
Fixes #13274
Fixes #8533

Most notably, if literal matches multiple items in union, it is not an error, it is only an error if it matches none of them, so I adjust the error message accordingly.

An import caveat is that an unrelated error like `{"key": 42 + "no"}` can cause no item to match (an hence an extra error), but I think it is fine, since we still show the actual error, and avoiding this would require some dirty hacks.

Also note there was an (obvious) bug in one of the fixtures, that caused one of repros not repro in tests, fixing it required tweaking an unrelated test.