### PR TITLE
show dmypy errors post serving

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -210,6 +210,8 @@ class Server:
         """Serve requests, synchronously (no thread or fork)."""
         command = None
         server = IPCServer(CONNECTION_NAME, self.timeout)
+        orig_stdout = sys.stdout
+        orig_stderr = sys.stderr
         try:
             with open(self.status_file, "w") as f:
                 json.dump({"pid": os.getpid(), "connection_name": server.connection_name}, f)
@@ -252,6 +254,10 @@ class Server:
                         reset_global_state()
                         sys.exit(0)
         finally:
+            # Revert stdout/stderr so we can see any errors.
+            sys.stdout = orig_stdout
+            sys.stderr = orig_stderr
+
             # If the final command is something other than a clean
             # stop, remove the status file. (We can't just
             # simplify the logic and always remove the file, since


### PR DESCRIPTION
After dmypy starts serving, stdout and stderr gets captured. If we have an error, we assume we can send it to the client. However, if we have an error outside of client communication, that error is lost. The easiest way to see this is to run dmypy in daemonize mode, run a check once, then Control-C to send a KeyboardInterrupt. That exception is not printed though it should. After this change you can clearly see it.

```
term1$ python3 -m mypy.dmypy daemon

term2$ python3 -m mypy.dmypy check -v test.py
[... some output ...]

term1$ [Control-C]
^CTraceback (most recent call last):
  File "/home/svalentin/src/mypy-svalentin/mypy/dmypy_server.py", line 220, in serve
    with server:
  File "/home/svalentin/src/mypy-svalentin/mypy/ipc.py", line 232, in __enter__
    self.connection, _ = self.sock.accept()
  File "/usr/lib/python3.8/socket.py", line 292, in accept
    fd, addr = self._accept()
KeyboardInterrupt
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/svalentin/src/mypy-svalentin/mypy/dmypy/__main__.py", line 6, in <module>
    console_entry()
  File "/home/svalentin/src/mypy-svalentin/mypy/dmypy/client.py", line 748, in console_entry
    main(sys.argv[1:])
  File "/home/svalentin/src/mypy-svalentin/mypy/dmypy/client.py", line 275, in main
    args.action(args)
  File "/home/svalentin/src/mypy-svalentin/mypy/dmypy/client.py", line 629, in do_daemon
    Server(options, args.status_file, timeout=args.timeout).serve()
  File "/home/svalentin/src/mypy-svalentin/mypy/dmypy_server.py", line 220, in serve
    with server:
  File "/home/svalentin/src/mypy-svalentin/mypy/ipc.py", line 232, in __enter__
    self.connection, _ = self.sock.accept()
  File "/usr/lib/python3.8/socket.py", line 292, in accept
    fd, addr = self._accept()
KeyboardInterrupt
```