### PR TITLE
shellcheck: add workflow, shellcheck fix the scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+---
+name: Shellcheck
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  shellcheck:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y shellcheck
+      - name: shellcheck
+        run: |
+          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' | xargs shellcheck 

--- a/misc/build-debug-python.sh
+++ b/misc/build-debug-python.sh
@@ -23,12 +23,12 @@ if [[ $(uname) == Darwin ]]; then
     LDFLAGS="-L$(brew --prefix openssl)/lib"
 fi
 
-curl -O https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz
-tar zxf Python-$VERSION.tgz
-cd Python-$VERSION
-CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" ./configure CFLAGS="-DPy_DEBUG -DPy_TRACE_REFS -DPYMALLOC_DEBUG" --with-pydebug --prefix=$PREFIX
+curl -O https://www.python.org/ftp/python/"$VERSION"/Python-"$VERSION".tgz
+tar zxf Python-"$VERSION".tgz
+cd Python-"$VERSION"
+CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" ./configure CFLAGS="-DPy_DEBUG -DPy_TRACE_REFS -DPYMALLOC_DEBUG" --with-pydebug --prefix="$PREFIX"
 make -j4
 make install
-$PREFIX/bin/python3 -m pip install virtualenv
-$PREFIX/bin/python3 -m virtualenv $VENV
-ln -s python3-config $PREFIX/bin/python-config
+"$PREFIX"/bin/python3 -m pip install virtualenv
+"$PREFIX"/bin/python3 -m virtualenv "$VENV"
+ln -s python3-config "$PREFIX"/bin/python-config

--- a/misc/clean-mypyc.sh
+++ b/misc/clean-mypyc.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Cleaning C/C++ build artifacts..."
-(cd mypyc/lib-rt; make clean)
-(cd mypyc/external/googletest/make; make clean)
+(cd mypyc/lib-rt || exit; make clean)
+(cd mypyc/external/googletest/make || exit; make clean)

--- a/misc/test-stubgenc.sh
+++ b/misc/test-stubgenc.sh
@@ -12,8 +12,8 @@ python -m pip install .
 
 # Remove expected stubs and generate new inplace
 STUBGEN_OUTPUT_FOLDER=./test-data/pybind11_mypy_demo/stubgen
-rm -rf $STUBGEN_OUTPUT_FOLDER/*
-stubgen -p pybind11_mypy_demo -o $STUBGEN_OUTPUT_FOLDER
+rm -rf "${STUBGEN_OUTPUT_FOLDER:?}/"*
+stubgen -p pybind11_mypy_demo -o "$STUBGEN_OUTPUT_FOLDER"
 
 # Compare generated stubs to expected ones
-git diff --exit-code $STUBGEN_OUTPUT_FOLDER
+git diff --exit-code "$STUBGEN_OUTPUT_FOLDER"

--- a/misc/test-stubgenc.sh
+++ b/misc/test-stubgenc.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-cd "$(dirname $0)/.."
+cd "$(dirname "$0")/.."
 
 # Install dependencies, demo project and mypy
 python -m pip install -r test-requirements.txt

--- a/misc/trigger_wheel_build.sh
+++ b/misc/trigger_wheel_build.sh
@@ -14,10 +14,10 @@ pip install -r mypy-requirements.txt
 V=$(python3 -m mypy --version)
 V=$(echo "$V" | cut -d" " -f2)
 
-git clone --depth 1 https://${WHEELS_PUSH_TOKEN}@github.com/mypyc/mypy_mypyc-wheels.git build
+git clone --depth 1 https://"${WHEELS_PUSH_TOKEN}"@github.com/mypyc/mypy_mypyc-wheels.git build
 cd build
-echo $COMMIT > mypy_commit
+echo "$COMMIT" > mypy_commit
 git commit -am "Build wheels for mypy $V"
-git tag v$V
+git tag v"$V"
 # Push a tag, but no need to push the change to master
 git push --tags


### PR DESCRIPTION
Request to shellcheck contribution was given in https://github.com/python/mypy/pull/13284 recently. Project has some shell scripts but they are not checked by CI .  This PR does both - adds CI, and 

Individual commits would have more explanation and provenance on changes.

- [ ] add tox.ini env for shellcheck?  Question: what to do with dependency on binary which isn't python project.  There is https://pypi.org/project/shellcheck-py/ which says "A python wrapper to provide a pip-installable [shellcheck](https://shellcheck.net/) binary." but I have no experience with it/not sure of gotchas. If told to use/add to requirements-devel.txt -- can do ;)