### PR TITLE
Fix narrowing on match with function subject

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5046,7 +5046,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # Create a dummy subject expression to handle cases where a match
         # statement's subject is not a literal value which prevent us from correctly
         # narrowing types and checking exhaustivity
-        named_subject = NameExpr("match") if isinstance(s.subject, CallExpr) else s.subject
+        named_subject = NameExpr("dummy-match") if isinstance(s.subject, CallExpr) else s.subject
         with self.binder.frame_context(can_skip=False, fall_through=0):
             subject_type = get_proper_type(self.expr_checker.accept(s.subject))
             self.store_type(named_subject, subject_type)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5047,7 +5047,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # not a literal value. This lets us correctly narrow types and check exhaustivity
         if isinstance(s.subject, CallExpr):
             id = s.subject.callee.fullname if isinstance(s.subject.callee, RefExpr) else ""
-            name = "dummy-match-" + id
+            name = "dummy-match-" + id  # this is a hack
             v = Var(name)
             named_subject = NameExpr(name)
             named_subject.node = v

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5043,11 +5043,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         return None
 
     def visit_match_stmt(self, s: MatchStmt) -> None:
-        # Create a dummy subject expression to handle cases where a match statement's subject is
-        # not a literal value. This lets us correctly narrow types and check exhaustivity
+        named_subject: Expression
         if isinstance(s.subject, CallExpr):
+            # Create a dummy subject expression to handle cases where a match statement's subject
+            # is not a literal value. This lets us correctly narrow types and check exhaustivity
+            # This is hack!
             id = s.subject.callee.fullname if isinstance(s.subject.callee, RefExpr) else ""
-            name = "dummy-match-" + id  # this is a hack
+            name = "dummy-match-" + id
             v = Var(name)
             named_subject = NameExpr(name)
             named_subject.node = v

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1139,6 +1139,18 @@ match m:
 
 reveal_type(a)  # N: Revealed type is "builtins.str"
 
+[case testMatchCapturePatternFromFunctionReturningUnion]
+def func(arg: bool) -> str | int:
+    if arg:
+       return 1
+    return "a"
+
+match func(True):
+    case str(a):
+         reveal_type(a) # N: Revealed type is "builtins.str"
+    case a:
+         reveal_type(a) # N: Revealed type is "builtins.int"
+
 -- Guards --
 
 [case testMatchSimplePatternGuard]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1140,16 +1140,19 @@ match m:
 reveal_type(a)  # N: Revealed type is "builtins.str"
 
 [case testMatchCapturePatternFromFunctionReturningUnion]
-def func(arg: bool) -> str | int:
-    if arg:
-       return 1
-    return "a"
+def func1(arg: bool) -> str | int: ...
+def func2(arg: bool) -> bytes | int: ...
 
-match func(True):
-    case str(a):
-         reveal_type(a) # N: Revealed type is "builtins.str"
-    case a:
-         reveal_type(a) # N: Revealed type is "builtins.int"
+def main() -> None:
+    match func1(True):
+        case str(a):
+            match func2(True):
+                case c:
+                    reveal_type(a)  # N: Revealed type is "builtins.str"
+                    reveal_type(c)  # N: Revealed type is "Union[builtins.bytes, builtins.int]"
+            reveal_type(a)  # N: Revealed type is "builtins.str"
+        case a:
+            reveal_type(a)  # N: Revealed type is "builtins.int"
 
 -- Guards --
 


### PR DESCRIPTION
Fixes #12998

mypy can't narrow match statements with functions subjects because the callexpr node is not a literal node. This adds a 'dummy' literal node that the match statement visitor can use to do the type narrowing.

The python grammar describes the the match subject as a named expression so this uses that nameexpr node as it's literal.

