### PR TITLE
[mypyc] Don't use _PyErr_ChainExceptions on 3.12, since it's deprecated

### DIFF
--- a/mypyc/lib-rt/exc_ops.c
+++ b/mypyc/lib-rt/exc_ops.c
@@ -230,7 +230,11 @@ void CPy_AddTraceback(const char *filename, const char *funcname, int line, PyOb
     return;
 
 error:
+#if CPY_3_12_FEATURES
+    _PyErr_ChainExceptions1(exc);
+#else
     _PyErr_ChainExceptions(exc, val, tb);
+#endif
 }
 
 CPy_NOINLINE


### PR DESCRIPTION
See https://github.com/python/cpython/pull/102935.

Work on https://github.com/mypyc/mypyc/issues/995.