### PR TITLE
Improve misleading message in Enum() (#5317)

### DIFF
--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -220,14 +220,14 @@ class EnumCallAnalyzer:
                     items.append(field)
             else:
                 return self.fail_enum_call_arg(
-                    "%s() expects a string, tuple, list or dict literal as the second argument"
+                    "Non-literal string, tuple, list or dict as the second argument of %s() is not supported"
                     % class_name,
                     call,
                 )
         else:
             # TODO: Allow dict(x=1, y=2) as a substitute for {'x': 1, 'y': 2}?
             return self.fail_enum_call_arg(
-                "%s() expects a string, tuple, list or dict literal as the second argument"
+                "Non-literal string, tuple, list or dict as the second argument of %s() is not supported"
                 % class_name,
                 call,
             )

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -220,14 +220,14 @@ class EnumCallAnalyzer:
                     items.append(field)
             else:
                 return self.fail_enum_call_arg(
-                    "Non-literal string, tuple, list or dict as the second argument of %s() is not supported"
+                    "Second argument of %s() must be string, tuple, list or dict literal for mypy to determine Enum members"
                     % class_name,
                     call,
                 )
         else:
             # TODO: Allow dict(x=1, y=2) as a substitute for {'x': 1, 'y': 2}?
             return self.fail_enum_call_arg(
-                "Non-literal string, tuple, list or dict as the second argument of %s() is not supported"
+                "Second argument of %s() must be string, tuple, list or dict literal for mypy to determine Enum members"
                 % class_name,
                 call,
             )

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -482,13 +482,13 @@ W.c
 [typing fixtures/typing-medium.pyi]
 [out]
 main:2: error: Too few arguments for Enum()
-main:3: error: Non-literal string, tuple, list or dict as the second argument of Enum() is not supported
+main:3: error: Second argument of Enum() must be string, tuple, list or dict literal for mypy to determine Enum members
 main:4: error: Too many arguments for Enum()
-main:5: error: Non-literal string, tuple, list or dict as the second argument of Enum() is not supported
+main:5: error: Second argument of Enum() must be string, tuple, list or dict literal for mypy to determine Enum members
 main:5: error: Name "foo" is not defined
-main:7: error: Non-literal string, tuple, list or dict as the second argument of Enum() is not supported
+main:7: error: Second argument of Enum() must be string, tuple, list or dict literal for mypy to determine Enum members
 main:8: error: Too few arguments for IntEnum()
-main:9: error: Non-literal string, tuple, list or dict as the second argument of IntEnum() is not supported
+main:9: error: Second argument of IntEnum() must be string, tuple, list or dict literal for mypy to determine Enum members
 main:10: error: Too many arguments for IntEnum()
 main:11: error: Enum() needs at least one item
 main:12: error: Enum() needs at least one item

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -482,13 +482,13 @@ W.c
 [typing fixtures/typing-medium.pyi]
 [out]
 main:2: error: Too few arguments for Enum()
-main:3: error: Enum() expects a string, tuple, list or dict literal as the second argument
+main:3: error: Non-literal string, tuple, list or dict as the second argument of Enum() is not supported
 main:4: error: Too many arguments for Enum()
-main:5: error: Enum() expects a string, tuple, list or dict literal as the second argument
+main:5: error: Non-literal string, tuple, list or dict as the second argument of Enum() is not supported
 main:5: error: Name "foo" is not defined
-main:7: error: Enum() expects a string, tuple, list or dict literal as the second argument
+main:7: error: Non-literal string, tuple, list or dict as the second argument of Enum() is not supported
 main:8: error: Too few arguments for IntEnum()
-main:9: error: IntEnum() expects a string, tuple, list or dict literal as the second argument
+main:9: error: Non-literal string, tuple, list or dict as the second argument of IntEnum() is not supported
 main:10: error: Too many arguments for IntEnum()
 main:11: error: Enum() needs at least one item
 main:12: error: Enum() needs at least one item


### PR DESCRIPTION
Clarifying this is a mypy limitation, not an Enum() requirement.

Not a true fix, but a workaround for #5317 to avoid confusion (as seen by the many duplicates

Just clarifying a somewhat misleading error message 