### PR TITLE
stubgen: fix crash with PEP 604 union in typevar bound

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -95,6 +95,7 @@ from mypy.nodes import (
     MemberExpr,
     MypyFile,
     NameExpr,
+    OpExpr,
     OverloadedFuncDef,
     Statement,
     StrExpr,
@@ -401,6 +402,9 @@ class AliasPrinter(NodeVisitor[str]):
 
     def visit_ellipsis(self, node: EllipsisExpr) -> str:
         return "..."
+
+    def visit_op_expr(self, o: OpExpr) -> str:
+        return f"{o.left.accept(self)} {o.op} {o.right.accept(self)}"
 
 
 class ImportTracker:

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -2734,3 +2734,12 @@ class Some:
     def __int__(self) -> int: ...
     def __float__(self) -> float: ...
     def __index__(self) -> int: ...
+
+
+[case testTypeVarPEP604Bound]
+from typing import TypeVar
+T = TypeVar("T", bound=str | None)
+[out]
+from typing import TypeVar
+
+T = TypeVar('T', bound=str | None)


### PR DESCRIPTION
Fixes #14533