### PR TITLE
[backport] [mypyc] Fix test case testI64Cast on 32-bit architectures

### DIFF
--- a/mypyc/test-data/irbuild-i64.test
+++ b/mypyc/test-data/irbuild-i64.test
@@ -1731,7 +1731,7 @@ def f5():
 L0:
     return 4
 
-[case testI64Cast]
+[case testI64Cast_64bit]
 from typing import cast
 from mypy_extensions import i64
 
@@ -1771,6 +1771,39 @@ L2:
     keep_alive x
 L3:
     return r3
+
+[case testI64Cast_32bit]
+from typing import cast
+from mypy_extensions import i64
+
+def cast_int(x: int) -> i64:
+    return cast(i64, x)
+[out]
+def cast_int(x):
+    x :: int
+    r0 :: native_int
+    r1 :: bit
+    r2, r3, r4 :: int64
+    r5 :: ptr
+    r6 :: c_ptr
+    r7 :: int64
+L0:
+    r0 = x & 1
+    r1 = r0 == 0
+    if r1 goto L1 else goto L2 :: bool
+L1:
+    r2 = extend signed x: builtins.int to int64
+    r3 = r2 >> 1
+    r4 = r3
+    goto L3
+L2:
+    r5 = x ^ 1
+    r6 = r5
+    r7 = CPyLong_AsInt64(r6)
+    r4 = r7
+    keep_alive x
+L3:
+    return r4
 
 [case testI64ExplicitConversionFromVariousTypes]
 from mypy_extensions import i64


### PR DESCRIPTION
Backport of #14691.