### PR TITLE
When sync-typeshed fails to apply CP allow manual user merges

### DIFF
--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -198,7 +198,7 @@ def main() -> None:
                 " In a separate shell, please manually merge and continue cherry pick."
             )
             rsp = input("Did you finish the cherry pick? [y/N]: ")
-            if not rsp.lower().startswith("y"):
+            if rsp.lower() not in {"y", "yes"}:
                 raise
         print(f"Cherry-picked {commit}.")
 

--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -195,6 +195,8 @@ def main() -> None:
                     " In a separate shell, please manually merge and continue cherry pick."
                 )
                 input("Did you finish the cherry pick?")
+            else:
+                raise
         print(f"Cherry-picked {commit}.")
 
     if args.make_pr:

--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -188,14 +188,17 @@ def main() -> None:
         try:
             subprocess.run(["git", "cherry-pick", commit], check=True)
         except subprocess.CalledProcessError:
-            if sys.__stdin__.isatty():
-                # Allow the option to merge manually
-                print(
-                    f"Commit {commit} failed to cherry pick."
-                    " In a separate shell, please manually merge and continue cherry pick."
-                )
-                input("Did you finish the cherry pick?")
-            else:
+            if not sys.__stdin__.isatty():
+                # We're in an automated context
+                raise
+            
+            # Allow the option to merge manually
+            print(
+                f"Commit {commit} failed to cherry pick."
+                " In a separate shell, please manually merge and continue cherry pick."
+            )
+            rsp = input("Did you finish the cherry pick? [y/N]: ")
+            if not rsp.lower().startswith("y"):
                 raise
         print(f"Cherry-picked {commit}.")
 

--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -185,7 +185,16 @@ def main() -> None:
         "9f3bbbeb1",  # ParamSpec for functools.wraps
     ]
     for commit in commits_to_cherry_pick:
-        subprocess.run(["git", "cherry-pick", commit], check=True)
+        try:
+            subprocess.run(["git", "cherry-pick", commit], check=True)
+        except subprocess.CalledProcessError:
+            if sys.__stdin__.isatty():
+                # Allow the option to merge manually
+                print(
+                    f"Commit {commit} failed to cherry pick."
+                    " In a separate shell, please manually merge and continue cherry pick."
+                )
+                input("Did you finish the cherry pick?")
         print(f"Cherry-picked {commit}.")
 
     if args.make_pr:

--- a/misc/sync-typeshed.py
+++ b/misc/sync-typeshed.py
@@ -191,7 +191,7 @@ def main() -> None:
             if not sys.__stdin__.isatty():
                 # We're in an automated context
                 raise
-            
+
             # Allow the option to merge manually
             print(
                 f"Commit {commit} failed to cherry pick."


### PR DESCRIPTION
If misc/sync-typeshed.py fails to apply a cherry pick, it just fails. Let's try to give the user a chance to manually merge the CP and continue with the script.
This should block for user input only in cases where stdin is a tty. So automation should continue failing. (but the only way to test is by running it)