### PR TITLE
Support __bool__ with Literal in --warn-unreachable

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -600,10 +600,8 @@ def true_only(t: Type) -> ProperType:
     else:
         ret_type = _get_type_special_method_bool_ret_type(t)
 
-        if ret_type and ret_type.can_be_false and not ret_type.can_be_true:
-            new_t = copy_type(t)
-            new_t.can_be_true = False
-            return new_t
+        if ret_type and not ret_type.can_be_true:
+            return UninhabitedType(line=t.line, column=t.column)
 
         new_t = copy_type(t)
         new_t.can_be_false = False
@@ -635,10 +633,8 @@ def false_only(t: Type) -> ProperType:
     else:
         ret_type = _get_type_special_method_bool_ret_type(t)
 
-        if ret_type and ret_type.can_be_true and not ret_type.can_be_false:
-            new_t = copy_type(t)
-            new_t.can_be_false = False
-            return new_t
+        if ret_type and not ret_type.can_be_false:
+            return UninhabitedType(line=t.line)
 
         new_t = copy_type(t)
         new_t.can_be_true = False

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1380,6 +1380,38 @@ def f() -> None:
         x = 1  # E: Statement is unreachable
 [builtins fixtures/dict.pyi]
 
+[case testUnreachableLiteralFrom__bool__]
+# flags: --warn-unreachable
+from typing_extensions import Literal
+
+class Truth:
+    def __bool__(self) -> Literal[True]: ...
+
+class Lie:
+    def __bool__(self) -> Literal[False]: ...
+
+class Maybe:
+    def __bool__(self) -> Literal[True | False]: ...
+
+t = Truth()
+if t:
+    x = 1
+else:
+    x = 2  # E: Statement is unreachable
+
+if Lie():
+    x = 3  # E: Statement is unreachable
+
+if Maybe():
+    x = 4
+
+
+def foo() -> bool: ...
+
+y = Truth() or foo()  # E: Right operand of "or" is never evaluated
+z = Lie() and foo()  # E: Right operand of "and" is never evaluated
+[builtins fixtures/dict.pyi]
+
 [case testUnreachableModuleBody1]
 # flags: --warn-unreachable
 from typing import NoReturn


### PR DESCRIPTION
This adds support for `Literal` as return type of `__bool__` in the reachability analysis.

Example:

```
class AlwaysFalse:
    def __bool__(self) -> Literal[False]: ...

if AlwaysFalse():
    x = 1                   <- this line is unreachable
```


Addresses https://github.com/python/mypy/issues/7008
Fixes parts of https://github.com/python/mypy/issues/15523 (Handling `bool()` should probably be a separate PR)

To be honest, I did not understand what the purpose of this code was / why "the branch was even taken or analzyed" before: 

```
if ret_type and ret_type.can_be_false and not ret_type.can_be_true:
    new_t = copy_type(t)
    new_t.can_be_true = False
    return new_t
```

Now instead of the branch is taken with the updated type, it is marked as unreachable.

Edit: It is probably for the case that "--warn-unreachable" is not enabled. Should the type checker then continue in the unreachable block? But I guess it also never did for the other cases e.g. `if False` ...

Edit 2: It does not make sense to continue, because it might lead to incorrect preconditions of the blocks.