### PR TITLE
Allow mypy to output a junit file with per-file results

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -152,6 +152,17 @@ def check_follow_imports(choice: str) -> str:
     return choice
 
 
+def check_junit_format(choice: str) -> str:
+    choices = ["global", "per_file"]
+    if choice not in choices:
+        raise argparse.ArgumentTypeError(
+            "invalid choice '{}' (choose from {})".format(
+                choice, ", ".join(f"'{x}'" for x in choices)
+            )
+        )
+    return choice
+
+
 def split_commas(value: str) -> list[str]:
     # Uses a bit smarter technique to allow last trailing comma
     # and to remove last `""` item from the split.
@@ -173,6 +184,7 @@ ini_config_types: Final[dict[str, _INI_PARSER_CALLABLE]] = {
     "files": split_and_match_files,
     "quickstart_file": expand_path,
     "junit_xml": expand_path,
+    "junit_format": check_junit_format,
     "follow_imports": check_follow_imports,
     "no_site_packages": bool,
     "plugins": lambda s: [p.strip() for p in split_commas(s)],
@@ -200,6 +212,7 @@ toml_config_types.update(
         "python_version": parse_version,
         "mypy_path": lambda s: [expand_path(p) for p in try_split(s, "[,:]")],
         "files": lambda s: split_and_match_files_list(try_split(s)),
+        "junit_format": lambda s: check_junit_format(str(s)),
         "follow_imports": lambda s: check_follow_imports(str(s)),
         "plugins": try_split,
         "always_true": try_split,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -255,6 +255,8 @@ class Options:
         # Write junit.xml to given file
         self.junit_xml: str | None = None
 
+        self.junit_format: str = "global"  # global|per_file
+
         # Caching and incremental checking options
         self.incremental = True
         self.cache_dir = defaults.CACHE_DIR

--- a/mypy/test/testerrorstream.py
+++ b/mypy/test/testerrorstream.py
@@ -29,7 +29,7 @@ def test_error_stream(testcase: DataDrivenTestCase) -> None:
 
     logged_messages: list[str] = []
 
-    def flush_errors(msgs: list[str], serious: bool) -> None:
+    def flush_errors(filename: str | None, msgs: list[str], serious: bool) -> None:
         if msgs:
             logged_messages.append("==== Errors flushed ====")
             logged_messages.extend(msgs)

--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -50,7 +50,7 @@ class GraphSuite(Suite):
             plugin=Plugin(options),
             plugins_snapshot={},
             errors=errors,
-            flush_errors=lambda msgs, serious: None,
+            flush_errors=lambda filename, msgs, serious: None,
             fscache=fscache,
             stdout=sys.stdout,
             stderr=sys.stderr,

--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -4,7 +4,7 @@ import os
 from unittest import TestCase, mock
 
 from mypy.inspections import parse_location
-from mypy.util import get_terminal_width
+from mypy.util import _generate_junit_contents, get_terminal_width
 
 
 class TestGetTerminalSize(TestCase):
@@ -20,3 +20,70 @@ class TestGetTerminalSize(TestCase):
     def test_parse_location_windows(self) -> None:
         assert parse_location(r"C:\test.py:1:1") == (r"C:\test.py", [1, 1])
         assert parse_location(r"C:\test.py:1:1:1:1") == (r"C:\test.py", [1, 1, 1, 1])
+
+
+class TestWriteJunitXml(TestCase):
+    def test_junit_pass(self) -> None:
+        serious = False
+        messages_by_file: dict[str | None, list[str]] = {}
+        expected = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite errors="0" failures="0" name="mypy" skips="0" tests="1" time="1.230">
+  <testcase classname="mypy" file="mypy" line="1" name="mypy-py3.14-test-plat" time="1.230">
+  </testcase>
+</testsuite>
+"""
+        result = _generate_junit_contents(
+            dt=1.23,
+            serious=serious,
+            messages_by_file=messages_by_file,
+            version="3.14",
+            platform="test-plat",
+        )
+        assert result == expected
+
+    def test_junit_fail_two_files(self) -> None:
+        serious = False
+        messages_by_file: dict[str | None, list[str]] = {
+            "file1.py": ["Test failed", "another line"],
+            "file2.py": ["Another failure", "line 2"],
+        }
+        expected = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite errors="0" failures="2" name="mypy" skips="0" tests="2" time="1.230">
+  <testcase classname="mypy" file="file1.py" line="1" name="mypy-py3.14-test-plat file1.py" time="1.230">
+    <failure message="mypy produced messages">Test failed
+another line</failure>
+  </testcase>
+  <testcase classname="mypy" file="file2.py" line="1" name="mypy-py3.14-test-plat file2.py" time="1.230">
+    <failure message="mypy produced messages">Another failure
+line 2</failure>
+  </testcase>
+</testsuite>
+"""
+        result = _generate_junit_contents(
+            dt=1.23,
+            serious=serious,
+            messages_by_file=messages_by_file,
+            version="3.14",
+            platform="test-plat",
+        )
+        assert result == expected
+
+    def test_serious_error(self) -> None:
+        serious = True
+        messages_by_file: dict[str | None, list[str]] = {None: ["Error line 1", "Error line 2"]}
+        expected = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite errors="1" failures="0" name="mypy" skips="0" tests="1" time="1.230">
+  <testcase classname="mypy" file="mypy" line="1" name="mypy-py3.14-test-plat" time="1.230">
+    <failure message="mypy produced messages">Error line 1
+Error line 2</failure>
+  </testcase>
+</testsuite>
+"""
+        result = _generate_junit_contents(
+            dt=1.23,
+            serious=serious,
+            messages_by_file=messages_by_file,
+            version="3.14",
+            platform="test-plat",
+        )
+        assert result == expected

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -105,7 +105,9 @@ def emit_messages(options: Options, messages: list[str], dt: float, serious: boo
     # ... you know, just in case.
     if options.junit_xml:
         py_version = f"{options.python_version[0]}_{options.python_version[1]}"
-        write_junit_xml(dt, serious, messages, options.junit_xml, py_version, options.platform)
+        write_junit_xml(
+            dt, serious, {None: messages}, options.junit_xml, py_version, options.platform
+        )
     if messages:
         print("\n".join(messages))
 


### PR DESCRIPTION
Adds a new `--junit-format` flag to MyPy, which affects the structure of the junit file written when `--junit-xml` is specified (it has no effect when not writing a junit file). This flag can take `global` or `per_file` as values:
* `--junit-format=global` (the default) preserves the existing junit structure, creating a junit file specifying a single "test" for the entire mypy run.
* `--junit-format=per_file` will cause the junit file to have one test entry per file with failures (or a single entry, as in the existing behavior, in the case when typechecking passes).

In some settings it can be useful to know which files had typechecking failures (for example, a CI system might want to display failures by file); while that information can be parsed out of the error messages in the existing junit files, it's much more convenient to have that represented in the junit structure.

Tests for the old and new junit structure have been added.