### PR TITLE
Make sure to keep type variables even if unused.

### DIFF
--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3105,7 +3105,8 @@ T = TypeVar('T')
 
 def f(x: Optional[T] = None) -> Callable[..., T]: ...
 
-x = f()  # E: Need type annotation for "x"
+# Question: Is this alright?
+x: Callable[..., T] = f()
 y = x
 
 [case testDontNeedAnnotationForCallable]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1520,3 +1520,28 @@ def identity(func: Callable[P, None]) -> Callable[P, None]: ...
 @identity
 def f(f: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecificationSurvivesCall]
+# https://github.com/python/mypy/issues/12595
+from typing import TypeVar, Callable
+from typing_extensions import Concatenate, ParamSpec
+
+T = TypeVar('T')
+U = TypeVar('U')
+P = ParamSpec('P')
+
+def t(f: Callable[P, T]) -> Callable[P, T]: ...
+
+def pop_off(
+    transform: Callable[Concatenate[T, P], U]
+) -> Callable[P, Callable[[T], U]]: ...
+
+u = pop_off(t)
+reveal_type(u)  # N: Revealed type is "def [P, T] () -> def (def (*P.args, **P.kwargs) -> T`-2) -> def (*P.args, **P.kwargs) -> T`-2"
+
+@u()
+def f(x: int) -> None: ...
+
+reveal_type(f)  # N: Revealed type is "def (x: builtins.int)"
+f(0)
+[builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
I'm finally breaking up #14903 into smaller pieces. Sorry about that!

When mypy sees a typevar is unconstrained, it tries to set it to `<nothing>` (`UninhabitedType`). This PR modifies this keep the typevar in the returned callable. This is useful if (via ParamSpec) you get `[T] () -> (T) -> T`. Otherwise this would become `(<nothing>) -> <nothing>` which is just bad, I think! I believe this is significantly simpler than actually catching that ParamSpec case (in which you'd have to tell if the `TypeVar` is used *somewhere* in the args.), but if it isn't that is probably cleaner.

This fixes https://github.com/python/mypy/issues/12595.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
