### PR TITLE
Fix `assert_type` failures when some nodes are deferred

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4271,6 +4271,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             allow_none_return=True,
             always_allow_any=True,
         )
+        if self.chk.current_node_deferred:
+            return source_type
+
         target_type = expr.type
         proper_source_type = get_proper_type(source_type)
         if (

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1053,12 +1053,12 @@ T = TypeVar("T")
 def dec(f: Callable[[], T]) -> Callable[[], T]:
     return f
 
-def method1() -> None:
-    some_enum = _inner_method1()
-    assert_type(some_enum, int)
+def func() -> None:
+    some = _inner_func()
+    assert_type(some, int)
 
 @dec
-def _inner_method1() -> int:
+def _inner_func() -> int:
     return 1
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1045,6 +1045,23 @@ def reduce_it(s: Scalar) -> Scalar:
 assert_type(reduce_it(True), Scalar)
 [builtins fixtures/tuple.pyi]
 
+[case testAssertTypeWithDeferredNodes]
+from typing import Callable, TypeVar, assert_type
+
+T = TypeVar("T")
+
+def dec(f: Callable[[], T]) -> Callable[[], T]:
+    return f
+
+def method1() -> None:
+    some_enum = _inner_method1()
+    assert_type(some_enum, int)
+
+@dec
+def _inner_method1() -> int:
+    return 1
+[builtins fixtures/tuple.pyi]
+
 -- None return type
 -- ----------------
 


### PR DESCRIPTION
Now it is quite the same as `reveal_type`. Which is defined here: https://github.com/python/mypy/blob/2c1fd97986064161c542956bb3d9d5043dc0a480/mypy/checkexpr.py#L4297

Closes #15851