### PR TITLE
[mypyc] Fix self-compilation on Python 3.12

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -41,7 +41,7 @@ from mypyc.namegen import exported_name
 from mypyc.options import CompilerOptions
 
 if TYPE_CHECKING:
-    from distutils.core import Extension as _distutils_Extension
+    from distutils.core import Extension as _distutils_Extension  # type: ignore
     from typing_extensions import TypeAlias
 
     from setuptools import Extension as _setuptools_Extension
@@ -56,14 +56,14 @@ except ImportError:
     if sys.version_info >= (3, 12):
         # Raise on Python 3.12, since distutils will go away forever
         raise
-from distutils import ccompiler, sysconfig
+from distutils import ccompiler, sysconfig  # type: ignore
 
 
-def get_extension() -> type[Extension]:
+def get_extension() -> type[Extension]:  # type: ignore[no-any-unimported]
     # We can work with either setuptools or distutils, and pick setuptools
     # if it has been imported.
     use_setuptools = "setuptools" in sys.modules
-    extension_class: type[Extension]
+    extension_class: type[Extension]  # type: ignore[no-any-unimported]
 
     if not use_setuptools:
         import distutils.core
@@ -241,7 +241,7 @@ def generate_c(
     return ctext, "\n".join(format_modules(modules))
 
 
-def build_using_shared_lib(
+def build_using_shared_lib(  # type: ignore[no-any-unimported]
     sources: list[BuildSource],
     group_name: str,
     cfiles: list[str],
@@ -289,7 +289,7 @@ def build_using_shared_lib(
     return extensions
 
 
-def build_single_module(
+def build_single_module(  # type: ignore[no-any-unimported]
     sources: list[BuildSource], cfiles: list[str], extra_compile_args: list[str]
 ) -> list[Extension]:
     """Produce the list of extension modules for a standalone extension.
@@ -443,7 +443,7 @@ def mypyc_build(
     return groups, group_cfilenames
 
 
-def mypycify(
+def mypycify(  # type: ignore[no-any-unimported]
     paths: list[str],
     *,
     only_compile_paths: Iterable[str] | None = None,

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -58,8 +58,11 @@ if sys.version_info < (3, 12):
 else:
     import setuptools
     from setuptools import Extension
-    from setuptools._distutils import ccompiler as _ccompiler  # type: ignore[attr-defined]
-    from setuptools._distutils import sysconfig as _sysconfig  # type: ignore[attr-defined]
+    from setuptools._distutils import (
+        ccompiler as _ccompiler,  # type: ignore[attr-defined]
+        sysconfig as _sysconfig,  # type: ignore[attr-defined]
+    )
+
     ccompiler = _ccompiler
     sysconfig = _sysconfig
 


### PR DESCRIPTION
Python 3.12 no longer ships `distutils` (PEP 632), so we must rely on `setuptools`, which
includes a vendored (but modified) version of `distutils`. However, the stubs for the vendored
`distutils` are not very complete, so we need some workarounds to pass type checking.