### PR TITLE
Enforce typing_extensions >=4.7.0 on py37

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,5 +1,6 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
-typing_extensions>=4.1.0
+typing_extensions>=4.1.0; python_version >= '3.8'
+typing_extensions>=4.7.0; python_version < '3.8'
 mypy_extensions>=1.0.0
 typed_ast>=1.4.0,<2; python_version<'3.8'
 tomli>=1.1.0; python_version<'3.11'

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import typing_extensions
 from abc import abstractmethod
 from typing import Callable
 from typing_extensions import Final
@@ -498,9 +499,9 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
                 if builder.options.capi_version < (3, 8):
                     # TypedDict was added to typing in Python 3.8.
                     module = "typing_extensions"
-                    # It needs to be "_TypedDict" on typing_extensions 4.7.0+
-                    # and "TypedDict" otherwise.
-                    name = "_TypedDict"
+                    # TypedDict is not a real type on typing_extensions 4.7.0+
+                    if not isinstance(typing_extensions.TypedDict, type):
+                        name = "_TypedDict"
             else:
                 # In Python 3.9 TypedDict is not a real type.
                 name = "_TypedDict"

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -500,8 +500,13 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
                     # TypedDict was added to typing in Python 3.8.
                     module = "typing_extensions"
                     # TypedDict is not a real type on typing_extensions 4.7.0+
-                    if not isinstance(typing_extensions.TypedDict, type):
-                        name = "_TypedDict"
+                    name = "_TypedDict"
+                    if isinstance(typing_extensions.TypedDict, type):
+                        raise RuntimeError(
+                            "It looks like you may have an old version "
+                            "of typing_extensions installed. "
+                            "typing_extensions>=4.7.0 is required on Python 3.7."
+                        )
             else:
                 # In Python 3.9 TypedDict is not a real type.
                 name = "_TypedDict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ requires = [
     "setuptools >= 40.6.2",
     "wheel >= 0.30.0",
     # the following is from mypy-requirements.txt
-    "typing_extensions>=4.1.0",
+    "typing_extensions>=4.1.0; python_version >= '3.8'",
+    "typing_extensions>=4.7.0; python_version < '3.8'",
     "mypy_extensions>=1.0.0",
     "typed_ast>=1.4.0,<2; python_version<'3.8'",
     "tomli>=1.1.0; python_version<'3.11'",

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,8 @@ setup(
     # When changing this, also update mypy-requirements.txt.
     install_requires=[
         "typed_ast >= 1.4.0, < 2; python_version<'3.8'",
-        "typing_extensions>=4.1.0",
+        "typing_extensions>=4.1.0; python_version >= '3.8'",
+        "typing_extensions>=4.7.0; python_version < '3.8'",
         "mypy_extensions >= 1.0.0",
         "tomli>=1.1.0; python_version<'3.11'",
     ],


### PR DESCRIPTION
The changes made in #15543 mean that mypy's tests will no longer pass if you've got `typing_extensions<4.7` installed and you're running on Python 3.7. But if we go with this solution instead, our tests will pass on Python 3.7 regardless of whether you have `typing_extensions==4.6.3` or `typing_extensions==4.7.0` installed. (I've verified this locally.)