### PR TITLE
fix(docs): bool -> boolean in config_file.rst

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -366,7 +366,7 @@ section of the command line docs.
 
 .. confval:: no_site_packages
 
-    :type: bool
+    :type: boolean
     :default: False
 
     Disables using type information in installed packages (see :pep:`561`).


### PR DESCRIPTION
It appears that in the context of the `config_file.rst`, there is a consistent use of `boolean`, but only `no_site_packages` was mentioned as `bool`. Therefore, I have made the correction.