### PR TITLE
Add missing docs for error codes

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -255,6 +255,32 @@ mypy generates an error if it thinks that an expression is redundant.
         [i for i in range(x) if isinstance(i, int)]
 
 
+.. _code-possibly-undefined:
+
+Warn about variables that are defined only in some execution paths [possibly-undefined]
+---------------------------------------------------------------------------------------
+
+If you use :option:`--enable-error-code possibly-undefined <mypy --enable-error-code>`,
+mypy generates an error if it cannot verify that a variable will be defined in
+all execution paths. This includes situations when a variable definition
+appears in a loop, in a conditional branch, in an except handler, etc. For
+example:
+
+.. code-block:: python
+
+    # Use "mypy --enable-error-code possibly-undefined ..."
+
+    from typing import Iterable
+
+    def test(values: Iterable[int], flag: bool) -> None:
+        if flag:
+            a = 1
+        z = a + 1  # Error: Name "a" may be undefined [possibly-undefined]
+
+        for v in values:
+            b = v
+        z = b + 1  # Error: Name "b" may be undefined [possibly-undefined]
+
 .. _code-truthy-bool:
 
 Check that expression is not implicitly true in boolean context [truthy-bool]

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -23,19 +23,7 @@ class MypyHTMLBuilder(StandaloneHTMLBuilder):
     def _verify_error_codes(self) -> None:
         from mypy.errorcodes import error_codes
 
-        known_missing = {
-            # TODO: fix these before next release
-            "annotation-unchecked",
-            "empty-body",
-            "possibly-undefined",
-            "str-format",
-            "top-level-await",
-        }
-        missing_error_codes = {
-            c
-            for c in error_codes
-            if f"code-{c}" not in self._ref_to_doc and c not in known_missing
-        }
+        missing_error_codes = {c for c in error_codes if f"code-{c}" not in self._ref_to_doc}
         if missing_error_codes:
             raise ValueError(
                 f"Some error codes are not documented: {', '.join(sorted(missing_error_codes))}"

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -144,7 +144,7 @@ SAFE_SUPER: Final = ErrorCode(
     "safe-super", "Warn about calls to abstract methods with empty/trivial bodies", "General"
 )
 TOP_LEVEL_AWAIT: Final = ErrorCode(
-    "top-level-await", "Warn about top level await experessions", "General"
+    "top-level-await", "Warn about top level await expressions", "General"
 )
 
 # These error codes aren't enabled by default.


### PR DESCRIPTION
I am adding these mostly to get rid of the allowlist in `html_builder.py`, please feel free to tweak these docs, cc @JukkaL @hauntsaninja @JelleZijlstra 