### PR TITLE
Fix variable name in comment in `getting_started.rst`

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -264,7 +264,7 @@ Python standard library. For example, here is a function which uses the
     from pathlib import Path
 
     def load_template(template_path: Path, name: str) -> str:
-        # Mypy knows that `file_path` has a `read_text` method that returns a str
+        # Mypy knows that `template_path` has a `read_text` method that returns a str
         template = template_path.read_text()
         # ...so it understands this line type checks
         return template.replace('USERNAME', name)


### PR DESCRIPTION
This PR fixes a word within a code block of the `Getting Started/Types from libraries` documentation.  
In particular, the variable name `file_path` is used instead of the correct `template_path`.  
This commit fixes that and it replaces `file_path` with `template_path`.  

This PR doesn't change the behaviour of `mypy` code since it involves just a word change in the documentation, so no tests are provided and it is expected that current working code works as usual, given the change made by this PR.
