### PR TITLE
[mypyc] Fix 3.12 issue with pickling of instances with __dict__

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -270,7 +270,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     # that isn't what we want.
 
     # XXX: there is no reason for the __weakref__ stuff to be mixed up with __dict__
-    if cl.has_dict:
+    if cl.has_dict and not has_managed_dict(cl, emitter):
         # __dict__ lives right after the struct and __weakref__ lives right after that
         # TODO: They should get members in the struct instead of doing this nonsense.
         weak_offset = f"{base_size} + sizeof(PyObject *)"


### PR DESCRIPTION
This fixes the testPickling test case in mypyc/test-data/run-classes.test on Python 3.12.

Handle another case that was missed in #15471. On 3.12 we rely on Py_TPFLAGS_MANAGED_DICT and shouldn't define an explicit `__dict__` member.

Work on mypyc/mypyc#995.
