### PR TITLE
[backport] [used before def] correctly handle walrus operator (#14646)

### DIFF
--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -253,9 +253,9 @@ class TraverserVisitor(NodeVisitor[None]):
             o.expr.accept(self)
 
     def visit_call_expr(self, o: CallExpr) -> None:
+        o.callee.accept(self)
         for a in o.args:
             a.accept(self)
-        o.callee.accept(self)
         if o.analyzed:
             o.analyzed.accept(self)
 

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -573,6 +573,14 @@ def foo() -> None:
     [x := x + y for y in [1, 2, 3]]
 [builtins fixtures/dict.pyi]
 
+[case testWalrusUsedBeforeDef]
+# flags: --python-version 3.8
+class C:
+    def f(self, c: 'C') -> None: pass
+
+(x := C()).f(y)  # E: Cannot determine type of "y"  # E: Name "y" is used before definition
+(y := C()).f(y)
+
 [case testOverloadWithPositionalOnlySelf]
 # flags: --python-version 3.8
 from typing import overload, Optional


### PR DESCRIPTION
Fixes #14626.

I believe changing the way that we analyze call expression makes sense (first, we analyze the callee, then we analyze the arguments).