### PR TITLE
Add missing type annotations to the `primitives.pyi` fixture

### DIFF
--- a/test-data/unit/fixtures/primitives.pyi
+++ b/test-data/unit/fixtures/primitives.pyi
@@ -12,7 +12,7 @@ class object:
     def __ne__(self, other: object) -> bool: pass
 
 class type:
-    def __init__(self, x) -> None: pass
+    def __init__(self, x: object) -> None: pass
 
 class int:
     # Note: this is a simplification of the actual signature
@@ -30,7 +30,7 @@ class str(Sequence[str]):
     def __iter__(self) -> Iterator[str]: pass
     def __contains__(self, other: object) -> bool: pass
     def __getitem__(self, item: int) -> str: pass
-    def format(self, *args, **kwargs) -> str: pass
+    def format(self, *args: object, **kwargs: object) -> str: pass
 class bytes(Sequence[int]):
     def __iter__(self) -> Iterator[int]: pass
     def __contains__(self, other: object) -> bool: pass


### PR DESCRIPTION
This fixes some weird test failures I was seeing locally when trying to run just the tests in `check-enum.test` (invoked via `pytest mypy/test/testcheck.py::TypeCheckSuite::check-enum.test`):

<details>

```pytb
> pytest mypy/test/testcheck.py::TypeCheckSuite::check-enum.test
=================================================================== test session starts ===================================================================
platform win32 -- Python 3.11.2, pytest-7.4.0, pluggy-1.2.0
rootdir: C:\Users\alexw\coding\mypy
configfile: pyproject.toml
plugins: cov-4.1.0, xdist-3.3.1
4 workers [99 items]
............................................................F...F.......F..........................                                                  [100%]
======================================================================== FAILURES =========================================================================
________________________________________________________ testEnumReachabilityWithChainingDisjoint _________________________________________________________
[gw2] win32 -- Python 3.11.2 C:\Users\alexw\coding\mypy\venv\Scripts\python.exe
data: C:\Users\alexw\coding\mypy\test-data\unit\check-enum.test:1174:
Failed: Unexpected type checker output (C:\Users\alexw\coding\mypy\test-data\unit\check-enum.test, line 1174)
------------------------------------------------------------------ Captured stderr call -------------------------------------------------------------------
Expected:
  main:16: note: Revealed type is "Literal[__main__.Foo.A]" (diff)
  main:17: note: Revealed type is "Literal[__main__.Foo.B]" (diff)
  main:21: note: Revealed type is "__main__.Foo" (diff)
  main:22: note: Revealed type is "__main__.Foo" (diff)
  ...
Actual:
  tmp/builtins.pyi:15: error: Function is missing a type annotation for one or more arguments (diff)
  tmp/builtins.pyi:33: error: Function is missing a type annotation for one or more arguments (diff)
  main:16: note: Revealed type is "Literal[__main__.Foo.A]" (diff)
  main:17: note: Revealed type is "Literal[__main__.Foo.B]" (diff)
  main:21: note: Revealed type is "__main__.Foo" (diff)
  main:22: note: Revealed type is "__main__.Foo" (diff)
  ...

Alignment of first line difference:
  E: main:16: note: Revealed type is "Literal[__main__.Foo.A]"...
  A: tmp/builtins.pyi:15: error: Function is missing a type annotation for on...
     ^
_____________________________________________________ testEnumReachabilityWithChainingDirectConflict ______________________________________________________
[gw2] win32 -- Python 3.11.2 C:\Users\alexw\coding\mypy\venv\Scripts\python.exe
data: C:\Users\alexw\coding\mypy\test-data\unit\check-enum.test:1215:
Failed: Unexpected type checker output (C:\Users\alexw\coding\mypy\test-data\unit\check-enum.test, line 1215)
------------------------------------------------------------------ Captured stderr call -------------------------------------------------------------------
Expected:
  main:12: error: Statement is unreachable      (diff)
  main:14: note: Revealed type is "__main__.Foo" (diff)
  main:15: note: Revealed type is "__main__.Foo" (diff)
  main:20: error: Statement is unreachable      (diff)
  ...
Actual:
  tmp/builtins.pyi:15: error: Function is missing a type annotation for one or more arguments (diff)
  tmp/builtins.pyi:33: error: Function is missing a type annotation for one or more arguments (diff)
  main:12: error: Statement is unreachable      (diff)
  main:14: note: Revealed type is "__main__.Foo" (diff)
  main:15: note: Revealed type is "__main__.Foo" (diff)
  main:20: error: Statement is unreachable      (diff)
  ...

Alignment of first line difference:
  E: main:12: error: Statement is unreachable...
  A: tmp/builtins.pyi:15: error: Function is missing a type annotation for on...
     ^
______________________________________________________ testEnumReachabilityWithChainingBigDisjoints _______________________________________________________
[gw2] win32 -- Python 3.11.2 C:\Users\alexw\coding\mypy\venv\Scripts\python.exe
data: C:\Users\alexw\coding\mypy\test-data\unit\check-enum.test:1250:
Failed: Unexpected type checker output (C:\Users\alexw\coding\mypy\test-data\unit\check-enum.test, line 1250)
------------------------------------------------------------------ Captured stderr call -------------------------------------------------------------------
Expected:
  main:20: note: Revealed type is "Literal[__main__.Foo.A]" (diff)
  main:21: note: Revealed type is "Literal[__main__.Foo.A]" (diff)
  main:22: note: Revealed type is "Literal[__main__.Foo.A]" (diff)
  main:24: note: Revealed type is "Literal[__main__.Foo.B]" (diff)
  ...
Actual:
  tmp/builtins.pyi:15: error: Function is missing a type annotation for one or more arguments (diff)
  tmp/builtins.pyi:33: error: Function is missing a type annotation for one or more arguments (diff)
  main:20: note: Revealed type is "Literal[__main__.Foo.A]" (diff)
  main:21: note: Revealed type is "Literal[__main__.Foo.A]" (diff)
  main:22: note: Revealed type is "Literal[__main__.Foo.A]" (diff)
  main:24: note: Revealed type is "Literal[__main__.Foo.B]" (diff)
  ...

Alignment of first line difference:
  E: main:20: note: Revealed type is "Literal[__main__.Foo.A]"...
  A: tmp/builtins.pyi:15: error: Function is missing a type annotation for on...
     ^
================================================================= short test summary info =================================================================
FAILED mypy/test/testcheck.py::TypeCheckSuite::check-enum.test::testEnumReachabilityWithChainingDisjoint
FAILED mypy/test/testcheck.py::TypeCheckSuite::check-enum.test::testEnumReachabilityWithChainingDirectConflict
FAILED mypy/test/testcheck.py::TypeCheckSuite::check-enum.test::testEnumReachabilityWithChainingBigDisjoints
============================================================== 3 failed, 96 passed in 3.85s ===============================================================
```

</details>

I've no idea why this was happening for me locally but not in CI (possibly because I'm invoking the test in a slightly different way??). But, this fixes it -- and it seems like the correct thing to do anyway.