### PR TITLE
Warn for missing returns with explicit Any return types

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1336,7 +1336,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if self.options.warn_no_return:
                     if (
                         not self.current_node_deferred
-                        and not isinstance(return_type, (NoneType, AnyType))
+                        and not isinstance(return_type, NoneType)
+                        and (
+                            not isinstance(return_type, AnyType)
+                            or return_type.type_of_any == TypeOfAny.explicit
+                        )
                         and show_error
                     ):
                         # Control flow fell off the end of a function that was

--- a/mypyc/test-data/run-primitives.test
+++ b/mypyc/test-data/run-primitives.test
@@ -168,6 +168,7 @@ def get_item(o: Any, k: Any) -> Any:
     return o[k]
 def set_item(o: Any, k: Any, v: Any) -> Any:
     o[k] = v
+    return o
 [file driver.py]
 from native import *
 assert neg(6) == -6

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -187,6 +187,7 @@ def f(x: Any) -> Any:
     foo = 1
     if int():
         foo = "bar"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+    return foo
 
 @overload
 def g(x: 'A') -> 'B': ...
@@ -4906,6 +4907,7 @@ def f() -> None:
     def g(x: T) -> Dict[int, T]: ...
     def g(*args, **kwargs) -> Any:
         reveal_type(h(C()))  # N: Revealed type is "builtins.dict[builtins.str, __main__.C]"
+        return args
 
     @overload
     def h() -> None: ...
@@ -4913,6 +4915,7 @@ def f() -> None:
     def h(x: T) -> Dict[str, T]: ...
     def h(*args, **kwargs) -> Any:
         reveal_type(g(C()))  # N: Revealed type is "builtins.dict[builtins.int, __main__.C]"
+        return args
 
 [builtins fixtures/dict.pyi]
 [out]

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -154,6 +154,16 @@ def implicit(x: Any):
 def explicit(x: Any) -> Any:  # E: Missing return statement
     if maybe():
         return x
+        
+def explicit_with_none(x: Any) -> Any:
+    if maybe():
+        return x
+    return None
+    
+def explicit_with_just_return(x: Any) -> Any:
+    if maybe():
+        return x
+    return
 
 def mystery(x: Any) -> Mystery:
     if maybe():

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -140,6 +140,24 @@ def f() -> int:
     pass
 [out]
 
+[case testNoReturnExplicitAny]
+# flags: --warn-no-return
+from typing import Any
+from unknown import Mystery  # type: ignore[import]
+
+def maybe() -> bool: ...
+
+def implicit(x: Any):
+    if maybe():
+        return x
+
+def explicit(x: Any) -> Any:  # E: Missing return statement
+    if maybe():
+        return x
+
+def mystery(x: Any) -> Mystery:
+    if maybe():
+        return x
 
 -- Returning Any
 -- -------------

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -154,12 +154,12 @@ def implicit(x: Any):
 def explicit(x: Any) -> Any:  # E: Missing return statement
     if maybe():
         return x
-        
+
 def explicit_with_none(x: Any) -> Any:
     if maybe():
         return x
     return None
-    
+
 def explicit_with_just_return(x: Any) -> Any:
     if maybe():
         return x

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -917,6 +917,7 @@ def f(x: str) -> submod.B: pass
 def f(x) -> Any:
     y: submod.C
     y.x
+    return y
 [file submod.py]
 class A: pass
 class B: pass
@@ -959,6 +960,7 @@ def f(x: int) -> None: pass
 def f(x: str) -> str: pass
 def f(x: Any) -> Any:
     mod.g()
+    return mod
 [file mod.py]
 def g() -> int:
     pass
@@ -976,6 +978,7 @@ def outer() -> None:
     def f(x: str) -> mod.B: pass
     def f(x: Any) -> Any:
         mod.g()
+        return mod
 [file mod.py]
 def g() -> int:
     pass
@@ -997,6 +1000,7 @@ def outer() -> None:
     def f(x: str) -> str: pass
     def f(x: Any) -> Any:
         mod.g(str())
+        return mod
 [file mod.py]
 from typing import overload
 @overload
@@ -1018,7 +1022,7 @@ class Outer:
     @overload
     def f(self, x: str, cb=mod.g) -> str: pass
     def f(self, *args: Any, **kwargs: Any) -> Any:
-        pass
+        return args
 [file mod.py]
 from typing import overload
 @overload

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6995,6 +6995,7 @@ def outer() -> None:
     def f(x: str) -> str: pass
     def f(x: Any) -> Any:
         y: int = mod.f()
+        return y
 [file mod.py]
 def f() -> int:
     pass
@@ -7257,6 +7258,7 @@ def f(x: str) -> submod.B: pass
 def f(x) -> Any:
     y: submod.C
     y.x = int()
+    return y
 [file submod.py]
 import other
 class A: pass


### PR DESCRIPTION
As discussed in https://github.com/python/mypy/issues/7511, mypy's `--warn-no-return` isn't really a question of type safety. It does however enforce a PEP 8 rule that is "dear to Guido's heart", and I think we should enforce it for functions that explicitly return Any as well.

Fixes #16095