### PR TITLE
Remove `--extra-checks` from `strict` mode

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -828,7 +828,7 @@ def process_options(
     add_invertible_flag(
         "--extra-checks",
         default=False,
-        strict_flag=True,
+        strict_flag=False,
         help="Enable additional checks that are technically correct but may be impractical "
         "in real code. For example, this prohibits partial overlap in TypedDict updates, "
         "and makes arguments prepended via Concatenate positional-only",


### PR DESCRIPTION
`--extra-checks` was added in #15425 and included in `strict` mode. However, as the help text says it might be impractical in real code. Thus I don't think it should be included in `strict` mode.
```txt
Enable additional checks that are technically correct but may be impractical in real code.
```

_Of note, `--strict-concatenate` which this one replaces wasn't included in `strict` mode either._

/CC: @ilevkivskyi 