### PR TITLE
Simplify `len()` comparisons

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3301,7 +3301,7 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
             manager.trace(f"Queuing {fresh_msg} SCC ({scc_str})")
             fresh_scc_queue.append(scc)
         else:
-            if len(fresh_scc_queue) > 0:
+            if fresh_scc_queue:
                 manager.log(f"Processing {len(fresh_scc_queue)} queued fresh SCCs")
                 # Defer processing fresh SCCs until we actually run into a stale SCC
                 # and need the earlier modules to be loaded.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5920,7 +5920,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 non_optional_types.append(typ)
 
         # Make sure we have a mixture of optional and non-optional types.
-        if not non_optional_types or len(non_optional_types) == len(chain_indices):
+        if len(non_optional_types) == 0 or len(non_optional_types) == len(chain_indices):
             return {}, {}
 
         if_map = {}
@@ -6927,7 +6927,7 @@ def reduce_conditional_maps(type_maps: list[tuple[TypeMap, TypeMap]]) -> tuple[T
     We only retain the shared expression in the 'else' case because we don't actually know
     whether x was refined or y was refined -- only just that one of the two was refined.
     """
-    if not type_maps:
+    if len(type_maps) == 0:
         return {}, {}
     elif len(type_maps) == 1:
         return type_maps[0]

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5071,7 +5071,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             callables, uncallables = self.partition_by_callable(
                 erase_to_union_or_bound(typ), unsound_partition
             )
-            uncallables = [typ] if len(uncallables) else []
+            uncallables = [typ] if uncallables else []
             return callables, uncallables
 
         # A TupleType is callable if its fallback is, but needs special handling
@@ -5086,7 +5086,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 callables, uncallables = self.partition_by_callable(
                     method.type, unsound_partition=False
                 )
-                if len(callables) and not len(uncallables):
+                if callables and not uncallables:
                     # Only consider the type callable if its __call__ method is
                     # definitely callable.
                     return [typ], []
@@ -5122,14 +5122,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
         callables, uncallables = self.partition_by_callable(current_type, unsound_partition=False)
 
-        if len(callables) and len(uncallables):
-            callable_map = {expr: UnionType.make_union(callables)} if len(callables) else None
-            uncallable_map = (
-                {expr: UnionType.make_union(uncallables)} if len(uncallables) else None
-            )
+        if callables and uncallables:
+            callable_map = {expr: UnionType.make_union(callables)} if callables else None
+            uncallable_map = {expr: UnionType.make_union(uncallables)} if uncallables else None
             return callable_map, uncallable_map
 
-        elif len(callables):
+        elif callables:
             return {}, None
 
         return None, {}
@@ -5922,7 +5920,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 non_optional_types.append(typ)
 
         # Make sure we have a mixture of optional and non-optional types.
-        if len(non_optional_types) == 0 or len(non_optional_types) == len(chain_indices):
+        if not non_optional_types or len(non_optional_types) == len(chain_indices):
             return {}, {}
 
         if_map = {}
@@ -6504,7 +6502,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if intersection is None:
                     continue
                 out.append(intersection)
-        if len(out) == 0:
+        if not out:
             # Only report errors if no element in the union worked.
             if self.should_report_unreachable_issues():
                 for types, reason in errors:
@@ -6929,7 +6927,7 @@ def reduce_conditional_maps(type_maps: list[tuple[TypeMap, TypeMap]]) -> tuple[T
     We only retain the shared expression in the 'else' case because we don't actually know
     whether x was refined or y was refined -- only just that one of the two was refined.
     """
-    if len(type_maps) == 0:
+    if not type_maps:
         return {}, {}
     elif len(type_maps) == 1:
         return type_maps[0]
@@ -7344,7 +7342,7 @@ class DisjointDict(Generic[TKey, TValue]):
 
         Note that the given set of keys must be non-empty -- otherwise, nothing happens.
         """
-        if len(keys) == 0:
+        if not keys:
             return
 
         subtree_roots = [self._lookup_or_make_root_id(key) for key in keys]
@@ -7455,7 +7453,7 @@ def group_comparison_operands(
         if current_indices and (operator != last_operator or operator not in operators_to_group):
             # If some of the operands in the chain are assignable, defer adding it: we might
             # end up needing to merge it with other chains that appear later.
-            if len(current_hashes) == 0:
+            if not current_hashes:
                 simplified_operator_list.append((last_operator, sorted(current_indices)))
             else:
                 groups[last_operator].add_mapping(current_hashes, current_indices)
@@ -7478,7 +7476,7 @@ def group_comparison_operands(
                 current_hashes.add(right_hash)
 
     if last_operator is not None:
-        if len(current_hashes) == 0:
+        if not current_hashes:
             simplified_operator_list.append((last_operator, sorted(current_indices)))
         else:
             groups[last_operator].add_mapping(current_hashes, current_indices)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -686,7 +686,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         context: Context,
         orig_callee: Type | None,
     ) -> Type:
-        if len(args) >= 1 and all([ak == ARG_NAMED for ak in arg_kinds]):
+        if args and all([ak == ARG_NAMED for ak in arg_kinds]):
             # ex: Point(x=42, y=1337)
             assert all(arg_name is not None for arg_name in arg_names)
             item_names = cast(List[str], arg_names)
@@ -708,7 +708,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     callee, unique_arg.analyzed, context, orig_callee
                 )
 
-        if len(args) == 0:
+        if not args:
             # ex: EmptyDict()
             return self.check_typeddict_call_with_kwargs(callee, {}, context, orig_callee)
 
@@ -2423,8 +2423,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 inferred_types.append(infer_type)
                 type_maps.append(m)
 
-        if len(matches) == 0:
-            # No match was found
+        if not matches:
             return None
         elif any_causes_overload_ambiguity(matches, return_types, arg_types, arg_kinds, arg_names):
             # An argument of type or containing the type 'Any' caused ambiguity.
@@ -3015,7 +3014,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 if not encountered_partial_type and not failed_out:
                     iterable_type = UnionType.make_union(iterable_types)
                     if not is_subtype(left_type, iterable_type):
-                        if len(container_types) == 0:
+                        if not container_types:
                             self.msg.unsupported_operand_types("in", left_type, right_type, e)
                         else:
                             container_type = UnionType.make_union(container_types)
@@ -5478,7 +5477,7 @@ def any_causes_overload_ambiguity(
 
 
 def all_same_types(types: list[Type]) -> bool:
-    if len(types) == 0:
+    if not types:
         return True
     return all(is_same_type(t, types[0]) for t in types[1:])
 

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -316,7 +316,7 @@ class PatternChecker(PatternVisitor[PatternType]):
         if isinstance(t, UnionType):
             items = [self.get_sequence_type(item, context) for item in t.items]
             not_none_items = [item for item in items if item is not None]
-            if len(not_none_items) > 0:
+            if not_none_items:
                 return make_simplified_union(not_none_items)
             else:
                 return None

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -637,14 +637,14 @@ class Errors:
             used_ignored_codes = used_ignored_lines[line]
             unused_ignored_codes = set(ignored_codes) - set(used_ignored_codes)
             # `ignore` is used
-            if len(ignored_codes) == 0 and len(used_ignored_codes) > 0:
+            if not ignored_codes and used_ignored_codes:
                 continue
             # All codes appearing in `ignore[...]` are used
-            if len(ignored_codes) > 0 and len(unused_ignored_codes) == 0:
+            if ignored_codes and not unused_ignored_codes:
                 continue
             # Display detail only when `ignore[...]` specifies more than one error code
             unused_codes_message = ""
-            if len(ignored_codes) > 1 and len(unused_ignored_codes) > 0:
+            if len(ignored_codes) > 1 and unused_ignored_codes:
                 unused_codes_message = f"[{', '.join(sorted(unused_ignored_codes))}]"
             message = f'Unused "type: ignore{unused_codes_message}" comment'
             for unused in unused_ignored_codes:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2944,7 +2944,7 @@ def make_inferred_type_note(
 def format_key_list(keys: list[str], *, short: bool = False) -> str:
     formatted_keys = [f'"{key}"' for key in keys]
     td = "" if short else "TypedDict "
-    if not keys:
+    if len(keys) == 0:
         return f"no {td}keys"
     elif len(keys) == 1:
         return f"{td}key {formatted_keys[0]}"

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2781,7 +2781,7 @@ def strip_quotes(s: str) -> str:
 
 
 def format_string_list(lst: list[str]) -> str:
-    assert len(lst) > 0
+    assert lst
     if len(lst) == 1:
         return lst[0]
     elif len(lst) <= 5:
@@ -2944,7 +2944,7 @@ def make_inferred_type_note(
 def format_key_list(keys: list[str], *, short: bool = False) -> str:
     formatted_keys = [f'"{key}"' for key in keys]
     td = "" if short else "TypedDict "
-    if len(keys) == 0:
+    if not keys:
         return f"no {td}keys"
     elif len(keys) == 1:
         return f"{td}key {formatted_keys[0]}"

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -556,7 +556,7 @@ class OverloadedFuncDef(FuncBase, SymbolNode, Statement):
         self.items = items
         self.unanalyzed_items = items.copy()
         self.impl = None
-        if len(items) > 0:
+        if items:
             # TODO: figure out how to reliably set end position (we don't know the impl here).
             self.set_line(items[0].line, items[0].column)
         self.is_final = False

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -153,7 +153,7 @@ class BranchStatement:
             all_vars.update(b.must_be_defined)
         # For the rest of the things, we only care about branches that weren't skipped.
         non_skipped_branches = [b for b in self.branches if not b.skipped]
-        if len(non_skipped_branches) > 0:
+        if non_skipped_branches:
             must_be_defined = non_skipped_branches[0].must_be_defined
             for b in non_skipped_branches[1:]:
                 must_be_defined.intersection_update(b.must_be_defined)
@@ -660,7 +660,7 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
             else:
                 # When you do `import x.y`, only `x` becomes defined.
                 names = mod.split(".")
-                if len(names) > 0:
+                if names:
                     # `names` should always be nonempty, but we don't want mypy
                     # to crash on invalid code.
                     self.tracker.record_definition(names[0])

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2262,7 +2262,7 @@ class SemanticAnalyzer(
                     break
 
         metas = {defn.metaclass, with_meta_expr, add_meta_expr} - {None}
-        if not metas:
+        if len(metas) == 0:
             return
         if len(metas) > 1:
             self.fail("Multiple metaclass definitions", defn)
@@ -4602,7 +4602,7 @@ class SemanticAnalyzer(
         if s.unanalyzed_type:
             assert isinstance(s.unanalyzed_type, ProperType)
             actual_targets = [t for t in s.target if t is not None]
-            if not actual_targets:
+            if len(actual_targets) == 0:
                 # We have a type for no targets
                 self.fail('Invalid type comment: "with" statement has no targets', s)
             elif len(actual_targets) == 1:
@@ -6707,7 +6707,7 @@ def is_trivial_body(block: Block) -> bool:
     if body and isinstance(body[0], ExpressionStmt) and isinstance(body[0].expr, StrExpr):
         body = block.body[1:]
 
-    if not body:
+    if len(body) == 0:
         # There's only a docstring (or no body at all).
         return True
     elif len(body) > 1:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2262,7 +2262,7 @@ class SemanticAnalyzer(
                     break
 
         metas = {defn.metaclass, with_meta_expr, add_meta_expr} - {None}
-        if len(metas) == 0:
+        if not metas:
             return
         if len(metas) > 1:
             self.fail("Multiple metaclass definitions", defn)
@@ -4602,7 +4602,7 @@ class SemanticAnalyzer(
         if s.unanalyzed_type:
             assert isinstance(s.unanalyzed_type, ProperType)
             actual_targets = [t for t in s.target if t is not None]
-            if len(actual_targets) == 0:
+            if not actual_targets:
                 # We have a type for no targets
                 self.fail('Invalid type comment: "with" statement has no targets', s)
             elif len(actual_targets) == 1:
@@ -5113,7 +5113,7 @@ class SemanticAnalyzer(
                 return None
             types.append(analyzed)
 
-        if has_param_spec and num_args == 1 and len(types) > 0:
+        if has_param_spec and num_args == 1 and types:
             first_arg = get_proper_type(types[0])
             if not (
                 len(types) == 1
@@ -6707,7 +6707,7 @@ def is_trivial_body(block: Block) -> bool:
     if body and isinstance(body[0], ExpressionStmt) and isinstance(body[0].expr, StrExpr):
         body = block.body[1:]
 
-    if len(body) == 0:
+    if not body:
         # There's only a docstring (or no body at all).
         return True
     elif len(body) > 1:

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -232,7 +232,7 @@ class EnumCallAnalyzer:
                 % class_name,
                 call,
             )
-        if len(items) == 0:
+        if not items:
             return self.fail_enum_call_arg(f"{class_name}() needs at least one item", call)
         if not values:
             values = [None] * len(items)

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -281,7 +281,7 @@ class NamedTupleAnalyzer:
             #     two methods of a class can define a named tuple with the same name,
             #     and they will be stored in the same namespace (see below).
             name += "@" + str(call.line)
-        if len(defaults) > 0:
+        if defaults:
             default_items = {
                 arg_name: default for arg_name, default in zip(items[-len(defaults) :], defaults)
             }

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1062,7 +1062,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             return
         self.import_tracker.require_name("NamedTuple")
         self.add(f"{self._indent}class {lvalue.name}(NamedTuple):")
-        if len(items) == 0:
+        if not items:
             self.add(" ...\n")
         else:
             self.import_tracker.require_name("Incomplete")

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -474,7 +474,7 @@ def strip_list(l: list[str]) -> list[str]:
         # Strip spaces at end of line
         r.append(re.sub(r"\s+$", "", s))
 
-    while len(r) > 0 and r[-1] == "":
+    while r and r[-1] == "":
         r.pop()
 
     return r

--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -92,7 +92,7 @@ def test_pep561(testcase: DataDrivenTestCase) -> None:
             use_pip = False
         elif arg == "editable":
             editable = True
-    assert pkgs != [], "No packages to install for PEP 561 test?"
+    assert pkgs, "No packages to install for PEP 561 test?"
     with virtualenv(python) as venv:
         venv_dir, python_executable = venv
         for pkg in pkgs:

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -179,7 +179,7 @@ def generate_wrapper_function(
         nargs = "nargs"
     parse_fn = "CPyArg_ParseStackAndKeywords"
     # Special case some common signatures
-    if len(real_args) == 0:
+    if not real_args:
         # No args
         parse_fn = "CPyArg_ParseStackAndKeywordsNoArgs"
     elif len(real_args) == 1 and len(groups[ARG_POS]) == 1:

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1673,7 +1673,7 @@ class LowLevelIRBuilder:
         # for-loop and inline the SetMem operation, which is faster
         # than list_build_op, however generates more code.
         result_list = self.call_c(new_list_op, length, line)
-        if len(values) == 0:
+        if not values:
             return result_list
         args = [self.coerce(item, object_rprimitive, line) for item in values]
         ob_item_ptr = self.add(GetElementPtr(result_list, PyListObject, "ob_item", line))

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -145,7 +145,7 @@ def transform_return_stmt(builder: IRBuilder, stmt: ReturnStmt) -> None:
 
 def transform_assignment_stmt(builder: IRBuilder, stmt: AssignmentStmt) -> None:
     lvalues = stmt.lvalues
-    assert len(lvalues) >= 1
+    assert lvalues
     builder.disallow_class_assignments(lvalues, stmt.line)
     first_lvalue = lvalues[0]
     if stmt.type and isinstance(stmt.rvalue, TempNode):


### PR DESCRIPTION
This PR removes certain `len()` comparisons when it would be faster/more succinct to do a truthy check instead, such as `len(x) == 0` vs `not x`.

This fixes the [`FURB115`](https://github.com/dosisod/refurb/blob/master/docs/checks.md#furb115-no-len-compare) errors in Refurb (see #14887).