### PR TITLE
Show logging written to stderr in mypy daemon

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -671,6 +671,7 @@ def request(
             sys.stdout.write(stdout)
         stderr = response.get("stderr")
         if stderr:
+            print("-" * 79)
             print("stderr:")
             sys.stdout.write(stderr)
         return response

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -665,10 +665,14 @@ def request(
         return {"error": str(err)}
     # TODO: Other errors, e.g. ValueError, UnicodeError
     else:
-        # Display debugging output written to stdout in the server process for convenience.
+        # Display debugging output written to stdout/stderr in the server process for convenience.
         stdout = response.get("stdout")
         if stdout:
             sys.stdout.write(stdout)
+        stderr = response.get("stderr")
+        if stderr:
+            print("stderr:")
+            sys.stdout.write(stderr)
         return response
 
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -215,7 +215,9 @@ class Server:
                 with server:
                     data = receive(server)
                     debug_stdout = io.StringIO()
+                    debug_stderr = io.StringIO()
                     sys.stdout = debug_stdout
+                    sys.stderr = debug_stderr
                     resp: dict[str, Any] = {}
                     if "command" not in data:
                         resp = {"error": "No command found in request"}
@@ -233,9 +235,11 @@ class Server:
                                 resp = {"error": "Daemon crashed!\n" + "".join(tb)}
                                 resp.update(self._response_metadata())
                                 resp["stdout"] = debug_stdout.getvalue()
+                                resp["stderr"] = debug_stderr.getvalue()
                                 server.write(json.dumps(resp).encode("utf8"))
                                 raise
                     resp["stdout"] = debug_stdout.getvalue()
+                    resp["stderr"] = debug_stderr.getvalue()
                     try:
                         resp.update(self._response_metadata())
                         server.write(json.dumps(resp).encode("utf8"))


### PR DESCRIPTION
Previously stdout from mypy daemon was propagated to the client, but some verbose logging is written to stderr and it wasn't propagated. Now propagate stderr as well. Tested manually.

This builds on top of #13769.