### PR TITLE
Write stubs with utf-8 encoding

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1578,7 +1578,7 @@ def generate_stub_for_py_module(
     subdir = os.path.dirname(target)
     if subdir and not os.path.isdir(subdir):
         os.makedirs(subdir)
-    with open(target, "w") as file:
+    with open(target, "w", encoding="utf-8") as file:
         file.write(output)
 
 

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -3485,7 +3485,7 @@ def f2(): ...
 class A:
     """class docstring
 
-    a multiline docstring"""
+    a multiline 😊 docstring"""
     def func():
         """func docstring
         don't forget to indent"""
@@ -3512,7 +3512,7 @@ class B:
 class A:
     """class docstring
 
-    a multiline docstring"""
+    a multiline 😊 docstring"""
     def func() -> None:
         """func docstring
         don't forget to indent"""


### PR DESCRIPTION
This is to ensure that you don't get encoding errors if docstrings contains odd characters like emojis.