### PR TITLE
socket: add TCP_USER_TIMEOUT

### DIFF
--- a/mypy/typeshed/stdlib/socket.pyi
+++ b/mypy/typeshed/stdlib/socket.pyi
@@ -202,6 +202,7 @@ if sys.platform != "win32" and sys.platform != "darwin":
         TCP_QUICKACK as TCP_QUICKACK,
         TCP_SYNCNT as TCP_SYNCNT,
         TCP_WINDOW_CLAMP as TCP_WINDOW_CLAMP,
+        TCP_USER_TIMEOUT as TCP_USER_TIMEOUT,
     )
 if sys.platform != "win32":
     from _socket import (


### PR DESCRIPTION
Certain socket attributes were moved out of `socket.pyi` and into `_socket.pyi` without the appropriate imports, rendering them non-existent to mypy's attribute existence check, `attr-defined`, in this commit: https://github.com/python/mypy/commit/d131e91804ac887d12b207d53435718cd68bc475

I specifically noticed `TCP_USER_TIMEOUT` not being imported in `socket.pyi`, causing a false positive detection in Python 3.11.4. This attribute was added in [Python 3.6/3.7](https://github.com/python/cpython/blob/46366ca0486d07fe94c70d00771482c8ef1546fc/Doc/whatsnew/3.7.rst#L1282) (notes cite both?):

`test.py:3: error: Module has no attribute "TCP_USER_TIMEOUT"  [attr-defined]`

There's also other attributes available that are not imported, such as `SO_PROTOCOL` and `TCP_CONGESTION`, which also lead to false positives, so I didn't know if the plan is to add as many as possible in one PR, or to fix individual cases one by one:

https://github.com/python/mypy/blob/2b613e5ba1ada5a44f88a90528af834bf9f770a7/mypy/typeshed/stdlib/_socket.pyi#L508-L514

File I ran this mypy against:

```python
import socket

socket.SO_DOMAIN  # exists, failure ❌
socket.TCP_CONGESTION  # exists, failure ❌
socket.TCP_KEEPIDLE  # exists, no failure ✅
socket.TCP_USER_TIMEOUT  # exists, *now* no failure ✅
```

### Testing
I didn't see anything referencing `TCP_KEEPIDLE`, a valid attribute that doesn't cause a false positive, so not adding a test case at this time.