### PR TITLE
chore: add a utility to generate a schema file

### DIFF
--- a/misc/make_schema.py
+++ b/misc/make_schema.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+import textwrap
+from collections.abc import Generator, Sequence
+from pathlib import Path
+from typing import Any
+
+DIR = Path(__file__).parent.resolve()
+
+
+@dataclasses.dataclass(frozen=True)
+class ConfigOpt:
+    name: str
+    type_str: str
+    is_global: bool
+    description: str
+    default: str | None
+
+    def define(self) -> dict[str, str]:
+        retval: dict[str, Any] = {"description": self.description}
+        if self.default is not None:
+            match self.type_str:
+                case "boolean":
+                    retval["default"] = {"true": True, "false": False}[self.default.lower()]
+                case "integer":
+                    retval["default"] = int(self.default)
+                case "string":
+                    retval["default"] = self.default.strip("`")
+                case _:
+                    msg = f"Default not suppored for {self.type_str}"
+                    raise RuntimeError(msg)
+        match self.type_str:
+            case "boolean" | "integer" | "string":
+                retval["type"] = self.type_str
+            case "comma-separated list of strings" | "regular expression":
+                retval["oneOf"] = [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}},
+                ]
+            case _:
+                msg = f"{self.type_str} not supported for type"
+                raise RuntimeError(msg)
+
+        return retval
+
+
+def parse_rst_docs(txt: str) -> Generator[ConfigOpt, None, None]:
+    for match in re.finditer(r".. confval:: ([^\s]*)\n\n((?:    .*\n|\n)*)", txt):
+        name, body = match.groups()
+        body = textwrap.dedent(body)
+        body_match = re.match(r":type: (.*?)\n(?::default: (.*?)\n)?(.*)$", body, re.DOTALL)
+        assert body_match is not None
+        type_str, default, inner = body_match.groups()
+        is_global = "only be set in the global section" in body
+        description = inner.strip().split("\n\n")[0].replace("\n", " ")
+        # Patches
+        if name == "mypy_path":
+            type_str = "comma-separated list of strings"
+        yield ConfigOpt(
+            name=name,
+            type_str=type_str,
+            is_global=is_global,
+            description=description,
+            default=default,
+        )
+
+
+def make_schema(opts: Sequence[ConfigOpt]) -> dict[str, Any]:
+    definitions = {s.name: s.define() for s in opts}
+    overrides = {s.name: {"$ref": f"#/properties/{s.name}"} for s in opts if not s.is_global}
+    module = {
+        "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        ]
+    }
+
+    # Improve some fields
+    definitions["follow_imports"]["enum"] = ["normal", "silent", "skip", "error"]
+
+    return {
+        "$id": "https://json.schemastore.org/mypy.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": False,
+        "type": "object",
+        "properties": {
+            **definitions,
+            "overrides": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["module"],
+                    "minProperties": 2,
+                    "properties": {"module": module, **overrides},
+                },
+            },
+        },
+    }
+
+
+if __name__ == "__main__":
+    filepath = DIR.parent / "docs/source/config_file.rst"
+    opts = parse_rst_docs(filepath.read_text())
+    print(json.dumps(make_schema(list(opts)), indent=2))


### PR DESCRIPTION

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This is a utility script to generate a JSONSchema file, as PR'd to SchemaStore in https://github.com/SchemaStore/schemastore/pull/3422. Discussion at https://github.com/python/mypy/issues/16491. Currently, I'm not doing anything locally with the schema file. Ideally, I think it could be saved in `mypy/resources/mypy.schema.json`. A simple function to retrieve it plus an entry point would allow validate-pyproject to validate the schema file (as done by cibuildwheel & scikit-build-core). I could add a job to verify the rendering stays in sync in CI.

But starting with just the script I used to generate the SchemaStore submission, will take suggestions on what direction to go.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
