### PR TITLE
Add upper bound for lxml

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,8 @@
 attrs>=18.0
 black==23.3.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
-lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
+# lxml 4.9.3 switched to manylinux_2_28, the wheel builder still uses manylinux2014
+lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 pre-commit
 pre-commit-hooks==4.4.0
 psutil>=4.0


### PR DESCRIPTION
`lxml==4.9.3` was released yesterday which caused the wheel builder to fail again.
https://github.com/mypyc/mypy_mypyc-wheels/actions/runs/5473072463/jobs/9966070811#step:4:6979

The `lxml` project decided to change the manylinux builds from `manylinux2014` to `manylinux_2_28`. Thus to test our wheels we would need to compile `lxml` from source. Until will update to `manylinux_2_28` ourselves, I think pinning `lxml<4.9.3` is the best option.

https://pypi.org/project/lxml/4.9.2/#files
https://pypi.org/project/lxml/4.9.3/#files