### PR TITLE
Fix crash when expanding invalid Unpack in a `Callable` alias

### DIFF
--- a/test-data/unit/check-python311.test
+++ b/test-data/unit/check-python311.test
@@ -142,3 +142,34 @@ myclass3 = MyClass(float, float, float)  # E: No overload variant of "MyClass" m
                                          # N:     def [T1, T2] __init__(Type[T1], Type[T2], /) -> MyClass[T1, T2]
 reveal_type(myclass3)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
+
+[case testUnpackNewSyntaxInvalidCallableAlias]
+from typing import Any, Callable, List, Tuple, TypeVar, Unpack
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")  # E: Name "TypeVarTuple" is not defined
+
+def good(*x: int) -> int: ...
+def bad(*x: int, y: int) -> int: ...
+
+Alias1 = Callable[[*Ts], int]  # E: Variable "__main__.Ts" is not valid as a type \
+                               # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+x1: Alias1[int]  # E: Bad number of arguments for type alias, expected 0, given 1
+reveal_type(x1)  # N: Revealed type is "def (*Any) -> builtins.int"
+x1 = good
+x1 = bad  # E: Incompatible types in assignment (expression has type "Callable[[VarArg(int), NamedArg(int, 'y')], int]", variable has type "Callable[[VarArg(Any)], int]")
+
+Alias2 = Callable[[*T], int]  # E: "T" cannot be unpacked (must be tuple or TypeVarTuple)
+x2: Alias2[int]
+reveal_type(x2)  # N: Revealed type is "def (*Any) -> builtins.int"
+
+Unknown = Any
+Alias3 = Callable[[*Unknown], int]
+x3: Alias3[int]  # E: Bad number of arguments for type alias, expected 0, given 1
+reveal_type(x3)  # N: Revealed type is "def (*Any) -> builtins.int"
+
+IntList = List[int]
+Alias4 = Callable[[*IntList], int]  # E: "List[int]" cannot be unpacked (must be tuple or TypeVarTuple)
+x4: Alias4[int]  # E: Bad number of arguments for type alias, expected 0, given 1
+reveal_type(x4)  # N: Revealed type is "def (*Unpack[builtins.tuple[Any, ...]]) -> builtins.int"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -76,10 +76,9 @@ BadAlias1 = TypeAliasType("BadAlias1", tuple[*Ts])  # E: TypeVarTuple "Ts" is no
 ba1: BadAlias1[int]  # E: Bad number of arguments for type alias, expected 0, given 1
 reveal_type(ba1)  # N: Revealed type is "builtins.tuple[Any, ...]"
 
-# TODO this should report errors on the two following lines
-#BadAlias2 = TypeAliasType("BadAlias2", Callable[[*Ts], str])
-#ba2: BadAlias2[int]
-#reveal_type(ba2)
+BadAlias2 = TypeAliasType("BadAlias2", Callable[[*Ts], str])  # E: TypeVarTuple "Ts" is not included in type_params
+ba2: BadAlias2[int]  # E: Bad number of arguments for type alias, expected 0, given 1
+reveal_type(ba2)  # N: Revealed type is "def (*Any) -> builtins.str"
 
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1185,10 +1185,9 @@ Ta9 = TypeAliasType("Ta9", Callable[P, T])  # E: ParamSpec "P" is not included i
 unbound_ps_alias3: Ta9[int, str]  # E: Bad number of arguments for type alias, expected 0, given 2
 reveal_type(unbound_ps_alias3)  # N: Revealed type is "def [P] (*Any, **Any) -> Any"
 
-# TODO this should report errors on the two following lines
-#Ta10 = TypeAliasType("Ta10", Callable[[Unpack[Ts]], str])
-#unbound_tvt_alias2: Ta10[int]
-#reveal_type(unbound_tvt_alias2)
+Ta10 = TypeAliasType("Ta10", Callable[[Unpack[Ts]], str])  # E: TypeVarTuple "Ts" is not included in type_params
+unbound_tvt_alias2: Ta10[int]  # E: Bad number of arguments for type alias, expected 0, given 1
+reveal_type(unbound_tvt_alias2)  # N: Revealed type is "def (*Any) -> builtins.str"
 
 [builtins fixtures/dict.pyi]
 

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2278,6 +2278,22 @@ higher_order(bad3)  # E: Argument 1 to "higher_order" has incompatible type "Cal
 higher_order(bad4)  # E: Argument 1 to "higher_order" has incompatible type "Callable[[KwArg(None)], None]"; expected "Callable[[int, str, VarArg(Unpack[Tuple[Unpack[Tuple[Any, ...]], int]])], Any]"
 [builtins fixtures/tuple.pyi]
 
+[case testAliasToCallableWithUnpackInvalid]
+from typing import Any, Callable, List, Tuple, TypeVar, Unpack
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")  # E: Name "TypeVarTuple" is not defined
+
+def good(*x: int) -> int: ...
+def bad(*x: int, y: int) -> int: ...
+
+Alias = Callable[[Unpack[T]], int]  # E: "T" cannot be unpacked (must be tuple or TypeVarTuple)
+x: Alias[int]
+reveal_type(x)  # N: Revealed type is "def (*Any) -> builtins.int"
+x = good
+x = bad  # E: Incompatible types in assignment (expression has type "Callable[[VarArg(int), NamedArg(int, 'y')], int]", variable has type "Callable[[VarArg(Any)], int]")
+[builtins fixtures/tuple.pyi]
+
 [case testTypeVarTupleInvariant]
 from typing import Generic, Tuple
 from typing_extensions import Unpack, TypeVarTuple


### PR DESCRIPTION
Fixes #16937
