### PR TITLE
Create optional error code to flag missing return type

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -62,6 +62,21 @@ Example:
          def __init__(self) -> None:
              self.value = 0
 
+Check that every function has a return annotation [no-incomplete-def]
+------------------------------------------------------------
+
+If you use :option:`--disallow-incomplete-defs <mypy --disallow-incomplete-defs>`, mypy requires that all functions
+fully annotated
+
+Example:
+
+.. code-block:: python
+
+    # mypy: disallow-incomplete-defs
+
+    def example(x: int):  # Error: Function is missing a return type annotation  [no-incomplete-def]
+        pass
+
 Check that cast is not redundant [redundant-cast]
 -------------------------------------------------
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1421,7 +1421,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 elif any(is_unannotated_any(t) for t in fdef.type.arg_types):
                     self.fail(message_registry.ARGUMENT_TYPE_EXPECTED, fdef)
 
-
     def check___new___signature(self, fdef: FuncDef, typ: CallableType) -> None:
         self_type = fill_typevars_with_any(fdef.info)
         bound_type = bind_self(typ, self_type, is_classmethod=True)

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -221,6 +221,9 @@ REDUNDANT_SELF_TYPE = ErrorCode(
 USED_BEFORE_DEF: Final[ErrorCode] = ErrorCode(
     "used-before-def", "Warn about variables that are used before they are defined", "General"
 )
+NO_INCOMPLETE_DEF: Final[ErrorCode] = ErrorCode(
+    "no-incomplete-def", "Function is missing a return type annotation", "General"
+)
 
 
 # Syntax errors are often blocking.

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -119,8 +119,14 @@ ONLY_CLASS_APPLICATION: Final = ErrorMessage(
 RETURN_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a return type annotation", codes.NO_UNTYPED_DEF
 )
+RETURN_TYPE_EXPECTED_INCOMPLETE_DEF: Final = ErrorMessage(
+    "Function is missing a return type annotation", codes.NO_INCOMPLETE_DEF
+)
 ARGUMENT_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a type annotation for one or more arguments", codes.NO_UNTYPED_DEF
+)
+ARGUMENT_TYPE_EXPECTED_INCOMPLETE_DEF: Final = ErrorMessage(
+    "Function is missing a type annotation for one or more arguments", codes.NO_INCOMPLETE_DEF
 )
 KEYWORD_ARGUMENT_REQUIRES_STR_KEY_TYPE: Final = ErrorMessage(
     'Keyword argument only valid with "str" key type in call to "dict"'

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -379,6 +379,15 @@ def f() -> None:
 def g():
     pass
 
+[case testErrorCodeNoReturnAnnotation]
+# flags: --disallow-incomplete-defs
+
+def f(i: int): # E: Function is missing a return type annotation  [no-incomplete-def]
+    pass
+
+def g(i) -> None: # E: Function is missing a type annotation for one or more arguments  [no-incomplete-def]
+    pass
+
 [case testErrorCodeIndexing]
 from typing import Dict
 x: Dict[int, int]


### PR DESCRIPTION
Fixes #15127 

-This adds a new error code that flags when missing a return type on an annotation.
-This commit also contains documentation and tests for the error code. 
-You can test this error code by using: mypy --disallow-incomplete-defs <fileName>

