### PR TITLE
[mypyc] Try adjusting error kinds for all blocks

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -174,13 +174,6 @@ class FunctionEmitterVisitor(OpVisitor[None]):
 
     def visit_branch(self, op: Branch) -> None:
         true, false = op.true, op.false
-        if op.op == Branch.IS_ERROR and isinstance(op.value, GetAttr) and not op.negated:
-            op2 = op.value
-            if op2.class_type.class_ir.is_always_defined(op2.attr):
-                # Getting an always defined attribute never fails, so the branch can be omitted.
-                if false is not self.next_block:
-                    self.emit_line(f"goto {self.label(false)};")
-                return
         negated = op.negated
         negated_rare = False
         if true is self.next_block and op.traceback_entry is None:


### PR DESCRIPTION
`adjust_error_kinds()` should be run over every block, but the old impl. of `insert_exception_handling()` would stop iterating over blocks once it generated a default error handler. This made sense for its original purpose, but unfortunately limits the effectiveness of `adjust_error_kinds()`.

Changing `insert_exception_handling()` to loop over every block no matter what also means we can get rid of the weird GetAttr special casing in the branch emit logic (stumbling across that is what made me investigate in the first place!).

This reduces self-compile LOC by 1.1% in my experiments (avoiding error branches sometimes eliminates register assignments or on-error decrefs... according to my brief look through the C diff between master and this patch).

| Revision | Self-compile C LOC |
|--------|--------|
| PR | 2 265 486 (**-1.1%**) | 
| Master (905c2cbcc233727cbf42d9f3ac78849318482af2) | 2 290 748 |

Notable removals in the diff (other than the all of the label renumbering) ...[^1]

![image](https://github.com/python/mypy/assets/63936253/3efee503-0c63-441f-9ce8-2e4d7083d5e5)
![image](https://github.com/python/mypy/assets/63936253/06136e2a-4315-40aa-9ca5-ec72bbd7ac45)

[^1]: apologies for the screenshots, this diff was generated during a SSH session so copying and pasting is a real pain. 