### PR TITLE
Exclude private attributes from override checks

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1879,6 +1879,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             found_method_base_classes
             and not defn.is_explicit_override
             and defn.name not in ("__init__", "__new__")
+            and not is_private(defn.name)
         ):
             self.msg.explicit_override_decorator_missing(
                 defn.name, found_method_base_classes[0].fullname, context or defn
@@ -1921,7 +1922,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             base_attr = base.names.get(name)
             if base_attr:
                 # First, check if we override a final (always an error, even with Any types).
-                if is_final_node(base_attr.node):
+                if is_final_node(base_attr.node) and not is_private(name):
                     self.msg.cant_override_final(name, base.name, defn)
                 # Second, final can't override anything writeable independently of types.
                 if defn.is_final:
@@ -2680,7 +2681,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             ok = True
         # Final attributes can never be overridden, but can override
         # non-final read-only attributes.
-        if is_final_node(second.node):
+        if is_final_node(second.node) and not is_private(name):
             self.msg.cant_override_final(name, base2.name, ctx)
         if is_final_node(first.node):
             self.check_if_final_var_override_writable(name, second.node, ctx)
@@ -3307,6 +3308,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         Other situations are checked in `check_final()`.
         """
         if not isinstance(base_node, (Var, FuncBase, Decorator)):
+            return True
+        if is_private(node.name):
             return True
         if base_node.is_final and (node.is_final or not isinstance(base_node, Var)):
             # Give this error only for explicit override attempt with `Final`, or

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2531,3 +2531,16 @@ class Foo:
 
     c: int  # E: Name "c" already defined on line 5
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassInheritanceWorksWithExplicitOverrides]
+# flags: --enable-error-code explicit-override
+from dataclasses  import dataclass
+
+@dataclass
+class Base:
+    x: int
+
+@dataclass
+class Child(Base):
+    y: int
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1117,3 +1117,16 @@ from typing import Final
 class MyClass:
     a: None
     a: Final[int] = 1  # E: Cannot redefine an existing name as final  # E: Name "a" already defined on line 5
+
+[case testFinalOverrideAllowedForPrivate]
+from typing import Final, final
+
+class Parent:
+    __foo: Final[int] = 0
+    @final
+    def __bar(self) -> None: ...
+
+class Child(Parent):
+    __foo: Final[int] = 1
+    @final
+    def __bar(self) -> None: ...

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3159,6 +3159,17 @@ class D(A, B):
     def f(self, z: int) -> str: pass  # E: Method "f" is not using @override but is overriding a method in class "__main__.A"
 [typing fixtures/typing-override.pyi]
 
+[case testExplicitOverrideAllowedForPrivate]
+# flags: --enable-error-code explicit-override --python-version 3.12
+from typing import override
+
+class B:
+    def __f(self, y: int) -> str: pass
+
+class C(B):
+    def __f(self, y: int) -> str: pass  # OK
+[typing fixtures/typing-override.pyi]
+
 [case testCallableProperty]
 from typing import Callable
 

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3161,7 +3161,6 @@ class D(A, B):
 
 [case testExplicitOverrideAllowedForPrivate]
 # flags: --enable-error-code explicit-override --python-version 3.12
-from typing import override
 
 class B:
     def __f(self, y: int) -> str: pass

--- a/test-data/unit/fine-grained-dataclass-transform.test
+++ b/test-data/unit/fine-grained-dataclass-transform.test
@@ -86,9 +86,9 @@ class A(Dataclass):
 
 [out]
 main:7: error: Unexpected keyword argument "x" for "B"
-builtins.pyi:13: note: "B" defined here
+builtins.pyi:14: note: "B" defined here
 main:7: error: Unexpected keyword argument "y" for "B"
-builtins.pyi:13: note: "B" defined here
+builtins.pyi:14: note: "B" defined here
 ==
 
 [case frozenInheritanceViaDefault]

--- a/test-data/unit/fixtures/dataclasses.pyi
+++ b/test-data/unit/fixtures/dataclasses.pyi
@@ -1,8 +1,9 @@
 import _typeshed
 from typing import (
     Generic, Iterator, Iterable, Mapping, Optional, Sequence, Tuple,
-    TypeVar, Union, overload,
+    TypeVar, Union, overload
 )
+from typing_extensions import override
 
 _T = TypeVar('_T')
 _U = TypeVar('_U')
@@ -29,8 +30,10 @@ class dict(Mapping[KT, VT]):
     def __init__(self, **kwargs: VT) -> None: pass
     @overload
     def __init__(self, arg: Iterable[Tuple[KT, VT]], **kwargs: VT) -> None: pass
+    @override
     def __getitem__(self, key: KT) -> VT: pass
     def __setitem__(self, k: KT, v: VT) -> None: pass
+    @override
     def __iter__(self) -> Iterator[KT]: pass
     def __contains__(self, item: object) -> int: pass
     def update(self, a: Mapping[KT, VT]) -> None: pass
@@ -42,7 +45,9 @@ class dict(Mapping[KT, VT]):
 
 class list(Generic[_T], Sequence[_T]):
     def __contains__(self, item: object) -> int: pass
+    @override
     def __getitem__(self, key: int) -> _T: pass
+    @override
     def __iter__(self) -> Iterator[_T]: pass
 
 class function: pass

--- a/test-data/unit/fixtures/dataclasses.pyi
+++ b/test-data/unit/fixtures/dataclasses.pyi
@@ -1,7 +1,7 @@
 import _typeshed
 from typing import (
     Generic, Iterator, Iterable, Mapping, Optional, Sequence, Tuple,
-    TypeVar, Union, overload
+    TypeVar, Union, overload,
 )
 from typing_extensions import override
 


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/9910
Fixes https://github.com/python/mypy/issues/16452

We already exclude private names from override type compatibility checks etc., but it looks like some override checks were still performed, we need to skip them, since private name is actually a different name in subclass.