### PR TITLE
Fix crash on unimported Any in TypedDict

### DIFF
--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3402,9 +3402,9 @@ reveal_type(b["g"])  # N: Revealed type is "Union[builtins.int, None]"
 from typing import NotRequired, Required, TypedDict
 from thismoduledoesntexist import T  # type: ignore[import]
 
-B = TypedDict("B", {
-    "T1": NotRequired[T],  # E: Type of a TypedDict key becomes "Any" due to an unfollowed import
-    "T2": Required[T],  # E: Type of a TypedDict key becomes "Any" due to an unfollowed import
+B = TypedDict("B", {  # E: Type of a TypedDict key becomes "Any" due to an unfollowed import
+    "T1": NotRequired[T],
+    "T2": Required[T],
 })
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3399,9 +3399,12 @@ reveal_type(b["g"])  # N: Revealed type is "Union[builtins.int, None]"
 
 [case testNoCrashOnUnImportedAnyNotRequired]
 # flags: --disallow-any-unimported
-from typing import NotRequired, TypedDict
+from typing import NotRequired, Required, TypedDict
 from thismoduledoesntexist import T  # type: ignore[import]
 
-B = TypedDict("B", {"T": NotRequired[T]})  # E: Type of a TypedDict key becomes "Any" due to an unfollowed import
+B = TypedDict("B", {
+    "T1": NotRequired[T],  # E: Type of a TypedDict key becomes "Any" due to an unfollowed import
+    "T2": Required[T],  # E: Type of a TypedDict key becomes "Any" due to an unfollowed import
+})
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3396,3 +3396,12 @@ reveal_type(b["a"])  # N: Revealed type is "Union[builtins.str, None]"
 reveal_type(b["g"])  # N: Revealed type is "Union[builtins.int, None]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testNoCrashOnUnImportedAnyNotRequired]
+# flags: --disallow-any-unimported
+from typing import NotRequired, TypedDict
+from thismoduledoesntexist import T  # type: ignore[import]
+
+B = TypedDict("B", {"T": NotRequired[T]})  # E: Type of a TypedDict key becomes "Any" due to an unfollowed import
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16498

Fix is trivial: no operations can be done with `Required` types before unwrapping (because they are not real types).
