### PR TITLE
Use error subcodes to differentiate import errors

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2776,7 +2776,16 @@ def module_not_found(
     else:
         daemon = manager.options.fine_grained_incremental
         msg, notes = reason.error_message_templates(daemon)
-        errors.report(line, 0, msg.format(module=target), code=codes.IMPORT)
+        if reason == ModuleNotFoundReason.NOT_FOUND:
+            code = codes.IMPORT_NOT_FOUND
+        elif (
+            reason == ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS
+            or reason == ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
+        ):
+            code = codes.IMPORT_UNTYPED
+        else:
+            code = codes.IMPORT
+        errors.report(line, 0, msg.format(module=target), code=code)
         top_level, second_level = get_top_two_prefixes(target)
         if second_level in legacy_bundled_packages or second_level in non_bundled_packages:
             top_level = second_level

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -96,6 +96,12 @@ HAS_TYPE: Final = ErrorCode(
 IMPORT: Final = ErrorCode(
     "import", "Require that imported module can be found or has stubs", "General"
 )
+IMPORT_NOT_FOUND: Final = ErrorCode(
+    "import-not-found", "Require that imported module can be found", "General", sub_code_of=IMPORT
+)
+IMPORT_UNTYPED: Final = ErrorCode(
+    "import-untyped", "Require that imported module has stubs", "General", sub_code_of=IMPORT
+)
 NO_REDEF: Final = ErrorCode("no-redef", "Check that each name is defined once", "General")
 FUNC_RETURNS_VALUE: Final = ErrorCode(
     "func-returns-value", "Check that called function returns a value in value context", "General"


### PR DESCRIPTION
Resolves #9789

Users could use `--disable-error-code=import-untyped` to only ignore errors about libraries not having stubs, but continue to get errors about e.g. typos in an import name.

The sub error code mechanism is new. Note that users will now get a different error code depending on whether or not a package is installed, and may not know that they can use the parent error code to ignore the issue regardless. I think this is okay, in general type checking results can change if you run them in two different environments.