### PR TITLE
Build the docs in CI for all PRs touching the `mypy/` directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,9 +9,9 @@ on:
     paths:
     - 'docs/**'
     # We now have a docs check that fails if any error codes don't have documentation,
-    # so it's important to do the docs build on all PRs touching the mypy/ directory
+    # so it's important to do the docs build on all PRs touching mypy/errocodes.py
     # in case somebody's adding a new error code without any docs
-    - 'mypy/**'
+    - 'mypy/errocodes.py'
     - 'mypyc/doc/**'
     - '**/*.rst'
     - '**/*.md'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
     paths:
     - 'docs/**'
     # We now have a docs check that fails if any error codes don't have documentation,
-    # so it's important to do the docs build on all PRs touching mypy/errocodes.py
+    # so it's important to do the docs build on all PRs touching mypy/errorcodes.py
     # in case somebody's adding a new error code without any docs
     - 'mypy/errorcodes.py'
     - 'mypyc/doc/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     paths:
     - 'docs/**'
+    # We now have a docs check that fails if any error codes don't have documentation,
+    # so it's important to do the docs build on all PRs touching the mypy/ directory
+    # in case somebody's adding a new error code without any docs
+    - 'mypy/**'  
     - 'mypyc/doc/**'
     - '**/*.rst'
     - '**/*.md'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
     # We now have a docs check that fails if any error codes don't have documentation,
     # so it's important to do the docs build on all PRs touching mypy/errocodes.py
     # in case somebody's adding a new error code without any docs
-    - 'mypy/errocodes.py'
+    - 'mypy/errorcodes.py'
     - 'mypyc/doc/**'
     - '**/*.rst'
     - '**/*.md'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
     # We now have a docs check that fails if any error codes don't have documentation,
     # so it's important to do the docs build on all PRs touching the mypy/ directory
     # in case somebody's adding a new error code without any docs
-    - 'mypy/**'  
+    - 'mypy/**'
     - 'mypyc/doc/**'
     - '**/*.rst'
     - '**/*.md'


### PR DESCRIPTION
1. #16061 added a new error code, but didn't add any docs for the new error code
2. Because nothing in the `docs/` directory was modified, the docs CI job didn't run on that PR
3. Now the docs build is failing on `master` because we have an error code without any documentation: https://github.com/python/mypy/actions/runs/6112378542/job/16589719563