### PR TITLE
Update  `project_urls` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -234,8 +234,9 @@ setup(
     python_requires=">=3.8",
     include_package_data=True,
     project_urls={
-        "News": "https://mypy-lang.org/news.html",
         "Documentation": "https://mypy.readthedocs.io/en/stable/index.html",
         "Repository": "https://github.com/python/mypy",
+        "Changelog": "https://github.com/python/mypy/blob/master/CHANGELOG.md",
+        "Issues": "https://github.com/python/mypy/issues",
     },
 )


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Currently, In the "Project links" section on `pypi.org` there is a link called `News` that goes to [a page](https://mypy-lang.org/news.html) that doesn't seem to be actively maintained. 



Made the following changes to `project_urls` in `setup.py`:
- removed link to "News" 
- added link to "Changelog" 
- added link to "Issues"


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
