### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
       github-actions:
         patterns:
           - '*'
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This introduces a Dependabot configuration that will auto-update GitHub action versions.

Currently, mypy's CI has inconsistent updates to action versions. For example, `actions/checkout` is current (`@v4`) in `test.yml` ~but is out-of-date (`@v3`) in `codespell.yml`~ but other actions haven't been maintained:

* `actions/github-script@v6` in `mypy_primer_comment.yml` is currently at `v7`
* `gabrielfalcao/pyenv-action@v13` in `test.yml` is currently at `v17`

Rather than attempt to manually look up and correctly update the action versions in a one-off PR, this change will configure Dependabot to submit PRs with batched updates in perpetuity.

If this merges, you can expect Dependabot to open a single PR that batches all GitHub action updates together. You can then expect Dependabot to submit a maximum of 12 PRs per year to update GitHub action versions.

Thanks for your work on mypy!

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
