### PR TITLE
[mypyc] Add Python 3.12 feature macro

### DIFF
--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -69,4 +69,7 @@ static inline CPyTagged CPyTagged_ShortFromSsize_t(Py_ssize_t x) {
     return x << 1;
 }
 
+// Are we targeting Python 3.12 or newer?
+#define CPY_3_12_FEATURES (PY_VERSION_HEX >= 0x030c0000)
+
 #endif


### PR DESCRIPTION
It's currently unused but I have other PRs that will need this.

We can later make this more general and support things like "are we running on Python 3.12 beta 2 or later", but this seems good enough for now.