### PR TITLE
propose edit: getting_started.rst: replace 'when the program run' with 'when the program runs'

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -66,7 +66,7 @@ This is the case even if you misuse the function!
    def greeting(name):
        return 'Hello ' + name
 
-   # These calls will fail when the program run, but mypy does not report an error
+   # These calls will fail when the program runs, but mypy does not report an error
    # because "greeting" does not have type annotations.
    greeting(123)
    greeting(b"Alice")


### PR DESCRIPTION
I read 'when the program run' as a typo where the phrase intended is 'when the program runs'. 
