### PR TITLE
fix: typo fix for positional-only and keyword-only arguments

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -133,7 +133,7 @@ Functions
    # Mypy understands positional-only and keyword-only arguments
    # Positional-only arguments can also be marked by using a name starting with
    # two underscores
-   def quux(x: int, / *, y: int) -> None:
+   def quux(x: int, /, *, y: int) -> None:
        pass
 
    quux(3, y=5)  # Ok


### PR DESCRIPTION
Forgotten comma between parameters.