### PR TITLE
Remove `py` and `pytest-forked` test dependencies

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,6 @@ pytest>=6.2.4
 pytest-xdist>=1.34.0
 pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0
-py>=1.5.2
 ruff==0.0.272  # must match version in .pre-commit-config.yaml
 setuptools>=65.5.1
 six

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -11,7 +11,6 @@ psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10
 pytest>=6.2.4
 pytest-xdist>=1.34.0
-pytest-forked>=1.3.0,<2.0.0
 pytest-cov>=2.10.0
 ruff==0.0.272  # must match version in .pre-commit-config.yaml
 setuptools>=65.5.1


### PR DESCRIPTION
We don't use either of these in our own code at all. Neither of them should be needed in 2023.

py used to be a dependency of pytest but no longer is. It was added to test-requirements.txt 6 years ago in order to pin a specific version to fix an issue where some tests were failing: https://github.com/python/mypy/commit/5168c2580ff81ba114776936bdeaf5d81812c34a and https://github.com/python/mypy/commit/ad6dd4ed6923a5eb6227fc9bfcb8e30a5e0fde53.

pytest-forked used to be a dependency of pytest-xdist, but no longer is. It was added to test-requirements.txt` 4 years ago in order to pin a specific version to fix builds on macOS: https://github.com/python/mypy/commit/e006b94e097184451e6baf9b9c55e56176728ab8.