### PR TITLE
FIx stubtest's tests to work with the latest version of `typing_extensions`

### DIFF
--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -61,6 +61,8 @@ class _TypedDict(Mapping[str, object]):
     __optional_keys__: frozenset[str]
     __readonly_keys__: frozenset[str]
     __mutable_keys__: frozenset[str]
+    __closed__: bool
+    __extra_items__: Any
     __total__: bool
 
 def TypedDict(typename: str, fields: Dict[str, Type[_T]], *, total: Any = ...) -> Type[dict]: ...


### PR DESCRIPTION
Stubtest's tests will start failing when `typing_extensions==4.10.0` comes out, due to some new `ClassVar`s on `typing_extensions.TypedDict`. This PR fixes that.

Fixes https://github.com/python/typing_extensions/issues/339. Note: there's no need to cherry-pick this to the `release-1.9.0` branch, since the daily workflow `typing_extensions` uses runs mypy's tests using the mypy `master` branch.