### PR TITLE
Add ReadTheDocs configuration files

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/source/conf.py
+
+formats: [pdf, htmlzip, epub]
+
+python:
+   install:
+   - requirements: docs/requirements-docs.txt

--- a/mypyc/.readthedocs.yaml
+++ b/mypyc/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: mypyc/doc/conf.py
+
+formats: [pdf, htmlzip, epub]
+
+python:
+   install:
+   - requirements: docs/requirements-docs.txt


### PR DESCRIPTION
[ReadTheDocs will stop building projects without a configuration file in September](https://blog.readthedocs.com/migrate-configuration-v2/). Let's migrate early. Not sure how to test this, frankly. 

@hauntsaninja I'll need your help as I don't have admin access to the mypy RTD project. Once this is merged, you'll have to set this field for mypy.
![image](https://github.com/python/mypy/assets/63936253/f5c74929-b459-4e46-a73b-03d6fd6881aa)

(I can set this for mypyc myself.)