### PR TITLE
[dataclass_transform] support function overloads

### DIFF
--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -202,3 +202,57 @@ Foo(5)
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformOverloadsDecoratorOnOverload]
+# flags: --python-version 3.11
+from typing import dataclass_transform, overload, Any, Callable, Type, Literal
+
+@overload
+def my_dataclass(*, foo: str) -> Callable[[Type], Type]: ...
+@overload
+@dataclass_transform(frozen_default=True)
+def my_dataclass(*, foo: int) -> Callable[[Type], Type]: ...
+def my_dataclass(*, foo: Any) -> Callable[[Type], Type]:
+    return lambda cls: cls
+@my_dataclass(foo="hello")
+class A:
+    a: int
+@my_dataclass(foo=5)
+class B:
+    b: int
+
+reveal_type(A)  # N: Revealed type is "def (a: builtins.int) -> __main__.A"
+reveal_type(B)  # N: Revealed type is "def (b: builtins.int) -> __main__.B"
+A(1, "hello")  # E: Too many arguments for "A"
+a = A(1)
+a.a = 2  # E: Property "a" defined in "A" is read-only
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformOverloadsDecoratorOnImpl]
+# flags: --python-version 3.11
+from typing import dataclass_transform, overload, Any, Callable, Type, Literal
+
+@overload
+def my_dataclass(*, foo: str) -> Callable[[Type], Type]: ...
+@overload
+def my_dataclass(*, foo: int) -> Callable[[Type], Type]: ...
+@dataclass_transform(frozen_default=True)
+def my_dataclass(*, foo: Any) -> Callable[[Type], Type]:
+    return lambda cls: cls
+@my_dataclass(foo="hello")
+class A:
+    a: int
+@my_dataclass(foo=5)
+class B:
+    b: int
+
+reveal_type(A)  # N: Revealed type is "def (a: builtins.int) -> __main__.A"
+reveal_type(B)  # N: Revealed type is "def (b: builtins.int) -> __main__.B"
+A(1, "hello")  # E: Too many arguments for "A"
+a = A(1)
+a.a = 2  # E: Property "a" defined in "A" is read-only
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -234,29 +234,6 @@ A(1, "hello")  # E: Too many arguments for "A"
 a = A(1)
 a.a = 2  # E: Property "a" defined in "A" is read-only
 
-[case testDataclassTransformViaBaseClass]
-# flags: --python-version 3.11
-from typing import dataclass_transform
-
-@dataclass_transform(frozen_default=True)
-class Dataclass:
-    def __init_subclass__(cls, *, kw_only: bool = False): ...
-
-class Person(Dataclass, kw_only=True):
-    name: str
-    age: int
-
-reveal_type(Person)  # N: Revealed type is "def (*, name: builtins.str, age: builtins.int) -> __main__.Person"
-Person('Jonh', 21)  # E: Too many positional arguments for "Person"
-person = Person(name='John', age=32)
-person.name = "John Smith"  # E: Property "name" defined in "Person" is read-only
-
-class Contact(Person):
-    email: str
-
-reveal_type(Contact)  # N: Revealed type is "def (email: builtins.str, *, name: builtins.str, age: builtins.int) -> __main__.Contact"
-Contact('john@john.com', name='John', age=32)
-
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
 
@@ -283,6 +260,35 @@ reveal_type(B)  # N: Revealed type is "def (b: builtins.int) -> __main__.B"
 A(1, "hello")  # E: Too many arguments for "A"
 a = A(1)
 a.a = 2  # E: Property "a" defined in "A" is read-only
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformViaBaseClass]
+# flags: --python-version 3.11
+from typing import dataclass_transform
+
+@dataclass_transform(frozen_default=True)
+class Dataclass:
+    def __init_subclass__(cls, *, kw_only: bool = False): ...
+
+class Person(Dataclass, kw_only=True):
+    name: str
+    age: int
+
+reveal_type(Person)  # N: Revealed type is "def (*, name: builtins.str, age: builtins.int) -> __main__.Person"
+Person('Jonh', 21)  # E: Too many positional arguments for "Person"
+person = Person(name='John', age=32)
+person.name = "John Smith"  # E: Property "name" defined in "Person" is read-only
+
+class Contact(Person):
+    email: str
+
+reveal_type(Contact)  # N: Revealed type is "def (email: builtins.str, *, name: builtins.str, age: builtins.int) -> __main__.Contact"
+Contact('john@john.com', name='John', age=32)
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
 
 [case testDataclassTransformViaMetaclass]
 # flags: --python-version 3.11


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Extends the existing decorator support to include overloads. This doesn't require much extra work: we just update `find_dataclass_transform_spec` to search for the first overload decorated with `dataclass_transform()`.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
