### PR TITLE
[1.0 Backport] Fix crash on prefixed paramspec with deferral (#14569)

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -713,13 +713,13 @@ class ParamSpecType(TypeVarLikeType):
         return n
 
     def __hash__(self) -> int:
-        return hash((self.id, self.flavor))
+        return hash((self.id, self.flavor, self.prefix))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ParamSpecType):
             return NotImplemented
         # Upper bound can be ignored, since it's determined by flavor.
-        return self.id == other.id and self.flavor == other.flavor
+        return self.id == other.id and self.flavor == other.flavor and self.prefix == other.prefix
 
     def serialize(self) -> JsonDict:
         assert not self.id.is_meta_var()

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1456,3 +1456,18 @@ class C(Generic[T]): ...
 C[Callable[P, int]]()  # E: The first argument to Callable must be a list of types, parameter specification, or "..." \
                        # N: See https://mypy.readthedocs.io/en/stable/kinds_of_types.html#callable-types-and-lambdas
 [builtins fixtures/paramspec.pyi]
+
+[case testConcatDeferralNoCrash]
+from typing import Callable, TypeVar
+from typing_extensions import Concatenate, ParamSpec
+
+P = ParamSpec("P")
+T = TypeVar("T", bound="Defer")
+
+Alias = Callable[P, bool]
+Concat = Alias[Concatenate[T, P]]
+
+def test(f: Concat[T, ...]) -> None: ...
+
+class Defer: ...
+[builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
Fixes #14565

The fix looks simple, looks like an obvious omission.