### PR TITLE
Fix TypedDict init from Type with optional keys

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -949,7 +949,10 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def typeddict_callable_from_context(self, callee: TypedDictType) -> CallableType:
         return CallableType(
             list(callee.items.values()),
-            [ArgKind.ARG_NAMED] * len(callee.items),
+            [
+                ArgKind.ARG_NAMED if name in callee.required_keys else ArgKind.ARG_NAMED_OPT
+                for name in callee.items
+            ],
             list(callee.items.keys()),
             callee,
             self.named_type("builtins.type"),

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3450,16 +3450,40 @@ reveal_type(p) # N: Revealed type is "TypedDict('__main__.Params', {'x': builtin
 
 [case testInitTypedDictFromType]
 from typing import TypedDict, Type
+from typing_extensions import Required
 
-class Point(TypedDict):
-    x: int
+class Point(TypedDict, total=False):
+    x: Required[int]
     y: int
 
 def func(cls: Type[Point]) -> None:
-    reveal_type(cls)  # N: Revealed type is "Type[TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})]"
+    reveal_type(cls)  # N: Revealed type is "Type[TypedDict('__main__.Point', {'x': builtins.int, 'y'?: builtins.int})]"
     cls(x=1, y=2)
     cls(1, 2)  # E: Too many positional arguments
-    cls(x=1)  # E: Missing named argument "y"
+    cls(x=1)
+    cls(y=2)  # E: Missing named argument "x"
     cls(x=1, y=2, error="")  # E: Unexpected keyword argument "error"
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]
+
+[case testInitTypedDictFromTypeGeneric]
+from typing import Generic, TypedDict, Type, TypeVar
+from typing_extensions import Required
+
+class Point(TypedDict, total=False):
+    x: Required[int]
+    y: int
+
+T = TypeVar("T", bound=Point)
+
+class A(Generic[T]):
+    def __init__(self, a: Type[T]) -> None:
+        self.a = a
+
+    def func(self) -> T:
+        reveal_type(self.a)  # N: Revealed type is "Type[T`1]"
+        self.a(x=1, y=2)
+        self.a(y=2)  # E: Missing named argument "x"
+        return self.a(x=1)
 [typing fixtures/typing-full.pyi]
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/lib-stub/typing_extensions.pyi
+++ b/test-data/unit/lib-stub/typing_extensions.pyi
@@ -39,6 +39,8 @@ Never: _SpecialForm
 
 TypeVarTuple: _SpecialForm
 Unpack: _SpecialForm
+Required: _SpecialForm
+NotRequired: _SpecialForm
 
 @final
 class TypeAliasType:


### PR DESCRIPTION
Followup to #16963
Correctly set optional and required keys for the TypedDict init callable.

Ref: https://github.com/python/mypy/issues/11644