### PR TITLE
Fix multiprocessing warnings when runnign tests on Python 3.12

### DIFF
--- a/mypy/moduleinspect.py
+++ b/mypy/moduleinspect.py
@@ -8,7 +8,7 @@ import os
 import pkgutil
 import queue
 import sys
-from multiprocessing import Process, Queue
+from multiprocessing import Queue, get_context
 from types import ModuleType
 
 
@@ -123,9 +123,13 @@ class ModuleInspect:
         self._start()
 
     def _start(self) -> None:
-        self.tasks: Queue[str] = Queue()
-        self.results: Queue[ModuleProperties | str] = Queue()
-        self.proc = Process(target=worker, args=(self.tasks, self.results, sys.path))
+        if sys.platform == "linux":
+            ctx = get_context("forkserver")
+        else:
+            ctx = get_context("spawn")
+        self.tasks: Queue[str] = ctx.Queue()
+        self.results: Queue[ModuleProperties | str] = ctx.Queue()
+        self.proc = ctx.Process(target=worker, args=(self.tasks, self.results, sys.path))
         self.proc.start()
         self.counter = 0  # Number of successful roundtrips
 


### PR DESCRIPTION
I saw a bunch of warnings when running tests in parallel using pytest. When running tests sequentially using `-n0` I didn't see warnings. This only seems to happen on Linux.

The warnings were like these, which can be fixed by avoiding the use of fork, and using forkserver instead:
```
mypy/test/teststubgen.py::StubgenPythonSuite::stubgen.test::testNestedClass_inspect
  /usr/local/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=84587) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()
```

Relevant discussion:
https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555