### PR TITLE
Docs: adding missing `mutable-override` to section title

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -487,7 +487,6 @@ Example:
 Check that overrides of mutable attributes are safe [mutable-override]
 ----------------------------------------------------------------------
 
-Introduced in Mypy version 1.8,
 `mutable-override` will enable the check for unsafe overrides of mutable attributes.
 For historical reasons, and because this is a relatively common pattern in Python,
 this check is not enabled by default. The example below is unsafe, and will be

--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -484,11 +484,12 @@ Example:
 
 .. _code-mutable-override:
 
-Check that overrides of mutable attributes are safe
----------------------------------------------------
+Check that overrides of mutable attributes are safe [mutable-override]
+----------------------------------------------------------------------
 
-This will enable the check for unsafe overrides of mutable attributes. For
-historical reasons, and because this is a relatively common pattern in Python,
+Introduced in Mypy version 1.8,
+`mutable-override` will enable the check for unsafe overrides of mutable attributes.
+For historical reasons, and because this is a relatively common pattern in Python,
 this check is not enabled by default. The example below is unsafe, and will be
 flagged when this error code is enabled:
 


### PR DESCRIPTION
Closes https://github.com/python/mypy/issues/16880
Supercedes https://github.com/python/mypy/pull/16881