### PR TITLE
Support TypedDict functional syntax as class base type

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2164,8 +2164,16 @@ class SemanticAnalyzer(
             if (
                 isinstance(base_expr, RefExpr)
                 and base_expr.fullname in TYPED_NAMEDTUPLE_NAMES + TPDICT_NAMES
+            ) or (
+                isinstance(base_expr, CallExpr)
+                and isinstance(base_expr.callee, RefExpr)
+                and base_expr.callee.fullname in TPDICT_NAMES
             ):
                 # Ignore magic bases for now.
+                # For example:
+                #  class Foo(TypedDict): ...  # RefExpr
+                #  class Foo(NamedTuple): ...  # RefExpr
+                #  class Foo(TypedDict("Foo", {"a": int})): ...  # CallExpr
                 continue
 
             try:

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -79,6 +79,8 @@ class TypedDictAnalyzer:
         """
         possible = False
         for base_expr in defn.base_type_exprs:
+            if isinstance(base_expr, CallExpr):
+                base_expr = base_expr.callee
             if isinstance(base_expr, IndexExpr):
                 base_expr = base_expr.base
             if isinstance(base_expr, RefExpr):
@@ -117,7 +119,12 @@ class TypedDictAnalyzer:
         typeddict_bases: list[Expression] = []
         typeddict_bases_set = set()
         for expr in defn.base_type_exprs:
-            if isinstance(expr, RefExpr) and expr.fullname in TPDICT_NAMES:
+            ok, info, _ = self.check_typeddict(expr, None, False)
+            if ok and info is not None:
+                # expr is a CallExpr
+                typeddict_bases_set.add(info.fullname)
+                typeddict_bases.append(expr)
+            elif isinstance(expr, RefExpr) and expr.fullname in TPDICT_NAMES:
                 if "TypedDict" not in typeddict_bases_set:
                     typeddict_bases_set.add("TypedDict")
                 else:
@@ -180,8 +187,7 @@ class TypedDictAnalyzer:
             assert isinstance(base.node, TypeInfo)
             info = base.node
             base_args: list[Type] = []
-        else:
-            assert isinstance(base, IndexExpr)
+        elif isinstance(base, IndexExpr):
             assert isinstance(base.base, RefExpr)
             assert isinstance(base.base.node, TypeInfo)
             info = base.base.node
@@ -189,6 +195,11 @@ class TypedDictAnalyzer:
             if args is None:
                 return
             base_args = args
+        else:
+            assert isinstance(base, CallExpr)
+            assert isinstance(base.analyzed, TypedDictExpr)
+            info = base.analyzed.info
+            base_args: list[Type] = []
 
         assert info.typeddict_type is not None
         base_typed_dict = info.typeddict_type

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -119,9 +119,10 @@ class TypedDictAnalyzer:
         typeddict_bases: list[Expression] = []
         typeddict_bases_set = set()
         for expr in defn.base_type_exprs:
-            ok, info, _ = self.check_typeddict(expr, None, False)
-            if ok and info is not None:
+            ok, maybe_type_info, _ = self.check_typeddict(expr, None, False)
+            if ok and maybe_type_info is not None:
                 # expr is a CallExpr
+                info = maybe_type_info
                 typeddict_bases_set.add(info.fullname)
                 typeddict_bases.append(expr)
             elif isinstance(expr, RefExpr) and expr.fullname in TPDICT_NAMES:
@@ -183,10 +184,10 @@ class TypedDictAnalyzer:
         required_keys: set[str],
         ctx: Context,
     ) -> None:
+        base_args: list[Type] = []
         if isinstance(base, RefExpr):
             assert isinstance(base.node, TypeInfo)
             info = base.node
-            base_args: list[Type] = []
         elif isinstance(base, IndexExpr):
             assert isinstance(base.base, RefExpr)
             assert isinstance(base.base.node, TypeInfo)
@@ -199,7 +200,6 @@ class TypedDictAnalyzer:
             assert isinstance(base, CallExpr)
             assert isinstance(base.analyzed, TypedDictExpr)
             info = base.analyzed.info
-            base_args: list[Type] = []
 
         assert info.typeddict_type is not None
         base_typed_dict = info.typeddict_type

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3438,3 +3438,13 @@ class TotalInTheMiddle(TypedDict, a=1, total=True, b=2, c=3):  # E: Unexpected k
     ...
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testCanCreateClassWithFunctionBasedTypedDictBase]
+from mypy_extensions import TypedDict
+
+class Params(TypedDict("Params", {'x': int})):
+    pass
+
+p: Params = {'x': 2}
+reveal_type(p) # N: Revealed type is "TypedDict('__main__.Params', {'x': builtins.int})"
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Fixes https://github.com/python/mypy/issues/16701

This PR allows `TypedDict(...)` calls to be used as a base class. This fixes the error emitted by mypy described in https://github.com/python/mypy/issues/16701 .

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
