### PR TITLE
[mypyc] Be stricter about function prototypes

### DIFF
--- a/mypyc/lib-rt/float_ops.c
+++ b/mypyc/lib-rt/float_ops.c
@@ -6,12 +6,12 @@
 #include "CPy.h"
 
 
-static double CPy_DomainError() {
+static double CPy_DomainError(void) {
     PyErr_SetString(PyExc_ValueError, "math domain error");
     return CPY_FLOAT_ERROR;
 }
 
-static double CPy_MathRangeError() {
+static double CPy_MathRangeError(void) {
     PyErr_SetString(PyExc_OverflowError, "math range error");
     return CPY_FLOAT_ERROR;
 }


### PR DESCRIPTION
I'm trying to fix this error:
```
float_ops.c:9:15: error: function declaration isn't a prototype [-Werror=strict-prototypes]
   9 | static double CPy_DomainError() {
```