### PR TITLE
Polymorphic inference: support for parameter specifications and lambdas

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -109,7 +109,6 @@ def apply_generic_arguments(
     if param_spec is not None:
         nt = id_to_type.get(param_spec.id)
         if nt is not None:
-            nt = get_proper_type(nt)
             if isinstance(nt, Parameters):
                 callable = callable.expand_param_spec(nt)
 

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -9,7 +9,6 @@ from mypy.types import (
     AnyType,
     CallableType,
     Instance,
-    Parameters,
     ParamSpecType,
     PartialType,
     TupleType,
@@ -109,8 +108,13 @@ def apply_generic_arguments(
     if param_spec is not None:
         nt = id_to_type.get(param_spec.id)
         if nt is not None:
-            if isinstance(nt, Parameters):
-                callable = callable.expand_param_spec(nt)
+            # ParamSpec expansion is special-cased, so we need to always expand callable
+            # as a whole, not expanding arguments individually.
+            callable = expand_type(callable, id_to_type)
+            assert isinstance(callable, CallableType)
+            return callable.copy_modified(
+                variables=[tv for tv in tvars if tv.id not in id_to_type]
+            )
 
     # Apply arguments to argument types.
     var_arg = callable.var_arg()

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -110,7 +110,7 @@ def apply_generic_arguments(
         nt = id_to_type.get(param_spec.id)
         if nt is not None:
             nt = get_proper_type(nt)
-            if isinstance(nt, (CallableType, Parameters)):
+            if isinstance(nt, Parameters):
                 callable = callable.expand_param_spec(nt)
 
     # Apply arguments to argument types.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4280,12 +4280,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 return_type = self.return_types[-1]
             return_type = get_proper_type(return_type)
 
+            is_lambda = isinstance(self.scope.top_function(), LambdaExpr)
             if isinstance(return_type, UninhabitedType):
-                self.fail(message_registry.NO_RETURN_EXPECTED, s)
-                return
+                # Avoid extra error messages for failed inference in lambdas
+                if not is_lambda or not return_type.ambiguous:
+                    self.fail(message_registry.NO_RETURN_EXPECTED, s)
+                    return
 
             if s.expr:
-                is_lambda = isinstance(self.scope.top_function(), LambdaExpr)
                 declared_none_return = isinstance(return_type, NoneType)
                 declared_any_return = isinstance(return_type, AnyType)
 
@@ -7365,6 +7367,11 @@ class InvalidInferredTypes(BoolTypeQuery):
     def visit_erased_type(self, t: ErasedType) -> bool:
         # This can happen inside a lambda.
         return True
+
+    def visit_type_var(self, t: TypeVarType) -> bool:
+        # This is needed to prevent leaking into partial types during
+        # multi-step type inference.
+        return t.id.is_meta_var()
 
 
 class SetNothingToAny(TypeTranslator):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5638,11 +5638,15 @@ class PolyTranslator(TypeTranslator):
     def collect_vars(self, t: CallableType | Parameters) -> list[TypeVarLikeType]:
         found_vars = []
         for arg in t.arg_types:
-            found_vars += [
-                tv
-                for tv in get_all_type_vars(arg)
-                if tv in self.poly_tvars and tv not in self.bound_tvars
-            ]
+            for tv in get_all_type_vars(arg):
+                if isinstance(tv, ParamSpecType):
+                    normalized: TypeVarLikeType = tv.copy_modified(
+                        flavor=ParamSpecFlavor.BARE, prefix=Parameters([], [], [])
+                    )
+                else:
+                    normalized = tv
+                if normalized in self.poly_tvars and normalized not in self.bound_tvars:
+                    found_vars.append(normalized)
         return remove_dups(found_vars)
 
     def visit_callable_type(self, t: CallableType) -> Type:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5715,6 +5715,11 @@ class PolyTranslator(TypeTranslator):
 
     def visit_instance(self, t: Instance) -> Type:
         if t.type.has_param_spec_type:
+            # We need this special-casing to preserve the possibility to store a
+            # generic function in an instance type. Things like
+            #     forall T . Foo[[x: T], T]
+            # are not really expressible in current type system, but this looks like
+            # a useful feature, so let's keep it.
             param_spec_index = next(
                 i for (i, tv) in enumerate(t.type.defn.type_vars) if isinstance(tv, ParamSpecType)
             )

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -918,7 +918,6 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                 if (
                     type_state.infer_polymorphic
                     and cactual.variables
-                    and cactual.param_spec() is None
                     and not self.skip_neg_op
                     # Technically, the correct inferred type for application of e.g.
                     # Callable[..., T] -> Callable[..., T] (with literal ellipsis), to a generic

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -960,15 +960,12 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                     for t, a, tk, ak in zip(
                         template_args, cactual_args, template.arg_kinds, cactual.arg_kinds
                     ):
-                        # Unpack may have shifted indices.
-                        if not unpack_present:
-                            # This avoids bogus constraints like T <: P.args
-                            if (
-                                tk == ARG_STAR
-                                and ak != ARG_STAR
-                                or tk == ARG_STAR2
-                                and ak != ARG_STAR2
-                            ):
+                        # This avoids bogus constraints like T <: P.args
+                        if (tk == ARG_STAR and ak != ARG_STAR) or (
+                            tk == ARG_STAR2 and ak != ARG_STAR2
+                        ):
+                            # Unpack may have shifted indices.
+                            if not unpack_present:
                                 continue
                         if isinstance(a, ParamSpecType):
                             # TODO: can we infer something useful for *T vs P?

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -963,8 +963,8 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         if (tk == ARG_STAR and ak != ARG_STAR) or (
                             tk == ARG_STAR2 and ak != ARG_STAR2
                         ):
-                            # Unpack may have shifted indices.
-                            if not unpack_present:
+                            if cactual.param_spec():
+                                # TODO: we should be more careful also for non-ParamSpec functions
                                 continue
                         if isinstance(a, ParamSpecType):
                             # TODO: can we infer something useful for *T vs P?

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -699,7 +699,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         suffix = get_proper_type(instance_arg)
 
                         if isinstance(suffix, Parameters):
-                            # no such thing as variance for ParamSpecs
+                            # No such thing as variance for ParamSpecs, consider them covariant
                             # TODO: is there a case I am missing?
                             # TODO: constraints between prefixes
                             prefix = mapped_arg.prefix
@@ -708,9 +708,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                                 suffix.arg_kinds[len(prefix.arg_kinds) :],
                                 suffix.arg_names[len(prefix.arg_names) :],
                             )
-                            res.append(Constraint(mapped_arg, SUPERTYPE_OF, suffix))
+                            res.append(Constraint(mapped_arg, self.direction, suffix))
                         elif isinstance(suffix, ParamSpecType):
-                            res.append(Constraint(mapped_arg, SUPERTYPE_OF, suffix))
+                            res.append(Constraint(mapped_arg, self.direction, suffix))
                     else:
                         # This case should have been handled above.
                         assert not isinstance(tvar, TypeVarTupleType)
@@ -764,7 +764,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                         suffix = get_proper_type(mapped_arg)
 
                         if isinstance(suffix, Parameters):
-                            # no such thing as variance for ParamSpecs
+                            # No such thing as variance for ParamSpecs, consider them covariant
                             # TODO: is there a case I am missing?
                             # TODO: constraints between prefixes
                             prefix = template_arg.prefix
@@ -774,9 +774,9 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
                                 suffix.arg_kinds[len(prefix.arg_kinds) :],
                                 suffix.arg_names[len(prefix.arg_names) :],
                             )
-                            res.append(Constraint(template_arg, SUPERTYPE_OF, suffix))
+                            res.append(Constraint(template_arg, self.direction, suffix))
                         elif isinstance(suffix, ParamSpecType):
-                            res.append(Constraint(template_arg, SUPERTYPE_OF, suffix))
+                            res.append(Constraint(template_arg, self.direction, suffix))
                     else:
                         # This case should have been handled above.
                         assert not isinstance(tvar, TypeVarTupleType)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -862,7 +862,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
         elif isinstance(actual, TupleType) and self.direction == SUPERTYPE_OF:
             return infer_constraints(template, mypy.typeops.tuple_fallback(actual), self.direction)
         elif isinstance(actual, TypeVarType):
-            if not actual.values:
+            if not actual.values and not actual.id.is_meta_var():
                 return infer_constraints(template, actual.upper_bound, self.direction)
             return []
         elif isinstance(actual, ParamSpecType):

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -999,7 +999,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             res.extend(infer_constraints(template_ret_type, cactual_ret_type, self.direction))
             if extra_tvars:
                 for c in res:
-                    c.extra_tvars = list(cactual.variables)
+                    c.extra_tvars += cactual.variables
             return res
         elif isinstance(self.actual, AnyType):
             param_spec = template.param_spec()

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -239,7 +239,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             # TODO: what does prefix mean in this case?
             # TODO: why does this case even happen? Instances aren't plural.
             return repl
-        elif isinstance(repl, (ParamSpecType, Parameters, CallableType)):
+        elif isinstance(repl, (ParamSpecType, Parameters)):
             if isinstance(repl, ParamSpecType):
                 return repl.copy_modified(
                     flavor=t.flavor,
@@ -395,7 +395,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             # must expand both of them with all the argument types,
             # kinds and names in the replacement. The return type in
             # the replacement is ignored.
-            if isinstance(repl, (CallableType, Parameters)):
+            if isinstance(repl, Parameters):
                 # Substitute *args: P.args, **kwargs: P.kwargs
                 prefix = param_spec.prefix
                 # we need to expand the types in the prefix, so might as well

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -231,44 +231,27 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
         return repl
 
     def visit_param_spec(self, t: ParamSpecType) -> Type:
-        # set prefix to something empty so we don't duplicate it
-        repl = get_proper_type(
-            self.variables.get(t.id, t.copy_modified(prefix=Parameters([], [], [])))
-        )
-        if isinstance(repl, Instance):
-            # TODO: what does prefix mean in this case?
-            # TODO: why does this case even happen? Instances aren't plural.
-            return repl
-        elif isinstance(repl, (ParamSpecType, Parameters)):
-            if isinstance(repl, ParamSpecType):
-                return repl.copy_modified(
-                    flavor=t.flavor,
-                    prefix=t.prefix.copy_modified(
-                        arg_types=t.prefix.arg_types + repl.prefix.arg_types,
-                        arg_kinds=t.prefix.arg_kinds + repl.prefix.arg_kinds,
-                        arg_names=t.prefix.arg_names + repl.prefix.arg_names,
-                    ),
-                )
-            else:
-                # if the paramspec is *P.args or **P.kwargs:
-                if t.flavor != ParamSpecFlavor.BARE:
-                    assert isinstance(repl, CallableType), "Should not be able to get here."
-                    # Is this always the right thing to do?
-                    param_spec = repl.param_spec()
-                    if param_spec:
-                        return param_spec.with_flavor(t.flavor)
-                    else:
-                        return repl
-                else:
-                    return Parameters(
-                        t.prefix.arg_types + repl.arg_types,
-                        t.prefix.arg_kinds + repl.arg_kinds,
-                        t.prefix.arg_names + repl.arg_names,
-                        variables=[*t.prefix.variables, *repl.variables],
-                    )
-
+        # Set prefix to something empty, so we don't duplicate it below.
+        repl = self.variables.get(t.id, t.copy_modified(prefix=Parameters([], [], [])))
+        if isinstance(repl, ParamSpecType):
+            return repl.copy_modified(
+                flavor=t.flavor,
+                prefix=t.prefix.copy_modified(
+                    arg_types=self.expand_types(t.prefix.arg_types + repl.prefix.arg_types),
+                    arg_kinds=t.prefix.arg_kinds + repl.prefix.arg_kinds,
+                    arg_names=t.prefix.arg_names + repl.prefix.arg_names,
+                ),
+            )
+        elif isinstance(repl, Parameters):
+            assert t.flavor == ParamSpecFlavor.BARE
+            return Parameters(
+                self.expand_types(t.prefix.arg_types + repl.arg_types),
+                t.prefix.arg_kinds + repl.arg_kinds,
+                t.prefix.arg_names + repl.arg_names,
+                variables=[*t.prefix.variables, *repl.variables],
+            )
         else:
-            # TODO: should this branch be removed? better not to fail silently
+            # TODO: replace this with "assert False"
             return repl
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> Type:
@@ -387,7 +370,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
     def visit_callable_type(self, t: CallableType) -> CallableType:
         param_spec = t.param_spec()
         if param_spec is not None:
-            repl = get_proper_type(self.variables.get(param_spec.id))
+            repl = self.variables.get(param_spec.id)
             # If a ParamSpec in a callable type is substituted with a
             # callable type, we can't use normal substitution logic,
             # since ParamSpec is actually split into two components
@@ -396,34 +379,29 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             # kinds and names in the replacement. The return type in
             # the replacement is ignored.
             if isinstance(repl, Parameters):
-                # Substitute *args: P.args, **kwargs: P.kwargs
-                prefix = param_spec.prefix
-                # we need to expand the types in the prefix, so might as well
-                # not get them in the first place
-                t = t.expand_param_spec(repl, no_prefix=True)
+                # We need to expand both the types in the prefix and the ParamSpec itself
+                t = t.expand_param_spec(repl)
                 return t.copy_modified(
-                    arg_types=self.expand_types(prefix.arg_types) + t.arg_types,
-                    arg_kinds=prefix.arg_kinds + t.arg_kinds,
-                    arg_names=prefix.arg_names + t.arg_names,
+                    arg_types=self.expand_types(t.arg_types),
+                    arg_kinds=t.arg_kinds,
+                    arg_names=t.arg_names,
                     ret_type=t.ret_type.accept(self),
                     type_guard=(t.type_guard.accept(self) if t.type_guard is not None else None),
                 )
-            # TODO: Conceptually, the "len(t.arg_types) == 2" should not be here. However, this
-            #       errors without it. Either figure out how to eliminate this or place an
-            #       explanation for why this is necessary.
-            elif isinstance(repl, ParamSpecType) and len(t.arg_types) == 2:
-                # We're substituting one paramspec for another; this can mean that the prefix
-                # changes. (e.g. sub Concatenate[int, P] for Q)
+            elif isinstance(repl, ParamSpecType):
+                # We're substituting one ParamSpec for another; this can mean that the prefix
+                # changes, e.g. substitute Concatenate[int, P] in place of Q.
                 prefix = repl.prefix
-                old_prefix = param_spec.prefix
-
-                # Check assumptions. I'm not sure what order to place new prefix vs old prefix:
-                assert not old_prefix.arg_types or not prefix.arg_types
-
-                t = t.copy_modified(
-                    arg_types=prefix.arg_types + old_prefix.arg_types + t.arg_types,
-                    arg_kinds=prefix.arg_kinds + old_prefix.arg_kinds + t.arg_kinds,
-                    arg_names=prefix.arg_names + old_prefix.arg_names + t.arg_names,
+                clean_repl = repl.copy_modified(prefix=Parameters([], [], []))
+                return t.copy_modified(
+                    arg_types=self.expand_types(t.arg_types[:-2] + prefix.arg_types)
+                    + [
+                        clean_repl.with_flavor(ParamSpecFlavor.ARGS),
+                        clean_repl.with_flavor(ParamSpecFlavor.KWARGS),
+                    ],
+                    arg_kinds=t.arg_kinds[:-2] + prefix.arg_kinds + t.arg_kinds[-2:],
+                    arg_names=t.arg_names[:-2] + prefix.arg_names + t.arg_names[-2:],
+                    ret_type=t.ret_type.accept(self),
                 )
 
         var_arg = t.var_arg()

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -315,8 +315,14 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
         raise NotImplementedError
 
     def visit_parameters(self, t: Parameters) -> ProperType:
-        if self.s == t:
-            return t
+        if isinstance(self.s, Parameters):
+            if len(t.arg_types) != len(self.s.arg_types):
+                return self.default(self.s)
+            return t.copy_modified(
+                # Note that since during constraint inference we already treat whole ParamSpec as
+                # contravariant, we should join individual items, not meet them like for Callables
+                arg_types=[join_types(s_a, t_a) for s_a, t_a in zip(self.s.arg_types, t.arg_types)]
+            )
         else:
             return self.default(self.s)
 

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -701,11 +701,12 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
         raise NotImplementedError
 
     def visit_parameters(self, t: Parameters) -> ProperType:
-        # TODO: is this the right variance?
-        if isinstance(self.s, (Parameters, CallableType)):
+        if isinstance(self.s, Parameters):
             if len(t.arg_types) != len(self.s.arg_types):
                 return self.default(self.s)
             return t.copy_modified(
+                # Note that since during constraint inference we already treat whole ParamSpec as
+                # contravariant, we should meet individual items, not join them like for Callables
                 arg_types=[meet_types(s_a, t_a) for s_a, t_a in zip(self.s.arg_types, t.arg_types)]
             )
         else:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -349,7 +349,7 @@ class Options:
         # -1 means unlimited.
         self.many_errors_threshold = defaults.MANY_ERRORS_THRESHOLD
         # Enable new experimental type inference algorithm.
-        self.new_type_inference = False
+        self.new_type_inference = True
         # Disable recursive type aliases (currently experimental)
         self.disable_recursive_aliases = False
         # Deprecated reverse version of the above, do not use.

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -349,7 +349,7 @@ class Options:
         # -1 means unlimited.
         self.many_errors_threshold = defaults.MANY_ERRORS_THRESHOLD
         # Enable new experimental type inference algorithm.
-        self.new_type_inference = True
+        self.new_type_inference = False
         # Disable recursive type aliases (currently experimental)
         self.disable_recursive_aliases = False
         # Deprecated reverse version of the above, do not use.

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -12,7 +12,7 @@ from mypy.graph_utils import prepare_sccs, strongly_connected_components, topsor
 from mypy.join import join_types
 from mypy.meet import meet_type_list, meet_types
 from mypy.subtypes import is_subtype
-from mypy.typeops import get_type_vars
+from mypy.typeops import get_all_type_vars
 from mypy.types import (
     AnyType,
     Instance,
@@ -463,4 +463,4 @@ def check_linear(scc: set[TypeVarId], lowers: Bounds, uppers: Bounds) -> bool:
 
 def get_vars(target: Type, vars: list[TypeVarId]) -> set[TypeVarId]:
     """Find type variables for which we are solving in a target type."""
-    return {tv.id for tv in get_type_vars(target)} & set(vars)
+    return {tv.id for tv in get_all_type_vars(target)} & set(vars)

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -346,6 +346,7 @@ def normalize_constraints(
     """
     res = constraints.copy()
     for c in constraints:
+        # TODO: be careful with ParamSpecType here.
         if isinstance(c.target, TypeVarType):
             res.append(Constraint(c.target, neg_op(c.op), c.origin_type_var))
     return [c for c in remove_dups(constraints) if c.type_var in vars]

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -336,7 +336,9 @@ def is_trivial_bound(tp: ProperType) -> bool:
 
 
 def normalize_constraints(
-    constraints: list[Constraint], vars: list[TypeVarId]
+    # TODO: delete this function?
+    constraints: list[Constraint],
+    vars: list[TypeVarId],
 ) -> list[Constraint]:
     """Normalize list of constraints (to simplify life for the non-linear solver).
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1698,11 +1698,15 @@ def unify_generic_callable(
         return_constraint_direction = mypy.constraints.SUBTYPE_OF
 
     constraints: list[mypy.constraints.Constraint] = []
-    for arg_type, target_arg_type in zip(type.arg_types, target.arg_types):
-        c = mypy.constraints.infer_constraints(
-            arg_type, target_arg_type, mypy.constraints.SUPERTYPE_OF
-        )
-        constraints.extend(c)
+    # There is some special logic for inference in callables, so better use them
+    # as wholes instead of picking separate arguments.
+    cs = mypy.constraints.infer_constraints(
+        type.copy_modified(ret_type=UninhabitedType()),
+        target.copy_modified(ret_type=UninhabitedType()),
+        mypy.constraints.SUBTYPE_OF,
+        skip_neg_op=True,
+    )
+    constraints.extend(cs)
     if not ignore_return:
         c = mypy.constraints.infer_constraints(
             type.ret_type, target.ret_type, return_constraint_direction

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -1464,7 +1464,7 @@ def make_call(*items: tuple[str, str | None]) -> CallExpr:
 class TestExpandTypeLimitGetProperType(TestCase):
     # WARNING: do not increase this number unless absolutely necessary,
     # and you understand what you are doing.
-    ALLOWED_GET_PROPER_TYPES = 8
+    ALLOWED_GET_PROPER_TYPES = 6
 
     @skipUnless(mypy.expandtype.__file__.endswith(".py"), "Skip for compiled mypy")
     def test_count_get_proper_type(self) -> None:

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -348,7 +348,7 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return self.query_types([t.upper_bound, t.default] + t.values)
 
     def visit_param_spec(self, t: ParamSpecType) -> T:
-        return self.query_types([t.upper_bound, t.default])
+        return self.query_types([t.upper_bound, t.default, t.prefix])
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> T:
         return self.query_types([t.upper_bound, t.default])

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1546,6 +1546,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             if analyzed.prefix.arg_types:
                 self.fail("Invalid location for Concatenate", t, code=codes.VALID_TYPE)
                 self.note("You can use Concatenate as the first argument to Callable", t)
+                analyzed = AnyType(TypeOfAny.from_error)
             else:
                 self.fail(
                     f'Invalid location for ParamSpec "{analyzed.name}"', t, code=codes.VALID_TYPE
@@ -1555,6 +1556,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     "'Callable[{}, int]'".format(analyzed.name),
                     t,
                 )
+                analyzed = AnyType(TypeOfAny.from_error)
         return analyzed
 
     def anal_var_def(self, var_def: TypeVarLikeType) -> TypeVarLikeType:

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -952,21 +952,30 @@ def coerce_to_literal(typ: Type) -> Type:
 
 
 def get_type_vars(tp: Type) -> list[TypeVarType]:
-    return tp.accept(TypeVarExtractor())
+    return cast("list[TypeVarType]", tp.accept(TypeVarExtractor()))
 
 
-class TypeVarExtractor(TypeQuery[List[TypeVarType]]):
-    def __init__(self) -> None:
+def get_all_type_vars(tp: Type) -> list[TypeVarLikeType]:
+    # TODO: should we always use this function instead of get_type_vars() above?
+    return tp.accept(TypeVarExtractor(include_all=True))
+
+
+class TypeVarExtractor(TypeQuery[List[TypeVarLikeType]]):
+    def __init__(self, include_all: bool = False) -> None:
         super().__init__(self._merge)
+        self.include_all = include_all
 
-    def _merge(self, iter: Iterable[list[TypeVarType]]) -> list[TypeVarType]:
+    def _merge(self, iter: Iterable[list[TypeVarLikeType]]) -> list[TypeVarLikeType]:
         out = []
         for item in iter:
             out.extend(item)
         return out
 
-    def visit_type_var(self, t: TypeVarType) -> list[TypeVarType]:
+    def visit_type_var(self, t: TypeVarType) -> list[TypeVarLikeType]:
         return [t]
+
+    def visit_param_spec(self, t: ParamSpecType) -> list[TypeVarLikeType]:
+        return [t] if self.include_all else []
 
 
 def custom_special_method(typ: Type, name: str, check_all: bool = False) -> bool:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1577,6 +1577,7 @@ class Parameters(ProperType):
         self.arg_kinds = arg_kinds
         self.arg_names = list(arg_names)
         assert len(arg_types) == len(arg_kinds) == len(arg_names)
+        assert not any(isinstance(t, (Parameters, ParamSpecType)) for t in arg_types)
         self.min_args = arg_kinds.count(ARG_POS)
         self.is_ellipsis_args = is_ellipsis_args
         self.variables = variables or []
@@ -1788,6 +1789,11 @@ class CallableType(FunctionLike):
     ) -> None:
         super().__init__(line, column)
         assert len(arg_types) == len(arg_kinds) == len(arg_names)
+        for t, k in zip(arg_types, arg_kinds):
+            if isinstance(t, ParamSpecType):
+                assert not t.prefix.arg_types
+                # TODO: should we assert that only ARG_STAR contain ParamSpecType?
+                # See testParamSpecJoin, that relies on passing e.g `P.args` as plain argument.
         if variables is None:
             variables = []
         self.arg_types = list(arg_types)
@@ -2033,35 +2039,21 @@ class CallableType(FunctionLike):
         if not isinstance(arg_type, ParamSpecType):
             return None
 
-        # sometimes paramspectypes are analyzed in from mysterious places,
-        # e.g. def f(prefix..., *args: P.args, **kwargs: P.kwargs) -> ...: ...
-        prefix = arg_type.prefix
-        if not prefix.arg_types:
-            # TODO: confirm that all arg kinds are positional
-            prefix = Parameters(self.arg_types[:-2], self.arg_kinds[:-2], self.arg_names[:-2])
-
+        # Prepend prefix for def f(prefix..., *args: P.args, **kwargs: P.kwargs) -> ...
+        # TODO: confirm that all arg kinds are positional
+        prefix = Parameters(self.arg_types[:-2], self.arg_kinds[:-2], self.arg_names[:-2])
         return arg_type.copy_modified(flavor=ParamSpecFlavor.BARE, prefix=prefix)
 
-    def expand_param_spec(self, c: Parameters, no_prefix: bool = False) -> CallableType:
+    def expand_param_spec(self, c: Parameters) -> CallableType:
         # TODO: try deleting variables from Parameters after new type inference is default.
         variables = c.variables
-
-        if no_prefix:
-            return self.copy_modified(
-                arg_types=c.arg_types,
-                arg_kinds=c.arg_kinds,
-                arg_names=c.arg_names,
-                is_ellipsis_args=c.is_ellipsis_args,
-                variables=[*variables, *self.variables],
-            )
-        else:
-            return self.copy_modified(
-                arg_types=self.arg_types[:-2] + c.arg_types,
-                arg_kinds=self.arg_kinds[:-2] + c.arg_kinds,
-                arg_names=self.arg_names[:-2] + c.arg_names,
-                is_ellipsis_args=c.is_ellipsis_args,
-                variables=[*variables, *self.variables],
-            )
+        return self.copy_modified(
+            arg_types=self.arg_types[:-2] + c.arg_types,
+            arg_kinds=self.arg_kinds[:-2] + c.arg_kinds,
+            arg_names=self.arg_names[:-2] + c.arg_names,
+            is_ellipsis_args=c.is_ellipsis_args,
+            variables=[*variables, *self.variables],
+        )
 
     def with_unpacked_kwargs(self) -> NormalizedCallableType:
         if not self.unpack_kwargs:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2042,9 +2042,8 @@ class CallableType(FunctionLike):
 
         return arg_type.copy_modified(flavor=ParamSpecFlavor.BARE, prefix=prefix)
 
-    def expand_param_spec(
-        self, c: CallableType | Parameters, no_prefix: bool = False
-    ) -> CallableType:
+    def expand_param_spec(self, c: Parameters, no_prefix: bool = False) -> CallableType:
+        # TODO: try deleting variables from Parameters after new type inference is default.
         variables = c.variables
 
         if no_prefix:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1577,7 +1577,7 @@ class Parameters(ProperType):
         self.arg_kinds = arg_kinds
         self.arg_names = list(arg_names)
         assert len(arg_types) == len(arg_kinds) == len(arg_names)
-        assert not any(isinstance(t, (Parameters, ParamSpecType)) for t in arg_types)
+        assert not any(isinstance(t, Parameters) for t in arg_types)
         self.min_args = arg_kinds.count(ARG_POS)
         self.is_ellipsis_args = is_ellipsis_args
         self.variables = variables or []

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2330,7 +2330,7 @@ T = TypeVar('T')
 def deco() -> Callable[[T], T]: pass
 reveal_type(deco)  # N: Revealed type is "def () -> def [T] (T`-1) -> T`-1"
 f = deco()
-reveal_type(f)  # N: Revealed type is "def [T] (T`-1) -> T`-1"
+reveal_type(f)  # N: Revealed type is "def [T] (T`1) -> T`1"
 i = f(3)
 reveal_type(i)  # N: Revealed type is "builtins.int"
 
@@ -2343,7 +2343,7 @@ U = TypeVar('U')
 def deco(x: U) -> Callable[[T, U], T]: pass
 reveal_type(deco)  # N: Revealed type is "def [U] (x: U`-1) -> def [T] (T`-2, U`-1) -> T`-2"
 f = deco("foo")
-reveal_type(f)  # N: Revealed type is "def [T] (T`-2, builtins.str) -> T`-2"
+reveal_type(f)  # N: Revealed type is "def [T] (T`1, builtins.str) -> T`1"
 i = f(3, "eggs")
 reveal_type(i)  # N: Revealed type is "builtins.int"
 
@@ -2354,9 +2354,9 @@ T = TypeVar('T')
 R = TypeVar('R')
 def deco() -> Callable[[T], Callable[[T, R], R]]: pass
 f = deco()
-reveal_type(f)  # N: Revealed type is "def [T] (T`-1) -> def [R] (T`-1, R`-2) -> R`-2"
+reveal_type(f)  # N: Revealed type is "def [T] (T`2) -> def [R] (T`2, R`1) -> R`1"
 g = f(3)
-reveal_type(g)  # N: Revealed type is "def [R] (builtins.int, R`-2) -> R`-2"
+reveal_type(g)  # N: Revealed type is "def [R] (builtins.int, R`3) -> R`3"
 s = g(4, "foo")
 reveal_type(s)  # N: Revealed type is "builtins.str"
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3223,3 +3223,20 @@ def dec2(f: Callable[Concatenate[str, W], U]) -> Callable[Concatenate[bytes, W],
 reveal_type(transform(dec))  # N: Revealed type is "def [P, T] (def (builtins.int, *P.args, **P.kwargs) -> T`2) -> def (builtins.int, *P.args, **P.kwargs) -> T`2"
 reveal_type(transform(dec2))  # N: Revealed type is "def [W, T] (def (builtins.int, builtins.str, *W.args, **W.kwargs) -> T`6) -> def (builtins.int, builtins.bytes, *W.args, **W.kwargs) -> T`6"
 [builtins fixtures/tuple.pyi]
+
+[case testNoAccidentalVariableClashInNestedGeneric]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, Generic, Tuple
+
+T = TypeVar('T')
+S = TypeVar('S')
+U = TypeVar('U')
+
+def pipe(x: T, f1: Callable[[T], S], f2: Callable[[S], U]) -> U: ...
+def and_then(a: T) -> Callable[[S], Tuple[S, T]]: ...
+
+def apply(a: S, b: T) -> None:
+    v1 = and_then(b)
+    v2: Callable[[Tuple[S, T]], None]
+    return pipe(a, v1, v2)
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3244,3 +3244,22 @@ def apply(a: S, b: T) -> None:
     v2: Callable[[Tuple[S, T]], None]
     return pipe(a, v1, v2)
 [builtins fixtures/tuple.pyi]
+
+[case testInferenceAgainstGenericParamSpecSpuriousBoundsNotUsed]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, Generic
+from typing_extensions import ParamSpec, Concatenate
+
+Q = ParamSpec("Q")
+class Foo(Generic[Q]): ...
+
+T1 = TypeVar("T1", bound=Foo[...])
+T2 = TypeVar("T2", bound=Foo[...])
+P = ParamSpec("P")
+def pop_off(fn: Callable[Concatenate[T1, P], T2]) -> Callable[P, Callable[[T1], T2]]:
+    ...
+
+@pop_off
+def test(command: Foo[Q]) -> Foo[Q]: ...
+reveal_type(test)  # N: Revealed type is "def () -> def [Q] (__main__.Foo[Q`-1]) -> __main__.Foo[Q`-1]"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3049,7 +3049,9 @@ def dec1(f: Callable[[T], T]) -> Callable[[T], List[T]]:
 def dec2(f: Callable[[S], T]) -> Callable[[S], List[T]]:
     ...
 def dec3(f: Callable[[List[S]], T]) -> Callable[[S], T]:
-    ...
+    def g(x: S) -> T:
+        return f([x])
+    return g
 def dec4(f: Callable[[S], List[T]]) -> Callable[[S], T]:
     ...
 def dec5(f: Callable[[int], T]) -> Callable[[int], List[T]]:
@@ -3057,12 +3059,14 @@ def dec5(f: Callable[[int], T]) -> Callable[[int], List[T]]:
         return [f(x)] * x
     return g
 
-reveal_type(dec1(lambda x: x))  # N: Revealed type is "def [T] (T`2) -> builtins.list[T`2]"
-reveal_type(dec2(lambda x: x))  # N: Revealed type is "def [S] (S`3) -> builtins.list[S`3]"
-reveal_type(dec3(lambda x: x[0]))  # N: Revealed type is "def [S] (S`5) -> S`5"
-reveal_type(dec4(lambda x: [x]))  # N: Revealed type is "def [S] (S`7) -> S`7"
+reveal_type(dec1(lambda x: x))  # N: Revealed type is "def [T] (T`3) -> builtins.list[T`3]"
+reveal_type(dec2(lambda x: x))  # N: Revealed type is "def [S] (S`4) -> builtins.list[S`4]"
+reveal_type(dec3(lambda x: x[0]))  # N: Revealed type is "def [S] (S`6) -> S`6"
+reveal_type(dec4(lambda x: [x]))  # N: Revealed type is "def [S] (S`8) -> S`8"
 reveal_type(dec1(lambda x: 1))  # N: Revealed type is "def (builtins.int) -> builtins.list[builtins.int]"
 reveal_type(dec5(lambda x: x))  # N: Revealed type is "def (builtins.int) -> builtins.list[builtins.int]"
+reveal_type(dec3(lambda x: x))  # N: Revealed type is "def [S] (S`15) -> builtins.list[S`15]"
+dec4(lambda x: x)  # E: Incompatible return value type (got "S", expected "List[object]")
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecBasicInList]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2713,6 +2713,7 @@ reveal_type(func(1))  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testGenericLambdaGenericMethodNoCrash]
+# flags: --new-type-inference
 from typing import TypeVar, Union, Callable, Generic
 
 S = TypeVar("S")
@@ -2723,7 +2724,7 @@ def f(x: Callable[[G[T]], int]) -> T: ...
 class G(Generic[T]):
     def g(self, x: S) -> Union[S, T]: ...
 
-f(lambda x: x.g(0))  # E: Cannot infer type argument 1 of "f"
+f(lambda x: x.g(0))  # E: Incompatible return value type (got "Union[int, T]", expected "int")
 
 [case testDictStarInference]
 class B: ...
@@ -3035,6 +3036,34 @@ reveal_type(dec1(id2))  # N: Revealed type is "def [S in (builtins.int, builtins
 reveal_type(dec2(id1))  # N: Revealed type is "def [UC <: __main__.C] (UC`5) -> builtins.list[UC`5]"
 reveal_type(dec2(id2))  # N: Revealed type is "def (<nothing>) -> builtins.list[<nothing>]" \
                         # E: Argument 1 to "dec2" has incompatible type "Callable[[V], V]"; expected "Callable[[<nothing>], <nothing>]"
+
+[case testInferenceAgainstGenericLambdas]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, List
+
+S = TypeVar('S')
+T = TypeVar('T')
+
+def dec1(f: Callable[[T], T]) -> Callable[[T], List[T]]:
+    ...
+def dec2(f: Callable[[S], T]) -> Callable[[S], List[T]]:
+    ...
+def dec3(f: Callable[[List[S]], T]) -> Callable[[S], T]:
+    ...
+def dec4(f: Callable[[S], List[T]]) -> Callable[[S], T]:
+    ...
+def dec5(f: Callable[[int], T]) -> Callable[[int], List[T]]:
+    def g(x: int) -> List[T]:
+        return [f(x)] * x
+    return g
+
+reveal_type(dec1(lambda x: x))  # N: Revealed type is "def [T] (T`2) -> builtins.list[T`2]"
+reveal_type(dec2(lambda x: x))  # N: Revealed type is "def [S] (S`3) -> builtins.list[S`3]"
+reveal_type(dec3(lambda x: x[0]))  # N: Revealed type is "def [S] (S`5) -> S`5"
+reveal_type(dec4(lambda x: [x]))  # N: Revealed type is "def [S] (S`7) -> S`7"
+reveal_type(dec1(lambda x: 1))  # N: Revealed type is "def (builtins.int) -> builtins.list[builtins.int]"
+reveal_type(dec5(lambda x: x))  # N: Revealed type is "def (builtins.int) -> builtins.list[builtins.int]"
+[builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecBasicInList]
 # flags: --new-type-inference

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3090,6 +3090,7 @@ def pair(x: U, y: V) -> Tuple[U, V]: ...
 reveal_type(dec(id))  # N: Revealed type is "def () -> def [T] (T`1) -> T`1"
 reveal_type(dec(either))  # N: Revealed type is "def [T] (y: T`4) -> def (T`4) -> T`4"
 reveal_type(dec(pair))  # N: Revealed type is "def [V] (y: V`-2) -> def [T] (T`7) -> Tuple[T`7, V`-2]"
+reveal_type(dec(dec))  # N: Revealed type is "def () -> def [T, P, S] (def (T`-1, *P.args, **P.kwargs) -> S`-3) -> def (*P.args, **P.kwargs) -> def (T`-1) -> S`-3"
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecPopOn]
@@ -3110,4 +3111,45 @@ def pair(x: U) -> Callable[[V], Tuple[V, U]]: ...
 reveal_type(dec(id))  # N: Revealed type is "def [T] (T`2) -> T`2"
 reveal_type(dec(either))  # N: Revealed type is "def [T] (T`5, x: T`5) -> T`5"
 reveal_type(dec(pair))  # N: Revealed type is "def [T, U] (T`8, x: U`-1) -> Tuple[T`8, U`-1]"
+# This is counter-intuitive but looks correct, dec matches itself only if P is empty
+reveal_type(dec(dec))  # N: Revealed type is "def [T, S] (T`11, f: def () -> def (T`11) -> S`12) -> S`12"
+[builtins fixtures/list.pyi]
+
+[case testInferenceAgainstGenericParamSpecVsParamSpec]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, List, Tuple, Generic
+from typing_extensions import ParamSpec, Concatenate
+
+T = TypeVar('T')
+P = ParamSpec('P')
+Q = ParamSpec('Q')
+
+class Foo(Generic[P]): ...
+class Bar(Generic[P, T]): ...
+
+def dec(f: Callable[P, T]) -> Callable[P, List[T]]: ...
+def f(*args: Q.args, **kwargs: Q.kwargs) -> Foo[Q]: ...
+reveal_type(dec(f))  # N: Revealed type is "def [P] (*P.args, **P.kwargs) -> builtins.list[__main__.Foo[P`1]]"
+g: Callable[Concatenate[int, Q], Foo[Q]]
+reveal_type(dec(g))  # N: Revealed type is "def [Q] (builtins.int, *Q.args, **Q.kwargs) -> builtins.list[__main__.Foo[Q`-1]]"
+h: Callable[Concatenate[T, Q], Bar[Q, T]]
+reveal_type(dec(h))  # N: Revealed type is "def [T, Q] (T`-1, *Q.args, **Q.kwargs) -> builtins.list[__main__.Bar[Q`-2, T`-1]]"
+[builtins fixtures/list.pyi]
+
+[case testInferenceAgainstGenericParamSpecSecondary]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, List, Tuple, Generic
+from typing_extensions import ParamSpec, Concatenate
+
+T = TypeVar('T')
+P = ParamSpec('P')
+Q = ParamSpec('Q')
+
+class Foo(Generic[P]): ...
+
+def dec(f: Callable[P, Foo[P]]) -> Callable[P, Foo[P]]: ...
+g: Callable[[T], Foo[[int]]]
+reveal_type(dec(g))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[[builtins.int]]"
+h: Callable[Q, Foo[[int]]]
+reveal_type(dec(g))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[[builtins.int]]"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3071,3 +3071,43 @@ def either(x: U, y: U) -> U: ...
 reveal_type(dec(id))  # N: Revealed type is "def [T] (x: builtins.list[T`2]) -> T`2"
 reveal_type(dec(either))  # N: Revealed type is "def [T] (x: builtins.list[T`4], y: builtins.list[T`4]) -> T`4"
 [builtins fixtures/list.pyi]
+
+[case testInferenceAgainstGenericParamSpecPopOff]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, List, Tuple
+from typing_extensions import ParamSpec, Concatenate
+
+T = TypeVar('T')
+S = TypeVar('S')
+P = ParamSpec('P')
+U = TypeVar('U')
+V = TypeVar('V')
+
+def dec(f: Callable[Concatenate[T, P], S]) -> Callable[P, Callable[[T], S]]: ...
+def id(x: U) -> U: ...
+def either(x: U, y: U) -> U: ...
+def pair(x: U, y: V) -> Tuple[U, V]: ...
+reveal_type(dec(id))  # N: Revealed type is "def () -> def [T] (T`1) -> T`1"
+reveal_type(dec(either))  # N: Revealed type is "def [T] (y: T`4) -> def (T`4) -> T`4"
+reveal_type(dec(pair))  # N: Revealed type is "def [V] (y: V`-2) -> def [T] (T`7) -> Tuple[T`7, V`-2]"
+[builtins fixtures/list.pyi]
+
+[case testInferenceAgainstGenericParamSpecPopOn]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, List, Tuple
+from typing_extensions import ParamSpec, Concatenate
+
+T = TypeVar('T')
+S = TypeVar('S')
+P = ParamSpec('P')
+U = TypeVar('U')
+V = TypeVar('V')
+
+def dec(f: Callable[P, Callable[[T], S]]) -> Callable[Concatenate[T, P], S]: ...
+def id() -> Callable[[U], U]: ...
+def either(x: U) -> Callable[[U], U]: ...
+def pair(x: U) -> Callable[[V], Tuple[V, U]]: ...
+reveal_type(dec(id))  # N: Revealed type is "def [T] (T`2) -> T`2"
+reveal_type(dec(either))  # N: Revealed type is "def [T] (T`5, x: T`5) -> T`5"
+reveal_type(dec(pair))  # N: Revealed type is "def [T, U] (T`8, x: U`-1) -> Tuple[T`8, U`-1]"
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3165,6 +3165,25 @@ h: Callable[Concatenate[T, Q], Bar[Q, T]]
 reveal_type(dec(h))  # N: Revealed type is "def [T, Q] (T`-1, *Q.args, **Q.kwargs) -> builtins.list[__main__.Bar[Q`-2, T`-1]]"
 [builtins fixtures/list.pyi]
 
+[case testInferenceAgainstGenericParamSpecVsParamSpecConcatenate]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, List, Tuple, Generic
+from typing_extensions import ParamSpec, Concatenate
+
+T = TypeVar('T')
+P = ParamSpec('P')
+Q = ParamSpec('Q')
+
+class Foo(Generic[P]): ...
+class Bar(Generic[P, T]): ...
+
+def dec(f: Callable[P, int]) -> Callable[P, Foo[P]]: ...
+h: Callable[Concatenate[T, Q], int]
+g: Callable[Concatenate[T, Q], int]
+h = g
+reveal_type(dec(h))  # N: Revealed type is "def [T, Q] (T`-1, *Q.args, **Q.kwargs) -> __main__.Foo[[T`-1, **Q`-2]]"
+[builtins fixtures/list.pyi]
+
 [case testInferenceAgainstGenericParamSpecSecondary]
 # flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple, Generic
@@ -3182,3 +3201,25 @@ reveal_type(dec(g))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[[
 h: Callable[Q, Foo[[int]]]
 reveal_type(dec(g))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[[builtins.int]]"
 [builtins fixtures/list.pyi]
+
+[case testInferenceAgainstGenericParamSpecSecondOrder]
+# flags: --new-type-inference
+from typing import TypeVar, Callable
+from typing_extensions import ParamSpec, Concatenate
+
+T = TypeVar('T')
+S = TypeVar('S')
+P = ParamSpec('P')
+Q = ParamSpec('Q')
+U = TypeVar('U')
+W = ParamSpec('W')
+
+def transform(
+    dec: Callable[[Callable[P, T]], Callable[Q, S]]
+) -> Callable[[Callable[Concatenate[int, P], T]], Callable[Concatenate[int, Q], S]]: ...
+
+def dec(f: Callable[W, U]) -> Callable[W, U]: ...
+def dec2(f: Callable[Concatenate[str, W], U]) -> Callable[Concatenate[bytes, W], U]: ...
+reveal_type(transform(dec))  # N: Revealed type is "def [P, T] (def (builtins.int, *P.args, **P.kwargs) -> T`2) -> def (builtins.int, *P.args, **P.kwargs) -> T`2"
+reveal_type(transform(dec2))  # N: Revealed type is "def [W, T] (def (builtins.int, builtins.str, *W.args, **W.kwargs) -> T`6) -> def (builtins.int, builtins.bytes, *W.args, **W.kwargs) -> T`6"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3035,3 +3035,39 @@ reveal_type(dec1(id2))  # N: Revealed type is "def [S in (builtins.int, builtins
 reveal_type(dec2(id1))  # N: Revealed type is "def [UC <: __main__.C] (UC`5) -> builtins.list[UC`5]"
 reveal_type(dec2(id2))  # N: Revealed type is "def (<nothing>) -> builtins.list[<nothing>]" \
                         # E: Argument 1 to "dec2" has incompatible type "Callable[[V], V]"; expected "Callable[[<nothing>], <nothing>]"
+
+[case testInferenceAgainstGenericParamSpecBasicInList]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, List, Tuple
+from typing_extensions import ParamSpec
+
+T = TypeVar('T')
+P = ParamSpec('P')
+U = TypeVar('U')
+V = TypeVar('V')
+
+def dec(f: Callable[P, T]) -> Callable[P, List[T]]: ...
+def id(x: U) -> U: ...
+def either(x: U, y: U) -> U: ...
+def pair(x: U, y: V) -> Tuple[U, V]: ...
+reveal_type(dec(id))  # N: Revealed type is "def [T] (x: T`2) -> builtins.list[T`2]"
+reveal_type(dec(either))  # N: Revealed type is "def [T] (x: T`4, y: T`4) -> builtins.list[T`4]"
+reveal_type(dec(pair))  # N: Revealed type is "def [U, V] (x: U`-1, y: V`-2) -> builtins.list[Tuple[U`-1, V`-2]]"
+[builtins fixtures/list.pyi]
+
+[case testInferenceAgainstGenericParamSpecBasicDeList]
+# flags: --new-type-inference
+from typing import TypeVar, Callable, List, Tuple
+from typing_extensions import ParamSpec
+
+T = TypeVar('T')
+P = ParamSpec('P')
+U = TypeVar('U')
+V = TypeVar('V')
+
+def dec(f: Callable[P, List[T]]) -> Callable[P, T]: ...
+def id(x: U) -> U: ...
+def either(x: U, y: U) -> U: ...
+reveal_type(dec(id))  # N: Revealed type is "def [T] (x: builtins.list[T`2]) -> T`2"
+reveal_type(dec(either))  # N: Revealed type is "def [T] (x: builtins.list[T`4], y: builtins.list[T`4]) -> T`4"
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -693,6 +693,7 @@ f(lambda: None)
 g(lambda: None)
 
 [case testIsinstanceInInferredLambda]
+# flags: --new-type-inference
 from typing import TypeVar, Callable, Optional
 T = TypeVar('T')
 S = TypeVar('S')
@@ -700,7 +701,7 @@ class A: pass
 class B(A): pass
 class C(A): pass
 def f(func: Callable[[T], S], *z: T, r: Optional[S] = None) -> S: pass
-f(lambda x: 0 if isinstance(x, B) else 1) # E: Cannot infer type argument 1 of "f"
+reveal_type(f(lambda x: 0 if isinstance(x, B) else 1))  # N: Revealed type is "builtins.int"
 f(lambda x: 0 if isinstance(x, B) else 1, A())() # E: "int" not callable
 f(lambda x: x if isinstance(x, B) else B(), A(), r=B())() # E: "B" not callable
 f(

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1375,19 +1375,21 @@ class B: pass
 [builtins fixtures/list.pyi]
 
 [case testUninferableLambda]
+# flags: --new-type-inference
 from typing import TypeVar, Callable
 X = TypeVar('X')
 def f(x: Callable[[X], X]) -> X: pass
-y = f(lambda x: x) # E: Cannot infer type argument 1 of "f"
+y = f(lambda x: x)  # E: Need type annotation for "y"
 
 [case testUninferableLambdaWithTypeError]
+# flags: --new-type-inference
 from typing import TypeVar, Callable
 X = TypeVar('X')
 def f(x: Callable[[X], X], y: str) -> X: pass
 y = f(lambda x: x, 1) # Fail
 [out]
-main:4: error: Cannot infer type argument 1 of "f"
-main:4: error: Argument 2 to "f" has incompatible type "int"; expected "str"
+main:5: error: Need type annotation for "y"
+main:5: error: Argument 2 to "f" has incompatible type "int"; expected "str"
 
 [case testInferLambdaNone]
 # flags: --no-strict-optional

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1386,10 +1386,8 @@ y = f(lambda x: x)  # E: Need type annotation for "y"
 from typing import TypeVar, Callable
 X = TypeVar('X')
 def f(x: Callable[[X], X], y: str) -> X: pass
-y = f(lambda x: x, 1) # Fail
-[out]
-main:5: error: Need type annotation for "y"
-main:5: error: Argument 2 to "f" has incompatible type "int"; expected "str"
+y = f(lambda x: x, 1) # E: Need type annotation for "y" \
+                      # E: Argument 2 to "f" has incompatible type "int"; expected "str"
 
 [case testInferLambdaNone]
 # flags: --no-strict-optional

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6569,3 +6569,20 @@ S = TypeVar("S", bound=str)
 def foo(x: int = ...) -> Callable[[T], T]: ...
 @overload
 def foo(x: S = ...) -> Callable[[T], T]: ...
+
+[case testOverloadGenericStarArgOverlap]
+from typing import Any, Callable, TypeVar, overload, Union, Tuple, List
+
+F = TypeVar("F", bound=Callable[..., Any])
+S = TypeVar("S", bound=int)
+
+def id(f: F) -> F: ...
+
+@overload
+def struct(*cols: S) -> int: ...
+@overload
+def struct(__cols: Union[List[S], Tuple[S, ...]]) -> int: ...
+@id
+def struct(*cols: Union[S, Union[List[S], Tuple[S, ...]]]) -> int:
+    pass
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6456,7 +6456,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 @overload
-def func(x: Callable[Concatenate[Any, P], R]) -> Callable[P, R]: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
+def func(x: Callable[Concatenate[Any, P], R]) -> Callable[P, R]: ...
 @overload
 def func(x: Callable[P, R]) -> Callable[Concatenate[str, P], R]: ...
 def func(x: Callable[..., R]) -> Callable[..., R]: ...
@@ -6474,7 +6474,7 @@ eggs = lambda: 'eggs'
 reveal_type(func(eggs))  # N: Revealed type is "def (builtins.str) -> builtins.str"
 
 spam: Callable[..., str] = lambda x, y: 'baz'
-reveal_type(func(spam))  # N: Revealed type is "def (*Any, **Any) -> builtins.str"
+reveal_type(func(spam))  # N: Revealed type is "def (*Any, **Any) -> Any"
 
 [builtins fixtures/paramspec.pyi]
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1555,3 +1555,16 @@ def test(x: U) -> U: ...
 reveal_type(dec)  # N: Revealed type is "def [P, T] (f: def (*P.args, **P.kwargs) -> T`-2) -> def (*P.args, **P.kwargs) -> builtins.list[T`-2]"
 reveal_type(dec(test))  # N: Revealed type is "def [T] (x: T`2) -> builtins.list[T`2]"
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecNestedApplyNoCrash]
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+def apply(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T: ...
+def test() -> None: ...
+# TODO: avoid this error, although it may be non-trivial.
+apply(apply, test)  # E: Argument 2 to "apply" has incompatible type "Callable[[], None]"; expected "Callable[P, T]"
+[builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1473,8 +1473,7 @@ reveal_type(gs)  # N: Revealed type is "builtins.list[def (builtins.int, builtin
 
 T = TypeVar("T")
 class C(Generic[T]): ...
-C[Callable[P, int]]()  # E: The first argument to Callable must be a list of types, parameter specification, or "..." \
-                       # N: See https://mypy.readthedocs.io/en/stable/kinds_of_types.html#callable-types-and-lambdas
+C[Callable[P, int]]()
 [builtins fixtures/paramspec.pyi]
 
 [case testConcatDeferralNoCrash]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1029,7 +1029,7 @@ j = Job(generic_f)
 reveal_type(j)  # N: Revealed type is "__main__.Job[[x: _T`-1]]"
 
 jf = j.into_callable()
-reveal_type(jf)  # N: Revealed type is "def [_T] (x: _T`-1)"
+reveal_type(jf)  # N: Revealed type is "def [_T] (x: _T`2)"
 reveal_type(jf(1))  # N: Revealed type is "None"
 [builtins fixtures/paramspec.pyi]
 
@@ -1051,7 +1051,7 @@ j = Job(generic_f)
 reveal_type(j)  # N: Revealed type is "__main__.Job[[x: _T`2], _T`2]"
 
 jf = j.into_callable()
-reveal_type(jf)  # N: Revealed type is "def [_T] (x: _T`2) -> _T`2"
+reveal_type(jf)  # N: Revealed type is "def [_T] (x: _T`3) -> _T`3"
 reveal_type(jf(1))  # N: Revealed type is "builtins.int"
 [builtins fixtures/paramspec.pyi]
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1048,10 +1048,10 @@ class Job(Generic[_P, _T]):
 def generic_f(x: _T) -> _T: ...
 
 j = Job(generic_f)
-reveal_type(j)  # N: Revealed type is "__main__.Job[[x: _T`-1], _T`-1]"
+reveal_type(j)  # N: Revealed type is "__main__.Job[[x: _T`2], _T`2]"
 
 jf = j.into_callable()
-reveal_type(jf)  # N: Revealed type is "def [_T] (x: _T`-1) -> _T`-1"
+reveal_type(jf)  # N: Revealed type is "def [_T] (x: _T`2) -> _T`2"
 reveal_type(jf(1))  # N: Revealed type is "builtins.int"
 [builtins fixtures/paramspec.pyi]
 
@@ -1307,7 +1307,7 @@ reveal_type(bar(C(fn=foo, x=1)))  # N: Revealed type is "__main__.C[[x: builtins
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecClassConstructor]
-from typing import ParamSpec, Callable
+from typing import ParamSpec, Callable, TypeVar
 
 P = ParamSpec("P")
 
@@ -1315,7 +1315,10 @@ class SomeClass:
     def __init__(self, a: str) -> None:
         pass
 
-def func(t: Callable[P, SomeClass], val: Callable[P, SomeClass]) -> None:
+def func(t: Callable[P, SomeClass], val: Callable[P, SomeClass]) -> Callable[P, SomeClass]:
+    pass
+
+def func_regular(t: Callable[[T], SomeClass], val: Callable[[T], SomeClass]) -> Callable[[T], SomeClass]:
     pass
 
 def constructor(a: str) -> SomeClass:
@@ -1324,9 +1327,13 @@ def constructor(a: str) -> SomeClass:
 def wrong_constructor(a: bool) -> SomeClass:
     return SomeClass("a")
 
+def wrong_name_constructor(b: bool) -> SomeClass:
+    return SomeClass("a")
+
 func(SomeClass, constructor)
-func(SomeClass, wrong_constructor)  # E: Argument 1 to "func" has incompatible type "Type[SomeClass]"; expected "Callable[[VarArg(<nothing>), KwArg(<nothing>)], SomeClass]" \
-				    # E: Argument 2 to "func" has incompatible type "Callable[[bool], SomeClass]"; expected "Callable[[VarArg(<nothing>), KwArg(<nothing>)], SomeClass]"
+reveal_type(func(SomeClass, wrong_constructor))  # N: Revealed type is "def (a: <nothing>) -> __main__.SomeClass"
+reveal_type(func_regular(SomeClass, wrong_constructor))  # N: Revealed type is "def (<nothing>) -> __main__.SomeClass"
+func(SomeClass, wrong_name_constructor)  # E: Argument 1 to "func" has incompatible type "Type[SomeClass]"; expected "Callable[[<nothing>], SomeClass]"
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecInTypeAliasBasic]
@@ -1547,5 +1554,5 @@ U = TypeVar("U")
 def dec(f: Callable[P, T]) -> Callable[P, List[T]]: ...
 def test(x: U) -> U: ...
 reveal_type(dec)  # N: Revealed type is "def [P, T] (f: def (*P.args, **P.kwargs) -> T`-2) -> def (*P.args, **P.kwargs) -> builtins.list[T`-2]"
-reveal_type(dec(test))  # N: Revealed type is "def [U] (x: U`-1) -> builtins.list[U`-1]"
+reveal_type(dec(test))  # N: Revealed type is "def [T] (x: T`2) -> builtins.list[T`2]"
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1554,6 +1554,14 @@ def dec(f: Callable[P, T]) -> Callable[P, List[T]]: ...
 def test(x: U) -> U: ...
 reveal_type(dec)  # N: Revealed type is "def [P, T] (f: def (*P.args, **P.kwargs) -> T`-2) -> def (*P.args, **P.kwargs) -> builtins.list[T`-2]"
 reveal_type(dec(test))  # N: Revealed type is "def [T] (x: T`2) -> builtins.list[T`2]"
+
+class A: ...
+TA = TypeVar("TA", bound=A)
+
+def test_with_bound(x: TA) -> TA: ...
+reveal_type(dec(test_with_bound))  # N: Revealed type is "def [T <: __main__.A] (x: T`4) -> builtins.list[T`4]"
+dec(test_with_bound)(0)  # E: Value of type variable "T" of function cannot be "int"
+dec(test_with_bound)(A())  # OK
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecNestedApplyNoCrash]


### PR DESCRIPTION
This is a third follow-up for https://github.com/python/mypy/pull/15287 (likely there will be just one more PR, for `TypeVarTuple`s, and few less important items I mentioned in the original PR I will leave for more distant future).

After all this PR turned out to be larger than I wanted. The problem is that `Concatenate` support for `ParamSpec` was quite broken, and this caused many of my tests fail. So I decided to include some major cleanup in this PR (I tried splitting it into a separate PR but it turned out to be tricky). After all, if one ignores added tests, it is almost net zero line count.

The main problems that I encountered are:
* First, valid substitutions for a `ParamSpecType` were: another `ParamSpecType`, `Parameters`, and `CallableType` (and also `AnyType` and `UninhabitedType` but those seem to be handled trivially). Having `CallableType` in this list caused various missed cases, bogus `get_proper_type()`s, and was generally counter-intuitive.
* Second (and probably bigger) issue is that it is possible to represent `Concatenate` in two different forms: as a prefix for `ParamSpecType` (used mostly for instances), and as separate argument types (used mostly for callables). The problem is that some parts of the code were implicitly relying on it being in one or the other form, while some other code uncontrollably switched between the two.

I propose to fix this by introducing some simplifications and rules (some of which I enforce by asserts):
* Only valid non-trivial substitutions (and consequently upper/lower bound in constraints) for `ParamSpecType` are `ParamSpecType` and `Parameters`.
* When `ParamSpecType` appears in a callable it must have an empty `prefix`.
* `Parameters` cannot contain other `Parameters` (and ideally also `ParamSpecType`s) among argument types.
* For inference we bring `Concatenate` to common representation (because both callables and instances may appear in the same expression). Using the `ParamSpecType` representation with `prefix` looks significantly simpler (especially in solver).

Apart from this actual implementation of polymorphic inference is simple/straightforward, I just handle the additional `ParamSpecType` cases (in addition to `TypeVarType`) for inference, for solver, and for application. I also enabled polymorphic inference for lambda expressions, since they are handled by similar code paths.

Some minor comments:
* I fixed couple minor bugs uncovered by this PR (see e.g. test case for accidental `TypeVar` id clash).
* I switch few tests to `--new-type-inference` because there error messages are slightly different, and so it is easier for me to test global flip to `True` locally.
* I may tweak some of the "ground rules" if `mypy_primer` output will be particularly bad.

cc @A5rocks (for some reason cannot add you as a reviewer).