### PR TITLE
Improvements to stubgenc

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1720,6 +1720,7 @@ def generate_stubs(options: Options) -> None:
             )
 
     # Separately analyse C modules using different logic.
+    all_modules = sorted(m.module for m in (py_modules + c_modules))
     for mod in c_modules:
         if any(py_mod.module.startswith(mod.module + ".") for py_mod in py_modules + c_modules):
             target = mod.module.replace(".", "/") + "/__init__.pyi"
@@ -1728,7 +1729,9 @@ def generate_stubs(options: Options) -> None:
         target = os.path.join(options.output_dir, target)
         files.append(target)
         with generate_guarded(mod.module, target, options.ignore_errors, options.verbose):
-            generate_stub_for_c_module(mod.module, target, sig_generators=sig_generators)
+            generate_stub_for_c_module(
+                mod.module, target, known_modules=all_modules, sig_generators=sig_generators
+            )
     num_modules = len(py_modules) + len(c_modules)
     if not options.quiet and num_modules > 0:
         print("Processed %d modules" % num_modules)

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -168,7 +168,7 @@ class FallbackSignatureGenerator(SignatureGenerator):
 def generate_stub_for_c_module(
     module_name: str,
     target: str,
-    known_modules: Iterable[str],
+    known_modules: list[str],
     sig_generators: Iterable[SignatureGenerator],
 ) -> None:
     """Generate stub for C module.
@@ -314,7 +314,7 @@ def generate_c_function_stub(
     module: ModuleType,
     name: str,
     obj: object,
-    known_modules: Iterable[str],
+    known_modules: list[str],
     sig_generators: Iterable[SignatureGenerator],
     output: list[str],
     imports: list[str],
@@ -391,7 +391,7 @@ def generate_c_function_stub(
 
 
 def strip_or_import(
-    typ: str, module: ModuleType, known_modules: Iterable[str], imports: list[str]
+    typ: str, module: ModuleType, known_modules: list[str], imports: list[str]
 ) -> str:
     """Strips unnecessary module names from typ.
 
@@ -446,7 +446,7 @@ def generate_c_property_stub(
     ro_properties: list[str],
     readonly: bool,
     module: ModuleType | None = None,
-    known_modules: Iterable[str] | None = None,
+    known_modules: list[str] | None = None,
     imports: list[str] | None = None,
 ) -> None:
     """Generate property stub using introspection of 'obj'.
@@ -492,7 +492,7 @@ def generate_c_type_stub(
     class_name: str,
     obj: type,
     output: list[str],
-    known_modules: Iterable[str],
+    known_modules: list[str],
     imports: list[str],
     sig_generators: Iterable[SignatureGenerator],
 ) -> None:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -257,7 +257,7 @@ def add_typing_import(output: list[str]) -> list[str]:
         return output[:]
 
 
-def get_members(obj: type) -> list[tuple[str, Any]]:
+def get_members(obj: object) -> list[tuple[str, Any]]:
     obj_dict: Mapping[str, Any] = getattr(obj, "__dict__")  # noqa: B009
     results = []
     for name in obj_dict:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -402,9 +402,13 @@ def strip_or_import(
     stripped_type = typ
     if any(c in typ for c in "[,"):
         for subtyp in re.split(r"[\[,\]]", typ):
-            strip_or_import(subtyp.strip(), module, known_modules, imports)
-        if module:
-            stripped_type = re.sub(r"(^|[\[, ]+)" + re.escape(module.__name__ + "."), r"\1", typ)
+            stripped_subtyp = strip_or_import(subtyp.strip(), module, known_modules, imports)
+            if stripped_subtyp != subtyp:
+                stripped_type = re.sub(
+                    r"(^|[\[, ]+)" + re.escape(subtyp) + r"($|[\], ]+)",
+                    r"\1" + stripped_subtyp + r"\2",
+                    stripped_type,
+                )
     elif "." in typ:
         for module_name in local_modules + list(reversed(known_modules)):
             if typ.startswith(module_name + "."):

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -820,7 +820,8 @@ class StubgencSuite(unittest.TestCase):
             "alias",
             object,
             output,
-            imports,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(imports, [])
@@ -839,7 +840,8 @@ class StubgencSuite(unittest.TestCase):
             "C",
             TestClassVariableCls,
             output,
-            imports,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(imports, [])
@@ -857,7 +859,8 @@ class StubgencSuite(unittest.TestCase):
             "C",
             TestClass,
             output,
-            imports,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["class C(KeyError): ..."])
@@ -872,7 +875,8 @@ class StubgencSuite(unittest.TestCase):
             "C",
             TestClass,
             output,
-            imports,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["class C(TestBaseClass): ..."])
@@ -892,7 +896,8 @@ class StubgencSuite(unittest.TestCase):
             "C",
             TestClass,
             output,
-            imports,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["class C(argparse.Action): ..."])
@@ -910,7 +915,8 @@ class StubgencSuite(unittest.TestCase):
             "C",
             TestClass,
             output,
-            imports,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["class C(type): ..."])
@@ -930,11 +936,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: int) -> Any: ..."])
@@ -954,11 +961,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: int) -> Any: ..."])
@@ -977,11 +985,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="cls",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["@classmethod", "def test(cls, *args, **kwargs) -> Any: ..."])
@@ -1004,11 +1013,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="cls",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(
@@ -1038,11 +1048,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: str = ...) -> Any: ..."])
@@ -1064,22 +1075,23 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(arg0: argparse.Action) -> Any: ..."])
         assert_equal(imports, ["import argparse"])
 
-    def test_generate_c_function_same_module_arg(self) -> None:
-        """Test that if argument references type from same module but using full path, no module
+    def test_generate_c_function_same_module(self) -> None:
+        """Test that if annotation references type from same module but using full path, no module
         will be imported, and type specification will be striped to local reference.
         """
         # Provide different type in python spec than in docstring to make sure, that docstring
         # information is used.
         def test(arg0: str) -> None:
             """
-            test(arg0: argparse.Action)
+            test(arg0: argparse.Action) -> argparse.Action
             """
 
         output: list[str] = []
@@ -1089,19 +1101,20 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
-        assert_equal(output, ["def test(arg0: Action) -> Any: ..."])
+        assert_equal(output, ["def test(arg0: Action) -> Action: ..."])
         assert_equal(imports, [])
 
-    def test_generate_c_function_other_module_ret(self) -> None:
-        """Test that if return type references type from other module, module will be imported."""
+    def test_generate_c_function_other_module(self) -> None:
+        """Test that if annotation references type from other module, module will be imported."""
 
         def test(arg0: str) -> None:
             """
-            test(arg0: str) -> argparse.Action
+            test(arg0: argparse.Action) -> argparse.Action
             """
 
         output: list[str] = []
@@ -1111,21 +1124,23 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
-        assert_equal(output, ["def test(arg0: str) -> argparse.Action: ..."])
-        assert_equal(imports, ["import argparse"])
+        assert_equal(output, ["def test(arg0: argparse.Action) -> argparse.Action: ..."])
+        assert_equal(set(imports), {"import argparse"})
 
-    def test_generate_c_function_same_module_ret(self) -> None:
-        """Test that if return type references type from same module but using full path,
-        no module will be imported, and type specification will be striped to local reference.
+    def test_generate_c_function_same_module_nested(self) -> None:
+        """Test that if annotation references type from same module but using full path, no module
+        will be imported, and type specification will be stripped to local reference.
         """
-
+        # Provide different type in python spec than in docstring to make sure, that docstring
+        # information is used.
         def test(arg0: str) -> None:
             """
-            test(arg0: str) -> argparse.Action
+            test(arg0: list[argparse.Action]) -> list[argparse.Action]
             """
 
         output: list[str] = []
@@ -1135,12 +1150,37 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
-        assert_equal(output, ["def test(arg0: str) -> Action: ..."])
+        assert_equal(output, ["def test(arg0: list[Action]) -> list[Action]: ..."])
         assert_equal(imports, [])
+
+    def test_generate_c_function_other_module_nested(self) -> None:
+        """Test that if annotation references type from other module, module will be imported,
+        and the import will be restricted to one of the known modules."""
+
+        def test(arg0: str) -> None:
+            """
+            test(arg0: foo.bar.Action) -> other.Thing
+            """
+
+        output: list[str] = []
+        imports: list[str] = []
+        mod = ModuleType(self.__module__, "")
+        generate_c_function_stub(
+            mod,
+            "test",
+            test,
+            output=output,
+            imports=imports,
+            known_modules=["foo", "foo.spangle", "bar"],
+            sig_generators=get_sig_generators(parse_options([])),
+        )
+        assert_equal(output, ["def test(arg0: foo.bar.Action) -> other.Thing: ..."])
+        assert_equal(set(imports), {"import foo", "import other"})
 
     def test_generate_c_property_with_pybind11(self) -> None:
         """Signatures included by PyBind11 inside property.fget are read."""
@@ -1206,11 +1246,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: List[int]) -> Any: ..."])
@@ -1230,11 +1271,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: Dict[str,int]) -> Any: ..."])
@@ -1254,11 +1296,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: Dict[str,List[int]]) -> Any: ..."])
@@ -1278,11 +1321,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: Dict[argparse.Action,int]) -> Any: ..."])
@@ -1302,11 +1346,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "test",
             TestClass.test,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(output, ["def test(self, arg0: Dict[str,argparse.Action]) -> Any: ..."])
@@ -1331,11 +1376,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "__init__",
             TestClass.__init__,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(
@@ -1368,11 +1414,12 @@ class StubgencSuite(unittest.TestCase):
             mod,
             "__init__",
             TestClass.__init__,
-            output,
-            imports,
+            output=output,
+            imports=imports,
             self_var="self",
             cls=TestClass,
             class_name="TestClass",
+            known_modules=[mod.__name__],
             sig_generators=get_sig_generators(parse_options([])),
         )
         assert_equal(

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -799,7 +799,7 @@ class StubgencSuite(unittest.TestCase):
         ):
             assert_equal(infer_method_args(f"__{op}__"), [self_arg, ArgSig(name="other")])
 
-    def test_infer_equality_op_sig(self):
+    def test_infer_equality_op_sig(self) -> None:
         for op in ("eq", "ne", "lt", "le", "gt", "ge", "contains"):
             assert_equal(infer_method_ret_type(f"__{op}__"), "bool")
 
@@ -807,7 +807,7 @@ class StubgencSuite(unittest.TestCase):
         for op in ("neg", "pos"):
             assert_equal(infer_method_args(f"__{op}__"), [self_arg])
 
-    def test_infer_cast_sig(self):
+    def test_infer_cast_sig(self) -> None:
         for op in ("float", "bool", "bytes", "int"):
             assert_equal(infer_method_ret_type(f"__{op}__"), op)
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -1158,6 +1158,32 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ["def test(arg0: list[Action]) -> list[Action]: ..."])
         assert_equal(imports, [])
 
+    def test_generate_c_function_same_module_compound(self) -> None:
+        """Test that if annotation references type from same module but using full path, no module
+        will be imported, and type specification will be stripped to local reference.
+        """
+        # Provide different type in python spec than in docstring to make sure, that docstring
+        # information is used.
+        def test(arg0: str) -> None:
+            """
+            test(arg0: Union[argparse.Action, NoneType]) -> Tuple[argparse.Action, NoneType]
+            """
+
+        output: list[str] = []
+        imports: list[str] = []
+        mod = ModuleType("argparse", "")
+        generate_c_function_stub(
+            mod,
+            "test",
+            test,
+            output=output,
+            imports=imports,
+            known_modules=[mod.__name__],
+            sig_generators=get_sig_generators(parse_options([])),
+        )
+        assert_equal(output, ["def test(arg0: Union[Action,None]) -> Tuple[Action,None]: ..."])
+        assert_equal(imports, [])
+
     def test_generate_c_function_other_module_nested(self) -> None:
         """Test that if annotation references type from other module, module will be imported,
         and the import will be restricted to one of the known modules."""

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -933,6 +933,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -956,6 +957,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -978,6 +980,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="cls",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1004,6 +1007,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="cls",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1037,6 +1041,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1204,6 +1209,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1227,6 +1233,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1250,6 +1257,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1273,6 +1281,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1296,6 +1305,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1324,6 +1334,7 @@ class StubgencSuite(unittest.TestCase):
             output,
             imports,
             self_var="self",
+            cls=TestClass,
             class_name="TestClass",
             sig_generators=get_sig_generators(parse_options([])),
         )
@@ -1336,6 +1347,41 @@ class StubgencSuite(unittest.TestCase):
                 "def __init__(self, arg0: str, arg1: str) -> None: ...",
                 "@overload",
                 "def __init__(self, *args, **kwargs) -> Any: ...",
+            ],
+        )
+        assert_equal(set(imports), {"from typing import overload"})
+
+    def test_generate_c_type_with_overload_shiboken(self) -> None:
+        class TestClass:
+            """
+            TestClass(self: TestClass, arg0: str) -> None
+            TestClass(self: TestClass, arg0: str, arg1: str) -> None
+            """
+
+            def __init__(self, arg0: str) -> None:
+                pass
+
+        output: list[str] = []
+        imports: list[str] = []
+        mod = ModuleType(TestClass.__module__, "")
+        generate_c_function_stub(
+            mod,
+            "__init__",
+            TestClass.__init__,
+            output,
+            imports,
+            self_var="self",
+            cls=TestClass,
+            class_name="TestClass",
+            sig_generators=get_sig_generators(parse_options([])),
+        )
+        assert_equal(
+            output,
+            [
+                "@overload",
+                "def __init__(self, arg0: str) -> None: ...",
+                "@overload",
+                "def __init__(self, arg0: str, arg1: str) -> None: ...",
             ],
         )
         assert_equal(set(imports), {"from typing import overload"})


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This bundles together a handful of improvements to stubgenc.  Each one has its own commit, but it can be somewhat time consuming to get a PR reviewed and merged, so I'm putting them together for the sake of expediency.  I'll break them up if it is preferred.

An overview of the main changes:

- infer return types for known special methods:  previously only argument types were inferred
- check class docstrings for signatures in addition to `__init__`:  shiboken binding generator is known to put constructor signatures in class docstrings rather than on `__init__`
- use the list of analyzed modules to produce better imports:  previously when given `foo.Bar.Spangle`, it was assumed that `import foo.Bar` should be added, however, it could be that `Bar.Spangle` refers to nested classes within the module `foo`.  
- when fixing up types, also process children of compound types
- evaluate descriptors when getting members: necessary for shiboken bindings 


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
