### PR TITLE
CallableType.copy_modified: accept sequence for arg_names

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1775,7 +1775,7 @@ class CallableType(FunctionLike):
         self: CT,
         arg_types: Bogus[Sequence[Type]] = _dummy,
         arg_kinds: Bogus[list[ArgKind]] = _dummy,
-        arg_names: Bogus[list[str | None]] = _dummy,
+        arg_names: Bogus[Sequence[str | None]] = _dummy,
         ret_type: Bogus[Type] = _dummy,
         fallback: Bogus[Instance] = _dummy,
         name: Bogus[str | None] = _dummy,


### PR DESCRIPTION
In #4070, `CallableType.__init__` was changed to accept `arg_names: Sequence[str | None]` so we could pass e.g. `list[str]` to it. We're making a similar change to `CallableType.copy_modified`.