### PR TITLE
Fix daemon false positives related to module-level __getattr__

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1991,7 +1991,7 @@ class State:
                 raise ModuleNotFound
 
             # Parse the file (and then some) to get the dependencies.
-            self.parse_file()
+            self.parse_file(temporary=temporary)
             self.compute_dependencies()
 
     @property
@@ -2109,7 +2109,7 @@ class State:
 
     # Methods for processing modules from source code.
 
-    def parse_file(self) -> None:
+    def parse_file(self, *, temporary: bool = False) -> None:
         """Parse file and run first pass of semantic analysis.
 
         Everything done here is local to the file. Don't depend on imported
@@ -2194,12 +2194,14 @@ class State:
         else:
             self.early_errors = manager.ast_cache[self.id][1]
 
-        modules[self.id] = self.tree
+        if not temporary:
+            modules[self.id] = self.tree
 
         if not cached:
             self.semantic_analysis_pass1()
 
-        self.check_blockers()
+        if not temporary:
+            self.check_blockers()
 
         manager.ast_cache[self.id] = (self.tree, self.early_errors)
 

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -837,15 +837,13 @@ p.a.f(1)
 [file p/__init__.py]
 [file p/a.py]
 def f(x: str) -> None: pass
-[delete p/__init__.py.2]
-[delete p/a.py.2]
-def f(x: str) -> None: pass
+[delete p.2]
 [out]
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 ==
 main:1: error: Cannot find implementation or library stub for module named "p.a"
 main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-main:2: error: "object" has no attribute "a"
+main:1: error: Cannot find implementation or library stub for module named "p"
 
 [case testDeletePackage2]
 import p

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10341,8 +10341,10 @@ a.py:1: note: Use "-> None" if function does not return a value
 [case testModuleLevelGetAttrInStub]
 import stub
 import a
+import b
 
-[file stub.pyi]
+[file stub/__init__.pyi]
+s: str
 def __getattr__(self): pass
 
 [file a.py]
@@ -10352,5 +10354,13 @@ from stub import x
 from stub.pkg import y
 from stub.pkg.sub import z
 
+[file b.py]
+
+[file b.py.3]
+from stub import s
+reveal_type(s)
+
 [out]
 ==
+==
+b.py:2: note: Revealed type is "builtins.str"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10337,3 +10337,20 @@ b.py:1: note: Use "-> None" if function does not return a value
 ==
 a.py:1: error: Function is missing a return type annotation
 a.py:1: note: Use "-> None" if function does not return a value
+
+[case testModuleLevelGetAttrInStub]
+import stub
+import a
+
+[file stub.pyi]
+def __getattr__(self): pass
+
+[file a.py]
+
+[file a.py.2]
+from stub import x
+from stub.pkg import y
+from stub.pkg.sub import z
+
+[out]
+==


### PR DESCRIPTION
In some cases, mypy daemon could generate false positives about imports targeting packages with a module-level `__getattr__` methods. The root cause was that the `mypy.build.in_partial_package` function would leave a partially initialized module in the `modules` dictionary of `BuildManager`, which could probably cause all sorts of confusion. I fixed this by making sure that ASTs related to temporary `State` objects don't get persisted.

Also updated a test case to properly delete a package -- an empty directory is now actually a valid namespace package, so to delete a package we should delete the directory, not just the files inside it.