### PR TITLE
Handle TypeVarTupleType when checking overload constraints

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -949,7 +949,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             for item in actual.items:
                 if isinstance(item, UnpackType):
                     unpacked = get_proper_type(item.type)
-                    if isinstance(unpacked, (TypeVarType, TypeVarTupleType)):
+                    if isinstance(unpacked, TypeVarTupleType):
                         # Cannot infer anything for T from [T, ...] <: *Ts
                         continue
                     assert (

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -949,7 +949,7 @@ class ConstraintBuilderVisitor(TypeVisitor[List[Constraint]]):
             for item in actual.items:
                 if isinstance(item, UnpackType):
                     unpacked = get_proper_type(item.type)
-                    if isinstance(unpacked, TypeVarType):
+                    if isinstance(unpacked, (TypeVarType, TypeVarTupleType)):
                         # Cannot infer anything for T from [T, ...] <: *Ts
                         continue
                     assert (

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -1794,8 +1794,6 @@ from typing import Any, Tuple, TypeVar, TypeVarTuple, Unpack, overload
 
 T = TypeVar("T")
 Ts = TypeVarTuple("Ts")
-
-
 @overload
 def add(self: Tuple[Unpack[Ts]], other: Tuple[T]) -> Tuple[Unpack[Ts], T]:
     ...
@@ -1804,8 +1802,6 @@ def add(self: Tuple[T, ...], other: Tuple[T, ...]) -> Tuple[T, ...]:
     ...
 def add(self: Any, other: Any) -> Any:
     ...
-
-
 def test(a: Tuple[int, str], b: Tuple[bool], c: Tuple[bool, ...]):
     reveal_type(add(a, b))  # N: Revealed type is "Tuple[builtins.int, builtins.str, builtins.bool]"
     reveal_type(add(b, c))  # N: Revealed type is "builtins.tuple[builtins.bool, ...]"

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -1789,6 +1789,28 @@ def test(a: Container[Any], b: Container[int], c: Container[str]):
     reveal_type(build(b, c))  # N: Revealed type is "__main__.Array[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
+[case testTypeVarTupleOverloadArbitraryLength]
+from typing import Any, Tuple, TypeVar, TypeVarTuple, Unpack, overload
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+
+
+@overload
+def add(self: Tuple[Unpack[Ts]], other: Tuple[T]) -> Tuple[Unpack[Ts], T]:
+    ...
+@overload
+def add(self: Tuple[T, ...], other: Tuple[T, ...]) -> Tuple[T, ...]:
+    ...
+def add(self: Any, other: Any) -> Any:
+    ...
+
+
+def test(a: Tuple[int, str], b: Tuple[bool], c: Tuple[bool, ...]):
+    reveal_type(add(a, b))  # N: Revealed type is "Tuple[builtins.int, builtins.str, builtins.bool]"
+    reveal_type(add(b, c))  # N: Revealed type is "builtins.tuple[builtins.bool, ...]"
+[builtins fixtures/tuple.pyi]
+
 [case testTypeVarTupleIndexOldStyleNonNormalizedAndNonLiteral]
 from typing import Any, Tuple
 from typing_extensions import Unpack


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16427

The test case added in the first commit crashes.

The second commit addresses the crash - I don't know whether this fix is
correct, it just happens to stop the crash but it leads to a code branch
which just `continue`s out of a for loop iteration, so it might be
bypassing something it shouldn't. I don't completely understand it.
