### PR TITLE
Convert insecure links to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Web site and documentation
 
 Additional information is available at the web site:
 
-  http://www.mypy-lang.org/
+  https://www.mypy-lang.org/
 
 Jump straight to the documentation:
 

--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,7 @@ def pytest_configure(config):
 
 
 # This function name is special to pytest.  See
-# http://doc.pytest.org/en/latest/writing_plugins.html#initialization-command-line-and-configuration-hooks
+# https://doc.pytest.org/en/latest/how-to/writing_plugins.html#initialization-command-line-and-configuration-hooks
 def pytest_addoption(parser) -> None:
     parser.addoption(
         "--bench", action="store_true", default=False, help="Enable the benchmark test runs"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://www.sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -56,7 +56,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://www.sphinx-doc.org/
 	exit /b 1
 )
 

--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -178,7 +178,7 @@ Caveats/Known Issues
   :py:meth:`__init__ <object.__init__>` will be replaced by ``Any``.
 
 * :ref:`Validator decorators <attrs:examples-validators>`
-  and `default decorators <http://www.attrs.org/en/stable/examples.html#defaults>`_
+  and `default decorators <https://www.attrs.org/en/stable/examples.html#defaults>`_
   are not type-checked against the attribute they are setting/validating.
 
 * Method definitions added by mypy currently overwrite any existing method

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -267,8 +267,8 @@ rst_prolog = ".. |...| unicode:: U+2026   .. ellipsis\n"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "six": ("https://six.readthedocs.io", None),
-    "attrs": ("http://www.attrs.org/en/stable", None),
-    "cython": ("http://docs.cython.org/en/latest", None),
+    "attrs": ("https://www.attrs.org/en/stable/", None),
+    "cython": ("https://docs.cython.org/en/latest", None),
     "monkeytype": ("https://monkeytype.readthedocs.io/en/latest", None),
     "setuptools": ("https://setuptools.readthedocs.io/en/latest", None),
 }

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -36,7 +36,7 @@ Here are some potential benefits of mypy-style static typing:
   grows, you can adapt tricky application logic to static typing to
   help maintenance.
 
-See also the `front page <http://www.mypy-lang.org>`_ of the mypy web
+See also the `front page <https://www.mypy-lang.org>`_ of the mypy web
 site.
 
 Would my project benefit from static typing?
@@ -202,7 +202,7 @@ Mypy is a cool project. Can I help?
 ***********************************
 
 Any help is much appreciated! `Contact
-<http://www.mypy-lang.org/contact.html>`_ the developers if you would
+<https://www.mypy-lang.org/contact.html>`_ the developers if you would
 like to contribute. Any help related to development, design,
 publicity, documentation, testing, web site maintenance, financing,
 etc. can be helpful. You can learn a lot by contributing, and anybody

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -109,7 +109,7 @@ Contents
    :caption: Project Links
 
    GitHub <https://github.com/python/mypy>
-   Website <http://mypy-lang.org/>
+   Website <https://mypy-lang.org/>
 
 Indices and tables
 ==================

--- a/misc/remove-eol-whitespace.sh
+++ b/misc/remove-eol-whitespace.sh
@@ -3,6 +3,6 @@
 # Remove trailing whitespace from all non-binary files in a git repo.
 
 # From https://gist.github.com/dpaluy/3690668; originally from here:
-# http://unix.stackexchange.com/questions/36233/how-to-skip-file-in-sed-if-it-contains-regex/36240#36240
+# https://unix.stackexchange.com/questions/36233/how-to-skip-file-in-sed-if-it-contains-regex/36240#36240
 
 git grep -I --name-only -z -e '' | xargs -0 sed -i -e 's/[ \t]\+\(\r\?\)$/\1/'

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1739,8 +1739,8 @@ on at least one module for which the cache metadata is stale.)
 
 Now we can execute steps A-C from the first section.  Finding SCCs for
 step A shouldn't be hard; there's a recipe here:
-http://code.activestate.com/recipes/578507/.  There's also a plethora
-of topsort recipes, e.g. http://code.activestate.com/recipes/577413/.
+https://code.activestate.com/recipes/578507/.  There's also a plethora
+of topsort recipes, e.g. https://code.activestate.com/recipes/577413/.
 
 For single nodes, processing is simple.  If the node was cached, we
 deserialize the cache data and fix up cross-references.  Otherwise, we
@@ -3517,7 +3517,7 @@ def strongly_connected_components(
       exactly once; vertices not part of a SCC are returned as
       singleton sets.
 
-    From http://code.activestate.com/recipes/578507/.
+    From https://code.activestate.com/recipes/578507/.
     """
     identified: set[str] = set()
     stack: list[str] = []
@@ -3580,7 +3580,7 @@ def topsort(data: dict[T, set[T]]) -> Iterable[set[T]]:
         {B, C}
         {A}
 
-    From http://code.activestate.com/recipes/577413/.
+    From https://code.activestate.com/recipes/577413/.
     """
     # TODO: Use a faster algorithm?
     for k, v in data.items():

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -299,7 +299,7 @@ def attr_class_maker_callback(
     it will add an __init__ or all the compare methods.
     For frozen=True it will turn the attrs into properties.
 
-    See http://www.attrs.org/en/stable/how-does-it-work.html for information on how attrs works.
+    See https://www.attrs.org/en/stable/how-does-it-work.html for information on how attrs works.
 
     If this returns False, some required metadata was not ready yet and we need another
     pass.

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -606,7 +606,7 @@ def pytest_addoption(parser: Any) -> None:
 
 
 # This function name is special to pytest.  See
-# http://doc.pytest.org/en/latest/writing_plugins.html#collection-hooks
+# https://doc.pytest.org/en/latest/how-to/writing_plugins.html#collection-hooks
 def pytest_pycollect_makeitem(collector: Any, name: str, obj: object) -> Any | None:
     """Called by pytest on each object in modules configured in conftest.py files.
 

--- a/mypyc/doc/introduction.rst
+++ b/mypyc/doc/introduction.rst
@@ -10,7 +10,7 @@ The compiled language is a strict, *gradually typed* Python variant. It
 restricts the use of some dynamic Python features to gain performance,
 but it's mostly compatible with standard Python.
 
-Mypyc uses `mypy <http://www.mypy-lang.org/>`_ to perform type
+Mypyc uses `mypy <https://www.mypy-lang.org/>`_ to perform type
 checking and type inference. Most type system features in the stdlib
 `typing <https://docs.python.org/3/library/typing.html>`_ module are
 supported.

--- a/mypyc/doc/make.bat
+++ b/mypyc/doc/make.bat
@@ -21,7 +21,7 @@ if errorlevel 9009 (
 	echo.may add the Sphinx directory to PATH.
 	echo.
 	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
+	echo.https://www.sphinx-doc.org/
 	exit /b 1
 )
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,7 @@ python_files = test*.py
 # logic by implementing `pytest_pycollect_makeitem` in mypy.test.data;
 # the test files import that module, and pytest sees the magic name
 # and invokes it at the relevant moment.  See
-# http://doc.pytest.org/en/latest/writing_plugins.html#collection-hooks
+# https://doc.pytest.org/en/latest/how-to/writing_plugins.html#collection-hooks
 
 # Both our plugin and unittest provide their own collection logic,
 # So we can disable the default python collector by giving it empty

--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,7 @@ setup(
     long_description=long_description,
     author="Jukka Lehtosalo",
     author_email="jukka.lehtosalo@iki.fi",
-    url="http://www.mypy-lang.org/",
+    url="https://www.mypy-lang.org/",
     license="MIT License",
     py_modules=[],
     ext_modules=ext_modules,
@@ -236,7 +236,7 @@ setup(
     python_requires=">=3.7",
     include_package_data=True,
     project_urls={
-        "News": "http://mypy-lang.org/news.html",
+        "News": "https://mypy-lang.org/news.html",
         "Documentation": "https://mypy.readthedocs.io/en/stable/index.html",
         "Repository": "https://github.com/python/mypy",
     },


### PR DESCRIPTION
Also updated a few links that were pointing to redirects.

Skipped following files:

* XML/SVG files linking to XML namespaces
* `mypyc/external` - looks like vendored code
* `LICENSE` - because it's verbatim legal text, also pythonlabs.com isn't available on HTTPS
