### PR TITLE
stubgen: fix missing property setter in semantic analysis mode

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -633,6 +633,7 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
 
         Only preserve certain special decorators such as @abstractmethod.
         """
+        o.func.is_overload = False
         for decorator in o.original_decorators:
             if not isinstance(decorator, (NameExpr, MemberExpr)):
                 continue

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -669,8 +669,6 @@ class BaseStubGenerator:
                 self.add_name(f"{pkg}.{t}", require=False)
 
     def check_undefined_names(self) -> None:
-        print(self._all_)
-        print(self._toplevel_names)
         undefined_names = [name for name in self._all_ or [] if name not in self._toplevel_names]
         if undefined_names:
             if self._output:

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -377,6 +377,24 @@ class A:
     def f(self, x) -> None: ...
     def h(self) -> None: ...
 
+[case testProperty_semanal]
+class A:
+    @property
+    def f(self):
+        return 1
+    @f.setter
+    def f(self, x): ...
+
+    def h(self):
+        self.f = 1
+[out]
+class A:
+    @property
+    def f(self): ...
+    @f.setter
+    def f(self, x) -> None: ...
+    def h(self) -> None: ...
+
 -- a read/write property is treated the same as an attribute
 [case testProperty_inspect]
 class A:


### PR DESCRIPTION
The semantic analyzer treats properties as overloaded functions. This was previously ignored by stubgen but regressed in #15232.
This PR restores the original behavior.

Fixes #16300
