### PR TITLE
[1.1 backport] [dataclass_transform] include __dataclass_fields__ in transformed types (#14752)

### DIFF
--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -279,8 +279,7 @@ class Bad:
     bad1: int = field(alias=some_str())  # E: "alias" argument to dataclass field must be a string literal
     bad2: int = field(kw_only=some_bool())  # E: "kw_only" argument must be a boolean literal
 
-# this metadata should only exist for dataclasses.dataclass classes
-Foo.__dataclass_fields__  # E: "Type[Foo]" has no attribute "__dataclass_fields__"
+reveal_type(Foo.__dataclass_fields__)  # N: Revealed type is "builtins.dict[builtins.str, Any]"
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
`dataclasses` uses a `__dataclass_fields__` attribute on each class to mark that it is a dataclass, and Typeshed checks for this attribute in its stubs for functions like `dataclasses.is_dataclass` and `dataclasses.asdict`.

In #14667, I mistakenly removed this attribute for classes transformed by a `dataclass_transform`. This was due to a misinterpretation of PEP 681 on my part; after rereading the [section on dataclass semantics](https://peps.python.org/pep-0681/#dataclass-semantics), it says:

> Except where stated otherwise in this PEP, classes impacted by
`dataclass_transform`, either by inheriting from a class that is decorated with `dataclass_transform` or by being decorated with a function decorated with `dataclass_transform`, are assumed to behave like stdlib dataclass.

The PEP doesn't seem to state anything about `__dataclass_fields__` or the related functions as far as I can tell, so we should assume that transforms should match the behavior of `dataclasses.dataclass` in this regard and include the attribute. This also matches the behavior of Pyright, which the PEP defines as the reference implementation.

(cherry picked from commit 54635dec2379e2ac8b65b6ef07778015c69cfb6a)