### PR TITLE
Fix type narrowing of `== None` and `in (None,)` conditions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -215,7 +215,7 @@ from mypy.types import (
     is_literal_type,
     is_named_instance,
 )
-from mypy.types_utils import is_optional, remove_optional, store_argument_type, strip_type
+from mypy.types_utils import is_overlapping_none, remove_optional, store_argument_type, strip_type
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.typevars import fill_typevars, fill_typevars_with_any, has_no_typevars
 from mypy.util import is_dunder, is_sunder, is_typeshed_file
@@ -5652,13 +5652,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
                     if left_index in narrowable_operand_index_to_hash:
                         # We only try and narrow away 'None' for now
-                        if is_optional(item_type):
+                        if is_overlapping_none(item_type):
                             collection_item_type = get_proper_type(
                                 builtin_item_type(iterable_type)
                             )
                             if (
                                 collection_item_type is not None
-                                and not is_optional(collection_item_type)
+                                and not is_overlapping_none(collection_item_type)
                                 and not (
                                     isinstance(collection_item_type, Instance)
                                     and collection_item_type.type.fullname == "builtins.object"
@@ -6065,7 +6065,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         non_optional_types = []
         for i in chain_indices:
             typ = operand_types[i]
-            if not is_optional(typ):
+            if not is_overlapping_none(typ):
                 non_optional_types.append(typ)
 
         # Make sure we have a mixture of optional and non-optional types.
@@ -6075,7 +6075,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if_map = {}
         for i in narrowable_operand_indices:
             expr_type = operand_types[i]
-            if not is_optional(expr_type):
+            if not is_overlapping_none(expr_type):
                 continue
             if any(is_overlapping_erased_types(expr_type, t) for t in non_optional_types):
                 if_map[operands[i]] = remove_optional(expr_type)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -215,13 +215,7 @@ from mypy.types import (
     is_literal_type,
     is_named_instance,
 )
-from mypy.types_utils import (
-    can_be_none,
-    is_optional,
-    remove_optional,
-    store_argument_type,
-    strip_type,
-)
+from mypy.types_utils import is_optional, remove_optional, store_argument_type, strip_type
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.typevars import fill_typevars, fill_typevars_with_any, has_no_typevars
 from mypy.util import is_dunder, is_sunder, is_typeshed_file
@@ -5664,7 +5658,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             )
                             if (
                                 collection_item_type is not None
-                                and not can_be_none(collection_item_type)
+                                and not is_optional(collection_item_type)
                                 and not (
                                     isinstance(collection_item_type, Instance)
                                     and collection_item_type.type.fullname == "builtins.object"
@@ -6071,7 +6065,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         non_optional_types = []
         for i in chain_indices:
             typ = operand_types[i]
-            if not can_be_none(typ):
+            if not is_optional(typ):
                 non_optional_types.append(typ)
 
         # Make sure we have a mixture of optional and non-optional types.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -215,7 +215,13 @@ from mypy.types import (
     is_literal_type,
     is_named_instance,
 )
-from mypy.types_utils import is_optional, remove_optional, store_argument_type, strip_type
+from mypy.types_utils import (
+    can_be_none,
+    is_optional,
+    remove_optional,
+    store_argument_type,
+    strip_type,
+)
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.typevars import fill_typevars, fill_typevars_with_any, has_no_typevars
 from mypy.util import is_dunder, is_sunder, is_typeshed_file
@@ -5658,7 +5664,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             )
                             if (
                                 collection_item_type is not None
-                                and not is_optional(collection_item_type)
+                                and not can_be_none(collection_item_type)
                                 and not (
                                     isinstance(collection_item_type, Instance)
                                     and collection_item_type.type.fullname == "builtins.object"
@@ -6065,7 +6071,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         non_optional_types = []
         for i in chain_indices:
             typ = operand_types[i]
-            if not is_optional(typ):
+            if not can_be_none(typ):
                 non_optional_types.append(typ)
 
         # Make sure we have a mixture of optional and non-optional types.

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -169,7 +169,12 @@ from mypy.types import (
     is_named_instance,
     split_with_prefix_and_suffix,
 )
-from mypy.types_utils import is_generic_instance, is_optional, is_self_type_like, remove_optional
+from mypy.types_utils import (
+    is_generic_instance,
+    is_overlapping_none,
+    is_self_type_like,
+    remove_optional,
+)
 from mypy.typestate import type_state
 from mypy.typevars import fill_typevars
 from mypy.typevartuples import find_unpack_in_list
@@ -1809,7 +1814,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         # valid results.
         erased_ctx = replace_meta_vars(ctx, ErasedType())
         ret_type = callable.ret_type
-        if is_optional(ret_type) and is_optional(ctx):
+        if is_overlapping_none(ret_type) and is_overlapping_none(ctx):
             # If both the context and the return type are optional, unwrap the optional,
             # since in 99% cases this is what a user expects. In other words, we replace
             #     Optional[T] <: Optional[int]

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -43,7 +43,7 @@ from mypy.types import (
     deserialize_type,
     get_proper_type,
 )
-from mypy.types_utils import is_optional
+from mypy.types_utils import is_overlapping_none
 from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 
@@ -141,7 +141,7 @@ def find_shallow_matching_overload_item(overload: Overloaded, call: CallExpr) ->
                         break
                 elif (
                     arg_none
-                    and not is_optional(arg_type)
+                    and not is_overlapping_none(arg_type)
                     and not (
                         isinstance(arg_type, Instance)
                         and arg_type.type.fullname == "builtins.object"

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -43,7 +43,7 @@ from mypy.types import (
     deserialize_type,
     get_proper_type,
 )
-from mypy.types_utils import is_optional
+from mypy.types_utils import can_be_none
 from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 
@@ -141,7 +141,7 @@ def find_shallow_matching_overload_item(overload: Overloaded, call: CallExpr) ->
                         break
                 elif (
                     arg_none
-                    and not is_optional(arg_type)
+                    and not can_be_none(arg_type)
                     and not (
                         isinstance(arg_type, Instance)
                         and arg_type.type.fullname == "builtins.object"

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -43,7 +43,7 @@ from mypy.types import (
     deserialize_type,
     get_proper_type,
 )
-from mypy.types_utils import can_be_none
+from mypy.types_utils import is_optional
 from mypy.typevars import fill_typevars
 from mypy.util import get_unique_redefinition_name
 
@@ -141,7 +141,7 @@ def find_shallow_matching_overload_item(overload: Overloaded, call: CallExpr) ->
                         break
                 elif (
                     arg_none
-                    and not can_be_none(arg_type)
+                    and not is_optional(arg_type)
                     and not (
                         isinstance(arg_type, Instance)
                         and arg_type.type.fullname == "builtins.object"

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -79,7 +79,7 @@ from mypy.types import (
     UnionType,
     get_proper_type,
 )
-from mypy.types_utils import is_optional, remove_optional
+from mypy.types_utils import is_overlapping_none, remove_optional
 from mypy.util import split_target
 
 
@@ -752,7 +752,7 @@ class SuggestionEngine:
                 return 20
             if any(has_any_type(x) for x in t.items):
                 return 15
-            if not is_optional(t):
+            if not is_overlapping_none(t):
                 return 10
         if isinstance(t, CallableType) and (has_any_type(t) or is_tricky_callable(t)):
             return 10
@@ -868,7 +868,7 @@ class TypeFormatter(TypeStrVisitor):
         return t.fallback.accept(self)
 
     def visit_union_type(self, t: UnionType) -> str:
-        if len(t.items) == 2 and is_optional(t):
+        if len(t.items) == 2 and is_overlapping_none(t):
             return f"Optional[{remove_optional(t).accept(self)}]"
         else:
             return super().visit_union_type(t)

--- a/mypy/types_utils.py
+++ b/mypy/types_utils.py
@@ -103,14 +103,9 @@ def is_generic_instance(tp: Type) -> bool:
 
 def is_optional(t: Type) -> bool:
     t = get_proper_type(t)
-    return isinstance(t, UnionType) and any(
-        isinstance(get_proper_type(e), NoneType) for e in t.items
+    return isinstance(t, NoneType) or (
+        isinstance(t, UnionType) and any(isinstance(get_proper_type(e), NoneType) for e in t.items)
     )
-
-
-def can_be_none(t: Type) -> bool:
-    t = get_proper_type(t)
-    return isinstance(t, NoneType) or is_optional(t)
 
 
 def remove_optional(typ: Type) -> Type:

--- a/mypy/types_utils.py
+++ b/mypy/types_utils.py
@@ -101,7 +101,7 @@ def is_generic_instance(tp: Type) -> bool:
     return isinstance(tp, Instance) and bool(tp.args)
 
 
-def is_optional(t: Type) -> bool:
+def is_overlapping_none(t: Type) -> bool:
     t = get_proper_type(t)
     return isinstance(t, NoneType) or (
         isinstance(t, UnionType) and any(isinstance(get_proper_type(e), NoneType) for e in t.items)

--- a/mypy/types_utils.py
+++ b/mypy/types_utils.py
@@ -108,6 +108,11 @@ def is_optional(t: Type) -> bool:
     )
 
 
+def can_be_none(t: Type) -> bool:
+    t = get_proper_type(t)
+    return isinstance(t, NoneType) or is_optional(t)
+
+
 def remove_optional(typ: Type) -> Type:
     typ = get_proper_type(typ)
     if isinstance(typ, UnionType):

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1263,7 +1263,7 @@ def g() -> None:
 [builtins fixtures/dict.pyi]
 
 
-[case testNarrowingNoneEquality]
+[case testNarrowingOptionalEqualsNone]
 from typing import Optional
 
 class A: ...

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1261,3 +1261,30 @@ def g() -> None:
         def foo(): ...
     foo()
 [builtins fixtures/dict.pyi]
+
+
+[case testNarrowingNoneEquality]
+from typing import Optional
+
+class A: ...
+
+val: Optional[A]
+
+if val == None:
+    reveal_type(val)  # N: Revealed type is "Union[__main__.A, None]"
+else:
+    reveal_type(val)  # N: Revealed type is "Union[__main__.A, None]"
+if val != None:
+    reveal_type(val)  # N: Revealed type is "Union[__main__.A, None]"
+else:
+    reveal_type(val)  # N: Revealed type is "Union[__main__.A, None]"
+
+if val in (None,):
+    reveal_type(val)  # N: Revealed type is "Union[__main__.A, None]"
+else:
+    reveal_type(val)  # N: Revealed type is "Union[__main__.A, None]"
+if val not in (None,):
+    reveal_type(val)  # N: Revealed type is "Union[__main__.A, None]"
+else:
+    reveal_type(val)  # N: Revealed type is "Union[__main__.A, None]"
+[builtins fixtures/primitives.pyi]

--- a/test-data/unit/fixtures/primitives.pyi
+++ b/test-data/unit/fixtures/primitives.pyi
@@ -45,7 +45,8 @@ class memoryview(Sequence[int]):
     def __iter__(self) -> Iterator[int]: pass
     def __contains__(self, other: object) -> bool: pass
     def __getitem__(self, item: int) -> int: pass
-class tuple(Generic[T]): pass
+class tuple(Generic[T]):
+    def __contains__(self, other: object) -> bool: pass
 class list(Sequence[T]):
     def __iter__(self) -> Iterator[T]: pass
     def __contains__(self, other: object) -> bool: pass


### PR DESCRIPTION
Fixes #15759.

The type narrowing logic internally used `is_optional()` to check whether an operand type might be None. `is_optional()` only considers `UnionType`, and ignored an immediate `NoneType` type, which clearly is None-able.

I have created a new helper `can_be_none()`, which does also consider immediate `NoneType`.

The narrowing logic here could be further improved, but that's out of scope for the bugfix.

```python
# Old behavior
def func(val: str | None) -> None:
    if val == None:
        reveal_type(val)  # ❌ Revealed type is "builtins.str"
    if val in (None,):
        reveal_type(val)  # ❌ Revealed type is "builtins.str"

# New behavior
def func(val: str | None) -> None:
    if val == None:
        reveal_type(val)  # ✅ Revealed type is "Union[builtins.str, None]"
    if val in (None,):
        reveal_type(val)  # ✅ Revealed type is "Union[builtins.str, None]"
```

TODO:

- [x] Add tests
