### PR TITLE
[mypyc] fix IntEnum attributes not treated as final values

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -973,8 +973,7 @@ class IRBuilder:
             sym = expr.expr.node.get(expr.name)
             if sym and isinstance(sym.node, Var):
                 # Enum attribute are treated as final since they are added to the global cache
-                expr_fullname = expr.expr.node.bases[0].type.fullname
-                is_final = sym.node.is_final or expr_fullname == "enum.Enum"
+                is_final = sym.node.is_final or expr.expr.node.is_enum
                 if is_final:
                     final_var = sym.node
                     fullname = f"{sym.node.info.fullname}.{final_var.name}"

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -630,7 +630,7 @@ def add_non_ext_class_attr(
         # are final.
         if (
             cdef.info.bases
-            and cdef.info.bases[0].type.fullname == "enum.Enum"
+            and cdef.info.bases[0].type.is_enum
             # Skip these since Enum will remove it
             and lvalue.name not in ENUM_REMOVED_PROPS
         ):

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -467,12 +467,13 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
     The tuple is passed to the metaclass constructor.
     """
     is_named_tuple = cdef.info.is_named_tuple
+    is_enum = cdef.info.is_enum
     ir = builder.mapper.type_to_ir[cdef.info]
     bases = []
     for cls in cdef.info.mro[1:]:
         if cls.fullname == "builtins.object":
             continue
-        if is_named_tuple and cls.fullname in (
+        if (is_named_tuple or is_enum) and cls.fullname in (
             "typing.Sequence",
             "typing.Iterable",
             "typing.Collection",

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -273,6 +273,20 @@ class Pokemon(enum.Enum):
 assert Pokemon.magikarp.value == 1
 assert Pokemon.squirtle.name == 'squirtle'
 
+import sys, enum, typing_extensions
+
+# skip test on python 3.8 as it does not allow multiple data-type mixins of the same type
+if sys.version_info[:2] != (3, 8):
+    base_cls: typing_extensions.TypeAlias = enum.IntEnum
+else:
+    base_cls: typing_extensions.TypeAlias = enum.Enum
+
+class Color(base_cls):
+    GREEN = 1
+
+if sys.version_info[:2] != (3, 8):
+    assert Color.GREEN == 1
+
 [file other.py]
 # Force a multi-module test to make sure we can compile multi-file with
 # non-extension classes

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -250,11 +250,11 @@ assert o.get(20) == 20
 assert get_class_var() == 'xy'
 
 [case testEnum]
-from enum import Enum, IntEnum, Flag, auto
+import enum
 import sys, typing_extensions
 
 
-class TestEnum(Enum):
+class TestEnum(enum.Enum):
     _order_ = "a b"
     a : int = 1
     b : int = 2
@@ -265,7 +265,7 @@ class TestEnum(Enum):
 
 assert TestEnum.test() == 3
 
-class Pokemon(Enum):
+class Pokemon(enum.Enum):
     magikarp = 1
     squirtle = 2
     slowbro = 3
@@ -275,15 +275,37 @@ assert Pokemon.squirtle.name == 'squirtle'
 
 # skip test on python 3.8 as it does not allow multiple data-type mixins of the same type (see bpo-39587)
 if sys.version_info[:2] != (3, 8):
-    base_cls: typing_extensions.TypeAlias = IntEnum
+    int_enum_base_cls: typing_extensions.TypeAlias = enum.IntEnum
+    int_flag_enum_blase_cls: typing_extensions.TypeAlias = enum.IntFlag
 else:
-    base_cls: typing_extensions.TypeAlias = Enum
+    int_enum_base_cls: typing_extensions.TypeAlias = enum.Enum
+    int_flag_enum_blase_cls: typing_extensions.TypeAlias = enum.Enum
 
-class Color(base_cls):
+class Color(int_enum_base_cls):
     GREEN = 1
 
 if sys.version_info[:2] != (3, 8):
     assert Color.GREEN.value == 1
+
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 11:
+    str_enum_base_cls: typing_extensions.TypeAlias = enum.StrEnum
+else:
+    str_enum_base_cls: typing_extensions.TypeAlias = enum.Enum
+
+class BuildEnum(str_enum_base_cls):
+    DEBUG = "debug"
+    RELEASE = "release"
+
+class ColorFlagEnum(enum.Flag):
+    RED = enum.auto()
+    GREEN = enum.auto()
+    BLUE = enum.auto()
+
+class ColorIntFlagEnum(int_flag_enum_blase_cls):
+    RED = enum.auto()
+    GREEN = enum.auto()
+    BLUE = enum.auto()
+
 
 [file other.py]
 # Force a multi-module test to make sure we can compile multi-file with
@@ -291,6 +313,7 @@ if sys.version_info[:2] != (3, 8):
 
 [file driver.py]
 import sys
+from native import ColorFlagEnum
 # "_order_" isn't supported in 3.5
 if sys.version_info[:2] > (3, 5):
     from native import TestEnum
@@ -298,6 +321,18 @@ if sys.version_info[:2] > (3, 5):
     assert TestEnum.a.value == 1
     assert TestEnum.b.name == 'b'
     assert TestEnum.b.value == 2
+
+# StrEnum is available in 3.11
+if sys.version_info[:2] >= (3, 11):
+    from native import BuildEnum
+    assert BuildEnum.DEBUG == "debug"
+
+purple = ColorFlagEnum.RED | ColorFlagEnum.BLUE
+assert ColorFlagEnum.RED in purple
+
+if sys.version_info[:2] != (3, 8):
+    from native import ColorIntFlagEnum
+    assert ColorIntFlagEnum.GREEN == ColorIntFlagEnum.RED + 1
 
 [case testGetAttribute]
 class C:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -250,7 +250,9 @@ assert o.get(20) == 20
 assert get_class_var() == 'xy'
 
 [case testEnum]
-from enum import Enum
+from enum import Enum, IntEnum, Flag, auto
+import sys, typing_extensions
+
 
 class TestEnum(Enum):
     _order_ = "a b"
@@ -263,9 +265,7 @@ class TestEnum(Enum):
 
 assert TestEnum.test() == 3
 
-import enum
-
-class Pokemon(enum.Enum):
+class Pokemon(Enum):
     magikarp = 1
     squirtle = 2
     slowbro = 3
@@ -273,19 +273,17 @@ class Pokemon(enum.Enum):
 assert Pokemon.magikarp.value == 1
 assert Pokemon.squirtle.name == 'squirtle'
 
-import sys, enum, typing_extensions
-
-# skip test on python 3.8 as it does not allow multiple data-type mixins of the same type
+# skip test on python 3.8 as it does not allow multiple data-type mixins of the same type (see bpo-39587)
 if sys.version_info[:2] != (3, 8):
-    base_cls: typing_extensions.TypeAlias = enum.IntEnum
+    base_cls: typing_extensions.TypeAlias = IntEnum
 else:
-    base_cls: typing_extensions.TypeAlias = enum.Enum
+    base_cls: typing_extensions.TypeAlias = Enum
 
 class Color(base_cls):
     GREEN = 1
 
 if sys.version_info[:2] != (3, 8):
-    assert Color.GREEN == 1
+    assert Color.GREEN.value == 1
 
 [file other.py]
 # Force a multi-module test to make sure we can compile multi-file with


### PR DESCRIPTION
Fixes mypyc/mypyc#721

Generated `__native.c` will not compile when mypyc is invoked against the following `example.py`:

```python
from enum import IntEnum

class Color(IntEnum):
    GREEN = 1

assert Color.GREEN == 1
```

Error

```text
...
build/__native.c: In function ‘CPyDef___top_level__’:
build/__native.c:358:17: error: ‘CPyStatic_Color___GREEN’ undeclared (first use in this function)
  358 |     cpy_r_r74 = CPyStatic_Color___GREEN;
...
```

Previously code only treated `enum.Enum` attributes as Final, I switched to using `TypeInfo.is_enum` instead of checking type full name against hard-coded string

Your feedback is appreciated