### PR TITLE
Fix: --include-private issue (#16808)

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -122,6 +122,7 @@ from mypy.stubutil import (
     generate_guarded,
     infer_method_arg_types,
     infer_method_ret_type,
+    is_private_module,
     remove_misplaced_type_comments,
     report_missing,
     walk_packages,
@@ -1618,6 +1619,9 @@ def generate_stub_for_py_module(
     If directory for target doesn't exist it will created. Existing stub
     will be overwritten.
     """
+    if is_private_module(mod.module):
+        return
+
     if inspect:
         ngen = InspectionStubGenerator(
             module_name=mod.module,

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -807,3 +807,10 @@ class BaseStubGenerator:
         if self._all_:
             return name in self._all_
         return True
+
+
+def is_private_module(fully_qualified_name):
+    return any(
+        name.startswith("_") and not name.endswith("__")
+        for name in fully_qualified_name.split(".")
+    )


### PR DESCRIPTION
* (fix): when --include-private is not passed stubgen omits packages and modules which names start with "_" and do not end with "__"

___

This commit aims to close #16808.

___

Let me introduce you to my struggling.
At first I decided that this happens because of [`is_private_name()`](https://github.com/python/mypy/blob/3838bff555de4237cb77ef2a191a6791a4d0ae7a/mypy/stubutil.py#L769). Indeed, when stubgen iterates over nodes via visitor and calls `is_private_name()` [it checks only node's (function's in our case) name](https://github.com/python/mypy/blob/master/mypy/stubutil.py#L776):

_stubutil.py_
```python
    def is_private_name(self, name: str, fullname: str | None = None) -> bool:

        ...

        if name == "_":
            return False
        if not name.startswith("_"):
            return False

        ...

        return True
```
As you can see from the above, `is_private_name()` checks only `name` without considering the fullname.

However, if we modify it and make it check fqn, the problem would still persist — stubfiles would be created and there would be nothing (empty files).

Then, to make stubgen omit those packages/modules entirely, I decided to put this logic into [`generate_stub_for_py_module()`](https://github.com/python/mypy/blob/3838bff555de4237cb77ef2a191a6791a4d0ae7a/mypy/stubgen.py#L1604).

And it worked, checked manually on structure like the below.
```
(mypy) PS .../foobar$ tree /f /a
.
|   __init__.py
|
+---subpackage
|       open_module.py
|       _internal_use_module.py
|       __init__.py
|
\---_internal_use_subpackage
        whatever_mod.py
        __init__.py

```
The output:

```
(mypy) PS ...\out> tree /f /a
C:.
\---foobar
    |   __init__.pyi
    |
    \---subpackage
            open_module.pyi
            __init__.pyi
```
Seems to be OK.
