### PR TITLE
[release 1.5 cherry-pick] stubtest: Fix `__mypy-replace` false positives (#15689)

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -496,7 +496,11 @@ def verify_typeinfo(
     )
 
     # Check everything already defined on the stub class itself (i.e. not inherited)
-    to_check = set(stub.names)
+    #
+    # Filter out non-identifier names, as these are (hopefully always?) whacky/fictional things
+    # (like __mypy-replace or __mypy-post_init, etc.) that don't exist at runtime,
+    # and exist purely for internal mypy reasons
+    to_check = {name for name in stub.names if name.isidentifier()}
     # Check all public things on the runtime class
     to_check.update(
         m for m in vars(runtime) if not is_probably_private(m) and m not in IGNORABLE_CLASS_DUNDERS


### PR DESCRIPTION
Cherry-pick of https://github.com/python/mypy/commit/6bdcc92002a5e1a6feb1528d0221802f7514c836 to the release 1.5 branch. This fixes a recent stubtest regression that was inadvertently introduced by https://github.com/python/mypy/commit/6f2bfff521e708f015af1eec5118db4600b829be