### PR TITLE
Clear cache when adding --new-type-inference

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -62,6 +62,7 @@ OPTIONS_AFFECTING_CACHE: Final = (
     | {
         "platform",
         "bazel",
+        "new_type_inference",
         "plugins",
         "disable_bytearray_promotion",
         "disable_memoryview_promotion",


### PR DESCRIPTION
Add `new_type_inference` to the list of options affecting the cache.