### PR TITLE
Support self-types containing ParamSpec

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -331,7 +331,7 @@ def bind_self(method: F, original_type: Type | None = None, is_classmethod: bool
             )
 
         # Update the method signature with the solutions found.
-        # Technically, some constrains might be unsolvable, make them <nothing>.
+        # Technically, some constraints might be unsolvable, make them <nothing>.
         to_apply = [t if t is not None else UninhabitedType() for t in typeargs]
         func = expand_type(func, {tv.id: arg for tv, arg in zip(self_vars, to_apply)})
         variables = [v for v in func.variables if v not in self_vars]

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -1973,3 +1973,45 @@ class B(A):
         reveal_type(self.x.extra)  # N: Revealed type is "builtins.int"
         reveal_type(self.xs[0].extra)  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
+
+[case testSelfTypesWithParamSpecExtract]
+from typing import Any, Callable, Generic, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+F = TypeVar("F", bound=Callable[..., Any])
+class Example(Generic[F]):
+    def __init__(self, fn: F) -> None:
+        ...
+    def __call__(self: Example[Callable[P, Any]], *args: P.args, **kwargs: P.kwargs) -> None:
+        ...
+
+def test_fn(a: int, b: str) -> None:
+    ...
+
+example = Example(test_fn)
+example()  # E: Missing positional arguments "a", "b" in call to "__call__" of "Example"
+example(1, "b")  # OK
+[builtins fixtures/list.pyi]
+
+[case testSelfTypesWithParamSpecInfer]
+from typing import TypeVar, Protocol, Type, Callable
+from typing_extensions import ParamSpec
+
+R = TypeVar("R", covariant=True)
+P = ParamSpec("P")
+class AsyncP(Protocol[P]):
+    def meth(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        ...
+
+class Async:
+    @classmethod
+    def async_func(cls: Type[AsyncP[P]]) -> Callable[P, int]:
+        ...
+
+class Add(Async):
+    def meth(self, x: int, y: int) -> None: ...
+
+reveal_type(Add.async_func())  # N: Revealed type is "def (x: builtins.int, y: builtins.int) -> builtins.int"
+reveal_type(Add().async_func())  # N: Revealed type is "def (x: builtins.int, y: builtins.int) -> builtins.int"
+[builtins fixtures/classmethod.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/14968
Fixes https://github.com/python/mypy/issues/13911

The fix is simple, as I predicted on Discord, we simply should use `get_all_type_vars()` instead of `get_type_vars()` (that specifically returns only `TypeVarType`). I also use this opportunity to tidy-up code in `bind_self()`, it should be now more readable, and much faster (especially when compiled with mypyc).

cc @A5rocks 