### PR TITLE
[dataclass_transform] support class decorator parameters

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6637,5 +6637,16 @@ def is_trivial_body(block: Block) -> bool:
 def is_dataclass_transform_decorator(node: Node | None) -> bool:
     if isinstance(node, RefExpr):
         return is_dataclass_transform_decorator(node.node)
+    if isinstance(node, CallExpr):
+        # Like dataclasses.dataclass, transform-based decorators can be applied either with or
+        # without parameters; ie, both of these forms are accepted:
+        #
+        # @typing.dataclass_transform
+        # class Foo: ...
+        # @typing.dataclass_transform(eq=True, order=True, ...)
+        # class Bar: ...
+        #
+        # We need to unwrap the call for the second variant.
+        return is_dataclass_transform_decorator(node.callee)
 
     return isinstance(node, Decorator) and node.func.is_dataclass_transform

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -44,3 +44,20 @@ Person('Jonh', 21, None)  # E: Too many arguments for "Person"
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformParametersAreApplied]
+# flags: --python-version 3.7
+from typing import dataclass_transform, Callable, Type
+
+@dataclass_transform()
+def my_dataclass(*, eq: bool, order: bool) -> Callable[[Type], Type]:
+    def transform(cls: Type) -> Type:
+        return cls
+    return transform
+
+@my_dataclass(eq=False, order=True)
+class Application:  # E: eq must be True if order is True
+   ...
+
+[typing fixtures/typing-medium.pyi]
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -56,8 +56,32 @@ def my_dataclass(*, eq: bool, order: bool) -> Callable[[Type], Type]:
     return transform
 
 @my_dataclass(eq=False, order=True)
-class Application:  # E: eq must be True if order is True
-   ...
+class Person:  # E: eq must be True if order is True
+    name: str
+    age: int
+
+reveal_type(Person)  # N: Revealed type is "def (name: builtins.str, age: builtins.int) -> __main__.Person"
+Person('John', 32)
+Person('John', 21, None)  # E: Too many arguments for "Person"
+
+[typing fixtures/typing-medium.pyi]
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformParametersMustBeBoolLiterals]
+# flags: --python-version 3.7
+from typing import dataclass_transform, Callable, Type
+
+@dataclass_transform()
+def my_dataclass(*, eq: bool = True, order: bool = False) -> Callable[[Type], Type]:
+    def transform(cls: Type) -> Type:
+        return cls
+    return transform
+
+BOOL_CONSTANT = True
+@my_dataclass(eq=BOOL_CONSTANT)  # E: "eq" argument must be True or False.
+class A: ...
+@my_dataclass(order=not False)  # E: "order" argument must be True or False.
+class B: ...
 
 [typing fixtures/typing-medium.pyi]
 [builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

The initial implementation of `typing.dataclass_transform` only supported the no-argument `@decorator` form; this adds support for the `@decorator(...)` form supporting the same arguments we support for `dataclasses.dataclass`. This also matches the list of arguments specified in [PEP 681](https://peps.python.org/pep-0681/#decorator-function-and-class-metaclass-parameters).

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
