### PR TITLE
Fix tests on 3.7

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -498,6 +498,9 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
                 if builder.options.capi_version < (3, 8):
                     # TypedDict was added to typing in Python 3.8.
                     module = "typing_extensions"
+                    # It needs to be "_TypedDict" on typing_extensions 4.7.0+
+                    # and "TypedDict" otherwise.
+                    name = "_TypedDict"
             else:
                 # In Python 3.9 TypedDict is not a real type.
                 name = "_TypedDict"


### PR DESCRIPTION
Fixes #15542

This fixes tests for me locally, but the situation will still be problematic, in that things won't work on 3.7 if you have this code and have older typing-extensions, or if you don't have this code and you have newer typing-extensions.

Given that 3.7 is dead, I'm not sure we need to care much, but this will hopefully get CI green for now.