### PR TITLE
Update mypy daemon documentation note about local partial types

### DIFF
--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -61,7 +61,8 @@ you have a large codebase.)
 
 .. note::
 
-    The mypy daemon automatically enables ``--local-partial-types`` by default.
+    The mypy daemon strictly has ``--local-partial-types`` enabled. 
+    This is due to Fine-grained incremental not supporting general partial types.
 
 
 Daemon client commands

--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -61,8 +61,7 @@ you have a large codebase.)
 
 .. note::
 
-    The mypy daemon strictly has ``--local-partial-types`` enabled.
-    This is due to Fine-grained incremental not supporting general partial types.
+    The mypy daemon requires ``--local-partial-types`` and automatically enables it.
 
 
 Daemon client commands

--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -61,7 +61,7 @@ you have a large codebase.)
 
 .. note::
 
-    The mypy daemon strictly has ``--local-partial-types`` enabled. 
+    The mypy daemon strictly has ``--local-partial-types`` enabled.
     This is due to Fine-grained incremental not supporting general partial types.
 
 


### PR DESCRIPTION
The existing documentation almost makes it seem like the user has the option to toggle this. 

Updated wording to say strictly denoting it's not configurable with explanation from the code here https://github.com/python/mypy/blob/fbb738a4626976f83a7412df73533d87483a31b7/mypy/dmypy_server.py#L196-L198.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
