### PR TITLE
Run macOS mypyc tests with Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,8 @@ jobs:
           tox_extra_args: "-n 2"
           test_mypyc: true
 
-        - name: mypyc runtime tests with py38-macos
-          python: '3.8.17'
+        - name: mypyc runtime tests with py39-macos
+          python: '3.9.18'
           arch: x64
           os: macos-latest
           toxenv: py


### PR DESCRIPTION
The 3.8 tests have been flaking for several weeks and I don't think anyone has a good repro or idea as to the cause