### PR TITLE
Remove type aliases that are long supported

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -138,9 +138,7 @@ type_aliases: Final = {
 
 # This keeps track of the oldest supported Python version where the corresponding
 # alias source is available.
-type_aliases_source_versions: Final = {
-    "typing.LiteralString": (3, 11),
-}
+type_aliases_source_versions: Final = {"typing.LiteralString": (3, 11)}
 
 # This keeps track of aliases in `typing_extensions`, which we treat specially.
 typing_extensions_aliases: Final = {

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -139,15 +139,6 @@ type_aliases: Final = {
 # This keeps track of the oldest supported Python version where the corresponding
 # alias source is available.
 type_aliases_source_versions: Final = {
-    "typing.List": (2, 7),
-    "typing.Dict": (2, 7),
-    "typing.Set": (2, 7),
-    "typing.FrozenSet": (2, 7),
-    "typing.ChainMap": (3, 3),
-    "typing.Counter": (2, 7),
-    "typing.DefaultDict": (2, 7),
-    "typing.Deque": (2, 7),
-    "typing.OrderedDict": (3, 7),
     "typing.LiteralString": (3, 11),
 }
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -680,7 +680,7 @@ class SemanticAnalyzer(
         """
         assert tree.fullname == "typing"
         for alias, target_name in type_aliases.items():
-            if type_aliases_source_versions[alias] > self.options.python_version:
+            if alias in type_aliases_source_versions and type_aliases_source_versions[alias] > self.options.python_version:
                 # This alias is not available on this Python version.
                 continue
             name = alias.split(".")[-1]

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -680,7 +680,10 @@ class SemanticAnalyzer(
         """
         assert tree.fullname == "typing"
         for alias, target_name in type_aliases.items():
-            if alias in type_aliases_source_versions and type_aliases_source_versions[alias] > self.options.python_version:
+            if (
+                alias in type_aliases_source_versions
+                and type_aliases_source_versions[alias] > self.options.python_version
+            ):
                 # This alias is not available on this Python version.
                 continue
             name = alias.split(".")[-1]


### PR DESCRIPTION
Some builtin aliases are available for all python versions that we support. So, there's no need to check them in `semanal`:

https://github.com/python/mypy/blob/8738886861682e0d168ea321c2cc6ee5b566cb8b/mypy/semanal.py#L673-L689