### PR TITLE
TypeVarTuple as type arg for subclasses of generic TypedDict (fixes #16975)

### DIFF
--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -182,6 +182,7 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
         allow_tuple_literal: bool = False,
         allow_unbound_tvars: bool = False,
         allow_required: bool = False,
+        allow_unpack: bool = False,
         allow_placeholder: bool = False,
         report_invalid_types: bool = True,
         prohibit_self_type: str | None = None,

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -235,12 +235,17 @@ class TypedDictAnalyzer:
 
         for arg_expr in args:
             try:
-                type = expr_to_unanalyzed_type(arg_expr, self.options, self.api.is_stub_file)
+                type = expr_to_unanalyzed_type(arg_expr, self.options,
+                                               allow_new_syntax=self.api.is_stub_file,
+                                               allow_unpack=True)
             except TypeTranslationError:
                 self.fail("Invalid TypedDict type argument", ctx)
                 return None
             analyzed = self.api.anal_type(
-                type, allow_required=True, allow_placeholder=not self.api.is_func_scope()
+                type,
+                allow_required=True,
+                allow_unpack=True,
+                allow_placeholder=not self.api.is_func_scope()
             )
             if analyzed is None:
                 return None
@@ -316,6 +321,7 @@ class TypedDictAnalyzer:
                     analyzed = self.api.anal_type(
                         stmt.type,
                         allow_required=True,
+                        allow_unpack=True,
                         allow_placeholder=not self.api.is_func_scope(),
                         prohibit_self_type="TypedDict item type",
                     )
@@ -520,6 +526,7 @@ class TypedDictAnalyzer:
             analyzed = self.api.anal_type(
                 type,
                 allow_required=True,
+                allow_unpack=True,
                 allow_placeholder=not self.api.is_func_scope(),
                 prohibit_self_type="TypedDict item type",
             )

--- a/test-data/unit/check-python311.test
+++ b/test-data/unit/check-python311.test
@@ -142,3 +142,38 @@ myclass3 = MyClass(float, float, float)  # E: No overload variant of "MyClass" m
                                          # N:     def [T1, T2] __init__(Type[T1], Type[T2], /) -> MyClass[T1, T2]
 reveal_type(myclass3)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleNewSyntaxTypedDict]
+# flags: --python-version 3.11
+from typing import Tuple, Callable, Generic
+from typing_extensions import TypeVarTuple, Unpack, TypedDict
+
+Ts = TypeVarTuple("Ts")
+class A(TypedDict, Generic[*Ts, T]):
+    fn: Callable[[*Ts], None]
+    val: T
+
+class B(A[*Ts, T]):
+    gn: Callable[[*Ts], None]
+    vals: Tuple[*Ts]
+
+y: B[int, str]
+reveal_type(y)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int), 'val': builtins.str, 'gn': def (builtins.int), 'vals': Tuple[builtins.int]})"
+reveal_type(y["gn"])  # N: Revealed type is "def (builtins.int)"
+reveal_type(y["vals"])  # N: Revealed type is "Tuple[builtins.int]"
+
+z: B[*Tuple[int, ...]]
+reveal_type(z)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (*builtins.int), 'val': builtins.int, 'gn': def (*builtins.int), 'vals': builtins.tuple[builtins.int, ...]})"
+reveal_type(z["gn"])  # N: Revealed type is "def (*builtins.int)"
+
+t: B[int, *Tuple[int, str], str]
+reveal_type(t)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.int, builtins.str), 'val': builtins.str, 'gn': def (builtins.int, builtins.int, builtins.str), 'vals': Tuple[builtins.int, builtins.int, builtins.str]})"
+
+def ftest(x: int, y: str) -> None: ...
+def gtest(x: int, y: str) -> None: ...
+td = B({"fn": ftest, "val": 42, "gn": gtest, "vals": (6, "7")})
+reveal_type(td)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.str), 'val': builtins.int, 'gn': def (builtins.int, builtins.str), 'vals': Tuple[builtins.int, builtins.str]})"
+
+def gbad() -> int: ...
+td2 = B({"fn": ftest, "val": 42, "gn": gbad, "vals": (6, "7")})  # E: Incompatible types (expression has type "Callable[[], int]", TypedDict item "gn" has type "Callable[[int, str], None]")
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -1155,6 +1155,40 @@ def bad() -> int: ...
 td2 = A({"fn": bad, "val": 42})  # E: Incompatible types (expression has type "Callable[[], int]", TypedDict item "fn" has type "Callable[[], None]")
 [builtins fixtures/tuple.pyi]
 
+[case testVariadicTypedDictExtending]
+from typing import Tuple, Callable, Generic
+from typing_extensions import TypeVarTuple, Unpack, TypedDict
+
+Ts = TypeVarTuple("Ts")
+class A(TypedDict, Generic[Unpack[Ts], T]):
+    fn: Callable[[Unpack[Ts]], None]
+    val: T
+
+class B(A[Unpack[Ts], T]):
+    gn: Callable[[Unpack[Ts]], None]
+    vals: Tuple[Unpack[Ts]]
+
+y: B[int, str]
+reveal_type(y)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int), 'val': builtins.str, 'gn': def (builtins.int), 'vals': Tuple[builtins.int]})"
+reveal_type(y["gn"])  # N: Revealed type is "def (builtins.int)"
+reveal_type(y["vals"])  # N: Revealed type is "Tuple[builtins.int]"
+
+z: B[Unpack[Tuple[int, ...]]]
+reveal_type(z)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (*builtins.int), 'val': builtins.int, 'gn': def (*builtins.int), 'vals': builtins.tuple[builtins.int, ...]})"
+reveal_type(z["gn"])  # N: Revealed type is "def (*builtins.int)"
+
+t: B[int, Unpack[Tuple[int, str]], str]
+reveal_type(t)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.int, builtins.str), 'val': builtins.str, 'gn': def (builtins.int, builtins.int, builtins.str), 'vals': Tuple[builtins.int, builtins.int, builtins.str]})"
+
+def ftest(x: int, y: str) -> None: ...
+def gtest(x: int, y: str) -> None: ...
+td = B({"fn": ftest, "val": 42, "gn": gtest, "vals": (6, "7")})
+reveal_type(td)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.str), 'val': builtins.int, 'gn': def (builtins.int, builtins.str), 'vals': Tuple[builtins.int, builtins.str]})"
+
+def gbad() -> int: ...
+td2 = B({"fn": ftest, "val": 42, "gn": gbad, "vals": (6, "7")})  # E: Incompatible types (expression has type "Callable[[], int]", TypedDict item "gn" has type "Callable[[int, str], None]")
+[builtins fixtures/tuple.pyi]
+
 [case testFixedUnpackWithRegularInstance]
 from typing import Tuple, Generic, TypeVar
 from typing_extensions import Unpack


### PR DESCRIPTION
(fixes #16975)

I'm not entirely sure about this implementation -- it fixes the issue and doesn't seem to break anything else -- but it feels like I might be things in the wrong phase? If so, a little nudge in the right direction would be much appreciated.
