### PR TITLE
Use type variable bound when it appears as actual during inference

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -373,6 +373,11 @@ def _infer_constraints(
             return handle_recursive_union(template, actual, direction)
         return []
 
+    if isinstance(actual, TypeVarType) and not actual.id.is_meta_var():
+        # Unless template is also a type variable (that is handled above), using the upper
+        # bound for inference will usually give better result for actual that is a type variable.
+        actual = get_proper_type(actual.upper_bound)
+
     # Remaining cases are handled by ConstraintBuilderVisitor.
     return template.accept(ConstraintBuilderVisitor(actual, direction, skip_neg_op))
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3686,3 +3686,15 @@ def g(*args: str) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "Tuple[Never, Never]" \
                    # E: Argument 1 to "f" has incompatible type "Callable[[VarArg(str)], None]"; expected "Call[Never]"
 [builtins fixtures/list.pyi]
+
+[case testInferenceAgainstTypeVarActualBound]
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+S = TypeVar("S")
+def test(f: Callable[[T], S]) -> Callable[[T], S]: ...
+
+F = TypeVar("F", bound=Callable[..., object])
+def dec(f: F) -> F:
+    reveal_type(test(f))  # N: Revealed type is "def (Any) -> builtins.object"
+    return f

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3698,3 +3698,24 @@ F = TypeVar("F", bound=Callable[..., object])
 def dec(f: F) -> F:
     reveal_type(test(f))  # N: Revealed type is "def (Any) -> builtins.object"
     return f
+
+[case testInferenceAgainstTypeVarActualUnionBound]
+from typing import Protocol, Generic, TypeVar, Union, overload
+
+_T_co = TypeVar("_T_co", covariant=True)
+
+class SupportsFoo(Protocol[_T_co]):
+    def foo(self) -> _T_co: ...
+
+class A:
+    def foo(self) -> A: ...
+
+class B:
+    def foo(self) -> B: ...
+
+def foo(f: SupportsFoo[_T_co]) -> _T_co: ...
+
+ABT = TypeVar("ABT", bound=Union[A, B])
+
+def simpler(k: ABT):
+    foo(k)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3700,26 +3700,22 @@ def dec(f: F) -> F:
     return f
 
 [case testInferenceAgainstTypeVarActualUnionBound]
-from typing import Protocol, Generic, TypeVar, Union, overload
+from typing import Protocol, TypeVar, Union
 
-_T_co = TypeVar("_T_co", covariant=True)
-
-class SupportsFoo(Protocol[_T_co]):
-    def foo(self) -> _T_co: ...
+T_co = TypeVar("T_co", covariant=True)
+class SupportsFoo(Protocol[T_co]):
+    def foo(self) -> T_co: ...
 
 class A:
     def foo(self) -> A: ...
-
 class B:
     def foo(self) -> B: ...
 
-def foo(f: SupportsFoo[_T_co]) -> _T_co: ...
+def foo(f: SupportsFoo[T_co]) -> T_co: ...
 
 ABT = TypeVar("ABT", bound=Union[A, B])
-
 def simpler(k: ABT):
     foo(k)
-
 
 [case testInferenceWorksWithEmptyCollectionsNested]
 from typing import List, TypeVar, NoReturn


### PR DESCRIPTION
This should help with re-enabling the use of `ParamSpec` in `functools.wraps` (as it looks like some of the new errors in https://github.com/AlexWaygood/mypy/pull/11 are caused by not handling this).