### PR TITLE
More cases showing errors disappearing from dmypy reruns

### DIFF
--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -611,3 +611,42 @@ from foo.empty import *
 if False:
     a = 1
 a
+
+[case testUnusedTypeIgnorePreservedOnRerunWithIgnoredMissingImports]
+$ dmypy start -- --no-error-summary --ignore-missing-imports --warn-unused-ignores
+Daemon started
+$ dmypy check foo
+foo/main.py:3: error: Unused "type: ignore" comment
+== Return code: 1
+$ dmypy check foo
+foo/main.py:3: error: Unused "type: ignore" comment
+== Return code: 1
+
+[file unused/__init__.py]
+[file unused/submodule.py]
+[file foo/empty.py]
+[file foo/__init__.py]
+from foo.main import *
+from unused.submodule import *
+[file foo/main.py]
+from foo import empty
+from foo.does_not_exist import *
+a = 1  # type: ignore
+
+[case testModuleDoesNotExistPreservedOnRerun]
+$ dmypy start -- --no-error-summary --ignore-missing-imports
+Daemon started
+$ dmypy check foo
+foo/main.py:1: error: Module "foo" has no attribute "does_not_exist"  [attr-defined]
+== Return code: 1
+$ dmypy check foo
+foo/main.py:1: error: Module "foo" has no attribute "does_not_exist"  [attr-defined]
+== Return code: 1
+
+[file unused/__init__.py]
+[file unused/submodule.py]
+[file foo/__init__.py]
+from foo.main import *
+[file foo/main.py]
+from foo import does_not_exist
+from unused.submodule import *


### PR DESCRIPTION
This adds test for two cases where errors disappear from the second run of dmypy.

The first shows a way that "unused type ignore" errors can disappear. The case is a little complicated, but I haven't yet worked out how to make it smaller.

The second case shows how "module X has not attribute Y" errors can disappear.

I think this shows another instance of https://github.com/python/mypy/issues/9655, but my instinct is that the fix for this will differ from the fix for https://github.com/python/mypy/pull/15043.

I have added this as a proof of the issue, and plan to evolve this PR as I investigate the cause.