### PR TITLE
Fix stubtest's tests to work with the latest typing_extensions release

### DIFF
--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -59,6 +59,8 @@ class _TypedDict(Mapping[str, object]):
     # Stubtest's tests need the following items:
     __required_keys__: frozenset[str]
     __optional_keys__: frozenset[str]
+    __readonly_keys__: frozenset[str]
+    __mutable_keys__: frozenset[str]
     __total__: bool
 
 def TypedDict(typename: str, fields: Dict[str, Type[_T]], *, total: Any = ...) -> Type[dict]: ...


### PR DESCRIPTION
Stubtest's tests will start failing when `typing_extensions==4.9.0` comes out, due to some new `ClassVar`s on `typing_extensions.TypedDict`. This PR fixes that.

Fixes https://github.com/python/typing_extensions/issues/309