### PR TITLE
Add config file docs for `install_types` and `non_interactive`

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -1023,6 +1023,21 @@ Miscellaneous
 
 These options may only be set in the global section (``[mypy]``).
 
+.. confval:: install_types
+
+    :type: boolean
+    :default: False
+
+    Causes mypy to install known missing stub packages for third-party libraries using pip.
+
+.. confval:: non_interactive
+
+    :type: boolean
+    :default: False
+
+    When used together with `--install-types`, this causes mypy to install all suggested
+    stub packages using pip without asking for confirmation.
+
 .. confval:: junit_xml
 
     :type: string


### PR DESCRIPTION
Since the config file docs currently do not mention `install_types` and `non_interactive`, this PR lists the two options together with some short explanation, taken from the [command line docs](https://mypy.readthedocs.io/en/stable/command_line.html#miscellaneous).