### PR TITLE
Use latest `actions/checkout@v4`

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'python/mypy'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       TOX_SKIP_MISSING_INTERPRETERS: False
       VERIFY_MYPY_ERROR_CODES: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -33,7 +33,7 @@ jobs:
         shard-index: [0, 1, 2, 3, 4]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: mypy_to_test
           fetch-depth: 0

--- a/.github/workflows/sync_typeshed.yml
+++ b/.github/workflows/sync_typeshed.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'python/mypy'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
         # TODO: use whatever solution ends up working for

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
       # Pytest
       PYTEST_ADDOPTS: --color=yes
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
@@ -162,7 +162,7 @@ jobs:
       CXX: i686-linux-gnu-g++
       CC: i686-linux-gnu-gcc
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install 32-bit build dependencies
         run: |
           sudo dpkg --add-architecture i386 && \

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup 🐍 3.8
       uses: actions/setup-python@v4


### PR DESCRIPTION
Looks like recent CI failures are related.
Release docs: https://github.com/actions/checkout/releases/tag/v4.0.0