### PR TITLE
Use native ExpandTypeVisitor for expanding type aliases as well

### DIFF
--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -604,11 +604,11 @@ from typing_extensions import TypeGuard
 class Z:
     def typeguard1(self, *, x: object) -> TypeGuard[int]:  # line 4
         ...
-    
+
     @staticmethod
     def typeguard2(x: object) -> TypeGuard[int]:
         ...
-    
+
     @staticmethod  # line 11
     def typeguard3(*, x: object) -> TypeGuard[int]:
         ...
@@ -688,3 +688,14 @@ if typeguard(x=x, y="42"):
 if typeguard(y="42", x=x):
     reveal_type(x)  # N: Revealed type is "builtins.str"
 [builtins fixtures/tuple.pyi]
+
+[case testGenericAliasWithTypeGuard]
+from typing import Callable, List, TypeVar
+from typing_extensions import TypeGuard, TypeAlias
+
+A = Callable[[object], TypeGuard[List[T]]]
+def foo(x: object) -> TypeGuard[List[str]]: ...
+
+def test(f: A[T]) -> T: ...
+reveal_type(test(foo))  # N: Revealed type is "builtins.str"
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
This used to be a source of code duplication, and also using the "native" visitor will allow us to implement new features for type aliases easily (e.g. variadic type aliases, that I am going to do in next PR).