### PR TITLE
Fix crash with report generation on namespace packages (again)

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -171,8 +171,12 @@ class LineCountReporter(AbstractReporter):
     ) -> None:
         # Count physical lines.  This assumes the file's encoding is a
         # superset of ASCII (or at least uses \n in its line endings).
-        with open(tree.path, "rb") as f:
-            physical_lines = len(f.readlines())
+        try:
+            with open(tree.path, "rb") as f:
+                physical_lines = len(f.readlines())
+        except IsADirectoryError:
+            # can happen with namespace packages
+            physical_lines = 0
 
         func_counter = FuncCounterVisitor()
         tree.accept(func_counter)


### PR DESCRIPTION
Fixes #15979. Fix is similar to that in `iterate_python_lines`.