### PR TITLE
Document `force_union_syntax` and `force_uppercase_builtins`

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -816,12 +816,12 @@ These options may only be set in the global section (``[mypy]``).
 
     Show absolute paths to files.
 
-.. confval:: force_lowercase_builtins
+.. confval:: force_uppercase_builtins
 
     :type: boolean
     :default: False
 
-    Force to use ``List`` instead of ``list`` .
+    Force to use ``List`` instead of ``list``.
 
 .. confval:: force_union_syntax
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -816,6 +816,19 @@ These options may only be set in the global section (``[mypy]``).
 
     Show absolute paths to files.
 
+.. confval:: force_lowercase_builtins
+
+    :type: boolean
+    :default: False
+
+    Force to use ``List`` instead of ``list`` .
+
+.. confval:: force_union_syntax
+
+    :type: boolean
+    :default: False
+
+    Force to use ``Union[]`` type instead of ``|`` operator.
 
 Incremental mode
 ****************

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -821,14 +821,17 @@ These options may only be set in the global section (``[mypy]``).
     :type: boolean
     :default: False
 
-    Force to use ``List`` instead of ``list``.
+    Always use ``List`` instead of ``list`` in error messages,
+    even on Python 3.9+.
 
 .. confval:: force_union_syntax
 
     :type: boolean
     :default: False
 
-    Force to use ``Union[]`` type instead of ``|`` operator.
+    Always use ``Union[]`` and ``Optional[]`` for union types
+    in error messages (instead of the ``|`` operator),
+    even on Python 3.10+.
 
 Incremental mode
 ****************


### PR DESCRIPTION
Users don't know about them: https://github.com/typeddjango/pytest-mypy-plugins/issues/126
Since they are quite important for testing, I think that it is a must to include them.