### PR TITLE
Remove `--py2` argument

### DIFF
--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import os
 from typing import Final
 
-PYTHON2_VERSION: Final = (2, 7)
-
 # Earliest fully supported Python 3.x version. Used as the default Python
 # version in tests. Mypy wheels should be built starting with this version,
 # and CI tests should be run on this version (and later versions).

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -595,14 +595,6 @@ def process_options(
         dest="special-opts:python_version",
     )
     platform_group.add_argument(
-        "-2",
-        "--py2",
-        dest="special-opts:python_version",
-        action="store_const",
-        const=defaults.PYTHON2_VERSION,
-        help="Use Python 2 mode (same as --python-version 2.7)",
-    )
-    platform_group.add_argument(
         "--platform",
         action="store",
         metavar="PLATFORM",

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -345,7 +345,7 @@ def parse_options(
         options.force_union_syntax = True
 
     # Allow custom python version to override testfile_pyversion.
-    if all(flag.split("=")[0] not in ["--python-version", "-2", "--py2"] for flag in flag_list):
+    if all(flag.split("=")[0] != "--python-version" for flag in flag_list):
         options.python_version = testfile_pyversion(testcase.file)
 
     if testcase.config.getoption("--mypy-verbose"):


### PR DESCRIPTION
Remove the `--py2` argument. It already creates a parser error.

https://github.com/python/mypy/blob/7a9418356082092d2cb1585acb816b2074cff43e/mypy/main.py#L1267-L1271