### PR TITLE
[mypyc] Reduce codesize w/ generic attribute getters and setters

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -137,7 +137,7 @@ def get_mypy_config(
     # Needed to get types for all AST nodes
     options.export_types = True
     # We use mypy incremental mode when doing separate/incremental mypyc compilation
-    options.incremental = compiler_options.separate
+    options.incremental = compiler_options.separate or True
     options.preserve_asts = True
 
     for source in mypyc_sources:

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -137,7 +137,7 @@ def get_mypy_config(
     # Needed to get types for all AST nodes
     options.export_types = True
     # We use mypy incremental mode when doing separate/incremental mypyc compilation
-    options.incremental = compiler_options.separate or True
+    options.incremental = compiler_options.separate
     options.preserve_asts = True
 
     for source in mypyc_sources:

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -1183,3 +1183,8 @@ def c_array_initializer(components: list[str], *, indented: bool = False) -> str
     # Multi-line result
     res.append(indent + ", ".join(current))
     return "{\n    " + ",\n    ".join(res) + "\n" + indent + "}"
+
+
+def c_bool(value: bool) -> str:
+    """Return 'true' if value is True, otherwise 'false'."""
+    return "true" if value else "false"

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -364,6 +364,10 @@ class Emitter:
         attr = self.bitmap_field(index)
         return f"({cast}{obj})->{attr}"
 
+    def attr_bitmap_mask(self, index: int) -> int:
+        """Return integer mask used for attribute bitmap."""
+        return 1 << (index & (BITMAP_BITS - 1))
+
     def emit_attr_bitmap_set(
         self, value: str, obj: str, rtype: RType, cl: ClassIR, attr: str
     ) -> None:
@@ -388,7 +392,7 @@ class Emitter:
             check = self.error_value_check(rtype, value, "==")
             self.emit_line(f"if (unlikely({check})) {{")
         index = cl.bitmap_attrs.index(attr)
-        mask = 1 << (index & (BITMAP_BITS - 1))
+        mask = self.attr_bitmap_mask(index)
         bitmap = self.attr_bitmap_expr(obj, cl, index)
         if clear:
             self.emit_line(f"{bitmap} &= ~{mask};")

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -1004,9 +1004,12 @@ class Emitter:
             # N.B: bool is special cased to produce a borrowed value
             # after boxing, so we don't need to increment the refcount
             # when this comes directly from a Box op.
-            self.emit_lines(f"{declaration}{dest} = {src} ? Py_True : Py_False;")
-            if not can_borrow:
-                self.emit_inc_ref(dest, object_rprimitive)
+            if can_borrow:
+                self.emit_line(f"{declaration}{dest} = {src} ? Py_True : Py_False;")
+            else:
+                self.emit_line(f"{declaration}{dest} = Py_NewRef({src} ? Py_True : Py_False);")
+            # if not can_borrow:
+            #     self.emit_inc_ref(dest, object_rprimitive)
         elif is_none_rprimitive(typ):
             # N.B: None is special cased to produce a borrowed value
             # after boxing, so we don't need to increment the refcount

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -1004,12 +1004,9 @@ class Emitter:
             # N.B: bool is special cased to produce a borrowed value
             # after boxing, so we don't need to increment the refcount
             # when this comes directly from a Box op.
-            if can_borrow:
-                self.emit_line(f"{declaration}{dest} = {src} ? Py_True : Py_False;")
-            else:
-                self.emit_line(f"{declaration}{dest} = Py_NewRef({src} ? Py_True : Py_False);")
-            # if not can_borrow:
-            #     self.emit_inc_ref(dest, object_rprimitive)
+            self.emit_lines(f"{declaration}{dest} = {src} ? Py_True : Py_False;")
+            if not can_borrow:
+                self.emit_inc_ref(dest, object_rprimitive)
         elif is_none_rprimitive(typ):
             # N.B: None is special cased to produce a borrowed value
             # after boxing, so we don't need to increment the refcount

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -27,6 +27,7 @@ from mypyc.ir.rtypes import (
     is_bool_rprimitive,
     is_dict_rprimitive,
     is_float_rprimitive,
+    is_int16_rprimitive,
     is_int32_rprimitive,
     is_int64_rprimitive,
     is_list_rprimitive,
@@ -862,6 +863,8 @@ def generic_getter_name(rtype: RType) -> str | None:
         return "CPyAttr_GetterFloat"
     elif is_bool_rprimitive(rtype):
         return "CPyAttr_GetterBool"
+    elif is_int16_rprimitive(rtype):
+        return "CPyAttr_GetterInt16"
     elif is_int32_rprimitive(rtype):
         return "CPyAttr_GetterInt32"
     elif is_int64_rprimitive(rtype):
@@ -883,6 +886,12 @@ def generic_setter_name(rtype: RType) -> str | None:
         return "CPyAttr_SetterFloat"
     elif is_bool_rprimitive(rtype):
         return "CPyAttr_SetterBool"
+    elif is_int16_rprimitive(rtype):
+        return "CPyAttr_SetterInt16"
+    elif is_int32_rprimitive(rtype):
+        return "CPyAttr_SetterInt32"
+    elif is_int64_rprimitive(rtype):
+        return "CPyAttr_SetterInt64"
 
     return None
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -27,9 +27,6 @@ from mypyc.ir.rtypes import (
     is_bool_rprimitive,
     is_dict_rprimitive,
     is_float_rprimitive,
-    is_int16_rprimitive,
-    is_int32_rprimitive,
-    is_int64_rprimitive,
     is_list_rprimitive,
     is_object_rprimitive,
     is_optional_type,
@@ -863,12 +860,6 @@ def generic_getter_name(rtype: RType) -> str | None:
         return "CPyAttr_GetterFloat"
     elif is_bool_rprimitive(rtype):
         return "CPyAttr_GetterBool"
-    elif is_int16_rprimitive(rtype):
-        return "CPyAttr_GetterInt16"
-    elif is_int32_rprimitive(rtype):
-        return "CPyAttr_GetterInt32"
-    elif is_int64_rprimitive(rtype):
-        return "CPyAttr_GetterInt64"
 
     return None
 
@@ -886,12 +877,6 @@ def generic_setter_name(rtype: RType) -> str | None:
         return "CPyAttr_SetterFloat"
     elif is_bool_rprimitive(rtype):
         return "CPyAttr_SetterBool"
-    elif is_int16_rprimitive(rtype):
-        return "CPyAttr_SetterInt16"
-    elif is_int32_rprimitive(rtype):
-        return "CPyAttr_SetterInt32"
-    elif is_int64_rprimitive(rtype):
-        return "CPyAttr_SetterInt64"
 
     return None
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -22,11 +22,8 @@ from mypyc.common import BITMAP_BITS, BITMAP_TYPE, NATIVE_PREFIX, PREFIX, REG_PR
 from mypyc.ir.class_ir import ClassIR, VTableEntries
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD, FuncDecl, FuncIR
 from mypyc.ir.rtypes import (
-    RInstance,
-    RPrimitive,
     RTuple,
     RType,
-    RUnion,
     is_bool_rprimitive,
     is_float_rprimitive,
     is_int32_rprimitive,
@@ -34,7 +31,7 @@ from mypyc.ir.rtypes import (
     is_tagged,
     object_rprimitive,
 )
-from mypyc.namegen import NameGenerator, exported_name
+from mypyc.namegen import NameGenerator
 from mypyc.sametype import is_same_type
 
 
@@ -862,17 +859,18 @@ def generic_getter_name(rtype: RType) -> str | None:
 
 
 def generate_getseter_declarations(cl: ClassIR, emitter: Emitter) -> None:
+    cl_struct = cl.struct_name(emitter.names)
     if not cl.is_trait:
         for attr, rtype in cl.attributes.items():
-            cl_struct = cl.struct_name(emitter.names)
-
             context_name = attr_context_name(cl, attr, emitter.names)
             always_defined = cl.is_always_defined(attr) and not rtype.is_refcounted
+            always_defined_expr = "true" if always_defined else "false"
+
             emitter.emit_line(f"static CPyAttr_Context {context_name} = {{")
             emitter.emit_line(
-                f'"{attr}", offsetof({cl_struct}, {emitter.attr(attr)}), {"true" if always_defined else "false"},'
+                f'"{attr}", offsetof({cl_struct}, {emitter.attr(attr)}), {always_defined_expr},'
             )
-            if rtype.error_overlap and not cl.is_always_defined(attr):
+            if attr in cl.bitmap_attrs:
                 index = cl.bitmap_attrs.index(attr)
                 bitmap = emitter.bitmap_field(index)
                 mask = 1 << (index & (BITMAP_BITS - 1))
@@ -880,12 +878,12 @@ def generate_getseter_declarations(cl: ClassIR, emitter: Emitter) -> None:
             emitter.emit_line("};")
 
             if not generic_getter_name(rtype):
+                attr_getter = getter_name(cl, attr, emitter.names)
                 emitter.emit_line("static PyObject *")
-                emitter.emit_line(
-                    "{}({} *self, void *closure);".format(
-                        getter_name(cl, attr, emitter.names), cl_struct
-                    )
-                )
+                emitter.emit_line(f"{attr_getter}({cl_struct} *self, void *closure);")
+            attr_setter = setter_name(cl, attr, emitter.names)
+            emitter.emit_line("static int")
+            emitter.emit_line(f"{attr_setter}({cl_struct} *self, PyObject *value, void *closure);")
 
     for prop, (getter, setter) in cl.properties.items():
         if getter.decl.implicit:
@@ -913,11 +911,11 @@ def generate_getseters_table(cl: ClassIR, name: str, emitter: Emitter) -> None:
     emitter.emit_line(f"static PyGetSetDef {name}[] = {{")
     if not cl.is_trait:
         for attr, rtype in cl.attributes.items():
-            getter = generic_getter_name(rtype) or getter_name(cl, attr, emitter.names)
-            setter = reusable_setter_name(cl, attr, rtype)
+            attr_getter = generic_getter_name(rtype) or getter_name(cl, attr, emitter.names)
+            attr_setter = setter_name(cl, attr, emitter.names)
             context = "&{}".format(attr_context_name(cl, attr, emitter.names))
             emitter.emit_line(f'{{"{attr}",')
-            emitter.emit_line(f" (getter){getter}, (setter){setter},")
+            emitter.emit_line(f" (getter){attr_getter}, (setter){attr_setter},")
             emitter.emit_line(f" NULL, {context}}},")
     for prop, (getter, setter) in cl.properties.items():
         if getter.decl.implicit:
@@ -986,54 +984,25 @@ def generate_getter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
     emitter.emit_line("}")
 
 
-def rtype_unique_name(rtype: RType) -> str:
-    if isinstance(rtype, RPrimitive):
-        if "." in rtype.name:
-            return rtype.name.split(".")[1].title()
-        else:
-            return rtype.name.title()
-    elif isinstance(rtype, RTuple):
-        return rtype.struct_name
-    elif isinstance(rtype, RInstance):
-        return "instance_" + exported_name(rtype.name)
-    elif isinstance(rtype, RUnion):
-        return "union_" + "_".join(rtype_unique_name(t) for t in rtype.items)
-    else:
-        assert False, f"unsupported rtype: {rtype}"
-
-
-def reusable_setter_name(cl: ClassIR, attr: str, rtype: RType) -> str:
-    prefix = "CPyAttr_Setter_"  # + f"{cl.name}_{attr}_"
-    if cl.is_always_defined(attr) and not rtype.is_refcounted:
-        prefix += "ALWAYS_"
-    if cl.is_deletable(attr):
-        prefix += "DELETABLE_"
-    return prefix + rtype_unique_name(rtype)
-
-
 def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> None:
-    impl_name = reusable_setter_name(cl, attr, rtype)
-    if impl_name in emitter.context.declarations:
-        # print(f"\033[0;36m{cl.name}.{attr}: {rtype.name} (reusing setter!)\033[0m")
-        return
-
-    # print(f"{cl.name}.{attr}: {rtype.name} (new setter)")
-    header = impl_name + "(PyObject *self, PyObject *value, CPyAttr_Context *context)"
-    emitter.context.declarations[impl_name] = HeaderDeclaration(f"int {header};")
-    emitter.emit_lines("int", header, "{")
+    attr_field = emitter.attr(attr)
+    emitter.emit_line("static int")
+    emitter.emit_line(
+        "{}({} *self, PyObject *value, void *closure)".format(
+            setter_name(cl, attr, emitter.names), cl.struct_name(emitter.names)
+        )
+    )
+    emitter.emit_line("{")
 
     deletable = cl.is_deletable(attr)
     if not deletable:
         emitter.emit_line("if (value == NULL) {")
-        emitter.emit_line("PyErr_Format(PyExc_AttributeError,")
+        emitter.emit_line("PyErr_SetString(PyExc_AttributeError,")
         emitter.emit_line(
-            "    \"'%s' object attribute '%s' cannot be deleted\", Py_TYPE(self)->tp_name, context->attr_name);"
+            f'    "{repr(cl.name)} object attribute {repr(attr)} cannot be deleted");'
         )
         emitter.emit_line("return -1;")
         emitter.emit_line("}")
-
-    ctype = emitter.ctype_spaced(rtype)
-    emitter.emit_line(f"{ctype}*attr = ({ctype}*)((char *)self + context->offset);")
 
     # HACK: Don't consider refcounted values as always defined, since it's possible to
     #       access uninitialized values via 'gc.get_objects()'. Accessing non-refcounted
@@ -1041,13 +1010,10 @@ def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
     always_defined = cl.is_always_defined(attr) and not rtype.is_refcounted
 
     if rtype.is_refcounted:
+        attr_expr = f"self->{attr_field}"
         if not always_defined:
-            emitter.emit_undefined_attr_check(rtype, "(*attr)", "!=", "self", attr, cl)
-            # check = emitter.error_value_check(rtype, '(*attr)', '!=')
-            # if rtype.error_overlap:
-            #    check = f"{check} && _CPyAttr_IsUndefinedViaBitmap(self, context)"
-            # emitter.emit_line(f"if ({check}) {{")
-        emitter.emit_dec_ref("(*attr)", rtype)
+            emitter.emit_undefined_attr_check(rtype, attr_expr, "!=", "self", attr, cl)
+        emitter.emit_dec_ref(f"self->{attr_field}", rtype)
         if not always_defined:
             emitter.emit_line("}")
 
@@ -1056,27 +1022,21 @@ def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
 
     if rtype.is_unboxed:
         emitter.emit_unbox("value", "tmp", rtype, error=ReturnHandler("-1"), declare_dest=True)
-        emitter.emit_line("*attr = tmp;")
-        if rtype.error_overlap and not always_defined:
-            # emitter.emit_attr_bitmap_set("tmp", "self", rtype, cl, attr)
-            check = emitter.error_value_check(rtype, "tmp", "==")
-            emitter.emit_line(f"if (unlikely({check})) {{")
-            emitter.emit_line("CPyAttr_SetBitmap(self, context, true);")
-            emitter.emit_line("}")
     elif is_same_type(rtype, object_rprimitive):
-        emitter.emit_line("*attr = Py_NewRef(value);")
+        emitter.emit_line("PyObject *tmp = value;")
     else:
-        emitter.emit_cast("value", "*attr", rtype, error=ReturnHandler("-1"))
-        emitter.emit_inc_ref("value", rtype)
-        # emitter.emit_lines("if (!tmp)", "    return -1;")
+        emitter.emit_cast("value", "tmp", rtype, declare_dest=True)
+        emitter.emit_lines("if (!tmp)", "    return -1;")
+    emitter.emit_inc_ref("tmp", rtype)
+    emitter.emit_line(f"self->{attr_field} = tmp;")
+    if rtype.error_overlap and not always_defined:
+        emitter.emit_attr_bitmap_set("tmp", "self", rtype, cl, attr)
 
     if deletable:
-        emitter.emit_line("} else {")
-        emitter.emit_line(f"*attr = {emitter.c_undefined_value(rtype)};")
+        emitter.emit_line("} else")
+        emitter.emit_line(f"    self->{attr_field} = {emitter.c_undefined_value(rtype)};")
         if rtype.error_overlap:
-            emitter.emit_line("CPyAttr_SetBitmap(self, context, false);")
-            # emitter.emit_attr_bitmap_clear("self", rtype, cl, attr)
-        emitter.emit_line("}")
+            emitter.emit_attr_bitmap_clear("self", rtype, cl, attr)
     emitter.emit_line("return 0;")
     emitter.emit_line("}")
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -891,9 +891,14 @@ def generic_setter_boxed_type(rtype: RType) -> str | None:
     """Return the CPyAttr_BoxedType enum value for runtime type checks.
 
     Return None if rtype is unsupported."""
-    assert not rtype.is_unboxed, f"must be boxed type: {rtype}"
     if is_str_rprimitive(rtype):
         return "CPyAttr_UNICODE"
+    elif is_tagged(rtype):
+        return "CPyAttr_LONG"
+    elif is_bool_rprimitive(rtype):
+        return "CPyAttr_BOOL"
+    elif is_float_rprimitive(rtype):
+        return "CPyAttr_FLOAT"
     elif is_tuple_rprimitive(rtype):
         return "CPyAttr_TUPLE"
     elif is_list_rprimitive(rtype):
@@ -904,7 +909,7 @@ def generic_setter_boxed_type(rtype: RType) -> str | None:
         return "CPyAttr_SET"
     elif is_optional_type(rtype):
         inner_rtype = optional_value_type(rtype)
-        if inner_rtype is not None and not inner_rtype.is_unboxed:
+        if inner_rtype is not None:
             return generic_setter_boxed_type(inner_rtype)
     elif is_object_rprimitive(rtype):
         return "CPyAttr_ANY"

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -882,9 +882,6 @@ def generic_setter_name(rtype: RType) -> str | None:
 
 def setter_boxed_type_struct(rtype: RType) -> str | None:
     assert not rtype.is_unboxed, f"must be boxed type: {rtype}"
-    if rtype.is_unboxed:
-        return None
-
     if is_str_rprimitive(rtype):
         return "&PyUnicode_Type"
     elif is_tuple_rprimitive(rtype):
@@ -904,7 +901,6 @@ def setter_boxed_type_struct(rtype: RType) -> str | None:
     elif is_object_rprimitive(rtype):
         return "NULL"
 
-    # print(f"[type_struct] unsupported rtype: {rtype}")
     return None
 
 

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -79,6 +79,7 @@ RUNTIME_C_FILES: Final = [
     "exc_ops.c",
     "misc_ops.c",
     "generic_ops.c",
+    "attr.c",
 ]
 
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -114,6 +114,24 @@ static inline size_t CPy_FindAttrOffset(PyTypeObject *trait, CPyVTableItem *vtab
     ((method_type)(CPy_FindTraitVtable(trait, ((object_type *)obj)->vtable)[vtable_index]))
 
 
+typedef struct CPy_GetSetContext {
+    const char *attrname;
+    size_t offset;
+} CPy_GetSetContext;
+
+static PyObject *CPy_GenericGetAttr(PyObject *self, void *closure) {
+    CPy_GetSetContext *context = (CPy_GetSetContext *)closure;
+
+    char *addr = (char *)self + context->offset;
+    PyObject *value = *(PyObject **)addr;
+    if (value == NULL) {
+        PyErr_Format(PyExc_AttributeError,
+            "attribute '%s' of '%s' undefined", context->attrname, Py_TYPE(self)->tp_name);
+        return NULL;
+    }
+    return Py_NewRef(value);
+}
+
 // Int operations
 
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -94,16 +94,10 @@ PyObject *CPyAttr_GetterPyObject(PyObject *self, CPyAttr_Context *context);
 PyObject *CPyAttr_GetterTagged(PyObject *self, CPyAttr_Context *context);
 PyObject *CPyAttr_GetterBool(PyObject *self, CPyAttr_Context *context);
 PyObject *CPyAttr_GetterFloat(PyObject *self, CPyAttr_Context *context);
-PyObject *CPyAttr_GetterInt16(PyObject *self, CPyAttr_Context *context);
-PyObject *CPyAttr_GetterInt32(PyObject *self, CPyAttr_Context *context);
-PyObject *CPyAttr_GetterInt64(PyObject *self, CPyAttr_Context *context);
 int CPyAttr_SetterPyObject(PyObject *self, PyObject *value, CPyAttr_Context *context);
 int CPyAttr_SetterTagged(PyObject *self, PyObject *value, CPyAttr_Context *context);
 int CPyAttr_SetterBool(PyObject *self, PyObject *value, CPyAttr_Context *context);
 int CPyAttr_SetterFloat(PyObject *self, PyObject *value, CPyAttr_Context *context);
-int CPyAttr_SetterInt16(PyObject *self, PyObject *value, CPyAttr_Context *context);
-int CPyAttr_SetterInt32(PyObject *self, PyObject *value, CPyAttr_Context *context);
-int CPyAttr_SetterInt64(PyObject *self, PyObject *value, CPyAttr_Context *context);
 PyObject *CPyAttr_UndefinedError(PyObject *self, CPyAttr_Context *context);
 int CPyAttr_UndeletableError(PyObject *self, CPyAttr_Context *context);
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -69,8 +69,7 @@ typedef struct tuple_T4CIOO {
 
 typedef enum CPyAttr_BoxedType {
     CPyAttr_UNICODE, CPyAttr_LONG, CPyAttr_BOOL, CPyAttr_FLOAT,
-    CPyAttr_TUPLE, CPyAttr_LIST, CPyAttr_DICT, CPyAttr_SET,
-    CPyAttr_ANY
+    CPyAttr_TUPLE, CPyAttr_LIST, CPyAttr_DICT, CPyAttr_SET, CPyAttr_ANY
 } CPyAttr_BoxedType;
 
 // Closure type to drive generic attribute getters and setters.

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -647,7 +647,7 @@ typedef struct CPyAttr_Context {
     } bitmap;
 } CPyAttr_Context;
 
-static void *_CPyAttr_UndefinedError(PyObject *self, CPyAttr_Context *context) {
+static PyObject *_CPyAttr_UndefinedError(PyObject *self, CPyAttr_Context *context) {
     assert(!context->always_defined && "attribute should be initialized!");
     PyErr_Format(PyExc_AttributeError,
         "attribute '%s' of '%s' undefined", context->attr_name, Py_TYPE(self)->tp_name);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -67,6 +67,33 @@ typedef struct tuple_T4CIOO {
 
 // Native object operations
 
+// Closure type to drive generic attribute getters and setters.
+typedef struct CPyAttr_Context {
+    const char *attr_name;
+    size_t offset;
+    bool always_defined;
+    bool deletable;
+    struct {                    // Used for attributes with overlapping error values.
+        size_t offset;
+        size_t mask;
+    } bitmap;
+    struct {                    // Used for generic PyObject * setter.
+        const char *type_name;
+        bool optional;          // Is None allowed?
+        PyTypeObject *type;     // If NULL, treat attribute as Any (no type check).
+    } setter;
+} CPyAttr_Context;
+
+PyObject *CPyAttr_GetterPyObject(PyObject *self, CPyAttr_Context *context);
+PyObject *CPyAttr_GetterTagged(PyObject *self, CPyAttr_Context *context);
+PyObject *CPyAttr_GetterBool(PyObject *self, CPyAttr_Context *context);
+PyObject *CPyAttr_GetterFloat(PyObject *self, CPyAttr_Context *context);
+PyObject *CPyAttr_GetterInt32(PyObject *self, CPyAttr_Context *context);
+PyObject *CPyAttr_GetterInt64(PyObject *self, CPyAttr_Context *context);
+int CPyAttr_SetterPyObject(PyObject *self, PyObject *value, CPyAttr_Context *context);
+int CPyAttr_SetterTagged(PyObject *self, PyObject *value, CPyAttr_Context *context);
+int CPyAttr_SetterBool(PyObject *self, PyObject *value, CPyAttr_Context *context);
+int CPyAttr_SetterFloat(PyObject *self, PyObject *value, CPyAttr_Context *context);
 
 // Search backwards through the trait part of a vtable (which sits *before*
 // the start of the vtable proper) looking for the subvtable describing a trait
@@ -633,196 +660,6 @@ PyObject *CPySingledispatch_RegisterFunction(PyObject *singledispatch_func, PyOb
 
 PyObject *CPy_GetAIter(PyObject *obj);
 PyObject *CPy_GetANext(PyObject *aiter);
-
-
-// Native object attribute getter/setter implementations
-
-typedef struct CPyAttr_Context {
-    const char *attr_name;
-    size_t offset;
-    bool always_defined;
-    bool deletable;
-    struct {                    // Used for attributes with overlapping error values.
-        size_t offset;
-        size_t mask;
-    } bitmap;
-    struct {                    // Used for generic PyObject * setter.
-        const char *type_name;
-        bool optional;
-        PyTypeObject *type;     // If NULL, treat attribute as Any (no type check).
-    } setter;
-} CPyAttr_Context;
-
-static PyObject *_CPyAttr_UndefinedError(PyObject *self, CPyAttr_Context *context) {
-    assert(!context->always_defined && "attribute should be initialized!");
-    PyErr_Format(PyExc_AttributeError,
-        "attribute '%s' of '%s' undefined", context->attr_name, Py_TYPE(self)->tp_name);
-    return NULL;
-}
-
-static int _CPyAttr_UndeletableError(PyObject *self, CPyAttr_Context *context) {
-    PyErr_Format(PyExc_AttributeError,
-        "'%s' object attribute '%s' cannot be deleted", Py_TYPE(self)->tp_name, context->attr_name);
-    return -1;
-}
-
-static void _CPyAttr_SetBitmap(PyObject *self, CPyAttr_Context *context, bool defined) {
-    uint32_t *bitmap = (uint32_t *)((char *)self + context->bitmap.offset);
-    if (defined) {
-        *bitmap |= context->bitmap.mask;
-    } else {
-        *bitmap &= context->bitmap.mask;
-    }
-}
-
-static inline bool _CPyAttr_IsUndefinedViaBitmap(PyObject *self, CPyAttr_Context *context) {
-    return !(*(uint32_t *)((char *)self + context->bitmap.offset) & context->bitmap.mask);
-}
-
-static PyObject *CPyAttr_GetterPyObject(PyObject *self, CPyAttr_Context *context) {
-    PyObject *value = *(PyObject **)((char *)self + context->offset);
-    if (unlikely(value == NULL)) {
-        return _CPyAttr_UndefinedError(self, context);
-    }
-    return Py_NewRef(value);
-}
-
-static PyObject *CPyAttr_GetterTagged(PyObject *self, CPyAttr_Context *context) {
-    CPyTagged value = *(CPyTagged *)((char *)self + context->offset);
-    if (unlikely(value == CPY_INT_TAG)) {
-        return _CPyAttr_UndefinedError(self, context);
-    }
-    return CPyTagged_AsObject(value);
-}
-
-static PyObject *CPyAttr_GetterBool(PyObject *self, CPyAttr_Context *context) {
-    char value = *((char *)self + context->offset);
-    if (unlikely(value == 2)) {
-        return _CPyAttr_UndefinedError(self, context);
-    }
-    return Py_NewRef(value ? Py_True : Py_False);
-}
-
-static PyObject *CPyAttr_GetterInt32(PyObject *self, CPyAttr_Context *context) {
-    int32_t value = *(int32_t *)((char *)self + context->offset);
-    if (value == CPY_LL_INT_ERROR
-            && !context->always_defined
-            && _CPyAttr_IsUndefinedViaBitmap(self, context)) {
-        return _CPyAttr_UndefinedError(self, context);
-    }
-    return PyLong_FromLong(value);
-}
-
-static PyObject *CPyAttr_GetterInt64(PyObject *self, CPyAttr_Context *context) {
-    int64_t value = *(int64_t *)((char *)self + context->offset);
-    if (value == CPY_LL_INT_ERROR
-            && !context->always_defined
-            && _CPyAttr_IsUndefinedViaBitmap(self, context)) {
-        return _CPyAttr_UndefinedError(self, context);
-    }
-    return PyLong_FromLongLong(value);
-}
-
-static PyObject *CPyAttr_GetterFloat(PyObject *self, CPyAttr_Context *context) {
-    double value = *(double *)((char *)self + context->offset);
-    // uint32_t bitmap = *(uint32_t *)((char *)self + context->bitmap.offset);
-    // printf("bitmap: %u\n", bitmap);
-    if (value == CPY_FLOAT_ERROR
-            && !context->always_defined
-            && _CPyAttr_IsUndefinedViaBitmap(self, context)) {
-        return _CPyAttr_UndefinedError(self, context);
-    }
-    return PyFloat_FromDouble(value);
-}
-
-static int CPyAttr_SetterPyObject(PyObject *self, PyObject *value, CPyAttr_Context *context) {
-    if (value == NULL && !context->deletable) {
-        return _CPyAttr_UndeletableError(self, context);
-    }
-
-    PyObject **attr = (PyObject **)((char *)self + context->offset);
-    if (value != NULL) {
-        PyTypeObject *type = context->setter.type;
-        bool optional = context->setter.optional;
-        if (type != NULL && !PyObject_TypeCheck(value, type)) {
-            if (!optional || (optional && value != Py_None)) {
-                CPy_TypeError(context->setter.type_name, value);
-                return -1;
-            }
-        }
-        Py_XSETREF(*attr, Py_NewRef(value));
-    } else {
-        Py_CLEAR(*attr);
-    }
-    return 0;
-}
-
-static int CPyAttr_SetterTagged(PyObject *self, PyObject *value, CPyAttr_Context *context) {
-    if (value == NULL && !context->deletable) {
-        return _CPyAttr_UndeletableError(self, context);
-    }
-
-    CPyTagged *attr = (CPyTagged *)((char *)self + context->offset);
-    if (value != NULL) {
-        if (!PyLong_Check(value)) {
-            CPy_TypeError("int", value);
-            return -1;
-        }
-        *attr = CPyTagged_FromObject(value);
-    } else {
-        if (*attr != CPY_INT_TAG) {
-            CPyTagged_DECREF(*attr);
-        }
-        *attr = CPY_INT_TAG;
-    }
-    return 0;
-}
-
-static int CPyAttr_SetterBool(PyObject *self, PyObject *value, CPyAttr_Context *context)
-{
-    if (value == NULL && !context->deletable) {
-        return _CPyAttr_UndeletableError(self, context);
-    }
-
-    char *attr = (char *)self + context->offset;
-    if (value != NULL) {
-        if (!PyBool_Check(value)) {
-            CPy_TypeError("bool", value);
-            return -1;
-        }
-        *attr = value == Py_True;
-    } else {
-        *attr = 2;
-    }
-    return 0;
-}
-
-static int CPyAttr_SetterFloat(PyObject *self, PyObject *value, CPyAttr_Context *context)
-{
-    if (value == NULL && !context->deletable) {
-        return _CPyAttr_UndeletableError(self, context);
-    }
-
-    double *attr = (double *)((char *)self + context->offset);
-    if (value != NULL) {
-        if (!PyFloat_Check(value)) {
-            CPy_TypeError("float", value);
-            return -1;
-        }
-        double tmp = PyFloat_AsDouble(value);
-        if (tmp == -1.0 && PyErr_Occurred()) {
-            return -1;
-        }
-        *attr = tmp;
-        if (tmp == CPY_FLOAT_ERROR) {
-            _CPyAttr_SetBitmap(self, context, true);
-        }
-    } else {
-        *attr = CPY_FLOAT_ERROR;
-        _CPyAttr_SetBitmap(self, context, false);
-    }
-    return 0;
-}
 
 #ifdef __cplusplus
 }

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -94,6 +94,8 @@ int CPyAttr_SetterPyObject(PyObject *self, PyObject *value, CPyAttr_Context *con
 int CPyAttr_SetterTagged(PyObject *self, PyObject *value, CPyAttr_Context *context);
 int CPyAttr_SetterBool(PyObject *self, PyObject *value, CPyAttr_Context *context);
 int CPyAttr_SetterFloat(PyObject *self, PyObject *value, CPyAttr_Context *context);
+PyObject *CPyAttr_UndefinedError(PyObject *self, CPyAttr_Context *context);
+int CPyAttr_UndeletableError(PyObject *self, CPyAttr_Context *context);
 
 // Search backwards through the trait part of a vtable (which sits *before*
 // the start of the vtable proper) looking for the subvtable describing a trait

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -94,12 +94,16 @@ PyObject *CPyAttr_GetterPyObject(PyObject *self, CPyAttr_Context *context);
 PyObject *CPyAttr_GetterTagged(PyObject *self, CPyAttr_Context *context);
 PyObject *CPyAttr_GetterBool(PyObject *self, CPyAttr_Context *context);
 PyObject *CPyAttr_GetterFloat(PyObject *self, CPyAttr_Context *context);
+PyObject *CPyAttr_GetterInt16(PyObject *self, CPyAttr_Context *context);
 PyObject *CPyAttr_GetterInt32(PyObject *self, CPyAttr_Context *context);
 PyObject *CPyAttr_GetterInt64(PyObject *self, CPyAttr_Context *context);
 int CPyAttr_SetterPyObject(PyObject *self, PyObject *value, CPyAttr_Context *context);
 int CPyAttr_SetterTagged(PyObject *self, PyObject *value, CPyAttr_Context *context);
 int CPyAttr_SetterBool(PyObject *self, PyObject *value, CPyAttr_Context *context);
 int CPyAttr_SetterFloat(PyObject *self, PyObject *value, CPyAttr_Context *context);
+int CPyAttr_SetterInt16(PyObject *self, PyObject *value, CPyAttr_Context *context);
+int CPyAttr_SetterInt32(PyObject *self, PyObject *value, CPyAttr_Context *context);
+int CPyAttr_SetterInt64(PyObject *self, PyObject *value, CPyAttr_Context *context);
 PyObject *CPyAttr_UndefinedError(PyObject *self, CPyAttr_Context *context);
 int CPyAttr_UndeletableError(PyObject *self, CPyAttr_Context *context);
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -67,6 +67,10 @@ typedef struct tuple_T4CIOO {
 
 // Native object operations
 
+typedef enum CPyAttr_BoxedType {
+    CPyAttr_UNICODE, CPyAttr_TUPLE, CPyAttr_LIST, CPyAttr_DICT, CPyAttr_SET, CPyAttr_ANY
+} CPyAttr_BoxedType;
+
 // Closure type to drive generic attribute getters and setters.
 typedef struct CPyAttr_Context {
     const char *attr_name;
@@ -79,9 +83,9 @@ typedef struct CPyAttr_Context {
     } bitmap;
     struct {                    // Used for generic PyObject * setter.
         const char *type_name;
+        CPyAttr_BoxedType type;
         bool optional;          // Is None allowed?
-        PyTypeObject *type;     // If NULL, treat attribute as Any (no type check).
-    } setter;
+    } boxed_setter;
 } CPyAttr_Context;
 
 PyObject *CPyAttr_GetterPyObject(PyObject *self, CPyAttr_Context *context);

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -68,7 +68,9 @@ typedef struct tuple_T4CIOO {
 // Native object operations
 
 typedef enum CPyAttr_BoxedType {
-    CPyAttr_UNICODE, CPyAttr_TUPLE, CPyAttr_LIST, CPyAttr_DICT, CPyAttr_SET, CPyAttr_ANY
+    CPyAttr_UNICODE, CPyAttr_LONG, CPyAttr_BOOL, CPyAttr_FLOAT,
+    CPyAttr_TUPLE, CPyAttr_LIST, CPyAttr_DICT, CPyAttr_SET,
+    CPyAttr_ANY
 } CPyAttr_BoxedType;
 
 // Closure type to drive generic attribute getters and setters.

--- a/mypyc/lib-rt/attr.c
+++ b/mypyc/lib-rt/attr.c
@@ -90,11 +90,30 @@ int CPyAttr_SetterPyObject(PyObject *self, PyObject *value, CPyAttr_Context *con
 
     PyObject **attr = (PyObject **)((char *)self + context->offset);
     if (value != NULL) {
-        PyTypeObject *type = context->setter.type;
-        bool optional = context->setter.optional;
+        PyTypeObject *type = NULL;
+        switch (context->boxed_setter.type) {
+            case CPyAttr_UNICODE:
+                type = &PyUnicode_Type;
+                break;
+            case CPyAttr_TUPLE:
+                type = &PyTuple_Type;
+                break;
+            case CPyAttr_LIST:
+                type = &PyList_Type;
+                break;
+            case CPyAttr_DICT:
+                type = &PyDict_Type;
+                break;
+            case CPyAttr_SET:
+                type = &PySet_Type;
+                break;
+            case CPyAttr_ANY:
+                // Do nothing, type is already NULL.
+                break;
+        }
         if (type != NULL && !PyObject_TypeCheck(value, type)) {
-            if (!optional || (optional && value != Py_None)) {
-                CPy_TypeError(context->setter.type_name, value);
+            if (!context->boxed_setter.optional || value != Py_None) {
+                CPy_TypeError(context->boxed_setter.type_name, value);
                 return -1;
             }
         }

--- a/mypyc/lib-rt/attr.c
+++ b/mypyc/lib-rt/attr.c
@@ -63,6 +63,16 @@ PyObject *CPyAttr_GetterFloat(PyObject *self, CPyAttr_Context *context) {
     return PyFloat_FromDouble(value);
 }
 
+PyObject *CPyAttr_GetterInt16(PyObject *self, CPyAttr_Context *context) {
+    int16_t value = *(int16_t *)((char *)self + context->offset);
+    if (unlikely(value == CPY_LL_INT_ERROR
+            && !context->always_defined
+            && is_undefined_via_bitmap(self, context))) {
+        return CPyAttr_UndefinedError(self, context);
+    }
+    return PyLong_FromLong(value);
+}
+
 PyObject *CPyAttr_GetterInt32(PyObject *self, CPyAttr_Context *context) {
     int32_t value = *(int32_t *)((char *)self + context->offset);
     if (unlikely(value == CPY_LL_INT_ERROR
@@ -196,6 +206,84 @@ int CPyAttr_SetterFloat(PyObject *self, PyObject *value, CPyAttr_Context *contex
         }
     } else {
         *attr = CPY_FLOAT_ERROR;
+        set_definedness_in_bitmap(self, context, false);
+    }
+    return 0;
+}
+
+int CPyAttr_SetterInt16(PyObject *self, PyObject *value, CPyAttr_Context *context) {
+    if (value == NULL && !context->deletable) {
+        return CPyAttr_UndeletableError(self, context);
+    }
+
+    int16_t *attr = (int16_t *)((char *)self + context->offset);
+    if (value != NULL) {
+        if (unlikely(!PyLong_Check(value))) {
+            CPy_TypeError("int16", value);
+            return -1;
+        }
+        int16_t tmp = CPyLong_AsInt16(value);
+        if (unlikely(tmp == CPY_LL_INT_ERROR && PyErr_Occurred())) {
+            return -1;
+        }
+        *attr = tmp;
+        if (tmp == CPY_LL_INT_ERROR) {
+            set_definedness_in_bitmap(self, context, true);
+        }
+    } else {
+        *attr = CPY_LL_INT_ERROR;
+        set_definedness_in_bitmap(self, context, false);
+    }
+    return 0;
+}
+
+int CPyAttr_SetterInt32(PyObject *self, PyObject *value, CPyAttr_Context *context) {
+    if (value == NULL && !context->deletable) {
+        return CPyAttr_UndeletableError(self, context);
+    }
+
+    int32_t *attr = (int32_t *)((char *)self + context->offset);
+    if (value != NULL) {
+        if (unlikely(!PyLong_Check(value))) {
+            CPy_TypeError("int32", value);
+            return -1;
+        }
+        int32_t tmp = CPyLong_AsInt32(value);
+        if (unlikely(tmp == CPY_LL_INT_ERROR && PyErr_Occurred())) {
+            return -1;
+        }
+        *attr = tmp;
+        if (tmp == CPY_LL_INT_ERROR) {
+            set_definedness_in_bitmap(self, context, true);
+        }
+    } else {
+        *attr = CPY_LL_INT_ERROR;
+        set_definedness_in_bitmap(self, context, false);
+    }
+    return 0;
+}
+
+int CPyAttr_SetterInt64(PyObject *self, PyObject *value, CPyAttr_Context *context) {
+    if (value == NULL && !context->deletable) {
+        return CPyAttr_UndeletableError(self, context);
+    }
+
+    int64_t *attr = (int64_t *)((char *)self + context->offset);
+    if (value != NULL) {
+        if (unlikely(!PyLong_Check(value))) {
+            CPy_TypeError("int64", value);
+            return -1;
+        }
+        int64_t tmp = CPyLong_AsInt64(value);
+        if (unlikely(tmp == CPY_LL_INT_ERROR && PyErr_Occurred())) {
+            return -1;
+        }
+        *attr = tmp;
+        if (tmp == CPY_LL_INT_ERROR) {
+            set_definedness_in_bitmap(self, context, true);
+        }
+    } else {
+        *attr = CPY_LL_INT_ERROR;
         set_definedness_in_bitmap(self, context, false);
     }
     return 0;

--- a/mypyc/lib-rt/attr.c
+++ b/mypyc/lib-rt/attr.c
@@ -21,7 +21,7 @@ static void set_bitmap(PyObject *self, CPyAttr_Context *context, bool defined) {
     if (defined) {
         *bitmap |= context->bitmap.mask;
     } else {
-        *bitmap &= context->bitmap.mask;
+        *bitmap &= ~context->bitmap.mask;
     }
 }
 

--- a/mypyc/lib-rt/attr.c
+++ b/mypyc/lib-rt/attr.c
@@ -63,36 +63,6 @@ PyObject *CPyAttr_GetterFloat(PyObject *self, CPyAttr_Context *context) {
     return PyFloat_FromDouble(value);
 }
 
-PyObject *CPyAttr_GetterInt16(PyObject *self, CPyAttr_Context *context) {
-    int16_t value = *(int16_t *)((char *)self + context->offset);
-    if (unlikely(value == CPY_LL_INT_ERROR
-            && !context->always_defined
-            && is_undefined_via_bitmap(self, context))) {
-        return CPyAttr_UndefinedError(self, context);
-    }
-    return PyLong_FromLong(value);
-}
-
-PyObject *CPyAttr_GetterInt32(PyObject *self, CPyAttr_Context *context) {
-    int32_t value = *(int32_t *)((char *)self + context->offset);
-    if (unlikely(value == CPY_LL_INT_ERROR
-            && !context->always_defined
-            && is_undefined_via_bitmap(self, context))) {
-        return CPyAttr_UndefinedError(self, context);
-    }
-    return PyLong_FromLong(value);
-}
-
-PyObject *CPyAttr_GetterInt64(PyObject *self, CPyAttr_Context *context) {
-    int64_t value = *(int64_t *)((char *)self + context->offset);
-    if (unlikely(value == CPY_LL_INT_ERROR
-            && !context->always_defined
-            && is_undefined_via_bitmap(self, context))) {
-        return CPyAttr_UndefinedError(self, context);
-    }
-    return PyLong_FromLongLong(value);
-}
-
 int CPyAttr_SetterPyObject(PyObject *self, PyObject *value, CPyAttr_Context *context) {
     if (value == NULL && !context->deletable) {
         return CPyAttr_UndeletableError(self, context);
@@ -206,84 +176,6 @@ int CPyAttr_SetterFloat(PyObject *self, PyObject *value, CPyAttr_Context *contex
         }
     } else {
         *attr = CPY_FLOAT_ERROR;
-        set_definedness_in_bitmap(self, context, false);
-    }
-    return 0;
-}
-
-int CPyAttr_SetterInt16(PyObject *self, PyObject *value, CPyAttr_Context *context) {
-    if (value == NULL && !context->deletable) {
-        return CPyAttr_UndeletableError(self, context);
-    }
-
-    int16_t *attr = (int16_t *)((char *)self + context->offset);
-    if (value != NULL) {
-        if (unlikely(!PyLong_Check(value))) {
-            CPy_TypeError("int16", value);
-            return -1;
-        }
-        int16_t tmp = CPyLong_AsInt16(value);
-        if (unlikely(tmp == CPY_LL_INT_ERROR && PyErr_Occurred())) {
-            return -1;
-        }
-        *attr = tmp;
-        if (tmp == CPY_LL_INT_ERROR) {
-            set_definedness_in_bitmap(self, context, true);
-        }
-    } else {
-        *attr = CPY_LL_INT_ERROR;
-        set_definedness_in_bitmap(self, context, false);
-    }
-    return 0;
-}
-
-int CPyAttr_SetterInt32(PyObject *self, PyObject *value, CPyAttr_Context *context) {
-    if (value == NULL && !context->deletable) {
-        return CPyAttr_UndeletableError(self, context);
-    }
-
-    int32_t *attr = (int32_t *)((char *)self + context->offset);
-    if (value != NULL) {
-        if (unlikely(!PyLong_Check(value))) {
-            CPy_TypeError("int32", value);
-            return -1;
-        }
-        int32_t tmp = CPyLong_AsInt32(value);
-        if (unlikely(tmp == CPY_LL_INT_ERROR && PyErr_Occurred())) {
-            return -1;
-        }
-        *attr = tmp;
-        if (tmp == CPY_LL_INT_ERROR) {
-            set_definedness_in_bitmap(self, context, true);
-        }
-    } else {
-        *attr = CPY_LL_INT_ERROR;
-        set_definedness_in_bitmap(self, context, false);
-    }
-    return 0;
-}
-
-int CPyAttr_SetterInt64(PyObject *self, PyObject *value, CPyAttr_Context *context) {
-    if (value == NULL && !context->deletable) {
-        return CPyAttr_UndeletableError(self, context);
-    }
-
-    int64_t *attr = (int64_t *)((char *)self + context->offset);
-    if (value != NULL) {
-        if (unlikely(!PyLong_Check(value))) {
-            CPy_TypeError("int64", value);
-            return -1;
-        }
-        int64_t tmp = CPyLong_AsInt64(value);
-        if (unlikely(tmp == CPY_LL_INT_ERROR && PyErr_Occurred())) {
-            return -1;
-        }
-        *attr = tmp;
-        if (tmp == CPY_LL_INT_ERROR) {
-            set_definedness_in_bitmap(self, context, true);
-        }
-    } else {
-        *attr = CPY_LL_INT_ERROR;
         set_definedness_in_bitmap(self, context, false);
     }
     return 0;

--- a/mypyc/lib-rt/attr.c
+++ b/mypyc/lib-rt/attr.c
@@ -1,0 +1,173 @@
+// Generic native class attribute getters and setters
+
+#include <Python.h>
+#include "CPy.h"
+
+static PyObject *undefined_error(PyObject *self, CPyAttr_Context *context) {
+    assert(!context->always_defined && "attribute should be initialized!");
+    PyErr_Format(PyExc_AttributeError,
+        "attribute '%s' of '%s' undefined", context->attr_name, Py_TYPE(self)->tp_name);
+    return NULL;
+}
+
+static int undeletable_error(PyObject *self, CPyAttr_Context *context) {
+    PyErr_Format(PyExc_AttributeError,
+        "'%s' object attribute '%s' cannot be deleted", Py_TYPE(self)->tp_name, context->attr_name);
+    return -1;
+}
+
+static void set_bitmap(PyObject *self, CPyAttr_Context *context, bool defined) {
+    uint32_t *bitmap = (uint32_t *)((char *)self + context->bitmap.offset);
+    if (defined) {
+        *bitmap |= context->bitmap.mask;
+    } else {
+        *bitmap &= context->bitmap.mask;
+    }
+}
+
+static inline bool is_undefined_via_bitmap(PyObject *self, CPyAttr_Context *context) {
+    return !(*(uint32_t *)((char *)self + context->bitmap.offset) & context->bitmap.mask);
+}
+
+PyObject *CPyAttr_GetterPyObject(PyObject *self, CPyAttr_Context *context) {
+    PyObject *value = *(PyObject **)((char *)self + context->offset);
+    if (unlikely(value == NULL)) {
+        return undefined_error(self, context);
+    }
+    return Py_NewRef(value);
+}
+
+PyObject *CPyAttr_GetterTagged(PyObject *self, CPyAttr_Context *context) {
+    CPyTagged value = *(CPyTagged *)((char *)self + context->offset);
+    if (unlikely(value == CPY_INT_TAG)) {
+        return undefined_error(self, context);
+    }
+    return CPyTagged_AsObject(value);
+}
+
+PyObject *CPyAttr_GetterBool(PyObject *self, CPyAttr_Context *context) {
+    char value = *((char *)self + context->offset);
+    if (unlikely(value == 2)) {
+        return undefined_error(self, context);
+    }
+    return Py_NewRef(value ? Py_True : Py_False);
+}
+
+PyObject *CPyAttr_GetterFloat(PyObject *self, CPyAttr_Context *context) {
+    double value = *(double *)((char *)self + context->offset);
+    if (value == CPY_FLOAT_ERROR
+            && !context->always_defined
+            && is_undefined_via_bitmap(self, context)) {
+        return undefined_error(self, context);
+    }
+    return PyFloat_FromDouble(value);
+}
+
+PyObject *CPyAttr_GetterInt32(PyObject *self, CPyAttr_Context *context) {
+    int32_t value = *(int32_t *)((char *)self + context->offset);
+    if (value == CPY_LL_INT_ERROR
+            && !context->always_defined
+            && is_undefined_via_bitmap(self, context)) {
+        return undefined_error(self, context);
+    }
+    return PyLong_FromLong(value);
+}
+
+PyObject *CPyAttr_GetterInt64(PyObject *self, CPyAttr_Context *context) {
+    int64_t value = *(int64_t *)((char *)self + context->offset);
+    if (value == CPY_LL_INT_ERROR
+            && !context->always_defined
+            && is_undefined_via_bitmap(self, context)) {
+        return undefined_error(self, context);
+    }
+    return PyLong_FromLongLong(value);
+}
+
+int CPyAttr_SetterPyObject(PyObject *self, PyObject *value, CPyAttr_Context *context) {
+    if (value == NULL && !context->deletable) {
+        return undeletable_error(self, context);
+    }
+
+    PyObject **attr = (PyObject **)((char *)self + context->offset);
+    if (value != NULL) {
+        PyTypeObject *type = context->setter.type;
+        bool optional = context->setter.optional;
+        if (type != NULL && !PyObject_TypeCheck(value, type)) {
+            if (!optional || (optional && value != Py_None)) {
+                CPy_TypeError(context->setter.type_name, value);
+                return -1;
+            }
+        }
+        Py_XSETREF(*attr, Py_NewRef(value));
+    } else {
+        Py_CLEAR(*attr);
+    }
+    return 0;
+}
+
+int CPyAttr_SetterTagged(PyObject *self, PyObject *value, CPyAttr_Context *context) {
+    if (value == NULL && !context->deletable) {
+        return undeletable_error(self, context);
+    }
+
+    CPyTagged *attr = (CPyTagged *)((char *)self + context->offset);
+    if (value != NULL) {
+        if (!PyLong_Check(value)) {
+            CPy_TypeError("int", value);
+            return -1;
+        }
+        *attr = CPyTagged_FromObject(value);
+    } else {
+        if (*attr != CPY_INT_TAG) {
+            CPyTagged_DECREF(*attr);
+        }
+        *attr = CPY_INT_TAG;
+    }
+    return 0;
+}
+
+int CPyAttr_SetterBool(PyObject *self, PyObject *value, CPyAttr_Context *context)
+{
+    if (value == NULL && !context->deletable) {
+        return undeletable_error(self, context);
+    }
+
+    char *attr = (char *)self + context->offset;
+    if (value != NULL) {
+        if (!PyBool_Check(value)) {
+            CPy_TypeError("bool", value);
+            return -1;
+        }
+        *attr = value == Py_True;
+    } else {
+        *attr = 2;
+    }
+    return 0;
+}
+
+int CPyAttr_SetterFloat(PyObject *self, PyObject *value, CPyAttr_Context *context)
+{
+    if (value == NULL && !context->deletable) {
+        return undeletable_error(self, context);
+    }
+
+    double *attr = (double *)((char *)self + context->offset);
+    if (value != NULL) {
+        if (!PyFloat_Check(value)) {
+            CPy_TypeError("float", value);
+            return -1;
+        }
+        double tmp = PyFloat_AsDouble(value);
+        if (tmp == -1.0 && PyErr_Occurred()) {
+            return -1;
+        }
+        *attr = tmp;
+        if (tmp == CPY_FLOAT_ERROR) {
+            set_bitmap(self, context, true);
+        }
+    } else {
+        *attr = CPY_FLOAT_ERROR;
+        set_bitmap(self, context, false);
+    }
+    return 0;
+}

--- a/mypyc/test-data/run-bools.test
+++ b/mypyc/test-data/run-bools.test
@@ -227,3 +227,62 @@ y = False
 print((y or 0) and True)
 [out]
 0
+
+[case testBoolAttributes]
+from typing import Any
+from testutil import assertRaises
+
+class Settings:
+    __deletable__ = ["debug", "hidden"]
+
+    debug: bool = False
+    color: bool = True
+    hidden: bool
+
+def test_get_set() -> None:
+    s = Settings()
+    assert not s.debug
+    assert s.color
+    with assertRaises(AttributeError, "attribute 'hidden' of 'Settings' undefined"):
+        s.hidden
+    s.debug = True
+    s.color = False
+    s.hidden = True
+    assert s.debug
+    assert not s.color
+    assert s.hidden
+
+def test_get_set_any() -> None:
+    s: Any = Settings()
+    assert not s.debug
+    assert s.color
+    with assertRaises(AttributeError, "attribute 'hidden' of 'Settings' undefined"):
+        s.hidden
+    s.debug = True
+    s.color = False
+    s.hidden = True
+    assert s.debug
+    assert not s.color
+    assert s.hidden
+
+def test_del() -> None:
+    s = Settings()
+    s.hidden = True
+    del s.debug
+    del s.hidden
+    with assertRaises(AttributeError, "attribute 'debug' of 'Settings' undefined"):
+        s.debug
+    with assertRaises(AttributeError, "attribute 'hidden' of 'Settings' undefined"):
+        s.hidden
+
+def test_del_any() -> None:
+    s: Any = Settings()
+    s.hidden = True
+    del s.debug
+    del s.hidden
+    with assertRaises(AttributeError, "'Settings' object attribute 'color' cannot be deleted"):
+        del s.color
+    with assertRaises(AttributeError, "attribute 'debug' of 'Settings' undefined"):
+        s.debug
+    with assertRaises(AttributeError, "attribute 'hidden' of 'Settings' undefined"):
+        s.hidden

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -65,19 +65,26 @@ from typing import Any, cast
 from testutil import assertRaises
 
 class C:
-    __deletable__ = ['x', 'y']
+    __deletable__ = ['name', 'x', 'y']
+    name: str
+    identifier: str
     x: int
     y: int
     z: int
 
 def test_delete() -> None:
     c = C()
+    c.name = "foo"
+    c.identifier = "bar"
     c.x = 1
     c.y = 2
     c.z = 3
+    del c.name
     del c.x
     del c.y
     assert c.z == 3
+    with assertRaises(AttributeError, "attribute 'name' of 'C' undefined"):
+        c.name
     with assertRaises(AttributeError, "attribute 'x' of 'C' undefined"):
         c.x
     with assertRaises(AttributeError, "attribute 'y' of 'C' undefined"):
@@ -85,14 +92,22 @@ def test_delete() -> None:
 
 def test_delete_any() -> None:
     c: Any = C()
+    c.name = "foo"
+    c.identifier = "bar"
     c.x = 1
     c.y = 2
     c.z = 3
+    del c.name
+    with assertRaises(AttributeError, "'C' object attribute 'identifier' cannot be deleted"):
+        del c.identifier
+    assert c.identifier == "bar"
     del c.x
     del c.y
     with assertRaises(AttributeError, "'C' object attribute 'z' cannot be deleted"):
         del c.z
     assert c.z == 3
+    with assertRaises(AttributeError):
+        c.name
     with assertRaises(AttributeError):
         c.x
     with assertRaises(AttributeError):

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -659,7 +659,7 @@ except AttributeError:
 Traceback (most recent call last):
   File "driver.py", line 4, in <module>
     A().x
-AttributeError: attribute 'x' of 'X' undefined
+AttributeError: attribute 'x' of 'A' undefined
 
 [case testClassMethods]
 from typing import ClassVar, Any

--- a/mypyc/test-data/run-floats.test
+++ b/mypyc/test-data/run-floats.test
@@ -267,6 +267,8 @@ def test_float_attr() -> None:
         assert a.x == FLOAT_MAGIC
 
 class D:
+    __deletable__ = ["x"]
+
     def __init__(self, x: float) -> None:
         if x:
             self.x = x
@@ -292,6 +294,12 @@ def test_float_attr_maybe_undefned() -> None:
             a = cast(Any, d)
             a.x = FLOAT_MAGIC
             assert d.x == FLOAT_MAGIC
+            del d.x
+            with assertRaises(AttributeError):
+                d.x
+            del a.x
+            with assertRaises(AttributeError):
+                a.x
         else:
             f = float(i)
             d = D(f)

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -878,6 +878,27 @@ def test_del() -> None:
     with assertRaises(AttributeError):
         o.x
 
+def test_del_any() -> None:
+    o: Any = Delete()
+    o.x = MAGIC
+    o.y = -1
+    assert o.x == MAGIC
+    assert o.y == -1
+    del o.x
+    with assertRaises(AttributeError):
+        o.x
+    assert o.y == -1
+    del o.y
+    with assertRaises(AttributeError):
+        o.y
+    o.x = 5
+    assert o.x == 5
+    with assertRaises(AttributeError):
+        o.y
+    del o.x
+    with assertRaises(AttributeError):
+        o.x
+
 class UndefinedTuple:
     def __init__(self, x: i64, y: i64) -> None:
         if x != 0:


### PR DESCRIPTION
Implement a small collection of generic native attribute getters and setters to avoid generating custom verbose code for most attributes. Attribute types supported are:

- PyObject * (setter: only certain types!)
- Booleans
- Tagged integers
- Floats

It's possible to add support for native classes to the generic setter, but I ultimately chose not to as saving the type struct in the attribute context seems sketchy (sometimes it can't be resolved at compile-time which breaks the struct initialization). I can add support if it's really wanted. 

I also fixed a few bugs with the old setter generation logic so the tests I added didn't fail (see https://github.com/python/mypy/commit/42f1d29f3069948baf69d002d1cca2a44605bad7). 

I observed a 2.4% reduction in self-compile LOC with this patch.

| Revision | Self-compile LOC |
|--------|--------|
| PR | 2 111 755 (**-2.4%**) | 
| Master (3d2f43772262060fdb1921933da6dc8c7d8ad8a1) | 2 164 450 |

Resolves mypyc/mypyc#246.