### PR TITLE
Make dict expression inference more consistent

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -679,11 +679,13 @@ class MessageBuilder:
                 name.title(), n, actual_type_str, expected_type_str
             )
             code = codes.LIST_ITEM
-        elif callee_name == "<dict>":
+        elif callee_name == "<dict>" and isinstance(
+            get_proper_type(callee.arg_types[n - 1]), TupleType
+        ):
             name = callee_name[1:-1]
             n -= 1
             key_type, value_type = cast(TupleType, arg_type).items
-            expected_key_type, expected_value_type = cast(TupleType, callee.arg_types[0]).items
+            expected_key_type, expected_value_type = cast(TupleType, callee.arg_types[n]).items
 
             # don't increase verbosity unless there is need to do so
             if is_subtype(key_type, expected_key_type):
@@ -708,6 +710,14 @@ class MessageBuilder:
                 value_type_str,
                 expected_key_type_str,
                 expected_value_type_str,
+            )
+            code = codes.DICT_ITEM
+        elif callee_name == "<dict>":
+            value_type_str, expected_value_type_str = format_type_distinctly(
+                arg_type, callee.arg_types[n - 1], options=self.options
+            )
+            msg = "Unpacked dict entry {} has incompatible type {}; expected {}".format(
+                n - 1, value_type_str, expected_value_type_str
             )
             code = codes.DICT_ITEM
         elif callee_name == "<list-comprehension>":
@@ -1301,6 +1311,12 @@ class MessageBuilder:
         callee_name = callable_name(callee_type)
         if callee_name is not None and n > 0:
             self.fail(f"Cannot infer type argument {n} of {callee_name}", context)
+            if callee_name == "<dict>":
+                # Invariance in key type causes more of these errors than we would want.
+                self.note(
+                    "Try assigning the literal to a variable annotated as dict[<key>, <val>]",
+                    context,
+                )
         else:
             self.fail("Cannot infer function type argument", context)
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1800,11 +1800,12 @@ a = {'a': 1}
 b = {'z': 26, **a}
 c = {**b}
 d = {**a, **b, 'c': 3}
-e = {1: 'a', **a}  # E: Argument 1 to "update" of "dict" has incompatible type "Dict[str, int]"; expected "SupportsKeysAndGetItem[int, str]"
-f = {**b}  # type: Dict[int, int]  # E: List item 0 has incompatible type "Dict[str, int]"; expected "SupportsKeysAndGetItem[int, int]"
+e = {1: 'a', **a}  # E: Cannot infer type argument 1 of <dict> \
+                   # N: Try assigning the literal to a variable annotated as dict[<key>, <val>]
+f = {**b}  # type: Dict[int, int]  # E: Unpacked dict entry 0 has incompatible type "Dict[str, int]"; expected "SupportsKeysAndGetItem[int, int]"
 g = {**Thing()}
 h = {**a, **Thing()}
-i = {**Thing()}  # type: Dict[int, int]  # E: List item 0 has incompatible type "Thing"; expected "SupportsKeysAndGetItem[int, int]" \
+i = {**Thing()}  # type: Dict[int, int]  # E: Unpacked dict entry 0 has incompatible type "Thing"; expected "SupportsKeysAndGetItem[int, int]" \
                  # N: Following member(s) of "Thing" have conflicts: \
                  # N:     Expected: \
                  # N:         def __getitem__(self, int, /) -> int \
@@ -1814,16 +1815,8 @@ i = {**Thing()}  # type: Dict[int, int]  # E: List item 0 has incompatible type 
                  # N:         def keys(self) -> Iterable[int] \
                  # N:     Got: \
                  # N:         def keys(self) -> Iterable[str]
-j = {1: 'a', **Thing()}  # E: Argument 1 to "update" of "dict" has incompatible type "Thing"; expected "SupportsKeysAndGetItem[int, str]" \
-                         # N: Following member(s) of "Thing" have conflicts: \
-                         # N:     Expected: \
-                         # N:         def __getitem__(self, int, /) -> str \
-                         # N:     Got: \
-                         # N:         def __getitem__(self, str, /) -> int \
-                         # N:     Expected: \
-                         # N:         def keys(self) -> Iterable[int] \
-                         # N:     Got: \
-                         # N:         def keys(self) -> Iterable[str]
+j = {1: 'a', **Thing()}  # E: Cannot infer type argument 1 of <dict> \
+                         # N: Try assigning the literal to a variable annotated as dict[<key>, <val>]
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-medium.pyi]
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2711,3 +2711,13 @@ class G(Generic[T]):
     def g(self, x: S) -> Union[S, T]: ...
 
 f(lambda x: x.g(0))  # E: Cannot infer type argument 1 of "f"
+
+[case testDictStarInference]
+class B: ...
+class C1(B): ...
+class C2(B): ...
+
+dict1 = {"a": C1()}
+dict2 = {"a": C2(), **dict1}
+reveal_type(dict2)  # N: Revealed type is "builtins.dict[builtins.str, __main__.B]"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2721,3 +2721,15 @@ dict1 = {"a": C1()}
 dict2 = {"a": C2(), **dict1}
 reveal_type(dict2)  # N: Revealed type is "builtins.dict[builtins.str, __main__.B]"
 [builtins fixtures/dict.pyi]
+
+[case testDictStarAnyKeyJoinValue]
+from typing import Any
+
+class B: ...
+class C1(B): ...
+class C2(B): ...
+
+dict1: Any
+dict2 = {"a": C1(), **{x: C2() for x in dict1}}
+reveal_type(dict2)  # N: Revealed type is "builtins.dict[Any, __main__.B]"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -790,3 +790,18 @@ if sys.version_info < (3, 6):
 else:
     42  # type: ignore  # E: Unused "type: ignore" comment
 [builtins fixtures/ops.pyi]
+
+[case testDictExpressionErrorLocations]
+# flags: --pretty
+from typing import Dict
+
+other: Dict[str, str]
+dct: Dict[str, int] = {"a": "b", **other}
+[builtins fixtures/dict.pyi]
+[out]
+main:5: error: Dict entry 0 has incompatible type "str": "str"; expected "str": "int"
+    dct: Dict[str, int] = {"a": "b", **other}
+                           ^~~~~~~~
+main:5: error: Unpacked dict entry 1 has incompatible type "Dict[str, str]"; expected "SupportsKeysAndGetItem[str, int]"
+    dct: Dict[str, int] = {"a": "b", **other}
+                                       ^~~~~

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7546,7 +7546,7 @@ def d() -> Dict[int, int]: pass
 [builtins fixtures/dict.pyi]
 [out]
 ==
-main:5: error: Argument 1 to "update" of "dict" has incompatible type "Dict[int, int]"; expected "SupportsKeysAndGetItem[int, str]"
+main:5: error: Argument 2 to <dict> has incompatible type "Dict[int, int]"; expected "SupportsKeysAndGetItem[int, str]"
 
 [case testAwaitAndAsyncDef-only_when_nocache]
 from a import g

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7546,7 +7546,7 @@ def d() -> Dict[int, int]: pass
 [builtins fixtures/dict.pyi]
 [out]
 ==
-main:5: error: Argument 2 to <dict> has incompatible type "Dict[int, int]"; expected "SupportsKeysAndGetItem[int, str]"
+main:5: error: Unpacked dict entry 1 has incompatible type "Dict[int, int]"; expected "SupportsKeysAndGetItem[int, str]"
 
 [case testAwaitAndAsyncDef-only_when_nocache]
 from a import g

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1350,7 +1350,7 @@ def f() -> Dict[int, str]:
 def d() -> Dict[int, int]:
     return {}
 [out]
-_testDictWithStarStarSpecialCase.py:4: error: Argument 1 to "update" of "MutableMapping" has incompatible type "Dict[int, int]"; expected "SupportsKeysAndGetItem[int, str]"
+_testDictWithStarStarSpecialCase.py:4: error: Unpacked dict entry 1 has incompatible type "Dict[int, int]"; expected "SupportsKeysAndGetItem[int, str]"
 
 [case testLoadsOfOverloads]
 from typing import overload, Any, TypeVar, Iterable, List, Dict, Callable, Union


### PR DESCRIPTION
Fixes #12977

IMO current dict expression inference logic is quite arbitrary: we only take the non-star items to infer resulting type, then enforce it on the remaining (star) items. In this PR I simplify the logic to simply put all expressions as arguments into the same call. This has following benefits:
* Makes everything more consistent/predictable.
* Fixes one of top upvoted bugs
* Makes dict item indexes correct (previously we reshuffled them causing wrong indexes for non-star items after star items)
* No more weird wordings like `List item <n>` or `Argument <n> to "update" of "dict"`
* I also fix the end position of generated expressions to show correct spans in errors

The only downside is that we will see `Cannot infer type argument` error instead of `Incompatible type` more often. This is because `SupportsKeysAndGetItem` (used for star items) is invariant in key type. I think this is fine however, since:
* This only affects key types, that are mixed much less often than value types (they are usually just strings), and for latter we use joins.
* I added a dedicated note for this case