### PR TITLE
Add a separate error code for top level `await`

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -132,6 +132,9 @@ EMPTY_BODY: Final[ErrorCode] = ErrorCode(
 SAFE_SUPER: Final = ErrorCode(
     "safe-super", "Warn about calls to abstract methods with empty/trivial bodies", "General"
 )
+TOP_LEVEL_AWAIT: Final = ErrorCode(
+    "top-level-await", "Warn about top level await experessions", "General"
+)
 
 # These error codes aren't enabled by default.
 NO_UNTYPED_DEF: Final[ErrorCode] = ErrorCode(

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5249,7 +5249,9 @@ class SemanticAnalyzer(
     def visit_await_expr(self, expr: AwaitExpr) -> None:
         if not self.is_func_scope() or not self.function_stack:
             # We check both because is_function_scope() returns True inside comprehensions.
-            self.fail('"await" outside function', expr, serious=True, blocker=True)
+            # This is not a blocker, because some enviroments (like ipython)
+            # support top level awaits.
+            self.fail('"await" outside function', expr, serious=True, code=codes.TOP_LEVEL_AWAIT)
         elif not self.function_stack[-1].is_coroutine:
             self.fail('"await" outside coroutine ("async def")', expr, serious=True, blocker=True)
         expr.expr.accept(self)

--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -945,11 +945,15 @@ async def bar(x: Union[A, B]) -> None:
 [typing fixtures/typing-async.pyi]
 
 [case testInvalidComprehensionNoCrash]
+# flags: --show-error-codes
 async def foo(x: int) -> int: ...
 
-crasher = [await foo(x) for x in [1, 2, 3]]  # E: "await" outside function
+# These are allowed in some cases:
+top_level = await foo(1)  # E: "await" outside function  [top-level-await]
+crasher = [await foo(x) for x in [1, 2, 3]]  # E: "await" outside function  [top-level-await]
 
 def bad() -> None:
+    # These are always critical / syntax issues:
     y = [await foo(x) for x in [1, 2, 3]]  # E: "await" outside coroutine ("async def")
 async def good() -> None:
     y = [await foo(x) for x in [1, 2, 3]]  # OK


### PR DESCRIPTION
Now users can disable the first kind of error, but not the second kind (which is always a syntax error).

Refs https://github.com/python/mypy/pull/14486
Closes #14763