### PR TITLE
Remove the Python 37 environment from the `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py38,
     py39,
     py310,
+    py311,
     docs,
     lint,
     type,

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 minversion = 4.4.4
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 envlist =
-    py37,
     py38,
     py39,
     py310,


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Remove the Python 37 environment from the `tox.ini` since Python 3.7 is now end of life.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
