### PR TITLE
Fix crash on class-level import in protocol definition

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3083,7 +3083,7 @@ class TypeInfo(SymbolNode):
         for base in self.mro[:-1]:  # we skip "object" since everyone implements it
             if base.is_protocol:
                 for name, node in base.names.items():
-                    if isinstance(node.node, (TypeAlias, TypeVarExpr)):
+                    if isinstance(node.node, (TypeAlias, TypeVarExpr, MypyFile)):
                         # These are auxiliary definitions (and type aliases are prohibited).
                         continue
                     members.add(name)

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -3998,3 +3998,27 @@ TF = TypeVar("TF", bound=Foo)
 def outer(cls: Type[TF]) -> TF:
     reveal_type(test(cls))  # N: Revealed type is "TF`-1"
     return cls()
+
+[case testProtocolImportNotMember]
+import m
+import lib
+
+class Bad:
+    x: int
+class Good:
+    x: lib.C
+
+x: m.P = Bad()  # E: Incompatible types in assignment (expression has type "Bad", variable has type "P") \
+                # N: Following member(s) of "Bad" have conflicts: \
+                # N:     x: expected "C", got "int"
+x = Good()
+
+[file m.py]
+from typing import Protocol
+
+class P(Protocol):
+    import lib
+    x: lib.C
+
+[file lib.py]
+class C: ...


### PR DESCRIPTION
Fixes #14889

Fix is straightforward. PEP 544 doesn't say anything about this, but IMO ignoring the import (i.e. not counting it as a member) is the most reasonable thing to do.