### PR TITLE
Raise `RuntimeError` with better error messages

### DIFF
--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -71,7 +71,7 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
 
     def visit_partial_type(self, t: PartialType) -> ProperType:
         # Should not get here.
-        raise RuntimeError()
+        raise RuntimeError("Cannot erase partial types")
 
     def visit_deleted_type(self, t: DeletedType) -> ProperType:
         return t

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -203,7 +203,7 @@ class Node(Context):
         return ans
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
-        raise RuntimeError("Not implemented")
+        raise RuntimeError("Not implemented", type(self))
 
 
 @trait
@@ -213,7 +213,7 @@ class Statement(Node):
     __slots__ = ()
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
-        raise RuntimeError("Not implemented")
+        raise RuntimeError("Not implemented", type(self))
 
 
 @trait
@@ -223,7 +223,7 @@ class Expression(Node):
     __slots__ = ()
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
-        raise RuntimeError("Not implemented")
+        raise RuntimeError("Not implemented", type(self))
 
 
 class FakeExpression(Expression):

--- a/mypy/patterns.py
+++ b/mypy/patterns.py
@@ -19,7 +19,7 @@ class Pattern(Node):
     __slots__ = ()
 
     def accept(self, visitor: PatternVisitor[T]) -> T:
-        raise RuntimeError("Not implemented")
+        raise RuntimeError("Not implemented", type(self))
 
 
 class AsPattern(Pattern):

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -467,13 +467,13 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
 
     def visit_erased_type(self, t: ErasedType) -> None:
         # This type should exist only temporarily during type inference
-        raise RuntimeError
+        raise RuntimeError("Cannot handle erased type")
 
     def visit_deleted_type(self, typ: DeletedType) -> None:
         pass
 
     def visit_partial_type(self, typ: PartialType) -> None:
-        raise RuntimeError
+        raise RuntimeError("Cannot handle partial type")
 
     def visit_tuple_type(self, typ: TupleType) -> None:
         for item in typ.items:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -260,7 +260,7 @@ class Type(mypy.nodes.Context):
         return True
 
     def accept(self, visitor: TypeVisitor[T]) -> T:
-        raise RuntimeError("Not implemented")
+        raise RuntimeError("Not implemented", type(self))
 
     def __repr__(self) -> str:
         return self.accept(TypeStrVisitor(options=Options()))


### PR DESCRIPTION
While working on https://github.com/python/mypy/pull/15776 I've noticed that some `RuntimeError` do not have enough metadata to understand what is going on.
CI: https://github.com/python/mypy/actions/runs/5700479199/job/15450345887

This is the traceback I got:

```
 _______________________ testNamedTupleNestedClassRecheck _______________________
[gw1] linux -- Python 3.10.12 /home/runner/work/mypy/mypy/.tox/py/bin/python
data: /home/runner/work/mypy/mypy/test-data/unit/fine-grained.test:10213:
/home/runner/work/mypy/mypy/.tox/py/lib/python3.10/site-packages/_pytest/runner.py:341: in from_call
    result: Optional[TResult] = func()
/home/runner/work/mypy/mypy/.tox/py/lib/python3.10/site-packages/_pytest/runner.py:262: in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
/home/runner/work/mypy/mypy/.tox/py/lib/python3.10/site-packages/pluggy/_hooks.py:433: in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
/home/runner/work/mypy/mypy/.tox/py/lib/python3.10/site-packages/pluggy/_manager.py:112: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
/home/runner/work/mypy/mypy/.tox/py/lib/python3.10/site-packages/_pytest/runner.py:177: in pytest_runtest_call
    raise e
/home/runner/work/mypy/mypy/.tox/py/lib/python3.10/site-packages/_pytest/runner.py:169: in pytest_runtest_call
    item.runtest()
/home/runner/work/mypy/mypy/mypy/test/data.py:320: in runtest
    suite.run_case(self)
/home/runner/work/mypy/mypy/mypy/test/testfinegrained.py:113: in run_case
    output, triggered = self.perform_step(
/home/runner/work/mypy/mypy/mypy/test/testfinegrained.py:217: in perform_step
    new_messages = self.run_check(server, sources)
/home/runner/work/mypy/mypy/mypy/test/testfinegrained.py:167: in run_check
    response = server.check(sources, export_types=True, is_tty=False, terminal_width=-1)
/home/runner/work/mypy/mypy/mypy/dmypy_server.py:416: in check
    messages = self.fine_grained_increment(sources)
/home/runner/work/mypy/mypy/mypy/dmypy_server.py:562: in fine_grained_increment
    messages = self.fine_grained_manager.update(changed, removed)
/home/runner/work/mypy/mypy/mypy/server/update.py:267: in update
    result = self.update_one(
/home/runner/work/mypy/mypy/mypy/server/update.py:369: in update_one
    result = self.update_module(next_id, next_path, next_id in removed_set, followed)
/home/runner/work/mypy/mypy/mypy/server/update.py:452: in update_module
    remaining += propagate_changes_using_dependencies(
/home/runner/work/mypy/mypy/mypy/server/update.py:881: in propagate_changes_using_dependencies
    triggered |= reprocess_nodes(manager, graph, id, nodes, deps, processed_targets)
/home/runner/work/mypy/mypy/mypy/server/update.py:1017: in reprocess_nodes
    merge_asts(file_node, old_symbols[name], file_node, new_symbols[name])
/home/runner/work/mypy/mypy/mypy/server/astmerge.py:139: in merge_asts
    node = replace_nodes_in_ast(new, replacement_map)
/home/runner/work/mypy/mypy/mypy/server/astmerge.py:191: in replace_nodes_in_ast
    node.accept(visitor)
/home/runner/work/mypy/mypy/mypy/nodes.py:377: in accept
    return visitor.visit_mypy_file(self)
/home/runner/work/mypy/mypy/mypy/server/astmerge.py:212: in visit_mypy_file
    super().visit_mypy_file(node)
/home/runner/work/mypy/mypy/mypy/traverser.py:114: in visit_mypy_file
    d.accept(self)
/home/runner/work/mypy/mypy/mypy/nodes.py:1141: in accept
    return visitor.visit_class_def(self)
/home/runner/work/mypy/mypy/mypy/server/astmerge.py:237: in visit_class_def
    self.process_synthetic_type_info(info)
/home/runner/work/mypy/mypy/mypy/server/astmerge.py:404: in process_synthetic_type_info
    node.node.accept(self)
/home/runner/work/mypy/mypy/mypy/nodes.py:206: in accept
    raise RuntimeError("Not implemented")
E   RuntimeError: Not implemented
```

This PR adds more context to error messages.