### PR TITLE
[PEP646] Add tests/fixes for callable star args behavior

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -8,6 +8,7 @@ from mypy.nodes import ARG_STAR, Context
 from mypy.types import (
     AnyType,
     CallableType,
+    Instance,
     Parameters,
     ParamSpecType,
     PartialType,
@@ -155,10 +156,20 @@ def apply_generic_arguments(
                 assert False, f"mypy bug: unimplemented case, {expanded_tuple}"
         elif isinstance(unpacked_type, TypeVarTupleType):
             expanded_tvt = expand_unpack_with_variables(var_arg.typ, id_to_type)
-            assert isinstance(expanded_tvt, list)
-            for t in expanded_tvt:
-                assert not isinstance(t, UnpackType)
-            callable = replace_starargs(callable, expanded_tvt)
+            if isinstance(expanded_tvt, list):
+                for t in expanded_tvt:
+                    assert not isinstance(t, UnpackType)
+                callable = replace_starargs(callable, expanded_tvt)
+            else:
+                assert isinstance(expanded_tvt, Instance)
+                assert expanded_tvt.type.fullname == "builtins.tuple"
+                callable = callable.copy_modified(
+                    arg_types=(
+                        callable.arg_types[:star_index]
+                        + [expanded_tvt.args[0]]
+                        + callable.arg_types[star_index + 1 :]
+                    )
+                )
         else:
             assert False, "mypy bug: unhandled case applying unpack"
     else:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1661,9 +1661,7 @@ def fix_type_var_tuple_argument(any_type: Type, t: Instance) -> None:
         tvt = t.type.defn.type_vars[t.type.type_var_tuple_prefix]
         assert isinstance(tvt, TypeVarTupleType)
         args[t.type.type_var_tuple_prefix] = UnpackType(
-            Instance(
-                tvt.tuple_fallback.type, [any_type]
-            )
+            Instance(tvt.tuple_fallback.type, [any_type])
         )
         t.args = tuple(args)
 

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -117,8 +117,7 @@ variadic_single: Variadic[int]
 reveal_type(variadic_single)  # N: Revealed type is "__main__.Variadic[builtins.int]"
 
 empty: Variadic[()]
-# TODO: fix pretty printer to be better.
-reveal_type(empty)  # N: Revealed type is "__main__.Variadic"
+reveal_type(empty)  # N: Revealed type is "__main__.Variadic[Unpack[builtins.tuple[Any, ...]]]"
 
 bad: Variadic[Unpack[Tuple[int, ...]], str, Unpack[Tuple[bool, ...]]]  # E: More than one Unpack in a type is not allowed
 reveal_type(bad)  # N: Revealed type is "__main__.Variadic[Unpack[builtins.tuple[builtins.int, ...]], builtins.str]"
@@ -512,3 +511,62 @@ call_prefix(target=func_prefix, args=(0, 'foo'))
 call_prefix(target=func2_prefix, args=(0, 'foo'))  # E: Argument "target" to "call_prefix" has incompatible type "Callable[[str, int, str], None]"; expected "Callable[[bytes, int, str], None]"
 [builtins fixtures/tuple.pyi]
 
+[case testTypeVarTuplePep646UnspecifiedParameters]
+from typing import Tuple, Generic, TypeVar
+from typing_extensions import Unpack, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Array(Generic[Unpack[Ts]]):
+    ...
+
+def takes_any_array(arr: Array) -> None:
+    ...
+
+x: Array[int, bool]
+takes_any_array(x)
+
+T = TypeVar("T")
+
+class Array2(Generic[T, Unpack[Ts]]):
+    ...
+
+def takes_empty_array2(arr: Array2[int]) -> None:
+    ...
+
+y: Array2[int]
+takes_empty_array2(y)
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTuplePep646CallableStarArgs]
+from typing import Tuple, Callable
+from typing_extensions import Unpack, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+def call(
+    target: Callable[[Unpack[Ts]], None],
+    *args: Unpack[Ts],
+) -> None:
+    ...
+    # TODO: exposes unhandled case in checkexpr
+    # target(*args)
+
+class A:
+    def func(self, arg1: int, arg2: str) -> None: ...
+    def func2(self, arg1: int, arg2: int) -> None: ...
+    def func3(self, *args: int) -> None: ...
+
+vargs: Tuple[int, ...]
+vargs_str: Tuple[str, ...]
+
+call(A().func)  # E: Argument 1 to "call" has incompatible type "Callable[[int, str], None]"; expected "Callable[[VarArg(object)], None]"
+call(A().func, 0, 'foo')
+call(A().func, 0, 'foo', 0)  # E: Argument 1 to "call" has incompatible type "Callable[[int, str], None]"; expected "Callable[[VarArg(object)], None]"
+call(A().func, 0)  # E: Argument 1 to "call" has incompatible type "Callable[[int, str], None]"; expected "Callable[[VarArg(object)], None]"
+call(A().func, 0, 1)  # E: Argument 1 to "call" has incompatible type "Callable[[int, str], None]"; expected "Callable[[int, object], None]"
+call(A().func2, 0, 0)
+call(A().func3, 0, 1, 2)
+call(A().func3)
+
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
This adds tests for mixing star args with typevar tuples from PEP646. In order to do this we have to handle an additional case in applytype where the result of expanding an unpack is a homogenous tuple rather than a list of types.

This PR also includes (partially by accident) a fix to the empty case for type analysis. After re-reading the PEP we discover that the empty case is meant to be inferred as a Tuple[Any, ...] rather than an empty tuple and must fix that behavior as well as some of the previous test cases that assumed that it meant an empty tuple.

When we actually call `target(*args)` from the testcase in `call` we expose a crash in mypy. This will be handled by a subsequent PR.