### PR TITLE
Fix type analysis for typing.Unpack

### DIFF
--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -61,7 +61,17 @@ def test_python_evaluation(testcase: DataDrivenTestCase, cache_dir: str) -> None
 
     m = re.search("# flags: (.*)$", "\n".join(testcase.input), re.MULTILINE)
     if m:
-        mypy_cmdline.extend(m.group(1).split())
+        additional_flags = m.group(1).split()
+        for flag in additional_flags:
+            if flag.startswith("--python-version="):
+                targetted_python_version = flag.split("=")[1]
+                targetted_major, targetted_minor = targetted_python_version.split(".")
+                if (int(targetted_major), int(targetted_minor)) > (
+                    sys.version_info.major,
+                    sys.version_info.minor,
+                ):
+                    return
+        mypy_cmdline.extend(additional_flags)
 
     # Write the program to a file.
     program = "_" + testcase.name + ".py"

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1298,7 +1298,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 # Potentially a unpack.
                 sym = self.lookup_qualified(arg.name, arg)
                 if sym is not None:
-                    if sym.fullname == "typing_extensions.Unpack":
+                    if sym.fullname in ("typing_extensions.Unpack", "typing.Unpack"):
                         if found_unpack:
                             self.fail("Callables can only have a single unpack", arg)
                         found_unpack = True

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1986,3 +1986,28 @@ def good9(foo1: Foo[Concatenate[int, P]], foo2: Foo[[int, str, bytes]], *args: P
 
 [out]
 _testStrictEqualitywithParamSpec.py:11: error: Non-overlapping equality check (left operand type: "Foo[[int]]", right operand type: "Bar[[int]]")
+
+[case testTypeVarTuple]
+# flags: --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack --python-version=3.11
+from typing import Any, Callable, Unpack, TypeVarTuple
+                                                                               
+Ts = TypeVarTuple("Ts")
+                                                                                  
+def foo(callback: Callable[[], Any]) -> None:
+    call(callback)                                                          
+
+def call(callback: Callable[[Unpack[Ts]], Any], *args: Unpack[Ts]) -> Any:
+    ...
+
+[case testTypeVarTupleTypingExtensions]
+# flags: --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack
+from typing_extensions import Unpack, TypeVarTuple
+from typing import Any, Callable
+                                                                               
+Ts = TypeVarTuple("Ts")
+                                                                                  
+def foo(callback: Callable[[], Any]) -> None:
+    call(callback)                                                          
+
+def call(callback: Callable[[Unpack[Ts]], Any], *args: Unpack[Ts]) -> Any:
+    ...

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1992,9 +1992,9 @@ _testStrictEqualitywithParamSpec.py:11: error: Non-overlapping equality check (l
 from typing import Any, Callable, Unpack, TypeVarTuple
 
 Ts = TypeVarTuple("Ts")
-                                                                                  
+
 def foo(callback: Callable[[], Any]) -> None:
-    call(callback)                                                          
+    call(callback)
 
 def call(callback: Callable[[Unpack[Ts]], Any], *args: Unpack[Ts]) -> Any:
     ...
@@ -2003,11 +2003,11 @@ def call(callback: Callable[[Unpack[Ts]], Any], *args: Unpack[Ts]) -> Any:
 # flags: --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack
 from typing_extensions import Unpack, TypeVarTuple
 from typing import Any, Callable
-                                                                               
+
 Ts = TypeVarTuple("Ts")
-                                                                                  
+
 def foo(callback: Callable[[], Any]) -> None:
-    call(callback)                                                          
+    call(callback)
 
 def call(callback: Callable[[Unpack[Ts]], Any], *args: Unpack[Ts]) -> Any:
     ...

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1990,7 +1990,7 @@ _testStrictEqualitywithParamSpec.py:11: error: Non-overlapping equality check (l
 [case testTypeVarTuple]
 # flags: --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack --python-version=3.11
 from typing import Any, Callable, Unpack, TypeVarTuple
-                                                                               
+
 Ts = TypeVarTuple("Ts")
                                                                                   
 def foo(callback: Callable[[], Any]) -> None:


### PR DESCRIPTION
We were checking only for `typing_extensions.Unpack`, which breaks code when checking at 3.11+ even if importing `typing_extensions` because its just a re-export from `typing`.

These basic pythoneval tests also assert that the feature at least somewhat works with the real stubs - otherwise up until now we had basically no coverage of that, and were relying on the fake typing stubs to be close enough to the real thing.