### PR TITLE
[mypyc] Use primitives for calls via type aliases

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -41,6 +41,7 @@ from mypy.nodes import (
     Statement,
     SymbolNode,
     TupleExpr,
+    TypeAlias,
     TypeInfo,
     UnaryExpr,
     Var,
@@ -1018,7 +1019,8 @@ class IRBuilder:
 
         # Handle data-driven special-cased primitive call ops.
         if callee.fullname and expr.arg_kinds == [ARG_POS] * len(arg_values):
-            call_c_ops_candidates = function_ops.get(callee.fullname, [])
+            fullname = get_call_target_fullname(callee)
+            call_c_ops_candidates = function_ops.get(fullname, [])
             target = self.builder.matching_call_c(
                 call_c_ops_candidates, arg_values, expr.line, self.node_type(expr)
             )
@@ -1349,3 +1351,12 @@ def remangle_redefinition_name(name: str) -> str:
     lookups.
     """
     return name.replace("'", "__redef__")
+
+
+def get_call_target_fullname(ref: RefExpr) -> str:
+    if isinstance(ref.node, TypeAlias):
+        # Resolve simple type aliases. In calls they evaluate to the type they point to.
+        target = get_proper_type(ref.node.target)
+        if isinstance(target, Instance):
+            return target.type.fullname
+    return ref.fullname

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -84,6 +84,22 @@ L0:
     x = r0
     return 1
 
+[case testNewListEmptyViaAlias]
+from typing import List
+
+ListAlias = list
+
+def f() -> None:
+    x: List[int] = ListAlias()
+
+[out]
+def f():
+    r0, x :: list
+L0:
+    r0 = PyList_New(0)
+    x = r0
+    return 1
+
 [case testNewListTwoItems]
 from typing import List
 def f() -> None:


### PR DESCRIPTION
Previously type aliases were looked up from the globals dictionary, even if the target was a primitive type such as list. Now type aliases are treated the same as direct references to types in calls, since type aliases are assumed to be immutable.

This speeds up the deltablue benchmark by about 4%.