### PR TITLE
Fix crash on follow_imports_for_stubs

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -116,7 +116,6 @@ CORE_BUILTIN_MODULES: Final = {
     "types",
     "typing_extensions",
     "mypy_extensions",
-    "_importlib_modulespec",
     "_typeshed",
     "_collections_abc",
     "collections",
@@ -662,8 +661,6 @@ class BuildManager:
         )
         for module in CORE_BUILTIN_MODULES:
             if options.use_builtins_fixtures:
-                continue
-            if module == "_importlib_modulespec":
                 continue
             path = self.find_module_cache.find_module(module)
             if not isinstance(path, str):

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -117,6 +117,10 @@ CORE_BUILTIN_MODULES: Final = {
     "typing_extensions",
     "mypy_extensions",
     "_importlib_modulespec",
+    "_typeshed",
+    "_collections_abc",
+    "collections",
+    "collections.abc",
     "sys",
     "abc",
 }
@@ -2637,7 +2641,7 @@ def find_module_and_diagnose(
                 result.endswith(".pyi")  # Stubs are always normal
                 and not options.follow_imports_for_stubs  # except when they aren't
             )
-            or id in mypy.semanal_main.core_modules  # core is always normal
+            or id in CORE_BUILTIN_MODULES  # core is always normal
         ):
             follow_imports = "normal"
         if skip_diagnose:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2437,7 +2437,7 @@ def format_type_inner(
     if isinstance(typ, Instance):
         itype = typ
         # Get the short name of the type.
-        if itype.type.fullname in ("types.ModuleType", "_importlib_modulespec.ModuleType"):
+        if itype.type.fullname == "types.ModuleType":
             # Make some common error messages simpler and tidier.
             base_str = "Module"
             if itype.extra_attrs and itype.extra_attrs.mod_name and module_names:

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2174,3 +2174,13 @@ def f(x: bytes, y: bytearray, z: memoryview) -> None:
     x in y
     x in z
 [builtins fixtures/primitives.pyi]
+
+[case testNoCrashFollowImportsForStubs]
+# flags: --config-file tmp/mypy.ini
+{**{"x": "y"}}
+
+[file mypy.ini]
+\[mypy]
+follow_imports = skip
+follow_imports_for_stubs = true
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1484,6 +1484,10 @@ note: A user-defined top-level module with name "typing" is not supported
 [file dir/stdlib/types.pyi]
 [file dir/stdlib/typing.pyi]
 [file dir/stdlib/typing_extensions.pyi]
+[file dir/stdlib/_typeshed.pyi]
+[file dir/stdlib/_collections_abc.pyi]
+[file dir/stdlib/collections/abc.pyi]
+[file dir/stdlib/collections/__init__.pyi]
 [file dir/stdlib/VERSIONS]
 [out]
 Failed to find builtin module mypy_extensions, perhaps typeshed is broken?
@@ -1523,6 +1527,10 @@ class dict: pass
 [file dir/stdlib/typing.pyi]
 [file dir/stdlib/mypy_extensions.pyi]
 [file dir/stdlib/typing_extensions.pyi]
+[file dir/stdlib/_typeshed.pyi]
+[file dir/stdlib/_collections_abc.pyi]
+[file dir/stdlib/collections/abc.pyi]
+[file dir/stdlib/collections/__init__.pyi]
 [file dir/stdlib/foo.pyi]
 1()  # Errors are reported if the file was explicitly passed on the command line
 [file dir/stdlib/VERSIONS]


### PR DESCRIPTION
Fixes #15246 
Likely fixes #15319, but I didn't find a repro.

Note I also cleanup one thing, there should be clear separation:
* `CORE_BUILTIN_MODULES` must be always available, and their content must be unaltered, since we rely on it.
* `semanal_main.core_modules` should be analyzed first among `builtins` SCC in a specific order.
