### PR TITLE
Improve bytes formatting error

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -435,7 +435,7 @@ class StringFormatterChecker:
                 actual_type, "__str__"
             ):
                 self.msg.fail(
-                    'If "x = b\'abc\'" then f"{x}" or "{}".format(x) produces "b\'abc\'", '
+                    'If x = b\'abc\' then f"{x}" or "{}".format(x) produces "b\'abc\'", '
                     'not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). '
                     "Otherwise, decode the bytes",
                     call,
@@ -946,7 +946,7 @@ class StringFormatterChecker:
             # Couple special cases for string formatting.
             if has_type_component(typ, "builtins.bytes"):
                 self.msg.fail(
-                    'If "x = b\'abc\'" then "%s" % x produces "b\'abc\'", not "abc". '
+                    'If x = b\'abc\' then "%s" % x produces "b\'abc\'", not "abc". '
                     'If this is desired behavior use "%r" % x. Otherwise, decode the bytes',
                     context,
                     code=codes.STR_BYTES_PY3,

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -435,9 +435,8 @@ class StringFormatterChecker:
                 actual_type, "__str__"
             ):
                 self.msg.fail(
-                    'On Python 3 formatting "b\'abc\'" with "{}" '
-                    'produces "b\'abc\'", not "abc"; '
-                    'use "{!r}" if this is desired behavior',
+                    'If "x = b\'abc\'" then f"{x}" or "{}".format(x) produces "b\'abc\'", '
+                    'not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)',
                     call,
                     code=codes.STR_BYTES_PY3,
                 )
@@ -946,9 +945,8 @@ class StringFormatterChecker:
             # Couple special cases for string formatting.
             if has_type_component(typ, "builtins.bytes"):
                 self.msg.fail(
-                    'On Python 3 formatting "b\'abc\'" with "%s" '
-                    'produces "b\'abc\'", not "abc"; '
-                    'use "%r" if this is desired behavior',
+                    'If "x = b\'abc\'" then "%s" % x produces "b\'abc\'", not "abc"; '
+                    'if this is desired behavior use "%r" % x',
                     context,
                     code=codes.STR_BYTES_PY3,
                 )

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -436,7 +436,8 @@ class StringFormatterChecker:
             ):
                 self.msg.fail(
                     'If "x = b\'abc\'" then f"{x}" or "{}".format(x) produces "b\'abc\'", '
-                    'not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)',
+                    'not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). '
+                    "Otherwise, decode the bytes",
                     call,
                     code=codes.STR_BYTES_PY3,
                 )
@@ -945,8 +946,8 @@ class StringFormatterChecker:
             # Couple special cases for string formatting.
             if has_type_component(typ, "builtins.bytes"):
                 self.msg.fail(
-                    'If "x = b\'abc\'" then "%s" % x produces "b\'abc\'", not "abc"; '
-                    'if this is desired behavior use "%r" % x',
+                    'If "x = b\'abc\'" then "%s" % x produces "b\'abc\'", not "abc". '
+                    'If this is desired behavior use "%r" % x. Otherwise, decode the bytes',
                     context,
                     code=codes.STR_BYTES_PY3,
                 )

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -232,7 +232,7 @@ def test_fstring_basics() -> None:
 
     x = bytes([1, 2, 3, 4])
     # assert f'bytes: {x}' == "bytes: b'\\x01\\x02\\x03\\x04'"
-    # error: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+    # error: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
 
     float_num = 123.4
     assert f'{float_num}' == '123.4'

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -232,8 +232,7 @@ def test_fstring_basics() -> None:
 
     x = bytes([1, 2, 3, 4])
     # assert f'bytes: {x}' == "bytes: b'\\x01\\x02\\x03\\x04'"
-    # error: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc";
-    #        use "{!r}" if this is desired behavior behavior
+    # error: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
 
     float_num = 123.4
     assert f'{float_num}' == '123.4'

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -232,7 +232,7 @@ def test_fstring_basics() -> None:
 
     x = bytes([1, 2, 3, 4])
     # assert f'bytes: {x}' == "bytes: b'\\x01\\x02\\x03\\x04'"
-    # error: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+    # error: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
 
     float_num = 123.4
     assert f'{float_num}' == '123.4'

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -638,8 +638,8 @@ def g() -> int:
 '%d' % 'no'  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")  [str-format]
 '%d + %d' % (1, 2, 3)  # E: Not all arguments converted during string formatting  [str-format]
 
-'{}'.format(b'abc')  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior  [str-bytes-safe]
-'%s' % b'abc'  # E: On Python 3 formatting "b'abc'" with "%s" produces "b'abc'", not "abc"; use "%r" if this is desired behavior  [str-bytes-safe]
+'{}'.format(b'abc')  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)  [str-bytes-safe]
+'%s' % b'abc'  # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc"; if this is desired behavior use "%r" % x  [str-bytes-safe]
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-medium.pyi]
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -638,8 +638,8 @@ def g() -> int:
 '%d' % 'no'  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")  [str-format]
 '%d + %d' % (1, 2, 3)  # E: Not all arguments converted during string formatting  [str-format]
 
-'{}'.format(b'abc')  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes  [str-bytes-safe]
-'%s' % b'abc'  # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes  [str-bytes-safe]
+'{}'.format(b'abc')  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes  [str-bytes-safe]
+'%s' % b'abc'  # E: If x = b'abc' then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes  [str-bytes-safe]
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-medium.pyi]
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -638,8 +638,8 @@ def g() -> int:
 '%d' % 'no'  # E: Incompatible types in string interpolation (expression has type "str", placeholder has type "Union[int, float, SupportsInt]")  [str-format]
 '%d + %d' % (1, 2, 3)  # E: Not all arguments converted during string formatting  [str-format]
 
-'{}'.format(b'abc')  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)  [str-bytes-safe]
-'%s' % b'abc'  # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc"; if this is desired behavior use "%r" % x  [str-bytes-safe]
+'{}'.format(b'abc')  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes  [str-bytes-safe]
+'%s' % b'abc'  # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes  [str-bytes-safe]
 [builtins fixtures/primitives.pyi]
 [typing fixtures/typing-medium.pyi]
 

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -30,8 +30,8 @@ xb: bytes
 xs: str
 
 '%s' % xs   # OK
-'%s' % xb   # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc"; if this is desired behavior use "%r" % x
-'%(name)s' % {'name': b'value'}  # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc"; if this is desired behavior use "%r" % x
+'%s' % xb   # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes
+'%(name)s' % {'name': b'value'}  # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes
 [builtins fixtures/primitives.pyi]
 
 [case testStringInterpolationCount]
@@ -435,21 +435,21 @@ N = NewType('N', bytes)
 n: N
 
 '{}'.format(a)
-'{}'.format(b)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
-'{}'.format(x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
-'{}'.format(n)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+'{}'.format(b)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+'{}'.format(x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+'{}'.format(n)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
 
-f'{b}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
-f'{x}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
-f'{n}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+f'{b}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+f'{x}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+f'{n}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
 
 class C(Generic[B]):
     x: B
     def meth(self) -> None:
-        '{}'.format(self.x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+        '{}'.format(self.x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
 
 def func(x: A) -> A:
-    '{}'.format(x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+    '{}'.format(x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
     return x
 
 '{!r}'.format(a)

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -30,8 +30,8 @@ xb: bytes
 xs: str
 
 '%s' % xs   # OK
-'%s' % xb   # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes
-'%(name)s' % {'name': b'value'}  # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes
+'%s' % xb   # E: If x = b'abc' then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes
+'%(name)s' % {'name': b'value'}  # E: If x = b'abc' then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes
 [builtins fixtures/primitives.pyi]
 
 [case testStringInterpolationCount]
@@ -435,21 +435,21 @@ N = NewType('N', bytes)
 n: N
 
 '{}'.format(a)
-'{}'.format(b)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
-'{}'.format(x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
-'{}'.format(n)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+'{}'.format(b)  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+'{}'.format(x)  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+'{}'.format(n)  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
 
-f'{b}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
-f'{x}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
-f'{n}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+f'{b}'  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+f'{x}'  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+f'{n}'  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
 
 class C(Generic[B]):
     x: B
     def meth(self) -> None:
-        '{}'.format(self.x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+        '{}'.format(self.x)  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
 
 def func(x: A) -> A:
-    '{}'.format(x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
+    '{}'.format(x)  # E: If x = b'abc' then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). Otherwise, decode the bytes
     return x
 
 '{!r}'.format(a)

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -30,8 +30,8 @@ xb: bytes
 xs: str
 
 '%s' % xs   # OK
-'%s' % xb   # E: On Python 3 formatting "b'abc'" with "%s" produces "b'abc'", not "abc"; use "%r" if this is desired behavior
-'%(name)s' % {'name': b'value'}  # E: On Python 3 formatting "b'abc'" with "%s" produces "b'abc'", not "abc"; use "%r" if this is desired behavior
+'%s' % xb   # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc"; if this is desired behavior use "%r" % x
+'%(name)s' % {'name': b'value'}  # E: If "x = b'abc'" then "%s" % x produces "b'abc'", not "abc"; if this is desired behavior use "%r" % x
 [builtins fixtures/primitives.pyi]
 
 [case testStringInterpolationCount]
@@ -435,21 +435,21 @@ N = NewType('N', bytes)
 n: N
 
 '{}'.format(a)
-'{}'.format(b)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
-'{}'.format(x)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
-'{}'.format(n)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+'{}'.format(b)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+'{}'.format(x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+'{}'.format(n)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
 
-f'{b}'  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
-f'{x}'  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
-f'{n}'  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+f'{b}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+f'{x}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
+f'{n}'  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
 
 class C(Generic[B]):
     x: B
     def meth(self) -> None:
-        '{}'.format(self.x)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+        '{}'.format(self.x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
 
 def func(x: A) -> A:
-    '{}'.format(x)  # E: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior
+    '{}'.format(x)  # E: If "x = b'abc'" then f"{x}" or "{}".format(x) produces "b'abc'", not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x)
     return x
 
 '{!r}'.format(a)


### PR DESCRIPTION
Fixes #11806

This error message was last changed in #11139 to make it more applicable to f-strings. Since users are still getting confused, it makes sense to be more explicit about what the recommended fix is. There was also an extra set of quotes and a mention of Python 3 that didn't help.

I think this is still very much a useful error, it caught a bug I had recently.