### PR TITLE
Support `TypeAliasType` explicit call

### DIFF
--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1066,3 +1066,51 @@ def eval(e: Expr) -> int:
     elif e[0] == 456:
         return -eval(e[1])
 [builtins fixtures/dict-full.pyi]
+
+[case testTypeAliasType]
+from typing import Union
+from typing_extensions import TypeAliasType
+
+TestType = TypeAliasType("TestType", Union[int, str])
+x: TestType = 42
+y: TestType = 'a'
+z: TestType = object()  # E: Incompatible types in assignment (expression has type "object", variable has type "Union[int, str]")
+[builtins fixtures/tuple.pyi]
+
+[case testTypeAliasTypeInvalid]
+from typing_extensions import TypeAliasType
+
+TestType = TypeAliasType("T", int)  # E: String argument 1 "T" to TypeAliasType(...) does not match variable name "TestType"
+
+T1 = T2 = TypeAliasType("T", int)
+t1: T1  # E: Variable "__main__.T1" is not valid as a type \
+        # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+
+T3 = TypeAliasType("T3", -1)
+t3: T3  # E: Variable "__main__.T3" is not valid as a type \
+        # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+[builtins fixtures/tuple.pyi]
+
+[case testTypeAliasTypeGeneric]
+from typing_extensions import TypeAliasType
+from typing import Dict, TypeVar
+
+K = TypeVar('K')
+V = TypeVar('V')
+
+TestType = TypeAliasType("TestType", Dict[K, V], type_params=(K, V))
+x: TestType[int, str] = {1: 'a'}
+y: TestType[str, int] = {'a': 1}
+z: TestType[str, int] = {1: 'a'}  # E: Dict entry 0 has incompatible type "int": "str"; expected "str": "int"
+[builtins fixtures/dict.pyi]
+
+[case testTypeAliasType312]
+# flags: --python-version 3.12
+from typing import Union, TypeAliasType
+
+TestType = TypeAliasType("TestType", int | str)
+x: TestType = 42
+y: TestType = 'a'
+z: TestType = object()  # E: Incompatible types in assignment (expression has type "object", variable has type "Union[int, str]")
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -10,13 +10,17 @@ from abc import abstractmethod, ABCMeta
 
 class GenericMeta(type): pass
 
+class _SpecialForm: ...
+class TypeVar: ...
+class ParamSpec: ...
+class TypeVarTuple: ...
+
 def cast(t, o): ...
 def assert_type(o, t): ...
 overload = 0
 Any = 0
 Union = 0
 Optional = 0
-TypeVar = 0
 Generic = 0
 Protocol = 0
 Tuple = 0
@@ -38,6 +42,8 @@ T_contra = TypeVar('T_contra', contravariant=True)
 U = TypeVar('U')
 V = TypeVar('V')
 S = TypeVar('S')
+
+def final(x: T) -> T: ...
 
 class NamedTuple(tuple[Any, ...]): ...
 
@@ -182,8 +188,6 @@ class _TypedDict(Mapping[str, object]):
     def update(self: T, __m: T) -> None: ...
     def __delitem__(self, k: NoReturn) -> None: ...
 
-class _SpecialForm: pass
-
 def dataclass_transform(
     *,
     eq_default: bool = ...,
@@ -199,3 +203,10 @@ def reveal_type(__obj: T) -> T: ...
 
 # Only exists in type checking time:
 def type_check_only(__func_or_class: T) -> T: ...
+
+# Was added in 3.12
+@final
+class TypeAliasType:
+    def __init__(
+        self, name: str, value: Any, *, type_params: Tuple[Union[TypeVar, ParamSpec, TypeVarTuple], ...] = ()
+    ) -> None: ...

--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Callable, Mapping, Iterable, Iterator, NoReturn as NoReturn, Dict, Tuple, Type
+from typing import Any, Callable, Mapping, Iterable, Iterator, NoReturn as NoReturn, Dict, Tuple, Type, Union
 from typing import TYPE_CHECKING as TYPE_CHECKING
 from typing import NewType as NewType, overload as overload
 
@@ -38,6 +38,12 @@ Never: _SpecialForm
 
 TypeVarTuple: _SpecialForm
 Unpack: _SpecialForm
+
+@final
+class TypeAliasType:
+    def __init__(
+        self, name: str, value: Any, *, type_params: Tuple[Union[TypeVar, ParamSpec, TypeVarTuple], ...] = ()
+    ) -> None: ...
 
 # Fallback type for all typed dicts (does not exist at runtime).
 class _TypedDict(Mapping[str, object]):


### PR DESCRIPTION
The implementation turned out to be quite simple for the common cases.
Note: Right now there's no check that `type_params=` is correct, I am not sure that this is even required for a type-checker (in any case, this can and should be done in a follow-up PR)


Refs https://github.com/python/mypy/issues/16614