### PR TITLE
Add documentation for show-error-code-links

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -747,6 +747,17 @@ in error messages.
 
         main.py:12:9: error: Unsupported operand types for / ("int" and "str")
 
+.. option:: --show-error-code-links
+
+    This flag will also display a link to error code documentation, anchored to the error code reported by mypy.
+    The corresponding error code will be highlighted within the documentation page.
+    If we enable this flag, the error message now looks like this::
+
+        main.py:3: error: Unsupported operand types for - ("int" and "str")  [operator]
+        main.py:3: note: See 'https://mypy.rtfd.io/en/stable/_refs.html#code-operator' for more info
+        
+        
+
 .. option:: --show-error-end
 
     This flag will make mypy show not just that start position where

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -755,8 +755,8 @@ in error messages.
 
         main.py:3: error: Unsupported operand types for - ("int" and "str")  [operator]
         main.py:3: note: See 'https://mypy.rtfd.io/en/stable/_refs.html#code-operator' for more info
-        
-        
+
+
 
 .. option:: --show-error-end
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -787,6 +787,13 @@ These options may only be set in the global section (``[mypy]``).
 
     Shows column numbers in error messages.
 
+.. confval:: show_error_code_links
+
+    :type: boolean
+    :default: False
+
+    Shows documentation link to corresponding error code.
+
 .. confval:: hide_error_codes
 
     :type: boolean


### PR DESCRIPTION
This PR closes issue https://github.com/python/mypy/issues/16693 and a part of issue https://github.com/python/mypy/issues/17083

Propositional documentation updates for show-error-code-links, which update files command_line.rst and config_file.rst.
