### PR TITLE
Add `__match_args__` to dataclasses with no fields 

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -365,7 +365,6 @@ class DataclassTransformer:
             and (
                 "__match_args__" not in info.names or info.names["__match_args__"].plugin_generated
             )
-            and attributes
             and py_version >= (3, 10)
         ):
             str_type = self._api.named_type("builtins.str")

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1892,6 +1892,11 @@ class Two:
     bar: int
 t: Two
 reveal_type(t.__match_args__)  # N: Revealed type is "Tuple[Literal['bar']]"
+@dataclass
+class Empty:
+    ...
+e: Empty
+reveal_type(e.__match_args__)  # N: Revealed type is "Tuple[]"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassWithoutMatchArgs]


### PR DESCRIPTION
It exists at runtime.

Fixes #15748