### PR TITLE
Treat empty yield as no-op for reachability

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -132,6 +132,7 @@ from mypy.nodes import (
     Var,
     WhileStmt,
     WithStmt,
+    YieldExpr,
     is_final_node,
 )
 from mypy.options import Options
@@ -2738,6 +2739,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return True
         elif isinstance(s, ExpressionStmt):
             if isinstance(s.expr, EllipsisExpr):
+                return True
+            elif isinstance(s.expr, YieldExpr) and s.expr.expr is None:
                 return True
             elif isinstance(s.expr, CallExpr):
                 with self.expr_checker.msg.filter_errors():

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1446,3 +1446,21 @@ def f() -> None:
     Foo()['a'] = 'a'
     x = 0 # This should not be reported as unreachable
 [builtins fixtures/exception.pyi]
+
+[case testIntentionallyEmptyGenerator]
+# flags: --warn-unreachable
+from typing import Generator
+
+def f() -> Generator[None, None, None]:
+    return
+    yield
+
+[case testYieldNoneIgnored]
+# flags: --warn-unreachable
+from typing import Generator
+
+def f() -> Generator[None, None, None]:
+    return
+    yield
+    yield
+    x = 42  # E: Statement is unreachable


### PR DESCRIPTION
Fixes #15345.

We're getting slightly more than what we bargained for, i.e. not only we don't flag any statement as 'unreachable' in this canonical "empty generator":
```python
def f():
  return
  yield
```
but also here:
```python
def f():
  return 42
  yield
```
or here:
```python
def f():
  return
  yield
  yield
```

This is because it's simpler to add empty `yield`s to `is_noop_for_reachability`, than to track state ("up to 1 empty yield").

If there's anything more meaningful a function does, a different statement would be flagged as the first unreachable one, e.g.
```python
def f():
  return
  yield
  a = 42  # E: Statement is unreachable
```

## Alternative

Another alternative is to pattern-match the entire function body as being `return; yield`. This would be slightly more code, and perhaps necessitate to mark `suppress_unreachable_warnings` on the frame.

I'm not entirely convinced `return; yield` should be special-cased on its own. Since the presence of `yield` is the only way to promote a function into a generator, we could be more lenient to empty `yield`s (other statements would still get flagged so it's unlikely that unreachable code would evade attention).