### PR TITLE
fscache: handle trailing slash in exists_case prefix

### DIFF
--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -230,6 +230,7 @@ class FileSystemCache:
         if path in self.exists_case_cache:
             return self.exists_case_cache[path]
         head, tail = os.path.split(path)
+        prefix = prefix.rstrip(os.sep)
         if not head.startswith(prefix) or not tail:
             # Only perform the check for paths under prefix.
             self.exists_case_cache[path] = True

--- a/mypy/test/testfscache.py
+++ b/mypy/test/testfscache.py
@@ -88,6 +88,16 @@ class TestFileSystemCache(unittest.TestCase):
                 # this path is not under the prefix, case difference is fine.
                 assert self.isfile_case(os.path.join(other, "PKG/other_dir.py"))
 
+    def test_exists_case_1(self) -> None:
+        self.make_file("foo/bar/baz.py")
+        # Run twice to test both cached and non-cached code paths.
+        for i in range(2):
+            assert self.exists_case("foo/bar/baz.py", "foo")
+            assert self.exists_case("foo/bar", "foo")
+            assert not self.exists_case("foo/bar/non_existent1.py", "foo")
+            assert not self.exists_case("foo/bar/not_a_dir", "foo")
+            assert not self.exists_case("not_a_dir/not_a_subdir", "not_a_dir/")
+
     def make_file(self, path: str, base: str | None = None) -> None:
         if base is None:
             base = self.tempdir
@@ -99,3 +109,6 @@ class TestFileSystemCache(unittest.TestCase):
 
     def isfile_case(self, path: str) -> bool:
         return self.fscache.isfile_case(os.path.join(self.tempdir, path), self.tempdir)
+
+    def exists_case(self, path: str, prefix: str) -> bool:
+        return self.fscache.exists_case(os.path.join(self.tempdir, path), os.path.join(self.tempdir, prefix))


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

The current `exists_cache` implementation does not handle trailing separators on the given `prefix` correctly. More precisely, it decides that `foo/` is not a prefix of `foo`. This results in unexpectedly returning `True` for directories that don't exist and that are logically under the given prefix.

This also indirectly resolves https://github.com/python/mypy/issues/16767 because the [linked issue in typeshed](https://github.com/python/typeshed/issues/11254) causes mypy to end up with a trailing separator in one of its directory existence checks. The linked issue should still be fixed, but this lets mypy handle the case gracefully, rather than giving a confusing error about not being able to read a directory.
