### PR TITLE
Use `()` for `get_function_sig_hook` docs

### DIFF
--- a/docs/source/extending_mypy.rst
+++ b/docs/source/extending_mypy.rst
@@ -159,7 +159,7 @@ This hook will be also called for instantiation of classes.
 This is a good choice if the return type is too complex
 to be expressed by regular python typing.
 
-**get_function_signature_hook** is used to adjust the signature of a function.
+**get_function_signature_hook()** is used to adjust the signature of a function.
 
 **get_method_hook()** is the same as ``get_function_hook()`` but for methods
 instead of module level functions.


### PR DESCRIPTION
All other hooks have `()`, so adding it will make the docs consistent.

Right now it is:
<img width="729" alt="Снимок экрана 2023-06-23 в 06 49 45" src="https://github.com/python/mypy/assets/4660275/492ec472-eb28-432f-a5b2-f69980c1a094">
