### PR TITLE
Add a function to search for pyproject.toml in a project root

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -217,28 +217,6 @@ toml_config_types.update(
 )
 
 
-def _find_pyproject() -> list[str]:
-    """Search for file pyproject.toml in the parent directories recursively.
-
-    It resolves symlinks, so if there is any symlink up in the tree, it does not respect them
-    """
-    # We start from the parent dir, since 'pyproject.toml' is already parsed
-    current_dir = os.path.abspath(os.path.join(os.path.curdir, os.path.pardir))
-    is_root = False
-    while not is_root:
-        for pyproject_name in defaults.PYPROJECT_CONFIG_FILES:
-            config_file = os.path.join(current_dir, pyproject_name)
-            if os.path.isfile(config_file):
-                return [os.path.abspath(config_file)]
-        parent = os.path.abspath(os.path.join(current_dir, os.path.pardir))
-        is_root = current_dir == parent or any(
-            os.path.isdir(os.path.join(current_dir, cvs_root)) for cvs_root in (".git", ".hg")
-        )
-        current_dir = parent
-
-    return []
-
-
 def parse_config_file(
     options: Options,
     set_strict_flags: Callable[[], None],
@@ -258,9 +236,7 @@ def parse_config_file(
     if filename is not None:
         config_files: tuple[str, ...] = (filename,)
     else:
-        config_files_iter: Iterable[str] = map(
-            os.path.expanduser, defaults.CONFIG_FILES + _find_pyproject()
-        )
+        config_files_iter: Iterable[str] = map(os.path.expanduser, defaults.CONFIG_FILES)
         config_files = tuple(config_files_iter)
 
     config_parser = configparser.RawConfigParser()

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -12,9 +12,41 @@ PYTHON3_VERSION: Final = (3, 9)
 # mypy, at least version PYTHON3_VERSION is needed.
 PYTHON3_VERSION_MIN: Final = (3, 8)  # Keep in sync with typeshed's python support
 
+
+def find_pyproject() -> str:
+    """Search for file pyproject.toml in the parent directories recursively.
+
+    It resolves symlinks, so if there is any symlink up in the tree, it does not respect them
+
+    If the file is not found until the root of FS or repository, PYPROJECT_FILE is used
+    """
+
+    def is_root(current_dir: str) -> bool:
+        parent = os.path.join(current_dir, os.path.pardir)
+        return os.path.samefile(current_dir, parent) or any(
+            os.path.isdir(os.path.join(current_dir, cvs_root)) for cvs_root in (".git", ".hg")
+        )
+
+    # Preserve the original behavior, returning PYPROJECT_FILE if exists
+    if os.path.isfile(PYPROJECT_FILE) or is_root(os.path.curdir):
+        return PYPROJECT_FILE
+
+    # And iterate over the tree
+    current_dir = os.path.pardir
+    while not is_root(current_dir):
+        config_file = os.path.join(current_dir, PYPROJECT_FILE)
+        if os.path.isfile(config_file):
+            return config_file
+        parent = os.path.join(current_dir, os.path.pardir)
+        current_dir = parent
+
+    return PYPROJECT_FILE
+
+
 CACHE_DIR: Final = ".mypy_cache"
 CONFIG_FILE: Final = ["mypy.ini", ".mypy.ini"]
-PYPROJECT_CONFIG_FILES: Final = ["pyproject.toml"]
+PYPROJECT_FILE: Final = "pyproject.toml"
+PYPROJECT_CONFIG_FILES: Final = [find_pyproject()]
 SHARED_CONFIG_FILES: Final = ["setup.cfg"]
 USER_CONFIG_FILES: Final = ["~/.config/mypy/config", "~/.mypy.ini"]
 if os.environ.get("XDG_CONFIG_HOME"):

--- a/test-data/unit/cmdline.pyproject.test
+++ b/test-data/unit/cmdline.pyproject.test
@@ -133,3 +133,38 @@ Neither is this!
 description = "Factory ⸻ A code generator 🏭"
 \[tool.mypy]
 [file x.py]
+
+[case testSearchRecursively]
+# cmd: mypy x.py
+[file ../pyproject.toml]
+\[tool.mypy]
+\[tool.mypy.overrides]
+module = "x"
+disallow_untyped_defs = false
+[file x.py]
+pass
+[out]
+../pyproject.toml: tool.mypy.overrides sections must be an array. Please make sure you are using double brackets like so: [[tool.mypy.overrides]]
+== Return code: 0
+
+[case testSearchRecursivelyStopsGit]
+# cmd: mypy x.py
+[file .git/test]
+[file ../pyproject.toml]
+\[tool.mypy]
+\[tool.mypy.overrides]
+module = "x"
+disallow_untyped_defs = false
+[file x.py]
+i: int = 0
+
+[case testSearchRecursivelyStopsHg]
+# cmd: mypy x.py
+[file .hg/test]
+[file ../pyproject.toml]
+\[tool.mypy]
+\[tool.mypy.overrides]
+module = "x"
+disallow_untyped_defs = false
+[file x.py]
+i: int = 0


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

Here's a solution to fix https://github.com/python/mypy/issues/10613. The tests are covered.

It adds the functionality of searching `pyproject.toml` recursively from the current directory up to a project root (directory with either `.git` or `.hg`) to `mypy`

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
