### PR TITLE
Fix crash on star unpack in TypedDict

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -813,8 +813,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         Note `result` and `always_present_keys` are updated in place. Return true if the
         expression `item_arg` may valid in `callee` TypedDict context.
         """
-        with self.chk.local_type_map(), self.msg.filter_errors():
-            inferred = get_proper_type(self.accept(item_arg, type_context=callee))
+        inferred = get_proper_type(self.accept(item_arg, type_context=callee))
         possible_tds = []
         if isinstance(inferred, TypedDictType):
             possible_tds = [inferred]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3224,3 +3224,15 @@ t2: Foo = {**y}  # E: Missing key "a" for TypedDict "Foo"
 t3: Foo = {**z}  # E: Missing key "a" for TypedDict "Foo"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testTypedDictUnpackError]
+from typing import TypedDict
+
+class Foo(TypedDict):
+    a: int
+
+def foo(x: int) -> Foo: ...
+
+f: Foo = {**foo("no")}  # E: Argument 1 to "foo" has incompatible type "str"; expected "int"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -69,6 +69,40 @@ def untyped_function():
   </packages>
 </coverage>
 
+[case testCoberturaStarUnpacking]
+# cmd: mypy --cobertura-xml-report build a.py
+[file a.py]
+from typing import TypedDict
+
+class MyDict(TypedDict):
+    a: int
+
+def foo(a: int) -> MyDict:
+    return {"a": a}
+md: MyDict = MyDict(**foo(42))
+[outfile build/cobertura.xml]
+<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="0.8333" branch-rate="0">
+  <sources>
+    <source>$PWD</source>
+  </sources>
+  <packages>
+    <package complexity="1.0" name="a" branch-rate="0" line-rate="0.8333">
+      <classes>
+        <class complexity="1.0" filename="a.py" name="a.py" branch-rate="0" line-rate="0.8333">
+          <methods/>
+          <lines>
+            <line branch="false" hits="1" number="1" precision="precise"/>
+            <line branch="false" hits="1" number="3" precision="precise"/>
+            <line branch="false" hits="0" number="4" precision="any"/>
+            <line branch="false" hits="1" number="6" precision="precise"/>
+            <line branch="false" hits="1" number="7" precision="precise"/>
+            <line branch="false" hits="1" number="8" precision="precise"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
 
 [case testAnyExprReportDivisionByZero]
 # cmd: mypy --any-exprs-report=out -c 'pass'


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16107
Fixes https://github.com/python/mypy/issues/15891

I only vaguely remember why I added those context managers, it seemed to me giving full TypedDict as context may cause false positives. But since the current way causes crashes, let's just not do this (we will see if there will be actual false positives).