### PR TITLE
Improve the signatures of `expand_type` and `expand_type_by_instance`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1753,8 +1753,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             result: list[tuple[FuncItem, CallableType]] = []
             for substitutions in itertools.product(*subst):
                 mapping = dict(substitutions)
-                expanded = cast(CallableType, expand_type(typ, mapping))
-                result.append((expand_func(defn, mapping), expanded))
+                result.append((expand_func(defn, mapping), expand_type(typ, mapping)))
             return result
         else:
             return [(defn, typ)]
@@ -7111,7 +7110,6 @@ def overload_can_never_match(signature: CallableType, other: CallableType) -> bo
     exp_signature = expand_type(
         signature, {tvar.id: erase_def_to_union_or_bound(tvar) for tvar in signature.variables}
     )
-    assert isinstance(exp_signature, CallableType)
     return is_callable_compatible(
         exp_signature, other, is_compat=is_more_precise, ignore_return=True
     )

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5518,7 +5518,7 @@ def merge_typevars_in_callables_by_name(
                     variables.append(tv)
                 rename[tv.id] = unique_typevars[name]
 
-            target = cast(CallableType, expand_type(target, rename))
+            target = expand_type(target, rename)
         output.append(target)
 
     return output, variables

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1150,7 +1150,7 @@ def add_class_tvars(
             t = freshen_all_functions_type_vars(t)
             t = bind_self(t, original_type, is_classmethod=True)
             assert isuper is not None
-            t = cast(CallableType, expand_type_by_instance(t, isuper))
+            t = expand_type_by_instance(t, isuper)
             freeze_all_type_vars(t)
         return t.copy_modified(variables=list(tvars) + list(t.variables))
     elif isinstance(t, Overloaded):

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -442,7 +442,7 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
                 tv = v.copy_modified(id=tid)
             tvs.append(tv)
             tvmap[v.id] = tv
-        return cast(CallableType, expand_type(typ, tvmap)).copy_modified(variables=tvs)
+        return expand_type(typ, tvmap).copy_modified(variables=tvs)
 
     def visit_tuple_type(self, typ: TupleType) -> SnapshotItem:
         return ("TupleType", snapshot_types(typ.items))

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -52,7 +52,7 @@ Summary of how this works for certain kinds of differences:
 
 from __future__ import annotations
 
-from typing import Sequence, Tuple, Union, cast
+from typing import Sequence, Tuple, Union
 from typing_extensions import TypeAlias as _TypeAlias
 
 from mypy.expandtype import expand_type


### PR DESCRIPTION
By adding another overload, `CallableType -> CallableType`, we can avoid the need for several `cast`s across the code base.