### PR TITLE
Support inline instantiation of `NamedTuple` and `TypedDict`

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -6023,7 +6023,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             check_for_explicit_any(
                 typeddict_type, self.chk.options, self.chk.is_typeshed_stub, self.msg, context=e
             )
-            # Special-case for TypedDict it doesn't define a constructor.
+            # Special-case for TypedDict since it doesn't define a constructor.
             return self.typeddict_callable(e.info)
         return AnyType(TypeOfAny.special_form)
 

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5993,6 +5993,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             check_for_explicit_any(
                 tuple_type, self.chk.options, self.chk.is_typeshed_stub, self.msg, context=e
             )
+            return type_object_type(e.info, self.named_type)
         return AnyType(TypeOfAny.special_form)
 
     def visit_enum_call_expr(self, e: EnumCallExpr) -> Type:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5995,7 +5995,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             check_for_explicit_any(
                 tuple_type, self.chk.options, self.chk.is_typeshed_stub, self.msg, context=e
             )
-            return type_object_type(e.info, self.named_type)
+            if e.is_inline:
+                return type_object_type(e.info, self.named_type)
         return AnyType(TypeOfAny.special_form)
 
     def visit_enum_call_expr(self, e: EnumCallExpr) -> Type:
@@ -6015,7 +6016,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def visit_typeddict_expr(self, e: TypedDictExpr) -> Type:
         typeddict_type = e.info.typeddict_type
-        if typeddict_type:
+        if e.is_inline and typeddict_type:
             if self.chk.options.disallow_any_unimported and has_any_from_unimported_type(
                 typeddict_type
             ):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2644,7 +2644,7 @@ class TypeAliasExpr(Expression):
 class NamedTupleExpr(Expression):
     """Named tuple expression namedtuple(...) or NamedTuple(...)."""
 
-    __slots__ = ("info", "is_typed")
+    __slots__ = ("info", "is_typed", "is_inline")
 
     __match_args__ = ("info",)
 
@@ -2652,11 +2652,15 @@ class NamedTupleExpr(Expression):
     # the tuple item types)
     info: TypeInfo
     is_typed: bool  # whether this class was created with typing(_extensions).NamedTuple
+    # Whether this class was created inline as a call expression callee, for example:
+    #    (NamedTuple(...))(...)
+    is_inline: bool
 
-    def __init__(self, info: TypeInfo, is_typed: bool = False) -> None:
+    def __init__(self, info: TypeInfo, is_typed: bool = False, is_inline: bool = False) -> None:
         super().__init__()
         self.info = info
         self.is_typed = is_typed
+        self.is_inline = is_inline
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_namedtuple_expr(self)
@@ -2665,16 +2669,20 @@ class NamedTupleExpr(Expression):
 class TypedDictExpr(Expression):
     """Typed dict expression TypedDict(...)."""
 
-    __slots__ = ("info",)
+    __slots__ = ("info", "is_inline")
 
     __match_args__ = ("info",)
 
     # The class representation of this typed dict
     info: TypeInfo
+    # Whether this class was created inline as a call expression callee, for example:
+    #    (TypedDict(...))(...)
+    is_inline: bool
 
-    def __init__(self, info: TypeInfo) -> None:
+    def __init__(self, info: TypeInfo, is_inline: bool = False) -> None:
         super().__init__()
         self.info = info
+        self.is_inline = is_inline
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:
         return visitor.visit_typeddict_expr(self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5202,8 +5202,11 @@ class SemanticAnalyzer(
 
         If so, analyze the callee into a NamedTupleExpr.
         """
-        if isinstance(expr.callee, NamedTupleExpr):
-            if expr.callee.info.tuple_type and not has_placeholder(expr.callee.info.tuple_type):
+        callee = expr.callee
+        if isinstance(callee, CallExpr) and isinstance(callee.analyzed, NamedTupleExpr):
+            if callee.analyzed.info.tuple_type and not has_placeholder(
+                callee.analyzed.info.tuple_type
+            ):
                 return  # This is a valid and analyzed named tuple definition, nothing to do here.
         internal_name, info, tvar_defs = self.named_tuple_analyzer.check_namedtuple(
             expr.callee, None, self.is_func_scope()
@@ -5222,9 +5225,10 @@ class SemanticAnalyzer(
 
         If so, analyze the callee into a TypedDictExpr.
         """
-        if isinstance(expr.callee, TypedDictExpr):
-            if expr.callee.info.typeddict_type and not has_placeholder(
-                expr.callee.info.typeddict_type
+        callee = expr.callee
+        if isinstance(callee, CallExpr) and isinstance(callee.analyzed, TypedDictExpr):
+            if callee.analyzed.info.typeddict_type and not has_placeholder(
+                callee.analyzed.info.typeddict_type
             ):
                 return  # This is a valid and analyzed typed dict definition, nothing to do here.
         is_typed_dict, info, tvar_defs = self.typed_dict_analyzer.check_typeddict(

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5209,7 +5209,7 @@ class SemanticAnalyzer(
             ):
                 return  # This is a valid and analyzed named tuple definition, nothing to do here.
         internal_name, info, tvar_defs = self.named_tuple_analyzer.check_namedtuple(
-            expr.callee, None, self.is_func_scope()
+            callee, None, self.is_func_scope(), is_inline=True
         )
         if internal_name is None:
             return
@@ -5232,7 +5232,7 @@ class SemanticAnalyzer(
             ):
                 return  # This is a valid and analyzed typed dict definition, nothing to do here.
         is_typed_dict, info, tvar_defs = self.typed_dict_analyzer.check_typeddict(
-            expr.callee, None, self.is_func_scope()
+            callee, None, self.is_func_scope(), is_inline=True
         )
         if not is_typed_dict:
             return

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -283,7 +283,7 @@ class NamedTupleAnalyzer:
             #   * This is a local (function or method level) named tuple, since
             #     two methods of a class can define a named tuple with the same name,
             #     and they will be stored in the same namespace (see below).
-            #   * Or, this is an anonymous named tuple, which is immediately instantiated:
+            #   * Or, this is an inline named tuple, which is immediately instantiated:
             #         (NamedTuple('NT', [...]))(...)
             name += "@" + str(call.line)
         if defaults:

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -215,7 +215,7 @@ class NamedTupleAnalyzer:
         return items, types, default_items, statements
 
     def check_namedtuple(
-        self, node: Expression, var_name: str | None, is_func_scope: bool
+        self, node: Expression, var_name: str | None, is_func_scope: bool, is_inline: bool = False
     ) -> tuple[str | None, TypeInfo | None, list[TypeVarLikeType]]:
         """Check if a call defines a namedtuple.
 
@@ -306,7 +306,7 @@ class NamedTupleAnalyzer:
         if var_name:
             self.store_namedtuple_info(info, var_name, call, is_typed)
         else:
-            call.analyzed = NamedTupleExpr(info, is_typed=is_typed)
+            call.analyzed = NamedTupleExpr(info, is_typed=is_typed, is_inline=is_inline)
             call.analyzed.set_line(call)
         # There are three cases where we need to store the generated TypeInfo
         # second time (for the purpose of serialization):

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -275,7 +275,7 @@ class NamedTupleAnalyzer:
             name = typename
 
         if var_name is None or is_func_scope:
-            # There are two special cases where need to give it a unique name derived
+            # There are three special cases where we need to give it a unique name derived
             # from the line number:
             #   * This is a base class expression, since it often matches the class name:
             #         class NT(NamedTuple('NT', [...])):
@@ -283,6 +283,8 @@ class NamedTupleAnalyzer:
             #   * This is a local (function or method level) named tuple, since
             #     two methods of a class can define a named tuple with the same name,
             #     and they will be stored in the same namespace (see below).
+            #   * Or, this is an anonymous named tuple, which is immediately instantiated:
+            #         (NamedTuple('NT', [...]))(...)
             name += "@" + str(call.line)
         if defaults:
             default_items = {

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -342,7 +342,7 @@ class TypedDictAnalyzer:
         return fields, types, statements, required_keys
 
     def check_typeddict(
-        self, node: Expression, var_name: str | None, is_func_scope: bool
+        self, node: Expression, var_name: str | None, is_func_scope: bool, is_inline: bool = False
     ) -> tuple[bool, TypeInfo | None, list[TypeVarLikeType]]:
         """Check if a call defines a TypedDict.
 
@@ -423,7 +423,7 @@ class TypedDictAnalyzer:
             self.api.add_symbol_skip_local(name, info)
         if var_name:
             self.api.add_symbol(var_name, info, node)
-        call.analyzed = TypedDictExpr(info)
+        call.analyzed = TypedDictExpr(info, is_inline=is_inline)
         call.analyzed.set_line(call)
         return True, info, tvar_defs
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1371,3 +1371,30 @@ class Test3(NamedTuple, metaclass=type):  # E: Unexpected keyword argument "meta
     ...
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
+
+[case testNamedTupleInlineInstantiation]
+from collections import namedtuple
+from typing import NamedTuple
+
+x, y = namedtuple("Point2d", ["x", "y"])(2, 3)
+reveal_type(x)  # N: Revealed type is "Any"
+reveal_type(y)  # N: Revealed type is "Any"
+
+z, w = NamedTuple("Point2d", [("z", float), ("w", float)])(2, 3)
+reveal_type(z)  # N: Revealed type is "builtins.float"
+reveal_type(w)  # N: Revealed type is "builtins.float"
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]
+
+[case testNamedTupleInlineNoGenerics]
+from typing import TypeVar, NamedTuple
+
+T = TypeVar("T")
+
+(NamedTuple("NT", [("x", int), ("y", T)]))(0, 0)  # E: Generic named tuples cannot be immediately instantiated \
+                                                  # N: Use Python 3 class syntax, or assign the type to a variable \
+                                                  # E: Value of type variable "_NT" of "NT@5" cannot be "int"
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2305,7 +2305,7 @@ class A:
     def __init__(self) -> None:
         self.b = TypedDict('b', {'x': int, 'y': str})  # E: TypedDict type as attribute is not supported
 
-reveal_type(A().b)  # N: Revealed type is "Any"
+reveal_type(A().b)  # N: Revealed type is "def (*, x: builtins.int, y: builtins.str) -> TypedDict('__main__.A.b@5', {'x': builtins.int, 'y': builtins.str})"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3438,3 +3438,25 @@ class TotalInTheMiddle(TypedDict, a=1, total=True, b=2, c=3):  # E: Unexpected k
     ...
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testTypedDictInlineInstantiation]
+from typing import TypedDict
+
+d = (TypedDict("Point2d", {'x': int, 'y': int}))(x=1, y=2)
+reveal_type(d['x'])  # N: Revealed type is "builtins.int"
+reveal_type(d['y'])  # N: Revealed type is "builtins.int"
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+[case testTypedDictInlineNoGenerics]
+from typing import TypeVar, TypedDict
+
+T = TypeVar("T")
+
+(TypedDict("Point2d", {'x': int, 'y': T}))(x=1, y=2)  # E: Generic TypedDict cannot be immediately instantiated \
+                                                      # N: Use the class syntax, or assign the type to a variable \
+                                                      # E: Incompatible types (expression has type "int", TypedDict item "y" has type "T")
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2305,7 +2305,7 @@ class A:
     def __init__(self) -> None:
         self.b = TypedDict('b', {'x': int, 'y': str})  # E: TypedDict type as attribute is not supported
 
-reveal_type(A().b)  # N: Revealed type is "def (*, x: builtins.int, y: builtins.str) -> TypedDict('__main__.A.b@5', {'x': builtins.int, 'y': builtins.str})"
+reveal_type(A().b)  # N: Revealed type is "Any"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 


### PR DESCRIPTION
Fixes #16660. Adds support for inline instantiation of "anonymous" `NamedTuple(s)` and `TypedDict(s)`.

```python
from typing import NamedTuple, TypedDict

x, y = (NamedTuple("Point2d", [('x', float), ('y', float)]))(2, 3)
reveal_type(x)  # N: Revealed type is "builtins.float"
reveal_type(y)  # N: Revealed type is "builtins.float"

d = (TypedDict("Point2d", {'x': float, 'y': float}))(x=1, y=2)
reveal_type(d['x'])  # N: Revealed type is "builtins.float"
reveal_type(d['y'])  # N: Revealed type is "builtins.float"
```

* Doesn't support generic fields in inlined `NamedTuple(s)` or generic keys in inlined `TypedDict(s)`.
    * This has the unfortunate side effect that additional errors are raised aside from the added note and `misc` error. (See `testNamedTupleInlineNoGenerics` and `testTypedDictInlineNoGenerics`.)
* Also unfortunately requires `NamedTupleExpr` and `TypedDictExpr` to have an additional `is_inline` field.
    * This isn't strictly necessary, but it is used to avoid exposing the special form by returning `AnyType` when revealing the type of `NamedTupleExpr` or `TypedDictExpr` (See `testAssignTypedDictAsAttribute`, for example).
