### PR TITLE
Add foundation for TypeVar defaults (PEP 696)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7191,6 +7191,7 @@ def detach_callable(typ: CallableType) -> CallableType:
                 id=var.id,
                 values=var.values,
                 upper_bound=var.upper_bound,
+                default=var.default,
                 variance=var.variance,
             )
         )

--- a/mypy/copytype.py
+++ b/mypy/copytype.py
@@ -72,7 +72,9 @@ class TypeShallowCopier(TypeVisitor[ProperType]):
         return self.copy_common(t, t.copy_modified())
 
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
-        dup = ParamSpecType(t.name, t.fullname, t.id, t.flavor, t.upper_bound, prefix=t.prefix)
+        dup = ParamSpecType(
+            t.name, t.fullname, t.id, t.flavor, t.upper_bound, t.default, prefix=t.prefix
+        )
         return self.copy_common(t, dup)
 
     def visit_parameters(self, t: Parameters) -> ProperType:
@@ -86,7 +88,9 @@ class TypeShallowCopier(TypeVisitor[ProperType]):
         return self.copy_common(t, dup)
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> ProperType:
-        dup = TypeVarTupleType(t.name, t.fullname, t.id, t.upper_bound, t.tuple_fallback)
+        dup = TypeVarTupleType(
+            t.name, t.fullname, t.id, t.upper_bound, t.tuple_fallback, t.default
+        )
         return self.copy_common(t, dup)
 
     def visit_unpack_type(self, t: UnpackType) -> ProperType:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -130,14 +130,7 @@ def freshen_function_type_vars(callee: F) -> F:
         tvs = []
         tvmap: dict[TypeVarId, Type] = {}
         for v in callee.variables:
-            if isinstance(v, TypeVarType):
-                tv: TypeVarLikeType = TypeVarType.new_unification_variable(v)
-            elif isinstance(v, TypeVarTupleType):
-                assert isinstance(v, TypeVarTupleType)
-                tv = TypeVarTupleType.new_unification_variable(v)
-            else:
-                assert isinstance(v, ParamSpecType)
-                tv = ParamSpecType.new_unification_variable(v)
+            tv = v.new_unification_variable(v)
             tvs.append(tv)
             tvmap[v.id] = tv
         fresh = expand_type(callee, tvmap).copy_modified(variables=tvs)

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -171,17 +171,21 @@ class NodeFixer(NodeVisitor[None]):
                 for value in v.values:
                     value.accept(self.type_fixer)
             v.upper_bound.accept(self.type_fixer)
+            v.default.accept(self.type_fixer)
 
     def visit_type_var_expr(self, tv: TypeVarExpr) -> None:
         for value in tv.values:
             value.accept(self.type_fixer)
         tv.upper_bound.accept(self.type_fixer)
+        tv.default.accept(self.type_fixer)
 
     def visit_paramspec_expr(self, p: ParamSpecExpr) -> None:
         p.upper_bound.accept(self.type_fixer)
+        p.default.accept(self.type_fixer)
 
     def visit_type_var_tuple_expr(self, tv: TypeVarTupleExpr) -> None:
         tv.upper_bound.accept(self.type_fixer)
+        tv.default.accept(self.type_fixer)
 
     def visit_var(self, v: Var) -> None:
         if self.current_info is not None:
@@ -303,14 +307,16 @@ class TypeFixer(TypeVisitor[None]):
         if tvt.values:
             for vt in tvt.values:
                 vt.accept(self)
-        if tvt.upper_bound is not None:
-            tvt.upper_bound.accept(self)
+        tvt.upper_bound.accept(self)
+        tvt.default.accept(self)
 
     def visit_param_spec(self, p: ParamSpecType) -> None:
         p.upper_bound.accept(self)
+        p.default.accept(self)
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> None:
         t.upper_bound.accept(self)
+        t.default.accept(self)
 
     def visit_unpack_type(self, u: UnpackType) -> None:
         u.type.accept(self)

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -64,13 +64,13 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
         return set()
 
     def visit_type_var(self, t: types.TypeVarType) -> set[str]:
-        return self._visit(t.values) | self._visit(t.upper_bound)
+        return self._visit(t.values) | self._visit(t.upper_bound) | self._visit(t.default)
 
     def visit_param_spec(self, t: types.ParamSpecType) -> set[str]:
-        return set()
+        return self._visit(t.upper_bound) | self._visit(t.default)
 
     def visit_type_var_tuple(self, t: types.TypeVarTupleType) -> set[str]:
-        return self._visit(t.upper_bound)
+        return self._visit(t.upper_bound) | self._visit(t.default)
 
     def visit_unpack_type(self, t: types.UnpackType) -> set[str]:
         return t.type.accept(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2446,6 +2446,8 @@ class TypeVarLikeExpr(SymbolNode, Expression):
     # Upper bound: only subtypes of upper_bound are valid as values. By default
     # this is 'object', meaning no restriction.
     upper_bound: mypy.types.Type
+    # Default: used to resolve the TypeVar if the default is not explicitly given.
+    # By default this is 'AnyType(TypeOfAny.from_omitted_generics)'. See PEP 696.
     default: mypy.types.Type
     # Variance of the type variable. Invariant is the default.
     # TypeVar(..., covariant=True) defines a covariant type variable.

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2439,13 +2439,14 @@ class TypeVarLikeExpr(SymbolNode, Expression):
     Note that they are constructed by the semantic analyzer.
     """
 
-    __slots__ = ("_name", "_fullname", "upper_bound", "variance")
+    __slots__ = ("_name", "_fullname", "upper_bound", "default", "variance")
 
     _name: str
     _fullname: str
     # Upper bound: only subtypes of upper_bound are valid as values. By default
     # this is 'object', meaning no restriction.
     upper_bound: mypy.types.Type
+    default: mypy.types.Type
     # Variance of the type variable. Invariant is the default.
     # TypeVar(..., covariant=True) defines a covariant type variable.
     # TypeVar(..., contravariant=True) defines a contravariant type
@@ -2453,12 +2454,18 @@ class TypeVarLikeExpr(SymbolNode, Expression):
     variance: int
 
     def __init__(
-        self, name: str, fullname: str, upper_bound: mypy.types.Type, variance: int = INVARIANT
+        self,
+        name: str,
+        fullname: str,
+        upper_bound: mypy.types.Type,
+        default: mypy.types.Type,
+        variance: int = INVARIANT,
     ) -> None:
         super().__init__()
         self._name = name
         self._fullname = fullname
         self.upper_bound = upper_bound
+        self.default = default
         self.variance = variance
 
     @property
@@ -2496,9 +2503,10 @@ class TypeVarExpr(TypeVarLikeExpr):
         fullname: str,
         values: list[mypy.types.Type],
         upper_bound: mypy.types.Type,
+        default: mypy.types.Type,
         variance: int = INVARIANT,
     ) -> None:
-        super().__init__(name, fullname, upper_bound, variance)
+        super().__init__(name, fullname, upper_bound, default, variance)
         self.values = values
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
@@ -2511,6 +2519,7 @@ class TypeVarExpr(TypeVarLikeExpr):
             "fullname": self._fullname,
             "values": [t.serialize() for t in self.values],
             "upper_bound": self.upper_bound.serialize(),
+            "default": self.default.serialize(),
             "variance": self.variance,
         }
 
@@ -2522,6 +2531,7 @@ class TypeVarExpr(TypeVarLikeExpr):
             data["fullname"],
             [mypy.types.deserialize_type(v) for v in data["values"]],
             mypy.types.deserialize_type(data["upper_bound"]),
+            mypy.types.deserialize_type(data["default"]),
             data["variance"],
         )
 
@@ -2540,6 +2550,7 @@ class ParamSpecExpr(TypeVarLikeExpr):
             "name": self._name,
             "fullname": self._fullname,
             "upper_bound": self.upper_bound.serialize(),
+            "default": self.default.serialize(),
             "variance": self.variance,
         }
 
@@ -2550,6 +2561,7 @@ class ParamSpecExpr(TypeVarLikeExpr):
             data["name"],
             data["fullname"],
             mypy.types.deserialize_type(data["upper_bound"]),
+            mypy.types.deserialize_type(data["default"]),
             data["variance"],
         )
 
@@ -2569,9 +2581,10 @@ class TypeVarTupleExpr(TypeVarLikeExpr):
         fullname: str,
         upper_bound: mypy.types.Type,
         tuple_fallback: mypy.types.Instance,
+        default: mypy.types.Type,
         variance: int = INVARIANT,
     ) -> None:
-        super().__init__(name, fullname, upper_bound, variance)
+        super().__init__(name, fullname, upper_bound, default, variance)
         self.tuple_fallback = tuple_fallback
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
@@ -2584,6 +2597,7 @@ class TypeVarTupleExpr(TypeVarLikeExpr):
             "fullname": self._fullname,
             "upper_bound": self.upper_bound.serialize(),
             "tuple_fallback": self.tuple_fallback.serialize(),
+            "default": self.default.serialize(),
             "variance": self.variance,
         }
 
@@ -2595,6 +2609,7 @@ class TypeVarTupleExpr(TypeVarLikeExpr):
             data["fullname"],
             mypy.types.deserialize_type(data["upper_bound"]),
             mypy.types.Instance.deserialize(data["tuple_fallback"]),
+            mypy.types.deserialize_type(data["default"]),
             data["variance"],
         )
 

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -772,9 +772,14 @@ def _add_order(ctx: mypy.plugin.ClassDefContext, adder: MethodAdder) -> None:
         id=-1,
         values=[],
         upper_bound=object_type,
+        default=AnyType(TypeOfAny.from_omitted_generics),
     )
     self_tvar_expr = TypeVarExpr(
-        SELF_TVAR_NAME, ctx.cls.info.fullname + "." + SELF_TVAR_NAME, [], object_type
+        SELF_TVAR_NAME,
+        ctx.cls.info.fullname + "." + SELF_TVAR_NAME,
+        [],
+        object_type,
+        AnyType(TypeOfAny.from_omitted_generics),
     )
     ctx.cls.info.names[SELF_TVAR_NAME] = SymbolTableNode(MDEF, self_tvar_expr)
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -254,7 +254,11 @@ class DataclassTransformer:
             # Type variable for self types in generated methods.
             obj_type = self._api.named_type("builtins.object")
             self_tvar_expr = TypeVarExpr(
-                SELF_TVAR_NAME, info.fullname + "." + SELF_TVAR_NAME, [], obj_type
+                SELF_TVAR_NAME,
+                info.fullname + "." + SELF_TVAR_NAME,
+                [],
+                obj_type,
+                AnyType(TypeOfAny.from_omitted_generics),
             )
             info.names[SELF_TVAR_NAME] = SymbolTableNode(MDEF, self_tvar_expr)
 
@@ -273,6 +277,7 @@ class DataclassTransformer:
                     id=-1,
                     values=[],
                     upper_bound=obj_type,
+                    default=AnyType(TypeOfAny.from_omitted_generics),
                 )
                 order_return_type = self._api.named_type("builtins.bool")
                 order_args = [

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1065,18 +1065,25 @@ class SemanticAnalyzer(
         assert self.type is not None
         info = self.type
         if info.self_type is not None:
-            if has_placeholder(info.self_type.upper_bound):
+            if has_placeholder(info.self_type.upper_bound) or has_placeholder(
+                info.self_type.default
+            ):
                 # Similar to regular (user defined) type variables.
                 self.process_placeholder(
                     None,
-                    "Self upper bound",
+                    "Self upper bound or default",
                     info,
                     force_progress=info.self_type.upper_bound != fill_typevars(info),
                 )
             else:
                 return
         info.self_type = TypeVarType(
-            "Self", f"{info.fullname}.Self", id=0, values=[], upper_bound=fill_typevars(info)
+            "Self",
+            f"{info.fullname}.Self",
+            id=0,
+            values=[],
+            upper_bound=fill_typevars(info),
+            default=AnyType(TypeOfAny.from_omitted_generics),
         )
 
     def visit_overloaded_func_def(self, defn: OverloadedFuncDef) -> None:
@@ -1607,6 +1614,11 @@ class SemanticAnalyzer(
                 # Some type variable bounds or values are not ready, we need
                 # to re-analyze this class.
                 self.defer()
+            if has_placeholder(tvd.default):
+                # Placeholder values in TypeVarLikeTypes may get substituted in.
+                # Defer current target until they are ready.
+                self.mark_incomplete(defn.name, defn)
+                return
 
         self.analyze_class_keywords(defn)
         bases_result = self.analyze_base_classes(bases)
@@ -3981,7 +3993,7 @@ class SemanticAnalyzer(
         )
         if res is None:
             return False
-        variance, upper_bound = res
+        variance, upper_bound, default = res
 
         existing = self.current_symbol_table().get(name)
         if existing and not (
@@ -4003,7 +4015,7 @@ class SemanticAnalyzer(
                 prefix = "Upper bound of type variable"
                 self.msg.unimported_type_becomes_any(prefix, upper_bound, s)
 
-        for t in values + [upper_bound]:
+        for t in values + [upper_bound, default]:
             check_for_explicit_any(
                 t, self.options, self.is_typeshed_stub_file, self.msg, context=s
             )
@@ -4016,18 +4028,29 @@ class SemanticAnalyzer(
 
         # Yes, it's a valid type variable definition! Add it to the symbol table.
         if not call.analyzed:
-            type_var = TypeVarExpr(name, self.qualified_name(name), values, upper_bound, variance)
+            type_var = TypeVarExpr(
+                name, self.qualified_name(name), values, upper_bound, default, variance
+            )
             type_var.line = call.line
             call.analyzed = type_var
             updated = True
         else:
             assert isinstance(call.analyzed, TypeVarExpr)
-            updated = values != call.analyzed.values or upper_bound != call.analyzed.upper_bound
+            updated = (
+                values != call.analyzed.values
+                or upper_bound != call.analyzed.upper_bound
+                or default != call.analyzed.default
+            )
             call.analyzed.upper_bound = upper_bound
             call.analyzed.values = values
-        if any(has_placeholder(v) for v in values) or has_placeholder(upper_bound):
+            call.analyzed.default = default
+        if (
+            any(has_placeholder(v) for v in values)
+            or has_placeholder(upper_bound)
+            or has_placeholder(default)
+        ):
             self.process_placeholder(
-                None, f"TypeVar {'values' if values else 'upper bound'}", s, force_progress=updated
+                None, "TypeVar values, upper bound, or default", s, force_progress=updated
             )
 
         self.add_symbol(name, call.analyzed, s)
@@ -4077,11 +4100,12 @@ class SemanticAnalyzer(
         kinds: list[ArgKind],
         num_values: int,
         context: Context,
-    ) -> tuple[int, Type] | None:
+    ) -> tuple[int, Type, Type] | None:
         has_values = num_values > 0
         covariant = False
         contravariant = False
         upper_bound: Type = self.object_type()
+        default: Type = AnyType(TypeOfAny.from_omitted_generics)
         for param_value, param_name, param_kind in zip(args, names, kinds):
             if not param_kind.is_named():
                 self.fail(message_registry.TYPEVAR_UNEXPECTED_ARGUMENT, context)
@@ -4151,7 +4175,7 @@ class SemanticAnalyzer(
             variance = CONTRAVARIANT
         else:
             variance = INVARIANT
-        return variance, upper_bound
+        return variance, upper_bound, default
 
     def extract_typevarlike_name(self, s: AssignmentStmt, call: CallExpr) -> str | None:
         if not call:
@@ -4191,13 +4215,15 @@ class SemanticAnalyzer(
         if len(call.args) > 1:
             self.fail("Only the first argument to ParamSpec has defined semantics", s)
 
+        default: Type = AnyType(TypeOfAny.from_omitted_generics)
+
         # PEP 612 reserves the right to define bound, covariant and contravariant arguments to
         # ParamSpec in a later PEP. If and when that happens, we should do something
         # on the lines of process_typevar_parameters
 
         if not call.analyzed:
             paramspec_var = ParamSpecExpr(
-                name, self.qualified_name(name), self.object_type(), INVARIANT
+                name, self.qualified_name(name), self.object_type(), default, INVARIANT
             )
             paramspec_var.line = call.line
             call.analyzed = paramspec_var
@@ -4220,6 +4246,8 @@ class SemanticAnalyzer(
         if len(call.args) > 1:
             self.fail("Only the first argument to TypeVarTuple has defined semantics", s)
 
+        default: Type = AnyType(TypeOfAny.from_omitted_generics)
+
         if not self.incomplete_feature_enabled(TYPE_VAR_TUPLE, s):
             return False
 
@@ -4231,7 +4259,12 @@ class SemanticAnalyzer(
         if not call.analyzed:
             tuple_fallback = self.named_type("builtins.tuple", [self.object_type()])
             typevartuple_var = TypeVarTupleExpr(
-                name, self.qualified_name(name), self.object_type(), tuple_fallback, INVARIANT
+                name,
+                self.qualified_name(name),
+                self.object_type(),
+                tuple_fallback,
+                default,
+                INVARIANT,
             )
             typevartuple_var.line = call.line
             call.analyzed = typevartuple_var

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -549,6 +549,7 @@ class NamedTupleAnalyzer:
             id=self.api.tvar_scope.new_unique_func_id(),
             values=[],
             upper_bound=info.tuple_type,
+            default=AnyType(TypeOfAny.from_omitted_generics),
         )
         selftype = tvd
 
@@ -617,7 +618,11 @@ class NamedTupleAnalyzer:
         )
 
         self_tvar_expr = TypeVarExpr(
-            SELF_TVAR_NAME, info.fullname + "." + SELF_TVAR_NAME, [], info.tuple_type
+            SELF_TVAR_NAME,
+            info.fullname + "." + SELF_TVAR_NAME,
+            [],
+            info.tuple_type,
+            AnyType(TypeOfAny.from_omitted_generics),
         )
         info.names[SELF_TVAR_NAME] = SymbolTableNode(MDEF, self_tvar_expr)
         return info

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -32,6 +32,7 @@ from mypy.tvar_scope import TypeVarLikeScope
 from mypy.type_visitor import ANY_STRATEGY, BoolTypeQuery
 from mypy.types import (
     TPDICT_FB_NAMES,
+    AnyType,
     FunctionLike,
     Instance,
     Parameters,
@@ -41,6 +42,7 @@ from mypy.types import (
     ProperType,
     TupleType,
     Type,
+    TypeOfAny,
     TypeVarId,
     TypeVarLikeType,
     get_proper_type,
@@ -308,6 +310,7 @@ def paramspec_args(
         id,
         flavor=ParamSpecFlavor.ARGS,
         upper_bound=named_type_func("builtins.tuple", [named_type_func("builtins.object")]),
+        default=AnyType(TypeOfAny.from_omitted_generics),
         line=line,
         column=column,
         prefix=prefix,
@@ -332,6 +335,7 @@ def paramspec_kwargs(
         upper_bound=named_type_func(
             "builtins.dict", [named_type_func("builtins.str"), named_type_func("builtins.object")]
         ),
+        default=AnyType(TypeOfAny.from_omitted_generics),
         line=line,
         column=column,
         prefix=prefix,

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -190,6 +190,7 @@ def snapshot_symbol_table(name_prefix: str, table: SymbolTable) -> dict[str, Sym
                 node.variance,
                 [snapshot_type(value) for value in node.values],
                 snapshot_type(node.upper_bound),
+                snapshot_type(node.default),
             )
         elif isinstance(node, TypeAlias):
             result[name] = (
@@ -200,9 +201,19 @@ def snapshot_symbol_table(name_prefix: str, table: SymbolTable) -> dict[str, Sym
                 snapshot_optional_type(node.target),
             )
         elif isinstance(node, ParamSpecExpr):
-            result[name] = ("ParamSpec", node.variance, snapshot_type(node.upper_bound))
+            result[name] = (
+                "ParamSpec",
+                node.variance,
+                snapshot_type(node.upper_bound),
+                snapshot_type(node.default),
+            )
         elif isinstance(node, TypeVarTupleExpr):
-            result[name] = ("TypeVarTuple", node.variance, snapshot_type(node.upper_bound))
+            result[name] = (
+                "TypeVarTuple",
+                node.variance,
+                snapshot_type(node.upper_bound),
+                snapshot_type(node.default),
+            )
         else:
             assert symbol.kind != UNBOUND_IMPORTED
             if node and get_prefix(node.fullname) != name_prefix:
@@ -382,6 +393,7 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
             typ.id.meta_level,
             snapshot_types(typ.values),
             snapshot_type(typ.upper_bound),
+            snapshot_type(typ.default),
             typ.variance,
         )
 
@@ -392,6 +404,7 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
             typ.id.meta_level,
             typ.flavor,
             snapshot_type(typ.upper_bound),
+            snapshot_type(typ.default),
         )
 
     def visit_type_var_tuple(self, typ: TypeVarTupleType) -> SnapshotItem:
@@ -400,6 +413,7 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
             typ.id.raw_id,
             typ.id.meta_level,
             snapshot_type(typ.upper_bound),
+            snapshot_type(typ.default),
         )
 
     def visit_unpack_type(self, typ: UnpackType) -> SnapshotItem:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -250,6 +250,15 @@ class NodeReplaceVisitor(TraverserVisitor):
         for value in tv.values:
             self.fixup_type(value)
         self.fixup_type(tv.upper_bound)
+        self.fixup_type(tv.default)
+
+    def process_param_spec_def(self, tv: ParamSpecType) -> None:
+        self.fixup_type(tv.upper_bound)
+        self.fixup_type(tv.default)
+
+    def process_type_var_tuple_def(self, tv: TypeVarTupleType) -> None:
+        self.fixup_type(tv.upper_bound)
+        self.fixup_type(tv.default)
 
     def visit_assignment_stmt(self, node: AssignmentStmt) -> None:
         self.fixup_type(node.type)
@@ -478,14 +487,17 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
 
     def visit_type_var(self, typ: TypeVarType) -> None:
         typ.upper_bound.accept(self)
+        typ.default.accept(self)
         for value in typ.values:
             value.accept(self)
 
     def visit_param_spec(self, typ: ParamSpecType) -> None:
-        pass
+        typ.upper_bound.accept(self)
+        typ.default.accept(self)
 
     def visit_type_var_tuple(self, typ: TypeVarTupleType) -> None:
         typ.upper_bound.accept(self)
+        typ.default.accept(self)
 
     def visit_unpack_type(self, typ: UnpackType) -> None:
         typ.type.accept(self)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -1039,6 +1039,8 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
             triggers.append(make_trigger(typ.fullname))
         if typ.upper_bound:
             triggers.extend(self.get_type_triggers(typ.upper_bound))
+        if typ.default:
+            triggers.extend(self.get_type_triggers(typ.default))
         for val in typ.values:
             triggers.extend(self.get_type_triggers(val))
         return triggers
@@ -1047,6 +1049,10 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         triggers = []
         if typ.fullname:
             triggers.append(make_trigger(typ.fullname))
+        if typ.upper_bound:
+            triggers.extend(self.get_type_triggers(typ.upper_bound))
+        if typ.default:
+            triggers.extend(self.get_type_triggers(typ.default))
         triggers.extend(self.get_type_triggers(typ.upper_bound))
         return triggers
 
@@ -1054,6 +1060,10 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         triggers = []
         if typ.fullname:
             triggers.append(make_trigger(typ.fullname))
+        if typ.upper_bound:
+            triggers.extend(self.get_type_triggers(typ.upper_bound))
+        if typ.default:
+            triggers.extend(self.get_type_triggers(typ.default))
         triggers.extend(self.get_type_triggers(typ.upper_bound))
         return triggers
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -141,8 +141,23 @@ class TypesSuite(Suite):
         )
 
     def test_type_variable_binding(self) -> None:
-        assert_equal(str(TypeVarType("X", "X", 1, [], self.fx.o)), "X`1")
-        assert_equal(str(TypeVarType("X", "X", 1, [self.x, self.y], self.fx.o)), "X`1")
+        assert_equal(
+            str(TypeVarType("X", "X", 1, [], self.fx.o, AnyType(TypeOfAny.from_omitted_generics))),
+            "X`1",
+        )
+        assert_equal(
+            str(
+                TypeVarType(
+                    "X",
+                    "X",
+                    1,
+                    [self.x, self.y],
+                    self.fx.o,
+                    AnyType(TypeOfAny.from_omitted_generics),
+                )
+            ),
+            "X`1",
+        )
 
     def test_generic_function_type(self) -> None:
         c = CallableType(
@@ -152,11 +167,16 @@ class TypesSuite(Suite):
             self.y,
             self.function,
             name=None,
-            variables=[TypeVarType("X", "X", -1, [], self.fx.o)],
+            variables=[
+                TypeVarType("X", "X", -1, [], self.fx.o, AnyType(TypeOfAny.from_omitted_generics))
+            ],
         )
         assert_equal(str(c), "def [X] (X?, Y?) -> Y?")
 
-        v = [TypeVarType("Y", "Y", -1, [], self.fx.o), TypeVarType("X", "X", -2, [], self.fx.o)]
+        v = [
+            TypeVarType("Y", "Y", -1, [], self.fx.o, AnyType(TypeOfAny.from_omitted_generics)),
+            TypeVarType("X", "X", -2, [], self.fx.o, AnyType(TypeOfAny.from_omitted_generics)),
+        ]
         c2 = CallableType([], [], [], NoneType(), self.function, name=None, variables=v)
         assert_equal(str(c2), "def [Y, X] ()")
 
@@ -183,7 +203,7 @@ class TypesSuite(Suite):
 
     def test_recursive_nested_in_non_recursive(self) -> None:
         A, _ = self.fx.def_alias_1(self.fx.a)
-        T = TypeVarType("T", "T", -1, [], self.fx.o)
+        T = TypeVarType("T", "T", -1, [], self.fx.o, AnyType(TypeOfAny.from_omitted_generics))
         NA = self.fx.non_rec_alias(Instance(self.fx.gi, [T]), [T], [A])
         assert not NA.is_recursive
         assert has_recursive_types(NA)
@@ -634,7 +654,9 @@ class TypeOpsSuite(Suite):
         tv: list[TypeVarType] = []
         n = -1
         for v in vars:
-            tv.append(TypeVarType(v, v, n, [], self.fx.o))
+            tv.append(
+                TypeVarType(v, v, n, [], self.fx.o, AnyType(TypeOfAny.from_omitted_generics))
+            )
             n -= 1
         return CallableType(
             list(a[:-1]),

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -54,7 +54,15 @@ class TypeFixture:
         def make_type_var(
             name: str, id: int, values: list[Type], upper_bound: Type, variance: int
         ) -> TypeVarType:
-            return TypeVarType(name, name, id, values, upper_bound, variance)
+            return TypeVarType(
+                name,
+                name,
+                id,
+                values,
+                upper_bound,
+                AnyType(TypeOfAny.from_omitted_generics),
+                variance,
+            )
 
         self.t = make_type_var("T", 1, [], self.o, variance)  # T`1 (type variable)
         self.tf = make_type_var("T", -1, [], self.o, variance)  # T`-1 (type variable)
@@ -212,7 +220,14 @@ class TypeFixture:
         self._add_bool_dunder(self.ai)
 
         def make_type_var_tuple(name: str, id: int, upper_bound: Type) -> TypeVarTupleType:
-            return TypeVarTupleType(name, name, id, upper_bound, self.std_tuple)
+            return TypeVarTupleType(
+                name,
+                name,
+                id,
+                upper_bound,
+                self.std_tuple,
+                AnyType(TypeOfAny.from_omitted_generics),
+            )
 
         self.ts = make_type_var_tuple("Ts", 1, self.o)  # Ts`1 (type var tuple)
         self.ss = make_type_var_tuple("Ss", 2, self.o)  # Ss`2 (type var tuple)
@@ -301,13 +316,32 @@ class TypeFixture:
             v: list[TypeVarLikeType] = []
             for id, n in enumerate(typevars, 1):
                 if typevar_tuple_index is not None and id - 1 == typevar_tuple_index:
-                    v.append(TypeVarTupleType(n, n, id, self.o, self.std_tuple))
+                    v.append(
+                        TypeVarTupleType(
+                            n,
+                            n,
+                            id,
+                            self.o,
+                            self.std_tuple,
+                            AnyType(TypeOfAny.from_omitted_generics),
+                        )
+                    )
                 else:
                     if variances:
                         variance = variances[id - 1]
                     else:
                         variance = COVARIANT
-                    v.append(TypeVarType(n, n, id, [], self.o, variance=variance))
+                    v.append(
+                        TypeVarType(
+                            n,
+                            n,
+                            id,
+                            [],
+                            self.o,
+                            AnyType(TypeOfAny.from_omitted_generics),
+                            variance=variance,
+                        )
+                    )
             class_def.type_vars = v
 
         info = TypeInfo(SymbolTable(), class_def, module_name)

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -646,12 +646,17 @@ class TransformVisitor(NodeVisitor[Node]):
             node.fullname,
             self.types(node.values),
             self.type(node.upper_bound),
+            self.type(node.default),
             variance=node.variance,
         )
 
     def visit_paramspec_expr(self, node: ParamSpecExpr) -> ParamSpecExpr:
         return ParamSpecExpr(
-            node.name, node.fullname, self.type(node.upper_bound), variance=node.variance
+            node.name,
+            node.fullname,
+            self.type(node.upper_bound),
+            self.type(node.default),
+            variance=node.variance,
         )
 
     def visit_type_var_tuple_expr(self, node: TypeVarTupleExpr) -> TypeVarTupleExpr:
@@ -660,6 +665,7 @@ class TransformVisitor(NodeVisitor[Node]):
             node.fullname,
             self.type(node.upper_bound),
             node.tuple_fallback,
+            self.type(node.default),
             variance=node.variance,
         )
 

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -95,6 +95,7 @@ class TypeVarLikeScope:
                 id=TypeVarId(i, namespace=namespace),
                 values=tvar_expr.values,
                 upper_bound=tvar_expr.upper_bound,
+                default=tvar_expr.default,
                 variance=tvar_expr.variance,
                 line=tvar_expr.line,
                 column=tvar_expr.column,
@@ -106,6 +107,7 @@ class TypeVarLikeScope:
                 i,
                 flavor=ParamSpecFlavor.BARE,
                 upper_bound=tvar_expr.upper_bound,
+                default=tvar_expr.default,
                 line=tvar_expr.line,
                 column=tvar_expr.column,
             )
@@ -116,6 +118,7 @@ class TypeVarLikeScope:
                 i,
                 upper_bound=tvar_expr.upper_bound,
                 tuple_fallback=tvar_expr.tuple_fallback,
+                default=tvar_expr.default,
                 line=tvar_expr.line,
                 column=tvar_expr.column,
             )

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -346,13 +346,13 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return self.strategy([])
 
     def visit_type_var(self, t: TypeVarType) -> T:
-        return self.query_types([t.upper_bound] + t.values)
+        return self.query_types([t.upper_bound, t.default] + t.values)
 
     def visit_param_spec(self, t: ParamSpecType) -> T:
-        return self.strategy([])
+        return self.query_types([t.upper_bound, t.default])
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> T:
-        return self.strategy([])
+        return self.query_types([t.upper_bound, t.default])
 
     def visit_unpack_type(self, t: UnpackType) -> T:
         return self.query_types([t.type])
@@ -480,13 +480,13 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         return self.default
 
     def visit_type_var(self, t: TypeVarType) -> bool:
-        return self.query_types([t.upper_bound] + t.values)
+        return self.query_types([t.upper_bound, t.default] + t.values)
 
     def visit_param_spec(self, t: ParamSpecType) -> bool:
-        return self.default
+        return self.query_types([t.upper_bound, t.default])
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> bool:
-        return self.default
+        return self.query_types([t.upper_bound, t.default])
 
     def visit_unpack_type(self, t: UnpackType) -> bool:
         return self.query_types([t.type])

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -321,6 +321,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     tvar_def.id,
                     tvar_def.flavor,
                     tvar_def.upper_bound,
+                    tvar_def.default,
                     line=t.line,
                     column=t.column,
                 )
@@ -374,6 +375,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     tvar_def.id,
                     tvar_def.upper_bound,
                     sym.node.tuple_fallback,
+                    tvar_def.default,
                     line=t.line,
                     column=t.column,
                 )
@@ -1549,6 +1551,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 id=var_def.id.raw_id,
                 values=self.anal_array(var_def.values),
                 upper_bound=var_def.upper_bound.accept(self),
+                default=var_def.default.accept(self),
                 variance=var_def.variance,
                 line=var_def.line,
                 column=var_def.column,

--- a/mypy/typevars.py
+++ b/mypy/typevars.py
@@ -36,6 +36,7 @@ def fill_typevars(typ: TypeInfo) -> Instance | TupleType:
                     tv.id,
                     tv.upper_bound,
                     tv.tuple_fallback,
+                    tv.default,
                     line=-1,
                     column=-1,
                 )
@@ -43,7 +44,14 @@ def fill_typevars(typ: TypeInfo) -> Instance | TupleType:
         else:
             assert isinstance(tv, ParamSpecType)
             tv = ParamSpecType(
-                tv.name, tv.fullname, tv.id, tv.flavor, tv.upper_bound, line=-1, column=-1
+                tv.name,
+                tv.fullname,
+                tv.id,
+                tv.flavor,
+                tv.upper_bound,
+                tv.default,
+                line=-1,
+                column=-1,
             )
         tvs.append(tv)
     inst = Instance(typ, tvs)


### PR DESCRIPTION
Start implementing [PEP 696](https://peps.python.org/pep-0696/) TypeVar defaults. This PR
* Adds a `default` parameter to `TypeVarLikeExpr` and `TypeVarLikeType`.
* Updates most visitors to account for the new `default` parameter.
* Update existing calls to add value for `default` => `AnyType(TypeOfAny.from_omitted_generics)`.

A followup PR will update the semantic analyzer and add basic tests for `TypeVar`, `ParamSpec`, and `TypeVarTuple` calls with a `default` argument. -> #14873

Ref #14851