### PR TITLE
Stubtest: verify default values for `Final` variables in a stub

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -762,6 +762,54 @@ class StubtestUnit(unittest.TestCase):
             """,
             error=None,
         )
+        yield Case(
+            stub="""
+            from typing_extensions import Final
+            final1: Final = 1
+            final2: Final = 1
+            """,
+            runtime="""
+            final1 = 2
+            final2 = 1
+            """,
+            error="final1",
+        )
+        yield Case(
+            stub="""
+            from typing_extensions import Final
+            final3: Final = 1.5
+            final4: Final = 1.5
+            """,
+            runtime="""
+            final3 = 2.5
+            final4 = 1.5
+            """,
+            error="final3",
+        )
+        yield Case(
+            stub="""
+            from typing_extensions import Final
+            final5: Final = "foo"
+            final6: Final = "foo"
+            """,
+            runtime="""
+            final5 = "bar"
+            final6 = "foo"
+            """,
+            error="final5",
+        )
+        yield Case(
+            stub="""
+            from typing_extensions import Final
+            final7: Final = True
+            final8: Final = True
+            """,
+            runtime="""
+            final7 = False
+            final8 = True
+            """,
+            error="final7",
+        )
 
     @collect_cases
     def test_type_alias(self) -> Iterator[Case]:


### PR DESCRIPTION
Following https://github.com/python/mypy/commit/a9c62c5f82f34a923b8117a5394983aefce37b63, stubtest now verifies parameter defaults in a stub (when they're present). However, if a global or class variable in a stub has a default value, stubtest currently does no verification of the _value_ (only the type).

Unfortunately mypy does not store the value for most variable assignments, so it is hard to verify the value. However, it _does_ store the value for `Final` variables.