### PR TITLE
Fix right_type precision

### DIFF
--- a/test-data/unit/check-boolean-op-right-type.test
+++ b/test-data/unit/check-boolean-op-right-type.test
@@ -1,0 +1,6 @@
+[case testBooleanOpRightType]
+from typing import Dict
+def foo(x: Dict[str, str]) -> str: return x.get("a") or x.get("b", "c")
+def bar(x: Dict[str, str]) -> str: return None or  x.get("c","d")
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]


### PR DESCRIPTION
This is a fix for https://github.com/python/mypy/issues/15534

Without this fix mypy reports error (Incompatible return value type (got "str | None", expected "str")) for the following cases:
```
def foo(x: Dict[str, str]) -> str: return x.get("a") or x.get("b", "c")
def bar(x: Dict[str, str]) -> str: return None or  x.get("c","d")
```

I would appreciate your feedback

Best regards,
Hamid Alavi Toussi