### PR TITLE
Add `py312` target version to `black` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 99
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 skip-magic-trailing-comma = true
 force-exclude = '''
 ^/mypy/typeshed|


### PR DESCRIPTION
I won't have any effect, but will reflect our target versions better.