### PR TITLE
In error messages, quote just the module's name

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2209,6 +2209,7 @@ def quote_type_string(type_string: str) -> str:
     no_quote_regex = r"^<(tuple|union): \d+ items>$"
     if (
         type_string in ["Module", "overloaded function", "<nothing>", "<deleted>"]
+        or type_string.startswith("Module ")
         or re.match(no_quote_regex, type_string) is not None
         or type_string.endswith("?")
     ):
@@ -2285,7 +2286,7 @@ def format_type_inner(
             # Make some common error messages simpler and tidier.
             base_str = "Module"
             if itype.extra_attrs and itype.extra_attrs.mod_name and module_names:
-                return f"{base_str} {itype.extra_attrs.mod_name}"
+                return f'{base_str} "{itype.extra_attrs.mod_name}"'
             return base_str
         if itype.type.fullname == "typing._SpecialForm":
             # This is not a real type but used for some typing-related constructs.

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6054,7 +6054,7 @@ def update() -> str: ...
 [out]
 [out2]
 tmp/m.py:9: error: Argument 1 to "setup" has incompatible type Module; expected "Options"
-tmp/m.py:9: note: Following member(s) of "Module default_config" have conflicts:
+tmp/m.py:9: note: Following member(s) of Module "default_config" have conflicts:
 tmp/m.py:9: note:     Expected:
 tmp/m.py:9: note:         def update() -> bool
 tmp/m.py:9: note:     Got:

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1852,7 +1852,7 @@ class C:
 import stub
 
 reveal_type(stub.y)  # N: Revealed type is "builtins.int"
-reveal_type(stub.z)  # E: "Module stub" does not explicitly export attribute "z" \
+reveal_type(stub.z)  # E: Module "stub" does not explicitly export attribute "z" \
                      # N: Revealed type is "Any"
 
 [file stub.pyi]
@@ -1944,7 +1944,7 @@ import mod
 from mod import C, D  # E: Module "mod" does not explicitly export attribute "C"
 
 reveal_type(mod.x)  # N: Revealed type is "mod.submod.C"
-mod.C  # E: "Module mod" does not explicitly export attribute "C"
+mod.C  # E: Module "mod" does not explicitly export attribute "C"
 y = mod.D()
 reveal_type(y.a)  # N: Revealed type is "builtins.str"
 

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -3720,10 +3720,10 @@ setup(bad_config_1)  # E: Argument 1 to "setup" has incompatible type Module; ex
                      # N: "ModuleType" is missing following "Options" protocol member: \
                      # N:     timeout
 setup(bad_config_2)  # E: Argument 1 to "setup" has incompatible type Module; expected "Options" \
-                     # N: Following member(s) of "Module bad_config_2" have conflicts: \
+                     # N: Following member(s) of Module "bad_config_2" have conflicts: \
                      # N:     one_flag: expected "bool", got "int"
 setup(bad_config_3)  # E: Argument 1 to "setup" has incompatible type Module; expected "Options" \
-                     # N: Following member(s) of "Module bad_config_3" have conflicts: \
+                     # N: Following member(s) of Module "bad_config_3" have conflicts: \
                      # N:     Expected: \
                      # N:         def update() -> bool \
                      # N:     Got: \
@@ -3789,7 +3789,7 @@ class Result(Protocol):
 def run(x: Runner) -> None: ...
 run(runner)  # OK
 run(bad_runner)  # E: Argument 1 to "run" has incompatible type Module; expected "Runner" \
-                 # N: Following member(s) of "Module bad_runner" have conflicts: \
+                 # N: Following member(s) of Module "bad_runner" have conflicts: \
                  # N:     Expected: \
                  # N:         def (int, /) -> Result \
                  # N:     Got: \
@@ -3821,7 +3821,7 @@ class Result(Protocol):
 def run(x: Runner) -> None: ...
 run(runner)  # OK
 run(bad_runner)  # E: Argument 1 to "run" has incompatible type Module; expected "Runner" \
-                 # N: Following member(s) of "Module bad_runner" have conflicts: \
+                 # N: Following member(s) of Module "bad_runner" have conflicts: \
                  # N:     Expected: \
                  # N:         def (int, /) -> Result \
                  # N:     Got: \

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9975,7 +9975,7 @@ def update() -> str: ...
 [out]
 ==
 m.py:9: error: Argument 1 to "setup" has incompatible type Module; expected "Options"
-m.py:9: note: Following member(s) of "Module default_config" have conflicts:
+m.py:9: note: Following member(s) of Module "default_config" have conflicts:
 m.py:9: note:     Expected:
 m.py:9: note:         def update() -> bool
 m.py:9: note:     Got:


### PR DESCRIPTION
This makes it consistent with other error messages, e.g.
https://github.com/python/mypy/blob/1a781e7b46fa362718259187ca1f7cdfd9fad136/mypy/semanal.py#L2572-L2574