### PR TITLE
Fix `--strict-equality` crash for instances of a class generic over a `ParamSpec`

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from itertools import chain
 from typing import Callable
 
 from mypy import join
@@ -342,7 +343,15 @@ def is_overlapping_types(
     left_possible = get_possible_variants(left)
     right_possible = get_possible_variants(right)
 
-    # We start by checking multi-variant types like Unions first. We also perform
+    # First handle a special case: comparing a `Parameters` to a `ParamSpecType`.
+    # This should always be considered an overlapping equality check.
+    # This needs to be done before we move on to other TypeVarLike comparisons.
+    if (isinstance(left, Parameters) and isinstance(right, ParamSpecType)) or (
+        isinstance(left, ParamSpecType) and isinstance(right, Parameters)
+    ):
+        return True
+
+    # Now move on to checking multi-variant types like Unions. We also perform
     # the same logic if either type happens to be a TypeVar/ParamSpec/TypeVarTuple.
     #
     # Handling the TypeVarLikes now lets us simulate having them bind to the corresponding
@@ -450,6 +459,24 @@ def is_overlapping_types(
         left = left.fallback
     elif isinstance(right, CallableType):
         right = right.fallback
+
+    if isinstance(left, Parameters):
+        if not isinstance(right, Parameters):
+            return False
+        if len(left.arg_types) == len(right.arg_types):
+            return all(
+                _is_overlapping_types(left_arg, right_arg)
+                for left_arg, right_arg in zip(left.arg_types, right.arg_types)
+            )
+        if not any(
+            isinstance(arg, TypeVarLikeType) for arg in chain(left.arg_types, right.arg_types)
+        ):
+            return False
+        # TODO: Is this sound?
+        return True
+    if isinstance(right, Parameters):
+        assert not isinstance(left, (Parameters, TypeVarLikeType))
+        return False
 
     if isinstance(left, LiteralType) and isinstance(right, LiteralType):
         if left.value == right.value:

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1924,3 +1924,15 @@ _testStarUnpackNestedUnderscore.py:10: error: List item 0 has incompatible type 
 _testStarUnpackNestedUnderscore.py:10: error: List item 1 has incompatible type "int"; expected "str"
 _testStarUnpackNestedUnderscore.py:11: note: Revealed type is "builtins.list[builtins.str]"
 _testStarUnpackNestedUnderscore.py:16: note: Revealed type is "builtins.list[builtins.object]"
+
+[case testStrictEqualitywithParamSpec]
+# flags: --strict-equality
+from typing import Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+
+class Foo(Generic[P]): ...
+
+def check(foo1: Foo[[int]], foo2: Foo[[str]]) -> bool:
+    return foo1 == foo2

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1928,11 +1928,45 @@ _testStarUnpackNestedUnderscore.py:16: note: Revealed type is "builtins.list[bui
 [case testStrictEqualitywithParamSpec]
 # flags: --strict-equality
 from typing import Generic
-from typing_extensions import ParamSpec
+from typing_extensions import Concatenate, ParamSpec
 
 P = ParamSpec("P")
 
 class Foo(Generic[P]): ...
+class Bar(Generic[P]): ...
 
-def check(foo1: Foo[[int]], foo2: Foo[[str]]) -> bool:
+def bad1(foo1: Foo[[int]], foo2: Foo[[str]]) -> bool:
     return foo1 == foo2
+
+def bad2(foo1: Foo[[int, str]], foo2: Foo[[int, bytes]]) -> bool:
+    return foo1 == foo2
+
+def bad3(foo1: Foo[[int]], foo2: Foo[[int, int]]) -> bool:
+    return foo1 == foo2
+
+def bad4(foo: Foo[[int]], bar: Bar[[int]]) -> bool:
+    return foo == bar
+
+def good1(foo1: Foo[[int]], foo2: Foo[[int]]) -> bool:
+    return foo1 == foo2
+
+def good2(foo1: Foo[[int]], foo2: Foo[[bool]]) -> bool:
+    return foo1 == foo2
+
+def good3(foo1: Foo[[int, int]], foo2: Foo[[bool, bool]]) -> bool:
+    return foo1 == foo2
+
+def good4(foo1: Foo[[int]], foo2: Foo[P], *args: P.args, **kwargs: P.kwargs) -> bool:
+    return foo1 == foo2
+
+def good5(foo1: Foo[P], foo2: Foo[[int, str, bytes]], *args: P.args, **kwargs: P.kwargs) -> bool:
+    return foo1 == foo2
+
+def good6(foo1: Foo[Concatenate[int, P]], foo2: Foo[[int, str, bytes]], *args: P.args, **kwargs: P.kwargs) -> bool:
+    return foo1 == foo2
+
+[out]
+_testStrictEqualitywithParamSpec.py:11: error: Non-overlapping equality check (left operand type: "Foo[[int]]", right operand type: "Foo[[str]]")
+_testStrictEqualitywithParamSpec.py:14: error: Non-overlapping equality check (left operand type: "Foo[[int, str]]", right operand type: "Foo[[int, bytes]]")
+_testStrictEqualitywithParamSpec.py:17: error: Non-overlapping equality check (left operand type: "Foo[[int]]", right operand type: "Foo[[int, int]]")
+_testStrictEqualitywithParamSpec.py:20: error: Non-overlapping equality check (left operand type: "Foo[[int]]", right operand type: "Bar[[int]]")


### PR DESCRIPTION
Fixes #14783.

Running mypy on this snippet of code currently causes a crash if you have the `--strict-equality` option enabled:

```python
from typing import Generic, ParamSpec

P = ParamSpec("P")

class Foo(Generic[P]): ...

def checker(foo1: Foo[[int]], foo2: Foo[[str]]) -> None:
    foo1 == foo2
```

This is because the overlapping-equality logic in `meet.py` currently does not account for the fact that `left` and `right` might both be instances of `mypy.types.Parameters`, leading to this assertion being tripped:

https://github.com/python/mypy/blob/800e8ffdf17de9fc641fefff46389a940f147eef/mypy/meet.py#L519

This PR attempts to add the necessary logic to `meet.py` to handle instances of `mypy.types.Parameters`.