### PR TITLE
Fix error location for class patterns

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -468,7 +468,7 @@ class PatternChecker(PatternVisitor[PatternType]):
                 name = type_info.type.str_with_options(self.options)
             else:
                 name = type_info.name
-            self.msg.fail(message_registry.CLASS_PATTERN_TYPE_REQUIRED.format(name), o.class_ref)
+            self.msg.fail(message_registry.CLASS_PATTERN_TYPE_REQUIRED.format(name), o)
             return self.early_non_match()
 
         new_type, rest_type = self.chk.conditional_types_with_intersection(

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1958,3 +1958,23 @@ def redefinition_bad(a: int):
             ...
 
 [builtins fixtures/primitives.pyi]
+
+[case testPatternMatchingClassPatternLocation]
+# See https://github.com/python/mypy/issues/15496
+from some_missing_lib import DataFrame, Series  # type: ignore[import]
+from typing import TypeVar
+
+T = TypeVar("T", Series, DataFrame)
+
+def f(x: T) -> None:
+    match x:
+        case Series() | DataFrame():  # type: ignore[misc]
+            pass
+
+def f2(x: T) -> None:
+    match x:
+        case Series():  # type: ignore[misc]
+            pass
+        case DataFrame():  # type: ignore[misc]
+            pass
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Now it uses the same pattern for `.fail` as similar places:
- https://github.com/python/mypy/blob/2d8ad8ef240df262be80d9359e9f5892ea1f9ad3/mypy/checkpattern.py#L459
- https://github.com/python/mypy/blob/2d8ad8ef240df262be80d9359e9f5892ea1f9ad3/mypy/checkpattern.py#L493
- etc

Test proves that this problem is now fixed.
Closes #15496