### PR TITLE
Fix unpack with overloaded `__iter__` method

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6395,14 +6395,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # in case there is no explicit base class.
             return item_type
         # Try also structural typing.
-        iter_type = get_proper_type(find_member("__iter__", instance, instance, is_operator=True))
-        if iter_type and isinstance(iter_type, CallableType):
-            ret_type = get_proper_type(iter_type.ret_type)
-            if isinstance(ret_type, Instance):
-                iterator = map_instance_to_supertype(
-                    ret_type, self.lookup_typeinfo("typing.Iterator")
-                )
-                item_type = iterator.args[0]
+        ret_type, _ = self.expr_checker.check_method_call_by_name("__iter__", instance, [], [], instance)
+        if isinstance(ret_type, Instance):
+            iterator = map_instance_to_supertype(
+                ret_type, self.lookup_typeinfo("typing.Iterator")
+            )
+            item_type = iterator.args[0]
         return item_type
 
     def function_type(self, func: FuncBase) -> FunctionLike:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -4524,6 +4524,72 @@ WithMeta().a              # E: "WithMeta" has no attribute "a"
 t: Type[WithMeta]
 t.unknown  # OK
 
+[case testUnpackIterableClassWithOverloadedIter]
+from typing import Generic, overload, Iterator, TypeVar, Union
+
+AnyNum = TypeVar('AnyNum', int, float)
+
+class Foo(Generic[AnyNum]):
+    @overload
+    def __iter__(self: Foo[int]) -> Iterator[float]: ...
+    @overload
+    def __iter__(self: Foo[float]) -> Iterator[int]: ...
+    def __iter__(self) -> Iterator[Union[float, int]]:
+        ...
+
+a, b, c = Foo[int]()
+reveal_type(a)  # N: Revealed type is "builtins.float"
+reveal_type(b)  # N: Revealed type is "builtins.float"
+reveal_type(c)  # N: Revealed type is "builtins.float"
+
+x, y = Foo[float]()
+reveal_type(x)  # N: Revealed type is "builtins.int"
+reveal_type(y)  # N: Revealed type is "builtins.int"
+[builtins fixtures/list.pyi]
+
+[case testUnpackIterableClassWithOverloadedIter2]
+from typing import Union, TypeVar, Generic, overload, Iterator
+
+X = TypeVar('X')
+
+class Foo(Generic[X]):
+    @overload
+    def __iter__(self: Foo[str]) -> Iterator[int]: ...  # type: ignore
+    @overload
+    def __iter__(self: Foo[X]) -> Iterator[str]: ...
+    def __iter__(self) -> Iterator[Union[int, str]]:
+        ...
+
+a, b, c = Foo[str]()
+reveal_type(a)  # N: Revealed type is "builtins.int"
+reveal_type(b)  # N: Revealed type is "builtins.int"
+reveal_type(c)  # N: Revealed type is "builtins.int"
+
+x, y = Foo[float]()
+reveal_type(x)  # N: Revealed type is "builtins.str"
+reveal_type(y)  # N: Revealed type is "builtins.str"
+[builtins fixtures/list.pyi]
+
+[case testUnpackIterableRegular]
+from typing import TypeVar, Generic, Iterator
+
+X = TypeVar('X')
+
+class Foo(Generic[X]):
+    def __iter__(self) -> Iterator[X]:
+        ...
+
+a, b = Foo[int]()
+reveal_type(a)  # N: Revealed type is "builtins.int"
+reveal_type(b)  # N: Revealed type is "builtins.int"
+[builtins fixtures/list.pyi]
+
+[case testUnpackNotIterableClass]
+class Foo: ...
+
+a, b, c = Foo()  # E: "Foo" object is not iterable
+[builtins fixtures/list.pyi]
+
 [case testMetaclassIterable]
 from typing import Iterable, Iterator
 


### PR DESCRIPTION
The change is quite simple: instead of manually unpacking the return type of `find_item`, we use the regular machinery for it.

Note, that this PR does not include any metaclasses related work. We still have problems with them, but I will defer them to the next PR.

Closes https://github.com/python/mypy/issues/14811
CC @AlexWaygood 