### PR TITLE
fix: remove redundant `.format()`

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -686,7 +686,7 @@ class Emitter:
             if likely:
                 check = f"(likely{check})"
             self.emit_arg_check(src, dest, typ, check, optional)
-            self.emit_lines(f"    {dest} = {src};".format(dest, src), "else {")
+            self.emit_lines(f"    {dest} = {src};", "else {")
             self.emit_cast_error_handler(error, src, dest, typ, raise_exception)
             self.emit_line("}")
         elif is_none_rprimitive(typ):


### PR DESCRIPTION
* (fix): remove call to a `.format()` method for an f-string in the emit.py module.

___

It looks like there is a redundant `.format()` call for an f-string.
Originally this was added in 040f3ab64a86efcf7093ada1b13842e56715f243 revision at [562th line](https://github.com/python/mypy/commit/040f3ab64a86efcf7093ada1b13842e56715f243#diff-09b5e6725588fd1151b6c533dc4c0e748d73d6b4e85799a7737959175832fdeeR562).
I doubt there is any need to use `.format()` when it's been formatted using the f-string simultaneously. (Although it's legal and isn't producing any exception or unexpected behaviour...)

___

I didn't create a separate issue for this since it seems like a minor fix and does not affect behavior.

