### PR TITLE
Bump pytest to >=7.4.0

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -378,7 +378,10 @@ class DataDrivenTestCase(pytest.Item):
     def reportinfo(self) -> tuple[str, int, str]:
         return self.file, self.line, self.name
 
-    def repr_failure(self, excinfo: Any, style: Any | None = None) -> str:
+    def repr_failure(
+        self, excinfo: pytest.ExceptionInfo[BaseException], style: Any | None = None
+    ) -> str:
+        excrepr: object
         if isinstance(excinfo.value, SystemExit):
             # We assume that before doing exit() (which raises SystemExit) we've printed
             # enough context about what happened so that a stack trace is not useful.
@@ -388,7 +391,7 @@ class DataDrivenTestCase(pytest.Item):
         elif isinstance(excinfo.value, pytest.fail.Exception) and not excinfo.value.pytrace:
             excrepr = excinfo.exconly()
         else:
-            self.parent._prunetraceback(excinfo)
+            excinfo.traceback = self.parent._traceback_filter(excinfo)
             excrepr = excinfo.getrepr(style="short")
 
         return f"data: {self.file}:{self.line}:\n{excrepr}"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,9 +7,7 @@ lxml>=4.9.1; (python_version<'3.11' or sys_platform!='win32') and python_version
 pre-commit
 pre-commit-hooks==4.4.0
 psutil>=4.0
-# pytest 6.2.3 does not support Python 3.10
-# TODO: fix use of removed private APIs so we can use the latest pytest
-pytest>=6.2.4,<7.4.0
+pytest>=7.4.0
 pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
 ruff==0.0.272  # must match version in .pre-commit-config.yaml


### PR DESCRIPTION
The 7.4.0 release of pytest broke mypy because we were using some undocumented, private API that was removed. Ideally we'd stop using the private API, but nobody seems to remember why we started using the private API in the first place (see https://github.com/python/mypy/pull/15501#issuecomment-1607083799, and following comments). For now it (unfortunately) seems safer to just migrate to the new private API rather than try to figure out an alternative using public API.

I also took @bluetech's advice in https://github.com/python/mypy/pull/15501#issuecomment-1606259499 to improve the type annotations in the method in question.