### PR TITLE
Docs: update soft-error-limit default value to -1

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -787,7 +787,7 @@ in error messages.
     disable reporting most additional errors. The limit only applies
     if it seems likely that most of the remaining errors will not be
     useful or they may be overly noisy. If ``N`` is negative, there is
-    no limit. The default limit is 200.
+    no limit. The default limit is -1.
 
 .. option:: --force-uppercase-builtins
 


### PR DESCRIPTION
Default value of `MANY_ERRORS_THRESHOLD` was set to `-1` in https://github.com/python/mypy/pull/15138, which is also the default value of the `--soft-error-limit` CLI option. However the CLI docs were not updated accordingly.