### PR TITLE
[stubtest] Test `NamedTuple` definitions with default fields

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1638,6 +1638,36 @@ class StubtestUnit(unittest.TestCase):
         )
 
     @collect_cases
+    def test_named_tuple_typing_and_collections(self) -> Iterator[Case]:
+        yield Case(
+            stub="from typing import NamedTuple",
+            runtime="from collections import namedtuple",
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class X1(NamedTuple):
+                bar: int
+                foo: str = ...
+            """,
+            runtime="""
+            X1 = namedtuple('X1', ['bar', 'foo'], defaults=['a'])
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class X2(NamedTuple):
+                bar: int
+                foo: str
+            """,
+            runtime="""
+            X2 = namedtuple('X1', ['bar', 'foo'], defaults=['a'])
+            """,
+            error="X2.__new__",
+        )
+
+    @collect_cases
     def test_type_var(self) -> Iterator[Case]:
         yield Case(
             stub="from typing import TypeVar", runtime="from typing import TypeVar", error=None

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -68,6 +68,7 @@ class Mapping(Generic[_K, _V]): ...
 class Match(Generic[AnyStr]): ...
 class Sequence(Iterable[_T_co]): ...
 class Tuple(Sequence[_T_co]): ...
+class NamedTuple(tuple[Any, ...]): ...
 def overload(func: _T) -> _T: ...
 """
 
@@ -82,6 +83,7 @@ VT = TypeVar('VT')
 class object:
     __module__: str
     def __init__(self) -> None: pass
+    def __repr__(self) -> str: pass
 class type: ...
 
 class tuple(Sequence[T_co], Generic[T_co]): ...
@@ -1597,6 +1599,42 @@ class StubtestUnit(unittest.TestCase):
                 a: int
             """,
             error=None,
+        )
+
+    @collect_cases
+    def test_named_tuple(self) -> Iterator[Case]:
+        yield Case(
+            stub="from typing import NamedTuple",
+            runtime="from typing import NamedTuple",
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class X1(NamedTuple):
+                bar: int
+                foo: str = ...
+            """,
+            runtime="""
+            class X1(NamedTuple):
+                bar: int
+                foo: str = 'a'
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class X2(NamedTuple):
+                bar: int
+                foo: str
+            """,
+            runtime="""
+            class X2(NamedTuple):
+                bar: int
+                foo: str = 'a'
+            """,
+            # `__new__` will miss a deafult value for a `foo` parameter,
+            # but we don't generate special errors for `foo` missing `...` part.
+            error="X2.__new__",
         )
 
     @collect_cases

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1632,7 +1632,7 @@ class StubtestUnit(unittest.TestCase):
                 bar: int
                 foo: str = 'a'
             """,
-            # `__new__` will miss a deafult value for a `foo` parameter,
+            # `__new__` will miss a default value for a `foo` parameter,
             # but we don't generate special errors for `foo` missing `...` part.
             error="X2.__new__",
         )


### PR DESCRIPTION
This is a test case for https://github.com/python/mypy/pull/15680 from `stubtest`'s point of view.