### PR TITLE
Update isort to 5.11.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0  # must match test-requirements.txt
+    rev: 5.11.5  # must match test-requirements.txt
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4  # must match test-requirements.txt
+    rev: 5.12.0  # must match test-requirements.txt
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ filelock>=3.3.0
 flake8==5.0.4           # must match version in .pre-commit-config.yaml
 flake8-bugbear==22.12.6 # must match version in .pre-commit-config.yaml
 flake8-noqa==1.3.0      # must match version in .pre-commit-config.yaml
-isort[colors]==5.11.4   # must match version in .pre-commit-config.yaml
+isort[colors]==5.12.0   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ filelock>=3.3.0
 flake8==5.0.4           # must match version in .pre-commit-config.yaml
 flake8-bugbear==22.12.6 # must match version in .pre-commit-config.yaml
 flake8-noqa==1.3.0      # must match version in .pre-commit-config.yaml
-isort[colors]==5.12.0   # must match version in .pre-commit-config.yaml
+isort[colors]==5.11.5   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10


### PR DESCRIPTION
Release notes: https://github.com/PyCQA/isort/releases/tag/5.11.5

This resolves an issue with `pre-commit` and `poetry` which caused the pre-commit `isort` install to fail.

**Edit**: `5.12.0` requires Python 3.8