### PR TITLE
[Release 1.9] Stubtest: ignore a new protocol dunder (#16895)

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1486,6 +1486,7 @@ IGNORABLE_CLASS_DUNDERS: typing_extensions.Final = frozenset(
         # Added to all protocol classes on 3.12+ (or if using typing_extensions.Protocol)
         "__protocol_attrs__",
         "__callable_proto_members_only__",
+        "__non_callable_proto_members__",
         # typing implementation details, consider removing some of these:
         "__parameters__",
         "__origin__",


### PR DESCRIPTION
This is added to all protocol classes on Python 3.12.2+ (it was added in a patch release of 3.12 as part of a bugfix). There's no reason why you'd want to explicitly include it in a stub (and doing so would lead the type checker to incorrectly conclude that you wanted a member literally called `__non_callable_proto_members__`)

Cf. https://github.com/python/typeshed/pull/11384 and https://github.com/python/typeshed/issues/11383

(cherry picked from commit 517f5aee23ba218f615bcd4427bca62f120bc222)