### PR TITLE
Always allow returning Any from lambda

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4270,6 +4270,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             isinstance(return_type, Instance)
                             and return_type.type.fullname == "builtins.object"
                         )
+                        and not is_lambda
                     ):
                         self.msg.incorrectly_returning_any(return_type, s)
                     return

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2184,3 +2184,11 @@ def f(x: bytes, y: bytearray, z: memoryview) -> None:
 follow_imports = skip
 follow_imports_for_stubs = true
 [builtins fixtures/dict.pyi]
+
+[case testReturnAnyLambda]
+# flags: --warn-return-any
+from typing import Any, Callable
+
+def cb(f: Callable[[int], int]) -> None: ...
+a: Any
+cb(lambda x: a)  # OK

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2192,3 +2192,6 @@ from typing import Any, Callable
 def cb(f: Callable[[int], int]) -> None: ...
 a: Any
 cb(lambda x: a)  # OK
+
+fn = lambda x: a
+cb(fn)


### PR DESCRIPTION
Fixes #9656

Although it is not clear this is actually a bug, it is kind of inconsistent to say "Returning Any from function declared to return ..." for lambdas, that never have annotations, their types are always inferred, not declared. Also it is a surprisingly popular issue that is a one line fix, so I think we should do it.