### PR TITLE
Allow iterable class objects to be unpacked

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3385,6 +3385,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         undefined_rvalue: bool = False,
     ) -> None:
         """Check the assignment of one rvalue to a number of lvalues."""
+        # TODO: Overloaded `__iter__` methods
+        # lead to unpacked variables being silently inferred as `Any`.
+        # See #14811
 
         # Infer the type of an ordinary rvalue expression.
         # TODO: maybe elsewhere; redundant.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3404,6 +3404,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if isinstance(ret_type, Instance):
                 rvalue_type = ret_type.type.metaclass_type or rvalue_type
 
+        if isinstance(rvalue_type, TypeType) and isinstance(rvalue_type.item, Instance):
+            rvalue_type = rvalue_type.item.type.metaclass_type or rvalue_type
+
         if isinstance(rvalue_type, AnyType):
             for lv in lvalues:
                 if isinstance(lv, StarExpr):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3399,6 +3399,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if len(relevant_items) == 1:
                 rvalue_type = get_proper_type(relevant_items[0])
 
+        if isinstance(rvalue_type, FunctionLike) and rvalue_type.is_type_obj():
+            ret_type = get_proper_type(rvalue_type.items[0].ret_type)
+            if isinstance(ret_type, Instance):
+                rvalue_type = ret_type.type.metaclass_type or rvalue_type
+
         if isinstance(rvalue_type, AnyType):
             for lv in lvalues:
                 if isinstance(lv, StarExpr):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3405,10 +3405,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if isinstance(rvalue_type, FunctionLike) and rvalue_type.is_type_obj():
             ret_type = get_proper_type(rvalue_type.items[0].ret_type)
             if isinstance(ret_type, Instance):
-                rvalue_type = ret_type.type.metaclass_type or rvalue_type
+                metaclass = ret_type.type.metaclass_type
+                if metaclass and metaclass.type.get_method("__iter__"):
+                    rvalue_type = metaclass
 
         if isinstance(rvalue_type, TypeType) and isinstance(rvalue_type.item, Instance):
-            rvalue_type = rvalue_type.item.type.metaclass_type or rvalue_type
+            metaclass = rvalue_type.item.type.metaclass_type
+            if metaclass and metaclass.type.get_method("__iter__"):
+                rvalue_type = metaclass
 
         if isinstance(rvalue_type, AnyType):
             for lv in lvalues:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3385,9 +3385,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         undefined_rvalue: bool = False,
     ) -> None:
         """Check the assignment of one rvalue to a number of lvalues."""
-        # TODO: Overloaded `__iter__` methods
-        # lead to unpacked variables being silently inferred as `Any`.
-        # See #14811
 
         # Infer the type of an ordinary rvalue expression.
         # TODO: maybe elsewhere; redundant.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3399,13 +3399,19 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if len(relevant_items) == 1:
                 rvalue_type = get_proper_type(relevant_items[0])
 
+        # Some special-casing for class objects which are iterable
+        # by virtue of having __iter__ defined on the metaclass.
+        #
+        # Note that this doesn't handle metaclasses with overloaded __iter__ methods,
+        # but it's quite hard to come up with an overloaded __iter__ method
+        # without making the metaclass generic,
+        # and mypy has lots of issues with generic metaclasses in general
         if isinstance(rvalue_type, FunctionLike) and rvalue_type.is_type_obj():
             ret_type = get_proper_type(rvalue_type.items[0].ret_type)
             if isinstance(ret_type, Instance):
                 metaclass = ret_type.type.metaclass_type
                 if metaclass and metaclass.type.get_method("__iter__"):
                     rvalue_type = metaclass
-
         if isinstance(rvalue_type, TypeType) and isinstance(rvalue_type.item, Instance):
             metaclass = rvalue_type.item.type.metaclass_type
             if metaclass and metaclass.type.get_method("__iter__"):

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -279,11 +279,13 @@ class Meta(type):
 class Foo(metaclass=Meta): ...
 
 a, b, c = Foo
-reveal_type(a)  # N: Revealed type is "builtins.int"
+for var in [a, b, c]:
+    reveal_type(var)  # N: Revealed type is "builtins.int"
 
 F: Type[Foo] = Foo
 d, e, f = F
-reveal_type(d)  # N: Revealed type is "builtins.int"
+for var in [d, e, f]:
+    reveal_type(d)  # N: Revealed type is "builtins.int"
 [out]
 
 [case testInferringLvarTypesInMultiDefWithInvalidTuple]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -270,6 +270,18 @@ def f() -> None:
 class A: pass
 [out]
 
+[case testInferringLvarTypesUnpackedFromIterableClassObject]
+from typing import Iterator
+class Meta(type):
+    def __iter__(cls) -> Iterator[int]:
+        yield from [1, 2, 3]
+
+class Foo(metaclass=Meta): ...
+
+a, b, c = Foo
+reveal_type(a)  # N: Revealed type is "builtins.int"
+[out]
+
 [case testInferringLvarTypesInMultiDefWithInvalidTuple]
 from typing import Tuple
 t = None # type: Tuple[object, object, object]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -270,6 +270,30 @@ def f() -> None:
 class A: pass
 [out]
 
+[case testClassObjectsNotUnpackableWithoutIterableMetaclass]
+from typing import Type
+
+class Foo: ...
+A: Type[Foo] = Foo
+a, b = Foo  # E: "Type[Foo]" object is not iterable
+c, d = A  # E: "Type[Foo]" object is not iterable
+
+class Meta(type): ...
+class Bar(metaclass=Meta): ...
+B: Type[Bar] = Bar
+e, f = Bar  # E: "Type[Bar]" object is not iterable
+g, h = B  # E: "Type[Bar]" object is not iterable
+
+reveal_type(a)  # E: Cannot determine type of "a"  # N: Revealed type is "Any"
+reveal_type(b)  # E: Cannot determine type of "b"  # N: Revealed type is "Any"
+reveal_type(c)  # E: Cannot determine type of "c"  # N: Revealed type is "Any"
+reveal_type(d)  # E: Cannot determine type of "d"  # N: Revealed type is "Any"
+reveal_type(e)  # E: Cannot determine type of "e"  # N: Revealed type is "Any"
+reveal_type(f)  # E: Cannot determine type of "f"  # N: Revealed type is "Any"
+reveal_type(g)  # E: Cannot determine type of "g"  # N: Revealed type is "Any"
+reveal_type(h)  # E: Cannot determine type of "h"  # N: Revealed type is "Any"
+[out]
+
 [case testInferringLvarTypesUnpackedFromIterableClassObject]
 from typing import Iterator, Type, TypeVar, Union
 class Meta(type):
@@ -280,23 +304,34 @@ class Meta2(type):
     def __iter__(cls) -> Iterator[str]:
         yield from ["foo", "bar", "baz"]
 
+class Meta3(type): ...
+
 class Foo(metaclass=Meta): ...
 class Bar(metaclass=Meta2): ...
+class Baz(metaclass=Meta3): ...
+class Spam: ...
 
 A: Type[Foo] = Foo
 B: Type[Union[Foo, Bar]] = Foo
 C: Union[Type[Foo], Type[Bar]] = Foo
+D: Type[Union[Foo, Baz]] = Foo
+E: Type[Union[Foo, Spam]] = Foo
 
 a, b, c = Foo
 d, e, f = A
 g, h, i = B
 j, k, l = C
+m, n, o = D  # E: "Type[Baz]" object is not iterable
+p, q, r = E  # E: "Type[Spam]" object is not iterable
 
 for var in [a, b, c, d, e, f]:
     reveal_type(var)  # N: Revealed type is "builtins.int"
 
 for var2 in [g, h, i, j, k, l]:
     reveal_type(var2)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+for var3 in [m, n, o, p, q, r]:
+    reveal_type(var3)  # N: Revealed type is "Union[builtins.int, Any]"
 
 T = TypeVar("T", bound=Type[Foo])
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -271,21 +271,56 @@ class A: pass
 [out]
 
 [case testInferringLvarTypesUnpackedFromIterableClassObject]
-from typing import Iterator, Type
+from typing import Iterator, Type, TypeVar, Union
 class Meta(type):
     def __iter__(cls) -> Iterator[int]:
         yield from [1, 2, 3]
 
+class Meta2(type):
+    def __iter__(cls) -> Iterator[str]:
+        yield from ["foo", "bar", "baz"]
+
 class Foo(metaclass=Meta): ...
+class Bar(metaclass=Meta2): ...
+
+A: Type[Foo] = Foo
+B: Type[Union[Foo, Bar]] = Foo
+C: Union[Type[Foo], Type[Bar]] = Foo
 
 a, b, c = Foo
-for var in [a, b, c]:
+d, e, f = A
+g, h, i = B
+j, k, l = C
+
+for var in [a, b, c, d, e, f]:
     reveal_type(var)  # N: Revealed type is "builtins.int"
 
-F: Type[Foo] = Foo
-d, e, f = F
-for var in [d, e, f]:
-    reveal_type(d)  # N: Revealed type is "builtins.int"
+for var2 in [g, h, i, j, k, l]:
+    reveal_type(var2)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+T = TypeVar("T", bound=Type[Foo])
+
+def check(x: T) -> T:
+    a, b, c = x
+    for var in [a, b, c]:
+        reveal_type(var)  # N: Revealed type is "builtins.int"
+    return x
+
+T2 = TypeVar("T2", bound=Type[Union[Foo, Bar]])
+
+def check2(x: T2) -> T2:
+    a, b, c = x
+    for var in [a, b, c]:
+        reveal_type(var)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+    return x
+
+T3 = TypeVar("T3", bound=Union[Type[Foo], Type[Bar]])
+
+def check3(x: T3) -> T3:
+    a, b, c = x
+    for var in [a, b, c]:
+        reveal_type(var)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+    return x
 [out]
 
 [case testInferringLvarTypesInMultiDefWithInvalidTuple]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -271,7 +271,7 @@ class A: pass
 [out]
 
 [case testInferringLvarTypesUnpackedFromIterableClassObject]
-from typing import Iterator
+from typing import Iterator, Type
 class Meta(type):
     def __iter__(cls) -> Iterator[int]:
         yield from [1, 2, 3]
@@ -280,6 +280,10 @@ class Foo(metaclass=Meta): ...
 
 a, b, c = Foo
 reveal_type(a)  # N: Revealed type is "builtins.int"
+
+F: Type[Foo] = Foo
+d, e, f = F
+reveal_type(d)  # N: Revealed type is "builtins.int"
 [out]
 
 [case testInferringLvarTypesInMultiDefWithInvalidTuple]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1878,18 +1878,6 @@ _testEnumIterMetaInference.py:8: note: Revealed type is "typing.Iterator[_E`-1]"
 _testEnumIterMetaInference.py:9: note: Revealed type is "_E`-1"
 _testEnumIterMetaInference.py:13: note: Revealed type is "socket.SocketKind"
 
-[case testEnumUnpackedViaMetaclass]
-from enum import Enum
-
-class FooEnum(Enum):
-    A = 1
-    B = 2
-    C = 3
-
-a, b, c = FooEnum
-reveal_type(a)
-a, b = FooEnum
-
 [case testNativeIntTypes]
 # Spot check various native int operations with full stubs.
 from mypy_extensions import i64, i32

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1878,6 +1878,18 @@ _testEnumIterMetaInference.py:8: note: Revealed type is "typing.Iterator[_E`-1]"
 _testEnumIterMetaInference.py:9: note: Revealed type is "_E`-1"
 _testEnumIterMetaInference.py:13: note: Revealed type is "socket.SocketKind"
 
+[case testEnumUnpackedViaMetaclass]
+from enum import Enum
+
+class FooEnum(Enum):
+    A = 1
+    B = 2
+    C = 3
+
+a, b, c = FooEnum
+reveal_type(a)
+a, b = FooEnum
+
 [case testNativeIntTypes]
 # Spot check various native int operations with full stubs.
 from mypy_extensions import i64, i32


### PR DESCRIPTION
Currently, mypy issues a false positive on this code, where `Foo` is iterable by virtue of having `Meta` as its metaclass:

```python
from typing import Iterator
class Meta(type):
    def __iter__(cls) -> Iterator[int]:
        yield from [1, 2, 3]

class Foo(metaclass=Meta): ...

a, b, c = Foo  # error: "Type[Foo]" object is not iterable  [misc]
reveal_type(a)  # error: Cannot determine type of "a"  [has-type]  # note: Revealed type is "Any"
```

This PR fixes that false positive.

I started working on this PR hoping to address #14782, but wasn't able to -- this PR improves the situation somewhat, but doesn't close the issue. Prior to this PR, mypy had this behaviour:

```python
from enum import Enum

class E(Enum):
    A = 1
    B = 2

A, B = E  #  error: "Type[E]" object is not iterable  [misc]
```

With this PR, mypy has this behaviour instead:

```python
from enum import Enum

class E(Enum):
    A = 1
    B = 2

A, B = E  # error: Need type annotation for "A"  [var-annotated]  # error: Need type annotation for "B"  [var-annotated]
```

This is because there's a `TypeVar` being used in [typeshed's stub for `EnumMeta.__iter__`](https://github.com/python/typeshed/blob/904407f8e4967c73bfe18fecc089cf8d22e285ce/stdlib/enum.pyi#L107): I wasn't able to figure out how to get mypy to solve the type variable in this context.