### PR TITLE
tests: avoid leaving artifacts in the source tree

### DIFF
--- a/mypyc/lib-rt/setup.py
+++ b/mypyc/lib-rt/setup.py
@@ -5,7 +5,10 @@ The tests are written in C++ and use the Google Test framework.
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
+from distutils.command.build_ext import build_ext
 from distutils.core import Extension, setup
 from typing import Any
 
@@ -16,6 +19,30 @@ if sys.platform == "darwin":
 else:
     kwargs = {}
     compile_args = ["--std=c++11"]
+
+
+class build_ext_custom(build_ext):
+    def get_library_names(self):
+        return ["gtest"]
+
+    def run(self):
+        gtest_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "external", "googletest")
+        )
+
+        os.makedirs(self.build_temp, exist_ok=True)
+
+        # Build Google Test, the C++ framework we use for testing C code.
+        # The source code for Google Test is copied to this repository.
+        subprocess.check_call(
+            ["make", "-f", os.path.join(gtest_dir, "make", "Makefile"), f"GTEST_DIR={gtest_dir}"],
+            cwd=self.build_temp,
+        )
+
+        self.library_dirs = [self.build_temp]
+
+        return build_ext.run(self)
+
 
 setup(
     name="test_capi",
@@ -34,10 +61,10 @@ setup(
             ],
             depends=["CPy.h", "mypyc_util.h", "pythonsupport.h"],
             extra_compile_args=["-Wno-unused-function", "-Wno-sign-compare"] + compile_args,
-            library_dirs=["../external/googletest/make"],
             libraries=["gtest"],
             include_dirs=["../external/googletest", "../external/googletest/include"],
             **kwargs,
         )
     ],
+    cmdclass={"build_ext": build_ext_custom},
 )

--- a/mypyc/test/test_external.py
+++ b/mypyc/test/test_external.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 
 base_dir = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -22,19 +23,27 @@ class TestExternal(unittest.TestCase):
             cppflags += ["-mmacosx-version-min=10.10", "-stdlib=libc++"]
         env["CPPFLAGS"] = " ".join(cppflags)
         # Build Python wrapper for C unit tests.
-        status = subprocess.check_call(
-            [sys.executable, "setup.py", "build_ext", "--inplace"],
-            env=env,
-            cwd=os.path.join(base_dir, "mypyc", "lib-rt"),
-        )
-        # Run C unit tests.
-        env = os.environ.copy()
-        if "GTEST_COLOR" not in os.environ:
-            env["GTEST_COLOR"] = "yes"  # Use fancy colors
-        status = subprocess.call(
-            [sys.executable, "-c", "import sys, test_capi; sys.exit(test_capi.run_tests())"],
-            env=env,
-            cwd=os.path.join(base_dir, "mypyc", "lib-rt"),
-        )
-        if status != 0:
-            raise AssertionError("make test: C unit test failure")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status = subprocess.check_call(
+                [
+                    sys.executable,
+                    "setup.py",
+                    "build_ext",
+                    f"--build-lib={tmpdir}",
+                    f"--build-temp={tmpdir}",
+                ],
+                env=env,
+                cwd=os.path.join(base_dir, "mypyc", "lib-rt"),
+            )
+            # Run C unit tests.
+            env = os.environ.copy()
+            if "GTEST_COLOR" not in os.environ:
+                env["GTEST_COLOR"] = "yes"  # Use fancy colors
+            status = subprocess.call(
+                [sys.executable, "-c", "import sys, test_capi; sys.exit(test_capi.run_tests())"],
+                env=env,
+                cwd=tmpdir,
+            )
+            if status != 0:
+                raise AssertionError("make test: C unit test failure")

--- a/mypyc/test/test_external.py
+++ b/mypyc/test/test_external.py
@@ -16,21 +16,12 @@ class TestExternal(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith("win"), "rt tests don't work on windows")
     def test_c_unit_test(self) -> None:
         """Run C unit tests in a subprocess."""
-        # Build Google Test, the C++ framework we use for testing C code.
-        # The source code for Google Test is copied to this repository.
         cppflags: list[str] = []
         env = os.environ.copy()
         if sys.platform == "darwin":
             cppflags += ["-mmacosx-version-min=10.10", "-stdlib=libc++"]
         env["CPPFLAGS"] = " ".join(cppflags)
-        subprocess.check_call(
-            ["make", "libgtest.a"],
-            env=env,
-            cwd=os.path.join(base_dir, "mypyc", "external", "googletest", "make"),
-        )
         # Build Python wrapper for C unit tests.
-        env = os.environ.copy()
-        env["CPPFLAGS"] = " ".join(cppflags)
         status = subprocess.check_call(
             [sys.executable, "setup.py", "build_ext", "--inplace"],
             env=env,


### PR DESCRIPTION
When running the mypy unittests, most of the time any output files are produced into a temporary directory and cleaned up. In one case, it wasn't. Fix this for test_capi.