### PR TITLE
Fix type of linecache.cache

### DIFF
--- a/mypy/typeshed/stdlib/linecache.pyi
+++ b/mypy/typeshed/stdlib/linecache.pyi
@@ -1,6 +1,7 @@
 import sys
 from typing import Any, Protocol
 from typing_extensions import TypeAlias
+from collections.abc import Callable
 
 if sys.version_info >= (3, 9):
     __all__ = ["getline", "clearcache", "checkcache", "lazycache"]
@@ -10,8 +11,7 @@ else:
 _ModuleGlobals: TypeAlias = dict[str, Any]
 _ModuleMetadata: TypeAlias = tuple[int, float | None, list[str], str]
 
-class _SourceLoader(Protocol):
-    def __call__(self) -> str | None: ...
+_SourceLoader: TypeAlias = tuple[Callable[[], str | None]]
 
 cache: dict[str, _SourceLoader | _ModuleMetadata]  # undocumented
 


### PR DESCRIPTION
An entry of linecache.cache is either a lazy entry or a full entry. The full entries are typed correctly but the lazy entry is supposed to be a one-tuple consisting of a function that takes zero arguments and returns either a string or None:

Here you can see that the assigned value is a one-tuple with a callable: https://github.com/python/cpython/blob/v3.11.4/Lib/linecache.py#L178-L181

Here you can see that the callable is invoked with zero arguments and the expected output is a string or None:
https://github.com/python/cpython/blob/v3.11.4/Lib/linecache.py#L105-L115
