### PR TITLE
Show attrs auto_detect incompleteness

### DIFF
--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1656,6 +1656,42 @@ reveal_type(A.__attrs_init__)  # N: Revealed type is "def (self: __main__.A, b: 
 
 [builtins fixtures/plugin_attrs.pyi]
 
+[case testAttrsInitMethodGeneratedWhenAutoDetectTrue]
+from typing import Tuple
+import attr
+
+@attr.define(auto_detect=True)
+class A:
+    b: int
+    c: str
+    def __init__(self, bc: Tuple[int, str]) -> None:
+        b, c = bc
+        self.__attrs_init__(b, c)
+
+reveal_type(A)  # N: Revealed type is "def (bc: Tuple[builtins.int, builtins.str]) -> __main__.A"
+reveal_type(A.__init__)  # N: Revealed type is "def (self: __main__.A, bc: Tuple[builtins.int, builtins.str])"
+reveal_type(A.__attrs_init__)  # N: Revealed type is "def (self: __main__.A, b: builtins.int, c: builtins.str)"
+
+[builtins fixtures/plugin_attrs.pyi]
+
+[case testAttrsInitMethodGeneratedWhenAutoDetectTrueDefault]
+from typing import Tuple
+import attr
+
+@attr.define
+class A:
+    b: int
+    c: str
+    def __init__(self, bc: Tuple[int, str]) -> None:
+        b, c = bc
+        self.__attrs_init__(b, c)
+
+reveal_type(A)  # N: Revealed type is "def (bc: Tuple[builtins.int, builtins.str]) -> __main__.A"
+reveal_type(A.__init__)  # N: Revealed type is "def (self: __main__.A, bc: Tuple[builtins.int, builtins.str])"
+reveal_type(A.__attrs_init__)  # N: Revealed type is "def (self: __main__.A, b: builtins.int, c: builtins.str)"
+
+[builtins fixtures/plugin_attrs.pyi]
+
 [case testAttrsClassWithSlots]
 import attr
 


### PR DESCRIPTION
This test demonstrates that addition of dunder methods in attrs classes isn't quite complete.

While the existing test demonstrated that the `__attrs_init__` method was generated in classes defined with `init=False`, it wasn't generated in the same way when `__init__` was defined with `auto_detect=True` enabled (either explicitly, or by default).

The auto-generated `__attrs_init__` has been enabled in Attrs since version 21.1.0.

Related to: https://github.com/python/mypy/issues/10328
Ref: https://github.com/python-attrs/attrs/issues/793
Ref: https://www.attrs.org/en/stable/changelog.html

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
