### PR TITLE
Correctly recognize `typing_extensions.NewType`

### DIFF
--- a/mypy/semanal_newtype.py
+++ b/mypy/semanal_newtype.py
@@ -147,7 +147,7 @@ class NewTypeAnalyzer:
             and isinstance(s.lvalues[0], NameExpr)
             and isinstance(s.rvalue, CallExpr)
             and isinstance(s.rvalue.callee, RefExpr)
-            and s.rvalue.callee.fullname == "typing.NewType"
+            and (s.rvalue.callee.fullname in ("typing.NewType", "typing_extensions.NewType"))
         ):
             name = s.lvalues[0].name
 

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -379,3 +379,10 @@ N = NewType('N', XXX)  # E: Argument 2 to NewType(...) must be subclassable (got
                        # E: Name "XXX" is not defined
 x: List[Union[N, int]]
 [builtins fixtures/list.pyi]
+
+[case testTypingExtensionsNewType]
+# flags: --python-version 3.7
+from typing_extensions import NewType
+N = NewType("N", int)
+x: N
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->

fixes #16297.

since the `.+_NAMES` constants in `types.py` are each referenced multiple times while other examples like this (i.e.  a `.+_NAMES` tuple/set used only once) are inlined, I've inlined this one.

i added a test for this but for some reason it passes without this patch, even though it fails if it's run manually outside of the test suite. any idea why this is? thank you!