### PR TITLE
Fix junit writing bug introduced in #16388

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1504,7 +1504,12 @@ def maybe_write_junit_xml(
         py_version = f"{options.python_version[0]}_{options.python_version[1]}"
         if options.junit_format == "global":
             util.write_junit_xml(
-                td, serious, {None: all_messages}, options.junit_xml, py_version, options.platform
+                td,
+                serious,
+                {None: all_messages} if all_messages else {},
+                options.junit_xml,
+                py_version,
+                options.platform,
             )
         else:
             # per_file

--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -106,7 +106,12 @@ def emit_messages(options: Options, messages: list[str], dt: float, serious: boo
     if options.junit_xml:
         py_version = f"{options.python_version[0]}_{options.python_version[1]}"
         write_junit_xml(
-            dt, serious, {None: messages}, options.junit_xml, py_version, options.platform
+            dt,
+            serious,
+            {None: messages} if messages else {},
+            options.junit_xml,
+            py_version,
+            options.platform,
         )
     if messages:
         print("\n".join(messages))


### PR DESCRIPTION
#16388 introduced a bug where, with `--junit-format=global`, the junit file would indicate an error (with no message) even if everything passed. That was because `_generate_junit_contents` would check if `messages_by_file` was empty or not to determine if there were failures, but with `--junit-format=global` we'd pass in a dictionary of the form `{None: all_messages}`; `all_messages` would be empty, but the resulting dictionary wouldn't be.

The fix is to pass in an empty dictionary if there are no messages.

I've tested manually with `--junit-format=global` and `--junit-format=per_file` in the successful case to make sure the files are written correctly now.