### PR TITLE
Migrate checkstrformat to use `ErrorMessage` class

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -109,10 +109,10 @@ TYPE_ABSTRACT: Final = ErrorCode(
 VALID_NEWTYPE: Final = ErrorCode(
     "valid-newtype", "Check that argument 2 to NewType is valid", "General"
 )
-STRING_FORMATTING: Final = ErrorCode(
+STRING_FORMATTING: Final[ErrorCode] = ErrorCode(
     "str-format", "Check that string formatting/interpolation is type-safe", "General"
 )
-STR_BYTES_PY3: Final = ErrorCode(
+STR_BYTES_PY3: Final[ErrorCode] = ErrorCode(
     "str-bytes-safe", "Warn about implicit coercions related to bytes and string types", "General"
 )
 EXIT_RETURN: Final = ErrorCode(

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -313,3 +313,74 @@ ARG_CONSTRUCTOR_UNEXPECTED_ARG: Final = ErrorMessage(
 ARG_NAME_EXPECTED_STRING_LITERAL: Final = ErrorMessage(
     "Expected string literal for argument name, got {}", codes.SYNTAX
 )
+
+FORMAT_STR_INVALID_SPECIFIER: Final = ErrorMessage(
+    "Invalid conversion specifier in format string", codes.STRING_FORMATTING
+)
+FORMAT_STR_BRACES_IN_SPECIFIER: Final = ErrorMessage(
+    "Conversion value must not contain { or }", codes.STRING_FORMATTING
+)
+FORMAT_STR_NESTING_ATMOST_TWO_LEVELS: Final = ErrorMessage(
+    "Formatting nesting must be at most two levels deep", codes.STRING_FORMATTING
+)
+FORMAT_STR_UNEXPECTED_RBRACE: Final = ErrorMessage(
+    "Invalid conversion specifier in format string: unexpected }", codes.STRING_FORMATTING
+)
+FORMAT_STR_UNMATCHED_LBRACE: Final = ErrorMessage(
+    "Invalid conversion specifier in format string: unmatched {", codes.STRING_FORMATTING
+)
+UNRECOGNIZED_FORMAT_SPEC: Final = ErrorMessage(
+    'Unrecognized format specification "{}"', codes.STRING_FORMATTING
+)
+FORMAT_STR_INVALID_CONVERSION_TYPE: Final = ErrorMessage(
+    'Invalid conversion type "{}", must be one of "r", "s" or "a"', codes.STRING_FORMATTING
+)
+FORMAT_STR_BYTES_USE_REPR: Final = ErrorMessage(
+    'If x = b\'abc\' then f"{x}" or "{}".format(x) produces "b\'abc\'", '
+    'not "abc". If this is desired behavior, use f"{x!r}" or "{!r}".format(x). '
+    "Otherwise, decode the bytes",
+    codes.STR_BYTES_PY3,
+)
+FORMAT_STR_BYTES_USE_REPR_OLD: Final = ErrorMessage(
+    'If x = b\'abc\' then "%s" % x produces "b\'abc\'", not "abc". '
+    'If this is desired behavior use "%r" % x. Otherwise, decode the bytes',
+    codes.STR_BYTES_PY3,
+)
+FORMAT_STR_INVALID_NUMERIC_FLAG: Final = ErrorMessage(
+    "Numeric flags are only allowed for numeric types", codes.STRING_FORMATTING
+)
+FORMAT_STR_REPLACEMENT_NOT_FOUND: Final = ErrorMessage(
+    "Cannot find replacement for positional format specifier {}", codes.STRING_FORMATTING
+)
+FORMAT_STR_NAMED_REPLACEMENT_NOT_FOUND: Final = ErrorMessage(
+    'Cannot find replacement for named format specifier "{}"', codes.STRING_FORMATTING
+)
+FORMAT_STR_PARTIAL_FIELD_NUMBERING: Final = ErrorMessage(
+    "Cannot combine automatic field numbering and manual field specification",
+    codes.STRING_FORMATTING,
+)
+FORMAT_STR_SYNTAX_ERROR: Final = ErrorMessage(
+    'Syntax error in format specifier "{}"', codes.STRING_FORMATTING
+)
+FORMAT_STR_INVALID_ACCESSOR_EXPR: Final = ErrorMessage(
+    'Only index and member expressions are allowed in format field accessors; got "{}"',
+    codes.STRING_FORMATTING,
+)
+FORMAT_STR_INVALID_INDEX_ACCESSOR: Final = ErrorMessage(
+    'Invalid index expression in format field accessor "{}"', codes.STRING_FORMATTING
+)
+FORMAT_STR_BYTES_ABOVE_PY35: Final = ErrorMessage(
+    "Bytes formatting is only supported in Python 3.5 and later", codes.STRING_FORMATTING
+)
+FORMAT_STR_BYTES_DICT_KEYS_MUST_BE_BYTES: Final = ErrorMessage(
+    "Dictionary keys in bytes formatting must be bytes, not strings", codes.STRING_FORMATTING
+)
+FORMAT_STR_BYTES_REQUIRED_PY3: Final = ErrorMessage(
+    "On Python 3 b'%s' requires bytes, not string", codes.STRING_FORMATTING
+)
+FORMAT_STR_INVALID_BYTES_SPECIFIER_PY35: Final = ErrorMessage(
+    'Format character "b" is only supported in Python 3.5 and later', codes.STRING_FORMATTING
+)
+FORMAT_STR_INVALID_BYTES_SPECIFIER: Final = ErrorMessage(
+    'Format character "b" is only supported on bytes patterns', codes.STRING_FORMATTING
+)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -16,7 +16,7 @@ import itertools
 import re
 from contextlib import contextmanager
 from textwrap import dedent
-from typing import Any, Callable, Collection, Iterable, Iterator, List, Sequence, cast
+from typing import Any, Callable, Collection, Iterable, Iterator, List, Sequence, cast, overload
 from typing_extensions import Final
 
 import mypy.typeops
@@ -261,6 +261,7 @@ class MessageBuilder:
             allow_dups=allow_dups,
         )
 
+    @overload
     def fail(
         self,
         msg: str,
@@ -271,9 +272,39 @@ class MessageBuilder:
         allow_dups: bool = False,
         secondary_context: Context | None = None,
     ) -> None:
+        ...
+
+    @overload
+    def fail(
+        self,
+        msg: message_registry.ErrorMessage,
+        context: Context | None,
+        *,
+        file: str | None = None,
+        allow_dups: bool = False,
+        secondary_context: Context | None = None,
+    ) -> None:
+        ...
+
+    def fail(
+        self,
+        msg: str | message_registry.ErrorMessage,
+        context: Context | None,
+        *,
+        code: ErrorCode | None = None,
+        file: str | None = None,
+        allow_dups: bool = False,
+        secondary_context: Context | None = None,
+    ) -> None:
         """Report an error message (unless disabled)."""
+        if isinstance(msg, message_registry.ErrorMessage):
+            msg_str = msg.value
+            code = msg.code
+        else:
+            msg_str = msg
+
         self.report(
-            msg,
+            msg_str,
             context,
             "error",
             code=code,


### PR DESCRIPTION
A granular reimplementation of #12004

### Changes

- Migrates error codes in `checkstrformat.py` to use `ErrorMessage` objects stored in `message_registry`
- Modifies `fail` method in `MessageBuilder` to accept `ErrorMessage` objects (the overload is similar to the one [here](https://github.com/hauntsaninja/mypy/blob/c78a2cb995c80fcbb7c965b257c6315575afb9ee/mypy/checker.py#L5568)).