### PR TITLE
Fix disappearing errors when re-running dmypy check

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -668,6 +668,8 @@ class Errors:
                 False,
                 False,
                 False,
+                origin=(self.file, [line]),
+                target=self.target_module,
             )
             self._add_error_info(file, info)
 
@@ -720,6 +722,8 @@ class Errors:
                 False,
                 False,
                 False,
+                origin=(self.file, [line]),
+                target=self.target_module,
             )
             self._add_error_info(file, info)
 

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -667,6 +667,8 @@ def update_module_isolated(
     state.type_check_first_pass()
     state.type_check_second_pass()
     state.detect_possibly_undefined_vars()
+    state.generate_unused_ignore_notes()
+    state.generate_ignore_without_code_notes()
     t2 = time.time()
     state.finish_passes()
     t3 = time.time()

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -1027,6 +1027,10 @@ def reprocess_nodes(
         if graph[module_id].type_checker().check_second_pass():
             more = True
 
+    graph[module_id].detect_possibly_undefined_vars()
+    graph[module_id].generate_unused_ignore_notes()
+    graph[module_id].generate_ignore_without_code_notes()
+
     if manager.options.export_types:
         manager.all_types.update(graph[module_id].type_map())
 

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -557,6 +557,42 @@ bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code
 from foo.empty import *
 a = 1  # type: ignore
 
+[case testUnusedTypeIgnorePreservedAfterChange]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --warn-unused-ignores --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+$ echo '' >> bar.py
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore
+
+[case testTypeIgnoreWithoutCodePreservedAfterChange]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --enable-error-code ignore-without-code --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+$ echo '' >> bar.py
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore
+
 [case testPossiblyUndefinedVarsPreservedAfterUpdate]
 -- Regression test for https://github.com/python/mypy/issues/9655
 $ dmypy start -- --enable-error-code possibly-undefined --no-error-summary

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -539,3 +539,20 @@ bar.py:2: error: Unused "type: ignore" comment
 [file bar.py]
 from foo.empty import *
 a = 1  # type: ignore
+
+[case testTypeIgnoreWithoutCodePreservedAfterUpdate]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --enable-error-code ignore-without-code --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -564,7 +564,7 @@ Daemon started
 $ dmypy check -- bar.py
 bar.py:2: error: Unused "type: ignore" comment
 == Return code: 1
-$ echo '' >> bar.py
+$ {python} -c "print('\n')" >> bar.py
 $ dmypy check -- bar.py
 bar.py:2: error: Unused "type: ignore" comment
 == Return code: 1
@@ -582,7 +582,7 @@ Daemon started
 $ dmypy check -- bar.py
 bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
 == Return code: 1
-$ echo '' >> bar.py
+$ {python} -c "print('\n')" >> bar.py
 $ dmypy check -- bar.py
 bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
 == Return code: 1

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -522,3 +522,20 @@ class A:
     x: int
 class B:
     x: int
+
+[case testUnusedTypeIgnorePreservedAfterUpdate]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --warn-unused-ignores --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -556,3 +556,22 @@ bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code
 [file bar.py]
 from foo.empty import *
 a = 1  # type: ignore
+
+[case testPossiblyUndefinedVarsPreservedAfterUpdate]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --enable-error-code possibly-undefined --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:4: error: Name "a" may be undefined  [possibly-undefined]
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:4: error: Name "a" may be undefined  [possibly-undefined]
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+if False:
+    a = 1
+a

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -523,7 +523,7 @@ class A:
 class B:
     x: int
 
-[case testUnusedTypeIgnorePreservedAfterUpdate]
+[case testUnusedTypeIgnorePreservedOnRerun]
 -- Regression test for https://github.com/python/mypy/issues/9655
 $ dmypy start -- --warn-unused-ignores --no-error-summary
 Daemon started
@@ -540,7 +540,7 @@ bar.py:2: error: Unused "type: ignore" comment
 from foo.empty import *
 a = 1  # type: ignore
 
-[case testTypeIgnoreWithoutCodePreservedAfterUpdate]
+[case testTypeIgnoreWithoutCodePreservedOnRerun]
 -- Regression test for https://github.com/python/mypy/issues/9655
 $ dmypy start -- --enable-error-code ignore-without-code --no-error-summary
 Daemon started


### PR DESCRIPTION
This adds a commit which fixes issue https://github.com/python/mypy/issues/9655 wherein some types of error would be lost when a file was re-processed by dmypy. Regression tests are also included.

This also fixes another error where sometimes files would not be re-processed by dmypy if the only error in the file was either "unused type ignore" or "ignore without code".

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
