### PR TITLE
[mypyc] Use C99 compound literals for undefined tuple values

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -51,7 +51,7 @@ from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FuncIR
 from mypyc.ir.module_ir import ModuleIR, ModuleIRs, deserialize_modules
 from mypyc.ir.ops import DeserMaps, LoadLiteral
-from mypyc.ir.rtypes import RTuple, RType
+from mypyc.ir.rtypes import RType
 from mypyc.irbuild.main import build_ir
 from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.prepare import load_type_map
@@ -1052,11 +1052,7 @@ class GroupGenerator:
     def final_definition(self, module: str, name: str, typ: RType, emitter: Emitter) -> str:
         static_name = emitter.static_name(name, module)
         # Here we rely on the fact that undefined value and error value are always the same
-        if isinstance(typ, RTuple):
-            # We need to inline because initializer must be static
-            undefined = "{{ {} }}".format("".join(emitter.tuple_undefined_value_helper(typ)))
-        else:
-            undefined = emitter.c_undefined_value(typ)
+        undefined = emitter.c_initializer_undefined_value(typ)
         return f"{emitter.ctype_spaced(typ)}{static_name} = {undefined};"
 
     def declare_static_pyobject(self, identifier: str, emitter: Emitter) -> None:

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -41,7 +41,6 @@ typedef struct tuple_T3OOO {
     PyObject *f1;
     PyObject *f2;
 } tuple_T3OOO;
-static tuple_T3OOO tuple_undefined_T3OOO = { NULL, NULL, NULL };
 #endif
 
 // Our return tuple wrapper for dictionary iteration helper.
@@ -52,7 +51,6 @@ typedef struct tuple_T3CIO {
     CPyTagged f1;  // Last dict offset
     PyObject *f2;  // Next dictionary key or value
 } tuple_T3CIO;
-static tuple_T3CIO tuple_undefined_T3CIO = { 2, CPY_INT_TAG, NULL };
 #endif
 
 // Same as above but for both key and value.
@@ -64,7 +62,6 @@ typedef struct tuple_T4CIOO {
     PyObject *f2;  // Next dictionary key
     PyObject *f3;  // Next dictionary value
 } tuple_T4CIOO;
-static tuple_T4CIOO tuple_undefined_T4CIOO = { 2, CPY_INT_TAG, NULL, NULL };
 #endif
 
 

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -4,7 +4,7 @@ import unittest
 
 from mypyc.codegen.emit import Emitter, EmitterContext
 from mypyc.ir.ops import BasicBlock, Register, Value
-from mypyc.ir.rtypes import int_rprimitive
+from mypyc.ir.rtypes import RTuple, bool_rprimitive, int_rprimitive, str_rprimitive
 from mypyc.namegen import NameGenerator
 
 
@@ -48,4 +48,22 @@ class TestEmitter(unittest.TestCase):
             == """\
 CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
                   21, 22, 23, 24, 25, 26, 27, 28, 29] */\n"""
+        )
+
+    def test_emit_undefined_value_for_simple_type(self) -> None:
+        emitter = Emitter(self.context, {})
+        assert emitter.c_undefined_value(int_rprimitive) == "CPY_INT_TAG"
+        assert emitter.c_undefined_value(str_rprimitive) == "NULL"
+        assert emitter.c_undefined_value(bool_rprimitive) == "2"
+
+    def test_emit_undefined_value_for_tuple(self) -> None:
+        emitter = Emitter(self.context, {})
+        assert (
+            emitter.c_undefined_value(RTuple([str_rprimitive, int_rprimitive, bool_rprimitive]))
+            == "(tuple_T3OIC) { NULL, CPY_INT_TAG, 2 }"
+        )
+        assert emitter.c_undefined_value(RTuple([str_rprimitive])) == "(tuple_T1O) { NULL }"
+        assert (
+            emitter.c_undefined_value(RTuple([RTuple([str_rprimitive]), bool_rprimitive]))
+            == "(tuple_T2T1OC) { { NULL }, 2 }"
         )


### PR DESCRIPTION
This simplifies things a bit. All the C compilers we care about should support this.

This will make things easier once we support more types represented as C structs.

I expect this to have no measurable impact on performance.