### PR TITLE
Fixes to stubtest's new check for missing stdlib modules

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1724,8 +1724,10 @@ def get_importable_stdlib_modules() -> set[str]:
 
             try:
                 silent_import_module(submodule_name)
+            except KeyboardInterrupt:
+                raise
             # importing multiprocessing.popen_forkserver on Windows raises AttributeError...
-            except Exception:
+            except BaseException:
                 continue
             else:
                 importable_stdlib_modules.add(submodule_name)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1720,7 +1720,13 @@ def get_importable_stdlib_modules() -> set[str]:
             # The idlelib.* submodules are similarly annoying in opening random tkinter windows,
             # and we're unlikely to ever add stubs for idlelib in typeshed
             # (see discussion in https://github.com/python/typeshed/pull/9193)
-            if submodule_name.endswith(".__main__") or submodule_name.startswith("idlelib."):
+            #
+            # test.* modules do weird things like raising unraisable exceptions in __del__ methods
+            if (
+                submodule_name.endswith(".__main__")
+                or submodule_name.startswith("idlelib.")
+                or submodule_name.startswith("test.")
+            ):
                 continue
 
             try:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1721,7 +1721,9 @@ def get_importable_stdlib_modules() -> set[str]:
             # and we're unlikely to ever add stubs for idlelib in typeshed
             # (see discussion in https://github.com/python/typeshed/pull/9193)
             #
-            # test.* modules do weird things like raising unraisable exceptions in __del__ methods
+            # test.* modules do weird things like raising exceptions in __del__ methods,
+            # leading to unraisable exceptions being logged to the terminal
+            # as a warning at the end of the stubtest run
             if (
                 submodule_name.endswith(".__main__")
                 or submodule_name.startswith("idlelib.")


### PR DESCRIPTION
I did a trial run with my typeshed fork using GitHub Actions to see what the results of running stubtest on typeshed's stdlib stubs were with mypy's master branch. It's a good job that I did, as it revealed that there were a few flaws in the logic I introduced in #15729:
- It's not easy to predict where stdlib modules are going to be located. (It varies between platforms, and between venvs and conda envs; on some platforms it's in a completely different directory to the Python executable.)
- Some modules appear to raise `SystemExit` when stubtest tries to import them in CI, leading stubtest to instantly exit without logging a message to the terminal.
- Importing some `test.*` submodules leads to unraisable exceptions being printed to the terminal at the end of the stubtest run, which is somewhat annoying.

This PR fixes the bugs. This logic has now been tested locally using venv, locally using conda environments, on GitHub Actions, on py311, py38, Ubuntu, Windows and macOS.