### PR TITLE
Add constraint for pre-commit with Python 3.12

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,10 @@ black==23.3.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
 # lxml 4.9.3 switched to manylinux_2_28, the wheel builder still uses manylinux2014
 lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
+# PyYAML 6.0 (required by pre-commit) can't be build with cython 3.0.0
+# There aren't any wheels for Python 3.12 yet.
+# https://github.com/yaml/pyyaml/issues/724
+PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
 pre-commit
 pre-commit-hooks==4.4.0
 psutil>=4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,10 +5,9 @@ black==23.3.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
 # lxml 4.9.3 switched to manylinux_2_28, the wheel builder still uses manylinux2014
 lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
-# PyYAML 6.0 (required by pre-commit) can't be build with cython 3.0.0
-# There aren't any wheels for Python 3.12 yet.
+# PyYAML 6.0 (required by pre-commit) can't be build from source with cython 3.0.0
 # https://github.com/yaml/pyyaml/issues/724
-pre-commit; python_version<'3.12'
+pre-commit; python_version<'3.12' or platform_machine=='i386'
 pre-commit-hooks==4.4.0
 psutil>=4.0
 pytest>=7.4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,7 @@ lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_
 # PyYAML 6.0 (required by pre-commit) can't be build with cython 3.0.0
 # There aren't any wheels for Python 3.12 yet.
 # https://github.com/yaml/pyyaml/issues/724
-pyyaml>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
-pre-commit
+pre-commit; python_version<'3.12'
 pre-commit-hooks==4.4.0
 psutil>=4.0
 pytest>=7.4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ filelock>=3.3.0
 lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 # PyYAML 6.0 (required by pre-commit) can't be build from source with cython 3.0.0
 # https://github.com/yaml/pyyaml/issues/724
-pre-commit; python_version<'3.12' or platform_machine=='i386'
+pre-commit; python_version<'3.12' and platform_machine!='i386'
 pre-commit-hooks==4.4.0
 psutil>=4.0
 pytest>=7.4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_
 # PyYAML 6.0 (required by pre-commit) can't be build with cython 3.0.0
 # There aren't any wheels for Python 3.12 yet.
 # https://github.com/yaml/pyyaml/issues/724
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
+pyyaml>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
 pre-commit
 pre-commit-hooks==4.4.0
 psutil>=4.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ filelock>=3.3.0
 lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 # PyYAML 6.0 (required by pre-commit) can't be build from source with cython 3.0.0
 # https://github.com/yaml/pyyaml/issues/724
-pre-commit; python_version<'3.12' and platform_machine!='i386'
+pre-commit; python_version<'3.12' and platform_machine!='i686'
 pre-commit-hooks==4.4.0
 psutil>=4.0
 pytest>=7.4.0


### PR DESCRIPTION
`PyYAML`, required by `pre-commit`, can't be build with cython 3.0.0 (released today). For Python `<3.12` there are wheels on PyPI, so that continues to work. However, for Python 3.12 the wheels are build from source which started failing now.

See: https://github.com/yaml/pyyaml/issues/724