### PR TITLE
Fix edge-case stubtest crashes when an instanace of an `enum.Flag` that is not a member of that `enum.Flag` is used as a parameter default

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1553,7 +1553,7 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> mypy.types.Type | None:
     value: bool | int | str
     if isinstance(runtime, bytes):
         value = bytes_to_human_readable_repr(runtime)
-    elif isinstance(runtime, enum.Enum):
+    elif isinstance(runtime, enum.Enum) and isinstance(runtime.name, str):
         value = runtime.name
     elif isinstance(runtime, (bool, int, str)):
         value = runtime

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -954,22 +954,51 @@ class StubtestUnit(unittest.TestCase):
 
     @collect_cases
     def test_enum(self) -> Iterator[Case]:
+        yield Case(stub="import enum", runtime="import enum", error=None)
         yield Case(
             stub="""
-            import enum
             class X(enum.Enum):
                 a: int
                 b: str
                 c: str
             """,
             runtime="""
-            import enum
             class X(enum.Enum):
                 a = 1
                 b = "asdf"
                 c = 2
             """,
             error="X.c",
+        )
+        yield Case(
+            stub="""
+            class Flags1(enum.IntFlag):
+                a: int
+                b: int
+            def foo(x: Flags1 = ...) -> None: ...
+            """,
+            runtime="""
+            class Flags1(enum.IntFlag):
+                a = 0b000000000100
+                b = 0b000000001000
+            def foo(x=Flags1.a|Flags1.b): pass
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class Flags2(enum.IntFlag):
+                a: int
+                b: int
+            def bar(x: Flags2 | None = None) -> None: ...
+            """,
+            runtime="""
+            class Flags2(enum.IntFlag):
+                a = 0b000000000100
+                b = 0b000000001000
+            def bar(x=Flags2.a|Flags2.b): pass
+            """,
+            error="bar",
         )
 
     @collect_cases

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -139,8 +139,6 @@ class Flag(Enum):
         __ror__ = __or__
         __rand__ = __and__
         __rxor__ = __xor__
-
-class IntFlag(int, Flag): pass
 """
 
 
@@ -1012,30 +1010,30 @@ class StubtestUnit(unittest.TestCase):
         )
         yield Case(
             stub="""
-            class Flags1(enum.IntFlag):
+            class Flags1(enum.Flag):
                 a: int
                 b: int
             def foo(x: Flags1 = ...) -> None: ...
             """,
             runtime="""
-            class Flags1(enum.IntFlag):
-                a = 0b000000000100
-                b = 0b000000001000
+            class Flags1(enum.Flag):
+                a = 1
+                b = 2
             def foo(x=Flags1.a|Flags1.b): pass
             """,
             error=None,
         )
         yield Case(
             stub="""
-            class Flags2(enum.IntFlag):
+            class Flags2(enum.Flag):
                 a: int
                 b: int
             def bar(x: Flags2 | None = None) -> None: ...
             """,
             runtime="""
-            class Flags2(enum.IntFlag):
-                a = 0b000000000100
-                b = 0b000000001000
+            class Flags2(enum.Flag):
+                a = 1
+                b = 2
             def bar(x=Flags2.a|Flags2.b): pass
             """,
             error="bar",

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1038,6 +1038,36 @@ class StubtestUnit(unittest.TestCase):
             """,
             error="bar",
         )
+        yield Case(
+            stub="""
+            class Flags3(enum.Flag):
+                a: int
+                b: int
+            def baz(x: Flags3 | None = ...) -> None: ...
+            """,
+            runtime="""
+            class Flags3(enum.Flag):
+                a = 1
+                b = 2
+            def baz(x=Flags3(0)): pass
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class Flags4(enum.Flag):
+                a: int
+                b: int
+            def spam(x: Flags4 | None = None) -> None: ...
+            """,
+            runtime="""
+            class Flags4(enum.Flag):
+                a = 1
+                b = 2
+            def spam(x=Flags4(0)): pass
+            """,
+            error="spam",
+        )
 
     @collect_cases
     def test_decorator(self) -> Iterator[Case]:

--- a/test-data/unit/lib-stub/enum.pyi
+++ b/test-data/unit/lib-stub/enum.pyi
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, TypeVar, Union, Type, Sized, Iterator
 
 _T = TypeVar('_T')
@@ -36,13 +35,6 @@ def unique(enumeration: _T) -> _T: pass
 
 class Flag(Enum):
     def __or__(self: _T, other: Union[int, _T]) -> _T: pass
-    def __and__(self: _T, other: _T) -> _T: pass
-    def __xor__(self: _T, other: _T) -> _T: pass
-    def __invert__(self) -> Self: pass
-    if sys.version_info >= (3, 11):
-        __ror__ = __or__
-        __rand__ = __and__
-        __rxor__ = __xor__
 
 
 class IntFlag(int, Flag):

--- a/test-data/unit/lib-stub/enum.pyi
+++ b/test-data/unit/lib-stub/enum.pyi
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, TypeVar, Union, Type, Sized, Iterator
 
 _T = TypeVar('_T')
@@ -35,6 +36,13 @@ def unique(enumeration: _T) -> _T: pass
 
 class Flag(Enum):
     def __or__(self: _T, other: Union[int, _T]) -> _T: pass
+    def __and__(self: _T, other: _T) -> _T: pass
+    def __xor__(self: _T, other: _T) -> _T: pass
+    def __invert__(self) -> Self: pass
+    if sys.version_info >= (3, 11):
+        __ror__ = __or__
+        __rand__ = __and__
+        __rxor__ = __xor__
 
 
 class IntFlag(int, Flag):


### PR DESCRIPTION
Fixes #15923.

Note: the test cases I've added reproduce the crash, but only if you're using a compiled version of mypy. (Some of them only repro the crash on <=py310, but some repro it on py311+ as well.)

We run stubtest tests in CI with compiled mypy, so they do repro the crash in the context of our CI.