### PR TITLE
Clarify difference between disallow_untyped_defs and disallow_incomplete_defs

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -353,7 +353,7 @@ definitions or calls.
 .. option:: --disallow-untyped-defs
 
     This flag reports an error whenever it encounters a function definition
-    with without type annotations or with incomplete type annotations.
+    without type annotations or with incomplete type annotations.
     (a superset of :option:`--disallow-incomplete-defs`).
 
     For example, it would report an error for :code:`def f(a, b)` and :code:`def f(a: int, b)`.

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -353,12 +353,17 @@ definitions or calls.
 .. option:: --disallow-untyped-defs
 
     This flag reports an error whenever it encounters a function definition
-    without type annotations.
+    with without type annotations or with incomplete type annotations.
+    (a superset of :option:`--disallow-incomplete-defs`).
+
+    For example, it would report an error for :code:`def f(a, b)` and :code:`def f(a: int, b)`.
 
 .. option:: --disallow-incomplete-defs
 
     This flag reports an error whenever it encounters a partly annotated
-    function definition.
+    function definition, while still allowing entirely unannotated definitions.
+
+    For example, it would report an error for :code:`def f(a: int, b)` but not :code:`def f(a, b)`.
 
 .. option:: --check-untyped-defs
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -493,14 +493,19 @@ section of the command line docs.
     :default: False
 
     Disallows defining functions without type annotations or with incomplete type
-    annotations.
+    annotations (a superset of :confval:`disallow_incomplete_defs`).
+
+    For example, it would report an error for :code:`def f(a, b)` and :code:`def f(a: int, b)`.
 
 .. confval:: disallow_incomplete_defs
 
     :type: boolean
     :default: False
 
-    Disallows defining functions with incomplete type annotations.
+    Disallows defining functions with incomplete type annotations, while still
+    allowing entirely unannotated definitions.
+
+    For example, it would report an error for :code:`def f(a: int, b)` but not :code:`def f(a, b)`.
 
 .. confval:: check_untyped_defs
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -696,7 +696,8 @@ def process_options(
         "--disallow-incomplete-defs",
         default=False,
         strict_flag=True,
-        help="Disallow defining functions with incomplete type annotations",
+        help="Disallow defining functions with incomplete type annotations "
+        "(while still allowing entirely unannotated definitions)",
         group=untyped_group,
     )
     add_invertible_flag(


### PR DESCRIPTION
Fixes #9963, #12693.

Previously addressed in #9964.

`disallow_untyped_defs` is a superset of `disallow_incomplete_defs`, as seen here:
- https://mypy-play.net/?mypy=latest&python=3.11&gist=cddd4c1921f3f5d5ac34a514bec1675f
- https://mypy-play.net/?mypy=latest&python=3.11&gist=cddd4c1921f3f5d5ac34a514bec1675f&flags=disallow-untyped-defs

The latter playground results in:
```
main.py:1: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
```
