### PR TITLE
consolidate literal bool argument error messages

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -6,6 +6,7 @@ from typing import Iterable, List, cast
 from typing_extensions import Final, Literal
 
 import mypy.plugin  # To avoid circular imports.
+from mypy.errorcodes import LITERAL_REQ
 from mypy.exprtotype import TypeTranslationError, expr_to_unanalyzed_type
 from mypy.nodes import (
     ARG_NAMED,
@@ -246,7 +247,11 @@ def _get_decorator_optional_bool_argument(
                     return False
                 if attr_value.fullname == "builtins.None":
                     return None
-            ctx.api.fail(f'"{name}" argument must be True or False.', ctx.reason)
+            ctx.api.fail(
+                f'"{name}" argument must be a True, False, or None literal',
+                ctx.reason,
+                code=LITERAL_REQ,
+            )
             return default
         return default
     else:

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -20,7 +20,11 @@ from mypy.nodes import (
     Var,
 )
 from mypy.plugin import CheckerPluginInterface, ClassDefContext, SemanticAnalyzerPluginInterface
-from mypy.semanal_shared import ALLOW_INCOMPATIBLE_OVERRIDE, set_callable_name
+from mypy.semanal_shared import (
+    ALLOW_INCOMPATIBLE_OVERRIDE,
+    require_bool_literal_argument,
+    set_callable_name,
+)
 from mypy.typeops import (  # noqa: F401  # Part of public API
     try_getting_str_literals as try_getting_str_literals,
 )
@@ -54,11 +58,7 @@ def _get_bool_argument(ctx: ClassDefContext, expr: CallExpr, name: str, default:
     """
     attr_value = _get_argument(expr, name)
     if attr_value:
-        ret = ctx.api.parse_bool(attr_value)
-        if ret is None:
-            ctx.api.fail(f'"{name}" argument must be True or False.', expr)
-            return default
-        return ret
+        return require_bool_literal_argument(ctx.api, attr_value, name, default)
     return default
 
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -41,7 +41,7 @@ from mypy.plugins.common import (
     add_method_to_class,
     deserialize_and_fixup_type,
 )
-from mypy.semanal_shared import find_dataclass_transform_spec
+from mypy.semanal_shared import find_dataclass_transform_spec, require_bool_literal_argument
 from mypy.server.trigger import make_wildcard_trigger
 from mypy.state import state
 from mypy.typeops import map_type_from_supertype
@@ -678,11 +678,7 @@ class DataclassTransformer:
         # class's keyword arguments (ie `class Subclass(Parent, kwarg1=..., kwarg2=...)`)
         expression = self._cls.keywords.get(name)
         if expression is not None:
-            value = self._api.parse_bool(self._cls.keywords[name])
-            if value is not None:
-                return value
-            else:
-                self._api.fail(f'"{name}" argument must be True or False', expression)
+            return require_bool_literal_argument(self._api, expression, name, default)
         return default
 
 

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -151,9 +151,9 @@ class D:
 [case testAttrsNotBooleans]
 import attr
 x = True
-@attr.s(cmp=x)  # E: "cmp" argument must be True or False.
+@attr.s(cmp=x)  # E: "cmp" argument must be a True, False, or None literal
 class A:
-    a = attr.ib(init=x)  # E: "init" argument must be True or False.
+    a = attr.ib(init=x)  # E: "init" argument must be a True, False, or None literal
 [builtins fixtures/bool.pyi]
 
 [case testAttrsInitFalse]

--- a/test-data/unit/check-attr.test
+++ b/test-data/unit/check-attr.test
@@ -153,7 +153,7 @@ import attr
 x = True
 @attr.s(cmp=x)  # E: "cmp" argument must be a True, False, or None literal
 class A:
-    a = attr.ib(init=x)  # E: "init" argument must be a True, False, or None literal
+    a = attr.ib(init=x)  # E: "init" argument must be a True or False literal
 [builtins fixtures/bool.pyi]
 
 [case testAttrsInitFalse]

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -83,12 +83,12 @@ class BaseClass:
 class Metaclass(type): ...
 
 BOOL_CONSTANT = True
-@my_dataclass(eq=BOOL_CONSTANT)  # E: "eq" argument must be True or False.
+@my_dataclass(eq=BOOL_CONSTANT)  # E: "eq" argument must be a True or False literal
 class A: ...
-@my_dataclass(order=not False)  # E: "order" argument must be True or False.
+@my_dataclass(order=not False)  # E: "order" argument must be a True or False literal
 class B: ...
-class C(BaseClass, eq=BOOL_CONSTANT): ...  # E: "eq" argument must be True or False
-class D(metaclass=Metaclass, order=not False): ...  # E: "order" argument must be True or False
+class C(BaseClass, eq=BOOL_CONSTANT): ...  # E: "eq" argument must be a True or False literal
+class D(metaclass=Metaclass, order=not False): ...  # E: "order" argument must be a True or False literal
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1084,8 +1084,8 @@ reveal_type(d) \
 
 [case testTypedDictWithInvalidTotalArgument]
 from mypy_extensions import TypedDict
-A = TypedDict('A', {'x': int}, total=0) # E: TypedDict() "total" argument must be True or False
-B = TypedDict('B', {'x': int}, total=bool) # E: TypedDict() "total" argument must be True or False
+A = TypedDict('A', {'x': int}, total=0) # E: "total" argument must be a True or False literal
+B = TypedDict('B', {'x': int}, total=bool) # E: "total" argument must be a True or False literal
 C = TypedDict('C', {'x': int}, x=False) # E: Unexpected keyword argument "x" for "TypedDict"
 D = TypedDict('D', {'x': int}, False) # E: Unexpected arguments to TypedDict()
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1179,12 +1179,12 @@ reveal_type(d) # N: Revealed type is "TypedDict('__main__.D', {'x'?: builtins.in
 
 [case testTypedDictClassWithInvalidTotalArgument]
 from mypy_extensions import TypedDict
-class D(TypedDict, total=1): # E: Value of "total" must be True or False
+class D(TypedDict, total=1): # E: "total" argument must be a True or False literal
     x: int
-class E(TypedDict, total=bool): # E: Value of "total" must be True or False
+class E(TypedDict, total=bool): # E: "total" argument must be a True or False literal
     x: int
-class F(TypedDict, total=xyz): # E: Value of "total" must be True or False \
-                               # E: Name "xyz" is not defined
+class F(TypedDict, total=xyz): # E: Name "xyz" is not defined \
+                               # E: "total" argument must be a True or False literal
     x: int
 [builtins fixtures/dict.pyi]
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Follow up on some of the recurring feedback from #14580 and #14657. There are many error messages similar to `X must be True or False.` in MyPy. This commit updates them all to:

- remove the dangling period for consistency with other error messages
- clarify that we need a `True` or `False` literal
- use the `literal-required` error code for consistency with other literal errors

This should have no impact outside of error message formatting.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
