### PR TITLE
Disallow all super calls to methods with trivial bodies

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -359,13 +359,7 @@ def validate_super_call(node: FuncBase, mx: MemberContext) -> None:
             impl = node.impl if isinstance(node.impl, FuncDef) else node.impl.func
             unsafe_super = impl.is_trivial_body
     if unsafe_super:
-        ret_type = (
-            impl.type.ret_type
-            if isinstance(impl.type, CallableType)
-            else AnyType(TypeOfAny.unannotated)
-        )
-        if not subtypes.is_subtype(NoneType(), ret_type):
-            mx.msg.unsafe_super(node.name, node.info.name, mx.context)
+        mx.msg.unsafe_super(node.name, node.info.name, mx.context)
 
 
 def analyze_type_callable_member_access(name: str, typ: FunctionLike, mx: MemberContext) -> Type:

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -899,6 +899,8 @@ class B(A):
         return super().x.y # E: "int" has no attribute "y"
 [builtins fixtures/property.pyi]
 [out]
+main:9: error: Call to abstract method "x" of "A" with trivial body via super() is unsafe
+main:9: error: "int" has no attribute "y"
 
 [case testSuperWithReadWriteAbstractProperty]
 from abc import abstractproperty, ABCMeta
@@ -1659,10 +1661,10 @@ class Abstract:
 
 class SubProto(Proto):
     def meth(self) -> int:
-        return super().meth()
+        return super().meth()  # E: Call to abstract method "meth" of "Proto" with trivial body via super() is unsafe
 class SubAbstract(Abstract):
     def meth(self) -> int:
-        return super().meth()
+        return super().meth()  # E: Call to abstract method "meth" of "Abstract" with trivial body via super() is unsafe
 
 [case testEmptyBodyNoSuperWarningOptionalReturn]
 from typing import Protocol, Optional
@@ -1676,10 +1678,10 @@ class Abstract:
 
 class SubProto(Proto):
     def meth(self) -> Optional[int]:
-        return super().meth()
+        return super().meth()  # E: Call to abstract method "meth" of "Proto" with trivial body via super() is unsafe
 class SubAbstract(Abstract):
     def meth(self) -> Optional[int]:
-        return super().meth()
+        return super().meth()  # E: Call to abstract method "meth" of "Abstract" with trivial body via super() is unsafe
 
 [case testEmptyBodyTypeCheckingOnly]
 from typing import TYPE_CHECKING

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -896,11 +896,9 @@ class A(metaclass=ABCMeta):
 class B(A):
     @property
     def x(self) -> int:
-        return super().x.y # E: "int" has no attribute "y"
+        return super().x.y  # E: Call to abstract method "x" of "A" with trivial body via super() is unsafe \
+                            # E: "int" has no attribute "y"
 [builtins fixtures/property.pyi]
-[out]
-main:9: error: Call to abstract method "x" of "A" with trivial body via super() is unsafe
-main:9: error: "int" has no attribute "y"
 
 [case testSuperWithReadWriteAbstractProperty]
 from abc import abstractproperty, ABCMeta


### PR DESCRIPTION
Relates to:
https://discuss.python.org/t/calling-abstract-methods/42576

I think this makes mypy's behaviour more predictable