### PR TITLE
Properly strip types that come before a [

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -424,7 +424,7 @@ def strip_or_import(
             stripped_subtyp = strip_or_import(subtyp.strip(), module, known_modules, imports)
             if stripped_subtyp != subtyp:
                 stripped_type = re.sub(
-                    r"(^|[\[, ]+)" + re.escape(subtyp) + r"($|[\], ]+)",
+                    r"(^|[\[, ]+)" + re.escape(subtyp) + r"($|[\[\], ]+)",
                     r"\1" + stripped_subtyp + r"\2",
                     stripped_type,
                 )


### PR DESCRIPTION
Fixes #16138

The improvements in #14564 updated the regex replace to make sure the surrounding characters were part of the separating characters  (`]`, `,`, ` `). However, `[` was omitted. This results in the subtype preceding the `[` from not properly being replaced.

This PR adds `[` to the list of characters after the type in the regex replacement and allows proper replacement of the type.