### PR TITLE
Fix sdist build by not including CHANGELOG.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -42,7 +42,7 @@ include pytest.ini
 include tox.ini
 
 include LICENSE mypyc/README.md
-exclude .gitmodules CONTRIBUTING.md CREDITS ROADMAP.md action.yml .editorconfig
+exclude .gitmodules CONTRIBUTING.md CREDITS ROADMAP.md CHANGELOG.md action.yml .editorconfig
 exclude .git-blame-ignore-revs .pre-commit-config.yaml
 
 global-exclude *.py[cod]


### PR DESCRIPTION
This is an attempt to fix wheel builds. Perhaps we'd want to actually include the changelog in the sdist. We can decide this later after the build has bee fixed.

We've been getting these errors:
```
...
lists of files in version control and sdist do not match!
missing from sdist:
  CHANGELOG.md
listing source files under version control: 830 files and directories
building an sdist: mypy-1.7.0+dev.ffe89a21058eaa6eb1c1796d9ab87aece965e2d9.tar.gz: 829 files and directories
copying source files to a temporary directory
building a clean sdist: mypy-1.7.0+dev.tar.gz: 829 files and directories
suggested MANIFEST.in rules:
  include *.md
Error: Process completed with exit code 1.
``

Example failure:
https://github.com/mypyc/mypy_mypyc-wheels/actions/runs/6555980362/job/17805243900