### PR TITLE
Revert "Fix spurious errors on builtins.open (#15161)"

### DIFF
--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -75,7 +75,6 @@ core_modules: Final = [
     "abc",
     "collections",
     "collections.abc",
-    "typing_extensions",
 ]
 
 


### PR DESCRIPTION
This reverts commit 66602fcde3468d7a284aa89cb280d448f454e07b.

For https://github.com/python/typeshed/pull/10351