### PR TITLE
Fix walrus interaction with empty collections

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4057,7 +4057,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         value = self.accept(e.value)
         self.chk.check_assignment(e.target, e.value)
         self.chk.check_final(e)
-        self.chk.store_type(e.target, value)
+        if not has_uninhabited_component(value):
+            # TODO: can we get rid of this extra store_type()?
+            # Usually, check_assignment() already stores the lvalue type correctly.
+            self.chk.store_type(e.target, value)
         self.find_partial_type_ref_fast_path(e.target)
         return value
 

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -826,3 +826,11 @@ main:5: error: Dict entry 0 has incompatible type "str": "str"; expected "str": 
 main:5: error: Unpacked dict entry 1 has incompatible type "Dict[str, str]"; expected "SupportsKeysAndGetItem[str, int]"
     dct: Dict[str, int] = {"a": "b", **other}
                                        ^~~~~
+
+[case testWalrusAssignmentEmptyCollection]
+from typing import List
+
+y: List[int]
+if (y := []):
+    reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int]"
+[builtins fixtures/list.pyi]


### PR DESCRIPTION
This fixes a regression caused by https://github.com/python/mypy/pull/16122

@cdce8p Could you please check this fixes the issue for you? I tried your snippet and it passes, but there is a certain asymmetry in the reveal types that is hard to fix.
