### PR TITLE
Clarify "Using types...but not at runtime" docs

### DIFF
--- a/docs/source/runtime_troubles.rst
+++ b/docs/source/runtime_troubles.rst
@@ -277,9 +277,19 @@ sections, these can be dealt with by using :ref:`typing.TYPE_CHECKING
 
 .. code-block:: python
 
+   from __future__ import annotations
    from typing import TYPE_CHECKING
    if TYPE_CHECKING:
        from _typeshed import SupportsRichComparison
+
+    def f(x: SupportsRichComparison) -> None
+
+Note that the ``from __future__ import annotations`` is required to avoid
+a ``NameError`` at the use site of the excluded import. In the example above,
+``def f(x: SupportsRichComparison)`` would raise ``NameError`` if
+``from __future__ import annotations`` is not included. For more information,
+and additional caveats, see the section on
+:ref:`future annotations <future-annotations>`.
 
 .. _generic-builtins:
 

--- a/docs/source/runtime_troubles.rst
+++ b/docs/source/runtime_troubles.rst
@@ -284,11 +284,9 @@ sections, these can be dealt with by using :ref:`typing.TYPE_CHECKING
 
     def f(x: SupportsRichComparison) -> None
 
-Note that the ``from __future__ import annotations`` is required to avoid
-a ``NameError`` at the use site of the excluded import. In the example above,
-``def f(x: SupportsRichComparison)`` would raise ``NameError`` if
-``from __future__ import annotations`` is not included. For more information,
-and additional caveats, see the section on
+The ``from __future__ import annotations`` is required to avoid
+a ``NameError`` when using the imported symbol.
+For more information and caveats, see the section on
 :ref:`future annotations <future-annotations>`.
 
 .. _generic-builtins:


### PR DESCRIPTION
The section "Using classes that are generic in stubs but not at runtime" on the runtime_troubles.html page is very helpful, but naive readers who follow its instructions will almost inevitably create a runtime `NameError`. This PR updates the example to include an `annotations` import that will avert such a `NameError`.
