### PR TITLE
Set soft error limit default to -1 (unlimited)

### DIFF
--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -44,5 +44,5 @@ REPORTER_NAMES: Final = [
 ]
 
 # Threshold after which we sometimes filter out most errors to avoid very
-# verbose output. Current default is to show all errors.
+# verbose output. The default is to show all errors.
 MANY_ERRORS_THRESHOLD: Final = -1

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -44,5 +44,5 @@ REPORTER_NAMES: Final = [
 ]
 
 # Threshold after which we sometimes filter out most errors to avoid very
-# verbose output
-MANY_ERRORS_THRESHOLD: Final = 200
+# verbose output. Current default is to show all errors.
+MANY_ERRORS_THRESHOLD: Final = -1


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Fixes #14915 

When there are more than 200 errors to report, mypy "softly" trims the output without notifying the user that it did so. We want to currently disable this by setting the `--soft-error-limit` default to `-1` which would list out _all_ the errors.
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
