### PR TITLE
Update new type system discussion links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To report a bug or request an enhancement:
 To discuss a new type system feature:
 
 - discuss at [discuss.python.org](https://discuss.python.org/c/typing/32)
-- there is also some historical discussion at [typing-sig mail list](https://mail.python.org/archives/list/typing-sig@python.org/) and [github issues](https://github.com/python/typing/issues)
+- there is also some historical discussion at the [typing-sig mailing list](https://mail.python.org/archives/list/typing-sig@python.org/) and the [python/typing repo](https://github.com/python/typing/issues)
 
 What is mypy?
 -------------

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ To report a bug or request an enhancement:
 
 To discuss a new type system feature:
 
-- discuss at [typing-sig mailing list](https://mail.python.org/archives/list/typing-sig@python.org/)
-- there is also some historical discussion [here](https://github.com/python/typing/issues)
+- discuss at [discuss.python.org](https://discuss.python.org/c/typing/32)
+- there is also some historical discussion at [typing-sig mail list](https://mail.python.org/archives/list/typing-sig@python.org/) and [github issues](https://github.com/python/typing/issues)
 
 What is mypy?
 -------------


### PR DESCRIPTION
As of the 10th of September 2023 the typing-sig mail list is now replaced with [discuss.python.org](https://discuss.python.org/c/typing/32) as explained [here](https://mail.python.org/archives/list/typing-sig@python.org/thread/BENDBBUDRCRMTTK2B5HJ7RCKENFD6DW2/) and [here](https://discuss.python.org/t/about-the-typing-category/34155)

The README.md file was referencing the old link.