### PR TITLE
Expand TypeVarTuple default (PEP 696)

### DIFF
--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -277,6 +277,8 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
     def expand_unpack(self, t: UnpackType) -> list[Type]:
         assert isinstance(t.type, TypeVarTupleType)
         repl = get_proper_type(self.variables.get(t.type.id, t.type))
+        if isinstance(repl, UnpackType):
+            repl = get_proper_type(repl.type)
         if isinstance(repl, TupleType):
             return repl.items
         elif (

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -1541,7 +1541,7 @@ def make_call(*items: tuple[str, str | None]) -> CallExpr:
 class TestExpandTypeLimitGetProperType(TestCase):
     # WARNING: do not increase this number unless absolutely necessary,
     # and you understand what you are doing.
-    ALLOWED_GET_PROPER_TYPES = 8
+    ALLOWED_GET_PROPER_TYPES = 9
 
     @skipUnless(mypy.expandtype.__file__.endswith(".py"), "Skip for compiled mypy")
     def test_count_get_proper_type(self) -> None:

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -274,8 +274,8 @@ def func_c1(
     # reveal_type(a)  # Revealed type is "__main__.ClassC1[builtins.int, builtins.str]"  # TODO
     reveal_type(b)  # N: Revealed type is "__main__.ClassC1[builtins.float]"
 
-    # k = ClassC1()  # TODO
-    # reveal_type(k)  # Revealed type is "__main__.ClassC1[builtins.int, builtins.str]"  # TODO
+    k = ClassC1()
+    reveal_type(k)  # N: Revealed type is "__main__.ClassC1[builtins.int, builtins.str]"
     l = ClassC1[float]()
     reveal_type(l)  # N: Revealed type is "__main__.ClassC1[builtins.float]"
 
@@ -290,8 +290,8 @@ def func_c2(
     # reveal_type(b)  # Revealed type is "__main__.ClassC2[builtins.int, Unpack[builtins.tuple[builtins.float, ...]]]"  # TODO
     reveal_type(c)  # N: Revealed type is "__main__.ClassC2[builtins.int]"
 
-    # k = ClassC2()  # TODO
-    # reveal_type(k)  # Revealed type is "__main__.ClassC2[builtins.str, Unpack[builtins.tuple[builtins.float, ...]]]"  # TODO
+    k = ClassC2()
+    reveal_type(k)  # N: Revealed type is "__main__.ClassC2[builtins.str, Unpack[builtins.tuple[builtins.float, ...]]]"
     l = ClassC2[int]()
     # reveal_type(l)  # Revealed type is "__main__.ClassC2[builtins.int, Unpack[builtins.tuple[builtins.float, ...]]]"  # TODO
     m = ClassC2[int, Unpack[Tuple[()]]]()
@@ -308,8 +308,8 @@ def func_c3(
     reveal_type(b)  # N: Revealed type is "__main__.ClassC3[builtins.int]"
     reveal_type(c)  # N: Revealed type is "__main__.ClassC3[builtins.int, builtins.float]"
 
-    # k = ClassC3()  # TODO
-    # reveal_type(k)  # Revealed type is "__main__.ClassC3[builtins.str]"  # TODO
+    k = ClassC3()
+    reveal_type(k)  # N: Revealed type is "__main__.ClassC3[builtins.str]"
     l = ClassC3[int]()
     reveal_type(l)  # N: Revealed type is "__main__.ClassC3[builtins.int]"
     m = ClassC3[int, Unpack[Tuple[float]]]()


### PR DESCRIPTION
Small change to fix an error when expanding a TypeVarTuple default.

```
RuntimeError: Invalid type replacement to expand: Unpack[tuple[builtins.int, builtins.str]]
```

Ref: #14851