### PR TITLE
Fix sys.platform when cross-compiling with emscripten

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pprint
 import re
 import sys
+import sysconfig
 from typing import Any, Callable, Dict, Mapping, Pattern
 from typing_extensions import Final
 
@@ -86,7 +87,15 @@ class Options:
         # The executable used to search for PEP 561 packages. If this is None,
         # then mypy does not search for PEP 561 packages.
         self.python_executable: str | None = sys.executable
-        self.platform = sys.platform
+
+        # When cross compiling to emscripten, we need to rely on MACHDEP because
+        # sys.platform is the host build platform, not emscripten.
+        MACHDEP = sysconfig.get_config_var("MACHDEP")
+        if MACHDEP == "emscripten":
+            self.platform = MACHDEP
+        else:
+            self.platform = sys.platform
+
         self.custom_typing_module: str | None = None
         self.custom_typeshed_dir: str | None = None
         # The abspath() version of the above, we compute it once as an optimization.


### PR DESCRIPTION
This is a workaround for correctly detecting the platform when building mypy with mypyc on the Emscripten platform. This fixes https://github.com/mypyc/mypy_mypyc-wheels/issues/62. `pyodide build` overrides `sysconfig` for the host based on the target (confirmed on the pyodide matrix, [see also where the code is actually changed](https://github.com/pyodide/pyodide/blob/e835bf05ff4aa463024aaeb9689ae70ea5771314/pyodide-build/pyodide_build/pypabuild.py#L43-L50)).

 This should only change things when checking/building for the emscripten platform. There isn't really a cleaner workaround that I can think of unfortunately, the main issue is cross compiling is tricky with setuptools.