### PR TITLE
[mypyc] Emit errors for unsupported class defs (and don't crash)

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -155,6 +155,8 @@ def transform_class_def(builder: IRBuilder, cdef: ClassDef) -> None:
         elif isinstance(stmt, ExpressionStmt) and isinstance(stmt.expr, StrExpr):
             # Docstring. Ignore
             pass
+        elif isinstance(stmt, ClassDef):
+            builder.error("Nested classes are not supported", stmt.line)
         else:
             builder.error("Unsupported statement in class body", stmt.line)
 

--- a/mypyc/irbuild/visitor.py
+++ b/mypyc/irbuild/visitor.py
@@ -5,6 +5,7 @@ mypyc.irbuild.builder and mypyc.irbuild.main are closely related.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import NoReturn
 
 from mypy.nodes import (
@@ -159,11 +160,15 @@ class IRBuilderVisitor(IRVisitor):
     # state and many helpers. The attribute is initialized outside
     # this class since this class and IRBuilder form a reference loop.
     builder: IRBuilder
+    # If set, raise an error when a class definition is visited.
+    _error_message_on_class_def: str = ""
 
     def visit_mypy_file(self, mypyfile: MypyFile) -> None:
         assert False, "use transform_mypy_file instead"
 
     def visit_class_def(self, cdef: ClassDef) -> None:
+        if self._error_message_on_class_def:
+            self.bail(self._error_message_on_class_def, cdef.line)
         transform_class_def(self.builder, cdef)
 
     def visit_import(self, node: Import) -> None:
@@ -176,7 +181,8 @@ class IRBuilderVisitor(IRVisitor):
         transform_import_all(self.builder, node)
 
     def visit_func_def(self, fdef: FuncDef) -> None:
-        transform_func_def(self.builder, fdef)
+        with self.error_on_class_def("Class definitions within a function are not supported"):
+            transform_func_def(self.builder, fdef)
 
     def visit_overloaded_func_def(self, o: OverloadedFuncDef) -> None:
         transform_overloaded_func_def(self.builder, o)
@@ -202,7 +208,8 @@ class IRBuilderVisitor(IRVisitor):
         transform_operator_assignment_stmt(self.builder, stmt)
 
     def visit_if_stmt(self, stmt: IfStmt) -> None:
-        transform_if_stmt(self.builder, stmt)
+        with self.error_on_class_def("Conditional class definitions are not supported"):
+            transform_if_stmt(self.builder, stmt)
 
     def visit_while_stmt(self, stmt: WhileStmt) -> None:
         transform_while_stmt(self.builder, stmt)
@@ -395,3 +402,11 @@ class IRBuilderVisitor(IRVisitor):
         """
         self.builder.error(msg, line)
         raise UnsupportedException()
+
+    @contextmanager
+    def error_on_class_def(self, error: str) -> NoReturn:
+        self._error_message_on_class_def = error
+        try:
+            yield
+        finally:
+            self._error_message_on_class_def = ""

--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -191,6 +191,18 @@ class NonExt2:
     def test(self, x: int) -> None:
         pass
 
+if True:
+    class ConditionalClass:  # E: Conditional class definitions are not supported
+        pass
+
+class Outer:
+    class Inner:  # E: Nested classes are not supported
+        pass
+
+def make_class() -> None:
+    class LocalClass:  # E: Class definitions within a function are not supported
+        pass
+
 iterator_warning = (i+1 for i in range(10))  # W: Treating generator comprehension as list
 
 # But we don't want warnings for these cases:


### PR DESCRIPTION
Would this be cleaner if this check was done in the prebuild visitor? I couldn't find a reliable way to determine whether a class definition is within a if statement or any other block unfortunately. 