### PR TITLE
Speed up pythoneval tests

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -709,7 +709,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # At this point we should have set the impl already, and all remaining
         # items are decorators
 
-        if self.msg.errors.file in self.msg.errors.ignored_files:
+        if self.msg.errors.file in self.msg.errors.ignored_files or (
+            self.is_typeshed_stub and self.options.test_env
+        ):
             # This is a little hacky, however, the quadratic check here is really expensive, this
             # method has no side effects, so we should skip it if we aren't going to report
             # anything. In some other places we swallow errors in stubs, but this error is very

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1135,6 +1135,8 @@ def process_options(
     parser.add_argument("--dump-graph", action="store_true", help=argparse.SUPPRESS)
     # --semantic-analysis-only does exactly that.
     parser.add_argument("--semantic-analysis-only", action="store_true", help=argparse.SUPPRESS)
+    # Some tests use this to tell mypy that we are running a test.
+    parser.add_argument("--test-env", action="store_true", help=argparse.SUPPRESS)
     # --local-partial-types disallows partial types spanning module top level and a function
     # (implicitly defined in fine-grained incremental mode)
     parser.add_argument("--local-partial-types", action="store_true", help=argparse.SUPPRESS)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -321,6 +321,10 @@ class Options:
         # Use stub builtins fixtures to speed up tests
         self.use_builtins_fixtures = False
 
+        # This should only be set when running certain mypy tests.
+        # Use this sparingly to avoid tests diverging from non-test behavior.
+        self.test_env = False
+
         # -- experimental options --
         self.shadow_file: list[list[str]] | None = None
         self.show_column_numbers: bool = False

--- a/mypy/test/testpythoneval.py
+++ b/mypy/test/testpythoneval.py
@@ -53,6 +53,7 @@ def test_python_evaluation(testcase: DataDrivenTestCase, cache_dir: str) -> None
         "--hide-error-codes",
         "--allow-empty-bodies",
         "--force-uppercase-builtins",
+        "--test-env",  # Speeds up some checks
     ]
     interpreter = python3_path
     mypy_cmdline.append(f"--python-version={'.'.join(map(str, PYTHON3_VERSION))}")


### PR DESCRIPTION
Skip slow and unnecessary overload checks in stdlib stubs in these tests. These checks already seem to be skipped in most other contexts, but because pythoneval tests use `--no-silence-site-packages`, the checks were enabled.

This makes pythoneval tests about 13% faster on my Linux desktop, and it should also speed up CI a bit.