### PR TITLE
Support nested namedtuple classes. 

### DIFF
--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -166,6 +166,10 @@ class NamedTupleAnalyzer:
                 # And docstrings.
                 if isinstance(stmt, ExpressionStmt) and isinstance(stmt.expr, StrExpr):
                     continue
+                # Allow nested classes.
+                if isinstance(stmt, ClassDef):
+                    self.api.analyze_class(stmt)
+                    continue
                 statements.pop()
                 defn.removed_statements.append(stmt)
                 self.fail(NAMEDTUP_CLASS_ERROR, stmt)

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -251,6 +251,10 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
     ) -> None:
         raise NotImplementedError
 
+    @abstractmethod
+    def analyze_class(self, defn: ClassDef) -> None:
+        raise NotImplementedError
+
 
 def set_callable_name(sig: Type, fdef: FuncDef) -> ProperType:
     sig = get_proper_type(sig)

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -728,3 +728,21 @@ reveal_type(y) # N: Revealed type is "builtins.int"
 point.y = 6 # E: Property "y" defined in "Point" is read-only
 
 [builtins fixtures/tuple.pyi]
+
+[case testNestedNamedTuple]
+from enum import Enum
+from typing import NamedTuple
+
+class T(NamedTuple):
+  class State(Enum):
+    A =1
+  state:State
+
+class RaggedFeature(NamedTuple):
+  class RowSplits(NamedTuple):
+    x: int
+
+  splits: RowSplits
+
+reveal_type(T.State.A) # N: Revealed type is "Literal[__main__.T.State.A]"
+reveal_type(RaggedFeature.RowSplits.x) # N: Revealed type is "builtins.int"


### PR DESCRIPTION
Fixes #5362 including test cases from that report + my own duplicate [report](https://github.com/python/mypy/issues/15061). Fairly small change that directly allows class defs and analyzes them so that looking up later finds the needed symbol.

I suspect nested typeddict/enums might have similar issue given semanal_typeddict/enum don't appear to check class defs either.