### PR TITLE
Support next types-setuptools update

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -25,7 +25,7 @@ import os.path
 import re
 import sys
 import time
-from typing import TYPE_CHECKING, Any, Dict, Iterable, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, NoReturn, Union, cast
 
 from mypy.build import BuildSource
 from mypy.errors import CompileError
@@ -41,7 +41,13 @@ from mypyc.namegen import exported_name
 from mypyc.options import CompilerOptions
 
 if TYPE_CHECKING:
-    from setuptools import Extension
+    from distutils.core import Extension as _distutils_Extension
+    from typing_extensions import TypeAlias
+
+    from setuptools import Extension as _setuptools_Extension
+
+    Extension: TypeAlias = Union[_setuptools_Extension, _distutils_Extension]
+
 
 try:
     # Import setuptools so that it monkey-patch overrides distutils

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -41,7 +41,7 @@ from mypyc.namegen import exported_name
 from mypyc.options import CompilerOptions
 
 if TYPE_CHECKING:
-    from distutils.core import Extension
+    from setuptools import Extension
 
 try:
     # Import setuptools so that it monkey-patch overrides distutils

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import glob
 import os
 import os.path
 import sys
+from typing import cast
 
 if sys.version_info < (3, 7, 0):
     sys.stderr.write("ERROR: You need Python 3.7 or later to use mypy.\n")
@@ -17,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 # This requires setuptools when building; setuptools is not needed
 # when installing from a wheel file (though it is still needed for
 # alternative forms of installing, as suggested by README.md).
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_py import build_py
 
 from mypy.version import __version__ as version
@@ -158,13 +159,16 @@ if USE_MYPYC:
     opt_level = os.getenv("MYPYC_OPT_LEVEL", "3")
     debug_level = os.getenv("MYPYC_DEBUG_LEVEL", "1")
     force_multifile = os.getenv("MYPYC_MULTI_FILE", "") == "1"
-    ext_modules = mypycify(
-        mypyc_targets + ["--config-file=mypy_bootstrap.ini"],
-        opt_level=opt_level,
-        debug_level=debug_level,
-        # Use multi-file compilation mode on windows because without it
-        # our Appveyor builds run out of memory sometimes.
-        multi_file=sys.platform == "win32" or force_multifile,
+    ext_modules = cast(
+        Extension,
+        mypycify(
+            mypyc_targets + ["--config-file=mypy_bootstrap.ini"],
+            opt_level=opt_level,
+            debug_level=debug_level,
+            # Use multi-file compilation mode on windows because without it
+            # our Appveyor builds run out of memory sometimes.
+            multi_file=sys.platform == "win32" or force_multifile,
+        ),
     )
 else:
     ext_modules = []

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ types.
 
 
 def is_list_of_setuptools_extension(items: list[Any]) -> TypeGuard[list[Extension]]:
-    return all(item is Extension for item in items)
+    return all(isinstance(item, Extension) for item in items)
 
 
 def find_package_data(base, globs, root="mypy"):


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

A simple type-only change since mypyc explicitely uses setuptools' monkeypatching. And `setup.py` imports from setuptools.

Tests should stay the same. This should fix a sudden failure of tests once https://github.com/python/typeshed/pull/9795 is merged.
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
