### PR TITLE
Remove unnecessary cast in `semanal_namedtuple.py`

### DIFF
--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -373,7 +373,7 @@ class NamedTupleAnalyzer:
         if not isinstance(args[0], StrExpr):
             self.fail(f'"{type_name}()" expects a string literal as the first argument', call)
             return None
-        typename = cast(StrExpr, call.args[0]).value
+        typename = args[0].value
         types: list[Type] = []
         tvar_defs = []
         if not isinstance(args[1], (ListExpr, TupleExpr)):


### PR DESCRIPTION
Split off from #14860, since this one is a no-brainer.

`args[0]` has just been narrowed to be of type `StrExpr` in the lines immediately above, and `args` is the same as `call.args`.