### PR TITLE
Check fallout from restricting `IfStmt`s' `expr` and `body` to length 1

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4493,7 +4493,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # This frame records the knowledge from previous if/elif clauses not being taken.
         # Fall-through to the original frame is handled explicitly in each block.
         with self.binder.frame_context(can_skip=False, conditional_frame=True, fall_through=0):
-            for e, b in zip(s.expr, s.body):
+            for e, b in zip(s.expr[:1], s.body[:1]):
                 t = get_proper_type(self.expr_checker.accept(e))
 
                 if isinstance(t, DeletedType):

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -386,10 +386,10 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
         self.process_lvalue(o.target)
 
     def visit_if_stmt(self, o: IfStmt) -> None:
-        for e in o.expr:
+        for e in o.expr[:1]:
             e.accept(self)
         self.tracker.start_branch_statement()
-        for b in o.body:
+        for b in o.body[:1]:
             if b.is_unreachable:
                 continue
             b.accept(self)

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -477,7 +477,7 @@ class DataclassTransformer:
     def _get_assignment_statements_from_if_statement(
         self, stmt: IfStmt
     ) -> Iterator[AssignmentStmt]:
-        for body in stmt.body:
+        for body in stmt.body[:1]:
             if not body.is_unreachable:
                 yield from self._get_assignment_statements_from_block(body)
         if stmt.else_body is not None and not stmt.else_body.is_unreachable:

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -51,7 +51,7 @@ reverse_op: Final = {"==": "==", "!=": "!=", "<": ">", ">": "<", "<=": ">=", ">=
 
 
 def infer_reachability_of_if_statement(s: IfStmt, options: Options) -> None:
-    for i in range(len(s.expr)):
+    for i in range(len(s.expr[:1])):
         result = infer_condition_value(s.expr[i], options)
         if result in (ALWAYS_FALSE, MYPY_FALSE):
             # The condition is considered always false, so we skip the if/elif body.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -518,7 +518,7 @@ class SemanticAnalyzer(
         def helper(defs: list[Statement]) -> None:
             for stmt in defs.copy():
                 if isinstance(stmt, IfStmt):
-                    for body in stmt.body:
+                    for body in stmt.body[:1]:
                         helper(body.body)
                     if stmt.else_body:
                         helper(stmt.else_body.body)
@@ -4805,7 +4805,7 @@ class SemanticAnalyzer(
     def visit_if_stmt(self, s: IfStmt) -> None:
         self.statement = s
         infer_reachability_of_if_statement(s, self.options)
-        for i in range(len(s.expr)):
+        for i in range(len(s.expr[:1])):
             s.expr[i].accept(self)
             self.visit_block(s.body[i])
         self.visit_block_maybe(s.else_body)

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -115,9 +115,9 @@ class SemanticAnalyzerPreAnalysis(TraverserVisitor):
 
     def visit_if_stmt(self, s: IfStmt) -> None:
         infer_reachability_of_if_statement(s, self.options)
-        for expr in s.expr:
+        for expr in s.expr[:1]:
             expr.accept(self)
-        for node in s.body:
+        for node in s.body[:1]:
             node.accept(self)
         if s.else_body:
             s.else_body.accept(self)

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -251,7 +251,7 @@ class StrConv(NodeVisitor[str]):
 
     def visit_if_stmt(self, o: mypy.nodes.IfStmt) -> str:
         a: list[Any] = []
-        for i in range(len(o.expr)):
+        for i in range(len(o.expr[:1])):
             a.append(("If", [o.expr[i]]))
             a.append(("Then", o.body[i].body))
 

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -198,9 +198,9 @@ class TraverserVisitor(NodeVisitor[None]):
             o.expr.accept(self)
 
     def visit_if_stmt(self, o: IfStmt) -> None:
-        for e in o.expr:
+        for e in o.expr[:1]:
             e.accept(self)
-        for b in o.body:
+        for b in o.body[:1]:
             b.accept(self)
         if o.else_body:
             o.else_body.accept(self)

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -358,8 +358,8 @@ class TransformVisitor(NodeVisitor[Node]):
 
     def visit_if_stmt(self, node: IfStmt) -> IfStmt:
         return IfStmt(
-            self.expressions(node.expr),
-            self.blocks(node.body),
+            self.expressions(node.expr[:1]),
+            self.blocks(node.body[:1]),
             self.optional_block(node.else_body),
         )
 


### PR DESCRIPTION
Are the `IfStmt` attributes  `.expr: list[Expression]` and `.body: list[Block]` ever capable of having a length greater than one?

I gathered from `infer_reachability_of_if_statement` that the purpose of `.expr[1:]` and `.body[1:]` was to handle `elif` clauses, but in practice, `elif`s appear to be contained in the `.else_body: Block` attribute as a nested `IfStmt`, just like the standard library's AST. https://github.com/python/mypy/blob/cf045d924d6688f5f4d0c3402f38d30bc81db299/mypy/reachability.py#L53-L76

There's also the occasional assumptions or assertions of a length of 1, or analysis of only the first `.expr` or `.body` item.
 * https://github.com/python/mypy/blob/cf045d924d6688f5f4d0c3402f38d30bc81db299/mypyc/irbuild/statement.py#L380-L385
 * https://github.com/python/mypy/blob/cf045d924d6688f5f4d0c3402f38d30bc81db299/mypy/fastparse.py#L739-L762

I've ran the tests locally (`python runtests.py pytest-fast`), and there were no unexpected failures from these changes. 