### PR TITLE
Fix selfcheck with the latest version of `types-typed-ast`

### DIFF
--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -2,4 +2,4 @@
 -r mypy-requirements.txt
 types-psutil
 types-setuptools
-types-typed-ast>=1.5.8,<1.6.0
+types-typed-ast>=1.5.8.5,<1.6.0

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -844,7 +844,7 @@ class ASTConverter:
     def visit_Module(self, mod: ast3.Module) -> MypyFile:
         self.type_ignores = {}
         for ti in mod.type_ignores:
-            parsed = parse_type_ignore_tag(ti.tag)  # type: ignore[attr-defined]
+            parsed = parse_type_ignore_tag(ti.tag)
             if parsed is not None:
                 self.type_ignores[ti.lineno] = parsed
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires = [
     # the following is from build-requirements.txt
     "types-psutil",
     "types-setuptools",
-    "types-typed-ast>=1.5.8,<1.6.0",
+    "types-typed-ast>=1.5.8.5,<1.6.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
The latest version of `types-typed-ast` includes https://github.com/python/typeshed/commit/62a833c50f99e3bb32770cf74a119505e2e42961, which means we now have an unused `type: ignore` comment, which causes the selfcheck to fail with the latest version of `types-typed-ast`