### PR TITLE
Fix dmypy run on Windows

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -623,8 +623,9 @@ def do_daemon(args: argparse.Namespace) -> None:
         options = options_obj.apply_changes(options_dict)
     else:
         options = process_start_options(args.flags, allow_sources=False)
+        options_dict = options.snapshot()
 
-    Server(options, args.status_file, timeout=args.timeout).serve()
+    Server(options, args.status_file, timeout=args.timeout, options_snapshot=options_dict).serve()
 
 
 @action(help_parser)

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -623,9 +623,8 @@ def do_daemon(args: argparse.Namespace) -> None:
         options = options_obj.apply_changes(options_dict)
     else:
         options = process_start_options(args.flags, allow_sources=False)
-        options_dict = options.snapshot()
 
-    Server(options, args.status_file, timeout=args.timeout, options_snapshot=options_dict).serve()
+    Server(options, args.status_file, timeout=args.timeout).serve()
 
 
 @action(help_parser)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -170,17 +170,11 @@ class Server:
     # NOTE: the instance is constructed in the parent process but
     # serve() is called in the grandchild (by daemonize()).
 
-    def __init__(
-        self,
-        options: Options,
-        status_file: str,
-        timeout: int | None = None,
-        options_snapshot: dict[str, object] | None = None,
-    ) -> None:
+    def __init__(self, options: Options, status_file: str, timeout: int | None = None) -> None:
         """Initialize the server with the desired mypy flags."""
         self.options = options
         # Snapshot the options info before we muck with it, to detect changes
-        self.options_snapshot = options_snapshot or options.snapshot()
+        self.options_snapshot = options.snapshot()
         self.timeout = timeout
         self.fine_grained_manager: FineGrainedBuildManager | None = None
 
@@ -336,7 +330,7 @@ class Server:
                         header=argparse.SUPPRESS,
                     )
             # Signal that we need to restart if the options have changed
-            if self.options_snapshot != options.snapshot():
+            if not options.compare_stable(self.options_snapshot):
                 return {"restart": "configuration changed"}
             if __version__ != version:
                 return {"restart": "mypy version changed"}

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -170,11 +170,17 @@ class Server:
     # NOTE: the instance is constructed in the parent process but
     # serve() is called in the grandchild (by daemonize()).
 
-    def __init__(self, options: Options, status_file: str, timeout: int | None = None) -> None:
+    def __init__(
+        self,
+        options: Options,
+        status_file: str,
+        timeout: int | None = None,
+        options_snapshot: dict[str, object] | None = None,
+    ) -> None:
         """Initialize the server with the desired mypy flags."""
         self.options = options
         # Snapshot the options info before we muck with it, to detect changes
-        self.options_snapshot = options.snapshot()
+        self.options_snapshot = options_snapshot or options.snapshot()
         self.timeout = timeout
         self.fine_grained_manager: FineGrainedBuildManager | None = None
 

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -37,6 +37,14 @@ class ErrorCode:
     def __str__(self) -> str:
         return f"<ErrorCode {self.code}>"
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ErrorCode):
+            return False
+        return self.code == other.code
+
+    def __hash__(self) -> int:
+        return hash((self.code,))
+
 
 ATTR_DEFINED: Final = ErrorCode("attr-defined", "Check that attribute exists", "General")
 NAME_DEFINED: Final = ErrorCode("name-defined", "Check that name is defined", "General")

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -373,7 +373,7 @@ class Options:
     def new_semantic_analyzer(self) -> bool:
         return True
 
-    def snapshot(self) -> object:
+    def snapshot(self) -> dict[str, object]:
         """Produce a comparable snapshot of this Option"""
         # Under mypyc, we don't have a __dict__, so we need to do worse things.
         d = dict(getattr(self, "__dict__", ()))
@@ -388,6 +388,7 @@ class Options:
         return f"Options({pprint.pformat(self.snapshot())})"
 
     def apply_changes(self, changes: dict[str, object]) -> Options:
+        # Note: effects of this method *must* be idempotent.
         new_options = Options()
         # Under mypyc, we don't have a __dict__, so we need to do worse things.
         replace_object_state(new_options, self, copy_dict=True)
@@ -412,6 +413,17 @@ class Options:
             new_options.disabled_error_codes.discard(code)
 
         return new_options
+
+    def compare_stable(self, other_snapshot: dict[str, object]) -> bool:
+        """Compare options in a way that is stable for snapshot() -> apply_changes() roundtrip.
+
+        This is needed because apply_changes() has non-trivial effects for some flags, so
+        Options().apply_changes(options.snapshot()) may result in a (slightly) different object.
+        """
+        return (
+            Options().apply_changes(self.snapshot()).snapshot()
+            == Options().apply_changes(other_snapshot).snapshot()
+        )
 
     def build_per_module_cache(self) -> None:
         self._per_module_cache = {}

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -46,6 +46,15 @@ Daemon stopped
 [file foo.py]
 def f(): pass
 
+[case testDaemonRunCombinedOptions]
+$ dmypy run -- foo.py --follow-imports=error --ignore-missing-imports --disable-error-code=type-abstract
+Daemon started
+Success: no issues found in 1 source file
+$ dmypy stop
+Daemon stopped
+[file foo.py]
+def f(): pass
+
 [case testDaemonIgnoreConfigFiles]
 $ dmypy start -- --follow-imports=error
 Daemon started

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -28,6 +28,24 @@ Daemon stopped
 [file foo.py]
 def f(): pass
 
+[case testDaemonRunIgnoreMissingImports]
+$ dmypy run -- foo.py --follow-imports=error --ignore-missing-imports
+Daemon started
+Success: no issues found in 1 source file
+$ dmypy stop
+Daemon stopped
+[file foo.py]
+def f(): pass
+
+[case testDaemonRunErrorCodes]
+$ dmypy run -- foo.py --follow-imports=error --disable-error-code=type-abstract
+Daemon started
+Success: no issues found in 1 source file
+$ dmypy stop
+Daemon stopped
+[file foo.py]
+def f(): pass
+
 [case testDaemonIgnoreConfigFiles]
 $ dmypy start -- --follow-imports=error
 Daemon started


### PR DESCRIPTION
Fixes #10709 

Two changes here:
* Add equality methods to `ErrorCode` because they may appear in options snapshots
* Use stable comparison for option snapshots, since `Options.apply_changes()` does some unrelated things with flags

Both are only relevant on Windows where options may roundtrip as: `options -> snapshot -> pickle -> base64 -> unpickle -> apply_changes`.