### PR TITLE
Stubtest: add a hint when arguments in the stub need to be keyword-only

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -890,7 +890,10 @@ def _verify_signature(
                 # If the variable is in runtime.kwonly, it's just mislabelled as not a
                 # keyword-only argument
                 if stub_arg.variable.name not in runtime.kwonly:
-                    yield f'runtime does not have argument "{stub_arg.variable.name}"'
+                    msg = f'runtime does not have argument "{stub_arg.variable.name}"'
+                    if runtime.varkw is not None:
+                        msg += ". Maybe you forgot to make it keyword-only in the stub?"
+                    yield msg
                 else:
                     yield f'stub argument "{stub_arg.variable.name}" is not keyword-only'
             if stub.varpos is not None:


### PR DESCRIPTION
Something I've seen come up several times in typeshed is that a runtime library will have a class similar to this (which is contrived, but you hopefully see the point):

```py
class Foo:
    def __init__(self, **kwargs):
        self.a = kwargs.pop('a')
        self.b = kwargs.pop('b')
        self.c = kwargs.pop('c')
        if kwargs:
            raise Exception("no")
```

Somebody will then come along and try to write stubs for this class like this, which is _nearly_ correct, except that all the arguments need to be keyword-only:

```py
class Foo:
    def __init__(self, a: int = ..., b: int = ..., c: int = ...) -> None: ...
```

Stubtest then (correctly!) gets very angry and reports three errors for this function. However, none of the error messages tells the author of the stub that the arguments all need to be made keyword-only:

```
error: pkg.Foo.__init__ is inconsistent, runtime does not have argument "a"
Stub: in file pkg.pyi
def (self: pkg.Foo, a: int =, b: int =, c: int =)
Runtime: in file pkg.py:
def (self, **kwargs)

error: pkg.Foo.__init__ is inconsistent, runtime does not have argument "b"
Stub: in file pkg.pyi
def (self: pkg.Foo, a: int =, b: int =, c: int =)
Runtime: in file pkg.py:
def (self, **kwargs)

error: pkg.Foo.__init__ is inconsistent, runtime does not have argument "c"
Stub: in file pkg.pyi
def (self: pkg.Foo, a: int =, b: int =, c: int =)
Runtime: in file pkg.py:
def (self, **kwargs)
```

With this PR, stubtest instead emits the following error messages if the runtime has a `**kwargs` variadic keyword argument:

```
error: pkg.Foo.__init__ is inconsistent, runtime does not have argument "a". Maybe you forgot to make it keyword-only in the stub?
Stub: in file pkg.pyi
def (self: pkg.Foo, a: int =, b: int =, c: int =)
Runtime: in file pkg.py:
def (self, **kwargs)

error: pkg.Foo.__init__ is inconsistent, runtime does not have argument "b". Maybe you forgot to make it keyword-only in the stub?
Stub: in file pkg.pyi
def (self: pkg.Foo, a: int =, b: int =, c: int =)
Runtime: in file pkg.py:
def (self, **kwargs)

error: pkg.Foo.__init__ is inconsistent, runtime does not have argument "c". Maybe you forgot to make it keyword-only in the stub?
Stub: in file pkg.pyi
def (self: pkg.Foo, a: int =, b: int =, c: int =)
Runtime: in file pkg.py:
def (self, **kwargs)
```