### PR TITLE
Output distinct types when type names are ambiguous

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1656,11 +1656,9 @@ class MessageBuilder:
         )
 
     def assert_type_fail(self, source_type: Type, target_type: Type, context: Context) -> None:
+        (source, target) = format_type_distinctly(source_type, target_type, options=self.options)
         self.fail(
-            f"Expression is of type {format_type(source_type, self.options)}, "
-            f"not {format_type(target_type, self.options)}",
-            context,
-            code=codes.ASSERT_TYPE,
+            f"Expression is of type {source}, " f"not {target}", context, code=codes.ASSERT_TYPE
         )
 
     def unimported_type_becomes_any(self, prefix: str, typ: Type, ctx: Context) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1657,9 +1657,7 @@ class MessageBuilder:
 
     def assert_type_fail(self, source_type: Type, target_type: Type, context: Context) -> None:
         (source, target) = format_type_distinctly(source_type, target_type, options=self.options)
-        self.fail(
-            f"Expression is of type {source}, not {target}", context, code=codes.ASSERT_TYPE
-        )
+        self.fail(f"Expression is of type {source}, not {target}", context, code=codes.ASSERT_TYPE)
 
     def unimported_type_becomes_any(self, prefix: str, typ: Type, ctx: Context) -> None:
         self.fail(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1658,7 +1658,7 @@ class MessageBuilder:
     def assert_type_fail(self, source_type: Type, target_type: Type, context: Context) -> None:
         (source, target) = format_type_distinctly(source_type, target_type, options=self.options)
         self.fail(
-            f"Expression is of type {source}, " f"not {target}", context, code=codes.ASSERT_TYPE
+            f"Expression is of type {source}, not {target}", context, code=codes.ASSERT_TYPE
         )
 
     def unimported_type_becomes_any(self, prefix: str, typ: Type, ctx: Context) -> None:

--- a/test-data/unit/check-assert-type-fail.test
+++ b/test-data/unit/check-assert-type-fail.test
@@ -1,0 +1,28 @@
+[case testAssertTypeFail1]
+import typing
+import array as arr
+class array:
+    pass
+def f(si: arr.array[int]):
+    typing.assert_type(si, array) # E: Expression is of type "array.array[int]", not "__main__.array"
+[builtins fixtures/tuple.pyi]
+
+[case testAssertTypeFail2]
+import typing
+import array as arr
+class array:
+    class array:
+        i = 1
+def f(si: arr.array[int]):
+    typing.assert_type(si, array.array) # E: Expression is of type "array.array[int]", not "__main__.array.array"
+[builtins fixtures/tuple.pyi]
+
+[case testAssertTypeFail3]
+import typing
+import array as arr
+class array:
+    class array:
+        i = 1
+def f(si: arr.array[int]):
+    typing.assert_type(si, int) # E: Expression is of type "array[int]", not "int"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
#### Fixes #12677
When assert_type fails, when the type of value examined and the specified type have the same name, mypy returns an error with more descriptive and distinct names.

#### Example:
Error: Expression is of type "mypy-test.SupportsIndex", not "typing_extensions.SupportsIndex"

instead of

Error: Expression is of type "SupportsIndex", not "SupportsIndex" (previous behavior)

#### Testing:
Added unit tests in test-data/unit/check-assert-type-fail.test.