### PR TITLE
Unexpected unused type ignore refactor

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -498,9 +498,7 @@ class Errors:
             # Check each line in this context for "type: ignore" comments.
             # line == end_line for most nodes, so we only loop once.
             for scope_line in lines:
-                is_ignored_error = self._is_ignored_error(info, scope_line)
-
-                if is_ignored_error:
+                if self._is_ignored_error(info, scope_line):
                     # Annotation requests us to ignore all errors on this line.
                     self.used_ignored_lines[file][scope_line].append(
                         (info.code or codes.MISC).code

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -627,22 +627,22 @@ class Errors:
         )
         self._add_error_info(info.origin[0], new_info)
 
-    def is_ignored_error(self, line: int, info: ErrorInfo, ignores: dict[int, list[str]]) -> bool:
+    def is_ignored_error(self, scope_line: int, info: ErrorInfo, ignores: dict[int, list[str]]) -> bool:
         if info.blocker:
             # Blocking errors can never be ignored
             is_ignored_error = False
         elif info.code and not self.is_error_code_enabled(info.code):
             is_ignored_error = True
-        elif line not in ignores:
+        elif scope_line not in ignores:
             is_ignored_error = False
-        elif not ignores[line]:
+        elif not ignores[scope_line]:
             # Empty list means that we ignore all errors
             is_ignored_error = True
         elif info.code and self.is_error_code_enabled(info.code):
             is_ignored_error = (
-                info.code.code in ignores[line]
+                info.code.code in ignores[scope_line]
                 or info.code.sub_code_of is not None
-                and info.code.sub_code_of.code in ignores[line]
+                and info.code.sub_code_of.code in ignores[scope_line]
             )
         else:
             is_ignored_error = False

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -505,7 +505,7 @@ class Errors:
                     self.used_ignored_lines[file][scope_line].append(
                         (info.code or codes.MISC).code
                     )
-                    if self._should_record_ignored_line(info, file):
+                    if self._should_record_ignored_line(info):
                         info.hidden = True
                         self._add_error_info(file, info)
                     return
@@ -613,14 +613,13 @@ class Errors:
         else:
             return False
 
-    def _should_record_ignored_line(
-        self, info: ErrorInfo, file: str
-    ) -> bool:
+    def _should_record_ignored_line(self, info: ErrorInfo) -> bool:
         """
         Return whether we should record an error in the supplied ErrorInfo as a hidden error.
 
         This is necessary to prevent us from misreporting unused ignores on subsequent daemon runs.
         """
+        file = info.origin[0]
         if file in self.ignored_files:
             return False
         elif info.code and not self.is_error_code_enabled(info.code):

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -722,6 +722,8 @@ class Errors:
                 blocker=False,
                 only_once=False,
                 allow_dups=False,
+                origin=(self.file, [line]),
+                target=self.target_module,
             )
             self._add_error_info(file, info)
 
@@ -774,6 +776,8 @@ class Errors:
                 blocker=False,
                 only_once=False,
                 allow_dups=False,
+                origin=(self.file, [line]),
+                target=self.target_module,
             )
             self._add_error_info(file, info)
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -494,42 +494,41 @@ class Errors:
         if self._filter_error(file, info):
             return
         if not info.blocker:  # Blockers cannot be ignored
-            if file in self.ignored_lines:
-                ignores = self.ignored_lines[file]
-                # Check each line in this context for "type: ignore" comments.
-                # line == end_line for most nodes, so we only loop once.
-                for scope_line in lines:
-                    if info.code and not self.is_error_code_enabled(info.code):
-                        is_ignored_error = True
-                        record_ignored_line = False
-                    elif scope_line not in ignores:
-                        is_ignored_error = False
-                        record_ignored_line = False
-                    elif not ignores[scope_line]:
-                        # Empty list means that we ignore all errors
-                        is_ignored_error = True
-                        record_ignored_line = True
-                    elif info.code and self.is_error_code_enabled(info.code):
-                        is_ignored_error = (
-                            info.code.code in ignores[scope_line]
-                            or info.code.sub_code_of is not None
-                            and info.code.sub_code_of.code in ignores[scope_line]
-                        )
-                        record_ignored_line = is_ignored_error
-                    else:
-                        is_ignored_error = False
-                        record_ignored_line = False
+            ignores = self.ignored_lines.get(file, {})
+            # Check each line in this context for "type: ignore" comments.
+            # line == end_line for most nodes, so we only loop once.
+            for scope_line in lines:
+                if info.code and not self.is_error_code_enabled(info.code):
+                    is_ignored_error = True
+                    record_ignored_line = False
+                elif scope_line not in ignores:
+                    is_ignored_error = False
+                    record_ignored_line = False
+                elif not ignores[scope_line]:
+                    # Empty list means that we ignore all errors
+                    is_ignored_error = True
+                    record_ignored_line = True
+                elif info.code and self.is_error_code_enabled(info.code):
+                    is_ignored_error = (
+                        info.code.code in ignores[scope_line]
+                        or info.code.sub_code_of is not None
+                        and info.code.sub_code_of.code in ignores[scope_line]
+                    )
+                    record_ignored_line = is_ignored_error
+                else:
+                    is_ignored_error = False
+                    record_ignored_line = False
 
-                    if record_ignored_line and file not in self.ignored_files:
-                        info.hidden = True
-                        self._add_error_info(file, info)
+                if record_ignored_line and file not in self.ignored_files:
+                    info.hidden = True
+                    self._add_error_info(file, info)
 
-                    if is_ignored_error:
-                        # Annotation requests us to ignore all errors on this line.
-                        self.used_ignored_lines[file][scope_line].append(
-                            (info.code or codes.MISC).code
-                        )
-                        return
+                if is_ignored_error:
+                    # Annotation requests us to ignore all errors on this line.
+                    self.used_ignored_lines[file][scope_line].append(
+                        (info.code or codes.MISC).code
+                    )
+                    return
             if file in self.ignored_files:
                 return
         if info.only_once:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -630,21 +630,24 @@ class Errors:
     def is_ignored_error(self, line: int, info: ErrorInfo, ignores: dict[int, list[str]]) -> bool:
         if info.blocker:
             # Blocking errors can never be ignored
-            return False
-        if info.code and not self.is_error_code_enabled(info.code):
-            return True
-        if line not in ignores:
-            return False
-        if not ignores[line]:
+            is_ignored_error = False
+        elif info.code and not self.is_error_code_enabled(info.code):
+            is_ignored_error = True
+        elif line not in ignores:
+            is_ignored_error = False
+        elif not ignores[line]:
             # Empty list means that we ignore all errors
-            return True
-        if info.code and self.is_error_code_enabled(info.code):
-            return (
+            is_ignored_error = True
+        elif info.code and self.is_error_code_enabled(info.code):
+            is_ignored_error = (
                 info.code.code in ignores[line]
                 or info.code.sub_code_of is not None
                 and info.code.sub_code_of.code in ignores[line]
             )
-        return False
+        else:
+            is_ignored_error = False
+
+        return is_ignored_error
 
     def is_error_code_enabled(self, error_code: ErrorCode) -> bool:
         if self.options:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -495,10 +495,10 @@ class Errors:
             return
         if not info.blocker:  # Blockers cannot be ignored
             if file in self.ignored_lines:
+                ignores = self.ignored_lines[file]
                 # Check each line in this context for "type: ignore" comments.
                 # line == end_line for most nodes, so we only loop once.
                 for scope_line in lines:
-                    ignores = self.ignored_lines[file]
                     if info.code and not self.is_error_code_enabled(info.code):
                         is_ignored_error = True
                         record_ignored_line = False

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -505,7 +505,7 @@ class Errors:
                     self.used_ignored_lines[file][scope_line].append(
                         (info.code or codes.MISC).code
                     )
-                    if self._should_record_ignored_line(info):
+                    if self._should_record_ignored_lines(info):
                         info.hidden = True
                         self._add_error_info(file, info)
                     return
@@ -613,9 +613,9 @@ class Errors:
         else:
             return False
 
-    def _should_record_ignored_line(self, info: ErrorInfo) -> bool:
+    def _should_record_ignored_lines(self, info: ErrorInfo) -> bool:
         """
-        Return whether we should record an error in the supplied ErrorInfo as a hidden error.
+        Return whether we should record any ignored errors in the supplied ErrorInfo as a hidden error.
 
         This is necessary to prevent us from misreporting unused ignores on subsequent daemon runs.
         """

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -499,10 +499,7 @@ class Errors:
                 # line == end_line for most nodes, so we only loop once.
                 for scope_line in lines:
                     ignores = self.ignored_lines[file]
-                    if info.blocker:
-                        # Blocking errors can never be ignored
-                        is_ignored_error = False
-                    elif info.code and not self.is_error_code_enabled(info.code):
+                    if info.code and not self.is_error_code_enabled(info.code):
                         is_ignored_error = True
                     elif scope_line not in ignores:
                         is_ignored_error = False

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -500,17 +500,14 @@ class Errors:
             for scope_line in lines:
                 is_ignored_error = self._is_ignored_error(info, scope_line, ignores)
 
-                record_ignored_line = self._should_record_ignored_line(info, file, is_ignored_error)
-
-                if record_ignored_line:
-                    info.hidden = True
-                    self._add_error_info(file, info)
-
                 if is_ignored_error:
                     # Annotation requests us to ignore all errors on this line.
                     self.used_ignored_lines[file][scope_line].append(
                         (info.code or codes.MISC).code
                     )
+                    if self._should_record_ignored_line(info, file, is_ignored_error):
+                        info.hidden = True
+                        self._add_error_info(file, info)
                     return
             if file in self.ignored_files:
                 return

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -498,7 +498,26 @@ class Errors:
                 # Check each line in this context for "type: ignore" comments.
                 # line == end_line for most nodes, so we only loop once.
                 for scope_line in lines:
-                    if self.is_ignored_error(scope_line, info, self.ignored_lines[file]):
+                    ignores = self.ignored_lines[file]
+                    if info.blocker:
+                        # Blocking errors can never be ignored
+                        is_ignored_error = False
+                    elif info.code and not self.is_error_code_enabled(info.code):
+                        is_ignored_error = True
+                    elif scope_line not in ignores:
+                        is_ignored_error = False
+                    elif not ignores[scope_line]:
+                        # Empty list means that we ignore all errors
+                        is_ignored_error = True
+                    elif info.code and self.is_error_code_enabled(info.code):
+                        is_ignored_error = (
+                            info.code.code in ignores[scope_line]
+                            or info.code.sub_code_of is not None
+                            and info.code.sub_code_of.code in ignores[scope_line]
+                        )
+                    else:
+                        is_ignored_error = False
+                    if is_ignored_error:
                         # Annotation requests us to ignore all errors on this line.
                         self.used_ignored_lines[file][scope_line].append(
                             (info.code or codes.MISC).code
@@ -626,28 +645,6 @@ class Errors:
             target=info.target,
         )
         self._add_error_info(info.origin[0], new_info)
-
-    def is_ignored_error(self, scope_line: int, info: ErrorInfo, ignores: dict[int, list[str]]) -> bool:
-        if info.blocker:
-            # Blocking errors can never be ignored
-            is_ignored_error = False
-        elif info.code and not self.is_error_code_enabled(info.code):
-            is_ignored_error = True
-        elif scope_line not in ignores:
-            is_ignored_error = False
-        elif not ignores[scope_line]:
-            # Empty list means that we ignore all errors
-            is_ignored_error = True
-        elif info.code and self.is_error_code_enabled(info.code):
-            is_ignored_error = (
-                info.code.code in ignores[scope_line]
-                or info.code.sub_code_of is not None
-                and info.code.sub_code_of.code in ignores[scope_line]
-            )
-        else:
-            is_ignored_error = False
-
-        return is_ignored_error
 
     def is_error_code_enabled(self, error_code: ErrorCode) -> bool:
         if self.options:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -504,15 +504,9 @@ class Errors:
                 # This is necessary to prevent us from misreporting unused ignores on subsequent daemon runs.
                 if info.code and not self.is_error_code_enabled(info.code):
                     record_ignored_line = False
-                elif scope_line not in ignores:
-                    record_ignored_line = False
-                elif not ignores[scope_line]:
-                    record_ignored_line = True
-                elif info.code and self.is_error_code_enabled(info.code):
-                    record_ignored_line = is_ignored_error
                 else:
-                    record_ignored_line = False
-
+                    record_ignored_line = is_ignored_error
+                
                 if record_ignored_line and file not in self.ignored_files:
                     info.hidden = True
                     self._add_error_info(file, info)

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -494,12 +494,11 @@ class Errors:
         if self._filter_error(file, info):
             return
         if not info.blocker:  # Blockers cannot be ignored
-            ignores = self.ignored_lines.get(file, {})
             should_record_ignored_lines_for_info = self._should_record_ignored_lines(info)
             # Check each line in this context for "type: ignore" comments.
             # line == end_line for most nodes, so we only loop once.
             for scope_line in lines:
-                is_ignored_error = self._is_ignored_error(info, scope_line, ignores)
+                is_ignored_error = self._is_ignored_error(info, scope_line)
 
                 if is_ignored_error:
                     # Annotation requests us to ignore all errors on this line.
@@ -592,12 +591,13 @@ class Errors:
             )
             self._add_error_info(file, info)
 
-    def _is_ignored_error(
-        self, info: ErrorInfo, scope_line: int, ignores: dict[int, list[str]]
-    ) -> bool:
+    def _is_ignored_error(self, info: ErrorInfo, scope_line: int) -> bool:
         """
         Return whether the supplied ErrorInfo should be ignored for the line in question.
         """
+        file = info.origin[0]
+        ignores = self.ignored_lines.get(file, {})
+
         error_code_is_enabled = info.code and self.is_error_code_enabled(info.code)
         if not error_code_is_enabled:
             return True

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -505,7 +505,7 @@ class Errors:
                     self.used_ignored_lines[file][scope_line].append(
                         (info.code or codes.MISC).code
                     )
-                    if self._should_record_ignored_line(info, file, is_ignored_error):
+                    if self._should_record_ignored_line(info, file):
                         info.hidden = True
                         self._add_error_info(file, info)
                     return
@@ -614,7 +614,7 @@ class Errors:
             return False
 
     def _should_record_ignored_line(
-        self, info: ErrorInfo, file: str, is_ignored_error: bool
+        self, info: ErrorInfo, file: str
     ) -> bool:
         """
         Return whether we should record an error in the supplied ErrorInfo as a hidden error.
@@ -626,7 +626,7 @@ class Errors:
         elif info.code and not self.is_error_code_enabled(info.code):
             return False
         else:
-            return is_ignored_error
+            return True
 
     def has_many_errors(self) -> bool:
         if self.options.many_errors_threshold < 0:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -598,14 +598,15 @@ class Errors:
         """
         Return whether the supplied ErrorInfo should be ignored for the line in question.
         """
-        if info.code and not self.is_error_code_enabled(info.code):
+        error_code_is_enabled = info.code and self.is_error_code_enabled(info.code)
+        if not error_code_is_enabled:
             return True
         elif scope_line not in ignores:
             return False
         elif not ignores[scope_line]:
             # Empty list means that we ignore all errors
             return True
-        elif info.code and self.is_error_code_enabled(info.code):
+        elif info.code:
             return (
                 info.code.code in ignores[scope_line]
                 or info.code.sub_code_of is not None

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -502,12 +502,14 @@ class Errors:
 
                 # Should we record it as a hidden error?
                 # This is necessary to prevent us from misreporting unused ignores on subsequent daemon runs.
-                if info.code and not self.is_error_code_enabled(info.code):
+                if file in self.ignored_files:
+                    record_ignored_line = False
+                elif info.code and not self.is_error_code_enabled(info.code):
                     record_ignored_line = False
                 else:
                     record_ignored_line = is_ignored_error
-                
-                if record_ignored_line and file not in self.ignored_files:
+
+                if record_ignored_line:
                     info.hidden = True
                     self._add_error_info(file, info)
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -495,6 +495,7 @@ class Errors:
             return
         if not info.blocker:  # Blockers cannot be ignored
             ignores = self.ignored_lines.get(file, {})
+            should_record_ignored_lines_for_info = self._should_record_ignored_lines(info)
             # Check each line in this context for "type: ignore" comments.
             # line == end_line for most nodes, so we only loop once.
             for scope_line in lines:
@@ -505,7 +506,7 @@ class Errors:
                     self.used_ignored_lines[file][scope_line].append(
                         (info.code or codes.MISC).code
                     )
-                    if self._should_record_ignored_lines(info):
+                    if should_record_ignored_lines_for_info:
                         info.hidden = True
                         self._add_error_info(file, info)
                     return

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -667,6 +667,8 @@ def update_module_isolated(
     state.type_check_first_pass()
     state.type_check_second_pass()
     state.detect_possibly_undefined_vars()
+    state.generate_unused_ignore_notes()
+    state.generate_ignore_without_code_notes()
     t2 = time.time()
     state.finish_passes()
     t3 = time.time()
@@ -1027,6 +1029,10 @@ def reprocess_nodes(
         more = False
         if graph[module_id].type_checker().check_second_pass():
             more = True
+
+    graph[module_id].detect_possibly_undefined_vars()
+    graph[module_id].generate_unused_ignore_notes()
+    graph[module_id].generate_ignore_without_code_notes()
 
     if manager.options.export_types:
         manager.all_types.update(graph[module_id].type_map())

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -649,3 +649,22 @@ bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code
 [file bar.py]
 from foo.empty import *
 a = 1  # type: ignore
+
+[case testPossiblyUndefinedVarsPreservedAfterRerun]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --enable-error-code possibly-undefined --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:4: error: Name "a" may be undefined  [possibly-undefined]
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:4: error: Name "a" may be undefined  [possibly-undefined]
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+if False:
+    a = 1
+a

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -615,3 +615,20 @@ b: str
 from demo.test import a
 [file demo/test.py]
 a: int
+
+[case testUnusedTypeIgnorePreservedOnRerun]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --warn-unused-ignores --no-error-summary --hide-error-codes
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:2: error: Unused "type: ignore" comment
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -632,3 +632,20 @@ bar.py:2: error: Unused "type: ignore" comment
 [file bar.py]
 from foo.empty import *
 a = 1  # type: ignore
+
+[case testTypeIgnoreWithoutCodePreservedOnRerun]
+-- Regression test for https://github.com/python/mypy/issues/9655
+$ dmypy start -- --enable-error-code ignore-without-code --no-error-summary
+Daemon started
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+$ dmypy check -- bar.py
+bar.py:2: error: "type: ignore" comment without error code  [ignore-without-code]
+== Return code: 1
+
+[file foo/__init__.py]
+[file foo/empty.py]
+[file bar.py]
+from foo.empty import *
+a = 1  # type: ignore

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -668,3 +668,24 @@ from foo.empty import *
 if False:
     a = 1
 a
+
+[case testReturnTypeIgnoreAfterUnknownImport]
+-- Return type ignores after unknown imports and unused modules are respected on the second pass.
+$ dmypy start -- --warn-unused-ignores --no-error-summary
+Daemon started
+$ dmypy check -- foo.py
+foo.py:2: error: Cannot find implementation or library stub for module named "a_module_which_does_not_exist"  [import-not-found]
+foo.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+== Return code: 1
+$ dmypy check -- foo.py
+foo.py:2: error: Cannot find implementation or library stub for module named "a_module_which_does_not_exist"  [import-not-found]
+foo.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+== Return code: 1
+
+[file unused/__init__.py]
+[file unused/empty.py]
+[file foo.py]
+from unused.empty import *
+import a_module_which_does_not_exist
+def is_foo() -> str:
+    return True  # type: ignore

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10505,3 +10505,27 @@ from pkg.sub import modb
 
 [out]
 ==
+
+[case testUnusedTypeIgnorePreservedAfterChange]
+# flags: --warn-unused-ignores --no-error-summary
+[file main.py]
+a = 1  # type: ignore
+[file main.py.2]
+a = 1  # type: ignore
+# Comment to trigger reload.
+[out]
+main.py:1: error: Unused "type: ignore" comment
+==
+main.py:1: error: Unused "type: ignore" comment
+
+[case testTypeIgnoreWithoutCodePreservedAfterChange]
+# flags: --enable-error-code ignore-without-code --no-error-summary
+[file main.py]
+a = 1  # type: ignore
+[file main.py.2]
+a = 1  # type: ignore
+# Comment to trigger reload.
+[out]
+main.py:1: error: "type: ignore" comment without error code
+==
+main.py:1: error: "type: ignore" comment without error code


### PR DESCRIPTION
https://github.com/python/mypy/pull/15043 increases the already-long `add_error_method` to 112 lines. This adds a few proposed refactorings on top which shortens the method by 10 lines and (hopefully) makes the logic a little easier to follow.  
