### PR TITLE
[dataclass_transform] support implicit default for "init" parameter in field specifiers

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -750,17 +750,14 @@ class DataclassTransformer:
             return True
 
         specifier_type = _get_callee_type(call)
-        print("type", specifier_type, type(specifier_type))
         if specifier_type is None:
             return True
 
         parameter = specifier_type.argument_by_name("init")
-        print("parameter", parameter)
         if parameter is None:
             return True
 
         literals = try_getting_literals_from_type(parameter.typ, bool, "builtins.bool")
-        print("literals", literals)
         if literals is None or len(literals) != 1:
             return True
 

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -328,6 +328,38 @@ Foo(a=1, b='bye')
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
 
+[case testDataclassTransformFieldSpecifierImplicitInit]
+# flags: --python-version 3.11
+from typing import dataclass_transform, Literal, overload
+
+def init(*, init: Literal[True] = True): ...
+def no_init(*, init: Literal[False] = False): ...
+
+@overload
+def field_overload(*, custom: None, init: Literal[True] = True): ...
+@overload
+def field_overload(*, custom: str, init: Literal[False] = False): ...
+def field_overload(*, custom, init): ...
+
+@dataclass_transform(field_specifiers=(init, no_init, field_overload))
+def my_dataclass(cls): return cls
+
+@my_dataclass
+class Foo:
+    a: int = init()
+    b: int = field_overload(custom=None)
+
+    bad1: int = no_init()
+    bad2: int = field_overload(custom="bad2")
+
+reveal_type(Foo)  # N: Revealed type is "def (a: builtins.int, b: builtins.int) -> __main__.Foo"
+Foo(a=1, b=2)
+Foo(a=1, b=2, bad1=0)  # E: Unexpected keyword argument "bad1" for "Foo"
+Foo(a=1, b=2, bad2=0)  # E: Unexpected keyword argument "bad2" for "Foo"
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
 [case testDataclassTransformOverloadsDecoratorOnOverload]
 # flags: --python-version 3.11
 from typing import dataclass_transform, overload, Any, Callable, Type, Literal


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This note [from PEP 681](https://peps.python.org/pep-0681/#field-specifier-parameters) was missed in the initial implementation of field specifiers:

> If unspecified, init defaults to True. Field specifier functions can use overloads that implicitly specify the value of init using a literal bool value type (Literal[False] or Literal[True]).

This commit adds support for reading a default from the declared type of the `init` parameter if possible. Otherwise, it continues to use the typical default of `True`.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
