### PR TITLE
Introduce error category [unsafe-overload]

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -237,9 +237,7 @@ REDUNDANT_SELF_TYPE = ErrorCode(
     "General",
     default_enabled=False,
 )
-UNSAFE_OVERLOAD: Final[ErrorCode] = ErrorCode(
-    "unsafe-overload", "Warn if multiple @overload variants overlap in unsafe ways", "General"
-)
+
 USED_BEFORE_DEF: Final[ErrorCode] = ErrorCode(
     "used-before-def", "Warn about variables that are used before they are defined", "General"
 )
@@ -264,3 +262,10 @@ del error_codes[FILE.code]
 
 # This is a catch-all for remaining uncategorized errors.
 MISC: Final = ErrorCode("misc", "Miscellaneous other checks", "General")
+
+UNSAFE_OVERLOAD: Final[ErrorCode] = ErrorCode(
+    "unsafe-overload",
+    "Warn if multiple @overload variants overlap in unsafe ways",
+    "General",
+    sub_code_of=MISC,
+)

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -237,6 +237,9 @@ REDUNDANT_SELF_TYPE = ErrorCode(
     "General",
     default_enabled=False,
 )
+UNSAFE_OVERLOAD: Final[ErrorCode] = ErrorCode(
+    "unsafe-overload", "Warn if multiple @overload variants overlap in unsafe ways", "General"
+)
 USED_BEFORE_DEF: Final[ErrorCode] = ErrorCode(
     "used-before-def", "Warn about variables that are used before they are defined", "General"
 )

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1601,8 +1601,9 @@ class MessageBuilder:
 
     def overloaded_signatures_overlap(self, index1: int, index2: int, context: Context) -> None:
         self.fail(
-            "Overloaded function signatures {} and {} overlap with "
-            "incompatible return types".format(index1, index2),
+            f"Overloaded function signatures {index1} and {index2} overlap "
+            "with incompatible return types. "
+            "See https://mypy.readthedocs.io/en/stable/more_types.html#type-checking-the-variants.",
             context,
             code=codes.UNSAFE_OVERLOAD,
         )

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1601,9 +1601,8 @@ class MessageBuilder:
 
     def overloaded_signatures_overlap(self, index1: int, index2: int, context: Context) -> None:
         self.fail(
-            f"Overloaded function signatures {index1} and {index2} overlap "
-            "with incompatible return types. "
-            "See https://mypy.readthedocs.io/en/stable/more_types.html#type-checking-the-variants.",
+            f"Overloaded function signatures {index1} and {index2} overlap with incompatible return types",
+            # "See https://mypy.readthedocs.io/en/stable/more_types.html#type-checking-the-variants.",
             context,
             code=codes.UNSAFE_OVERLOAD,
         )

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1604,6 +1604,7 @@ class MessageBuilder:
             "Overloaded function signatures {} and {} overlap with "
             "incompatible return types".format(index1, index2),
             context,
+            code=codes.UNSAFE_OVERLOAD,
         )
 
     def overloaded_signature_will_never_match(

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3019,7 +3019,7 @@ def get_proper_type(typ: Type | None) -> ProperType | None:
 
 
 @overload
-def get_proper_types(types: list[Type] | tuple[Type, ...]) -> list[ProperType]:  # type: ignore[misc]
+def get_proper_types(types: list[Type] | tuple[Type, ...]) -> list[ProperType]:  # type: ignore[unsafe-overload]
     ...
 
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -1072,3 +1072,17 @@ A.f = h  # type: ignore[assignment]  # E: Unused "type: ignore" comment, use nar
 [case testUnusedIgnoreEnableCode]
 # flags: --enable-error-code=unused-ignore
 x = 1  # type: ignore  # E: Unused "type: ignore" comment  [unused-ignore]
+
+[case testErrorCodeUnsafeOverloadError]
+from typing import overload, Union
+
+@overload
+def unsafe_func(x: int) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types  [unsafe-overload]
+@overload
+def unsafe_func(x: object) -> str: ...
+def unsafe_func(x: object) -> Union[int, str]:
+    if isinstance(x, int):
+        return 42
+    else:
+        return "some string"
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

fixes #16060

- [x] adds `codes.UNSAFE_OVERLOAD`
- [x] unsafe overloads now raise `[unsafe-overload]`
- [ ] added unit test

Notes:

- Within `mypy` source code, `types/get_proper_types` needed a modified type-ignore.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
