### PR TITLE
[mypyc] Detect if attribute definition conflicts with base class/trait

### DIFF
--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -122,6 +122,7 @@ def build_type_map(
                 if attr in base_ir.attributes:
                     if not is_same_type(class_ir.attributes[attr], base_ir.attributes[attr]):
                         node = cdef.info.names[attr].node
+                        assert node is not None
                         kind = "trait" if base_ir.is_trait else "class"
                         errors.error(
                             f'Type of "{attr}" is incompatible with '

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -60,6 +60,7 @@ from mypyc.irbuild.util import (
     is_trait,
 )
 from mypyc.options import CompilerOptions
+from mypyc.sametype import is_same_type
 
 
 def build_type_map(
@@ -111,6 +112,23 @@ def build_type_map(
         for func in get_module_func_defs(module):
             prepare_func_def(module.fullname, None, func, mapper)
             # TODO: what else?
+
+    # Check for incompatible attribute definitions that were not
+    # flagged by mypy but can't be supported when compiling.
+    for module, cdef in classes:
+        class_ir = mapper.type_to_ir[cdef.info]
+        for attr in class_ir.attributes:
+            for base_ir in class_ir.mro[1:]:
+                if attr in base_ir.attributes:
+                    if not is_same_type(class_ir.attributes[attr], base_ir.attributes[attr]):
+                        node = cdef.info.names[attr].node
+                        kind = "trait" if base_ir.is_trait else "class"
+                        errors.error(
+                            f'Type of "{attr}" is incompatible with '
+                            f'definition in {kind} "{base_ir.name}"',
+                            module.path,
+                            node.line,
+                        )
 
 
 def is_from_module(node: SymbolNode, module: MypyFile) -> bool:

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1245,3 +1245,45 @@ L2:
     y = 4
 L3:
     return 1
+
+[case testIncompatibleDefinitionOfAttributeInSubclass]
+from mypy_extensions import trait
+
+class Base:
+    x: int
+
+class Bad1(Base):
+    x: bool  # E: Type of "x" is incompatible with definition in class "Base"
+
+class Good1(Base):
+    x: int
+
+class Good2(Base):
+    x: int = 0
+
+class Good3(Base):
+    x = 0
+
+class Good4(Base):
+    def __init__(self) -> None:
+        self.x = 0
+
+class Good5(Base):
+    def __init__(self) -> None:
+        self.x: int = 0
+
+class Base2(Base):
+    pass
+
+class Bad2(Base2):
+    x: bool = False  # E: Type of "x" is incompatible with definition in class "Base"
+
+class Bad3(Base):
+    x = False  # E: Type of "x" is incompatible with definition in class "Base"
+
+@trait
+class T:
+    y: object
+
+class E(T):
+    y: str  # E: Type of "y" is incompatible with definition in trait "T"


### PR DESCRIPTION
Require that all the attribute definitions have the same type. Overriding with a different type is unsafe, and we don't want to add runtime checks when accessing an attribute that might be overridden with a different type. If the types would have different runtime representations, supporting that at all would be complicated.

Fixes mypyc/mypyc#970.