### PR TITLE
Remove an unnecessary `cast` to `Any`

### DIFF
--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import Any, Iterator, cast
+from typing import Any, Iterator
 
 from mypy import build
 from mypy.errors import CompileError
@@ -108,15 +108,13 @@ def run_setup(script_name: str, script_args: list[str]) -> bool:
         finally:
             sys.argv = save_argv
     except SystemExit as e:
-        # typeshed reports code as being an int but that is wrong
-        code = cast(Any, e).code
         # distutils converts KeyboardInterrupt into a SystemExit with
         # "interrupted" as the argument. Convert it back so that
         # pytest will exit instead of just failing the test.
-        if code == "interrupted":
+        if e.code == "interrupted":
             raise KeyboardInterrupt from e
 
-        return code == 0 or code is None
+        return e.code == 0 or e.code is None
 
     return True
 


### PR DESCRIPTION
Typeshed has a more accurate annotation for this attribute these days