### PR TITLE
Update TypeAlias error messages for bad number of arguments

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1995,17 +1995,17 @@ def instantiate_type_alias(
                 if node.tvar_tuple_index is not None:
                     msg = (
                         "Bad number of arguments for type alias,"
-                        f" expected: at least {min_tv_count}, given: {act_len}"
+                        f" expected at least {min_tv_count}, given {act_len}"
                     )
                 elif min_tv_count != max_tv_count:
                     msg = (
                         "Bad number of arguments for type alias,"
-                        f" expected between {min_tv_count} and {max_tv_count}, given: {act_len}"
+                        f" expected between {min_tv_count} and {max_tv_count}, given {act_len}"
                     )
                 else:
                     msg = (
                         "Bad number of arguments for type alias,"
-                        f" expected: {min_tv_count}, given: {act_len}"
+                        f" expected {min_tv_count}, given {act_len}"
                     )
             fail(msg, ctx, code=codes.TYPE_ARG)
             args = []

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -630,7 +630,7 @@ main:11:5: error: "Node" expects 2 type arguments, but 3 given
 main:15:10: error: "list" expects 1 type argument, but 2 given
 main:16:19: error: "list" expects 1 type argument, but 2 given
 main:17:25: error: "Node" expects 2 type arguments, but 1 given
-main:19:5: error: Bad number of arguments for type alias, expected: 1, given: 2
+main:19:5: error: Bad number of arguments for type alias, expected 1, given 2
 main:22:13: note: Revealed type is "__main__.Node[builtins.int, builtins.str]"
 main:24:13: note: Revealed type is "__main__.Node[__main__.Node[builtins.int, builtins.int], builtins.list[builtins.int]]"
 main:26:5: error: Type variable "__main__.T" is invalid as target for type alias
@@ -944,7 +944,7 @@ Transform = Callable[[T, int], Tuple[T, R]]
 
 [case testGenericTypeAliasesImportingWithoutTypeVarError]
 from a import Alias
-x: Alias[int, str]  # E: Bad number of arguments for type alias, expected: 1, given: 2
+x: Alias[int, str]  # E: Bad number of arguments for type alias, expected 1, given 2
 reveal_type(x)  # N: Revealed type is "builtins.list[builtins.list[Any]]"
 
 [file a.py]
@@ -953,7 +953,6 @@ T = TypeVar('T')
 
 Alias = List[List[T]]
 [builtins fixtures/list.pyi]
-[out]
 
 [case testGenericAliasWithTypeVarsFromDifferentModules]
 from mod import Alias, TypeVar
@@ -1000,8 +999,8 @@ reveal_type(x)  # N: Revealed type is "Union[builtins.int, None]"
 reveal_type(y)  # N: Revealed type is "builtins.int"
 
 U[int]  # E: Type application targets a non-generic function or class
-O[int]  # E: Bad number of arguments for type alias, expected: 0, given: 1  # E: Type application is only supported for generic classes
-[out]
+O[int]  # E: Bad number of arguments for type alias, expected 0, given 1 \
+        # E: Type application is only supported for generic classes
 
 [case testAliasesInClassBodyNormalVsSubscripted]
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1506,9 +1506,10 @@ def g(x: A[P]) -> None: ...  # E: Invalid location for ParamSpec "P" \
                              # N: You can use ParamSpec as the first argument to Callable, e.g., 'Callable[P, int]'
 
 C = Callable[P, T]
-x: C[int]  # E: Bad number of arguments for type alias, expected: 2, given: 1
+x: C[int]  # E: Bad number of arguments for type alias, expected 2, given 1
 y: C[int, str]  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "int"
-z: C[int, str, bytes]  # E: Bad number of arguments for type alias, expected: 2, given: 3
+z: C[int, str, bytes]  # E: Bad number of arguments for type alias, expected 2, given 3
+
 [builtins fixtures/paramspec.pyi]
 
 [case testTrivialParametersHandledCorrectly]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -330,10 +330,9 @@ c: C
 t: T
 reveal_type(c)  # N: Revealed type is "def (*Any, **Any) -> Any"
 reveal_type(t)  # N: Revealed type is "builtins.tuple[Any, ...]"
-bad: C[int]  # E: Bad number of arguments for type alias, expected: 0, given: 1
-also_bad: T[int]  # E: Bad number of arguments for type alias, expected: 0, given: 1
+bad: C[int]  # E: Bad number of arguments for type alias, expected 0, given 1
+also_bad: T[int]  # E: Bad number of arguments for type alias, expected 0, given 1
 [builtins fixtures/tuple.pyi]
-[out]
 
 [case testAliasRefOnClass]
 from typing import Generic, TypeVar, Type

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -255,7 +255,7 @@ def func_a1(
     a: TA1,
     b: TA1[float],
     c: TA1[float, float],
-    d: TA1[float, float, float],  # E: Bad number of arguments for type alias, expected between 0 and 2, given: 3
+    d: TA1[float, float, float],  # E: Bad number of arguments for type alias, expected between 0 and 2, given 3
 ) -> None:
     reveal_type(a)  # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
     reveal_type(b)  # N: Revealed type is "builtins.dict[builtins.float, builtins.str]"
@@ -269,7 +269,7 @@ def func_a2(
     b: TA2[float],
     c: TA2[float, float],
     d: TA2[float, float, float],
-    e: TA2[float, float, float, float],  # E: Bad number of arguments for type alias, expected between 1 and 3, given: 4
+    e: TA2[float, float, float, float],  # E: Bad number of arguments for type alias, expected between 1 and 3, given 4
 ) -> None:
     reveal_type(a)  # N: Revealed type is "Tuple[Any, builtins.int, builtins.str]"
     reveal_type(b)  # N: Revealed type is "Tuple[builtins.float, builtins.int, builtins.str]"
@@ -284,7 +284,7 @@ def func_a3(
     b: TA3[float],
     c: TA3[float, float],
     d: TA3[float, float, float],
-    e: TA3[float, float, float, float],  # E: Bad number of arguments for type alias, expected between 1 and 3, given: 4
+    e: TA3[float, float, float, float],  # E: Bad number of arguments for type alias, expected between 1 and 3, given 4
 ) -> None:
     reveal_type(a)  # N: Revealed type is "Union[builtins.dict[Any, builtins.int], builtins.list[builtins.str]]"
     reveal_type(b)  # N: Revealed type is "Union[builtins.dict[builtins.float, builtins.int], builtins.list[builtins.str]]"
@@ -296,10 +296,10 @@ TA4 = Tuple[T1, T4, T2]
 
 def func_a4(
     a: TA4,  # E: Missing type parameters for generic type "TA4"
-    b: TA4[float],  # E: Bad number of arguments for type alias, expected between 2 and 3, given: 1
+    b: TA4[float],  # E: Bad number of arguments for type alias, expected between 2 and 3, given 1
     c: TA4[float, float],
     d: TA4[float, float, float],
-    e: TA4[float, float, float, float],  # E: Bad number of arguments for type alias, expected between 2 and 3, given: 4
+    e: TA4[float, float, float, float],  # E: Bad number of arguments for type alias, expected between 2 and 3, given 4
 ) -> None:
     reveal_type(a)  # N: Revealed type is "Tuple[Any, Any, builtins.int]"
     reveal_type(b)  # N: Revealed type is "Tuple[Any, Any, builtins.int]"
@@ -323,7 +323,7 @@ def func_b1(
     a: TB1,
     b: TB1[[float]],
     c: TB1[[float], [float]],
-    d: TB1[[float], [float], [float]],  # E: Bad number of arguments for type alias, expected between 0 and 2, given: 3
+    d: TB1[[float], [float], [float]],  # E: Bad number of arguments for type alias, expected between 0 and 2, given 3
 ) -> None:
     reveal_type(a)  # N: Revealed type is "__main__.ClassB1[[builtins.int, builtins.str], [*Any, **Any]]"
     reveal_type(b)  # N: Revealed type is "__main__.ClassB1[[builtins.float], [*Any, **Any]]"
@@ -337,7 +337,7 @@ def func_b2(
     a: TB2,  # E: Missing type parameters for generic type "TB2"
     b: TB2[[float]],
     c: TB2[[float], [float]],
-    d: TB2[[float], [float], [float]],  # E: Bad number of arguments for type alias, expected between 1 and 2, given: 3
+    d: TB2[[float], [float], [float]],  # E: Bad number of arguments for type alias, expected between 1 and 2, given 3
 ) -> None:
     reveal_type(a)  # N: Revealed type is "__main__.ClassB2[Any, [builtins.int, builtins.str]]"
     reveal_type(b)  # N: Revealed type is "__main__.ClassB2[[builtins.float], [builtins.int, builtins.str]]"

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -769,15 +769,15 @@ Ts = TypeVarTuple("Ts")
 class G(Generic[Unpack[Ts]]): ...
 
 A = List[Tuple[T, Unpack[Ts], S]]
-x: A[int]  # E: Bad number of arguments for type alias, expected: at least 2, given: 1
+x: A[int]  # E: Bad number of arguments for type alias, expected at least 2, given 1
 reveal_type(x)  # N: Revealed type is "builtins.list[Tuple[Any, Unpack[builtins.tuple[Any, ...]], Any]]"
 
 B = Callable[[T, S, Unpack[Ts]], int]
-y: B[int]  # E: Bad number of arguments for type alias, expected: at least 2, given: 1
+y: B[int]  # E: Bad number of arguments for type alias, expected at least 2, given 1
 reveal_type(y)  # N: Revealed type is "def (Any, Any, *Any) -> builtins.int"
 
 C = G[T, Unpack[Ts], S]
-z: C[int]  # E: Bad number of arguments for type alias, expected: at least 2, given: 1
+z: C[int]  # E: Bad number of arguments for type alias, expected at least 2, given 1
 reveal_type(z)  # N: Revealed type is "__main__.G[Any, Unpack[builtins.tuple[Any, ...]], Any]"
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -4032,7 +4032,7 @@ def f(x: a.A[str]):
 [builtins fixtures/dict.pyi]
 [out]
 ==
-b.py:2: error: Bad number of arguments for type alias, expected: 2, given: 1
+b.py:2: error: Bad number of arguments for type alias, expected 2, given 1
 
 [case testAliasFineAdded]
 import b
@@ -5542,7 +5542,7 @@ main:9: error: Function "a.T" is not valid as a type
 main:9: note: Perhaps you need "Callable[...]" or a callback protocol?
 main:12: error: Function "a.T" is not valid as a type
 main:12: note: Perhaps you need "Callable[...]" or a callback protocol?
-main:12: error: Bad number of arguments for type alias, expected: 0, given: 1
+main:12: error: Bad number of arguments for type alias, expected 0, given 1
 
 [case testChangeTypeVarToModule]
 
@@ -5576,7 +5576,7 @@ main:9: error: Module "T" is not valid as a type
 main:9: note: Perhaps you meant to use a protocol matching the module structure?
 main:12: error: Module "T" is not valid as a type
 main:12: note: Perhaps you meant to use a protocol matching the module structure?
-main:12: error: Bad number of arguments for type alias, expected: 0, given: 1
+main:12: error: Bad number of arguments for type alias, expected 0, given 1
 
 [case testChangeClassToModule]
 
@@ -5628,7 +5628,7 @@ T = int
 ==
 main:5: error: Free type variable expected in Generic[...]
 main:9: error: "C" expects no type arguments, but 1 given
-main:12: error: Bad number of arguments for type alias, expected: 0, given: 1
+main:12: error: Bad number of arguments for type alias, expected 0, given 1
 
 [case testChangeTypeAliasToModule]
 


### PR DESCRIPTION
Small update to adjust the error messages following the suggestion in https://github.com/python/mypy/pull/16825#discussion_r1468507923.