### PR TITLE
Centralise linting config in `.pre-commit-config.yaml`

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -50,9 +50,7 @@ cmds = {
     # Self type check
     "self": [executable, "-m", "mypy", "--config-file", "mypy_self_check.ini", "-p", "mypy"],
     # Lint
-    "lint": ["flake8", "-j3"],
-    "format-black": ["black", "."],
-    "format-isort": ["isort", "."],
+    "lint": ["pre-commit", "run", "--all-files"],
     # Fast test cases only (this is the bulk of the test suite)
     "pytest-fast": ["pytest", "-q", "-k", f"not ({' or '.join(ALL_NON_FAST)})"],
     # Test cases that invoke mypy (with small inputs)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,7 @@ flake8-bugbear==23.3.23; python_version >= "3.8" # must match version in .pre-co
 flake8-noqa==1.3.1; python_version >= "3.8"      # must match version in .pre-commit-config.yaml
 isort[colors]==5.12.0; python_version >= "3.8"   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
+pre-commit
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10
 pytest>=6.2.4

--- a/tox.ini
+++ b/tox.ini
@@ -41,10 +41,7 @@ commands =
 [testenv:lint]
 description = check the code style
 skip_install = true
-commands =
-    flake8 {posargs}
-    black --check --diff --color .
-    isort --check --diff --color .
+commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:type]
 description = type check ourselves


### PR DESCRIPTION
This makes it easier to maintain the configurations for the various linting tools we use in CI. It also makes it easier for contributors to run the linting tools locally. `black`, `isort` and `flake8` are all very fast checks, so I think it makes sense to just run them all together in `runtests.py`. 

With this PR, the following three invocations will all be equivalent:

```
pre-commit run --all-files
python runtests.py lint
tox -e lint
```

Closes #15076