### PR TITLE
Fix inference for attrs.fields

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4592,14 +4592,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if int_type:
             return iterator, int_type
 
-        if isinstance(iterable, TupleType):
+        if (
+            isinstance(iterable, TupleType)
+            and iterable.partial_fallback.type.fullname == "builtins.tuple"
+        ):
             joined: Type = UninhabitedType()
-            if iterable.partial_fallback.type.fullname != "builtins.tuple":
-                # If we're some fancier tuple variant, join with the item type
-                item_type = echk.check_method_call_by_name("__next__", iterator, [], [], expr)[0]
-                if not isinstance(get_proper_type(item_type), AnyType):
-                    joined = item_type
-
             for item in iterable.items:
                 joined = join_types(joined, item)
             return iterator, joined

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4592,8 +4592,15 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if int_type:
             return iterator, int_type
 
+
         if isinstance(iterable, TupleType):
             joined: Type = UninhabitedType()
+            if iterable.partial_fallback.type.fullname != "builtins.tuple":
+                # If we're some fancier tuple variant, join with the item type
+                item_type = echk.check_method_call_by_name("__next__", iterator, [], [], expr)[0]
+                if not isinstance(get_proper_type(item_type), AnyType):
+                    joined = item_type
+
             for item in iterable.items:
                 joined = join_types(joined, item)
             return iterator, joined

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4592,7 +4592,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if int_type:
             return iterator, int_type
 
-
         if isinstance(iterable, TupleType):
             joined: Type = UninhabitedType()
             if iterable.partial_fallback.type.fullname != "builtins.tuple":

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1570,6 +1570,9 @@ reveal_type(f(A)[0])  # N: Revealed type is "attr.Attribute[builtins.int]"
 reveal_type(f(A).b)  # N: Revealed type is "attr.Attribute[builtins.int]"
 f(A).x  # E: "____main___A_AttrsAttributes__" has no attribute "x"
 
+for ff in f(A):
+    reveal_type(ff)  # N: Revealed type is "attr.Attribute[Any]"
+
 [builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsGenericFields]

--- a/test-data/unit/fixtures/plugin_attrs.pyi
+++ b/test-data/unit/fixtures/plugin_attrs.pyi
@@ -1,5 +1,5 @@
 # Builtins stub used to support attrs plugin tests.
-from typing import Union, overload
+from typing import Union, overload, Generic, Sequence, TypeVar, Type, Iterable, Iterator
 
 class object:
     def __init__(self) -> None: pass
@@ -24,6 +24,13 @@ class complex:
 
 class str: pass
 class ellipsis: pass
-class tuple: pass
 class list: pass
 class dict: pass
+
+T = TypeVar("T")
+Tco = TypeVar('Tco', covariant=True)
+class tuple(Sequence[Tco], Generic[Tco]):
+    def __new__(cls: Type[T], iterable: Iterable[Tco] = ...) -> T: ...
+    def __iter__(self) -> Iterator[Tco]: pass
+    def __contains__(self, item: object) -> bool: pass
+    def __getitem__(self, x: int) -> Tco: pass


### PR DESCRIPTION
Fixes #15393. A little hacky, but not an unreasonable way of providing type context.