### PR TITLE
[backport] [used before def] handle walrus declaration in match subject correctly

### DIFF
--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -396,8 +396,8 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
         self.tracker.end_branch_statement()
 
     def visit_match_stmt(self, o: MatchStmt) -> None:
-        self.tracker.start_branch_statement()
         o.subject.accept(self)
+        self.tracker.start_branch_statement()
         for i in range(len(o.patterns)):
             pattern = o.patterns[i]
             pattern.accept(self)

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1813,6 +1813,19 @@ def f1(x: int) -> int:
 
 [typing fixtures/typing-medium.pyi]
 
+[case testUsedBeforeDefMatchWalrus]
+# flags: --enable-error-code used-before-def
+import typing
+
+def f0(x: int) -> None:
+    a = y  # E: Cannot determine type of "y"  # E: Name "y" is used before definition
+    match y := x:
+        case 1:
+            b = y
+        case 2:
+            c = y
+    d = y
+
 [case testTypeAliasWithNewUnionSyntaxAndNoneLeftOperand]
 from typing import overload
 class C:


### PR DESCRIPTION
Backport of #14665.

