### PR TITLE
Fix a crash when function-scope recursive alias appears as upper bound

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1110,7 +1110,13 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         return TypeType.make_normalized(self.anal_type(t.item), line=t.line)
 
     def visit_placeholder_type(self, t: PlaceholderType) -> Type:
-        n = None if not t.fullname else self.api.lookup_fully_qualified(t.fullname)
+        n = (
+            None
+            # No dot in fullname indicates we are at function scope, and recursive
+            # types are not supported there anyway, so we just give up.
+            if not t.fullname or "." not in t.fullname
+            else self.api.lookup_fully_qualified(t.fullname)
+        )
         if not n or isinstance(n.node, PlaceholderNode):
             self.api.defer()  # Still incomplete
             return t

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -897,3 +897,29 @@ Example = NamedTuple("Example", [("rec", List["Example"])])
 e: Example
 reveal_type(e)  # N: Revealed type is "Tuple[builtins.list[...], fallback=__main__.Example]"
 [builtins fixtures/tuple.pyi]
+
+[case testRecursiveBoundFunctionScopeNoCrash]
+from typing import TypeVar, Union, Dict
+
+def dummy() -> None:
+    A = Union[str, Dict[str, "A"]]  # E: Cannot resolve name "A" (possible cyclic definition) \
+                                  # N: Recursive types are not allowed at function scope
+    T = TypeVar("T", bound=A)
+
+    def bar(x: T) -> T:
+        pass
+    reveal_type(bar)  # N: Revealed type is "def [T <: Union[builtins.str, builtins.dict[builtins.str, Any]]] (x: T`-1) -> T`-1"
+[builtins fixtures/dict.pyi]
+
+[case testForwardBoundFunctionScopeWorks]
+from typing import TypeVar, Dict
+
+def dummy() -> None:
+    A = Dict[str, "B"]
+    B = Dict[str, str]
+    T = TypeVar("T", bound=A)
+
+    def bar(x: T) -> T:
+        pass
+    reveal_type(bar)  # N: Revealed type is "def [T <: builtins.dict[builtins.str, builtins.dict[builtins.str, builtins.str]]] (x: T`-1) -> T`-1"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -903,7 +903,7 @@ from typing import TypeVar, Union, Dict
 
 def dummy() -> None:
     A = Union[str, Dict[str, "A"]]  # E: Cannot resolve name "A" (possible cyclic definition) \
-                                  # N: Recursive types are not allowed at function scope
+                                    # N: Recursive types are not allowed at function scope
     T = TypeVar("T", bound=A)
 
     def bar(x: T) -> T:


### PR DESCRIPTION
Fixes #15018 

The fix is quite straightforward: function-scope aliases are not supported anyway, so we just give up early and let the error appear.