### PR TITLE
Allow Annotated to wrap NotRequired in a TypedDict definition.

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -591,7 +591,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     code=codes.VALID_TYPE,
                 )
                 return AnyType(TypeOfAny.from_error)
-            return self.anal_type(t.args[0])
+            return self.anal_type(t.args[0], allow_required=self.allow_required)
         elif fullname in ("typing_extensions.Required", "typing.Required"):
             if not self.allow_required:
                 self.fail(
@@ -1513,11 +1513,18 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         self.allow_param_spec_literals = old_allow_param_spec_literals
         return self.check_unpacks_in_list(res)
 
-    def anal_type(self, t: Type, nested: bool = True, *, allow_param_spec: bool = False) -> Type:
+    def anal_type(
+        self,
+        t: Type,
+        nested: bool = True,
+        *,
+        allow_param_spec: bool = False,
+        allow_required: bool = False,
+    ) -> Type:
         if nested:
             self.nesting_level += 1
         old_allow_required = self.allow_required
-        self.allow_required = False
+        self.allow_required = allow_required
         try:
             analyzed = t.accept(self)
         finally:

--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -157,3 +157,19 @@ from typing_extensions import Annotated
 a: Annotated[int, 1:2]
 reveal_type(a)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
+
+[case testAnnotatedNotRequired]
+from typing import TypedDict, NotRequired
+from typing_extensions import Annotated
+class Movie(TypedDict):
+    title: Annotated[str, "metadata"]
+    year: Annotated[NotRequired[int], "year_metadata"]
+m1: Movie = {
+    "title": "End of the World",
+    "year": 1977,
+}
+m2: Movie = {
+    "title": "End of the World",
+}
+[typing fixtures/typing-typeddict.pyi]
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Currently, it is impossible to annotate a non-required TypedDict field using Annotated because mypy complains that NotRequired can only be used in field definitions.

This PR relaxes the requirement such that you can use `Annotated[NotRequired[str], "annotation"]`. I've verified that the type-checking behavior is correct in this case.
