### PR TITLE
Correctly narrow types for `tuple[type[X], ...]`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7118,6 +7118,8 @@ def flatten_types(t: Type) -> list[Type]:
     t = get_proper_type(t)
     if isinstance(t, TupleType):
         return [b for a in t.items for b in flatten_types(a)]
+    elif is_named_instance(t, "builtins.tuple"):
+        return [t.args[0]]
     else:
         return [t]
 

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1268,3 +1268,21 @@ def g() -> None:
         def foo(): ...
     foo()
 [builtins fixtures/dict.pyi]
+
+
+[case testNarrowingWithTupleOfTypes]
+from typing import Tuple, Type
+
+class Base: ...
+
+class Impl1(Base): ...
+class Impl2(Base): ...
+
+impls: Tuple[Type[Base], ...] = (Impl1, Impl2)
+some: object
+
+if isinstance(some, impls):
+    reveal_type(some)  # N: Revealed type is "__main__.Base"
+else:
+    reveal_type(some)  # N: Revealed type is "builtins.object"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1294,16 +1294,16 @@ else:
 [builtins fixtures/dict.pyi]
 
 
-[case testNarrowingWithTupleOfTypesPy30Plus]
+[case testNarrowingWithTupleOfTypesPy310Plus]
 # flags: --python-version 3.10
 class Base: ...
 
 class Impl1(Base): ...
 class Impl2(Base): ...
 
-impls: tuple[type[Base], ...] = (Impl1, Impl2)
 some: int | Base
 
+impls: tuple[type[Base], ...] = (Impl1, Impl2)
 if isinstance(some, impls):
     reveal_type(some)  # N: Revealed type is "__main__.Base"
 else:

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1285,4 +1285,33 @@ if isinstance(some, impls):
     reveal_type(some)  # N: Revealed type is "__main__.Base"
 else:
     reveal_type(some)  # N: Revealed type is "builtins.object"
+
+raw: Tuple[type, ...]
+if isinstance(some, raw):
+    reveal_type(some)  # N: Revealed type is "builtins.object"
+else:
+    reveal_type(some)  # N: Revealed type is "builtins.object"
+[builtins fixtures/dict.pyi]
+
+
+[case testNarrowingWithTupleOfTypesPy30Plus]
+# flags: --python-version 3.10
+class Base: ...
+
+class Impl1(Base): ...
+class Impl2(Base): ...
+
+impls: tuple[type[Base], ...] = (Impl1, Impl2)
+some: int | Base
+
+if isinstance(some, impls):
+    reveal_type(some)  # N: Revealed type is "__main__.Base"
+else:
+    reveal_type(some)  # N: Revealed type is "Union[builtins.int, __main__.Base]"
+
+raw: tuple[type, ...]
+if isinstance(some, raw):
+    reveal_type(some)  # N: Revealed type is "Union[builtins.int, __main__.Base]"
+else:
+    reveal_type(some)  # N: Revealed type is "Union[builtins.int, __main__.Base]"
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
`flatten_types` forgot about the second way we represent `tuple` inside.

Closes https://github.com/python/mypy/issues/15443