### PR TITLE
Cleanup reference to master branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 <!--
 Checklist:
-- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
+- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/main/CONTRIBUTING.md)
 - Add tests for all changed behaviour.
 - If you can't add a test, please explain why and how you verified your changes work.
 - Make sure CI passes.

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,7 +2,7 @@ name: Trigger wheel build
 
 on:
   push:
-    branches: [main, master, 'release*']
+    branches: [main, 'release*']
     tags: ['*']
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Check documentation build
 on:
   workflow_dispatch:
   push:
-    branches: [main, master, 'release*']
+    branches: [main, 'release*']
     tags: ['*']
   pull_request:
     paths:

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -1,7 +1,7 @@
 name: Run mypy_primer
 
 on:
-  # Only run on PR, since we diff against master
+  # Only run on PR, since we diff against main
   pull_request:
     paths-ignore:
     - 'docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   workflow_dispatch:
   push:
-    branches: [main, master, 'release*']
+    branches: [main, 'release*']
     tags: ['*']
   pull_request:
     paths-ignore:

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -3,7 +3,7 @@ name: Test stubgenc on pybind11_fixtures
 on:
   workflow_dispatch:
   push:
-    branches: [main, master, 'release*']
+    branches: [main, 'release*']
     tags: ['*']
   pull_request:
     paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1075,7 +1075,7 @@ This feature was contributed by Ivan Levkivskyi (PR [16237](https://github.com/p
 
 ### Mypy Changelog
 
-We now maintain a [changelog](https://github.com/python/mypy/blob/master/CHANGELOG.md) in the mypy Git repository. It mirrors the contents of [mypy release blog posts](https://mypy-lang.blogspot.com/). We will continue to also publish release blog posts. In the future, release blog posts will be created based on the changelog near a release date.
+We now maintain a [changelog](https://github.com/python/mypy/blob/main/CHANGELOG.md) in the mypy Git repository. It mirrors the contents of [mypy release blog posts](https://mypy-lang.blogspot.com/). We will continue to also publish release blog posts. In the future, release blog posts will be created based on the changelog near a release date.
 
 This was contributed by Shantanu (PR [16280](https://github.com/python/mypy/pull/16280)).
 

--- a/CREDITS
+++ b/CREDITS
@@ -2,7 +2,7 @@ Credits
 -------
 
 For a full list of contributors you can mine the commit history:
-https://github.com/python/mypy/commits/master
+https://github.com/python/mypy/commits/main
 
 For lists of contributors per mypy release (including typeshed) see
 the release blog posts at https://mypy-lang.blogspot.com/.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ repo directly:
 ```bash
 python3 -m pip install -U git+https://github.com/python/mypy.git
 # or if you don't have 'git' installed
-python3 -m pip install -U https://github.com/python/mypy/zipball/master
+python3 -m pip install -U https://github.com/python/mypy/zipball/main
 ```
 
 Now you can type-check the [statically typed parts] of a program like this:

--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -263,7 +263,7 @@ Your CI script might work like this:
 
 * Create a tarball from the ``.mypy_cache`` directory.
 
-* Determine the current git master branch commit id (say, using
+* Determine the current git main branch commit id (say, using
   ``git rev-parse HEAD``).
 
 * Upload the tarball to the shared repository with a name derived from the
@@ -278,13 +278,13 @@ populates the local ``.mypy_cache`` directory from the shared
 repository and then runs a normal incremental build.
 
 The wrapper script needs some logic to determine the most recent
-central repository commit (by convention, the ``origin/master`` branch
+central repository commit (by convention, the ``origin/main`` branch
 for git) the local development branch is based on. In a typical git
 setup you can do it like this:
 
 .. code::
 
-    git merge-base HEAD origin/master
+    git merge-base HEAD origin/main
 
 The next step is to download the cache data (contents of the
 ``.mypy_cache`` directory) from the shared repository based on the
@@ -331,11 +331,11 @@ at least if your codebase is hundreds of thousands of lines or more:
   potentially large number of changes in an incremental build, as this can
   be much slower than downloading cache data and restarting the daemon.
 
-* If the current local branch is based on a very recent master commit,
+* If the current local branch is based on a very recent main commit,
   the remote cache data may not yet be available for that commit, as
   there will necessarily be some latency to build the cache files. It
   may be a good idea to look for cache data for, say, the 5 latest
-  master commits and use the most recent data that is available.
+  main commits and use the most recent data that is available.
 
 * If the remote cache is not accessible for some reason (say, from a public
   network), the script can still fall back to a normal incremental build.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,7 +109,7 @@ html_theme = "furo"
 
 html_theme_options = {
     "source_repository": "https://github.com/python/mypy",
-    "source_branch": "master",
+    "source_branch": "main",
     "source_directory": "docs/source",
 }
 

--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -93,9 +93,9 @@ can be specified after colon:
 
 In the following sections we describe the basics of the plugin system with
 some examples. For more technical details, please read the docstrings in
-`mypy/plugin.py <https://github.com/python/mypy/blob/master/mypy/plugin.py>`_
+`mypy/plugin.py <https://github.com/python/mypy/blob/main/mypy/plugin.py>`_
 in mypy source code. Also you can find good examples in the bundled plugins
-located in `mypy/plugins <https://github.com/python/mypy/tree/master/mypy/plugins>`_.
+located in `mypy/plugins <https://github.com/python/mypy/tree/main/mypy/plugins>`_.
 
 High-level overview
 *******************

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. Mypy documentation master file, created by
+.. Mypy documentation main file, created by
    sphinx-quickstart on Sun Sep 14 19:50:35 2014.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/misc/generate_changelog.py
+++ b/misc/generate_changelog.py
@@ -99,7 +99,7 @@ def filter_omitted_commits(commits: list[CommitInfo]) -> list[CommitInfo]:
 def normalize_title(title: str) -> str:
     # We sometimes add a title prefix when cherry-picking commits to a
     # release branch. Attempt to remove these prefixes so that we can
-    # match them to the corresponding master branch.
+    # match them to the corresponding main branch.
     if m := re.match(r"\[release [0-9.]+\] *", title, flags=re.I):
         title = title.replace(m.group(0), "")
     return title

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -2,7 +2,7 @@
 
 Simple usage:
 
-  python misc/perf_compare.py my-branch master ...
+  python misc/perf_compare.py my-branch main ...
 
 What this does:
 

--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -92,12 +92,7 @@ def create_or_update_pull_request(*, title: str, body: str, branch_name: str) ->
 
     with requests.post(
         "https://api.github.com/repos/python/mypy/pulls",
-        json={
-            "title": title,
-            "body": body,
-            "head": f"{fork_owner}:{branch_name}",
-            "base": "master",
-        },
+        json={"title": title, "body": body, "head": f"{fork_owner}:{branch_name}", "base": "main"},
         headers=get_github_api_headers(),
     ) as response:
         resp_json = response.json()
@@ -108,7 +103,7 @@ def create_or_update_pull_request(*, title: str, body: str, branch_name: str) ->
             # Find the existing PR
             with requests.get(
                 "https://api.github.com/repos/python/mypy/pulls",
-                params={"state": "open", "head": f"{fork_owner}:{branch_name}", "base": "master"},
+                params={"state": "open", "head": f"{fork_owner}:{branch_name}", "base": "main"},
                 headers=get_github_api_headers(),
             ) as response:
                 response.raise_for_status()
@@ -158,7 +153,7 @@ def main() -> None:
         shutil.copytree(typeshed_patches, tmp_patches)
 
         branch_name = "mypybot/sync-typeshed"
-        subprocess.run(["git", "checkout", "-B", branch_name, "origin/master"], check=True)
+        subprocess.run(["git", "checkout", "-B", branch_name, "origin/main"], check=True)
 
         # Copy the stashed patches back
         shutil.rmtree(typeshed_patches, ignore_errors=True)

--- a/misc/trigger_wheel_build.sh
+++ b/misc/trigger_wheel_build.sh
@@ -19,5 +19,5 @@ cd build
 echo $COMMIT > mypy_commit
 git commit -am "Build wheels for mypy $V"
 git tag v$V
-# Push a tag, but no need to push the change to master
+# Push a tag, but no need to push the change to main
 git push --tags

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -1261,7 +1261,7 @@ def report_internal_error(
     # Print "INTERNAL ERROR" message.
     print(
         f"{prefix}error: INTERNAL ERROR --",
-        "Please try using mypy master on GitHub:\n"
+        "Please try using mypy main on GitHub:\n"
         "https://mypy.readthedocs.io/en/stable/common_issues.html"
         "#using-a-development-mypy-build",
         file=stderr,
@@ -1270,7 +1270,7 @@ def report_internal_error(
         print("Please report a bug at https://github.com/python/mypy/issues", file=stderr)
     else:
         print(
-            "If this issue continues with mypy master, "
+            "If this issue continues with mypy main, "
             "please report a bug at https://github.com/python/mypy/issues",
             file=stderr,
         )

--- a/mypyc/doc/dev-intro.md
+++ b/mypyc/doc/dev-intro.md
@@ -63,7 +63,7 @@ features.
 ## Development Environment
 
 First you should set up the mypy development environment as described in
-the [mypy docs](https://github.com/python/mypy/blob/master/README.md).
+the [mypy docs](https://github.com/python/mypy/blob/main/README.md).
 macOS, Linux and Windows are supported.
 
 ## Compiling and Running Programs

--- a/mypyc/doc/index.rst
+++ b/mypyc/doc/index.rst
@@ -1,4 +1,4 @@
-.. mypyc documentation master file, created by
+.. mypyc documentation main file, created by
    sphinx-quickstart on Sun Apr  5 14:01:55 2020.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ setup(
     project_urls={
         "Documentation": "https://mypy.readthedocs.io/en/stable/index.html",
         "Repository": "https://github.com/python/mypy",
-        "Changelog": "https://github.com/python/mypy/blob/master/CHANGELOG.md",
+        "Changelog": "https://github.com/python/mypy/blob/main/CHANGELOG.md",
         "Issues": "https://github.com/python/mypy/issues",
     },
 )


### PR DESCRIPTION
Followup to #15310

> **Note**
> This should only be merged **after** the branch was renamed.

Cleanup references to `master` branch and replace them with `main`.
This also updates the `sync-typeshed` script to use the correct base when creating a new PR.

Fixes #13985