### PR TITLE
Additional validation for TypeVar defaults (PEP 696)

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5197,6 +5197,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         return e.type
 
     def visit_type_var_expr(self, e: TypeVarExpr) -> Type:
+        p_default = get_proper_type(e.default)
+        if not (
+            isinstance(p_default, AnyType)
+            and p_default.type_of_any == TypeOfAny.from_omitted_generics
+        ):
+            if not is_subtype(p_default, e.upper_bound):
+                self.chk.fail("TypeVar default must be a subtype of the bound type", e)
+            if e.values and not any(p_default == value for value in e.values):
+                self.chk.fail("TypeVar default must be one of the constraint types", e)
         return AnyType(TypeOfAny.special_form)
 
     def visit_paramspec_expr(self, e: ParamSpecExpr) -> Type:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2493,7 +2493,7 @@ class TypeVarExpr(TypeVarLikeExpr):
 
     __slots__ = ("values",)
 
-    __match_args__ = ("name", "values", "upper_bound")
+    __match_args__ = ("name", "values", "upper_bound", "default")
 
     # Value restriction: only types in the list are valid as values. If the
     # list is empty, there is no restriction.
@@ -2541,7 +2541,7 @@ class TypeVarExpr(TypeVarLikeExpr):
 class ParamSpecExpr(TypeVarLikeExpr):
     __slots__ = ()
 
-    __match_args__ = ("name", "upper_bound")
+    __match_args__ = ("name", "upper_bound", "default")
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_paramspec_expr(self)
@@ -2575,7 +2575,7 @@ class TypeVarTupleExpr(TypeVarLikeExpr):
 
     tuple_fallback: mypy.types.Instance
 
-    __match_args__ = ("name", "upper_bound")
+    __match_args__ = ("name", "upper_bound", "default")
 
     def __init__(
         self,

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -72,3 +72,12 @@ Ts1 = TypeVarTuple("Ts1", default=2) # E: The default argument to TypeVarTuple m
 Ts2 = TypeVarTuple("Ts2", default=int)  # E: The default argument to TypeVarTuple must be an Unpacked tuple
 Ts3 = TypeVarTuple("Ts3", default=Tuple[int])  # E: The default argument to TypeVarTuple must be an Unpacked tuple
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarDefaultsInvalid2]
+from typing import TypeVar, List, Union
+
+T1 = TypeVar("T1", bound=str, default=int)  # E: TypeVar default must be a subtype of the bound type
+T2 = TypeVar("T2", bound=List[str], default=List[int])  # E: TypeVar default must be a subtype of the bound type
+T3 = TypeVar("T3", int, str, default=bytes)  # E: TypeVar default must be one of the constraint types
+T4 = TypeVar("T4", int, str, default=Union[int, str])  # E: TypeVar default must be one of the constraint types
+T5 = TypeVar("T5", float, str, default=int)  # E: TypeVar default must be one of the constraint types


### PR DESCRIPTION
Check that `default` type is a subtype of `bound` or one of the constraint types.

Add `default` to nodes `__match_args__`. Missed that initially.

Ref: #14851