### PR TITLE
Disallow explicit type aliases in function scope

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3554,6 +3554,11 @@ class SemanticAnalyzer(
             # unless using PEP 613 `cls: TypeAlias = A`
             return False
 
+        if pep_613 and self.is_func_scope():
+            # Explicit alias (Alias: TypeAlias = A) is forbidden inside of function scope.
+            self.fail("Type aliases can only be defined inside modules or classes", s)
+            return False
+
         if isinstance(s.rvalue, CallExpr) and s.rvalue.analyzed:
             return False
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5698,7 +5698,6 @@ class C:
         @dataclass
         class DC:
             c: int
-        Alias: TypeAlias = NT1
         N = NewType("N", NT1)
 
         c: C = C()
@@ -5709,7 +5708,6 @@ class C:
         td2: TD2 = TD2(c=1)
         e: E = E.X
         dc: DC = DC(c=1)
-        al: Alias = Alias(c=1)
         n: N = N(NT1(c=1))
 
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -739,13 +739,13 @@ x6: Int6 = "str"  # E: Incompatible types in assignment (expression has type "st
 from typing_extensions import TypeAlias
 
 def f() -> None:
-    x: TypeAlias = str
+    x: TypeAlias = str  # E: Type aliases can only be defined inside modules or classes
     a: x
-    reveal_type(a)  # N: Revealed type is "builtins.str"
+    reveal_type(a)  # N: Revealed type is "Any"
 
-    y: TypeAlias = "str"
+    y: TypeAlias = "str"  # E: Type aliases can only be defined inside modules or classes
     b: y
-    reveal_type(b)  # N: Revealed type is "builtins.str"
+    reveal_type(b)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testImportCyclePep613]


### PR DESCRIPTION
According to PEP 613, it should not be possible to define an explicit type alias inside of a function. Prohibiting explicit aliases in functions may also help to make clearer the distinction between implicit `TypeAlias` and `Type[...]` assignments.

From https://peps.python.org/pep-0613/#scope-restrictions:
> ```python
> x: TypeAlias = ClassName
> def foo() -> None:
>   x = ClassName
>def bar() -> None:
>   x: TypeAlias = ClassName
>```
> With explicit aliases, the outer assignment is still a valid type variable. Inside `foo`, the inner assignment should be interpreted as `x: Type[ClassName]`. Inside `bar`, the type checker should raise a clear error, communicating to the author that type aliases cannot be defined inside a function.

Since it has been possible to define aliases in functions with Mypy for a while, it is possible that existing packages rely on this behavior, in which case we might need to consider not making this change and diverging from the PEP on this point.