### PR TITLE
Type comment strip

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -238,8 +238,18 @@ def parse(
                     and TYPE_COMMENT_PATTERN.match(e.text)
                 ):
                     stripped_source = strip_comment_from_line(source, e.lineno)
-                    # TODO: log a note of what was stripped
-                    print(f"{e.lineno}: Stripped comment from {e.text}")
+                    errors.report(
+                        e.lineno or -1,
+                        e.offset or -1,
+                        # TODO: It would be nicer if the message included the line text via
+                        # `e.text.strip()`. However, I can't figure out how to make the unit
+                        # test pass, because the # N: <expected_result> in the unit test must
+                        # contain itself. If there was some partial matching mechanism for the
+                        # unit test comment, then we could make this work.
+                        "Ignored bad type comment",
+                        severity="note",
+                        code=codes.SYNTAX,
+                    )
                     return None, stripped_source
                 raise
             return ast, source

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1077,6 +1077,11 @@ def process_options(
         group=other_group,
         inverse="--interactive",
     )
+    other_group.add_argument(
+        "--ignore-comment-errors",
+        action="store_true",
+        help="Ignore syntax errors in type comments",
+    )
 
     if server_options:
         # TODO: This flag is superfluous; remove after a short transition (2018-03-16)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -42,6 +42,7 @@ PER_MODULE_OPTIONS: Final = {
     "extra_checks",
     "follow_imports_for_stubs",
     "follow_imports",
+    "ignore_comment_errors",
     "ignore_errors",
     "ignore_missing_imports",
     "implicit_optional",
@@ -172,6 +173,9 @@ class Options:
 
         # Files in which to ignore all non-fatal errors
         self.ignore_errors = False
+
+        # Files in which to ignore all syntax errors in type comments
+        self.ignore_comment_errors = False
 
         # Apply strict None checking
         self.strict_optional = True

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -174,7 +174,7 @@ class Options:
         # Files in which to ignore all non-fatal errors
         self.ignore_errors = False
 
-        # Files in which to ignore all syntax errors in type comments
+        # Ignore syntax errors in type comments
         self.ignore_comment_errors = False
 
         # Apply strict None checking

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -9,8 +9,8 @@ x = None # type: a : b  # E: Syntax error in type comment "a : b"
 [case testFastParseIgnoreTypeCommentSyntaxError]
 # flags: --ignore-comment-errors
 
-x: int = "1"  # type: bad  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
-y: str = 1  # type: bad  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+x: int = "1"  # type: bad  # E: Incompatible types in assignment (expression has type "str", variable has type "int") # N: Ignored bad type comment
+y: str = 1  # type: bad  # E: Incompatible types in assignment (expression has type "int", variable has type "str") # N: Ignored bad type comment
 
 [case testFastParseInvalidTypeComment]
 

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -9,9 +9,12 @@ x = None # type: a : b  # E: Syntax error in type comment "a : b"
 [case testFastParseIgnoreTypeCommentSyntaxError]
 # flags: --ignore-comment-errors
 x: int = "1"  # type: bad
+y: str = 1  # type: bad
 [out]
 main:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 main:2: note: Ignored bad type comment: x: int = "1"  # type: bad
+main:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+main:3: note: Ignored bad type comment: y: str = 1  # type: bad
 
 [case testFastParseIgnoreTypeCommentSyntaxError2]
 # flags: --ignore-comment-errors
@@ -22,9 +25,9 @@ main:3: note: Ignored bad type comment: # type: bad
 
 [case testFastParseIgnoreTypeCommentSyntaxError3]
 # flags: --ignore-comment-errors
-s = "# type: kind of bad because this is not a comment'
+s = "# type: This syntax error is not due to a bad type comment'
 [out]
-main:2: note: Ignored bad type comment: s = "# type: kind of bad because this is not a comment'
+main:2: note: Ignored bad type comment: s = "# type: This syntax error is not due to a bad type comment'
 main:2: error: unterminated string literal (detected at line 2)
 
 [case testFastParseInvalidTypeComment]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -6,6 +6,12 @@
 
 x = None # type: a : b  # E: Syntax error in type comment "a : b"
 
+[case testFastParseIgnoreTypeCommentSyntaxError]
+# flags: --ignore-comment-errors
+
+x: int = "1"  # type: bad  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+y: str = 1  # type: bad  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+
 [case testFastParseInvalidTypeComment]
 
 x = None # type: a + b  # E: Invalid type comment or annotation

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -8,9 +8,24 @@ x = None # type: a : b  # E: Syntax error in type comment "a : b"
 
 [case testFastParseIgnoreTypeCommentSyntaxError]
 # flags: --ignore-comment-errors
+x: int = "1"  # type: bad
+[out]
+main:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:2: note: Ignored bad type comment: x: int = "1"  # type: bad
 
-x: int = "1"  # type: bad  # E: Incompatible types in assignment (expression has type "str", variable has type "int") # N: Ignored bad type comment
-y: str = 1  # type: bad  # E: Incompatible types in assignment (expression has type "int", variable has type "str") # N: Ignored bad type comment
+[case testFastParseIgnoreTypeCommentSyntaxError2]
+# flags: --ignore-comment-errors
+s = "# type: not bad"
+# type: bad
+[out]
+main:3: note: Ignored bad type comment: # type: bad
+
+[case testFastParseIgnoreTypeCommentSyntaxError3]
+# flags: --ignore-comment-errors
+s = "# type: kind of bad because this is not a comment'
+[out]
+main:2: note: Ignored bad type comment: s = "# type: kind of bad because this is not a comment'
+main:2: error: unterminated string literal (detected at line 2)
 
 [case testFastParseInvalidTypeComment]
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Fixes #15678 

This PR adds a new option to mypy `--ignore-comment-errors`. If this option is set, when a module is parsed, if a syntax error is encountered, and the line contains a type comment, strip the comment from the line, and try to parse the source again. This process is repeated for the source every time a syntax error is encountered. This could be potentially expensive if the source contains many bad type comments, but I think anything more efficient would require changing the AST parser.

This option is useful when your code imports modules with malformed type comments, that you can't change. Since this is a syntax error at the AST level, if such a comment is encountered, the entire type checking process halts. `ignore_errors` does not work, and `follow_imports=skip` is not an ideal solution.

A unit test is also included.