### PR TITLE
[1.0 backport] Fix internal crash when resolve same partial type twice (#14552)

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -895,7 +895,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return
             var, partial_types = ret
             typ = self.try_infer_partial_value_type_from_call(e, callee.name, var)
-            if typ is not None:
+            # Var may be deleted from partial_types in try_infer_partial_value_type_from_call
+            if typ is not None and var in partial_types:
                 var.type = typ
                 del partial_types[var]
         elif isinstance(callee.expr, IndexExpr) and isinstance(callee.expr.base, RefExpr):

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1951,6 +1951,13 @@ class A:
 [out]
 main:4: error: "None" has no attribute "__iter__" (not iterable)
 
+[case testPartialTypeErrorSpecialCase4]
+# This used to crash.
+arr = []
+arr.append(arr.append(1))
+[builtins fixtures/list.pyi]
+[out]
+main:3: error: "append" of "list" does not return a value
 
 -- Multipass
 -- ---------


### PR DESCRIPTION
Fixes: #14548

Fixed case when untyped list item type resolving can lead to an internal crash.

Code to reproduce this issue:
```py
arr = []
arr.append(arr.append(1))
```

Basically, the issue is that after the first resolving of `arr.append` method, `var` is deleted from `partial_types`, and as war as `arr.append` is a nested call we try to delete the same `var` that was already deleted.