### PR TITLE
Fix some deprecation warnings on Python 3.12

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1881,7 +1881,7 @@ class TypeConverter:
             return UnboundType("None", line=self.line)
         if isinstance(val, str):
             # Parse forward reference.
-            return parse_type_string(n.s, "builtins.str", self.line, n.col_offset)
+            return parse_type_string(n.value, "builtins.str", self.line, n.col_offset)
         if val is Ellipsis:
             # '...' is valid in some types.
             return EllipsisType(line=self.line)


### PR DESCRIPTION
Use `value` instead of `s` attribute to fix deprecation warnings. The use of `s` generated lots of deprecation warnings when compiled with mypyc, in particular.