### PR TITLE
Make typeddict-unknown-key sub-code of typeddict-item

### DIFF
--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -526,6 +526,9 @@ Whereas reading an unknown value will generate the more generic/serious
     # Error: TypedDict "Point" has no key "z"  [typeddict-item]
     _ = a["z"]
 
+.. note::
+
+    This error code is a sub-error code of a wider ``[typeddict-item]`` code.
 
 Check that type of target is known [has-type]
 ---------------------------------------------

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -84,8 +84,11 @@ DICT_ITEM: Final = ErrorCode(
 TYPEDDICT_ITEM: Final = ErrorCode(
     "typeddict-item", "Check items when constructing TypedDict", "General"
 )
-TYPPEDICT_UNKNOWN_KEY: Final = ErrorCode(
-    "typeddict-unknown-key", "Check unknown keys when constructing TypedDict", "General"
+TYPEDDICT_UNKNOWN_KEY: Final = ErrorCode(
+    "typeddict-unknown-key",
+    "Check unknown keys when constructing TypedDict",
+    "General",
+    sub_code_of=TYPEDDICT_ITEM,
 )
 HAS_TYPE: Final = ErrorCode(
     "has-type", "Check that type of reference can be determined", "General"

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1652,7 +1652,7 @@ class MessageBuilder:
                         format_key_list(extra, short=True), format_type(typ)
                     ),
                     context,
-                    code=codes.TYPPEDICT_UNKNOWN_KEY,
+                    code=codes.TYPEDDICT_UNKNOWN_KEY,
                 )
             if missing or extra:
                 # No need to check for further errors
@@ -1693,7 +1693,7 @@ class MessageBuilder:
                 context,
             )
         else:
-            err_code = codes.TYPPEDICT_UNKNOWN_KEY if setitem else codes.TYPEDDICT_ITEM
+            err_code = codes.TYPEDDICT_UNKNOWN_KEY if setitem else codes.TYPEDDICT_ITEM
             self.fail(
                 f'TypedDict {format_type(typ)} has no key "{item_name}"', context, code=err_code
             )

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -481,6 +481,14 @@ not_exist = a['not_exist'] # type: ignore[typeddict-item]
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testErrorCodeTypedDictSubCodeIgnore]
+from typing_extensions import TypedDict
+class D(TypedDict):
+    x: int
+d: D = {'x': 1, 'y': 2}  # type: ignore[typeddict-item]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testErrorCodeCannotDetermineType]
 y = x  # E: Cannot determine type of "x"  [has-type]  # E: Name "x" is used before definition  [used-before-def]
 reveal_type(y)  # N: Revealed type is "Any"


### PR DESCRIPTION
The PR that added the error code didn't make into 1.0, so I make it a sub-code, to improve backwards compatibility. Also fixing a type while I am touching this code.