### PR TITLE
Don't do lint checks twice in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,11 +93,6 @@ jobs:
           arch: x64
           os: windows-latest
           toxenv: type
-        - name: Formatting with Black + isort and code style with flake8
-          python: '3.7'
-          arch: x64
-          os: ubuntu-latest
-          toxenv: lint
 
     name: ${{ matrix.name }}
     env:


### PR DESCRIPTION
We now run flake8, black and isort on PRs using `pre-commit.ci`. This is faster than using `tox` on GitHub Actions, and for black and isort, it also autofixes PRs (and the check in CI fails if it can't autofix a PR).