### PR TITLE
Remove confusing instance variable example in cheat sheet

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -178,8 +178,6 @@ Classes
    class AuditedBankAccount(BankAccount):
        # You can optionally declare instance variables in the class body
        audit_log: list[str]
-       # This is an instance variable with a default value
-       auditor_name: str = "The Spanish Inquisition"
 
        def __init__(self, account_name: str, initial_balance: int = 0) -> None:
            super().__init__(account_name, initial_balance)


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

The mypy cheat sheet documentation provides an example on how to type instance and class attributes. However, it shows that an attribute with a default value in the class body is an instance variable, and I don't think this is correct. I understand that strings are immutable, which makes the example valid in the end, but I don't believe this is a great practice to define instance variables with a value outside of the init method.

Please let me know if you disagree or would prefer to change the comment rather than deleting the example.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
