### PR TITLE
Substitute type variables in return type of static methods

### DIFF
--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2297,6 +2297,19 @@ def func(x: S) -> S:
     return C[S].get()
 [builtins fixtures/classmethod.pyi]
 
+[case testGenericStaticMethodInGenericFunction]
+from typing import Generic, TypeVar
+T = TypeVar('T')
+S = TypeVar('S')
+
+class C(Generic[T]):
+    @staticmethod
+    def get() -> T: ...
+
+def func(x: S) -> S:
+    return C[S].get()
+[builtins fixtures/staticmethod.pyi]
+
 [case testMultipleAssignmentFromAnyIterable]
 from typing import Any
 class A:


### PR DESCRIPTION
`add_class_tvars` correctly instantiates type variables in the return type for class methods but not for static methods. Check if the analyzed member is a static method in `analyze_class_attribute_access` and substitute the type variable in the return type in `add_class_tvars` accordingly.

Fixes #16668.
