### PR TITLE
Avoid over eagerly using type context in union returns

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1946,6 +1946,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # in this case external context is almost everything we have.
             if not is_generic_instance(ctx) and not is_literal_type_like(ctx):
                 return callable.copy_modified()
+            
+        proper_ret_type = get_proper_type(ret_type)
+        if isinstance(proper_ret_type, Instance) and proper_ret_type.type.fullname == "typing.Coroutine":
+            proper_ret_type = proper_ret_type.args[-1]
+
+        if isinstance(proper_ret_type, UnionType) and any(isinstance(t, TypeVarType) for t in proper_ret_type.items):
+            # Avoid over eager inference of type variables in unions containing a type variable.
+            # See github issue #15886
+            return callable.copy_modified()
+        
         args = infer_type_arguments(callable.variables, ret_type, erased_ctx)
         # Only substitute non-Uninhabited and non-erased types.
         new_args: list[Type | None] = []

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3402,3 +3402,31 @@ reveal_type(dec(g))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[b
 h: Callable[[Unpack[Us]], Foo[int]]
 reveal_type(dec(g))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[builtins.int]"
 [builtins fixtures/list.pyi]
+
+[case testEagerInferenceOfGenericUnionReturn]
+from typing import Generic, TypeVar, Union
+
+T = TypeVar("T")
+
+class Cls(Generic[T]):
+    pass
+
+def inner(c: Cls[T]) -> Union[T, int]:
+    return 1
+
+def outer(c: Cls[T]) -> Union[T, int]:
+    return inner(c)
+
+[case testEagerInferenceOfGenericUnionReturnAsync]
+from typing import Generic, TypeVar, Optional
+
+T = TypeVar("T")
+
+class Cls(Generic[T]):
+    pass
+
+async def inner(c: Cls[T]) -> Optional[T]:
+    return None
+
+async def outer(c: Cls[T]) -> Optional[T]:
+    return await inner(c)


### PR DESCRIPTION
Avoid an incorrect arg-type error in cases like:
```python
from typing import Generic, TypeVar

T = TypeVar("T")

class Cls(Generic[T]):
    pass

def inner(c: Cls[T]) -> T | int:
    return 1

def outer(c: Cls[T]) -> T | int:
    return inner(c) # Argument 1 to "inner" has incompatible type "Cls[T]"; expected "Cls[T | int]"  [arg-type]
```

Fixes https://github.com/python/mypy/issues/15886.

