### PR TITLE
Fix pybind stubs20230526

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -206,6 +206,9 @@ class DocStringParser:
                     self.reset()
                     return
                 self.ret_type = self.accumulator
+                m = re.match(r"^[A-Za-z_][A-Za-z0-9_]*\.((ItemsView|KeysView|ValuesView).+)$", self.ret_type)
+                if m is not None:
+                    self.ret_type = m.group(1)
                 self.accumulator = ""
                 self.state.pop()
 

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -17,7 +17,7 @@ from typing_extensions import Final, TypeAlias as _TypeAlias
 Sig: _TypeAlias = Tuple[str, str]
 
 
-_TYPE_RE: Final = re.compile(r"^[a-zA-Z_][\w\[\], ]*(\.[a-zA-Z_][\w\[\], ]*)*$")
+_TYPE_RE: Final = re.compile(r"^[a-zA-Z_][\w\[\]\(\), ]*(\.[a-zA-Z_][\w\[\]\(\), ]*)*$")
 _ARG_NAME_RE: Final = re.compile(r"\**[A-Za-z_][A-Za-z0-9_]*$")
 
 

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -39,6 +39,9 @@ _DEFAULT_TYPING_IMPORTS: Final = (
     "Tuple",
     "Union",
     "Annotated",
+    "KeysView",
+    "ItemsView",
+    "ValuesView",
 )
 
 
@@ -278,8 +281,10 @@ def get_members(obj: object) -> list[tuple[str, Any]]:
             value = getattr(obj, name)
         except AttributeError:
             continue
-        else:
-            results.append((name, value))
+        if inspect.isclass(value) and not value.__name__.isidentifier():
+            # like `KeysView[str]`
+            continue
+        results.append((name, value))
     return results
 
 

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -38,6 +38,7 @@ _DEFAULT_TYPING_IMPORTS: Final = (
     "Optional",
     "Tuple",
     "Union",
+    "Annotated",
 )
 
 
@@ -252,7 +253,16 @@ def add_typing_import(output: list[str]) -> list[str]:
         if any(re.search(r"\b%s\b" % name, line) for line in output):
             names.append(name)
     if names:
+        if 'Annotated' in names:
+            names.append('TYPE_CHECKING')
+            output = [
+                "if TYPE_CHECKING:",
+                "    if FixedSize not in vars():",
+                "        def FixedSize(value):",
+                "            pass",
+            ] + output
         return [f"from typing import {', '.join(names)}", ""] + output
+
     else:
         return output.copy()
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

1. pybind11's std::array docstring was generating `List[int[2]]`, which was not correct. https://github.com/pybind/pybind11/pull/4679 corrected the docstring to `Annotated[List[int], FixedSize(2)]`, which is correct syntax. But stubgen has to be updated.
2. pybind11's bind map could not be parsed by stubgen correctly, which was corrected.

/cc @rwgk @felixvd

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
