### PR TITLE
Fix crash on invalid type variable with ParamSpec

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -458,14 +458,15 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # These do not support mypy_extensions VarArgs, etc. as they were already analyzed
         # TODO: should these be re-analyzed to get rid of this inconsistency?
         count = len(an_args)
-        if count > 0:
-            if count == 1 and isinstance(get_proper_type(an_args[0]), AnyType):
-                # Single Any is interpreted as ..., rather that a single argument with Any type.
-                # I didn't find this in the PEP, but it sounds reasonable.
-                return list(an_args)
-            if any(isinstance(a, (Parameters, ParamSpecType)) for a in an_args):
-                # Nested parameter specifications are not allowed.
-                return list(an_args)
+        if count == 0:
+            return []
+        if count == 1 and isinstance(get_proper_type(an_args[0]), AnyType):
+            # Single Any is interpreted as ..., rather that a single argument with Any type.
+            # I didn't find this in the PEP, but it sounds reasonable.
+            return list(an_args)
+        if any(isinstance(a, (Parameters, ParamSpecType)) for a in an_args):
+            # Nested parameter specifications are not allowed.
+            return list(an_args)
         return [Parameters(an_args, [ARG_POS] * count, [None] * count)]
 
     def cannot_resolve_type(self, t: UnboundType) -> None:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -460,7 +460,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         count = len(an_args)
         if count > 0:
             if count == 1 and isinstance(get_proper_type(an_args[0]), AnyType):
-                # Single Any is interpreted as ..., rather that a single argument with Ay type.
+                # Single Any is interpreted as ..., rather that a single argument with Any type.
                 # I didn't find this in the PEP, but it sounds reasonable.
                 return list(an_args)
             if any(isinstance(a, (Parameters, ParamSpecType)) for a in an_args):

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1754,3 +1754,13 @@ def dec(fn: Callable[P, T]) -> Alias[P, T]: ...  # type: ignore
 f: Any
 dec(f)  # No crash
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecErrorNestedParams]
+from typing import Generic
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+class C(Generic[P]): ...
+c: C[int, [int, str], str]  # E: Nested parameter specifications are not allowed
+reveal_type(c)  # N: Revealed type is "__main__.C[Any]"
+[builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1741,3 +1741,16 @@ def bar(x): ...
 
 reveal_type(bar)  # N: Revealed type is "Overload(def (x: builtins.int) -> builtins.float, def (x: builtins.str) -> builtins.str)"
 [builtins fixtures/paramspec.pyi]
+
+[case testParamSpecDecoratorOverloadNoCrashOnInvalidTypeVar]
+from typing import Any, Callable, List
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+T = 1
+
+Alias = Callable[P, List[T]]  # type: ignore
+def dec(fn: Callable[P, T]) -> Alias[P, T]: ...  # type: ignore
+f: Any
+dec(f)  # No crash
+[builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/15948

The fix is straightforward: invalid type variable resulted in applying type arguments packing/simplification when we shouldn't. Making the latter more strict fixes the issue.

cc @A5rocks 
