### PR TITLE
Fix `Any` inference when unpacking iterators that don't directly inherit from `typing.Iterator`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6395,14 +6395,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # in case there is no explicit base class.
             return item_type
         # Try also structural typing.
-        ret_type, _ = self.expr_checker.check_method_call_by_name(
-            "__iter__", instance, [], [], instance
-        )
-        ret_type = get_proper_type(ret_type)
-        if isinstance(ret_type, Instance):
-            iterator = map_instance_to_supertype(ret_type, self.lookup_typeinfo("typing.Iterator"))
-            item_type = iterator.args[0]
-        return item_type
+        return self.analyze_iterable_item_type_without_expression(instance, instance)[1]
 
     def function_type(self, func: FuncBase) -> FunctionLike:
         return function_type(func, self.named_type("builtins.function"))

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -394,7 +394,6 @@ if int():
 from typing import Iterator
 class Nums:
     def __iter__(self) -> Iterator[int]: pass
-    def __next__(self) -> int: pass
 a, b = Nums()
 reveal_type(a)  # N: Revealed type is "builtins.int"
 reveal_type(b)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -380,6 +380,8 @@ class Nums(Iterable[int]):
     def __iter__(self): pass
     def __next__(self): pass
 a, b = Nums()
+reveal_type(a)  # N: Revealed type is "builtins.int"
+reveal_type(b)  # N: Revealed type is "builtins.int"
 if int():
     a = b = 1
 if int():
@@ -387,6 +389,38 @@ if int():
 if int():
     b = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [builtins fixtures/for.pyi]
+
+[case testInferringTypesFromIterableStructuralSubtyping1]
+from typing import Iterator
+class Nums:
+    def __iter__(self) -> Iterator[int]: pass
+    def __next__(self) -> int: pass
+a, b = Nums()
+reveal_type(a)  # N: Revealed type is "builtins.int"
+reveal_type(b)  # N: Revealed type is "builtins.int"
+if int():
+    a = b = 1
+if int():
+    a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    b = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/for.pyi]
+
+[case testInferringTypesFromIterableStructuralSubtyping2]
+from typing import Self
+class Nums:
+    def __iter__(self) -> Self: pass
+    def __next__(self) -> int: pass
+a, b = Nums()
+reveal_type(a)  # N: Revealed type is "builtins.int"
+reveal_type(b)  # N: Revealed type is "builtins.int"
+if int():
+    a = b = 1
+if int():
+    a = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+if int():
+    b = '' # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[builtins fixtures/tuple.pyi]
 
 
 -- Type variable inference for generic functions


### PR DESCRIPTION
Fixes #14819.

Mypy currently silently infers an `Any` type when unpacking an iterator that doesn't explicitly inherit from `typing.Iterator` (i.e., an iterator that's a _structural_ subtype of `typing.Iterator`, but not a _nominal_ subtype):

```python
from typing import TypeVar

T = TypeVar("T")

class Foo:
    count: int
    def __init__(self) -> None:
        self.count = 0
    def __iter__(self: T) -> T:
        return self
    def __next__(self) -> int:
        self.count += 1
        if self.count > 3:
            raise StopIteration
        return self.count

a, b, c = Foo()
reveal_type(a)  # note: Revealed type is "Any"
```

However, we have enough information here to infer that the type of `a` should really be `int`. This PR fixes that bug.

There's discussion on the issue thread about an alternative solution that would involve changing some mypy behaviour that's been established for around 10 years. For now, I haven't gone for that solution.