### PR TITLE
Don't add strange fictional parameters to the signature of `NamedTuple._make()`

### DIFF
--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -605,16 +605,11 @@ class NamedTupleAnalyzer:
 
         add_method("__new__", ret=selftype, args=[make_init_arg(var) for var in vars], is_new=True)
         add_method("_asdict", args=[], ret=ordereddictype)
-        special_form_any = AnyType(TypeOfAny.special_form)
         add_method(
             "_make",
             ret=selftype,
             is_classmethod=True,
-            args=[
-                Argument(Var("iterable", iterable_type), iterable_type, None, ARG_POS),
-                Argument(Var("new"), special_form_any, EllipsisExpr(), ARG_NAMED_OPT),
-                Argument(Var("len"), special_form_any, EllipsisExpr(), ARG_NAMED_OPT),
-            ],
+            args=[Argument(Var("iterable", iterable_type), iterable_type, None, ARG_POS)],
         )
 
         self_tvar_expr = TypeVarExpr(

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -992,7 +992,7 @@ class SubO(Out): pass
 
 o: SubO
 
-reveal_type(SubO._make)  # N: Revealed type is "def (iterable: typing.Iterable[Any], *, new: Any =, len: Any =) -> Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.SubO]"
+reveal_type(SubO._make)  # N: Revealed type is "def (iterable: typing.Iterable[Any]) -> Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.SubO]"
 reveal_type(o._replace(y=Other()))  # N: Revealed type is "Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.SubO]"
 [builtins fixtures/tuple.pyi]
 
@@ -1009,7 +1009,7 @@ o: Out
 reveal_type(o)  # N: Revealed type is "Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]"
 reveal_type(o.x)  # N: Revealed type is "Tuple[builtins.str, __main__.Other, fallback=__main__.In]"
 reveal_type(o.x.t)  # N: Revealed type is "__main__.Other"
-reveal_type(Out._make)  # N: Revealed type is "def (iterable: typing.Iterable[Any], *, new: Any =, len: Any =) -> Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]"
+reveal_type(Out._make)  # N: Revealed type is "def (iterable: typing.Iterable[Any]) -> Tuple[Tuple[builtins.str, __main__.Other, fallback=__main__.In], __main__.Other, fallback=__main__.Out]"
 [builtins fixtures/tuple.pyi]
 
 [case testNewAnalyzerIncompleteRefShadowsBuiltin1]


### PR DESCRIPTION
It appears that mypy currently synthesises two fictional parameters for the NamedTuple classmethod `_make()`: `new` and `len`. I'm not sure why we do this? They've never existed at runtime, and all tests pass if we remove them (except for two that need to be changed slightly, due to the output of `reveal_type(namedtuple_cls._make)` changing).

It looks like we've been adding these parameters since support for `_make()` was first added in 2016: https://github.com/python/mypy/pull/1810. I can't find any reference in that PR thread about why we add these parameters, however.

This PR proposes that we stop adding these parameters, which makes the output of `reveal_type(namedtuple_class._make)` much more accurate :)