### PR TITLE
An attempt to fix mypyc tests on MacOS

### DIFF
--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -172,12 +172,10 @@ class TestRun(MypycDataSuite):
             # new by distutils, shift the mtime of all of the
             # generated artifacts back by a second.
             fudge_dir_mtimes(WORKDIR, -1)
-            # On Ubuntu, changing the mtime doesn't work reliably. As
+            # On some OS, changing the mtime doesn't work reliably. As
             # a workaround, sleep.
-            #
             # TODO: Figure out a better approach, since this slows down tests.
-            if sys.platform == "linux":
-                time.sleep(1.0)
+            time.sleep(1.0)
 
             step += 1
             with chdir_manager(".."):


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16420

Although this is not 100% clear yet, but after 20 runs on a Mac I have it no longer fails (without this patch it failed 20% of times). Btw, contrary to the comment, _my_ Linux Mint (which is an Ubuntu derivative) works perfectly (i.e. test passed 20 times even after I removed the `sleep()`). So it is not really Mac vs Linux issue.