### PR TITLE
[stubgen] Preserve PEP 604 Unions in generated pyi files

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -134,6 +134,7 @@ from mypy.types import (
     TypeList,
     TypeStrVisitor,
     UnboundType,
+    UnionType,
     get_proper_type,
 )
 from mypy.visitor import NodeVisitor
@@ -325,6 +326,9 @@ class AnnotationPrinter(TypeStrVisitor):
 
     def visit_type_list(self, t: TypeList) -> str:
         return f"[{self.list_str(t.items)}]"
+
+    def visit_union_type(self, t: UnionType) -> str:
+        return " | ".join([item.accept(self) for item in t.items])
 
     def args_str(self, args: Iterable[Type]) -> str:
         """Convert an array of arguments to strings and join the results with commas.

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -2783,3 +2783,13 @@ T = TypeVar("T", bound=str | None)
 from typing import TypeVar
 
 T = TypeVar('T', bound=str | None)
+
+
+[case testPEP604UnionType]
+a: str | int
+
+def f(x: str | None) -> None: ...
+[out]
+a: str | int
+
+def f(x: str | None) -> None: ...


### PR DESCRIPTION
When a PEP 604 Union exists in the runtime, stubgen was generating a `Union[...]` syntax without importing `Union` from `typing`. With this change, stubgen preserves the ` | `-unions in the output.

Fixes #12929
Closes #13428
Ref #12920
