### PR TITLE
Fix generic TypedDict/NamedTuple fixup

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -80,9 +80,13 @@ class NodeFixer(NodeVisitor[None]):
             if info.tuple_type:
                 info.tuple_type.accept(self.type_fixer)
                 info.update_tuple_type(info.tuple_type)
+                if info.special_alias:
+                    info.special_alias.alias_tvars = list(info.defn.type_vars)
             if info.typeddict_type:
                 info.typeddict_type.accept(self.type_fixer)
                 info.update_typeddict_type(info.typeddict_type)
+                if info.special_alias:
+                    info.special_alias.alias_tvars = list(info.defn.type_vars)
             if info.declared_metaclass:
                 info.declared_metaclass.accept(self.type_fixer)
             if info.metaclass_type:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3498,8 +3498,13 @@ class TypeAlias(SymbolNode):
 
     @classmethod
     def from_tuple_type(cls, info: TypeInfo) -> TypeAlias:
-        """Generate an alias to the tuple type described by a given TypeInfo."""
+        """Generate an alias to the tuple type described by a given TypeInfo.
+
+        NOTE: this doesn't set type alias type variables (for generic tuple types),
+        they must be set by the caller (when fully analyzed).
+        """
         assert info.tuple_type
+        # TODO: is it possible to refactor this to set the correct type vars here?
         return TypeAlias(
             info.tuple_type.copy_modified(fallback=mypy.types.Instance(info, info.defn.type_vars)),
             info.fullname,
@@ -3509,8 +3514,13 @@ class TypeAlias(SymbolNode):
 
     @classmethod
     def from_typeddict_type(cls, info: TypeInfo) -> TypeAlias:
-        """Generate an alias to the TypedDict type described by a given TypeInfo."""
+        """Generate an alias to the TypedDict type described by a given TypeInfo.
+
+        NOTE: this doesn't set type alias type variables (for generic TypedDicts),
+        they must be set by the caller (when fully analyzed).
+        """
         assert info.typeddict_type
+        # TODO: is it possible to refactor this to set the correct type vars here?
         return TypeAlias(
             info.typeddict_type.copy_modified(
                 fallback=mypy.types.Instance(info, info.defn.type_vars)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6372,3 +6372,34 @@ y: int = x
 [builtins fixtures/tuple.pyi]
 [out]
 [out2]
+
+[case testGenericTypedDictWithError]
+import b
+[file a.py]
+from typing import Generic, TypeVar
+from typing_extensions import TypedDict
+
+TValue = TypeVar("TValue")
+class Dict(TypedDict, Generic[TValue]):
+    value: TValue
+
+[file b.py]
+from a import Dict, TValue
+
+def f(d: Dict[TValue]) -> TValue:
+    return d["value"]
+def g(d: Dict[TValue]) -> TValue:
+    return d["x"]
+
+[file b.py.2]
+from a import Dict, TValue
+
+def f(d: Dict[TValue]) -> TValue:
+    return d["value"]
+def g(d: Dict[TValue]) -> TValue:
+    return d["y"]
+[builtins fixtures/dict.pyi]
+[out]
+tmp/b.py:6: error: TypedDict "a.Dict[TValue]" has no key "x"
+[out2]
+tmp/b.py:6: error: TypedDict "a.Dict[TValue]" has no key "y"


### PR DESCRIPTION
Fixes #14638 

TBH I don't remember why do we need to create the "incomplete" type alias (with empty type variables), and set up type variables later. But I didn't want to risk a larger refactoring and just fixed the missing calls surfaced by the issue instead.