### PR TITLE
Docs: Update `TypedDict` import statements

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -541,7 +541,7 @@ Consider this example:
 
 .. code-block:: python
 
-   from typing_extensions import Protocol
+   from typing import Protocol
 
    class P(Protocol):
        x: float
@@ -561,7 +561,7 @@ the protocol definition:
 
 .. code-block:: python
 
-   from typing_extensions import Protocol
+   from typing import Protocol
 
    class P(Protocol):
        @property

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -537,7 +537,7 @@ Example:
 
 .. code-block:: python
 
-    from typing_extensions import TypedDict
+    from typing import TypedDict
 
     class Point(TypedDict):
         x: int
@@ -562,7 +562,7 @@ to have been validated at the point of construction. Example:
 
 .. code-block:: python
 
-    from typing_extensions import TypedDict
+    from typing import TypedDict
 
     class Point(TypedDict):
         x: int
@@ -868,7 +868,7 @@ the return type affects which lines mypy thinks are reachable after a
 ``True`` may swallow exceptions. An imprecise return type can result
 in mysterious errors reported near ``with`` statements.
 
-To fix this, use either ``typing_extensions.Literal[False]`` or
+To fix this, use either ``typing.Literal[False]`` or
 ``None`` as the return type. Returning ``None`` is equivalent to
 returning ``False`` in this context, since both are treated as false
 values.
@@ -888,7 +888,7 @@ This produces the following output from mypy:
 .. code-block:: text
 
    example.py:3: error: "bool" is invalid as return type for "__exit__" that always returns False
-   example.py:3: note: Use "typing_extensions.Literal[False]" as the return type or change it to
+   example.py:3: note: Use "typing.Literal[False]" as the return type or change it to
        "None"
    example.py:3: note: If return type of "__exit__" implies that it may return True, the context
        manager may swallow exceptions
@@ -897,7 +897,7 @@ You can use ``Literal[False]`` to fix the error:
 
 .. code-block:: python
 
-   from typing_extensions import Literal
+   from typing import Literal
 
    class MyContext:
        ...

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -888,7 +888,7 @@ This produces the following output from mypy:
 .. code-block:: text
 
    example.py:3: error: "bool" is invalid as return type for "__exit__" that always returns False
-   example.py:3: note: Use "typing.Literal[False]" as the return type or change it to
+   example.py:3: note: Use "typing_extensions.Literal[False]" as the return type or change it to
        "None"
    example.py:3: note: If return type of "__exit__" implies that it may return True, the context
        manager may swallow exceptions

--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -547,7 +547,7 @@ Correct usage:
 .. code-block:: python
 
     # Use "mypy --enable-error-code unimported-reveal"
-    from typing import reveal_type   # or `typing_extensions`
+    from typing import reveal_type   # "from typing_extensions" in Python 3.10 and earlier
 
     x = 1
     # This won't raise an error:

--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -547,7 +547,7 @@ Correct usage:
 .. code-block:: python
 
     # Use "mypy --enable-error-code unimported-reveal"
-    from typing import reveal_type   # "from typing_extensions" in Python 3.10 and earlier
+    from typing import reveal_type   # or `typing_extensions`
 
     x = 1
     # This won't raise an error:

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -770,8 +770,7 @@ protocols mostly follow the normal rules for generic classes. Example:
 
 .. code-block:: python
 
-   from typing import TypeVar
-   from typing_extensions import Protocol
+   from typing import Protocol, TypeVar
 
    T = TypeVar('T')
 

--- a/docs/source/protocols.rst
+++ b/docs/source/protocols.rst
@@ -68,8 +68,7 @@ class:
 
 .. code-block:: python
 
-   from typing import Iterable
-   from typing_extensions import Protocol
+   from typing import Iterable, Protocol
 
    class SupportsClose(Protocol):
        # Empty method body (explicit '...')
@@ -226,8 +225,7 @@ such as trees and linked lists:
 
 .. code-block:: python
 
-   from typing import TypeVar, Optional
-   from typing_extensions import Protocol
+   from typing import TypeVar, Optional, Protocol
 
    class TreeLike(Protocol):
        value: int
@@ -255,7 +253,7 @@ rudimentary support for runtime structural checks:
 
 .. code-block:: python
 
-   from typing_extensions import Protocol, runtime_checkable
+   from typing import Protocol, runtime_checkable
 
    @runtime_checkable
    class Portable(Protocol):
@@ -298,8 +296,7 @@ member:
 
 .. code-block:: python
 
-   from typing import Optional, Iterable
-   from typing_extensions import Protocol
+   from typing import Optional, Iterable, Protocol
 
    class Combiner(Protocol):
        def __call__(self, *vals: bytes, maxlen: Optional[int] = None) -> list[bytes]: ...
@@ -323,8 +320,7 @@ a double underscore prefix is used. For example:
 
 .. code-block:: python
 
-   from typing import Callable, TypeVar
-   from typing_extensions import Protocol
+   from typing import Callable, Protocol, TypeVar
 
    T = TypeVar('T')
 

--- a/docs/source/stubs.rst
+++ b/docs/source/stubs.rst
@@ -114,7 +114,7 @@ For example:
 
 .. code-block:: python
 
-    from typing_extensions import Protocol
+    from typing import Protocol
 
     class Resource(Protocol):
         def ok_1(self, foo: list[str] = ...) -> None: ...

--- a/docs/source/typed_dict.rst
+++ b/docs/source/typed_dict.rst
@@ -189,7 +189,7 @@ in Python 3.6 and later:
 
 .. code-block:: python
 
-   from typing import TypedDict # "from typing_extensions" in Python 3.7 and earlier
+   from typing import TypedDict  # "from typing_extensions" in Python 3.7 and earlier
 
    class Movie(TypedDict):
        name: str

--- a/docs/source/typed_dict.rst
+++ b/docs/source/typed_dict.rst
@@ -25,7 +25,7 @@ dictionary value depends on the key:
 
 .. code-block:: python
 
-   from typing_extensions import TypedDict
+   from typing import TypedDict
 
    Movie = TypedDict('Movie', {'name': str, 'year': int})
 
@@ -189,7 +189,7 @@ in Python 3.6 and later:
 
 .. code-block:: python
 
-   from typing_extensions import TypedDict
+   from typing import TypedDict
 
    class Movie(TypedDict):
        name: str

--- a/docs/source/typed_dict.rst
+++ b/docs/source/typed_dict.rst
@@ -189,7 +189,7 @@ in Python 3.6 and later:
 
 .. code-block:: python
 
-   from typing import TypedDict
+   from typing import TypedDict # "from typing_extensions" in Python 3.7 and earlier
 
    class Movie(TypedDict):
        name: str


### PR DESCRIPTION
Since Python 3.8, `TypedDict` has been available from the `typing` module. 

As Python 3.8+ is needed to use mypy (https://github.com/python/mypy/blob/master/setup.py#L12), then it's best for the docs to reflect Python 3.8+ usage.

For previous versions, there's already a disclaimer on the page that explains that `typing_extensions` must be used: https://github.com/python/mypy/blob/master/docs/source/typed_dict.rst?plain=1#L102-L110

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->