### PR TITLE
Pin `types-setuptools` to <67.4.0.2

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -2,5 +2,5 @@
 -r mypy-requirements.txt
 types-psutil
 # TODO: fix build when using the latest version of types-setuptools
-types-setuptools<67.4.0.3
+types-setuptools<67.4.0.2
 types-typed-ast>=1.5.8,<1.6.0

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,5 +1,6 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
 -r mypy-requirements.txt
 types-psutil
-types-setuptools
+# TODO: fix build when using the latest version of types-setuptools
+types-setuptools<67.4.0.3
 types-typed-ast>=1.5.8,<1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "tomli>=1.1.0; python_version<'3.11'",
     # the following is from build-requirements.txt
     "types-psutil",
-    "types-setuptools<67.4.0.2",
+    "types-setuptools<67.4.0.2",  # TODO: fix build when using the latest version of types-setuptools
     "types-typed-ast>=1.5.8,<1.6.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "tomli>=1.1.0; python_version<'3.11'",
     # the following is from build-requirements.txt
     "types-psutil",
-    "types-setuptools",
+    "types-setuptools<67.4.0.2",
     "types-typed-ast>=1.5.8,<1.6.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The mypyc build is failing on `master` due to the latest release of `types-setuptools`: see, e.g. https://github.com/python/mypy/actions/runs/4275505309/jobs/7442902732.

#14787 fixes the mypyc _build_, but there's still a bunch of mypyc tests failing on that PR. I haven't got time to debug them right now (and I'm also not particularly knowledgeable about mypyc!), so this is a stopgap PR to pin `types-setuptools` so that we avoid the latest release.
