### PR TITLE
Disable commented type annotation errors

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -283,9 +283,12 @@ def parse(
                 lines = str(source).split("\n")
                 result = ""
                 for line in lines:
-                    if not str(line).startswith("# type:"):
+                    if "# type:" not in str(line):
                         result += str(line) + str("\n")
-                source = result
+                    else:
+                        line = line.split("#")[0] + "\n"
+                        result += line
+                    source = result
             ast = ast3_parse(source, fnam, "exec", feature_version=feature_version)
 
         tree = ASTConverter(options=options, is_stub=is_stub_file, errors=errors).visit(ast)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -279,6 +279,13 @@ def parse(
         # Disable deprecation warnings about \u
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
+            if options.allow_commented_type_annotations:
+                lines = source.split("\n")
+                result = ""
+                for line in lines:
+                    if not line.startswith("# type:"):
+                        result += line + "\n"
+                source = result
             ast = ast3_parse(source, fnam, "exec", feature_version=feature_version)
 
         tree = ASTConverter(options=options, is_stub=is_stub_file, errors=errors).visit(ast)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -280,11 +280,11 @@ def parse(
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             if options.allow_commented_type_annotations:
-                lines = source.split("\n")
+                lines = str(source).split("\n")
                 result = ""
                 for line in lines:
-                    if not line.startswith("# type:"):
-                        result += line + "\n"
+                    if not str(line).startswith("# type:"):
+                        result += str(line) + str("\n")
                 source = result
             ast = ast3_parse(source, fnam, "exec", feature_version=feature_version)
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -845,11 +845,11 @@ def process_options(
         default=[],
         help="Enable a specific error code",
     )
-    strictness_group.add_argument(		
-        "--allow-commented-type-annotations",		
-        action="store_true",		
-        default=False,		
-        help="Allow type annotations in comments formatted # type: [type]",		
+    strictness_group.add_argument(
+        "--allow-commented-type-annotations",
+        action="store_true",
+        default=False,
+        help="Allow type annotations in comments formatted # type: [type]",
     )
 
     error_group = parser.add_argument_group(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -845,6 +845,12 @@ def process_options(
         default=[],
         help="Enable a specific error code",
     )
+    strictness_group.add_argument(		
+        "--allow-commented-type-annotations",		
+        action="store_true",		
+        default=False,		
+        help="Allow type annotations in comments formatted # type: [type]",		
+    )
 
     error_group = parser.add_argument_group(
         title="Configuring error messages",

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -19,6 +19,7 @@ class BuildType:
 
 PER_MODULE_OPTIONS: Final = {
     # Please keep this list sorted
+    "allow_commented_type_annotations",
     "allow_redefinition",
     "allow_untyped_globals",
     "always_false",
@@ -179,6 +180,9 @@ class Options:
 
         # Don't re-export names unless they are imported with `from ... as ...`
         self.implicit_reexport = True
+
+        # Suppress errors from type annotations in comments		
+        self.allow_commented_type_annotations = False
 
         # Suppress toplevel errors caused by missing annotations
         self.allow_untyped_globals = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -181,7 +181,7 @@ class Options:
         # Don't re-export names unless they are imported with `from ... as ...`
         self.implicit_reexport = True
 
-        # Suppress errors from type annotations in comments		
+        # Suppress errors from type annotations in comments
         self.allow_commented_type_annotations = False
 
         # Suppress toplevel errors caused by missing annotations

--- a/test-data/unit/check-commented-type-annotations.test
+++ b/test-data/unit/check-commented-type-annotations.test
@@ -31,3 +31,10 @@ class A():
 # type: str 
 [out]
 main:2: error: invalid syntax
+
+[case testCommentedTypeAnnotationsNotAtStart]
+# flags: --allow-commented-type-annotations
+
+class A():
+    b = "" # type: str
+# type: str

--- a/test-data/unit/check-commented-type-annotations.test
+++ b/test-data/unit/check-commented-type-annotations.test
@@ -1,0 +1,33 @@
+[case testCommentedTypeAnnotations]
+# flags: --allow-commented-type-annotations
+
+class A():
+    b = ""
+# type: str
+
+
+[case testIncorrectTypeAnnotations]
+# flags: --allow-commented-type-annotations
+
+class A():
+    b: int = ""
+# type: str
+[out]
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testCommentedTypeAnnotationsWithVal]
+# flags: --allow-commented-type-annotations
+
+# type: str = "hello"
+class A():
+    b = ""
+# type: str 
+
+[case testCommentedTypeAnnotationsWithoutFlag]
+
+# type: str = "hello"
+class A():
+    b = ""
+# type: str 
+[out]
+main:2: error: invalid syntax


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #13177 
This PR adds a new flag (--allow-commented-type-annotations) which will disable commented type annotations in the format of '# type: ___' from being flagged as syntax error. This was necessary for when people have comments in this format that are just meant for humans to read rather than an actual type annotation.

Tests were added to make sure that when the flag is set the errors are not raised as well as when the flag is not set the errors are still getting raised. In addition a test makes sure that syntactically incorrect type annotations that are not commented still raise an error when the flag is set. All new tests pass. 

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
