### PR TITLE
Allow TypedDict unpacking in Callable types

### DIFF
--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -196,6 +196,8 @@ def expr_to_unanalyzed_type(
     elif isinstance(expr, EllipsisExpr):
         return EllipsisType(expr.line)
     elif allow_unpack and isinstance(expr, StarExpr):
-        return UnpackType(expr_to_unanalyzed_type(expr.expr, options, allow_new_syntax))
+        return UnpackType(
+            expr_to_unanalyzed_type(expr.expr, options, allow_new_syntax), from_star_syntax=True
+        )
     else:
         raise TypeTranslationError()

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -2041,7 +2041,7 @@ class TypeConverter:
 
     # Used for Callable[[X *Ys, Z], R]
     def visit_Starred(self, n: ast3.Starred) -> Type:
-        return UnpackType(self.visit(n.value))
+        return UnpackType(self.visit(n.value), from_star_syntax=True)
 
     # List(expr* elts, expr_context ctx)
     def visit_List(self, n: ast3.List) -> Type:

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -214,7 +214,9 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
             # Avoid extra errors if there were some errors already. Also interpret plain Any
             # as tuple[Any, ...] (this is better for the code in type checker).
             self.fail(
-                message_registry.INVALID_UNPACK.format(format_type(proper_type, self.options)), typ
+                message_registry.INVALID_UNPACK.format(format_type(proper_type, self.options)),
+                typ.type,
+                code=codes.VALID_TYPE,
             )
         typ.type = self.named_type("builtins.tuple", [AnyType(TypeOfAny.from_error)])
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1053,11 +1053,14 @@ class UnpackType(ProperType):
     wild west, technically anything can be present in the wrapped type.
     """
 
-    __slots__ = ["type"]
+    __slots__ = ["type", "from_star_syntax"]
 
-    def __init__(self, typ: Type, line: int = -1, column: int = -1) -> None:
+    def __init__(
+        self, typ: Type, line: int = -1, column: int = -1, from_star_syntax: bool = False
+    ) -> None:
         super().__init__(line, column)
         self.type = typ
+        self.from_star_syntax = from_star_syntax
 
     def accept(self, visitor: TypeVisitor[T]) -> T:
         return visitor.visit_unpack_type(self)

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -1079,3 +1079,18 @@ class C:
 class D:
     def __init__(self, **kwds: Unpack[int, str]) -> None: ...  # E: Unpack[...] requires exactly one type argument
 [builtins fixtures/dict.pyi]
+
+[case testUnpackInCallableType]
+from typing import Callable
+from typing_extensions import Unpack, TypedDict
+
+class TD(TypedDict):
+    key: str
+    value: str
+
+foo: Callable[[Unpack[TD]], None]
+foo(key="yes", value=42)  # E: Argument "value" has incompatible type "int"; expected "str"
+foo(key="yes", value="ok")
+
+bad: Callable[[*TD], None]  # E: "TD" cannot be unpacked (must be tuple or TypeVarTuple)
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16082

Currently we only allow `Unpack` of a TypedDict when it appears in a function definition. This PR also allows this in `Callable` types, similarly to how we do this for variadic types.

Note this still doesn't allow having both variadic unpack and a TypedDict unpack in the same `Callable`. Supporting this is tricky, so let's not so this until people will actually ask for this. FWIW we can always suggest callback protocols for such tricky cases.