### PR TITLE
[dataclass_transform] fix frozen behavior for base classes with direct metaclasses

### DIFF
--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -415,7 +415,11 @@ from typing import dataclass_transform
 @dataclass_transform(frozen_default=True)
 class Dataclass(type): ...
 
-class Person(metaclass=Dataclass, kw_only=True):
+# Note that PEP 681 states that a class that directly specifies a dataclass_transform-decorated
+# metaclass should be treated as neither frozen nor unfrozen. For Person to have frozen semantics,
+# it may not directly specify the metaclass.
+class BaseDataclass(metaclass=Dataclass): ...
+class Person(BaseDataclass, kw_only=True):
     name: str
     age: int
 
@@ -774,6 +778,32 @@ class FunctionModel:
         z2: int
 
 FunctionModel(x=1, y=2, z1=3, z2=4)
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformDirectMetaclassNeitherFrozenNorNotFrozen]
+# flags: --python-version 3.11
+from typing import dataclass_transform, Type
+
+@dataclass_transform()
+class Meta(type): ...
+class Base(metaclass=Meta):
+    base: int
+class Foo(Base, frozen=True):
+    foo: int
+class Bar(Base, frozen=False):
+    bar: int
+
+
+foo = Foo(0, 1)
+foo.foo = 5  # E: Property "foo" defined in "Foo" is read-only
+foo.base = 6
+reveal_type(foo.base)  # N: Revealed type is "builtins.int"
+bar = Bar(0, 1)
+bar.bar = 5
+bar.base = 6
+reveal_type(bar.base)  # N: Revealed type is "builtins.int"
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #14857. The initial implementation overlooked this statement in [PEP 681](https://peps.python.org/pep-0681/#dataclass-semantics):

> Similarly, a class that directly specifies a metaclass that is decorated with dataclass_transform is considered neither frozen nor non-frozen.

As far as I can tell, this is a special case that _only_ applies to classes that directly specify a `dataclass_transform` metaclass. This is import for projects like Pydantic, which requires clients to use a base class but still supports a `frozen` parameter.

Note that this allows mixed frozen and non-frozen behavior if the base class _does_ have fields:

```
@dataclass_transform()
class Meta(type): ...
class Base(metaclass=Meta, frozen=False):
    base: int = 0
class Foo(Base, frozen=True):
    foo: int = 0

foo = Foo()
foo.foo = 1 # an error because Foo is frozen
foo.base = 1 # NOT an error — Base is neither frozen nor non-frozen
```

While this is probably surprising behavior, it seems to match the text of the PEP as well as the behavior of Pyright.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
