### PR TITLE
Fixes #14512

### DIFF
--- a/test-data/unit/fixtures/attr.pyi
+++ b/test-data/unit/fixtures/attr.pyi
@@ -23,6 +23,5 @@ class complex:
     def __init__(self, real: str = ...) -> None: ...
 
 class str: pass
-class unicode: pass
 class ellipsis: pass
 class tuple: pass

--- a/test-data/unit/fixtures/bool.pyi
+++ b/test-data/unit/fixtures/bool.pyi
@@ -14,7 +14,6 @@ class int: pass
 class bool(int): pass
 class float: pass
 class str: pass
-class unicode: pass
 class ellipsis: pass
 class list(Generic[T]): pass
 class property: pass

--- a/test-data/unit/fixtures/dict.pyi
+++ b/test-data/unit/fixtures/dict.pyi
@@ -41,7 +41,6 @@ class int: # for convenience
     imag: int
 
 class str: pass # for keyword argument key type
-class unicode: pass # needed for py2 docstrings
 class bytes: pass
 
 class list(Sequence[T]): # needed by some test cases

--- a/test-data/unit/fixtures/exception.pyi
+++ b/test-data/unit/fixtures/exception.pyi
@@ -11,7 +11,6 @@ class tuple(Generic[T]):
 class function: pass
 class int: pass
 class str: pass
-class unicode: pass
 class bool: pass
 class ellipsis: pass
 

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -33,8 +33,6 @@ class str:
     def startswith(self, x: 'str') -> bool: pass
     def strip(self) -> 'str': pass
 
-class unicode: pass
-
 class int:
     def __add__(self, x: 'int') -> 'int': pass
     def __radd__(self, x: 'int') -> 'int': pass

--- a/test-data/unit/fixtures/staticmethod.pyi
+++ b/test-data/unit/fixtures/staticmethod.pyi
@@ -16,6 +16,5 @@ class int:
     def from_bytes(bytes: bytes, byteorder: str) -> int: pass
 
 class str: pass
-class unicode: pass
 class bytes: pass
 class ellipsis: pass

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -37,7 +37,6 @@ class bool(int): pass
 class str: pass # For convenience
 class bytes: pass
 class bytearray: pass
-class unicode: pass
 
 class list(Sequence[T], Generic[T]):
     @overload

--- a/test-data/unit/fixtures/type.pyi
+++ b/test-data/unit/fixtures/type.pyi
@@ -24,5 +24,4 @@ class function: pass
 class bool: pass
 class int: pass
 class str: pass
-class unicode: pass
 class ellipsis: pass

--- a/test-data/unit/lib-stub/__builtin__.pyi
+++ b/test-data/unit/lib-stub/__builtin__.pyi
@@ -18,7 +18,6 @@ class int: pass
 class float: pass
 
 class str: pass
-class unicode: pass
 
 class tuple(Generic[_T]): pass
 class function: pass


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)
Removed references to `class unicode` under test-data/unit as it is deprecated.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
