### PR TITLE
Stubtest: add some hacks so that `sys.monitoring` is checked in typeshed's CI

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -355,7 +355,7 @@ def verify_mypyfile(
     def _belongs_to_runtime(r: types.ModuleType, attr: str) -> bool:
         """Heuristics to determine whether a name originates from another module."""
         obj = getattr(r, attr)
-        if isinstance(obj, types.ModuleType):
+        if isinstance(obj, types.ModuleType) and not (r is sys and attr == "monitoring"):
             return False
         if callable(obj):
             # It's highly likely to be a class or a function if it's callable,
@@ -390,7 +390,9 @@ def verify_mypyfile(
 
     for entry in sorted(to_check):
         stub_entry = stub.names[entry].node if entry in stub.names else MISSING
-        if isinstance(stub_entry, nodes.MypyFile):
+        if isinstance(stub_entry, nodes.MypyFile) and not (
+            runtime is sys and entry == "monitoring"
+        ):
             # Don't recursively check exported modules, since that leads to infinite recursion
             continue
         assert stub_entry is not None


### PR DESCRIPTION
Currently, stubtest isn't detecting that `sys.monitoring` is missing in typeshed's CI. Even if you add `sys.monitoring`, stubtest doesn't verify that any of the details about `sys.monitoring` are correct, since `sys.monitoring` is somewhat unique: it's a genuine instance of `types.ModuleType` in the global namespace of the `sys` module, but `import sys.monitoring` will fail at runtime (`sys` isn't a package).

I verified locally that these changes cause stubtest to start complaining about `sys.monitoring` being missing with typeshed's current setup; and, if https://github.com/python/typeshed/pull/10890 were merged, these changes here would cause stubtest to start complaining if there were any inaccuracies between the runtime and the stubs for `sys.monitoring`