### PR TITLE
Fix narrowing unions in tuple pattern matches

### DIFF
--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -407,6 +407,66 @@ match m, (n, o):
         pass
 [builtins fixtures/tuple.pyi]
 
+[case testPartialMatchTuplePatternNarrowsUnion]
+from typing import Tuple, Union
+
+m: Tuple[Union[int, None], Union[int, None]]
+
+match m:
+    case a, None:
+        reveal_type(a) # N: Revealed type is "Union[builtins.int, None]"
+        reveal_type(m) # N: Revealed type is "Tuple[Union[builtins.int, None], None]"
+    case None, b:
+        reveal_type(b) # N: Revealed type is "builtins.int"
+        reveal_type(m) # N: Revealed type is "Tuple[None, builtins.int]"
+    case t:
+        reveal_type(t) # N: Revealed type is "Tuple[builtins.int, builtins.int]"
+[builtins fixtures/tuple.pyi]
+
+[case testPartialMatchTuplePatternNarrowsUnionWithFullMatch]
+from typing import Tuple, Union
+
+m: Tuple[Union[int, None], Union[int, None]]
+
+match m:
+    case None, None:
+        reveal_type(m) # N: Revealed type is "Tuple[None, None]"
+    case a, None:
+        reveal_type(a) # N: Revealed type is "Union[builtins.int, None]"
+        reveal_type(m) # N: Revealed type is "Tuple[Union[builtins.int, None], None]"
+    case None, b:
+        reveal_type(b) # N: Revealed type is "builtins.int"
+        reveal_type(m) # N: Revealed type is "Tuple[None, builtins.int]"
+    case t:
+        reveal_type(t) # N: Revealed type is "Tuple[builtins.int, builtins.int]"
+[builtins fixtures/tuple.pyi]
+
+[case testPartialMatchTuplePatternNarrowsUnionWithUninhibitedMatch]
+from typing import Tuple, Union
+
+m: Tuple[Union[int, None], Union[int, None]]
+
+match m:
+    case a, b:
+        reveal_type(m) # N: Revealed type is "Tuple[Union[builtins.int, None], Union[builtins.int, None]]"
+    case t:
+        reveal_type(t)
+[builtins fixtures/tuple.pyi]
+
+[case testMatchTuplePatterNarrowsWithOrMatch]
+from typing import Tuple, Union
+
+m: Tuple[Union[int, None], Union[int, None]]
+
+match m:
+    case (None, _) | (_, None):
+        reveal_type(m) # N: Revealed type is "Union[Tuple[None, Union[builtins.int, None]], Tuple[builtins.int, None]]"
+    case a, b:
+        reveal_type(a) # N: Revealed type is "builtins.int"
+        reveal_type(b) # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]
+
+
 -- Mapping Pattern --
 
 [case testMatchMappingPatternCaptures]


### PR DESCRIPTION
Allows sequence pattern matching of tuple types with union members to use an unmatched pattern to narrow the possible type of union member to the type that was not matched in the sequence pattern.

For example given a type of `tuple[int, int | None]` a pattern match like:

```
match tuple_type:
    case a, None:
         return
    case t:
         reveal_type(t) # narrows tuple type to tuple[int, int]
         return
```

The case ..., None sequence pattern match can now narrow the type in further match statements to rule out the None side of the union.

This is implemented by moving the original implementation of tuple narrowing in sequence pattern matching since its functionality should be to the special case where a tuple only has length of one. This implementation does not hold for tuples of length greater than one since it does not account all combinations of alternative types.

This replace that implementation with a new one that  builds the rest type by iterating over the potential rest type members preserving narrowed types if they are available and replacing any uninhabited types with the original type of tuple member since these matches are only exhaustive if all members of the tuple are matched.

Fixes #14731

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
