### PR TITLE
doc: remove duplicate word

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -133,7 +133,7 @@ imports.
 
     This flag tells mypy that top-level packages will be based in either the
     current directory, or a member of the ``MYPYPATH`` environment variable or
-    :confval:`mypy_path` config option. This option is only useful in
+    :confval:`mypy_path` config option. This option is only useful
     in the absence of `__init__.py`. See :ref:`Mapping file
     paths to modules <mapping-paths-to-modules>` for details.
 


### PR DESCRIPTION
This PR removes one of the duplicate **in** in the sentence "This option is only useful in in the absence of `__init__.py`" in the file `docs/source/command_line.rst`.

No executable code was changed. So, my changes were verified only by reviewing the final sentence in the documentation.