### PR TITLE
[undocumented] Optionally export line-level information about references

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1017,6 +1017,8 @@ def process_options(
     add_invertible_flag(
         "--allow-empty-bodies", default=False, help=argparse.SUPPRESS, group=internals_group
     )
+    # This undocumented feature exports limited line-level dependency information.
+    internals_group.add_argument("--export-ref-info", action="store_true", help=argparse.SUPPRESS)
 
     report_group = parser.add_argument_group(
         title="Report generation", description="Generate a report in the specified format."

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -339,6 +339,9 @@ class Options:
         self.disable_recursive_aliases = False
         # Deprecated reverse version of the above, do not use.
         self.enable_recursive_aliases = False
+        # Export line-level, limited, fine-grained dependency information in cache data
+        # (undocumented feature).
+        self.export_ref_info = False
 
         self.disable_bytearray_promotion = False
         self.disable_memoryview_promotion = False

--- a/mypy/refinfo.py
+++ b/mypy/refinfo.py
@@ -1,0 +1,32 @@
+"""Find line-level reference information from a mypy AST (undocumented feature)"""
+
+from __future__ import annotations
+
+from mypy.nodes import LDEF, MemberExpr, MypyFile, NameExpr, RefExpr
+from mypy.traverser import TraverserVisitor
+
+
+class RefInfoVisitor(TraverserVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.data: list[dict[str, object]] = []
+
+    def visit_name_expr(self, expr: NameExpr) -> None:
+        super().visit_name_expr(expr)
+        self.record_ref_expr(expr)
+
+    def visit_member_expr(self, expr: MemberExpr) -> None:
+        super().visit_member_expr(expr)
+        self.record_ref_expr(expr)
+
+    def record_ref_expr(self, expr: RefExpr) -> None:
+        if expr.kind != LDEF and "." in expr.fullname:
+            self.data.append({"line": expr.line, "target": expr.fullname})
+        elif isinstance(expr, MemberExpr) and not expr.fullname:
+            self.data.append({"line": expr.line, "target": f"*.{expr.name}"})
+
+
+def get_undocumented_ref_info_json(tree: MypyFile) -> list[dict[str, object]]:
+    visitor = RefInfoVisitor()
+    tree.accept(visitor)
+    return visitor.data

--- a/mypy/refinfo.py
+++ b/mypy/refinfo.py
@@ -20,10 +20,13 @@ class RefInfoVisitor(TraverserVisitor):
         self.record_ref_expr(expr)
 
     def record_ref_expr(self, expr: RefExpr) -> None:
+        fullname = None
         if expr.kind != LDEF and "." in expr.fullname:
-            self.data.append({"line": expr.line, "target": expr.fullname})
+            fullname = expr.fullname
         elif isinstance(expr, MemberExpr) and not expr.fullname:
-            self.data.append({"line": expr.line, "target": f"*.{expr.name}"})
+            fullname = f"*.{expr.name}"
+        if fullname is not None:
+            self.data.append({"line": expr.line, "column": expr.column, "target": fullname})
 
 
 def get_undocumented_ref_info_json(tree: MypyFile) -> list[dict[str, object]]:


### PR DESCRIPTION
When run with `--export-ref-info`, store line-level reference information in the cache, in a JSON file with a `.refs.json` extension. It includes the line numbers and targets of each RefExpr in the program. This only works properly if incremental mode is disabled.

The target can either be a fullname, or `*.name` for an `name` attribute reference where the type of the object is unknown.

This is an undocumented, experimental feature that may be useful for certain tools, but it shouldn't be used in production use cases.
