### PR TITLE
Make error messages start with a capital letter

### DIFF
--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -42,7 +42,7 @@ def f(): # E: Type signature has too many arguments  [syntax]
     # type: (int) -> None
     1
 
-x = 0  # type: x y  # E: syntax error in type comment "x y"  [syntax]
+x = 0  # type: x y  # E: Syntax error in type comment "x y"  [syntax]
 
 [case testErrorCodeSyntaxError3]
 # This is a bit inconsistent -- syntax error would be more logical?

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1781,7 +1781,7 @@ None < None  # E: Unsupported left operand type for < ("None")
 
 [case testDictWithStarExpr]
 
-b = {'z': 26, *a}  # E: invalid syntax
+b = {'z': 26, *a}  # E: Invalid syntax
 [builtins fixtures/dict.pyi]
 
 [case testDictWithStarStarExpr]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -1,10 +1,10 @@
 [case testFastParseSyntaxError]
 
-1 +  # E: invalid syntax
+1 +  # E: Invalid syntax
 
 [case testFastParseTypeCommentSyntaxError]
 
-x = None # type: a : b  # E: syntax error in type comment "a : b"
+x = None # type: a : b  # E: Syntax error in type comment "a : b"
 
 [case testFastParseInvalidTypeComment]
 
@@ -14,13 +14,13 @@ x = None # type: a + b  # E: Invalid type comment or annotation
 -- This happens in both parsers.
 [case testFastParseFunctionAnnotationSyntaxError]
 
-def f():  # E: syntax error in type comment "None -> None" # N: Suggestion: wrap argument types in parentheses
+def f():  # E: Syntax error in type comment "None -> None" # N: Suggestion: wrap argument types in parentheses
   # type: None -> None
   pass
 
 [case testFastParseFunctionAnnotationSyntaxErrorSpaces]
 
-def f():  # E: syntax error in type comment "None -> None" # N: Suggestion: wrap argument types in parentheses
+def f():  # E: Syntax error in type comment "None -> None" # N: Suggestion: wrap argument types in parentheses
   # type:             None -> None
   pass
 
@@ -159,7 +159,7 @@ def f(a,        # type: A
 
 [case testFastParsePerArgumentAnnotationsWithAnnotatedBareStar]
 
-def f(*, # type: int  # E: bare * has associated type comment
+def f(*, # type: int  # E: Bare * has associated type comment
       x  # type: str
       ):
       # type: (...) -> int

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -19,7 +19,7 @@ reveal_type(g2)  # N: Revealed type is "def (x: Literal['A B'])"
 
 [case testLiteralInvalidTypeComment]
 from typing_extensions import Literal
-def f(x):  # E: syntax error in type comment "(A[) -> None"
+def f(x):  # E: Syntax error in type comment "(A[) -> None"
     # type: (A[) -> None
     pass
 

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -5,7 +5,7 @@ x: int = 5  # E: Variable annotation syntax is only supported in Python 3.6 and 
 
 [case testNewSyntaxSyntaxError]
 # flags: --python-version 3.6
-x: int: int  # E: invalid syntax
+x: int: int  # E: Invalid syntax
 [out]
 
 [case testNewSyntaxBasics]

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1270,7 +1270,7 @@ def f() -> Iterator[List[int]]:
 
 [case testYieldFromNotAppliedToNothing]
 def h():
-    yield from  # E: invalid syntax
+    yield from  # E: Invalid syntax
 [out]
 
 [case testYieldFromAndYieldTogether]

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -937,7 +937,7 @@ main:1: error: invalid syntax
 main:1: error: invalid syntax. Perhaps you forgot a comma?
 
 [case testNotIs]
-x not is y # E: invalid syntax
+x not is y # E: Invalid syntax
 [out]
 
 [case testBinaryNegAsBinaryOp]

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -490,7 +490,7 @@ main:2: error: Can use starred expression only as assignment target
 
 [case testInvalidDel1]
 x = 1
-del x(1)  # E: can't delete function call
+del x(1)  # E: Can't delete function call
 [out]
 
 [case testInvalidDel2]
@@ -1275,7 +1275,7 @@ main:2: note: Did you forget to import it from "typing"? (Suggestion: "from typi
 
 [case testInvalidWithTarget]
 def f(): pass
-with f() as 1: pass  # E: can't assign to literal
+with f() as 1: pass  # E: Can't assign to literal
 [out]
 
 [case testInvalidTypeAnnotation]


### PR DESCRIPTION
Fixes #15125

Edit some error messages so they start with a capital letter. For example, `# E: Syntax error` instead of `# E: syntax error`. The purpose of this is for consistency & aesthetics.

This PR leaves some error messages without first word caps intact, if they reference a particular variable or identifier or they are a comment.