### PR TITLE
Better support for variadic calls and indexing

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2792,11 +2792,17 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     )
             is_match = not w.has_new_errors()
             if is_match:
-                # Return early if possible; otherwise record info so we can
+                # Return early if possible; otherwise record info, so we can
                 # check for ambiguity due to 'Any' below.
                 if not args_contain_any:
                     return ret_type, infer_type
-                matches.append(typ)
+                p_infer_type = get_proper_type(infer_type)
+                if isinstance(p_infer_type, CallableType):
+                    # Prefer inferred types if possible, this will avoid false triggers for
+                    # Any-ambiguity caused by arguments with Any passed to generic overloads.
+                    matches.append(p_infer_type)
+                else:
+                    matches.append(typ)
                 return_types.append(ret_type)
                 inferred_types.append(infer_type)
                 type_maps.append(m)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4168,6 +4168,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                         out.append(item)
                     else:
                         self.chk.fail(message_registry.TUPLE_INDEX_OUT_OF_RANGE, e)
+                        if any(isinstance(t, UnpackType) for t in left_type.items):
+                            self.chk.note(
+                                f"Variadic tuple can have length {left_type.length() - 1}", e
+                            )
                         return AnyType(TypeOfAny.from_error)
                 return make_simplified_union(out)
             else:

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -137,25 +137,38 @@ def infer_constraints_for_callable(
             unpack_type = callee.arg_types[i]
             assert isinstance(unpack_type, UnpackType)
 
-            # In this case we are binding all of the actuals to *args
+            # In this case we are binding all the actuals to *args,
             # and we want a constraint that the typevar tuple being unpacked
             # is equal to a type list of all the actuals.
             actual_types = []
+
+            unpacked_type = get_proper_type(unpack_type.type)
+            if isinstance(unpacked_type, TypeVarTupleType):
+                tuple_instance = unpacked_type.tuple_fallback
+            elif isinstance(unpacked_type, TupleType):
+                tuple_instance = unpacked_type.partial_fallback
+            else:
+                assert False, "mypy bug: unhandled constraint inference case"
+
             for actual in actuals:
                 actual_arg_type = arg_types[actual]
                 if actual_arg_type is None:
                     continue
 
-                actual_types.append(
-                    mapper.expand_actual_type(
-                        actual_arg_type,
-                        arg_kinds[actual],
-                        callee.arg_names[i],
-                        callee.arg_kinds[i],
-                    )
+                expanded_actual = mapper.expand_actual_type(
+                    actual_arg_type, arg_kinds[actual], callee.arg_names[i], callee.arg_kinds[i]
                 )
 
-            unpacked_type = get_proper_type(unpack_type.type)
+                if arg_kinds[actual] != ARG_STAR or isinstance(
+                    get_proper_type(actual_arg_type), TupleType
+                ):
+                    actual_types.append(expanded_actual)
+                else:
+                    # If we are expanding an iterable inside * actual, append a homogeneous item instead
+                    actual_types.append(
+                        UnpackType(tuple_instance.copy_modified(args=[expanded_actual]))
+                    )
+
             if isinstance(unpacked_type, TypeVarTupleType):
                 constraints.append(
                     Constraint(

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -82,7 +82,9 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
             # Valid erasure for *Ts is *tuple[Any, ...], not just Any.
             if isinstance(tv, TypeVarTupleType):
                 args.append(
-                    tv.tuple_fallback.copy_modified(args=[AnyType(TypeOfAny.special_form)])
+                    UnpackType(
+                        tv.tuple_fallback.copy_modified(args=[AnyType(TypeOfAny.special_form)])
+                    )
                 )
             else:
                 args.append(AnyType(TypeOfAny.special_form))

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -83,6 +83,7 @@ INCOMPATIBLE_TYPES_IN_STR_INTERPOLATION: Final = "Incompatible types in string i
 INCOMPATIBLE_TYPES_IN_CAPTURE: Final = ErrorMessage("Incompatible types in capture pattern")
 MUST_HAVE_NONE_RETURN_TYPE: Final = ErrorMessage('The return type of "{}" must be None')
 TUPLE_INDEX_OUT_OF_RANGE: Final = ErrorMessage("Tuple index out of range")
+AMBIGUOUS_SLICE_OF_VARIADIC_TUPLE: Final = ErrorMessage("Ambiguous slice of a variadic tuple")
 INVALID_SLICE_INDEX: Final = ErrorMessage("Slice index must be an integer, SupportsIndex or None")
 CANNOT_INFER_LAMBDA_TYPE: Final = ErrorMessage("Cannot infer type of lambda")
 CANNOT_ACCESS_INIT: Final = (

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6501,8 +6501,7 @@ eggs = lambda: 'eggs'
 reveal_type(func(eggs))  # N: Revealed type is "def (builtins.str) -> builtins.str"
 
 spam: Callable[..., str] = lambda x, y: 'baz'
-reveal_type(func(spam))  # N: Revealed type is "def (*Any, **Any) -> Any"
-
+reveal_type(func(spam))  # N: Revealed type is "def (*Any, **Any) -> builtins.str"
 [builtins fixtures/paramspec.pyi]
 
 [case testGenericOverloadOverlapWithType]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1664,7 +1664,6 @@ def zip(*i: Iterable[Any]) -> Iterator[Tuple[Any, ...]]: ...
 def zip(i): ...
 
 def g(t: Tuple):
-    # Ideally, we'd infer that these are iterators of tuples
-    reveal_type(zip(*t))  # N: Revealed type is "typing.Iterator[Any]"
-    reveal_type(zip(t))  # N: Revealed type is "typing.Iterator[Any]"
+    reveal_type(zip(*t))  # N: Revealed type is "typing.Iterator[builtins.tuple[Any, ...]]"
+    reveal_type(zip(t))  # N: Revealed type is "typing.Iterator[Tuple[Any]]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -366,13 +366,21 @@ from typing_extensions import TypeVarTuple, Unpack
 
 Ts = TypeVarTuple("Ts")
 
-# TODO: add less trivial tests with prefix/suffix etc.
-# TODO: add tests that call with a type var tuple instead of just args.
 def args_to_tuple(*args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
     reveal_type(args)  # N: Revealed type is "Tuple[Unpack[Ts`-1]]"
-    return args
+    reveal_type(args_to_tuple(1, *args))  # N: Revealed type is "Tuple[Literal[1]?, Unpack[Ts`-1]]"
+    reveal_type(args_to_tuple(*args, 'a'))  # N: Revealed type is "Tuple[Unpack[Ts`-1], Literal['a']?]"
+    reveal_type(args_to_tuple(1, *args, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, Unpack[Ts`-1], Literal['a']?]"
+    if int():
+        return args
+    else:
+        return args_to_tuple(*args)
 
 reveal_type(args_to_tuple(1, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, Literal['a']?]"
+vt: Tuple[int, ...]
+reveal_type(args_to_tuple(1, *vt))  # N: Revealed type is "Tuple[Literal[1]?, Unpack[builtins.tuple[builtins.int, ...]]]"
+reveal_type(args_to_tuple(*vt, 'a'))  # N: Revealed type is "Tuple[Unpack[builtins.tuple[builtins.int, ...]], Literal['a']?]"
+reveal_type(args_to_tuple(1, *vt, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, Unpack[builtins.tuple[builtins.int, ...]], Literal['a']?]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarTuplePep646TypeVarStarArgs]
@@ -381,8 +389,17 @@ from typing_extensions import TypeVarTuple, Unpack
 
 Ts = TypeVarTuple("Ts")
 
+def args_to_tuple(*args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
+    with_prefix_suffix(*args)  # E: Too few arguments for "with_prefix_suffix" \
+                               # E: Argument 1 to "with_prefix_suffix" has incompatible type "*Tuple[Unpack[Ts]]"; expected "bool"
+    new_args = (True, "foo", *args, 5)
+    with_prefix_suffix(*new_args)
+    return args
+
 def with_prefix_suffix(*args: Unpack[Tuple[bool, str, Unpack[Ts], int]]) -> Tuple[bool, str, Unpack[Ts], int]:
     reveal_type(args)  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Unpack[Ts`-1], builtins.int]"
+    reveal_type(args_to_tuple(*args))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Unpack[Ts`-1], builtins.int]"
+    reveal_type(args_to_tuple(1, *args, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, builtins.bool, builtins.str, Unpack[Ts`-1], builtins.int, Literal['a']?]"
     return args
 
 reveal_type(with_prefix_suffix(True, "bar", "foo", 5))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Literal['foo']?, builtins.int]"
@@ -395,8 +412,7 @@ t = (True, "bar", "foo", 5)
 reveal_type(with_prefix_suffix(*t))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, builtins.str, builtins.int]"
 reveal_type(with_prefix_suffix(True, *("bar", "foo"), 5))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Literal['foo']?, builtins.int]"
 
-# TODO: handle list case
-#reveal_type(with_prefix_suffix(True, "bar", *["foo1", "foo2"], 5))
+reveal_type(with_prefix_suffix(True, "bar", *["foo1", "foo2"], 5))  # N: Revealed type is "Tuple[builtins.bool, builtins.str, Unpack[builtins.tuple[builtins.str, ...]], builtins.int]"
 
 bad_t = (True, "bar")
 with_prefix_suffix(*bad_t)  # E: Too few arguments for "with_prefix_suffix"
@@ -908,7 +924,7 @@ def cons(
     return wrapped
 
 def star(f: Callable[[X], Y]) -> Callable[[Unpack[Tuple[X, ...]]], Tuple[Y, ...]]:
-    def wrapped(*xs: X):
+    def wrapped(*xs: X) -> Tuple[Y, ...]:
         if not xs:
             return nil()
         return cons(f, star(f))(*xs)

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -371,6 +371,9 @@ def args_to_tuple(*args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
     reveal_type(args_to_tuple(1, *args))  # N: Revealed type is "Tuple[Literal[1]?, Unpack[Ts`-1]]"
     reveal_type(args_to_tuple(*args, 'a'))  # N: Revealed type is "Tuple[Unpack[Ts`-1], Literal['a']?]"
     reveal_type(args_to_tuple(1, *args, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, Unpack[Ts`-1], Literal['a']?]"
+    args_to_tuple(*args, *args)  # E: Passing multiple variadic unpacks in a call is not supported
+    ok = (1, 'a')
+    reveal_type(args_to_tuple(*ok, *ok))  # N: Revealed type is "Tuple[builtins.int, builtins.str, builtins.int, builtins.str]"
     if int():
         return args
     else:
@@ -381,6 +384,7 @@ vt: Tuple[int, ...]
 reveal_type(args_to_tuple(1, *vt))  # N: Revealed type is "Tuple[Literal[1]?, Unpack[builtins.tuple[builtins.int, ...]]]"
 reveal_type(args_to_tuple(*vt, 'a'))  # N: Revealed type is "Tuple[Unpack[builtins.tuple[builtins.int, ...]], Literal['a']?]"
 reveal_type(args_to_tuple(1, *vt, 'a'))  # N: Revealed type is "Tuple[Literal[1]?, Unpack[builtins.tuple[builtins.int, ...]], Literal['a']?]"
+args_to_tuple(*vt, *vt)  # E: Passing multiple variadic unpacks in a call is not supported
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarTuplePep646TypeVarStarArgs]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -1565,3 +1565,28 @@ T = TypeVar("T")
 def g(data: Sequence[Tuple[T, Unpack[Ts]]]) -> List[T]:
     return [d[0] for d in data]  # OK
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleOverloadMatch]
+from typing import Any, Generic, overload, Tuple, TypeVar
+from typing_extensions import TypeVarTuple, Unpack
+
+_Ts = TypeVarTuple("_Ts")
+_T = TypeVar("_T")
+_T2 = TypeVar("_T2")
+
+class Container(Generic[_T]): ...
+class Array(Generic[Unpack[_Ts]]): ...
+
+@overload
+def build(entity: Container[_T], /) -> Array[_T]: ...
+@overload
+def build(entity: Container[_T], entity2: Container[_T2], /) -> Array[_T, _T2]: ...
+@overload
+def build(*entities: Container[Any]) -> Array[Unpack[Tuple[Any, ...]]]: ...
+def build(*entities: Container[Any]) -> Array[Unpack[Tuple[Any, ...]]]:
+    ...
+
+def test(a: Container[Any], b: Container[int], c: Container[str]):
+    reveal_type(build(a, b))  # N: Revealed type is "__main__.Array[Any, builtins.int]"
+    reveal_type(build(b, c))  # N: Revealed type is "__main__.Array[builtins.int, builtins.str]"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -454,7 +454,7 @@ reveal_type(C().foo2)  # N: Revealed type is "def (*args: Unpack[Tuple[builtins.
 
 [case testTypeVarTuplePep646TypeVarStarArgsVariableLengthTuple]
 from typing import Tuple
-from typing_extensions import Unpack
+from typing_extensions import Unpack, TypeVarTuple
 
 def foo(*args: Unpack[Tuple[int, ...]]) -> None:
     reveal_type(args)  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
@@ -462,11 +462,26 @@ def foo(*args: Unpack[Tuple[int, ...]]) -> None:
 foo(0, 1, 2)
 foo(0, 1, "bar")  # E: Argument 3 to "foo" has incompatible type "str"; expected "int"
 
-
 def foo2(*args: Unpack[Tuple[str, Unpack[Tuple[int, ...]], bool, bool]]) -> None:
     reveal_type(args)  # N: Revealed type is "Tuple[builtins.str, Unpack[builtins.tuple[builtins.int, ...]], builtins.bool, builtins.bool]"
-    # TODO: generate an error
-    # reveal_type(args[1])
+    reveal_type(args[1])  # N: Revealed type is "builtins.int"
+
+def foo3(*args: Unpack[Tuple[str, Unpack[Tuple[int, ...]], str, float]]) -> None:
+    reveal_type(args[0])  # N: Revealed type is "builtins.str"
+    reveal_type(args[1])  # N: Revealed type is "Union[builtins.int, builtins.str]"
+    reveal_type(args[2])  # N: Revealed type is "Union[builtins.int, builtins.str, builtins.float]"
+    args[3]  # E: Tuple index out of range
+    reveal_type(args[-1])  # N: Revealed type is "builtins.float"
+    reveal_type(args[-2])  # N: Revealed type is "builtins.str"
+    reveal_type(args[-3])  # N: Revealed type is "Union[builtins.str, builtins.int]"
+    args[-4]  # E: Tuple index out of range
+    reveal_type(args[::-1])  # N: Revealed type is "Tuple[builtins.float, builtins.str, Unpack[builtins.tuple[builtins.int, ...]], builtins.str]"
+    args[::2]  # E: Ambiguous slice of a variadic tuple
+    args[:2]  # E: Ambiguous slice of a variadic tuple
+
+Ts = TypeVarTuple("Ts")
+def foo4(*args: Unpack[Tuple[str, Unpack[Ts], bool, bool]]) -> None:
+    reveal_type(args[1])  # N: Revealed type is "builtins.object"
 
 foo2("bar", 1, 2, 3, False, True)
 foo2(0, 1, 2, 3, False, True)  # E: Argument 1 to "foo2" has incompatible type "int"; expected "str"
@@ -1535,4 +1550,18 @@ T = TypeVar("T")
 def test(x: int, t: Tuple[T, ...]) -> Tuple[int, Unpack[Tuple[T, ...]]]:
     ...
 a: Any = test(42, ())
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleIndexTypeVar]
+from typing import Any, List, Sequence, Tuple, TypeVar
+from typing_extensions import TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+def f(data: Sequence[Tuple[Unpack[Ts]]]) -> List[Any]:
+    # Tuple may be empty
+    return [d[0] for d in data]  # E: Tuple index out of range
+
+T = TypeVar("T")
+def g(data: Sequence[Tuple[T, Unpack[Ts]]]) -> List[T]:
+    return [d[0] for d in data]  # OK
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -470,11 +470,13 @@ def foo3(*args: Unpack[Tuple[str, Unpack[Tuple[int, ...]], str, float]]) -> None
     reveal_type(args[0])  # N: Revealed type is "builtins.str"
     reveal_type(args[1])  # N: Revealed type is "Union[builtins.int, builtins.str]"
     reveal_type(args[2])  # N: Revealed type is "Union[builtins.int, builtins.str, builtins.float]"
-    args[3]  # E: Tuple index out of range
+    args[3]  # E: Tuple index out of range \
+             # N: Variadic tuple can have length 3
     reveal_type(args[-1])  # N: Revealed type is "builtins.float"
     reveal_type(args[-2])  # N: Revealed type is "builtins.str"
     reveal_type(args[-3])  # N: Revealed type is "Union[builtins.str, builtins.int]"
-    args[-4]  # E: Tuple index out of range
+    args[-4]  # E: Tuple index out of range \
+              # N: Variadic tuple can have length 3
     reveal_type(args[::-1])  # N: Revealed type is "Tuple[builtins.float, builtins.str, Unpack[builtins.tuple[builtins.int, ...]], builtins.str]"
     args[::2]  # E: Ambiguous slice of a variadic tuple
     args[:2]  # E: Ambiguous slice of a variadic tuple
@@ -1558,8 +1560,8 @@ from typing_extensions import TypeVarTuple, Unpack
 
 Ts = TypeVarTuple("Ts")
 def f(data: Sequence[Tuple[Unpack[Ts]]]) -> List[Any]:
-    # Tuple may be empty
-    return [d[0] for d in data]  # E: Tuple index out of range
+    return [d[0] for d in data]  # E: Tuple index out of range \
+                                 # N: Variadic tuple can have length 0
 
 T = TypeVar("T")
 def g(data: Sequence[Tuple[T, Unpack[Ts]]]) -> List[T]:

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -1592,3 +1592,15 @@ def test(a: Container[Any], b: Container[int], c: Container[str]):
     reveal_type(build(a, b))  # N: Revealed type is "__main__.Array[Any, builtins.int]"
     reveal_type(build(b, c))  # N: Revealed type is "__main__.Array[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleIndexOldStyleNonNormalizedAndNonLiteral]
+from typing import Any, Tuple
+from typing_extensions import Unpack
+
+t: Tuple[Unpack[Tuple[int, ...]]]
+reveal_type(t[42])  # N: Revealed type is "builtins.int"
+i: int
+reveal_type(t[i])  # N: Revealed type is "builtins.int"
+t1: Tuple[int, Unpack[Tuple[int, ...]]]
+reveal_type(t1[i])  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
This improves support for two features that were supported but only partially: variadic calls, and variadic indexing. Some notes:
* I did not add dedicated support for slicing of tuples with homogeneous variadic items (except for cases covered by TypeVarTuple support, i.e. those not involving splitting of variadic item). This is tricky and it is not clear what cases people actually want. I left a TODO for this.
* I prohibit multiple variadic items in a call expression. Technically, we can support some situations involving these, but this is tricky, and prohibiting this would be in the "spirit" of the PEP, IMO.
* I may have still missed some cases for the calls, since there are so many options. If you have ideas for additional test cases, please let me know.
* It was necessary to fix overload ambiguity logic to make some tests pass. This goes beyond TypeVarTuple support, but I think this is a correct change (note btw @hauntsaninja this fixes one of tests you added).

@mehdigmira could you also please test this PR on your code base (and play with it in general)?