### PR TITLE
Remove `six` as a test dependency

### DIFF
--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -1370,9 +1370,8 @@ except TypeError as e:
 
 [case testMetaclass]
 from meta import Meta
-import six
 
-class Nothing1(metaclass=Meta):
+class Nothing(metaclass=Meta):
     pass
 
 def ident(x): return x
@@ -1381,15 +1380,7 @@ def ident(x): return x
 class Test:
     pass
 
-class Nothing2(six.with_metaclass(Meta, Test)):
-    pass
-
-@six.add_metaclass(Meta)
-class Nothing3:
-    pass
-
 [file meta.py]
-from typing import Any
 class Meta(type):
     def __new__(mcs, name, bases, dct):
         dct['X'] = 10
@@ -1397,10 +1388,8 @@ class Meta(type):
 
 
 [file driver.py]
-from native import Nothing1, Nothing2, Nothing3
-assert Nothing1.X == 10
-assert Nothing2.X == 10
-assert Nothing3.X == 10
+from native import Nothing
+assert Nothing.X == 10
 
 [case testPickling]
 from mypy_extensions import trait, mypyc_attr

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,5 +14,4 @@ pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
 ruff==0.0.272  # must match version in .pre-commit-config.yaml
 setuptools>=65.5.1
-six
-tomli>=1.1.0
+tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.7


### PR DESCRIPTION
Only one test fails if we remove `six` as a test dependency. The test was added in https://github.com/python/mypy/pull/8119, and isn't really testing anything to do with `six` specifically -- it's just a general test for mypyc's handling of metaclasses -- so I think it's fine to change the test so that it just doesn't import `six` anymore. We will still have plenty of other tests that check that mypy's special handling of `six` works correctly.