### PR TITLE
attrs: Fix emulating hash method logic

### DIFF
--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3015,7 +3015,7 @@ class NoInit:
 class NoCmp:
     x: int
 
-[builtins fixtures/list.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 [rechecked]
 [stale]
 [out1]

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -2460,3 +2460,18 @@ class B(A):
 reveal_type(B.__hash__)  # N: Revealed type is "None"
 
 [builtins fixtures/plugin_attrs.pyi]
+
+[case testUnsafeHashPrecedence]
+from attrs import define, frozen
+
+@define(unsafe_hash=True, hash=False)
+class A:
+    pass
+reveal_type(A.__hash__)  # N: Revealed type is "def (self: builtins.object) -> builtins.int"
+
+@define(unsafe_hash=False, hash=True)
+class B:
+    pass
+reveal_type(B.__hash__)  # N: Revealed type is "None"
+
+[builtins fixtures/plugin_attrs.pyi]

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -360,7 +360,8 @@ class A:
 
 a = A(5)
 a.a = 16  # E: Property "a" defined in "A" is read-only
-[builtins fixtures/bool.pyi]
+[builtins fixtures/plugin_attrs.pyi]
+
 [case testAttrsNextGenFrozen]
 from attr import frozen, field
 
@@ -370,7 +371,7 @@ class A:
 
 a = A(5)
 a.a = 16  # E: Property "a" defined in "A" is read-only
-[builtins fixtures/bool.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsNextGenDetect]
 from attr import define, field
@@ -420,7 +421,7 @@ reveal_type(A)  # N: Revealed type is "def (a: builtins.int, b: builtins.bool) -
 reveal_type(B)  # N: Revealed type is "def (a: builtins.bool, b: builtins.int) -> __main__.B"
 reveal_type(C)  # N: Revealed type is "def (a: builtins.int) -> __main__.C"
 
-[builtins fixtures/bool.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsDataClass]
 import attr
@@ -1155,7 +1156,7 @@ c = NonFrozenFrozen(1, 2)
 c.a = 17  # E: Property "a" defined in "NonFrozenFrozen" is read-only
 c.b = 17  # E: Property "b" defined in "NonFrozenFrozen" is read-only
 
-[builtins fixtures/bool.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 [case testAttrsCallableAttributes]
 from typing import Callable
 import attr
@@ -1178,7 +1179,7 @@ class G:
 class FFrozen(F):
     def bar(self) -> bool:
         return self._cb(5, 6)
-[builtins fixtures/callable.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsWithFactory]
 from typing import List
@@ -1450,7 +1451,7 @@ class C:
     total = attr.ib(type=Bad)  # E: Name "Bad" is not defined
 
 C(0).total = 1  # E: Property "total" defined in "C" is read-only
-[builtins fixtures/bool.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testTypeInAttrDeferredStar]
 import lib
@@ -1941,7 +1942,7 @@ class C:
         default=None, converter=default_if_none(factory=dict) \
         # E: Unsupported converter, only named functions, types and lambdas are currently supported
     )
-[builtins fixtures/dict.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsUnannotatedConverter]
 import attr
@@ -2012,7 +2013,7 @@ class Sub(Base):
 
     @property
     def name(self) -> str: ...
-[builtins fixtures/property.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testOverrideWithPropertyInFrozenClassChecked]
 from attrs import frozen
@@ -2035,7 +2036,7 @@ class Sub(Base):
 
 # This matches runtime semantics
 reveal_type(Sub)  # N: Revealed type is "def (*, name: builtins.str, first_name: builtins.str, last_name: builtins.str) -> __main__.Sub"
-[builtins fixtures/property.pyi]
+[builtins fixtures/plugin_attrs.pyi]
 
 [case testFinalInstanceAttribute]
 from attrs import define
@@ -2374,6 +2375,85 @@ class A:
     a: int
 
 @define
+class B(A):
+    pass
+
+reveal_type(B.__hash__)  # N: Revealed type is "None"
+
+[builtins fixtures/plugin_attrs.pyi]
+
+[case testManualOwnHashability]
+from attrs import define, frozen
+
+@define
+class A:
+    a: int
+    def __hash__(self) -> int:
+        ...
+
+reveal_type(A.__hash__)  # N: Revealed type is "def (self: __main__.A) -> builtins.int"
+
+[builtins fixtures/plugin_attrs.pyi]
+
+[case testSubclassDefaultLosesHashability]
+from attrs import define, frozen
+
+@define
+class A:
+    a: int
+    def __hash__(self) -> int:
+        ...
+
+@define
+class B(A):
+    pass
+
+reveal_type(B.__hash__)  # N: Revealed type is "None"
+
+[builtins fixtures/plugin_attrs.pyi]
+
+[case testSubclassEqFalseKeepsHashability]
+from attrs import define, frozen
+
+@define
+class A:
+    a: int
+    def __hash__(self) -> int:
+        ...
+
+@define(eq=False)
+class B(A):
+    pass
+
+reveal_type(B.__hash__)  # N: Revealed type is "def (self: __main__.A) -> builtins.int"
+
+[builtins fixtures/plugin_attrs.pyi]
+
+[case testSubclassingFrozenHashability]
+from attrs import define, frozen
+
+@define
+class A:
+    a: int
+
+@frozen
+class B(A):
+    pass
+
+reveal_type(B.__hash__)  # N: Revealed type is "def (self: builtins.object) -> builtins.int"
+
+[builtins fixtures/plugin_attrs.pyi]
+
+[case testSubclassingFrozenHashOffHashability]
+from attrs import define, frozen
+
+@define
+class A:
+    a: int
+    def __hash__(self) -> int:
+        ...
+
+@frozen(unsafe_hash=False)
 class B(A):
     pass
 

--- a/test-data/unit/fixtures/plugin_attrs.pyi
+++ b/test-data/unit/fixtures/plugin_attrs.pyi
@@ -35,3 +35,5 @@ class tuple(Sequence[Tco], Generic[Tco]):
     def __iter__(self) -> Iterator[Tco]: pass
     def __contains__(self, item: object) -> bool: pass
     def __getitem__(self, x: int) -> Tco: pass
+
+property = object()  # Dummy definition


### PR DESCRIPTION
This commit fixes a couple regressions in 1.9.0 from 91be285.

Attrs' logic for hashability is slightly complex:

* https://www.attrs.org/en/stable/hashing.html
* https://github.com/python-attrs/attrs/blob/9e443b18527dc96b194e92805fa751cbf8434ba9/src/attr/_make.py#L1660-L1689

Mypy now properly emulates attrs' logic so that custom `__hash__` implementations are preserved, `@frozen` subclasses are always hashable, and classes are only made unhashable based on the values of `eq` and `unsafe_hash`.

Fixes #17015
Fixes https://github.com/python/mypy/pull/16556#issuecomment-1987116488

Based on a patch in #17012
Co-Authored-By: Tin Tvrtkovic <tinchester@gmail.com>