### PR TITLE
Fix crash on lambda in generic context with generic method in body

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -75,7 +75,6 @@ def apply_generic_arguments(
     report_incompatible_typevar_value: Callable[[CallableType, Type, str, Context], None],
     context: Context,
     skip_unsatisfied: bool = False,
-    allow_erased_callables: bool = False,
 ) -> CallableType:
     """Apply generic type arguments to a callable type.
 
@@ -119,15 +118,9 @@ def apply_generic_arguments(
         star_index = callable.arg_kinds.index(ARG_STAR)
         callable = callable.copy_modified(
             arg_types=(
-                [
-                    expand_type(at, id_to_type, allow_erased_callables)
-                    for at in callable.arg_types[:star_index]
-                ]
+                [expand_type(at, id_to_type) for at in callable.arg_types[:star_index]]
                 + [callable.arg_types[star_index]]
-                + [
-                    expand_type(at, id_to_type, allow_erased_callables)
-                    for at in callable.arg_types[star_index + 1 :]
-                ]
+                + [expand_type(at, id_to_type) for at in callable.arg_types[star_index + 1 :]]
             )
         )
 
@@ -163,14 +156,12 @@ def apply_generic_arguments(
             assert False, "mypy bug: unhandled case applying unpack"
     else:
         callable = callable.copy_modified(
-            arg_types=[
-                expand_type(at, id_to_type, allow_erased_callables) for at in callable.arg_types
-            ]
+            arg_types=[expand_type(at, id_to_type) for at in callable.arg_types]
         )
 
     # Apply arguments to TypeGuard if any.
     if callable.type_guard is not None:
-        type_guard = expand_type(callable.type_guard, id_to_type, allow_erased_callables)
+        type_guard = expand_type(callable.type_guard, id_to_type)
     else:
         type_guard = None
 
@@ -178,7 +169,7 @@ def apply_generic_arguments(
     remaining_tvars = [tv for tv in tvars if tv.id not in id_to_type]
 
     return callable.copy_modified(
-        ret_type=expand_type(callable.ret_type, id_to_type, allow_erased_callables),
+        ret_type=expand_type(callable.ret_type, id_to_type),
         variables=remaining_tvars,
         type_guard=type_guard,
     )

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1714,7 +1714,7 @@ def unify_generic_callable(
     # (probably also because solver needs subtyping). See also comment in
     # ExpandTypeVisitor.visit_erased_type().
     applied = mypy.applytype.apply_generic_arguments(
-        type, non_none_inferred_vars, report, context=target, allow_erased_callables=True
+        type, non_none_inferred_vars, report, context=target
     )
     if had_errors:
         return None

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2698,3 +2698,16 @@ def func(var: T) -> T:
 reveal_type(func(1))  # N: Revealed type is "builtins.int"
 
 [builtins fixtures/tuple.pyi]
+
+[case testGenericLambdaGenericMethodNoCrash]
+from typing import TypeVar, Union, Callable, Generic
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+def f(x: Callable[[G[T]], int]) -> T: ...
+
+class G(Generic[T]):
+    def g(self, x: S) -> Union[S, T]: ...
+
+f(lambda x: x.g(0))  # E: Cannot infer type argument 1 of "f"


### PR DESCRIPTION
Fixes #15060 

The example in the issue contains another case where an erased type may legitimately appear in a generic function. Namely, when we have a lambda in a generic context, and its body contains a call to a generic _method_. First, since we infer the type of lambda in erased context, some of lambda parameters may get assigned a type containing erased components. Then, when accessing a generic method on such type we may get a callable that is both generic and has erased components, thus causing the crash (actually there are two very similar crashes depending on the details of the generic method).

Provided that we now have two legitimate cases for erased type appearing in `expand_type()`, and special-casing (enabling) them would be tricky (a lot of functions will need to have `allow_erased_callables`), I propose to simply remove the check.