### PR TITLE
Fix module cache invalidation when `per_module_options` change

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -53,6 +53,7 @@ from mypy.semanal import SemanticAnalyzer
 from mypy.semanal_pass1 import SemanticAnalyzerPreAnalysis
 from mypy.util import (
     DecodeError,
+    compute_hash,
     decode_python_encoding,
     get_mypy_comments,
     hash_digest,
@@ -1490,15 +1491,6 @@ def validate_meta(
     # It's a match on (id, path, size, hash, mtime).
     manager.log(f"Metadata fresh for {id}: file {path}")
     return meta
-
-
-def compute_hash(text: str) -> str:
-    # We use a crypto hash instead of the builtin hash(...) function
-    # because the output of hash(...)  can differ between runs due to
-    # hash randomization (enabled by default in Python 3.3).  See the
-    # note in
-    # https://docs.python.org/3/reference/datamodel.html#object.__hash__.
-    return hash_digest(text.encode("utf-8"))
 
 
 def json_dumps(obj: Any, debug_cache: bool) -> str:

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -15,29 +15,13 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Final,
-    Iterable,
-    List,
-    Mapping,
-    MutableMapping,
-    Sequence,
-    TextIO,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Final, Iterable, Mapping, MutableMapping, Sequence, TextIO, cast
 from typing_extensions import TypeAlias as _TypeAlias
 
 from mypy import defaults
-from mypy.options import PER_MODULE_OPTIONS, Options
+from mypy.options import PER_MODULE_OPTIONS, ConfigValueType, Options
 
-_CONFIG_VALUE_TYPES: _TypeAlias = Union[
-    str, bool, int, float, Dict[str, str], List[str], Tuple[int, int]
-]
-_INI_PARSER_CALLABLE: _TypeAlias = Callable[[Any], _CONFIG_VALUE_TYPES]
+_INI_PARSER_CALLABLE: _TypeAlias = Callable[[Any], ConfigValueType]
 
 
 def parse_version(v: str | float) -> tuple[int, int]:
@@ -429,14 +413,14 @@ def parse_section(
     template: Options,
     set_strict_flags: Callable[[], None],
     section: Mapping[str, Any],
-    config_types: dict[str, Any],
+    config_types: dict[str, _INI_PARSER_CALLABLE],
     stderr: TextIO = sys.stderr,
-) -> tuple[dict[str, object], dict[str, str]]:
+) -> tuple[dict[str, ConfigValueType], dict[str, str]]:
     """Parse one section of a config file.
 
     Returns a dict of option values encountered, and a dict of report directories.
     """
-    results: dict[str, object] = {}
+    results: dict[str, ConfigValueType] = {}
     report_dirs: dict[str, str] = {}
 
     # Because these fields exist on Options, without proactive checking, we would accept them
@@ -446,6 +430,7 @@ def parse_section(
         "disabled_error_codes": "disable_error_code",
     }
 
+    ct: Any
     for key in section:
         invert = False
         options_key = key
@@ -496,13 +481,13 @@ def parse_section(
                 else:
                     continue
             ct = type(dv)
-        v: Any = None
+        v: ConfigValueType
         try:
             if ct is bool:
                 if isinstance(section, dict):
                     v = convert_to_boolean(section.get(key))
                 else:
-                    v = section.getboolean(key)  # type: ignore[attr-defined]  # Until better stub
+                    v = cast(bool, section.getboolean(key))  # type: ignore[attr-defined]  # Until better stub
                 if invert:
                     v = not v
             elif callable(ct):
@@ -596,7 +581,7 @@ def mypy_comments_to_config_map(line: str, template: Options) -> tuple[dict[str,
 
 def parse_mypy_comments(
     args: list[tuple[int, str]], template: Options
-) -> tuple[dict[str, object], list[tuple[int, str]]]:
+) -> tuple[dict[str, ConfigValueType], list[tuple[int, str]]]:
     """Parse a collection of inline mypy: configuration comments.
 
     Returns a dictionary of options to be applied and a list of error messages
@@ -604,7 +589,7 @@ def parse_mypy_comments(
     """
 
     errors: list[tuple[int, str]] = []
-    sections = {}
+    sections: dict[str, ConfigValueType] = {}
 
     for lineno, line in args:
         # In order to easily match the behavior for bools, we abuse configparser.

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -826,3 +826,12 @@ def quote_docstring(docstr: str) -> str:
         return f"''{docstr_repr}''"
     else:
         return f'""{docstr_repr}""'
+
+
+def compute_hash(text: str) -> str:
+    # We use a crypto hash instead of the builtin hash(...) function
+    # because the output of hash(...)  can differ between runs due to
+    # hash randomization (enabled by default in Python 3.3).  See the
+    # note in
+    # https://docs.python.org/3/reference/datamodel.html#object.__hash__.
+    return hash_digest(text.encode("utf-8"))

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -14,7 +14,6 @@ from mypy.build import (
     BuildSource,
     State,
     build,
-    compute_hash,
     create_metastore,
     get_cache_names,
     sorted_components,
@@ -24,7 +23,7 @@ from mypy.fscache import FileSystemCache
 from mypy.nodes import MypyFile
 from mypy.options import Options
 from mypy.plugin import Plugin, ReportConfigContext
-from mypy.util import hash_digest
+from mypy.util import compute_hash, hash_digest
 from mypyc.codegen.cstring import c_string_initializer
 from mypyc.codegen.emit import Emitter, EmitterContext, HeaderDeclaration, c_array_initializer
 from mypyc.codegen.emitclass import generate_class, generate_class_type_decl

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5053,6 +5053,59 @@ python_version=3.6
 [out2]
 tmp/a.py:2: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
+[case testChangedPerModuleOptionsInvalidateCache]
+# flags: --config-file tmp/mypy.ini
+import m
+[file m.py]
+def foo():
+    pass
+[file mypy.ini]
+\[mypy]
+\[mypy-a]
+warn_no_return = True
+[file mypy.ini.2]
+\[mypy]
+\[mypy-a]
+warn_no_return = False
+[out]
+[out2]
+-- Every file should get reloaded, potentially contains changed modules
+[rechecked m, _typeshed, builtins, typing]
+
+[case testAddedPerModuleOptionsInvalidateCache]
+# flags: --config-file tmp/mypy.ini
+import m
+[file m.py]
+def foo():
+    pass
+[file mypy.ini]
+\[mypy]
+[file mypy.ini.2]
+\[mypy]
+\[mypy-a]
+warn_no_return = False
+[out]
+[out2]
+-- Every file should get reloaded, potentially contains changed modules
+[rechecked m, _typeshed, builtins, typing]
+
+[case testRemovedPerModuleOptionsInvalidateCache]
+# flags: --config-file tmp/mypy.ini
+import m
+[file m.py]
+def foo():
+    pass
+[file mypy.ini]
+\[mypy]
+\[mypy-a]
+warn_no_return = True
+[file mypy.ini.2]
+\[mypy]
+[out]
+[out2]
+-- Every file should get reloaded, potentially contains changed modules
+[rechecked m, _typeshed, builtins, typing]
+
 [case testPluginConfigData]
 # flags: --config-file tmp/mypy.ini
 import a


### PR DESCRIPTION
Fixes #7777

Adds a hashed version of per_module_options to `.meta.json` files. This means that any changes to `per_module_options` will invalidate module caches. Previously old cache was used regardless of the previous modules options used.

**Commits**

4833299f27a293cb129de75cdae710211ed41d72 adds 3 tests which demonstrate that **adding**, **removing** or **changing** `per_moduled_options` did not properly invalidate the cache. (#7777 reported one of these issues).

424711d2e38a972ff5c76373718710f32a62a73f adds type annotations to `per_moduled_options`. All of the types are serializable with `json.dumps`

9c72de424e3c139660fe7ae773cdeea799aaa225 implements the hashing logic, which fix all three test cases added in the first commit

**Implementation details**

- Uses existing `compute_hash` function (moved from `build.py` to `utils.py` as it is now needed in multiple files).
- `json.dumps(... separators=(",", ":") ...)` pattern is already used in this repo in multiple places as part of hashing
- Test naming copied from plugin examples: `testAddedPluginsInvalidateCache` --> `testAddedPerModuleOptionsInvalidateCache`
- The hash is calculated at the first `clone_for_module` call. Options "...should be considered read-only..." after the first call based on the docstring
- The hash is stored in `Options.per_module_options_hash` and added to `OPTIONS_AFFECTING_CACHE`, which means it will get added to `.meta.json` files

**Notes**

The current `.mypy_cache`'s `.meta.json` files do not contain `per_module_options_hash`. Based on my manual testing running mypy back and forth with these changes and without it does not seem to cause any issues.


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
