### PR TITLE
Unbreak CI

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,7 +9,7 @@ pre-commit
 pre-commit-hooks==4.4.0
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10
-pytest>=6.2.4
+pytest>=6.2.4,<7.4.0
 pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
 ruff==0.0.272  # must match version in .pre-commit-config.yaml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,6 +9,7 @@ pre-commit
 pre-commit-hooks==4.4.0
 psutil>=4.0
 # pytest 6.2.3 does not support Python 3.10
+# TODO: fix use of removed private APIs so we can use the latest pytest
 pytest>=6.2.4,<7.4.0
 pytest-xdist>=1.34.0
 pytest-cov>=2.10.0


### PR DESCRIPTION
pytest 7.4.0 was just released, and our CI on `master` is very red as a result. Looks like we're using a private API that we shouldn't be: https://github.com/python/mypy/pull/15501#issuecomment-1604177495. For now let's just pin to pytest <7.4.0.

https://pypi.org/project/pytest/7.4.0/
