### PR TITLE
Improve error message for bound typevar in TypeAliasType

### DIFF
--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1195,6 +1195,11 @@ reveal_type(unbound_ps_alias3)  # N: Revealed type is "def [P] (*Any, **Any) -> 
 #unbound_tvt_alias2: Ta10[int]
 #reveal_type(unbound_tvt_alias2)
 
+class A(Generic[T]):
+    Ta11 = TypeAliasType("Ta11", Dict[str, T], type_params=(T,))  # E: Can't use bound type variable "T" to define generic alias \
+                                                                  # E: "T" is a type variable and only valid in type context
+x: A.Ta11 = {"a": 1}
+reveal_type(x)  # N: Revealed type is "builtins.dict[builtins.str, Any]"
 [builtins fixtures/dict.pyi]
 
 [case testTypeAliasTypeNoUnpackInTypeParams311]


### PR DESCRIPTION
Follow up to #17038

When a type variable is bound to a class, it cannot be reused in a type alias. Previously in `TypeAliasType`, this error was reported as "not included in type_params". However in the following example, the error is misleading:
```python
from typing import Dict, Generic, TypeVar
from typing_extensions import TypeAliasType

T = TypeVar("T")


class A(Generic[T]):
    Ta11 = TypeAliasType("Ta11", Dict[str, T], type_params=(T,))


x: A.Ta11 = {"a": 1}
reveal_type(x)
```

On the master branch:
```
main.py:8: error: Type variable "T" is not included in type_params  [valid-type]
main.py:8: error: "T" is a type variable and only valid in type context  [misc]
main.py:8: error: Free type variable expected in type_params argument to TypeAliasType  [type-var]
main.py:12: note: Revealed type is "builtins.dict[builtins.str, Any]"
Found 3 errors in 1 file (checked 1 source file)
```

With this PR:
```
typealiastype.py:8: error: Can't use bound type variable "T" to define generic alias  [valid-type]
typealiastype.py:8: error: "T" is a type variable and only valid in type context  [misc]
typealiastype.py:12: note: Revealed type is "builtins.dict[builtins.str, Any]"
Found 2 errors in 1 file (checked 1 source file)
```

This is possible by storing the names of all the declared type_params, even those that are invalid, and checking if the offending type variables are in the list.