### PR TITLE
Try tweaking `attrs.fields()`

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -875,6 +875,10 @@ def _add_attrs_magic_attribute(
         if isinstance(proper_type, Instance):
             var.info = proper_type.type
         ti.names[name] = SymbolTableNode(MDEF, var, plugin_generated=True)
+
+    # We fix up the `__iter__` name so these tuples are iterable as attr.Attributes
+    ti.names["__iter__"] = fallback_type.type.names["__iter__"]
+
     attributes_type = Instance(ti, [])
 
     # We need to stash the type of the magic attribute so it can be

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1569,6 +1569,20 @@ f(A).x  # E: "____main___A_AttrsAttributes__" has no attribute "x"
 
 [builtins fixtures/plugin_attrs.pyi]
 
+[case testAttrsFieldsIteration]
+import attr
+from attrs import fields as f  # Common usage.
+
+@attr.define
+class A:
+    b: int
+    c: str
+
+for a in f(A):
+    reveal_type(a)  # N: Revealed type is "attr.Attribute[Any]" 
+
+[builtins fixtures/tuple.pyi]
+
 [case testAttrsGenericFields]
 from typing import TypeVar
 

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1579,7 +1579,7 @@ class A:
     c: str
 
 for a in f(A):
-    reveal_type(a)  # N: Revealed type is "attr.Attribute[Any]" 
+    reveal_type(a)  # N: Revealed type is "attr.Attribute[Any]"
 
 [builtins fixtures/tuple.pyi]
 


### PR DESCRIPTION
Trying to fix https://github.com/python/mypy/pull/15393 in an alternative way.

@JukkaL I might need some help here. I'm still getting `builtins.object` while iterating:

```python
from attrs import define, fields


@define
class Test:
    a: int
    b: float


for f in fields(Test):
    reveal_type(f)  # note: Revealed type is "builtins.object"
```
But if I do this:
```python
for f in iter(fields(Test)):
    reveal_type(f)  # note: Revealed type is "attr.Attribute[Any]"
```

Any ideas?