### PR TITLE
Fix type argument inference for overloaded functions with explicit self types (Fixes #14943).

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -10,7 +10,7 @@ import mypy.typeops
 from mypy.argmap import ArgTypeExpander
 from mypy.erasetype import erase_typevars
 from mypy.maptype import map_instance_to_supertype
-from mypy.nodes import ARG_OPT, ARG_POS, CONTRAVARIANT, COVARIANT, ArgKind, FuncDef
+from mypy.nodes import ARG_OPT, ARG_POS, CONTRAVARIANT, COVARIANT, ArgKind
 from mypy.types import (
     TUPLE_LIKE_INSTANCE_NAMES,
     AnyType,
@@ -1138,13 +1138,8 @@ def find_matching_overload_item(overloaded: Overloaded, template: CallableType) 
             item, template, is_compat=mypy.subtypes.is_subtype, ignore_return=True
         ):
             return item
-    # Try to return the first item with the correct self type (fixes issue 14943).
-    for item in items:
-        if isinstance(item.definition, FuncDef) and isinstance(item.definition.type, CallableType):
-            if item.bound_args and item.definition.type.arg_types:
-                if item.bound_args[0] == item.definition.type.arg_types[0]:
-                    return item
-    # Give up and just return the first of all items.
+    # Fall back to the first item if we can't find a match. This is totally arbitrary --
+    # maybe we should just bail out at this point.
     return items[0]
 
 

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -10,7 +10,7 @@ import mypy.typeops
 from mypy.argmap import ArgTypeExpander
 from mypy.erasetype import erase_typevars
 from mypy.maptype import map_instance_to_supertype
-from mypy.nodes import ARG_OPT, ARG_POS, CONTRAVARIANT, COVARIANT, ArgKind
+from mypy.nodes import ARG_OPT, ARG_POS, CONTRAVARIANT, COVARIANT, ArgKind, FuncDef
 from mypy.types import (
     TUPLE_LIKE_INSTANCE_NAMES,
     AnyType,
@@ -1138,8 +1138,13 @@ def find_matching_overload_item(overloaded: Overloaded, template: CallableType) 
             item, template, is_compat=mypy.subtypes.is_subtype, ignore_return=True
         ):
             return item
-    # Fall back to the first item if we can't find a match. This is totally arbitrary --
-    # maybe we should just bail out at this point.
+    # Try to return the first item with the correct self type (fixes issue 14943).
+    for item in items:
+        if isinstance(item.definition, FuncDef) and isinstance(item.definition.type, CallableType):
+            if item.bound_args and item.definition.type.arg_types:
+                if item.bound_args[0] == item.definition.type.arg_types[0]:
+                    return item
+    # Give up and just return the first of all items.
     return items[0]
 
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -291,7 +291,10 @@ def _is_subtype(
         # ErasedType as we do for non-proper subtyping.
         return True
 
-    if subtype_context.ignore_type_vars and (isinstance(left, TypeVarType) or isinstance(right, TypeVarType)):
+
+    if subtype_context.ignore_type_vars and (
+        isinstance(left, TypeVarType) or isinstance(right, TypeVarType)
+    ):
         return True
 
     if isinstance(right, UnionType) and not isinstance(left, UnionType):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -291,7 +291,6 @@ def _is_subtype(
         # ErasedType as we do for non-proper subtyping.
         return True
 
-
     if subtype_context.ignore_type_vars and (
         isinstance(left, TypeVarType) or isinstance(right, TypeVarType)
     ):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -86,6 +86,7 @@ class SubtypeContext:
         # Supported for both proper and non-proper
         ignore_promotions: bool = False,
         ignore_uninhabited: bool = False,
+        ignore_type_vars: bool = False,
         # Proper subtype flags
         erase_instances: bool = False,
         keep_erased_types: bool = False,
@@ -96,6 +97,7 @@ class SubtypeContext:
         self.ignore_declared_variance = ignore_declared_variance
         self.ignore_promotions = ignore_promotions
         self.ignore_uninhabited = ignore_uninhabited
+        self.ignore_type_vars = ignore_type_vars
         self.erase_instances = erase_instances
         self.keep_erased_types = keep_erased_types
         self.options = options
@@ -119,6 +121,7 @@ def is_subtype(
     ignore_declared_variance: bool = False,
     ignore_promotions: bool = False,
     ignore_uninhabited: bool = False,
+    ignore_type_vars: bool = False,
     options: Options | None = None,
 ) -> bool:
     """Is 'left' subtype of 'right'?
@@ -139,6 +142,7 @@ def is_subtype(
             ignore_declared_variance=ignore_declared_variance,
             ignore_promotions=ignore_promotions,
             ignore_uninhabited=ignore_uninhabited,
+            ignore_type_vars=ignore_type_vars,
             options=options,
         )
     else:
@@ -285,6 +289,9 @@ def _is_subtype(
     ):
         # TODO: should we consider all types proper subtypes of UnboundType and/or
         # ErasedType as we do for non-proper subtyping.
+        return True
+
+    if subtype_context.ignore_type_vars and (isinstance(left, TypeVarType) or isinstance(right, TypeVarType)):
         return True
 
     if isinstance(right, UnionType) and not isinstance(left, UnionType):

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -296,7 +296,7 @@ def bind_self(
                 selftype = get_self_type(methoditem, origtype)
                 selftype_proper = get_proper_type(selftype)
                 if not isinstance(selftype_proper, Instance) or is_subtype(
-                    origtype, selftype_proper, ignore_type_vars=False
+                    origtype, selftype_proper, ignore_type_vars=True
                 ):
                     methoditems.append(methoditem)
                     if selftypes is not None:

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -285,7 +285,7 @@ def bind_self(method: F, original_type: Type | None = None, is_classmethod: bool
             for mi in method.items:
                 selftype = get_proper_type(mi.arg_types[0])
                 if not isinstance(selftype, Instance) or is_subtype(
-                    origtype, selftype, ignore_type_vars=True
+                    origtype, selftype, ignore_type_vars=False
                 ):
                     methoditems.append(mi)
             if len(methoditems) == 0:

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4020,3 +4020,42 @@ class P(Protocol):
 
 [file lib.py]
 class C: ...
+
+[case TestOverloadedMethodWithExplictSelfTypes]
+from typing import Generic, overload, Protocol, TypeVar, Union
+
+AnyStr = TypeVar("AnyStr", str, bytes)
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class SupportsRead(Protocol[T_co]):
+    def read(self) -> T_co: ...
+
+class SupportsWrite(Protocol[T_contra]):
+    def write(self, s: T_contra) -> int: ...
+
+class Input(Generic[AnyStr]):
+    def read(self) -> AnyStr: ...
+
+class Output(Generic[AnyStr]):
+    @overload
+    def write(self: Output[str], s: str) -> int: ...
+    @overload
+    def write(self: Output[bytes], s: bytes) -> int: ...
+    def write(self, s: Union[str, bytes]) -> int: ...
+
+def f(src: SupportsRead[AnyStr], dst: SupportsWrite[AnyStr]) -> None: ...
+
+def g1(a: Input[bytes], b: Output[bytes]) -> None:
+    f(a, b)
+
+def g2(a: Input[bytes], b: Output[bytes]) -> None:
+    f(a, b)
+
+def g3(a: Input[str], b: Output[bytes]) -> None:
+    f(a, b)  # E: Cannot infer type argument 1 of "f"
+
+def g4(a: Input[bytes], b: Output[str]) -> None:
+    f(a, b)  # E: Cannot infer type argument 1 of "f"
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -266,6 +266,26 @@ class B(A):
     def f(*a, **kw): ...
 [builtins fixtures/dict.pyi]
 
+[case testSelfTypeOverrideCompatibilitySelfTypeVar]
+from typing import Any, Generic, Self, TypeVar, overload
+
+T_co = TypeVar('T_co', covariant=True)
+
+class Config(Generic[T_co]):
+	@overload
+	def get(self, instance: None) -> Self: ...
+	@overload
+	def get(self, instance: Any) -> T_co: ...
+	def get(self, *a, **kw): ...
+
+class MultiConfig(Config[T_co]):
+	@overload
+	def get(self, instance: None) -> Self: ...
+	@overload
+	def get(self, instance: Any) -> T_co: ...
+	def get(self, *a, **kw): ...
+[builtins fixtures/dict.pyi]
+
 [case testSelfTypeSuper]
 from typing import TypeVar, cast
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -232,7 +232,7 @@ class C(A[None]):
                                      # N:          def f(self, s: int) -> int
 [builtins fixtures/tuple.pyi]
 
-[case testSelfTypeOverrideCompatibilityTypeVar-xfail]
+[case testSelfTypeOverrideCompatibilityTypeVar]
 from typing import overload, TypeVar, Union
 
 AT = TypeVar("AT", bound="A")


### PR DESCRIPTION
Fix type argument inference for overloaded functions with explicit self types (Fixes #14943).

When finding no compatible callable right away, try to let method `ConstraintBuilderVisitor.find_matching_overload_item` return the first overloaded function with the suitable self type.

Checked by test case `TestOverloadedMethodWithExplictSelfTypes`.