### PR TITLE
Fix crash with `dataclass_transform` cache

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3889,7 +3889,7 @@ class DataclassTransformSpec:
         eq_default: bool | None = None,
         order_default: bool | None = None,
         kw_only_default: bool | None = None,
-        field_specifiers: tuple[str, ...] | None = None,
+        field_specifiers: list[str] | None = None,
         # Specified outside of PEP 681:
         # frozen_default was added to CPythonin https://github.com/python/cpython/pull/99958 citing
         # positive discussion in typing-sig
@@ -3899,7 +3899,7 @@ class DataclassTransformSpec:
         self.order_default = order_default if order_default is not None else False
         self.kw_only_default = kw_only_default if kw_only_default is not None else False
         self.frozen_default = frozen_default if frozen_default is not None else False
-        self.field_specifiers = field_specifiers if field_specifiers is not None else ()
+        self.field_specifiers = field_specifiers or []
 
     def serialize(self) -> JsonDict:
         return {

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -70,7 +70,7 @@ _TRANSFORM_SPEC_FOR_DATACLASSES = DataclassTransformSpec(
     order_default=False,
     kw_only_default=False,
     frozen_default=False,
-    field_specifiers=("dataclasses.Field", "dataclasses.field"),
+    field_specifiers=["dataclasses.Field", "dataclasses.field"],
 )
 
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6515,18 +6515,18 @@ class SemanticAnalyzer(
 
         return parameters
 
-    def parse_dataclass_transform_field_specifiers(self, arg: Expression) -> tuple[str, ...]:
+    def parse_dataclass_transform_field_specifiers(self, arg: Expression) -> list[str]:
         if not isinstance(arg, TupleExpr):
             self.fail('"field_specifiers" argument must be a tuple literal', arg)
-            return tuple()
+            return []
 
-        names = []
+        names: list[str] = []
         for specifier in arg.items:
             if not isinstance(specifier, RefExpr):
                 self.fail('"field_specifiers" must only contain identifiers', specifier)
-                return tuple()
+                return []
             names.append(specifier.fullname)
-        return tuple(names)
+        return names
 
 
 def replace_implicit_first_type(sig: FunctionLike, new: Type) -> FunctionLike:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10341,3 +10341,40 @@ reveal_type(x)
 [out]
 ==
 a.py:3: note: Revealed type is "Union[def (x: builtins.int) -> builtins.int, def (*x: builtins.int) -> builtins.int]"
+
+[case testDataclassTransformFieldSpecifiers]
+# flags: --python-version 3.7
+import b
+
+[file b.py]
+from abc import ABCMeta
+from typing import Any, Optional
+from typing_extensions import dataclass_transform
+
+class Field:
+    def __init__(self, default: Any = None) -> None: ...
+
+class FieldInfo:
+    def __init__(self, default: Any = None, *, alias: Optional[str] = None) -> None: ...
+
+@dataclass_transform(field_specifiers=(Field, FieldInfo))
+class ModelMetaclass(ABCMeta): ...
+
+class BaseModel(metaclass=ModelMetaclass): ...
+
+class Event(BaseModel):
+    id: Optional[int] = None
+[builtins fixtures/tuple.pyi]
+
+[file c.py]
+from b import Event
+Event()
+
+[file c.py.2]
+from b import Event
+Event()
+reveal_type(1)
+
+[out]
+==
+c.py:3: note: Revealed type is "Literal[1]?"


### PR DESCRIPTION
When serializing a `tuple[...]` field to json, it's automatically converted to `[...]`.
Thus when reading the cache a list would get assigned to a class field specified as tuple which causes a crash with the compiled version of mypy.

Issue was added in #14667 as it started to parse the `field_specifiers` argument.
/cc: @wesleywright