### PR TITLE
Remove special casing for "cannot" in error messages

### DIFF
--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -46,15 +46,9 @@ def run_mypy(args: list[str]) -> None:
 def assert_string_arrays_equal(expected: list[str], actual: list[str], msg: str) -> None:
     """Assert that two string arrays are equal.
 
-    We consider "can't" and "cannot" equivalent, by replacing the
-    former with the latter before comparing.
-
     Display any differences in a human-readable form.
     """
     actual = clean_up(actual)
-    actual = [line.replace("can't", "cannot") for line in actual]
-    expected = [line.replace("can't", "cannot") for line in expected]
-
     if actual != expected:
         num_skip_start = num_skipped_prefix_lines(expected, actual)
         num_skip_end = num_skipped_suffix_lines(expected, actual)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2019,7 +2019,7 @@ tmp/foo.pyi:5: note:          @overload
 tmp/foo.pyi:5: note:          def __add__(self, int, /) -> int
 tmp/foo.pyi:5: note:          @overload
 tmp/foo.pyi:5: note:          def __add__(self, str, /) -> str
-tmp/foo.pyi:5: note: Overloaded operator methods cannot have wider argument types in overrides
+tmp/foo.pyi:5: note: Overloaded operator methods can't have wider argument types in overrides
 
 [case testOperatorMethodOverrideWideningArgumentType]
 import typing
@@ -2138,7 +2138,7 @@ tmp/foo.pyi:8: note:          @overload
 tmp/foo.pyi:8: note:          def __add__(self, str, /) -> A
 tmp/foo.pyi:8: note:          @overload
 tmp/foo.pyi:8: note:          def __add__(self, type, /) -> A
-tmp/foo.pyi:8: note: Overloaded operator methods cannot have wider argument types in overrides
+tmp/foo.pyi:8: note: Overloaded operator methods can't have wider argument types in overrides
 
 [case testOverloadedOperatorMethodOverrideWithSwitchedItemOrder]
 from foo import *

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6442,8 +6442,6 @@ if True:
         def f3(g: D) -> D: ...
 def f3(g): ...  # E: Name "f3" already defined on line 32
 
-
-
 [case testOverloadingWithParamSpec]
 from typing import TypeVar, Callable, Any, overload
 from typing_extensions import ParamSpec, Concatenate

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4745,7 +4745,7 @@ main:12: note:          @overload
 main:12: note:          def __add__(self, Other, /) -> B
 main:12: note:          @overload
 main:12: note:          def __add__(self, A, /) -> A
-main:12: note: Overloaded operator methods cannot have wider argument types in overrides
+main:12: note: Overloaded operator methods can't have wider argument types in overrides
 main:32: note: Revealed type is "__main__.Other"
 
 [case testOverloadErrorMessageManyMatches]
@@ -5405,26 +5405,26 @@ if False:
 def f2(g): ...
 reveal_type(f2(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f2(C()))  # E: No overload variant of "f2" matches argument type "C" \
-    # N: Possible overload variants: \
-    # N:     def f2(g: A) -> A \
-    # N:     def f2(g: B) -> B \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f2(g: A) -> A \
+                      # N:     def f2(g: B) -> B \
+                      # N: Revealed type is "Any"
 
 @overload
 def f3(g: A) -> A: ...
 @overload
 def f3(g: B) -> B: ...
-if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                 # E: Name "maybe_true" is not defined
     @overload
     def f3(g: C) -> C: ...
 def f3(g): ...
 reveal_type(f3(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f3(C()))  # E: No overload variant of "f3" matches argument type "C" \
-    # N: Possible overload variants: \
-    # N:     def f3(g: A) -> A \
-    # N:     def f3(g: B) -> B \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f3(g: A) -> A \
+                      # N:     def f3(g: B) -> B \
+                      # N: Revealed type is "Any"
 
 if True:
     @overload
@@ -5731,10 +5731,10 @@ def f1(x): ...
 reveal_type(f1(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f1(B()))  # N: Revealed type is "__main__.B"
 reveal_type(f1(D()))  # E: No overload variant of "f1" matches argument type "D" \
-    # N: Possible overload variants: \
-    # N:     def f1(x: A) -> A \
-    # N:     def f1(x: B) -> B \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f1(x: A) -> A \
+                      # N:     def f1(x: B) -> B \
+                      # N: Revealed type is "Any"
 
 @overload
 def f2(x: A) -> A: ...
@@ -5751,14 +5751,14 @@ def f2(x): ...
 reveal_type(f2(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f2(B()))  # N: Revealed type is "__main__.B"
 reveal_type(f2(C()))  # E: No overload variant of "f2" matches argument type "C" \
-    # N: Possible overload variants: \
-    # N:     def f2(x: A) -> A \
-    # N:     def f2(x: B) -> B \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f2(x: A) -> A \
+                      # N:     def f2(x: B) -> B \
+                      # N: Revealed type is "Any"
 
 @overload  # E: Single overload definition, multiple required
 def f3(x: A) -> A: ...
-if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                 # E: Name "maybe_true" is not defined
     @overload
     def f3(x: B) -> B: ...
@@ -5771,13 +5771,13 @@ else:
 def f3(x): ...
 reveal_type(f3(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f3(B()))  # E: No overload variant of "f3" matches argument type "B" \
-    # N: Possible overload variant: \
-    # N:     def f3(x: A) -> A \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variant: \
+                      # N:     def f3(x: A) -> A \
+                      # N: Revealed type is "Any"
 
 @overload  # E: Single overload definition, multiple required
 def f4(x: A) -> A: ...
-if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                 # E: Name "maybe_true" is not defined
     @overload
     def f4(x: B) -> B: ...
@@ -5787,9 +5787,10 @@ else:
 def f4(x): ...
 reveal_type(f4(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f4(B()))  # E: No overload variant of "f4" matches argument type "B" \
-    # N: Possible overload variant: \
-    # N:     def f4(x: A) -> A \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variant: \
+                      # N:     def f4(x: A) -> A \
+                      # N: Revealed type is "Any"
+
 
 [case testOverloadIfElse3]
 # flags: --always-false False
@@ -5817,10 +5818,10 @@ else:
 def f1(x): ...
 reveal_type(f1(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f1(B()))  # E: No overload variant of "f1" matches argument type "B" \
-    # N: Possible overload variants: \
-    # N:     def f1(x: A) -> A \
-    # N:     def f1(x: D) -> D \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f1(x: A) -> A \
+                      # N:     def f1(x: D) -> D \
+                      # N: Revealed type is "Any"
 reveal_type(f1(D()))  # N: Revealed type is "__main__.D"
 
 @overload  # E: Single overload definition, multiple required
@@ -5828,7 +5829,7 @@ def f2(x: A) -> A: ...
 if False:
     @overload
     def f2(x: B) -> B: ...
-elif maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+elif maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                   # E: Name "maybe_true" is not defined
     @overload
     def f2(x: C) -> C: ...
@@ -5838,13 +5839,13 @@ else:
 def f2(x): ...
 reveal_type(f2(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f2(C()))  # E: No overload variant of "f2" matches argument type "C" \
-    # N: Possible overload variant: \
-    # N:     def f2(x: A) -> A \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variant: \
+                      # N:     def f2(x: A) -> A \
+                      # N: Revealed type is "Any"
 
 @overload  # E: Single overload definition, multiple required
 def f3(x: A) -> A: ...
-if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                 # E: Name "maybe_true" is not defined
     @overload
     def f3(x: B) -> B: ...
@@ -5857,14 +5858,14 @@ else:
 def f3(x): ...
 reveal_type(f3(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f3(B()))  # E: No overload variant of "f3" matches argument type "B" \
-    # N: Possible overload variant: \
-    # N:     def f3(x: A) -> A \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variant: \
+                      # N:     def f3(x: A) -> A \
+                      # N: Revealed type is "Any"
 
 def g(bool_var: bool) -> None:
     @overload
     def f4(x: A) -> A: ...
-    if bool_var:  # E: Condition cannot be inferred, unable to merge overloads
+    if bool_var:  # E: Condition can't be inferred, unable to merge overloads
         @overload
         def f4(x: B) -> B: ...
     elif maybe_true:  # E: Name "maybe_true" is not defined
@@ -5880,10 +5881,11 @@ def g(bool_var: bool) -> None:
     def f4(x): ...
     reveal_type(f4(E()))  # N: Revealed type is "__main__.E"
     reveal_type(f4(B()))  # E: No overload variant of "f4" matches argument type "B" \
-        # N: Possible overload variants: \
-        # N:     def f4(x: A) -> A \
-        # N:     def f4(x: E) -> E \
-        # N: Revealed type is "Any"
+                          # N: Possible overload variants: \
+                          # N:     def f4(x: A) -> A \
+                          # N:     def f4(x: E) -> E \
+                          # N: Revealed type is "Any"
+
 
 [case testOverloadIfSkipUnknownExecution]
 # flags: --always-true True
@@ -5901,14 +5903,14 @@ class D: ...
 
 @overload  # E: Single overload definition, multiple required
 def f1(x: A) -> A: ...
-if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                 # E: Name "maybe_true" is not defined
     @overload
     def f1(x: B) -> B: ...
 def f1(x): ...
 reveal_type(f1(A()))  # N: Revealed type is "__main__.A"
 
-if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                 # E: Name "maybe_true" is not defined
     @overload
     def f2(x: A) -> A: ...
@@ -5918,15 +5920,15 @@ def f2(x: B) -> B: ...
 def f2(x: C) -> C: ...
 def f2(x): ...
 reveal_type(f2(A()))  # E: No overload variant of "f2" matches argument type "A" \
-    # N: Possible overload variants: \
-    # N:     def f2(x: B) -> B \
-    # N:     def f2(x: C) -> C \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f2(x: B) -> B \
+                      # N:     def f2(x: C) -> C \
+                      # N: Revealed type is "Any"
 
 if True:
     @overload  # E: Single overload definition, multiple required
     def f3(x: A) -> A: ...
-    if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+    if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                     # E: Name "maybe_true" is not defined
         @overload
         def f3(x: B) -> B: ...
@@ -5934,7 +5936,7 @@ if True:
 reveal_type(f3(A()))  # N: Revealed type is "__main__.A"
 
 if True:
-    if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+    if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                     # E: Name "maybe_true" is not defined
         @overload
         def f4(x: A) -> A: ...
@@ -5944,10 +5946,10 @@ if True:
     def f4(x: C) -> C: ...
     def f4(x): ...
 reveal_type(f4(A()))  # E: No overload variant of "f4" matches argument type "A" \
-    # N: Possible overload variants: \
-    # N:     def f4(x: B) -> B \
-    # N:     def f4(x: C) -> C \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f4(x: B) -> B \
+                      # N:     def f4(x: C) -> C \
+                      # N: Revealed type is "Any"
 
 [case testOverloadIfDontSkipUnrelatedOverload]
 # flags: --always-true True
@@ -6187,16 +6189,16 @@ if False:
 def f8(x): ...
 reveal_type(f8(A()))  # N: Revealed type is "__main__.A"
 reveal_type(f8(C()))  # E: No overload variant of "f8" matches argument type "C" \
-    # N: Possible overload variants: \
-    # N:     def f8(x: A) -> A \
-    # N:     def f8(x: B) -> B \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f8(x: A) -> A \
+                      # N:     def f8(x: B) -> B \
+                      # N: Revealed type is "Any"
 
-if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                 # E: Name "maybe_true" is not defined
     @overload
     def f9(x: A) -> A: ...
-if another_maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+if another_maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                         # E: Name "another_maybe_true" is not defined
     @overload
     def f9(x: B) -> B: ...
@@ -6206,18 +6208,18 @@ def f9(x: C) -> C: ...
 def f9(x: D) -> D: ...
 def f9(x): ...
 reveal_type(f9(A()))  # E: No overload variant of "f9" matches argument type "A" \
-    # N: Possible overload variants: \
-    # N:     def f9(x: C) -> C \
-    # N:     def f9(x: D) -> D \
-    # N: Revealed type is "Any"
+                      # N: Possible overload variants: \
+                      # N:     def f9(x: C) -> C \
+                      # N:     def f9(x: D) -> D \
+                      # N: Revealed type is "Any"
 reveal_type(f9(C()))  # N: Revealed type is "__main__.C"
 
 if True:
-    if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+    if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                     # E: Name "maybe_true" is not defined
         @overload
         def f10(x: A) -> A: ...
-    if another_maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+    if another_maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                             # E: Name "another_maybe_true" is not defined
         @overload
         def f10(x: B) -> B: ...
@@ -6227,10 +6229,10 @@ if True:
     def f10(x: D) -> D: ...
     def f10(x): ...
 reveal_type(f10(A()))  # E: No overload variant of "f10" matches argument type "A" \
-    # N: Possible overload variants: \
-    # N:     def f10(x: C) -> C \
-    # N:     def f10(x: D) -> D \
-    # N: Revealed type is "Any"
+                       # N: Possible overload variants: \
+                       # N:     def f10(x: C) -> C \
+                       # N:     def f10(x: D) -> D \
+                       # N: Revealed type is "Any"
 reveal_type(f10(C()))  # N: Revealed type is "__main__.C"
 
 if some_var:  # E: Name "some_var" is not defined
@@ -6251,6 +6253,7 @@ if True:
     def f12(x: B) -> B: ...
     def f12(x): ...
 reveal_type(f12(A()))  # N: Revealed type is "__main__.A"
+
 [typing fixtures/typing-medium.pyi]
 
 [case testOverloadIfUnconditionalFuncDef]
@@ -6406,7 +6409,7 @@ def f1(g: A) -> A: ...
 if True:
     @overload  # E: Single overload definition, multiple required
     def f1(g: B) -> B: ...
-    if maybe_true:  # E: Condition cannot be inferred, unable to merge overloads \
+    if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                     # E: Name "maybe_true" is not defined
         @overload
         def f1(g: C) -> C: ...
@@ -6432,12 +6435,14 @@ if True:
     def f3(g: B) -> B: ...
     if True:
         pass  # Some other node
-        @overload  # E: Name "f3" already defined on line 32  \
+        @overload  # E: Name "f3" already defined on line 32 \
                    # E: An overloaded function outside a stub file must have an implementation
         def f3(g: C) -> C: ...
         @overload
         def f3(g: D) -> D: ...
 def f3(g): ...  # E: Name "f3" already defined on line 32
+
+
 
 [case testOverloadingWithParamSpec]
 from typing import TypeVar, Callable, Any, overload

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -409,8 +409,8 @@ def local() -> None:
     x: L
     reveal_type(x)  # N: Revealed type is "builtins.list[Union[builtins.int, Any]]"
 
-S = Type[S]  # E: Type[...] cannot contain another Type[...]
-U = Type[Union[int, U]]  # E: Type[...] cannot contain another Type[...]
+S = Type[S]  # E: Type[...] can't contain another Type[...]
+U = Type[Union[int, U]]  # E: Type[...] can't contain another Type[...]
 x: U
 reveal_type(x)  # N: Revealed type is "Type[Any]"
 
@@ -419,6 +419,8 @@ F = D[T]  # Error reported above
 E = List[E[E[T]]]  # E: Invalid recursive alias: type variable nesting on right hand side
 d: D
 reveal_type(d)  # N: Revealed type is "Any"
+
+
 [builtins fixtures/isinstancelist.pyi]
 
 [case testBasicRecursiveNamedTuple]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -419,8 +419,6 @@ F = D[T]  # Error reported above
 E = List[E[E[T]]]  # E: Invalid recursive alias: type variable nesting on right hand side
 d: D
 reveal_type(d)  # N: Revealed type is "Any"
-
-
 [builtins fixtures/isinstancelist.pyi]
 
 [case testBasicRecursiveNamedTuple]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1398,23 +1398,6 @@ t5: Tuple[int, int] = (1, 2, "s", 4)  # E: Incompatible types in assignment (exp
 # long initializer assignment with mismatched pairs
 t6: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str", 1, 1, 1, 1, 1) # E: Incompatible types in assignment (expression has type Tuple[int, int, ... <15 more items>], variable has type Tuple[int, int, ... <10 more items>])
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 [builtins fixtures/tuple.pyi]
 
 [case testTupleWithStarExpr]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1367,42 +1367,53 @@ reveal_type(a + b)  # N: Revealed type is "Tuple[builtins.int, builtins.str, bui
 from typing import Tuple
 
 # long initializer assignment with few mismatches
-t: Tuple[int, ...] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", 11) \
-                                                                    # E: Incompatible types in assignment (3 tuple items are incompatible) \
-                                                                    # N: Expression tuple item 8 has type "str"; "int" expected; \
-                                                                    # N: Expression tuple item 9 has type "str"; "int" expected; \
-                                                                    # N: Expression tuple item 10 has type "str"; "int" expected;
+t: Tuple[int, ...] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", 11) # E: Incompatible types in assignment (3 tuple items are incompatible) \
+                                                                       # N: Expression tuple item 8 has type "str"; "int" expected;  \
+                                                                       # N: Expression tuple item 9 has type "str"; "int" expected;  \
+                                                                       # N: Expression tuple item 10 has type "str"; "int" expected;
 
 # long initializer assignment with more mismatches
-t1: Tuple[int, ...] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str") \
-                                                                    # E: Incompatible types in assignment (4 tuple items are incompatible; 1 items are omitted) \
-                                                                    # N: Expression tuple item 8 has type "str"; "int" expected; \
-                                                                    # N: Expression tuple item 9 has type "str"; "int" expected; \
-                                                                    # N: Expression tuple item 10 has type "str"; "int" expected;
+t1: Tuple[int, ...] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str") # E: Incompatible types in assignment (4 tuple items are incompatible; 1 items are omitted) \
+                                                                           # N: Expression tuple item 8 has type "str"; "int" expected;  \
+                                                                           # N: Expression tuple item 9 has type "str"; "int" expected;  \
+                                                                           # N: Expression tuple item 10 has type "str"; "int" expected;
 
 # short tuple initializer assignment
-t2: Tuple[int, ...] = (1, 2, "s", 4) \
-                                # E: Incompatible types in assignment (expression has type "Tuple[int, int, str, int]", variable has type "Tuple[int, ...]")
+t2: Tuple[int, ...] = (1, 2, "s", 4) # E: Incompatible types in assignment (expression has type "Tuple[int, int, str, int]", variable has type "Tuple[int, ...]")
 
 # long initializer assignment with few mismatches, no ellipsis
-t3: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "str", "str") \
-                                                                    # E: Incompatible types in assignment (2 tuple items are incompatible) \
-                                                                    # N: Expression tuple item 10 has type "str"; "int" expected; \
-                                                                    # N: Expression tuple item 11 has type "str"; "int" expected;
+t3: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "str", "str") # E: Incompatible types in assignment (2 tuple items are incompatible) \
+                                                                                                                      # N: Expression tuple item 10 has type "str"; "int" expected;  \
+                                                                                                                      # N: Expression tuple item 11 has type "str"; "int" expected;
 
 # long initializer assignment with more mismatches, no ellipsis
-t4: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str") \
-                                                                    # E: Incompatible types in assignment (4 tuple items are incompatible; 1 items are omitted) \
-                                                                    # N: Expression tuple item 8 has type "str"; "int" expected; \
-                                                                    # N: Expression tuple item 9 has type "str"; "int" expected; \
-                                                                    # N: Expression tuple item 10 has type "str"; "int" expected;
+t4: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str") # E: Incompatible types in assignment (4 tuple items are incompatible; 1 items are omitted) \
+                                                                                                                             # N: Expression tuple item 8 has type "str"; "int" expected;  \
+                                                                                                                             # N: Expression tuple item 9 has type "str"; "int" expected;  \
+                                                                                                                             # N: Expression tuple item 10 has type "str"; "int" expected;
 
 # short tuple initializer assignment, no ellipsis
 t5: Tuple[int, int] = (1, 2, "s", 4)  # E: Incompatible types in assignment (expression has type "Tuple[int, int, str, int]", variable has type "Tuple[int, int]")
 
 # long initializer assignment with mismatched pairs
-t6: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str", 1, 1, 1, 1, 1) \
-                                                                    # E: Incompatible types in assignment (expression has type Tuple[int, int, ... <15 more items>], variable has type Tuple[int, int, ... <10 more items>])
+t6: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str", 1, 1, 1, 1, 1) # E: Incompatible types in assignment (expression has type Tuple[int, int, ... <15 more items>], variable has type Tuple[int, int, ... <10 more items>])
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -361,84 +361,84 @@ main:2: error: "yield" outside function
 [case testInvalidLvalues1]
 1 = 1
 [out]
-main:1: error: can't assign to literal
+main:1: error: cannot assign to literal
 [out version>=3.10]
-main:1: error: can't assign to literal here. Maybe you meant '==' instead of '='?
+main:1: error: cannot assign to literal here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues2]
 (1) = 1
 [out]
-main:1: error: can't assign to literal
+main:1: error: cannot assign to literal
 [out version>=3.10]
-main:1: error: can't assign to literal here. Maybe you meant '==' instead of '='?
+main:1: error: cannot assign to literal here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues3]
 (1, 1) = 1
 [out]
-main:1: error: can't assign to literal
+main:1: error: cannot assign to literal
 
 [case testInvalidLvalues4]
 [1, 1] = 1
 [out]
-main:1: error: can't assign to literal
+main:1: error: cannot assign to literal
 
 [case testInvalidLvalues6]
 x = y = z = 1  # ok
 x, (y, 1) = 1
 [out]
-main:2: error: can't assign to literal
+main:2: error: cannot assign to literal
 
 [case testInvalidLvalues7]
 x, [y, 1] = 1
 [out]
-main:1: error: can't assign to literal
+main:1: error: cannot assign to literal
 
 [case testInvalidLvalues8]
 x, [y, [z, 1]] = 1
 [out]
-main:1: error: can't assign to literal
+main:1: error: cannot assign to literal
 
 [case testInvalidLvalues9]
 x, (y) = 1 # ok
 x, (y, (z, z)) = 1 # ok
 x, (y, (z, 1)) = 1
 [out]
-main:3: error: can't assign to literal
+main:3: error: cannot assign to literal
 
 [case testInvalidLvalues10]
 x + x = 1
 [out]
 main:1: error: can't assign to operator
 [out version>=3.10]
-main:1: error: can't assign to expression here. Maybe you meant '==' instead of '='?
+main:1: error: cannot assign to expression here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues11]
 -x = 1
 [out]
 main:1: error: can't assign to operator
 [out version>=3.10]
-main:1: error: can't assign to expression here. Maybe you meant '==' instead of '='?
+main:1: error: cannot assign to expression here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues12]
 1.1 = 1
 [out]
-main:1: error: can't assign to literal
+main:1: error: cannot assign to literal
 [out version>=3.10]
-main:1: error: can't assign to literal here. Maybe you meant '==' instead of '='?
+main:1: error: cannot assign to literal here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues13]
 'x' = 1
 [out]
-main:1: error: can't assign to literal
+main:1: error: cannot assign to literal
 [out version>=3.10]
-main:1: error: can't assign to literal here. Maybe you meant '==' instead of '='?
+main:1: error: cannot assign to literal here. Maybe you meant '==' instead of '='?
 
 [case testInvalidLvalues14]
 x() = 1
 [out]
-main:1: error: can't assign to function call
+main:1: error: cannot assign to function call
 [out version>=3.10]
-main:1: error: can't assign to function call here. Maybe you meant '==' instead of '='?
+main:1: error: cannot assign to function call here. Maybe you meant '==' instead of '='?
 
 [case testTwoStarExpressions]
 a, *b, *c = 1
@@ -490,7 +490,7 @@ main:2: error: Can use starred expression only as assignment target
 
 [case testInvalidDel1]
 x = 1
-del x(1)  # E: can't delete function call
+del x(1)  # E: cannot delete function call
 [out]
 
 [case testInvalidDel2]
@@ -897,9 +897,9 @@ import typing
 def f(): pass
 f() = 1 # type: int
 [out]
-main:3: error: can't assign to function call
+main:3: error: cannot assign to function call
 [out version>=3.10]
-main:3: error: can't assign to function call here. Maybe you meant '==' instead of '='?
+main:3: error: cannot assign to function call here. Maybe you meant '==' instead of '='?
 
 [case testIndexedAssignmentWithTypeDeclaration]
 import typing
@@ -1275,7 +1275,7 @@ main:2: note: Did you forget to import it from "typing"? (Suggestion: "from typi
 
 [case testInvalidWithTarget]
 def f(): pass
-with f() as 1: pass  # E: can't assign to literal
+with f() as 1: pass  # E: cannot assign to literal
 [out]
 
 [case testInvalidTypeAnnotation]
@@ -1290,9 +1290,9 @@ import typing
 def f() -> None:
     f() = 1  # type: int
 [out]
-main:3: error: can't assign to function call
+main:3: error: cannot assign to function call
 [out version>=3.10]
-main:3: error: can't assign to function call here. Maybe you meant '==' instead of '='?
+main:3: error: cannot assign to function call here. Maybe you meant '==' instead of '='?
 
 [case testInvalidReferenceToAttributeOfOuterClass]
 class A:

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -559,7 +559,7 @@ def f(x, y) -> None:
 [out]
 main:2: error: can't delete operator
 [out version>=3.10]
-main:2: error: can't delete expression
+main:2: error: cannot delete expression
 
 [case testTry]
 class c: pass


### PR DESCRIPTION
This tripped me up the other day when grepping for an error message. Thanks to ikonst's --update-data improvements, very easy to fix everywhere.