### PR TITLE
Make some stubtest tests less verbose

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -767,6 +767,20 @@ class StubtestUnit(unittest.TestCase):
     def test_type_alias(self) -> Iterator[Case]:
         yield Case(
             stub="""
+            import collections.abc
+            import re
+            import typing
+            from typing import Callable, Dict, Generic, Iterable, List, Match, Tuple, TypeVar, Union
+            """,
+            runtime="""
+            import collections.abc
+            import re
+            from typing import Callable, Dict, Generic, Iterable, List, Match, Tuple, TypeVar, Union
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
             class X:
                 def f(self) -> None: ...
             Y = X
@@ -778,27 +792,18 @@ class StubtestUnit(unittest.TestCase):
             """,
             error="Y.f",
         )
-        yield Case(
-            stub="""
-            from typing import Tuple
-            A = Tuple[int, str]
-            """,
-            runtime="A = (int, str)",
-            error="A",
-        )
+        yield Case(stub="A = Tuple[int, str]", runtime="A = (int, str)", error="A")
         # Error if an alias isn't present at runtime...
         yield Case(stub="B = str", runtime="", error="B")
         # ... but only if the alias isn't private
         yield Case(stub="_C = int", runtime="", error=None)
         yield Case(
             stub="""
-            from typing import Tuple
             D = tuple[str, str]
             E = Tuple[int, int, int]
             F = Tuple[str, int]
             """,
             runtime="""
-            from typing import List, Tuple
             D = Tuple[str, str]
             E = Tuple[int, int, int]
             F = List[str]
@@ -807,13 +812,11 @@ class StubtestUnit(unittest.TestCase):
         )
         yield Case(
             stub="""
-            from typing import Union
             G = str | int
             H = Union[str, bool]
             I = str | int
             """,
             runtime="""
-            from typing import Union
             G = Union[str, int]
             H = Union[str, bool]
             I = str
@@ -822,16 +825,12 @@ class StubtestUnit(unittest.TestCase):
         )
         yield Case(
             stub="""
-            import typing
-            from collections.abc import Iterable
-            from typing import Dict
             K = dict[str, str]
             L = Dict[int, int]
-            KK = Iterable[str]
+            KK = collections.abc.Iterable[str]
             LL = typing.Iterable[str]
             """,
             runtime="""
-            from typing import Iterable, Dict
             K = Dict[str, str]
             L = Dict[int, int]
             KK = Iterable[str]
@@ -841,14 +840,12 @@ class StubtestUnit(unittest.TestCase):
         )
         yield Case(
             stub="""
-            from typing import Generic, TypeVar
             _T = TypeVar("_T")
             class _Spam(Generic[_T]):
                 def foo(self) -> None: ...
             IntFood = _Spam[int]
             """,
             runtime="""
-            from typing import Generic, TypeVar
             _T = TypeVar("_T")
             class _Bacon(Generic[_T]):
                 def foo(self, arg): pass
@@ -859,14 +856,11 @@ class StubtestUnit(unittest.TestCase):
         yield Case(stub="StrList = list[str]", runtime="StrList = ['foo', 'bar']", error="StrList")
         yield Case(
             stub="""
-            import collections.abc
-            from typing import Callable
-            N = Callable[[str], bool]
+            N = typing.Callable[[str], bool]
             O = collections.abc.Callable[[int], str]
-            P = Callable[[str], bool]
+            P = typing.Callable[[str], bool]
             """,
             runtime="""
-            from typing import Callable
             N = Callable[[str], bool]
             O = Callable[[int], str]
             P = int
@@ -897,17 +891,7 @@ class StubtestUnit(unittest.TestCase):
             """,
             error=None,
         )
-        yield Case(
-            stub="""
-            from typing import Match
-            M = Match[str]
-            """,
-            runtime="""
-            from typing import Match
-            M = Match[str]
-            """,
-            error=None,
-        )
+        yield Case(stub="M = Match[str]", runtime="M = Match[str]", error=None)
         yield Case(
             stub="""
             class Baz:
@@ -940,37 +924,32 @@ class StubtestUnit(unittest.TestCase):
         if sys.version_info >= (3, 10):
             yield Case(
                 stub="""
-                import collections.abc
-                import re
-                from typing import Callable, Dict, Match, Iterable, Tuple, Union
                 Q = Dict[str, str]
                 R = dict[int, int]
                 S = Tuple[int, int]
                 T = tuple[str, str]
                 U = int | str
                 V = Union[int, str]
-                W = Callable[[str], bool]
+                W = typing.Callable[[str], bool]
                 Z = collections.abc.Callable[[str], bool]
-                QQ = Iterable[str]
+                QQ = typing.Iterable[str]
                 RR = collections.abc.Iterable[str]
-                MM = Match[str]
+                MM = typing.Match[str]
                 MMM = re.Match[str]
                 """,
                 runtime="""
-                from collections.abc import Callable, Iterable
-                from re import Match
                 Q = dict[str, str]
                 R = dict[int, int]
                 S = tuple[int, int]
                 T = tuple[str, str]
                 U = int | str
                 V = int | str
-                W = Callable[[str], bool]
-                Z = Callable[[str], bool]
-                QQ = Iterable[str]
-                RR = Iterable[str]
-                MM = Match[str]
-                MMM = Match[str]
+                W = collections.abc.Callable[[str], bool]
+                Z = collections.abc.Callable[[str], bool]
+                QQ = collections.abc.Iterable[str]
+                RR = collections.abc.Iterable[str]
+                MM = re.Match[str]
+                MMM = re.Match[str]
                 """,
                 error=None,
             )


### PR DESCRIPTION
I was working on adding some extra checks around type aliases to stubtest, and realised that some tests for type aliases that I added previously could be made much less verbose and much easier to read. (Consolidate the imports into a single case at the top.)