### PR TITLE
Run `pyupgrade --py38-plus` on the source code

### DIFF
--- a/misc/analyze_cache.py
+++ b/misc/analyze_cache.py
@@ -6,9 +6,8 @@ import json
 import os
 import os.path
 from collections import Counter
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Final, Iterable
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 ROOT: Final = ".mypy_cache/3.5"
 

--- a/misc/analyze_cache.py
+++ b/misc/analyze_cache.py
@@ -7,7 +7,8 @@ import os
 import os.path
 from collections import Counter
 from typing import Any, Dict, Iterable
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 ROOT: Final = ".mypy_cache/3.5"
 

--- a/misc/incremental_checker.py
+++ b/misc/incremental_checker.py
@@ -45,7 +45,8 @@ import textwrap
 import time
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 from typing import Any, Dict
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 CACHE_PATH: Final = ".incremental_checker_cache.json"
 MYPY_REPO_URL: Final = "https://github.com/python/mypy.git"

--- a/misc/incremental_checker.py
+++ b/misc/incremental_checker.py
@@ -44,9 +44,8 @@ import sys
 import textwrap
 import time
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
-from typing import Any, Dict
+from typing import Any, Dict, Final
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 CACHE_PATH: Final = ".incremental_checker_cache.json"
 MYPY_REPO_URL: Final = "https://github.com/python/mypy.git"

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -31,6 +31,7 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    Final,
     Iterator,
     Mapping,
     NamedTuple,
@@ -39,7 +40,6 @@ from typing import (
     TextIO,
 )
 from typing_extensions import TypeAlias as _TypeAlias, TypedDict
-from typing import Final
 
 import mypy.semanal_main
 from mypy.checker import TypeChecker

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -38,7 +38,8 @@ from typing import (
     Sequence,
     TextIO,
 )
-from typing_extensions import Final, TypeAlias as _TypeAlias, TypedDict
+from typing_extensions import TypeAlias as _TypeAlias, TypedDict
+from typing import Final
 
 import mypy.semanal_main
 from mypy.checker import TypeChecker

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -9,6 +9,7 @@ from typing import (
     AbstractSet,
     Callable,
     Dict,
+    Final,
     Generic,
     Iterable,
     Iterator,
@@ -23,7 +24,6 @@ from typing import (
     overload,
 )
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 import mypy.checkexpr
 from mypy import errorcodes as codes, message_registry, nodes, operators

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -22,7 +22,8 @@ from typing import (
     cast,
     overload,
 )
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 import mypy.checkexpr
 from mypy import errorcodes as codes, message_registry, nodes, operators
@@ -1546,7 +1547,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if opt_meta is not None:
                     forward_inst = opt_meta
 
-        def has_readable_member(typ: Union[UnionType, Instance], name: str) -> bool:
+        def has_readable_member(typ: UnionType | Instance, name: str) -> bool:
             # TODO: Deal with attributes of TupleType etc.
             if isinstance(typ, Instance):
                 return typ.type.has_readable_member(name)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -6,9 +6,8 @@ import itertools
 import time
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Callable, ClassVar, Iterable, Iterator, List, Optional, Sequence, cast
+from typing import Callable, ClassVar, Final, Iterable, Iterator, List, Optional, Sequence, cast
 from typing_extensions import TypeAlias as _TypeAlias, overload
-from typing import Final
 
 import mypy.checker
 import mypy.errorcodes as codes

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -7,7 +7,8 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Callable, ClassVar, Iterable, Iterator, List, Optional, Sequence, cast
-from typing_extensions import Final, TypeAlias as _TypeAlias, overload
+from typing_extensions import TypeAlias as _TypeAlias, overload
+from typing import Final
 
 import mypy.checker
 import mypy.errorcodes as codes
@@ -5581,7 +5582,7 @@ def replace_callable_return_type(c: CallableType, new_ret_type: Type) -> Callabl
     return c.copy_modified(ret_type=new_ret_type)
 
 
-def apply_poly(tp: CallableType, poly_tvars: Sequence[TypeVarLikeType]) -> Optional[CallableType]:
+def apply_poly(tp: CallableType, poly_tvars: Sequence[TypeVarLikeType]) -> CallableType | None:
     """Make free type variables generic in the type if possible.
 
     This will translate the type `tp` while trying to create valid bindings for

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import NamedTuple
-from typing import Final
+from typing import Final, NamedTuple
 
 import mypy.checker
 from mypy import message_registry

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from typing import NamedTuple
-from typing_extensions import Final
+from typing import Final
 
 import mypy.checker
 from mypy import message_registry

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 import re
 from typing import TYPE_CHECKING, Callable, Dict, Match, Pattern, Tuple, Union, cast
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 import mypy.errorcodes as codes
 from mypy.errors import Errors

--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -13,9 +13,8 @@ implementation simple.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Callable, Dict, Match, Pattern, Tuple, Union, cast
+from typing import TYPE_CHECKING, Callable, Dict, Final, Match, Pattern, Tuple, Union, cast
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 import mypy.errorcodes as codes
 from mypy.errors import Errors

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -19,6 +19,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Final,
     Iterable,
     List,
     Mapping,
@@ -29,7 +30,6 @@ from typing import (
     Union,
 )
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 from mypy import defaults
 from mypy.options import PER_MODULE_OPTIONS, Options

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -28,7 +28,8 @@ from typing import (
     Tuple,
     Union,
 )
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 from mypy import defaults
 from mypy.options import PER_MODULE_OPTIONS, Options

--- a/mypy/constant_fold.py
+++ b/mypy/constant_fold.py
@@ -5,8 +5,7 @@ For example, 3 + 5 can be constant folded into 8.
 
 from __future__ import annotations
 
-from typing import Union
-from typing import Final
+from typing import Final, Union
 
 from mypy.nodes import (
     ComplexExpr,

--- a/mypy/constant_fold.py
+++ b/mypy/constant_fold.py
@@ -6,7 +6,7 @@ For example, 3 + 5 can be constant folded into 8.
 from __future__ import annotations
 
 from typing import Union
-from typing_extensions import Final
+from typing import Final
 
 from mypy.nodes import (
     ComplexExpr,

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, List, Sequence, cast
-from typing import Final
+from typing import TYPE_CHECKING, Final, Iterable, List, Sequence, cast
 
 import mypy.subtypes
 import mypy.typeops

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable, List, Sequence, cast
-from typing_extensions import Final
+from typing import Final
 
 import mypy.subtypes
 import mypy.typeops

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing_extensions import Final
+from typing import Final
 
 PYTHON2_VERSION: Final = (2, 7)
 

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -18,7 +18,8 @@ import time
 import traceback
 from contextlib import redirect_stderr, redirect_stdout
 from typing import AbstractSet, Any, Callable, List, Sequence, Tuple
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 import mypy.build
 import mypy.errors

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -17,9 +17,8 @@ import sys
 import time
 import traceback
 from contextlib import redirect_stderr, redirect_stdout
-from typing import AbstractSet, Any, Callable, List, Sequence, Tuple
+from typing import AbstractSet, Any, Callable, Final, List, Sequence, Tuple
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 import mypy.build
 import mypy.errors

--- a/mypy/dmypy_util.py
+++ b/mypy/dmypy_util.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from typing_extensions import Final
+from typing import Final
 
 from mypy.ipc import IPCBase
 

--- a/mypy/dmypy_util.py
+++ b/mypy/dmypy_util.py
@@ -6,8 +6,7 @@ This should be pretty lightweight and not depend on other mypy code (other than 
 from __future__ import annotations
 
 import json
-from typing import Any
-from typing import Final
+from typing import Any, Final
 
 from mypy.ipc import IPCBase
 

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -6,7 +6,7 @@ These can be used for filtering specific errors.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing_extensions import Final
+from typing import Final
 
 from mypy_extensions import mypyc_attr
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -5,7 +5,8 @@ import sys
 import traceback
 from collections import defaultdict
 from typing import Callable, Iterable, NoReturn, Optional, TextIO, Tuple, TypeVar
-from typing_extensions import Final, Literal, TypeAlias as _TypeAlias
+from typing_extensions import Literal, TypeAlias as _TypeAlias
+from typing import Final
 
 from mypy import errorcodes as codes
 from mypy.errorcodes import IMPORT, ErrorCode

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -4,9 +4,8 @@ import os.path
 import sys
 import traceback
 from collections import defaultdict
-from typing import Callable, Iterable, NoReturn, Optional, TextIO, Tuple, TypeVar
+from typing import Callable, Final, Iterable, NoReturn, Optional, TextIO, Tuple, TypeVar
 from typing_extensions import Literal, TypeAlias as _TypeAlias
-from typing import Final
 
 from mypy import errorcodes as codes
 from mypy.errorcodes import IMPORT, ErrorCode

--- a/mypy/evalexpr.py
+++ b/mypy/evalexpr.py
@@ -7,7 +7,7 @@ put it in a mypyc-compiled file.
 
 """
 import ast
-from typing_extensions import Final
+from typing import Final
 
 import mypy.nodes
 from mypy.visitor import ExpressionVisitor

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Mapping, Sequence, TypeVar, cast, overload
-from typing import Final
+from typing import Final, Iterable, Mapping, Sequence, TypeVar, cast, overload
 
 from mypy.nodes import ARG_POS, ARG_STAR, ArgKind, Var
 from mypy.state import state

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable, Mapping, Sequence, TypeVar, cast, overload
-from typing_extensions import Final
+from typing import Final
 
 from mypy.nodes import ARG_POS, ARG_STAR, ArgKind, Var
 from mypy.state import state

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -4,9 +4,8 @@ import copy
 import re
 import sys
 import warnings
-from typing import Any, Callable, List, Optional, Sequence, TypeVar, Union, cast
+from typing import Any, Callable, Final, List, Optional, Sequence, TypeVar, Union, cast
 from typing_extensions import Literal, overload
-from typing import Final
 
 from mypy import defaults, errorcodes as codes, message_registry
 from mypy.errors import Errors

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -5,7 +5,8 @@ import re
 import sys
 import warnings
 from typing import Any, Callable, List, Optional, Sequence, TypeVar, Union, cast
-from typing_extensions import Final, Literal, overload
+from typing_extensions import Literal, overload
+from typing import Final
 
 from mypy import defaults, errorcodes as codes, message_registry
 from mypy.errors import Errors

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import functools
 import os
-from typing import Sequence
-from typing import Final
+from typing import Final, Sequence
 
 from mypy.fscache import FileSystemCache
 from mypy.modulefinder import PYTHON_EXTENSIONS, BuildSource, matches_exclude, mypy_path

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import os
 from typing import Sequence
-from typing_extensions import Final
+from typing import Final
 
 from mypy.fscache import FileSystemCache
 from mypy.modulefinder import PYTHON_EXTENSIONS, BuildSource, matches_exclude, mypy_path
@@ -160,7 +160,7 @@ class SourceFinder:
     def crawl_up_dir(self, dir: str) -> tuple[str, str]:
         return self._crawl_up_helper(dir) or ("", dir)
 
-    @functools.lru_cache()  # noqa: B019
+    @functools.lru_cache  # noqa: B019
     def _crawl_up_helper(self, dir: str) -> tuple[str, str] | None:
         """Given a directory, maybe returns module and base directory.
 

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-from typing import Final
+from typing import Any, Final
 
 from mypy.lookup import lookup_fully_qualified
 from mypy.nodes import (

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from typing_extensions import Final
+from typing import Final
 
 from mypy.lookup import lookup_fully_qualified
 from mypy.nodes import (

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -12,8 +12,7 @@ import shutil
 import sys
 import tempfile
 from types import TracebackType
-from typing import Callable
-from typing import Final
+from typing import Callable, Final
 
 if sys.platform == "win32":
     # This may be private, but it is needed for IPC on Windows, and is basically stable

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 from types import TracebackType
 from typing import Callable
-from typing_extensions import Final
+from typing import Final
 
 if sys.platform == "win32":
     # This may be private, but it is needed for IPC on Windows, and is basically stable

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from typing import Any, Iterable, Optional, Tuple
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 from mypy.nodes import (
     LITERAL_NO,

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any, Final, Iterable, Optional, Tuple
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 from mypy.nodes import (
     LITERAL_NO,

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -8,8 +8,7 @@ import subprocess
 import sys
 import time
 from gettext import gettext
-from typing import IO, Any, NoReturn, Sequence, TextIO
-from typing import Final
+from typing import IO, Any, Final, NoReturn, Sequence, TextIO
 
 from mypy import build, defaults, state, util
 from mypy.config_parser import get_config_module_names, parse_config_file, parse_version

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -9,7 +9,7 @@ import sys
 import time
 from gettext import gettext
 from typing import IO, Any, NoReturn, Sequence, TextIO
-from typing_extensions import Final
+from typing import Final
 
 from mypy import build, defaults, state, util
 from mypy.config_parser import get_config_module_names, parse_config_file, parse_version

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -8,8 +8,7 @@ add a method to MessageBuilder and call this instead.
 
 from __future__ import annotations
 
-from typing import NamedTuple
-from typing import Final
+from typing import Final, NamedTuple
 
 from mypy import errorcodes as codes
 

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -9,7 +9,7 @@ add a method to MessageBuilder and call this instead.
 from __future__ import annotations
 
 from typing import NamedTuple
-from typing_extensions import Final
+from typing import Final
 
 from mypy import errorcodes as codes
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -16,8 +16,7 @@ import itertools
 import re
 from contextlib import contextmanager
 from textwrap import dedent
-from typing import Any, Callable, Collection, Iterable, Iterator, List, Sequence, cast
-from typing import Final
+from typing import Any, Callable, Collection, Final, Iterable, Iterator, List, Sequence, cast
 
 import mypy.typeops
 from mypy import errorcodes as codes, message_registry

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -17,7 +17,7 @@ import re
 from contextlib import contextmanager
 from textwrap import dedent
 from typing import Any, Callable, Collection, Iterable, Iterator, List, Sequence, cast
-from typing_extensions import Final
+from typing import Final
 
 import mypy.typeops
 from mypy import errorcodes as codes, message_registry

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -22,7 +22,8 @@ else:
     import tomli as tomllib
 
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 from mypy import pyinfo
 from mypy.fscache import FileSystemCache

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -21,9 +21,8 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Dict, Final, List, NamedTuple, Optional, Tuple, Union
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 from mypy import pyinfo
 from mypy.fscache import FileSystemCache

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -20,7 +20,8 @@ from typing import (
     Union,
     cast,
 )
-from typing_extensions import Final, TypeAlias as _TypeAlias, TypeGuard
+from typing_extensions import TypeAlias as _TypeAlias, TypeGuard
+from typing import Final
 
 from mypy_extensions import trait
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Final,
     Iterator,
     List,
     Optional,
@@ -21,7 +22,6 @@ from typing import (
     cast,
 )
 from typing_extensions import TypeAlias as _TypeAlias, TypeGuard
-from typing import Final
 
 from mypy_extensions import trait
 

--- a/mypy/operators.py
+++ b/mypy/operators.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import Final
+from typing import Final
 
 # Map from binary operator id to related method name (in Python 3).
 op_methods: Final = {

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -5,7 +5,7 @@ import re
 import sys
 import sysconfig
 from typing import Any, Callable, Dict, Mapping, Pattern
-from typing_extensions import Final
+from typing import Final
 
 from mypy import defaults
 from mypy.errorcodes import ErrorCode, error_codes
@@ -529,7 +529,7 @@ class Options:
         return re.compile(expr + "\\Z")
 
     def select_options_affecting_cache(self) -> Mapping[str, object]:
-        result: Dict[str, object] = {}
+        result: dict[str, object] = {}
         for opt in OPTIONS_AFFECTING_CACHE:
             val = getattr(self, opt)
             if opt in ("disabled_error_codes", "enabled_error_codes"):

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -4,8 +4,7 @@ import pprint
 import re
 import sys
 import sysconfig
-from typing import Any, Callable, Dict, Mapping, Pattern
-from typing import Final
+from typing import Any, Callable, Final, Mapping, Pattern
 
 from mypy import defaults
 from mypy.errorcodes import ErrorCode, error_codes

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from collections import defaultdict
 from functools import reduce
-from typing import Iterable, List, Mapping, cast
+from typing import Final, Iterable, List, Mapping, cast
 from typing_extensions import Literal
-from typing import Final
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.applytype import apply_generic_arguments

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections import defaultdict
 from functools import reduce
 from typing import Iterable, List, Mapping, cast
-from typing_extensions import Final, Literal
+from typing_extensions import Literal
+from typing import Final
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.applytype import apply_generic_arguments

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator, Optional
-from typing import Final
+from typing import TYPE_CHECKING, Final, Iterator
 
 from mypy import errorcodes, message_registry
 from mypy.expandtype import expand_type, expand_type_by_instance

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterator, Optional
-from typing_extensions import Final
+from typing import Final
 
 from mypy import errorcodes, message_registry
 from mypy.expandtype import expand_type, expand_type_by_instance
@@ -132,7 +132,7 @@ class DataclassAttribute:
             kind=arg_kind,
         )
 
-    def expand_type(self, current_info: TypeInfo) -> Optional[Type]:
+    def expand_type(self, current_info: TypeInfo) -> Type | None:
         if self.type is not None and self.info.self_type is not None:
             # In general, it is not safe to call `expand_type()` during semantic analyzis,
             # however this plugin is called very late, so all types should be fully ready.

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -12,8 +12,7 @@ semanal_enum.py).
 """
 from __future__ import annotations
 
-from typing import Iterable, Sequence, TypeVar, cast
-from typing import Final
+from typing import Final, Iterable, Sequence, TypeVar, cast
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.nodes import TypeInfo

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -13,7 +13,7 @@ semanal_enum.py).
 from __future__ import annotations
 
 from typing import Iterable, Sequence, TypeVar, cast
-from typing_extensions import Final
+from typing import Final
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.nodes import TypeInfo

--- a/mypy/plugins/functools.py
+++ b/mypy/plugins/functools.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from typing import NamedTuple
-from typing_extensions import Final
+from typing import Final
 
 import mypy.plugin
 from mypy.nodes import ARG_POS, ARG_STAR2, Argument, FuncItem, Var

--- a/mypy/plugins/functools.py
+++ b/mypy/plugins/functools.py
@@ -1,8 +1,7 @@
 """Plugin for supporting the functools standard library module."""
 from __future__ import annotations
 
-from typing import NamedTuple
-from typing import Final
+from typing import Final, NamedTuple
 
 import mypy.plugin
 from mypy.nodes import ARG_POS, ARG_STAR2, Argument, FuncItem, Var

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from typing import NamedTuple, Sequence, TypeVar, Union
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 from mypy.messages import format_type
 from mypy.nodes import ARG_POS, Argument, Block, ClassDef, Context, SymbolTable, TypeInfo, Var

--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import NamedTuple, Sequence, TypeVar, Union
+from typing import Final, NamedTuple, Sequence, TypeVar, Union
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 from mypy.messages import format_type
 from mypy.nodes import ARG_POS, Argument, Block, ClassDef, Context, SymbolTable, TypeInfo, Var

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Tuple, TypeVar
-from typing import Final
+from typing import Final, Tuple, TypeVar
 
 from mypy.literals import literal
 from mypy.nodes import (

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Tuple, TypeVar
-from typing_extensions import Final
+from typing import Final
 
 from mypy.literals import literal
 from mypy.nodes import (

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Iterator
-from typing import Final
+from typing import Final, Iterator
 
 from mypy.nodes import (
     AssignmentStmt,

--- a/mypy/renaming.py
+++ b/mypy/renaming.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Iterator
-from typing_extensions import Final
+from typing import Final
 
 from mypy.nodes import (
     AssignmentStmt,

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -13,7 +13,8 @@ import tokenize
 from abc import ABCMeta, abstractmethod
 from operator import attrgetter
 from typing import Any, Callable, Dict, Iterator, Tuple
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 from urllib.request import pathname2url
 
 from mypy import stats

--- a/mypy/report.py
+++ b/mypy/report.py
@@ -12,9 +12,8 @@ import time
 import tokenize
 from abc import ABCMeta, abstractmethod
 from operator import attrgetter
-from typing import Any, Callable, Dict, Iterator, Tuple
+from typing import Any, Callable, Dict, Final, Iterator, Tuple
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 from urllib.request import pathname2url
 
 from mypy import stats

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -51,9 +51,8 @@ Some important properties:
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any, Callable, Collection, Iterable, Iterator, List, TypeVar, cast
+from typing import Any, Callable, Collection, Final, Iterable, Iterator, List, TypeVar, cast
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 from mypy import errorcodes as codes, message_registry
 from mypy.constant_fold import constant_fold_expr

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -52,7 +52,8 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Any, Callable, Collection, Iterable, Iterator, List, TypeVar, cast
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 from mypy import errorcodes as codes, message_registry
 from mypy.constant_fold import constant_fold_expr

--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -5,7 +5,7 @@ These happen after semantic analysis and before type checking.
 
 from __future__ import annotations
 
-from typing_extensions import Final
+from typing import Final
 
 from mypy.errors import Errors
 from mypy.nodes import (

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -5,8 +5,7 @@ This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 
 from __future__ import annotations
 
-from typing import cast
-from typing import Final
+from typing import Final, cast
 
 from mypy.nodes import (
     ARG_NAMED,

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -6,7 +6,7 @@ This is conceptually part of mypy.semanal (semantic analyzer pass 2).
 from __future__ import annotations
 
 from typing import cast
-from typing_extensions import Final
+from typing import Final
 
 from mypy.nodes import (
     ARG_NAMED,

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -28,7 +28,8 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 import mypy.build
 import mypy.state

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -27,9 +27,8 @@ will be incomplete.
 from __future__ import annotations
 
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Final, List, Optional, Tuple, Union
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 import mypy.build
 import mypy.state

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -6,8 +6,7 @@ This is conceptually part of mypy.semanal.
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Iterator, List, Mapping, cast
-from typing import Final
+from typing import Final, Iterator, List, Mapping, cast
 
 from mypy.exprtotype import TypeTranslationError, expr_to_unanalyzed_type
 from mypy.nodes import (

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Iterator, List, Mapping, cast
-from typing_extensions import Final
+from typing import Final
 
 from mypy.exprtotype import TypeTranslationError, expr_to_unanalyzed_type
 from mypy.nodes import (

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Callable, overload
-from typing_extensions import Final, Literal, Protocol
+from typing_extensions import Literal, Protocol
+from typing import Final
 
 from mypy_extensions import trait
 

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Callable, overload
+from typing import Callable, Final, overload
 from typing_extensions import Literal, Protocol
-from typing import Final
 
 from mypy_extensions import trait
 

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import Final
+from typing import Final
 
 from mypy import errorcodes as codes, message_registry
 from mypy.errorcodes import ErrorCode

--- a/mypy/server/mergecheck.py
+++ b/mypy/server/mergecheck.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import Final
+from typing import Final
 
 from mypy.nodes import Decorator, FakeInfo, FuncDef, SymbolNode, Var
 from mypy.server.objgraph import get_path, get_reachable_graph

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -6,7 +6,7 @@ import types
 import weakref
 from collections.abc import Iterable
 from typing import Iterator, Mapping
-from typing_extensions import Final
+from typing import Final
 
 method_descriptor_type: Final = type(object.__dir__)
 method_wrapper_type: Final = type(object().__ne__)

--- a/mypy/server/objgraph.py
+++ b/mypy/server/objgraph.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import types
 import weakref
 from collections.abc import Iterable
-from typing import Iterator, Mapping
-from typing import Final
+from typing import Final, Iterator, Mapping
 
 method_descriptor_type: Final = type(object.__dir__)
 method_wrapper_type: Final = type(object().__ne__)

--- a/mypy/server/trigger.py
+++ b/mypy/server/trigger.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import Final
+from typing import Final
 
 # Used as a suffix for triggers to handle "from m import *" dependencies (see also
 # make_wildcard_trigger)

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -118,9 +118,8 @@ import os
 import re
 import sys
 import time
-from typing import Callable, NamedTuple, Sequence, Union
+from typing import Callable, Final, NamedTuple, Sequence, Union
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 from mypy.build import (
     DEBUG_FINE_GRAINED,

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -119,7 +119,8 @@ import re
 import sys
 import time
 from typing import Callable, NamedTuple, Sequence, Union
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 from mypy.build import (
     DEBUG_FINE_GRAINED,

--- a/mypy/sharedparse.py
+++ b/mypy/sharedparse.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing_extensions import Final
+from typing import Final
 
 """Shared logic between our three mypy parser files."""
 

--- a/mypy/state.py
+++ b/mypy/state.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Iterator
-from typing import Final
+from typing import Final, Iterator
 
 # These are global mutable state. Don't add anything here unless there's a very
 # good reason.

--- a/mypy/state.py
+++ b/mypy/state.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Iterator
-from typing_extensions import Final
+from typing import Final
 
 # These are global mutable state. Don't add anything here unless there's a very
 # good reason.

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import os
 from collections import Counter
 from contextlib import contextmanager
-from typing import Iterator
-from typing import Final
+from typing import Final, Iterator
 
 from mypy import nodes
 from mypy.argmap import map_formals_to_actuals

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -6,7 +6,7 @@ import os
 from collections import Counter
 from contextlib import contextmanager
 from typing import Iterator
-from typing_extensions import Final
+from typing import Final
 
 from mypy import nodes
 from mypy.argmap import map_formals_to_actuals

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -10,9 +10,8 @@ import contextlib
 import io
 import re
 import tokenize
-from typing import Any, MutableMapping, MutableSequence, NamedTuple, Sequence, Tuple
+from typing import Any, Final, MutableMapping, MutableSequence, NamedTuple, Sequence, Tuple
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 # Type alias for signatures strings in format ('func_name', '(arg, opt_arg=False)').
 Sig: _TypeAlias = Tuple[str, str]

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -11,7 +11,8 @@ import io
 import re
 import tokenize
 from typing import Any, MutableMapping, MutableSequence, NamedTuple, Sequence, Tuple
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 # Type alias for signatures strings in format ('func_name', '(arg, opt_arg=False)').
 Sig: _TypeAlias = Tuple[str, str]

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -49,8 +49,7 @@ import os.path
 import sys
 import traceback
 from collections import defaultdict
-from typing import Iterable, Mapping
-from typing import Final
+from typing import Final, Iterable, Mapping
 
 import mypy.build
 import mypy.mixedtraverser

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -50,7 +50,7 @@ import sys
 import traceback
 from collections import defaultdict
 from typing import Iterable, Mapping
-from typing_extensions import Final
+from typing import Final
 
 import mypy.build
 import mypy.mixedtraverser

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -13,7 +13,7 @@ import re
 from abc import abstractmethod
 from types import ModuleType
 from typing import Any, Iterable, Mapping
-from typing_extensions import Final
+from typing import Final
 
 from mypy.moduleinspect import is_c_module
 from mypy.stubdoc import (
@@ -502,7 +502,7 @@ def generate_c_type_stub(
     """
     raw_lookup = getattr(obj, "__dict__")  # noqa: B009
     items = sorted(get_members(obj), key=lambda x: method_name_sort_key(x[0]))
-    names = set(x[0] for x in items)
+    names = {x[0] for x in items}
     methods: list[str] = []
     types: list[str] = []
     static_properties: list[str] = []

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -12,8 +12,7 @@ import os.path
 import re
 from abc import abstractmethod
 from types import ModuleType
-from typing import Any, Iterable, Mapping
-from typing import Final
+from typing import Any, Final, Iterable, Mapping
 
 from mypy.moduleinspect import is_c_module
 from mypy.stubdoc import (

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, List, TypeVar, cast
+from typing import Any, Callable, Final, Iterator, List, TypeVar, cast
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 import mypy.applytype
 import mypy.constraints

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Any, Callable, Iterator, List, TypeVar, cast
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 import mypy.applytype
 import mypy.constraints

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -12,9 +12,8 @@ import tempfile
 from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, NamedTuple, NoReturn, Pattern, Union
+from typing import Any, Final, Iterator, NamedTuple, NoReturn, Pattern, Union
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 import pytest
 

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -13,7 +13,8 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, NamedTuple, NoReturn, Pattern, Union
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 import pytest
 

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Any, Callable, Generic, Iterable, Sequence, TypeVar, cast
-from typing_extensions import Final
+from typing import Final
 
 from mypy_extensions import mypyc_attr, trait
 

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -14,8 +14,7 @@ other modules refer to them.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Callable, Generic, Iterable, Sequence, TypeVar, cast
-from typing import Final
+from typing import Any, Callable, Final, Generic, Iterable, Sequence, TypeVar, cast
 
 from mypy_extensions import mypyc_attr, trait
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import itertools
 from contextlib import contextmanager
 from typing import Callable, Iterable, Iterator, List, Sequence, Tuple, TypeVar
-from typing_extensions import Final, Protocol
+from typing_extensions import Protocol
+from typing import Final
 
 from mypy import errorcodes as codes, message_registry, nodes
 from mypy.errorcodes import ErrorCode

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import itertools
 from contextlib import contextmanager
-from typing import Callable, Iterable, Iterator, List, Sequence, Tuple, TypeVar
+from typing import Callable, Final, Iterable, Iterator, List, Sequence, Tuple, TypeVar
 from typing_extensions import Protocol
-from typing import Final
 
 from mypy import errorcodes as codes, message_registry, nodes
 from mypy.errorcodes import ErrorCode

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    Final,
     Iterable,
     NamedTuple,
     NewType,
@@ -18,7 +19,6 @@ from typing import (
     cast,
 )
 from typing_extensions import Self, TypeAlias as _TypeAlias, TypeGuard, overload
-from typing import Final
 
 import mypy.nodes
 from mypy.bogus_type import Bogus

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -17,7 +17,8 @@ from typing import (
     Union,
     cast,
 )
-from typing_extensions import Final, Self, TypeAlias as _TypeAlias, TypeGuard, overload
+from typing_extensions import Self, TypeAlias as _TypeAlias, TypeGuard, overload
+from typing import Final
 
 import mypy.nodes
 from mypy.bogus_type import Bogus

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -5,9 +5,8 @@ and potentially other mutable TypeInfo state. This module contains mutable globa
 
 from __future__ import annotations
 
-from typing import Dict, Set, Tuple
+from typing import Dict, Final, Set, Tuple
 from typing_extensions import TypeAlias as _TypeAlias
-from typing import Final
 
 from mypy.nodes import TypeInfo
 from mypy.server.trigger import make_trigger

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -6,7 +6,8 @@ and potentially other mutable TypeInfo state. This module contains mutable globa
 from __future__ import annotations
 
 from typing import Dict, Set, Tuple
-from typing_extensions import Final, TypeAlias as _TypeAlias
+from typing_extensions import TypeAlias as _TypeAlias
+from typing import Final
 
 from mypy.nodes import TypeInfo
 from mypy.server.trigger import make_trigger

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -12,7 +12,8 @@ import sys
 import time
 from importlib import resources as importlib_resources
 from typing import IO, Callable, Container, Iterable, Sequence, Sized, TypeVar
-from typing_extensions import Final, Literal
+from typing_extensions import Literal
+from typing import Final
 
 try:
     import curses

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -11,9 +11,8 @@ import shutil
 import sys
 import time
 from importlib import resources as importlib_resources
-from typing import IO, Callable, Container, Iterable, Sequence, Sized, TypeVar
+from typing import IO, Callable, Container, Final, Iterable, Sequence, Sized, TypeVar
 from typing_extensions import Literal
-from typing import Final
 
 try:
     import curses

--- a/mypyc/analysis/attrdefined.py
+++ b/mypyc/analysis/attrdefined.py
@@ -63,8 +63,7 @@ run this on __init__ methods, this analysis pass will be fairly quick.
 
 from __future__ import annotations
 
-from typing import Set, Tuple
-from typing import Final
+from typing import Final, Set, Tuple
 
 from mypyc.analysis.dataflow import (
     CFG,

--- a/mypyc/analysis/attrdefined.py
+++ b/mypyc/analysis/attrdefined.py
@@ -64,7 +64,7 @@ run this on __init__ methods, this analysis pass will be fairly quick.
 from __future__ import annotations
 
 from typing import Set, Tuple
-from typing_extensions import Final
+from typing import Final
 
 from mypyc.analysis.dataflow import (
     CFG,
@@ -414,7 +414,7 @@ def update_always_defined_attrs_using_subclasses(cl: ClassIR, seen: set[ClassIR]
     seen.add(cl)
 
 
-def detect_undefined_bitmap(cl: ClassIR, seen: Set[ClassIR]) -> None:
+def detect_undefined_bitmap(cl: ClassIR, seen: set[ClassIR]) -> None:
     if cl.is_trait:
         return
 

--- a/mypyc/codegen/cstring.py
+++ b/mypyc/codegen/cstring.py
@@ -21,7 +21,7 @@ octal digits.
 from __future__ import annotations
 
 import string
-from typing_extensions import Final
+from typing import Final
 
 CHAR_MAP: Final = [f"\\{i:03o}" for i in range(256)]
 

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import pprint
 import sys
 import textwrap
-from typing import Callable
-from typing import Final
+from typing import Callable, Final
 
 from mypyc.codegen.literals import Literals
 from mypyc.common import (

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -6,7 +6,7 @@ import pprint
 import sys
 import textwrap
 from typing import Callable
-from typing_extensions import Final
+from typing import Final
 
 from mypyc.codegen.literals import Literals
 from mypyc.common import (
@@ -926,7 +926,7 @@ class Emitter:
         elif is_float_rprimitive(typ):
             assert not optional  # Not supported for overlapping error values
             if declare_dest:
-                self.emit_line("double {};".format(dest))
+                self.emit_line(f"double {dest};")
             # TODO: Don't use __float__ and __index__
             self.emit_line(f"{dest} = PyFloat_AsDouble({src});")
             self.emit_lines(f"if ({dest} == -1.0 && PyErr_Occurred()) {{", failure, "}")

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import Final
+from typing import Final
 
 from mypyc.analysis.blockfreq import frequently_executed_blocks
 from mypyc.codegen.emit import DEBUG_ERRORS, Emitter, TracebackAndGotoHandler, c_array_initializer
@@ -686,10 +686,10 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         lhs = self.reg(op.lhs)
         rhs = self.reg(op.rhs)
         if op.op != FloatOp.MOD:
-            self.emit_line("%s = %s %s %s;" % (dest, lhs, op.op_str[op.op], rhs))
+            self.emit_line(f"{dest} = {lhs} {op.op_str[op.op]} {rhs};")
         else:
             # TODO: This may set errno as a side effect, that is a little sketchy.
-            self.emit_line("%s = fmod(%s, %s);" % (dest, lhs, rhs))
+            self.emit_line(f"{dest} = fmod({lhs}, {rhs});")
 
     def visit_float_neg(self, op: FloatNeg) -> None:
         dest = self.reg(op)
@@ -700,7 +700,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         dest = self.reg(op)
         lhs = self.reg(op.lhs)
         rhs = self.reg(op.rhs)
-        self.emit_line("%s = %s %s %s;" % (dest, lhs, op.op_str[op.op], rhs))
+        self.emit_line(f"{dest} = {lhs} {op.op_str[op.op]} {rhs};")
 
     def visit_load_mem(self, op: LoadMem) -> None:
         dest = self.reg(op)

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import FrozenSet, List, Tuple, Union
+from typing import Final, FrozenSet, Tuple, Union
 from typing_extensions import TypeGuard
-from typing import Final
 
 # Supported Python literal types. All tuple / frozenset items must have supported
 # literal types as well, but we can't represent the type precisely.

--- a/mypyc/codegen/literals.py
+++ b/mypyc/codegen/literals.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from typing import FrozenSet, List, Tuple, Union
-from typing_extensions import Final, TypeGuard
+from typing_extensions import TypeGuard
+from typing import Final
 
 # Supported Python literal types. All tuple / frozenset items must have supported
 # literal types as well, but we can't represent the type precisely.
@@ -140,7 +141,7 @@ class Literals:
     def encoded_tuple_values(self) -> list[str]:
         return self._encode_collection_values(self.tuple_literals)
 
-    def encoded_frozenset_values(self) -> List[str]:
+    def encoded_frozenset_values(self) -> list[str]:
         return self._encode_collection_values(self.frozenset_literals)
 
     def _encode_collection_values(

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import sys
 import sysconfig
-from typing import Any, Dict
-from typing import Final
+from typing import Any, Dict, Final
 
 from mypy.util import unnamed_function
 

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 import sysconfig
 from typing import Any, Dict
-from typing_extensions import Final
+from typing import Final
 
 from mypy.util import unnamed_function
 

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -70,7 +70,7 @@ from mypyc.namegen import NameGenerator, exported_name
 
 
 class VTableMethod(NamedTuple):
-    cls: ClassIR
+    cls: "ClassIR"
     name: str
     method: FuncIR
     shadow_method: FuncIR | None

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -70,10 +70,10 @@ from mypyc.namegen import NameGenerator, exported_name
 
 
 class VTableMethod(NamedTuple):
-    cls: "ClassIR"
+    cls: ClassIR
     name: str
     method: FuncIR
-    shadow_method: Optional[FuncIR]
+    shadow_method: FuncIR | None
 
 
 VTableEntries = List[VTableMethod]
@@ -192,7 +192,7 @@ class ClassIR:
         # bitmap for types such as native ints that can't have a dedicated error
         # value that doesn't overlap a valid value. The bitmap is used if the
         # value of an attribute is the same as the error value.
-        self.bitmap_attrs: List[str] = []
+        self.bitmap_attrs: list[str] = []
 
     def __repr__(self) -> str:
         return (

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, NamedTuple, Optional
+from typing import List, NamedTuple
 
 from mypyc.common import PROPSET_PREFIX, JsonDict
 from mypyc.ir.func_ir import FuncDecl, FuncIR, FuncSignature

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Sequence
-from typing_extensions import Final
+from typing import Final
 
 from mypy.nodes import ARG_POS, ArgKind, Block, FuncDef
 from mypyc.common import BITMAP_BITS, JsonDict, bitmap_name, get_id_from_name, short_id_from_name
@@ -86,7 +86,7 @@ class FuncSignature:
             return self.args[: -self.num_bitmap_args]
         return self.args
 
-    def bound_sig(self) -> "FuncSignature":
+    def bound_sig(self) -> FuncSignature:
         if self.num_bitmap_args:
             return FuncSignature(self.args[1 : -self.num_bitmap_args], self.ret_type)
         else:

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Sequence
-from typing import Final
+from typing import Final, Sequence
 
 from mypy.nodes import ARG_POS, ArgKind, Block, FuncDef
 from mypyc.common import BITMAP_BITS, JsonDict, bitmap_name, get_id_from_name, short_id_from_name

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1574,5 +1574,5 @@ class OpVisitor(Generic[T]):
 # (Serialization and deserialization *will* be used for incremental
 # compilation but so far it is not hooked up to anything.)
 class DeserMaps(NamedTuple):
-    classes: dict[str, ClassIR]
-    functions: dict[str, FuncIR]
+    classes: dict[str, "ClassIR"]
+    functions: dict[str, "FuncIR"]

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Dict, Generic, List, NamedTuple, Sequence, TypeVar, Union
-from typing_extensions import Final
+from typing import Final
 
 from mypy_extensions import trait
 
@@ -1204,10 +1204,10 @@ class FloatOp(RegisterOp):
         self.rhs = rhs
         self.op = op
 
-    def sources(self) -> List[Value]:
+    def sources(self) -> list[Value]:
         return [self.lhs, self.rhs]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_float_op(self)
 
 
@@ -1226,10 +1226,10 @@ class FloatNeg(RegisterOp):
         self.type = float_rprimitive
         self.src = src
 
-    def sources(self) -> List[Value]:
+    def sources(self) -> list[Value]:
         return [self.src]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_float_neg(self)
 
 
@@ -1254,10 +1254,10 @@ class FloatComparisonOp(RegisterOp):
         self.rhs = rhs
         self.op = op
 
-    def sources(self) -> List[Value]:
+    def sources(self) -> list[Value]:
         return [self.lhs, self.rhs]
 
-    def accept(self, visitor: "OpVisitor[T]") -> T:
+    def accept(self, visitor: OpVisitor[T]) -> T:
         return visitor.visit_float_comparison_op(self)
 
 
@@ -1575,5 +1575,5 @@ class OpVisitor(Generic[T]):
 # (Serialization and deserialization *will* be used for incremental
 # compilation but so far it is not hooked up to anything.)
 class DeserMaps(NamedTuple):
-    classes: Dict[str, "ClassIR"]
-    functions: Dict[str, "FuncIR"]
+    classes: dict[str, ClassIR]
+    functions: dict[str, FuncIR]

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -12,8 +12,7 @@ value has a type (RType). A value can hold various things, such as:
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Dict, Generic, List, NamedTuple, Sequence, TypeVar, Union
-from typing import Final
+from typing import TYPE_CHECKING, Final, Generic, List, NamedTuple, Sequence, TypeVar, Union
 
 from mypy_extensions import trait
 

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from typing import Any, Sequence, Union
-from typing_extensions import Final
+from typing import Final
 
 from mypyc.common import short_name
 from mypyc.ir.func_ir import FuncIR, all_values_full

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Sequence, Union
-from typing import Final
+from typing import Any, Final, Sequence, Union
 
 from mypyc.common import short_name
 from mypyc.ir.func_ir import FuncIR, all_values_full

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
-from typing_extensions import Final
+from typing import Final
 
 from mypyc.common import IS_32_BIT_PLATFORM, PLATFORM_SIZE, JsonDict, short_name
 from mypyc.namegen import NameGenerator

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -23,8 +23,7 @@ RTypes.
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
-from typing import Final
+from typing import TYPE_CHECKING, ClassVar, Final, Generic, TypeVar
 
 from mypyc.common import IS_32_BIT_PLATFORM, PLATFORM_SIZE, JsonDict, short_name
 from mypyc.namegen import NameGenerator

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Any, Callable, Iterator, Sequence, Union
-from typing_extensions import Final, overload
+from typing_extensions import overload
+from typing import Final
 
 from mypy.build import Graph
 from mypy.maptype import map_instance_to_supertype

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -13,9 +13,8 @@ functions are transformed in mypyc.irbuild.function.
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, Sequence, Union
+from typing import Any, Callable, Final, Iterator, Sequence, Union
 from typing_extensions import overload
-from typing import Final
 
 from mypy.build import Graph
 from mypy.maptype import map_instance_to_supertype

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import typing_extensions
 from abc import abstractmethod
-from typing import Callable
-from typing import Final
+from typing import Callable, Final
 
 from mypy.nodes import (
     AssignmentStmt,

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import typing_extensions
 from abc import abstractmethod
 from typing import Callable
-from typing_extensions import Final
+from typing import Final
 
 from mypy.nodes import (
     AssignmentStmt,

--- a/mypyc/irbuild/constant_fold.py
+++ b/mypyc/irbuild/constant_fold.py
@@ -10,8 +10,7 @@ to other compiled modules in the same compilation unit.
 
 from __future__ import annotations
 
-from typing import Union
-from typing import Final
+from typing import Final, Union
 
 from mypy.constant_fold import constant_fold_binary_op, constant_fold_unary_op
 from mypy.nodes import (

--- a/mypyc/irbuild/constant_fold.py
+++ b/mypyc/irbuild/constant_fold.py
@@ -11,7 +11,7 @@ to other compiled modules in the same compilation unit.
 from __future__ import annotations
 
 from typing import Union
-from typing_extensions import Final
+from typing import Final
 
 from mypy.constant_fold import constant_fold_binary_op, constant_fold_unary_op
 from mypy.nodes import (

--- a/mypyc/irbuild/format_str_tokenizer.py
+++ b/mypyc/irbuild/format_str_tokenizer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum, unique
-from typing_extensions import Final
+from typing import Final
 
 from mypy.checkstrformat import (
     ConversionSpecifier,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -11,7 +11,7 @@ level---it has *no knowledge* of mypy types or expressions.
 from __future__ import annotations
 
 from typing import Callable, Optional, Sequence, Tuple
-from typing_extensions import Final
+from typing import Final
 
 from mypy.argmap import map_actuals_to_formals
 from mypy.nodes import ARG_POS, ARG_STAR, ARG_STAR2, ArgKind

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -10,8 +10,7 @@ level---it has *no knowledge* of mypy types or expressions.
 
 from __future__ import annotations
 
-from typing import Callable, Optional, Sequence, Tuple
-from typing import Final
+from typing import Callable, Final, Optional, Sequence, Tuple
 
 from mypy.argmap import map_actuals_to_formals
 from mypy.nodes import ARG_POS, ARG_STAR, ARG_STAR2, ArgKind

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -755,7 +755,7 @@ def translate_bool(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value
 
 
 @specialize_function("builtins.float")
-def translate_float(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Optional[Value]:
+def translate_float(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
     if len(expr.args) != 1 or expr.arg_kinds[0] != ARG_POS:
         return None
     arg = expr.args[0]

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -37,8 +37,7 @@ optimized implementations of all ops.
 
 from __future__ import annotations
 
-from typing import List, NamedTuple, Optional, Tuple
-from typing import Final
+from typing import Final, NamedTuple
 
 from mypyc.ir.ops import StealsDescription
 from mypyc.ir.rtypes import RType

--- a/mypyc/primitives/registry.py
+++ b/mypyc/primitives/registry.py
@@ -38,7 +38,7 @@ optimized implementations of all ops.
 from __future__ import annotations
 
 from typing import List, NamedTuple, Optional, Tuple
-from typing_extensions import Final
+from typing import Final
 
 from mypyc.ir.ops import StealsDescription
 from mypyc.ir.rtypes import RType
@@ -50,16 +50,16 @@ ERR_NEG_INT: Final = 10
 
 class CFunctionDescription(NamedTuple):
     name: str
-    arg_types: List[RType]
+    arg_types: list[RType]
     return_type: RType
-    var_arg_type: Optional[RType]
-    truncated_type: Optional[RType]
+    var_arg_type: RType | None
+    truncated_type: RType | None
     c_function_name: str
     error_kind: int
     steals: StealsDescription
     is_borrowed: bool
-    ordering: Optional[List[int]]
-    extra_int_constants: List[Tuple[int, RType]]
+    ordering: list[int] | None
+    extra_int_constants: list[tuple[int, RType]]
     priority: int
 
 

--- a/mypyc/test-data/fixtures/testutil.py
+++ b/mypyc/test-data/fixtures/testutil.py
@@ -7,7 +7,7 @@ from typing import (
     Any, Iterator, TypeVar, Generator, Optional, List, Tuple, Sequence,
     Union, Callable, Awaitable,
 )
-from typing_extensions import Final
+from typing import Final
 
 FLOAT_MAGIC: Final = -113.0
 


### PR DESCRIPTION
After `py3.7` support is gone (https://github.com/python/mypy/pull/15566), we can update our source code with new python syntax. 