### PR TITLE
ParamSpecs upper bounds should be a `Parameters` object and not an actual object

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4183,9 +4183,13 @@ class SemanticAnalyzer(
         # on the lines of process_typevar_parameters
 
         if not call.analyzed:
-            paramspec_var = ParamSpecExpr(
-                name, self.qualified_name(name), self.object_type(), INVARIANT
+            parameters = Parameters(
+                arg_types=[self.object_type(), self.object_type()],
+                arg_kinds=[ARG_STAR, ARG_STAR2],
+                arg_names=[None, None],
+                is_ellipsis_args=True,
             )
+            paramspec_var = ParamSpecExpr(name, self.qualified_name(name), parameters, INVARIANT)
             paramspec_var.line = call.line
             call.analyzed = paramspec_var
         else:

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -310,7 +310,11 @@ class C(Generic[P, P2]):
 
     def m3(self, c: C[P, P3]) -> None:
         reveal_type(join(c, c))  # N: Revealed type is "__main__.C[P`1, P3`-1]"
-        reveal_type(join(self, c))  # N: Revealed type is "builtins.object"
+        # TODO: undo this join change
+        reveal_type(join(self, c))  # E: Value of type variable "T" of "join" cannot be "[VarArg(object), KwArg(object)]" \
+                                    # N: Revealed type is "..." \
+                                    # E: Argument 1 to "join" has incompatible type "C[P, P2]"; expected "[VarArg(object), KwArg(object)]" \
+                                    # E: Argument 2 to "join" has incompatible type "C[P, P3]"; expected "[VarArg(object), KwArg(object)]"
 [builtins fixtures/dict.pyi]
 
 [case testParamSpecClassWithAny]

--- a/test-data/unit/semanal-types.test
+++ b/test-data/unit/semanal-types.test
@@ -1549,7 +1549,8 @@ MypyFile:1(
   ImportFrom:1(typing, [ParamSpec])
   AssignmentStmt:2(
     NameExpr(P* [__main__.P])
-    ParamSpecExpr:2()))
+    ParamSpecExpr:2(
+      UpperBound(...))))
 
 [case testTypeVarTuple]
 from typing_extensions import TypeVarTuple


### PR DESCRIPTION
There is some part of #14903 that fixes the joining, but I will have to check again. I also need to find some things that are fixed by this.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This changes the upper bound for parameter specifications.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
