### PR TITLE
Added exit zero option to resolve #15051

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -982,5 +982,10 @@ Miscellaneous
     have many scripts that import a large package, the behavior enabled
     by this flag is often more convenient.)
 
+.. option:: --exit-zero
+
+    This flag will make the program always exit with a zero exit code.
+    This is useful for debugging and testing.
+
 .. _lxml: https://pypi.org/project/lxml/
 .. _SQLite: https://www.sqlite.org/

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -1015,6 +1015,14 @@ These options may only be set in the global section (``[mypy]``).
     Controls how much debug output will be generated.  Higher numbers are more verbose.
 
 
+.. confval:: exit_zero
+
+    :type: boolean
+    :default: False
+
+    This flag will make the program always exit with a zero exit code.
+    This is useful for debugging and testing.
+
 .. _using-a-pyproject-toml:
 
 Using a pyproject.toml file

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -132,7 +132,7 @@ def main(
             code = 2
 
     code = 0 if options.exit_zero else code
-   
+
     if options.fast_exit:
         # Exit without freeing objects -- it's faster.
         #

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -131,6 +131,8 @@ def main(
             print("note: Run mypy again for up-to-date results with installed types")
             code = 2
 
+    code = 0 if options.exit_zero else code
+   
     if options.fast_exit:
         # Exit without freeing objects -- it's faster.
         #
@@ -1044,6 +1046,14 @@ def process_options(
         "--scripts-are-modules",
         action="store_true",
         help="Script x becomes module x instead of __main__",
+    )
+    other_group.add_argument(
+        "--exit-zero",
+        action="store_true",
+        help=(
+            "Exit with code 0 even if errors were encountered. "
+            + "This is useful for debugging and testing."
+        ),
     )
 
     add_invertible_flag(

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -346,6 +346,9 @@ class Options:
         self.disable_bytearray_promotion = False
         self.disable_memoryview_promotion = False
 
+        # Exit with exit code zero even if errors are encountered
+        self.exit_zero = False
+
     # To avoid breaking plugin compatibility, keep providing new_semantic_analyzer
     @property
     def new_semantic_analyzer(self) -> bool:


### PR DESCRIPTION
Fixes #15051 (Cool number, like my commit)

This adds an option to always exit with a zero exit code, even if errors occur. This is useful for debugging and testing. 

I will add a test later, you can still review the changes though.

