### PR TITLE
Remove --python-version 3.7 references from tests

### DIFF
--- a/test-data/unit/check-async-await.test
+++ b/test-data/unit/check-async-await.test
@@ -819,8 +819,6 @@ def bar() -> None:
 [typing fixtures/typing-async.pyi]
 
 [case testAsyncForOutsideCoroutine]
-# flags: --python-version 3.7
-
 async def g():
     yield 0
 
@@ -841,8 +839,6 @@ async for x in g(): ... # E: "async for" outside async function
 [typing fixtures/typing-async.pyi]
 
 [case testAsyncWithOutsideCoroutine]
-# flags: --python-version 3.7
-
 class C:
     async def __aenter__(self): pass
     async def __aexit__(self, x, y, z): pass
@@ -858,7 +854,6 @@ async with C() as x: # E: "async with" outside async function
 [typing fixtures/typing-async.pyi]
 
 [case testAwaitMissingNote]
-# flags: --python-version 3.7
 from typing import Generic, TypeVar, Generator, Any, Awaitable, Type
 
 class C:

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -525,7 +525,7 @@ else:
 [builtins fixtures/callable.pyi]
 
 [case testBuiltinsTypeAsCallable]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 from __future__ import annotations
 
 reveal_type(type)  # N: Revealed type is "def (x: Any) -> builtins.type"

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -525,7 +525,6 @@ else:
 [builtins fixtures/callable.pyi]
 
 [case testBuiltinsTypeAsCallable]
-# flags: --python-version 3.8
 from __future__ import annotations
 
 reveal_type(type)  # N: Revealed type is "def (x: Any) -> builtins.type"

--- a/test-data/unit/check-dataclass-transform.test
+++ b/test-data/unit/check-dataclass-transform.test
@@ -22,7 +22,6 @@ Person('Jonh', 21, None)  # E: Too many arguments for "Person"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassTransformIsFoundInTypingExtensions]
-# flags: --python-version 3.7
 from typing import Type
 from typing_extensions import dataclass_transform
 

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1,5 +1,4 @@
 [case testDataclassesBasic]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -18,7 +17,6 @@ Person('Jonh', 21, None)  # E: Too many arguments for "Person"
 [typing fixtures/typing-medium.pyi]
 
 [case testDataclassesCustomInit]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -33,7 +31,6 @@ A('1')
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesBasicInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -56,7 +53,6 @@ Person(21, 'Jonh', None)  # E: Too many arguments for "Person"
 [typing fixtures/typing-medium.pyi]
 
 [case testDataclassesDeepInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -83,7 +79,6 @@ reveal_type(D)  # N: Revealed type is "def (a: builtins.int, b: builtins.int, c:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesMultipleInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field, InitVar
 @dataclass
 class A:
@@ -106,7 +101,6 @@ reveal_type(C)  # N: Revealed type is "def (b: builtins.bool, a: builtins.bool) 
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesDeepInitVarInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field, InitVar
 @dataclass
 class A:
@@ -135,7 +129,6 @@ reveal_type(D)  # N: Revealed type is "def (b: builtins.bool) -> __main__.D"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOverriding]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -169,7 +162,6 @@ ExtraSpecialPerson(21, 'John', 0.5)
 
 [case testDataclassesOverridingWithDefaults]
 # Issue #5681 https://github.com/python/mypy/issues/5681
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Any
 
@@ -188,7 +180,6 @@ reveal_type(C)  # N: Revealed type is "def (some_int: builtins.int, some_str: bu
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassIncompatibleOverrides]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -217,7 +208,6 @@ class BadDerived3(Base):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassMultipleInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 class Unrelated:
@@ -237,7 +227,6 @@ reveal_type(d.bar)  # N: Revealed type is "builtins.int"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassIncompatibleFrozenOverride]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
@@ -252,7 +241,6 @@ class BadDerived(Base):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesFreezing]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
@@ -265,7 +253,6 @@ john.name = 'Ben'  # E: Property "name" defined in "Person" is read-only
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesInconsistentFreezing]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
@@ -287,7 +274,6 @@ class BadFrozenDerived(NormalBase):  # E: Cannot inherit frozen dataclass from a
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesFields]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 
 @dataclass
@@ -303,7 +289,6 @@ john.age = 24
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesBadInit]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 
 @dataclass
@@ -318,7 +303,6 @@ class Person:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesMultiInit]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 from typing import List
 
@@ -334,7 +318,6 @@ reveal_type(Person)  # N: Revealed type is "def (name: builtins.str, friend_name
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesMultiInitDefaults]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -351,7 +334,6 @@ reveal_type(Person)  # N: Revealed type is "def (name: builtins.str, friend_name
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesDefaults]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -365,7 +347,6 @@ app = Application()
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesDefaultFactories]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 
 @dataclass
@@ -377,7 +358,6 @@ class Application:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesDefaultFactoryTypeChecking]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 
 @dataclass
@@ -388,7 +368,6 @@ class Application:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesDefaultOrdering]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -533,7 +512,6 @@ class Base:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesClassmethods]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -549,7 +527,6 @@ app = Application.parse('')
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOverloadsAndClassmethods]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import overload, Union
 
@@ -582,20 +559,18 @@ reveal_type(A.foo("foo"))  # N: Revealed type is "builtins.str"
 [builtins fixtures/dataclasses.pyi]
 
 [case testClassmethodShadowingFieldDoesNotCrash]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 # This used to crash -- see #6217
 @dataclass
 class Foo:
     bar: str
-    @classmethod  # E: Name "bar" already defined on line 7
+    @classmethod  # E: Name "bar" already defined on line 6
     def bar(cls) -> "Foo":
         return cls('asdf')
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesClassVars]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -613,7 +588,6 @@ Application.COUNTER = 1
 [builtins fixtures/dataclasses.pyi]
 
 [case testTypeAliasInDataclassDoesNotCrash]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Callable
 from typing_extensions import TypeAlias
@@ -642,7 +616,6 @@ reveal_type(x)  # N: Revealed type is "typing._SpecialForm"
 [typing fixtures/typing-medium.pyi]
 
 [case testDataclassOrdering]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass(order=True)
@@ -673,7 +646,6 @@ app1 >= app3
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassOrderingWithoutEquality]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass(eq=False, order=True)  # E: "eq" must be True if "order" is True
@@ -683,7 +655,6 @@ class Application:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassOrderingWithCustomMethods]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass(order=True)
@@ -694,7 +665,6 @@ class Application:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassDefaultsInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Optional
 
@@ -712,7 +682,6 @@ reveal_type(SpecializedApplication)  # N: Revealed type is "def (id: Union[built
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenerics]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, List, Optional, TypeVar
 
@@ -757,7 +726,6 @@ class MyDataclass(Generic[T_co]):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassUntypedGenericInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -778,7 +746,6 @@ reveal_type(sub.attr)  # N: Revealed type is "Any"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenericSubtype]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -805,7 +772,6 @@ reveal_type(sub_str.attr)  # N: Revealed type is "builtins.str"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenericInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -832,7 +798,6 @@ reveal_type(sub.three)  # N: Revealed type is "builtins.float"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassMultiGenericInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -860,7 +825,6 @@ reveal_type(sub.middle_attr)  # N: Revealed type is "builtins.str"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenericsClassmethod]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -882,7 +846,6 @@ reveal_type(A(0).other)  # N: Revealed type is "def (x: builtins.int) -> __main_
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesForwardRefs]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -901,7 +864,6 @@ A(b=42)  # E: Argument "b" to "A" has incompatible type "int"; expected "B"
 
 
 [case testDataclassesInitVars]
-# flags: --python-version 3.7
 from dataclasses import InitVar, dataclass
 
 @dataclass
@@ -930,7 +892,6 @@ app.database_name  # E: "SpecializedApplication" has no attribute "database_name
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesInitVarsAndDefer]
-# flags: --python-version 3.7
 from dataclasses import InitVar, dataclass
 
 defer: Yes
@@ -950,7 +911,6 @@ class Yes: ...
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesNoInitInitVarInheritance]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field, InitVar
 
 @dataclass
@@ -967,7 +927,6 @@ sub.bar
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassFactory]
-# flags: --python-version 3.7
 from typing import Type, TypeVar
 from dataclasses import dataclass
 
@@ -983,7 +942,6 @@ class A:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesInitVarOverride]
-# flags: --python-version 3.7
 import dataclasses
 
 @dataclasses.dataclass
@@ -1006,7 +964,6 @@ class B(A):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesInitVarNoOverride]
-# flags: --python-version 3.7
 import dataclasses
 
 @dataclasses.dataclass
@@ -1032,7 +989,6 @@ B(1, 'a') # E: Argument 2 to "B" has incompatible type "str"; expected "int"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesInitVarPostInitOverride]
-# flags: --python-version 3.7
 import dataclasses
 
 @dataclasses.dataclass
@@ -1068,7 +1024,6 @@ C(1, 'a')  # E: Argument 2 to "C" has incompatible type "str"; expected "int"
 [builtins fixtures/primitives.pyi]
 
 [case testDataclassesInitVarIncremental]
-# flags: --python-version 3.7
 import a
 
 [file a.py]
@@ -1114,7 +1069,6 @@ tmp/a.py:12: note: Revealed type is "def (a: builtins.int) -> a.B"
 
 
 [case testNoComplainFieldNone]
-# flags: --python-version 3.7
 # flags: --no-strict-optional
 from dataclasses import dataclass, field
 from typing import Optional
@@ -1126,7 +1080,6 @@ class Foo:
 [out]
 
 [case testNoComplainFieldNoneStrict]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -1137,7 +1090,7 @@ class Foo:
 [out]
 
 [case testDisallowUntypedWorksForward]
-# flags: --disallow-untyped-defs --python-version 3.7
+# flags: --disallow-untyped-defs
 from dataclasses import dataclass
 from typing import List
 
@@ -1152,7 +1105,7 @@ reveal_type(B)  # N: Revealed type is "def (x: __main__.C) -> __main__.B"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDisallowUntypedWorksForwardBad]
-# flags: --disallow-untyped-defs --python-version 3.7
+# flags: --disallow-untyped-defs
 from dataclasses import dataclass
 
 @dataclass
@@ -1164,7 +1117,6 @@ reveal_type(B)  # N: Revealed type is "def (x: Any) -> __main__.B"
 [builtins fixtures/dataclasses.pyi]
 
 [case testMemberExprWorksAsField]
-# flags: --python-version 3.7
 import dataclasses
 
 @dataclasses.dataclass
@@ -1184,7 +1136,6 @@ class C:
 [builtins fixtures/dict.pyi]
 
 [case testDataclassOrderingDeferred]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 defer: Yes
@@ -1202,7 +1153,6 @@ class Yes: ...
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassFieldDeferred]
-# flags: --python-version 3.7
 from dataclasses import field, dataclass
 
 @dataclass
@@ -1214,7 +1164,6 @@ C('no')  # E: Argument 1 to "C" has incompatible type "str"; expected "int"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassFieldDeferredFrozen]
-# flags: --python-version 3.7
 from dataclasses import field, dataclass
 
 @dataclass(frozen=True)
@@ -1227,7 +1176,6 @@ c.x = 1  # E: Property "x" defined in "C" is read-only
 [builtins fixtures/dataclasses.pyi]
 
 [case testTypeInDataclassDeferredStar]
-# flags: --python-version 3.7
 import lib
 [file lib.py]
 from dataclasses import dataclass
@@ -1246,7 +1194,7 @@ import lib
 [builtins fixtures/dataclasses.pyi]
 
 [case testDeferredDataclassInitSignature]
-# flags: --python-version 3.7 --no-strict-optional
+# flags: --no-strict-optional
 from dataclasses import dataclass
 from typing import Optional, Type
 
@@ -1263,7 +1211,6 @@ class Deferred: pass
 [builtins fixtures/dataclasses.pyi]
 
 [case testDeferredDataclassInitSignatureSubclass]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Optional
 
@@ -1279,7 +1226,6 @@ a = C(None, 'abc')
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesDefaultsIncremental]
-# flags: --python-version 3.7
 import a
 
 [file a.py]
@@ -1311,7 +1257,6 @@ class Person:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesDefaultsMroOtherFile]
-# flags: --python-version 3.7
 import a
 
 [file a.py]
@@ -1340,14 +1285,13 @@ class A2:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesInheritingDuplicateField]
-# flags: --python-version 3.7
 # see mypy issue #7792
 from dataclasses import dataclass
 
 @dataclass
 class A:
     x: int = 0
-    x: int = 0  # E: Name "x" already defined on line 7
+    x: int = 0  # E: Name "x" already defined on line 6
 
 @dataclass
 class B(A):
@@ -1356,7 +1300,6 @@ class B(A):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassInheritanceNoAnnotation]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -1373,7 +1316,6 @@ reveal_type(B)  # N: Revealed type is "def (foo: builtins.int) -> __main__.B"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassInheritanceNoAnnotation2]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
@@ -1390,7 +1332,6 @@ reveal_type(B)  # N: Revealed type is "def (foo: builtins.int) -> __main__.B"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassHasAttributeWithFields]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 @dataclass
@@ -1402,7 +1343,6 @@ reveal_type(A.__dataclass_fields__)  # N: Revealed type is "builtins.dict[builti
 [builtins fixtures/dict.pyi]
 
 [case testDataclassCallableFieldAccess]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Callable
 
@@ -1420,7 +1360,6 @@ reveal_type(A.y)  # N: Revealed type is "def (builtins.int) -> builtins.int"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassCallableFieldAssignment]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Callable
 
@@ -1439,7 +1378,6 @@ a.x = x2 # E: Incompatible types in assignment (expression has type "Callable[[s
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassFieldDoesNotFailOnKwargsUnpacking]
-# flags: --python-version 3.7
 # https://github.com/python/mypy/issues/10879
 from dataclasses import dataclass, field
 
@@ -1447,16 +1385,15 @@ from dataclasses import dataclass, field
 class Foo:
     bar: float = field(**{"repr": False})
 [out]
-main:7: error: Unpacking **kwargs in "field()" is not supported
-main:7: error: No overload variant of "field" matches argument type "Dict[str, bool]"
-main:7: note: Possible overload variants:
-main:7: note:     def [_T] field(*, default: _T, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> _T
-main:7: note:     def [_T] field(*, default_factory: Callable[[], _T], init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> _T
-main:7: note:     def field(*, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> Any
+main:6: error: Unpacking **kwargs in "field()" is not supported
+main:6: error: No overload variant of "field" matches argument type "Dict[str, bool]"
+main:6: note: Possible overload variants:
+main:6: note:     def [_T] field(*, default: _T, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> _T
+main:6: note:     def [_T] field(*, default_factory: Callable[[], _T], init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> _T
+main:6: note:     def field(*, init: bool = ..., repr: bool = ..., hash: Optional[bool] = ..., compare: bool = ..., metadata: Optional[Mapping[str, Any]] = ..., kw_only: bool = ...) -> Any
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassFieldWithPositionalArguments]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 
 @dataclass
@@ -1470,7 +1407,6 @@ class C:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassFieldWithTypedDictUnpacking]
-# flags: --python-version 3.7
 from dataclasses import dataclass, field
 from typing_extensions import TypedDict
 
@@ -1668,7 +1604,6 @@ class PublishedMessages:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesAnyInherit]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Any
 B: Any
@@ -1682,7 +1617,6 @@ A(a="foo")  # E: Argument "a" to "A" has incompatible type "str"; expected "int"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesCallableFrozen]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Any, Callable
 @dataclass(frozen=True)
@@ -1698,7 +1632,6 @@ A(a=func).a = func  # E: Property "a" defined in "A" is read-only
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassInFunctionDoesNotCrash]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 def foo() -> None:
@@ -1728,7 +1661,6 @@ class Derived(A, B):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenericInheritance2]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Any, Callable, Generic, TypeVar, List
 
@@ -1760,7 +1692,6 @@ reveal_type(Child2[int, A]([A()], [1]).b)  # N: Revealed type is "builtins.list[
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassInheritOptionalType]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Any, Callable, Generic, TypeVar, List, Optional
 
@@ -1779,7 +1710,6 @@ Child(x=None, y=None)
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenericInheritanceSpecialCase1]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, TypeVar, List
 
@@ -1803,7 +1733,6 @@ def g(c: Child1) -> None:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenericInheritanceSpecialCase2]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -1829,7 +1758,6 @@ Child2(y=1, key='')
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenericWithBound]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -1845,7 +1773,6 @@ C(x=2)
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassGenericBoundToInvalidTypeVarDoesNotCrash]
-# flags: --python-version 3.7
 import dataclasses
 from typing import Generic, TypeVar
 
@@ -1857,7 +1784,6 @@ class C(Generic[T]):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassInitVarCannotBeSet]
-# flags: --python-version 3.7
 from dataclasses import dataclass, InitVar
 
 @dataclass
@@ -1877,7 +1803,6 @@ c.x  # E: "C" has no attribute "x"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassCheckTypeVarBounds]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import ClassVar, Protocol, Dict, TypeVar, Generic
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -127,7 +127,7 @@ x
 y # type: ignore  # ignore the lack of error code since we're ignore the whole file
 
 [case testErrorCodeMissingMultiple]
-# flags: --enable-error-code ignore-without-code --python-version 3.7
+# flags: --enable-error-code ignore-without-code --python-version 3.8
 from __future__ import annotations
 class A:
     attr: int

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -127,7 +127,7 @@ x
 y # type: ignore  # ignore the lack of error code since we ignore the whole file
 
 [case testErrorCodeMissingMultiple]
-# flags: --enable-error-code ignore-without-code --python-version 3.8
+# flags: --enable-error-code ignore-without-code
 from __future__ import annotations
 class A:
     attr: int

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -124,7 +124,7 @@ z # type: ignore[ignore-without-code] # E: Unused "type: ignore" comment  [unuse
 # flags: --enable-error-code ignore-without-code
 # type: ignore  # whole file ignore
 x
-y # type: ignore  # ignore the lack of error code since we're ignore the whole file
+y # type: ignore  # ignore the lack of error code since we ignore the whole file
 
 [case testErrorCodeMissingMultiple]
 # flags: --enable-error-code ignore-without-code --python-version 3.8

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1655,7 +1655,7 @@ __all__ = ('b',)
 [builtins fixtures/tuple.pyi]
 
 [case testNoImplicitReexportGetAttr]
-# flags: --no-implicit-reexport --python-version 3.7
+# flags: --no-implicit-reexport
 from other_module_2 import a  # E: Module "other_module_2" does not explicitly export attribute "a"
 reveal_type(a)  # N: Revealed type is "builtins.int"
 from other_module_2 import b  # E: Module "other_module_2" does not explicitly export attribute "b"

--- a/test-data/unit/check-generic-alias.test
+++ b/test-data/unit/check-generic-alias.test
@@ -44,7 +44,6 @@ t10: collections.ChainMap[int, str]  # E: "ChainMap" is not subscriptable, use "
 
 
 [case testGenericBuiltinFutureAnnotations]
-# flags: --python-version 3.8
 from __future__ import annotations
 t1: list
 t2: list[int]
@@ -64,7 +63,6 @@ t11: type[int]
 
 
 [case testGenericCollectionsFutureAnnotations]
-# flags: --python-version 3.8
 from __future__ import annotations
 import collections
 

--- a/test-data/unit/check-generic-alias.test
+++ b/test-data/unit/check-generic-alias.test
@@ -1,7 +1,7 @@
 -- Test cases for generic aliases
 
 [case testGenericBuiltinWarning]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 t1: list
 t2: list[int]  # E: "list" is not subscriptable, use "typing.List" instead
 t3: list[str]  # E: "list" is not subscriptable, use "typing.List" instead
@@ -21,14 +21,14 @@ t11: type[int]  # E: "type" expects no type arguments, but 1 given
 
 
 [case testGenericBuiltinSetWarning]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 t1: set
 t2: set[int]  # E: "set" is not subscriptable, use "typing.Set" instead
 [builtins fixtures/set.pyi]
 
 
 [case testGenericCollectionsWarning]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 import collections
 
 t01: collections.deque
@@ -44,7 +44,7 @@ t10: collections.ChainMap[int, str]  # E: "ChainMap" is not subscriptable, use "
 
 
 [case testGenericBuiltinFutureAnnotations]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 from __future__ import annotations
 t1: list
 t2: list[int]
@@ -64,7 +64,7 @@ t11: type[int]
 
 
 [case testGenericCollectionsFutureAnnotations]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 from __future__ import annotations
 import collections
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3796,7 +3796,6 @@ import b
 [rechecked b]
 
 [case testIncrementalDataclassesSubclassingCached]
-# flags: --python-version 3.7
 from a import A
 from dataclasses import dataclass
 
@@ -3829,7 +3828,6 @@ class A:
 [out2]
 
 [case testIncrementalDataclassesSubclassingCachedType]
-# flags: --python-version 3.7
 import b
 
 [file b.py]
@@ -3863,7 +3861,6 @@ class A:
 tmp/b.py:8: note: Revealed type is "def (x: builtins.int) -> b.B"
 
 [case testIncrementalDataclassesArguments]
-# flags: --python-version 3.7
 import b
 
 [file b.py]
@@ -3912,7 +3909,6 @@ tmp/b.py:15: error: Unsupported left operand type for > ("NoCmp")
 tmp/b.py:16: error: Unsupported left operand type for >= ("NoCmp")
 
 [case testIncrementalDataclassesDunder]
-# flags: --python-version 3.7
 import b
 
 [file b.py]
@@ -3977,7 +3973,6 @@ tmp/b.py:27: error: Unsupported operand types for < ("A" and "int")
 tmp/b.py:28: error: Unsupported operand types for <= ("A" and "int")
 
 [case testIncrementalDataclassesSubclassModified]
-# flags: --python-version 3.7
 from b import B
 B(5, 'foo')
 
@@ -4007,11 +4002,10 @@ class B(A):
 [builtins fixtures/dataclasses.pyi]
 [out1]
 [out2]
-main:3: error: Argument 2 to "B" has incompatible type "str"; expected "int"
+main:2: error: Argument 2 to "B" has incompatible type "str"; expected "int"
 [rechecked b]
 
 [case testIncrementalDataclassesSubclassModifiedErrorFirst]
-# flags: --python-version 3.7
 from b import B
 B(5, 'foo')
 
@@ -4040,13 +4034,12 @@ class B(A):
 
 [builtins fixtures/dataclasses.pyi]
 [out1]
-main:3: error: Argument 2 to "B" has incompatible type "str"; expected "int"
+main:2: error: Argument 2 to "B" has incompatible type "str"; expected "int"
 
 [out2]
 [rechecked b]
 
 [case testIncrementalDataclassesThreeFiles]
-# flags: --python-version 3.7
 from c import C
 C('foo', 5, True)
 
@@ -4085,10 +4078,9 @@ class C(A, B):
 [out1]
 [out2]
 tmp/c.py:7: error: Incompatible types in assignment (expression has type "bool", base class "B" defined the type as "str")
-main:3: error: Argument 2 to "C" has incompatible type "int"; expected "bool"
+main:2: error: Argument 2 to "C" has incompatible type "int"; expected "bool"
 
 [case testIncrementalDataclassesThreeRuns]
-# flags: --python-version 3.7
 from a import A
 A(5)
 
@@ -4116,7 +4108,7 @@ class A:
 [builtins fixtures/dataclasses.pyi]
 [out1]
 [out2]
-main:3: error: Argument 1 to "A" has incompatible type "int"; expected "str"
+main:2: error: Argument 1 to "A" has incompatible type "int"; expected "str"
 [out3]
 
 [case testParentPatchingMess]
@@ -5664,7 +5656,6 @@ A().g()
 [out2]
 
 [case testIncrementalWithDifferentKindsOfNestedTypesWithinMethod]
-# flags: --python-version 3.7
 
 import a
 

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -64,7 +64,6 @@ reveal_type(bar)                    # N: Revealed type is "def (x: Tuple[Literal
 [out]
 
 [case testLiteralInsideOtherTypesTypeCommentsPython3]
-# flags: --python-version 3.7
 from typing import Tuple, Optional
 from typing_extensions import Literal
 

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2075,9 +2075,7 @@ def __getattr__(name): ...
 
 [builtins fixtures/module.pyi]
 
-[case testModuleLevelGetattrNotStub37]
-# flags: --python-version 3.7
-
+[case testModuleLevelGetattrNotStub]
 import has_getattr
 reveal_type(has_getattr.any_attribute)  # N: Revealed type is "builtins.str"
 
@@ -2109,8 +2107,7 @@ def __getattr__(name: str) -> int: ...
 
 [builtins fixtures/module.pyi]
 
-[case testModuleLevelGetattrImportFromNotStub37]
-# flags: --python-version 3.7
+[case testModuleLevelGetattrImportFromNotStub]
 from non_stub import name
 reveal_type(name)  # N: Revealed type is "Any"
 
@@ -2145,7 +2142,6 @@ def __getattr__(name: str) -> int: ...
 
 
 [case testModuleLevelGetattrAssignedGood]
-# flags: --python-version 3.7
 import non_stub
 reveal_type(non_stub.name)  # N: Revealed type is "builtins.int"
 
@@ -2156,7 +2152,6 @@ def make_getattr_good() -> Callable[[str], int]: ...
 __getattr__ = make_getattr_good()  # OK
 
 [case testModuleLevelGetattrAssignedBad]
-# flags: --python-version 3.7
 import non_stub
 reveal_type(non_stub.name)
 
@@ -2168,10 +2163,9 @@ __getattr__ = make_getattr_bad()
 
 [out]
 tmp/non_stub.py:4: error: Invalid signature "Callable[[], int]" for "__getattr__"
-main:3: note: Revealed type is "builtins.int"
+main:2: note: Revealed type is "builtins.int"
 
 [case testModuleLevelGetattrImportedGood]
-# flags: --python-version 3.7
 import non_stub
 reveal_type(non_stub.name)  # N: Revealed type is "builtins.int"
 
@@ -2182,7 +2176,6 @@ from has_getattr import __getattr__
 def __getattr__(name: str) -> int: ...
 
 [case testModuleLevelGetattrImportedBad]
-# flags: --python-version 3.7
 import non_stub
 reveal_type(non_stub.name)
 
@@ -2194,7 +2187,7 @@ def __getattr__() -> int: ...
 
 [out]
 tmp/has_getattr.py:1: error: Invalid signature "Callable[[], int]" for "__getattr__"
-main:3: note: Revealed type is "builtins.int"
+main:2: note: Revealed type is "builtins.int"
 
 [builtins fixtures/module.pyi]
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -131,7 +131,6 @@ main:6: error: Unexpected keyword argument "unrecognized_arg" for "namedtuple"
 main:7: error: Too many positional arguments for "namedtuple"
 
 [case testNamedTupleDefaults]
-# flags: --python-version 3.7
 from collections import namedtuple
 
 X = namedtuple('X', ['x', 'y'], defaults=(1,))

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1,5 +1,4 @@
 [case testNarrowingParentWithStrsBasic]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import NamedTuple, Tuple, Union
 from typing_extensions import Literal, TypedDict
@@ -83,7 +82,6 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingParentWithEnumsBasic]
-# flags: --python-version 3.7
 from enum import Enum
 from dataclasses import dataclass
 from typing import NamedTuple, Tuple, Union
@@ -173,7 +171,6 @@ else:
 [builtins fixtures/narrowing.pyi]
 
 [case testNarrowingParentWithIsInstanceBasic]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import NamedTuple, Tuple, Union
 from typing_extensions import TypedDict

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2577,8 +2577,7 @@ import n
 [file n.pyi]
 class C: pass
 
-[case testNewAnalyzerModuleGetAttrInPython37]
-# flags: --python-version 3.7
+[case testNewAnalyzerModuleGetAttrInPython]
 import m
 import n
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2577,7 +2577,7 @@ import n
 [file n.pyi]
 class C: pass
 
-[case testNewAnalyzerModuleGetAttrInPython]
+[case testNewAnalyzerModuleGetAttr]
 import m
 import n
 

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -381,7 +381,6 @@ x: List[Union[N, int]]
 [builtins fixtures/list.pyi]
 
 [case testTypingExtensionsNewType]
-# flags: --python-version 3.7
 from typing_extensions import NewType
 N = NewType("N", int)
 x: N

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -127,7 +127,6 @@ cast(str | int, 'x')  # E: Cast target is not a type
 x = 1  # type: int | str
 
 [case testUnionOrSyntaxFutureImport]
-# flags: --python-version 3.8
 from __future__ import annotations
 x: int | None
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -127,7 +127,7 @@ cast(str | int, 'x')  # E: Cast target is not a type
 x = 1  # type: int | str
 
 [case testUnionOrSyntaxFutureImport]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 from __future__ import annotations
 x: int | None
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -798,7 +798,7 @@ def baz(x: int) -> int:
 [builtins fixtures/exception.pyi]
 
 [case testUnreachableFlagIgnoresSemanticAnalysisUnreachable]
-# flags: --warn-unreachable --python-version 3.7 --platform win32 --always-false FOOBAR
+# flags: --warn-unreachable --python-version 3.8 --platform win32 --always-false FOOBAR
 import sys
 from typing import TYPE_CHECKING
 
@@ -828,7 +828,7 @@ if sys.version_info == (2, 7):
 else:
     reveal_type(x)  # N: Revealed type is "builtins.int"
 
-if sys.version_info == (3, 7):
+if sys.version_info == (3, 8):
     reveal_type(x)  # N: Revealed type is "builtins.int"
 else:
     reveal_type(x)

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1155,7 +1155,7 @@ def f_suppress() -> int:  # E: Missing return statement
 [builtins fixtures/tuple.pyi]
 
 [case testUnreachableFlagContextAsyncManagersNoSuppress]
-# flags: --warn-unreachable --python-version 3.7
+# flags: --warn-unreachable
 from contextlib import asynccontextmanager
 from typing import Optional, AsyncIterator, Any
 from typing_extensions import Literal
@@ -1221,7 +1221,7 @@ async def f_no_suppress_5() -> int:
 [builtins fixtures/tuple.pyi]
 
 [case testUnreachableFlagContextAsyncManagersSuppressed]
-# flags: --warn-unreachable --python-version 3.7
+# flags: --warn-unreachable
 from contextlib import asynccontextmanager
 from typing import Optional, AsyncIterator, Any
 from typing_extensions import Literal
@@ -1268,7 +1268,7 @@ async def f_mix() -> int:         # E: Missing return statement
 [builtins fixtures/tuple.pyi]
 
 [case testUnreachableFlagContextAsyncManagersAbnormal]
-# flags: --warn-unreachable --python-version 3.7
+# flags: --warn-unreachable
 from contextlib import asynccontextmanager
 from typing import Optional, AsyncIterator, Any
 from typing_extensions import Literal

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -1369,7 +1369,6 @@ def h() -> None:
 <m.D> -> m.D, m.h
 
 [case testDataclassDepsOldVersion]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 
 Z = int

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -652,7 +652,6 @@ class M(type):
 a.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testDataclassUpdate1]
-# flags: --python-version 3.7
 [file a.py]
 from dataclasses import dataclass
 
@@ -691,7 +690,6 @@ b.py:8: error: Argument 1 to "B" has incompatible type "int"; expected "str"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassUpdate2]
-# flags: --python-version 3.7
 [file c.py]
 Foo = int
 
@@ -722,7 +720,6 @@ b.py:8: error: Argument 1 to "B" has incompatible type "int"; expected "str"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassUpdate3]
-# flags: --python-version 3.7
 from b import B
 B(1, 2)
 [file b.py]
@@ -746,10 +743,9 @@ class A:
 [builtins fixtures/dataclasses.pyi]
 [out]
 ==
-main:3: error: Missing positional argument "b" in call to "B"
+main:2: error: Missing positional argument "b" in call to "B"
 
 [case testDataclassUpdate4]
-# flags: --python-version 3.7
 from b import B
 B(1, 2)
 [file b.py]
@@ -773,10 +769,9 @@ class A:
 [builtins fixtures/dataclasses.pyi]
 [out]
 ==
-main:3: error: Missing positional argument "b" in call to "B"
+main:2: error: Missing positional argument "b" in call to "B"
 
 [case testDataclassUpdate5]
-# flags: --python-version 3.7
 from b import B
 B(1, 2)
 [file b.py]
@@ -807,11 +802,10 @@ class A:
 [builtins fixtures/dataclasses.pyi]
 [out]
 ==
-main:3: error: Missing positional argument "b" in call to "B"
+main:2: error: Missing positional argument "b" in call to "B"
 ==
 
 [case testDataclassUpdate6]
-# flags: --python-version 3.7
 from b import B
 B(1, 2) < B(1, 2)
 [file b.py]
@@ -834,10 +828,9 @@ class A:
 [builtins fixtures/dataclasses.pyi]
 [out]
 ==
-main:3: error: Unsupported left operand type for < ("B")
+main:2: error: Unsupported left operand type for < ("B")
 
 [case testDataclassUpdate8]
-# flags: --python-version 3.7
 from c import C
 C(1, 2, 3)
 [file c.py]
@@ -867,10 +860,9 @@ class A:
 [builtins fixtures/dataclasses.pyi]
 [out]
 ==
-main:3: error: Missing positional argument "c" in call to "C"
+main:2: error: Missing positional argument "c" in call to "C"
 
 [case testDataclassUpdate9]
-# flags: --python-version 3.7
 from c import C
 C(1, 2, 3)
 [file c.py]
@@ -907,7 +899,7 @@ class A:
 [builtins fixtures/dataclasses.pyi]
 [out]
 ==
-main:3: error: Missing positional argument "c" in call to "C"
+main:2: error: Missing positional argument "c" in call to "C"
 ==
 
 [case testAttrsUpdate1]
@@ -9799,7 +9791,6 @@ class ExampleClass(Generic[T]):
 ==
 
 [case testDataclassCheckTypeVarBoundsInReprocess]
-# flags: --python-version 3.7
 from dataclasses import dataclass
 from typing import ClassVar, Protocol, Dict, TypeVar, Generic
 from m import x

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -867,7 +867,7 @@ _program.py:20: error: Argument 1 to "tst" has incompatible type "defaultdict[st
 _program.py:24: error: Invalid index type "str" for "MyDDict[Dict[Never, Never]]"; expected type "int"
 
 [case testNoSubcriptionOfStdlibCollections]
-# flags: --python-version 3.8
+# flags: --python-version 3.7
 import collections
 from collections import Counter
 from typing import TypeVar
@@ -1590,11 +1590,12 @@ _testNoPython3StubAvailable.py:3: note: (or run "mypy --install-types" to instal
 
 
 [case testTypingOrderedDictAlias]
+# flags: --python-version 3.7
 from typing import OrderedDict
 x: OrderedDict[str, int] = OrderedDict({})
 reveal_type(x)
 [out]
-_testTypingOrderedDictAlias.py:3: note: Revealed type is "collections.OrderedDict[builtins.str, builtins.int]"
+_testTypingOrderedDictAlias.py:4: note: Revealed type is "collections.OrderedDict[builtins.str, builtins.int]"
 
 [case testTypingExtensionsOrderedDictAlias]
 from typing_extensions import OrderedDict
@@ -1710,7 +1711,7 @@ _testTypeAliasWithNewStyleUnion.py:25: note: Revealed type is "Union[Type[builti
 _testTypeAliasWithNewStyleUnion.py:28: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
 
 [case testTypeAliasWithNewStyleUnionInStub]
-# flags: --python-version 3.8
+# flags: --python-version 3.7
 import m
 a: m.A
 reveal_type(a)

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1590,12 +1590,11 @@ _testNoPython3StubAvailable.py:3: note: (or run "mypy --install-types" to instal
 
 
 [case testTypingOrderedDictAlias]
-# flags: --python-version 3.7
 from typing import OrderedDict
 x: OrderedDict[str, int] = OrderedDict({})
 reveal_type(x)
 [out]
-_testTypingOrderedDictAlias.py:4: note: Revealed type is "collections.OrderedDict[builtins.str, builtins.int]"
+_testTypingOrderedDictAlias.py:3: note: Revealed type is "collections.OrderedDict[builtins.str, builtins.int]"
 
 [case testTypingExtensionsOrderedDictAlias]
 from typing_extensions import OrderedDict

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -867,7 +867,7 @@ _program.py:20: error: Argument 1 to "tst" has incompatible type "defaultdict[st
 _program.py:24: error: Invalid index type "str" for "MyDDict[Dict[Never, Never]]"; expected type "int"
 
 [case testNoSubcriptionOfStdlibCollections]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 import collections
 from collections import Counter
 from typing import TypeVar
@@ -1710,7 +1710,7 @@ _testTypeAliasWithNewStyleUnion.py:25: note: Revealed type is "Union[Type[builti
 _testTypeAliasWithNewStyleUnion.py:28: note: Revealed type is "Union[Type[builtins.int], builtins.str]"
 
 [case testTypeAliasWithNewStyleUnionInStub]
-# flags: --python-version 3.7
+# flags: --python-version 3.8
 import m
 a: m.A
 reveal_type(a)

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -16,4 +16,4 @@ pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
 ruff==0.1.4  # must match version in .pre-commit-config.yaml
 setuptools>=65.5.1
-tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.7
+tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.8


### PR DESCRIPTION
Remove `--python-version 3.7` from tests if not necessary anymore or use `3.8` where it makes sense instead.