### PR TITLE
stubdoc: Fix crash on non-str docstring

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -254,7 +254,7 @@ def infer_sig_from_docstring(docstr: str | None, name: str) -> list[FunctionSig]
         * docstr: docstring
         * name: name of function for which signatures are to be found
     """
-    if not docstr:
+    if not (isinstance(docstr, str) and docstr):
         return None
 
     state = DocStringParser(name)

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -1214,10 +1214,10 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(set(imports), {"import foo", "import other"})
 
     def test_generate_c_function_no_crash_for_non_str_docstring(self) -> None:
-        def test(arg0):
+        def test(arg0: str) -> None:
             ...
 
-        test.__doc__ = property(lambda self: "test(arg0: str) -> None")
+        test.__doc__ = property(lambda self: "test(arg0: str) -> None")  # type: ignore[assignment]
 
         output: list[str] = []
         imports: list[str] = []

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -1213,6 +1213,27 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ["def test(arg0: foo.bar.Action) -> other.Thing: ..."])
         assert_equal(set(imports), {"import foo", "import other"})
 
+    def test_generate_c_function_no_crash_for_non_str_docstring(self) -> None:
+        def test(arg0):
+            ...
+
+        test.__doc__ = property(lambda self: "test(arg0: str) -> None")
+
+        output: list[str] = []
+        imports: list[str] = []
+        mod = ModuleType(self.__module__, "")
+        generate_c_function_stub(
+            mod,
+            "test",
+            test,
+            output=output,
+            imports=imports,
+            known_modules=[mod.__name__],
+            sig_generators=get_sig_generators(parse_options([])),
+        )
+        assert_equal(output, ["def test(*args, **kwargs) -> Any: ..."])
+        assert_equal(imports, [])
+
     def test_generate_c_property_with_pybind11(self) -> None:
         """Signatures included by PyBind11 inside property.fget are read."""
 


### PR DESCRIPTION
Encourted this while testing stubgen on pandas:

```console
$ stubgen -p pandas
Traceback (most recent call last):
  File "/tmp/.venv/bin/stubgen", line 8, in <module>
    sys.exit(main())
  File "mypy/stubgen.py", line 1945, in main
  File "mypy/stubgen.py", line 1799, in generate_stubs
  File "/tmp/.venv/lib/python3.10/site-packages/mypy/stubgenc.py", line 212, in generate_stub_for_c_module
    generate_c_type_stub(
  File "/tmp/.venv/lib/python3.10/site-packages/mypy/stubgenc.py", line 528, in generate_c_type_stub
    generate_c_function_stub(
  File "/tmp/.venv/lib/python3.10/site-packages/mypy/stubgenc.py", line 337, in generate_c_function_stub
    inferred = sig_gen.get_method_sig(
  File "/tmp/.venv/lib/python3.10/site-packages/mypy/stubgenc.py", line 140, in get_method_sig
    inferred = self.get_function_sig(cls, module_name, class_name)
  File "/tmp/.venv/lib/python3.10/site-packages/mypy/stubgenc.py", line 120, in get_function_sig
    inferred = infer_sig_from_docstring(docstr, name)
  File "/tmp/.venv/lib/python3.10/site-packages/mypy/stubdoc.py", line 264, in infer_sig_from_docstring
    tokens = tokenize.tokenize(io.BytesIO(docstr.encode("utf-8")).readline)
AttributeError: 'getset_descriptor' object has no attribute 'encode'
```

This is because of the definition of docstring as a descriptor here https://github.com/pandas-dev/pandas/blob/main/pandas/_libs/properties.pyx

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
