### PR TITLE
adjust inconsistent dataclasses plugin error messages

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -229,7 +229,7 @@ class DataclassTransformer:
         # Add <, >, <=, >=, but only if the class has an eq method.
         if decorator_arguments["order"]:
             if not decorator_arguments["eq"]:
-                ctx.api.fail("eq must be True if order is True", ctx.cls)
+                ctx.api.fail('"eq" must be True if "order" is True', ctx.reason)
 
             for method_name in ["__lt__", "__gt__", "__le__", "__ge__"]:
                 # Like for __eq__ and __ne__, we want "other" to match
@@ -247,7 +247,7 @@ class DataclassTransformer:
                 if existing_method is not None and not existing_method.plugin_generated:
                     assert existing_method.node
                     ctx.api.fail(
-                        f"You may not have a custom {method_name} method when order=True",
+                        f'You may not have a custom "{method_name}" method when "order" is True',
                         existing_method.node,
                     )
 

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -55,8 +55,8 @@ def my_dataclass(*, eq: bool, order: bool) -> Callable[[Type], Type]:
         return cls
     return transform
 
-@my_dataclass(eq=False, order=True)
-class Person:  # E: eq must be True if order is True
+@my_dataclass(eq=False, order=True)  # E: "eq" must be True if "order" is True
+class Person:
     name: str
     age: int
 

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -672,8 +672,8 @@ app1 >= app3
 # flags: --python-version 3.7
 from dataclasses import dataclass
 
-@dataclass(eq=False, order=True)
-class Application:  # E: eq must be True if order is True
+@dataclass(eq=False, order=True)  # E: "eq" must be True if "order" is True
+class Application:
    ...
 
 [builtins fixtures/dataclasses.pyi]
@@ -684,7 +684,7 @@ from dataclasses import dataclass
 
 @dataclass(order=True)
 class Application:
-  def __lt__(self, other: 'Application') -> bool: # E: You may not have a custom __lt__ method when order=True
+  def __lt__(self, other: 'Application') -> bool: # E: You may not have a custom "__lt__" method when "order" is True
     ...
 
 [builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Small changes prompted by @JukkaL's [comment](https://github.com/python/mypy/pull/14580#discussion_r1098776695) on another review. Splitting this out from that PR since it's unrelated and the messages here have been around for a few years.

This commit specifically adds quotes around Python identifiers in two error messages, and points the error for `"eq" must be True if "order" is True` more directly at the decorator that triggers the error message.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
