### PR TITLE
Better `tox` configuration

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -50,10 +50,14 @@ cmds = {
     # Self type check
     "self": [
         executable,
-        "-m", "mypy",
-        "--config-file", "mypy_self_check.ini",
-        "-p", "mypy",
-        "-p", "mypyc",
+        "-m",
+        "mypy",
+        "--config-file",
+        "mypy_self_check.ini",
+        "-p",
+        "mypy",
+        "-p",
+        "mypyc",
     ],
     # Lint
     "lint": ["pre-commit", "run", "--all-files"],

--- a/runtests.py
+++ b/runtests.py
@@ -48,7 +48,13 @@ MYPYC_OPT_IN = [MYPYC_RUN, MYPYC_RUN_MULTI]
 # time to run.
 cmds = {
     # Self type check
-    "self": [executable, "-m", "mypy", "--config-file", "mypy_self_check.ini", "-p", "mypy"],
+    "self": [
+        executable,
+        "-m", "mypy",
+        "--config-file", "mypy_self_check.ini",
+        "-p", "mypy",
+        "-p", "mypyc",
+    ],
     # Lint
     "lint": ["pre-commit", "run", "--all-files"],
     # Fast test cases only (this is the bulk of the test suite)

--- a/tox.ini
+++ b/tox.ini
@@ -53,5 +53,5 @@ passenv =
     MYPY_FORCE_COLOR
     MYPY_FORCE_TERMINAL_WIDTH
 commands =
-    python -m mypy --config-file mypy_self_check.ini -p mypy -p mypyc
-    python -m mypy --config-file mypy_self_check.ini misc --exclude misc/fix_annotate.py --exclude misc/async_matrix.py --exclude misc/sync-typeshed.py
+    python runtests.py self
+    python -m mypy --config-file mypy_self_check.ini misc --exclude misc/sync-typeshed.py


### PR DESCRIPTION
It solves two problems:
1. `fix_annotate` and `async_matrix` were removed in https://github.com/python/mypy/pull/15728
2. It is better to reuse stuff like `runtests.py` not to rewrite the same command we already have