### PR TITLE
Suggest a more complete annotation pkg for lxml

### DIFF
--- a/mypy/stubinfo.py
+++ b/mypy/stubinfo.py
@@ -169,5 +169,5 @@ non_bundled_packages = {
     # Since these can be installed automatically via --install-types, we have a high trust bar
     # for additions here
     "pandas": "pandas-stubs",  # https://github.com/pandas-dev/pandas-stubs
-    "lxml": "lxml-stubs",  # https://github.com/lxml/lxml-stubs
+    "lxml": "types-lxml",  # https://github.com/abelcheung/types-lxml
 }


### PR DESCRIPTION
This is a continuation of PR #14737 ; I'd want to officially recommend [external annotation I've been working](https://github.com/abelcheung/types-lxml) over `lxml-stubs`, because annotation of the whole `lxml` package is basically complete (except a few minor submodules that I'm doubtful anybody is using at all), and I'm still actively maintaining it.