### PR TITLE
Stream dmypy output instead of dumping everything at the end

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -17,7 +17,7 @@ import traceback
 from typing import Any, Callable, Mapping, NoReturn
 
 from mypy.dmypy_os import alive, kill
-from mypy.dmypy_util import DEFAULT_STATUS_FILE, receive
+from mypy.dmypy_util import DEFAULT_STATUS_FILE, receive, send
 from mypy.ipc import IPCClient, IPCException
 from mypy.util import check_python_version, get_terminal_width, should_force_color
 from mypy.version import __version__
@@ -659,28 +659,29 @@ def request(
     # so that it can format the type checking output accordingly.
     args["is_tty"] = sys.stdout.isatty() or should_force_color()
     args["terminal_width"] = get_terminal_width()
-    bdata = json.dumps(args).encode("utf8")
     _, name = get_status(status_file)
     try:
         with IPCClient(name, timeout) as client:
-            client.write(bdata)
-            response = receive(client)
+            send(client, args)
+
+            final = False
+            while not final:
+                response = receive(client)
+                final = bool(response.pop("final", False))
+                # Display debugging output written to stdout/stderr in the server process for convenience.
+                # This should not be confused with "out" and "err" fields in the response.
+                # Those fields hold the output of the "check" command, and are handled in check_output().
+                stdout = response.pop("stdout", None)
+                if stdout:
+                    sys.stdout.write(stdout)
+                stderr = response.pop("stderr", None)
+                if stderr:
+                    sys.stderr.write(stderr)
     except (OSError, IPCException) as err:
         return {"error": str(err)}
     # TODO: Other errors, e.g. ValueError, UnicodeError
-    else:
-        # Display debugging output written to stdout/stderr in the server process for convenience.
-        # This should not be confused with "out" and "err" fields in the response.
-        # Those fields hold the output of the "check" command, and are handled in check_output().
-        stdout = response.get("stdout")
-        if stdout:
-            sys.stdout.write(stdout)
-        stderr = response.get("stderr")
-        if stderr:
-            print("-" * 79)
-            print("stderr:")
-            sys.stdout.write(stderr)
-        return response
+
+    return response
 
 
 def get_status(status_file: str) -> tuple[int, str]:

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -17,13 +17,13 @@ import sys
 import time
 import traceback
 from contextlib import redirect_stderr, redirect_stdout
-from typing import AbstractSet, Any, Callable, Final, Iterable, List, Sequence, Tuple
+from typing import AbstractSet, Any, Callable, Final, List, Sequence, Tuple
 from typing_extensions import TypeAlias as _TypeAlias
 
 import mypy.build
 import mypy.errors
 import mypy.main
-from mypy.dmypy_util import receive, send
+from mypy.dmypy_util import receive, send, WriteToConn
 from mypy.find_sources import InvalidSourceList, create_source_list
 from mypy.fscache import FileSystemCache
 from mypy.fswatcher import FileData, FileSystemWatcher
@@ -208,21 +208,6 @@ class Server:
 
     def serve(self) -> None:
         """Serve requests, synchronously (no thread or fork)."""
-
-        class WriteToConn(object):
-            def __init__(self, server: IPCBase, output_key: str = "stdout"):
-                self.server = server
-                self.output_key = output_key
-
-            def write(self, output: str) -> int:
-                resp: dict[str, Any] = {}
-                resp[self.output_key] = output
-                send(server, resp)
-                return len(output)
-
-            def writelines(self, lines: Iterable[str]) -> None:
-                for s in lines:
-                    self.write(s)
 
         command = None
         server = IPCServer(CONNECTION_NAME, self.timeout)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -23,12 +23,12 @@ from typing_extensions import TypeAlias as _TypeAlias
 import mypy.build
 import mypy.errors
 import mypy.main
-from mypy.dmypy_util import receive, send, WriteToConn
+from mypy.dmypy_util import WriteToConn, receive, send
 from mypy.find_sources import InvalidSourceList, create_source_list
 from mypy.fscache import FileSystemCache
 from mypy.fswatcher import FileData, FileSystemWatcher
 from mypy.inspections import InspectionEngine
-from mypy.ipc import IPCBase, IPCServer
+from mypy.ipc import IPCServer
 from mypy.modulefinder import BuildSource, FindModuleCache, SearchPaths, compute_search_paths
 from mypy.options import Options
 from mypy.server.update import FineGrainedBuildManager, refresh_suppressed_submodules

--- a/mypy/dmypy_util.py
+++ b/mypy/dmypy_util.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 from typing import Any, Final, Iterable
-from io import TextIOWrapper
 
 from mypy.ipc import IPCBase
 
@@ -31,6 +30,7 @@ def receive(connection: IPCBase) -> Any:
         raise OSError(f"Data received is not a dict ({type(data)})")
     return data
 
+
 def send(connection: IPCBase, data: Any) -> None:
     """Send data to a connection encoded and framed.
 
@@ -40,7 +40,7 @@ def send(connection: IPCBase, data: Any) -> None:
     connection.write(json.dumps(data))
 
 
-class WriteToConn(object):
+class WriteToConn:
     """Helper class to write to a connection instead of standard output."""
 
     def __init__(self, server: IPCBase, output_key: str = "stdout"):

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -7,13 +7,13 @@ On Windows, this uses NamedPipes.
 from __future__ import annotations
 
 import base64
+import codecs
 import os
 import shutil
 import sys
 import tempfile
 from types import TracebackType
 from typing import Callable, Final
-import codecs
 
 if sys.platform == "win32":
     # This may be private, but it is needed for IPC on Windows, and is basically stable
@@ -60,13 +60,13 @@ class IPCBase:
         if space_pos == -1:
             return None
         # We have a full frame
-        bdata = self.buffer[: space_pos]
+        bdata = self.buffer[:space_pos]
         self.buffer = self.buffer[space_pos + 1 :]
         return bdata
 
     def read(self, size: int = 100000) -> str:
         """Read bytes from an IPC connection until we have a full frame."""
-        bdata : bytearray | None = bytearray()
+        bdata: bytearray | None = bytearray()
         if sys.platform == "win32":
             while True:
                 # Check if we already have a message in the buffer before
@@ -119,14 +119,14 @@ class IPCBase:
         if not bdata:
             # Socket was empty and we didn't get any frame.
             # This should only happen if the socket was closed.
-            return ''
-        return codecs.decode(bdata, 'base64').decode("utf8")
+            return ""
+        return codecs.decode(bdata, "base64").decode("utf8")
 
     def write(self, data: str) -> None:
         """Write to an IPC connection."""
 
         # Frame the data by urlencoding it and separating by space.
-        encoded_data = codecs.encode(data.encode("utf8"), 'base64') + b' '
+        encoded_data = codecs.encode(data.encode("utf8"), "base64") + b" "
 
         if sys.platform == "win32":
             try:

--- a/mypy/test/testipc.py
+++ b/mypy/test/testipc.py
@@ -22,6 +22,7 @@ def server(msg: str, q: Queue[str]) -> None:
             data = server.read()
     server.cleanup()
 
+
 def server_multi_message_echo(q: Queue[str]) -> None:
     server = IPCServer(CONNECTION_NAME)
     q.put(server.connection_name)
@@ -73,9 +74,9 @@ class IPCTests(TestCase):
         with IPCClient(connection_name, timeout=1) as client:
             # "foo bar" with extra accents on letters.
             # In UTF-8 encoding so we don't confuse editors opening this file.
-            fancy_text = b'f\xcc\xb6o\xcc\xb2\xf0\x9d\x91\x9c \xd0\xb2\xe2\xb7\xa1a\xcc\xb6r\xcc\x93\xcd\x98\xcd\x8c'
-            client.write(fancy_text.decode('utf-8'))
-            assert client.read() == fancy_text.decode('utf-8')
+            fancy_text = b"f\xcc\xb6o\xcc\xb2\xf0\x9d\x91\x9c \xd0\xb2\xe2\xb7\xa1a\xcc\xb6r\xcc\x93\xcd\x98\xcd\x8c"
+            client.write(fancy_text.decode("utf-8"))
+            assert client.read() == fancy_text.decode("utf-8")
 
             client.write("Test with spaces")
             client.write("Test write before reading previous")


### PR DESCRIPTION
This does 2 things:
1. It changes the IPC code to work with multiple messages.
2. It changes the dmypy client/server communication so that it streams stdout/stderr instead of dumping everything at the end.

For 1, we have to provide a way to separate out different messages. I chose to frame messages as bytes separated by whitespace character. That means we have to encode the message in a scheme that escapes whitespace. The urllib.parse quote/unquote seems reasonable. It encodes more than needed but the application is not IPC IO limited so it should be fine. With this convention in place, all we have to do is read from the socket stream until we have a whitespace character.
The framing logic can be easily changed.

For 2, since we communicate with JSONs, it's easy to add a "finished" key that tells us it's the final response from dmypy. Anything else is just stdout/stderr output.

Note: dmypy server also returns out/err which is the output of actual mypy type checking. Right now this change does not stream that output. We can stream that in a followup change. We just have to decide on how to differenciate the 4 text streams (stdout/stderr/out/err) that will now be interleaved.

Played around with it on Linux quite a bit. Will also test it some more on Windows.

The WriteToConn class could use more love. I just put a bare minimum to test the rest.
