### PR TITLE
[dataclass_transform] support field_specifiers

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -270,3 +270,7 @@ CLASS_PATTERN_DUPLICATE_KEYWORD_PATTERN: Final = 'Duplicate keyword pattern "{}"
 CLASS_PATTERN_UNKNOWN_KEYWORD: Final = 'Class "{}" has no attribute "{}"'
 MULTIPLE_ASSIGNMENTS_IN_PATTERN: Final = 'Multiple assignments to name "{}" in pattern'
 CANNOT_MODIFY_MATCH_ARGS: Final = 'Cannot assign to "__match_args__"'
+
+DATACLASS_FIELD_ALIAS_MUST_BE_LITERAL: Final = (
+    '"alias" argument to dataclass field must be a string literal'
+)

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -298,6 +298,10 @@ class SemanticAnalyzerPluginInterface:
         raise NotImplementedError
 
     @abstractmethod
+    def parse_str_literal(self, expr: Expression) -> str | None:
+        """Parse string literals."""
+
+    @abstractmethod
     def fail(
         self,
         msg: str,

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -689,6 +689,12 @@ class DataclassTransformer:
                         # the best we can do for now is not to fail.
                         # TODO: we can infer what's inside `**` and try to collect it.
                         message = 'Unpacking **kwargs in "field()" is not supported'
+                    elif self._spec is not _TRANSFORM_SPEC_FOR_DATACLASSES:
+                        # dataclasses.field can only be used with keyword args, but this
+                        # restriction is only enforced for the *standardized* arguments to
+                        # dataclass_transform field specifiers. If this is not a
+                        # dataclasses.dataclass class, we can just skip positional args safely.
+                        continue
                     else:
                         message = '"field()" does not accept positional arguments'
                     self._api.fail(message, expr)

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -524,7 +524,7 @@ class DataclassTransformer:
                 if value is not None:
                     is_kw_only = value
                 else:
-                    self._api.fail('"kw_only" argument must be True or False.', stmt.rvalue)
+                    self._api.fail('"kw_only" argument must be a boolean literal', stmt.rvalue)
 
             if sym.type is None and node.is_final and node.is_inferred:
                 # This is a special case, assignment like x: Final = 42 is classified

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6462,6 +6462,8 @@ class SemanticAnalyzer(
         return None
 
     def parse_str_literal(self, expr: Expression) -> str | None:
+        """Attempt to find the string literal value of the given expression. Returns `None` if no
+        literal value can be found."""
         if isinstance(expr, StrExpr):
             return expr.value
         if isinstance(expr, RefExpr) and isinstance(expr.node, Var) and expr.node.type is not None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6517,6 +6517,7 @@ class SemanticAnalyzer(
 
     def parse_dataclass_transform_field_specifiers(self, arg: Expression) -> tuple[str, ...]:
         if not isinstance(arg, TupleExpr):
+            self.fail('"field_specifiers" argument must be a tuple literal', arg)
             return tuple()
 
         names = []

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -269,7 +269,7 @@ def some_bool() -> bool: ...
 @my_dataclass
 class Bad:
     bad1: int = field(alias=some_str())  # E: "alias" argument to dataclass field must be a string literal
-    bad2: int = field(kw_only=some_bool())  # E: "kw_only" argument must be True or False.
+    bad2: int = field(kw_only=some_bool())  # E: "kw_only" argument must be a boolean literal
 
 # this metadata should only exist for dataclasses.dataclass classes
 Foo.__dataclass_fields__  # E: "Type[Foo]" has no attribute "__dataclass_fields__"

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -250,7 +250,7 @@ def field(
 def my_dataclass(cls: Type) -> Type:
     return cls
 
-B: Final = 'b'
+B: Final = 'b_'
 @my_dataclass
 class Foo:
     a: int = field(alias='a_')
@@ -264,13 +264,13 @@ class Foo:
     unused2: int = field(factory=lambda: 0)
     unused3: int = field(default_factory=lambda: 0)
 
-Foo(a=5, b=1)  # E: Unexpected keyword argument "a" for "Foo"
-Foo(a_=1, b=1, noinit=1)  # E: Unexpected keyword argument "noinit" for "Foo"
+Foo(a=5, b_=1)  # E: Unexpected keyword argument "a" for "Foo"
+Foo(a_=1, b_=1, noinit=1)  # E: Unexpected keyword argument "noinit" for "Foo"
 Foo(1, 2, 3)  # E: Too many positional arguments for "Foo"
-foo = Foo(a_=5, b=1)
+foo = Foo(1, 2, kwonly=3)
 reveal_type(foo.noinit)  # N: Revealed type is "builtins.int"
 reveal_type(foo.unused1)  # N: Revealed type is "builtins.int"
-Foo(a_=5, b=1, unused1=2, unused2=3, unused3=4)
+Foo(a_=5, b_=1, unused1=2, unused2=3, unused3=4)
 
 def some_str() -> str: ...
 def some_bool() -> bool: ...

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -277,6 +277,28 @@ Foo.__dataclass_fields__  # E: "Type[Foo]" has no attribute "__dataclass_fields_
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
 
+[case testDataclassTransformFieldSpecifierExtraArgs]
+# flags: --python-version 3.11
+from typing import dataclass_transform
+
+def field(extra1, *, kw_only=False, extra2=0): ...
+@dataclass_transform(field_specifiers=(field,))
+def my_dataclass(cls):
+    return cls
+
+@my_dataclass
+class Good:
+    a: int = field(5)
+    b: int = field(5, extra2=1)
+    c: int = field(5, kw_only=True)
+
+@my_dataclass
+class Bad:
+    a: int = field(kw_only=True)  # E: Missing positional argument "extra1" in call to "field"
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
 [case testDataclassTransformOverloadsDecoratorOnOverload]
 # flags: --python-version 3.11
 from typing import dataclass_transform, overload, Any, Callable, Type, Literal

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -307,6 +307,28 @@ class Bad:
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
 
+[case testDataclassTransformMultipleFieldSpecifiers]
+# flags: --python-version 3.11
+from typing import dataclass_transform
+
+def field1(*, default: int) -> int: ...
+def field2(*, default: str) -> str: ...
+
+@dataclass_transform(field_specifiers=(field1, field2))
+def my_dataclass(cls): return cls
+
+@my_dataclass
+class Foo:
+    a: int = field1(default=0)
+    b: str = field2(default='hello')
+
+reveal_type(Foo)  # N: Revealed type is "def (a: builtins.int =, b: builtins.str =) -> __main__.Foo"
+Foo()
+Foo(a=1, b='bye')
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
 [case testDataclassTransformOverloadsDecoratorOnOverload]
 # flags: --python-version 3.11
 from typing import dataclass_transform, overload, Any, Callable, Type, Literal

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -212,15 +212,23 @@ Foo(5)
 
 [case testDataclassTransformFieldSpecifierRejectMalformed]
 # flags: --python-version 3.11
-from typing import dataclass_transform, Callable, Type
+from typing import dataclass_transform, Any, Callable, Final, Type
 
 def some_type() -> Type: ...
 def some_function() -> Callable[[], None]: ...
+
+def field(*args, **kwargs): ...
+def fields_tuple() -> tuple[type | Callable[..., Any], ...]: return (field,)
+CONSTANT: Final = (field,)
 
 @dataclass_transform(field_specifiers=(some_type(),))  # E: "field_specifiers" must only contain identifiers
 def bad_dataclass1() -> None: ...
 @dataclass_transform(field_specifiers=(some_function(),))  # E: "field_specifiers" must only contain identifiers
 def bad_dataclass2() -> None: ...
+@dataclass_transform(field_specifiers=CONSTANT)  # E: "field_specifiers" argument must be a tuple literal
+def bad_dataclass3() -> None: ...
+@dataclass_transform(field_specifiers=fields_tuple())  # E: "field_specifiers" argument must be a tuple literal
+def bad_dataclass4() -> None: ...
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -202,3 +202,70 @@ Foo(5)
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformFieldSpecifierRejectMalformed]
+# flags: --python-version 3.11
+from typing import dataclass_transform, Callable, Type
+
+def some_type() -> Type: ...
+def some_function() -> Callable[[], None]: ...
+
+@dataclass_transform(field_specifiers=(some_type(),))  # E: "field_specifiers" must only contain identifiers
+def bad_dataclass1() -> None: ...
+@dataclass_transform(field_specifiers=(some_function(),))  # E: "field_specifiers" must only contain identifiers
+def bad_dataclass2() -> None: ...
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformFieldSpecifierParams]
+# flags: --python-version 3.11
+from typing import dataclass_transform, Any, Callable, Type, Final
+
+def field(
+    *,
+    init: bool = True,
+    kw_only: bool = False,
+    alias: str | None = None,
+    default: Any | None = None,
+    default_factory: Callable[[], Any] | None = None,
+    factory: Callable[[], Any] | None = None,
+): ...
+@dataclass_transform(field_specifiers=(field,))
+def my_dataclass(cls: Type) -> Type:
+    return cls
+
+B: Final = 'b'
+@my_dataclass
+class Foo:
+    a: int = field(alias='a_')
+    b: int = field(alias=B)
+    # cannot be passed as a positional
+    kwonly: int = field(kw_only=True, default=0)
+    # Safe to omit from constructor, error to pass
+    noinit: int = field(init=False, default=1)
+    # It should be safe to call the constructor without passing any of these
+    unused1: int = field(default=0)
+    unused2: int = field(factory=lambda: 0)
+    unused3: int = field(default_factory=lambda: 0)
+
+Foo(a=5, b=1)  # E: Unexpected keyword argument "a" for "Foo"
+Foo(a_=1, b=1, noinit=1)  # E: Unexpected keyword argument "noinit" for "Foo"
+Foo(1, 2, 3)  # E: Too many positional arguments for "Foo"
+foo = Foo(a_=5, b=1)
+reveal_type(foo.noinit)  # N: Revealed type is "builtins.int"
+reveal_type(foo.unused1)  # N: Revealed type is "builtins.int"
+Foo(a_=5, b=1, unused1=2, unused2=3, unused3=4)
+
+def some_str() -> str: ...
+def some_bool() -> bool: ...
+@my_dataclass
+class Bad:
+    bad1: int = field(alias=some_str())  # E: "alias" argument to dataclass field must be a string literal
+    bad2: int = field(kw_only=some_bool())  # E: "kw_only" argument must be True or False.
+
+# this metadata should only exist for dataclasses.dataclass classes
+Foo.__dataclass_fields__  # E: "Type[Foo]" has no attribute "__dataclass_fields__"
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

These are analogous to `dataclasses.field`/`dataclasses.Field`.

Like most dataclass_transform features so far, this commit mostly just plumbs through the necessary metadata so that we can re-use the existing `dataclasses` plugin logic. It also adds support for the `alias=` and `factory=` kwargs for fields, which are small; we rely on typeshed to enforce that these aren't used with `dataclasses.field`.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
