### PR TITLE
Fix for bug with `in` operation on optionals in `no-strict-optional` mode

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2950,7 +2950,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 right_type = get_proper_type(right_type)
                 item_types: Sequence[Type] = [right_type]
                 if isinstance(right_type, UnionType):
-                    item_types = list(right_type.items)
+                    item_types = list(right_type.relevant_items())
 
                 sub_result = self.bool_type()
 

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -1031,3 +1031,12 @@ def f1(b: bool) -> Optional[int]:
 class Defer:
     def __init__(self) -> None:
         self.defer = 10
+
+[case testOptionalIterator]
+# mypy: no-strict-optional
+from typing import Optional, List
+
+x: Optional[List[int]]
+if 3 in x:
+    pass
+


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/python/mypy/pull/14384 wherein a union that includes `None` is no longer treated as a valid right-hand type for the `in` operator in `no-strict-optional` mode. (The reported error is `error: "None" has no attribute "__iter__" (not iterable)  [attr-defined]`).

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
