### PR TITLE
Fix crash on Callable self in __call__

### DIFF
--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -2056,3 +2056,18 @@ reveal_type(C.copy(c))  # N: Revealed type is "__main__.C[builtins.int, builtins
 B.copy(42)  # E: Value of type variable "Self" of "copy" of "B" cannot be "int"
 C.copy(42)  # E: Value of type variable "Self" of "copy" of "B" cannot be "int"
 [builtins fixtures/tuple.pyi]
+
+[case testRecursiveSelfTypeCallMethodNoCrash]
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+class Partial:
+    def __call__(self: Callable[..., T]) -> T: ...
+
+class Partial2:
+    def __call__(self: Callable[..., T], x: T) -> T: ...
+
+p: Partial
+reveal_type(p())  # N: Revealed type is "Never"
+p2: Partial2
+reveal_type(p2(42))  # N: Revealed type is "builtins.int"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16450

The fix is a bit ad-hoc, but OTOH there is nothing meaningful we can infer in such situation, so it is probably OK.
