### PR TITLE
Fix daemon crash caused by deleted submodule

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3824,6 +3824,8 @@ class SymbolTableNode:
         # Include declared type of variables and functions.
         if self.type is not None:
             s += f" : {self.type}"
+        if self.cross_ref:
+            s += f" cross_ref:{self.cross_ref}"
         return s
 
     def serialize(self, prefix: str, name: str) -> JsonDict:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10486,3 +10486,22 @@ reveal_type(s)
 ==
 ==
 b.py:2: note: Revealed type is "builtins.str"
+
+[case testRenameSubModule]
+import a
+
+[file a.py]
+import pkg.sub
+
+[file pkg/__init__.py]
+[file pkg/sub/__init__.py]
+from pkg.sub import mod
+[file pkg/sub/mod.py]
+
+[file pkg/sub/__init__.py.2]
+from pkg.sub import modb
+[delete pkg/sub/mod.py.2]
+[file pkg/sub/modb.py.2]
+
+[out]
+==


### PR DESCRIPTION
If a submodule has been deleted while using a fine-grained cache, the daemon could crash during fixup, since there could be a symbol table entry in a parent package that would appear to refer to itself. Handle the case by adding a placeholder symbol table entry instead. Eventually the parent package will be reprocessed and the symbol table will be completed.