### PR TITLE
Docs: mention --no-silence-site-packages

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -524,5 +524,5 @@ Adjusting import following behaviour is often most useful when restricted to
 specific modules. This can be accomplished by setting a per-module
 :confval:`follow_imports` config option.
 
-There is an additional setting `--no-silence-site-packages` (enabled by default) 
+There is an additional setting `--no-silence-site-packages` (enabled by default)
 that will silence type errors found in the modules from site_packages.


### PR DESCRIPTION
This changes the docs page https://mypy.readthedocs.io/en/stable/running_mypy.html#finding-imports to mention the `--no-silence-site-packages` option.

We (package maintainers of stripe-python) had been reading the description of `--follow-imports="normal"` and for a long time were struggling to understand why the type errors we were seeing when running mypy locally on our project weren't showing up for our users and squaring that away with the description on the docs page. Seeing `--no-silence-site-packages` mentioned on this docs page would have helped us understand this behavior sooner.

