### PR TITLE
Support descriptors in dataclass transform

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -770,6 +770,11 @@ class DataclassTransformer:
         if sym.implicit:
             return default
         t = get_proper_type(sym.type)
+
+        # Perform a simple-minded inference from the signature of __set__, if present.
+        # We can't use mypy.checkmember here, since this plugin runs before type checking.
+        # We only support some basic scanerios here, which is hopefully sufficient for
+        # the vast majority of use cases.
         if not isinstance(t, Instance):
             return default
         setter = t.type.get("__set__")

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -100,7 +100,7 @@ class DataclassAttribute:
         self.has_default = has_default
         self.line = line
         self.column = column
-        self.type = type
+        self.type = type  # Type as __init__ argument
         self.info = info
         self.kw_only = kw_only
         self.is_neither_frozen_nor_nonfrozen = is_neither_frozen_nor_nonfrozen

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -771,10 +771,14 @@ class DataclassTransformer:
         t = get_proper_type(sym.type)
         if not isinstance(t, Instance):
             return default
-        if "__set__" in t.type.names:
-            setter = t.type.names["__set__"]
+        setter = t.type.get("__set__")
+        if setter:
             if isinstance(setter.node, FuncDef):
-                setter_type = get_proper_type(setter.type)
+                super_info = t.type.get_containing_type_info("__set__")
+                assert super_info
+                setter_type = get_proper_type(
+                    map_type_from_supertype(setter.type, t.type, super_info)
+                )
                 if isinstance(setter_type, CallableType) and setter_type.arg_kinds == [
                     ARG_POS,
                     ARG_POS,

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -582,7 +582,7 @@ class DataclassTransformer:
                     )
 
             current_attr_names.add(lhs.name)
-            attr_type = _infer_dataclass_attr_type(sym)
+            init_type = _infer_dataclass_attr_init_type(sym)
             found_attrs[lhs.name] = DataclassAttribute(
                 name=lhs.name,
                 alias=alias,
@@ -591,7 +591,7 @@ class DataclassTransformer:
                 has_default=has_default,
                 line=stmt.line,
                 column=stmt.column,
-                type=attr_type,
+                type=init_type,
                 info=cls.info,
                 kw_only=is_kw_only,
                 is_neither_frozen_nor_nonfrozen=_has_direct_dataclass_transform_metaclass(
@@ -818,7 +818,7 @@ def _has_direct_dataclass_transform_metaclass(info: TypeInfo) -> bool:
     )
 
 
-def _infer_dataclass_attr_type(sym: SymbolTableNode) -> Type | None:
+def _infer_dataclass_attr_init_type(sym: SymbolTableNode) -> Type | None:
     if sym.implicit:
         return sym.type
     t = get_proper_type(sym.type)

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -540,7 +540,8 @@ class DataclassTransformer:
                 # Make all non-default dataclass attributes implicit because they are de-facto
                 # set on self in the generated __init__(), not in the class body. On the other
                 # hand, we don't know how custom dataclass transforms initialize attributes,
-                # so we don't treat them as implicit. This is required to support descriptors.
+                # so we don't treat them as implicit. This is required to support descriptors
+                # (https://github.com/python/mypy/issues/14868).
                 sym.implicit = True
 
             is_kw_only = kw_only

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -6,7 +6,7 @@ from typing import Iterator, Optional
 from typing_extensions import Final
 
 from mypy import errorcodes, message_registry
-from mypy.expandtype import expand_type
+from mypy.expandtype import expand_type, expand_type_by_instance
 from mypy.nodes import (
     ARG_NAMED,
     ARG_NAMED_OPT,
@@ -831,5 +831,5 @@ def _infer_dataclass_attr_type(sym: SymbolTableNode) -> Type | None:
             if not isinstance(setter_type, CallableType):
                 assert False, "unknown type"
             if setter_type.arg_kinds == [ARG_POS, ARG_POS, ARG_POS]:
-                return setter_type.arg_types[2]
+                return expand_type_by_instance(setter_type.arg_types[2], t)
     return sym.type

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -845,7 +845,7 @@ reveal_type(C.x)  # N: Revealed type is "__main__.Desc"
 from typing import dataclass_transform, overload, Any, TypeVar, Generic
 
 @dataclass_transform()
-def my_dataclass(cls): ...
+def my_dataclass(frozen: bool = False): ...
 
 T = TypeVar("T")
 
@@ -858,7 +858,7 @@ class Desc(Generic[T]):
 
     def __set__(self, instance: Any, value: T) -> None: ...
 
-@my_dataclass
+@my_dataclass()
 class C:
     x: Desc[str]
 
@@ -866,6 +866,15 @@ C(x='x')
 C(x=1)  # E: Argument "x" to "C" has incompatible type "int"; expected "str"
 reveal_type(C(x='x').x)  # N: Revealed type is "builtins.str"
 reveal_type(C.x)  # N: Revealed type is "__main__.Desc[builtins.str]"
+
+@my_dataclass(frozen=True)
+class F:
+    x: Desc[str]
+
+F(x='x')
+F(x=1)  # E: Argument "x" to "F" has incompatible type "int"; expected "str"
+reveal_type(F(x='x').x)  # N: Revealed type is "builtins.str"
+reveal_type(F.x)  # N: Revealed type is "__main__.Desc[builtins.str]"
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -919,3 +919,40 @@ c.x = 1  # E: Incompatible types in assignment (expression has type "int", varia
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformUnsupportedDescriptors]
+# flags: --python-version 3.11
+
+from typing import dataclass_transform, overload, Any
+
+@dataclass_transform()
+def my_dataclass(cls): ...
+
+class Desc:
+    @overload
+    def __get__(self, instance: None, owner: Any) -> int: ...
+    @overload
+    def __get__(self, instance: object, owner: Any) -> str: ...
+    def __get__(self, instance, owner): ...
+
+    def __set__(*args, **kwargs): ...
+
+class Desc2:
+    @overload
+    def __get__(self, instance: None, owner: Any) -> int: ...
+    @overload
+    def __get__(self, instance: object, owner: Any) -> str: ...
+    def __get__(self, instance, owner): ...
+
+    @overload
+    def __set__(self, instance: Any, value: bytes) -> None: ...
+    @overload
+    def __set__(self) -> None: ...
+    def __set__(self, *args, **kawrga) -> None: ...
+
+@my_dataclass
+class C:
+    x: Desc  # E: Unsupported signature for "__set__" in "Desc"
+    y: Desc2  # E: Unsupported "__set__" in "Desc2"
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -807,3 +807,32 @@ reveal_type(bar.base)  # N: Revealed type is "builtins.int"
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformDescriptors]
+# flags: --python-version 3.11
+
+from typing import dataclass_transform, overload, Any
+
+@dataclass_transform()
+def my_dataclass(cls): ...
+
+class Desc:
+    @overload
+    def __get__(self, instance: None, owner: Any) -> Desc: ...
+    @overload
+    def __get__(self, instance: object, owner: Any) -> str: ...
+    def __get__(self, instance: object | None, owner: Any) -> Desc | str: ...
+
+    def __set__(self, instance: Any, value: str) -> None: ...
+
+@my_dataclass
+class C:
+    x: Desc
+
+C(x='x')
+C(x=1)  # E: Argument "x" to "C" has incompatible type "int"; expected "str"
+reveal_type(C(x='x').x)  # N: Revealed type is "builtins.str"
+reveal_type(C.x)  # N: Revealed type is "__main__.Desc"
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -808,7 +808,7 @@ reveal_type(bar.base)  # N: Revealed type is "builtins.int"
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
 
-[case testDataclassTransformDescriptors]
+[case testDataclassTransformSimpleDescriptor]
 # flags: --python-version 3.11
 
 from typing import dataclass_transform, overload, Any
@@ -828,11 +828,44 @@ class Desc:
 @my_dataclass
 class C:
     x: Desc
+    y: int
+
+C(x='x', y=1)
+C(x=1, y=1)  # E: Argument "x" to "C" has incompatible type "int"; expected "str"
+reveal_type(C(x='x', y=1).x)  # N: Revealed type is "builtins.str"
+reveal_type(C(x='x', y=1).y)  # N: Revealed type is "builtins.int"
+reveal_type(C.x)  # N: Revealed type is "__main__.Desc"
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformGenericDescriptor]
+# flags: --python-version 3.11
+
+from typing import dataclass_transform, overload, Any, TypeVar, Generic
+
+@dataclass_transform()
+def my_dataclass(cls): ...
+
+T = TypeVar("T")
+
+class Desc(Generic[T]):
+    @overload
+    def __get__(self, instance: None, owner: Any) -> Desc[T]: ...
+    @overload
+    def __get__(self, instance: object, owner: Any) -> T: ...
+    def __get__(self, instance: object | None, owner: Any) -> Desc | T: ...
+
+    def __set__(self, instance: Any, value: T) -> None: ...
+
+@my_dataclass
+class C:
+    x: Desc[str]
 
 C(x='x')
 C(x=1)  # E: Argument "x" to "C" has incompatible type "int"; expected "str"
 reveal_type(C(x='x').x)  # N: Revealed type is "builtins.str"
-reveal_type(C.x)  # N: Revealed type is "__main__.Desc"
+reveal_type(C.x)  # N: Revealed type is "__main__.Desc[builtins.str]"
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -889,6 +889,40 @@ reveal_type(F.x)  # N: Revealed type is "__main__.Desc[builtins.str]"
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
 
+[case testDataclassTransformGenericDescriptorWithInheritance]
+# flags: --python-version 3.11
+
+from typing import dataclass_transform, overload, Any, TypeVar, Generic
+
+@dataclass_transform()
+def my_dataclass(cls): ...
+
+T = TypeVar("T")
+
+class Desc(Generic[T]):
+    @overload
+    def __get__(self, instance: None, owner: Any) -> Desc[T]: ...
+    @overload
+    def __get__(self, instance: object, owner: Any) -> T: ...
+    def __get__(self, instance: object | None, owner: Any) -> Desc | T: ...
+
+    def __set__(self, instance: Any, value: T) -> None: ...
+
+class Desc2(Desc[str]):
+    pass
+
+@my_dataclass
+class C:
+    x: Desc2
+
+C(x='x')
+C(x=1)  # E: Argument "x" to "C" has incompatible type "int"; expected "str"
+reveal_type(C(x='x').x)  # N: Revealed type is "builtins.str"
+reveal_type(C.x)  # N: Revealed type is "__main__.Desc[builtins.str]"
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
 [case testDataclassTransformDescriptorWithDifferentGetSetTypes]
 # flags: --python-version 3.11
 

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -839,6 +839,37 @@ reveal_type(C.x)  # N: Revealed type is "__main__.Desc"
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]
 
+[case testDataclassTransformUnannotatedDescriptor]
+# flags: --python-version 3.11
+
+from typing import dataclass_transform, overload, Any
+
+@dataclass_transform()
+def my_dataclass(cls): ...
+
+class Desc:
+    @overload
+    def __get__(self, instance: None, owner: Any) -> Desc: ...
+    @overload
+    def __get__(self, instance: object, owner: Any) -> str: ...
+    def __get__(self, instance: object | None, owner: Any) -> Desc | str: ...
+
+    def __set__(*args, **kwargs): ...
+
+@my_dataclass
+class C:
+    x: Desc
+    y: int
+
+C(x='x', y=1)
+C(x=1, y=1)
+reveal_type(C(x='x', y=1).x)  # N: Revealed type is "builtins.str"
+reveal_type(C(x='x', y=1).y)  # N: Revealed type is "builtins.int"
+reveal_type(C.x)  # N: Revealed type is "__main__.Desc"
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
 [case testDataclassTransformGenericDescriptor]
 # flags: --python-version 3.11
 
@@ -969,7 +1000,7 @@ class Desc:
     def __get__(self, instance: object, owner: Any) -> str: ...
     def __get__(self, instance, owner): ...
 
-    def __set__(*args, **kwargs): ...
+    def __set__(*args, **kwargs) -> None: ...
 
 class Desc2:
     @overload

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -867,14 +867,55 @@ C(x=1)  # E: Argument "x" to "C" has incompatible type "int"; expected "str"
 reveal_type(C(x='x').x)  # N: Revealed type is "builtins.str"
 reveal_type(C.x)  # N: Revealed type is "__main__.Desc[builtins.str]"
 
+@my_dataclass()
+class D(C):
+    y: Desc[int]
+
+d = D(x='x', y=1)
+reveal_type(d.x)  # N: Revealed type is "builtins.str"
+reveal_type(d.y)  # N: Revealed type is "builtins.int"
+reveal_type(D.x)  # N: Revealed type is "__main__.Desc[builtins.str]"
+reveal_type(D.y)  # N: Revealed type is "__main__.Desc[builtins.int]"
+
 @my_dataclass(frozen=True)
 class F:
-    x: Desc[str]
+    x: Desc[str] = Desc()
 
 F(x='x')
 F(x=1)  # E: Argument "x" to "F" has incompatible type "int"; expected "str"
 reveal_type(F(x='x').x)  # N: Revealed type is "builtins.str"
 reveal_type(F.x)  # N: Revealed type is "__main__.Desc[builtins.str]"
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassTransformDescriptorWithDifferentGetSetTypes]
+# flags: --python-version 3.11
+
+from typing import dataclass_transform, overload, Any
+
+@dataclass_transform()
+def my_dataclass(cls): ...
+
+class Desc:
+    @overload
+    def __get__(self, instance: None, owner: Any) -> int: ...
+    @overload
+    def __get__(self, instance: object, owner: Any) -> str: ...
+    def __get__(self, instance, owner): ...
+
+    def __set__(self, instance: Any, value: bytes) -> None: ...
+
+@my_dataclass
+class C:
+    x: Desc
+
+c = C(x=b'x')
+C(x=1)  # E: Argument "x" to "C" has incompatible type "int"; expected "bytes"
+reveal_type(c.x)  # N: Revealed type is "builtins.str"
+reveal_type(C.x)  # N: Revealed type is "builtins.int"
+c.x = b'x'
+c.x = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "bytes")
 
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
Infer `__init__` argument types from the signatures of descriptor `__set__` methods, if present. We can't (easily) perform full type inference in a plugin, so we cheat and use a simplified implementation that should still cover most use cases. Here we assume that `__set__` is not decorated or overloaded, in particular.

Fixes #14868.