### PR TITLE
Support enum Literals in the enum plugin

### DIFF
--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -12,14 +12,23 @@ semanal_enum.py).
 """
 from __future__ import annotations
 
-from typing import Final, Iterable, Sequence, TypeVar, cast
+from itertools import chain
+from typing import Final, Iterable, List, Sequence, TypeVar, Union, cast
 
 import mypy.plugin  # To avoid circular imports.
 from mypy.nodes import TypeInfo
 from mypy.semanal_enum import ENUM_BASES
 from mypy.subtypes import is_equivalent
 from mypy.typeops import fixup_partial_type, make_simplified_union
-from mypy.types import CallableType, Instance, LiteralType, ProperType, Type, get_proper_type
+from mypy.types import (
+    CallableType,
+    Instance,
+    LiteralType,
+    ProperType,
+    Type,
+    UnionType,
+    get_proper_type,
+)
 
 ENUM_NAME_ACCESS: Final = {f"{prefix}.name" for prefix in ENUM_BASES} | {
     f"{prefix}._name_" for prefix in ENUM_BASES
@@ -46,6 +55,7 @@ def enum_name_callback(ctx: mypy.plugin.AttributeContext) -> Type:
     """
     enum_field_name = _extract_underlying_field_name(ctx.type)
     if enum_field_name is None:
+        # TODO: handle full enums/unions of enums for names
         return ctx.default_attr_type
     else:
         str_type = ctx.api.named_generic_type("builtins.str", [])
@@ -148,65 +158,80 @@ def enum_value_callback(ctx: mypy.plugin.AttributeContext) -> Type:
         # same value-type, then it doesn't matter which member was passed in.
         # The value-type is still known.
         if isinstance(ctx.type, Instance):
-            info = ctx.type.type
+            items: List[Union[Instance, LiteralType]] = [ctx.type]
+        elif isinstance(ctx.type, UnionType):
+            tmp_items = [get_proper_type(item) for item in ctx.type.items]
+            items = [item for item in tmp_items if isinstance(item, (Instance, LiteralType))]
+        else:
+            return ctx.default_attr_type
 
-            # As long as mypy doesn't understand attribute creation in __new__,
-            # there is no way to predict the value type if the enum class has a
-            # custom implementation
-            if _implements_new(info):
-                return ctx.default_attr_type
+        # As long as mypy doesn't understand attribute creation in __new__,
+        # there is no way to predict the value type if the enum class has a
+        # custom implementation
+        if any(
+            _implements_new(item.type if isinstance(item, Instance) else item.fallback.type)
+            for item in items
+        ):
+            return ctx.default_attr_type
 
-            stnodes = (info.get(name) for name in info.names)
+        # there may be duplicate typeinfos in `infos`, but union simplification handles that
+        # stnodes = (info.get(name) for info in infos for name in info.names)
+        stnodes = chain.from_iterable(
+            [item.type.get(name) for name in item.type.names] if isinstance(item, Instance)
+            # this cast is fine because we guard on item.is_enum_literal()
+            else [item.fallback.type.get(cast(str, item.value))]
+            for item in items
+            if isinstance(item, Instance) or item.is_enum_literal()
+        )
 
-            # Enums _can_ have methods and instance attributes.
-            # Omit methods and attributes created by assigning to self.*
-            # for our value inference.
-            node_types = (
-                get_proper_type(n.type) if n else None
-                for n in stnodes
-                if n is None or not n.implicit
-            )
-            proper_types = list(
-                _infer_value_type_with_auto_fallback(ctx, t)
-                for t in node_types
-                if t is None or not isinstance(t, CallableType)
-            )
-            underlying_type = _first(proper_types)
-            if underlying_type is None:
-                return ctx.default_attr_type
+        # Enums _can_ have methods and instance attributes.
+        # Omit methods and attributes created by assigning to self.*
+        # for our value inference.
+        node_types = (
+            get_proper_type(n.type) if n else None for n in stnodes if n is None or not n.implicit
+        )
+        proper_types = list(
+            _infer_value_type_with_auto_fallback(ctx, t)
+            for t in node_types
+            if t is None or not isinstance(t, CallableType)
+        )
+        underlying_type = _first(proper_types)
+        if underlying_type is None:
+            return ctx.default_attr_type
 
-            # At first we try to predict future `value` type if all other items
-            # have the same type. For example, `int`.
-            # If this is the case, we simply return this type.
-            # See https://github.com/python/mypy/pull/9443
-            all_same_value_type = all(
-                proper_type is not None and proper_type == underlying_type
-                for proper_type in proper_types
-            )
-            if all_same_value_type:
-                if underlying_type is not None:
-                    return underlying_type
+        # At first we try to predict future `value` type if all other items
+        # have the same type. For example, `int`.
+        # If this is the case, we simply return this type.
+        # See https://github.com/python/mypy/pull/9443
+        all_same_value_type = all(
+            proper_type is not None and proper_type == underlying_type
+            for proper_type in proper_types
+        )
+        if all_same_value_type:
+            if underlying_type is not None:
+                return underlying_type
 
-            # But, after we started treating all `Enum` values as `Final`,
-            # we start to infer types in
-            # `item = 1` as `Literal[1]`, not just `int`.
-            # So, for example types in this `Enum` will all be different:
-            #
-            #  class Ordering(IntEnum):
-            #      one = 1
-            #      two = 2
-            #      three = 3
-            #
-            # We will infer three `Literal` types here.
-            # They are not the same, but they are equivalent.
-            # So, we unify them to make sure `.value` prediction still works.
-            # Result will be `Literal[1] | Literal[2] | Literal[3]` for this case.
-            all_equivalent_types = all(
-                proper_type is not None and is_equivalent(proper_type, underlying_type)
-                for proper_type in proper_types
-            )
-            if all_equivalent_types:
-                return make_simplified_union(cast(Sequence[Type], proper_types))
+        # But, after we started treating all `Enum` values as `Final`,
+        # we start to infer types in
+        # `item = 1` as `Literal[1]`, not just `int`.
+        # So, for example types in this `Enum` will all be different:
+        #
+        #  class Ordering(IntEnum):
+        #      one = 1
+        #      two = 2
+        #      three = 3
+        #
+        # We will infer three `Literal` types here.
+        # They are not the same, but they are equivalent.
+        # So, we unify them to make sure `.value` prediction still works.
+        # Result will be `Literal[1] | Literal[2] | Literal[3]` for this case.
+        all_equivalent_types = all(
+            proper_type is not None and is_equivalent(proper_type, underlying_type)
+            for proper_type in proper_types
+        )
+        if all_equivalent_types:
+            return make_simplified_union(cast(Sequence[Type], proper_types))
+
         return ctx.default_attr_type
 
     assert isinstance(ctx.type, (Instance, LiteralType))

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2151,6 +2151,24 @@ else:
 
 y: Literal[E.A, E.B]
 reveal_type(y)  # N: Revealed type is "Union[Literal[__main__.E.A], Literal[__main__.E.B]]"
-reveal_type(y.value)  # N: Revealed type is "Any"
+reveal_type(y.value)  # N: Revealed type is "Union[Literal[1]?, Literal[2]?]"
 reveal_type(y.name)  # N: Revealed type is "builtins.str"
+[builtins fixtures/tuple.pyi]
+
+[case testEnumUnionsSupportedByPlugin]
+from enum import Enum
+from typing import Union
+
+class E1(Enum):
+    A = 1
+    B = 2
+
+class E2(Enum):
+    C = 1
+    D = 2
+
+x: Union[E1, E2]
+reveal_type(x)  # N: Revealed type is "Union[__main__.E1, __main__.E2]"
+reveal_type(x.value)  # N: Revealed type is "Union[Literal[1]?, Literal[2]?]"
+reveal_type(x.name)  # N: Revealed type is "builtins.str"
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This makes the enum plugin (e.g. `.name` and `.value`) work on enum `Literal`s.

Fixes https://github.com/python/mypy/issues/14092

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
