### PR TITLE
Basic support for decorated overloads

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -353,12 +353,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         elif isinstance(node, FuncDef):
             # Reference to a global function.
             result = function_type(node, self.named_type("builtins.function"))
-        elif isinstance(node, OverloadedFuncDef) and node.type is not None:
-            # node.type is None when there are multiple definitions of a function
-            # and it's decorated by something that is not typing.overload
-            # TODO: use a dummy Overloaded instead of AnyType in this case
-            # like we do in mypy.types.function_type()?
-            result = node.type
+        elif isinstance(node, OverloadedFuncDef):
+            if node.type is None:
+                if self.chk.in_checked_function():
+                    self.chk.handle_cannot_determine_type(node.name, e)
+                result = AnyType(TypeOfAny.from_error)
+            else:
+                result = node.type
         elif isinstance(node, TypeInfo):
             # Reference to a type object.
             if node.typeddict_type:
@@ -1337,6 +1338,56 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
         return callee
 
+    def is_generic_decorator_overload_call(
+        self, callee_type: ProperType, args: list[Expression]
+    ) -> Overloaded | None:
+        """Check if this looks like an application of a generic function to overload argument."""
+        if not isinstance(callee_type, CallableType) or not callee_type.variables:
+            return None
+        if len(callee_type.arg_types) != 1 or len(args) != 1:
+            # TODO: can we handle more general cases?
+            return None
+        if not isinstance(get_proper_type(callee_type.arg_types[0]), CallableType):
+            return None
+        if not isinstance(get_proper_type(callee_type.ret_type), CallableType):
+            return None
+        with self.chk.local_type_map():
+            with self.msg.filter_errors():
+                arg_type = get_proper_type(self.accept(args[0], type_context=None))
+        if isinstance(arg_type, Overloaded):
+            return arg_type
+        return None
+
+    def handle_decorator_overload_call(
+        self, callee_type: CallableType, overloaded: Overloaded, ctx: Context
+    ) -> tuple[Type, Type] | None:
+        """Type-check application of a generic callable to an overload.
+
+        We check call on each individual overload item, and then combine results into a new
+        overload. This function should be only used if callee_type takes and returns a Callable.
+        """
+        result = []
+        inferred_args = []
+        for item in overloaded.items:
+            arg = TempNode(typ=item)
+            with self.msg.filter_errors() as err:
+                item_result, inferred_arg = self.check_call(callee_type, [arg], [ARG_POS], ctx)
+            if err.has_new_errors():
+                # This overload doesn't match.
+                continue
+            p_item_result = get_proper_type(item_result)
+            if not isinstance(p_item_result, CallableType):
+                continue
+            p_inferred_arg = get_proper_type(inferred_arg)
+            if not isinstance(p_inferred_arg, CallableType):
+                continue
+            inferred_args.append(p_inferred_arg)
+            result.append(p_item_result)
+        if not result or not inferred_args:
+            # None of the overload matched (or overload was initially malformed).
+            return None
+        return Overloaded(result), Overloaded(inferred_args)
+
     def check_call_expr_with_callee_type(
         self,
         callee_type: Type,
@@ -1449,6 +1500,15 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 on which the method is being called
         """
         callee = get_proper_type(callee)
+
+        overloaded = self.is_generic_decorator_overload_call(callee, args)
+        if overloaded is not None:
+            # Special casing for inline application of generic callables to overloads.
+            # Supporting general case would be tricky, but this should cover 95% of cases.
+            assert isinstance(callee, CallableType)
+            overloaded_result = self.handle_decorator_overload_call(callee, overloaded, context)
+            if overloaded_result is not None:
+                return overloaded_result
 
         if isinstance(callee, CallableType):
             return self.check_callable_call(

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -355,7 +355,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             result = function_type(node, self.named_type("builtins.function"))
         elif isinstance(node, OverloadedFuncDef):
             if node.type is None:
-                if self.chk.in_checked_function():
+                if self.chk.in_checked_function() and node.items:
                     self.chk.handle_cannot_determine_type(node.name, e)
                 result = AnyType(TypeOfAny.from_error)
             else:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -323,7 +323,7 @@ def analyze_instance_member_access(
             if method.type is None:
                 # Overloads may be not ready if they are decorated. Handle this in same
                 # manner as we would handle a regular decorated function: defer if possible.
-                if not mx.no_deferral:
+                if not mx.no_deferral and method.items:
                     mx.not_ready_callback(method.name, mx.context)
                 return AnyType(TypeOfAny.special_form)
             assert isinstance(method.type, Overloaded)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1153,7 +1153,9 @@ class SemanticAnalyzer(
             elif not non_overload_indexes:
                 self.handle_missing_overload_implementation(defn)
 
-        if types:
+        if types and (not isinstance(defn.impl, Decorator) or not defn.impl.decorators):
+            # TODO: should we enforce decorated overloads consistency somehow?
+            # TODO: how do support decorated overloads in stubs without major slow-down?
             defn.type = Overloaded(types)
             defn.type.line = defn.line
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1153,9 +1153,15 @@ class SemanticAnalyzer(
             elif not non_overload_indexes:
                 self.handle_missing_overload_implementation(defn)
 
-        if types and (not isinstance(defn.impl, Decorator) or not defn.impl.decorators):
+        if types and not any(
+            # If some overload items are decorated with other decorators, then
+            # the overload type will be determined during type checking.
+            isinstance(it, Decorator) and len(it.decorators) > 1 for it in defn.items
+        ):
             # TODO: should we enforce decorated overloads consistency somehow?
-            # TODO: how to support decorated overloads in stubs without major slow-down?
+            # Some existing code uses both styles:
+            #   * Put decorator only on implementation, use "effective" types in overloads
+            #   * Put decorator everywhere, use "bare" types in overloads.
             defn.type = Overloaded(types)
             defn.type.line = defn.line
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1155,7 +1155,7 @@ class SemanticAnalyzer(
 
         if types and (not isinstance(defn.impl, Decorator) or not defn.impl.decorators):
             # TODO: should we enforce decorated overloads consistency somehow?
-            # TODO: how do support decorated overloads in stubs without major slow-down?
+            # TODO: how to support decorated overloads in stubs without major slow-down?
             defn.type = Overloaded(types)
             defn.type.line = defn.line
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1156,7 +1156,8 @@ class SemanticAnalyzer(
         if types and not any(
             # If some overload items are decorated with other decorators, then
             # the overload type will be determined during type checking.
-            isinstance(it, Decorator) and len(it.decorators) > 1 for it in defn.items
+            isinstance(it, Decorator) and len(it.decorators) > 1
+            for it in defn.items
         ):
             # TODO: should we enforce decorated overloads consistency somehow?
             # Some existing code uses both styles:

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3062,10 +3062,10 @@ def dec5(f: Callable[[int], T]) -> Callable[[int], List[T]]:
 reveal_type(dec1(lambda x: x))  # N: Revealed type is "def [T] (T`3) -> builtins.list[T`3]"
 reveal_type(dec2(lambda x: x))  # N: Revealed type is "def [S] (S`4) -> builtins.list[S`4]"
 reveal_type(dec3(lambda x: x[0]))  # N: Revealed type is "def [S] (S`6) -> S`6"
-reveal_type(dec4(lambda x: [x]))  # N: Revealed type is "def [S] (S`8) -> S`8"
+reveal_type(dec4(lambda x: [x]))  # N: Revealed type is "def [S] (S`9) -> S`9"
 reveal_type(dec1(lambda x: 1))  # N: Revealed type is "def (builtins.int) -> builtins.list[builtins.int]"
 reveal_type(dec5(lambda x: x))  # N: Revealed type is "def (builtins.int) -> builtins.list[builtins.int]"
-reveal_type(dec3(lambda x: x))  # N: Revealed type is "def [S] (S`15) -> builtins.list[S`15]"
+reveal_type(dec3(lambda x: x))  # N: Revealed type is "def [S] (S`16) -> builtins.list[S`16]"
 dec4(lambda x: x)  # E: Incompatible return value type (got "S", expected "List[object]")
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3207,8 +3207,7 @@ class User:
         self.first_name = value
 
     def __init__(self, name: str) -> None:
-        self.name = name  # E: Cannot assign to a method \
-                          # E: Cannot determine type of "name"
+        self.name = name  # E: Cannot assign to a method
 
 [case testNewAnalyzerMemberNameMatchesTypedDict]
 from typing import Union, Any

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3208,7 +3208,7 @@ class User:
 
     def __init__(self, name: str) -> None:
         self.name = name  # E: Cannot assign to a method \
-                          # E: Incompatible types in assignment (expression has type "str", variable has type "Callable[..., Any]")
+                          # E: Cannot determine type of "name"
 
 [case testNewAnalyzerMemberNameMatchesTypedDict]
 from typing import Union, Any

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -11,18 +11,17 @@ f(0)
 @overload  # E: Name "overload" is not defined
 def g(a:int): pass
 def g(a): pass  # E: Name "g" already defined on line 9
-g(0)  # E: Cannot determine type of "g"
+g(0)
 
 @something  # E: Name "something" is not defined
 def r(a:int): pass
 def r(a): pass  # E: Name "r" already defined on line 14
-r(0)  # E: Cannot determine type of "r"
+r(0)
 [out]
 main:2: error: Name "overload" is not defined
 main:4: error: Name "f" already defined on line 2
 main:4: error: Name "overload" is not defined
 main:6: error: Name "f" already defined on line 2
-main:7: error: Cannot determine type of "f"
 
 [case testTypeCheckOverloadWithImplementation]
 from typing import overload, Any
@@ -5227,7 +5226,6 @@ def func(x):
 [out]
 tmp/lib.pyi:1: error: Name "overload" is not defined
 tmp/lib.pyi:4: error: Name "func" already defined on line 1
-main:2: error: Cannot determine type of "func"
 main:2: note: Revealed type is "Any"
 
 -- Order of errors is different
@@ -5244,7 +5242,6 @@ def func(x: str) -> str: ...
 tmp/lib.pyi:1: error: Name "overload" is not defined
 tmp/lib.pyi:3: error: Name "func" already defined on line 1
 tmp/lib.pyi:3: error: Name "overload" is not defined
-main:3: error: Cannot determine type of "func"
 main:3: note: Revealed type is "Any"
 
 [case testLiteralSubtypeOverlap]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -11,17 +11,18 @@ f(0)
 @overload  # E: Name "overload" is not defined
 def g(a:int): pass
 def g(a): pass  # E: Name "g" already defined on line 9
-g(0)
+g(0)  # E: Cannot determine type of "g"
 
 @something  # E: Name "something" is not defined
 def r(a:int): pass
 def r(a): pass  # E: Name "r" already defined on line 14
-r(0)
+r(0)  # E: Cannot determine type of "r"
 [out]
 main:2: error: Name "overload" is not defined
 main:4: error: Name "f" already defined on line 2
 main:4: error: Name "overload" is not defined
 main:6: error: Name "f" already defined on line 2
+main:7: error: Cannot determine type of "f"
 
 [case testTypeCheckOverloadWithImplementation]
 from typing import overload, Any
@@ -5226,6 +5227,7 @@ def func(x):
 [out]
 tmp/lib.pyi:1: error: Name "overload" is not defined
 tmp/lib.pyi:4: error: Name "func" already defined on line 1
+main:2: error: Cannot determine type of "func"
 main:2: note: Revealed type is "Any"
 
 -- Order of errors is different
@@ -5242,6 +5244,7 @@ def func(x: str) -> str: ...
 tmp/lib.pyi:1: error: Name "overload" is not defined
 tmp/lib.pyi:3: error: Name "func" already defined on line 1
 tmp/lib.pyi:3: error: Name "overload" is not defined
+main:3: error: Cannot determine type of "func"
 main:3: note: Revealed type is "Any"
 
 [case testLiteralSubtypeOverlap]
@@ -6613,3 +6616,30 @@ def struct(__cols: Union[List[S], Tuple[S, ...]]) -> int: ...
 def struct(*cols: Union[S, Union[List[S], Tuple[S, ...]]]) -> int:
     pass
 [builtins fixtures/tuple.pyi]
+
+[case testRegularGenericDecoratorOverload]
+from typing import Callable, overload, TypeVar, List
+
+S = TypeVar("S")
+T = TypeVar("T")
+def transform(func: Callable[[S], List[T]]) -> Callable[[S], T]: ...
+
+@overload
+def foo(x: int) -> List[float]: ...
+@overload
+def foo(x: str) -> List[str]: ...
+def foo(x): ...
+
+reveal_type(transform(foo))  # N: Revealed type is "Overload(def (builtins.int) -> builtins.float, def (builtins.str) -> builtins.str)"
+
+@transform
+@overload
+def bar(x: int) -> List[float]: ...
+@transform
+@overload
+def bar(x: str) -> List[str]: ...
+@transform
+def bar(x): ...
+
+reveal_type(bar)  # N: Revealed type is "Overload(def (builtins.int) -> builtins.float, def (builtins.str) -> builtins.str)"
+[builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1646,3 +1646,31 @@ def bar(b: B[P]) -> A[Concatenate[int, P]]:
               # N:     Got: \
               # N:         def foo(self, a: int, b: int, *args: P.args, **kwargs: P.kwargs) -> Any
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecDecoratorOverload]
+from typing import Callable, overload, TypeVar, List
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+T = TypeVar("T")
+def transform(func: Callable[P, List[T]]) -> Callable[P, T]: ...
+
+@overload
+def foo(x: int) -> List[float]: ...
+@overload
+def foo(x: str) -> List[str]: ...
+def foo(x): ...
+
+reveal_type(transform(foo))  # N: Revealed type is "Overload(def (x: builtins.int) -> builtins.float, def (x: builtins.str) -> builtins.str)"
+
+@transform
+@overload
+def bar(x: int) -> List[float]: ...
+@transform
+@overload
+def bar(x: str) -> List[str]: ...
+@transform
+def bar(x): ...
+
+reveal_type(bar)  # N: Revealed type is "Overload(def (x: builtins.int) -> builtins.float, def (x: builtins.str) -> builtins.str)"
+[builtins fixtures/paramspec.pyi]

--- a/test-data/unit/lib-stub/functools.pyi
+++ b/test-data/unit/lib-stub/functools.pyi
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar, Callable, Any, Mapping
+from typing import Generic, TypeVar, Callable, Any, Mapping, overload
 
 _T = TypeVar("_T")
 


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/15737
Fixes https://github.com/python/mypy/issues/12844
Fixes https://github.com/python/mypy/issues/12716

My goal was to fix the `ParamSpec` issues, but it turns out decorated overloads were not supported at all. Namely:
* Decorators on overload items were ignored, caller would see original undecorated item types
* Overload item overlap checks were performed for original types, while arguably we should use decorated types
* Overload items completeness w.r.t. to implementation was checked with decorated implementation, and undecorated items

Here I add basic support using same logic as for regular decorated functions: initially set type to `None` and defer callers until definition is type-checked. Note this results in few more `Cannot determine type` in case of other errors, but I think it is fine.

Note I also add special-casing for "inline" applications of generic functions to overload arguments. This use case was mentioned few times alongside overloads. The general fix would be tricky, and my special-casing should cover typical use cases.