### PR TITLE
Apply TypeVar defaults to functions (PEP 696)

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -18,6 +18,7 @@ from mypy.types import (
     TypeVarLikeType,
     TypeVarTupleType,
     TypeVarType,
+    UninhabitedType,
     UnpackType,
     get_proper_type,
 )
@@ -32,13 +33,15 @@ def get_target_type(
     context: Context,
     skip_unsatisfied: bool,
 ) -> Type | None:
+    p_type = get_proper_type(type)
+    if isinstance(p_type, UninhabitedType) and tvar.has_default():
+        return tvar.default
     if isinstance(tvar, ParamSpecType):
         return type
     if isinstance(tvar, TypeVarTupleType):
         return type
     assert isinstance(tvar, TypeVarType)
     values = tvar.values
-    p_type = get_proper_type(type)
     if values:
         if isinstance(p_type, AnyType):
             return type

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -81,3 +81,38 @@ T2 = TypeVar("T2", bound=List[str], default=List[int])  # E: TypeVar default mus
 T3 = TypeVar("T3", int, str, default=bytes)  # E: TypeVar default must be one of the constraint types
 T4 = TypeVar("T4", int, str, default=Union[int, str])  # E: TypeVar default must be one of the constraint types
 T5 = TypeVar("T5", float, str, default=int)  # E: TypeVar default must be one of the constraint types
+
+[case testTypeVarDefaultsFunctions]
+from typing import TypeVar, ParamSpec, List, Union, Callable, Tuple
+from typing_extensions import TypeVarTuple, Unpack
+
+T1 = TypeVar("T1", default=str)
+T2 = TypeVar("T2", bound=str, default=str)
+T3 = TypeVar("T3", bytes, str, default=str)
+P1 = ParamSpec("P1", default=[int, str])
+Ts1 = TypeVarTuple("Ts1", default=Unpack[Tuple[int, str]])
+
+def callback1(x: str) -> None: ...
+
+def func_a1(x: Union[int, T1]) -> T1: ...
+reveal_type(func_a1(2))  # N: Revealed type is "builtins.str"
+reveal_type(func_a1(2.1))  # N: Revealed type is "builtins.float"
+
+def func_a2(x: Union[int, T1]) -> List[T1]: ...
+reveal_type(func_a2(2))  # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type(func_a2(2.1))  # N: Revealed type is "builtins.list[builtins.float]"
+
+def func_a3(x: Union[int, T2]) -> T2: ...
+reveal_type(func_a3(2))  # N: Revealed type is "builtins.str"
+
+def func_a4(x: Union[int, T3]) -> T3: ...
+reveal_type(func_a4(2))  # N: Revealed type is "builtins.str"
+
+def func_b1(x: Union[int, Callable[P1, None]]) -> Callable[P1, None]: ...
+reveal_type(func_b1(callback1))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(func_b1(2))  # N: Revealed type is "def (builtins.int, builtins.str)"
+
+def func_c1(x: Union[int, Callable[[Unpack[Ts1]], None]]) -> Tuple[Unpack[Ts1]]: ...
+# reveal_type(func_c1(callback1))  # Revealed type is "builtins.tuple[str]"  # TODO
+# reveal_type(func_c1(2))  # Revealed type is "builtins.tuple[builtins.int, builtins.str]"  # TODO
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Use TypeVar defaults to resolve fallback return type of functions.

**Note**: Defaults for TypeVarTuples don't yet work, probably a result of the limited support for `Unpack` / `TypeVarTuple`.

Ref: #14851