### PR TITLE
[mypyc] Fix generators on Python 3.12

### DIFF
--- a/mypyc/lib-rt/exc_ops.c
+++ b/mypyc/lib-rt/exc_ops.c
@@ -24,6 +24,12 @@ void CPy_Reraise(void) {
 }
 
 void CPyErr_SetObjectAndTraceback(PyObject *type, PyObject *value, PyObject *traceback) {
+    if (!PyType_Check(type) && value == Py_None) {
+        // The first argument must be an exception instance
+        value = type;
+        type = (PyObject *)Py_TYPE(value);
+    }
+
     // Set the value and traceback of an error. Because calling
     // PyErr_Restore takes away a reference to each object passed in
     // as an argument, we manually increase the reference count of


### PR DESCRIPTION
I think we relied on undocumented behavior on older Python versions. Now it works consistently across all supported Python versions.

Work on mypyc/mypyc#995.