### PR TITLE
Fix xml writing bug introduced in #16388

### DIFF
--- a/mypy/test/testutil.py
+++ b/mypy/test/testutil.py
@@ -41,6 +41,28 @@ class TestWriteJunitXml(TestCase):
         )
         assert result == expected
 
+    def test_junit_fail_escape_xml_chars(self) -> None:
+        serious = False
+        messages_by_file: dict[str | None, list[str]] = {
+            "file1.py": ["Test failed", "another line < > &"]
+        }
+        expected = """<?xml version="1.0" encoding="utf-8"?>
+<testsuite errors="0" failures="1" name="mypy" skips="0" tests="1" time="1.230">
+  <testcase classname="mypy" file="file1.py" line="1" name="mypy-py3.14-test-plat file1.py" time="1.230">
+    <failure message="mypy produced messages">Test failed
+another line &lt; &gt; &amp;</failure>
+  </testcase>
+</testsuite>
+"""
+        result = _generate_junit_contents(
+            dt=1.23,
+            serious=serious,
+            messages_by_file=messages_by_file,
+            version="3.14",
+            platform="test-plat",
+        )
+        assert result == expected
+
     def test_junit_fail_two_files(self) -> None:
         serious = False
         messages_by_file: dict[str | None, list[str]] = {

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -263,6 +263,8 @@ def _generate_junit_contents(
     version: str,
     platform: str,
 ) -> str:
+    from xml.sax.saxutils import escape
+
     if serious:
         failures = 0
         errors = len(messages_by_file)
@@ -284,7 +286,7 @@ def _generate_junit_contents(
         for filename, messages in messages_by_file.items():
             if filename is not None:
                 xml += JUNIT_TESTCASE_FAIL_TEMPLATE.format(
-                    text="\n".join(messages),
+                    text=escape("\n".join(messages)),
                     filename=filename,
                     time=dt,
                     name="mypy-py{ver}-{platform} {filename}".format(
@@ -293,7 +295,7 @@ def _generate_junit_contents(
                 )
             else:
                 xml += JUNIT_TESTCASE_FAIL_TEMPLATE.format(
-                    text="\n".join(messages),
+                    text=escape("\n".join(messages)),
                     filename="mypy",
                     time=dt,
                     name="mypy-py{ver}-{platform}".format(ver=version, platform=platform),


### PR DESCRIPTION
#16388 introduced a bug where invalid xml could be produced by `write_junit_xml`, as special characters were no longer being escaped.

The fix is to revert the removal of `from xml.sax.saxutils import escape` and `escape("\n".join(messages))` in the `write_junit_xml` function.

I've added a small test case which checks that the `<`, `>`, `&` are escaped correctly in the xml.