### PR TITLE
Add forgotten reveal_type import in documentation

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -88,7 +88,7 @@ Functions
 
 .. code-block:: python
 
-   from typing import Callable, Iterator, Union, Optional
+   from typing import Callable, Iterator, Union, Optional, reveal_type
 
    # This is how you annotate a function definition
    def stringify(num: int) -> str:
@@ -217,7 +217,7 @@ When you're puzzled or when things are complicated
 
 .. code-block:: python
 
-   from typing import Union, Any, Optional, TYPE_CHECKING, cast
+   from typing import Union, Any, Optional, TYPE_CHECKING, cast, reveal_type
 
    # To find out what type mypy infers for an expression anywhere in
    # your program, wrap it in reveal_type().  Mypy will print an error


### PR DESCRIPTION
In my opinion documentation reader should see all library imports in code examples even if they are not supposed to be runnable.