### PR TITLE
Handle type[TypeVar] (fixes #14755)

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -412,6 +412,13 @@ def analyze_type_type_member_access(
         upper_bound = get_proper_type(typ.item.upper_bound)
         if isinstance(upper_bound, Instance):
             item = upper_bound
+        elif isinstance(upper_bound, UnionType):
+            return _analyze_member_access(
+                name,
+                TypeType.make_normalized(upper_bound, line=typ.line, column=typ.column),
+                mx,
+                override_info,
+            )
         elif isinstance(upper_bound, TupleType):
             item = tuple_fallback(upper_bound)
         elif isinstance(upper_bound, AnyType):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -516,6 +516,12 @@ class MessageBuilder:
                         context,
                         code=codes.UNION_ATTR,
                     )
+            else:
+                self.fail(
+                    '{} has no attribute "{}"{}'.format(format_type(original_type), member, extra),
+                    context,
+                    code=codes.ATTR_DEFINED,
+                )
         return AnyType(TypeOfAny.from_error)
 
     def unsupported_operand_types(

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3464,9 +3464,9 @@ class ProUser(User): pass
 class BasicUser(User): pass
 U = TypeVar('U', bound=Union[ProUser, BasicUser])
 def process(cls: Type[U]):
-    cls.foo()  # E: "Type[U]" has no attribute "foo"
+    cls.foo()
     obj = cls()
-    cls.bar(obj)  # E: "Type[U]" has no attribute "bar"
+    cls.bar(obj)
     cls.mro()  # Defined in class type
     cls.error  # E: "Type[U]" has no attribute "error"
 [builtins fixtures/classmethod.pyi]


### PR DESCRIPTION
Fixes #14755.

This case is already covered by `check-classes.test::testTypeUsingTypeCClassMethodFromTypeVarUnionBound`, now we just remove from it errors that shouldn't be reported.
