### PR TITLE
Unsupport targetting 3.7.

### DIFF
--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -10,7 +10,7 @@ PYTHON3_VERSION: Final = (3, 8)
 
 # Earliest Python 3.x version supported via --python-version 3.x. To run
 # mypy, at least version PYTHON3_VERSION is needed.
-PYTHON3_VERSION_MIN: Final = (3, 7)  # Keep in sync with typeshed's python support
+PYTHON3_VERSION_MIN: Final = (3, 8)  # Keep in sync with typeshed's python support
 
 CACHE_DIR: Final = ".mypy_cache"
 CONFIG_FILE: Final = ["mypy.ini", ".mypy.ini"]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -592,7 +592,7 @@ main.py:1: error: Cannot find implementation or library stub for module named "a
 \[tool.mypy]
 python_version = 3.10
 [out]
-pyproject.toml: [mypy]: python_version: Python 3.1 is not supported (must be 3.7 or higher). You may need to put quotes around your Python version
+pyproject.toml: [mypy]: python_version: Python 3.1 is not supported (must be 3.8 or higher). You may need to put quotes around your Python version
 == Return code: 0
 
 [case testPythonVersionTooOld10]
@@ -604,13 +604,13 @@ python_version = 1.0
 mypy.ini: [mypy]: python_version: Python major version '1' out of range (must be 3)
 == Return code: 0
 
-[case testPythonVersionTooOld36]
+[case testPythonVersionTooOld37]
 # cmd: mypy -c pass
 [file mypy.ini]
 \[mypy]
-python_version = 3.6
+python_version = 3.7
 [out]
-mypy.ini: [mypy]: python_version: Python 3.6 is not supported (must be 3.7 or higher)
+mypy.ini: [mypy]: python_version: Python 3.7 is not supported (must be 3.8 or higher)
 == Return code: 0
 
 [case testPythonVersionTooNew40]
@@ -633,11 +633,11 @@ usage: mypy [-h] [-v] [-V] [more options; see below]
 mypy: error: Mypy no longer supports checking Python 2 code. Consider pinning to mypy<0.980 if you need to check Python 2 code.
 == Return code: 2
 
-[case testPythonVersionAccepted37]
+[case testPythonVersionAccepted38]
 # cmd: mypy -c pass
 [file mypy.ini]
 \[mypy]
-python_version = 3.7
+python_version = 3.8
 [out]
 
 [case testPythonVersionAccepted311]


### PR DESCRIPTION
This syncs up this constant to the actual minimum version that typeshed is now targetting.