### PR TITLE
Remove special handling of `kw_only` in `dataclass` plugin serialization

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -158,8 +158,6 @@ class DataclassAttribute:
         cls, info: TypeInfo, data: JsonDict, api: SemanticAnalyzerPluginInterface
     ) -> DataclassAttribute:
         data = data.copy()
-        if data.get("kw_only") is None:
-            data["kw_only"] = False
         typ = deserialize_and_fixup_type(data.pop("type"), api)
         return cls(type=typ, info=info, **data)
 


### PR DESCRIPTION
It is not needed, because it is always serialized as `bool` and is always present.

It was added a long time ago in https://github.com/python/mypy/pull/10867 as a compat layer. But, since then we've added at least one `is_neither_frozen_nor_nonfrozen` attribute that is serialized / deserialized in a common way.

So, let's remove this hack for good.
