### PR TITLE
Clearly differentiate between venv and tox setups in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,16 +110,8 @@ tox -e dev -- mypy --verbose test_case.py
 tox -e dev --override testenv:dev.allowlist_externals+=env -- env  # inspect the environment
 ```
 
-If you don't already have `tox` installed, you can use a virtual environment.
-
-``` bash
-# On Windows, the commands may be slightly different. For more details, see
-# https://docs.python.org/3/library/venv.html#creating-virtual-environments
-python3 -m venv venv
-source venv/bin/activate
-python3 -m pip install tox
-hash -r  # This resets shell PATH cache, not necessary on Windows
-```
+If you don't already have `tox` installed, you can use a virtual environment as
+described above to install `tox` via `pip` (e.g., ``python3 -m pip install tox``).
 
 ## First time contributors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,18 +62,6 @@ like this:
 python3 runtests.py
 ```
 
-You can also use `tox` to run tests (`tox` handles setting up the test environment for you):
-
-```bash
-tox run -e py
-
-# Or some specific python version:
-tox run -e py39
-
-# Or some specific command:
-tox run -e lint
-```
-
 Some useful commands for running specific tests include:
 
 ```bash
@@ -94,6 +82,44 @@ python runtests.py lint
 
 For an in-depth guide on running and writing tests,
 see [the README in the test-data directory](test-data/unit/README.md).
+
+#### Using `tox`
+
+You can also use [`tox`](https://tox.wiki/en/latest/) to run tests and other commands.
+`tox` handles setting up test environments for you.
+
+```bash
+# Run tests
+tox run -e py
+
+# Run tests using some specific Python version
+tox run -e py311
+
+# Run a specific command
+tox run -e lint
+
+# Run a single test from the test suite
+tox run -e py -- -n0 -k 'test_name'
+
+# Run all test cases in the "test-data/unit/check-dataclasses.test" file using
+# Python 3.11 specifically
+tox run -e py311 -- mypy/test/testcheck.py::TypeCheckSuite::check-dataclasses.test
+
+# Set up a development environment with all the project libraries and run a command
+tox -e dev -- mypy --verbose test_case.py
+tox -e dev --override testenv:dev.allowlist_externals+=env -- env  # inspect the environment
+```
+
+If you don't already have `tox` installed, you can use a virtual environment.
+
+``` bash
+# On Windows, the commands may be slightly different. For more details, see
+# https://docs.python.org/3/library/venv.html#creating-virtual-environments
+python3 -m venv venv
+source venv/bin/activate
+python3 -m pip install tox
+hash -r  # This resets shell PATH cache, not necessary on Windows
+```
 
 ## First time contributors
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
 commands =
     python -m pip list --format=columns
     python -c 'import sys; print(sys.executable)'
+    {posargs}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
Documentation changes are visible [here](https://github.com/posita/mypy/blob/posita/0/tweak-contributing-docs/CONTRIBUTING.md#using-tox). Commit message below.

---

The blurb on how to use `tox` existed in the middle of the [**Running tests** section](/mypy/blob/master/CONTRIBUTING.md#running-tests), and was bookended without headings by non-`tox` workflow material. This more clearly delineates between `tox` and non-`tox` workflows for the newcomer.

This also non-invasively allows running arbitrary commands using `testenv:dev`.

``` sh
% tox -e dev
# ... works as before
% tox -e dev -- mypy runtests.py
# ... runs dev commands and then runs mypy on runtests.py
dev: commands[2]> mypy runtests.py
Success: no issues found in 1 source file
# ...
% tox -e dev --override testenv:dev.allowlist_externals+=env -- env
# ... runs dev commands and then runs env in dev environment
test_case.py
dev: commands[2]> env
HOME=/home/posita
LANG=en_US.UTF-8
LANGUAGE=en_US.UTF8
TERM=xterm-256color
PATH=/home/posita/dev/3p/mypy/.tox/dev/bin:/home/posita/dev/3p/mypy/venv/bin:...
PYTHONHASHSEED=...
PIP_DISABLE_PIP_VERSION_CHECK=1
PYTHONIOENCODING=utf-8
TOX_ENV_NAME=dev
TOX_WORK_DIR=/home/posita/dev/3p/mypy/.tox
TOX_ENV_DIR=/home/posita/dev/3p/mypy/.tox/dev
VIRTUAL_ENV=/home/posita/dev/3p/mypy/.tox/dev
TOX_PACKAGE=/home/posita/dev/3p/mypy/.tox/.tmp/package/28/mypy-1.7.0+dev.6d19f9ddf110d4ad3af63d472e8d7aaf69e6260c.dirty-0.editable-py3-none-any.whl
# ...
```