### PR TITLE
PEP 702: decorator is in warnings, not typing-extensions

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -75,14 +75,6 @@ def type_check_only(func: _T) -> _T: ...
 def final(func: _T) -> _T: ...
 """
 
-stubtest_warnings_stub = """
-from typing import Callable, TypeVar
-
-_T = TypeVar("_T")
-
-def deprecated(__msg: str) -> Callable[[_T], _T]: ...
-"""
-
 stubtest_builtins_stub = """
 from typing import Generic, Mapping, Sequence, TypeVar, overload
 
@@ -162,8 +154,6 @@ def run_stubtest(
             f.write(stubtest_typing_stub)
         with open("enum.pyi", "w") as f:
             f.write(stubtest_enum_stub)
-        with open("warnings.pyi", "w") as f:
-            f.write(stubtest_warnings_stub)
         with open(f"{TEST_MODULE_NAME}.pyi", "w") as f:
             f.write(stub)
         with open(f"{TEST_MODULE_NAME}.py", "w") as f:
@@ -645,7 +635,7 @@ class StubtestUnit(unittest.TestCase):
         yield Case(
             stub="""
             from typing import final
-            from warnings import deprecated
+            from typing_extensions import deprecated
             class Foo:
                 @overload
                 @final

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -72,8 +72,15 @@ class Tuple(Sequence[_T_co]): ...
 class NamedTuple(tuple[Any, ...]): ...
 def overload(func: _T) -> _T: ...
 def type_check_only(func: _T) -> _T: ...
-def deprecated(__msg: str) -> Callable[[_T], _T]: ...
 def final(func: _T) -> _T: ...
+"""
+
+stubtest_warnings_stub = """
+from typing import Callable, TypeVar
+
+_T = TypeVar("_T")
+
+def deprecated(__msg: str) -> Callable[[_T], _T]: ...
 """
 
 stubtest_builtins_stub = """
@@ -155,6 +162,8 @@ def run_stubtest(
             f.write(stubtest_typing_stub)
         with open("enum.pyi", "w") as f:
             f.write(stubtest_enum_stub)
+        with open("warnings.pyi", "w") as f:
+            f.write(stubtest_warnings_stub)
         with open(f"{TEST_MODULE_NAME}.pyi", "w") as f:
             f.write(stub)
         with open(f"{TEST_MODULE_NAME}.py", "w") as f:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -635,7 +635,8 @@ class StubtestUnit(unittest.TestCase):
         )
         yield Case(
             stub="""
-            from typing import deprecated, final
+            from typing import final
+            from warnings import deprecated
             class Foo:
                 @overload
                 @final

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -123,7 +123,7 @@ LITERAL_TYPE_NAMES: Final = ("typing.Literal", "typing_extensions.Literal")
 ANNOTATED_TYPE_NAMES: Final = ("typing.Annotated", "typing_extensions.Annotated")
 
 # Supported @deprecated type names
-DEPRECATED_TYPE_NAMES: Final = ("typing.deprecated", "typing_extensions.deprecated")
+DEPRECATED_TYPE_NAMES: Final = ("warnings.deprecated", "typing_extensions.deprecated")
 
 # We use this constant in various places when checking `tuple` subtyping:
 TUPLE_LIKE_INSTANCE_NAMES: Final = (

--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Mapping, Iterable, Iterator, NoReturn as NoReturn, Dict, Tuple, Type
+from typing import Any, Callable, Mapping, Iterable, Iterator, NoReturn as NoReturn, Dict, Tuple, Type
 from typing import TYPE_CHECKING as TYPE_CHECKING
 from typing import NewType as NewType, overload as overload
 
@@ -75,5 +75,6 @@ def dataclass_transform(
 ) -> Callable[[T], T]: ...
 
 def override(__arg: _T) -> _T: ...
+def deprecated(__msg: str) -> Callable[[_T], _T]: ...
 
 _FutureFeatureFixture = 0


### PR DESCRIPTION
Followup from https://github.com/python/mypy/pull/16457/files#r1392715784