### PR TITLE
Bump test deps: `ruff` and `pre-commit-hooks`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^(mypyc/external/)|(mypy/typeshed/)'  # Exclude all vendored code from lints
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0  # must match test-requirements.txt
+    rev: v4.5.0  # must match test-requirements.txt
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292  # must match test-requirements.txt
+    rev: v0.1.0  # must match test-requirements.txt
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,11 +6,11 @@ filelock>=3.3.0
 # lxml 4.9.3 switched to manylinux_2_28, the wheel builder still uses manylinux2014
 lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
 pre-commit
-pre-commit-hooks==4.4.0
+pre-commit-hooks==4.5.0
 psutil>=4.0
 pytest>=7.4.0
 pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
-ruff==0.0.292  # must match version in .pre-commit-config.yaml
+ruff==0.1.0  # must match version in .pre-commit-config.yaml
 setuptools>=65.5.1
 tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.7


### PR DESCRIPTION
Release post: https://astral.sh/blog/ruff-v0.1.0