### PR TITLE
Unpin the `types-setuptools` build dependency

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,6 +1,5 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
 -r mypy-requirements.txt
 types-psutil
-# TODO: fix build when using the latest version of types-setuptools
-types-setuptools<67.4.0.2
+types-setuptools
 types-typed-ast>=1.5.8,<1.6.0

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -66,9 +66,11 @@ def get_extension() -> type[Extension]:
     extension_class: type[Extension]
 
     if not use_setuptools:
-        from distutils.core import Extension as extension_class
+        import distutils.core
+        extension_class = distutils.core.Extension
     else:
-        from setuptools import Extension as extension_class
+        import setuptools
+        extension_class = setuptools.Extension
 
     return extension_class
 

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -63,13 +63,14 @@ def get_extension() -> type[Extension]:
     # We can work with either setuptools or distutils, and pick setuptools
     # if it has been imported.
     use_setuptools = "setuptools" in sys.modules
+    extension_class: type[Extension]
 
     if not use_setuptools:
-        from distutils.core import Extension
+        from distutils.core import Extension as extension_class
     else:
-        from setuptools import Extension
+        from setuptools import Extension as extension_class
 
-    return Extension
+    return extension_class
 
 
 def setup_mypycify_vars() -> None:

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
 try:
     # Import setuptools so that it monkey-patch overrides distutils
-    import setuptools  # noqa: F401
+    import setuptools
 except ImportError:
     if sys.version_info >= (3, 12):
         # Raise on Python 3.12, since distutils will go away forever
@@ -67,9 +67,9 @@ def get_extension() -> type[Extension]:
 
     if not use_setuptools:
         import distutils.core
+
         extension_class = distutils.core.Extension
     else:
-        import setuptools
         extension_class = setuptools.Extension
 
     return extension_class

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "tomli>=1.1.0; python_version<'3.11'",
     # the following is from build-requirements.txt
     "types-psutil",
-    "types-setuptools<67.4.0.2",  # TODO: fix build when using the latest version of types-setuptools
+    "types-setuptools",
     "types-typed-ast>=1.5.8,<1.6.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- The latest release of `types-setuptools` started causing type-check errors (and, therefore, mypyc build errors) on the `master` branch: see, e.g. https://github.com/python/mypy/actions/runs/4275505309/jobs/7442902732.
- #14781 addressed some of the new errors, but didn't quite fix the build.
- #14788 then pinned the `types-setuptools` dependency as a temporary stopgap measure.
- This PR now attempts to unpin `types-setuptools` and fix the build errors in a more principled way.