### PR TITLE
Mark ErrorCodes as serializable

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -6,8 +6,9 @@ These can be used for filtering specific errors.
 from __future__ import annotations
 
 from collections import defaultdict
-from mypy_extensions import mypyc_attr
 from typing_extensions import Final
+
+from mypy_extensions import mypyc_attr
 
 error_codes: dict[str, ErrorCode] = {}
 sub_code_map: dict[str, set[str]] = defaultdict(set)

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -6,12 +6,14 @@ These can be used for filtering specific errors.
 from __future__ import annotations
 
 from collections import defaultdict
+from mypy_extensions import mypyc_attr
 from typing_extensions import Final
 
 error_codes: dict[str, ErrorCode] = {}
 sub_code_map: dict[str, set[str]] = defaultdict(set)
 
 
+@mypyc_attr(serializable=True)
 class ErrorCode:
     def __init__(
         self,


### PR DESCRIPTION
When starting mypy daemon, we pickle options. Error codes are part of options and need to be pickle-able. This decorator is needed for this to be possible with mypyc.

Fixes #14671 