### PR TITLE
Fix crash on NamedTuple as attribute

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3067,6 +3067,12 @@ class SemanticAnalyzer(
         if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], (NameExpr, MemberExpr)):
             return False
         lvalue = s.lvalues[0]
+        if isinstance(lvalue, MemberExpr):
+            if isinstance(s.rvalue, CallExpr) and isinstance(s.rvalue.callee, RefExpr):
+                fullname = s.rvalue.callee.fullname
+                if fullname == "collections.namedtuple" or fullname in TYPED_NAMEDTUPLE_NAMES:
+                    self.fail("NamedTuple type as an attribute is not supported", lvalue)
+            return False
         name = lvalue.name
         namespace = self.qualified_name(name)
         with self.tvar_scope_frame(self.tvar_scope.class_frame(namespace)):
@@ -3074,9 +3080,6 @@ class SemanticAnalyzer(
                 s.rvalue, name, self.is_func_scope()
             )
             if internal_name is None:
-                return False
-            if isinstance(lvalue, MemberExpr):
-                self.fail("NamedTuple type as an attribute is not supported", lvalue)
                 return False
             if internal_name != name:
                 self.fail(

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -938,8 +938,9 @@ class A:
     def __init__(self) -> None:
         self.b = NamedTuple('x', [('s', str), ('n', int)])  # E: NamedTuple type as an attribute is not supported
 
-reveal_type(A().b)  # N: Revealed type is "Any"
+reveal_type(A().b)  # N: Revealed type is "typing.NamedTuple"
 [builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
 
 [case testNamedTupleWrongfile]
 from typing import NamedTuple
@@ -983,7 +984,7 @@ class Both2(Other, Bar): ...
 class Both3(Biz, Other): ...
 
 def print_namedtuple(obj: NamedTuple) -> None:
-    reveal_type(obj.name)  # N: Revealed type is "builtins.str"
+    reveal_type(obj._fields)  # N: Revealed type is "builtins.tuple[builtins.str, ...]"
 
 b1: Bar
 b2: Baz
@@ -1335,5 +1336,14 @@ class NT(NamedTuple, Generic[T]):
 
 class SNT(NT[int]): ...
 reveal_type(SNT("test", 42).meth())  # N: Revealed type is "Tuple[builtins.str, builtins.int, fallback=__main__.SNT]"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
+
+[case testNoCrashUnsupportedNamedTuple]
+from typing import NamedTuple
+class Test:
+    def __init__(self, field) -> None:
+        self.Item = NamedTuple("x", [(field, str)])  # E: NamedTuple type as an attribute is not supported
+        self.item: self.Item  # E: Name "self.Item" is not defined
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]

--- a/test-data/unit/fixtures/typing-namedtuple.pyi
+++ b/test-data/unit/fixtures/typing-namedtuple.pyi
@@ -6,6 +6,8 @@ Type = 0
 Literal = 0
 Optional = 0
 Self = 0
+Tuple = 0
+ClassVar = 0
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
@@ -18,6 +20,9 @@ class Mapping(Iterable[KT], Generic[KT, T_co]):
     def keys(self) -> Iterable[T]: pass  # Approximate return type
     def __getitem__(self, key: T) -> T_co: pass
 
-class Tuple(Sequence): pass
-class NamedTuple(Tuple):
-    name: str
+class NamedTuple(tuple[Any, ...]):
+    _fields: ClassVar[tuple[str, ...]]
+    @overload
+    def __init__(self, typename: str, fields: Iterable[tuple[str, Any]] = ...) -> None: ...
+    @overload
+    def __init__(self, typename: str, fields: None = None, **kwargs: Any) -> None: ...


### PR DESCRIPTION
Fixes #15380

Note I also update the `NamedTuple` fixture to be much closer to real definition in `typing.pyi` in typeshed.
