### PR TITLE
Solve import cycles for `mypy/expandtype.py` and `mypy/test/testtypes.py`

### DIFF
--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -5,7 +5,6 @@ from typing_extensions import Final
 
 from mypy.nodes import ARG_POS, ARG_STAR, ArgKind, Var
 from mypy.state import state
-from mypy.type_visitor import TypeTranslator
 from mypy.types import (
     ANY_STRATEGY,
     AnyType,
@@ -43,6 +42,9 @@ from mypy.types import (
     split_with_prefix_and_suffix,
 )
 from mypy.typevartuples import find_unpack_in_list, split_with_instance
+
+# Solving the import cycle:
+import mypy.type_visitor  # ruff: isort: skip
 
 # WARNING: these functions should never (directly or indirectly) depend on
 # is_subtype(), meet_types(), join_types() etc.
@@ -167,7 +169,7 @@ def freshen_all_functions_type_vars(t: T) -> T:
         return result
 
 
-class FreshenCallableVisitor(TypeTranslator):
+class FreshenCallableVisitor(mypy.type_visitor.TypeTranslator):
     def visit_callable_type(self, t: CallableType) -> Type:
         result = super().visit_callable_type(t)
         assert isinstance(result, ProperType) and isinstance(result, CallableType)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import re
 from unittest import TestCase, skipUnless
 
-import mypy.expandtype
 from mypy.erasetype import erase_type, remove_instance_last_known_values
-from mypy.expandtype import expand_type
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.join import join_simple, join_types
 from mypy.meet import meet_types, narrow_declared_type
@@ -52,6 +50,9 @@ from mypy.types import (
     get_proper_type,
     has_recursive_types,
 )
+
+# Solving the import cycle:
+import mypy.expandtype  # ruff: isort: skip
 
 
 class TypesSuite(Suite):
@@ -268,7 +269,7 @@ class TypeOpsSuite(Suite):
         for id, t in map_items:
             lower_bounds[id] = t
 
-        exp = expand_type(orig, lower_bounds)
+        exp = mypy.expandtype.expand_type(orig, lower_bounds)
         # Remove erased tags (asterisks).
         assert_equal(str(exp).replace("*", ""), str(result))
 


### PR DESCRIPTION
Now it passes:

```
» pytest mypy/test/testtypes.py   
=================================== test session starts ===================================
platform darwin -- Python 3.11.3, pytest-7.3.2, pluggy-1.2.0
rootdir: /Users/sobolev/Desktop/mypy
configfile: pyproject.toml
plugins: cov-4.1.0, xdist-3.3.1
12 workers [116 items]    
.......................................s...................s....................... [ 71%]
.................................                                                   [100%]
============================= 114 passed, 2 skipped in 0.63s ==============================
```

I've also fixed this problem:

```
» python mypy/expandtype.py
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/mypy/mypy/expandtype.py", line 7, in <module>
    import mypy.type_visitor  # ruff: isort: skip
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sobolev/Desktop/mypy/mypy/type_visitor.py", line 22, in <module>
    from mypy.types import (
  File "/Users/sobolev/Desktop/mypy/mypy/types.py", line 2968, in <module>
    from mypy.type_visitor import (  # noqa: F811
ImportError: cannot import name 'ALL_STRATEGY' from partially initialized module 'mypy.type_visitor' (most likely due to a circular import) (/Users/sobolev/Desktop/mypy/mypy/type_visitor.py)
```

Closes https://github.com/python/mypy/issues/15570
