### PR TITLE
testupdatedata: fix cwd

### DIFF
--- a/mypy/test/testupdatedata.py
+++ b/mypy/test/testupdatedata.py
@@ -14,7 +14,9 @@ class UpdateDataSuite(Suite):
         Runs a suite of data test cases through 'pytest --update-data' until either tests pass
         or until a maximum number of attempts (needed for incremental tests).
         """
-        p = Path(test_data_prefix) / "check-update-data.test"
+        p_test_data = Path(test_data_prefix)
+        p_root = p_test_data.parent.parent
+        p = p_test_data / "check-update-data.test"
         assert not p.exists()
         try:
             p.write_text(textwrap.dedent(data_suite).lstrip())
@@ -26,7 +28,7 @@ class UpdateDataSuite(Suite):
             else:
                 cmd = " ".join(args)
             for i in range(max_attempts - 1, -1, -1):
-                res = subprocess.run(args)
+                res = subprocess.run(args, cwd=p_root)
                 if res.returncode == 0:
                     break
                 print(f"`{cmd}` returned {res.returncode}: {i} attempts remaining")


### PR DESCRIPTION
This should allow the inner pytest to pass even when the outer pytest is invoked outside of the mypy root, e.g.
```shell
cd ..
pytest mypy/mypy/test/testupdatedata.py
```

Addresses https://github.com/python/mypy/pull/15283#issuecomment-1578609223.