### PR TITLE
tests: --update-data incompatible with xdist

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -614,6 +614,13 @@ def pytest_addoption(parser: Any) -> None:
     )
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    if config.getoption("--update-data") and config.getoption("--numprocesses", default=1) > 1:
+        raise pytest.UsageError(
+            "--update-data incompatible with parallelized tests; re-run with -n 1"
+        )
+
+
 # This function name is special to pytest.  See
 # https://doc.pytest.org/en/latest/how-to/writing_plugins.html#collection-hooks
 def pytest_pycollect_makeitem(collector: Any, name: str, obj: object) -> Any | None:


### PR DESCRIPTION
Fixes a [gotcha](https://github.com/python/mypy/pull/15283#issuecomment-1631820071) with `--update-data`.

When using `--update-data` with parallelized tests (xdist), the line offsets determined at test time may become wrong by update time, as multiple workers perform their updates to the same file.

This makes it so we exit with a usage error when `--update-data` is used with parallelism.