### PR TITLE
Handle more ParamSpec literal form special cases

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -105,6 +105,7 @@ from mypy.typeanal import (
     has_any_from_unimported_type,
     instantiate_type_alias,
     make_optional_type,
+    pack_paramspec_args,
     set_any_tvars,
 )
 from mypy.typeops import (
@@ -4083,6 +4084,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         tp = get_proper_type(tp)
 
         if isinstance(tp, CallableType):
+            if len(tp.variables) == 1 and isinstance(tp.variables[0], ParamSpecType):
+                args = pack_paramspec_args(args)
+
             if len(tp.variables) != len(args):
                 if tp.is_type_obj() and tp.type_object().fullname == "builtins.tuple":
                     # TODO: Specialize the callable for the type arguments

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -325,9 +325,12 @@ class C(Generic[P]):
     def m(self, *args: P.args, **kwargs: P.kwargs) -> int:
         return 1
 
-c: C[Any]
-reveal_type(c)  # N: Revealed type is "__main__.C[Any]"
-reveal_type(c.m)  # N: Revealed type is "def (*args: Any, **kwargs: Any) -> builtins.int"
+c_old: C[Any]
+reveal_type(c_old)  # N: Revealed type is "__main__.C[[Any]]"
+reveal_type(c_old.m)  # N: Revealed type is "def (Any) -> builtins.int"
+c: C[...]
+reveal_type(c)  # N: Revealed type is "__main__.C[...]"
+reveal_type(c.m)  # N: Revealed type is "def (*Any, **Any) -> builtins.int"
 c.m(4, 6, y='x')
 c = c
 
@@ -1519,4 +1522,17 @@ def identity(func: Callable[P, None]) -> Callable[P, None]: ...
 
 @identity
 def f(f: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
+[builtins fixtures/paramspec.pyi]
+
+[case testRuntimeSpecialParamspecLiteralSyntax]
+import sub
+
+reveal_type(sub.Ex[None]())  # N: Revealed type is "sub.Ex[[None]]"
+[file sub/__init__.py]
+from typing_extensions import ParamSpec
+from typing import Generic
+
+P = ParamSpec("P")
+
+class Ex(Generic[P]): ...
 [builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
This is more:tm: correct as shown by changes in test cases. I can't find any issues that are closed by this though. From what I remember, this was a followup fix for https://github.com/python/mypy/pull/14903 in order to fix some incorrect mypy-primer output.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This just removes a previous too-broad special case for `Z[Any]` where `Z` has a single paramspec parameter. Previously, this would be equivalent to `Z[...]`. Now, it is equivalent to `Z[[Any]]`, unless the `Any` is from an error (invalid paramspec expressions will return an `Any` with `TypeOfAny.from_error`).

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
