### PR TITLE
Surface lowercase `type` instead of `Type` in error messages on Python 3.9 and above

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2517,7 +2517,8 @@ def format_type_inner(
         else:
             return "<nothing>"
     elif isinstance(typ, TypeType):
-        return f"Type[{format(typ.item)}]"
+        type_name = "type" if options.use_lowercase_names() else "Type"
+        return f"{type_name}[{format(typ.item)}]"
     elif isinstance(typ, FunctionLike):
         func = typ
         if func.is_type_obj():

--- a/test-data/unit/check-lowercase.test
+++ b/test-data/unit/check-lowercase.test
@@ -42,3 +42,10 @@ x = 3  # E: Incompatible types in assignment (expression has type "int", variabl
 x = {3}
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "set[int]")
 [builtins fixtures/set.pyi]
+
+[case testTypeLowercaseSettingOff]
+# flags: --python-version 3.9 --no-force-uppercase-builtins
+x: type[type]
+y: int
+
+y = x  # E: Incompatible types in assignment (expression has type "type[type]", variable has type "int")


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Fixes #13027 (or at least half of it)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
