### PR TITLE
Follow PEP 673 instead of PEP 484 when dealing with implicit `self`

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -972,7 +972,7 @@ class SemanticAnalyzer(
             elif isinstance(functype, CallableType):
                 self_type = get_proper_type(functype.arg_types[0])
                 if isinstance(self_type, AnyType):
-                    leading_type = info.self_type if info.self_type else fill_typevars(info)
+                    leading_type: Type = info.self_type if info.self_type else fill_typevars(info)
                     if func.is_class or func.name == "__new__":
                         leading_type = self.class_type(leading_type)
                     func.type = replace_implicit_first_type(functype, leading_type)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -972,7 +972,8 @@ class SemanticAnalyzer(
             elif isinstance(functype, CallableType):
                 self_type = get_proper_type(functype.arg_types[0])
                 if isinstance(self_type, AnyType):
-                    leading_type: Type = info.self_type if info.self_type else fill_typevars(info)
+                    self.setup_self_type()
+                    leading_type: Type = info.self_type
                     if func.is_class or func.name == "__new__":
                         leading_type = self.class_type(leading_type)
                     func.type = replace_implicit_first_type(functype, leading_type)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -972,11 +972,7 @@ class SemanticAnalyzer(
             elif isinstance(functype, CallableType):
                 self_type = get_proper_type(functype.arg_types[0])
                 if isinstance(self_type, AnyType):
-                    if has_self_type:
-                        assert self.type is not None and self.type.self_type is not None
-                        leading_type: Type = self.type.self_type
-                    else:
-                        leading_type = fill_typevars(info)
+                    leading_type = info.self_type if info.self_type else fill_typevars(info)
                     if func.is_class or func.name == "__new__":
                         leading_type = self.class_type(leading_type)
                     func.type = replace_implicit_first_type(functype, leading_type)

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -1692,9 +1692,8 @@ class C:
         return self
     def baz(self: Self) -> None:
         self.x = self
-    def bad(self) -> None:
-        # This is unfortunate, but required by PEP 484
-        self.x = self  # E: Incompatible types in assignment (expression has type "C", variable has type "Self")
+    def eggs(self) -> None:
+        self.x = self
 
 [case testTypingSelfClashInBodies]
 from typing import Self, TypeVar


### PR DESCRIPTION
I am opening this PR as a possible fix for #14075, where there seems to be a clash of PEP's, prioritizing the newer and more complete one, as it describes the feature that is being implemented and supported here.

I was not able to find any discussions on this subject apart from in the before mentioned issue and the pr that adds `typing.Self` support mentioning the opening of the followup issue (https://github.com/python/mypy/pull/14041#issuecomment-1312563450)

For more info on the reason behind this change, see: https://github.com/python/mypy/issues/14075#issuecomment-1312601910 and https://github.com/python/mypy/issues/14708#issue-1585977641

Fixes #14075
