### PR TITLE
Improve GitHub Actions specs

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, master, 'release*']
     tags: ['*']
 
+permissions:
+  contents: write
+
 jobs:
   build-wheels:
     if: github.repository == 'python/mypy'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,13 @@ on:
     - CREDITS
     - LICENSE
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -15,6 +15,9 @@ on:
     - 'mypy/test/**'
     - 'test-data/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ on:
     - CREDITS
     - LICENSE
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -12,6 +12,13 @@ on:
     - 'mypy/stubdoc.py'
     - 'test-data/stubgen/**'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   stubgenc:
     # Check stub file generation for a small pybind11 project


### PR DESCRIPTION
Two main changes:
1. Always use secure permissions, when some workflow does not do anything, it has to be `contents: read` only
2. Be more consistent with canceling workflows