### PR TITLE
Support more complex dictionary value types with TypedDict setdefault accessed via LiteralType

### DIFF
--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -316,13 +316,15 @@ def typed_dict_setdefault_signature_callback(ctx: MethodSigContext) -> CallableT
         and len(signature.arg_types) == 2
         and len(ctx.args[1]) == 1
     ):
+        key = None
         if isinstance(ctx.args[0][0], StrExpr):
             key = ctx.args[0][0].value
         if isinstance(ctx.args[0][0], NameExpr):
             key = ctx.args[0][0].name
-        value_type = ctx.type.items.get(key)
-        if value_type:
-            return signature.copy_modified(arg_types=[str_type, value_type])
+        if key is not None:
+            value_type = ctx.type.items.get(key)
+            if value_type:
+                return signature.copy_modified(arg_types=[str_type, value_type])
     return signature.copy_modified(arg_types=[str_type, signature.arg_types[1]])
 
 

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 import mypy.errorcodes as codes
 from mypy import message_registry
-from mypy.nodes import DictExpr, IntExpr, StrExpr, UnaryExpr
+from mypy.nodes import DictExpr, IntExpr, NameExpr, StrExpr, UnaryExpr
 from mypy.plugin import (
     AttributeContext,
     ClassDefContext,
@@ -313,11 +313,13 @@ def typed_dict_setdefault_signature_callback(ctx: MethodSigContext) -> CallableT
         isinstance(ctx.type, TypedDictType)
         and len(ctx.args) == 2
         and len(ctx.args[0]) == 1
-        and isinstance(ctx.args[0][0], StrExpr)
         and len(signature.arg_types) == 2
         and len(ctx.args[1]) == 1
     ):
-        key = ctx.args[0][0].value
+        if isinstance(ctx.args[0][0], StrExpr):
+            key = ctx.args[0][0].value
+        if isinstance(ctx.args[0][0], NameExpr):
+            key = ctx.args[0][0].name
         value_type = ctx.type.items.get(key)
         if value_type:
             return signature.copy_modified(arg_types=[str_type, value_type])

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2047,16 +2047,23 @@ class A: pass
 
 class Test(TypedDict):
     a: List[Optional[int]]
+    b: List[Optional[str]]
     
 test: Test
 
 a: Literal["a"]
+aa: Literal["a"]
 b: Literal["b"]
+c: Literal["c"]
 
-test.setdefault(a, [])
-test.setdefault("a", [])        
-test.setdefault(b, 1)         # E: TypedDict "Test" has no key "b"
-test.setdefault("b", 1)       # E: TypedDict "Test" has no key "b"
+test.setdefault(a, [1])
+test.setdefault(aa, [1])
+test.setdefault(aa, ["1"])    # E: List item 0 has incompatible type "str"; expected "int"
+test.setdefault("a", [])    
+test.setdefault(b, ["1"])
+test.setdefault("b", ["1"])
+test.setdefault(c, 1)         # E: TypedDict "Test" has no key "c"
+test.setdefault("c", 1)       # E: TypedDict "Test" has no key "c"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 [out]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2035,6 +2035,10 @@ del test[good_keys]             # E: Key "a" of TypedDict "Test" cannot be delet
 del test[bad_keys]              # E: Key "a" of TypedDict "Test" cannot be deleted \
                                 # E: TypedDict "Test" has no key "bad"
 
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+[out]
+
 [case testTypedDictLiteralTypeSetDefault]
 
 from typing_extensions import Literal

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2034,6 +2034,29 @@ del test[good_keys]             # E: Key "a" of TypedDict "Test" cannot be delet
                                 # E: Key "b" of TypedDict "Test" cannot be deleted
 del test[bad_keys]              # E: Key "a" of TypedDict "Test" cannot be deleted \
                                 # E: TypedDict "Test" has no key "bad"
+
+[case testTypedDictLiteralTypeSetDefault]
+
+from typing_extensions import Literal
+from mypy_extensions import TypedDict
+from typing import List, Optional
+
+class A: pass
+
+class Test(TypedDict):
+    a: List[Optional[int]]
+    
+test: Test
+
+a: Literal["a"]
+b: Literal["b"]
+
+test.setdefault(a, [])
+test.setdefault("a", [])        
+
+test.setdefault(b, 1)         # E: TypedDict "Test" has no key "b"
+test.setdefault("b", 1)       # E: TypedDict "Test" has no key "b"
+
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 [out]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2043,7 +2043,6 @@ from typing_extensions import Literal
 from mypy_extensions import TypedDict
 from typing import List, Optional
 
-class A: pass
 
 class Test(TypedDict):
     a: List[Optional[int]]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2034,13 +2034,11 @@ del test[good_keys]             # E: Key "a" of TypedDict "Test" cannot be delet
                                 # E: Key "b" of TypedDict "Test" cannot be deleted
 del test[bad_keys]              # E: Key "a" of TypedDict "Test" cannot be deleted \
                                 # E: TypedDict "Test" has no key "bad"
-
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testTypedDictLiteralTypeSetDefault]
-
 from typing_extensions import Literal
 from mypy_extensions import TypedDict
 from typing import List, Optional
@@ -2057,10 +2055,8 @@ b: Literal["b"]
 
 test.setdefault(a, [])
 test.setdefault("a", [])        
-
 test.setdefault(b, 1)         # E: TypedDict "Test" has no key "b"
 test.setdefault("b", 1)       # E: TypedDict "Test" has no key "b"
-
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 [out]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #14762.

Previously using `setdefault` on a TypedDict with a LiteralType would produce incorrect typing incompatibilities:
```python
from typing import List, Literal, Optional, TypedDict

class Test(TypedDict, total=False):
    a: List[Optional[int]]

a: Literal["a"] = "a"

test: Test = {}

# Argument 2 to "setdefault" of "TypedDict" has incompatible type "list[<nothing>]"; expected "list[int | None]"  [typeddict-item]
test.setdefault(a, [])

# Okay
test.setdefault("a", [])
```

This resolves that.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
