### PR TITLE
meta tests: fix flake

### DIFF
--- a/mypy/test/meta/test_parse_data.py
+++ b/mypy/test/meta/test_parse_data.py
@@ -5,6 +5,7 @@ but to ensure we maintain a basic level of ergonomics for mypy contributors.
 import subprocess
 import sys
 import textwrap
+import uuid
 from pathlib import Path
 
 from mypy.test.config import test_data_prefix
@@ -18,7 +19,7 @@ class ParseTestDataSuite(Suite):
     def _run_pytest(self, data_suite: str) -> str:
         p_test_data = Path(test_data_prefix)
         p_root = p_test_data.parent.parent
-        p = p_test_data / "check-__fixture__.test"
+        p = p_test_data / f"check-meta-{uuid.uuid4()}.test"
         assert not p.exists()
         try:
             p.write_text(data_suite)

--- a/mypy/test/meta/test_update_data.py
+++ b/mypy/test/meta/test_update_data.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 import sys
 import textwrap
+import uuid
 from pathlib import Path
 
 from mypy.test.config import test_data_prefix
@@ -21,7 +22,7 @@ class UpdateDataSuite(Suite):
         """
         p_test_data = Path(test_data_prefix)
         p_root = p_test_data.parent.parent
-        p = p_test_data / "check-__fixture__.test"
+        p = p_test_data / f"check-meta-{uuid.uuid4()}.test"
         assert not p.exists()
         try:
             p.write_text(textwrap.dedent(data_suite).lstrip())


### PR DESCRIPTION
Since tests are parallelized, the temporary test name must be unique.