### PR TITLE
Replace `x[:]` with `x.copy()`

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1921,7 +1921,7 @@ class State:
         self.caller_state = caller_state
         self.caller_line = caller_line
         if caller_state:
-            self.import_context = caller_state.import_context[:]
+            self.import_context = caller_state.import_context.copy()
             self.import_context.append((caller_state.xpath, caller_line))
         else:
             self.import_context = []

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4457,7 +4457,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 is_ellipsis_args=False,
                 arg_types=[AnyType(TypeOfAny.special_form)] * len(arg_kinds),
                 arg_kinds=arg_kinds,
-                arg_names=e.arg_names[:],
+                arg_names=e.arg_names.copy(),
             )
 
         if ARG_STAR in arg_kinds or ARG_STAR2 in arg_kinds:

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1159,7 +1159,7 @@ def find_matching_overload_items(
     if not res:
         # Falling back to all items if we can't find a match is pretty arbitrary, but
         # it maintains backward compatibility.
-        res = items[:]
+        res = items.copy()
     return res
 
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -600,7 +600,7 @@ class Server:
         messages = fine_grained_manager.update(changed, [], followed=True)
 
         # Follow deps from changed modules (still within graph).
-        worklist = changed[:]
+        worklist = changed.copy()
         while worklist:
             module = worklist.pop()
             if module[0] not in graph:
@@ -707,7 +707,7 @@ class Server:
         """
         changed = []
         new_files = []
-        worklist = roots[:]
+        worklist = roots.copy()
         seen.update(source.module for source in worklist)
         while worklist:
             nxt = worklist.pop()

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -349,11 +349,11 @@ class Errors:
 
     def import_context(self) -> list[tuple[str, int]]:
         """Return a copy of the import context."""
-        return self.import_ctx[:]
+        return self.import_ctx.copy()
 
     def set_import_context(self, ctx: list[tuple[str, int]]) -> None:
         """Replace the entire import context with a new value."""
-        self.import_ctx = ctx[:]
+        self.import_ctx = ctx.copy()
 
     def report(
         self,

--- a/mypy/memprofile.py
+++ b/mypy/memprofile.py
@@ -103,7 +103,7 @@ def find_recursive_objects(objs: list[object]) -> None:
             objs.append(o)
             seen.add(id(o))
 
-    for obj in objs[:]:
+    for obj in objs.copy():
         if type(obj) is FakeInfo:
             # Processing these would cause a crash.
             continue

--- a/mypy/mro.py
+++ b/mypy/mro.py
@@ -44,7 +44,7 @@ def linearize_hierarchy(
 
 
 def merge(seqs: list[list[TypeInfo]]) -> list[TypeInfo]:
-    seqs = [s[:] for s in seqs]
+    seqs = [s.copy() for s in seqs]
     result: list[TypeInfo] = []
     while True:
         seqs = [s for s in seqs if s]

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -190,7 +190,7 @@ def process_top_levels(graph: Graph, scc: list[str], patches: Patches) -> None:
     # Initially all namespaces in the SCC are incomplete (well they are empty).
     state.manager.incomplete_namespaces.update(scc)
 
-    worklist = scc[:]
+    worklist = scc.copy()
     # HACK: process core stuff first. This is mostly needed to support defining
     # named tuples in builtin SCC.
     if all(m in worklist for m in core_modules):

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -1027,7 +1027,7 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
     def visit_type_type(self, typ: TypeType) -> list[str]:
         triggers = self.get_type_triggers(typ.item)
         if not self.use_logical_deps:
-            old_triggers = triggers[:]
+            old_triggers = triggers.copy()
             for trigger in old_triggers:
                 triggers.append(trigger.rstrip(">") + ".__init__>")
                 triggers.append(trigger.rstrip(">") + ".__new__>")

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -187,7 +187,7 @@ class FineGrainedBuildManager:
         # Merge in any root dependencies that may not have been loaded
         merge_dependencies(manager.load_fine_grained_deps(FAKE_ROOT_MODULE), self.deps)
         self.previous_targets_with_errors = manager.errors.targets()
-        self.previous_messages: list[str] = result.errors[:]
+        self.previous_messages: list[str] = result.errors.copy()
         # Module, if any, that had blocking errors in the last run as (id, path) tuple.
         self.blocking_error: tuple[str, str] | None = None
         # Module that we haven't processed yet but that are known to be stale.
@@ -302,7 +302,7 @@ class FineGrainedBuildManager:
                     break
 
         messages = sort_messages_preserving_file_order(messages, self.previous_messages)
-        self.previous_messages = messages[:]
+        self.previous_messages = messages.copy()
         return messages
 
     def trigger(self, target: str) -> list[str]:
@@ -322,7 +322,7 @@ class FineGrainedBuildManager:
         )
         # Preserve state needed for the next update.
         self.previous_targets_with_errors = self.manager.errors.targets()
-        self.previous_messages = self.manager.errors.new_messages()[:]
+        self.previous_messages = self.manager.errors.new_messages().copy()
         return self.update(changed_modules, [])
 
     def flush_cache(self) -> None:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -144,7 +144,7 @@ class StrConv(NodeVisitor[str]):
         return self.dump(a, o)
 
     def visit_overloaded_func_def(self, o: mypy.nodes.OverloadedFuncDef) -> str:
-        a: Any = o.items[:]
+        a: Any = o.items.copy()
         if o.type:
             a.insert(0, o.type)
         if o.impl:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -215,7 +215,7 @@ def add_typing_import(output: list[str]) -> list[str]:
     if names:
         return [f"from typing import {', '.join(names)}", ""] + output
     else:
-        return output[:]
+        return output.copy()
 
 
 def is_c_function(obj: object) -> bool:

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -258,7 +258,7 @@ def local_sys_path_set() -> Iterator[None]:
     This can be used by test cases that do runtime imports, for example
     by the stubgen tests.
     """
-    old_sys_path = sys.path[:]
+    old_sys_path = sys.path.copy()
     if not ("" in sys.path or "." in sys.path):
         sys.path.insert(0, "")
     try:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -19,7 +19,7 @@ from mypy.test.data import root_dir
 @contextlib.contextmanager
 def use_tmp_dir(mod_name: str) -> Iterator[str]:
     current = os.getcwd()
-    current_syspath = sys.path[:]
+    current_syspath = sys.path.copy()
     with tempfile.TemporaryDirectory() as tmp:
         try:
             os.chdir(tmp)
@@ -27,7 +27,7 @@ def use_tmp_dir(mod_name: str) -> Iterator[str]:
                 sys.path.insert(0, tmp)
             yield tmp
         finally:
-            sys.path = current_syspath[:]
+            sys.path = current_syspath.copy()
             if mod_name in sys.modules:
                 del sys.modules[mod_name]
 

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -145,7 +145,7 @@ class TransformVisitor(NodeVisitor[Node]):
     def visit_mypy_file(self, node: MypyFile) -> MypyFile:
         assert self.test_only, "This visitor should not be used for whole files."
         # NOTE: The 'names' and 'imports' instance variables will be empty!
-        ignored_lines = {line: codes[:] for line, codes in node.ignored_lines.items()}
+        ignored_lines = {line: codes.copy() for line, codes in node.ignored_lines.items()}
         new = MypyFile(self.statements(node.defs), [], node.is_bom, ignored_lines=ignored_lines)
         new._fullname = node._fullname
         new.path = node.path
@@ -153,10 +153,10 @@ class TransformVisitor(NodeVisitor[Node]):
         return new
 
     def visit_import(self, node: Import) -> Import:
-        return Import(node.ids[:])
+        return Import(node.ids.copy())
 
     def visit_import_from(self, node: ImportFrom) -> ImportFrom:
-        return ImportFrom(node.id, node.relative, node.names[:])
+        return ImportFrom(node.id, node.relative, node.names.copy())
 
     def visit_import_all(self, node: ImportAll) -> ImportAll:
         return ImportAll(node.id, node.relative)
@@ -267,10 +267,10 @@ class TransformVisitor(NodeVisitor[Node]):
         return new
 
     def visit_global_decl(self, node: GlobalDecl) -> GlobalDecl:
-        return GlobalDecl(node.names[:])
+        return GlobalDecl(node.names.copy())
 
     def visit_nonlocal_decl(self, node: NonlocalDecl) -> NonlocalDecl:
-        return NonlocalDecl(node.names[:])
+        return NonlocalDecl(node.names.copy())
 
     def visit_block(self, node: Block) -> Block:
         return Block(self.statements(node.body))
@@ -513,8 +513,8 @@ class TransformVisitor(NodeVisitor[Node]):
         return CallExpr(
             self.expr(node.callee),
             self.expressions(node.args),
-            node.arg_kinds[:],
-            node.arg_names[:],
+            node.arg_kinds.copy(),
+            node.arg_names.copy(),
             self.optional_expr(node.analyzed),
         )
 

--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -146,7 +146,7 @@ def cleanup_cfg(blocks: list[BasicBlock]) -> None:
         # Then delete any blocks that have no predecessors
         changed = False
         cfg = get_cfg(blocks)
-        orig_blocks = blocks[:]
+        orig_blocks = blocks.copy()
         blocks.clear()
         for i, block in enumerate(orig_blocks):
             if i == 0 or cfg.pred[block]:

--- a/mypyc/ir/module_ir.py
+++ b/mypyc/ir/module_ir.py
@@ -23,7 +23,7 @@ class ModuleIR:
         final_names: list[tuple[str, RType]],
     ) -> None:
         self.fullname = fullname
-        self.imports = imports[:]
+        self.imports = imports.copy()
         self.functions = functions
         self.classes = classes
         self.final_names = final_names

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -299,7 +299,7 @@ class AssignMulti(BaseAssign):
         self.src = src
 
     def sources(self) -> list[Value]:
-        return self.src[:]
+        return self.src.copy()
 
     def stolen(self) -> list[Value]:
         return []
@@ -542,7 +542,7 @@ class Call(RegisterOp):
         super().__init__(line)
 
     def sources(self) -> list[Value]:
-        return list(self.args[:])
+        return list(self.args.copy())
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_call(self)
@@ -570,7 +570,7 @@ class MethodCall(RegisterOp):
         super().__init__(line)
 
     def sources(self) -> list[Value]:
-        return self.args[:] + [self.obj]
+        return self.args.copy() + [self.obj]
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_method_call(self)
@@ -790,7 +790,7 @@ class TupleSet(RegisterOp):
         self.type = self.tuple_type
 
     def sources(self) -> list[Value]:
-        return self.items[:]
+        return self.items.copy()
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_tuple_set(self)
@@ -1394,7 +1394,7 @@ class KeepAlive(RegisterOp):
         self.src = src
 
     def sources(self) -> list[Value]:
-        return self.src[:]
+        return self.src.copy()
 
     def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_keep_alive(self)

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -385,7 +385,7 @@ def translate_method_call(builder: IRBuilder, expr: CallExpr, callee: MemberExpr
 def call_classmethod(builder: IRBuilder, ir: ClassIR, expr: CallExpr, callee: MemberExpr) -> Value:
     decl = ir.method_decl(callee.name)
     args = []
-    arg_kinds, arg_names = expr.arg_kinds[:], expr.arg_names[:]
+    arg_kinds, arg_names = expr.arg_kinds.copy(), expr.arg_names.copy()
     # Add the class argument for class methods in extension classes
     if decl.kind == FUNC_CLASSMETHOD and ir.is_ext_class:
         args.append(builder.load_native_type_object(ir.fullname))
@@ -452,7 +452,7 @@ def translate_super_method_call(builder: IRBuilder, expr: CallExpr, callee: Supe
 
     decl = base.method_decl(callee.name)
     arg_values = [builder.accept(arg) for arg in expr.args]
-    arg_kinds, arg_names = expr.arg_kinds[:], expr.arg_names[:]
+    arg_kinds, arg_names = expr.arg_kinds.copy(), expr.arg_names.copy()
 
     if decl.kind != FUNC_STATICMETHOD:
         # Grab first argument

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -266,7 +266,7 @@ class LowLevelIRBuilder:
 
     def flush_keep_alives(self) -> None:
         if self.keep_alives:
-            self.add(KeepAlive(self.keep_alives[:]))
+            self.add(KeepAlive(self.keep_alives.copy()))
             self.keep_alives = []
 
     # Type conversions

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -85,7 +85,7 @@ def build_type_map(
         )
         class_ir.is_ext_class = is_extension_class(cdef)
         if class_ir.is_ext_class:
-            class_ir.deletable = cdef.info.deletable_attributes[:]
+            class_ir.deletable = cdef.info.deletable_attributes.copy()
         # If global optimizations are disabled, turn of tracking of class children
         if not options.global_opts:
             class_ir.children = None

--- a/mypyc/transform/refcount.py
+++ b/mypyc/transform/refcount.py
@@ -70,7 +70,7 @@ def insert_ref_count_opcodes(ir: FuncIR) -> None:
     defined = analyze_must_defined_regs(ir.blocks, cfg, args, values, strict_errors=True)
     ordering = make_value_ordering(ir)
     cache: BlockCache = {}
-    for block in ir.blocks[:]:
+    for block in ir.blocks.copy():
         if isinstance(block.ops[-1], (Branch, Goto)):
             insert_branch_inc_and_decrefs(
                 block,

--- a/runtests.py
+++ b/runtests.py
@@ -129,7 +129,7 @@ def main() -> None:
         exit(1)
 
     if not args:
-        args = DEFAULT_COMMANDS[:]
+        args = DEFAULT_COMMANDS.copy()
 
     status = 0
 


### PR DESCRIPTION
This PR fixes the [`FURB145`](https://github.com/dosisod/refurb/blob/master/docs/checks.md#furb145-no-slice-copy) error code from Refurb. In my (limited) testing, using `x.copy()` is faster then both the interpreted and compiled versions of `x[:]` (see https://github.com/python/mypy/pull/14887#discussion_r1134836243).

See https://github.com/python/mypy/pull/14887 for more info.