### PR TITLE
Fix PEP 561 - editable install - test case

### DIFF
--- a/mypy/test/testpep561.py
+++ b/mypy/test/testpep561.py
@@ -46,9 +46,19 @@ def virtualenv(python_executable: str = sys.executable) -> Iterator[tuple[str, s
             yield venv_dir, os.path.abspath(os.path.join(venv_dir, "bin", "python"))
 
 
-def upgrade_pip(python_executable: str, version_str: str) -> None:
-    """Install a newer pip version."""
-    install_cmd = [python_executable, "-m", "pip", "install", f"pip{version_str}"]
+def upgrade_pip(python_executable: str) -> None:
+    """Install pip>=21.3.1. Required for editable installs with PEP 660."""
+    if (
+        sys.version_info >= (3, 11)
+        or (3, 10, 3) <= sys.version_info < (3, 11)
+        or (3, 9, 11) <= sys.version_info < (3, 10)
+        or (3, 8, 13) <= sys.version_info < (3, 9)
+    ):
+        # Skip for more recent Python releases which come with pip>=21.3.1
+        # out of the box - for performance reasons.
+        return
+
+    install_cmd = [python_executable, "-m", "pip", "install", "pip>=21.3.1"]
     try:
         with filelock.FileLock(pip_lock, timeout=pip_timeout):
             proc = subprocess.run(install_cmd, capture_output=True, env=os.environ)
@@ -107,7 +117,7 @@ def test_pep561(testcase: DataDrivenTestCase) -> None:
         venv_dir, python_executable = venv
         if editable:
             # Editable installs with PEP 660 require pip>=21.3
-            upgrade_pip(python_executable, ">=21.3.1")
+            upgrade_pip(python_executable)
         for pkg in pkgs:
             install_package(pkg, python_executable, editable)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,6 @@ black==23.3.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
 isort[colors]==5.12.0; python_version >= "3.8"   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
-pip>=21.3.1
 pre-commit
 pre-commit-hooks==4.4.0
 psutil>=4.0


### PR DESCRIPTION
This reverts #15482. Upgrading pip was the right idea, however the test case creates a new temporary venv which still uses the original pip version. Added a new call to upgrade pip to `pip>=21.3.1` for editable installs.

This does indeed fix the issue. I was able to verify it with Github Actions on my fork.

/CC: @hauntsaninja