### PR TITLE
Add error code for mutable covariant override

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -505,8 +505,8 @@ flagged when this error code is enabled:
         x: int  # Error: Covariant override of a mutable attribute
                 # (base class "C" defined the type as "float",
                 # expression has type "int")  [mutable-override]
-        y: float
-        z: Any
+        y: float  # OK
+        z: Any  # OK
 
     def f(c: C) -> None:
         c.x = 1.1

--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -482,6 +482,37 @@ Example:
         def g(self, y: int) -> None:
             pass
 
+.. _code-mutable-override:
+
+Check that overrides of mutable attributes are safe
+---------------------------------------------------
+
+This will enable the check for unsafe overrides of mutable attributes. For
+historical reasons, and because this is a relatively common pattern in Python,
+this check is not enabled by default. The example below is unsafe, and will be
+flagged when this error code is enabled:
+
+.. code-block:: python
+
+    from typing import Any
+
+    class C:
+        x: float
+        y: float
+        z: float
+
+    class D(C):
+        x: int  # Error: Covariant override of a mutable attribute
+                # (base class "C" defined the type as "float",
+                # expression has type "int")  [mutable-override]
+        y: float
+        z: Any
+
+    def f(c: C) -> None:
+        c.x = 1.1
+    d = D()
+    f(d)
+    d.x >> 1  # This will crash at runtime, because d.x is now float, not an int
 
 .. _code-unimported-reveal:
 

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -255,7 +255,7 @@ UNIMPORTED_REVEAL: Final = ErrorCode(
     "General",
     default_enabled=False,
 )
-MUTABLE_OVERRIDE: Final = ErrorCode(
+MUTABLE_OVERRIDE: Final[ErrorCode] = ErrorCode(
     "mutable-override",
     "Reject covariant overrides for mutable attributes",
     "General",

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -255,6 +255,12 @@ UNIMPORTED_REVEAL: Final = ErrorCode(
     "General",
     default_enabled=False,
 )
+MUTABLE_OVERRIDE: Final = ErrorCode(
+    "mutable-override",
+    "Reject covariant overrides for mutable attributes",
+    "General",
+    default_enabled=False,
+)
 
 
 # Syntax errors are often blocking.

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -63,6 +63,9 @@ INCOMPATIBLE_TYPES: Final = ErrorMessage("Incompatible types")
 INCOMPATIBLE_TYPES_IN_ASSIGNMENT: Final = ErrorMessage(
     "Incompatible types in assignment", code=codes.ASSIGNMENT
 )
+COVARIANT_OVERRIDE_OF_MUTABLE_ATTRIBUTE: Final = ErrorMessage(
+    "Covariant override of a mutable attribute", code=codes.MUTABLE_OVERRIDE
+)
 INCOMPATIBLE_TYPES_IN_AWAIT: Final = ErrorMessage('Incompatible types in "await"')
 INCOMPATIBLE_REDEFINITION: Final = ErrorMessage("Incompatible redefinition")
 INCOMPATIBLE_TYPES_IN_ASYNC_WITH_AENTER: Final = (

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -1164,6 +1164,9 @@ class C:
     def bar(self) -> float: ...
     @bar.setter
     def bar(self, val: float) -> None: ...
+    baz: float
+    bad1: float
+    bad2: float
 class D(C):
     x: int  # E: Covariant override of a mutable attribute (base class "C" defined the type as "float", expression has type "int")  [mutable-override]
     y: float
@@ -1171,4 +1174,9 @@ class D(C):
     w: float
     foo: int
     bar: int  # E: Covariant override of a mutable attribute (base class "C" defined the type as "float", expression has type "int")  [mutable-override]
+    def one(self) -> None:
+        self.baz = 5
+    bad1 = 5  # E: Covariant override of a mutable attribute (base class "C" defined the type as "float", expression has type "int")  [mutable-override]
+    def other(self) -> None:
+        self.bad2: int = 5  # E: Covariant override of a mutable attribute (base class "C" defined the type as "float", expression has type "int")  [mutable-override]
 [builtins fixtures/property.pyi]

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -1148,3 +1148,27 @@ main:3: note: Revealed local types are:
 main:3: note:     x: builtins.int
 main:3: error: Name "reveal_locals" is not defined  [unimported-reveal]
 [builtins fixtures/isinstancelist.pyi]
+
+[case testCovariantMutableOverride]
+# flags: --enable-error-code=mutable-override
+from typing import Any
+
+class C:
+    x: float
+    y: float
+    z: float
+    w: Any
+    @property
+    def foo(self) -> float: ...
+    @property
+    def bar(self) -> float: ...
+    @bar.setter
+    def bar(self, val: float) -> None: ...
+class D(C):
+    x: int  # E: Covariant override of a mutable attribute (base class "C" defined the type as "float", expression has type "int")  [mutable-override]
+    y: float
+    z: Any
+    w: float
+    foo: int
+    bar: int  # E: Covariant override of a mutable attribute (base class "C" defined the type as "float", expression has type "int")  [mutable-override]
+[builtins fixtures/property.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/3208

Interestingly, we already prohibit this when the override is a mutable property (goes through `FuncDef`-related code), and in multiple inheritance. The logic there is not very principled, but I just left a TODO instead of extending the scope of this PR.

