### PR TITLE
Make PEP 695 constructs give a reasonable error message

### DIFF
--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -241,7 +241,9 @@ def num_skipped_suffix_lines(a1: list[str], a2: list[str]) -> int:
 
 
 def testfile_pyversion(path: str) -> tuple[int, int]:
-    if path.endswith("python311.test"):
+    if path.endswith("python312.test"):
+        return 3, 12
+    elif path.endswith("python311.test"):
         return 3, 11
     elif path.endswith("python310.test"):
         return 3, 10

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -43,6 +43,8 @@ if sys.version_info < (3, 10):
     typecheck_files.remove("check-python310.test")
 if sys.version_info < (3, 11):
     typecheck_files.remove("check-python311.test")
+if sys.version_info < (3, 12):
+    typecheck_files.remove("check-python312.test")
 
 # Special tests for platforms with case-insensitive filesystems.
 if sys.platform not in ("darwin", "win32"):

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1,0 +1,35 @@
+[case test695TypeAlias]
+type MyInt = int  # E: PEP 695 type aliases are not yet supported
+
+def f(x: MyInt) -> MyInt:
+    return reveal_type(x)  # N: Revealed type is "builtins.int"
+
+type MyList[T] = list[T]  # E: PEP 695 type aliases are not yet supported \
+                          # E: Name "T" is not defined
+
+def g(x: MyList[int]) -> MyList[int]:  # E: Variable "__main__.MyList" is not valid as a type \
+                                       # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+    return reveal_type(x)  # N: Revealed type is "MyList?[builtins.int]"
+
+[case test695Class]
+class MyGen[T]:  # E: PEP 695 generics are not yet supported
+    def __init__(self, x: T) -> None:  # E: Name "T" is not defined
+        self.x = x
+
+def f(x: MyGen[int]):  # E: "MyGen" expects no type arguments, but 1 given
+    reveal_type(x.x)  # N: Revealed type is "Any"
+
+[case test695Function]
+def f[T](x: T) -> T:  # E: PEP 695 generics are not yet supported \
+                      # E: Name "T" is not defined
+    return reveal_type(x)  # N: Revealed type is "Any"
+
+reveal_type(f(1))  # N: Revealed type is "Any"
+
+async def g[T](x: T) -> T:  # E: PEP 695 generics are not yet supported \
+                            # E: Name "T" is not defined
+    return reveal_type(x)  # N: Revealed type is "Any"
+
+reveal_type(g(1))  # E: Value of type "Coroutine[Any, Any, Any]" must be used \
+                   # N: Are you missing an await? \
+                   # N: Revealed type is "typing.Coroutine[Any, Any, Any]"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -33,3 +33,27 @@ async def g[T](x: T) -> T:  # E: PEP 695 generics are not yet supported \
 reveal_type(g(1))  # E: Value of type "Coroutine[Any, Any, Any]" must be used \
                    # N: Are you missing an await? \
                    # N: Revealed type is "typing.Coroutine[Any, Any, Any]"
+
+[case test695TypeVar]
+from typing import Callable
+type Alias1[T: int] = list[T]  # E: PEP 695 type aliases are not yet supported
+type Alias2[**P] = Callable[P, int]  # E: PEP 695 type aliases are not yet supported \
+                                     # E: Value of type "int" is not indexable \
+                                     # E: Name "P" is not defined
+type Alias3[*Ts] = tuple[*Ts]  # E: PEP 695 type aliases are not yet supported \
+                               # E: Type expected within [...] \
+                               # E: The type "Type[Tuple[Any, ...]]" is not generic and not indexable \
+                               # E: Name "Ts" is not defined
+
+class Cls1[T: int]: ...  # E: PEP 695 generics are not yet supported
+class Cls2[**P]: ...  # E: PEP 695 generics are not yet supported
+class Cls3[*Ts]: ...  # E: PEP 695 generics are not yet supported
+
+def func1[T: int](x: T) -> T: ...  # E: PEP 695 generics are not yet supported
+def func2[**P](x: Callable[P, int]) -> Callable[P, str]: ...  # E: PEP 695 generics are not yet supported \
+                                                              # E: The first argument to Callable must be a list of types, parameter specification, or "..." \
+                                                              # N: See https://mypy.readthedocs.io/en/stable/kinds_of_types.html#callable-types-and-lambdas \
+                                                              # E: Name "P" is not defined
+def func3[*Ts](x: tuple[*Ts]) -> tuple[int, *Ts]: ...  # E: PEP 695 generics are not yet supported \
+                                                       # E: Name "Ts" is not defined
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Mypy does not yet support PEP 695

Fixes #16011, linking #15238