### PR TITLE
Improve error messages for `super` checks and add more tests

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -206,10 +206,10 @@ SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1: Final = ErrorMessage(
 )
 TARGET_CLASS_HAS_NO_BASE_CLASS: Final = ErrorMessage("Target class has no base class")
 SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED: Final = ErrorMessage(
-    "super() outside of a method is not supported"
+    '"super" outside of a method is not supported'
 )
 SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED: Final = ErrorMessage(
-    "super() requires one or more positional arguments in enclosing function"
+    '"super" requires one or more positional arguments in enclosing function'
 )
 
 # Self-type

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -206,7 +206,7 @@ SUPER_ARG_2_NOT_INSTANCE_OF_ARG_1: Final = ErrorMessage(
 )
 TARGET_CLASS_HAS_NO_BASE_CLASS: Final = ErrorMessage("Target class has no base class")
 SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED: Final = ErrorMessage(
-    '"super" outside of a method is not supported'
+    '"super()" outside of a method is not supported'
 )
 SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED: Final = ErrorMessage(
     '"super" requires one or more positional arguments in enclosing function'

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -209,7 +209,7 @@ SUPER_OUTSIDE_OF_METHOD_NOT_SUPPORTED: Final = ErrorMessage(
     '"super()" outside of a method is not supported'
 )
 SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED: Final = ErrorMessage(
-    '"super" requires one or more positional arguments in enclosing function'
+    '"super()" requires one or two positional arguments in enclosing function'
 )
 
 # Self-type

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -376,14 +376,14 @@ class A:
 
 class B(A):
     def g() -> None: # E: Method must have at least one argument. Did you forget the "self" argument?
-        super().f() # E: "super" requires one or more positional arguments in enclosing function
+        super().f() # E: "super()" requires one or two positional arguments in enclosing function
     def h(self) -> None:
         def a() -> None:
-            super().f() # E: "super" requires one or more positional arguments in enclosing function
+            super().f() # E: "super()" requires one or two positional arguments in enclosing function
     @staticmethod
     def st() -> int:
         reveal_type(super(B, B).st())  # N: Revealed type is "builtins.int"
-        super().st() # E: "super" requires one or more positional arguments in enclosing function
+        super().st() # E: "super()" requires one or two positional arguments in enclosing function
         return 2
 [builtins fixtures/staticmethod.pyi]
 

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -285,7 +285,7 @@ class A:
 class B(A): pass
 class C(B):
     b = super(B, B).x
-    a = super().whatever  # E: "super" outside of a method is not supported
+    a = super().whatever  # E: "super()" outside of a method is not supported
 
 [case testSuperWithObjectClassAsFirstArgument]
 class A:

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -280,8 +280,12 @@ class B(A):
 
 
 [case testSuperOutsideMethodNoCrash]
-class C:
-    a = super().whatever  # E: super() outside of a method is not supported
+class A:
+    x = 1
+class B(A): pass
+class C(B):
+    a = super().whatever  # E: "super" outside of a method is not supported
+    b = super(B, B).x
 
 [case testSuperWithObjectClassAsFirstArgument]
 class A:
@@ -366,13 +370,22 @@ class C(B):
 [case testSuperInMethodWithNoArguments]
 class A:
     def f(self) -> None: pass
+    @staticmethod
+    def st() -> int:
+        return 1
 
 class B(A):
     def g() -> None: # E: Method must have at least one argument. Did you forget the "self" argument?
-        super().f() # E: super() requires one or more positional arguments in enclosing function
+        super().f() # E: "super" requires one or more positional arguments in enclosing function
     def h(self) -> None:
         def a() -> None:
-            super().f() # E: super() requires one or more positional arguments in enclosing function
+            super().f() # E: "super" requires one or more positional arguments in enclosing function
+    @staticmethod
+    def st() -> int:
+        reveal_type(super(B, B).st())  # N: Revealed type is "builtins.int"
+        super().st() # E: "super" requires one or more positional arguments in enclosing function
+        return 2
+[builtins fixtures/staticmethod.pyi]
 
 [case testSuperWithUnsupportedTypeObject]
 from typing import Type

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -284,8 +284,8 @@ class A:
     x = 1
 class B(A): pass
 class C(B):
-    a = super().whatever  # E: "super" outside of a method is not supported
     b = super(B, B).x
+    a = super().whatever  # E: "super" outside of a method is not supported
 
 [case testSuperWithObjectClassAsFirstArgument]
 class A:


### PR DESCRIPTION
Now all messages use the same `"super"` formatting, it used to be a bit different.