### PR TITLE
Update linters and python version for linting in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
           # but it's useful to run them with tox too,
           # to ensure the tox env works as expected
         - name: Formatting with Black + isort and code style with flake8
-          python: '3.7'
+          python: '3.10'
           arch: x64
           os: ubuntu-latest
           toxenv: lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,16 +4,16 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.5  # must match test-requirements.txt (cannot use version 5.12 until python 3.7 support is dropped)
+    rev: 5.12.0  # must match test-requirements.txt
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4  # must match test-requirements.txt (cannot use version 6 until python 3.7 support is dropped)
+    rev: 6.0.0  # must match test-requirements.txt
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear==22.12.6  # must match test-requirements.txt
-          - flake8-noqa==1.3.0       # must match test-requirements.txt
+          - flake8-bugbear==23.3.23  # must match test-requirements.txt
+          - flake8-noqa==1.3.1       # must match test-requirements.txt
 
 ci:
   # We run flake8 as part of our GitHub Actions suite in CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ hash -r  # This resets shell PATH cache, not necessary on Windows
 ```
 
 > **Note**
-> Some code quality tools are not compatible with old python versions, you'll
-> need python version 3.8 or higher to install and run them.
+> You'll need Python 3.8 or higher to install all requirements listed in
+> test-requirements.txt
 
 ### Running tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,10 @@ python3 -m pip install -e .
 hash -r  # This resets shell PATH cache, not necessary on Windows
 ```
 
+> **Note**
+> Some code quality tools are not compatible with old python versions, you'll
+> need python version 3.8 or higher to install and run them.
+
 ### Running tests
 
 Running the full test suite can take a while, and usually isn't necessary when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ force-exclude = '''
 '''
 
 [tool.isort]
+py_version = 37
 profile = "black"
 line_length = 99
 combine_as_imports = true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,10 +3,10 @@
 attrs>=18.0
 black==23.3.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
-flake8==6.0.0           # must match version in .pre-commit-config.yaml
-flake8-bugbear==23.3.23 # must match version in .pre-commit-config.yaml
-flake8-noqa==1.3.1      # must match version in .pre-commit-config.yaml
-isort[colors]==5.12.0   # must match version in .pre-commit-config.yaml
+flake8==6.0.0; python_version >= "3.8"           # must match version in .pre-commit-config.yaml
+flake8-bugbear==23.3.23; python_version >= "3.8" # must match version in .pre-commit-config.yaml
+flake8-noqa==1.3.1; python_version >= "3.8"      # must match version in .pre-commit-config.yaml
+isort[colors]==5.12.0; python_version >= "3.8"   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,10 +3,10 @@
 attrs>=18.0
 black==23.3.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
-flake8==5.0.4           # must match version in .pre-commit-config.yaml
-flake8-bugbear==22.12.6 # must match version in .pre-commit-config.yaml
-flake8-noqa==1.3.0      # must match version in .pre-commit-config.yaml
-isort[colors]==5.11.5   # must match version in .pre-commit-config.yaml
+flake8==6.0.0           # must match version in .pre-commit-config.yaml
+flake8-bugbear==23.3.23 # must match version in .pre-commit-config.yaml
+flake8-noqa==1.3.1      # must match version in .pre-commit-config.yaml
+isort[colors]==5.12.0   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ commands =
 
 [testenv:lint]
 description = check the code style
+skip_install = true
 commands =
     flake8 {posargs}
     black --check --diff --color .


### PR DESCRIPTION
x-ref: #15197

I updated the python version used for linting to 3.10. This gives us some time before we have to update again.

The only downside I see is if someone is using a 3.7 python environment locally and they run linters in that environment or if they installed tox with python 3.7 and they run `tox run -e lint`. A note can be added in the contributing guide to tell users what python versions are supported for dev tools. Another solution would be to delay merging this PR until python 3.7 support is dropped altogether but in this case the pre-commit-ci updates and the #15197 situation would happen again.

(cc @AlexWaygood)