### PR TITLE
Add `warn_name_override`

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -592,6 +592,14 @@ section of the command line docs.
     Shows a warning when encountering any code inferred to be unreachable or
     redundant after performing type analysis.
 
+.. confval:: warn_name_override
+
+    :type: boolean
+    :default: False
+
+    Shows a warning when an argument could be used as either a positional or
+    keyword argument, but it has a different name than the parent argument.
+
 
 Suppressing errors
 ******************

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2051,7 +2051,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # Use boolean variable to clarify code.
         fail = False
         op_method_wider_note = False
-        if not is_subtype(override, original, ignore_pos_arg_names=True):
+        if not is_subtype(
+            override, original, ignore_pos_arg_names=not self.options.warn_name_override
+        ):
             fail = True
         elif isinstance(override, Overloaded) and self.is_forward_op_method(name):
             # Operator method overrides cannot extend the domain, as

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -781,6 +781,13 @@ def process_options(
         help="Warn about statements or expressions inferred to be unreachable",
         group=lint_group,
     )
+    add_invertible_flag(
+        "--warn-name-override",
+        default=False,
+        strict_flag=False,
+        help="Warn about overridden positional argument names that could be used as keywords",
+        group=lint_group,
+    )
 
     # Note: this group is intentionally added here even though we don't add
     # --strict to this group near the end.

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -55,6 +55,7 @@ PER_MODULE_OPTIONS: Final = {
     "warn_return_any",
     "warn_unreachable",
     "warn_unused_ignores",
+    "warn_name_override",
 }
 
 OPTIONS_AFFECTING_CACHE: Final = (
@@ -202,6 +203,10 @@ class Options:
 
         # Make arguments prepended via Concatenate be truly positional-only.
         self.strict_concatenate = False
+
+        # Warn about methods that override the name of an argument that could be used
+        # either positionally or as a keyword argument.
+        self.warn_name_override = False
 
         # Report an error for any branches inferred to be unreachable as a result of
         # type analysis.

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -60,6 +60,27 @@ class B(A):
 class C(A):
     def f(self, foo: int, bar: str) -> None: pass
 
+[case testPositionalOverridingArgumentNameSensitivityWithWarnNameOverride]
+# flags: --warn-name-override
+import typing
+
+class A(object):
+    def f(self, a: int, b: str) -> None: pass
+
+class B(A):
+    def f(self, b: str, a: int) -> None: pass # E: Argument 1 of "f" is incompatible with supertype "A"; supertype defines the argument type as "int" \
+                                              # N: This violates the Liskov substitution principle \
+                                              # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides \
+                                              # E: Argument 2 of "f" is incompatible with supertype "A"; supertype defines the argument type as "str"
+
+class C(A):
+    def f(self, foo: int, bar: str) -> None: pass # E: Signature of "f" incompatible with supertype "A" \
+                                                  # N:      Superclass: \
+                                                  # N:          def f(self, a: int, b: str) -> None \
+                                                  # N:      Subclass: \
+                                                  # N:          def f(self, foo: int, bar: str) -> None
+
+
 
 [case testPositionalOverridingArgumentNamesCheckedWhenMismatchingPos]
 import typing


### PR DESCRIPTION
Fixes #1013

The issue states:

> The reason is that a lot of code doesn't define these names consistently, and mypy would generate a ton of useless errors if it insisted on compatibility here.

I've made this optional, but only noticed a few dozens of issues when I ran it against a codebase with hundreds of thousands of lines of code, and one of them was a real problem that could've raised an exception at runtime.

Very open to feedback, especially:

* Whether to make this optional (or if it _does_  remain an option, whether it should be enabled by default)
* What to name it
* Any other changes I'd need to make -- this seems suspiciously simple
