### PR TITLE
Stubtest: verify stub methods or properties are decorated with `@final` if they are decorated with `@final` at runtime

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -558,6 +558,9 @@ def _verify_static_class_methods(
             yield "stub is a classmethod but runtime is not"
         return
 
+    if static_runtime is MISSING:
+        return
+
     if isinstance(static_runtime, classmethod) and not stub.is_class:
         yield "runtime is a classmethod but stub is not"
     if not isinstance(static_runtime, classmethod) and stub.is_class:
@@ -1065,7 +1068,8 @@ def verify_overloadedfuncdef(
     for message in _verify_static_class_methods(stub, runtime, static_runtime, object_path):
         yield Error(object_path, "is inconsistent, " + message, stub, runtime)
 
-    # TODO: Should call _verify_final_method here, but it crashes stubtest: see #14950
+    # TODO: Should call _verify_final_method here,
+    # but overloaded final methods in stubs cause a stubtest crash: see #14950
 
     signature = safe_inspect_signature(runtime)
     if not signature:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1065,6 +1065,8 @@ def verify_overloadedfuncdef(
     for message in _verify_static_class_methods(stub, runtime, static_runtime, object_path):
         yield Error(object_path, "is inconsistent, " + message, stub, runtime)
 
+    # TODO: Should call _verify_final_method here, but it crashes stubtest: see #14950
+
     signature = safe_inspect_signature(runtime)
     if not signature:
         return
@@ -1154,15 +1156,13 @@ def _verify_abstract_status(stub: nodes.FuncDef, runtime: Any) -> Iterator[str]:
         yield f"is inconsistent, runtime {item_type} is abstract but stub is not"
 
 
-def _verify_final_method(stub: nodes.FuncDef, runtime: Any, static_runtime: MaybeMissing[Any]) -> Iterator[str]:
+def _verify_final_method(
+    stub: nodes.FuncDef, runtime: Any, static_runtime: MaybeMissing[Any]
+) -> Iterator[str]:
     if stub.is_final:
         return
-    if (
-        getattr(runtime, "__final__", False)
-        or (
-            static_runtime is not MISSING
-            and getattr(static_runtime, "__final__", False)
-        )
+    if getattr(runtime, "__final__", False) or (
+        static_runtime is not MISSING and getattr(static_runtime, "__final__", False)
     ):
         yield "is decorated with @final at runtime, but not in the stub"
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1311,43 +1311,71 @@ class StubtestUnit(unittest.TestCase):
         yield Case(
             stub="""
             class H:
-                @classmethod
-                def foo(cls) -> None: ...
+                @staticmethod
+                def foo() -> None: ...
             """,
             runtime="""
             class H:
+                @staticmethod
                 @final
-                @classmethod
-                def foo(cls): pass
+                def foo(): pass
             """,
             error="H.foo",
         )
         yield Case(
             stub="""
             class I:
-                @property
-                def foo(self) -> int: ...
+                @classmethod
+                def foo(cls) -> None: ...
             """,
             runtime="""
             class I:
-                @property
                 @final
-                def foo(self): return 42
+                @classmethod
+                def foo(cls): pass
             """,
             error="I.foo",
         )
         yield Case(
             stub="""
             class J:
-                def foo(self, obj: int) -> int: ...
+                @classmethod
+                def foo(cls) -> None: ...
             """,
             runtime="""
             class J:
+                @classmethod
+                @final
+                def foo(cls): pass
+            """,
+            error="J.foo",
+        )
+        yield Case(
+            stub="""
+            class K:
+                @property
+                def foo(self) -> int: ...
+            """,
+            runtime="""
+            class K:
+                @property
+                @final
+                def foo(self): return 42
+            """,
+            error="K.foo",
+        )
+        yield Case(
+            stub="""
+            class L:
+                def foo(self, obj: int) -> int: ...
+            """,
+            runtime="""
+            class L:
                 @final
                 @functools.lru_cache()
                 def foo(self, obj): return obj * 2
             """,
-            error="J.foo",
+            error="L.foo",
         )
 
     @collect_cases

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1364,6 +1364,24 @@ class StubtestUnit(unittest.TestCase):
             """,
             error="K.foo",
         )
+        # This test wouldn't pass,
+        # because the runtime can't set __final__ on instances of builtins.property,
+        # so stubtest has non way of knowing that the runtime was decorated with @final:
+        #
+        # yield Case(
+        #     stub="""
+        #     class K2:
+        #         @property
+        #         def foo(self) -> int: ...
+        #     """,
+        #     runtime="""
+        #     class K2:
+        #         @final
+        #         @property
+        #         def foo(self): return 42
+        #     """,
+        #     error="K2.foo",
+        # )
         yield Case(
             stub="""
             class L:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1188,12 +1188,21 @@ class StubtestUnit(unittest.TestCase):
                 @final
                 @staticmethod
                 def bar() -> None: ...
+                @staticmethod
+                @final
+                def bar2() -> None: ...
                 @final
                 @classmethod
                 def baz(cls) -> None: ...
+                @classmethod
+                @final
+                def baz2(cls) -> None: ...
                 @property
                 @final
                 def eggs(self) -> int: ...
+                @final
+                @property
+                def eggs2(self) -> int: ...
                 @final
                 def ham(self, obj: int) -> int: ...
             """,
@@ -1204,12 +1213,21 @@ class StubtestUnit(unittest.TestCase):
                 @final
                 @staticmethod
                 def bar(): pass
+                @staticmethod
+                @final
+                def bar2(): pass
                 @final
                 @classmethod
                 def baz(cls): pass
+                @classmethod
+                @final
+                def baz2(cls): pass
                 @property
                 @final
                 def eggs(self): return 42
+                @final
+                @property
+                def eggs2(self): pass
                 @final
                 @functools.lru_cache()
                 def ham(self, obj): return obj * 2
@@ -1225,12 +1243,21 @@ class StubtestUnit(unittest.TestCase):
                 @final
                 @staticmethod
                 def bar() -> None: ...
+                @staticmethod
+                @final
+                def bar2() -> None: ...
                 @final
                 @classmethod
                 def baz(cls) -> None: ...
+                @classmethod
+                @final
+                def baz2(cls) -> None: ...
                 @property
                 @final
                 def eggs(self) -> int: ...
+                @final
+                @property
+                def eggs2(self) -> int: ...
                 @final
                 def ham(self, obj: int) -> int: ...
             """,
@@ -1239,10 +1266,16 @@ class StubtestUnit(unittest.TestCase):
                 def foo(self): pass
                 @staticmethod
                 def bar(): pass
+                @staticmethod
+                def bar2(): pass
                 @classmethod
                 def baz(cls): pass
+                @classmethod
+                def baz2(cls): pass
                 @property
                 def eggs(self): return 42
+                @property
+                def eggs2(self): return 42
                 @functools.lru_cache()
                 def ham(self, obj): return obj * 2
             """,


### PR DESCRIPTION
This implements most of #14924. The only thing it _doesn't_ implement is verification for overloaded methods decorated with `@final` -- I tried working on that, but hit #14950.