### PR TITLE
stubtest: hack for "<unrepresentable>" defaults

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -55,8 +55,10 @@ MISSING: typing_extensions.Final = Missing()
 T = TypeVar("T")
 MaybeMissing: typing_extensions.TypeAlias = Union[T, Missing]
 
+
 class Unrepresentable:
     """Marker object for unrepresentable parameter defaults."""
+
     def __repr__(self) -> str:
         return "<unrepresentable>"
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -658,6 +658,10 @@ def _verify_arg_default_value(
                 if (
                     stub_default is not UNKNOWN
                     and stub_default is not ...
+                    # We use "..." as a hacky representation for "<unrepresentable>"
+                    # defaults on builtins, so ignore those. "..." is unlikely to be used
+                    # as a real default.
+                    and runtime_arg.default is not ...
                     and (
                         stub_default != runtime_arg.default
                         # We want the types to match exactly, e.g. in case the stub has

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -428,12 +428,12 @@ class StubtestUnit(unittest.TestCase):
 
         # Simulate "<unrepresentable>"
         yield Case(
-            stub="def f11(text: object = None) -> None: ...",
+            stub="def f11() -> None: ...",
             runtime="""
             def f11(text=None) -> None: pass
             f11.__text_signature__ = "(text=<unrepresentable>)"
             """,
-            error=None,
+            error="f11",
         )
 
     @collect_cases

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -429,7 +429,10 @@ class StubtestUnit(unittest.TestCase):
         # Simulate "<unrepresentable>"
         yield Case(
             stub="def f11(text: object = None) -> None: ...",
-            runtime="def f11(text = ...): pass",
+            runtime="""
+            def f11(text=None) -> None: pass
+            f11.__text_signature__ = "(text=<unrepresentable>)"
+            """,
             error=None,
         )
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -2195,6 +2195,14 @@ class StubtestMiscUnit(unittest.TestCase):
             == "def (a, b, *, c, d = ..., **kwargs)"
         )
 
+    def test_builtin_signature_with_unrepresentable_default(self) -> None:
+        sig = mypy.stubtest.safe_inspect_signature(bytes.hex)
+        assert sig is not None
+        assert (
+            str(mypy.stubtest.Signature.from_inspect_signature(sig))
+            == "def (self, sep = ..., bytes_per_sep = ...)"
+        )
+
     def test_config_file(self) -> None:
         runtime = "temp = 5\n"
         stub = "from decimal import Decimal\ntemp: Decimal\n"

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -426,6 +426,13 @@ class StubtestUnit(unittest.TestCase):
             error=None,
         )
 
+        # Simulate "<unrepresentable>"
+        yield Case(
+            stub="def f11(text: object = None) -> None: ...",
+            runtime="def f11(text = ...): pass",
+            error=None,
+        )
+
     @collect_cases
     def test_static_class_method(self) -> Iterator[Case]:
         yield Case(


### PR DESCRIPTION
See python/cpython#87233