### PR TITLE
Delete a ProperType join hack

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -29,7 +29,6 @@ from mypy.types import (
     Parameters,
     ParamSpecType,
     PartialType,
-    PlaceholderType,
     ProperType,
     TupleType,
     Type,

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -246,14 +246,6 @@ def join_types(s: Type, t: Type, instance_joiner: InstanceJoiner | None = None) 
     if isinstance(s, UninhabitedType) and not isinstance(t, UninhabitedType):
         s, t = t, s
 
-    # We shouldn't run into PlaceholderTypes here, but in practice we can encounter them
-    # here in the presence of undefined names
-    if isinstance(t, PlaceholderType) and not isinstance(s, PlaceholderType):
-        # mypyc does not allow switching the values like above.
-        return s.accept(TypeJoinVisitor(t))
-    elif isinstance(t, PlaceholderType):
-        return AnyType(TypeOfAny.from_error)
-
     # Meets/joins require callable type normalization.
     s, t = normalize_callables(s, t)
 


### PR DESCRIPTION
The tests added with this piece of code now pass even without it. It looks like the crash was properly fixed by https://github.com/python/mypy/pull/13371