### PR TITLE
honor NO_COLOR env variable to disable colors even with --color-output

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -69,6 +69,9 @@ def main(
 
     formatter = util.FancyFormatter(stdout, stderr, options.hide_error_codes)
 
+    if options.color_output and os.getenv("NO_COLOR"):
+        options.color_output = False
+
     if options.install_types and (stdout is not sys.stdout or stderr is not sys.stderr):
         # Since --install-types performs user input, we want regular stdout and stderr.
         fail("error: --install-types not supported in this mode of running mypy", stderr, options)


### PR DESCRIPTION
`NO_COLOR` is a pseudo-standard adopted by [many apps](https://no-color.org/#software-directly-supporting-no_color-to-disable-default-color-output). Just setting an env var disables coloring even if app configuration tells to use color.

That's useful:
- to have a mean of overriding configuration or command-line options in situations where it's not possible to edit them
- a standard solution for IDEs to disable colors in all tools they may run

Since this variable overrides the conf anyway, rather than modifying every line `if conf.color_output` into `if conf.color_output and not ...NO_COLOR...` (sometimes `conf.color_output` value is copied to a variable, then read from the variable instead of from conf, making harder to find modifications), I took the simpler approach to modify conf value early in a single place, so it's impossible to forget one line to edit to add the `and not ...NO_COLOR...`.