### PR TITLE
Exclude the same special attributes from Protocol as CPython

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2801,34 +2801,6 @@ class TempNode(Expression):
         return visitor.visit_temp_node(self)
 
 
-# Special attributes not collected as protocol members by Python 3.12
-# See typing.EXCLUDED_ATTRIBUTES and typing._get_protocol_attrs
-EXCLUDED_ATTRIBUTES = frozenset(
-    {
-        "__parameters__",
-        "__orig_bases__",
-        "__orig_class__",
-        "_is_protocol",
-        "_is_runtime_protocol",
-        "__protocol_attrs__",
-        "__callable_proto_members_only__",
-        "__type_params__",
-        "__abstractmethods__",
-        "__annotations__",
-        "__dict__",
-        "__doc__",
-        "__init__",
-        "__module__",
-        "__new__",
-        "__slots__",
-        "__subclasshook__",
-        "__weakref__",
-        "__class_getitem__",
-        "_MutableMapping__marker",
-    }
-)
-
-
 class TypeInfo(SymbolNode):
     """The type structure of a single class.
 
@@ -3045,6 +3017,24 @@ class TypeInfo(SymbolNode):
         "is_intersection",
     ]
 
+    # Special attributes not collected as protocol members by Python 3.12
+    # See typing._SPECIAL_NAMES
+    EXCLUDED_ATTRIBUTES: Final = frozenset(
+        {
+            "__abstractmethods__",
+            "__annotations__",
+            "__dict__",
+            "__doc__",
+            "__init__",
+            "__module__",
+            "__new__",
+            "__slots__",
+            "__subclasshook__",
+            "__weakref__",
+            "__class_getitem__",  # Since Python 3.9
+        }
+    )
+
     def __init__(self, names: SymbolTable, defn: ClassDef, module_name: str) -> None:
         """Initialize a TypeInfo."""
         super().__init__()
@@ -3143,7 +3133,7 @@ class TypeInfo(SymbolNode):
                     if isinstance(node.node, (TypeAlias, TypeVarExpr, MypyFile)):
                         # These are auxiliary definitions (and type aliases are prohibited).
                         continue
-                    if name in EXCLUDED_ATTRIBUTES:
+                    if name in self.EXCLUDED_ATTRIBUTES:
                         continue
                     members.add(name)
         return sorted(list(members))

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2801,6 +2801,34 @@ class TempNode(Expression):
         return visitor.visit_temp_node(self)
 
 
+# Special attributes not collected as protocol members by Python 3.12
+# See typing.EXCLUDED_ATTRIBUTES and typing._get_protocol_attrs
+EXCLUDED_ATTRIBUTES = frozenset(
+    {
+        "__parameters__",
+        "__orig_bases__",
+        "__orig_class__",
+        "_is_protocol",
+        "_is_runtime_protocol",
+        "__protocol_attrs__",
+        "__callable_proto_members_only__",
+        "__type_params__",
+        "__abstractmethods__",
+        "__annotations__",
+        "__dict__",
+        "__doc__",
+        "__init__",
+        "__module__",
+        "__new__",
+        "__slots__",
+        "__subclasshook__",
+        "__weakref__",
+        "__class_getitem__",
+        "_MutableMapping__marker",
+    }
+)
+
+
 class TypeInfo(SymbolNode):
     """The type structure of a single class.
 
@@ -3114,6 +3142,8 @@ class TypeInfo(SymbolNode):
                 for name, node in base.names.items():
                     if isinstance(node.node, (TypeAlias, TypeVarExpr, MypyFile)):
                         # These are auxiliary definitions (and type aliases are prohibited).
+                        continue
+                    if name in EXCLUDED_ATTRIBUTES:
                         continue
                     members.add(name)
         return sorted(list(members))

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2801,6 +2801,25 @@ class TempNode(Expression):
         return visitor.visit_temp_node(self)
 
 
+# Special attributes not collected as protocol members by Python 3.12
+# See typing._SPECIAL_NAMES
+EXCLUDED_PROTOCOL_ATTRIBUTES: Final = frozenset(
+    {
+        "__abstractmethods__",
+        "__annotations__",
+        "__dict__",
+        "__doc__",
+        "__init__",
+        "__module__",
+        "__new__",
+        "__slots__",
+        "__subclasshook__",
+        "__weakref__",
+        "__class_getitem__",  # Since Python 3.9
+    }
+)
+
+
 class TypeInfo(SymbolNode):
     """The type structure of a single class.
 
@@ -3017,24 +3036,6 @@ class TypeInfo(SymbolNode):
         "is_intersection",
     ]
 
-    # Special attributes not collected as protocol members by Python 3.12
-    # See typing._SPECIAL_NAMES
-    EXCLUDED_ATTRIBUTES: Final = frozenset(
-        {
-            "__abstractmethods__",
-            "__annotations__",
-            "__dict__",
-            "__doc__",
-            "__init__",
-            "__module__",
-            "__new__",
-            "__slots__",
-            "__subclasshook__",
-            "__weakref__",
-            "__class_getitem__",  # Since Python 3.9
-        }
-    )
-
     def __init__(self, names: SymbolTable, defn: ClassDef, module_name: str) -> None:
         """Initialize a TypeInfo."""
         super().__init__()
@@ -3133,7 +3134,7 @@ class TypeInfo(SymbolNode):
                     if isinstance(node.node, (TypeAlias, TypeVarExpr, MypyFile)):
                         # These are auxiliary definitions (and type aliases are prohibited).
                         continue
-                    if name in self.EXCLUDED_ATTRIBUTES:
+                    if name in EXCLUDED_PROTOCOL_ATTRIBUTES:
                         continue
                     members.add(name)
         return sorted(list(members))

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2789,6 +2789,42 @@ class A(Protocol):
 
 [builtins fixtures/tuple.pyi]
 
+[case testProtocolSlotsIsNotProtocolMember]
+# https://github.com/python/mypy/issues/11884
+from typing import Protocol
+
+class Foo(Protocol):
+    __slots__ = ()
+class NoSlots:
+    pass
+class EmptySlots:
+    __slots__ = ()
+class TupleSlots:
+    __slots__ = ('x', 'y')
+class StringSlots:
+    __slots__ = 'x y'
+def foo(f: Foo):
+    pass
+
+# All should pass:
+foo(NoSlots())
+foo(EmptySlots())
+foo(TupleSlots())
+foo(StringSlots())
+[builtins fixtures/tuple.pyi]
+
+[case testProtocolSlotsAndRuntimeCheckable]
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class Foo(Protocol):
+    __slots__ = ()
+class Bar:
+    pass
+issubclass(Bar, Foo)  # Used to be an error, when `__slots__` counted as a protocol member
+[builtins fixtures/isinstance.pyi]
+[typing fixtures/typing-full.pyi]
+
 [case testNoneVsProtocol]
 # mypy: strict-optional
 from typing_extensions import Protocol

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2825,6 +2825,29 @@ issubclass(Bar, Foo)  # Used to be an error, when `__slots__` counted as a proto
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
 
+
+[case testProtocolWithClassGetItem]
+# https://github.com/python/mypy/issues/11886
+from typing import Any, Iterable, Protocol, Union
+
+class B:
+    ...
+
+class C:
+    def __class_getitem__(cls, __item: Any) -> Any:
+        ...
+
+class SupportsClassGetItem(Protocol):
+    __slots__: Union[str, Iterable[str]] = ()
+    def __class_getitem__(cls, __item: Any) -> Any:
+        ...
+
+b1: SupportsClassGetItem = B()
+c1: SupportsClassGetItem = C()
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+
 [case testNoneVsProtocol]
 # mypy: strict-optional
 from typing_extensions import Protocol

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2803,6 +2803,10 @@ class TupleSlots:
     __slots__ = ('x', 'y')
 class StringSlots:
     __slots__ = 'x y'
+class InitSlots:
+    __slots__ = ('x',)
+    def __init__(self) -> None:
+        self.x = None
 def foo(f: Foo):
     pass
 
@@ -2811,6 +2815,7 @@ foo(NoSlots())
 foo(EmptySlots())
 foo(TupleSlots())
 foo(StringSlots())
+foo(InitSlots())
 [builtins fixtures/tuple.pyi]
 
 [case testProtocolSlotsAndRuntimeCheckable]


### PR DESCRIPTION
Fixes #11884
Fixes #11886
Tests have been added for these cases.

PR is based on #11885
@sobolevn

CPython holds a collection of attributes which it excludes from protocols. [It can be viewed here](https://github.com/python/cpython/blob/fc32522b081c895f3798e4a16788b800cff08166/Lib/typing.py#L1672-L1693). This list isn't a public part of the API so I copied it into Mypy.  Using this collection directly from Python would cause version-based problems anyways.

I'm not sure about where `EXCLUDED_ATTRIBUTES` should go in Mypy.  Different versions of CPython also exclude different things and I'm not sure how to handle that in Mypy's source.  `__class_getitem__` was added to this collection in Python 3.9 for example. This is using the latest version of the collection which is likely to change again in the future, so maybe a new test could check for that happening.

I wanted to add the PathLike example from #11886 but couldn't figure out how to include `from types import GenericAlias` in a test.

#11886 had a debate over what should be included or excluded.  This PR chooses to refer to CPython instead of arguing over each item.  A debase can still be had, but I think this collection is a better starting point. I chose to use the items only from `typing._SPECIAL_NAMES` as the others looked like CPython internals.

Also fixes #11013

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->

