### PR TITLE
Add explanation if argument type is incompatible because of a "numbers" type

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -3004,7 +3004,7 @@ def append_invariance_notes(
 def append_numbers_notes(
     notes: list[str], arg_type: Instance, expected_type: Instance
 ) -> list[str]:
-    """Explain if an unsupported type from "numbres" is used in a subtype check."""
+    """Explain if an unsupported type from "numbers" is used in a subtype check."""
     if expected_type.type.fullname in UNSUPPORTED_NUMBERS_TYPES:
         notes.append('Types from "numbers" aren\'t supported for static type checking')
         notes.append("See https://peps.python.org/pep-0484/#the-numeric-tower")

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -137,6 +137,14 @@ SUGGESTED_TEST_FIXTURES: Final = {
     "typing._SpecialForm": "typing-medium.pyi",
 }
 
+UNSUPPORTED_NUMBERS_TYPES: Final = {
+    "numbers.Number",
+    "numbers.Complex",
+    "numbers.Real",
+    "numbers.Rational",
+    "numbers.Integral",
+}
+
 
 class MessageBuilder:
     """Helper class for reporting type checker error messages with parameters.
@@ -792,6 +800,7 @@ class MessageBuilder:
                 for type in get_proper_types(expected_types):
                     if isinstance(arg_type, Instance) and isinstance(type, Instance):
                         notes = append_invariance_notes(notes, arg_type, type)
+                        notes = append_numbers_notes(notes, arg_type, type)
             object_type = get_proper_type(object_type)
             if isinstance(object_type, TypedDictType):
                 code = codes.TYPEDDICT_ITEM
@@ -2989,6 +2998,16 @@ def append_invariance_notes(
             + "https://mypy.readthedocs.io/en/stable/common_issues.html#variance"
         )
         notes.append(covariant_suggestion)
+    return notes
+
+
+def append_numbers_notes(
+    notes: list[str], arg_type: Instance, expected_type: Instance
+) -> list[str]:
+    """Explain if an unsupported type from "numbres" is used in a subtype check."""
+    if expected_type.type.fullname in UNSUPPORTED_NUMBERS_TYPES:
+        notes.append('Types from "numbers" aren\'t supported for static type checking')
+        notes.append("See https://peps.python.org/pep-0484/#the-numeric-tower")
     return notes
 
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -3008,6 +3008,7 @@ def append_numbers_notes(
     if expected_type.type.fullname in UNSUPPORTED_NUMBERS_TYPES:
         notes.append('Types from "numbers" aren\'t supported for static type checking')
         notes.append("See https://peps.python.org/pep-0484/#the-numeric-tower")
+        notes.append("Consider using a protocol instead, such as typing.SupportsFloat")
     return notes
 
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7826,3 +7826,31 @@ class D:
         # and that's what matters.
         a, b = self.f()  # E: "C" has no attribute "__iter__" (not iterable)
 [builtins fixtures/tuple.pyi]
+
+[case testUsingNumbersType]
+from numbers import Number, Complex, Real, Rational, Integral
+
+def f1(x: Number) -> None: pass
+f1(1)  # E: Argument 1 to "f1" has incompatible type "int"; expected "Number" \
+       # N: Types from "numbers" aren't supported for static type checking \
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+
+def f2(x: Complex) -> None: pass
+f2(1)  # E: Argument 1 to "f2" has incompatible type "int"; expected "Complex" \
+       # N: Types from "numbers" aren't supported for static type checking \
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+
+def f3(x: Real) -> None: pass
+f3(1)  # E: Argument 1 to "f3" has incompatible type "int"; expected "Real" \
+       # N: Types from "numbers" aren't supported for static type checking \
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+
+def f4(x: Rational) -> None: pass
+f4(1)  # E: Argument 1 to "f4" has incompatible type "int"; expected "Rational" \
+       # N: Types from "numbers" aren't supported for static type checking \
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+
+def f5(x: Integral) -> None: pass
+f5(1)  # E: Argument 1 to "f5" has incompatible type "int"; expected "Integral" \
+       # N: Types from "numbers" aren't supported for static type checking \
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7833,24 +7833,29 @@ from numbers import Number, Complex, Real, Rational, Integral
 def f1(x: Number) -> None: pass
 f1(1)  # E: Argument 1 to "f1" has incompatible type "int"; expected "Number" \
        # N: Types from "numbers" aren't supported for static type checking \
-       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower \
+       # N: Consider using a protocol instead, such as typing.SupportsFloat
 
 def f2(x: Complex) -> None: pass
 f2(1)  # E: Argument 1 to "f2" has incompatible type "int"; expected "Complex" \
        # N: Types from "numbers" aren't supported for static type checking \
-       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower \
+       # N: Consider using a protocol instead, such as typing.SupportsFloat
 
 def f3(x: Real) -> None: pass
 f3(1)  # E: Argument 1 to "f3" has incompatible type "int"; expected "Real" \
        # N: Types from "numbers" aren't supported for static type checking \
-       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower \
+       # N: Consider using a protocol instead, such as typing.SupportsFloat
 
 def f4(x: Rational) -> None: pass
 f4(1)  # E: Argument 1 to "f4" has incompatible type "int"; expected "Rational" \
        # N: Types from "numbers" aren't supported for static type checking \
-       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower \
+       # N: Consider using a protocol instead, such as typing.SupportsFloat
 
 def f5(x: Integral) -> None: pass
 f5(1)  # E: Argument 1 to "f5" has incompatible type "int"; expected "Integral" \
        # N: Types from "numbers" aren't supported for static type checking \
-       # N: See https://peps.python.org/pep-0484/#the-numeric-tower
+       # N: See https://peps.python.org/pep-0484/#the-numeric-tower \
+       # N: Consider using a protocol instead, such as typing.SupportsFloat

--- a/test-data/unit/lib-stub/numbers.pyi
+++ b/test-data/unit/lib-stub/numbers.pyi
@@ -1,0 +1,10 @@
+# Test fixture for numbers
+#
+# The numbers module isn't properly supported, but we want to test that mypy
+# can tell that it doesn't work as expected.
+
+class Number: pass
+class Complex: pass
+class Real: pass
+class Rational: pass
+class Integral: pass


### PR DESCRIPTION
Types from `numbers` aren't really supported in any useful way. Make it more explicit, since this is surprising.

Work on #3186.
