### PR TITLE
Consistently use type-abstract error code

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1787,7 +1787,9 @@ class MessageBuilder:
 
     def concrete_only_assign(self, typ: Type, context: Context) -> None:
         self.fail(
-            f"Can only assign concrete classes to a variable of type {format_type(typ)}", context
+            f"Can only assign concrete classes to a variable of type {format_type(typ)}",
+            context,
+            code=codes.TYPE_ABSTRACT,
         )
 
     def concrete_only_call(self, typ: Type, context: Context) -> None:

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -998,6 +998,11 @@ T = TypeVar("T")
 def test(tp: Type[T]) -> T: ...
 test(C)  # E: Only concrete class can be given where "Type[C]" is expected  [type-abstract]
 
+class D(C):
+    @abc.abstractmethod
+    def bar(self) -> None: ...
+cls: Type[C] = D  # E: Can only assign concrete classes to a variable of type "Type[C]"  [type-abstract]
+
 [case testUncheckedAnnotationCodeShown]
 def f():
     x: int = "no"  # N: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]


### PR DESCRIPTION
Ref #4717

Although function use case is much more important, the variable assignment should use the same error code, otherwise this may cause confusion.
