### PR TITLE
Bump ruff to 0.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: black
         exclude: '^(test-data/)'
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.15  # must match test-requirements.txt
+    rev: v0.2.0  # must match test-requirements.txt
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,20 @@ line-length = 99
 target-version = "py38"
 fix = true
 
+extend-exclude = [
+  "@*",
+  # Sphinx configuration is irrelevant
+  "docs/source/conf.py",
+  "mypyc/doc/conf.py",
+  # tests have more relaxed styling requirements
+  # fixtures have their own .pyi-specific configuration
+  "test-data/*",
+  "mypyc/test-data/*",
+  # typeshed has its own .pyi-specific configuration
+  "mypy/typeshed/*",
+]
+
+[tool.ruff.lint]
 select = [
   "E",       # pycodestyle (error)
   "F",       # pyflakes
@@ -66,20 +80,7 @@ unfixable = [
     "UP036", # sometimes it's better to just noqa this
 ]
 
-extend-exclude = [
-  "@*",
-  # Sphinx configuration is irrelevant
-  "docs/source/conf.py",
-  "mypyc/doc/conf.py",
-  # tests have more relaxed styling requirements
-  # fixtures have their own .pyi-specific configuration
-  "test-data/*",
-  "mypyc/test-data/*",
-  # typeshed has its own .pyi-specific configuration
-  "mypy/typeshed/*",
-]
-
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 extra-standard-library = ["typing_extensions"]
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -14,6 +14,6 @@ psutil>=4.0
 pytest>=7.4.0
 pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
-ruff==0.1.15  # must match version in .pre-commit-config.yaml
+ruff==0.2.0  # must match version in .pre-commit-config.yaml
 setuptools>=65.5.1
 tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -67,7 +67,7 @@ ruamel-yaml==0.17.40
     # via pre-commit-hooks
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.1.15
+ruff==0.2.0
     # via -r test-requirements.in
 tomli==2.0.1
     # via -r test-requirements.in


### PR DESCRIPTION
Fix this deprecation warning when running ruff on the repository directly:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'unfixable' -> 'lint.unfixable'
  - 'isort' -> 'lint.isort'
```

Note that you don't see the deprecation warnings if you run ruff via pre-commit (only if you run ruff directly, e.g. via ruff .), since pre-commit [swallows all output from a tool if the tool exits with code 0](https://stackoverflow.com/questions/72895720/pre-commit-hook-does-not-echo-on-terminal/72898524#72898524).