### PR TITLE
Fix performance in union subtyping

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -917,13 +917,9 @@ class SubtypeVisitor(TypeVisitor[bool]):
 
             for item in _flattened(self.right.relevant_items()):
                 p_item = get_proper_type(item)
-                if isinstance(p_item, LiteralType):
-                    fast_check.add(p_item)
-                elif isinstance(p_item, Instance):
-                    if p_item.last_known_value is None:
-                        fast_check.add(p_item)
-                    else:
-                        fast_check.add(p_item.last_known_value)
+                fast_check.add(p_item)
+                if isinstance(p_item, Instance) and p_item.last_known_value is not None:
+                    fast_check.add(p_item.last_known_value)
 
             for item in left.relevant_items():
                 p_item = get_proper_type(item)


### PR DESCRIPTION
This is a performance optimisation for subtyping between two unions that are largely the same.

Fixes #14034

This makes @adriangb's example in https://github.com/python/mypy/issues/14034#issuecomment-1470252641 finish basically instantly. I could add it as a unit test?

Type checking pydantic core is still not fast — takes like four or five minutes with uncompiled mypy — but at least it's now feasible. I think there's room for doing some optimisation in make_simplified_union that would improve this.