### PR TITLE
[mypyc] Provide an easier way to define IR-to-IR transforms

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -230,12 +230,12 @@ def compile_scc_to_ir(
         for fn in module.functions:
             # Insert uninit checks.
             insert_uninit_checks(fn)
-            # Perform copy propagation optimization.
-            do_copy_propagation(fn, compiler_options)
             # Insert exception handling.
             insert_exception_handling(fn)
             # Insert refcount handling.
             insert_ref_count_opcodes(fn)
+            # Perform copy propagation optimization.
+            do_copy_propagation(fn, compiler_options)
 
     return modules
 

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -56,6 +56,7 @@ from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.prepare import load_type_map
 from mypyc.namegen import NameGenerator, exported_name
 from mypyc.options import CompilerOptions
+from mypyc.transform.copy_propagation import do_copy_propagation
 from mypyc.transform.exceptions import insert_exception_handling
 from mypyc.transform.refcount import insert_ref_count_opcodes
 from mypyc.transform.uninit import insert_uninit_checks
@@ -225,17 +226,15 @@ def compile_scc_to_ir(
     if errors.num_errors > 0:
         return modules
 
-    # Insert uninit checks.
     for module in modules.values():
         for fn in module.functions:
+            # Insert uninit checks.
             insert_uninit_checks(fn)
-    # Insert exception handling.
-    for module in modules.values():
-        for fn in module.functions:
+            # Perform copy propagation optimization.
+            do_copy_propagation(fn, compiler_options)
+            # Insert exception handling.
             insert_exception_handling(fn)
-    # Insert refcount handling.
-    for module in modules.values():
-        for fn in module.functions:
+            # Insert refcount handling.
             insert_ref_count_opcodes(fn)
 
     return modules

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -160,7 +160,7 @@ class IRBuilder:
         options: CompilerOptions,
         singledispatch_impls: dict[FuncDef, list[RegisterImplInfo]],
     ) -> None:
-        self.builder = LowLevelIRBuilder(current_module, errors, mapper, options)
+        self.builder = LowLevelIRBuilder(errors, options)
         self.builders = [self.builder]
         self.symtables: list[dict[SymbolNode, SymbolTarget]] = [{}]
         self.runtime_args: list[list[RuntimeArg]] = [[]]
@@ -1112,7 +1112,7 @@ class IRBuilder:
         if isinstance(fn_info, str):
             fn_info = FuncInfo(name=fn_info)
         self.builder = LowLevelIRBuilder(
-            self.current_module, self.errors, self.mapper, self.options
+            self.errors, self.options
         )
         self.builder.set_module(self.module_name, self.module_path)
         self.builders.append(self.builder)

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1111,9 +1111,7 @@ class IRBuilder:
     def enter(self, fn_info: FuncInfo | str = "") -> None:
         if isinstance(fn_info, str):
             fn_info = FuncInfo(name=fn_info)
-        self.builder = LowLevelIRBuilder(
-            self.errors, self.options
-        )
+        self.builder = LowLevelIRBuilder(self.errors, self.options)
         self.builder.set_module(self.module_name, self.module_path)
         self.builders.append(self.builder)
         self.symtables.append({})

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -219,9 +219,7 @@ BOOL_BINARY_OPS: Final = {"&", "&=", "|", "|=", "^", "^=", "==", "!=", "<", "<="
 
 
 class LowLevelIRBuilder:
-    def __init__(
-        self, errors: Errors | None, options: CompilerOptions
-    ) -> None:
+    def __init__(self, errors: Errors | None, options: CompilerOptions) -> None:
         self.errors = errors
         self.options = options
         self.args: list[Register] = []

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -126,7 +126,6 @@ from mypyc.ir.rtypes import (
     short_int_rprimitive,
     str_rprimitive,
 )
-from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.util import concrete_arg_kind
 from mypyc.options import CompilerOptions
 from mypyc.primitives.bytes_ops import bytes_compare
@@ -221,11 +220,9 @@ BOOL_BINARY_OPS: Final = {"&", "&=", "|", "|=", "^", "^=", "==", "!=", "<", "<="
 
 class LowLevelIRBuilder:
     def __init__(
-        self, current_module: str, errors: Errors, mapper: Mapper, options: CompilerOptions
+        self, errors: Errors | None, options: CompilerOptions
     ) -> None:
-        self.current_module = current_module
         self.errors = errors
-        self.mapper = mapper
         self.options = options
         self.args: list[Register] = []
         self.blocks: list[BasicBlock] = []
@@ -2394,6 +2391,7 @@ class LowLevelIRBuilder:
             return self.call_c(dict_new_op, [], line)
 
     def error(self, msg: str, line: int) -> None:
+        assert self.errors is not None, "cannot generate errors in this compiler phase"
         self.errors.error(msg, self.module_path, line)
 
 

--- a/mypyc/test-data/opt-copy-propagation.test
+++ b/mypyc/test-data/opt-copy-propagation.test
@@ -42,8 +42,6 @@ L1:
 L2:
     y = 2
     return y
-L3:
-    unreachable
 
 [case testCopyPropagationArg]
 def f(x: int) -> int:
@@ -54,6 +52,31 @@ def f(x):
     x :: int
 L0:
     x = 4
+    return x
+
+[case testCopyPropagationPartiallyDefined1]
+def f(b: bool) -> int:
+    if b:
+        x = 1
+    y = x
+    return y
+[out]
+def f(b):
+    b :: bool
+    r0, x :: int
+    r1 :: bool
+L0:
+    r0 = <error> :: int
+    x = r0
+    if b goto L1 else goto L2 :: bool
+L1:
+    x = 2
+L2:
+    if is_error(x) goto L3 else goto L4
+L3:
+    r1 = raise UnboundLocalError('local variable "x" referenced before assignment')
+    unreachable
+L4:
     return x
 
 -- The remaining test cases test basic IRTransform functionality and are not
@@ -77,8 +100,24 @@ L1:
     return 2
 L2:
     return 4
-L3:
-    unreachable
+
+[case testIRTransformAssignment]
+def f(b: bool, x: int) -> int:
+    y = x
+    if b:
+        return y
+    else:
+        return 1
+[out]
+def f(b, x):
+    b :: bool
+    x :: int
+L0:
+    if b goto L1 else goto L2 :: bool
+L1:
+    return x
+L2:
+    return 2
 
 [case testIRTransformRegisterOps1]
 from __future__ import annotations

--- a/mypyc/test-data/opt-copy-propagation.test
+++ b/mypyc/test-data/opt-copy-propagation.test
@@ -11,6 +11,17 @@ def f(x):
 L0:
     return x
 
+[case testCopyPropagationChain]
+def f(x: int) -> int:
+    y = x
+    z = y
+    return z
+[out]
+def f(x):
+    x :: int
+L0:
+    return x
+
 [case testCopyPropagationTooComplex]
 def f(b: bool, x: int) -> int:
     if b:

--- a/mypyc/test-data/opt-copy-propagation.test
+++ b/mypyc/test-data/opt-copy-propagation.test
@@ -1,0 +1,284 @@
+-- Test cases for copy propagation optimization.  This also tests IR transforms in general,
+-- as copy propagation was the first IR transform that was implemented.
+
+[case testCopyPropagationSimple]
+def f(x: int) -> int:
+    y = x
+    return y
+[out]
+def f(x):
+    x :: int
+L0:
+    return x
+
+[case testCopyPropagationTooComplex]
+def f(b: bool, x: int) -> int:
+    if b:
+        y = x
+        return y
+    else:
+        y = 1
+        return y
+[out]
+def f(b, x):
+    b :: bool
+    x, y :: int
+L0:
+    if b goto L1 else goto L2 :: bool
+L1:
+    y = x
+    return y
+L2:
+    y = 2
+    return y
+L3:
+    unreachable
+
+[case testCopyPropagationArg]
+def f(x: int) -> int:
+    x = 2
+    return x
+[out]
+def f(x):
+    x :: int
+L0:
+    x = 4
+    return x
+
+-- The remaining test cases test basic IRTransform functionality and are not
+-- all needed for testing copy propagation as such.
+
+[case testIRTransformBranch]
+from mypy_extensions import i64
+
+def f(x: bool) -> int:
+    y = x
+    if y:
+        return 1
+    else:
+        return 2
+[out]
+def f(x):
+    x :: bool
+L0:
+    if x goto L1 else goto L2 :: bool
+L1:
+    return 2
+L2:
+    return 4
+L3:
+    unreachable
+
+[case testIRTransformRegisterOps1]
+from __future__ import annotations
+from typing import cast
+
+class C:
+    a: int
+
+    def m(self, x: int) -> None: pass
+
+def get_attr(x: C) -> int:
+    y = x
+    return y.a
+
+def set_attr(x: C) -> None:
+    y = x
+    y.a = 1
+
+def tuple_get(x: tuple[int, int]) -> int:
+    y = x
+    return y[0]
+
+def tuple_set(x: int, xx: int) -> tuple[int, int]:
+    y = x
+    z = xx
+    return y, z
+
+def call(x: int) -> int:
+    y = x
+    return call(y)
+
+def method_call(c: C, x: int) -> None:
+    y = x
+    c.m(y)
+
+def cast_op(x: object) -> str:
+    y = x
+    return cast(str, y)
+
+def box(x: int) -> object:
+    y = x
+    return y
+
+def unbox(x: object) -> int:
+    y = x
+    return cast(int, y)
+
+def call_c(x: list[str]) -> None:
+    y = x
+    y.append("x")
+
+def keep_alive(x: C) -> int:
+    y = x
+    return y.a + 1
+[out]
+def C.m(self, x):
+    self :: __main__.C
+    x :: int
+L0:
+    return 1
+def get_attr(x):
+    x :: __main__.C
+    r0 :: int
+L0:
+    r0 = x.a
+    return r0
+def set_attr(x):
+    x :: __main__.C
+    r0 :: bool
+L0:
+    x.a = 2; r0 = is_error
+    return 1
+def tuple_get(x):
+    x :: tuple[int, int]
+    r0 :: int
+L0:
+    r0 = x[0]
+    return r0
+def tuple_set(x, xx):
+    x, xx :: int
+    r0 :: tuple[int, int]
+L0:
+    r0 = (x, xx)
+    return r0
+def call(x):
+    x, r0 :: int
+L0:
+    r0 = call(x)
+    return r0
+def method_call(c, x):
+    c :: __main__.C
+    x :: int
+    r0 :: None
+L0:
+    r0 = c.m(x)
+    return 1
+def cast_op(x):
+    x :: object
+    r0 :: str
+L0:
+    r0 = cast(str, x)
+    return r0
+def box(x):
+    x :: int
+    r0 :: object
+L0:
+    r0 = box(int, x)
+    return r0
+def unbox(x):
+    x :: object
+    r0 :: int
+L0:
+    r0 = unbox(int, x)
+    return r0
+def call_c(x):
+    x :: list
+    r0 :: str
+    r1 :: i32
+    r2 :: bit
+L0:
+    r0 = 'x'
+    r1 = PyList_Append(x, r0)
+    r2 = r1 >= 0 :: signed
+    return 1
+def keep_alive(x):
+    x :: __main__.C
+    r0, r1 :: int
+L0:
+    r0 = borrow x.a
+    r1 = CPyTagged_Add(r0, 2)
+    keep_alive x
+    return r1
+
+[case testIRTransformRegisterOps2]
+from mypy_extensions import i32, i64
+
+def truncate(x: i64) -> i32:
+    y = x
+    return i32(y)
+
+def extend(x: i32) -> i64:
+    y = x
+    return i64(y)
+
+def int_op(x: i64, xx: i64) -> i64:
+    y = x
+    z = xx
+    return y + z
+
+def comparison_op(x: i64, xx: i64) -> bool:
+    y = x
+    z = xx
+    return y == z
+
+def float_op(x: float, xx: float) -> float:
+    y = x
+    z = xx
+    return y + z
+
+def float_neg(x: float) -> float:
+    y = x
+    return -y
+
+def float_comparison_op(x: float, xx: float) -> bool:
+    y = x
+    z = xx
+    return y == z
+[out]
+def truncate(x):
+    x :: i64
+    r0 :: i32
+L0:
+    r0 = truncate x: i64 to i32
+    return r0
+def extend(x):
+    x :: i32
+    r0 :: i64
+L0:
+    r0 = extend signed x: i32 to i64
+    return r0
+def int_op(x, xx):
+    x, xx, r0 :: i64
+L0:
+    r0 = x + xx
+    return r0
+def comparison_op(x, xx):
+    x, xx :: i64
+    r0 :: bit
+L0:
+    r0 = x == xx
+    return r0
+def float_op(x, xx):
+    x, xx, r0 :: float
+L0:
+    r0 = x + xx
+    return r0
+def float_neg(x):
+    x, r0 :: float
+L0:
+    r0 = -x
+    return r0
+def float_comparison_op(x, xx):
+    x, xx :: float
+    r0 :: bit
+L0:
+    r0 = x == xx
+    return r0
+
+-- Note that transforms of these ops aren't tested here:
+-- * LoadMem
+-- * SetMem
+-- * GetElementPtr
+-- * LoadAddress
+-- * Unborrow

--- a/mypyc/test-data/opt-copy-propagation.test
+++ b/mypyc/test-data/opt-copy-propagation.test
@@ -2,14 +2,21 @@
 -- as copy propagation was the first IR transform that was implemented.
 
 [case testCopyPropagationSimple]
-def f(x: int) -> int:
-    y = x
+def g() -> int:
+    return 1
+
+def f() -> int:
+    y = g()
     return y
 [out]
-def f(x):
-    x :: int
+def g():
 L0:
-    return x
+    return 2
+def f():
+    r0 :: int
+L0:
+    r0 = g()
+    return r0
 
 [case testCopyPropagationChain]
 def f(x: int) -> int:
@@ -21,6 +28,63 @@ def f(x):
     x :: int
 L0:
     return x
+
+[case testCopyPropagationChainPartial]
+def f(x: int) -> int:
+    y = x
+    z = y
+    x = 2
+    return z
+[out]
+def f(x):
+    x, y :: int
+L0:
+    y = x
+    x = 4
+    return y
+
+[case testCopyPropagationChainBad]
+def f(x: int) -> int:
+    y = x
+    z = y
+    y = 2
+    return z
+[out]
+def f(x):
+    x, y, z :: int
+L0:
+    y = x
+    z = y
+    y = 4
+    return z
+
+[case testCopyPropagationMutatedSource1]
+def f(x: int) -> int:
+    y = x
+    x = 1
+    return y
+[out]
+def f(x):
+    x, y :: int
+L0:
+    y = x
+    x = 2
+    return y
+
+[case testCopyPropagationMutatedSource2]
+def f() -> int:
+    z = 1
+    y = z
+    z = 2
+    return y
+[out]
+def f():
+    z, y :: int
+L0:
+    z = 2
+    y = z
+    z = 4
+    return y
 
 [case testCopyPropagationTooComplex]
 def f(b: bool, x: int) -> int:
@@ -65,6 +129,7 @@ def f(b):
     b :: bool
     r0, x :: int
     r1 :: bool
+    y :: int
 L0:
     r0 = <error> :: int
     x = r0
@@ -77,7 +142,8 @@ L3:
     r1 = raise UnboundLocalError('local variable "x" referenced before assignment')
     unreachable
 L4:
-    return x
+    y = x
+    return y
 
 -- The remaining test cases test basic IRTransform functionality and are not
 -- all needed for testing copy propagation as such.

--- a/mypyc/test/test_copy_propagation.py
+++ b/mypyc/test/test_copy_propagation.py
@@ -19,6 +19,7 @@ from mypyc.test.testutil import (
     use_custom_builtins,
 )
 from mypyc.transform.copy_propagation import do_copy_propagation
+from mypyc.transform.uninit import insert_uninit_checks
 
 files = ["opt-copy-propagation.test"]
 
@@ -39,6 +40,7 @@ class TestCopyPropagation(MypycDataSuite):
                 for fn in ir:
                     if fn.name == TOP_LEVEL_NAME and not testcase.name.endswith("_toplevel"):
                         continue
+                    insert_uninit_checks(fn)
                     do_copy_propagation(fn, CompilerOptions())
                     actual.extend(format_func(fn))
 

--- a/mypyc/test/test_copy_propagation.py
+++ b/mypyc/test/test_copy_propagation.py
@@ -1,0 +1,45 @@
+"""Runner for copy propagation optimization tests."""
+
+from __future__ import annotations
+
+import os.path
+
+from mypy.errors import CompileError
+from mypy.test.config import test_temp_dir
+from mypy.test.data import DataDrivenTestCase
+from mypyc.common import TOP_LEVEL_NAME
+from mypyc.ir.pprint import format_func
+from mypyc.options import CompilerOptions
+from mypyc.test.testutil import (
+    ICODE_GEN_BUILTINS,
+    MypycDataSuite,
+    assert_test_output,
+    build_ir_for_single_file,
+    remove_comment_lines,
+    use_custom_builtins,
+)
+from mypyc.transform.copy_propagation import do_copy_propagation
+
+files = ["opt-copy-propagation.test"]
+
+
+class TestCopyPropagation(MypycDataSuite):
+    files = files
+    base_path = test_temp_dir
+
+    def run_case(self, testcase: DataDrivenTestCase) -> None:
+        with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
+            expected_output = remove_comment_lines(testcase.output)
+            try:
+                ir = build_ir_for_single_file(testcase.input)
+            except CompileError as e:
+                actual = e.messages
+            else:
+                actual = []
+                for fn in ir:
+                    if fn.name == TOP_LEVEL_NAME and not testcase.name.endswith("_toplevel"):
+                        continue
+                    do_copy_propagation(fn, CompilerOptions())
+                    actual.extend(format_func(fn))
+
+            assert_test_output(testcase, actual, "Invalid source code output", expected_output)

--- a/mypyc/transform/copy_propagation.py
+++ b/mypyc/transform/copy_propagation.py
@@ -1,0 +1,62 @@
+"""Simple copy propagation optimization.
+
+Example input:
+
+    x = f()
+    y = x
+
+The register x is redundant and we can directly assign its value to y:
+
+    y = f()
+
+This can optimize away registers that are assigned to once.
+"""
+
+from __future__ import annotations
+
+from mypyc.ir.func_ir import FuncIR
+from mypyc.ir.ops import Assign, AssignMulti, Value
+from mypyc.irbuild.ll_builder import LowLevelIRBuilder
+from mypyc.options import CompilerOptions
+from mypyc.transform.ir_transform import IRTransform
+
+
+def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
+    """Perform copy propagation optimization for fn."""
+    counts = {}
+    replacements: dict[Value, Value] = {}
+    for arg in fn.arg_regs:
+        # Arguments can't be propagated, so use value >1
+        counts[arg] = 2
+
+    for block in fn.blocks:
+        for op in block.ops:
+            if isinstance(op, Assign):
+                c = counts.get(op.dest, 0)
+                counts[op.dest] = c + 1
+                if c == 0:
+                    replacements[op.dest] = op.src
+                elif c == 1:
+                    del replacements[op.dest]
+            elif isinstance(op, AssignMulti):
+                # Copy propagation not supported
+                counts[op.dest] = 2
+                replacements.pop(op.dest, 0)
+
+    b = LowLevelIRBuilder(None, options)
+    t = CopyPropagationTransform(b, replacements)
+    t.transform_blocks(fn.blocks)
+    fn.blocks = b.blocks
+
+
+
+class CopyPropagationTransform(IRTransform):
+    def __init__(self, builder: LowLevelIRBuilder, m: dict[Value, Value]) -> None:
+        super().__init__(builder)
+        self.op_map.update(m)
+        self.removed = set(m)
+
+    def visit_assign(self, op: Assign) -> Value | None:
+        if op.dest in self.removed:
+            return None
+        return self.add(op)

--- a/mypyc/transform/copy_propagation.py
+++ b/mypyc/transform/copy_propagation.py
@@ -41,7 +41,7 @@ def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
                 c = counts.get(op.dest, 0)
                 counts[op.dest] = c + 1
                 # Does this look like a supported assignment?
-                # TODO: Some transform needs LoadErrorValue assignments to be preserved
+                # TODO: Something needs LoadErrorValue assignments to be preserved
                 if (
                     c == 0
                     and is_same_type(op.dest.type, op.src.type)

--- a/mypyc/transform/copy_propagation.py
+++ b/mypyc/transform/copy_propagation.py
@@ -15,11 +15,11 @@ This can optimize away registers that are assigned to once.
 from __future__ import annotations
 
 from mypyc.ir.func_ir import FuncIR
-from mypyc.ir.ops import Assign, AssignMulti, Value
+from mypyc.ir.ops import Assign, AssignMulti, LoadErrorValue, Value
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder
 from mypyc.options import CompilerOptions
-from mypyc.transform.ir_transform import IRTransform
 from mypyc.sametype import is_same_type
+from mypyc.transform.ir_transform import IRTransform
 
 
 def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
@@ -40,7 +40,13 @@ def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
             if isinstance(op, Assign):
                 c = counts.get(op.dest, 0)
                 counts[op.dest] = c + 1
-                if c == 0 and is_same_type(op.dest.type, op.src.type):
+                # Does this look like a supported assignment?
+                # TODO: Some transform needs LoadErrorValue assignments to be preserved
+                if (
+                    c == 0
+                    and is_same_type(op.dest.type, op.src.type)
+                    and not isinstance(op.src, LoadErrorValue)
+                ):
                     replacements[op.dest] = op.src
                 elif c == 1:
                     replacements.pop(op.dest, 0)
@@ -59,7 +65,6 @@ def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
     t = CopyPropagationTransform(b, replacements)
     t.transform_blocks(fn.blocks)
     fn.blocks = b.blocks
-
 
 
 class CopyPropagationTransform(IRTransform):

--- a/mypyc/transform/copy_propagation.py
+++ b/mypyc/transform/copy_propagation.py
@@ -19,6 +19,7 @@ from mypyc.ir.ops import Assign, AssignMulti, Value
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder
 from mypyc.options import CompilerOptions
 from mypyc.transform.ir_transform import IRTransform
+from mypyc.sametype import is_same_type
 
 
 def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
@@ -39,10 +40,10 @@ def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
             if isinstance(op, Assign):
                 c = counts.get(op.dest, 0)
                 counts[op.dest] = c + 1
-                if c == 0:
+                if c == 0 and is_same_type(op.dest.type, op.src.type):
                     replacements[op.dest] = op.src
                 elif c == 1:
-                    del replacements[op.dest]
+                    replacements.pop(op.dest, 0)
             elif isinstance(op, AssignMulti):
                 # Copy propagation not supported for AssignMulti destinations
                 counts[op.dest] = 2

--- a/mypyc/transform/copy_propagation.py
+++ b/mypyc/transform/copy_propagation.py
@@ -27,7 +27,7 @@ def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
 
     # Anything with an assignment count >1 will not be optimized
     # here, as it would be require data flow analysis and we want to
-    # keep this simple & fast, at least until we've made data flow
+    # keep this simple and fast, at least until we've made data flow
     # analysis much faster.
     counts: dict[Value, int] = {}
     replacements: dict[Value, Value] = {}
@@ -41,7 +41,7 @@ def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
                 c = counts.get(op.dest, 0)
                 counts[op.dest] = c + 1
                 # Does this look like a supported assignment?
-                # TODO: Something needs LoadErrorValue assignments to be preserved
+                # TODO: Something needs LoadErrorValue assignments to be preserved?
                 if (
                     c == 0
                     and is_same_type(op.dest.type, op.src.type)
@@ -49,6 +49,7 @@ def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
                 ):
                     replacements[op.dest] = op.src
                 elif c == 1:
+                    # Too many assignments -- don't replace this one
                     replacements.pop(op.dest, 0)
             elif isinstance(op, AssignMulti):
                 # Copy propagation not supported for AssignMulti destinations
@@ -61,29 +62,31 @@ def do_copy_propagation(fn: FuncIR, options: CompilerOptions) -> None:
                     counts[op.src] = 2
                     replacements.pop(op.src, 0)
 
-    # Follow chains of propagation with multiple assignments.
+    # Follow chains of propagation with more than one assignment.
     for src, dst in list(replacements.items()):
         if counts.get(dst, 0) > 1:
+            # Not supported
             del replacements[src]
         else:
             while dst in replacements:
                 dst = replacements[dst]
                 if counts.get(dst, 0) > 1:
+                    # Not supported
                     del replacements[src]
         if src in replacements:
             replacements[src] = dst
 
-    b = LowLevelIRBuilder(None, options)
-    t = CopyPropagationTransform(b, replacements)
-    t.transform_blocks(fn.blocks)
-    fn.blocks = b.blocks
+    builder = LowLevelIRBuilder(None, options)
+    transform = CopyPropagationTransform(builder, replacements)
+    transform.transform_blocks(fn.blocks)
+    fn.blocks = builder.blocks
 
 
 class CopyPropagationTransform(IRTransform):
-    def __init__(self, builder: LowLevelIRBuilder, m: dict[Value, Value]) -> None:
+    def __init__(self, builder: LowLevelIRBuilder, map: dict[Value, Value]) -> None:
         super().__init__(builder)
-        self.op_map.update(m)
-        self.removed = set(m)
+        self.op_map.update(map)
+        self.removed = set(map)
 
     def visit_assign(self, op: Assign) -> Value | None:
         if op.dest in self.removed:

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -206,8 +206,9 @@ class IRTransform(OpVisitor[Optional[Value]]):
 
 
 class PatchVisitor(OpVisitor[None]):
-    def __init__(self, ops: dict[Value, Value | None],
-                 blocks: dict[BasicBlock, BasicBlock]) -> None:
+    def __init__(
+        self, ops: dict[Value, Value | None], blocks: dict[BasicBlock, BasicBlock]
+    ) -> None:
         self.ops: Final = ops
         self.blocks: Final = blocks
 

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -91,8 +91,8 @@ class IRTransform(OpVisitor[Value]):
             if block.error_handler is not None:
                 block.error_handler = block_map[block.error_handler]
 
-    def add(self, op: Op) -> None:
-        self.builder.add(op)
+    def add(self, op: Op) -> Value:
+        return self.builder.add(op)
 
     def visit_goto(self, op: Goto) -> Value:
         return self.add(op)
@@ -221,7 +221,7 @@ class PatchVisitor(OpVisitor[None]):
         op.label = self.fix_block(op.label)
 
     def visit_branch(self, op: Branch) -> None:
-        op.value = self.fix_block(op.value)
+        op.value = self.fix_op(op.value)
         op.true = self.fix_block(op.true)
         op.false = self.fix_block(op.false)
 
@@ -235,7 +235,7 @@ class PatchVisitor(OpVisitor[None]):
         op.src = self.fix_op(op.src)
 
     def visit_assign_multi(self, op: AssignMulti) -> None:
-        op.src = [self.fix_op(s) for s in self.fix_op(op.src)]
+        op.src = [self.fix_op(s) for s in op.src]
 
     def visit_load_error_value(self, op: LoadErrorValue) -> None:
         pass
@@ -289,7 +289,7 @@ class PatchVisitor(OpVisitor[None]):
             op.value = self.fix_op(op.value)
 
     def visit_call_c(self, op: CallC) -> None:
-        op.args [self.fix_op(arg) for arg in op.args]
+        op.args = [self.fix_op(arg) for arg in op.args]
 
     def visit_truncate(self, op: Truncate) -> None:
         op.src = self.fix_op(op.src)

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -6,7 +6,7 @@ any IR changes. The default implementations implement an identity transform.
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Final, Optional
 
 from mypyc.ir.ops import (
     Assign,
@@ -54,7 +54,7 @@ from mypyc.ir.ops import (
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder
 
 
-class IRTransform(OpVisitor[Value]):
+class IRTransform(OpVisitor[Optional[Value]]):
     """Identity transform.
 
     Subclass and override to perform changes to IR.
@@ -65,14 +65,15 @@ class IRTransform(OpVisitor[Value]):
 
     def __init__(self, builder: LowLevelIRBuilder) -> None:
         self.builder = builder
+        self.op_map: dict[Value, Value | None] = {}
 
     def transform_blocks(self, blocks: list[BasicBlock]) -> None:
         """Transform basic blocks that represent a single function.
 
         The result of the transform will be collected at self.builder.blocks.
         """
-        op_map: dict[Value, Value] = {}
         block_map: dict[BasicBlock, BasicBlock] = {}
+        op_map = self.op_map
         for block in blocks:
             new_block = BasicBlock()
             block_map[block] = new_block
@@ -104,113 +105,116 @@ class IRTransform(OpVisitor[Value]):
     def visit_unreachable(self, op: Unreachable) -> Value:
         return self.add(op)
 
-    def visit_assign(self, op: Assign) -> Value:
+    def visit_assign(self, op: Assign) -> Value | None:
         return self.add(op)
 
-    def visit_assign_multi(self, op: AssignMulti) -> Value:
+    def visit_assign_multi(self, op: AssignMulti) -> Value | None:
         return self.add(op)
 
-    def visit_load_error_value(self, op: LoadErrorValue) -> Value:
+    def visit_load_error_value(self, op: LoadErrorValue) -> Value | None:
         return self.add(op)
 
-    def visit_load_literal(self, op: LoadLiteral) -> Value:
+    def visit_load_literal(self, op: LoadLiteral) -> Value | None:
         return self.add(op)
 
-    def visit_get_attr(self, op: GetAttr) -> Value:
+    def visit_get_attr(self, op: GetAttr) -> Value | None:
         return self.add(op)
 
-    def visit_set_attr(self, op: SetAttr) -> Value:
+    def visit_set_attr(self, op: SetAttr) -> Value | None:
         return self.add(op)
 
-    def visit_load_static(self, op: LoadStatic) -> Value:
+    def visit_load_static(self, op: LoadStatic) -> Value | None:
         return self.add(op)
 
-    def visit_init_static(self, op: InitStatic) -> Value:
+    def visit_init_static(self, op: InitStatic) -> Value | None:
         return self.add(op)
 
-    def visit_tuple_get(self, op: TupleGet) -> Value:
+    def visit_tuple_get(self, op: TupleGet) -> Value | None:
         return self.add(op)
 
-    def visit_tuple_set(self, op: TupleSet) -> Value:
+    def visit_tuple_set(self, op: TupleSet) -> Value | None:
         return self.add(op)
 
-    def visit_inc_ref(self, op: IncRef) -> Value:
+    def visit_inc_ref(self, op: IncRef) -> Value | None:
         return self.add(op)
 
-    def visit_dec_ref(self, op: DecRef) -> Value:
+    def visit_dec_ref(self, op: DecRef) -> Value | None:
         return self.add(op)
 
-    def visit_call(self, op: Call) -> Value:
+    def visit_call(self, op: Call) -> Value | None:
         return self.add(op)
 
-    def visit_method_call(self, op: MethodCall) -> Value:
+    def visit_method_call(self, op: MethodCall) -> Value | None:
         return self.add(op)
 
-    def visit_cast(self, op: Cast) -> Value:
+    def visit_cast(self, op: Cast) -> Value | None:
         return self.add(op)
 
-    def visit_box(self, op: Box) -> Value:
+    def visit_box(self, op: Box) -> Value | None:
         return self.add(op)
 
-    def visit_unbox(self, op: Unbox) -> Value:
+    def visit_unbox(self, op: Unbox) -> Value | None:
         return self.add(op)
 
-    def visit_raise_standard_error(self, op: RaiseStandardError) -> Value:
+    def visit_raise_standard_error(self, op: RaiseStandardError) -> Value | None:
         return self.add(op)
 
-    def visit_call_c(self, op: CallC) -> Value:
+    def visit_call_c(self, op: CallC) -> Value | None:
         return self.add(op)
 
-    def visit_truncate(self, op: Truncate) -> Value:
+    def visit_truncate(self, op: Truncate) -> Value | None:
         return self.add(op)
 
-    def visit_extend(self, op: Extend) -> Value:
+    def visit_extend(self, op: Extend) -> Value | None:
         return self.add(op)
 
-    def visit_load_global(self, op: LoadGlobal) -> Value:
+    def visit_load_global(self, op: LoadGlobal) -> Value | None:
         return self.add(op)
 
-    def visit_int_op(self, op: IntOp) -> Value:
+    def visit_int_op(self, op: IntOp) -> Value | None:
         return self.add(op)
 
-    def visit_comparison_op(self, op: ComparisonOp) -> Value:
+    def visit_comparison_op(self, op: ComparisonOp) -> Value | None:
         return self.add(op)
 
-    def visit_float_op(self, op: FloatOp) -> Value:
+    def visit_float_op(self, op: FloatOp) -> Value | None:
         return self.add(op)
 
-    def visit_float_neg(self, op: FloatNeg) -> Value:
+    def visit_float_neg(self, op: FloatNeg) -> Value | None:
         return self.add(op)
 
-    def visit_float_comparison_op(self, op: FloatComparisonOp) -> Value:
+    def visit_float_comparison_op(self, op: FloatComparisonOp) -> Value | None:
         return self.add(op)
 
-    def visit_load_mem(self, op: LoadMem) -> Value:
+    def visit_load_mem(self, op: LoadMem) -> Value | None:
         return self.add(op)
 
-    def visit_set_mem(self, op: SetMem) -> Value:
+    def visit_set_mem(self, op: SetMem) -> Value | None:
         return self.add(op)
 
-    def visit_get_element_ptr(self, op: GetElementPtr) -> Value:
+    def visit_get_element_ptr(self, op: GetElementPtr) -> Value | None:
         return self.add(op)
 
-    def visit_load_address(self, op: LoadAddress) -> Value:
+    def visit_load_address(self, op: LoadAddress) -> Value | None:
         return self.add(op)
 
-    def visit_keep_alive(self, op: KeepAlive) -> Value:
+    def visit_keep_alive(self, op: KeepAlive) -> Value | None:
         return self.add(op)
 
-    def visit_unborrow(self, op: Unborrow) -> Value:
+    def visit_unborrow(self, op: Unborrow) -> Value | None:
         return self.add(op)
 
 
 class PatchVisitor(OpVisitor[None]):
-    def __init__(self, ops: dict[Value, Value], blocks: dict[BasicBlock, BasicBlock]) -> None:
+    def __init__(self, ops: dict[Value, Value | None],
+                 blocks: dict[BasicBlock, BasicBlock]) -> None:
         self.ops: Final = ops
         self.blocks: Final = blocks
 
     def fix_op(self, op: Value) -> Value:
-        return self.ops.get(op, op)
+        new = self.ops.get(op, op)
+        assert new is not None, "use of removed op"
+        return new
 
     def fix_block(self, block: BasicBlock) -> BasicBlock:
         return self.blocks.get(block, block)

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -1,4 +1,4 @@
-"""Generic IR to IR transform.
+"""Helpers for implementing generic IR to IR transforms.
 
 Subclass IRTransform and override any OpVisitor visit_* methods that perform
 any IR changes. The default implementations implement an identity transform.
@@ -43,7 +43,6 @@ from mypyc.ir.ops import (
     MethodCall,
     Op,
     OpVisitor,
-    PrimitiveOp,
     RaiseStandardError,
     RegisterOp,
     Return,
@@ -83,7 +82,8 @@ class IRTransform(OpVisitor[Value]):
             self.builder.activate_block(new_block)
             for op in block.ops:
                 new_op = op.accept(self)
-                op_map[op] = new_op
+                if new_op is not op:
+                    op_map[op] = new_op
         patcher = PatchVisitor(op_map, block_map)
         for block in self.builder.blocks:
             for op in block.ops:
@@ -91,137 +91,119 @@ class IRTransform(OpVisitor[Value]):
             if block.error_handler is not None:
                 block.error_handler = block_map[block.error_handler]
 
+    def add(self, op: Op) -> None:
+        self.builder.add(op)
+
     def visit_goto(self, op: Goto) -> Value:
-        return Goto(op.label, op.line)
+        return self.add(op)
 
     def visit_branch(self, op: Branch) -> Value:
-        new = Branch(op.value, op.true, op.false, op.op, op.line, rare=op.rare)
-        new.negated = op.negated
-        new.traceback_entry = op.traceback_entry
-        return self.builder.add(new)
+        return self.add(op)
 
     def visit_return(self, op: Return) -> Value:
-        return self.builder.add(Return(op.value, op.line))
+        return self.add(op)
 
     def visit_unreachable(self, op: Unreachable) -> Value:
-        return self.builder.add(Unreachable(op.line))
+        return self.add(op)
 
     def visit_assign(self, op: Assign) -> Value:
-        return self.builder.add(Assign(op.dest, op.src, op.line))
+        return self.add(op)
 
     def visit_assign_multi(self, op: AssignMulti) -> Value:
-        return self.builder.add(AssignMulti(op.dest, op.src, op.line))
+        return self.add(op)
 
     def visit_load_error_value(self, op: LoadErrorValue) -> Value:
-        assert False # TODO
+        return self.add(op)
 
     def visit_load_literal(self, op: LoadLiteral) -> Value:
-        assert False # TODO
+        return self.add(op)
 
     def visit_get_attr(self, op: GetAttr) -> Value:
-        assert False # TODO
+        return self.add(op)
 
     def visit_set_attr(self, op: SetAttr) -> Value:
-        assert False # TODO
+        return self.add(op)
 
     def visit_load_static(self, op: LoadStatic) -> Value:
-        assert False # TODO
+        return self.add(op)
 
     def visit_init_static(self, op: InitStatic) -> Value:
-        assert False # TODO
+        return self.add(op)
 
     def visit_tuple_get(self, op: TupleGet) -> Value:
-        assert False # TODO
+        return self.add(op)
 
     def visit_tuple_set(self, op: TupleSet) -> Value:
-        assert False # TODO
+        return self.add(op)
 
     def visit_inc_ref(self, op: IncRef) -> Value:
-        return self.builder.add(IncRef(op.src, op.line))
+        return self.add(op)
 
     def visit_dec_ref(self, op: DecRef) -> Value:
-        return self.builder.add(DecRef(src=op.src, is_xdec=op.is_xdec, line=op.line))
+        return self.add(op)
 
     def visit_call(self, op: Call) -> Value:
-        new = Call(op.fn, op.args, op.line)
-        new.error_kind = op.error_kind
-        new.type = op.type
-        return self.builder.add(new)
+        return self.add(op)
 
     def visit_method_call(self, op: MethodCall) -> Value:
-        new = MethodCall(op.obj, op.method, op.args, op.line)
-        new.receiver_type = op.receiver_type
-        new.type = op.type
-        new.error_kind = op.error_kind
-        return self.builder.add(new)
+        return self.add(op)
 
     def visit_cast(self, op: Cast) -> Value:
-        return self.builder.add(Cast(op.src, op.type, op.line, borrow=op.is_borrowed))
+        return self.add(op)
 
     def visit_box(self, op: Box) -> Value:
-        return self.builder.add(Box(op.src, op.line))
+        return self.add(op)
 
     def visit_unbox(self, op: Unbox) -> Value:
-        return self.builder.add(Unbox(op.src, op.type, op.line))
+        return self.add(op)
 
     def visit_raise_standard_error(self, op: RaiseStandardError) -> Value:
-        return self.builder.add(RaiseStandardError(op.class_name, op.value, op.line))
+        return self.add(op)
 
     def visit_call_c(self, op: CallC) -> Value:
-        return self.builder.add(CallC(function_name=op.function_name,
-                     args=op.args,
-                     ret_type=op.type,
-                     steals=op.steals,
-                     is_borrowed=op.is_borrowed,
-                     error_kind=op.error_kind,
-                     line=op.line,
-                     var_arg_idx=op.var_arg_idx))
-
-    def visit_primitive_op(self, op: PrimitiveOp) -> Value:
-        return self.builder.add(PrimitiveOp(op.args, op.desc, op.type_args, op.line))
+        return self.add(op)
 
     def visit_truncate(self, op: Truncate) -> Value:
-        return self.builder.add(Truncate(op.src, op.type, op.line))
+        return self.add(op)
 
     def visit_extend(self, op: Extend) -> Value:
-        return self.builder.add(Extend(op.src, op.type, signed=op.signed, line=op.line))
+        return self.add(op)
 
     def visit_load_global(self, op: LoadGlobal) -> Value:
-        return self.builder.add(LoadGlobal(op.type, op.identifier, line=op.line, ann=op.ann))
+        return self.add(op)
 
     def visit_int_op(self, op: IntOp) -> Value:
-        return self.builder.add(IntOp(type=op.type, lhs=op.lhs, rhs=op.rhs, op=op.op,
-                                      line=op.line))
+        return self.add(op)
 
     def visit_comparison_op(self, op: ComparisonOp) -> Value:
-        return self.builder.add(ComparisonOp(lhs=op.lhs, rhs=op.rhs, op=op.op, line=op.line))
+        return self.add(op)
 
     def visit_float_op(self, op: FloatOp) -> Value:
-        return self.builder.add(FloatOp(lhs=op.lhs, rhs=op.rhs, op=op.op, line=op.line))
+        return self.add(op)
 
     def visit_float_neg(self, op: FloatNeg) -> Value:
-        return self.builder.add(FloatNeg(op.src, op.line))
+        return self.add(op)
 
     def visit_float_comparison_op(self, op: FloatComparisonOp) -> Value:
-        return self.builder.add(FloatComparisonOp(lhs=op.lhs, rhs=op.rhs, op=op.op, line=op.line))
+        return self.add(op)
 
     def visit_load_mem(self, op: LoadMem) -> Value:
-        return self.builder.add(LoadMem(op.type, op.src, op.line))
+        return self.add(op)
 
     def visit_set_mem(self, op: SetMem) -> Value:
-        return self.builder.add(SetMem(op.dest_type, op.dest, op.src, op.line))
+        return self.add(op)
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> Value:
-        return self.builder.add(GetElementPtr(op.src, op.src_type, op.field, op.line))
+        return self.add(op)
 
     def visit_load_address(self, op: LoadAddress) -> Value:
-        return self.builder.add(LoadAddress(op.type, op.src, op.line))
+        return self.add(op)
 
     def visit_keep_alive(self, op: KeepAlive) -> Value:
-        return self.builder.add(KeepAlive(op.src, steal=op.steal))
+        return self.add(op)
 
     def visit_unborrow(self, op: Unborrow) -> Value:
-        return self.builder.add(Unborrow(op.src, op.line))
+        return self.add(op)
 
 
 class PatchVisitor(OpVisitor[None]):
@@ -229,26 +211,31 @@ class PatchVisitor(OpVisitor[None]):
         self.ops: Final = ops
         self.blocks: Final = blocks
 
+    def fix_op(self, op: Value) -> Value:
+        return self.ops.get(op, op)
+
+    def fix_block(self, block: BasicBlock) -> BasicBlock:
+        return self.blocks.get(block, block)
+
     def visit_goto(self, op: Goto) -> None:
-        op.label = self.blocks.get(op.label, op.label)
+        op.label = self.fix_block(op.label)
 
     def visit_branch(self, op: Branch) -> None:
-        op.value = self.ops.get(op.value, op.value)
-        op.true = self.blocks.get(op.true, op.true)
-        op.false = self.blocks.get(op.false, op.false)
+        op.value = self.fix_block(op.value)
+        op.true = self.fix_block(op.true)
+        op.false = self.fix_block(op.false)
 
     def visit_return(self, op: Return) -> None:
-        op.value = self.ops.get(op.value, op.value)
+        op.value = self.fix_op(op.value)
 
     def visit_unreachable(self, op: Unreachable) -> None:
         pass
 
     def visit_assign(self, op: Assign) -> None:
-        # TODO
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_assign_multi(self, op: AssignMulti) -> None:
-        raise NotImplementedError
+        op.src = [self.fix_op(s) for s in self.fix_op(op.src)]
 
     def visit_load_error_value(self, op: LoadErrorValue) -> None:
         pass
@@ -257,93 +244,99 @@ class PatchVisitor(OpVisitor[None]):
         pass
 
     def visit_get_attr(self, op: GetAttr) -> None:
-        op.obj = self.ops.get(op.obj, op.obj)
+        op.obj = self.fix_op(op.obj)
 
     def visit_set_attr(self, op: SetAttr) -> None:
-        op.obj = self.ops.get(op.obj, op.obj)
-        op.src = self.ops.get(op.src, op.src)
+        op.obj = self.fix_op(op.obj)
+        op.src = self.fix_op(op.src)
 
     def visit_load_static(self, op: LoadStatic) -> None:
         pass
 
     def visit_init_static(self, op: InitStatic) -> None:
-        op.value = self.ops.get(op.value, op.value)
+        op.value = self.fix_op(op.value)
 
     def visit_tuple_get(self, op: TupleGet) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_tuple_set(self, op: TupleSet) -> None:
-        raise NotImplementedError
+        op.items = [self.fix_op(item) for item in op.items]
 
     def visit_inc_ref(self, op: IncRef) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_dec_ref(self, op: DecRef) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_call(self, op: Call) -> None:
-        raise NotImplementedError
+        op.args = [self.fix_op(arg) for arg in op.args]
 
     def visit_method_call(self, op: MethodCall) -> None:
-        raise NotImplementedError
+        op.obj = self.fix_op(op.obj)
+        op.args = [self.fix_op(arg) for arg in op.args]
 
     def visit_cast(self, op: Cast) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_box(self, op: Box) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_unbox(self, op: Unbox) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_raise_standard_error(self, op: RaiseStandardError) -> None:
         if isinstance(op.value, Value):
-            op.value = self.ops.get(op.value, op.value)
+            op.value = self.fix_op(op.value)
 
     def visit_call_c(self, op: CallC) -> None:
-        raise NotImplementedError
-
-    def visit_primitive_op(self, op: PrimitiveOp) -> None:
-        raise NotImplementedError
+        op.args [self.fix_op(arg) for arg in op.args]
 
     def visit_truncate(self, op: Truncate) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_extend(self, op: Extend) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_load_global(self, op: LoadGlobal) -> None:
-        raise NotImplementedError
+        pass
 
     def visit_int_op(self, op: IntOp) -> None:
-        raise NotImplementedError
+        op.lhs = self.fix_op(op.lhs)
+        op.rhs = self.fix_op(op.rhs)
 
     def visit_comparison_op(self, op: ComparisonOp) -> None:
-        raise NotImplementedError
+        op.lhs = self.fix_op(op.lhs)
+        op.rhs = self.fix_op(op.rhs)
 
     def visit_float_op(self, op: FloatOp) -> None:
-        raise NotImplementedError
+        op.lhs = self.fix_op(op.lhs)
+        op.rhs = self.fix_op(op.rhs)
 
     def visit_float_neg(self, op: FloatNeg) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_float_comparison_op(self, op: FloatComparisonOp) -> None:
-        raise NotImplementedError
+        op.lhs = self.fix_op(op.lhs)
+        op.rhs = self.fix_op(op.rhs)
 
     def visit_load_mem(self, op: LoadMem) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_set_mem(self, op: SetMem) -> None:
-        raise NotImplementedError
+        op.dest = self.fix_op(op.dest)
+        op.src = self.fix_op(op.src)
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> None:
-        raise NotImplementedError
+        op.src = self.fix_op(op.src)
 
     def visit_load_address(self, op: LoadAddress) -> None:
-        raise NotImplementedError
+        if isinstance(op.src, LoadStatic):
+            new = self.fix_op(op.src)
+            assert isinstance(new, LoadStatic)
+            op.src = new
 
     def visit_keep_alive(self, op: KeepAlive) -> None:
-        op.src = [self.ops.get(s, s) for s in op.src]
+        op.src = [self.fix_op(s) for s in op.src]
 
     def visit_unborrow(self, op: Unborrow) -> None:
-        op.src = self.ops.get(op.src, op.src)
+        op.src = self.fix_op(op.src)

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -67,6 +67,10 @@ class IRTransform(OpVisitor[Value]):
         self.builder = builder
 
     def transform_blocks(self, blocks: list[BasicBlock]) -> None:
+        """Transform basic blocks that represent a single function.
+
+        The result of the transform will be collected at self.builder.blocks.
+        """
         op_map: dict[Value, Value] = {}
         block_map: dict[BasicBlock, BasicBlock] = {}
         for block in blocks:

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -1,0 +1,349 @@
+"""Generic IR to IR transform.
+
+Subclass IRTransform and override any OpVisitor visit_* methods that perform
+any IR changes. The default implementations implement an identity transform.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from mypyc.irbuild.ll_builder import LowLevelIRBuilder
+from mypyc.ir.ops import (
+    Assign,
+    AssignMulti,
+    BasicBlock,
+    Box,
+    Branch,
+    Call,
+    CallC,
+    Cast,
+    ComparisonOp,
+    ControlOp,
+    Extend,
+    Float,
+    FloatComparisonOp,
+    FloatNeg,
+    FloatOp,
+    GetAttr,
+    GetElementPtr,
+    Goto,
+    IncRef,
+    DecRef,
+    InitStatic,
+    Integer,
+    IntOp,
+    KeepAlive,
+    LoadAddress,
+    LoadErrorValue,
+    LoadGlobal,
+    LoadLiteral,
+    LoadMem,
+    LoadStatic,
+    MethodCall,
+    Op,
+    OpVisitor,
+    PrimitiveOp,
+    RaiseStandardError,
+    RegisterOp,
+    Return,
+    SetAttr,
+    SetMem,
+    Truncate,
+    TupleGet,
+    TupleSet,
+    Unborrow,
+    Unbox,
+    Unreachable,
+    Value,
+)
+
+
+
+class IRTransform(OpVisitor[Value]):
+    """Identity transform.
+
+    Subclass and override to perform changes to IR.
+
+    You can retain old BasicBlock and op references in ops. The transform
+    will automatically patch these for you as needed.
+    """
+
+    def __init__(self, builder: LowLevelIRBuilder) -> None:
+        self.builder = builder
+
+    def transform_blocks(self,
+                         blocks: list[BasicBlock]) -> None:
+        op_map: dict[Value, Value] = {}
+        block_map: dict[BasicBlock, BasicBlock] = {}
+        for block in blocks:
+            new_block = BasicBlock()
+            new_block.error_handler = block.error_handler
+            block_map[block] = new_block
+            self.builder.activate_block(new_block)
+            for op in block.ops:
+                new_op = op.accept(self)
+                op_map[op] = new_op
+        patcher = PatchVisitor(op_map, block_map)
+        for block in self.builder.blocks:
+            for op in block.ops:
+                op.accept(patcher)
+            if block.error_handler is not None:
+                block.error_handler = block_map[block.error_handler]
+
+    def visit_goto(self, op: Goto) -> Value:
+        return Goto(op.label, op.line)
+
+    def visit_branch(self, op: Branch) -> Value:
+        new = Branch(op.value, op.true, op.false, op.op, op.line, rare=op.rare)
+        new.negated = op.negated
+        new.traceback_entry = op.traceback_entry
+        return self.builder.add(new)
+
+    def visit_return(self, op: Return) -> Value:
+        return self.builder.add(Return(op.value, op.line))
+
+    def visit_unreachable(self, op: Unreachable) -> Value:
+        return self.builder.add(Unreachable(op.line))
+
+    def visit_assign(self, op: Assign) -> Value:
+        return self.builder.add(Assign(op.dest, op.src, op.line))
+
+    def visit_assign_multi(self, op: AssignMulti) -> Value:
+        return self.builder.add(AssignMulti(op.dest, op.src, op.line))
+
+    def visit_load_error_value(self, op: LoadErrorValue) -> Value:
+        assert False # TODO
+
+    def visit_load_literal(self, op: LoadLiteral) -> Value:
+        assert False # TODO
+
+    def visit_get_attr(self, op: GetAttr) -> Value:
+        assert False # TODO
+
+    def visit_set_attr(self, op: SetAttr) -> Value:
+        assert False # TODO
+
+    def visit_load_static(self, op: LoadStatic) -> Value:
+        assert False # TODO
+
+    def visit_init_static(self, op: InitStatic) -> Value:
+        assert False # TODO
+
+    def visit_tuple_get(self, op: TupleGet) -> Value:
+        assert False # TODO
+
+    def visit_tuple_set(self, op: TupleSet) -> Value:
+        assert False # TODO
+
+    def visit_inc_ref(self, op: IncRef) -> Value:
+        return self.builder.add(IncRef(op.src, op.line))
+
+    def visit_dec_ref(self, op: DecRef) -> Value:
+        return self.builder.add(DecRef(src=op.src, is_xdec=op.is_xdec, line=op.line))
+
+    def visit_call(self, op: Call) -> Value:
+        new = Call(op.fn, op.args, op.line)
+        new.error_kind = op.error_kind
+        new.type = op.type
+        return self.builder.add(new)
+
+    def visit_method_call(self, op: MethodCall) -> Value:
+        new = MethodCall(op.obj, op.method, op.args, op.line)
+        new.receiver_type = op.receiver_type
+        new.type = op.type
+        new.error_kind = op.error_kind
+        return self.builder.add(new)
+
+    def visit_cast(self, op: Cast) -> Value:
+        return self.builder.add(Cast(op.src, op.type, op.line, borrow=op.is_borrowed))
+
+    def visit_box(self, op: Box) -> Value:
+        return self.builder.add(Box(op.src, op.line))
+
+    def visit_unbox(self, op: Unbox) -> Value:
+        return self.builder.add(Unbox(op.src, op.type, op.line))
+
+    def visit_raise_standard_error(self, op: RaiseStandardError) -> Value:
+        return self.builder.add(RaiseStandardError(op.class_name, op.value, op.line))
+
+    def visit_call_c(self, op: CallC) -> Value:
+        return self.builder.add(CallC(function_name=op.function_name,
+                     args=op.args,
+                     ret_type=op.type,
+                     steals=op.steals,
+                     is_borrowed=op.is_borrowed,
+                     error_kind=op.error_kind,
+                     line=op.line,
+                     var_arg_idx=op.var_arg_idx))
+
+    def visit_primitive_op(self, op: PrimitiveOp) -> Value:
+        return self.builder.add(PrimitiveOp(op.args, op.desc, op.type_args, op.line))
+
+    def visit_truncate(self, op: Truncate) -> Value:
+        return self.builder.add(Truncate(op.src, op.type, op.line))
+
+    def visit_extend(self, op: Extend) -> Value:
+        return self.builder.add(Extend(op.src, op.type, signed=op.signed, line=op.line))
+
+    def visit_load_global(self, op: LoadGlobal) -> Value:
+        return self.builder.add(LoadGlobal(op.type, op.identifier, line=op.line, ann=op.ann))
+
+    def visit_int_op(self, op: IntOp) -> Value:
+        return self.builder.add(IntOp(type=op.type, lhs=op.lhs, rhs=op.rhs, op=op.op,
+                                      line=op.line))
+
+    def visit_comparison_op(self, op: ComparisonOp) -> Value:
+        return self.builder.add(ComparisonOp(lhs=op.lhs, rhs=op.rhs, op=op.op, line=op.line))
+
+    def visit_float_op(self, op: FloatOp) -> Value:
+        return self.builder.add(FloatOp(lhs=op.lhs, rhs=op.rhs, op=op.op, line=op.line))
+
+    def visit_float_neg(self, op: FloatNeg) -> Value:
+        return self.builder.add(FloatNeg(op.src, op.line))
+
+    def visit_float_comparison_op(self, op: FloatComparisonOp) -> Value:
+        return self.builder.add(FloatComparisonOp(lhs=op.lhs, rhs=op.rhs, op=op.op, line=op.line))
+
+    def visit_load_mem(self, op: LoadMem) -> Value:
+        return self.builder.add(LoadMem(op.type, op.src, op.line))
+
+    def visit_set_mem(self, op: SetMem) -> Value:
+        return self.builder.add(SetMem(op.dest_type, op.dest, op.src, op.line))
+
+    def visit_get_element_ptr(self, op: GetElementPtr) -> Value:
+        return self.builder.add(GetElementPtr(op.src, op.src_type, op.field, op.line))
+
+    def visit_load_address(self, op: LoadAddress) -> Value:
+        return self.builder.add(LoadAddress(op.type, op.src, op.line))
+
+    def visit_keep_alive(self, op: KeepAlive) -> Value:
+        return self.builder.add(KeepAlive(op.src, steal=op.steal))
+
+    def visit_unborrow(self, op: Unborrow) -> Value:
+        return self.builder.add(Unborrow(op.src, op.line))
+
+
+class PatchVisitor(OpVisitor[None]):
+    def __init__(self, ops: dict[Value, Value], blocks: dict[BasicBlock, BasicBlock]) -> None:
+        self.ops: Final = ops
+        self.blocks: Final = blocks
+
+    def visit_goto(self, op: Goto) -> None:
+        op.label = self.blocks.get(op.label, op.label)
+
+    def visit_branch(self, op: Branch) -> None:
+        op.value = self.ops.get(op.value, op.value)
+        op.true = self.blocks.get(op.true, op.true)
+        op.false = self.blocks.get(op.false, op.false)
+
+    def visit_return(self, op: Return) -> None:
+        op.value = self.ops.get(op.value, op.value)
+
+    def visit_unreachable(self, op: Unreachable) -> None:
+        pass
+
+    def visit_assign(self, op: Assign) -> None:
+        # TODO
+        raise NotImplementedError
+
+    def visit_assign_multi(self, op: AssignMulti) -> None:
+        raise NotImplementedError
+
+    def visit_load_error_value(self, op: LoadErrorValue) -> None:
+        pass
+
+    def visit_load_literal(self, op: LoadLiteral) -> None:
+        pass
+
+    def visit_get_attr(self, op: GetAttr) -> None:
+        op.obj = self.ops.get(op.obj, op.obj)
+
+    def visit_set_attr(self, op: SetAttr) -> None:
+        op.obj = self.ops.get(op.obj, op.obj)
+        op.src = self.ops.get(op.src, op.src)
+
+    def visit_load_static(self, op: LoadStatic) -> None:
+        pass
+
+    def visit_init_static(self, op: InitStatic) -> None:
+        op.value = self.ops.get(op.value, op.value)
+
+    def visit_tuple_get(self, op: TupleGet) -> None:
+        raise NotImplementedError
+
+    def visit_tuple_set(self, op: TupleSet) -> None:
+        raise NotImplementedError
+
+    def visit_inc_ref(self, op: IncRef) -> None:
+        raise NotImplementedError
+
+    def visit_dec_ref(self, op: DecRef) -> None:
+        raise NotImplementedError
+
+    def visit_call(self, op: Call) -> None:
+        raise NotImplementedError
+
+    def visit_method_call(self, op: MethodCall) -> None:
+        raise NotImplementedError
+
+    def visit_cast(self, op: Cast) -> None:
+        raise NotImplementedError
+
+    def visit_box(self, op: Box) -> None:
+        raise NotImplementedError
+
+    def visit_unbox(self, op: Unbox) -> None:
+        raise NotImplementedError
+
+    def visit_raise_standard_error(self, op: RaiseStandardError) -> None:
+        if isinstance(op.value, Value):
+            op.value = self.ops.get(op.value, op.value)
+
+    def visit_call_c(self, op: CallC) -> None:
+        raise NotImplementedError
+
+    def visit_primitive_op(self, op: PrimitiveOp) -> None:
+        raise NotImplementedError
+
+    def visit_truncate(self, op: Truncate) -> None:
+        raise NotImplementedError
+
+    def visit_extend(self, op: Extend) -> None:
+        raise NotImplementedError
+
+    def visit_load_global(self, op: LoadGlobal) -> None:
+        raise NotImplementedError
+
+    def visit_int_op(self, op: IntOp) -> None:
+        raise NotImplementedError
+
+    def visit_comparison_op(self, op: ComparisonOp) -> None:
+        raise NotImplementedError
+
+    def visit_float_op(self, op: FloatOp) -> None:
+        raise NotImplementedError
+
+    def visit_float_neg(self, op: FloatNeg) -> None:
+        raise NotImplementedError
+
+    def visit_float_comparison_op(self, op: FloatComparisonOp) -> None:
+        raise NotImplementedError
+
+    def visit_load_mem(self, op: LoadMem) -> None:
+        raise NotImplementedError
+
+    def visit_set_mem(self, op: SetMem) -> None:
+        raise NotImplementedError
+
+    def visit_get_element_ptr(self, op: GetElementPtr) -> None:
+        raise NotImplementedError
+
+    def visit_load_address(self, op: LoadAddress) -> None:
+        raise NotImplementedError
+
+    def visit_keep_alive(self, op: KeepAlive) -> None:
+        op.src = [self.ops.get(s, s) for s in op.src]
+
+    def visit_unborrow(self, op: Unborrow) -> None:
+        op.src = self.ops.get(op.src, op.src)

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -70,7 +70,7 @@ class IRTransform(OpVisitor[Optional[Value]]):
     def __init__(self, builder: LowLevelIRBuilder) -> None:
         self.builder = builder
         # Subclasses add additional op mappings here. A None value indicates
-        # that the op is deleted.
+        # that the op/register is deleted.
         self.op_map: dict[Value, Value | None] = {}
 
     def transform_blocks(self, blocks: list[BasicBlock]) -> None:

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -58,7 +58,6 @@ from mypyc.ir.ops import (
 )
 
 
-
 class IRTransform(OpVisitor[Value]):
     """Identity transform.
 
@@ -71,8 +70,7 @@ class IRTransform(OpVisitor[Value]):
     def __init__(self, builder: LowLevelIRBuilder) -> None:
         self.builder = builder
 
-    def transform_blocks(self,
-                         blocks: list[BasicBlock]) -> None:
+    def transform_blocks(self, blocks: list[BasicBlock]) -> None:
         op_map: dict[Value, Value] = {}
         block_map: dict[BasicBlock, BasicBlock] = {}
         for block in blocks:

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import Final
 
-from mypyc.irbuild.ll_builder import LowLevelIRBuilder
 from mypyc.ir.ops import (
     Assign,
     AssignMulti,
@@ -19,9 +18,8 @@ from mypyc.ir.ops import (
     CallC,
     Cast,
     ComparisonOp,
-    ControlOp,
+    DecRef,
     Extend,
-    Float,
     FloatComparisonOp,
     FloatNeg,
     FloatOp,
@@ -29,9 +27,7 @@ from mypyc.ir.ops import (
     GetElementPtr,
     Goto,
     IncRef,
-    DecRef,
     InitStatic,
-    Integer,
     IntOp,
     KeepAlive,
     LoadAddress,
@@ -44,7 +40,6 @@ from mypyc.ir.ops import (
     Op,
     OpVisitor,
     RaiseStandardError,
-    RegisterOp,
     Return,
     SetAttr,
     SetMem,
@@ -56,6 +51,7 @@ from mypyc.ir.ops import (
     Unreachable,
     Value,
 )
+from mypyc.irbuild.ll_builder import LowLevelIRBuilder
 
 
 class IRTransform(OpVisitor[Value]):

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -75,9 +75,9 @@ class IRTransform(OpVisitor[Value]):
         block_map: dict[BasicBlock, BasicBlock] = {}
         for block in blocks:
             new_block = BasicBlock()
-            new_block.error_handler = block.error_handler
             block_map[block] = new_block
             self.builder.activate_block(new_block)
+            new_block.error_handler = block.error_handler
             for op in block.ops:
                 new_op = op.accept(self)
                 if new_op is not op:
@@ -87,7 +87,7 @@ class IRTransform(OpVisitor[Value]):
             for op in block.ops:
                 op.accept(patcher)
             if block.error_handler is not None:
-                block.error_handler = block_map[block.error_handler]
+                block.error_handler = block_map.get(block.error_handler, block.error_handler)
 
     def add(self, op: Op) -> Value:
         return self.builder.add(op)


### PR DESCRIPTION
This makes it easy to define simple IR-to-IR transforms by subclassing `IRTansform` and overriding some visit methods.

Add an implementation of a simple copy propagation optimization as an example.

This will be used by the implementation of mypyc/mypyc#854, and this can also be used for various optimizations.

The IR transform preserves the identities of ops that are not modified. This means that the old IR is no longer valid after the transform, but the transform can be fast since we don't need to allocate many objects if only a small subset of ops will be modified by a transform.