### PR TITLE
Fix a crash on walrus in comprehension at class scope

### DIFF
--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -734,3 +734,8 @@ class C(Generic[T]):
 [out]
 main:10: note: Revealed type is "builtins.int"
 main:10: note: Revealed type is "builtins.str"
+
+[case testNoCrashOnAssignmentExprClass]
+class C:
+    [(j := i) for i in [1, 2, 3]]  # E: Assignment expression within a comprehension cannot be used in a class body
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -2194,3 +2194,7 @@ class B: pass
 
 def foo(x: int) -> Union[Generator[A, None, None], Generator[B, None, None]]:
     yield x  # E: Incompatible types in "yield" (actual type "int", expected type "Union[A, B]")
+
+[case testNoCrashOnStarRightHandSide]
+x = *(1, 2, 3)  # E: Can use starred expression only as assignment target
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #14201

The fix is trivial, turn an assert condition into a blocker error (with message matching Python syntax error). I also add a test case for a crash from the same issue that looks already fixed.
