### PR TITLE
Unexpected unused type ignore alt 2

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -725,6 +725,8 @@ class Errors:
                 blocker=False,
                 only_once=False,
                 allow_dups=False,
+                origin=(self.file, [line]),
+                target=self.target_module,
             )
             self._add_error_info(file, info)
 
@@ -777,6 +779,8 @@ class Errors:
                 blocker=False,
                 only_once=False,
                 allow_dups=False,
+                origin=(self.file, [line]),
+                target=self.target_module,
             )
             self._add_error_info(file, info)
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -503,6 +503,9 @@ class Errors:
                         self.used_ignored_lines[file][scope_line].append(
                             (info.code or codes.MISC).code
                         )
+                        if file not in self.ignored_files:
+                            info.hidden = True
+                            self._add_error_info(file, info)
                         return
             if file in self.ignored_files:
                 return
@@ -805,8 +808,9 @@ class Errors:
         return None
 
     def is_errors_for_file(self, file: str) -> bool:
-        """Are there any errors for the given file?"""
-        return file in self.error_info_map
+        """Are there any visible errors for the given file?"""
+        errors = self.error_info_map.get(file, ())
+        return any(error.hidden is False for error in errors)
 
     def prefer_simple_messages(self) -> bool:
         """Should we generate simple/fast error messages?

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -676,7 +676,7 @@ class Errors:
                     new_errors.append(info)
                     has_blocker |= info.blocker
                 elif info.only_once:
-                    self.only_once_messages.remove(info.message)
+                    self.only_once_messages.discard(info.message)
             self.error_info_map[path] = new_errors
             if not has_blocker and path in self.has_blockers:
                 self.has_blockers.remove(path)

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -940,7 +940,10 @@ class Errors:
         # TODO: Make sure that either target is always defined or that not being defined
         #       is okay for fine-grained incremental checking.
         return {
-            info.target for errs in self.error_info_map.values() for info in errs if info.target
+            info.target
+            for errs in self.error_info_map.values()
+            for info in errs
+            if info.target and not info.hidden
         }
 
     def render_messages(self, errors: list[ErrorInfo]) -> list[ErrorTuple]:

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -667,6 +667,8 @@ def update_module_isolated(
     state.type_check_first_pass()
     state.type_check_second_pass()
     state.detect_possibly_undefined_vars()
+    state.generate_unused_ignore_notes()
+    state.generate_ignore_without_code_notes()
     t2 = time.time()
     state.finish_passes()
     t3 = time.time()
@@ -1027,6 +1029,10 @@ def reprocess_nodes(
         more = False
         if graph[module_id].type_checker().check_second_pass():
             more = True
+
+    graph[module_id].detect_possibly_undefined_vars()
+    graph[module_id].generate_unused_ignore_notes()
+    graph[module_id].generate_ignore_without_code_notes()
 
     if manager.options.export_types:
         manager.all_types.update(graph[module_id].type_map())

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -632,3 +632,20 @@ bar.py:2: error: Unused "type: ignore" comment
 [file bar.py]
 from foo.empty import *
 a = 1  # type: ignore
+
+[case testTypeIgnoreWithoutCodePreservedOnRerun]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --enable-error-code ignore-without-code --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -704,3 +704,24 @@ from foo.empty import *
 if False:
     a = 1
 a
+
+[case testReturnTypeIgnoreAfterUnknownImport]
+-- Return type ignores after unknown imports and unused modules are respected on the second pass.
+$ dmypy start -- --warn-unused-ignores --no-error-summary
+Daemon started
+$ dmypy check -- foo.py
+foo.py:2: error: Cannot find implementation or library stub for module named "a_module_which_does_not_exist"  [import-not-found]
+foo.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+== Return code: 1
+$ dmypy check -- foo.py
+foo.py:2: error: Cannot find implementation or library stub for module named "a_module_which_does_not_exist"  [import-not-found]
+foo.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+== Return code: 1
+
+[file unused/__init__.py]
+[file unused/empty.py]
+[file foo.py]
+from unused.empty import *
+import a_module_which_does_not_exist
+def is_foo() -> str:
+    return True  # type: ignore

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -615,3 +615,20 @@ b: str
 from demo.test import a
 [file demo/test.py]
 a: int
+
+[case testUnusedTypeIgnorePreservedOnRerun]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --warn-unused-ignores --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -618,7 +618,7 @@ a: int
 
 [case testUnusedTypeIgnorePreservedOnRerun]
 -- Regression test for https://github.com/python/mypy/issues/9655
-$ dmypy start -- --warn-unused-ignores --no-error-summary
+$ dmypy start -- --warn-unused-ignores --no-error-summary --hide-error-codes
 Daemon started
 $ dmypy check -- bar.py
 bar.py:2: error: Unused "type: ignore" comment
@@ -640,6 +640,42 @@ Daemon started
 $ dmypy check -- bar.py
 bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
 == Return code: 1
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore
+
+[case testUnusedTypeIgnorePreservedAfterChange]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --warn-unused-ignores --no-error-summary --hide-error-codes
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+$ echo '' >> bar.py
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore
+
+[case testTypeIgnoreWithoutCodePreservedAfterChange]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --enable-error-code ignore-without-code --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+$ echo '' >> bar.py
 $ dmypy check -- bar.py
 bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
 == Return code: 1

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -649,3 +649,22 @@ bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code
 [file bar.py]
 from foo.empty import *
 a = 1  # type: ignore
+
+[case testPossiblyUndefinedVarsPreservedAfterUpdate]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --enable-error-code possibly-undefined --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:4: error: Name "a" may be undefined  [possibly-undefined]
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:4: error: Name "a" may be undefined  [possibly-undefined]
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+if False:
+    a = 1
+a


### PR DESCRIPTION
Another demo PR in support of https://github.com/python/mypy/pull/15043.

This one doesn't use any special casing of builtins, and only has one failing test - but it's one of the tests that we're trying to fix.

I wonder if `mypy.errors.Errors.targets` should be split into two methods, sometimes perhaps we want the hidden files and sometimes we don't.

```
mypy/test/testdaemon.py::DaemonSuite::daemon.test::testReturnTypeIgnoreAfterUnknownImport
```