### PR TITLE
Update black pre-commit mirror link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  - repo: https://github.com/hauntsaninja/black-pre-commit-mirror
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.7.0  # must match test-requirements.txt
     hooks:
       - id: black


### PR DESCRIPTION
The black pre-commit mirror is now hosted at: https://github.com/psf/black-pre-commit-mirror