### PR TITLE
Adding optional error flag missing return type

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -151,6 +151,11 @@ TOP_LEVEL_AWAIT: Final = ErrorCode(
 NO_UNTYPED_DEF: Final[ErrorCode] = ErrorCode(
     "no-untyped-def", "Check that every function has an annotation", "General"
 )
+NO_UNTYPED_RET: Final[ErrorCode] = ErrorCode(
+    "no-untyped-ret",
+    "Check that every function with at least one typed argument has a typed return",
+    "General",
+)
 NO_UNTYPED_CALL: Final = ErrorCode(
     "no-untyped-call",
     "Disallow calling functions without type annotations from annotated functions",

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -119,6 +119,9 @@ ONLY_CLASS_APPLICATION: Final = ErrorMessage(
 RETURN_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a return type annotation", codes.NO_UNTYPED_DEF
 )
+RETURN_TYPE_EXPECTED_TYPED_ARG: Final = ErrorMessage(
+    "Function is missing a return type annotation", codes.NO_UNTYPED_RET
+)
 ARGUMENT_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a type annotation for one or more arguments", codes.NO_UNTYPED_DEF
 )


### PR DESCRIPTION
Adding optional error flag for missing return type, when a function has at least one typed argument. This will address issue #15127