### PR TITLE
Fix crash in dataclass protocol with self attribute assignment

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3853,12 +3853,13 @@ class SemanticAnalyzer(
                 and explicit_type
             ):
                 self.attribute_already_defined(lval.name, lval, cur_node)
-            # If the attribute of self is not defined in superclasses, create a new Var, ...
             if (
+                # If the attribute of self is not defined, create a new Var, ...
                 node is None
-                or (isinstance(node.node, Var) and node.node.is_abstract_var)
+                # ... or if it is defined as abstract in a *superclass*.
+                or (cur_node is None and isinstance(node.node, Var) and node.node.is_abstract_var)
                 # ... also an explicit declaration on self also creates a new Var.
-                # Note that `explicit_type` might has been erased for bare `Final`,
+                # Note that `explicit_type` might have been erased for bare `Final`,
                 # so we also check if `is_final` is passed.
                 or (cur_node is None and (explicit_type or is_final))
             ):

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2037,3 +2037,16 @@ Foo(
     present_5=5,
 )
 [builtins fixtures/dataclasses.pyi]
+
+[case testProtocolNoCrash]
+from typing import Protocol, Union, ClassVar
+from dataclasses import dataclass, field
+
+DEFAULT = 0
+
+@dataclass
+class Test(Protocol):
+    x: int
+    def reset(self) -> None:
+        self.x = DEFAULT
+[builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
Fix #15004 

FWIW I don't think dataclass protocols make much sense, but we definitely should not crash. Also the root cause has nothing to do with dataclasses, the problem is that a self attribute assignment in a protocol created a new `Var` (after an original `Var` was created in class body), which is obviously wrong.