### PR TITLE
Experiment with intersection on TypeVars

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -685,6 +685,8 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
         # this may be alright on things other than just instances
         elif isinstance(self.s, Instance):
             return t.copy_modified(upper_bound=meet_types(t.upper_bound, self.s))
+        elif isinstance(self.s, UnionType):
+            return meet_types(t, self.s)
         else:
             return self.default(self.s)
 

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -683,7 +683,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
         if isinstance(self.s, TypeVarType) and self.s.id == t.id:
             return self.s
         # this may be alright on things other than just instances
-        elif isinstance(self.s, Instance):
+        elif isinstance(self.s, (Instance, NoneType, TupleType)):
             return t.copy_modified(upper_bound=meet_types(t.upper_bound, self.s))
         elif isinstance(self.s, UnionType):
             return meet_types(t, self.s)

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -683,7 +683,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
         if isinstance(self.s, TypeVarType) and self.s.id == t.id:
             return self.s
         else:
-            return self.default(self.s)
+            return t.copy_modified(upper_bound=meet_types(t.upper_bound, self.s))
 
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
         if self.s == t:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -682,8 +682,11 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
     def visit_type_var(self, t: TypeVarType) -> ProperType:
         if isinstance(self.s, TypeVarType) and self.s.id == t.id:
             return self.s
-        else:
+        # this may be alright on things other than just instances
+        elif isinstance(self.s, Instance):
             return t.copy_modified(upper_bound=meet_types(t.upper_bound, self.s))
+        else:
+            return self.default(self.s)
 
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
         if self.s == t:
@@ -753,13 +756,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
             if is_subtype(self.s.fallback, t):
                 return self.s
             return self.default(self.s)
-        elif isinstance(self.s, TypeType):
-            return meet_types(t, self.s)
-        elif isinstance(self.s, TupleType):
-            return meet_types(t, self.s)
-        elif isinstance(self.s, LiteralType):
-            return meet_types(t, self.s)
-        elif isinstance(self.s, TypedDictType):
+        elif isinstance(self.s, (TypeType, TupleType, LiteralType, TypedDictType, TypeVarType)):
             return meet_types(t, self.s)
         return self.default(self.s)
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -1135,7 +1135,9 @@ class MeetSuite(Suite):
         self.assert_meet(self.fx.ga, self.fx.nonet, self.fx.nonet)
         self.assert_meet(self.fx.ga, self.fx.anyt, self.fx.ga)
 
-        for t in [self.fx.a, self.fx.t, self.tuple(), self.callable(self.fx.a, self.fx.b)]:
+        self.assert_meet(self.fx.t, self.fx.ga, self.fx.t)
+
+        for t in [self.fx.a, self.tuple(), self.callable(self.fx.a, self.fx.b)]:
             self.assert_meet(t, self.fx.ga, self.fx.nonet)
 
     def test_generics_with_multiple_args(self) -> None:


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

While working on https://github.com/python/mypy/pull/15711 and reflecting, I had a thought about how the upper bound on `T` is essentially an intersection: `T` with an upper bound of `int` is kinda somewhat `T & int`.

This means `T & int & <something>` is essentially `T & (int & <something>)`. I implemented this, I want to see how mypy primer looks.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
