### PR TITLE
Add `add_overloaded_method_to_class` helper to `plugins/common.py`

### DIFF
--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -18,10 +18,10 @@ from mypy.nodes import (
     JsonDict,
     NameExpr,
     Node,
+    OverloadedFuncDef,
     PassStmt,
     RefExpr,
     SymbolTableNode,
-    OverloadedFuncDef,
     TypeInfo,
     Var,
 )
@@ -239,14 +239,19 @@ def add_method_to_class(
     """Adds a new method to a class definition."""
     _prepare_class_namespace(cls, name)
 
-    func, sym = _add_method_by_spec(api, cls.info, name, MethodSpec(
-        args=args,
-        return_type=return_type,
-        self_type=self_type,
-        tvar_defs=[tvar_def] if tvar_def else None,
-        is_classmethod=is_classmethod,
-        is_staticmethod=is_staticmethod,
-    ))
+    func, sym = _add_method_by_spec(
+        api,
+        cls.info,
+        name,
+        MethodSpec(
+            args=args,
+            return_type=return_type,
+            self_type=self_type,
+            tvar_defs=[tvar_def] if tvar_def else None,
+            is_classmethod=is_classmethod,
+            is_staticmethod=is_staticmethod,
+        ),
+    )
     cls.info.names[name] = sym
     cls.info.defn.defs.body.append(func)
     return func

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -244,12 +244,7 @@ def add_method_to_class(
         api,
         cls.info,
         name,
-        MethodSpec(
-            args=args,
-            return_type=return_type,
-            self_type=self_type,
-            tvar_defs=tvar_def,
-        ),
+        MethodSpec(args=args, return_type=return_type, self_type=self_type, tvar_defs=tvar_def),
         is_classmethod=is_classmethod,
         is_staticmethod=is_staticmethod,
     )

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -278,7 +278,7 @@ def add_overloaded_method_to_class(
     _prepare_class_namespace(cls, name)
 
     # Create function bodies for each passed method spec.
-    funcs = []
+    funcs: list[Decorator | FuncDef] = []
     for item in items:
         func, _sym = _add_method_by_spec(api, cls.info, name, item)
         if isinstance(func, FuncDef):

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import NamedTuple
+
 from mypy.argmap import map_actuals_to_formals
 from mypy.fixup import TypeFixer
 from mypy.nodes import (
@@ -19,6 +21,8 @@ from mypy.nodes import (
     PassStmt,
     RefExpr,
     SymbolTableNode,
+    OverloadedFuncDef,
+    TypeInfo,
     Var,
 )
 from mypy.plugin import CheckerPluginInterface, ClassDefContext, SemanticAnalyzerPluginInterface
@@ -209,24 +213,96 @@ def add_method(
     )
 
 
+class MethodSpec(NamedTuple):
+    """Represents a method signature to be added, except for `name`."""
+
+    args: list[Argument]
+    return_type: Type
+    self_type: Type | None = None
+    tvar_defs: list[TypeVarType] | None = None
+    is_classmethod: bool = False
+    is_staticmethod: bool = False
+
+
 def add_method_to_class(
     api: SemanticAnalyzerPluginInterface | CheckerPluginInterface,
     cls: ClassDef,
     name: str,
+    # MethodSpec items kept for backward compatibility:
     args: list[Argument],
     return_type: Type,
     self_type: Type | None = None,
     tvar_def: TypeVarType | None = None,
     is_classmethod: bool = False,
     is_staticmethod: bool = False,
-) -> None:
+) -> FuncDef | Decorator:
     """Adds a new method to a class definition."""
+    _prepare_class_namespace(cls, name)
 
-    assert not (
-        is_classmethod is True and is_staticmethod is True
-    ), "Can't add a new method that's both staticmethod and classmethod."
+    func, sym = _add_method_by_spec(api, cls.info, name, MethodSpec(
+        args=args,
+        return_type=return_type,
+        self_type=self_type,
+        tvar_defs=[tvar_def] if tvar_def else None,
+        is_classmethod=is_classmethod,
+        is_staticmethod=is_staticmethod,
+    ))
+    cls.info.names[name] = sym
+    cls.info.defn.defs.body.append(func)
+    return func
 
+
+def add_overloaded_method_to_class(
+    api: SemanticAnalyzerPluginInterface | CheckerPluginInterface,
+    cls: ClassDef,
+    name: str,
+    items: list[MethodSpec],
+) -> OverloadedFuncDef:
+    """Adds a new overloaded method to a class definition."""
+    assert len(items) >= 2, "Overloads must contain at least two cases"
+
+    _prepare_class_namespace(cls, name)
+
+    # Validate that passed items has matching semantics.
+    first_item = items[0]
+    for item in items:
+        if first_item.is_classmethod and not item.is_classmethod:
+            raise AssertionError("All items must be classemethods")
+        if first_item.is_staticmethod and not item.is_staticmethod:
+            raise AssertionError("All items must be staticmethods")
+
+    # Create function bodies for each passed method spec.
+    funcs = []
+    for item in items:
+        func, _sym = _add_method_by_spec(api, cls.info, name, item)
+        if isinstance(func, FuncDef):
+            var = Var(func.name, func.type)
+            var.set_line(func.line)
+            func.is_decorated = True
+            func.deco_line = func.line
+
+            deco = Decorator(func, [], var)
+        else:
+            deco = func
+        deco.is_overload = True
+        funcs.append(deco)
+
+    # Create the final OverloadedFuncDef node:
+    overload_def = OverloadedFuncDef(funcs)
+    overload_def.info = cls.info
+    overload_def.is_class = items[0].is_classmethod
+    overload_def.is_static = items[0].is_staticmethod
+    sym = SymbolTableNode(MDEF, overload_def)
+    sym.plugin_generated = True
+
+    cls.info.names[name] = sym
+    cls.info.defn.defs.body.append(overload_def)
+    return overload_def
+
+
+def _prepare_class_namespace(cls: ClassDef, name: str) -> None:
     info = cls.info
+    assert info
 
     # First remove any previously generated methods with the same name
     # to avoid clashes and problems in the semantic analyzer.
@@ -234,6 +310,26 @@ def add_method_to_class(
         sym = info.names[name]
         if sym.plugin_generated and isinstance(sym.node, FuncDef):
             cls.defs.body.remove(sym.node)
+
+    # NOTE: we would like the plugin generated node to dominate, but we still
+    # need to keep any existing definitions so they get semantically analyzed.
+    if name in info.names:
+        # Get a nice unique name instead.
+        r_name = get_unique_redefinition_name(name, info.names)
+        info.names[r_name] = info.names[name]
+
+
+def _add_method_by_spec(
+    api: SemanticAnalyzerPluginInterface | CheckerPluginInterface,
+    info: TypeInfo,
+    name: str,
+    spec: MethodSpec,
+) -> tuple[FuncDef | Decorator, SymbolTableNode]:
+    args, return_type, self_type, tvar_defs, is_classmethod, is_staticmethod = spec
+
+    assert not (
+        is_classmethod is True and is_staticmethod is True
+    ), "Can't add a new method that's both staticmethod and classmethod."
 
     if isinstance(api, SemanticAnalyzerPluginInterface):
         function_type = api.named_type("builtins.function")
@@ -258,8 +354,8 @@ def add_method_to_class(
         arg_kinds.append(arg.kind)
 
     signature = CallableType(arg_types, arg_kinds, arg_names, return_type, function_type)
-    if tvar_def:
-        signature.variables = [tvar_def]
+    if tvar_defs:
+        signature.variables = tvar_defs
 
     func = FuncDef(name, args, Block([PassStmt()]))
     func.info = info
@@ -268,13 +364,6 @@ def add_method_to_class(
     func.is_static = is_staticmethod
     func._fullname = info.fullname + "." + name
     func.line = info.line
-
-    # NOTE: we would like the plugin generated node to dominate, but we still
-    # need to keep any existing definitions so they get semantically analyzed.
-    if name in info.names:
-        # Get a nice unique name instead.
-        r_name = get_unique_redefinition_name(name, info.names)
-        info.names[r_name] = info.names[name]
 
     # Add decorator for is_staticmethod. It's unnecessary for is_classmethod.
     if is_staticmethod:
@@ -286,12 +375,12 @@ def add_method_to_class(
         dec = Decorator(func, [], v)
         dec.line = info.line
         sym = SymbolTableNode(MDEF, dec)
-    else:
-        sym = SymbolTableNode(MDEF, func)
-    sym.plugin_generated = True
-    info.names[name] = sym
+        sym.plugin_generated = True
+        return dec, sym
 
-    info.defn.defs.body.append(func)
+    sym = SymbolTableNode(MDEF, func)
+    sym.plugin_generated = True
+    return func, sym
 
 
 def add_attribute_to_class(
@@ -304,7 +393,7 @@ def add_attribute_to_class(
     override_allow_incompatible: bool = False,
     fullname: str | None = None,
     is_classvar: bool = False,
-) -> None:
+) -> Var:
     """
     Adds a new attribute to a class definition.
     This currently only generates the symbol table entry and no corresponding AssignmentStatement
@@ -335,6 +424,7 @@ def add_attribute_to_class(
     info.names[name] = SymbolTableNode(
         MDEF, node, plugin_generated=True, no_serialize=no_serialize
     )
+    return node
 
 
 def deserialize_and_fixup_type(data: str | JsonDict, api: SemanticAnalyzerPluginInterface) -> Type:

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -295,8 +295,8 @@ def add_overloaded_method_to_class(
     # Create the final OverloadedFuncDef node:
     overload_def = OverloadedFuncDef(funcs)
     overload_def.info = cls.info
-    overload_def.is_class = items[0].is_classmethod
-    overload_def.is_static = items[0].is_staticmethod
+    overload_def.is_class = first_item.is_classmethod
+    overload_def.is_static = first_item.is_staticmethod
     sym = SymbolTableNode(MDEF, overload_def)
     sym.plugin_generated = True
 

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -232,12 +232,15 @@ def add_method_to_class(
     args: list[Argument],
     return_type: Type,
     self_type: Type | None = None,
-    tvar_def: TypeVarType | None = None,
+    tvar_def: list[TypeVarType] | TypeVarType | None = None,
     is_classmethod: bool = False,
     is_staticmethod: bool = False,
 ) -> FuncDef | Decorator:
     """Adds a new method to a class definition."""
     _prepare_class_namespace(cls, name)
+
+    if tvar_def is not None and not isinstance(tvar_def, list):
+        tvar_def = [tvar_def]
 
     func, sym = _add_method_by_spec(
         api,
@@ -247,7 +250,7 @@ def add_method_to_class(
             args=args,
             return_type=return_type,
             self_type=self_type,
-            tvar_defs=[tvar_def] if tvar_def else None,
+            tvar_defs=tvar_def,
             is_classmethod=is_classmethod,
             is_staticmethod=is_staticmethod,
         ),

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -266,8 +266,6 @@ def add_overloaded_method_to_class(
     """Adds a new overloaded method to a class definition."""
     assert len(items) >= 2, "Overloads must contain at least two cases"
 
-    _prepare_class_namespace(cls, name)
-
     # Validate that passed items has matching semantics.
     first_item = items[0]
     for item in items:
@@ -275,6 +273,9 @@ def add_overloaded_method_to_class(
             raise AssertionError("All items must be classemethods")
         if first_item.is_staticmethod and not item.is_staticmethod:
             raise AssertionError("All items must be staticmethods")
+
+    # Save old definition, if it exists.
+    _prepare_class_namespace(cls, name)
 
     # Create function bodies for each passed method spec.
     funcs = []

--- a/mypy/plugins/common.py
+++ b/mypy/plugins/common.py
@@ -269,10 +269,10 @@ def add_overloaded_method_to_class(
     # Validate that passed items has matching semantics.
     first_item = items[0]
     for item in items:
-        if first_item.is_classmethod and not item.is_classmethod:
-            raise AssertionError("All items must be classemethods")
-        if first_item.is_staticmethod and not item.is_staticmethod:
-            raise AssertionError("All items must be staticmethods")
+        if first_item.is_classmethod != item.is_classmethod:
+            raise AssertionError("Either all items must be classmethods or none")
+        if first_item.is_staticmethod != item.is_staticmethod:
+            raise AssertionError("Either all items must be staticmethods or none")
 
     # Save old definition, if it exists.
     _prepare_class_namespace(cls, name)

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -1011,12 +1011,34 @@ class BaseAddMethod: pass
 class MyClass(BaseAddMethod):
     pass
 
-my_class = MyClass()
 reveal_type(MyClass.foo_classmethod)  # N: Revealed type is "def ()"
 reveal_type(MyClass.foo_staticmethod)  # N: Revealed type is "def (builtins.int) -> builtins.str"
+
+my_class = MyClass()
+reveal_type(my_class.foo_classmethod)  # N: Revealed type is "def ()"
+reveal_type(my_class.foo_staticmethod)  # N: Revealed type is "def (builtins.int) -> builtins.str"
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/add_classmethod.py
+
+[case testAddOverloadedMethodPlugin]
+# flags: --config-file tmp/mypy.ini
+class AddOverloadedMethod: pass
+
+class MyClass(AddOverloadedMethod):
+    pass
+
+reveal_type(MyClass.method)  # N: Revealed type is "Overload(def (self: __main__.MyClass, arg: builtins.int) -> builtins.str, def (self: __main__.MyClass, arg: builtins.str) -> builtins.int)"
+reveal_type(MyClass.clsmethod)  # N: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+reveal_type(MyClass.stmethod)  # N: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+
+my_class = MyClass()
+reveal_type(my_class.method)  # N: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+reveal_type(my_class.clsmethod)  # N: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+reveal_type(my_class.stmethod)  # N: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/add_overloaded_method.py
 
 [case testCustomErrorCodePlugin]
 # flags: --config-file tmp/mypy.ini  --show-error-codes

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5935,6 +5935,44 @@ tmp/b.py:4: note: Revealed type is "def ()"
 tmp/b.py:5: note: Revealed type is "def (builtins.int) -> builtins.str"
 tmp/b.py:6: note: Revealed type is "def ()"
 tmp/b.py:7: note: Revealed type is "def (builtins.int) -> builtins.str"
+
+[case testIncrementalAddOverloadedMethodPlugin]
+# flags: --config-file tmp/mypy.ini
+import b
+
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/add_overloaded_method.py
+
+[file a.py]
+class AddOverloadedMethod: pass
+
+class MyClass(AddOverloadedMethod):
+    pass
+
+[file b.py]
+import a
+
+[file b.py.2]
+import a
+
+reveal_type(a.MyClass.method)
+reveal_type(a.MyClass.clsmethod)
+reveal_type(a.MyClass.stmethod)
+
+my_class = a.MyClass()
+reveal_type(my_class.method)
+reveal_type(my_class.clsmethod)
+reveal_type(my_class.stmethod)
+[rechecked b]
+[out2]
+tmp/b.py:3: note: Revealed type is "Overload(def (self: a.MyClass, arg: builtins.int) -> builtins.str, def (self: a.MyClass, arg: builtins.str) -> builtins.int)"
+tmp/b.py:4: note: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+tmp/b.py:5: note: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+tmp/b.py:8: note: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+tmp/b.py:9: note: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+tmp/b.py:10: note: Revealed type is "Overload(def (arg: builtins.int) -> builtins.str, def (arg: builtins.str) -> builtins.int)"
+
 [case testGenericNamedTupleSerialization]
 import b
 [file a.py]

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1387,12 +1387,13 @@ class B(A):
 <m.A.(abstract)> -> <m.B.__init__>, m
 <m.A.__dataclass_fields__> -> <m.B.__dataclass_fields__>
 <m.A.__init__> -> <m.B.__init__>, m.B.__init__
-<m.A.__mypy-replace> -> <m.B.__mypy-replace>, m.B.__mypy-replace
+<m.A.__mypy-replace> -> <m.B.__mypy-replace>, m, m.B.__mypy-replace
 <m.A.__new__> -> <m.B.__new__>
 <m.A.x> -> <m.B.x>
 <m.A.y> -> <m.B.y>
 <m.A> -> m, m.A, m.B
 <m.A[wildcard]> -> m
+<m.B.__mypy-replace> -> m
 <m.B.y> -> m
 <m.B> -> m.B
 <m.Z> -> m
@@ -1419,12 +1420,13 @@ class B(A):
 <m.A.__dataclass_fields__> -> <m.B.__dataclass_fields__>
 <m.A.__init__> -> <m.B.__init__>, m.B.__init__
 <m.A.__match_args__> -> <m.B.__match_args__>
-<m.A.__mypy-replace> -> <m.B.__mypy-replace>, m.B.__mypy-replace
+<m.A.__mypy-replace> -> <m.B.__mypy-replace>, m, m.B.__mypy-replace
 <m.A.__new__> -> <m.B.__new__>
 <m.A.x> -> <m.B.x>
 <m.A.y> -> <m.B.y>
 <m.A> -> m, m.A, m.B
 <m.A[wildcard]> -> m
+<m.B.__mypy-replace> -> m
 <m.B.y> -> m
 <m.B> -> m.B
 <m.Z> -> m

--- a/test-data/unit/plugins/add_overloaded_method.py
+++ b/test-data/unit/plugins/add_overloaded_method.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from mypy.nodes import ARG_POS, Argument, Var
+from mypy.plugin import ClassDefContext, Plugin
+from mypy.plugins.common import MethodSpec, add_overloaded_method_to_class
+
+
+class OverloadedMethodPlugin(Plugin):
+    def get_base_class_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
+        if "AddOverloadedMethod" in fullname:
+            return add_overloaded_method_hook
+        return None
+
+
+def add_overloaded_method_hook(ctx: ClassDefContext) -> None:
+    add_overloaded_method_to_class(ctx.api, ctx.cls, "method", _generate_method_specs(ctx))
+    add_overloaded_method_to_class(
+        ctx.api, ctx.cls, "clsmethod", _generate_method_specs(ctx, is_classmethod=True)
+    )
+    add_overloaded_method_to_class(
+        ctx.api, ctx.cls, "stmethod", _generate_method_specs(ctx, is_staticmethod=True)
+    )
+
+
+def _generate_method_specs(
+    ctx: ClassDefContext, *, is_classmethod: bool = False, is_staticmethod=False
+) -> list[MethodSpec]:
+    return [
+        MethodSpec(
+            args=[Argument(Var("arg"), ctx.api.named_type("builtins.int"), None, ARG_POS)],
+            return_type=ctx.api.named_type("builtins.str"),
+            is_staticmethod=is_staticmethod,
+            is_classmethod=is_classmethod,
+        ),
+        MethodSpec(
+            args=[Argument(Var("arg"), ctx.api.named_type("builtins.str"), None, ARG_POS)],
+            return_type=ctx.api.named_type("builtins.int"),
+            is_staticmethod=is_staticmethod,
+            is_classmethod=is_classmethod,
+        ),
+    ]
+
+
+def plugin(version: str) -> type[OverloadedMethodPlugin]:
+    return OverloadedMethodPlugin

--- a/test-data/unit/plugins/add_overloaded_method.py
+++ b/test-data/unit/plugins/add_overloaded_method.py
@@ -25,7 +25,7 @@ def add_overloaded_method_hook(ctx: ClassDefContext) -> None:
 
 
 def _generate_method_specs(
-    ctx: ClassDefContext, *, is_classmethod: bool = False, is_staticmethod=False
+    ctx: ClassDefContext, *, is_classmethod: bool = False, is_staticmethod: bool = False
 ) -> list[MethodSpec]:
     return [
         MethodSpec(

--- a/test-data/unit/plugins/add_overloaded_method.py
+++ b/test-data/unit/plugins/add_overloaded_method.py
@@ -17,28 +17,22 @@ class OverloadedMethodPlugin(Plugin):
 def add_overloaded_method_hook(ctx: ClassDefContext) -> None:
     add_overloaded_method_to_class(ctx.api, ctx.cls, "method", _generate_method_specs(ctx))
     add_overloaded_method_to_class(
-        ctx.api, ctx.cls, "clsmethod", _generate_method_specs(ctx, is_classmethod=True)
+        ctx.api, ctx.cls, "clsmethod", _generate_method_specs(ctx), is_classmethod=True
     )
     add_overloaded_method_to_class(
-        ctx.api, ctx.cls, "stmethod", _generate_method_specs(ctx, is_staticmethod=True)
+        ctx.api, ctx.cls, "stmethod", _generate_method_specs(ctx), is_staticmethod=True
     )
 
 
-def _generate_method_specs(
-    ctx: ClassDefContext, *, is_classmethod: bool = False, is_staticmethod: bool = False
-) -> list[MethodSpec]:
+def _generate_method_specs(ctx: ClassDefContext) -> list[MethodSpec]:
     return [
         MethodSpec(
             args=[Argument(Var("arg"), ctx.api.named_type("builtins.int"), None, ARG_POS)],
             return_type=ctx.api.named_type("builtins.str"),
-            is_staticmethod=is_staticmethod,
-            is_classmethod=is_classmethod,
         ),
         MethodSpec(
             args=[Argument(Var("arg"), ctx.api.named_type("builtins.str"), None, ARG_POS)],
             return_type=ctx.api.named_type("builtins.int"),
-            is_staticmethod=is_staticmethod,
-            is_classmethod=is_classmethod,
         ),
     ]
 


### PR DESCRIPTION
There are several changes:

1. `add_overloaded_method_to_class` itself. It is very useful for plugin authors, because right now it is quite easy to add a regular method, but it is very hard to add a method with `@overload`s. I don't think that user must face all the chalenges that I've covered in this method. Moreover, it is quite easy even for experienced developers to forget some flags / props / etc (I am pretty sure that I might forgot something in the implementation)
2. `add_overloaded_method_to_class` and `add_method_to_class` now return added nodes, it is also helpful if you want to do something with this node in your plugin after it is created
3. I've refactored how `add_method_to_class` works and reused its parts in the new method as well
4. `tvar_def` in `add_method_to_class` can now accept a list of type vars, not just one

Notice that `add_method_to_class` is unchanged from the user's POV, it should continue to work as before.

Tests are also updated to check that our overloads are correct.

Things to do later (in the next PRs / releases):
1. We can possibly add `is_final` param to methods as well
2. We can also support `@property` in a separate method at some point