### PR TITLE
Bump typing_extensions dependency

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,5 +1,5 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
-typing_extensions>=3.10
+typing_extensions>=4.1.0
 mypy_extensions>=1.0.0
 typed_ast>=1.4.0,<2; python_version<'3.8'
 tomli>=1.1.0; python_version<'3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "setuptools >= 40.6.2",
     "wheel >= 0.30.0",
     # the following is from mypy-requirements.txt
-    "typing_extensions>=3.10",
+    "typing_extensions>=4.1.0",
     "mypy_extensions>=1.0.0",
     "typed_ast>=1.4.0,<2; python_version<'3.8'",
     "tomli>=1.1.0; python_version<'3.11'",

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
     # When changing this, also update mypy-requirements.txt.
     install_requires=[
         "typed_ast >= 1.4.0, < 2; python_version<'3.8'",
-        "typing_extensions>=4.0.1",
+        "typing_extensions>=4.1.0",
         "mypy_extensions >= 1.0.0",
         "tomli>=1.1.0; python_version<'3.11'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
     # When changing this, also update mypy-requirements.txt.
     install_requires=[
         "typed_ast >= 1.4.0, < 2; python_version<'3.8'",
-        "typing_extensions>=3.10",
+        "typing_extensions>=4.0.1",
         "mypy_extensions >= 1.0.0",
         "tomli>=1.1.0; python_version<'3.11'",
     ],


### PR DESCRIPTION
Mypy started using `typing_extensions.Self` which is only available in `>=4.0.0`.
https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-401-november-30-2021

Fixes: #15487 
