### PR TITLE
[1.0 backport] Fix `AttrsInstance` protocol check with cache (#14551)

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -828,7 +828,7 @@ def _add_attrs_magic_attribute(
         ctx.cls,
         MAGIC_ATTR_NAME,
         TupleType(attributes_types, fallback=attributes_type),
-        fullname=f"{ctx.cls.fullname}.{attr_name}",
+        fullname=f"{ctx.cls.fullname}.{MAGIC_ATTR_NAME}",
         override_allow_incompatible=True,
         is_classvar=True,
     )

--- a/test-data/unit/fine-grained-attr.test
+++ b/test-data/unit/fine-grained-attr.test
@@ -46,3 +46,37 @@ A.__attrs_attrs__.b
 
 [out]
 ==
+
+[case magicAttributeConsistency2-only_when_cache]
+[file c.py]
+import attr
+
+@attr.s
+class Entry:
+    var: int = attr.ib()
+[builtins fixtures/attr.pyi]
+
+[file m.py]
+from typing import Any, ClassVar, Protocol
+from c import Entry
+
+class AttrsInstance(Protocol):
+    __attrs_attrs__: ClassVar[Any]
+
+def func(e: AttrsInstance) -> None: ...
+func(Entry(2))
+
+[file m.py.2]
+from typing import Any, ClassVar, Protocol
+from c import Entry
+
+class AttrsInstance(Protocol):
+    __attrs_attrs__: ClassVar[Any]
+
+def func(e: AttrsInstance) -> int:
+    return 2  # Change return type to force reanalysis
+
+func(Entry(2))
+
+[out]
+==


### PR DESCRIPTION
Use correct fullname for `__attrs_attrs__` ClassVar to fix issue with warm cache.
Closes #14099

(cherry picked from commit 8e9f89a8498a1242cf1a163f6dbdbd15da54c9a0)