### PR TITLE
Fix some TypeVarTuple Callable edge cases.

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -14,6 +14,7 @@ from mypy.types import (
     Type,
     TypedDictType,
     TypeOfAny,
+    UnpackType,
     get_proper_type,
 )
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2130,6 +2130,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 expanded_actual = mapper.expand_actual_type(
                     actual_type, actual_kind, callee.arg_names[i], callee_arg_kind
                 )
+                # TODO: We encounter a case where `expanded_actual` is Unpack and `calle_arg_type`
+                # is like a Tuple[Unpack[...]]. Is this the correct place to handle it, or are the
+                # inputs themselves wrong here?
+                if isinstance(expanded_actual, UnpackType) and isinstance(
+                    callee_arg_type, TupleType
+                ):
+                    expanded_actual = TupleType(
+                        [expanded_actual], fallback=callee_arg_type.partial_fallback
+                    )
                 check_arg(
                     expanded_actual,
                     actual_type,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1998,21 +1998,27 @@ class CallableType(FunctionLike):
     ) -> CallableType:
         variables = c.variables
 
-        if no_prefix:
-            return self.copy_modified(
-                arg_types=c.arg_types,
-                arg_kinds=c.arg_kinds,
-                arg_names=c.arg_names,
-                is_ellipsis_args=c.is_ellipsis_args,
-                variables=[*variables, *self.variables],
-            )
+        var_arg = c.var_arg()
+        if var_arg is not None and isinstance(var_arg.typ, UnpackType):
+            variables = [*variables, *self.variables]
         else:
-            return self.copy_modified(
-                arg_types=self.arg_types[:-2] + c.arg_types,
-                arg_kinds=self.arg_kinds[:-2] + c.arg_kinds,
-                arg_names=self.arg_names[:-2] + c.arg_names,
-                is_ellipsis_args=c.is_ellipsis_args,
-                variables=[*variables, *self.variables],
+            variables = [*variables, *self.variables]
+
+        result = self.copy_modified(
+            arg_types=c.arg_types,
+            arg_kinds=c.arg_kinds,
+            arg_names=c.arg_names,
+            is_ellipsis_args=c.is_ellipsis_args,
+            variables=variables,
+        )
+
+        if no_prefix:
+            return result
+        else:
+            return result.copy_modified(
+                arg_types=self.arg_types[:-2] + result.arg_types,
+                arg_kinds=self.arg_kinds[:-2] + result.arg_kinds,
+                arg_names=self.arg_names[:-2] + result.arg_names,
             )
 
     def with_unpacked_kwargs(self) -> NormalizedCallableType:

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -568,5 +568,53 @@ call(A().func, 0, 1)  # E: Argument 1 to "call" has incompatible type "Callable[
 call(A().func2, 0, 0)
 call(A().func3, 0, 1, 2)
 call(A().func3)
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleNotConcreteCallable]
+from typing_extensions import Unpack, TypeVarTuple
+from typing import Callable, TypeVar, Tuple
+
+T = TypeVar("T")
+Args = TypeVarTuple("Args")
+Args2 = TypeVarTuple("Args2")
+
+def submit(fn: Callable[[Unpack[Args]], T], *args: Unpack[Args]) -> T:
+    ...
+
+#def submit2(fn: Callable[[int, Unpack[Args]], T], *args: Unpack[Tuple[int, Unpack[Args]]]) -> T:
+#    ...
+
+def foo(func: Callable[[Unpack[Args]], T], *args: Unpack[Args]) -> T:
+   return submit(func, *args)
+
+def foo2(func: Callable[[Unpack[Args2]], T], *args: Unpack[Args2]) -> T:
+   return submit(func, *args)
+
+# TODO: implement this case.
+#def foo3(func: Callable[[Unpack[Args2]], T], *args: Unpack[Args2]) -> T:
+#   return submit2(func, 1, *args)
+
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleParamSpecInteraction]
+from typing_extensions import Unpack, TypeVarTuple, ParamSpec
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+Args = TypeVarTuple("Args")
+Args2 = TypeVarTuple("Args2")
+P = ParamSpec("P")
+
+def submit(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    ...
+
+def foo(func: Callable[[Unpack[Args]], T], *args: Unpack[Args]) -> T:
+   return submit(func, *args)
+
+def foo2(func: Callable[[Unpack[Args]], T], *args: Unpack[Args2]) -> T:
+   return submit(func, *args)  # E: Argument 2 to "submit" has incompatible type "*Tuple[Unpack[Args2]]"; expected "Tuple[Unpack[Args]]"
+
+def foo3(func: Callable[[Unpack[Args2]], T], *args: Unpack[Args2]) -> T:
+   return submit(func, *args)
 
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Previously we mostly only tested substituting in concrete values to Callables (see tests in PR). Now we test in substituting Unpack[Args], etc. Prefices and suffices are not implemented yet because they seem very nontrivial to get working.

We also test what happens when the `submit` function in the test case is defined using ParamSpec but we pass in an Unpack through *args, and we fix a crash related to that scenario.