### PR TITLE
Fix alignment of cheat sheet example

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -106,7 +106,7 @@ Functions
    # Note that arguments without a type are dynamically typed (treated as Any)
    # and that functions without any annotations not checked
    def untyped(x):
-        x.anything() + 1 + "string"  # no errors
+       x.anything() + 1 + "string"  # no errors
 
    # This is how you annotate a callable (function) value
    x: Callable[[int, float], float] = f

--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -103,9 +103,9 @@ Functions
    def show(value: str, excitement: int = 10) -> None:
        print(value + "!" * excitement)
 
-    # Note that arguments without a type are dynamically typed (treated as Any)
-    # and that functions without any annotations not checked
-    def untyped(x):
+   # Note that arguments without a type are dynamically typed (treated as Any)
+   # and that functions without any annotations not checked
+   def untyped(x):
         x.anything() + 1 + "string"  # no errors
 
    # This is how you annotate a callable (function) value


### PR DESCRIPTION
In `cheat_sheep_py3.rst` functions examples, there is one function example misaligned with to other examples in the code block. This PR just removes leading space.