### PR TITLE
Add foundation to enable `--strict-optional` in all test files

### DIFF
--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -343,7 +343,7 @@ def parse_options(
         flag_list = []
         options = Options()
         # TODO: Enable strict optional in test cases by default (requires *many* test case changes)
-        if os.path.split(testcase.file)[1] in no_strict_optional_files:
+        if os.path.basename(testcase.file) in no_strict_optional_files:
             options.strict_optional = False
 
         options.error_summary = False

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -343,7 +343,7 @@ def parse_options(
         flag_list = []
         options = Options()
         # TODO: Enable strict optional in test cases by default (requires *many* test case changes)
-        if testcase.file.rpartition("/")[2] in no_strict_optional_files:
+        if os.path.split(testcase.file)[1] in no_strict_optional_files:
             options.strict_optional = False
 
         options.error_summary = False

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import sys
 import time
-from typing import Any, Callable, Iterable, Iterator, Pattern
+from typing import Any, Callable, Collection, Iterable, Iterator, Pattern
 
 # Exporting Suite as alias to TestCase for backwards compatibility
 # TODO: avoid aliasing - import and subclass TestCase directly
@@ -317,7 +317,10 @@ def assert_type(typ: type, value: object) -> None:
 
 
 def parse_options(
-    program_text: str, testcase: DataDrivenTestCase, incremental_step: int
+    program_text: str,
+    testcase: DataDrivenTestCase,
+    incremental_step: int,
+    no_strict_optional_files: Collection[str] = (),
 ) -> Options:
     """Parse comments like '# flags: --foo' in a test case."""
     options = Options()
@@ -340,7 +343,9 @@ def parse_options(
         flag_list = []
         options = Options()
         # TODO: Enable strict optional in test cases by default (requires *many* test case changes)
-        options.strict_optional = False
+        if testcase.file.rpartition("/")[2] in no_strict_optional_files:
+            options.strict_optional = False
+
         options.error_summary = False
         options.hide_error_codes = True
         options.force_uppercase_builtins = True

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -49,6 +49,48 @@ if sys.platform not in ("darwin", "win32"):
     typecheck_files.remove("check-modules-case.test")
 
 
+# TODO: Enable strict optional in test cases by default. Remove files here, once test cases are updated
+no_strict_optional_files = {
+    "check-abstract.test",
+    "check-async-await.test",
+    "check-basic.test",
+    "check-bound.test",
+    "check-classes.test",
+    "check-dynamic-typing.test",
+    "check-enum.test",
+    "check-expressions.test",
+    "check-formatting.test",
+    "check-functions.test",
+    "check-generic-subtyping.test",
+    "check-generics.test",
+    "check-incremental.test",
+    "check-inference-context.test",
+    "check-inference.test",
+    "check-inline-config.test",
+    "check-isinstance.test",
+    "check-kwargs.test",
+    "check-lists.test",
+    "check-literal.test",
+    "check-modules.test",
+    "check-namedtuple.test",
+    "check-newsemanal.test",
+    "check-overloading.test",
+    "check-plugin-attrs.test",
+    "check-protocols.test",
+    "check-selftype.test",
+    "check-serialize.test",
+    "check-statements.test",
+    "check-super.test",
+    "check-tuples.test",
+    "check-type-aliases.test",
+    "check-type-checks.test",
+    "check-typeddict.test",
+    "check-typevar-values.test",
+    "check-unions.test",
+    "check-varargs.test",
+}
+
+
 class TypeCheckSuite(DataSuite):
     files = typecheck_files
 
@@ -121,7 +163,9 @@ class TypeCheckSuite(DataSuite):
             perform_file_operations(operations)
 
         # Parse options after moving files (in case mypy.ini is being moved).
-        options = parse_options(original_program_text, testcase, incremental_step)
+        options = parse_options(
+            original_program_text, testcase, incremental_step, no_strict_optional_files
+        )
         options.use_builtins_fixtures = True
         if not testcase.name.endswith("_no_incomplete"):
             options.enable_incomplete_feature = [TYPE_VAR_TUPLE, UNPACK]

--- a/mypy/test/testfinegrained.py
+++ b/mypy/test/testfinegrained.py
@@ -45,6 +45,9 @@ from mypy.test.helpers import (
 # Set to True to perform (somewhat expensive) checks for duplicate AST nodes after merge
 CHECK_CONSISTENCY = False
 
+# TODO: Enable strict optional in test cases by default. Remove files here, once test cases are updated
+no_strict_optional_files = {"fine-grained.test", "fine-grained-suggest.test"}
+
 
 class FineGrainedSuite(DataSuite):
     files = find_test_files(
@@ -140,7 +143,9 @@ class FineGrainedSuite(DataSuite):
 
     def get_options(self, source: str, testcase: DataDrivenTestCase, build_cache: bool) -> Options:
         # This handles things like '# flags: --foo'.
-        options = parse_options(source, testcase, incremental_step=1)
+        options = parse_options(
+            source, testcase, incremental_step=1, no_strict_optional_files=no_strict_optional_files
+        )
         options.incremental = True
         options.use_builtins_fixtures = True
         options.show_traceback = True


### PR DESCRIPTION
Enabling `--strict-optional` in all test files would require a lot of changes currently. This PR adds a blacklist for test files which still require `--no-strict-optional`. It will allow us to update those incrementally.

_The same could be done for the `force_uppercase_builtins` and `force_union_syntax` settings afterwards._