### PR TITLE
Update getting started docs for mypyc for Windows

### DIFF
--- a/mypyc/doc/getting_started.rst
+++ b/mypyc/doc/getting_started.rst
@@ -32,7 +32,7 @@ Ubuntu 18.04, for example:
 Windows
 *******
 
-Install `Visual C++ <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_.
+From `Build Tools for Visual Studio 2022 <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2022>`_, install MSVC C++ build tools for your architecture and a Windows SDK. (latest versions recommended)
 
 Installation
 ------------


### PR DESCRIPTION
Update the link to latest version MS has on its website. (there's no more build tools for 2017, just 2022) and also provide a bit more information as to what to install. The Windows SDK is needed as well.