### PR TITLE
Remove unneeded `--strict-optional` flags from test cases

### DIFF
--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -1125,7 +1125,6 @@ b.y = 1
 -- -----------------------------------------------
 
 [case testEmptyBodyProhibitedFunction]
-# flags: --strict-optional
 from typing import overload, Union
 
 def func1(x: str) -> int: pass  # E: Missing return statement
@@ -1148,7 +1147,6 @@ def func5(x: Union[int, str]) -> Union[int, str]:  # E: Missing return statement
     """Some function."""
 
 [case testEmptyBodyProhibitedMethodNonAbstract]
-# flags: --strict-optional
 from typing import overload, Union
 
 class A:
@@ -1183,7 +1181,6 @@ class C:
 [builtins fixtures/classmethod.pyi]
 
 [case testEmptyBodyProhibitedPropertyNonAbstract]
-# flags: --strict-optional
 class A:
     @property
     def x(self) -> int: ...  # E: Missing return statement
@@ -1212,7 +1209,6 @@ class C:
 [builtins fixtures/property.pyi]
 
 [case testEmptyBodyNoteABCMeta]
-# flags: --strict-optional
 from abc import ABC
 
 class A(ABC):
@@ -1221,7 +1217,6 @@ class A(ABC):
         ...
 
 [case testEmptyBodyAllowedFunctionStub]
-# flags: --strict-optional
 import stub
 [file stub.pyi]
 from typing import overload, Union
@@ -1232,7 +1227,6 @@ def func3(x: str) -> int:
     """Some function."""
 
 [case testEmptyBodyAllowedMethodNonAbstractStub]
-# flags: --strict-optional
 import stub
 [file stub.pyi]
 from typing import overload, Union
@@ -1254,7 +1248,6 @@ class B:
 [builtins fixtures/classmethod.pyi]
 
 [case testEmptyBodyAllowedPropertyNonAbstractStub]
-# flags: --strict-optional
 import stub
 [file stub.pyi]
 class A:
@@ -1285,7 +1278,6 @@ class C:
 [builtins fixtures/property.pyi]
 
 [case testEmptyBodyAllowedMethodAbstract]
-# flags: --strict-optional
 from typing import overload, Union
 from abc import abstractmethod
 
@@ -1333,7 +1325,6 @@ class C:
 [builtins fixtures/classmethod.pyi]
 
 [case testEmptyBodyAllowedPropertyAbstract]
-# flags: --strict-optional
 from abc import abstractmethod
 class A:
     @property
@@ -1372,7 +1363,6 @@ class C:
 [builtins fixtures/property.pyi]
 
 [case testEmptyBodyImplicitlyAbstractProtocol]
-# flags: --strict-optional
 from typing import Protocol, overload, Union
 
 class P1(Protocol):
@@ -1413,7 +1403,6 @@ C3()
 [builtins fixtures/classmethod.pyi]
 
 [case testEmptyBodyImplicitlyAbstractProtocolProperty]
-# flags: --strict-optional
 from typing import Protocol
 
 class P1(Protocol):
@@ -1443,7 +1432,6 @@ C2()
 [builtins fixtures/property.pyi]
 
 [case testEmptyBodyImplicitlyAbstractProtocolStub]
-# flags: --strict-optional
 from stub import P1, P2, P3, P4
 
 class B1(P1): ...
@@ -1479,7 +1467,6 @@ class P4(Protocol):
 [builtins fixtures/classmethod.pyi]
 
 [case testEmptyBodyUnsafeAbstractSuper]
-# flags: --strict-optional
 from stub import StubProto, StubAbstract
 from typing import Protocol
 from abc import abstractmethod
@@ -1528,7 +1515,6 @@ class StubAbstract:
     def meth(self) -> int: ...
 
 [case testEmptyBodyUnsafeAbstractSuperProperty]
-# flags: --strict-optional
 from stub import StubProto, StubAbstract
 from typing import Protocol
 from abc import abstractmethod
@@ -1586,7 +1572,6 @@ class StubAbstract:
 [builtins fixtures/property.pyi]
 
 [case testEmptyBodyUnsafeAbstractSuperOverloads]
-# flags: --strict-optional
 from stub import StubProto
 from typing import Protocol, overload, Union
 
@@ -1671,7 +1656,6 @@ class SubAbstract(Abstract):
         return super().meth()
 
 [case testEmptyBodyNoSuperWarningOptionalReturn]
-# flags: --strict-optional
 from typing import Protocol, Optional
 from abc import abstractmethod
 
@@ -1689,7 +1673,6 @@ class SubAbstract(Abstract):
         return super().meth()
 
 [case testEmptyBodyTypeCheckingOnly]
-# flags: --strict-optional
 from typing import TYPE_CHECKING
 
 class C:

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -385,7 +385,6 @@ y = x # E: Incompatible types in assignment (expression has type "Dict[str, int]
 [builtins fixtures/dict.pyi]
 
 [case testDistinctTypes]
-# flags: --strict-optional
 import b
 
 [file a.py]

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -419,7 +419,6 @@ UserDefined(1)  # E: Argument 1 to "UserDefined" has incompatible type "int"; ex
 [builtins fixtures/list.pyi]
 
 [case testNewNamedTupleWithDefaultsStrictOptional]
-# flags: --strict-optional
 from typing import List, NamedTuple, Optional
 
 class HasNone(NamedTuple):

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1661,13 +1661,13 @@ class D:
     def __get__(self, inst: Base, own: Type[Base]) -> str: pass
 [builtins fixtures/bool.pyi]
 [out]
-main:5: error: Argument 2 to "__get__" of "D" has incompatible type "Type[A]"; expected "Type[Base]"
-main:5: note: Revealed type is "d.D"
-main:6: error: No overload variant of "__get__" of "D" matches argument types "A", "Type[A]"
-main:6: note: Possible overload variants:
-main:6: note:     def __get__(self, inst: None, own: Type[Base]) -> D
-main:6: note:     def __get__(self, inst: Base, own: Type[Base]) -> str
-main:6: note: Revealed type is "Any"
+main:4: error: Argument 2 to "__get__" of "D" has incompatible type "Type[A]"; expected "Type[Base]"
+main:4: note: Revealed type is "d.D"
+main:5: error: No overload variant of "__get__" of "D" matches argument types "A", "Type[A]"
+main:5: note: Possible overload variants:
+main:5: note:     def __get__(self, inst: None, own: Type[Base]) -> D
+main:5: note:     def __get__(self, inst: Base, own: Type[Base]) -> str
+main:5: note: Revealed type is "Any"
 
 [case testAccessingGenericNonDataDescriptor]
 from typing import TypeVar, Type, Generic, Any
@@ -1740,8 +1740,8 @@ class D(Generic[T, V]):
     def __get__(self, inst: T, own: Type[T]) -> V: pass
 [builtins fixtures/bool.pyi]
 [out]
-main:8: note: Revealed type is "d.D[__main__.A, builtins.int]"
-main:9: note: Revealed type is "d.D[__main__.A, builtins.str]"
+main:7: note: Revealed type is "d.D[__main__.A, builtins.int]"
+main:8: note: Revealed type is "d.D[__main__.A, builtins.str]"
 
 [case testAccessingGenericDescriptorFromClassBadOverload]
 from d import D
@@ -1760,11 +1760,11 @@ class D(Generic[T, V]):
     def __get__(self, inst: T, own: Type[T]) -> V: pass
 [builtins fixtures/bool.pyi]
 [out]
-main:5: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
-main:5: note: Possible overload variants:
-main:5: note:     def __get__(self, inst: None, own: None) -> D[A, int]
-main:5: note:     def __get__(self, inst: A, own: Type[A]) -> int
-main:5: note: Revealed type is "Any"
+main:4: error: No overload variant of "__get__" of "D" matches argument types "None", "Type[A]"
+main:4: note: Possible overload variants:
+main:4: note:     def __get__(self, inst: None, own: None) -> D[A, int]
+main:4: note:     def __get__(self, inst: A, own: Type[A]) -> int
+main:4: note: Revealed type is "Any"
 
 [case testAccessingNonDataDescriptorSubclass]
 from typing import Any

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -935,7 +935,6 @@ if int():
     b = D2()
 
 [case testConstructorJoinsWithCustomMetaclass]
-# flags: --strict-optional
 from typing import TypeVar
 import abc
 
@@ -1629,7 +1628,6 @@ a = A()
 reveal_type(a.f)  # N: Revealed type is "__main__.D"
 
 [case testAccessingDescriptorFromClass]
-# flags: --strict-optional
 from d import D, Base
 class A(Base):
     f = D()
@@ -1647,7 +1645,6 @@ class D:
 [builtins fixtures/bool.pyi]
 
 [case testAccessingDescriptorFromClassWrongBase]
-# flags: --strict-optional
 from d import D, Base
 class A:
     f = D()
@@ -1702,7 +1699,6 @@ a.g = ''
 a.g = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 [case testAccessingGenericDescriptorFromClass]
-# flags: --strict-optional
 from d import D
 class A:
     f = D(10)  # type: D[A, int]
@@ -1724,7 +1720,6 @@ class D(Generic[T, V]):
 [builtins fixtures/bool.pyi]
 
 [case testAccessingGenericDescriptorFromInferredClass]
-# flags: --strict-optional
 from typing import Type
 from d import D
 class A:
@@ -1749,7 +1744,6 @@ main:8: note: Revealed type is "d.D[__main__.A, builtins.int]"
 main:9: note: Revealed type is "d.D[__main__.A, builtins.str]"
 
 [case testAccessingGenericDescriptorFromClassBadOverload]
-# flags: --strict-optional
 from d import D
 class A:
     f = D(10)  # type: D[A, int]
@@ -6484,7 +6478,6 @@ def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
 [out]
 
 [case testOptionalDescriptorsBinder]
-# flags: --strict-optional
 from typing import Type, TypeVar, Optional
 T = TypeVar('T')
 
@@ -6698,7 +6691,6 @@ class C(Generic[T]):
 [builtins fixtures/isinstancelist.pyi]
 
 [case testIsInstanceTypeSubclass]
-# flags: --strict-optional
 from typing import Type, Optional
 class Base: ...
 class One(Base):

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -27,7 +27,6 @@ A().f(1, 1) # E:10: Argument 2 to "f" of "A" has incompatible type "int"; expect
 (A().f(1, 'hello', 'hi')) # E:2: Too many arguments for "f" of "A"
 
 [case testColumnsInvalidArgumentType]
-# flags: --strict-optional
 def f(x: int, y: str) -> None: ...
 def g(*x: int) -> None: pass
 def h(**x: int) -> None: pass

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -802,7 +802,7 @@ else:
 plugins=<ROOT>/test-data/unit/plugins/union_method.py
 
 [case testGetMethodHooksOnUnionsStrictOptional]
-# flags: --config-file tmp/mypy.ini --strict-optional
+# flags: --config-file tmp/mypy.ini
 from typing import Union
 
 class Foo:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1127,7 +1127,6 @@ class Foo:
 
 [case testNoComplainFieldNoneStrict]
 # flags: --python-version 3.7
-# flags: --strict-optional
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -1264,7 +1263,7 @@ class Deferred: pass
 [builtins fixtures/dataclasses.pyi]
 
 [case testDeferredDataclassInitSignatureSubclass]
-# flags: --strict-optional --python-version 3.7
+# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Optional
 
@@ -1745,7 +1744,7 @@ reveal_type(Child2[int, A]([A()], [1]).b)  # N: Revealed type is "builtins.list[
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassInheritOptionalType]
-# flags: --python-version 3.7 --strict-optional
+# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Any, Callable, Generic, TypeVar, List, Optional
 
@@ -1979,7 +1978,6 @@ B = List[C]
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassSelfType]
-# flags: --strict-optional
 from dataclasses import dataclass
 from typing import Self, TypeVar, Generic, Optional
 
@@ -2104,7 +2102,6 @@ a2 = replace(a, q='42')  # E: Argument "q" to "replace" of "A" has incompatible 
 reveal_type(a2)  # N: Revealed type is "__main__.A"
 
 [case testReplaceUnion]
-# flags: --strict-optional
 from typing import Generic, Union, TypeVar
 from dataclasses import dataclass, replace, InitVar
 
@@ -2136,7 +2133,6 @@ _ = replace(a_or_b, y=42, init_var=42)  # E: Argument "y" to "replace" of "Union
 [builtins fixtures/dataclasses.pyi]
 
 [case testReplaceUnionOfTypeVar]
-# flags: --strict-optional
 from typing import Generic, Union, TypeVar
 from dataclasses import dataclass, replace
 

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -953,7 +953,6 @@ else:
 [builtins fixtures/bool.pyi]
 
 [case testEnumReachabilityWithNone]
-# flags: --strict-optional
 from enum import Enum
 from typing import Optional
 
@@ -1016,7 +1015,6 @@ reveal_type(x3) # N: Revealed type is "Union[__main__.Foo, __main__.Bar]"
 [builtins fixtures/bool.pyi]
 
 [case testEnumReachabilityPEP484ExampleWithFinal]
-# flags: --strict-optional
 from typing import Union
 from typing_extensions import Final
 from enum import Enum
@@ -1063,7 +1061,6 @@ def process(response: Union[str, Reason] = '') -> str:
 
 
 [case testEnumReachabilityPEP484ExampleSingleton]
-# flags: --strict-optional
 from typing import Union
 from typing_extensions import Final
 from enum import Enum
@@ -1088,7 +1085,6 @@ def func(x: Union[int, None, Empty] = _empty) -> int:
 [builtins fixtures/primitives.pyi]
 
 [case testEnumReachabilityPEP484ExampleSingletonWithMethod]
-# flags: --strict-optional
 from typing import Union
 from typing_extensions import Final
 from enum import Enum

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -732,7 +732,6 @@ class InvalidReturn:
 [builtins fixtures/bool.pyi]
 
 [case testErrorCodeOverloadedOperatorMethod]
-# flags: --strict-optional
 from typing import Optional, overload
 
 class A:
@@ -758,7 +757,6 @@ class C:
 x - C()  # type: ignore[operator]
 
 [case testErrorCodeMultiLineBinaryOperatorOperand]
-# flags: --strict-optional
 from typing import Optional
 
 class C: pass
@@ -897,7 +895,6 @@ if any_or_object:
 [builtins fixtures/list.pyi]
 
 [case testTruthyFunctions]
-# flags: --strict-optional
 def f():
     pass
 if f:  # E: Function "f" could always be true in boolean context  [truthy-function]
@@ -907,7 +904,7 @@ if not f:  # E: Function "f" could always be true in boolean context  [truthy-fu
 conditional_result = 'foo' if f else 'bar'  # E: Function "f" could always be true in boolean context  [truthy-function]
 
 [case testTruthyIterable]
-# flags: --strict-optional --enable-error-code truthy-iterable
+# flags: --enable-error-code truthy-iterable
 from typing import Iterable
 def func(var: Iterable[str]) -> None:
     if var:  # E: "var" has type "Iterable[str]" which can always be true in boolean context. Consider using "Collection[str]" instead.  [truthy-iterable]
@@ -995,7 +992,6 @@ var: int = ""  # E: Incompatible types in assignment (expression has type "str",
 show_error_codes = True
 
 [case testErrorCodeUnsafeSuper_no_empty]
-# flags: --strict-optional
 from abc import abstractmethod
 
 class Base:
@@ -1008,7 +1004,6 @@ class Sub(Base):
 [builtins fixtures/exception.pyi]
 
 [case testDedicatedErrorCodeForEmpty_no_empty]
-# flags: --strict-optional
 from typing import Optional
 def foo() -> int: ...  # E: Missing return statement  [empty-body]
 def bar() -> None: ...

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1210,7 +1210,6 @@ a[:None]
 [builtins fixtures/slice.pyi]
 
 [case testNoneSliceBoundsWithStrictOptional]
-# flags: --strict-optional
 from typing import Any
 a: Any
 a[None:1]
@@ -2049,7 +2048,7 @@ x is 42
 [typing fixtures/typing-full.pyi]
 
 [case testStrictEqualityStrictOptional]
-# flags: --strict-equality --strict-optional
+# flags: --strict-equality
 
 x: str
 if x is not None:  # OK even with strict-optional
@@ -2065,7 +2064,7 @@ if x is not None:  # OK without strict-optional
 [builtins fixtures/bool.pyi]
 
 [case testStrictEqualityEqNoOptionalOverlap]
-# flags: --strict-equality --strict-optional
+# flags: --strict-equality
 from typing import Optional
 
 x: Optional[str]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -427,7 +427,7 @@ async def h() -> NoReturn:  # E: Implicit return in function which does not retu
 [typing fixtures/typing-async.pyi]
 
 [case testNoWarnNoReturn]
-# flags: --no-warn-no-return --strict-optional
+# flags: --no-warn-no-return
 import typing
 
 def implicit_optional_return(arg) -> typing.Optional[str]:

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2545,7 +2545,6 @@ reveal_type(bar(None))  # N: Revealed type is "None"
 [out]
 
 [case testNoComplainOverloadNoneStrict]
-# flags: --strict-optional
 from typing import overload, Optional
 @overload
 def bar(x: None) -> None:
@@ -2574,7 +2573,6 @@ xx: Optional[int] = X(x_in)
 [out]
 
 [case testNoComplainInferredNoneStrict]
-# flags: --strict-optional
 from typing import TypeVar, Optional
 T = TypeVar('T')
 def X(val: T) -> T: ...

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2323,7 +2323,6 @@ class B(A):
 [builtins fixtures/classmethod.pyi]
 
 [case testSubclassingGenericSelfClassMethodOptional]
-# flags: --strict-optional
 from typing import TypeVar, Type, Optional
 
 AT = TypeVar('AT', bound='A')
@@ -2935,7 +2934,7 @@ reveal_type(dec(id))  # N: Revealed type is "def [S] (S`1) -> builtins.list[S`1]
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableGenericProtocol]
-# flags: --strict-optional --new-type-inference
+# flags: --new-type-inference
 from typing import TypeVar, Protocol, Generic, Optional
 
 T = TypeVar('T')
@@ -2951,7 +2950,7 @@ reveal_type(lift(g))  # N: Revealed type is "def [T] (Union[T`1, None]) -> Union
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericSplitOrder]
-# flags: --strict-optional --new-type-inference
+# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -2966,7 +2965,7 @@ reveal_type(dec(id, id))  # N: Revealed type is "def (builtins.int) -> builtins.
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericSplitOrderGeneric]
-# flags: --strict-optional --new-type-inference
+# flags: --new-type-inference
 from typing import TypeVar, Callable, Tuple
 
 S = TypeVar('S')

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2901,7 +2901,6 @@ tmp/main.py:2: error: Expression has type "Any"
 tmp/main.py:2: error: Expression has type "Any"
 
 [case testIncrementalStrictOptional]
-# flags: --strict-optional
 import a
 1 + a.foo()
 [file a.py]
@@ -3457,7 +3456,6 @@ main:2: error: Cannot find implementation or library stub for module named "a"
 main:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 
 [case testIncrementalInheritanceAddAnnotation]
-# flags: --strict-optional
 import a
 [file a.py]
 import b
@@ -5757,7 +5755,6 @@ class C:
 [builtins fixtures/tuple.pyi]
 
 [case testNamedTupleUpdateNonRecursiveToRecursiveCoarse]
-# flags: --strict-optional
 import c
 [file a.py]
 from b import M
@@ -5800,7 +5797,6 @@ tmp/c.py:5: error: Incompatible types in assignment (expression has type "Option
 tmp/c.py:7: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 
 [case testTupleTypeUpdateNonRecursiveToRecursiveCoarse]
-# flags: --strict-optional
 import c
 [file a.py]
 from b import M
@@ -5833,7 +5829,6 @@ tmp/c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins
 tmp/c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
 
 [case testTypeAliasUpdateNonRecursiveToRecursiveCoarse]
-# flags: --strict-optional
 import c
 [file a.py]
 from b import M
@@ -5866,7 +5861,6 @@ tmp/c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins
 tmp/c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
 
 [case testTypedDictUpdateNonRecursiveToRecursiveCoarse]
-# flags: --strict-optional
 import c
 [file a.py]
 from b import M
@@ -6061,7 +6055,6 @@ tmp/m.py:9: note:     Got:
 tmp/m.py:9: note:         def update() -> str
 
 [case testAbstractBodyTurnsEmptyCoarse]
-# flags: --strict-optional
 from b import Base
 
 class Sub(Base):

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2910,8 +2910,8 @@ from typing import Optional
 def foo() -> Optional[int]: return 0
 [out1]
 [out2]
-main:3: error: Unsupported operand types for + ("int" and "None")
-main:3: note: Right operand is of type "Optional[int]"
+main:2: error: Unsupported operand types for + ("int" and "None")
+main:2: note: Right operand is of type "Optional[int]"
 
 [case testAttrsIncrementalSubclassingCached]
 from a import A
@@ -6074,7 +6074,7 @@ class Base:
     def meth(self) -> int: ...
 [out]
 [out2]
-main:6: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
+main:5: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
 
 [case testNoCrashDoubleReexportFunctionEmpty]
 import m

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -925,7 +925,6 @@ reveal_type(f(None)) # N: Revealed type is "Union[None, builtins.list[builtins.i
 [builtins fixtures/list.pyi]
 
 [case testUnionWithGenericTypeItemContextAndStrictOptional]
-# flags: --strict-optional
 from typing import TypeVar, Union, List
 
 T = TypeVar('T')
@@ -953,7 +952,6 @@ reveal_type(c.f(None)) # N: Revealed type is "Union[builtins.list[builtins.int],
 [builtins fixtures/list.pyi]
 
 [case testGenericMethodCalledInGenericContext]
-# flags: --strict-optional
 from typing import TypeVar, Generic
 
 _KT = TypeVar('_KT')
@@ -1221,7 +1219,6 @@ x: Iterable[Union[A, B]] = f(B())
 [builtins fixtures/list.pyi]
 
 [case testWideOuterContextOptional]
-# flags: --strict-optional
 from typing import Optional, Type, TypeVar
 
 class Custom:
@@ -1235,7 +1232,6 @@ def b(x: T) -> Optional[T]:
     return a(x)
 
 [case testWideOuterContextOptionalGenericReturn]
-# flags: --strict-optional
 from typing import Optional, Type, TypeVar, Iterable
 
 class Custom:
@@ -1249,7 +1245,6 @@ def b(x: T) -> Iterable[Optional[T]]:
     return a(x)
 
 [case testWideOuterContextOptionalMethod]
-# flags: --strict-optional
 from typing import Optional, Type, TypeVar
 
 class A: pass
@@ -1282,7 +1277,6 @@ def bar(xs: List[S]) -> S:
 [builtins fixtures/list.pyi]
 
 [case testWideOuterContextOptionalTypeVarReturn]
-# flags: --strict-optional
 from typing import Callable, Iterable, List, Optional, TypeVar
 
 class C:
@@ -1298,7 +1292,6 @@ def g(l: List[C], x: str) -> Optional[C]:
 [builtins fixtures/list.pyi]
 
 [case testWideOuterContextOptionalTypeVarReturnLambda]
-# flags: --strict-optional
 from typing import Callable, Iterable, List, Optional, TypeVar
 
 class C:
@@ -1335,7 +1328,6 @@ y: List[str] = f([]) \
 [builtins fixtures/list.pyi]
 
 [case testWideOuterContextNoArgs]
-# flags: --strict-optional
 from typing import TypeVar, Optional
 
 T = TypeVar('T', bound=int)
@@ -1344,7 +1336,6 @@ def f(x: Optional[T] = None) -> T: ...
 y: str = f()
 
 [case testWideOuterContextNoArgsError]
-# flags: --strict-optional
 from typing import TypeVar, Optional, List
 
 T = TypeVar('T', bound=int)
@@ -1427,7 +1418,6 @@ bar({1: 2})
 [builtins fixtures/dict.pyi]
 
 [case testOptionalTypeNarrowedByGenericCall]
-# flags: --strict-optional
 from typing import Dict, Optional
 
 d: Dict[str, str] = {}
@@ -1439,7 +1429,6 @@ def foo(arg: Optional[str] = None) -> None:
 [builtins fixtures/dict.pyi]
 
 [case testOptionalTypeNarrowedByGenericCall2]
-# flags: --strict-optional
 from typing import Dict, Optional
 
 d: Dict[str, str] = {}
@@ -1451,7 +1440,6 @@ if x:
 [builtins fixtures/dict.pyi]
 
 [case testOptionalTypeNarrowedByGenericCall3]
-# flags: --strict-optional
 from typing import Generic, TypeVar, Union
 
 T = TypeVar("T")
@@ -1464,7 +1452,6 @@ def foo(arg: Union[str, int]) -> None:
 [builtins fixtures/isinstance.pyi]
 
 [case testOptionalTypeNarrowedByGenericCall4]
-# flags: --strict-optional
 from typing import Optional, List, Generic, TypeVar
 
 T = TypeVar("T", covariant=True)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1402,7 +1402,6 @@ f(b)
 g(b)
 
 [case testLambdaDefaultContext]
-# flags: --strict-optional
 from typing import Callable
 def f(a: Callable[..., None] = lambda *a, **k: None):
     pass
@@ -1811,7 +1810,6 @@ reveal_type(C().a)  # N: Revealed type is "builtins.dict[builtins.int, builtins.
 [builtins fixtures/dict.pyi]
 
 [case testInferAttributeInitializedToNoneAndAssigned]
-# flags: --strict-optional
 class C:
     def __init__(self) -> None:
         self.a = None
@@ -1858,7 +1856,6 @@ reveal_type(C().a)  # N: Revealed type is "builtins.dict[Any, Any]"
 [builtins fixtures/dict.pyi]
 
 [case testInferAttributeInitializedToNoneAndAssignedOtherMethod]
-# flags: --strict-optional
 class C:
     def __init__(self) -> None:
         self.a = None
@@ -1891,7 +1888,6 @@ reveal_type(C().a)  # N: Revealed type is "builtins.dict[Any, Any]"
 [builtins fixtures/dict.pyi]
 
 [case testInferAttributeInitializedToNoneAndAssignedClassBody]
-# flags: --strict-optional
 class C:
     a = None
     def __init__(self) -> None:
@@ -2538,7 +2534,6 @@ if bool():
 [out]
 
 [case testDontMarkUnreachableAfterInferenceUninhabited2]
-# flags: --strict-optional
 from typing import TypeVar, Optional
 T = TypeVar('T')
 def f(x: Optional[T] = None) -> T: pass
@@ -2609,7 +2604,7 @@ x = ''
 reveal_type(x) # N: Revealed type is "builtins.str"
 
 [case testLocalPartialTypesWithGlobalInitializedToNoneStrictOptional]
-# flags: --local-partial-types --strict-optional
+# flags: --local-partial-types
 x = None
 
 def f() -> None:
@@ -2761,7 +2756,7 @@ class B(A):
 reveal_type(B.x) # N: Revealed type is "None"
 
 [case testLocalPartialTypesWithInheritance2]
-# flags: --local-partial-types --strict-optional
+# flags: --local-partial-types
 class A:
     x: str
 
@@ -2769,7 +2764,7 @@ class B(A):
     x = None  # E: Incompatible types in assignment (expression has type "None", base class "A" defined the type as "str")
 
 [case testLocalPartialTypesWithAnyBaseClass]
-# flags: --local-partial-types --strict-optional
+# flags: --local-partial-types
 from typing import Any
 
 A: Any
@@ -2781,7 +2776,7 @@ class C(B):
     y = None
 
 [case testLocalPartialTypesInMultipleMroItems]
-# flags: --local-partial-types --strict-optional
+# flags: --local-partial-types
 from typing import Optional
 
 class A:
@@ -3106,7 +3101,6 @@ class B(A):
     x = 2  # E: Incompatible types in assignment (expression has type "int", base class "A" defined the type as "str")
 
 [case testInheritedAttributeStrictOptional]
-# flags: --strict-optional
 class A:
     x: str
 
@@ -3209,7 +3203,6 @@ x: Inv[int]
 reveal_type(f(x))  # N: Revealed type is "builtins.int"
 
 [case testOptionalTypeVarAgainstOptional]
-# flags: --strict-optional
 from typing import Optional, TypeVar, Iterable, Iterator, List
 
 _T = TypeVar('_T')
@@ -3256,7 +3249,6 @@ reveal_type(b) # N: Revealed type is "collections.defaultdict[builtins.int, buil
 [builtins fixtures/dict.pyi]
 
 [case testPartialDefaultDictListValueStrictOptional]
-# flags: --strict-optional
 from collections import defaultdict
 a = defaultdict(list)
 a['x'].append(1)
@@ -3333,7 +3325,6 @@ def g() -> None: pass
 reveal_type(f(g))  # N: Revealed type is "None"
 
 [case testInferCallableReturningNone2]
-# flags: --strict-optional
 from typing import Callable, TypeVar
 
 T = TypeVar("T")
@@ -3404,7 +3395,6 @@ def collection_from_dict_value(model: Type[T2]) -> None:
 [builtins fixtures/isinstancelist.pyi]
 
 [case testRegression11705_Strict]
-# flags: --strict-optional
 # See: https://github.com/python/mypy/issues/11705
 from typing import Dict, Optional, NamedTuple
 class C(NamedTuple):
@@ -3454,7 +3444,6 @@ foo(("a", {"a": "b"}, "b"))
 [builtins fixtures/dict.pyi]
 
 [case testUseSupertypeAsInferenceContext]
-# flags: --strict-optional
 from typing import List, Optional
 
 class B:

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -165,7 +165,6 @@ main:1: error: Unrecognized option: skip_file = True
 main:1: error: Setting "strict" not supported in inline configuration: specify it in a configuration file instead, or set individual inline flags (see "mypy -h" for the list of flags enabled in strict mode)
 
 [case testInlineErrorCodes]
-# flags: --strict-optional
 # mypy: enable-error-code="ignore-without-code,truthy-bool"
 class Foo:
     pass
@@ -175,7 +174,7 @@ if foo: ...  # E: "__main__.foo" has type "Foo" which does not implement __bool_
 42 + "no"  # type: ignore  # E: "type: ignore" comment without error code (consider "type: ignore[operator]" instead)
 
 [case testInlineErrorCodesOverrideConfig]
-# flags: --strict-optional --config-file tmp/mypy.ini
+# flags: --config-file tmp/mypy.ini
 import foo
 import tests.bar
 import tests.baz
@@ -243,7 +242,6 @@ class C:
         self.x = 1
 
 [case testIgnoreErrorsWithUnsafeSuperCall_no_empty]
-# flags: --strict-optional
 
 from m import C
 

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1801,7 +1801,6 @@ if issubclass(fm, Bar):
 [builtins fixtures/isinstance.pyi]
 
 [case testIssubclassWithMetaclassesStrictOptional]
-# flags: --strict-optional
 class FooMetaclass(type): ...
 class BarMetaclass(type): ...
 class Foo(metaclass=FooMetaclass): ...
@@ -1906,7 +1905,6 @@ def narrow_any_to_str_then_reassign_to_int() -> None:
 [builtins fixtures/isinstance.pyi]
 
 [case testNarrowTypeAfterInList]
-# flags: --strict-optional
 from typing import List, Optional
 
 x: List[int]
@@ -1924,7 +1922,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInListOfOptional]
-# flags: --strict-optional
 from typing import List, Optional
 
 x: List[Optional[int]]
@@ -1938,7 +1935,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInListNonOverlapping]
-# flags: --strict-optional
 from typing import List, Optional
 
 x: List[str]
@@ -1952,7 +1948,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInListNested]
-# flags: --strict-optional
 from typing import List, Optional, Any
 
 x: Optional[int]
@@ -1967,7 +1962,6 @@ if x in nested_any:
 [out]
 
 [case testNarrowTypeAfterInTuple]
-# flags: --strict-optional
 from typing import Optional
 class A: pass
 class B(A): pass
@@ -1982,7 +1976,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInNamedTuple]
-# flags: --strict-optional
 from typing import NamedTuple, Optional
 class NT(NamedTuple):
     x: int
@@ -1998,7 +1991,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInDict]
-# flags: --strict-optional
 from typing import Dict, Optional
 x: Dict[str, int]
 y: Optional[str]
@@ -2015,7 +2007,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInNoAnyOrObject]
-# flags: --strict-optional
 from typing import Any, List, Optional
 x: List[Any]
 z: List[object]
@@ -2035,7 +2026,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInUserDefined]
-# flags: --strict-optional
 from typing import Container, Optional
 
 class C(Container[int]):
@@ -2057,7 +2047,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInSet]
-# flags: --strict-optional
 from typing import Optional, Set
 s: Set[str]
 
@@ -2074,7 +2063,6 @@ else:
 [out]
 
 [case testNarrowTypeAfterInTypedDict]
-# flags: --strict-optional
 from typing import Optional
 from mypy_extensions import TypedDict
 class TD(TypedDict):
@@ -2150,7 +2138,6 @@ else:
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceInitialNoneCheckSkipsImpossibleCasesNoStrictOptional]
-# flags: --strict-optional
 from typing import Optional, Union
 
 class A: pass
@@ -2197,7 +2184,6 @@ def foo2(x: Optional[str]) -> None:
 [builtins fixtures/isinstance.pyi]
 
 [case testNoneCheckDoesNotNarrowWhenUsingTypeVars]
-# flags: --strict-optional
 
 # Note: this test (and the following one) are testing checker.conditional_type_map:
 # if you set the 'prohibit_none_typevar_overlap' keyword argument to False when calling
@@ -2249,7 +2235,6 @@ def bar(x: Union[List[str], List[int], None]) -> None:
 [builtins fixtures/isinstancelist.pyi]
 
 [case testNoneAndGenericTypesOverlapStrictOptional]
-# flags: --strict-optional
 from typing import Union, Optional, List
 
 # This test is the same as the one above, except for strict-optional.

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -350,7 +350,6 @@ class A: pass
 [builtins fixtures/dict.pyi]
 
 [case testInvalidTypeForKeywordVarArg]
-# flags: --strict-optional
 from typing import Dict, Any, Optional
 class A: pass
 def f(**kwargs: 'A') -> None: pass

--- a/test-data/unit/check-lists.test
+++ b/test-data/unit/check-lists.test
@@ -89,7 +89,6 @@ reveal_type(c)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testComprehensionShadowBinder]
-# flags: --strict-optional
 def foo(x: object) -> None:
     if isinstance(x, str):
         [reveal_type(x) for x in [1, 2, 3]]  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -659,7 +659,6 @@ def foo(b: Literal[T]) -> Tuple[T]: pass   # E: Parameter 1 of Literal[...] is i
 --
 
 [case testLiteralMultipleValues]
-# flags: --strict-optional
 from typing_extensions import Literal
 a: Literal[1, 2, 3]
 b: Literal["a", "b", "c"]
@@ -689,7 +688,6 @@ reveal_type(b)  # N: Revealed type is "Union[Literal[1], Literal[2], Literal[3]]
 [out]
 
 [case testLiteralNestedUsage]
-# flags: --strict-optional
 
 from typing_extensions import Literal
 a: Literal[Literal[3], 4, Literal["foo"]]
@@ -818,7 +816,6 @@ foo(c)  # E: Argument 1 to "foo" has incompatible type "Literal[4, 'foo']"; expe
 [out]
 
 [case testLiteralCheckSubtypingStrictOptional]
-# flags: --strict-optional
 from typing import Any, NoReturn
 from typing_extensions import Literal
 
@@ -1807,7 +1804,6 @@ reveal_type(unify(f6))  # N: Revealed type is "None"
 [out]
 
 [case testLiteralMeetsWithStrictOptional]
-# flags: --strict-optional
 from typing import TypeVar, Callable, Union
 from typing_extensions import Literal
 
@@ -1834,7 +1830,6 @@ reveal_type(unify(func))  # N: Revealed type is "<nothing>"
 --
 
 [case testLiteralIntelligentIndexingTuples]
-# flags: --strict-optional
 from typing import Tuple, NamedTuple, Optional, Final
 from typing_extensions import Literal
 
@@ -2247,7 +2242,6 @@ force4(reveal_type(f.instancevar4))  # N: Revealed type is "None"
 [out]
 
 [case testLiteralFinalErasureInMutableDatastructures1]
-# flags: --strict-optional
 from typing_extensions import Final
 
 var1: Final = [0, None]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -567,7 +567,6 @@ x = 1
 x = 1
 
 [case testAssignToFuncDefViaImport]
-# flags: --strict-optional
 
 # Errors differ with the new analyzer. (Old analyzer gave error on the
 # input, which is maybe better, but no error about f, which seems

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -747,7 +747,6 @@ def test3(switch: FlipFlopEnum) -> None:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityRequiresExplicitStrLiteral]
-# flags: --strict-optional
 from typing_extensions import Literal, Final
 
 A_final: Final = "A"
@@ -794,7 +793,6 @@ reveal_type(x_union)      # N: Revealed type is "Union[Literal['A'], Literal['B'
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityRequiresExplicitEnumLiteral]
-# flags: --strict-optional
 from typing import Union
 from typing_extensions import Literal, Final
 from enum import Enum
@@ -879,7 +877,7 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityDisabledForCustomEqualityChain]
-# flags: --strict-optional --strict-equality --warn-unreachable
+# flags: --strict-equality --warn-unreachable
 from typing import Union
 from typing_extensions import Literal
 
@@ -916,7 +914,7 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingUnreachableCases]
-# flags: --strict-optional --strict-equality --warn-unreachable
+# flags: --strict-equality --warn-unreachable
 from typing import Union
 from typing_extensions import Literal
 
@@ -964,7 +962,7 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingUnreachableCases2]
-# flags: --strict-optional --strict-equality --warn-unreachable
+# flags: --strict-equality --warn-unreachable
 from typing import Union
 from typing_extensions import Literal
 
@@ -1064,7 +1062,6 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingBooleanIdentityCheck]
-# flags: --strict-optional
 from typing import Optional
 from typing_extensions import Literal
 
@@ -1087,7 +1084,6 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingBooleanTruthiness]
-# flags: --strict-optional
 from typing import Optional
 from typing_extensions import Literal
 
@@ -1109,7 +1105,6 @@ reveal_type(opt_bool_val)   # N: Revealed type is "Union[builtins.bool, None]"
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingBooleanBoolOp]
-# flags: --strict-optional
 from typing import Optional
 from typing_extensions import Literal
 
@@ -1161,7 +1156,6 @@ def f(d: Union[Foo, Bar]) -> None:
 [builtins fixtures/dict.pyi]
 
 [case testNarrowingUsingMetaclass]
-# flags: --strict-optional
 from typing import Type
 
 class M(type):
@@ -1181,7 +1175,6 @@ def f(t: Type[C]) -> None:
     reveal_type(t)  # N: Revealed type is "Type[__main__.C]"
 
 [case testNarrowingUsingTypeVar]
-# flags: --strict-optional
 from typing import Type, TypeVar
 
 class A: pass

--- a/test-data/unit/check-native-int.test
+++ b/test-data/unit/check-native-int.test
@@ -69,7 +69,6 @@ reveal_type(join(a, n64))  # N: Revealed type is "Any"
 [builtins fixtures/dict.pyi]
 
 [case testNativeIntMeets]
-# flags: --strict-optional
 from typing import TypeVar, Callable, Any
 from mypy_extensions import i32, i64
 
@@ -130,7 +129,6 @@ reveal_type(y)  # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
 
 [case testNativeIntFloatConversion]
-# flags: --strict-optional
 from typing import TypeVar, Callable
 from mypy_extensions import i32
 

--- a/test-data/unit/check-newsyntax.test
+++ b/test-data/unit/check-newsyntax.test
@@ -49,20 +49,17 @@ TstInstance().a = 'ab'
 [out]
 
 [case testNewSyntaxWithClassVars]
-# flags: --strict-optional
 class CCC:
     a: str = None  # E: Incompatible types in assignment (expression has type "None", variable has type "str")
 [out]
 
 [case testNewSyntaxWithStrictOptional]
-# flags: --strict-optional
 strict: int
 strict = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
 strict2: int = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")
 [out]
 
 [case testNewSyntaxWithStrictOptionalFunctions]
-# flags: --strict-optional
 def f() -> None:
     x: int
     if int():
@@ -70,7 +67,6 @@ def f() -> None:
 [out]
 
 [case testNewSyntaxWithStrictOptionalClasses]
-# flags: --strict-optional
 class C:
     def meth(self) -> None:
         x: int = None  # E: Incompatible types in assignment (expression has type "None", variable has type "int")

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -3264,7 +3264,6 @@ f(x, B())  # E: Argument 1 to "f" has incompatible type "Union[A, B]"; expected 
 [builtins fixtures/tuple.pyi]
 
 [case testOverloadInferUnionWithMixOfPositionalAndOptionalArgs]
-# flags: --strict-optional
 from typing import overload, Union, Optional
 
 class A: ...
@@ -3603,7 +3602,6 @@ reveal_type(g(b))  # N: Revealed type is "builtins.str"
 reveal_type(g(c))  # N: Revealed type is "builtins.str"
 
 [case testOverloadsAndNoneWithStrictOptional]
-# flags: --strict-optional
 from typing import overload, Optional
 
 @overload
@@ -3651,7 +3649,6 @@ reveal_type(mymap(f3, seq))  # N: Revealed type is "typing.Iterable[builtins.str
 [typing fixtures/typing-medium.pyi]
 
 [case testOverloadsNoneAndTypeVarsWithStrictOptional]
-# flags: --strict-optional
 from typing import Callable, Iterable, TypeVar, overload, Optional
 
 T = TypeVar('T')
@@ -3708,7 +3705,6 @@ def test_narrow_int() -> None:
 [typing fixtures/typing-medium.pyi]
 
 [case testOverloadsAndNoReturnNarrowTypeWithStrictOptional1]
-# flags: --strict-optional
 from typing import overload, Union, NoReturn
 
 @overload
@@ -3772,7 +3768,6 @@ def test_narrow_none() -> None:
 [typing fixtures/typing-medium.pyi]
 
 [case testOverloadsAndNoReturnNarrowTypeWithStrictOptional2]
-# flags: --strict-optional
 from typing import overload, Union, TypeVar, NoReturn, Optional
 
 T = TypeVar('T')
@@ -3836,7 +3831,6 @@ def test_narrow_none_v2() -> None:
 [typing fixtures/typing-medium.pyi]
 
 [case testOverloadsAndNoReturnNarrowTypeWithStrictOptional3]
-# flags: --strict-optional
 from typing import overload, TypeVar, NoReturn, Optional
 
 @overload
@@ -4648,7 +4642,6 @@ def none_second(x: int) -> int:
     return x
 
 [case testOverloadsWithNoneComingSecondIsOkInStrictOptional]
-# flags: --strict-optional
 from typing import overload, Optional
 
 @overload

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -4665,8 +4665,8 @@ def none_loose_impl(x: int) -> int: ...
 def none_loose_impl(x: int) -> int:
     return x
 [out]
-main:22: error: Overloaded function implementation does not accept all possible arguments of signature 1
-main:22: error: Overloaded function implementation cannot produce return type of signature 1
+main:21: error: Overloaded function implementation does not accept all possible arguments of signature 1
+main:21: error: Overloaded function implementation cannot produce return type of signature 1
 
 [case testTooManyUnionsException]
 from typing import overload, Union

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1307,7 +1307,6 @@ reveal_type(bar(C(fn=foo, x=1)))  # N: Revealed type is "__main__.C[[x: builtins
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecClassConstructor]
-# flags: --strict-optional
 from typing import ParamSpec, Callable
 
 P = ParamSpec("P")

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1199,7 +1199,6 @@ class C:
 [builtins fixtures/bool.pyi]
 
 [case testAttrsOptionalConverter]
-# flags: --strict-optional
 import attr
 from attr.converters import optional
 from typing import Optional
@@ -1219,7 +1218,6 @@ A(None, None)
 [builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsOptionalConverterNewPackage]
-# flags: --strict-optional
 import attrs
 from attrs.converters import optional
 from typing import Optional

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -346,12 +346,12 @@ x: P = C() # Error!
 def f(x: P) -> None: pass
 f(C()) # Error!
 [out]
-main:9: error: Incompatible types in assignment (expression has type "C", variable has type "P")
-main:9: note: Following member(s) of "C" have conflicts:
-main:9: note:     x: expected "int", got "None"
-main:11: error: Argument 1 to "f" has incompatible type "C"; expected "P"
-main:11: note: Following member(s) of "C" have conflicts:
-main:11: note:     x: expected "int", got "None"
+main:8: error: Incompatible types in assignment (expression has type "C", variable has type "P")
+main:8: note: Following member(s) of "C" have conflicts:
+main:8: note:     x: expected "int", got "None"
+main:10: error: Argument 1 to "f" has incompatible type "C"; expected "P"
+main:10: note: Following member(s) of "C" have conflicts:
+main:10: note:     x: expected "int", got "None"
 
 -- Semanal errors in protocol types
 -- --------------------------------

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -324,7 +324,6 @@ var: MyHashable = C()  # E: Incompatible types in assignment (expression has typ
                        # N:     __my_hash__: expected "Callable[[], int]", got "None"
 
 [case testNoneDisablesProtocolSubclassingWithStrictOptional]
-# flags: --strict-optional
 from typing import Protocol
 
 class MyHashable(Protocol):
@@ -336,7 +335,6 @@ class C(MyHashable):
 (expression has type "None", base class "MyHashable" defined the type as "Callable[[MyHashable], int]")
 
 [case testProtocolsWithNoneAndStrictOptional]
-# flags: --strict-optional
 from typing import Protocol
 class P(Protocol):
     x = 0  # type: int
@@ -2412,7 +2410,6 @@ x: P = None
 [out]
 
 [case testNoneSubtypeOfEmptyProtocolStrict]
-# flags: --strict-optional
 from typing import Protocol
 class P(Protocol):
     pass
@@ -2959,7 +2956,6 @@ class MyClass:
 
 
 [case testPartialAttributeNoneTypeStrictOptional]
-# flags: --strict-optional
 from typing import Optional, Protocol, runtime_checkable
 
 @runtime_checkable
@@ -3080,7 +3076,6 @@ def round(number: SupportsRound[_T], ndigits: int) -> _T: ...
 round(C(), 1)
 
 [case testEmptyBodyImplicitlyAbstractProtocol]
-# flags: --strict-optional
 from typing import Protocol, overload, Union
 
 class P1(Protocol):
@@ -3127,7 +3122,6 @@ C3()
 [builtins fixtures/classmethod.pyi]
 
 [case testEmptyBodyImplicitlyAbstractProtocolProperty]
-# flags: --strict-optional
 from typing import Protocol
 
 class P1(Protocol):
@@ -3222,7 +3216,6 @@ D() # E: Cannot instantiate abstract class "D" with abstract attribute "meth"
 [builtins fixtures/exception.pyi]
 
 [case testEmptyBodyNoneCompatibleProtocol]
-# flags: --strict-optional
 from abc import abstractmethod
 from typing import Any, Optional, Protocol, Union, overload
 from typing_extensions import TypeAlias

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1140,7 +1140,6 @@ match m:
         reveal_type(a)
 
 [case testMatchRedefiningPatternGuard]
-# flags: --strict-optional
 m: str
 
 match m:
@@ -1382,7 +1381,6 @@ def f(x: int | str) -> int:  # E: Missing return statement
 [builtins fixtures/isinstance.pyi]
 
 [case testMatchNarrowDownUnionPartially]
-# flags: --strict-optional
 
 def f(x: int | str) -> None:
     match x:
@@ -1493,7 +1491,6 @@ def f(x: A) -> None:
     reveal_type(y)  # N: Revealed type is "Union[__main__.<subclass of "A" and "B">, __main__.<subclass of "A" and "C">]"
 
 [case testMatchWithBreakAndContinue]
-# flags: --strict-optional
 def f(x: int | str | None) -> None:
     i = int()
     while i:
@@ -1626,7 +1623,6 @@ def func(e: Union[str, tuple[str]]) -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testMatchTupleOptionalNoCrash]
-# flags: --strict-optional
 foo: tuple[int] | None
 match foo:
     case x,:
@@ -1865,7 +1861,6 @@ def f() -> None:
             reveal_type(y.a)  # N: Revealed type is "builtins.int"
 
 [case testNarrowedVariableInNestedModifiedInMatch]
-# flags: --strict-optional
 from typing import Optional
 
 def match_stmt_error1(x: Optional[str]) -> None:

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -223,7 +223,7 @@ h(arg=0)  # E: Unexpected keyword argument "arg" for "h"
 i(arg=0)  # E: Unexpected keyword argument "arg"
 
 [case testWalrus]
-# flags: --strict-optional --python-version 3.8
+# flags: --python-version 3.8
 from typing import NamedTuple, Optional, List
 from typing_extensions import Final
 
@@ -427,7 +427,7 @@ else:
 [builtins fixtures/list.pyi]
 
 [case testWalrusConditionalTypeCheck]
-# flags: --strict-optional --python-version 3.8
+# flags: --python-version 3.8
 from typing import Optional
 
 maybe_str: Optional[str]
@@ -729,7 +729,6 @@ def f1() -> None:
 [builtins fixtures/dict.pyi]
 
 [case testNarrowOnSelfInGeneric]
-# flags: --strict-optional
 from typing import Generic, TypeVar, Optional
 
 T = TypeVar("T", int, str)
@@ -778,7 +777,6 @@ class C:
 [builtins fixtures/list.pyi]
 
 [case testNarrowedVariableInNestedModifiedInWalrus]
-# flags: --strict-optional
 from typing import Optional
 
 def walrus_with_nested_error(x: Optional[str]) -> None:

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -740,8 +740,8 @@ class C(Generic[T]):
             reveal_type(y)
         return None
 [out]
-main:10: note: Revealed type is "builtins.int"
-main:10: note: Revealed type is "builtins.str"
+main:9: note: Revealed type is "builtins.int"
+main:9: note: Revealed type is "builtins.str"
 
 [case testTypeGuardWithPositionalOnlyArg]
 # flags: --python-version 3.8

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -422,7 +422,6 @@ reveal_type(d)  # N: Revealed type is "Any"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testBasicRecursiveNamedTuple]
-# flags: --strict-optional
 from typing import NamedTuple, Optional
 
 NT = NamedTuple("NT", [("x", Optional[NT]), ("y", int)])
@@ -457,7 +456,6 @@ reveal_type(f(tnt, nt))  # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/tuple.pyi]
 
 [case testBasicRecursiveNamedTupleClass]
-# flags: --strict-optional
 from typing import NamedTuple, Optional
 
 class NT(NamedTuple):
@@ -684,7 +682,6 @@ itd2 = TD(x=0, y=TD(x=0, y=TD(x=0, y=None)))
 [typing fixtures/typing-typeddict.pyi]
 
 [case testRecursiveTypedDictMethods]
-# flags: --strict-optional
 from typing import TypedDict
 
 class TD(TypedDict, total=False):
@@ -787,7 +784,6 @@ reveal_type(std)  # N: Revealed type is "TypedDict('__main__.STD', {'val': built
 [typing fixtures/typing-typeddict.pyi]
 
 [case testRecursiveClassLevelAlias]
-# flags: --strict-optional
 from typing import Union, Sequence
 
 class A:

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -740,7 +740,6 @@ main:4: note: Revealed type is "def (x: builtins.int) -> Tuple[builtins.int, fal
 --
 
 [case testSerializeOptionalType]
-# flags: --strict-optional
 import a
 [file a.py]
 import b

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -305,7 +305,6 @@ reveal_type(y)  # N: Revealed type is "Union[builtins.int, None]"
 [builtins fixtures/bool.pyi]
 
 [case testNoneAliasStrict]
-# flags: --strict-optional
 from typing import Optional, Union
 void = type(None)
 x: int

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -595,7 +595,6 @@ reveal_type(f(g))  # N: Revealed type is "TypedDict({'x': builtins.int, 'y': bui
 [builtins fixtures/dict.pyi]
 
 [case testMeetOfTypedDictsWithIncompatibleCommonKeysIsUninhabited]
-# flags: --strict-optional
 from mypy_extensions import TypedDict
 from typing import TypeVar, Callable
 XYa = TypedDict('XYa', {'x': int, 'y': int})
@@ -619,7 +618,6 @@ reveal_type(f(g))  # N: Revealed type is "TypedDict({'x': builtins.int, 'z': bui
 
 # TODO: It would be more accurate for the meet to be TypedDict instead.
 [case testMeetOfTypedDictWithCompatibleMappingIsUninhabitedForNow]
-# flags: --strict-optional
 from mypy_extensions import TypedDict
 from typing import TypeVar, Callable, Mapping
 X = TypedDict('X', {'x': int})
@@ -631,7 +629,6 @@ reveal_type(f(g))  # N: Revealed type is "<nothing>"
 [builtins fixtures/dict.pyi]
 
 [case testMeetOfTypedDictWithIncompatibleMappingIsUninhabited]
-# flags: --strict-optional
 from mypy_extensions import TypedDict
 from typing import TypeVar, Callable, Mapping
 X = TypedDict('X', {'x': int})
@@ -643,7 +640,6 @@ reveal_type(f(g))  # N: Revealed type is "<nothing>"
 [builtins fixtures/dict.pyi]
 
 [case testMeetOfTypedDictWithCompatibleMappingSuperclassIsUninhabitedForNow]
-# flags: --strict-optional
 from mypy_extensions import TypedDict
 from typing import TypeVar, Callable, Iterable
 X = TypedDict('X', {'x': int})
@@ -677,7 +673,6 @@ reveal_type(f(g))  # N: Revealed type is "TypedDict({'x'?: builtins.int, 'y': bu
 [builtins fixtures/dict.pyi]
 
 [case testMeetOfTypedDictsWithIncompatibleNonTotalAndTotal]
-# flags: --strict-optional
 from mypy_extensions import TypedDict
 from typing import TypeVar, Callable
 XY = TypedDict('XY', {'x': int, 'y': int}, total=False)
@@ -972,7 +967,6 @@ if int():
 -- Other TypedDict methods
 
 [case testTypedDictGetMethod]
-# flags: --strict-optional
 from mypy_extensions import TypedDict
 class A: pass
 D = TypedDict('D', {'x': int, 'y': str})
@@ -986,7 +980,6 @@ reveal_type(d.get('y', None)) # N: Revealed type is "Union[builtins.str, None]"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictGetMethodTypeContext]
-# flags: --strict-optional
 from typing import List
 from mypy_extensions import TypedDict
 class A: pass
@@ -1044,7 +1037,6 @@ p.get('x', 1 + 'y')     # E: Unsupported operand types for + ("int" and "str")
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictChainedGetWithEmptyDictDefault]
-# flags: --strict-optional
 from mypy_extensions import TypedDict
 C = TypedDict('C', {'a': int})
 D = TypedDict('D', {'x': C, 'y': str})

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -248,7 +248,6 @@ def main1(a: object) -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testTypeGuardOverload]
-# flags: --strict-optional
 from typing import overload, Any, Callable, Iterable, Iterator, List, Optional, TypeVar
 from typing_extensions import TypeGuard
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -929,7 +929,6 @@ reveal_type(z) # N: Revealed type is "Union[builtins.int, __main__.A, builtins.s
 [out]
 
 [case testUnpackUnionNoCrashOnPartialNone]
-# flags: --strict-optional
 from typing import Dict, Tuple, List, Any
 
 a: Any
@@ -944,7 +943,6 @@ if x:
 [out]
 
 [case testUnpackUnionNoCrashOnPartialNone2]
-# flags: --strict-optional
 from typing import Dict, Tuple, List, Any
 
 a: Any
@@ -960,7 +958,6 @@ if x:
 [out]
 
 [case testUnpackUnionNoCrashOnPartialNoneBinder]
-# flags: --strict-optional
 from typing import Dict, Tuple, List, Any
 
 x: object
@@ -975,7 +972,6 @@ if x:
 [out]
 
 [case testUnpackUnionNoCrashOnPartialList]
-# flags: --strict-optional
 from typing import Dict, Tuple, List, Any
 
 a: Any
@@ -1081,7 +1077,6 @@ def bar(a: T4, b: T4) -> T4:  # test multi-level alias
 [builtins fixtures/ops.pyi]
 
 [case testJoinUnionWithUnionAndAny]
-# flags: --strict-optional
 from typing import TypeVar, Union, Any
 T = TypeVar("T")
 def f(x: T, y: T) -> T:

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -615,7 +615,6 @@ reveal_type(x)  # N: Revealed type is "__main__.B"
 [typing fixtures/typing-medium.pyi]
 
 [case testUnreachableWhenSuperclassIsAny]
-# flags: --strict-optional
 from typing import Any
 
 # This can happen if we're importing a class from a missing module

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -630,7 +630,6 @@ if int():
 [builtins fixtures/list.pyi]
 
 [case testCallerTupleVarArgsAndGenericCalleeVarArg]
-# flags: --strict-optional
 from typing import TypeVar
 
 T = TypeVar('T')

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -207,7 +207,7 @@ def f() -> Any: return g()
 [out]
 
 [case testOKReturnAnyIfProperSubtype]
-# flags: --warn-return-any --strict-optional
+# flags: --warn-return-any
 from typing import Any, Optional
 
 class Test(object):

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -612,7 +612,6 @@ class A:
 <m.C> -> <m.A.x>, m.A.f, m.C
 
 [case testPartialNoneTypeAttributeCrash2]
-# flags: --strict-optional
 class C: pass
 
 class A:

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -62,7 +62,6 @@ foo('3', '4')
 ==
 
 [case testSuggestInferFunc1]
-# flags: --strict-optional
 # suggest: foo.foo
 [file foo.py]
 def foo(arg, lol=None):
@@ -85,7 +84,6 @@ def untyped(x) -> None:
 ==
 
 [case testSuggestInferFunc2]
-# flags: --strict-optional
 # suggest: foo.foo
 [file foo.py]
 def foo(arg):
@@ -222,7 +220,6 @@ Foo('lol')
 ==
 
 [case testSuggestInferMethod1]
-# flags: --strict-optional
 # suggest: --no-any foo.Foo.foo
 [file foo.py]
 class Foo:
@@ -248,7 +245,6 @@ def bar() -> None:
 ==
 
 [case testSuggestInferMethod2]
-# flags: --strict-optional
 # suggest: foo.Foo.foo
 [file foo.py]
 class Foo:
@@ -275,7 +271,6 @@ def bar() -> None:
 ==
 
 [case testSuggestInferMethod3]
-# flags: --strict-optional
 # suggest2: foo.Foo.foo
 [file foo.py]
 class Foo:
@@ -372,7 +367,6 @@ def has_nested(x):
 ==
 
 [case testSuggestInferFunctionUnreachable]
-# flags: --strict-optional
 # suggest: foo.foo
 [file foo.py]
 import sys
@@ -390,7 +384,6 @@ foo('test')
 ==
 
 [case testSuggestInferMethodStep2]
-# flags: --strict-optional
 # suggest2: foo.Foo.foo
 [file foo.py]
 class Foo:
@@ -417,7 +410,6 @@ def bar() -> None:
 (Union[str, int, None], Optional[int]) -> Union[int, str]
 
 [case testSuggestInferNestedMethod]
-# flags: --strict-optional
 # suggest: foo.Foo.Bar.baz
 [file foo.py]
 class Foo:
@@ -435,7 +427,6 @@ def bar() -> None:
 ==
 
 [case testSuggestCallable]
-# flags: --strict-optional
 # suggest: foo.foo
 # suggest: foo.bar
 # suggest: --flex-any=0.9 foo.bar
@@ -483,7 +474,6 @@ No guesses that match criteria!
 ==
 
 [case testSuggestNewSemanal]
-# flags: --strict-optional
 # suggest: foo.Foo.foo
 # suggest: foo.foo
 [file foo.py]
@@ -521,7 +511,6 @@ def baz() -> None:
 ==
 
 [case testSuggestInferFuncDecorator1]
-# flags: --strict-optional
 # suggest: foo.foo
 [file foo.py]
 from typing import TypeVar
@@ -543,7 +532,6 @@ def bar() -> None:
 ==
 
 [case testSuggestInferFuncDecorator2]
-# flags: --strict-optional
 # suggest: foo.foo
 [file foo.py]
 from typing import TypeVar, Callable, Any
@@ -565,7 +553,6 @@ def bar() -> None:
 ==
 
 [case testSuggestInferFuncDecorator3]
-# flags: --strict-optional
 # suggest: foo.foo
 [file foo.py]
 from typing import TypeVar, Callable, Any
@@ -589,7 +576,6 @@ def bar() -> None:
 ==
 
 [case testSuggestInferFuncDecorator4]
-# flags: --strict-optional
 # suggest: foo.foo
 [file dec.py]
 from typing import TypeVar, Callable, Any
@@ -616,7 +602,6 @@ def bar() -> None:
 ==
 
 [case testSuggestFlexAny1]
-# flags: --strict-optional
 # suggest: --flex-any=0.4 m.foo
 # suggest: --flex-any=0.7 m.foo
 # suggest: --flex-any=0.4 m.bar
@@ -661,7 +646,6 @@ No guesses that match criteria!
 
 
 [case testSuggestFlexAny2]
-# flags: --strict-optional
 # suggest: --flex-any=0.5 m.baz
 # suggest: --flex-any=0.0 m.baz
 # suggest: --flex-any=0.5 m.F.foo
@@ -693,7 +677,6 @@ No guesses that match criteria!
 ==
 
 [case testSuggestClassMethod]
-# flags: --strict-optional
 # suggest: foo.F.bar
 # suggest: foo.F.baz
 # suggest: foo.F.eggs

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4707,7 +4707,7 @@ x: Optional[int]
 y: int
 [out]
 ==
-main:3: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "int")
+main:2: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "int")
 
 [case testStrictOptionalFunction]
 import a
@@ -4725,7 +4725,7 @@ def g(x: int) -> None:
     pass
 [out]
 ==
-main:6: error: Argument 1 to "g" has incompatible type "Optional[int]"; expected "int"
+main:5: error: Argument 1 to "g" has incompatible type "Optional[int]"; expected "int"
 
 [case testStrictOptionalMethod]
 import a
@@ -4746,7 +4746,7 @@ class B:
         pass
 [out]
 ==
-main:7: error: Argument 1 to "g" of "B" has incompatible type "Optional[int]"; expected "int"
+main:6: error: Argument 1 to "g" of "B" has incompatible type "Optional[int]"; expected "int"
 
 [case testPerFileStrictOptionalModule]
 import a
@@ -10057,7 +10057,7 @@ class Base:
     def meth(self) -> int: ...
 [out]
 ==
-main:6: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
+main:5: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
 
 [case testAbstractBodyTurnsEmptyProtocol]
 from b import Base
@@ -10076,7 +10076,7 @@ class Base(Protocol):
     def meth(self) -> int: ...
 [out]
 ==
-main:6: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
+main:5: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
 
 [case testPrettyMessageSorting]
 # flags: --pretty

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -2083,7 +2083,6 @@ a.py:5: error: "list" expects 1 type argument, but 2 given
 ==
 
 [case testPreviousErrorInOverloadedFunction]
-# flags: --strict-optional
 import a
 [file a.py]
 from typing import overload
@@ -3494,7 +3493,6 @@ def foo() -> None:
 b.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testNamedTupleUpdateNonRecursiveToRecursiveFine]
-# flags: --strict-optional
 import c
 [file a.py]
 from b import M
@@ -3537,7 +3535,6 @@ c.py:5: error: Incompatible types in assignment (expression has type "Optional[N
 c.py:7: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 
 [case testTupleTypeUpdateNonRecursiveToRecursiveFine]
-# flags: --strict-optional
 import c
 [file a.py]
 from b import M
@@ -3570,7 +3567,6 @@ c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int
 c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
 
 [case testTypeAliasUpdateNonRecursiveToRecursiveFine]
-# flags: --strict-optional
 import c
 [file a.py]
 from b import M
@@ -4699,7 +4695,6 @@ class B:
 main:7: error: Argument 1 to "g" of "B" has incompatible type "Optional[int]"; expected "str"
 
 [case testStrictOptionalModule]
-# flags: --strict-optional
 import a
 a.y = a.x
 [file a.py]
@@ -4715,7 +4710,6 @@ y: int
 main:3: error: Incompatible types in assignment (expression has type "Optional[int]", variable has type "int")
 
 [case testStrictOptionalFunction]
-# flags: --strict-optional
 import a
 from typing import Optional
 def f() -> None:
@@ -4734,7 +4728,6 @@ def g(x: int) -> None:
 main:6: error: Argument 1 to "g" has incompatible type "Optional[int]"; expected "int"
 
 [case testStrictOptionalMethod]
-# flags: --strict-optional
 import a
 from typing import Optional
 class C:
@@ -7953,7 +7946,7 @@ class Foo(a.I):
 ==
 
 [case testImplicitOptionalRefresh1]
-# flags: --strict-optional --implicit-optional
+# flags: --implicit-optional
 from x import f
 def foo(x: int = None) -> None:
     f()
@@ -9793,7 +9786,6 @@ class ExampleClass(Generic[T]):
 [out]
 ==
 [case testStrictNoneAttribute]
-# flags: --strict-optional
 from typing import Generic, TypeVar
 
 T = TypeVar('T', int, str)
@@ -10046,7 +10038,6 @@ class C(B): ...
 main.py:4: note: Revealed type is "def () -> builtins.str"
 
 [case testAbstractBodyTurnsEmpty]
-# flags: --strict-optional
 from b import Base
 
 class Sub(Base):
@@ -10069,7 +10060,6 @@ class Base:
 main:6: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
 
 [case testAbstractBodyTurnsEmptyProtocol]
-# flags: --strict-optional
 from b import Base
 
 class Sub(Base):

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1666,10 +1666,10 @@ else:
     reveal_type(k)
 
 [out]
-_testNarrowTypeForDictKeys.py:7: note: Revealed type is "builtins.str"
-_testNarrowTypeForDictKeys.py:9: note: Revealed type is "Union[builtins.str, None]"
-_testNarrowTypeForDictKeys.py:14: note: Revealed type is "builtins.str"
-_testNarrowTypeForDictKeys.py:16: note: Revealed type is "Union[builtins.str, None]"
+_testNarrowTypeForDictKeys.py:6: note: Revealed type is "builtins.str"
+_testNarrowTypeForDictKeys.py:8: note: Revealed type is "Union[builtins.str, None]"
+_testNarrowTypeForDictKeys.py:13: note: Revealed type is "builtins.str"
+_testNarrowTypeForDictKeys.py:15: note: Revealed type is "Union[builtins.str, None]"
 
 [case testTypeAliasWithNewStyleUnion]
 # flags: --python-version 3.10

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1649,7 +1649,6 @@ foo(list((list(""), "")))
 [out]
 
 [case testNarrowTypeForDictKeys]
-# flags: --strict-optional
 from typing import Dict, KeysView, Optional
 
 d: Dict[str, int]


### PR DESCRIPTION
Following @cdce8p's excellent work, these are now redundant!