### PR TITLE
Optimize Unpack for failures

### DIFF
--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -272,7 +272,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
         # it is hard to assert this without getting proper type.
         return UnpackType(t.type.accept(self))
 
-    def expand_unpack(self, t: UnpackType) -> list[Type] | AnyType | UninhabitedType:
+    def expand_unpack(self, t: UnpackType) -> list[Type]:
         assert isinstance(t.type, TypeVarTupleType)
         repl = get_proper_type(self.variables.get(t.type.id, t.type))
         if isinstance(repl, TupleType):
@@ -284,9 +284,9 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
         ):
             return [UnpackType(typ=repl)]
         elif isinstance(repl, (AnyType, UninhabitedType)):
-            # tuple[Any, ...] for Any would be better, but we don't have
-            # the type info to construct that type here.
-            return repl
+            # Replace *Ts = Any with *Ts = *tuple[Any, ...] and some for <nothing>.
+            # These types may appear here as a result of user error or failed inference.
+            return [UnpackType(t.type.tuple_fallback.copy_modified(args=[repl]))]
         else:
             raise RuntimeError(f"Invalid type replacement to expand: {repl}")
 
@@ -309,12 +309,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             # We have plain Unpack[Ts]
             assert isinstance(var_arg_type, TypeVarTupleType)
             fallback = var_arg_type.tuple_fallback
-            expanded_items_res = self.expand_unpack(var_arg)
-            if isinstance(expanded_items_res, list):
-                expanded_items = expanded_items_res
-            else:
-                # We got Any or <nothing>
-                return prefix + [expanded_items_res] + suffix
+            expanded_items = self.expand_unpack(var_arg)
         new_unpack = UnpackType(TupleType(expanded_items, fallback))
         return prefix + [new_unpack] + suffix
 
@@ -393,14 +388,8 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
         items: list[Type] = []
         for item in typs:
             if isinstance(item, UnpackType) and isinstance(item.type, TypeVarTupleType):
-                unpacked_items = self.expand_unpack(item)
-                if isinstance(unpacked_items, (AnyType, UninhabitedType)):
-                    # TODO: better error for <nothing>, something like tuple of unknown?
-                    return unpacked_items
-                else:
-                    items.extend(unpacked_items)
+                items.extend(self.expand_unpack(item))
             else:
-                # Must preserve original aliases when possible.
                 items.append(item.accept(self))
         return items
 

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -381,6 +381,7 @@ def check_type_arguments(graph: Graph, scc: list[str], errors: Errors) -> None:
             errors,
             state.options,
             is_typeshed_file(state.options.abs_custom_typeshed_dir, state.path or ""),
+            state.manager.semantic_analyzer.named_type,
         )
         with state.wrap_context():
             with mypy.state.state.strict_optional_set(state.options.strict_optional):
@@ -399,6 +400,7 @@ def check_type_arguments_in_targets(
         errors,
         state.options,
         is_typeshed_file(state.options.abs_custom_typeshed_dir, state.path or ""),
+        state.manager.semantic_analyzer.named_type,
     )
     with state.wrap_context():
         with mypy.state.state.strict_optional_set(state.options.strict_optional):

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -17,8 +17,7 @@ reveal_type(f(args))  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
 
 reveal_type(f(varargs))  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 
-if object():
-    f(0)  # E: Argument 1 to "f" has incompatible type "int"; expected <nothing>
+f(0)  # E: Argument 1 to "f" has incompatible type "int"; expected "Tuple[<nothing>, ...]"
 
 def g(a: Tuple[Unpack[Ts]], b: Tuple[Unpack[Ts]]) -> Tuple[Unpack[Ts]]:
     return a
@@ -26,7 +25,7 @@ def g(a: Tuple[Unpack[Ts]], b: Tuple[Unpack[Ts]]) -> Tuple[Unpack[Ts]]:
 reveal_type(g(args, args))  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
 reveal_type(g(args, args2))  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
 reveal_type(g(args, args3))  # N: Revealed type is "builtins.tuple[builtins.object, ...]"
-reveal_type(g(any, any))  # N: Revealed type is "Any"
+reveal_type(g(any, any))  # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarTupleMixed]


### PR DESCRIPTION
This is a small but possibly important PR. Wherever possible we should represent user error and/or failed type inference as `*tuple[Any, ...]`/`*tuple[<nothing>, ...]`, rather than `Unpack[Any]`/`Unpack[<nothing>]` or plain `Any`/`<nothing>`. This way we will not need any special casing for failure conditions in various places without risking a crash instead of a graceful failure (error message).