### PR TITLE
[dataclass_transform] fix serialization for frozen_default

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3915,7 +3915,7 @@ class DataclassTransformSpec:
             "eq_default": self.eq_default,
             "order_default": self.order_default,
             "kw_only_default": self.kw_only_default,
-            "frozen_only_default": self.frozen_default,
+            "frozen_default": self.frozen_default,
             "field_specifiers": list(self.field_specifiers),
         }
 

--- a/test-data/unit/fine-grained-dataclass-transform.test
+++ b/test-data/unit/fine-grained-dataclass-transform.test
@@ -90,3 +90,45 @@ builtins.pyi:12: note: "B" defined here
 main:7: error: Unexpected keyword argument "y" for "B"
 builtins.pyi:12: note: "B" defined here
 ==
+
+[case frozenStays]
+# flags: --python-version 3.11
+from foo import Foo
+
+foo = Foo(base=0, foo=1)
+
+[file transform.py]
+from typing import dataclass_transform, Type
+
+@dataclass_transform(frozen_default=True)
+def dataclass(cls: Type) -> Type: return cls
+
+[file base.py]
+from transform import dataclass
+
+@dataclass
+class Base:
+    base: int
+
+[file foo.py]
+from base import Base
+from transform import dataclass
+
+@dataclass
+class Foo(Base):
+    foo: int
+
+[file foo.py.2]
+from base import Base
+from transform import dataclass
+
+@dataclass
+class Foo(Base):
+    foo: int
+    bar: int = 0
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
+[out]
+==

--- a/test-data/unit/fine-grained-dataclass-transform.test
+++ b/test-data/unit/fine-grained-dataclass-transform.test
@@ -91,7 +91,7 @@ main:7: error: Unexpected keyword argument "y" for "B"
 builtins.pyi:12: note: "B" defined here
 ==
 
-[case frozenStays]
+[case frozenInheritanceViaDefault]
 # flags: --python-version 3.11
 from foo import Foo
 

--- a/test-data/unit/fine-grained-dataclass-transform.test
+++ b/test-data/unit/fine-grained-dataclass-transform.test
@@ -130,5 +130,12 @@ class Foo(Base):
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
 
+# If the frozen parameter is being maintained correctly, we *don't* expect to see issues; if it's
+# broken in incremental mode, then we'll see an error about inheriting a non-frozen class from a
+# frozen one.
+#
+# Ideally we'd also add a `foo.foo = 2` to confirm that frozen semantics are actually being
+# enforced, but incremental tests currently can't start with an error, which makes it tricky to
+# write such a test case.
 [out]
 ==


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fix a typo when serializing the `frozen_default` parameter; fixes #14952.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
