### PR TITLE
Use lower-case generics more consistently in error messages

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1779,6 +1779,8 @@ class MessageBuilder:
                 alias = alias.split(".")[-1]
                 if alias == "Dict":
                     type_dec = f"{type_dec}, {type_dec}"
+                if self.options.use_lowercase_names():
+                    alias = alias.lower()
                 recommended_type = f"{alias}[{type_dec}]"
         if recommended_type is not None:
             hint = f' (hint: "{node.name}: {recommended_type} = ...")'

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3405,7 +3405,11 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         return "..."
 
     def visit_type_type(self, t: TypeType) -> str:
-        return f"Type[{t.item.accept(self)}]"
+        if self.options.use_lowercase_names():
+            type_name = "type"
+        else:
+            type_name = "Type"
+        return f"{type_name}[{t.item.accept(self)}]"
 
     def visit_placeholder_type(self, t: PlaceholderType) -> str:
         return f"<placeholder {t.fullname}>"

--- a/test-data/unit/check-lowercase.test
+++ b/test-data/unit/check-lowercase.test
@@ -49,3 +49,17 @@ x: type[type]
 y: int
 
 y = x  # E: Incompatible types in assignment (expression has type "type[type]", variable has type "int")
+
+[case testLowercaseSettingOnTypeAnnotationHint]
+# flags: --python-version 3.9 --no-force-uppercase-builtins
+x = []  # E: Need type annotation for "x" (hint: "x: list[<type>] = ...")
+y = {}  # E: Need type annotation for "y" (hint: "y: dict[<type>, <type>] = ...")
+z = set()  # E: Need type annotation for "z" (hint: "z: set[<type>] = ...")
+[builtins fixtures/primitives.pyi]
+
+[case testLowercaseSettingOnRevealTypeType]
+# flags: --python-version 3.9 --no-force-uppercase-builtins
+def f(t: type[int]) -> None:
+    reveal_type(t)  # N: Revealed type is "type[builtins.int]"
+reveal_type(f)  # N: Revealed type is "def (t: type[builtins.int])"
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Suggest `list[x]` instead of `List[x]` on Python 3.9 and later in hints. We already suggest `x | None` instead of `Optional[x]` on 3.10+, so this makes the error messages more consistent.

Use lower-case `type[x]` when using `reveal_type` on Python 3.9 and later.