### PR TITLE
[Release 1.1] Cherry-pick some mypyc build fixes

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -25,7 +25,7 @@ import os.path
 import re
 import sys
 import time
-from typing import TYPE_CHECKING, Any, Dict, Iterable, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, NoReturn, Union, cast
 
 from mypy.build import BuildSource
 from mypy.errors import CompileError
@@ -41,7 +41,13 @@ from mypyc.namegen import exported_name
 from mypyc.options import CompilerOptions
 
 if TYPE_CHECKING:
-    from distutils.core import Extension
+    from distutils.core import Extension as _distutils_Extension
+    from typing_extensions import TypeAlias
+
+    from setuptools import Extension as _setuptools_Extension
+
+    Extension: TypeAlias = Union[_setuptools_Extension, _distutils_Extension]
+
 
 try:
     # Import setuptools so that it monkey-patch overrides distutils

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
 try:
     # Import setuptools so that it monkey-patch overrides distutils
-    import setuptools  # noqa: F401
+    import setuptools
 except ImportError:
     if sys.version_info >= (3, 12):
         # Raise on Python 3.12, since distutils will go away forever
@@ -63,13 +63,16 @@ def get_extension() -> type[Extension]:
     # We can work with either setuptools or distutils, and pick setuptools
     # if it has been imported.
     use_setuptools = "setuptools" in sys.modules
+    extension_class: type[Extension]
 
     if not use_setuptools:
-        from distutils.core import Extension
-    else:
-        from setuptools import Extension
+        import distutils.core
 
-    return Extension
+        extension_class = distutils.core.Extension
+    else:
+        extension_class = setuptools.Extension
+
+    return extension_class
 
 
 def setup_mypycify_vars() -> None:

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import glob
 import os
 import os.path
 import sys
+from typing import TYPE_CHECKING, Any
 
 if sys.version_info < (3, 7, 0):
     sys.stderr.write("ERROR: You need Python 3.7 or later to use mypy.\n")
@@ -17,10 +18,13 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 # This requires setuptools when building; setuptools is not needed
 # when installing from a wheel file (though it is still needed for
 # alternative forms of installing, as suggested by README.md).
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_py import build_py
 
 from mypy.version import __version__ as version
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeGuard
 
 description = "Optional static typing for Python"
 long_description = """
@@ -34,6 +38,10 @@ actually having to run it.  Mypy has a powerful type system with
 features such as type inference, gradual typing, generics and union
 types.
 """.lstrip()
+
+
+def is_list_of_setuptools_extension(items: list[Any]) -> TypeGuard[list[Extension]]:
+    return all(isinstance(item, Extension) for item in items)
 
 
 def find_package_data(base, globs, root="mypy"):
@@ -166,6 +174,8 @@ if USE_MYPYC:
         # our Appveyor builds run out of memory sometimes.
         multi_file=sys.platform == "win32" or force_multifile,
     )
+    assert is_list_of_setuptools_extension(ext_modules), "Expected mypycify to use setuptools"
+
 else:
     ext_modules = []
 


### PR DESCRIPTION
The mypyc build was recently broken by a new release of `types-setuptools`. This was fixed on `master` by the following two PRs:
- #14781
- #14787

However, the mypyc build is still broken on the 1.1 branch: https://github.com/python/mypy/actions/runs/4311688115/jobs/7521345529.

This PR cherry-picks the two PRs that fixed the build to the 1.1 branch.