### PR TITLE
Remove potentially dead code from make_simplified_union

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -530,8 +530,6 @@ def _remove_redundant_union_items(items: list[Type], keep_erased: bool) -> list[
             if safe_skip:
                 continue
 
-        # Keep track of the truthiness info for deleted subtypes which can be relevant
-        cbt = cbf = False
         for j, tj in enumerate(items):
             proper_tj = get_proper_type(tj)
             if (
@@ -553,13 +551,6 @@ def _remove_redundant_union_items(items: list[Type], keep_erased: bool) -> list[
             ):
                 # We found a redundant item in the union.
                 removed.add(j)
-                cbt = cbt or tj.can_be_true
-                cbf = cbf or tj.can_be_false
-        # if deleted subtypes had more general truthiness, use that
-        if not item.can_be_true and cbt:
-            items[i] = true_or_false(item)
-        elif not item.can_be_false and cbf:
-            items[i] = true_or_false(item)
 
     return [items[i] for i in range(len(items)) if i not in removed]
 


### PR DESCRIPTION
I was looking into optimising a couple code paths. This change is likely incorrect, but unit tests seemed to pass for me locally without this. We should have a test that covers this and hopefully primer reveals one.