### PR TITLE
Track classes with explicit __module__ attributes

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2893,6 +2893,7 @@ class SemanticAnalyzer(
         self.process__all__(s)
         self.process__deletable__(s)
         self.process__slots__(s)
+        self.process__module__(s)
 
     def analyze_identity_global_assignment(self, s: AssignmentStmt) -> bool:
         """Special case 'X = X' in global scope.
@@ -4717,6 +4718,22 @@ class SemanticAnalyzer(
                 assert super_type.slots is not None
                 slots.extend(super_type.slots)
             self.type.slots = set(slots)
+
+    def process__module__(self, s: AssignmentStmt) -> None:
+        """
+        Processing ``__module__`` if defined in type.
+        """
+        # if isinstance(self.type, TypeInfo) and "ZoneInfo" in self.type.fullname:
+        #     breakpoint()
+        if (
+            isinstance(self.type, TypeInfo)
+            and len(s.lvalues) == 1
+            and isinstance(s.lvalues[0], NameExpr)
+            and s.lvalues[0].name == "__module__"
+            and s.lvalues[0].kind == MDEF
+            and isinstance(s.rvalue, StrExpr)
+        ):
+            self.type.module_override = s.rvalue.value
 
     #
     # Misc statements

--- a/test-data/unit/semanal-typeinfo.test
+++ b/test-data/unit/semanal-typeinfo.test
@@ -89,3 +89,15 @@ TypeInfoMap(
     Mro(__main__.A, builtins.object)
     Names(
       a)))
+
+[case testExplicit__module__]
+class A:
+    __module__ = "other.module"
+[out]
+TypeInfoMap(
+  __main__.A : TypeInfo(
+    Name(other.module.A)
+    Bases(builtins.object)
+    Mro(other.module.A, builtins.object)
+    Names(
+      __module__ (builtins.str))))


### PR DESCRIPTION
Having access to this information can be used for more accurate diagnostics and tests

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

At runtime, classes which declare their \_\_module\_\_ attribute explicitly have that reflected in
their repr. This MR stores this information on TypeInfo nodes as the module_override attribute.
The original motivation for that is this typeshed discussion https://github.com/python/typeshed/issues/11141 

This is a relatively minimal change to enable the desired behavior. In trying to understand how this part of mypy works, I considered whether it was possible to store the module name and qualname separately and only generate the fullname on demand, like runtime does. I quickly discovered how much state is indexed by the fullname, so that seems like it'd be a massive project.

I was originally looking at modules which set their \_\_name\_\_ attribute explicitly. That's similarly easy to capture, but the number of places that would need to propagate to was a bit intimidating.

Strictly speaking, we don't need the qualname property, but it seemed reasonable to make that available since I had to generate it anyway. Changing TypeInfo.dump() to use the new realname property was done solely for the sake of being able to write a test.

I don't love `realname` as the name for this property, but I couldn't think of anything better. Real in the sense that that's what runtime would say it's name is.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
