### PR TITLE
Narrow `is` with final types correctly

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1782,6 +1782,10 @@ def covers_at_runtime(item: Type, supertype: Type) -> bool:
     item = get_proper_type(item)
     supertype = get_proper_type(supertype)
 
+    if isinstance(item, (CallableType, TypeType)) and item.is_singleton_type():
+        if is_proper_subtype(item, supertype):
+            return True
+
     # Since runtime type checks will ignore type arguments, erase the types.
     supertype = erase_type(supertype)
     if is_proper_subtype(

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2085,6 +2085,9 @@ class CallableType(FunctionLike):
             )
         )
 
+    def is_singleton_type(self) -> bool:
+        return self.is_type_obj() and self.type_object().is_final
+
     def __hash__(self) -> int:
         # self.is_type_obj() will fail if self.fallback.type is a FakeInfo
         if isinstance(self.fallback.type, FakeInfo):
@@ -2855,6 +2858,12 @@ class TypeType(ProperType):
         if not isinstance(other, TypeType):
             return NotImplemented
         return self.item == other.item
+
+    def is_singleton_type(self) -> bool:
+        return (
+            (isinstance(self.item, Instance) and self.item.type.is_final)
+            or isinstance(self.item, NoneType)
+        )
 
     def serialize(self) -> JsonDict:
         return {".class": "TypeType", "item": self.item.serialize()}

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1269,3 +1269,79 @@ def g() -> None:
         def foo(): ...
     foo()
 [builtins fixtures/dict.pyi]
+
+
+[case testNarrowingIsFinalType]
+from typing import Type, Union
+from typing_extensions import final
+
+@final
+class Mark: ...
+
+@final
+class Other: ...
+
+x: Union[Type[Mark], Type[Other], Type[None], int]
+
+if x is Mark:
+    reveal_type(x)  # N: Revealed type is "Type[__main__.Mark]"
+else:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Other], Type[None], builtins.int]"
+
+if x is not Mark:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Other], Type[None], builtins.int]"
+else:
+    reveal_type(x)  # N: Revealed type is "Type[__main__.Mark]"
+
+y: Type[Mark] = Mark
+if x is y:
+    reveal_type(x)  # N: Revealed type is "Type[__main__.Mark]"
+else:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Other], Type[None], builtins.int]"
+
+if x is not y:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Other], Type[None], builtins.int]"
+else:
+    reveal_type(x)  # N: Revealed type is "Type[__main__.Mark]"
+
+if x is type(None):
+    reveal_type(x)  # N: Revealed type is "Type[None]"
+else:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Mark], Type[__main__.Other], builtins.int]"
+
+if x is not type(None):
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Mark], Type[__main__.Other], builtins.int]"
+else:
+    reveal_type(x)  # N: Revealed type is "Type[None]"
+
+z: Type[None]
+if x is z:
+    reveal_type(x)  # N: Revealed type is "Type[None]"
+else:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Mark], Type[__main__.Other], builtins.int]"
+
+if x is not z:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Mark], Type[__main__.Other], builtins.int]"
+else:
+    reveal_type(x)  # N: Revealed type is "Type[None]"
+[builtins fixtures/isinstancelist.pyi]
+
+
+[case testNarrowingIsRegualType]
+from typing import Type, Union
+
+class Mark: ...
+
+x: Union[Type[Mark], Type[None], int]
+
+if x is Mark:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Mark], Type[None], builtins.int]"
+else:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Mark], Type[None], builtins.int]"
+
+y: Type[Mark] = Mark
+if x is y:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Mark], Type[None], builtins.int]"
+else:
+    reveal_type(x)  # N: Revealed type is "Union[Type[__main__.Mark], Type[None], builtins.int]"
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
Now we can narrow `@final` types with `is` and `is not`.

Closes #15553