### PR TITLE
Update cheat_sheet_py3.rst 2 properly xplain Callable

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -109,8 +109,11 @@ Functions
        x.anything() + 1 + "string"  # no errors
 
    # This is how you annotate a callable (function) value
+   Callable[[A1, A2, A3], Rt] represents a function with three arguments with types A1, A2, and A3, respectively. The return type of the function is Rt.
    x: Callable[[int, float], float] = f
    def register(callback: Callable[[str], int]) -> None: ...
+   Callable[..., ReturnType] (literal ellipsis) can be used to type hint a callable taking any number of arguments and returning ReturnType
+   ReturnType can only be of a single type.
 
    # A generator function that yields ints is secretly just a function that
    # returns an iterator of ints, so that's how we annotate it


### PR DESCRIPTION
There was a bit of a gap as to which part are the input and where the return type is.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
