### PR TITLE
[mypyc] Optimize TYPE_CHECKING to False at Runtime

### DIFF
--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -126,6 +126,8 @@ def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
         return builder.true()
     if fullname == "builtins.False":
         return builder.false()
+    if fullname in ('typing.TYPE_CHECKING', 'typing_extensions.TYPE_CHECKING'):
+        return builder.false()
 
     math_literal = transform_math_literal(builder, fullname)
     if math_literal is not None:
@@ -185,6 +187,10 @@ def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
 
 
 def transform_member_expr(builder: IRBuilder, expr: MemberExpr) -> Value:
+    # Special Cases
+    if expr.fullname in ('typing.TYPE_CHECKING', 'typing_extensions.TYPE_CHECKING'):
+        return builder.false()
+
     # First check if this is maybe a final attribute.
     final = builder.get_final_ref(expr)
     if final is not None:

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -126,7 +126,7 @@ def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
         return builder.true()
     if fullname == "builtins.False":
         return builder.false()
-    if fullname in ('typing.TYPE_CHECKING', 'typing_extensions.TYPE_CHECKING'):
+    if fullname in ("typing.TYPE_CHECKING", "typing_extensions.TYPE_CHECKING"):
         return builder.false()
 
     math_literal = transform_math_literal(builder, fullname)
@@ -188,7 +188,7 @@ def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
 
 def transform_member_expr(builder: IRBuilder, expr: MemberExpr) -> Value:
     # Special Cases
-    if expr.fullname in ('typing.TYPE_CHECKING', 'typing_extensions.TYPE_CHECKING'):
+    if expr.fullname in ("typing.TYPE_CHECKING", "typing_extensions.TYPE_CHECKING"):
         return builder.false()
 
     # First check if this is maybe a final attribute.

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3705,3 +3705,33 @@ def f(arg):
     arg :: __main__.A
 L0:
     return arg
+
+[case testTypeCheckingFlag]
+from typing import TYPE_CHECKING, List
+
+def f(arg: List[int]) -> int:
+    if TYPE_CHECKING:
+        from collections.abc import Sized
+    s: Sized = arg
+    return len(s)
+
+[out]
+def f(arg):
+    arg :: list
+    r0 :: bool
+    r1 :: int
+    r2 :: bit
+    s :: object
+    r3 :: int
+L0:
+    r0 = 0 << 1
+    r1 = extend r0: builtins.bool to builtins.int
+    r2 = r1 != 0
+    if r2 goto L1 else goto L2 :: bool
+L1:
+    goto L3
+L2:
+L3:
+    s = arg
+    r3 = CPyObject_Size(s)
+    return r3


### PR DESCRIPTION
Fixes [mypyc/mypyc#902](https://github.com/mypyc/mypyc/issues/902)

This PR finds references of `typing.TYPE_CHECKING` or `typing_extensions.TYPE_CHECKING` and optimizes them to `False` in mypyc.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
