### PR TITLE
Add pip as test requirement to support editable installs in tests with PEP 660

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,6 +8,7 @@ flake8-bugbear==23.3.23; python_version >= "3.8" # must match version in .pre-co
 flake8-noqa==1.3.1; python_version >= "3.8"      # must match version in .pre-commit-config.yaml
 isort[colors]==5.12.0; python_version >= "3.8"   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
+pip>=21.3.1
 pre-commit
 pre-commit-hooks==4.4.0
 psutil>=4.0


### PR DESCRIPTION
Pip version `21.3` is required to support editable installs with PEP 660. Currently, the mypy wheel build fails for `cp38-macosx_x86_64` with the following error:

```
 ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode: /Users/runner/work/mypy_mypyc-wheels/mypy_mypyc-wheels/mypy/test-data/packages/typedpkg
 (A "pyproject.toml" file was found, but editable mode currently requires a setuptools-based build.)
```
https://github.com/mypyc/mypy_mypyc-wheels/actions/runs/5323325694/jobs/9640999946#step:4:6103

https://pip.pypa.io/en/stable/news/#id232