### PR TITLE
@final class without __bool__ cannot have falsey instances

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -635,7 +635,10 @@ def false_only(t: Type) -> ProperType:
     else:
         ret_type = _get_type_special_method_bool_ret_type(t)
 
-        if ret_type and not ret_type.can_be_false:
+        if ret_type:
+            if not ret_type.can_be_false:
+                return UninhabitedType(line=t.line)
+        elif isinstance(t, Instance) and t.type.is_final:
             return UninhabitedType(line=t.line)
 
         new_t = copy_type(t)

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1130,3 +1130,42 @@ class Child(Parent):
     __foo: Final[int] = 1
     @final
     def __bar(self) -> None: ...
+
+[case testFinalWithoutBool]
+from typing_extensions import final, Literal
+
+class A:
+    pass
+
+@final
+class B:
+    pass
+
+@final
+class C:
+    def __len__(self) -> Literal[1]: return 1
+
+reveal_type(A() and 42)  # N: Revealed type is "Union[__main__.A, Literal[42]?]"
+reveal_type(B() and 42)  # N: Revealed type is "Literal[42]?"
+reveal_type(C() and 42)  # N: Revealed type is "Literal[42]?"
+
+[builtins fixtures/bool.pyi]
+
+[case testFinalWithoutBoolButWithLen-xfail]
+from typing_extensions import final, Literal
+
+# Per Python data model, __len__ is called if __bool__ does not exist.In a @final class,
+# __bool__ would not exist.
+
+@final
+class A:
+    def __len__(self) -> int: ...
+
+@final
+class B:
+    def __len__(self) -> Literal[1]: return 1
+
+reveal_type(A() and 42)  # N: Revealed type is "Union[__main__.A, Literal[42]?]"
+reveal_type(B() and 42)  # N: Revealed type is "__main__.A"
+
+[builtins fixtures/bool.pyi]


### PR DESCRIPTION
Perhaps we should make it respect `__len__`, or perhaps leave it as XFAIL for a follow-up PR.

Relates to #16565.