### PR TITLE
Add `yaml` extension to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{py,pyi,c,cpp,h,rst,md,yml,json,test}]
+[*.{py,pyi,c,cpp,h,rst,md,yml,yaml,json,test}]
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
@@ -8,5 +8,5 @@ indent_style = space
 [*.{py,pyi,c,h,json,test}]
 indent_size = 4
 
-[*.yml]
+[*.{yml,yaml}]
 indent_size = 2


### PR DESCRIPTION
I found this while looking at https://github.com/python/mypy/blob/master/.pre-commit-config.yaml My IDE suggested 4 spaces instead of 2
