### PR TITLE
Document --enable-incomplete-feature possible values in "mypy --help"

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -995,7 +995,7 @@ format into the specified directory.
 Enabling incomplete/experimental features
 *****************************************
 
-.. option:: --enable-incomplete-feature FEATURE
+.. option:: --enable-incomplete-feature {PreciseTupleTypes}
 
     Some features may require several mypy releases to implement, for example
     due to their complexity, potential for backwards incompatibility, or

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1010,7 +1010,7 @@ def process_options(
     parser.add_argument(
         "--enable-incomplete-feature",
         action="append",
-        metavar="FEATURE",
+        metavar="{" + ",".join(sorted(INCOMPLETE_FEATURES)) + "}",
         help="Enable support of incomplete/experimental features for early preview",
     )
     internals_group.add_argument(

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -15,7 +15,7 @@ from typing import Any, Iterator
 
 from mypy import build
 from mypy.errors import CompileError
-from mypy.options import TYPE_VAR_TUPLE, UNPACK, Options
+from mypy.options import Options
 from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase
 from mypy.test.helpers import assert_module_equivalence, perform_file_operations
@@ -194,7 +194,6 @@ class TestRun(MypycDataSuite):
         options.preserve_asts = True
         options.allow_empty_bodies = True
         options.incremental = self.separate
-        options.enable_incomplete_feature = [TYPE_VAR_TUPLE, UNPACK]
 
         # Avoid checking modules/packages named 'unchecked', to provide a way
         # to test interacting with code we don't have types for.

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1579,7 +1579,7 @@ always_true =
 [out]
 
 [case testTypeVarTupleUnpackEnabled]
-# cmd: mypy a.py
+# cmd: mypy --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack a.py
 [file a.py]
 from typing_extensions import TypeVarTuple
 Ts = TypeVarTuple("Ts")

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1579,7 +1579,7 @@ always_true =
 [out]
 
 [case testTypeVarTupleUnpackEnabled]
-# cmd: mypy --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack a.py
+# cmd: mypy a.py
 [file a.py]
 from typing_extensions import TypeVarTuple
 Ts = TypeVarTuple("Ts")

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2007,7 +2007,7 @@ _testInferenceOfDunderDictOnClassObjects.py:4: error: Property "__dict__" define
 _testInferenceOfDunderDictOnClassObjects.py:4: error: Incompatible types in assignment (expression has type "Dict[Never, Never]", variable has type "MappingProxyType[str, Any]")
 
 [case testTypeVarTuple]
-# flags: --enable-incomplete-feature=TypeVarTuple --python-version=3.11
+# flags: --python-version=3.11
 from typing import Any, Callable, Unpack, TypeVarTuple
 
 Ts = TypeVarTuple("Ts")
@@ -2019,7 +2019,6 @@ def call(callback: Callable[[Unpack[Ts]], Any], *args: Unpack[Ts]) -> Any:
     ...
 
 [case testTypeVarTupleTypingExtensions]
-# flags: --enable-incomplete-feature=TypeVarTuple
 from typing_extensions import Unpack, TypeVarTuple
 from typing import Any, Callable
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2007,7 +2007,7 @@ _testInferenceOfDunderDictOnClassObjects.py:4: error: Property "__dict__" define
 _testInferenceOfDunderDictOnClassObjects.py:4: error: Incompatible types in assignment (expression has type "Dict[Never, Never]", variable has type "MappingProxyType[str, Any]")
 
 [case testTypeVarTuple]
-# flags: --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack --python-version=3.11
+# flags: --enable-incomplete-feature=TypeVarTuple --python-version=3.11
 from typing import Any, Callable, Unpack, TypeVarTuple
 
 Ts = TypeVarTuple("Ts")
@@ -2019,7 +2019,7 @@ def call(callback: Callable[[Unpack[Ts]], Any], *args: Unpack[Ts]) -> Any:
     ...
 
 [case testTypeVarTupleTypingExtensions]
-# flags: --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack
+# flags: --enable-incomplete-feature=TypeVarTuple
 from typing_extensions import Unpack, TypeVarTuple
 from typing import Any, Callable
 


### PR DESCRIPTION
Document --enable-incomplete-feature possible values in "mypy --help"

By the way, also remove `--enable-incomplete-feature=Unpack --enable-incomplete-feature=TypeVarTuple` when running the tests, as they are no more incomplete features.
    
Fixes #14452

