### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,7 +202,7 @@ setup(
     author="Jukka Lehtosalo",
     author_email="jukka.lehtosalo@iki.fi",
     url="https://www.mypy-lang.org/",
-    license="MIT License",
+    license="MIT",
     py_modules=[],
     ext_modules=ext_modules,
     packages=find_packages(),


### PR DESCRIPTION
It does not change the license itself, only its identifier in `setup.py`, so external tools can read it better.

Full list: https://spdx.org/licenses/
Closes https://github.com/python/mypy/issues/16228
