### PR TITLE
Use emit_lines instead of bunches of emit_line calls

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -1165,9 +1165,7 @@ class Emitter:
         self, dest: str, typ: RType, failure: str
     ) -> None:
         self.emit_lines(
-            f"if ({dest} == {self.c_error_value(typ)} && PyErr_Occurred()) {{",
-            failure,
-            "}",
+            f"if ({dest} == {self.c_error_value(typ)} && PyErr_Occurred()) {{", failure, "}"
         )
 
 

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -472,11 +472,7 @@ def generate_vtables(
         )
 
     # Emit vtable setup function
-    emitter.emit_lines(
-        "static bool",
-        f"{NATIVE_PREFIX}{vtable_setup_name}(void)",
-        "{",
-    )
+    emitter.emit_lines("static bool", f"{NATIVE_PREFIX}{vtable_setup_name}(void)", "{")
 
     if base.allow_interpreted_subclasses and not shadow:
         emitter.emit_line(f"{NATIVE_PREFIX}{vtable_setup_name}_shadow();")
@@ -491,10 +487,7 @@ def generate_vtables(
 
     generate_vtable(base.vtable_entries, vtable_name, emitter, subtables, shadow)
 
-    emitter.emit_lines(
-        "return 1;",
-        "}",
-    )
+    emitter.emit_lines("return 1;", "}")
 
     return vtable_name if not subtables else f"{vtable_name} + {len(subtables) * 3}"
 
@@ -607,10 +600,7 @@ def generate_setup_for_class(
             "}",
         )
 
-    emitter.emit_lines(
-        "return (PyObject *)self;",
-        "}",
-    )
+    emitter.emit_lines("return (PyObject *)self;", "}")
 
 
 def generate_constructor_for_class(
@@ -654,10 +644,7 @@ def generate_constructor_for_class(
             "}",
         )
 
-    emitter.emit_lines(
-        "return self;",
-        "}",
-    )
+    emitter.emit_lines("return self;", "}")
 
 
 def generate_init_for_class(cl: ClassIR, init_fn: FuncIR, emitter: Emitter) -> str:
@@ -670,9 +657,7 @@ def generate_init_for_class(cl: ClassIR, init_fn: FuncIR, emitter: Emitter) -> s
     func_name = f"{cl.name_prefix(emitter.names)}_init"
 
     emitter.emit_lines(
-        "static int",
-        f"{func_name}(PyObject *self, PyObject *args, PyObject *kwds)",
-        "{",
+        "static int", f"{func_name}(PyObject *self, PyObject *args, PyObject *kwds)", "{"
     )
     if cl.allow_interpreted_subclasses or cl.builtin_base:
         emitter.emit_line(
@@ -718,9 +703,11 @@ def generate_new_for_class(
         # is needed to support always defined attributes.
         emitter.emit_lines(
             f"PyObject *self = {setup_name}(type);",
-            "if (self == NULL)", "    return NULL;",
+            "if (self == NULL)",
+            "    return NULL;",
             f"PyObject *ret = {PREFIX}{init_fn.cname(emitter.names)}(self, args, kwds);",
-            "if (ret == NULL)", "    return NULL;",
+            "if (ret == NULL)",
+            "    return NULL;",
             "return self;",
         )
     emitter.emit_line("}")

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -872,11 +872,7 @@ class GroupGenerator:
                     "NULL /* docstring */}},"
                 ).format(name=name, cname=fn.cname(emitter.names), prefix=PREFIX, flag=flag)
             )
-        emitter.emit_lines(
-            "{NULL, NULL, 0, NULL}",
-            "};",
-            "",
-        )
+        emitter.emit_lines("{NULL, NULL, 0, NULL}", "};", "")
 
         # Emit module definition struct
         emitter.emit_lines(

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -567,20 +567,24 @@ class GroupGenerator:
         # (which are shared between shared libraries via dynamic
         # exports tables and not accessed directly.)
         ext_declarations = Emitter(self.context)
-        ext_declarations.emit_line(f"#ifndef MYPYC_NATIVE{self.group_suffix}_H")
-        ext_declarations.emit_line(f"#define MYPYC_NATIVE{self.group_suffix}_H")
-        ext_declarations.emit_line("#include <Python.h>")
-        ext_declarations.emit_line("#include <CPy.h>")
+        ext_declarations.emit_lines(
+            f"#ifndef MYPYC_NATIVE{self.group_suffix}_H",
+            f"#define MYPYC_NATIVE{self.group_suffix}_H",
+            "#include <Python.h>",
+            "#include <CPy.h>",
+        )
 
         declarations = Emitter(self.context)
-        declarations.emit_line(f"#ifndef MYPYC_NATIVE_INTERNAL{self.group_suffix}_H")
-        declarations.emit_line(f"#define MYPYC_NATIVE_INTERNAL{self.group_suffix}_H")
-        declarations.emit_line("#include <Python.h>")
-        declarations.emit_line("#include <CPy.h>")
-        declarations.emit_line(f'#include "__native{self.short_group_suffix}.h"')
-        declarations.emit_line()
-        declarations.emit_line("int CPyGlobalsInit(void);")
-        declarations.emit_line()
+        declarations.emit_lines(
+            f"#ifndef MYPYC_NATIVE_INTERNAL{self.group_suffix}_H",
+            f"#define MYPYC_NATIVE_INTERNAL{self.group_suffix}_H",
+            "#include <Python.h>",
+            "#include <CPy.h>",
+            f'#include "__native{self.short_group_suffix}.h"',
+            "",
+            "int CPyGlobalsInit(void);",
+            "",
+        )
 
         for module_name, module in self.modules.items():
             self.declare_finals(module_name, module.final_names, declarations)
@@ -868,9 +872,11 @@ class GroupGenerator:
                     "NULL /* docstring */}},"
                 ).format(name=name, cname=fn.cname(emitter.names), prefix=PREFIX, flag=flag)
             )
-        emitter.emit_line("{NULL, NULL, 0, NULL}")
-        emitter.emit_line("};")
-        emitter.emit_line()
+        emitter.emit_lines(
+            "{NULL, NULL, 0, NULL}",
+            "};",
+            "",
+        )
 
         # Emit module definition struct
         emitter.emit_lines(

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -52,12 +52,7 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
 
     def test_emit_lines(self) -> None:
         emitter = Emitter(self.context, {})
-        emitter.emit_lines(
-            "line;",
-            "a {",
-            "f();",
-            "}",
-        )
+        emitter.emit_lines("line;", "a {", "f();", "}")
         assert emitter.fragments == ["line;\n", "a {\n", "    f();\n", "}\n"]
 
     def test_emit_undefined_value_for_simple_type(self) -> None:

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -50,6 +50,16 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
                   21, 22, 23, 24, 25, 26, 27, 28, 29] */\n"""
         )
 
+    def test_emit_lines(self) -> None:
+        emitter = Emitter(self.context, {})
+        emitter.emit_lines(
+            "line;",
+            "a {",
+            "f();",
+            "}",
+        )
+        assert emitter.fragments == ["line;\n", "a {\n", "    f();\n", "}\n"]
+
     def test_emit_undefined_value_for_simple_type(self) -> None:
         emitter = Emitter(self.context, {})
         assert emitter.c_undefined_value(int_rprimitive) == "CPY_INT_TAG"


### PR DESCRIPTION
There are places in Mypyc where `emit_line` is called over and over instead of `emit_lines`. This is a change to improve readability by using `emit_lines` more often. Also adds a small unit test.