### PR TITLE
Refactor class decorator: this enables `type_check_only` support for `TypedDict` and `NamedTuple`

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1877,9 +1877,9 @@ class SemanticAnalyzer(
     def analyze_class_decorator_common(
         self, defn: ClassDef, info: TypeInfo, decorator: Expression
     ) -> None:
-        """Common part for all class decorators.
+        """Common method for applying class decorators.
 
-        Including classes, typeddicts, and namedtuples.
+        Called on regular classes, typeddicts, and namedtuples.
         """
         if refers_to_fullname(decorator, FINAL_DECORATOR_NAMES):
             info.is_final = True

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -2073,6 +2073,28 @@ class StubtestUnit(unittest.TestCase):
             runtime="class A2: ...",
             error="A2",
         )
+        # The same is true for NamedTuples and TypedDicts:
+        yield Case(
+            stub="from typing_extensions import NamedTuple, TypedDict",
+            runtime="from typing_extensions import NamedTuple, TypedDict",
+            error=None,
+        )
+        yield Case(
+            stub="""
+            @type_check_only
+            class NT1(NamedTuple): ...
+            """,
+            runtime="class NT1(NamedTuple): ...",
+            error="NT1",
+        )
+        yield Case(
+            stub="""
+            @type_check_only
+            class TD1(TypedDict): ...
+            """,
+            runtime="class TD1(TypedDict): ...",
+            error="TD1",
+        )
         # The same is true for functions:
         yield Case(
             stub="""


### PR DESCRIPTION
I've noticed that `TypedDict` and `NamedTuple` classes are special cased during semantic analyzisys. They had their own logic for class-level decorators. This is fine, but we need some common ground.

As a side-effect, they can now be `type_check_only`!