### PR TITLE
Use dict keys for order-preserving dedupes instead of set + list

### DIFF
--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -820,7 +820,7 @@ class RUnion(RType):
         items = flatten_nested_unions(items)
         assert items
 
-        unique_items = list(dict.fromkeys(items, None))
+        unique_items = list(dict.fromkeys(items))
         if len(unique_items) > 1:
             return RUnion(unique_items)
         else:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -820,7 +820,7 @@ class RUnion(RType):
         items = flatten_nested_unions(items)
         assert items
 
-        unique_items = list(dict.fromkeys(items, None).keys())
+        unique_items = list(dict.fromkeys(items, None))
         if len(unique_items) > 1:
             return RUnion(unique_items)
         else:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -23,7 +23,7 @@ RTypes.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 from typing_extensions import Final
 
 from mypyc.common import IS_32_BIT_PLATFORM, PLATFORM_SIZE, JsonDict, short_name

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -820,11 +820,11 @@ class RUnion(RType):
         items = flatten_nested_unions(items)
         assert items
 
-        unique_items = list(dict.fromkeys(items))
+        unique_items = dict.fromkeys(items)
         if len(unique_items) > 1:
-            return RUnion(unique_items)
+            return RUnion(list(unique_items))
         else:
-            return unique_items[0]
+            return next(iter(unique_items))
 
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_runion(self)

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -820,11 +820,7 @@ class RUnion(RType):
         items = flatten_nested_unions(items)
         assert items
 
-        # Use a dict for O(1) lookups that preserve order; values are ignored
-        seen: dict[RType, Any] = {}
-        for item in items:
-            if item not in seen:
-                seen[item] = None
+        seen = dict.fromkeys(items, None)
         if len(seen) > 1:
             return RUnion(list(seen.keys()))
         else:

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -820,11 +820,11 @@ class RUnion(RType):
         items = flatten_nested_unions(items)
         assert items
 
-        seen = dict.fromkeys(items, None)
-        if len(seen) > 1:
-            return RUnion(list(seen.keys()))
+        unique_items = list(dict.fromkeys(items, None).keys())
+        if len(unique_items) > 1:
+            return RUnion(unique_items)
         else:
-            return next(iter(seen.keys()))
+            return unique_items[0]
 
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_runion(self)

--- a/mypyc/test/test_typeops.py
+++ b/mypyc/test/test_typeops.py
@@ -81,3 +81,6 @@ class TestUnionSimplification(unittest.TestCase):
         assert RUnion.make_simplified_union(
             [int_rprimitive, RUnion([str_rprimitive, RUnion([int_rprimitive])])]
         ) == RUnion([int_rprimitive, str_rprimitive])
+
+    def test_remove_duplicate_preserves_order(self) -> None:
+        assert RUnion.make_simplified_union([int_rprimitive, int_rprimitive]) == int_rprimitive

--- a/mypyc/test/test_typeops.py
+++ b/mypyc/test/test_typeops.py
@@ -81,6 +81,3 @@ class TestUnionSimplification(unittest.TestCase):
         assert RUnion.make_simplified_union(
             [int_rprimitive, RUnion([str_rprimitive, RUnion([int_rprimitive])])]
         ) == RUnion([int_rprimitive, str_rprimitive])
-
-    def test_remove_duplicate_preserves_order(self) -> None:
-        assert RUnion.make_simplified_union([int_rprimitive, int_rprimitive]) == int_rprimitive


### PR DESCRIPTION
I figured this might be faster and less code. Also just curious what the process is like to contribute to mypy.