### PR TITLE
Add a helper function for narrowing `list[Expression]` to `list[StrExpr]`

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -20,7 +20,7 @@ from typing import (
     Union,
     cast,
 )
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import Final, TypeAlias as _TypeAlias, TypeGuard
 
 from mypy_extensions import trait
 
@@ -1633,6 +1633,10 @@ class StrExpr(Expression):
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_str_expr(self)
+
+
+def is_StrExpr_list(seq: list[Expression]) -> TypeGuard[list[StrExpr]]:
+    return all(isinstance(item, StrExpr) for item in seq)
 
 
 class BytesExpr(Expression):

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -27,6 +27,7 @@ from mypy.nodes import (
     TupleExpr,
     TypeInfo,
     Var,
+    is_StrExpr_list,
 )
 from mypy.options import Options
 from mypy.semanal_shared import SemanticAnalyzerInterface
@@ -177,8 +178,8 @@ class EnumCallAnalyzer:
                 items.append(field)
         elif isinstance(names, (TupleExpr, ListExpr)):
             seq_items = names.items
-            if all(isinstance(seq_item, StrExpr) for seq_item in seq_items):
-                items = [cast(StrExpr, seq_item).value for seq_item in seq_items]
+            if is_StrExpr_list(seq_items):
+                items = [seq_item.value for seq_item in seq_items]
             elif all(
                 isinstance(seq_item, (TupleExpr, ListExpr))
                 and len(seq_item.items) == 2

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -41,6 +41,7 @@ from mypy.nodes import (
     TypeInfo,
     TypeVarExpr,
     Var,
+    is_StrExpr_list,
 )
 from mypy.options import Options
 from mypy.semanal_shared import (
@@ -392,10 +393,10 @@ class NamedTupleAnalyzer:
             listexpr = args[1]
             if fullname == "collections.namedtuple":
                 # The fields argument contains just names, with implicit Any types.
-                if any(not isinstance(item, StrExpr) for item in listexpr.items):
+                if not is_StrExpr_list(listexpr.items):
                     self.fail('String literal expected as "namedtuple()" item', call)
                     return None
-                items = [cast(StrExpr, item).value for item in listexpr.items]
+                items = [item.value for item in listexpr.items]
             else:
                 type_exprs = [
                     t.items[1]

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -48,7 +48,7 @@ import os.path
 import sys
 import traceback
 from collections import defaultdict
-from typing import Iterable, List, Mapping, cast
+from typing import Iterable, List, Mapping
 from typing_extensions import Final
 
 import mypy.build

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -102,6 +102,7 @@ from mypy.nodes import (
     TupleExpr,
     TypeInfo,
     UnaryExpr,
+    is_StrExpr_list,
 )
 from mypy.options import Options as MypyOptions
 from mypy.stubdoc import Sig, find_unique_signatures, parse_all_signatures
@@ -1052,7 +1053,8 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         if isinstance(rvalue.args[1], StrExpr):
             items = rvalue.args[1].value.replace(",", " ").split()
         elif isinstance(rvalue.args[1], (ListExpr, TupleExpr)):
-            list_items = cast(List[StrExpr], rvalue.args[1].items)
+            list_items = rvalue.args[1].items
+            assert is_StrExpr_list(list_items)
             items = [item.value for item in list_items]
         else:
             self.add(f"{self._indent}{lvalue.name}: Incomplete")


### PR DESCRIPTION
There are several places in the code base where we need to narrow `list[Expression]` -> `list[StrExpr]`. Currently we do this using `cast`s, but `TypeGuard`s are arguably a much more idiomatic way to do this kind of operation nowadays.