### PR TITLE
Speed up tests by simplifying test fixtures

### DIFF
--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -301,7 +301,7 @@ reveal_type(X._field_defaults)  # N: Revealed type is "builtins.dict[builtins.st
 # but it's inferred as `Mapping[str, object]` here due to the fixture we're using
 reveal_type(X.__annotations__)  # N: Revealed type is "typing.Mapping[builtins.str, builtins.object]"
 
-[builtins fixtures/dict.pyi]
+[builtins fixtures/dict-full.pyi]
 
 [case testNewNamedTupleUnit]
 from typing import NamedTuple

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1589,8 +1589,7 @@ if str():
 ....a  # E: "ellipsis" has no attribute "a"
 
 class A: pass
-[builtins fixtures/dict.pyi]
-[out]
+[builtins fixtures/dict-full.pyi]
 
 
 -- Yield expression

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -931,7 +931,7 @@ match x:
 reveal_type(x)  # N: Revealed type is "builtins.list[builtins.list[builtins.dict[builtins.int, builtins.int]]]"
 reveal_type(y)  # N: Revealed type is "builtins.int"
 reveal_type(z)  # N: Revealed type is "builtins.int"
-[builtins fixtures/dict.pyi]
+[builtins fixtures/dict-full.pyi]
 
 [case testMatchNonFinalMatchArgs]
 class A:

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -957,6 +957,12 @@ for x in B(), A():
 [builtins fixtures/for.pyi]
 
 [case testTupleIterable]
+from typing import Iterable, Optional, TypeVar
+
+T = TypeVar("T")
+
+def sum(iterable: Iterable[T], start: Optional[T] = None) -> T: pass
+
 y = 'a'
 x = sum((1,2))
 if int():

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1065,4 +1065,4 @@ def eval(e: Expr) -> int:
         return e[1]
     elif e[0] == 456:
         return -eval(e[1])
-[builtins fixtures/dict.pyi]
+[builtins fixtures/dict-full.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2708,7 +2708,7 @@ class TD(TypedDict):
 reveal_type(TD.__iter__)  # N: Revealed type is "def (typing._TypedDict) -> typing.Iterator[builtins.str]"
 reveal_type(TD.__annotations__)  # N: Revealed type is "typing.Mapping[builtins.str, builtins.object]"
 reveal_type(TD.values)  # N: Revealed type is "def (self: typing.Mapping[T`1, T_co`2]) -> typing.Iterable[T_co`2]"
-[builtins fixtures/dict.pyi]
+[builtins fixtures/dict-full.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
 [case testGenericTypedDictAlias]
@@ -3299,7 +3299,7 @@ main:10: error: No overload variant of "__ror__" of "dict" matches argument type
 main:10: note: Possible overload variants:
 main:10: note:     def __ror__(self, Dict[Any, Any], /) -> Dict[Any, Any]
 main:10: note:     def [T, T2] __ror__(self, Dict[T, T2], /) -> Dict[Union[Any, T], Union[Any, T2]]
-[builtins fixtures/dict.pyi]
+[builtins fixtures/dict-full.pyi]
 [typing fixtures/typing-typeddict-iror.pyi]
 
 [case testTypedDictWith__ror__method]

--- a/test-data/unit/fixtures/dict-full.pyi
+++ b/test-data/unit/fixtures/dict-full.pyi
@@ -1,7 +1,4 @@
-# Builtins stub used in dictionary-related test cases (stripped down).
-#
-# NOTE: Use dict-full.pyi if you need more builtins instead of adding here,
-#       if feasible.
+# Builtins stub used in dictionary-related test cases (more complete).
 
 from _typeshed import SupportsKeysAndGetItem
 import _typeshed
@@ -17,9 +14,11 @@ VT = TypeVar('VT')
 
 class object:
     def __init__(self) -> None: pass
+    def __init_subclass__(cls) -> None: pass
     def __eq__(self, other: object) -> bool: pass
 
-class type: pass
+class type:
+    __annotations__: Mapping[str, object]
 
 class dict(Mapping[KT, VT]):
     @overload
@@ -37,10 +36,28 @@ class dict(Mapping[KT, VT]):
     def get(self, k: KT, default: Union[VT, T]) -> Union[VT, T]: pass
     def __len__(self) -> int: ...
 
+    # This was actually added in 3.9:
+    @overload
+    def __or__(self, __value: dict[KT, VT]) -> dict[KT, VT]: ...
+    @overload
+    def __or__(self, __value: dict[T, T2]) -> dict[Union[KT, T], Union[VT, T2]]: ...
+    @overload
+    def __ror__(self, __value: dict[KT, VT]) -> dict[KT, VT]: ...
+    @overload
+    def __ror__(self, __value: dict[T, T2]) -> dict[Union[KT, T], Union[VT, T2]]: ...
+    # dict.__ior__ should be kept roughly in line with MutableMapping.update()
+    @overload  # type: ignore[misc]
+    def __ior__(self, __value: _typeshed.SupportsKeysAndGetItem[KT, VT]) -> Self: ...
+    @overload
+    def __ior__(self, __value: Iterable[Tuple[KT, VT]]) -> Self: ...
+
 class int: # for convenience
     def __add__(self, x: Union[int, complex]) -> int: pass
     def __radd__(self, x: int) -> int: pass
     def __sub__(self, x: Union[int, complex]) -> int: pass
+    def __neg__(self) -> int: pass
+    real: int
+    imag: int
 
 class str: pass # for keyword argument key type
 class bytes: pass
@@ -57,8 +74,10 @@ class function: pass
 class float: pass
 class complex: pass
 class bool(int): pass
-class ellipsis: pass
+
+class ellipsis:
+    __class__: object
+def isinstance(x: object, t: Union[type, Tuple[type, ...]]) -> bool: pass
 class BaseException: pass
 
-def isinstance(x: object, t: Union[type, Tuple[type, ...]]) -> bool: pass
 def iter(__iterable: Iterable[T]) -> Iterator[T]: pass

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -49,8 +49,6 @@ class list(Sequence[T], Generic[T]):
 
 def isinstance(x: object, t: type) -> bool: pass
 
-def sum(iterable: Iterable[T], start: Optional[T] = None) -> T: pass
-
 class BaseException: pass
 
 class dict: pass


### PR DESCRIPTION
Move some definitions away from commonly used fixtures that are only needed in one or two test cases, as they will slow down many test cases.

This speeds up `mypy/test/testcheck.py` by about 5% on my Linux desktop.