### PR TITLE
Add get_expression_type to CheckerPluginInterface

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6793,6 +6793,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             )
         return not watcher.has_new_errors()
 
+    def get_expression_type(self, node: Expression, type_context: Type | None = None) -> Type:
+        return self.expr_checker.accept(node, type_context=type_context)
+
 
 class CollectArgTypeVarTypes(TypeTraverserVisitor):
     """Collects the non-nested argument types in a set."""

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -250,6 +250,11 @@ class CheckerPluginInterface:
         """Construct an instance of a builtin type with given type arguments."""
         raise NotImplementedError
 
+    @abstractmethod
+    def get_expression_type(self, node: Expression, type_context: Type | None = None) -> Type:
+        """Checks the type of the given expression."""
+        raise NotImplementedError
+
 
 @trait
 class SemanticAnalyzerPluginInterface:

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -887,7 +887,10 @@ plugins=<ROOT>/test-data/unit/plugins/descriptor.py
 # flags: --config-file tmp/mypy.ini
 
 def dynamic_signature(arg1: str) -> str: ...
-reveal_type(dynamic_signature(1))  # N: Revealed type is "builtins.int"
+a: int = 1
+reveal_type(dynamic_signature(a))  # N: Revealed type is "builtins.int"
+b: bytes = b'foo'
+reveal_type(dynamic_signature(b))  # N: Revealed type is "builtins.bytes"
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/function_sig_hook.py

--- a/test-data/unit/plugins/function_sig_hook.py
+++ b/test-data/unit/plugins/function_sig_hook.py
@@ -1,5 +1,5 @@
-from mypy.plugin import CallableType, CheckerPluginInterface, FunctionSigContext, Plugin
-from mypy.types import Instance, Type
+from mypy.plugin import CallableType, FunctionSigContext, Plugin
+
 
 class FunctionSigPlugin(Plugin):
     def get_function_signature_hook(self, fullname):
@@ -7,20 +7,17 @@ class FunctionSigPlugin(Plugin):
             return my_hook
         return None
 
-def _str_to_int(api: CheckerPluginInterface, typ: Type) -> Type:
-    if isinstance(typ, Instance):
-        if typ.type.fullname == 'builtins.str':
-            return api.named_generic_type('builtins.int', [])
-        elif typ.args:
-            return typ.copy_modified(args=[_str_to_int(api, t) for t in typ.args])
-
-    return typ
 
 def my_hook(ctx: FunctionSigContext) -> CallableType:
+    arg1_args = ctx.args[0]
+    if len(arg1_args) != 1:
+        return ctx.default_signature
+    arg1_type = ctx.api.get_expression_type(arg1_args[0])
     return ctx.default_signature.copy_modified(
-        arg_types=[_str_to_int(ctx.api, t) for t in ctx.default_signature.arg_types],
-        ret_type=_str_to_int(ctx.api, ctx.default_signature.ret_type),
+        arg_types=[arg1_type],
+        ret_type=arg1_type,
     )
+
 
 def plugin(version):
     return FunctionSigPlugin


### PR DESCRIPTION
Fixes #14845.

p.s. In the issue above, I was concerned that adding this method would create an avenue for infinite recursions (if called carelessly), but in fact I haven't managed to induce it, e.g. FunctionSigContext has `args` but not the call expression itself.