### PR TITLE
Correct type annotations on two fields in _Arguments that are optional but are not marked as such

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1921,8 +1921,8 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
     options = Options()
     options.incremental = False
     options.custom_typeshed_dir = args.custom_typeshed_dir
-    if args.custom_typeshed_dir:
-        options.abs_custom_typeshed_dir = os.path.abspath(args.custom_typeshed_dir)
+    if options.custom_typeshed_dir:
+        options.abs_custom_typeshed_dir = os.path.abspath(options.custom_typeshed_dir)
     options.config_file = args.mypy_config_file
     options.use_builtins_fixtures = use_builtins_fixtures
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1921,7 +1921,7 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
     options = Options()
     options.incremental = False
     options.custom_typeshed_dir = args.custom_typeshed_dir
-    if options.custom_typeshed_dir:
+    if args.custom_typeshed_dir:
         options.abs_custom_typeshed_dir = os.path.abspath(args.custom_typeshed_dir)
     options.config_file = args.mypy_config_file
     options.use_builtins_fixtures = use_builtins_fixtures

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1878,8 +1878,8 @@ class _Arguments:
     allowlist: list[str]
     generate_allowlist: bool
     ignore_unused_allowlist: bool
-    mypy_config_file: str
-    custom_typeshed_dir: str
+    mypy_config_file: str | None
+    custom_typeshed_dir: str | None
     check_typeshed: bool
     version: str
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Hello mypy team,

I am working as part of a research team developing a code analysis tool for Python. One of the issues the tool discovered in mypy's codebase is that two fields in the `_Arguments` class, `mypy_config_file` and `custom_typeshed_dir`, can take on a None value, but they are not marked as such. Calling `stubtest.parse_options` on an empty list of arguments reproduces the situation where these two fields are None.

If you are interested in learning more about the tool and how it found this issue, let me know down in the comments, or you can contact me at xifaras.s@northeastern.edu. If you find that this issue is not legitimate, I would be interested in understanding why.

Note that I did not add any test cases as no functional changes to the code were made.

Thank you for your consideration!

-Sam

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
