### PR TITLE
[dmypy] special case stdout and stderr in show_stats too

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -562,6 +562,7 @@ def check_output(
     sys.stdout.write(out)
     sys.stdout.flush()
     sys.stderr.write(err)
+    sys.stderr.flush()
     if verbose:
         show_stats(response)
     if junit_xml:
@@ -588,13 +589,14 @@ def check_output(
 
 def show_stats(response: Mapping[str, object]) -> None:
     for key, value in sorted(response.items()):
-        if key not in ("out", "err"):
-            print("%-24s: %10s" % (key, "%.3f" % value if isinstance(value, float) else value))
-        else:
+        if key in ("out", "err", "stdout", "stderr"):
+            # Special case text output to display just 40 characters of text
             value = repr(value)[1:-1]
             if len(value) > 50:
-                value = value[:40] + " ..."
+                value = f"{value[:40]} ... {len(value)-40} more characters"
             print("%-24s: %s" % (key, value))
+            continue
+        print("%-24s: %10s" % (key, "%.3f" % value if isinstance(value, float) else value))
 
 
 @action(hang_parser)
@@ -668,6 +670,8 @@ def request(
     # TODO: Other errors, e.g. ValueError, UnicodeError
     else:
         # Display debugging output written to stdout/stderr in the server process for convenience.
+        # This should not be confused with "out" and "err" fields in the response.
+        # Those fields hold the output of the "check" command, and are handled in check_output().
         stdout = response.get("stdout")
         if stdout:
             sys.stdout.write(stdout)


### PR DESCRIPTION
When running dmypy, the communication between client and server is via JSON. The JSON contains the keys "out" and "err" for the actual result of "check" command, and "stdout" and "stderr" for the any other stdout and stderr text.
show_stats is shown when running with --verbose. It's meant to show other keys in the JSON response, like python version or time taken. It already had some special casing to only show 1 line of text for "out" and "err". Let's add "stdout" and "stderr" to the special casing as well. Also, let's show the remaining number of characters as well.

Finally, added a comment in code about stdout, stderr, out, err and how we shouldn't confuse them. (I did)

Some more cleanup is needed in this area of the codebase, but will be a separate PR.

show_stats outputs something like this:
```
err                     :
out                     : analytics/scripts/presto/report_query_lo ... 100 more characters
platform                :      linux
python_version          :        3_9
roundtrip_time          :     31.996
status                  :          2
stderr                  : \nLOG:  Mypy Version:           1.6.0+de ... 50186630 more characters
stdout                  :
```