### PR TITLE
Remove unused `imported_names` field

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -461,20 +461,17 @@ class ImportFrom(ImportBase):
 class ImportAll(ImportBase):
     """from m import *"""
 
-    __slots__ = ("id", "relative", "imported_names")
+    __slots__ = ("id", "relative")
 
     __match_args__ = ("id", "relative")
 
     id: str
     relative: int
-    # NOTE: Only filled and used by old semantic analyzer.
-    imported_names: list[str]
 
     def __init__(self, id: str, relative: int) -> None:
         super().__init__()
         self.id = id
         self.relative = relative
-        self.imported_names = []
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_import_all(self)


### PR DESCRIPTION
This PR removes the unused `imported_names` field from the `ImportAll` node class. Nothing outside of this class references it, so it should be safe to remove.