### PR TITLE
Allow Ellipsis in Concatenate; cleanup ParamSpec literals

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5276,20 +5276,18 @@ class SemanticAnalyzer(
         else:
             items = [index]
 
-        # whether param spec literals be allowed here
-        # TODO: should this be computed once and passed in?
-        #   or is there a better way to do this?
+        # TODO: this needs a clean-up.
+        # Probably always allow Parameters literals, and validate in semanal_typeargs.py
         base = expr.base
         if isinstance(base, RefExpr) and isinstance(base.node, TypeAlias):
             alias = base.node
-            target = get_proper_type(alias.target)
-            if isinstance(target, Instance):
-                has_param_spec = target.type.has_param_spec_type
-                num_args = len(target.type.type_vars)
+            if any(isinstance(t, ParamSpecType) for t in alias.alias_tvars):
+                has_param_spec = True
+                num_args = len(alias.alias_tvars)
             else:
                 has_param_spec = False
                 num_args = -1
-        elif isinstance(base, NameExpr) and isinstance(base.node, TypeInfo):
+        elif isinstance(base, RefExpr) and isinstance(base.node, TypeInfo):
             has_param_spec = base.node.has_param_spec_type
             num_args = len(base.node.type_vars)
         else:

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -611,8 +611,7 @@ from typing_extensions import Literal
 a: (1, 2, 3)                    # E: Syntax error in type annotation \
                                 # N: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
 b: Literal[[1, 2, 3]]           # E: Parameter 1 of Literal[...] is invalid
-c: [1, 2, 3]                    # E: Bracketed expression "[...]" is not valid as a type \
-                                # N: Did you mean "List[...]"?
+c: [1, 2, 3]                    # E: Bracketed expression "[...]" is not valid as a type
 [builtins fixtures/tuple.pyi]
 [out]
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -38,6 +38,74 @@ def foo6(x: Callable[[P], int]) -> None: ...  # E: Invalid location for ParamSpe
                                               # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
 [builtins fixtures/paramspec.pyi]
 
+[case testParamSpecImports]
+import lib
+from lib import Base
+
+class C(Base[[int]]):
+    def test(self, x: int): ...
+
+class D(lib.Base[[int]]):
+    def test(self, x: int): ...
+
+class E(lib.Base[...]): ...
+reveal_type(E().test)  # N: Revealed type is "def (*Any, **Any)"
+
+[file lib.py]
+from typing import Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+class Base(Generic[P]):
+    def test(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        ...
+[builtins fixtures/paramspec.pyi]
+
+[case testParamSpecEllipsisInAliases]
+from typing import Any, Callable, Generic, TypeVar
+from typing_extensions import ParamSpec
+
+P = ParamSpec('P')
+R = TypeVar('R')
+Alias = Callable[P, R]
+
+class B(Generic[P]): ...
+Other = B[P]
+
+T = TypeVar('T', bound=Alias[..., Any])
+Alias[..., Any]  # E: Type application is only supported for generic classes
+B[...]
+Other[...]
+[builtins fixtures/paramspec.pyi]
+
+[case testParamSpecEllipsisInConcatenate]
+from typing import Any, Callable, Generic, TypeVar
+from typing_extensions import ParamSpec, Concatenate
+
+P = ParamSpec('P')
+R = TypeVar('R')
+Alias = Callable[P, R]
+
+IntFun = Callable[Concatenate[int, ...], None]
+f: IntFun
+reveal_type(f)  # N: Revealed type is "def (builtins.int, *Any, **Any)"
+
+g: Callable[Concatenate[int, ...], None]
+reveal_type(g)  # N: Revealed type is "def (builtins.int, *Any, **Any)"
+
+class B(Generic[P]):
+    def test(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        ...
+
+x: B[Concatenate[int, ...]]
+reveal_type(x.test)  # N: Revealed type is "def (builtins.int, *Any, **Any)"
+
+Bad = Callable[Concatenate[int, [int, str]], None]  # E: The last parameter to Concatenate needs to be a ParamSpec \
+                                                    # E: Bracketed expression "[...]" is not valid as a type
+def bad(fn: Callable[Concatenate[P, int], None]):  # E: The last parameter to Concatenate needs to be a ParamSpec
+    ...
+[builtins fixtures/paramspec.pyi]
+
 [case testParamSpecContextManagerLike]
 from typing import Callable, List, Iterator, TypeVar
 from typing_extensions import ParamSpec
@@ -1431,8 +1499,7 @@ from typing import ParamSpec, Generic, List, TypeVar, Callable
 P = ParamSpec("P")
 T = TypeVar("T")
 A = List[T]
-def f(x: A[[int, str]]) -> None: ...  # E: Bracketed expression "[...]" is not valid as a type \
-                                      # N: Did you mean "List[...]"?
+def f(x: A[[int, str]]) -> None: ...  # E: Bracketed expression "[...]" is not valid as a type
 def g(x: A[P]) -> None: ...  # E: Invalid location for ParamSpec "P" \
                              # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
 

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -59,9 +59,9 @@ from typing import TypeVar, ParamSpec, Tuple
 from typing_extensions import TypeVarTuple, Unpack
 
 T1 = TypeVar("T1", default=2)  # E: TypeVar "default" must be a type
-T2 = TypeVar("T2", default=[int, str])  # E: Bracketed expression "[...]" is not valid as a type \
-                                        # N: Did you mean "List[...]"? \
-                                        # E: TypeVar "default" must be a type
+T2 = TypeVar("T2", default=[int])  # E: Bracketed expression "[...]" is not valid as a type \
+                                   # N: Did you mean "List[...]"? \
+                                   # E: TypeVar "default" must be a type
 
 P1 = ParamSpec("P1", default=int)  # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
 P2 = ParamSpec("P2", default=2)  # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -810,8 +810,8 @@ class C(Generic[t]): pass
 cast(str + str, None)    # E: Cast target is not a type
 cast(C[str][str], None)  # E: Cast target is not a type
 cast(C[str + str], None) # E: Cast target is not a type
-cast([int, str], None)   # E: Bracketed expression "[...]" is not valid as a type \
-                         # N: Did you mean "List[...]"?
+cast([int], None)   # E: Bracketed expression "[...]" is not valid as a type \
+                    # N: Did you mean "List[...]"?
 [out]
 
 [case testInvalidCastTargetType]
@@ -859,8 +859,8 @@ Any(arg=str)  # E: Any(...) is no longer supported. Use cast(Any, ...) instead
 
 [case testTypeListAsType]
 
-def f(x:[int, str]) -> None: # E: Bracketed expression "[...]" is not valid as a type \
-                             # N: Did you mean "List[...]"?
+def f(x: [int]) -> None: # E: Bracketed expression "[...]" is not valid as a type \
+                         # N: Did you mean "List[...]"?
     pass
 [out]
 


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/14761
Fixes https://github.com/python/mypy/issues/15318
Fixes https://github.com/python/mypy/issues/14656
Fixes https://github.com/python/mypy/issues/13518

I noticed there is a bunch of inconsistencies in `semanal`/`typeanal` for ParamSpecs, so I decided do a small cleanup. Using this opportunity I also allow `Concatenate[int, ...]` (with literal Ellipsis), and reduce verbosity of some errors.

cc @A5rocks 
