### PR TITLE
Improve ruff config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
           # We also run these checks with pre-commit in CI,
           # but it's useful to run them with tox too,
           # to ensure the tox env works as expected
-        - name: Formatting with Black + isort and code style with ruff
+        - name: Formatting and code style with Black + ruff
           python: '3.10'
           arch: x64
           os: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,6 @@ repos:
     rev: 23.3.0  # must match test-requirements.txt
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0  # must match test-requirements.txt
-    hooks:
-      - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.272  # must match test-requirements.txt
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,4 @@ repos:
     rev: v0.0.272  # must match test-requirements.txt
     hooks:
       - id: ruff
+        args: [--exit-non-zero-on-fix]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,11 +88,8 @@ pytest -n0 -k 'test_name'
 # Run all test cases in the "test-data/unit/check-dataclasses.test" file
 pytest mypy/test/testcheck.py::TypeCheckSuite::check-dataclasses.test
 
-# Run the linter
-ruff .
-
-# Run formatters
-black . && isort .
+# Run the formatters and linters
+python runtests.py lint
 ```
 
 For an in-depth guide on running and writing tests,
@@ -153,10 +150,6 @@ to review, which helps your pull request get merged quickly!  Standard
 advice about good pull requests for open-source projects applies; we
 have [our own writeup](https://github.com/python/mypy/wiki/Good-Pull-Request)
 of this advice.
-
-We are using `black` and `isort` to enforce a consistent coding style.
-Run `black . && isort .` before your commits, otherwise you would receive
-a CI failure.
 
 Also, do not squash your commits after you have submitted a pull request, as this
 erases context during review. We will squash commits when the pull request is merged.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mypy: Static Typing for Python
 [![Chat at https://gitter.im/python/typing](https://badges.gitter.im/python/typing.svg)](https://gitter.im/python/typing?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
+[![Linting: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Got a question?
 ---------------

--- a/mypy/copytype.py
+++ b/mypy/copytype.py
@@ -28,7 +28,7 @@ from mypy.types import (
 )
 
 # type_visitor needs to be imported after types
-from mypy.type_visitor import TypeVisitor  # isort: skip
+from mypy.type_visitor import TypeVisitor  # ruff: isort: skip
 
 
 def copy_type(t: ProperType) -> ProperType:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ ignore = [
   "E741",  # Ambiguous variable name
 ]
 
+unfixable = [
+    "F841",  # unused variable. ruff keeps the call, but mostly we want to get rid of it all
+    "F601",  # automatic fix might obscure issue
+    "F602",  # automatic fix might obscure issue
+    "B018",  # automatic fix might obscure issue
+]
+
 extend-exclude = [
   "@*",
   # Sphinx configuration is irrelevant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,29 +27,18 @@ force-exclude = '''
 ^/test-data
 '''
 
-[tool.isort]
-py_version = 37
-profile = "black"
-line_length = 99
-combine_as_imports = true
-skip_gitignore = true
-extra_standard_library = ["typing_extensions"]
-skip_glob = [
-    "mypy/typeshed/*",
-    "mypyc/test-data/*",
-    "test-data/*",
-]
-
 [tool.ruff]
 line-length = 99
 target-version = "py37"
+fix = true
 
 select = [
-  "E",       # pycoderstyle (error)
+  "E",       # pycodestyle (error)
   "F",       # pyflakes
   "B",       # flake8-bugbear
+  "I",       # isort
   "RUF100",  # Unused noqa comments
-  "PGH004"  # blanket noqa comments
+  "PGH004"   # blanket noqa comments
 ]
 
 ignore = [
@@ -76,3 +65,7 @@ extend-exclude = [
   # typeshed has its own .pyi-specific configuration
   "mypy/typeshed/*",
 ]
+
+[tool.ruff.isort]
+combine-as-imports = true
+extra-standard-library = ["typing_extensions"]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,6 @@
 attrs>=18.0
 black==23.3.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
-isort[colors]==5.12.0; python_version >= "3.8"   # must match version in .pre-commit-config.yaml
 lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 pre-commit
 pre-commit-hooks==4.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ commands =
 [testenv:lint]
 description = check the code style
 skip_install = true
+deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:type]


### PR DESCRIPTION
- Add `fix = true` to `pyproject.toml`. This means ruff will apply autofixes when possible if `ruff .` is run (and will apply autofixes to PRs).
- Remove isort as a test dependency; just use ruff instead. It has the same import-sorting style, is faster, and requires less configuration.
- Remove an outdated paragraph in `CONTRIBUTING.md` about how you'll get a CI failure if you don't run black and isort before filing a PR. This is no longer true since we switched to using pre-commit.ci.