### PR TITLE
Fix inference with UninhabitedType

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -108,9 +108,9 @@ class InstanceJoiner:
                     # TODO: contravariant case should use meet but pass seen instances as
                     # an argument to keep track of recursive checks.
                     elif type_var.variance in (INVARIANT, CONTRAVARIANT):
-                        if isinstance(ta_proper, UninhabitedType):
+                        if isinstance(ta_proper, UninhabitedType) and not ta_proper.is_noreturn:
                             new_type = sa
-                        elif isinstance(sa_proper, UninhabitedType):
+                        elif isinstance(sa_proper, UninhabitedType) and not sa_proper.is_noreturn:
                             new_type = ta
                         elif not is_equivalent(ta, sa):
                             self.seen_instances.pop()

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -108,12 +108,17 @@ class InstanceJoiner:
                     # TODO: contravariant case should use meet but pass seen instances as
                     # an argument to keep track of recursive checks.
                     elif type_var.variance in (INVARIANT, CONTRAVARIANT):
-                        if not is_equivalent(ta, sa):
+                        if isinstance(ta, UninhabitedType):
+                            new_type = sa
+                        elif isinstance(sa, UninhabitedType):
+                            new_type = ta
+                        elif not is_equivalent(ta, sa):
                             self.seen_instances.pop()
                             return object_from_instance(t)
-                        # If the types are different but equivalent, then an Any is involved
-                        # so using a join in the contravariant case is also OK.
-                        new_type = join_types(ta, sa, self)
+                        else:
+                            # If the types are different but equivalent, then an Any is involved
+                            # so using a join in the contravariant case is also OK.
+                            new_type = join_types(ta, sa, self)
                 elif isinstance(type_var, TypeVarTupleType):
                     new_type = get_proper_type(join_types(ta, sa, self))
                     # Put the joined arguments back into instance in the normal form:

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -108,9 +108,9 @@ class InstanceJoiner:
                     # TODO: contravariant case should use meet but pass seen instances as
                     # an argument to keep track of recursive checks.
                     elif type_var.variance in (INVARIANT, CONTRAVARIANT):
-                        if isinstance(ta, UninhabitedType):
+                        if isinstance(ta_proper, UninhabitedType):
                             new_type = sa
-                        elif isinstance(sa, UninhabitedType):
+                        elif isinstance(sa_proper, UninhabitedType):
                             new_type = ta
                         elif not is_equivalent(ta, sa):
                             self.seen_instances.pop()

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3820,6 +3820,7 @@ from typing import Dict, Generic, TypeVar
 T = TypeVar("T")
 
 class A(Generic[T]): ...
+class B(Dict[T, T]): ...
 
 def func1(a: A[T], b: T) -> T: ...
 def func2(a: T, b: A[T]) -> T: ...
@@ -3827,4 +3828,15 @@ def func2(a: T, b: A[T]) -> T: ...
 def a1(a: A[Dict[str, int]]) -> None:
     reveal_type(func1(a, {}))  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
     reveal_type(func2({}, a))  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
+
+def a2(check: bool, a: B[str]) -> None:
+    reveal_type(a if check else {})  # N: Revealed type is "builtins.dict[builtins.str, builtins.str]"
+
+def a3() -> None:
+    a = {}  # E: Need type annotation for "a" (hint: "a: Dict[<type>, <type>] = ...")
+    b = {1: {}}  # E: Need type annotation for "b"
+    c = {1: {}, 2: {"key": {}}}  # E: Need type annotation for "c"
+    reveal_type(a)  # N: Revealed type is "builtins.dict[Any, Any]"
+    reveal_type(b)  # N: Revealed type is "builtins.dict[builtins.int, builtins.dict[Any, Any]]"
+    reveal_type(c)  # N: Revealed type is "builtins.dict[builtins.int, builtins.dict[builtins.str, builtins.dict[Any, Any]]]"
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3813,3 +3813,18 @@ def m1() -> float: ...
 def m2() -> float: ...
 reveal_type(Combine(m1, m2))  # N: Revealed type is "builtins.float"
 [builtins fixtures/list.pyi]
+
+[case testInferenceWithUninhabitedType]
+from typing import Dict, Generic, TypeVar
+
+T = TypeVar("T")
+
+class A(Generic[T]): ...
+
+def func1(a: A[T], b: T) -> T: ...
+def func2(a: T, b: A[T]) -> T: ...
+
+def a1(a: A[Dict[str, int]]) -> None:
+    reveal_type(func1(a, {}))  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
+    reveal_type(func2({}, a))  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3815,7 +3815,7 @@ reveal_type(Combine(m1, m2))  # N: Revealed type is "builtins.float"
 [builtins fixtures/list.pyi]
 
 [case testInferenceWithUninhabitedType]
-from typing import Dict, Generic, TypeVar
+from typing import Dict, Generic, List, Never, TypeVar
 
 T = TypeVar("T")
 
@@ -3839,4 +3839,11 @@ def a3() -> None:
     reveal_type(a)  # N: Revealed type is "builtins.dict[Any, Any]"
     reveal_type(b)  # N: Revealed type is "builtins.dict[builtins.int, builtins.dict[Any, Any]]"
     reveal_type(c)  # N: Revealed type is "builtins.dict[builtins.int, builtins.dict[builtins.str, builtins.dict[Any, Any]]]"
+
+def a4(x: List[str], y: List[Never]) -> None:
+    z1 = [x, y]
+    z2 = [y, x]
+    reveal_type(z1)  # N: Revealed type is "builtins.list[builtins.object]"
+    reveal_type(z2)  # N: Revealed type is "builtins.list[builtins.object]"
+    z1[1].append("asdf")  # E: "object" has no attribute "append"
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
At the moment, inference fails if an empty dict is used (without annotation) as one of the types. It's because the constraint solver can't resolve `dict[str, int]` and `dict[Never, Never]`. However in this case it's more reasonable to interpret the empty dict as `dict[Any, Any]` and just using the first type instead. That matches the behavior of pyright.
```py
T = TypeVar("T")
class A(Generic[T]): ...

def func1(a: A[T], b: T) -> T: ...

def a1(a: A[Dict[str, int]]) -> None:
    reveal_type(func1(a, {}))
```
```
# before
main: error: Cannot infer type argument 1 of "func1" (diff)
main: note: Revealed type is "Any" (diff)

# after
main: note: Revealed type is "builtins.dict[builtins.str, builtins.int]"
```