### PR TITLE
Rename attrs tests

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -387,7 +387,7 @@ main:7: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incom
 [case testEqMethodsOverridingWithNonObjects]
 class A:
   def __eq__(self, other: A) -> bool: pass  # Fail
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 [out]
 main:2: error: Argument 1 of "__eq__" is incompatible with supertype "object"; supertype defines the argument type as "object"
 main:2: note: This violates the Liskov substitution principle

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1311,7 +1311,7 @@ import attr
 class Unannotated:
     foo = attr.ib()
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testDisallowIncompleteDefsAttrsWithAnnotations]
 # flags: --disallow-incomplete-defs
@@ -1321,7 +1321,7 @@ import attr
 class Annotated:
     bar: int = attr.ib()
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testDisallowIncompleteDefsAttrsPartialAnnotations]
 # flags: --disallow-incomplete-defs
@@ -1332,7 +1332,7 @@ class PartiallyAnnotated:  # E: Function is missing a type annotation for one or
     bar: int = attr.ib()
     baz = attr.ib()
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAlwaysTrueAlwaysFalseFlags]
 # flags: --always-true=YOLO --always-true=YOLO1 --always-false=BLAH1 --always-false BLAH --ignore-missing-imports

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3069,7 +3069,7 @@ from attr import attrib, attrs
 class A:
     a: int
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 [rechecked]
 [stale]
 [out2]
@@ -3410,7 +3410,7 @@ class C:
     b: int = attr.ib(converter=int)
     c: A = attr.ib(converter=A)
     d: int = attr.ib(converter=parse)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 [out1]
 main:6: note: Revealed type is "def (a: Union[builtins.float, builtins.str], b: Union[builtins.str, builtins.bytes, builtins.int], c: builtins.str, d: Union[builtins.int, builtins.str]) -> a.C"
 main:10: note: Revealed type is "def (a: Union[builtins.float, builtins.str], b: Union[builtins.str, builtins.bytes, builtins.int], c: builtins.str, d: Union[builtins.int, builtins.str], x: builtins.str) -> __main__.D"

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -210,7 +210,7 @@ A(1) != 1
 1 >= A(1)  # E: Unsupported operand types for <= ("A" and "int")
 1 == A(1)
 1 != A(1)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsEqFalse]
 from attr import attrib, attrs
@@ -241,7 +241,7 @@ A(1) != 1
 1 >= A(1)  # E: Unsupported left operand type for >= ("int")
 1 == A(1)
 1 != A(1)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsOrderFalse]
 from attr import attrib, attrs
@@ -270,7 +270,7 @@ A(1) != 1
 1 >= A(1)  # E: Unsupported left operand type for >= ("int")
 1 == A(1)
 1 != A(1)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsCmpEqOrderValues]
 from attr import attrib, attrs
@@ -289,7 +289,7 @@ class Mixed:
 @attrs(order=True, eq=False)  # E: eq must be True if order is True
 class Confused:
    ...
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 
 [case testAttrsInheritance]
@@ -969,7 +969,7 @@ class C:
 
 o = C("1", "2", "3")
 o = C(1, 2, "3")
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsCmpWithSubclasses]
 import attr
@@ -1208,7 +1208,7 @@ class A:
 
 A(None, None)
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsOptionalConverterNewPackage]
 # flags: --strict-optional
@@ -1228,7 +1228,7 @@ class A:
 
 A(None, None)
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 
 [case testAttrsTypeVarNoCollision]
@@ -1241,7 +1241,7 @@ T = TypeVar("T", bytes, str)
 @attr.s(auto_attribs=True)
 class A(Generic[T]):
     v: T
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsKwOnlyAttrib]
 import attr
@@ -1251,7 +1251,7 @@ class A:
 A()  # E: Missing named argument "a" for "A"
 A(15) # E: Too many positional arguments for "A"
 A(a=15)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsKwOnlyClass]
 import attr
@@ -1261,7 +1261,7 @@ class A:
     b: bool
 A()  # E: Missing named argument "a" for "A" # E: Missing named argument "b" for "A"
 A(b=True, a=15)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsKwOnlyClassNoInit]
 import attr
@@ -1270,7 +1270,7 @@ class B:
     a = attr.ib(init=False)
     b = attr.ib()
 B(b=True)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsKwOnlyWithDefault]
 import attr
@@ -1280,7 +1280,7 @@ class C:
     b = attr.ib(kw_only=True)
     c = attr.ib(16, kw_only=True)
 C(b=17)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsKwOnlyClassWithMixedDefaults]
 import attr
@@ -1290,7 +1290,7 @@ class D:
     b = attr.ib()
     c = attr.ib(15)
 D(b=17)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 
 [case testAttrsKwOnlySubclass]
@@ -1302,7 +1302,7 @@ class A2:
 class B2(A2):
     b = attr.ib(kw_only=True)
 B2(b=1)
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsNonKwOnlyAfterKwOnly]
 import attr
@@ -1317,7 +1317,7 @@ class C:
     a = attr.ib(kw_only=True)
     b = attr.ib(15)
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsDisallowUntypedWorksForward]
 # flags: --disallow-untyped-defs
@@ -1491,7 +1491,7 @@ reveal_type(A.__attrs_attrs__[0])  # N: Revealed type is "attr.Attribute[builtin
 reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[builtins.int]"
 A.__attrs_attrs__.x  # E: "____main___A_AttrsAttributes__" has no attribute "x"
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsBareClassHasMagicAttribute]
 import attr
@@ -1506,7 +1506,7 @@ reveal_type(A.__attrs_attrs__[0])  # N: Revealed type is "attr.Attribute[Any]"
 reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[Any]"
 A.__attrs_attrs__.x  # E: "____main___A_AttrsAttributes__" has no attribute "x"
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsNGClassHasMagicAttribute]
 import attr
@@ -1521,7 +1521,7 @@ reveal_type(A.__attrs_attrs__[0])  # N: Revealed type is "attr.Attribute[builtin
 reveal_type(A.__attrs_attrs__.b)  # N: Revealed type is "attr.Attribute[builtins.int]"
 A.__attrs_attrs__.x  # E: "____main___A_AttrsAttributes__" has no attribute "x"
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsMagicAttributeProtocol]
 import attr
@@ -1546,7 +1546,7 @@ takes_attrs_instance(A(1, ""))
 
 takes_attrs_cls(A(1, ""))  # E: Argument 1 to "takes_attrs_cls" has incompatible type "A"; expected "Type[AttrsInstance]"
 takes_attrs_instance(A)  # E: Argument 1 to "takes_attrs_instance" has incompatible type "Type[A]"; expected "AttrsInstance" # N: ClassVar protocol member AttrsInstance.__attrs_attrs__ can never be matched by a class object
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsInitMethodAlwaysGenerates]
 from typing import Tuple
@@ -1564,7 +1564,7 @@ reveal_type(A)  # N: Revealed type is "def (bc: Tuple[builtins.int, builtins.str
 reveal_type(A.__init__)  # N: Revealed type is "def (self: __main__.A, bc: Tuple[builtins.int, builtins.str])"
 reveal_type(A.__attrs_init__)  # N: Revealed type is "def (self: __main__.A, b: builtins.int, c: builtins.str)"
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsClassWithSlots]
 import attr
@@ -1594,7 +1594,7 @@ class C:
     def __attrs_post_init__(self) -> None:
         self.b = 1  # E: Trying to assign name "b" that is not in "__slots__" of type "__main__.C"
         self.c = 2  # E: Trying to assign name "c" that is not in "__slots__" of type "__main__.C"
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsWithMatchArgs]
 # flags: --python-version 3.10
@@ -1610,7 +1610,7 @@ class ToMatch:
 
 reveal_type(ToMatch(x=1, y=2, z=3).__match_args__)  # N: Revealed type is "Tuple[Literal['x']?, Literal['y']?]"
 reveal_type(ToMatch(1, 2, z=3).__match_args__)      # N: Revealed type is "Tuple[Literal['x']?, Literal['y']?]"
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsWithMatchArgsDefaultCase]
 # flags: --python-version 3.10
@@ -1631,7 +1631,7 @@ class ToMatch2:
 
 t2: ToMatch2
 reveal_type(t2.__match_args__)  # N: Revealed type is "Tuple[Literal['x']?, Literal['y']?]"
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsWithMatchArgsOverrideExisting]
 # flags: --python-version 3.10
@@ -1654,7 +1654,7 @@ class WithoutMatch:
     y: int
 
 reveal_type(WithoutMatch(x=1, y=2).__match_args__)  # N: Revealed type is "Tuple[Literal['a']?, Literal['b']?]"
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsWithMatchArgsOldVersion]
 # flags: --python-version 3.9
@@ -1668,7 +1668,7 @@ n: NoMatchArgs
 
 reveal_type(n.__match_args__)  # E: "NoMatchArgs" has no attribute "__match_args__" \
                                # N: Revealed type is "Any"
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsMultipleInheritance]
 # flags: --python-version 3.10
@@ -1684,7 +1684,7 @@ class B:
 
 class AB(A, B):
     pass
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsForwardReferenceInTypeVarBound]
 from typing import TypeVar, Generic
@@ -1698,7 +1698,7 @@ class D(Generic[T]):
 
 class C:
     pass
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testComplexTypeInAttrIb]
 import a
@@ -1953,7 +1953,7 @@ def f() -> C:
 
 c = attr.evolve(f(), name='foo')
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveFromNonAttrs]
 import attr
@@ -1988,7 +1988,7 @@ reveal_type(a2)  # N: Revealed type is "__main__.A[builtins.int]"
 a2 = attrs.evolve(a, x='42')  # E: Argument "x" to "evolve" of "A[int]" has incompatible type "str"; expected "int"
 reveal_type(a2)  # N: Revealed type is "__main__.A[builtins.int]"
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveUnion]
 # flags: --python-version 3.10
@@ -2018,7 +2018,7 @@ a2 = attrs.evolve(a_or_b, x=42, y=True)
 a2 = attrs.evolve(a_or_b, x=42, y=True, z='42')  # E: Argument "z" to "evolve" of "Union[A[int], B]" has incompatible type "str"; expected <nothing>
 a2 = attrs.evolve(a_or_b, x=42, y=True, w={})  # E: Argument "w" to "evolve" of "Union[A[int], B]" has incompatible type "Dict[<nothing>, <nothing>]"; expected <nothing>
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveUnionOfTypeVar]
 # flags: --python-version 3.10
@@ -2043,7 +2043,7 @@ def f(b_or_t: TA | TB | int) -> None:
     a2 = attrs.evolve(b_or_t)   # E: Argument 1 to "evolve" has type "Union[TA, TB, int]" whose item "TB" is not bound to an attrs class  # E: Argument 1 to "evolve" has incompatible type "Union[TA, TB, int]" whose item "int" is not an attrs class
 
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveTypeVarBound]
 import attrs
@@ -2068,7 +2068,7 @@ def f(t: TA) -> TA:
 f(A(x=42))
 f(B(x=42))
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveTypeVarBoundNonAttrs]
 import attrs
@@ -2091,7 +2091,7 @@ def h(t: TNone) -> None:
 def x(t: TUnion) -> None:
     _ = attrs.evolve(t, x=42)  # E: Argument 1 to "evolve" has incompatible type "TUnion" whose item "str" is not an attrs class  # E: Argument 1 to "evolve" has incompatible type "TUnion" whose item "int" is not an attrs class
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveTypeVarConstrained]
 import attrs
@@ -2116,7 +2116,7 @@ def f(t: T) -> T:
 f(A(x=42))
 f(B(x='42'))
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveVariants]
 from typing import Any
@@ -2139,5 +2139,5 @@ c = attrs.evolve(c, name=42)  # E: Argument "name" to "evolve" of "C" has incomp
 c = attrs.assoc(c, name='test')
 c = attrs.assoc(c, name=42)  # E: Argument "name" to "assoc" of "C" has incompatible type "int"; expected "str"
 
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 [typing fixtures/typing-medium.pyi]

--- a/test-data/unit/fine-grained-attr.test
+++ b/test-data/unit/fine-grained-attr.test
@@ -17,7 +17,7 @@ from attr import define
 @define
 class A:
     a: float
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 [out]
 ==
 main:5: error: Incompatible return value type (got "Attribute[float]", expected "Attribute[int]")
@@ -32,7 +32,7 @@ from attr import define
 class A:
     a: float
     b: int
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [file m.py]
 from c import A
@@ -54,7 +54,7 @@ import attr
 @attr.s
 class Entry:
     var: int = attr.ib()
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [file m.py]
 from typing import Any, ClassVar, Protocol

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1047,7 +1047,7 @@ import attr
 @attr.s(kw_only=True)
 class A:
     a = attr.ib(15)   # type: int
-[builtins fixtures/attr.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 [out]
 ==
 main:2: error: Too many positional arguments for "B"

--- a/test-data/unit/fixtures/plugin_attrs.pyi
+++ b/test-data/unit/fixtures/plugin_attrs.pyi
@@ -1,4 +1,4 @@
-# Builtins stub used to support @attr.s tests.
+# Builtins stub used to support attrs plugin tests.
 from typing import Union, overload
 
 class object:


### PR DESCRIPTION
- the library is named "attrs", not "attr"[^1]
- "attrs" could mean a test of Python attributes, so adding "plugin"

[^1]: at some point we'd also need to change tests to use `attrs.define` and `attrs.fields` in all but tests meant to exercise the "old API"