### PR TITLE
Skip expensive repr() in logging call when not needed

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -255,7 +255,8 @@ def _build(
         stdout=stdout,
         stderr=stderr,
     )
-    manager.trace(repr(options))
+    if manager.verbosity() >= 2:
+        manager.trace(repr(options))
 
     reset_global_state()
     try:


### PR DESCRIPTION
We were spending quite a lot of time in this function when running tests, based on profiling.