### PR TITLE
Make `None` compatible with `SupportsBool` protocol

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -406,7 +406,9 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 # None is compatible with Hashable (and other similar protocols). This is
                 # slightly sloppy since we don't check the signature of "__hash__".
                 # None is also compatible with `SupportsStr` protocol.
-                return not members or all(member in ("__hash__", "__str__") for member in members)
+                return not members or all(
+                    member in ("__hash__", "__str__", "__bool__") for member in members
+                )
             return False
         else:
             return True

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2890,6 +2890,12 @@ class SupportsStr(Protocol):
 def ss(s: SupportsStr) -> None: pass
 ss(None)
 
+class SupportsBool(Protocol):
+    def __bool__(self) -> bool: ...
+
+def sb(s: SupportsBool) -> None: pass
+sb(None)
+
 class HashableStr(Protocol):
     def __str__(self) -> str: ...
     def __hash__(self) -> int: ...


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

None had special case for `__str__` and `__hash__`, but it can be extened for `__bool__` as well.

```python
>>> bool(None)
False
```

https://mypy-play.net/?mypy=latest&python=3.11&gist=9cb116083fe0712a4af49f52ac2e434e

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
