### PR TITLE
Fix crash in daemon mode on new import cycle

### DIFF
--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -501,7 +501,9 @@ class NamedTupleAnalyzer:
         info.is_named_tuple = True
         tuple_base = TupleType(types, fallback)
         if info.special_alias and has_placeholder(info.special_alias.target):
-            self.api.defer(force_progress=True)
+            self.api.process_placeholder(
+                None, "NamedTuple item", info, force_progress=tuple_base != info.tuple_type
+            )
         info.update_tuple_type(tuple_base)
         info.line = line
         # For use by mypyc.

--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -249,10 +249,16 @@ class NewTypeAnalyzer:
         init_func = FuncDef("__init__", args, Block([]), typ=signature)
         init_func.info = info
         init_func._fullname = info.fullname + ".__init__"
+        if not existing_info:
+            updated = True
+        else:
+            previous_sym = info.names["__init__"].node
+            assert isinstance(previous_sym, FuncDef)
+            updated = old_type != previous_sym.arguments[1].variable.type
         info.names["__init__"] = SymbolTableNode(MDEF, init_func)
 
-        if has_placeholder(old_type) or info.tuple_type and has_placeholder(info.tuple_type):
-            self.api.defer(force_progress=True)
+        if has_placeholder(old_type):
+            self.api.process_placeholder(None, "NewType base", info, force_progress=updated)
         return info
 
     # Helpers

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -232,6 +232,12 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
     def is_typeshed_stub_file(self) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
+    def process_placeholder(
+        self, name: str | None, kind: str, ctx: Context, force_progress: bool = False
+    ) -> None:
+        raise NotImplementedError
+
 
 def set_callable_name(sig: Type, fdef: FuncDef) -> ProperType:
     sig = get_proper_type(sig)

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -535,7 +535,9 @@ class TypedDictAnalyzer:
         info = existing_info or self.api.basic_new_typeinfo(name, fallback, line)
         typeddict_type = TypedDictType(dict(zip(items, types)), required_keys, fallback)
         if info.special_alias and has_placeholder(info.special_alias.target):
-            self.api.defer(force_progress=True)
+            self.api.process_placeholder(
+                None, "TypedDict item", info, force_progress=typeddict_type != info.typeddict_type
+            )
         info.update_typeddict_type(typeddict_type)
         return info
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2857,6 +2857,14 @@ class PlaceholderType(ProperType):
         assert isinstance(visitor, SyntheticTypeVisitor)
         return cast(T, visitor.visit_placeholder_type(self))
 
+    def __hash__(self) -> int:
+        return hash((self.fullname, tuple(self.args)))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PlaceholderType):
+            return NotImplemented
+        return self.fullname == other.fullname and self.args == other.args
+
     def serialize(self) -> str:
         # We should never get here since all placeholders should be replaced
         # during semantic analysis.

--- a/test-data/unit/fine-grained-follow-imports.test
+++ b/test-data/unit/fine-grained-follow-imports.test
@@ -769,3 +769,80 @@ from . import mod3
 ==
 main.py:1: error: Cannot find implementation or library stub for module named "pkg"
 main.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+
+[case testNewImportCycleTypeVarBound]
+# flags: --follow-imports=normal
+# cmd: mypy main.py
+# cmd2: mypy other.py
+
+[file main.py]
+# empty
+
+[file other.py.2]
+import trio
+
+[file trio/__init__.py.2]
+from typing import TypeVar
+import trio
+from . import abc as abc
+
+T = TypeVar("T", bound=trio.abc.A)
+
+[file trio/abc.py.2]
+import trio
+class A: ...
+[out]
+==
+
+[case testNewImportCycleTupleBase]
+# flags: --follow-imports=normal
+# cmd: mypy main.py
+# cmd2: mypy other.py
+
+[file main.py]
+# empty
+
+[file other.py.2]
+import trio
+
+[file trio/__init__.py.2]
+from typing import TypeVar, Tuple
+import trio
+from . import abc as abc
+
+class C(Tuple[trio.abc.A, trio.abc.A]): ...
+
+[file trio/abc.py.2]
+import trio
+class A: ...
+[builtins fixtures/tuple.pyi]
+[out]
+==
+
+[case testNewImportCycleTypedDict]
+# flags: --follow-imports=normal
+# cmd: mypy main.py
+# cmd2: mypy other.py
+
+[file main.py]
+# empty
+
+[file other.py.2]
+import trio
+
+[file trio/__init__.py.2]
+from typing import TypeVar
+from typing_extensions import TypedDict
+import trio
+from . import abc as abc
+
+class C(TypedDict):
+    x: trio.abc.A
+    y: trio.abc.A
+
+[file trio/abc.py.2]
+import trio
+class A: ...
+[builtins fixtures/dict.pyi]
+[out]
+==


### PR DESCRIPTION
Fixes #14329

This fixes the second crash reported in the issue (other one is already fixed). This one is tricky, it looks like it happens only when we bring in a new import cycle in an incremental update with `--follow-import=normal`. To explain the reason, a little reminder of how semantic analyzer passes work:
* Originally, we recorded progress automatically when some new symbol was resolved and added to symbol tables.
* With implementation of recursive types, this mechanism was insufficient, as recursive types require modifying some symbols _in place_, this is why `force_progress` flag was added to `defer()`.
* I was only careful with this flag for recursive type aliases (that were implemented first), for other things (like recursive TypedDicts, etc) I just always passed `force_progress=True` (without checking if we actually resolved some placeholder types).
* The reasoning for that is if we ever add `becomes_typeinfo=True`, there is no way this symbol will later be unresolved (otherwise how would we know this is something that is a type).
* It turns out this reasoning doesn't work in some edge cases in daemon mode, we do put some placeholders with `becomes_typeinfo=True` for symbols imported from modules that were not yet processed, thus causing a crash (see test cases).
* There were two options to fix this: one is to stop creating placeholders with `becomes_typeinfo=True` for unimported symbols in daemon mode, other one is to always carefully check if in-place update of a symbol actually resulted in progress.
* Ultimately I decided that the first way is too fragile (and I don't understand how import following works for daemon anyway), and the second way is something that is technically correct anyway, so here is this PR

I didn't add test cases for each of the crash scenarios, since they are all very similar. I only added two that I encountered "in the wild", upper bound and tuple base caused actual crash in `trio` stubs, plus also randomly a test for a TypedDict crash.

_EDIT:_ and one more thing, the "cannot resolve name" error should never appear in normal mode, only in daemon update (see reasoning above), so I don't make those error messages detailed, just add some minimal info if we will need to debug them.