### PR TITLE
Update the cheatsheet for functions and keyword argument typing

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -88,7 +88,7 @@ Functions
 
 .. code-block:: python
 
-   from typing import Callable, Iterator, Union, Optional
+   from typing import Callable, Iterator, Union, Unpack, Optional, TypedDict
 
    # This is how you annotate a function definition
    def stringify(num: int) -> str:
@@ -146,6 +146,19 @@ Functions
        reveal_type(kwargs)  # Revealed type is "dict[str, str]"
        request = make_request(*args, **kwargs)
        return self.do_api_query(request)
+    
+    # For more preise keyword typing, you can use `Unpack` along with a
+    # `TypedDict`
+    class Options(TypedDict):
+        timeout: int 
+        on_error: Callable[[int], None]
+    
+    # This function expects a keyword argument `timeout` of type `int` and a
+    # keyword argument `on_error` that is a `Callable[[int], None]`
+    def call(**options: Unpack[Options]) -> str:
+        reveal_type(options)  # Revealed type is "Options"
+        request = create_request(options['timeout'], options['on_error'])
+        return self.do_api_query(request)
 
 Classes
 *******


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

PEP 692 has been accepted and issue #4441 is fixed - added an entry to the cheatsheet mentioning a new way of annotating `**kwargs` in a function signature.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
