### PR TITLE
Simplify suppression of spurious 'unused-ignore's

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2239,7 +2239,6 @@ class State:
         analyzer = SemanticAnalyzerPreAnalysis()
         with self.wrap_context():
             analyzer.visit_file(self.tree, self.xpath, self.id, options)
-        self.manager.errors.set_unreachable_lines(self.xpath, self.tree.unreachable_lines)
         # TODO: Do this while constructing the AST?
         self.tree.names = SymbolTable()
         if not self.tree.is_stub:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -222,9 +222,6 @@ class Errors:
     # (path -> line -> error-codes)
     ignored_lines: dict[str, dict[int, list[str]]]
 
-    # Lines that are statically unreachable (e.g. due to platform/version check).
-    unreachable_lines: dict[str, set[int]]
-
     # Lines on which an error was actually ignored.
     used_ignored_lines: dict[str, dict[int, list[str]]]
 
@@ -280,7 +277,6 @@ class Errors:
         self.import_ctx = []
         self.function_or_member = [None]
         self.ignored_lines = {}
-        self.unreachable_lines = {}
         self.used_ignored_lines = defaultdict(lambda: defaultdict(list))
         self.ignored_files = set()
         self.only_once_messages = set()
@@ -328,9 +324,6 @@ class Errors:
         self.ignored_lines[file] = ignored_lines
         if ignore_all:
             self.ignored_files.add(file)
-
-    def set_unreachable_lines(self, file: str, unreachable_lines: set[int]) -> None:
-        self.unreachable_lines[file] = unreachable_lines
 
     def current_target(self) -> str | None:
         """Retrieves the current target from the associated scope.
@@ -630,8 +623,6 @@ class Errors:
         ignored_lines = self.ignored_lines[file]
         used_ignored_lines = self.used_ignored_lines[file]
         for line, ignored_codes in ignored_lines.items():
-            if line in self.unreachable_lines[file]:
-                continue
             if codes.UNUSED_IGNORE.code in ignored_codes:
                 continue
             used_ignored_codes = used_ignored_lines[line]

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     Optional,
@@ -314,8 +315,6 @@ class MypyFile(SymbolNode):
     # If the value is empty, ignore all errors; otherwise, the list contains all
     # error codes to ignore.
     ignored_lines: dict[int, list[str]]
-    # Lines that are statically unreachable (e.g. due to platform/version check).
-    unreachable_lines: set[int]
     # Is this file represented by a stub file (.pyi)?
     is_stub: bool
     # Is this loaded from the cache and thus missing the actual body of the file?
@@ -348,7 +347,6 @@ class MypyFile(SymbolNode):
             self.ignored_lines = ignored_lines
         else:
             self.ignored_lines = {}
-        self.unreachable_lines = set()
 
         self.path = ""
         self.is_stub = False
@@ -379,6 +377,11 @@ class MypyFile(SymbolNode):
 
     def is_future_flag_set(self, flag: str) -> bool:
         return flag in self.future_import_flags
+
+    def remove_ignored_lines(self, lines: Iterable[int]) -> None:
+        """Called to prevent spurious 'unused-ignore' errors in lines that we skip checking."""
+        for line in lines:
+            self.ignored_lines.pop(line, None)
 
     def serialize(self) -> JsonDict:
         return {

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -986,7 +986,6 @@ def reprocess_nodes(
     manager.errors.set_file_ignored_lines(
         file_node.path, file_node.ignored_lines, options.ignore_errors or state.ignore_all
     )
-    manager.errors.set_unreachable_lines(file_node.path, file_node.unreachable_lines)
 
     targets = set()
     for node in nodes:


### PR DESCRIPTION
In #15164 we've made it so that `# type: ignore`s in "unreachable" code are not flagged as unused.

Here I'm removing the `unreachable_lines` attribute (and related setters). It appears that the same effect can be achieved by pruning the lines from the existing `ignored_lines` dict.

This change also has the advantage (IMO) of directly spelling out what we're doing here. In contrast, when assigning to `unreachable_lines` one has to follow the code to determine what it's being used for. And yes, it's more open-ended to keep "unreachable_lines" but then (a) it's not so simple because not all "unreachabilities" are the same, (b) unused open-end is unwarranted complexity.

## Motivation

While looking at #12409, it became clear to me that the term "unreachable" became somewhat overloaded:
- code that cannot be soundly reached
  ```python
  if False:
    a = 42  # E: Statement is unreachable
  if True:
    raise Exception
    a = 42  # E: Statement is unreachable
  assert False
  a = 42  # E: Statement is unreachable
  ```
- code unreachable on current version/platform
  ```python
  if sys.version_info < (3,):
     a = 42
  if sys.platform == 'foobar':
     a = 42
  assert sys.platform == 'foobar'
  a = 42
  ```

IMO it would be helpful to disambiguate and I suggest we stop referring to the latter as "reachability".