### PR TITLE
Attempt to fix daemon crash related to ABCs

### DIFF
--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -46,6 +46,8 @@ def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: E
     abstract attribute.  Also compute a list of abstract attributes.
     Report error is required ABCMeta metaclass is missing.
     """
+    typ.is_abstract = False
+    typ.abstract_attributes = []
     if typ.typeddict_type:
         return  # TypedDict can't be abstract
     concrete: set[str] = set()
@@ -56,7 +58,6 @@ def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: E
         # Special case: NewTypes are considered as always non-abstract, so they can be used as:
         #     Config = NewType('Config', Mapping[str, str])
         #     default = Config({'cannot': 'modify'})  # OK
-        typ.abstract_attributes = []
         return
     for base in typ.mro:
         for name, symnode in base.names.items():


### PR DESCRIPTION
I couldn't reproduce the crash with a small example, but this seems to fix this crash in a large codebase:
```
Traceback (most recent call last):
  File "/Users/jukka/src/mypy/mypy/dmypy_server.py", line 234, in serve
    resp = self.run_command(command, data)
  File "/Users/jukka/src/mypy/mypy/dmypy_server.py", line 281, in run_command
    ret = method(self, **data)
  File "/Users/jukka/src/mypy/mypy/dmypy_server.py", line 359, in cmd_check
    return self.check(sources, export_types, is_tty, terminal_width)
  File "/Users/jukka/src/mypy/mypy/dmypy_server.py", line 413, in check
    res = self.initialize_fine_grained(sources, is_tty, terminal_width)
  File "/Users/jukka/src/mypy/mypy/dmypy_server.py", line 498, in initialize_fine_grained
    messages = self.fine_grained_manager.update(changed, removed)
  File "/Users/jukka/src/mypy/mypy/server/update.py", line 267, in update
    result = self.update_one(
  File "/Users/jukka/src/mypy/mypy/server/update.py", line 369, in update_one
    result = self.update_module(next_id, next_path, next_id in removed_set, followed)
  File "/Users/jukka/src/mypy/mypy/server/update.py", line 431, in update_module
    result = update_module_isolated(
  File "/Users/jukka/src/mypy/mypy/server/update.py", line 667, in update_module_isolated
    state.type_check_first_pass()
  File "/Users/jukka/src/mypy/mypy/build.py", line 2306, in type_check_first_pass
    self.type_checker().check_first_pass()
  File "/Users/jukka/src/mypy/mypy/checker.py", line 475, in check_first_pass
    self.accept(d)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 587, in accept
    report_internal_error(err, self.errors.file, stmt.line, self.errors, self.options)
  File "/Users/jukka/src/mypy/mypy/errors.py", line 1261, in report_internal_error
    raise err
  File "/Users/jukka/src/mypy/mypy/checker.py", line 585, in accept
    stmt.accept(self)
  File "/Users/jukka/src/mypy/mypy/nodes.py", line 900, in accept
    return visitor.visit_decorator(self)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 4773, in visit_decorator
    self.visit_decorator_inner(e)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 4778, in visit_decorator_inner
    self.check_func_item(e.func, name=e.func.name, allow_empty=allow_empty)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 1071, in check_func_item
    self.check_func_def(defn, typ, name, allow_empty)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 1281, in check_func_def
    self.accept(item.body)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 587, in accept
    report_internal_error(err, self.errors.file, stmt.line, self.errors, self.options)
  File "/Users/jukka/src/mypy/mypy/errors.py", line 1261, in report_internal_error
    raise err
  File "/Users/jukka/src/mypy/mypy/checker.py", line 585, in accept
    stmt.accept(self)
  File "/Users/jukka/src/mypy/mypy/nodes.py", line 1226, in accept
    return visitor.visit_block(self)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 2754, in visit_block
    self.accept(s)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 587, in accept
    report_internal_error(err, self.errors.file, stmt.line, self.errors, self.options)
  File "/Users/jukka/src/mypy/mypy/errors.py", line 1261, in report_internal_error
    raise err
  File "/Users/jukka/src/mypy/mypy/checker.py", line 585, in accept
    stmt.accept(self)
  File "/Users/jukka/src/mypy/mypy/nodes.py", line 1313, in accept
    return visitor.visit_assignment_stmt(self)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 2802, in visit_assignment_stmt
    self.check_assignment(s.lvalues[-1], s.rvalue, s.type is None, s.new_syntax)
  File "/Users/jukka/src/mypy/mypy/checker.py", line 3009, in check_assignment
    rvalue_type = self.expr_checker.accept(rvalue, type_context=type_context)
  File "/Users/jukka/src/mypy/mypy/checkexpr.py", line 5372, in accept
    report_internal_error(
  File "/Users/jukka/src/mypy/mypy/errors.py", line 1261, in report_internal_error
    raise err
  File "/Users/jukka/src/mypy/mypy/checkexpr.py", line 5370, in accept
    typ = node.accept(self)
  File "/Users/jukka/src/mypy/mypy/nodes.py", line 1907, in accept
    return visitor.visit_call_expr(self)
  File "/Users/jukka/src/mypy/mypy/checkexpr.py", line 452, in visit_call_expr
    return self.visit_call_expr_inner(e, allow_none_return=allow_none_return)
  File "/Users/jukka/src/mypy/mypy/checkexpr.py", line 581, in visit_call_expr_inner
    ret_type = self.check_call_expr_with_callee_type(
  File "/Users/jukka/src/mypy/mypy/checkexpr.py", line 1420, in check_call_expr_with_callee_type
    ret_type, callee_type = self.check_call(
  File "/Users/jukka/src/mypy/mypy/checkexpr.py", line 1514, in check_call
    return self.check_callable_call(
  File "/Users/jukka/src/mypy/mypy/checkexpr.py", line 1638, in check_callable_call
    self.msg.cannot_instantiate_abstract_class(
  File "/Users/jukka/src/mypy/mypy/messages.py", line 1479, in cannot_instantiate_abstract_class
    attrs = format_string_list([f'"{a}"' for a in abstract_attributes])
  File "/Users/jukka/src/mypy/mypy/messages.py", line 2948, in format_string_list
    assert lst
AssertionError
```

I suspect that we first set `is_abstract` to true, and later the class was no longer abstract and `abstract_attributes` got cleared, but `is_abstract` was stuck at true.