### PR TITLE
Cleanup codebase using Refurb

### DIFF
--- a/misc/apply-cache-diff.py
+++ b/misc/apply-cache-diff.py
@@ -20,8 +20,8 @@ from mypy.metastore import FilesystemMetadataStore, MetadataStore, SqliteMetadat
 def make_cache(input_dir: str, sqlite: bool) -> MetadataStore:
     if sqlite:
         return SqliteMetadataStore(input_dir)
-    else:
-        return FilesystemMetadataStore(input_dir)
+
+    return FilesystemMetadataStore(input_dir)
 
 
 def apply_diff(cache_dir: str, diff_file: str, sqlite: bool = False) -> None:

--- a/misc/diff-cache.py
+++ b/misc/diff-cache.py
@@ -22,8 +22,8 @@ from mypy.metastore import FilesystemMetadataStore, MetadataStore, SqliteMetadat
 def make_cache(input_dir: str, sqlite: bool) -> MetadataStore:
     if sqlite:
         return SqliteMetadataStore(input_dir)
-    else:
-        return FilesystemMetadataStore(input_dir)
+
+    return FilesystemMetadataStore(input_dir)
 
 
 def merge_deps(all: dict[str, set[str]], new: dict[str, set[str]]) -> None:

--- a/misc/find_type.py
+++ b/misc/find_type.py
@@ -53,8 +53,8 @@ def get_revealed_type(line: str, relevant_file: str, relevant_line: int) -> str 
     m = re.match(r'(.+?):(\d+): note: Revealed type is "(.*)"$', line)
     if m and int(m.group(2)) == relevant_line and os.path.samefile(relevant_file, m.group(1)):
         return m.group(3)
-    else:
-        return None
+
+    return None
 
 
 def process_output(output: str, filename: str, start_line: int) -> tuple[str | None, bool]:

--- a/misc/upload-pypi.py
+++ b/misc/upload-pypi.py
@@ -26,7 +26,7 @@ REPO = "mypyc/mypy_mypyc-wheels"
 
 
 def is_whl_or_tar(name: str) -> bool:
-    return name.endswith(".tar.gz") or name.endswith(".whl")
+    return name.endswith((".tar.gz", ".whl"))
 
 
 def item_ok_for_pypi(name: str) -> bool:

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -110,7 +110,7 @@ def apply_generic_arguments(
         nt = id_to_type.get(param_spec.id)
         if nt is not None:
             nt = get_proper_type(nt)
-            if isinstance(nt, CallableType) or isinstance(nt, Parameters):
+            if isinstance(nt, (CallableType, Parameters)):
                 callable = callable.expand_param_spec(nt)
 
     # Apply arguments to argument types.

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -46,10 +46,9 @@ def get_target_type(
             # is also a legal value of T.
             if all(any(mypy.subtypes.is_same_type(v, v1) for v in values) for v1 in p_type.values):
                 return type
-        matching = []
-        for value in values:
-            if mypy.subtypes.is_subtype(type, value):
-                matching.append(value)
+
+        matching = [value for value in values if mypy.subtypes.is_subtype(type, value)]
+
         if matching:
             best = matching[0]
             # If there are more than one matching value, we select the narrowest

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1092,7 +1092,7 @@ def read_quickstart_file(
             for file, (x, y, z) in raw_quickstart.items():
                 quickstart[file] = (x, y, z)
         except Exception as e:
-            print(f"Warning: Failed to load quickstart file: {str(e)}\n", file=stdout)
+            print(f"Warning: Failed to load quickstart file: {e}\n", file=stdout)
     return quickstart
 
 
@@ -1287,7 +1287,7 @@ def find_cache_meta(id: str, path: str, manager: BuildManager) -> CacheMeta | No
     if meta is None:
         return None
     if not isinstance(meta, dict):
-        manager.log(f"Could not load cache for {id}: meta cache is not a dict: {repr(meta)}")
+        manager.log(f"Could not load cache for {id}: meta cache is not a dict: {meta!r}")
         return None
     m = cache_meta_from_dict(meta, data_json)
     t2 = time.time()
@@ -2168,7 +2168,7 @@ class State:
                     if self.path.endswith(".pyd"):
                         err = f"mypy: stubgen does not support .pyd files: '{self.path}'"
                     else:
-                        err = f"mypy: can't decode file '{self.path}': {str(decodeerr)}"
+                        err = f"mypy: can't decode file '{self.path}': {decodeerr}"
                     raise CompileError([err], module_with_blocker=self.id) from decodeerr
             elif self.path and self.manager.fscache.isdir(self.path):
                 source = ""

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -742,8 +742,7 @@ class BuildManager:
                 else:
                     self.shadow_equivalence_map[path] = None
 
-        shadow_file = self.shadow_equivalence_map.get(path)
-        return shadow_file if shadow_file else path
+        return self.shadow_equivalence_map.get(path) or path
 
     def get_stat(self, path: str) -> os.stat_result:
         return self.fscache.stat(self.maybe_swap_for_shadow_path(path))

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -321,8 +321,8 @@ def normpath(path: str, options: Options) -> str:
     # name without changing its size, mtime or hash.)
     if options.bazel:
         return os.path.relpath(path)
-    else:
-        return os.path.abspath(path)
+
+    return os.path.abspath(path)
 
 
 class CacheMeta(NamedTuple):
@@ -755,8 +755,8 @@ class BuildManager:
         """
         if self.options.bazel:
             return 0
-        else:
-            return int(self.metastore.getmtime(path))
+
+        return int(self.metastore.getmtime(path))
 
     def all_imported_modules_in_file(self, file: MypyFile) -> list[tuple[int, str, int]]:
         """Find all reachable import statements in a file.
@@ -1516,8 +1516,8 @@ def compute_hash(text: str) -> str:
 def json_dumps(obj: Any, debug_cache: bool) -> str:
     if debug_cache:
         return json.dumps(obj, indent=2, sort_keys=True)
-    else:
-        return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
 
 
 def write_cache(

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1920,7 +1920,7 @@ class State:
         self.caller_state = caller_state
         self.caller_line = caller_line
         if caller_state:
-            self.import_context = caller_state.import_context[:]
+            self.import_context = caller_state.import_context.copy()
             self.import_context.append((caller_state.xpath, caller_line))
         else:
             self.import_context = []

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3300,7 +3300,7 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
             manager.trace(f"Queuing {fresh_msg} SCC ({scc_str})")
             fresh_scc_queue.append(scc)
         else:
-            if len(fresh_scc_queue) > 0:
+            if fresh_scc_queue:
                 manager.log(f"Processing {len(fresh_scc_queue)} queued fresh SCCs")
                 # Defer processing fresh SCCs until we actually run into a stale SCC
                 # and need the earlier modules to be loaded.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2393,11 +2393,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         for i, tvar in enumerate(tvars):
             up_args: list[Type] = [
                 object_type if i == j else AnyType(TypeOfAny.special_form)
-                for j, _ in enumerate(tvars)
+                for j in range(len(tvars))
             ]
             down_args: list[Type] = [
                 UninhabitedType() if i == j else AnyType(TypeOfAny.special_form)
-                for j, _ in enumerate(tvars)
+                for j in range(len(tvars))
             ]
             up, down = Instance(info, up_args), Instance(info, down_args)
             # TODO: add advanced variance checks for recursive protocols

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3035,7 +3035,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     compare_static = is_node_static(compare_type.definition)
 
                 # Compare against False, as is_node_static can return None
-                if base_static is False and compare_static is False:
+                if base_static is compare_static is False:
                     # Class-level function objects and classmethods become bound
                     # methods: the former to the instance, the latter to the
                     # class
@@ -5490,7 +5490,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     # chain have custom __eq__ or __ne__ methods. But we (maybe optimistically)
                     # assume nobody would actually create a custom objects that considers itself
                     # equal to None.
-                    if if_map == {} and else_map == {}:
+                    if if_map == else_map == {}:
                         if_map, else_map = self.refine_away_none_in_comparison(
                             operands,
                             operand_types,
@@ -5500,7 +5500,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
                     # If we haven't been able to narrow types yet, we might be dealing with a
                     # explicit type(x) == some_type check
-                    if if_map == {} and else_map == {}:
+                    if if_map == else_map == {}:
                         if_map, else_map = self.find_type_equals_check(node, expr_indices)
                 elif operator in {"in", "not in"}:
                     assert len(expr_indices) == 2

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1967,8 +1967,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     mapped_typ = Overloaded(filtered_items)
 
             return bind_self(mapped_typ, active_self_type, is_class_method)
-        else:
-            return cast(FunctionLike, map_type_from_supertype(typ, sub_info, super_info))
+
+        return cast(FunctionLike, map_type_from_supertype(typ, sub_info, super_info))
 
     def get_op_other_domain(self, tp: FunctionLike) -> Type | None:
         if isinstance(tp, CallableType):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5071,7 +5071,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             callables, uncallables = self.partition_by_callable(
                 erase_to_union_or_bound(typ), unsound_partition
             )
-            uncallables = [typ] if len(uncallables) else []
+            uncallables = [typ] if uncallables else []
             return callables, uncallables
 
         # A TupleType is callable if its fallback is, but needs special handling
@@ -5086,7 +5086,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 callables, uncallables = self.partition_by_callable(
                     method.type, unsound_partition=False
                 )
-                if len(callables) and not len(uncallables):
+                if callables and not uncallables:
                     # Only consider the type callable if its __call__ method is
                     # definitely callable.
                     return [typ], []
@@ -5122,14 +5122,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         callables, uncallables = self.partition_by_callable(current_type, unsound_partition=False)
 
-        if len(callables) and len(uncallables):
-            callable_map = {expr: UnionType.make_union(callables)} if len(callables) else None
+        if callables and uncallables:
+            callable_map = {expr: UnionType.make_union(callables)} if callables else None
             uncallable_map = (
-                {expr: UnionType.make_union(uncallables)} if len(uncallables) else None
+                {expr: UnionType.make_union(uncallables)} if uncallables else None
             )
             return callable_map, uncallable_map
 
-        elif len(callables):
+        elif callables:
             return {}, None
 
         return None, {}
@@ -5922,7 +5922,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 non_optional_types.append(typ)
 
         # Make sure we have a mixture of optional and non-optional types.
-        if len(non_optional_types) == 0 or len(non_optional_types) == len(chain_indices):
+        if not non_optional_types or len(non_optional_types) == len(chain_indices):
             return {}, {}
 
         if_map = {}
@@ -6502,7 +6502,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if intersection is None:
                     continue
                 out.append(intersection)
-        if len(out) == 0:
+        if not out:
             # Only report errors if no element in the union worked.
             if self.should_report_unreachable_issues():
                 for types, reason in errors:
@@ -6927,7 +6927,7 @@ def reduce_conditional_maps(type_maps: list[tuple[TypeMap, TypeMap]]) -> tuple[T
     We only retain the shared expression in the 'else' case because we don't actually know
     whether x was refined or y was refined -- only just that one of the two was refined.
     """
-    if len(type_maps) == 0:
+    if not type_maps:
         return {}, {}
     elif len(type_maps) == 1:
         return type_maps[0]
@@ -7342,7 +7342,7 @@ class DisjointDict(Generic[TKey, TValue]):
 
         Note that the given set of keys must be non-empty -- otherwise, nothing happens.
         """
-        if len(keys) == 0:
+        if not keys:
             return
 
         subtree_roots = [self._lookup_or_make_root_id(key) for key in keys]
@@ -7453,7 +7453,7 @@ def group_comparison_operands(
         if current_indices and (operator != last_operator or operator not in operators_to_group):
             # If some of the operands in the chain are assignable, defer adding it: we might
             # end up needing to merge it with other chains that appear later.
-            if len(current_hashes) == 0:
+            if not current_hashes:
                 simplified_operator_list.append((last_operator, sorted(current_indices)))
             else:
                 groups[last_operator].add_mapping(current_hashes, current_indices)
@@ -7476,7 +7476,7 @@ def group_comparison_operands(
                 current_hashes.add(right_hash)
 
     if last_operator is not None:
-        if len(current_hashes) == 0:
+        if not current_hashes:
             simplified_operator_list.append((last_operator, sorted(current_indices)))
         else:
             groups[last_operator].add_mapping(current_hashes, current_indices)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -852,33 +852,33 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         if isinstance(return_type, AnyType):
             return AnyType(TypeOfAny.from_another_any, source_any=return_type)
-        elif isinstance(return_type, UnionType):
+        if isinstance(return_type, UnionType):
             return make_simplified_union(
                 [self.get_generator_yield_type(item, is_coroutine) for item in return_type.items]
             )
-        elif not self.is_generator_return_type(
+        if not self.is_generator_return_type(
             return_type, is_coroutine
         ) and not self.is_async_generator_return_type(return_type):
             # If the function doesn't have a proper Generator (or
             # Awaitable) return type, anything is permissible.
             return AnyType(TypeOfAny.from_error)
-        elif not isinstance(return_type, Instance):
+        if not isinstance(return_type, Instance):
             # Same as above, but written as a separate branch so the typechecker can understand.
             return AnyType(TypeOfAny.from_error)
-        elif return_type.type.fullname == "typing.Awaitable":
+        if return_type.type.fullname == "typing.Awaitable":
             # Awaitable: ty is Any.
             return AnyType(TypeOfAny.special_form)
-        elif return_type.args:
+        if return_type.args:
             # AwaitableGenerator, Generator, AsyncGenerator, Iterator, or Iterable; ty is args[0].
             ret_type = return_type.args[0]
             # TODO not best fix, better have dedicated yield token
             return ret_type
-        else:
-            # If the function's declared supertype of Generator has no type
-            # parameters (i.e. is `object`), then the yielded values can't
-            # be accessed so any type is acceptable.  IOW, ty is Any.
-            # (However, see https://github.com/python/mypy/issues/1933)
-            return AnyType(TypeOfAny.special_form)
+
+        # If the function's declared supertype of Generator has no type
+        # parameters (i.e. is `object`), then the yielded values can't
+        # be accessed so any type is acceptable.  IOW, ty is Any.
+        # (However, see https://github.com/python/mypy/issues/1933)
+        return AnyType(TypeOfAny.special_form)
 
     def get_generator_receive_type(self, return_type: Type, is_coroutine: bool) -> Type:
         """Given a declared generator return type (t), return the type its yield receives (tc)."""
@@ -886,34 +886,34 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         if isinstance(return_type, AnyType):
             return AnyType(TypeOfAny.from_another_any, source_any=return_type)
-        elif isinstance(return_type, UnionType):
+        if isinstance(return_type, UnionType):
             return make_simplified_union(
                 [self.get_generator_receive_type(item, is_coroutine) for item in return_type.items]
             )
-        elif not self.is_generator_return_type(
+        if not self.is_generator_return_type(
             return_type, is_coroutine
         ) and not self.is_async_generator_return_type(return_type):
             # If the function doesn't have a proper Generator (or
             # Awaitable) return type, anything is permissible.
             return AnyType(TypeOfAny.from_error)
-        elif not isinstance(return_type, Instance):
+        if not isinstance(return_type, Instance):
             # Same as above, but written as a separate branch so the typechecker can understand.
             return AnyType(TypeOfAny.from_error)
-        elif return_type.type.fullname == "typing.Awaitable":
+        if return_type.type.fullname == "typing.Awaitable":
             # Awaitable, AwaitableGenerator: tc is Any.
             return AnyType(TypeOfAny.special_form)
-        elif (
+        if (
             return_type.type.fullname in ("typing.Generator", "typing.AwaitableGenerator")
             and len(return_type.args) >= 3
         ):
             # Generator: tc is args[1].
             return return_type.args[1]
-        elif return_type.type.fullname == "typing.AsyncGenerator" and len(return_type.args) >= 2:
+        if return_type.type.fullname == "typing.AsyncGenerator" and len(return_type.args) >= 2:
             return return_type.args[1]
-        else:
-            # `return_type` is a supertype of Generator, so callers won't be able to send it
-            # values.  IOW, tc is None.
-            return NoneType()
+
+        # `return_type` is a supertype of Generator, so callers won't be able to send it
+        # values.  IOW, tc is None.
+        return NoneType()
 
     def get_coroutine_return_type(self, return_type: Type) -> Type:
         return_type = get_proper_type(return_type)
@@ -929,29 +929,29 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         if isinstance(return_type, AnyType):
             return AnyType(TypeOfAny.from_another_any, source_any=return_type)
-        elif isinstance(return_type, UnionType):
+        if isinstance(return_type, UnionType):
             return make_simplified_union(
                 [self.get_generator_return_type(item, is_coroutine) for item in return_type.items]
             )
-        elif not self.is_generator_return_type(return_type, is_coroutine):
+        if not self.is_generator_return_type(return_type, is_coroutine):
             # If the function doesn't have a proper Generator (or
             # Awaitable) return type, anything is permissible.
             return AnyType(TypeOfAny.from_error)
-        elif not isinstance(return_type, Instance):
+        if not isinstance(return_type, Instance):
             # Same as above, but written as a separate branch so the typechecker can understand.
             return AnyType(TypeOfAny.from_error)
-        elif return_type.type.fullname == "typing.Awaitable" and len(return_type.args) == 1:
+        if return_type.type.fullname == "typing.Awaitable" and len(return_type.args) == 1:
             # Awaitable: tr is args[0].
             return return_type.args[0]
-        elif (
+        if (
             return_type.type.fullname in ("typing.Generator", "typing.AwaitableGenerator")
             and len(return_type.args) >= 3
         ):
             # AwaitableGenerator, Generator: tr is args[2].
             return return_type.args[2]
-        else:
-            # Supertype of Generator (Iterator, Iterable, object): tr is any.
-            return AnyType(TypeOfAny.special_form)
+
+        # Supertype of Generator (Iterator, Iterable, object): tr is any.
+        return AnyType(TypeOfAny.special_form)
 
     def visit_func_def(self, defn: FuncDef) -> None:
         if not self.recurse_into_functions:
@@ -1756,8 +1756,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 mapping = dict(substitutions)
                 result.append((expand_func(defn, mapping), expand_type(typ, mapping)))
             return result
-        else:
-            return [(defn, typ)]
+
+        return [(defn, typ)]
 
     def check_method_override(self, defn: FuncDef | OverloadedFuncDef | Decorator) -> None:
         """Check if function definition is compatible with base classes.
@@ -4457,17 +4457,17 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         typ = get_proper_type(typ)
         if isinstance(typ, TupleType):
             return typ.items
-        elif isinstance(typ, UnionType):
+        if isinstance(typ, UnionType):
             return [
                 union_typ
                 for item in typ.relevant_items()
                 for union_typ in self.get_types_from_except_handler(item, n)
             ]
-        elif is_named_instance(typ, "builtins.tuple"):
+        if is_named_instance(typ, "builtins.tuple"):
             # variadic tuple
             return [typ.args[0]]
-        else:
-            return [typ]
+
+        return [typ]
 
     def visit_for_stmt(self, s: ForStmt) -> None:
         """Type check a for statement."""
@@ -4506,9 +4506,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             for item in iterable.items:
                 joined = join_types(joined, item)
             return iterator, joined
-        else:
-            # Non-tuple iterable.
-            return iterator, echk.check_method_call_by_name("__next__", iterator, [], [], expr)[0]
+
+        # Non-tuple iterable.
+        return iterator, echk.check_method_call_by_name("__next__", iterator, [], [], expr)[0]
 
     def analyze_iterable_item_type_without_expression(
         self, type: Type, context: Context
@@ -4523,12 +4523,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             for item in iterable.items:
                 joined = join_types(joined, item)
             return iterator, joined
-        else:
-            # Non-tuple iterable.
-            return (
-                iterator,
-                echk.check_method_call_by_name("__next__", iterator, [], [], context)[0],
-            )
+
+        # Non-tuple iterable.
+        return (
+            iterator, echk.check_method_call_by_name("__next__", iterator, [], [], context)[0]
+        )
 
     def analyze_range_native_int_type(self, expr: Expression) -> Type | None:
         """Try to infer native int item type from arguments to range(...).
@@ -5100,9 +5099,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         if unsound_partition:
             return [], [typ]
-        else:
-            # We don't know how properly make the type callable.
-            return [typ], [typ]
+
+        # We don't know how properly make the type callable.
+        return [typ], [typ]
 
     def conditional_callable_type_map(
         self, expr: Expression, current_type: Type | None
@@ -5201,16 +5200,16 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             typ = format_type(t)
             if isinstance(expr, MemberExpr):
                 return f'Member "{expr.name}" has type {typ}'
-            elif isinstance(expr, RefExpr) and expr.fullname:
+            if isinstance(expr, RefExpr) and expr.fullname:
                 return f'"{expr.fullname}" has type {typ}'
-            elif isinstance(expr, CallExpr):
+            if isinstance(expr, CallExpr):
                 if isinstance(expr.callee, MemberExpr):
                     return f'"{expr.callee.name}" returns {typ}'
-                elif isinstance(expr.callee, RefExpr) and expr.callee.fullname:
+                if isinstance(expr.callee, RefExpr) and expr.callee.fullname:
                     return f'"{expr.callee.fullname}" returns {typ}'
                 return f"Call returns {typ}"
-            else:
-                return f"Expression has type {typ}"
+
+            return f"Expression has type {typ}"
 
         if isinstance(t, FunctionLike):
             self.fail(message_registry.FUNCTION_ALWAYS_TRUE.format(format_type(t)), expr)
@@ -5690,10 +5689,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             chk=self,
                             in_literal_context=False,
                         )
-                    if w.has_new_errors():
-                        return None
-                    else:
-                        return member_type
+
+                    return None if w.has_new_errors() else member_type
 
             elif isinstance(expr, IndexExpr):
                 parent_expr = collapse_walrus(expr.base)
@@ -6960,10 +6957,10 @@ def flatten(t: Expression) -> list[Expression]:
     """Flatten a nested sequence of tuples/lists into one list of nodes."""
     if isinstance(t, (TupleExpr, ListExpr)):
         return [b for a in t.items for b in flatten(a)]
-    elif isinstance(t, StarExpr):
+    if isinstance(t, StarExpr):
         return flatten(t.expr)
-    else:
-        return [t]
+
+    return [t]
 
 
 def flatten_types(t: Type) -> list[Type]:
@@ -6971,8 +6968,8 @@ def flatten_types(t: Type) -> list[Type]:
     t = get_proper_type(t)
     if isinstance(t, TupleType):
         return [b for a in t.items for b in flatten_types(a)]
-    else:
-        return [t]
+
+    return [t]
 
 
 def expand_func(defn: FuncItem, map: dict[TypeVarId, Type]) -> FuncItem:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2706,7 +2706,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         new_syntax: bool = False,
     ) -> None:
         """Type check a single assignment: lvalue = rvalue."""
-        if isinstance(lvalue, TupleExpr) or isinstance(lvalue, ListExpr):
+        if isinstance(lvalue, (TupleExpr, ListExpr)):
             self.check_assignment_to_multiple_lvalues(
                 lvalue.items, rvalue, rvalue, infer_lvalue_type
             )
@@ -3284,7 +3284,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         context: Context,
         infer_lvalue_type: bool = True,
     ) -> None:
-        if isinstance(rvalue, TupleExpr) or isinstance(rvalue, ListExpr):
+        if isinstance(rvalue, (TupleExpr, ListExpr)):
             # Recursively go into Tuple or List expression rhs instead of
             # using the type of rhs, because this allowed more fine grained
             # control in cases like: a, b = [int, str] where rhs would get
@@ -3672,7 +3672,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         elif isinstance(lvalue, NameExpr):
             lvalue_type = self.expr_checker.analyze_ref_expr(lvalue, lvalue=True)
             self.store_type(lvalue, lvalue_type)
-        elif isinstance(lvalue, TupleExpr) or isinstance(lvalue, ListExpr):
+        elif isinstance(lvalue, (TupleExpr, ListExpr)):
             types = [
                 self.check_lvalue(sub_expr)[0] or
                 # This type will be used as a context for further inference of rvalue,
@@ -5037,7 +5037,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         """
         typ = get_proper_type(typ)
 
-        if isinstance(typ, FunctionLike) or isinstance(typ, TypeType):
+        if isinstance(typ, (FunctionLike, TypeType)):
             return [typ], []
 
         if isinstance(typ, AnyType):
@@ -6958,7 +6958,7 @@ def convert_to_typetype(type_map: TypeMap) -> TypeMap:
 
 def flatten(t: Expression) -> list[Expression]:
     """Flatten a nested sequence of tuples/lists into one list of nodes."""
-    if isinstance(t, TupleExpr) or isinstance(t, ListExpr):
+    if isinstance(t, (TupleExpr, ListExpr)):
         return [b for a in t.items for b in flatten(a)]
     elif isinstance(t, StarExpr):
         return flatten(t.expr)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7362,11 +7362,9 @@ class DisjointDict(Generic[TKey, TValue]):
                 root_id_to_keys[root_id] = set()
             root_id_to_keys[root_id].add(key)
 
-        output = []
-        for root_id, keys in root_id_to_keys.items():
-            output.append((keys, self._root_id_to_values[root_id]))
-
-        return output
+        return [
+            (keys, self._root_id_to_values[root_id]) for root_id, keys in root_id_to_keys.items()
+        ]
 
     def _lookup_or_make_root_id(self, key: TKey) -> int:
         if key in self._key_to_id:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4525,9 +4525,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return iterator, joined
 
         # Non-tuple iterable.
-        return (
-            iterator, echk.check_method_call_by_name("__next__", iterator, [], [], context)[0]
-        )
+        return (iterator, echk.check_method_call_by_name("__next__", iterator, [], [], context)[0])
 
     def analyze_range_native_int_type(self, expr: Expression) -> Type | None:
         """Try to infer native int item type from arguments to range(...).
@@ -5123,9 +5121,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         if callables and uncallables:
             callable_map = {expr: UnionType.make_union(callables)} if callables else None
-            uncallable_map = (
-                {expr: UnionType.make_union(uncallables)} if uncallables else None
-            )
+            uncallable_map = {expr: UnionType.make_union(uncallables)} if uncallables else None
             return callable_map, uncallable_map
 
         elif callables:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3616,7 +3616,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         with self.msg.filter_errors(filter_errors=right_map is None):
             right_type = self.analyze_cond_branch(right_map, e.right, expanded_left_type)
 
-        if left_map is None and right_map is None:
+        if left_map is right_map is None:
             return UninhabitedType()
 
         if right_map is None:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2459,13 +2459,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         Assumes all of the given targets have argument counts compatible with the caller.
         """
-        matches: list[CallableType] = []
-        for typ in plausible_targets:
+
+        return [
+            typ
+            for typ in plausible_targets
             if self.erased_signature_similarity(
                 arg_types, arg_kinds, arg_names, args, typ, context
-            ):
-                matches.append(typ)
-        return matches
+            )
+        ]
 
     def union_overload_result(
         self,
@@ -3785,9 +3786,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return self.nonliteral_tuple_index_helper(left_type, slic)
             stride = stride_raw
 
-        items: list[Type] = []
-        for b, e, s in itertools.product(begin, end, stride):
-            items.append(left_type.slice(b, e, s))
+        items = [
+            left_type.slice(b, e, s) for b, e, s in itertools.product(begin, end, stride)
+        ]
+
         return make_simplified_union(items)
 
     def try_getting_int_literals(self, index: Expression) -> list[int] | None:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2334,9 +2334,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         def has_shape(typ: Type) -> bool:
             typ = get_proper_type(typ)
-            return (
-                isinstance(typ, (TupleType, TypedDictType))
-                or (isinstance(typ, Instance) and typ.type.is_named_tuple)
+            return isinstance(typ, (TupleType, TypedDictType)) or (
+                isinstance(typ, Instance) and typ.type.is_named_tuple
             )
 
         matches: list[CallableType] = []
@@ -3556,11 +3555,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             return results_final, inferred_final
 
         return self.check_method_call_by_name(
-            method=method,
-            base_type=base_type,
-            args=[arg],
-            arg_kinds=[ARG_POS],
-            context=context,
+            method=method, base_type=base_type, args=[arg], arg_kinds=[ARG_POS], context=context
         )
 
     def check_boolean_op(self, e: OpExpr, context: Context) -> Type:
@@ -3786,9 +3781,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 return self.nonliteral_tuple_index_helper(left_type, slic)
             stride = stride_raw
 
-        items = [
-            left_type.slice(b, e, s) for b, e, s in itertools.product(begin, end, stride)
-        ]
+        items = [left_type.slice(b, e, s) for b, e, s in itertools.product(begin, end, stride)]
 
         return make_simplified_union(items)
 
@@ -4918,12 +4911,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def is_valid_var_arg(self, typ: Type) -> bool:
         """Is a type valid as a *args argument?"""
         typ = get_proper_type(typ)
-        return (
-            isinstance(typ, (TupleType, AnyType, ParamSpecType, UnpackType))
-            or is_subtype(
-                typ,
-                self.chk.named_generic_type("typing.Iterable", [AnyType(TypeOfAny.special_form)]),
-            )
+        return isinstance(typ, (TupleType, AnyType, ParamSpecType, UnpackType)) or is_subtype(
+            typ, self.chk.named_generic_type("typing.Iterable", [AnyType(TypeOfAny.special_form)])
         )
 
     def is_valid_keyword_var_arg(self, typ: Type) -> bool:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2338,8 +2338,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         def has_shape(typ: Type) -> bool:
             typ = get_proper_type(typ)
             return (
-                isinstance(typ, TupleType)
-                or isinstance(typ, TypedDictType)
+                isinstance(typ, (TupleType, TypedDictType))
                 or (isinstance(typ, Instance) and typ.type.is_named_tuple)
             )
 
@@ -4921,14 +4920,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """Is a type valid as a *args argument?"""
         typ = get_proper_type(typ)
         return (
-            isinstance(typ, TupleType)
+            isinstance(typ, (TupleType, AnyType, ParamSpecType, UnpackType))
             or is_subtype(
                 typ,
                 self.chk.named_generic_type("typing.Iterable", [AnyType(TypeOfAny.special_form)]),
             )
-            or isinstance(typ, AnyType)
-            or isinstance(typ, ParamSpecType)
-            or isinstance(typ, UnpackType)
         )
 
     def is_valid_keyword_var_arg(self, typ: Type) -> bool:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -686,7 +686,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         context: Context,
         orig_callee: Type | None,
     ) -> Type:
-        if len(args) >= 1 and all([ak == ARG_NAMED for ak in arg_kinds]):
+        if args and all([ak == ARG_NAMED for ak in arg_kinds]):
             # ex: Point(x=42, y=1337)
             assert all(arg_name is not None for arg_name in arg_names)
             item_names = cast(List[str], arg_names)
@@ -708,7 +708,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     callee, unique_arg.analyzed, context, orig_callee
                 )
 
-        if len(args) == 0:
+        if not args:
             # ex: EmptyDict()
             return self.check_typeddict_call_with_kwargs(callee, {}, context, orig_callee)
 
@@ -2423,10 +2423,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 inferred_types.append(infer_type)
                 type_maps.append(m)
 
-        if len(matches) == 0:
-            # No match was found
+        if not matches:
             return None
-        elif any_causes_overload_ambiguity(matches, return_types, arg_types, arg_kinds, arg_names):
+
+        if any_causes_overload_ambiguity(matches, return_types, arg_types, arg_kinds, arg_names):
             # An argument of type or containing the type 'Any' caused ambiguity.
             # We try returning a precise type if we can. If not, we give up and just return 'Any'.
             if all_same_types(return_types):
@@ -3015,7 +3015,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if not encountered_partial_type and not failed_out:
                     iterable_type = UnionType.make_union(iterable_types)
                     if not is_subtype(left_type, iterable_type):
-                        if len(container_types) == 0:
+                        if not container_types:
                             self.msg.unsupported_operand_types("in", left_type, right_type, e)
                         else:
                             container_type = UnionType.make_union(container_types)
@@ -5478,7 +5478,7 @@ def any_causes_overload_ambiguity(
 
 
 def all_same_types(types: list[Type]) -> bool:
-    if len(types) == 0:
+    if not types:
         return True
     return all(is_same_type(t, types[0]) for t in types[1:])
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4455,7 +4455,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 is_ellipsis_args=False,
                 arg_types=[AnyType(TypeOfAny.special_form)] * len(arg_kinds),
                 arg_kinds=arg_kinds,
-                arg_names=e.arg_names[:],
+                arg_names=e.arg_names.copy(),
             )
 
         if ARG_STAR in arg_kinds or ARG_STAR2 in arg_kinds:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -206,8 +206,8 @@ def analyze_member_access(
         and possible_literal.last_known_value is not None
     ):
         return possible_literal.last_known_value
-    else:
-        return result
+
+    return result
 
 
 def _analyze_member_access(
@@ -338,9 +338,9 @@ def analyze_instance_member_access(
         member_type = expand_type_by_instance(signature, typ)
         freeze_all_type_vars(member_type)
         return member_type
-    else:
-        # Not a method.
-        return analyze_member_var_access(name, typ, info, mx)
+
+    # Not a method.
+    return analyze_member_var_access(name, typ, info, mx)
 
 
 def validate_super_call(node: FuncBase, mx: MemberContext) -> None:
@@ -463,8 +463,8 @@ def analyze_none_member_access(name: str, typ: NoneType, mx: MemberContext) -> T
             ret_type=literal_false,
             fallback=mx.named_type("builtins.function"),
         )
-    else:
-        return _analyze_member_access(name, mx.named_type("builtins.object"), mx)
+
+    return _analyze_member_access(name, mx.named_type("builtins.object"), mx)
 
 
 def analyze_member_var_access(
@@ -590,8 +590,8 @@ def analyze_member_var_access(
     if mx.is_super:
         mx.msg.undefined_in_superclass(name, mx.context)
         return AnyType(TypeOfAny.from_error)
-    else:
-        return report_missing_attribute(mx.original_type, itype, name, mx)
+
+    return report_missing_attribute(mx.original_type, itype, name, mx)
 
 
 def check_final_member(name: str, info: TypeInfo, msg: MessageBuilder, ctx: Context) -> None:
@@ -815,10 +815,8 @@ def lookup_member_var_or_accessor(info: TypeInfo, name: str, is_lvalue: bool) ->
     """Find the attribute/accessor node that refers to a member of a type."""
     # TODO handle lvalues
     node = info.get(name)
-    if node:
-        return node.node
-    else:
-        return None
+
+    return node.node if node else None
 
 
 def check_self_arg(

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -325,8 +325,7 @@ class PatternChecker(PatternVisitor[PatternType]):
             if isinstance(t, TupleType):
                 t = tuple_fallback(t)
             return self.chk.iterable_item_type(t)
-        else:
-            return None
+        return None
 
     def contract_starred_pattern_types(
         self, types: list[Type], star_pos: int | None, num_patterns: int
@@ -664,8 +663,8 @@ class PatternChecker(PatternVisitor[PatternType]):
             empty_type = fill_typevars(proper_type.type)
             partial_type = expand_type_by_instance(empty_type, sequence)
             return expand_type_by_instance(partial_type, proper_type)
-        else:
-            return sequence
+
+        return sequence
 
     def early_non_match(self) -> PatternType:
         return PatternType(UninhabitedType(), self.type_context[-1], {})

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -154,10 +154,11 @@ class PatternChecker(PatternVisitor[PatternType]):
         #
         # Collect the final type
         #
-        types = []
-        for pattern_type in pattern_types:
-            if not is_uninhabited(pattern_type.type):
-                types.append(pattern_type.type)
+        types = [
+            pattern_type.type
+            for pattern_type in pattern_types
+            if not is_uninhabited(pattern_type.type)
+        ]
 
         #
         # Check the capture types

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -316,7 +316,7 @@ class PatternChecker(PatternVisitor[PatternType]):
         if isinstance(t, UnionType):
             items = [self.get_sequence_type(item) for item in t.items]
             not_none_items = [item for item in items if item is not None]
-            if len(not_none_items) > 0:
+            if not_none_items:
                 return make_simplified_union(not_none_items)
             else:
                 return None

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -170,10 +170,9 @@ class ConversionSpecifier:
 
 def parse_conversion_specifiers(format_str: str) -> list[ConversionSpecifier]:
     """Parse c-printf-style format string into list of conversion specifiers."""
-    specifiers: list[ConversionSpecifier] = []
-    for m in re.finditer(FORMAT_RE, format_str):
-        specifiers.append(ConversionSpecifier(m, start_pos=m.start()))
-    return specifiers
+    return [
+        ConversionSpecifier(m, start_pos=m.start()) for m in re.finditer(FORMAT_RE, format_str)
+    ]
 
 
 def parse_format_value(

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -695,7 +695,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                             from_concat = bool(prefix.arg_types) or suffix.from_concatenate
                             suffix = suffix.copy_modified(from_concatenate=from_concat)
 
-                        if isinstance(suffix, Parameters) or isinstance(suffix, CallableType):
+                        if isinstance(suffix, (Parameters, CallableType)):
                             # no such thing as variance for ParamSpecs
                             # TODO: is there a case I am missing?
                             # TODO: constraints between prefixes
@@ -765,7 +765,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                             from_concat = bool(prefix.arg_types) or suffix.from_concatenate
                             suffix = suffix.copy_modified(from_concatenate=from_concat)
 
-                        if isinstance(suffix, Parameters) or isinstance(suffix, CallableType):
+                        if isinstance(suffix, (Parameters, CallableType)):
                             # no such thing as variance for ParamSpecs
                             # TODO: is there a case I am missing?
                             # TODO: constraints between prefixes

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1159,7 +1159,7 @@ def find_matching_overload_items(
     if not res:
         # Falling back to all items if we can't find a match is pretty arbitrary, but
         # it maintains backward compatibility.
-        res = items[:]
+        res = items.copy()
     return res
 
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -485,10 +485,8 @@ def _is_similar_constraints(x: list[Constraint], y: list[Constraint]) -> bool:
 
 def simplify_away_incomplete_types(types: Iterable[Type]) -> list[Type]:
     complete = [typ for typ in types if is_complete_type(typ)]
-    if complete:
-        return complete
-    else:
-        return list(types)
+
+    return complete or list(types)
 
 
 def is_complete_type(typ: Type) -> bool:
@@ -1054,10 +1052,11 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         infer_constraints(template_items[i], actual_items[i], self.direction)
                     )
             return res
-        elif isinstance(actual, AnyType):
+
+        if isinstance(actual, AnyType):
             return self.infer_against_any(template.items, actual)
-        else:
-            return []
+
+        return []
 
     def visit_typeddict_type(self, template: TypedDictType) -> list[Constraint]:
         actual = self.actual
@@ -1068,10 +1067,11 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             for (item_name, template_item_type, actual_item_type) in template.zip(actual):
                 res.extend(infer_constraints(template_item_type, actual_item_type, self.direction))
             return res
-        elif isinstance(actual, AnyType):
+
+        if isinstance(actual, AnyType):
             return self.infer_against_any(template.items.values(), actual)
-        else:
-            return []
+
+        return []
 
     def visit_union_type(self, template: UnionType) -> list[Constraint]:
         assert False, (
@@ -1107,14 +1107,14 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
     def visit_type_type(self, template: TypeType) -> list[Constraint]:
         if isinstance(self.actual, CallableType):
             return infer_constraints(template.item, self.actual.ret_type, self.direction)
-        elif isinstance(self.actual, Overloaded):
+        if isinstance(self.actual, Overloaded):
             return infer_constraints(template.item, self.actual.items[0].ret_type, self.direction)
-        elif isinstance(self.actual, TypeType):
+        if isinstance(self.actual, TypeType):
             return infer_constraints(template.item, self.actual.item, self.direction)
-        elif isinstance(self.actual, AnyType):
+        if isinstance(self.actual, AnyType):
             return infer_constraints(template.item, self.actual, self.direction)
-        else:
-            return []
+
+        return []
 
 
 def neg_op(op: int) -> int:

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -395,7 +395,7 @@ def any_constraints(options: list[list[Constraint] | None], eager: bool) -> list
                 else:
                     merged_option = None
                 merged_options.append(merged_option)
-            return any_constraints(list(merged_options), eager)
+            return any_constraints(merged_options.copy(), eager)
 
     # If normal logic didn't work, try excluding trivially unsatisfiable constraint (due to
     # upper bounds) from each option, and comparing them again.

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -557,7 +557,7 @@ def check_output(
     try:
         out, err, status_code = response["out"], response["err"], response["status"]
     except KeyError:
-        fail(f"Response: {str(response)}")
+        fail(f"Response: {response}")
     sys.stdout.write(out)
     sys.stdout.flush()
     sys.stderr.write(err)

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -649,7 +649,7 @@ def request(
     closed prematurely as well as invalid JSON received.
     """
     response: dict[str, str] = {}
-    args = dict(kwds)
+    args = kwds.copy()
     args["command"] = command
     # Tell the server whether this request was initiated from a human-facing terminal,
     # so that it can format the type checking output accordingly.

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -390,7 +390,7 @@ class Server:
         if not self.following_imports():
             messages = self.fine_grained_increment(sources, remove, update)
         else:
-            assert remove is None and update is None
+            assert remove is update is None
             messages = self.fine_grained_increment_follow_imports(sources)
         res = self.increment_output(messages, sources, is_tty, terminal_width)
         self.flush_caches()
@@ -541,7 +541,7 @@ class Server:
         manager = self.fine_grained_manager.manager
 
         t0 = time.time()
-        if remove is None and update is None:
+        if remove is update is None:
             # Use the fswatcher to determine which files were changed
             # (updated or added) or removed.
             self.update_sources(sources)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -600,7 +600,7 @@ class Server:
         messages = fine_grained_manager.update(changed, [], followed=True)
 
         # Follow deps from changed modules (still within graph).
-        worklist = changed[:]
+        worklist = changed.copy()
         while worklist:
             module = worklist.pop()
             if module[0] not in graph:
@@ -707,7 +707,7 @@ class Server:
         """
         changed = []
         new_files = []
-        worklist = roots[:]
+        worklist = roots.copy()
         seen.update(source.module for source in worklist)
         while worklist:
             nxt = worklist.pop()

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -637,14 +637,14 @@ class Errors:
             used_ignored_codes = used_ignored_lines[line]
             unused_ignored_codes = set(ignored_codes) - set(used_ignored_codes)
             # `ignore` is used
-            if len(ignored_codes) == 0 and len(used_ignored_codes) > 0:
+            if not ignored_codes and used_ignored_codes:
                 continue
             # All codes appearing in `ignore[...]` are used
-            if len(ignored_codes) > 0 and len(unused_ignored_codes) == 0:
+            if ignored_codes and not unused_ignored_codes:
                 continue
             # Display detail only when `ignore[...]` specifies more than one error code
             unused_codes_message = ""
-            if len(ignored_codes) > 1 and len(unused_ignored_codes) > 0:
+            if len(ignored_codes) > 1 and unused_ignored_codes:
                 unused_codes_message = f"[{', '.join(sorted(unused_ignored_codes))}]"
             message = f'Unused "type: ignore{unused_codes_message}" comment'
             for unused in unused_ignored_codes:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -349,11 +349,11 @@ class Errors:
 
     def import_context(self) -> list[tuple[str, int]]:
         """Return a copy of the import context."""
-        return self.import_ctx[:]
+        return self.import_ctx.copy()
 
     def set_import_context(self, ctx: list[tuple[str, int]]) -> None:
         """Replace the entire import context with a new value."""
-        self.import_ctx = ctx[:]
+        self.import_ctx = ctx.copy()
 
     def report(
         self,

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -603,12 +603,12 @@ class Errors:
 
         if error_code in current_mod_disabled:
             return False
-        elif error_code in current_mod_enabled:
+        if error_code in current_mod_enabled:
             return True
-        elif error_code.sub_code_of is not None and error_code.sub_code_of in current_mod_disabled:
+        if error_code.sub_code_of is not None and error_code.sub_code_of in current_mod_disabled:
             return False
-        else:
-            return error_code.default_enabled
+
+        return error_code.default_enabled
 
     def clear_errors_in_targets(self, path: str, targets: set[str]) -> None:
         """Remove errors in specific fine-grained targets within a file."""
@@ -1111,8 +1111,8 @@ def remove_path_prefix(path: str, prefix: str | None) -> str:
     """
     if prefix is not None and path.startswith(prefix):
         return path[len(prefix) :]
-    else:
-        return path
+
+    return path
 
 
 def report_internal_error(

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -230,8 +230,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
         args = self.expand_types_with_unpack(list(t.args))
         if isinstance(args, list):
             return t.copy_modified(args=args)
-        else:
-            return args
+        return args
 
     def visit_type_var(self, t: TypeVarType) -> Type:
         # Normally upper bounds can't contain other type variables, the only exception is
@@ -251,11 +250,11 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
             # TODO: what does prefix mean in this case?
             # TODO: why does this case even happen? Instances aren't plural.
             return repl
-        elif isinstance(repl, (ParamSpecType, Parameters, CallableType)):
+        if isinstance(repl, (ParamSpecType, Parameters, CallableType)):
             return expand_param_spec(t, repl)
-        else:
-            # TODO: should this branch be removed? better not to fail silently
-            return repl
+
+        # TODO: should this branch be removed? better not to fail silently
+        return repl
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> Type:
         raise NotImplementedError
@@ -446,8 +445,8 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
             if not isinstance(fallback, Instance):
                 fallback = t.partial_fallback
             return t.copy_modified(items=items, fallback=fallback)
-        else:
-            return items
+
+        return items
 
     def visit_typeddict_type(self, t: TypedDictType) -> Type:
         fallback = t.fallback.accept(self)

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -484,10 +484,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
         return t.copy_modified(args=self.expand_types(t.args))
 
     def expand_types(self, types: Iterable[Type]) -> list[Type]:
-        a: list[Type] = []
-        for t in types:
-            a.append(t.accept(self))
-        return a
+        return [t.accept(self) for t in types]
 
 
 def expand_unpack_with_variables(

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -369,7 +369,7 @@ class ExpandTypeVisitor(TypeVisitor[Type]):
             # must expand both of them with all the argument types,
             # kinds and names in the replacement. The return type in
             # the replacement is ignored.
-            if isinstance(repl, CallableType) or isinstance(repl, Parameters):
+            if isinstance(repl, (CallableType, Parameters)):
                 # Substitute *args: P.args, **kwargs: P.kwargs
                 prefix = param_spec.prefix
                 # we need to expand the types in the prefix, so might as well

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -596,7 +596,7 @@ class ASTConverter:
             if_overload_name: str | None = None
             if_block_with_overload: Block | None = None
             if_unknown_truth_value: IfStmt | None = None
-            if isinstance(stmt, IfStmt) and seen_unconditional_func_def is False:
+            if isinstance(stmt, IfStmt) and not seen_unconditional_func_def:
                 # Check IfStmt block to determine if function overloads can be merged
                 if_overload_name = self._check_ifstmt_for_overloads(stmt, current_overload_name)
                 if if_overload_name is not None:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1769,10 +1769,7 @@ class TypeConverter:
         Column numbers are sometimes incorrect in the AST and the column
         override can be used to work around that.
         """
-        if self.override_column < 0:
-            return column
-        else:
-            return self.override_column
+        return column if self.override_column < 0 else self.override_column
 
     def invalid_type(self, node: AST, note: str | None = None) -> RawExpressionType:
         """Constructs a type representing some expression that normally forms an invalid type.
@@ -1920,8 +1917,8 @@ class TypeConverter:
     def visit_NameConstant(self, n: NameConstant) -> Type:
         if isinstance(n.value, bool):
             return RawExpressionType(n.value, "builtins.bool", line=self.line)
-        else:
-            return UnboundType(str(n.value), line=self.line, column=n.col_offset)
+
+        return UnboundType(str(n.value), line=self.line, column=n.col_offset)
 
     # Only for 3.8 and newer
     def visit_Constant(self, n: Constant) -> Type:
@@ -2043,8 +2040,8 @@ class TypeConverter:
                 column=value.column,
                 empty_tuple_index=empty_tuple_index,
             )
-        else:
-            return self.invalid_type(n)
+
+        return self.invalid_type(n)
 
     def visit_Tuple(self, n: ast3.Tuple) -> Type:
         return TupleType(
@@ -2061,8 +2058,8 @@ class TypeConverter:
 
         if isinstance(before_dot, UnboundType) and not before_dot.args:
             return UnboundType(f"{before_dot.name}.{n.attr}", line=self.line)
-        else:
-            return self.invalid_type(n)
+
+        return self.invalid_type(n)
 
     # Ellipsis
     def visit_Ellipsis(self, n: ast3_Ellipsis) -> Type:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -783,8 +783,8 @@ class ASTConverter:
             return None, None
         if (
             stmt.else_body is None
-            or stmt.body[0].is_unreachable is False
-            and stmt.else_body.is_unreachable is False
+            or not stmt.body[0].is_unreachable
+            and not stmt.else_body.is_unreachable
         ):
             # The truth value is unknown, thus not conclusive
             return None, stmt

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -13,8 +13,8 @@ def extract_module_names(type_name: str | None) -> list[str]:
         # Discard the first one, which is just the qualified name of the type
         possible_module_names = split_module_names(type_name)
         return possible_module_names[1:]
-    else:
-        return []
+
+    return []
 
 
 class TypeIndirectionVisitor(TypeVisitor[Set[str]]):

--- a/mypy/inspections.py
+++ b/mypy/inspections.py
@@ -458,9 +458,7 @@ class InspectionEngine:
             modules, reload_needed = self.modules_for_nodes(nodes, expression)
             assert not reload_needed
 
-        result = []
-        for node in modules:
-            result.append(self.format_node(modules[node], node))
+        result = [self.format_node(modules[node], node) for node in modules]
 
         if not result:
             return self.missing_node(expression), False

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -460,9 +460,8 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             )
             assert isinstance(fallback, Instance)
             if self.s.length() == t.length():
-                items: list[Type] = []
-                for i in range(t.length()):
-                    items.append(join_types(t.items[i], self.s.items[i]))
+                items = [join_types(t.items[i], self.s.items[i]) for i in range(t.length())]
+
                 return TupleType(items, fallback)
             else:
                 return fallback
@@ -572,9 +571,8 @@ def is_similar_callables(t: CallableType, s: CallableType) -> bool:
 def join_similar_callables(t: CallableType, s: CallableType) -> CallableType:
     from mypy.meet import meet_types
 
-    arg_types: list[Type] = []
-    for i in range(len(t.arg_types)):
-        arg_types.append(meet_types(t.arg_types[i], s.arg_types[i]))
+    arg_types = [meet_types(t.arg_types[i], s.arg_types[i]) for i in range(len(t.arg_types))]
+
     # TODO in combine_similar_callables also applies here (names and kinds; user metaclasses)
     # The fallback type can be either 'function', 'type', or some user-provided metaclass.
     # The result should always use 'function' as a fallback if either operands are using it.
@@ -592,9 +590,8 @@ def join_similar_callables(t: CallableType, s: CallableType) -> CallableType:
 
 
 def combine_similar_callables(t: CallableType, s: CallableType) -> CallableType:
-    arg_types: list[Type] = []
-    for i in range(len(t.arg_types)):
-        arg_types.append(join_types(t.arg_types[i], s.arg_types[i]))
+    arg_types = [join_types(t.arg_types[i], s.arg_types[i]) for i in range(len(t.arg_types))]
+
     # TODO kinds and argument names
     # TODO what should happen if one fallback is 'type' and the other is a user-provided metaclass?
     # The fallback type can be either 'function', 'type', or some user-provided metaclass.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -220,10 +220,9 @@ class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
         if "\n" in text:
             # Assume we want to manually format the text
             return super()._fill_text(text, width, indent)
-        else:
-            # Assume we want argparse to manage wrapping, indenting, and
-            # formatting the text for us.
-            return argparse.HelpFormatter._fill_text(self, text, width, indent)
+
+        # Assume we want argparse to manage wrapping, indenting, and formatting the text for us.
+        return argparse.HelpFormatter._fill_text(self, text, width, indent)
 
 
 # Define pairs of flag prefixes with inverse meaning.
@@ -257,8 +256,8 @@ def python_executable_prefix(v: str) -> list[str]:
         # execute an installed Python 3.8 interpreter. See also:
         # https://docs.python.org/3/using/windows.html#python-launcher-for-windows
         return ["py", f"-{v}"]
-    else:
-        return [f"python{v}"]
+
+    return [f"python{v}"]
 
 
 def _python_executable_from_version(python_version: tuple[int, int]) -> str:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1489,7 +1489,7 @@ def read_types_packages_to_install(cache_dir: str, after_run: bool) -> list[str]
         # No missing stubs.
         return []
     with open(fnam) as f:
-        return [line.strip() for line in f.readlines()]
+        return [line.strip() for line in f]
 
 
 def install_types(

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -702,7 +702,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
 
     def visit_parameters(self, t: Parameters) -> ProperType:
         # TODO: is this the right variance?
-        if isinstance(self.s, Parameters) or isinstance(self.s, CallableType):
+        if isinstance(self.s, (Parameters, CallableType)):
             if len(t.arg_types) != len(self.s.arg_types):
                 return self.default(self.s)
             return t.copy_modified(

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -803,9 +803,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
 
     def visit_tuple_type(self, t: TupleType) -> ProperType:
         if isinstance(self.s, TupleType) and self.s.length() == t.length():
-            items: list[Type] = [
-                self.meet(t.items[i], self.s.items[i]) for i in range(t.length())
-            ]
+            items: list[Type] = [self.meet(t.items[i], self.s.items[i]) for i in range(t.length())]
 
             # TODO: What if the fallbacks are different?
             return TupleType(items, tuple_fallback(t))

--- a/mypy/memprofile.py
+++ b/mypy/memprofile.py
@@ -103,7 +103,7 @@ def find_recursive_objects(objs: list[object]) -> None:
             objs.append(o)
             seen.add(id(o))
 
-    for obj in objs[:]:
+    for obj in objs.copy():
         if type(obj) is FakeInfo:
             # Processing these would cause a crash.
             continue

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2894,11 +2894,9 @@ def append_invariance_notes(
             'Consider using "Mapping" instead, ' "which is covariant in the value type"
         )
     if invariant_type and covariant_suggestion:
-        notes.append(
-            f'"{invariant_type}" is invariant -- see '
-            + "https://mypy.readthedocs.io/en/stable/common_issues.html#variance"
-        )
-        notes.append(covariant_suggestion)
+        url = "https://mypy.readthedocs.io/en/stable/common_issues.html#variance"
+
+        notes.extend((f'"{invariant_type}" is invariant -- see {url}', covariant_suggestion))
     return notes
 
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2214,9 +2214,9 @@ class MessageBuilder:
                     )
                 error_cnt += 1
 
-        info = f" ({str(error_cnt)} tuple items are incompatible"
+        info = f" ({error_cnt} tuple items are incompatible"
         if error_cnt - 3 > 0:
-            info += f"; {str(error_cnt - 3)} items are omitted)"
+            info += f"; {error_cnt - 3} items are omitted)"
         else:
             info += ")"
         msg = msg.with_additional_msg(info)
@@ -2276,7 +2276,7 @@ def format_callable_args(
             if arg_kind.is_star() or arg_name is None:
                 arg_strings.append(f"{constructor}({format(arg_type)})")
             else:
-                arg_strings.append(f"{constructor}({format(arg_type)}, {repr(arg_name)})")
+                arg_strings.append(f"{constructor}({format(arg_type)}, {arg_name!r})")
 
     return ", ".join(arg_strings)
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2877,15 +2877,13 @@ def append_invariance_notes(
     invariant_type = ""
     covariant_suggestion = ""
     if (
-        arg_type.type.fullname == "builtins.list"
-        and expected_type.type.fullname == "builtins.list"
+        arg_type.type.fullname == expected_type.type.fullname == "builtins.list"
         and is_subtype(arg_type.args[0], expected_type.args[0])
     ):
         invariant_type = "List"
         covariant_suggestion = 'Consider using "Sequence" instead, which is covariant'
     elif (
-        arg_type.type.fullname == "builtins.dict"
-        and expected_type.type.fullname == "builtins.dict"
+        arg_type.type.fullname == expected_type.type.fullname == "builtins.dict"
         and is_same_type(arg_type.args[0], expected_type.args[0])
         and is_subtype(arg_type.args[1], expected_type.args[1])
     ):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2775,7 +2775,7 @@ def strip_quotes(s: str) -> str:
 
 
 def format_string_list(lst: list[str]) -> str:
-    assert len(lst) > 0
+    assert lst
     if len(lst) == 1:
         return lst[0]
     elif len(lst) <= 5:
@@ -2936,7 +2936,7 @@ def make_inferred_type_note(
 def format_key_list(keys: list[str], *, short: bool = False) -> str:
     formatted_keys = [f'"{key}"' for key in keys]
     td = "" if short else "TypedDict "
-    if len(keys) == 0:
+    if not keys:
         return f"no {td}keys"
     elif len(keys) == 1:
         return f"{td}key {formatted_keys[0]}"

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -226,10 +226,10 @@ class MessageBuilder:
             """
             if isinstance(ctx, (ClassDef, FuncDef)):
                 return range(ctx.deco_line or ctx.line, ctx.line + 1)
-            elif not isinstance(ctx, Expression):
+            if not isinstance(ctx, Expression):
                 return [ctx.line]
-            else:
-                return range(ctx.line, (ctx.end_line or ctx.line) + 1)
+
+            return range(ctx.line, (ctx.end_line or ctx.line) + 1)
 
         origin_span: Iterable[int] | None
         if origin is not None:
@@ -2191,8 +2191,8 @@ class MessageBuilder:
             return "Tuple[{}, {}, ... <{} more items>]".format(
                 format_type_bare(typ.items[0]), format_type_bare(typ.items[1]), str(item_cnt - 2)
             )
-        else:
-            return format_type_bare(typ)
+
+        return format_type_bare(typ)
 
     def generate_incompatible_tuple_error(
         self,
@@ -2302,8 +2302,8 @@ def format_type_inner(
         if typ.is_enum_literal():
             underlying_type = format(typ.fallback)
             return f"{underlying_type}.{typ.value}"
-        else:
-            return typ.value_repr()
+
+        return typ.value_repr()
 
     if isinstance(typ, TypeAliasType) and typ.is_recursive:
         # TODO: find balance here, str(typ) doesn't support custom verbosity, and may be
@@ -2558,8 +2558,8 @@ def format_type_distinctly(*types: Type, bare: bool = False) -> tuple[str, ...]:
             break
     if bare:
         return tuple(strs)
-    else:
-        return tuple(quote_type_string(s) for s in strs)
+
+    return tuple(quote_type_string(s) for s in strs)
 
 
 def pretty_class_or_static_decorator(tp: CallableType) -> str | None:
@@ -2672,10 +2672,10 @@ def pretty_callable(tp: CallableType, skip_self: bool = False) -> str:
 def variance_string(variance: int) -> str:
     if variance == COVARIANT:
         return "covariant"
-    elif variance == CONTRAVARIANT:
+    if variance == CONTRAVARIANT:
         return "contravariant"
-    else:
-        return "invariant"
+
+    return "invariant"
 
 
 def get_missing_protocol_members(left: Instance, right: Instance, skip: list[str]) -> list[str]:
@@ -2752,10 +2752,7 @@ def get_bad_protocol_flags(
 
 def capitalize(s: str) -> str:
     """Capitalize the first character of a string."""
-    if s == "":
-        return ""
-    else:
-        return s[0].upper() + s[1:]
+    return "" if s == "" else s[0].upper() + s[1:]
 
 
 def extract_type(name: str) -> str:
@@ -2778,22 +2775,22 @@ def format_string_list(lst: list[str]) -> str:
     assert lst
     if len(lst) == 1:
         return lst[0]
-    elif len(lst) <= 5:
+    if len(lst) <= 5:
         return f"{', '.join(lst[:-1])} and {lst[-1]}"
-    else:
-        return "%s, ... and %s (%i methods suppressed)" % (
-            ", ".join(lst[:2]),
-            lst[-1],
-            len(lst) - 3,
-        )
+
+    return "%s, ... and %s (%i methods suppressed)" % (
+        ", ".join(lst[:2]),
+        lst[-1],
+        len(lst) - 3,
+    )
 
 
 def format_item_name_list(s: Iterable[str]) -> str:
     lst = list(s)
     if len(lst) <= 5:
         return "(" + ", ".join([f'"{name}"' for name in lst]) + ")"
-    else:
-        return "(" + ", ".join([f'"{name}"' for name in lst[:5]]) + ", ...)"
+
+    return "(" + ", ".join([f'"{name}"' for name in lst[:5]]) + ", ...)"
 
 
 def callable_name(type: FunctionLike) -> str | None:
@@ -2936,7 +2933,7 @@ def format_key_list(keys: list[str], *, short: bool = False) -> str:
     td = "" if short else "TypedDict "
     if not keys:
         return f"no {td}keys"
-    elif len(keys) == 1:
+    if len(keys) == 1:
         return f"{td}key {formatted_keys[0]}"
-    else:
-        return f"{td}keys ({', '.join(formatted_keys)})"
+
+    return f"{td}keys ({', '.join(formatted_keys)})"

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2778,11 +2778,7 @@ def format_string_list(lst: list[str]) -> str:
     if len(lst) <= 5:
         return f"{', '.join(lst[:-1])} and {lst[-1]}"
 
-    return "%s, ... and %s (%i methods suppressed)" % (
-        ", ".join(lst[:2]),
-        lst[-1],
-        len(lst) - 3,
-    )
+    return "%s, ... and %s (%i methods suppressed)" % (", ".join(lst[:2]), lst[-1], len(lst) - 3)
 
 
 def format_item_name_list(s: Iterable[str]) -> str:
@@ -2873,9 +2869,8 @@ def append_invariance_notes(
     """Explain that the type is invariant and give notes for how to solve the issue."""
     invariant_type = ""
     covariant_suggestion = ""
-    if (
-        arg_type.type.fullname == expected_type.type.fullname == "builtins.list"
-        and is_subtype(arg_type.args[0], expected_type.args[0])
+    if arg_type.type.fullname == expected_type.type.fullname == "builtins.list" and is_subtype(
+        arg_type.args[0], expected_type.args[0]
     ):
         invariant_type = "List"
         covariant_suggestion = 'Consider using "Sequence" instead, which is covariant'

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -347,8 +347,8 @@ class FindModuleCache:
             return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
         if plausible_match:
             return ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS
-        else:
-            return ModuleNotFoundReason.NOT_FOUND
+
+        return ModuleNotFoundReason.NOT_FOUND
 
     def _update_ns_ancestors(self, components: list[str], match: tuple[str, bool]) -> None:
         path, verify = match
@@ -564,8 +564,8 @@ class FindModuleCache:
             return ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED
         elif found_possible_third_party_missing_type_hints:
             return ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS
-        else:
-            return ModuleNotFoundReason.NOT_FOUND
+
+        return ModuleNotFoundReason.NOT_FOUND
 
     def _is_compatible_stub_package(self, stub_dir: str) -> bool:
         """Does a stub package support the target Python version?

--- a/mypy/mro.py
+++ b/mypy/mro.py
@@ -44,7 +44,7 @@ def linearize_hierarchy(
 
 
 def merge(seqs: list[list[TypeInfo]]) -> list[TypeInfo]:
-    seqs = [s[:] for s in seqs]
+    seqs = [s.copy() for s in seqs]
     result: list[TypeInfo] = []
     while True:
         seqs = [s for s in seqs if s]

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -556,7 +556,7 @@ class OverloadedFuncDef(FuncBase, SymbolNode, Statement):
         self.items = items
         self.unanalyzed_items = items.copy()
         self.impl = None
-        if len(items) > 0:
+        if items:
             # TODO: figure out how to reliably set end position (we don't know the impl here).
             self.set_line(items[0].line, items[0].column)
         self.is_final = False

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3741,20 +3741,17 @@ class SymbolTableNode:
 
     @property
     def fullname(self) -> str | None:
-        if self.node is not None:
-            return self.node.fullname
-        else:
-            return None
+        return self.node.fullname if self.node else None
 
     @property
     def type(self) -> mypy.types.Type | None:
         node = self.node
         if isinstance(node, (Var, SYMBOL_FUNCBASE_TYPES)) and node.type is not None:
             return node.type
-        elif isinstance(node, Decorator):
+        if isinstance(node, Decorator):
             return node.var.type
-        else:
-            return None
+
+        return None
 
     def copy(self) -> SymbolTableNode:
         new = SymbolTableNode(

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3847,7 +3847,7 @@ class SymbolTable(Dict[str, SymbolTableNode]):
                     value.fullname != "builtins"
                     and (value.fullname or "").split(".")[-1] not in implicit_module_attrs
                 ):
-                    a.append("  " + str(key) + " : " + str(value))
+                    a.append(f"  {key} : {value}")
             else:
                 a.append("  <invalid item>")
         a = sorted(a)

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -153,7 +153,7 @@ class BranchStatement:
             all_vars.update(b.must_be_defined)
         # For the rest of the things, we only care about branches that weren't skipped.
         non_skipped_branches = [b for b in self.branches if not b.skipped]
-        if len(non_skipped_branches) > 0:
+        if non_skipped_branches:
             must_be_defined = non_skipped_branches[0].must_be_defined
             for b in non_skipped_branches[1:]:
                 must_be_defined.intersection_update(b.must_be_defined)
@@ -660,7 +660,7 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
             else:
                 # When you do `import x.y`, only `x` becomes defined.
                 names = mod.split(".")
-                if len(names) > 0:
+                if names:
                     # `names` should always be nonempty, but we don't want mypy
                     # to crash on invalid code.
                     self.tracker.record_definition(names[0])

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -255,10 +255,8 @@ def _get_decorator_optional_bool_argument(
                 ctx.reason,
                 code=LITERAL_REQ,
             )
-            return default
-        return default
-    else:
-        return default
+
+    return default
 
 
 def attr_tag_callback(ctx: mypy.plugin.ClassDefContext) -> None:

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -152,7 +152,7 @@ def add_method_to_class(
     """Adds a new method to a class definition."""
 
     assert not (
-        is_classmethod is True and is_staticmethod is True
+        is_classmethod is is_staticmethod is True
     ), "Can't add a new method that's both staticmethod and classmethod."
 
     info = cls.info

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -48,8 +48,8 @@ def _get_decorator_bool_argument(ctx: ClassDefContext, name: str, default: bool)
     """
     if isinstance(ctx.reason, CallExpr):
         return _get_bool_argument(ctx, ctx.reason, name, default)
-    else:
-        return default
+
+    return default
 
 
 def _get_bool_argument(ctx: ClassDefContext, expr: CallExpr, name: str, default: bool) -> bool:

--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -69,8 +69,7 @@ def _autoconvertible_to_cdata(tp: Type, api: mypy.plugin.CheckerPluginInterface)
                 if t.type.has_base("ctypes._PointerLike"):
                     # Pointer-like _SimpleCData subclasses can also be converted from
                     # an int or None.
-                    allowed_types.append(api.named_generic_type("builtins.int", []))
-                    allowed_types.append(NoneType())
+                    allowed_types.extend((api.named_generic_type("builtins.int", []), NoneType()))
 
     return make_simplified_union(allowed_types)
 

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -170,8 +170,7 @@ def typed_dict_get_signature_callback(ctx: MethodSigContext) -> CallableType:
         and len(ctx.args[0]) == 1
         and isinstance(ctx.args[0][0], StrExpr)
         and len(signature.arg_types) == 2
-        and len(signature.variables) == 1
-        and len(ctx.args[1]) == 1
+        and len(signature.variables) == len(ctx.args[1]) == 1
     ):
         key = ctx.args[0][0].value
         value_type = get_proper_type(ctx.type.items.get(key))
@@ -216,7 +215,7 @@ def typed_dict_get_callback(ctx: MethodContext) -> Type:
 
             if len(ctx.arg_types) == 1:
                 output_types.append(value_type)
-            elif len(ctx.arg_types) == 2 and len(ctx.arg_types[1]) == 1 and len(ctx.args[1]) == 1:
+            elif len(ctx.arg_types) == 2 and len(ctx.arg_types[1]) == len(ctx.args[1]) == 1:
                 default_arg = ctx.args[1][0]
                 if (
                     isinstance(default_arg, DictExpr)
@@ -249,8 +248,7 @@ def typed_dict_pop_signature_callback(ctx: MethodSigContext) -> CallableType:
         and len(ctx.args[0]) == 1
         and isinstance(ctx.args[0][0], StrExpr)
         and len(signature.arg_types) == 2
-        and len(signature.variables) == 1
-        and len(ctx.args[1]) == 1
+        and len(signature.variables) == len(ctx.args[1]) == 1
     ):
         key = ctx.args[0][0].value
         value_type = ctx.type.items.get(key)
@@ -295,7 +293,7 @@ def typed_dict_pop_callback(ctx: MethodContext) -> Type:
 
         if len(ctx.args[1]) == 0:
             return make_simplified_union(value_types)
-        elif len(ctx.arg_types) == 2 and len(ctx.arg_types[1]) == 1 and len(ctx.args[1]) == 1:
+        elif len(ctx.arg_types) == 2 and len(ctx.arg_types[1]) == len(ctx.args[1]) == 1:
             return make_simplified_union([*value_types, ctx.arg_types[1][0]])
     return ctx.default_return_type
 
@@ -328,8 +326,7 @@ def typed_dict_setdefault_callback(ctx: MethodContext) -> Type:
     if (
         isinstance(ctx.type, TypedDictType)
         and len(ctx.arg_types) == 2
-        and len(ctx.arg_types[0]) == 1
-        and len(ctx.arg_types[1]) == 1
+        and len(ctx.arg_types[0]) == len(ctx.arg_types[1]) == 1
     ):
         keys = try_getting_str_literals(ctx.args[0][0], ctx.arg_types[0][0])
         if keys is None:
@@ -368,11 +365,7 @@ def typed_dict_setdefault_callback(ctx: MethodContext) -> Type:
 
 def typed_dict_delitem_callback(ctx: MethodContext) -> Type:
     """Type check TypedDict.__delitem__."""
-    if (
-        isinstance(ctx.type, TypedDictType)
-        and len(ctx.arg_types) == 1
-        and len(ctx.arg_types[0]) == 1
-    ):
+    if isinstance(ctx.type, TypedDictType) and len(ctx.arg_types) == len(ctx.arg_types[0]) == 1:
         keys = try_getting_str_literals(ctx.args[0][0], ctx.arg_types[0][0])
         if keys is None:
             ctx.api.fail(

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -226,8 +226,7 @@ def typed_dict_get_callback(ctx: MethodContext) -> Type:
                     # Special case '{}' as the default for a typed dict type.
                     output_types.append(value_type.copy_modified(required_keys=set()))
                 else:
-                    output_types.append(value_type)
-                    output_types.append(ctx.arg_types[1][0])
+                    output_types.extend((value_type, ctx.arg_types[1][0]))
 
         if len(ctx.arg_types) == 1:
             output_types.append(NoneType())

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -167,11 +167,11 @@ def enum_value_callback(ctx: mypy.plugin.AttributeContext) -> Type:
                 for n in stnodes
                 if n is None or not n.implicit
             )
-            proper_types = list(
+            proper_types = [
                 _infer_value_type_with_auto_fallback(ctx, t)
                 for t in node_types
                 if t is None or not isinstance(t, CallableType)
-            )
+            ]
             underlying_type = _first(proper_types)
             if underlying_type is None:
                 return ctx.default_attr_type

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -184,8 +184,6 @@ def register_function(
             ),
             func.definition,
         )
-        return
-    return
 
 
 def get_dispatch_type(func: CallableType, register_arg: Type | None) -> Type | None:

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -164,12 +164,12 @@ def infer_condition_value(expr: Expression, options: Options) -> int:
 def infer_pattern_value(pattern: Pattern) -> int:
     if isinstance(pattern, AsPattern) and pattern.pattern is None:
         return ALWAYS_TRUE
-    elif isinstance(pattern, OrPattern) and any(
+    if isinstance(pattern, OrPattern) and any(
         infer_pattern_value(p) == ALWAYS_TRUE for p in pattern.patterns
     ):
         return ALWAYS_TRUE
-    else:
-        return TRUTH_VALUE_UNKNOWN
+
+    return TRUTH_VALUE_UNKNOWN
 
 
 def consider_sys_version_info(expr: Expression, pyversion: tuple[int, ...]) -> int:

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -401,12 +401,12 @@ class VariableRenameVisitor(TraverserVisitor):
                 # This doesn't support arbitrary redefinition.
                 var_blocks[name] = -1
             return True
-        elif var_blocks[name] == block:
+        if var_blocks[name] == block:
             # Redefinition -- defines a new variable with the same name.
             return True
-        else:
-            # Assigns to an existing variable.
-            return False
+
+        # Assigns to an existing variable.
+        return False
 
 
 class LimitedVariableRenameVisitor(TraverserVisitor):

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -537,8 +537,8 @@ class MemoryXmlReporter(AbstractReporter):
             for any_type, occurrences in counter.items():
                 result += f"\n{type_of_any_name_map[any_type]} (x{occurrences})"
             return result
-        else:
-            return "No Anys on this line!"
+
+        return "No Anys on this line!"
 
     def on_finish(self) -> None:
         self.last_xml = None
@@ -573,8 +573,8 @@ register_reporter("memory-xml", MemoryXmlReporter, needs_lxml=True)
 def get_line_rate(covered_lines: int, total_lines: int) -> str:
     if total_lines == 0:
         return str(1.0)
-    else:
-        return f"{covered_lines / total_lines:.4f}"
+
+    return f"{covered_lines / total_lines:.4f}"
 
 
 class CoberturaPackage:

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -425,12 +425,11 @@ class LineCoverageReporter(AbstractReporter):
         coverage_visitor = LineCoverageVisitor(tree_source)
         tree.accept(coverage_visitor)
 
-        covered_lines = []
-        for line_number, (_, typed) in enumerate(coverage_visitor.lines_covered):
-            if typed:
-                covered_lines.append(line_number + 1)
-
-        self.lines_covered[os.path.abspath(tree.path)] = covered_lines
+        self.lines_covered[os.path.abspath(tree.path)] = [
+            line_number + 1
+            for line_number, (_, typed) in enumerate(coverage_visitor.lines_covered)
+            if typed
+        ]
 
     def on_finish(self) -> None:
         with open(os.path.join(self.output_dir, "coverage.json"), "w") as f:

--- a/mypy/scope.py
+++ b/mypy/scope.py
@@ -33,7 +33,7 @@ class Scope:
         assert self.module
         if self.function:
             fullname = self.function.fullname
-            return fullname or ""
+            return fullname
         return self.module
 
     def current_full_target(self) -> str:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5116,12 +5116,7 @@ class SemanticAnalyzer(
         if has_param_spec and num_args == 1 and types:
             first_arg = get_proper_type(types[0])
             if not (
-                len(types) == 1
-                and (
-                    isinstance(first_arg, Parameters)
-                    or isinstance(first_arg, ParamSpecType)
-                    or isinstance(first_arg, AnyType)
-                )
+                len(types) == 1 and isinstance(first_arg, (Parameters, ParamSpecType, AnyType))
             ):
                 types = [Parameters(types, [ARG_POS] * len(types), [None] * len(types))]
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6528,13 +6528,13 @@ class SemanticAnalyzer(
     def parse_dataclass_transform_field_specifiers(self, arg: Expression) -> tuple[str, ...]:
         if not isinstance(arg, TupleExpr):
             self.fail('"field_specifiers" argument must be a tuple literal', arg)
-            return tuple()
+            return ()
 
         names = []
         for specifier in arg.items:
             if not isinstance(specifier, RefExpr):
                 self.fail('"field_specifiers" must only contain identifiers', specifier)
-                return tuple()
+                return ()
             names.append(specifier.fullname)
         return tuple(names)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1415,7 +1415,7 @@ class SemanticAnalyzer(
 
         args = func.var_arg()
         kwargs = func.kw_arg()
-        if args is None and kwargs is None:
+        if args is kwargs is None:
             return  # Looks like this function does not have starred args
 
         args_defn_type = None

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1038,8 +1038,8 @@ class SemanticAnalyzer(
         if isinstance(previous, (FuncDef, Var, Decorator)) and new.is_conditional:
             new.original_def = previous
             return True
-        else:
-            return False
+
+        return False
 
     def update_function_type_variables(self, fun_type: CallableType, defn: FuncItem) -> bool:
         """Make any type variables in the signature of defn explicit.
@@ -4650,10 +4650,9 @@ class SemanticAnalyzer(
     def is_valid_del_target(self, s: Expression) -> bool:
         if isinstance(s, (IndexExpr, NameExpr, MemberExpr)):
             return True
-        elif isinstance(s, (TupleExpr, ListExpr)):
+        if isinstance(s, (TupleExpr, ListExpr)):
             return all(self.is_valid_del_target(item) for item in s.items)
-        else:
-            return False
+        return False
 
     def visit_global_decl(self, g: GlobalDecl) -> None:
         self.statement = g
@@ -5412,10 +5411,10 @@ class SemanticAnalyzer(
         # but it is fine because we want an overloaded function to be treated as a single unit.
         if self.is_overloaded_item(node, self.statement):
             return False
-        elif isinstance(node, Decorator) and not node.is_overload:
+        if isinstance(node, Decorator) and not node.is_overload:
             return line_diff > len(node.original_decorators)
-        else:
-            return line_diff > 0
+
+        return line_diff > 0
 
     def is_overloaded_item(self, node: SymbolNode, statement: Statement) -> bool:
         """Check whether the function belongs to the overloaded variants"""
@@ -5641,10 +5640,10 @@ class SemanticAnalyzer(
     def lookup_current_scope(self, name: str) -> SymbolTableNode | None:
         if self.locals[-1] is not None:
             return self.locals[-1].get(name)
-        elif self.type is not None:
+        if self.type is not None:
             return self.type.names.get(name)
-        else:
-            return self.globals.get(name)
+
+        return self.globals.get(name)
 
     #
     # Adding symbols
@@ -6034,10 +6033,10 @@ class SemanticAnalyzer(
     def qualified_name(self, name: str) -> str:
         if self.type is not None:
             return self.type._fullname + "." + name
-        elif self.is_func_scope():
+        if self.is_func_scope():
             return name
-        else:
-            return self.cur_mod_id + "." + name
+
+        return self.cur_mod_id + "." + name
 
     @contextmanager
     def enter(

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2262,7 +2262,7 @@ class SemanticAnalyzer(
                     break
 
         metas = {defn.metaclass, with_meta_expr, add_meta_expr} - {None}
-        if len(metas) == 0:
+        if not metas:
             return
         if len(metas) > 1:
             self.fail("Multiple metaclass definitions", defn)
@@ -4602,7 +4602,7 @@ class SemanticAnalyzer(
         if s.unanalyzed_type:
             assert isinstance(s.unanalyzed_type, ProperType)
             actual_targets = [t for t in s.target if t is not None]
-            if len(actual_targets) == 0:
+            if not actual_targets:
                 # We have a type for no targets
                 self.fail('Invalid type comment: "with" statement has no targets', s)
             elif len(actual_targets) == 1:
@@ -5113,7 +5113,7 @@ class SemanticAnalyzer(
                 return None
             types.append(analyzed)
 
-        if has_param_spec and num_args == 1 and len(types) > 0:
+        if has_param_spec and num_args == 1 and types:
             first_arg = get_proper_type(types[0])
             if not (
                 len(types) == 1
@@ -6707,7 +6707,7 @@ def is_trivial_body(block: Block) -> bool:
     if body and isinstance(body[0], ExpressionStmt) and isinstance(body[0].expr, StrExpr):
         body = block.body[1:]
 
-    if len(body) == 0:
+    if not body:
         # There's only a docstring (or no body at all).
         return True
     elif len(body) > 1:

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -232,7 +232,7 @@ class EnumCallAnalyzer:
                 % class_name,
                 call,
             )
-        if len(items) == 0:
+        if not items:
             return self.fail_enum_call_arg(f"{class_name}() needs at least one item", call)
         if not values:
             values = [None] * len(items)

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -190,7 +190,7 @@ def process_top_levels(graph: Graph, scc: list[str], patches: Patches) -> None:
     # Initially all namespaces in the SCC are incomplete (well they are empty).
     state.manager.incomplete_namespaces.update(scc)
 
-    worklist = scc[:]
+    worklist = scc.copy()
     # HACK: process core stuff first. This is mostly needed to support defining
     # named tuples in builtin SCC.
     if all(m in worklist for m in core_modules):

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -369,8 +369,8 @@ def semantic_analyze_target(
 
     if analyzer.deferred:
         return [target], analyzer.incomplete, analyzer.progress
-    else:
-        return [], analyzer.incomplete, analyzer.progress
+
+    return [], analyzer.incomplete, analyzer.progress
 
 
 def check_type_arguments(graph: Graph, scc: list[str], errors: Errors) -> None:

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -309,11 +309,11 @@ TargetInfo: _TypeAlias = Tuple[
 
 def get_all_leaf_targets(file: MypyFile) -> list[TargetInfo]:
     """Return all leaf targets in a symbol table (module-level and methods)."""
-    result: list[TargetInfo] = []
-    for fullname, node, active_type in file.local_definitions():
-        if isinstance(node.node, (FuncDef, OverloadedFuncDef, Decorator)):
-            result.append((fullname, node.node, active_type))
-    return result
+    return [
+        (fullname, node.node, active_type)
+        for fullname, node, active_type in file.local_definitions()
+        if isinstance(node.node, (FuncDef, OverloadedFuncDef, Decorator))
+    ]
 
 
 def semantic_analyze_target(

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -281,7 +281,7 @@ class NamedTupleAnalyzer:
             #     two methods of a class can define a named tuple with the same name,
             #     and they will be stored in the same namespace (see below).
             name += "@" + str(call.line)
-        if len(defaults) > 0:
+        if defaults:
             default_items = {
                 arg_name: default for arg_name, default in zip(items[-len(defaults) :], defaults)
             }

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -305,10 +305,7 @@ def snapshot_type(typ: Type) -> SnapshotItem:
 
 
 def snapshot_optional_type(typ: Type | None) -> SnapshotItem:
-    if typ:
-        return snapshot_type(typ)
-    else:
-        return ("<not set>",)
+    return snapshot_type(typ) if typ else ("<not set>",)
 
 
 def snapshot_types(types: Sequence[Type]) -> SnapshotItem:
@@ -320,10 +317,7 @@ def snapshot_simple_type(typ: Type) -> SnapshotItem:
 
 
 def encode_optional_str(s: str | None) -> str:
-    if s is None:
-        return "<None>"
-    else:
-        return s
+    return "<None>" if s is None else s
 
 
 class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -903,25 +903,24 @@ class DependencyVisitor(TraverserVisitor):
         if isinstance(typ, Instance):
             member = f"{typ.type.fullname}.{name}"
             return [make_trigger(member)]
-        elif isinstance(typ, FunctionLike) and typ.is_type_obj():
+        if isinstance(typ, FunctionLike) and typ.is_type_obj():
             member = f"{typ.type_object().fullname}.{name}"
             triggers = [make_trigger(member)]
             triggers.extend(self.attribute_triggers(typ.fallback, name))
             return triggers
-        elif isinstance(typ, UnionType):
+        if isinstance(typ, UnionType):
             targets = []
             for item in typ.items:
                 targets.extend(self.attribute_triggers(item, name))
             return targets
-        elif isinstance(typ, TypeType):
+        if isinstance(typ, TypeType):
             triggers = self.attribute_triggers(typ.item, name)
             if isinstance(typ.item, Instance) and typ.item.type.metaclass_type is not None:
                 triggers.append(
                     make_trigger(f"{typ.item.type.metaclass_type.type.fullname}.{name}")
                 )
             return triggers
-        else:
-            return []
+        return []
 
     def add_attribute_dependency_for_expr(self, e: Expression, name: str) -> None:
         typ = self.type_map.get(e)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -1026,7 +1026,7 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
     def visit_type_type(self, typ: TypeType) -> list[str]:
         triggers = self.get_type_triggers(typ.item)
         if not self.use_logical_deps:
-            old_triggers = triggers[:]
+            old_triggers = triggers.copy():
             for trigger in old_triggers:
                 triggers.append(trigger.rstrip(">") + ".__init__>")
                 triggers.append(trigger.rstrip(">") + ".__new__>")

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -1026,7 +1026,7 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
     def visit_type_type(self, typ: TypeType) -> list[str]:
         triggers = self.get_type_triggers(typ.item)
         if not self.use_logical_deps:
-            old_triggers = triggers.copy():
+            old_triggers = triggers.copy()
             for trigger in old_triggers:
                 triggers.append(trigger.rstrip(">") + ".__init__>")
                 triggers.append(trigger.rstrip(">") + ".__new__>")

--- a/mypy/server/mergecheck.py
+++ b/mypy/server/mergecheck.py
@@ -70,7 +70,7 @@ def path_to_str(path: list[tuple[object, object]]) -> str:
     for attr, obj in path:
         t = type(obj).__name__
         if t in ("dict", "tuple", "SymbolTable", "list"):
-            result += f"[{repr(attr)}]"
+            result += f"[{attr!r}]"
         else:
             if isinstance(obj, Var):
                 result += f".{attr}({t}:{obj.name})"

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -187,7 +187,7 @@ class FineGrainedBuildManager:
         # Merge in any root dependencies that may not have been loaded
         merge_dependencies(manager.load_fine_grained_deps(FAKE_ROOT_MODULE), self.deps)
         self.previous_targets_with_errors = manager.errors.targets()
-        self.previous_messages: list[str] = result.errors[:]
+        self.previous_messages: list[str] = result.errors.copy()
         # Module, if any, that had blocking errors in the last run as (id, path) tuple.
         self.blocking_error: tuple[str, str] | None = None
         # Module that we haven't processed yet but that are known to be stale.
@@ -302,7 +302,7 @@ class FineGrainedBuildManager:
                     break
 
         messages = sort_messages_preserving_file_order(messages, self.previous_messages)
-        self.previous_messages = messages[:]
+        self.previous_messages = messages.copy()
         return messages
 
     def trigger(self, target: str) -> list[str]:
@@ -322,7 +322,7 @@ class FineGrainedBuildManager:
         )
         # Preserve state needed for the next update.
         self.previous_targets_with_errors = self.manager.errors.targets()
-        self.previous_messages = self.manager.errors.new_messages()[:]
+        self.previous_messages = self.manager.errors.new_messages().copy()
         return self.update(changed_modules, [])
 
     def flush_cache(self) -> None:

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -1184,11 +1184,13 @@ def target_from_node(module: str, node: FuncDef | MypyFile | OverloadedFuncDef) 
             # Actually a reference to another module -- likely a stale dependency.
             return None
         return module
-    else:  # OverloadedFuncDef or FuncDef
-        if node.info:
-            return f"{node.info.fullname}.{node.name}"
-        else:
-            return f"{module}.{node.name}"
+
+    # OverloadedFuncDef or FuncDef
+
+    if node.info:
+        return f"{node.info.fullname}.{node.name}"
+
+    return f"{module}.{node.name}"
 
 
 if sys.platform != "win32":

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -746,11 +746,11 @@ def get_sources(
     changed_modules: list[tuple[str, str]],
     followed: bool,
 ) -> list[BuildSource]:
-    sources = []
-    for id, path in changed_modules:
-        if fscache.isfile(path):
-            sources.append(BuildSource(path, id, None, followed=followed))
-    return sources
+    return [
+        BuildSource(path, id, None, followed=followed)
+        for id, path in changed_modules
+        if fscache.isfile(path)
+    ]
 
 
 def calculate_active_triggers(

--- a/mypy/split_namespace.py
+++ b/mypy/split_namespace.py
@@ -31,5 +31,5 @@ class SplitNamespace(argparse.Namespace):
     def __getattr__(self, name: str) -> Any:
         if name.startswith(self._alt_prefix):
             return getattr(self._alt_namespace, name[len(self._alt_prefix) :])
-        else:
-            return getattr(self._standard_namespace, name)
+
+        return getattr(self._standard_namespace, name)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -40,8 +40,8 @@ class StrConv(NodeVisitor[str]):
     def format_id(self, o: object) -> str:
         if self.id_mapper:
             return f"<{self.get_id(o)}>"
-        else:
-            return ""
+
+        return ""
 
     def dump(self, nodes: Sequence[object], obj: mypy.nodes.Context) -> str:
         """Convert a list of items to a multiline pretty-printed string.
@@ -247,8 +247,8 @@ class StrConv(NodeVisitor[str]):
 
         if not o.else_body:
             return self.dump(a, o)
-        else:
-            return self.dump([a, ("Else", o.else_body.body)], o)
+
+        return self.dump([a, ("Else", o.else_body.body)], o)
 
     def visit_break_stmt(self, o: mypy.nodes.BreakStmt) -> str:
         return self.dump([], o)
@@ -265,8 +265,8 @@ class StrConv(NodeVisitor[str]):
     def visit_assert_stmt(self, o: mypy.nodes.AssertStmt) -> str:
         if o.msg is not None:
             return self.dump([o.expr, o.msg], o)
-        else:
-            return self.dump([o.expr], o)
+
+        return self.dump([o.expr], o)
 
     def visit_await_expr(self, o: mypy.nodes.AwaitExpr) -> str:
         return self.dump([o.expr], o)
@@ -390,8 +390,8 @@ class StrConv(NodeVisitor[str]):
     def visit_yield_from_expr(self, o: mypy.nodes.YieldFromExpr) -> str:
         if o.expr:
             return self.dump([o.expr.accept(self)], o)
-        else:
-            return self.dump([], o)
+
+        return self.dump([], o)
 
     def visit_call_expr(self, o: mypy.nodes.CallExpr) -> str:
         if o.analyzed:
@@ -429,9 +429,9 @@ class StrConv(NodeVisitor[str]):
     def visit_reveal_expr(self, o: mypy.nodes.RevealExpr) -> str:
         if o.kind == mypy.nodes.REVEAL_TYPE:
             return self.dump([o.expr], o)
-        else:
-            # REVEAL_LOCALS
-            return self.dump([o.local_nodes], o)
+
+        # REVEAL_LOCALS
+        return self.dump([o.local_nodes], o)
 
     def visit_assignment_expr(self, o: mypy.nodes.AssignmentExpr) -> str:
         return self.dump([o.target, o.value], o)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -144,7 +144,7 @@ class StrConv(NodeVisitor[str]):
         return self.dump(a, o)
 
     def visit_overloaded_func_def(self, o: mypy.nodes.OverloadedFuncDef) -> str:
-        a: Any = o.items[:]
+        a: Any = o.items.copy()
         if o.type:
             a.insert(0, o.type)
         if o.impl:

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -378,11 +378,11 @@ def find_unique_signatures(sigs: Sequence[Sig]) -> list[Sig]:
     for name, sig in sigs:
         sig_map.setdefault(name, []).append(sig)
 
-    result = []
-    for name, name_sigs in sig_map.items():
-        if len(set(name_sigs)) == 1:
-            result.append((name, name_sigs[0]))
-    return sorted(result)
+    return sorted(
+        (name, name_sigs[0])
+        for name, name_sigs in sig_map.items()
+        if len(set(name_sigs)) == 1
+    )
 
 
 def infer_prop_type_from_docstring(docstr: str | None) -> str | None:

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -379,9 +379,7 @@ def find_unique_signatures(sigs: Sequence[Sig]) -> list[Sig]:
         sig_map.setdefault(name, []).append(sig)
 
     return sorted(
-        (name, name_sigs[0])
-        for name, name_sigs in sig_map.items()
-        if len(set(name_sigs)) == 1
+        (name, name_sigs[0]) for name, name_sigs in sig_map.items() if len(set(name_sigs)) == 1
     )
 
 

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1062,7 +1062,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             return
         self.import_tracker.require_name("NamedTuple")
         self.add(f"{self._indent}class {lvalue.name}(NamedTuple):")
-        if len(items) == 0:
+        if not items:
             self.add(" ...\n")
         else:
             self.import_tracker.require_name("Incomplete")

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1013,7 +1013,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             ):
                 self.process_typealias(lvalue, o.rvalue)
                 continue
-            if isinstance(lvalue, TupleExpr) or isinstance(lvalue, ListExpr):
+            if isinstance(lvalue, (TupleExpr, ListExpr)):
                 items = lvalue.items
                 if isinstance(o.unanalyzed_type, TupleType):  # type: ignore[misc]
                     annotations: Iterable[Type | None] = o.unanalyzed_type.items

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1263,8 +1263,8 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         if name in self.defined_names:
             # Avoid name clash between name from typing and a name defined in stub.
             return "_" + name
-        else:
-            return name
+
+        return name
 
     def add_typing_import(self, name: str) -> None:
         """Add a name to be imported from typing, unless it's imported already.
@@ -1341,8 +1341,8 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         if can_be_any:
             self.add_typing_import("Incomplete")
             return self.typing_name("Incomplete")
-        else:
-            return ""
+
+        return ""
 
     def print_annotation(self, t: Type) -> str:
         printer = AnnotationPrinter(self)
@@ -1406,10 +1406,10 @@ def find_self_initializers(fdef: FuncBase) -> list[tuple[str, Expression]]:
 def get_qualified_name(o: Expression) -> str:
     if isinstance(o, NameExpr):
         return o.name
-    elif isinstance(o, MemberExpr):
+    if isinstance(o, MemberExpr):
         return f"{get_qualified_name(o.expr)}.{o.name}"
-    else:
-        return ERROR_MARKER
+
+    return ERROR_MARKER
 
 
 def remove_blacklisted_modules(modules: list[StubSource]) -> list[StubSource]:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -215,7 +215,7 @@ def add_typing_import(output: list[str]) -> list[str]:
     if names:
         return [f"from typing import {', '.join(names)}", ""] + output
 
-    return output[:]
+    return output.copy()
 
 
 def is_c_function(obj: object) -> bool:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -79,8 +79,8 @@ class ExternalSignatureGenerator(SignatureGenerator):
                     ret_type="Any",
                 )
             ]
-        else:
-            return None
+
+        return None
 
     def get_method_sig(
         self, func: object, module_name: str, class_name: str, name: str, self_var: str
@@ -214,8 +214,8 @@ def add_typing_import(output: list[str]) -> list[str]:
             names.append(name)
     if names:
         return [f"from typing import {', '.join(names)}", ""] + output
-    else:
-        return output[:]
+
+    return output[:]
 
 
 def is_c_function(obj: object) -> bool:
@@ -389,8 +389,8 @@ def generate_c_property_stub(
             if not inferred:
                 inferred = infer_prop_type_from_docstring(docstr)
             return inferred
-        else:
-            return None
+
+        return None
 
     # Ignore special properties/attributes.
     if is_skipped_attribute(name):

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1351,18 +1351,10 @@ def is_probably_private(name: str) -> bool:
 
 
 def is_probably_a_function(runtime: Any) -> bool:
-    return (
-        isinstance(
-            runtime,
-            (
-                types.FunctionType,
-                types.BuiltinFunctionType,
-                types.MethodType,
-                types.BuiltinMethodType,
-            )
-        )
-        or (inspect.ismethoddescriptor(runtime) and callable(runtime))
-    )
+    return isinstance(
+        runtime,
+        (types.FunctionType, types.BuiltinFunctionType, types.MethodType, types.BuiltinMethodType),
+    ) or (inspect.ismethoddescriptor(runtime) and callable(runtime))
 
 
 def is_read_only_property(runtime: object) -> bool:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1352,8 +1352,15 @@ def is_probably_private(name: str) -> bool:
 
 def is_probably_a_function(runtime: Any) -> bool:
     return (
-        isinstance(runtime, (types.FunctionType, types.BuiltinFunctionType))
-        or isinstance(runtime, (types.MethodType, types.BuiltinMethodType))
+        isinstance(
+            runtime,
+            (
+                types.FunctionType,
+                types.BuiltinFunctionType,
+                types.MethodType,
+                types.BuiltinMethodType,
+            )
+        )
         or (inspect.ismethoddescriptor(runtime) and callable(runtime))
     )
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1615,7 +1615,7 @@ def get_allowlist_entries(allowlist_file: str) -> Iterator[str]:
             return s.strip()
 
     with open(allowlist_file) as f:
-        for line in f.readlines():
+        for line in f:
             entry = strip_comments(line)
             if entry:
                 yield entry

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -167,8 +167,8 @@ def remove_misplaced_type_comments(source: str | bytes) -> str | bytes:
 
     if isinstance(source, bytes):
         return text.encode("latin1")
-    else:
-        return text
+
+    return text
 
 
 def common_dir_prefix(paths: list[str]) -> str:

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1624,7 +1624,7 @@ def are_parameters_compatible(
 
         # All *required* left-hand arguments must have a corresponding
         # right-hand argument.  Optional args do not matter.
-        if left_arg.required and right_by_pos is None and right_by_name is None:
+        if left_arg.required and right_by_pos is right_by_name is None:
             return False
 
     return True

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -278,11 +278,7 @@ def _is_subtype(
     left = get_proper_type(left)
     right = get_proper_type(right)
 
-    if not proper_subtype and (
-        isinstance(right, AnyType)
-        or isinstance(right, UnboundType)
-        or isinstance(right, ErasedType)
-    ):
+    if not proper_subtype and isinstance(right, (AnyType, UnboundType, ErasedType)):
         # TODO: should we consider all types proper subtypes of UnboundType and/or
         # ErasedType as we do for non-proper subtyping.
         return True
@@ -661,7 +657,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
         return False
 
     def visit_parameters(self, left: Parameters) -> bool:
-        if isinstance(self.right, Parameters) or isinstance(self.right, CallableType):
+        if isinstance(self.right, (Parameters, CallableType)):
             right = self.right
             if isinstance(right, CallableType):
                 right = right.with_unpacked_kwargs()

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -110,16 +110,10 @@ class SuggestionPlugin(Plugin):
         self.mystery_hits: list[Callsite] = []
 
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
-        if fullname == self.target:
-            return self.log
-        else:
-            return None
+        return self.log if fullname == self.target else None
 
     def get_method_hook(self, fullname: str) -> Callable[[MethodContext], Type] | None:
-        if fullname == self.target:
-            return self.log
-        else:
-            return None
+        return self.log if fullname == self.target else None
 
     def log(self, ctx: FunctionContext | MethodContext) -> Type:
         self.mystery_hits.append(
@@ -268,8 +262,8 @@ class SuggestionEngine:
 
         if self.give_json:
             return self.json_suggestion(mod, func_name, node, suggestion)
-        else:
-            return self.format_signature(suggestion)
+
+        return self.format_signature(suggestion)
 
     def suggest_callsites(self, function: str) -> str:
         """Find a list of call sites of function."""
@@ -326,8 +320,8 @@ class SuggestionEngine:
     def get_starting_type(self, fdef: FuncDef) -> CallableType:
         if isinstance(fdef.type, CallableType):
             return make_suggestion_anys(fdef.type)
-        else:
-            return self.get_trivial_type(fdef)
+
+        return self.get_trivial_type(fdef)
 
     def get_args(
         self,
@@ -817,8 +811,8 @@ class TypeFormatter(TypeStrVisitor):
     def visit_any(self, t: AnyType) -> str:
         if t.missing_import_name:
             return t.missing_import_name
-        else:
-            return "Any"
+
+        return "Any"
 
     def visit_instance(self, t: Instance) -> str:
         s = t.type.fullname or t.type.name or None
@@ -870,8 +864,8 @@ class TypeFormatter(TypeStrVisitor):
     def visit_union_type(self, t: UnionType) -> str:
         if len(t.items) == 2 and is_optional(t):
             return f"Optional[{remove_optional(t).accept(self)}]"
-        else:
-            return super().visit_union_type(t)
+
+        return super().visit_union_type(t)
 
     def visit_callable_type(self, t: CallableType) -> str:
         # TODO: use extended callables?
@@ -904,8 +898,8 @@ class MakeSuggestionAny(TypeTranslator):
     def visit_any(self, t: AnyType) -> Type:
         if not t.missing_import_name:
             return t.copy_modified(type_of_any=TypeOfAny.suggestion_engine)
-        else:
-            return t
+
+        return t
 
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:
         return t.copy_modified(args=[a.accept(self) for a in t.args])
@@ -921,8 +915,8 @@ def generate_type_combinations(types: list[Type]) -> list[Type]:
     union_type = make_simplified_union(types)
     if joined_type == union_type:
         return [joined_type]
-    else:
-        return [joined_type, union_type]
+
+    return [joined_type, union_type]
 
 
 def count_errors(msgs: list[str]) -> int:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -469,10 +469,8 @@ def strip_list(l: list[str]) -> list[str]:
     lines from the end of the array.
     """
 
-    r: list[str] = []
-    for s in l:
-        # Strip spaces at end of line
-        r.append(re.sub(r"\s+$", "", s))
+    # Strip spaces at end of line
+    r = [re.sub(r"\s+$", "", s) for s in l]
 
     while r and r[-1] == "":
         r.pop()

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -216,7 +216,7 @@ def parse_test_case(case: DataDrivenTestCase) -> None:
     case.expected_stale_modules = stale_modules
     case.expected_rechecked_modules = rechecked_modules
     case.deleted_paths = deleted_paths
-    case.triggered = triggered or []
+    case.triggered = triggered
     case.normalize_output = normalize_output
     case.expected_fine_grained_targets = targets
     case.test_modules = test_modules

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -713,8 +713,8 @@ def add_test_name_suffix(name: str, suffix: str) -> str:
         # are using endswith() checks.
         magic_suffix = m.group(0)
         return name[: -len(magic_suffix)] + suffix + magic_suffix
-    else:
-        return name + suffix
+
+    return name + suffix
 
 
 def is_incremental(testcase: DataDrivenTestCase) -> bool:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -474,7 +474,7 @@ def strip_list(l: list[str]) -> list[str]:
         # Strip spaces at end of line
         r.append(re.sub(r"\s+$", "", s))
 
-    while len(r) > 0 and r[-1] == "":
+    while r and r[-1] == "":
         r.pop()
 
     return r

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -284,14 +284,14 @@ def num_skipped_suffix_lines(a1: list[str], a2: list[str]) -> int:
 def testfile_pyversion(path: str) -> tuple[int, int]:
     if path.endswith("python311.test"):
         return 3, 11
-    elif path.endswith("python310.test"):
+    if path.endswith("python310.test"):
         return 3, 10
-    elif path.endswith("python39.test"):
+    if path.endswith("python39.test"):
         return 3, 9
-    elif path.endswith("python38.test"):
+    if path.endswith("python38.test"):
         return 3, 8
-    else:
-        return defaults.PYTHON3_VERSION
+
+    return defaults.PYTHON3_VERSION
 
 
 def normalize_error_messages(messages: list[str]) -> list[str]:
@@ -347,8 +347,8 @@ def assert_equal(a: object, b: object, fmt: str = "{} != {}") -> None:
 def typename(t: type) -> str:
     if "." in str(t):
         return str(t).split(".")[-1].rstrip("'>")
-    else:
-        return str(t)[8:-2]
+
+    return str(t)[8:-2]
 
 
 def assert_type(typ: type, value: object) -> None:

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -297,10 +297,7 @@ def testfile_pyversion(path: str) -> tuple[int, int]:
 def normalize_error_messages(messages: list[str]) -> list[str]:
     """Translate an array of error messages to use / as path separator."""
 
-    a = []
-    for m in messages:
-        a.append(m.replace(os.sep, "/"))
-    return a
+    return [m.replace(os.sep, "/") for m in messages]
 
 
 def retry_on_error(func: Callable[[], Any], max_wait: float = 1.0) -> None:

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -258,7 +258,7 @@ def local_sys_path_set() -> Iterator[None]:
     This can be used by test cases that do runtime imports, for example
     by the stubgen tests.
     """
-    old_sys_path = sys.path[:]
+    old_sys_path = sys.path.copy()
     if not ("" in sys.path or "." in sys.path):
         sys.path.insert(0, "")
     try:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -303,5 +303,5 @@ class TypeCheckSuite(DataSuite):
                     program_text = f.read()
                 out.append((module_name, path, program_text))
             return out
-        else:
-            return [("__main__", "main", program_text)]
+
+        return [("__main__", "main", program_text)]

--- a/mypy/test/testmerge.py
+++ b/mypy/test/testmerge.py
@@ -168,7 +168,7 @@ class ASTMergeSuite(DataSuite):
                 return "UNBOUND_IMPORTED"
             return "None"
         if isinstance(node.node, Node):
-            s = f"{str(type(node.node).__name__)}<{self.id_mapper.id(node.node)}>"
+            s = f"{type(node.node).__name__}<{self.id_mapper.id(node.node)}>"
         else:
             s = f"? ({type(node.node)})"
         if (

--- a/mypy/test/testmodulefinder.py
+++ b/mypy/test/testmodulefinder.py
@@ -153,7 +153,7 @@ class ModuleFinderSitePackagesSuite(Suite):
         self.search_paths = SearchPaths(
             python_path=(),
             mypy_path=(os.path.join(data_path, "pkg1"),),
-            package_path=tuple(package_paths),
+            package_path=package_paths,
             typeshed_path=(),
         )
         options = Options()

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -92,7 +92,7 @@ def test_pep561(testcase: DataDrivenTestCase) -> None:
             use_pip = False
         elif arg == "editable":
             editable = True
-    assert pkgs != [], "No packages to install for PEP 561 test?"
+    assert pkgs, "No packages to install for PEP 561 test?"
     with virtualenv(python) as venv:
         venv_dir, python_executable = venv
         for pkg in pkgs:

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -98,7 +98,7 @@ def test_pep561(testcase: DataDrivenTestCase) -> None:
         for pkg in pkgs:
             install_package(pkg, python_executable, use_pip, editable)
 
-        cmd_line = list(mypy_args)
+        cmd_line = mypy_args.copy()
         has_program = not ("-p" in cmd_line or "--package" in cmd_line)
         if has_program:
             program = testcase.name + ".py"

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -737,8 +737,8 @@ class StubgenPythonSuite(DataSuite):
         modules = re.search("# modules: (.*)$", program_text, flags=re.MULTILINE)
         if modules:
             return modules.group(1).split()
-        else:
-            return ["main"]
+
+        return ["main"]
 
     def add_file(self, path: str, result: list[str], header: bool) -> None:
         if not os.path.exists(path):

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -19,7 +19,7 @@ from mypy.test.data import root_dir
 @contextlib.contextmanager
 def use_tmp_dir(mod_name: str) -> Iterator[str]:
     current = os.getcwd()
-    current_syspath = sys.path[:]
+    current_syspath = sys.path.copy()
     with tempfile.TemporaryDirectory() as tmp:
         try:
             os.chdir(tmp)
@@ -27,7 +27,7 @@ def use_tmp_dir(mod_name: str) -> Iterator[str]:
                 sys.path.insert(0, tmp)
             yield tmp
         finally:
-            sys.path = current_syspath[:]
+            sys.path = current_syspath.copy()
             if mod_name in sys.modules:
                 del sys.modules[mod_name]
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -561,9 +561,8 @@ class TypeOpsSuite(Suite):
 
     def test_simplify_very_large_union(self) -> None:
         fx = self.fx
-        literals = []
-        for i in range(5000):
-            literals.append(LiteralType("v%d" % i, fx.str_type))
+        literals = [LiteralType("v%d" % i, fx.str_type) for i in range(5000)]
+
         # This shouldn't be very slow, even if the union is big.
         self.assert_simplified_union([*literals, fx.str_type], fx.str_type)
 

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -215,8 +215,8 @@ class TransformVisitor(NodeVisitor[Node]):
             result = self.func_placeholder_map[node]
             replace_object_state(result, new)
             return result
-        else:
-            return new
+
+        return new
 
     def visit_lambda_expr(self, node: LambdaExpr) -> LambdaExpr:
         new = LambdaExpr(
@@ -543,9 +543,9 @@ class TransformVisitor(NodeVisitor[Node]):
         if node.kind == REVEAL_TYPE:
             assert node.expr is not None
             return RevealExpr(kind=REVEAL_TYPE, expr=self.expr(node.expr))
-        else:
-            # Reveal locals expressions don't have any sub expressions
-            return node
+
+        # Reveal locals expressions don't have any sub expressions
+        return node
 
     def visit_super_expr(self, node: SuperExpr) -> SuperExpr:
         call = self.expr(node.call)
@@ -717,10 +717,7 @@ class TransformVisitor(NodeVisitor[Node]):
     # All the node helpers also propagate line numbers.
 
     def optional_expr(self, expr: Expression | None) -> Expression | None:
-        if expr:
-            return self.expr(expr)
-        else:
-            return None
+        return self.expr(expr) if expr else None
 
     def block(self, block: Block) -> Block:
         new = self.visit_block(block)
@@ -728,10 +725,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return new
 
     def optional_block(self, block: Block | None) -> Block | None:
-        if block:
-            return self.block(block)
-        else:
-            return None
+        return self.block(block) if block else None
 
     def statements(self, statements: list[Statement]) -> list[Statement]:
         return [self.stmt(stmt) for stmt in statements]
@@ -764,10 +758,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return type
 
     def optional_type(self, type: Type | None) -> Type | None:
-        if type:
-            return self.type(type)
-        else:
-            return None
+        return self.type(type) if type else None
 
     def types(self, types: list[Type]) -> list[Type]:
         return [self.type(type) for type in types]

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -145,7 +145,7 @@ class TransformVisitor(NodeVisitor[Node]):
     def visit_mypy_file(self, node: MypyFile) -> MypyFile:
         assert self.test_only, "This visitor should not be used for whole files."
         # NOTE: The 'names' and 'imports' instance variables will be empty!
-        ignored_lines = {line: codes[:] for line, codes in node.ignored_lines.items()}
+        ignored_lines = {line: codes.copy() for line, codes in node.ignored_lines.items()}
         new = MypyFile(self.statements(node.defs), [], node.is_bom, ignored_lines=ignored_lines)
         new._fullname = node._fullname
         new.path = node.path
@@ -153,10 +153,10 @@ class TransformVisitor(NodeVisitor[Node]):
         return new
 
     def visit_import(self, node: Import) -> Import:
-        return Import(node.ids[:])
+        return Import(node.ids.copy())
 
     def visit_import_from(self, node: ImportFrom) -> ImportFrom:
-        return ImportFrom(node.id, node.relative, node.names[:])
+        return ImportFrom(node.id, node.relative, node.names.copy())
 
     def visit_import_all(self, node: ImportAll) -> ImportAll:
         return ImportAll(node.id, node.relative)
@@ -267,10 +267,10 @@ class TransformVisitor(NodeVisitor[Node]):
         return new
 
     def visit_global_decl(self, node: GlobalDecl) -> GlobalDecl:
-        return GlobalDecl(node.names[:])
+        return GlobalDecl(node.names.copy())
 
     def visit_nonlocal_decl(self, node: NonlocalDecl) -> NonlocalDecl:
-        return NonlocalDecl(node.names[:])
+        return NonlocalDecl(node.names.copy())
 
     def visit_block(self, node: Block) -> Block:
         return Block(self.statements(node.body))
@@ -513,8 +513,8 @@ class TransformVisitor(NodeVisitor[Node]):
         return CallExpr(
             self.expr(node.callee),
             self.expressions(node.args),
-            node.arg_kinds[:],
-            node.arg_names[:],
+            node.arg_kinds.copy(),
+            node.arg_names.copy(),
             self.optional_expr(node.analyzed),
         )
 

--- a/mypy/tvar_scope.py
+++ b/mypy/tvar_scope.py
@@ -132,10 +132,10 @@ class TypeVarLikeScope:
         assert fullname
         if fullname in self.scope:
             return self.scope[fullname]
-        elif self.parent is not None:
+        if self.parent is not None:
             return self.parent.get_binding(fullname)
-        else:
-            return None
+
+        return None
 
     def __str__(self) -> str:
         me = ", ".join(f"{k}: {v.name}`{v.id}" for k, v in self.scope.items())

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -507,8 +507,8 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         ret = t.ret_type.accept(self)
         if self.strategy == ANY_STRATEGY:
             return args or ret
-        else:
-            return args and ret
+
+        return args and ret
 
     def visit_tuple_type(self, t: TupleType) -> bool:
         return self.query_types(t.items)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1844,13 +1844,12 @@ class TypeVarLikeQuery(TypeQuery[TypeVarLikeList]):
         name = t.name
         node = None
         # Special case P.args and P.kwargs for ParamSpecs only.
-        if name.endswith("args"):
-            if name.endswith(".args") or name.endswith(".kwargs"):
-                base = ".".join(name.split(".")[:-1])
-                n = self.api.lookup_qualified(base, t)
-                if n is not None and isinstance(n.node, ParamSpecExpr):
-                    node = n
-                    name = base
+        if name.endswith((".args", ".kwargs")):
+            base = ".".join(name.split(".")[:-1])
+            n = self.api.lookup_qualified(base, t)
+            if n is not None and isinstance(n.node, ParamSpecExpr):
+                node = n
+                name = base
         if node is None:
             node = self.api.lookup_qualified(name, t)
         if (

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1495,9 +1495,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
     ) -> list[Type]:
         old_allow_param_spec_literals = self.allow_param_spec_literals
         self.allow_param_spec_literals = allow_param_spec_literals
-        res: list[Type] = []
-        for t in a:
-            res.append(self.anal_type(t, nested, allow_param_spec=allow_param_spec))
+
+        res = [self.anal_type(t, nested, allow_param_spec=allow_param_spec) for t in a]
+
         self.allow_param_spec_literals = old_allow_param_spec_literals
         return self.check_unpacks_in_list(res)
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1084,8 +1084,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def visit_union_type(self, t: UnionType) -> Type:
         if (
-            t.uses_pep604_syntax is True
-            and t.is_evaluated is True
+            t.uses_pep604_syntax
+            and t.is_evaluated
             and not self.always_allow_new_syntax
             and not self.options.python_version >= (3, 10)
         ):

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1542,8 +1542,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 var_def.variance,
                 var_def.line,
             )
-        else:
-            return var_def
+
+        return var_def
 
     def anal_var_defs(self, var_defs: Sequence[TypeVarLikeType]) -> list[TypeVarLikeType]:
         return [self.anal_var_def(vd) for vd in var_defs]
@@ -1859,21 +1859,18 @@ class TypeVarLikeQuery(TypeQuery[TypeVarLikeList]):
         ):
             assert isinstance(node.node, TypeVarLikeExpr)
             return [(name, node.node)]
-        elif not self.include_callables and self._seems_like_callable(t):
+        if not self.include_callables and self._seems_like_callable(t):
             return []
-        elif node and node.fullname in LITERAL_TYPE_NAMES:
+        if node and node.fullname in LITERAL_TYPE_NAMES:
             return []
-        elif node and node.fullname in ANNOTATED_TYPE_NAMES and t.args:
+        if node and node.fullname in ANNOTATED_TYPE_NAMES and t.args:
             # Don't query the second argument to Annotated for TypeVars
             return self.query_types([t.args[0]])
-        else:
-            return super().visit_unbound_type(t)
+
+        return super().visit_unbound_type(t)
 
     def visit_callable_type(self, t: CallableType) -> TypeVarLikeList:
-        if self.include_callables:
-            return super().visit_callable_type(t)
-        else:
-            return []
+        return super().visit_callable_type(t) if self.include_callables else []
 
 
 class DivergingAliasDetector(TrivialSyntheticTypeTranslator):
@@ -2010,7 +2007,7 @@ def make_optional_type(t: Type) -> Type:
     p_t = get_proper_type(t)
     if isinstance(p_t, NoneType):
         return t
-    elif isinstance(p_t, UnionType):
+    if isinstance(p_t, UnionType):
         # Eagerly expanding aliases is not safe during semantic analysis.
         items = [
             item
@@ -2018,8 +2015,8 @@ def make_optional_type(t: Type) -> Type:
             if not isinstance(get_proper_type(item), NoneType)
         ]
         return UnionType(items + [NoneType()], t.line, t.column)
-    else:
-        return UnionType([t, NoneType()], t.line, t.column)
+
+    return UnionType([t, NoneType()], t.line, t.column)
 
 
 def fix_instance_types(

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1061,7 +1061,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             if t.base_type_name in ("builtins.int", "builtins.bool"):
                 # The only time it makes sense to use an int or bool is inside of
                 # a literal type.
-                msg = f"Invalid type: try using Literal[{repr(t.literal_value)}] instead?"
+                msg = f"Invalid type: try using Literal[{t.literal_value!r}] instead?"
             elif t.base_type_name in ("builtins.float", "builtins.complex"):
                 # We special-case warnings for floats and complex numbers.
                 msg = f"Invalid type: {t.simple_name()} literals cannot be used as a type"

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1718,7 +1718,7 @@ def expand_type_alias(
             fail=fail,
             unexpanded_type=unexpanded_type,
         )
-    if exp_len == 0 and act_len == 0:
+    if exp_len == act_len == 0:
         if no_args:
             assert isinstance(node.target, Instance)  # type: ignore[misc]
             # Note: this is the only case where we use an eager expansion. See more info about

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -380,7 +380,8 @@ def callable_corresponding_argument(
 
         if (
             not (by_name.required or by_pos.required)
-            and by_pos.name is by_name.pos is None
+            and by_pos.name is None
+            and by_name.pos is None
             and is_equivalent(by_name.typ, by_pos.typ)
         ):
             return FormalArgument(by_name.name, by_pos.pos, by_name.typ, False)

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -156,9 +156,12 @@ def type_object_type_from_function(
     else:
         # Overloaded __init__/__new__.
         assert isinstance(signature, Overloaded)
-        items: list[CallableType] = []
-        for item, orig_self in zip(signature.items, orig_self_types):
-            items.append(class_callable(item, info, fallback, special_sig, is_new, orig_self))
+
+        items = [
+            class_callable(item, info, fallback, special_sig, is_new, orig_self)
+            for item, orig_self in zip(signature.items, orig_self_types)
+        ]
+
         return Overloaded(items)
 
 

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -362,7 +362,7 @@ def callable_corresponding_argument(
 
     by_name = typ.argument_by_name(model.name)
     by_pos = typ.argument_by_position(model.pos)
-    if by_name is None and by_pos is None:
+    if by_name is by_pos is None:
         return None
     if by_name is not None and by_pos is not None:
         if by_name == by_pos:
@@ -377,8 +377,7 @@ def callable_corresponding_argument(
 
         if (
             not (by_name.required or by_pos.required)
-            and by_pos.name is None
-            and by_name.pos is None
+            and by_pos.name is by_name.pos is None
             and is_equivalent(by_name.typ, by_pos.typ)
         ):
             return FormalArgument(by_name.name, by_pos.pos, by_name.typ, False)

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -113,10 +113,10 @@ def tuple_fallback(typ: TupleType) -> Instance:
 def get_self_type(func: CallableType, default_self: Instance | TupleType) -> Type | None:
     if isinstance(get_proper_type(func.ret_type), UninhabitedType):
         return func.ret_type
-    elif func.arg_types and func.arg_types[0] != default_self and func.arg_kinds[0] == ARG_POS:
+    if func.arg_types and func.arg_types[0] != default_self and func.arg_kinds[0] == ARG_POS:
         return func.arg_types[0]
-    else:
-        return None
+
+    return None
 
 
 def type_object_type_from_function(
@@ -664,15 +664,15 @@ def erase_def_to_union_or_bound(tdef: TypeVarLikeType) -> Type:
     assert isinstance(tdef, TypeVarType)
     if tdef.values:
         return make_simplified_union(tdef.values)
-    else:
-        return tdef.upper_bound
+
+    return tdef.upper_bound
 
 
 def erase_to_union_or_bound(typ: TypeVarType) -> ProperType:
     if typ.values:
         return make_simplified_union(typ.values)
-    else:
-        return get_proper_type(typ.upper_bound)
+
+    return get_proper_type(typ.upper_bound)
 
 
 def function_type(func: FuncBase, fallback: Instance) -> FunctionLike:
@@ -810,16 +810,16 @@ def is_literal_type_like(t: Type | None) -> bool:
     t = get_proper_type(t)
     if t is None:
         return False
-    elif isinstance(t, LiteralType):
+    if isinstance(t, LiteralType):
         return True
-    elif isinstance(t, UnionType):
+    if isinstance(t, UnionType):
         return any(is_literal_type_like(item) for item in t.items)
-    elif isinstance(t, TypeVarType):
+    if isinstance(t, TypeVarType):
         return is_literal_type_like(t.upper_bound) or any(
             is_literal_type_like(item) for item in t.values
         )
-    else:
-        return False
+
+    return False
 
 
 def is_singleton_type(typ: Type) -> bool:
@@ -1047,5 +1047,5 @@ def fixup_partial_type(typ: Type) -> Type:
         return typ
     if typ.type is None:
         return UnionType.make_union([AnyType(TypeOfAny.unannotated), NoneType()])
-    else:
-        return Instance(typ.type, [AnyType(TypeOfAny.unannotated)] * len(typ.type.type_vars))
+
+    return Instance(typ.type, [AnyType(TypeOfAny.unannotated)] * len(typ.type.type_vars))

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1960,10 +1960,7 @@ class CallableType(FunctionLike):
         return bool(self.variables)
 
     def type_var_ids(self) -> list[TypeVarId]:
-        a: list[TypeVarId] = []
-        for tv in self.variables:
-            a.append(tv.id)
-        return a
+        return [tv.id for tv in self.variables]
 
     def param_spec(self) -> ParamSpecType | None:
         """Return ParamSpec if callable can be called with one.
@@ -2158,10 +2155,7 @@ class Overloaded(FunctionLike):
         return self._items[0].type_object()
 
     def with_name(self, name: str) -> Overloaded:
-        ni: list[CallableType] = []
-        for it in self._items:
-            ni.append(it.with_name(name))
-        return Overloaded(ni)
+        return Overloaded([it.with_name(name) for it in self._items])
 
     def get_name(self) -> str | None:
         return self._items[0].name
@@ -3135,9 +3129,8 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         return f"def {s}"
 
     def visit_overloaded(self, t: Overloaded) -> str:
-        a = []
-        for i in t.items:
-            a.append(i.accept(self))
+        a = [i.accept(self) for i in t.items]
+
         return f"Overload({', '.join(a)})"
 
     def visit_tuple_type(self, t: TupleType) -> str:
@@ -3207,10 +3200,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         """Convert items of an array to strings (pretty-print types)
         and join the results with commas.
         """
-        res = []
-        for t in a:
-            res.append(t.accept(self))
-        return ", ".join(res)
+        return ", ".join(t.accept(self) for t in a)
 
 
 class TrivialSyntheticTypeTranslator(TypeTranslator, SyntheticTypeVisitor[Type]):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1663,7 +1663,7 @@ class Parameters(ProperType):
         )
 
     def __eq__(self, other: object) -> bool:
-        if isinstance(other, Parameters) or isinstance(other, CallableType):
+        if isinstance(other, (Parameters, CallableType)):
             return (
                 self.arg_types == other.arg_types
                 and self.arg_names == other.arg_names
@@ -3290,7 +3290,7 @@ class InstantiateAliasVisitor(TrivialSyntheticTypeTranslator):
             # TODO: this branch duplicates the one in expand_type(), find a way to reuse it
             # without import cycle types <-> typeanal <-> expandtype.
             repl = get_proper_type(self.replacements.get(param_spec.id))
-            if isinstance(repl, CallableType) or isinstance(repl, Parameters):
+            if isinstance(repl, (CallableType, Parameters)):
                 prefix = param_spec.prefix
                 t = t.expand_param_spec(repl, no_prefix=True)
                 return t.copy_modified(

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -429,8 +429,8 @@ class RequiredType(Type):
     def __repr__(self) -> str:
         if self.required:
             return f"Required[{self.item}]"
-        else:
-            return f"NotRequired[{self.item}]"
+
+        return f"NotRequired[{self.item}]"
 
     def accept(self, visitor: TypeVisitor[T]) -> T:
         return self.item.accept(visitor)
@@ -1613,22 +1613,22 @@ class Parameters(ProperType):
         )
         if kind.is_positional():
             return FormalArgument(name, position, typ, kind == ARG_POS)
-        else:
-            return self.try_synthesizing_arg_from_vararg(position)
+
+        return self.try_synthesizing_arg_from_vararg(position)
 
     def try_synthesizing_arg_from_kwarg(self, name: str | None) -> FormalArgument | None:
         kw_arg = self.kw_arg()
         if kw_arg is not None:
             return FormalArgument(name, None, kw_arg.typ, False)
-        else:
-            return None
+
+        return None
 
     def try_synthesizing_arg_from_vararg(self, position: int | None) -> FormalArgument | None:
         var_arg = self.var_arg()
         if var_arg is not None:
             return FormalArgument(None, position, var_arg.typ, False)
-        else:
-            return None
+
+        return None
 
     def accept(self, visitor: TypeVisitor[T]) -> T:
         return visitor.visit_parameters(self)
@@ -1670,8 +1670,8 @@ class Parameters(ProperType):
                 and self.arg_kinds == other.arg_kinds
                 and self.is_ellipsis_args == other.is_ellipsis_args
             )
-        else:
-            return NotImplemented
+
+        return NotImplemented
 
 
 CT = TypeVar("CT", bound="CallableType")
@@ -1935,22 +1935,22 @@ class CallableType(FunctionLike):
         )
         if kind.is_positional():
             return FormalArgument(name, position, typ, kind == ARG_POS)
-        else:
-            return self.try_synthesizing_arg_from_vararg(position)
+
+        return self.try_synthesizing_arg_from_vararg(position)
 
     def try_synthesizing_arg_from_kwarg(self, name: str | None) -> FormalArgument | None:
         kw_arg = self.kw_arg()
         if kw_arg is not None:
             return FormalArgument(name, None, kw_arg.typ, False)
-        else:
-            return None
+
+        return None
 
     def try_synthesizing_arg_from_vararg(self, position: int | None) -> FormalArgument | None:
         var_arg = self.var_arg()
         if var_arg is not None:
             return FormalArgument(None, position, var_arg.typ, False)
-        else:
-            return None
+
+        return None
 
     @property
     def items(self) -> list[CallableType]:
@@ -2006,14 +2006,14 @@ class CallableType(FunctionLike):
                 is_ellipsis_args=c.is_ellipsis_args,
                 variables=[*variables, *self.variables],
             )
-        else:
-            return self.copy_modified(
-                arg_types=self.arg_types[:-2] + c.arg_types,
-                arg_kinds=self.arg_kinds[:-2] + c.arg_kinds,
-                arg_names=self.arg_names[:-2] + c.arg_names,
-                is_ellipsis_args=c.is_ellipsis_args,
-                variables=[*variables, *self.variables],
-            )
+
+        return self.copy_modified(
+            arg_types=self.arg_types[:-2] + c.arg_types,
+            arg_kinds=self.arg_kinds[:-2] + c.arg_kinds,
+            arg_names=self.arg_names[:-2] + c.arg_names,
+            is_ellipsis_args=c.is_ellipsis_args,
+            variables=[*variables, *self.variables],
+        )
 
     def with_unpacked_kwargs(self) -> NormalizedCallableType:
         if not self.unpack_kwargs:
@@ -2067,8 +2067,8 @@ class CallableType(FunctionLike):
                 and self.is_ellipsis_args == other.is_ellipsis_args
                 and self.fallback == other.fallback
             )
-        else:
-            return NotImplemented
+
+        return NotImplemented
 
     def serialize(self) -> JsonDict:
         # TODO: As an optimization, leave out everything related to
@@ -2506,8 +2506,8 @@ class RawExpressionType(ProperType):
                 self.base_type_name == other.base_type_name
                 and self.literal_value == other.literal_value
             )
-        else:
-            return NotImplemented
+
+        return NotImplemented
 
 
 class LiteralType(ProperType):
@@ -2553,8 +2553,8 @@ class LiteralType(ProperType):
     def __eq__(self, other: object) -> bool:
         if isinstance(other, LiteralType):
             return self.fallback == other.fallback and self.value == other.value
-        else:
-            return NotImplemented
+
+        return NotImplemented
 
     def is_enum_literal(self) -> bool:
         return self.fallback.type.is_enum
@@ -2577,11 +2577,11 @@ class LiteralType(ProperType):
             # Note: 'builtins.bytes' only appears in Python 3, so we want to
             # explicitly prefix with a "b"
             return "b" + raw
-        else:
-            # 'builtins.str' could mean either depending on context, but either way
-            # we don't prefix: it's the "native" string. And of course, if value is
-            # some other type, we just return that string repr directly.
-            return raw
+
+        # 'builtins.str' could mean either depending on context, but either way
+        # we don't prefix: it's the "native" string. And of course, if value is
+        # some other type, we just return that string repr directly.
+        return raw
 
     def serialize(self) -> JsonDict | str:
         return {
@@ -2649,10 +2649,10 @@ class UnionType(ProperType):
     def make_union(items: Sequence[Type], line: int = -1, column: int = -1) -> Type:
         if len(items) > 1:
             return UnionType(items, line, column)
-        elif len(items) == 1:
+        if len(items) == 1:
             return items[0]
-        else:
-            return UninhabitedType()
+
+        return UninhabitedType()
 
     def length(self) -> int:
         return len(self.items)
@@ -2676,8 +2676,8 @@ class UnionType(ProperType):
         """Removes NoneTypes from Unions when strict Optional checking is off."""
         if state.strict_optional:
             return self.items
-        else:
-            return [i for i in self.items if not isinstance(get_proper_type(i), NoneType)]
+
+        return [i for i in self.items if not isinstance(get_proper_type(i), NoneType)]
 
     def serialize(self) -> JsonDict:
         return {".class": "UnionType", "items": [t.serialize() for t in self.items]}
@@ -2918,8 +2918,8 @@ def get_proper_types(
         ):
             return cast("list[ProperType]", typelist)
         return [get_proper_type(t) for t in typelist]
-    else:
-        return [get_proper_type(t) for t in types]
+
+    return [get_proper_type(t) for t in types]
 
 
 # We split off the type visitor base classes to another module
@@ -2967,8 +2967,8 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         typ = t.typ.accept(self)
         if t.name is None:
             return f"{t.constructor}({typ})"
-        else:
-            return f"{t.constructor}({typ}, {t.name})"
+
+        return f"{t.constructor}({typ}, {t.name})"
 
     def visit_any(self, t: AnyType) -> str:
         if self.any_as_dots and t.type_of_any == TypeOfAny.special_form:
@@ -2987,8 +2987,8 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
     def visit_deleted_type(self, t: DeletedType) -> str:
         if t.source is None:
             return "<Deleted>"
-        else:
-            return f"<Deleted '{t.source}'>"
+
+        return f"<Deleted '{t.source}'>"
 
     def visit_instance(self, t: Instance) -> str:
         if t.last_known_value and not t.args:
@@ -3152,8 +3152,8 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         def item_str(name: str, typ: str) -> str:
             if name in t.required_keys:
                 return f"{name!r}: {typ}"
-            else:
-                return f"{name!r}?: {typ}"
+
+            return f"{name!r}?: {typ}"
 
         s = (
             "{"
@@ -3179,8 +3179,8 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
     def visit_partial_type(self, t: PartialType) -> str:
         if t.type is None:
             return "<partial None>"
-        else:
-            return "<partial {}[{}]>".format(t.type.name, ", ".join(["?"] * len(t.type.type_vars)))
+
+        return "<partial {}[{}]>".format(t.type.name, ", ".join(["?"] * len(t.type.type_vars)))
 
     def visit_ellipsis_type(self, t: EllipsisType) -> str:
         return "..."
@@ -3258,10 +3258,10 @@ def strip_type(typ: Type) -> Type:
     typ = get_proper_type(typ)
     if isinstance(typ, CallableType):
         return typ.copy_modified(name=None)
-    elif isinstance(typ, Overloaded):
+    if isinstance(typ, Overloaded):
         return Overloaded([cast(CallableType, strip_type(item)) for item in typ.items])
-    else:
-        return orig_typ
+
+    return orig_typ
 
 
 def is_named_instance(t: Type, fullnames: str | tuple[str, ...]) -> TypeGuard[Instance]:
@@ -3475,8 +3475,8 @@ def remove_optional(typ: Type) -> Type:
         return UnionType.make_union(
             [t for t in typ.items if not isinstance(get_proper_type(t), NoneType)]
         )
-    else:
-        return typ
+
+    return typ
 
 
 def is_literal_type(typ: ProperType, fallback_fullname: str, value: LiteralValue) -> bool:

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -161,7 +161,7 @@ class TypeState:
             # These are unlikely to match, due to the large space of
             # possible values.  Avoid uselessly increasing cache sizes.
             return
-        cache = self._subtype_caches.setdefault(right.type, dict())
+        cache = self._subtype_caches.setdefault(right.type, {})
         cache.setdefault(kind, set()).add((left, right))
 
     def reset_protocol_deps(self) -> None:

--- a/mypy/typevartuples.py
+++ b/mypy/typevartuples.py
@@ -116,7 +116,7 @@ def fully_split_with_mapped_and_template(
     if mapped_prefix_len is not None:
         assert mapped_suffix_len is not None
         mapped_prefix, mapped_middle, mapped_suffix = split_with_prefix_and_suffix(
-            tuple(mapped), mapped_prefix_len, mapped_suffix_len
+            mapped, mapped_prefix_len, mapped_suffix_len
         )
     else:
         mapped_prefix = ()
@@ -124,7 +124,7 @@ def fully_split_with_mapped_and_template(
         mapped_middle = mapped
 
     template_prefix, template_middle, template_suffix = split_with_prefix_and_suffix(
-        tuple(template), template_prefix_len, template_suffix_len
+        template, template_prefix_len, template_suffix_len
     )
 
     unpack_prefix = find_unpack_in_list(template_middle)

--- a/mypy/typevartuples.py
+++ b/mypy/typevartuples.py
@@ -119,8 +119,8 @@ def fully_split_with_mapped_and_template(
             tuple(mapped), mapped_prefix_len, mapped_suffix_len
         )
     else:
-        mapped_prefix = tuple()
-        mapped_suffix = tuple()
+        mapped_prefix = ()
+        mapped_suffix = ()
         mapped_middle = mapped
 
     template_prefix, template_middle, template_suffix = split_with_prefix_and_suffix(

--- a/mypy/typevartuples.py
+++ b/mypy/typevartuples.py
@@ -31,8 +31,8 @@ def split_with_prefix_and_suffix(
 ) -> tuple[tuple[T, ...], tuple[T, ...], tuple[T, ...]]:
     if suffix:
         return (types[:prefix], types[prefix:-suffix], types[-suffix:])
-    else:
-        return (types[:prefix], types[prefix:], ())
+
+    return (types[:prefix], types[prefix:], ())
 
 
 def split_with_instance(

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -716,17 +716,17 @@ class FancyFormatter:
                 + self.highlight_quote_groups(msg)
                 + self.style(code, "yellow")
             )
-        elif ": note:" in error:
+        if ": note:" in error:
             loc, msg = error.split("note:", maxsplit=1)
             formatted = self.highlight_quote_groups(self.underline_link(msg))
             return loc + self.style("note:", "blue") + formatted
-        elif error.startswith(" " * DEFAULT_SOURCE_OFFSET):
+        if error.startswith(" " * DEFAULT_SOURCE_OFFSET):
             # TODO: detecting source code highlights through an indent can be surprising.
             if "^" not in error:
                 return self.style(error, "none", dim=True)
             return self.style(error, "red")
-        else:
-            return error
+
+        return error
 
     def highlight_quote_groups(self, msg: str) -> str:
         """Make groups quoted with double quotes bold (including quotes).
@@ -816,7 +816,5 @@ def time_spent_us(t0: int) -> int:
 
 def plural_s(s: int | Sized) -> str:
     count = s if isinstance(s, int) else len(s)
-    if count != 1:
-        return "s"
-    else:
-        return ""
+
+    return "" if count == 1 else "s"

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -228,9 +228,7 @@ def get_mypy_comments(source: str) -> list[tuple[int, str]]:
     lines = source.split("\n")
 
     return [
-        (i + 1, line[len(PREFIX) :])
-        for i, line in enumerate(lines)
-        if line.startswith(PREFIX)
+        (i + 1, line[len(PREFIX) :]) for i, line in enumerate(lines) if line.startswith(PREFIX)
     ]
 
 

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -226,12 +226,12 @@ def get_mypy_comments(source: str) -> list[tuple[int, str]]:
     if PREFIX not in source:
         return []
     lines = source.split("\n")
-    results = []
-    for i, line in enumerate(lines):
-        if line.startswith(PREFIX):
-            results.append((i + 1, line[len(PREFIX) :]))
 
-    return results
+    return [
+        (i + 1, line[len(PREFIX) :])
+        for i, line in enumerate(lines)
+        if line.startswith(PREFIX)
+    ]
 
 
 PASS_TEMPLATE: Final = """<?xml version="1.0" encoding="utf-8"?>

--- a/mypyc/analysis/blockfreq.py
+++ b/mypyc/analysis/blockfreq.py
@@ -27,6 +27,5 @@ def frequently_executed_blocks(entry_point: BasicBlock) -> set[BasicBlock]:
             if t.rare or t.traceback_entry is not None:
                 worklist.append(t.false)
             else:
-                worklist.append(t.true)
-                worklist.append(t.false)
+                worklist.extend((t.true, t.false))
     return result

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -545,7 +545,7 @@ def run_analysis(
         block_kill[block] = kill
 
     # Set up initial state for worklist algorithm.
-    worklist = list(blocks)
+    worklist = blocks.copy()
     if not backward:
         worklist = worklist[::-1]  # Reverse for a small performance improvement
     workset = set(worklist)

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -143,7 +143,7 @@ def cleanup_cfg(blocks: list[BasicBlock]) -> None:
         # Then delete any blocks that have no predecessors
         changed = False
         cfg = get_cfg(blocks)
-        orig_blocks = blocks[:]
+        orig_blocks = blocks.copy()
         blocks.clear()
         for i, block in enumerate(orig_blocks):
             if i == 0 or cfg.pred[block]:

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -297,8 +297,8 @@ class DefinedVisitor(BaseAnalysisVisitor[Value]):
         # Loading an error value may undefine the register.
         if isinstance(op.src, LoadErrorValue) and (op.src.undefines or self.strict_errors):
             return set(), {op.dest}
-        else:
-            return {op.dest}, set()
+
+        return {op.dest}, set()
 
     def visit_assign_multi(self, op: AssignMulti) -> GenAndKill[Value]:
         # Array registers are special and we don't track the definedness of them.
@@ -457,8 +457,8 @@ class LivenessVisitor(BaseAnalysisVisitor[Value]):
     def visit_return(self, op: Return) -> GenAndKill[Value]:
         if not isinstance(op.value, Integer):
             return {op.value}, set()
-        else:
-            return set(), set()
+
+        return set(), set()
 
     def visit_unreachable(self, op: Unreachable) -> GenAndKill[Value]:
         return set(), set()
@@ -467,8 +467,8 @@ class LivenessVisitor(BaseAnalysisVisitor[Value]):
         gen = non_trivial_sources(op)
         if not op.is_void:
             return gen, {op}
-        else:
-            return gen, set()
+
+        return gen, set()
 
     def visit_assign(self, op: Assign) -> GenAndKill[Value]:
         return non_trivial_sources(op), {op.dest}

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -67,10 +67,11 @@ class CFG:
         self.exits = exits
 
     def __str__(self) -> str:
-        lines = []
-        lines.append("exits: %s" % sorted(self.exits, key=lambda e: int(e.label)))
-        lines.append("succ: %s" % self.succ)
-        lines.append("pred: %s" % self.pred)
+        lines = [
+            "exits: %s" % sorted(self.exits, key=lambda e: int(e.label)),
+            "succ: %s" % self.succ,
+            "pred: %s" % self.pred,
+        ]
         return "\n".join(lines)
 
 

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -249,8 +249,8 @@ class Emitter:
         if target_group_name and target_group_name != self.context.group_name:
             self.context.group_deps.add(target_group_name)
             return f"exports_{exported_name(target_group_name)}."
-        else:
-            return ""
+
+        return ""
 
     def get_group_prefix(self, obj: ClassIR | FuncDecl) -> str:
         """Get the group prefix for an object."""
@@ -285,8 +285,8 @@ class Emitter:
         ctype = self.ctype(rtype)
         if ctype[-1] == "*":
             return ctype
-        else:
-            return ctype + " "
+
+        return ctype + " "
 
     def c_undefined_value(self, rtype: RType) -> str:
         if not rtype.is_unboxed:
@@ -408,8 +408,8 @@ class Emitter:
             return self.tuple_undefined_check_cond(
                 rtype, value, self.c_error_value, compare, check_exception=False
             )
-        else:
-            return f"{value} {compare} {self.c_error_value(rtype)}"
+
+        return f"{value} {compare} {self.c_error_value(rtype)}"
 
     def tuple_undefined_check_cond(
         self,

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -326,7 +326,7 @@ class Emitter:
                     self.ctype(rtuple), self.tuple_undefined_value(rtuple), "".join(values)
                 ),
                 "#endif",
-                ""
+                "",
             )
         )
 

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -320,13 +320,15 @@ class Emitter:
                 i += 1
         result.append(f"}} {rtuple.struct_name};")
         values = self.tuple_undefined_value_helper(rtuple)
-        result.append(
-            "static {} {} = {{ {} }};".format(
-                self.ctype(rtuple), self.tuple_undefined_value(rtuple), "".join(values)
+        result.extend(
+            (
+                "static {} {} = {{ {} }};".format(
+                    self.ctype(rtuple), self.tuple_undefined_value(rtuple), "".join(values)
+                ),
+                "#endif",
+                ""
             )
         )
-        result.append("#endif")
-        result.append("")
 
         return result
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -944,9 +944,7 @@ def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
     if not deletable:
         emitter.emit_line("if (value == NULL) {")
         emitter.emit_line("PyErr_SetString(PyExc_AttributeError,")
-        emitter.emit_line(
-            f'    "{cl.name!r} object attribute {attr!r} cannot be deleted");'
-        )
+        emitter.emit_line(f'    "{cl.name!r} object attribute {attr!r} cannot be deleted");')
         emitter.emit_line("return -1;")
         emitter.emit_line("}")
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -399,8 +399,7 @@ def generate_object_struct(cl: ClassIR, emitter: Emitter) -> None:
                     if isinstance(rtype, RTuple):
                         emitter.declare_tuple_struct(rtype)
 
-    lines.append(f"}} {cl.struct_name(emitter.names)};")
-    lines.append("")
+    lines.extend((f"}} {cl.struct_name(emitter.names)};", ""))
     emitter.context.declarations[cl.struct_name(emitter.names)] = HeaderDeclaration(
         lines, is_type=True
     )

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -139,9 +139,9 @@ def generate_call_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> str:
     if emitter.use_vectorcall():
         # Use vectorcall wrapper if supported (PEP 590).
         return "PyVectorcall_Call"
-    else:
-        # On older Pythons use the legacy wrapper.
-        return wrapper_slot(cl, fn, emitter)
+
+    # On older Pythons use the legacy wrapper.
+    return wrapper_slot(cl, fn, emitter)
 
 
 def slot_key(attr: str) -> str:

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -922,7 +922,7 @@ def generate_getter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
     if not always_defined:
         emitter.emit_undefined_attr_check(rtype, attr_expr, "==", "self", attr, cl, unlikely=True)
         emitter.emit_line("PyErr_SetString(PyExc_AttributeError,")
-        emitter.emit_line(f'    "attribute {repr(attr)} of {repr(cl.name)} undefined");')
+        emitter.emit_line(f'    "attribute {attr!r} of {cl.name!r} undefined");')
         emitter.emit_line("return NULL;")
         emitter.emit_line("}")
     emitter.emit_inc_ref(f"self->{attr_field}", rtype)
@@ -946,7 +946,7 @@ def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
         emitter.emit_line("if (value == NULL) {")
         emitter.emit_line("PyErr_SetString(PyExc_AttributeError,")
         emitter.emit_line(
-            f'    "{repr(cl.name)} object attribute {repr(attr)} cannot be deleted");'
+            f'    "{cl.name!r} object attribute {attr!r} cannot be deleted");'
         )
         emitter.emit_line("return -1;")
         emitter.emit_line("}")

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -75,9 +75,9 @@ def native_function_type(fn: FuncIR, emitter: Emitter) -> str:
 
 
 def native_function_header(fn: FuncDecl, emitter: Emitter) -> str:
-    args = []
-    for arg in fn.sig.args:
-        args.append(f"{emitter.ctype_spaced(arg.type)}{REG_PREFIX}{arg.name}")
+    args = [
+        f"{emitter.ctype_spaced(arg.type)}{REG_PREFIX}{arg.name}" for arg in fn.sig.args
+    ]
 
     return "{ret_type}{name}({args})".format(
         ret_type=emitter.ctype_spaced(fn.sig.ret_type),

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -75,9 +75,7 @@ def native_function_type(fn: FuncIR, emitter: Emitter) -> str:
 
 
 def native_function_header(fn: FuncDecl, emitter: Emitter) -> str:
-    args = [
-        f"{emitter.ctype_spaced(arg.type)}{REG_PREFIX}{arg.name}" for arg in fn.sig.args
-    ]
+    args = [f"{emitter.ctype_spaced(arg.type)}{REG_PREFIX}{arg.name}" for arg in fn.sig.args]
 
     return "{ret_type}{name}({args})".format(
         ret_type=emitter.ctype_spaced(fn.sig.ret_type),

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -489,8 +489,8 @@ class FunctionEmitterVisitor(OpVisitor[None]):
     def get_dest_assign(self, dest: Value) -> str:
         if not dest.is_void:
             return self.reg(dest) + " = "
-        else:
-            return ""
+
+        return ""
 
     def visit_call(self, op: Call) -> None:
         """Call native function."""
@@ -732,8 +732,8 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             elif val <= -(1 << 31):
                 s += "LL"
             return s
-        else:
-            return self.emitter.reg(reg)
+
+        return self.emitter.reg(reg)
 
     def ctype(self, rtype: RType) -> str:
         return self.emitter.ctype(rtype)
@@ -781,15 +781,12 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             self.emit_line('assert(PyErr_Occurred() != NULL && "failure w/o err!");')
 
     def emit_signed_int_cast(self, type: RType) -> str:
-        if is_tagged(type):
-            return "(Py_ssize_t)"
-        else:
-            return ""
+        return "(Py_ssize_t)" if is_tagged(type) else ""
 
     def emit_unsigned_int_cast(self, type: RType) -> str:
         if is_int32_rprimitive(type):
             return "(uint32_t)"
-        elif is_int64_rprimitive(type):
+        if is_int64_rprimitive(type):
             return "(uint64_t)"
-        else:
-            return ""
+
+        return ""

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -452,9 +452,9 @@ def pointerize(decl: str, name: str) -> str:
     if "(" in decl:
         # Function pointer. Stick an * in front of the name and wrap it in parens.
         return decl.replace(name, f"(*{name})")
-    else:
-        # Non-function pointer. Just stick an * in front of the name.
-        return decl.replace(name, f"*{name}")
+
+    # Non-function pointer. Just stick an * in front of the name.
+    return decl.replace(name, f"*{name}")
 
 
 def group_dir(group_name: str) -> str:

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -179,7 +179,7 @@ def generate_wrapper_function(
         nargs = "nargs"
     parse_fn = "CPyArg_ParseStackAndKeywords"
     # Special case some common signatures
-    if len(real_args) == 0:
+    if not real_args:
         # No args
         parse_fn = "CPyArg_ParseStackAndKeywordsNoArgs"
     elif len(real_args) == 1 and len(groups[ARG_POS]) == 1:

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -961,9 +961,9 @@ class WrapperGenerator:
         if self.cleanups or self.traceback_code:
             # We'll have a label at the end with error handling code.
             return GotoHandler("fail")
-        else:
-            # Nothing special needs to done to handle errors, so just return.
-            return ReturnHandler("NULL")
+
+        # Nothing special needs to done to handle errors, so just return.
+        return ReturnHandler("NULL")
 
     def emit_error_handling(self) -> None:
         """Emit error handling block at the end of the wrapper, if needed."""

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -182,7 +182,7 @@ def generate_wrapper_function(
     if not real_args:
         # No args
         parse_fn = "CPyArg_ParseStackAndKeywordsNoArgs"
-    elif len(real_args) == 1 and len(groups[ARG_POS]) == 1:
+    elif len(real_args) == len(groups[ARG_POS]) == 1:
         # Single positional arg
         parse_fn = "CPyArg_ParseStackAndKeywordsOneArg"
     elif len(real_args) == len(groups[ARG_POS]) + len(groups[ARG_OPT]):
@@ -680,7 +680,7 @@ def generate_set_del_item_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> 
         emitter.emit_line("if (super == NULL) return -1;")
         emitter.emit_line("PyObject *result;")
 
-        if method_cls is None and cl.builtin_base is None:
+        if method_cls is cl.builtin_base is None:
             msg = f"'{cl.name}' object does not support item assignment"
             emitter.emit_line(f'PyErr_SetString(PyExc_TypeError, "{msg}");')
             emitter.emit_line("result = NULL;")

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -680,7 +680,7 @@ def generate_set_del_item_wrapper(cl: ClassIR, fn: FuncIR, emitter: Emitter) -> 
         emitter.emit_line("if (super == NULL) return -1;")
         emitter.emit_line("PyObject *result;")
 
-        if method_cls is cl.builtin_base is None:
+        if method_cls is None and cl.builtin_base is None:
             msg = f"'{cl.name}' object does not support item assignment"
             emitter.emit_line(f'PyErr_SetString(PyExc_TypeError, "{msg}");')
             emitter.emit_line("result = NULL;")

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -295,6 +295,5 @@ def _encode_complex_values(values: dict[complex, int]) -> list[str]:
     result.append(str(num))
     for i in range(num):
         value = value_by_index[i]
-        result.append(float_to_c(value.real))
-        result.append(float_to_c(value.imag))
+        result.extend((float_to_c(value.real), float_to_c(value.imag)))
     return result

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -40,12 +40,12 @@ SIZEOF_SIZE_T: Final = (
     else (sys.maxsize + 1).bit_length() // 8
 )
 
-IS_32_BIT_PLATFORM: Final = int(SIZEOF_SIZE_T) == 4
+IS_32_BIT_PLATFORM: Final = SIZEOF_SIZE_T == 4
 
 PLATFORM_SIZE = 4 if IS_32_BIT_PLATFORM else 8
 
 # Maximum value for a short tagged integer.
-MAX_SHORT_INT: Final = 2 ** (8 * int(SIZEOF_SIZE_T) - 2) - 1
+MAX_SHORT_INT: Final = 2 ** (8 * SIZEOF_SIZE_T - 2) - 1
 
 # Minimum value for a short tagged integer.
 MIN_SHORT_INT: Final = -(MAX_SHORT_INT) - 1

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -120,10 +120,8 @@ def get_id_from_name(name: str, fullname: str, line: int) -> str:
     a dictionary key. This is usually the fullname of the function, but this is different in that
     it handles the case where the function is named '_', in which case multiple different functions
     could have the same name."""
-    if unnamed_function(name):
-        return f"{fullname}.{line}"
-    else:
-        return fullname
+
+    return f"{fullname}.{line}" if unnamed_function(name) else fullname
 
 
 def short_id_from_name(func_name: str, shortname: str, line: int | None) -> str:

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -257,8 +257,8 @@ class ClassIR:
                 if subc.method_decl(name) != method_decl:
                     return False
             return True
-        else:
-            return not any(subc.has_method(name) for subc in subs)
+
+        return not any(subc.has_method(name) for subc in subs)
 
     def has_attr(self, name: str) -> bool:
         try:

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -89,8 +89,8 @@ class FuncSignature:
     def bound_sig(self) -> "FuncSignature":
         if self.num_bitmap_args:
             return FuncSignature(self.args[1 : -self.num_bitmap_args], self.ret_type)
-        else:
-            return FuncSignature(self.args[1:], self.ret_type)
+
+        return FuncSignature(self.args[1:], self.ret_type)
 
     def __repr__(self) -> str:
         return f"FuncSignature(args={self.args!r}, ret={self.ret_type!r})"
@@ -293,8 +293,8 @@ class FuncIR:
     def __repr__(self) -> str:
         if self.class_name:
             return f"<FuncIR {self.class_name}.{self.name}>"
-        else:
-            return f"<FuncIR {self.name}>"
+
+        return f"<FuncIR {self.name}>"
 
     def serialize(self) -> JsonDict:
         # We don't include blocks in the serialized version

--- a/mypyc/ir/module_ir.py
+++ b/mypyc/ir/module_ir.py
@@ -23,7 +23,7 @@ class ModuleIR:
         final_names: list[tuple[str, RType]],
     ) -> None:
         self.fullname = fullname
-        self.imports = imports[:]
+        self.imports = imports.copy()
         self.functions = functions
         self.classes = classes
         self.final_names = final_names

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -279,7 +279,7 @@ class AssignMulti(BaseAssign):
         self.src = src
 
     def sources(self) -> list[Value]:
-        return self.src[:]
+        return self.src.copy()
 
     def stolen(self) -> list[Value]:
         return []
@@ -522,7 +522,7 @@ class Call(RegisterOp):
         super().__init__(line)
 
     def sources(self) -> list[Value]:
-        return list(self.args[:])
+        return list(self.args.copy())
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_call(self)
@@ -550,7 +550,7 @@ class MethodCall(RegisterOp):
         super().__init__(line)
 
     def sources(self) -> list[Value]:
-        return self.args[:] + [self.obj]
+        return self.args.copy() + [self.obj]
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_method_call(self)
@@ -770,7 +770,7 @@ class TupleSet(RegisterOp):
         self.type = self.tuple_type
 
     def sources(self) -> list[Value]:
-        return self.items[:]
+        return self.items.copy()
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_tuple_set(self)
@@ -1285,7 +1285,7 @@ class KeepAlive(RegisterOp):
         self.src = src
 
     def sources(self) -> list[Value]:
-        return self.src[:]
+        return self.src.copy()
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_keep_alive(self)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -949,8 +949,8 @@ class CallC(RegisterOp):
         if isinstance(self.steals, list):
             assert len(self.steals) == len(self.args)
             return [arg for arg, steal in zip(self.args, self.steals) if steal]
-        else:
-            return [] if not self.steals else self.sources()
+
+        return [] if not self.steals else self.sources()
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_call_c(self)
@@ -1253,8 +1253,8 @@ class LoadAddress(RegisterOp):
     def sources(self) -> list[Value]:
         if isinstance(self.src, Register):
             return [self.src]
-        else:
-            return []
+
+        return []
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_load_address(self)

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -427,11 +427,7 @@ def generate_names_for_ir(args: list[Register], blocks: list[BasicBlock]) -> dic
 
     for block in blocks:
         for op in block.ops:
-            values = []
-
-            for source in op.sources():
-                if source not in names:
-                    values.append(source)
+            values = [source for source in op.sources() if source not in names]
 
             if isinstance(op, (Assign, AssignMulti)):
                 values.append(op.dest)

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -137,7 +137,7 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
             return self.format("%r.%s = %r; %r = is_error", op.obj, op.attr, op.src, op)
 
     def visit_load_static(self, op: LoadStatic) -> str:
-        ann = f"  ({repr(op.ann)})" if op.ann else ""
+        ann = f"  ({op.ann!r})" if op.ann else ""
         name = op.identifier
         if op.module_name is not None:
             name = f"{op.module_name}.{name}"
@@ -224,7 +224,7 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         return self.format("%r = extend%s %r: %t to %t", op, extra, op.src, op.src_type, op.type)
 
     def visit_load_global(self, op: LoadGlobal) -> str:
-        ann = f"  ({repr(op.ann)})" if op.ann else ""
+        ann = f"  ({op.ann!r})" if op.ann else ""
         return self.format("%r = load_global %s :: static%s", op, op.identifier, ann)
 
     def visit_int_op(self, op: IntOp) -> str:

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -133,8 +133,8 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         if op.error_kind == ERR_NEVER:
             # Initialization and direct struct access can never fail
             return self.format("%r.%s = %r", op.obj, op.attr, op.src)
-        else:
-            return self.format("%r.%s = %r; %r = is_error", op.obj, op.attr, op.src, op)
+
+        return self.format("%r.%s = %r; %r = is_error", op.obj, op.attr, op.src, op)
 
     def visit_load_static(self, op: LoadStatic) -> str:
         ann = f"  ({op.ann!r})" if op.ann else ""
@@ -210,8 +210,8 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
         args_str = ", ".join(self.format("%r", arg) for arg in op.args)
         if op.is_void:
             return self.format("%s(%s)", op.function_name, args_str)
-        else:
-            return self.format("%r = %s(%s)", op, op.function_name, args_str)
+
+        return self.format("%r = %s(%s)", op, op.function_name, args_str)
 
     def visit_truncate(self, op: Truncate) -> str:
         return self.format("%r = truncate %r: %t to %t", op, op.src, op.src_type, op.type)
@@ -253,8 +253,8 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
     def visit_load_address(self, op: LoadAddress) -> str:
         if isinstance(op.src, Register):
             return self.format("%r = load_address %r", op, op.src)
-        else:
-            return self.format("%r = load_address %s", op, op.src)
+
+        return self.format("%r = load_address %s", op, op.src)
 
     def visit_keep_alive(self, op: KeepAlive) -> str:
         return self.format("keep_alive %s" % ", ".join(self.format("%r", v) for v in op.src))

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -818,8 +818,8 @@ class RUnion(RType):
                 seen.add(item)
         if len(new_items) > 1:
             return RUnion(new_items)
-        else:
-            return new_items[0]
+
+        return new_items[0]
 
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_runion(self)

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -883,8 +883,8 @@ class IRBuilder:
         assert isinstance(target_type, Instance), target_type
         if target_type.type.fullname == "builtins.str":
             return str_rprimitive
-        else:
-            return self.type_to_rtype(target_type.args[0])
+
+        return self.type_to_rtype(target_type.args[0])
 
     def get_dict_base_type(self, expr: Expression) -> list[Instance]:
         """Find dict type of a dict-like expression.

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -866,10 +866,10 @@ class IRBuilder:
     def extract_int(self, e: Expression) -> int | None:
         if isinstance(e, IntExpr):
             return e.value
-        elif isinstance(e, UnaryExpr) and e.op == "-" and isinstance(e.expr, IntExpr):
+        if isinstance(e, UnaryExpr) and e.op == "-" and isinstance(e.expr, IntExpr):
             return -e.expr.value
-        else:
-            return None
+
+        return None
 
     def get_sequence_type(self, expr: Expression) -> RType:
         return self.get_sequence_type_from_type(self.types[expr])
@@ -943,9 +943,9 @@ class IRBuilder:
             for item in iterable.items:
                 joined = join_types(joined, item)
             return joined
-        else:
-            # Non-tuple iterable.
-            return echk.check_method_call_by_name("__next__", iterator, [], [], expr)[0]
+
+        # Non-tuple iterable.
+        return echk.check_method_call_by_name("__next__", iterator, [], [], expr)[0]
 
     def is_native_module(self, module: str) -> bool:
         """Is the given module one compiled by mypyc?"""
@@ -1011,10 +1011,10 @@ class IRBuilder:
         """
         if final_var.final_value is not None:  # this is safe even for non-native names
             return self.load_final_literal_value(final_var.final_value, line)
-        elif native:
+        if native:
             return self.load_final_static(fullname, self.mapper.type_to_rtype(typ), line, name)
-        else:
-            return None
+
+        return None
 
     def is_module_member_expr(self, expr: MemberExpr) -> bool:
         return isinstance(expr.expr, RefExpr) and isinstance(expr.expr.node, MypyFile)

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -492,7 +492,7 @@ def transform_op_expr(builder: IRBuilder, expr: OpExpr) -> Value:
         return builder.shortcircuit_expr(expr)
 
     # Special case for string formatting
-    if expr.op == "%" and (isinstance(expr.left, StrExpr) or isinstance(expr.left, BytesExpr)):
+    if expr.op == "%" and isinstance(expr.left, (StrExpr, BytesExpr)):
         ret = translate_printf_style_formatting(builder, expr.left, expr.right)
         if ret is not None:
             return ret

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -381,7 +381,7 @@ def translate_method_call(builder: IRBuilder, expr: CallExpr, callee: MemberExpr
 def call_classmethod(builder: IRBuilder, ir: ClassIR, expr: CallExpr, callee: MemberExpr) -> Value:
     decl = ir.method_decl(callee.name)
     args = []
-    arg_kinds, arg_names = expr.arg_kinds[:], expr.arg_names[:]
+    arg_kinds, arg_names = expr.arg_kinds.copy(), expr.arg_names.copy()
     # Add the class argument for class methods in extension classes
     if decl.kind == FUNC_CLASSMETHOD and ir.is_ext_class:
         args.append(builder.load_native_type_object(ir.fullname))
@@ -448,7 +448,7 @@ def translate_super_method_call(builder: IRBuilder, expr: CallExpr, callee: Supe
 
     decl = base.method_decl(callee.name)
     arg_values = [builder.accept(arg) for arg in expr.args]
-    arg_kinds, arg_names = expr.arg_kinds[:], expr.arg_names[:]
+    arg_kinds, arg_names = expr.arg_kinds.copy(), expr.arg_names.copy()
 
     if decl.kind != FUNC_STATICMETHOD:
         # Grab first argument

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -274,10 +274,10 @@ def transform_call_expr(builder: IRBuilder, expr: CallExpr) -> Value:
     callee = expr.callee
     if isinstance(expr.analyzed, CastExpr):
         return translate_cast_expr(builder, expr.analyzed)
-    elif isinstance(expr.analyzed, AssertTypeExpr):
+    if isinstance(expr.analyzed, AssertTypeExpr):
         # Compile to a no-op.
         return builder.accept(expr.analyzed.expr)
-    elif (
+    if (
         isinstance(callee, (NameExpr, MemberExpr))
         and isinstance(callee.node, TypeInfo)
         and callee.node.is_newtype
@@ -292,10 +292,10 @@ def transform_call_expr(builder: IRBuilder, expr: CallExpr) -> Value:
         return apply_method_specialization(builder, expr, callee) or translate_method_call(
             builder, expr, callee
         )
-    elif isinstance(callee, SuperExpr):
+    if isinstance(callee, SuperExpr):
         return translate_super_method_call(builder, expr, callee)
-    else:
-        return translate_call(builder, expr, callee)
+
+    return translate_call(builder, expr, callee)
 
 
 def translate_call(builder: IRBuilder, expr: CallExpr, callee: Expression) -> Value:
@@ -1020,8 +1020,8 @@ def transform_slice_expr(builder: IRBuilder, expr: SliceExpr) -> Value:
     def get_arg(arg: Expression | None) -> Value:
         if arg is None:
             return builder.none_object()
-        else:
-            return builder.accept(arg)
+
+        return builder.accept(arg)
 
     args = [get_arg(expr.begin_index), get_arg(expr.end_index), get_arg(expr.stride)]
     return builder.call_c(new_slice_op, args, expr.line)

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -806,10 +806,10 @@ def transform_basic_comparison(
     if (
         is_int_rprimitive(left.type)
         and is_int_rprimitive(right.type)
-        and op in int_comparison_op_mapping.keys()
+        and op in int_comparison_op_mapping
     ):
         return builder.compare_tagged(left, right, op, line)
-    if is_fixed_width_rtype(left.type) and op in int_comparison_op_mapping.keys():
+    if is_fixed_width_rtype(left.type) and op in int_comparison_op_mapping:
         if right.type == left.type:
             op_id = ComparisonOp.signed_ops[op]
             return builder.builder.comparison_op(left, right, op_id, line)
@@ -820,7 +820,7 @@ def transform_basic_comparison(
             )
     elif (
         is_fixed_width_rtype(right.type)
-        and op in int_comparison_op_mapping.keys()
+        and op in int_comparison_op_mapping
         and isinstance(left, Integer)
     ):
         op_id = ComparisonOp.signed_ops[op]

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -209,7 +209,7 @@ def sequence_from_generator_preallocate_helper(
             See `new_list_set_item_op` and `new_tuple_set_item_op` for detailed
             implementation.
     """
-    if len(gen.sequences) == 1 and len(gen.indices) == 1 and len(gen.condlists[0]) == 0:
+    if len(gen.sequences) == len(gen.indices) == 1 and len(gen.condlists[0]) == 0:
         rtype = builder.node_type(gen.sequences[0])
         if is_list_rprimitive(rtype) or is_tuple_rprimitive(rtype) or is_str_rprimitive(rtype):
             sequence = builder.accept(gen.sequences[0])

--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -665,8 +665,8 @@ def unsafe_index(builder: IRBuilder, target: Value, index: Value, line: int) -> 
     # so we just check manually.
     if is_list_rprimitive(target.type):
         return builder.call_c(list_get_item_unsafe_op, [target, index], line)
-    else:
-        return builder.gen_method_call(target, "__getitem__", [index], None, line)
+
+    return builder.gen_method_call(target, "__getitem__", [index], None, line)
 
 
 class ForSequence(ForGenerator):

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -567,8 +567,8 @@ def gen_glue(
     """
     if fdef.is_property:
         return gen_glue_property(builder, base_sig, target, cls, base, fdef.line, do_py_ops)
-    else:
-        return gen_glue_method(builder, base_sig, target, cls, base, fdef.line, do_py_ops)
+
+    return gen_glue_method(builder, base_sig, target, cls, base, fdef.line, do_py_ops)
 
 
 class ArgInfo(NamedTuple):

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -257,7 +257,7 @@ class LowLevelIRBuilder:
 
     def flush_keep_alives(self) -> None:
         if self.keep_alives:
-            self.add(KeepAlive(self.keep_alives[:]))
+            self.add(KeepAlive(self.keep_alives.copy()))
             self.keep_alives = []
 
     # Type conversions

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1631,7 +1631,7 @@ class LowLevelIRBuilder:
         # for-loop and inline the SetMem operation, which is faster
         # than list_build_op, however generates more code.
         result_list = self.call_c(new_list_op, length, line)
-        if len(values) == 0:
+        if not values:
             return result_list
         args = [self.coerce(item, object_rprimitive, line) for item in values]
         ob_item_ptr = self.add(GetElementPtr(result_list, PyListObject, "ob_item", line))

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1474,7 +1474,7 @@ class LowLevelIRBuilder:
         equal = True if op == "==" else False
         result = Register(bool_rprimitive)
         # empty tuples
-        if len(lhs.type.types) == 0 and len(rhs.type.types) == 0:
+        if len(lhs.type.types) == len(rhs.type.types) == 0:
             self.add(Assign(result, self.true() if equal else self.false(), line))
             return result
         length = len(lhs.type.types)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -267,8 +267,8 @@ class LowLevelIRBuilder:
             if isinstance(src, Integer) and is_tagged(src.type):
                 return self.add(LoadLiteral(src.value >> 1, rtype=object_rprimitive))
             return self.add(Box(src))
-        else:
-            return src
+
+        return src
 
     def unbox_or_cast(
         self, src: Value, target_type: RType, line: int, *, can_borrow: bool = False
@@ -524,10 +524,10 @@ class LowLevelIRBuilder:
             if op.is_borrowed:
                 self.keep_alives.append(obj)
             return self.add(op)
-        elif isinstance(obj.type, RUnion):
+        if isinstance(obj.type, RUnion):
             return self.union_get_attr(obj, obj.type, attr, result_type, line)
-        else:
-            return self.py_get_attr(obj, attr, line)
+
+        return self.py_get_attr(obj, attr, line)
 
     def union_get_attr(
         self, obj: Value, rtype: RUnion, attr: str, result_type: RType, line: int
@@ -1161,8 +1161,8 @@ class LowLevelIRBuilder:
         """Load a tagged (Python) integer literal value."""
         if value > MAX_LITERAL_SHORT_INT or value < MIN_LITERAL_SHORT_INT:
             return self.add(LoadLiteral(value, int_rprimitive))
-        else:
-            return Integer(value)
+
+        return Integer(value)
 
     def load_float(self, value: float) -> Value:
         """Load a float literal value."""
@@ -2021,8 +2021,8 @@ class LowLevelIRBuilder:
         # generic case
         if use_pyssize_t:
             return self.call_c(generic_ssize_t_len_op, [val], line)
-        else:
-            return self.call_c(generic_len_op, [val], line)
+
+        return self.call_c(generic_len_op, [val], line)
 
     def new_tuple(self, items: list[Value], line: int) -> Value:
         size: Value = Integer(len(items), c_pyssize_t_rprimitive)
@@ -2184,8 +2184,8 @@ class LowLevelIRBuilder:
             # merge keys and values
             items = [i for t in list(zip(keys, values)) for i in t]
             return self.call_c(dict_build_op, [size_value] + items, line)
-        else:
-            return self.call_c(dict_new_op, [], line)
+
+        return self.call_c(dict_new_op, [], line)
 
 
 def num_positional_args(arg_values: list[Value], arg_kinds: list[ArgKind] | None) -> int:

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -145,10 +145,10 @@ class Mapper:
     def get_arg_rtype(self, typ: Type, kind: ArgKind) -> RType:
         if kind == ARG_STAR:
             return tuple_rprimitive
-        elif kind == ARG_STAR2:
+        if kind == ARG_STAR2:
             return dict_rprimitive
-        else:
-            return self.type_to_rtype(typ)
+
+        return self.type_to_rtype(typ)
 
     def fdef_to_sig(self, fdef: FuncDef) -> FuncSignature:
         if isinstance(fdef.type, CallableType):

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -85,7 +85,7 @@ def build_type_map(
         )
         class_ir.is_ext_class = is_extension_class(cdef)
         if class_ir.is_ext_class:
-            class_ir.deletable = cdef.info.deletable_attributes[:]
+            class_ir.deletable = cdef.info.deletable_attributes.copy()
         # If global optimizations are disabled, turn of tracking of class children
         if not options.global_opts:
             class_ir.children = None

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -226,10 +226,10 @@ def dict_methods_fast_path(builder: IRBuilder, expr: CallExpr, callee: RefExpr) 
     # generic logic.
     if attr == "keys":
         return builder.call_c(dict_keys_op, [obj], expr.line)
-    elif attr == "values":
+    if attr == "values":
         return builder.call_c(dict_values_op, [obj], expr.line)
-    else:
-        return builder.call_c(dict_items_op, [obj], expr.line)
+
+    return builder.call_c(dict_items_op, [obj], expr.line)
 
 
 @specialize_function("builtins.list")

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -145,7 +145,7 @@ def transform_return_stmt(builder: IRBuilder, stmt: ReturnStmt) -> None:
 
 def transform_assignment_stmt(builder: IRBuilder, stmt: AssignmentStmt) -> None:
     lvalues = stmt.lvalues
-    assert len(lvalues) >= 1
+    assert lvalues
     builder.disallow_class_assignments(lvalues, stmt.line)
     first_lvalue = lvalues[0]
     if stmt.type and isinstance(stmt.rvalue, TempNode):

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -695,8 +695,8 @@ def transform_with(
 
         if is_async:
             return emit_await(builder, exit_val, line)
-        else:
-            return exit_val
+
+        return exit_val
 
     def try_body() -> None:
         if target:

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -42,7 +42,7 @@ def is_trait(cdef: ClassDef) -> bool:
 def dataclass_decorator_type(d: Expression) -> str | None:
     if isinstance(d, RefExpr) and d.fullname in DATACLASS_DECORATORS:
         return d.fullname.split(".")[0]
-    elif (
+    if (
         isinstance(d, CallExpr)
         and isinstance(d.callee, RefExpr)
         and d.callee.fullname in DATACLASS_DECORATORS
@@ -55,8 +55,8 @@ def dataclass_decorator_type(d: Expression) -> str | None:
             if isinstance(auto, NameExpr) and auto.name == "True":
                 return "attr-auto"
         return name
-    else:
-        return None
+
+    return None
 
 
 def is_dataclass_decorator(d: Expression) -> bool:
@@ -149,10 +149,10 @@ def concrete_arg_kind(kind: ArgKind) -> ArgKind:
     """Find the concrete version of an arg kind that is being passed."""
     if kind == ARG_OPT:
         return ARG_POS
-    elif kind == ARG_NAMED_OPT:
+    if kind == ARG_NAMED_OPT:
         return ARG_NAMED
-    else:
-        return kind
+
+    return kind
 
 
 def is_constant(e: Expression) -> bool:

--- a/mypyc/test/test_emitclass.py
+++ b/mypyc/test/test_emitclass.py
@@ -10,7 +10,7 @@ from mypyc.namegen import NameGenerator
 class TestEmitClass(unittest.TestCase):
     def test_slot_key(self) -> None:
         attrs = ["__add__", "__radd__", "__rshift__", "__rrshift__", "__setitem__", "__delitem__"]
-        s = sorted(attrs, key=lambda x: slot_key(x))
+        s = sorted(attrs, key=slot_key)
         # __delitem__ and reverse methods should come last.
         assert s == [
             "__add__",

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -364,8 +364,8 @@ class TestRun(MypycDataSuite):
             m = re.search(template.format(""), program_text, flags=re.MULTILINE)
         if m:
             return ast.literal_eval(m.group(1))
-        else:
-            return True
+
+        return True
 
 
 class TestRunMultiFile(TestRun):

--- a/mypyc/test/test_serialization.py
+++ b/mypyc/test/test_serialization.py
@@ -19,8 +19,8 @@ from mypyc.sametype import is_same_signature, is_same_type
 def get_dict(x: Any) -> dict[str, Any]:
     if hasattr(x, "__mypyc_attrs__"):
         return {k: getattr(x, k) for k in x.__mypyc_attrs__ if hasattr(x, k)}
-    else:
-        return dict(x.__dict__)
+
+    return dict(x.__dict__)
 
 
 def get_function_dict(x: FuncIR) -> dict[str, Any]:

--- a/mypyc/transform/refcount.py
+++ b/mypyc/transform/refcount.py
@@ -70,7 +70,7 @@ def insert_ref_count_opcodes(ir: FuncIR) -> None:
     defined = analyze_must_defined_regs(ir.blocks, cfg, args, values, strict_errors=True)
     ordering = make_value_ordering(ir)
     cache: BlockCache = {}
-    for block in ir.blocks[:]:
+    for block in ir.blocks.copy():
         if isinstance(block.ops[-1], (Branch, Goto)):
             insert_branch_inc_and_decrefs(
                 block,

--- a/mypyc/transform/uninit.py
+++ b/mypyc/transform/uninit.py
@@ -116,8 +116,7 @@ def split_blocks_at_uninits(
         new_ops: list[Op] = []
         for reg in init_registers:
             err = LoadErrorValue(reg.type, undefines=True)
-            new_ops.append(err)
-            new_ops.append(Assign(reg, err))
+            new_ops.extend((err, Assign(reg, err)))
         for reg in bitmap_registers:
             new_ops.append(Assign(reg, Integer(0, bitmap_rprimitive)))
         new_blocks[0].ops[0:0] = new_ops
@@ -153,10 +152,10 @@ def check_for_uninit_using_bitmap(
         IntOp.AND,
         line,
     )
-    ops.append(masked)
     chk = ComparisonOp(masked, Integer(0, bitmap_rprimitive), ComparisonOp.EQ)
-    ops.append(chk)
-    ops.append(Branch(chk, error_block, ok_block, Branch.BOOL))
+    br = Branch(chk, error_block, ok_block, Branch.BOOL)
+
+    ops.extend((masked, chk, br))
 
 
 def update_register_assignments_to_set_bitmap(
@@ -183,8 +182,7 @@ def update_register_assignments_to_set_bitmap(
                         IntOp.OR,
                         op.line,
                     )
-                    new_ops.append(new)
-                    new_ops.append(Assign(reg, new))
+                    new_ops.extend((new, Assign(reg, new)))
                 else:
                     new_ops.append(op)
             block.ops = new_ops

--- a/runtests.py
+++ b/runtests.py
@@ -129,7 +129,7 @@ def main() -> None:
         exit(1)
 
     if not args:
-        args = DEFAULT_COMMANDS[:]
+        args = DEFAULT_COMMANDS.copy()
 
     status = 0
 


### PR DESCRIPTION
This PR includes a lot of cleanups from a tool I wrote called [Refurb](https://github.com/dosisod/refurb). Most of the checks are readability related, but some of them do provide (small) performance improvements, such as using list comprehensions in more places, and micro-optimizations such as using `x.copy()` instead of a slice copy (`x[:]`). I made a commit for each error code (or group of similar error codes), so feel free to yay or nay any error codes which you don't want included.

The full list of error codes and their meanings can be viewed [here](https://github.com/dosisod/refurb/blob/master/docs/checks.md).

This PR ended up being a lot bigger then I intended, so if you would like me to break it up into smaller PR's I would be more then happy to do so!
