### PR TITLE
Properly use proper subtyping for callables

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1352,7 +1352,11 @@ def find_matching_overload_item(overloaded: Overloaded, template: CallableType) 
         # Return type may be indeterminate in the template, so ignore it when performing a
         # subtype check.
         if mypy.subtypes.is_callable_compatible(
-            item, template, is_compat=mypy.subtypes.is_subtype, ignore_return=True
+            item,
+            template,
+            is_compat=mypy.subtypes.is_subtype,
+            is_proper_subtype=False,
+            ignore_return=True,
         ):
             return item
     # Fall back to the first item if we can't find a match. This is totally arbitrary --
@@ -1370,7 +1374,11 @@ def find_matching_overload_items(
         # Return type may be indeterminate in the template, so ignore it when performing a
         # subtype check.
         if mypy.subtypes.is_callable_compatible(
-            item, template, is_compat=mypy.subtypes.is_subtype, ignore_return=True
+            item,
+            template,
+            is_compat=mypy.subtypes.is_subtype,
+            is_proper_subtype=False,
+            ignore_return=True,
         ):
             res.append(item)
     if not res:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -462,6 +462,7 @@ def is_overlapping_types(
             left,
             right,
             is_compat=_is_overlapping_types,
+            is_proper_subtype=False,
             ignore_pos_arg_names=True,
             allow_partial_overlap=True,
         )

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -658,6 +658,8 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 left,
                 self.right,
                 is_compat=self._is_subtype,
+                # TODO: this should pass the current value, but then couple tests fail.
+                is_proper_subtype=False,
                 ignore_pos_arg_names=self.subtype_context.ignore_pos_arg_names,
             )
         else:
@@ -677,6 +679,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
                 left,
                 right,
                 is_compat=self._is_subtype,
+                is_proper_subtype=self.proper_subtype,
                 ignore_pos_arg_names=self.subtype_context.ignore_pos_arg_names,
                 strict_concatenate=(self.options.extra_checks or self.options.strict_concatenate)
                 if self.options
@@ -932,6 +935,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
                                 left_item,
                                 right_item,
                                 is_compat=self._is_subtype,
+                                is_proper_subtype=self.proper_subtype,
                                 ignore_return=True,
                                 ignore_pos_arg_names=self.subtype_context.ignore_pos_arg_names,
                                 strict_concatenate=strict_concat,
@@ -940,6 +944,7 @@ class SubtypeVisitor(TypeVisitor[bool]):
                                 right_item,
                                 left_item,
                                 is_compat=self._is_subtype,
+                                is_proper_subtype=self.proper_subtype,
                                 ignore_return=True,
                                 ignore_pos_arg_names=self.subtype_context.ignore_pos_arg_names,
                                 strict_concatenate=strict_concat,
@@ -1358,6 +1363,7 @@ def is_callable_compatible(
     right: CallableType,
     *,
     is_compat: Callable[[Type, Type], bool],
+    is_proper_subtype: bool,
     is_compat_return: Callable[[Type, Type], bool] | None = None,
     ignore_return: bool = False,
     ignore_pos_arg_names: bool = False,
@@ -1517,6 +1523,7 @@ def is_callable_compatible(
         left,
         right,
         is_compat=is_compat,
+        is_proper_subtype=is_proper_subtype,
         ignore_pos_arg_names=ignore_pos_arg_names,
         allow_partial_overlap=allow_partial_overlap,
         strict_concatenate_check=strict_concatenate_check,
@@ -1552,12 +1559,13 @@ def are_parameters_compatible(
     right: Parameters | NormalizedCallableType,
     *,
     is_compat: Callable[[Type, Type], bool],
+    is_proper_subtype: bool,
     ignore_pos_arg_names: bool = False,
     allow_partial_overlap: bool = False,
     strict_concatenate_check: bool = False,
 ) -> bool:
     """Helper function for is_callable_compatible, used for Parameter compatibility"""
-    if right.is_ellipsis_args:
+    if right.is_ellipsis_args and not is_proper_subtype:
         return True
 
     left_star = left.var_arg()
@@ -1566,9 +1574,9 @@ def are_parameters_compatible(
     right_star2 = right.kw_arg()
 
     # Treat "def _(*a: Any, **kw: Any) -> X" similarly to "Callable[..., X]"
-    if are_trivial_parameters(right):
+    if are_trivial_parameters(right) and not is_proper_subtype:
         return True
-    trivial_suffix = is_trivial_suffix(right)
+    trivial_suffix = is_trivial_suffix(right) and not is_proper_subtype
 
     # Match up corresponding arguments and check them for compatibility. In
     # every pair (argL, argR) of corresponding arguments from L and R, argL must

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6501,7 +6501,7 @@ eggs = lambda: 'eggs'
 reveal_type(func(eggs))  # N: Revealed type is "def (builtins.str) -> builtins.str"
 
 spam: Callable[..., str] = lambda x, y: 'baz'
-reveal_type(func(spam))  # N: Revealed type is "def (*Any, **Any) -> builtins.str"
+reveal_type(func(spam))  # N: Revealed type is "def (*Any, **Any) -> Any"
 [builtins fixtures/paramspec.pyi]
 
 [case testGenericOverloadOverlapWithType]
@@ -6672,4 +6672,24 @@ reveal_type(c())  # N: Revealed type is "builtins.str"
 c2 = MyCallable("test")
 reveal_type(c2)  # N: Revealed type is "__main__.MyCallable[builtins.str]"
 reveal_type(c2()) # should be int  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]
+
+[case testOverloadWithStarAnyFallback]
+from typing import overload, Any
+
+class A:
+    @overload
+    def f(self, e: str) -> str: ...
+    @overload
+    def f(self, *args: Any, **kwargs: Any) -> Any: ...
+    def f(self, *args, **kwargs):
+        pass
+
+class B:
+    @overload
+    def f(self, e: str, **kwargs: Any) -> str: ...
+    @overload
+    def f(self, *args: Any, **kwargs: Any) -> Any: ...
+    def f(self, *args, **kwargs):
+        pass
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16338

This is kind of a major change, but it is technically correct: we should not treat `(*args: Any, **kwargs: Any)` special in `is_proper_subtype()` (only in `is_subtype()`). Unfortunately, this requires an additional flag for `is_callable_compatible()`, since currently we are passing the subtype kind information via a callback, which is not applicable to handling argument kinds.
