### PR TITLE
Fix incremental crash on TypedDict in method

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1745,7 +1745,7 @@ class SemanticAnalyzer(
             if info is None:
                 self.mark_incomplete(defn.name, defn)
             else:
-                self.prepare_class_def(defn, info)
+                self.prepare_class_def(defn, info, custom_names=True)
             return True
         return False
 
@@ -2099,8 +2099,9 @@ class SemanticAnalyzer(
                 # Preserve name from previous fine-grained incremental run.
                 global_name = defn.info.name
             defn.fullname = defn.info._fullname
-            if defn.info.is_named_tuple:
-                # Named tuple nested within a class is stored in the class symbol table.
+            if defn.info.is_named_tuple or defn.info.typeddict_type:
+                # Named tuples and Typed dicts nested within a class are stored
+                # in the class symbol table.
                 self.add_symbol_skip_local(global_name, defn.info)
             else:
                 self.globals[global_name] = SymbolTableNode(GDEF, defn.info)

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -101,6 +101,8 @@ class TypedDictAnalyzer:
             fields, types, statements, required_keys = self.analyze_typeddict_classdef_fields(defn)
             if fields is None:
                 return True, None  # Defer
+            if self.api.is_func_scope() and "@" not in defn.name:
+                defn.name += "@" + str(defn.line)
             info = self.build_typeddict_typeinfo(
                 defn.name, fields, types, required_keys, defn.line, existing_info
             )

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5135,7 +5135,6 @@ tmp/b.py:4: error: First argument to namedtuple() should be "NT", not "BadName"
 tmp/b.py:4: error: First argument to namedtuple() should be "NT", not "BadName"
 
 [case testNewAnalyzerIncrementalMethodNamedTuple]
-
 import a
 [file a.py]
 from b import C
@@ -6540,3 +6539,24 @@ from typing_extensions import TypedDict
 def test() -> None:
     Counts = TypedDict("Counts", {k: int for k in "abc"})  # type: ignore
 [builtins fixtures/dict.pyi]
+
+[case testNoIncrementalCrashOnTypedDictMethod]
+import a
+[file a.py]
+from b import C
+x: C
+[file a.py.2]
+from b import C
+x: C
+reveal_type(x.h)
+[file b.py]
+from typing_extensions import TypedDict
+class C:
+    def __init__(self) -> None:
+        self.h: Hidden
+        class Hidden(TypedDict):
+            x: int
+[builtins fixtures/dict.pyi]
+[out]
+[out2]
+tmp/a.py:3: note: Revealed type is "TypedDict('b.C.Hidden@5', {'x': builtins.int})"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16336

All the story with `@`-names is a mess. FWIW I just copied the logic from named tuples, where it works. So although it is a mess, it will be now a consistent mess, with full parity between `NamedTuple` and `TypedDict`.