### PR TITLE
Fix Literal strings containing pipe characters

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -319,14 +319,7 @@ def parse_type_string(
     """
     try:
         _, node = parse_type_comment(f"({expr_string})", line=line, column=column, errors=None)
-        if isinstance(node, UnboundType) and node.original_str_expr is None:
-            node.original_str_expr = expr_string
-            node.original_str_fallback = expr_fallback_name
-            return node
-        elif isinstance(node, UnionType):
-            return node
-        else:
-            return RawExpressionType(expr_string, expr_fallback_name, line, column)
+        return RawExpressionType(expr_string, expr_fallback_name, line, column, node=node)
     except (SyntaxError, ValueError):
         # Note: the parser will raise a `ValueError` instead of a SyntaxError if
         # the string happens to contain things like \x00.
@@ -1034,6 +1027,8 @@ class ASTConverter:
             return
         # Indicate that type should be wrapped in an Optional if arg is initialized to None.
         optional = isinstance(initializer, NameExpr) and initializer.name == "None"
+        if isinstance(type, RawExpressionType) and type.node is not None:
+            type = type.node
         if isinstance(type, UnboundType):
             type.optional = optional
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -266,7 +266,6 @@ from mypy.types import (
     ParamSpecType,
     PlaceholderType,
     ProperType,
-    RawExpressionType,
     TrivialSyntheticTypeTranslator,
     TupleType,
     Type,
@@ -4715,8 +4714,9 @@ class SemanticAnalyzer(
         return sym.node.fullname == "typing.ClassVar"
 
     def unwrap_final_type(self, typ: Type | None) -> UnboundType | None:
-        if isinstance(typ, RawExpressionType) and typ.node is not None:
-            typ = typ.node
+        if typ is None:
+            return None
+        typ = typ.resolve_string_annotation()
         if not isinstance(typ, UnboundType):
             return None
         sym = self.lookup_qualified(typ.name, typ)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -266,6 +266,7 @@ from mypy.types import (
     ParamSpecType,
     PlaceholderType,
     ProperType,
+    RawExpressionType,
     TrivialSyntheticTypeTranslator,
     TupleType,
     Type,
@@ -3231,10 +3232,10 @@ class SemanticAnalyzer(
     def analyze_lvalues(self, s: AssignmentStmt) -> None:
         # We cannot use s.type, because analyze_simple_literal_type() will set it.
         explicit = s.unanalyzed_type is not None
-        if self.is_final_type(s.unanalyzed_type):
+        final_type = self.unwrap_final_type(s.unanalyzed_type)
+        if final_type is not None:
             # We need to exclude bare Final.
-            assert isinstance(s.unanalyzed_type, UnboundType)
-            if not s.unanalyzed_type.args:
+            if not final_type.args:
                 explicit = False
 
         if s.rvalue:
@@ -3300,19 +3301,19 @@ class SemanticAnalyzer(
 
         Returns True if Final[...] was present.
         """
-        if not s.unanalyzed_type or not self.is_final_type(s.unanalyzed_type):
+        final_type = self.unwrap_final_type(s.unanalyzed_type)
+        if final_type is None:
             return False
-        assert isinstance(s.unanalyzed_type, UnboundType)
-        if len(s.unanalyzed_type.args) > 1:
-            self.fail("Final[...] takes at most one type argument", s.unanalyzed_type)
+        if len(final_type.args) > 1:
+            self.fail("Final[...] takes at most one type argument", final_type)
         invalid_bare_final = False
-        if not s.unanalyzed_type.args:
+        if not final_type.args:
             s.type = None
             if isinstance(s.rvalue, TempNode) and s.rvalue.no_rhs:
                 invalid_bare_final = True
                 self.fail("Type in Final[...] can only be omitted if there is an initializer", s)
         else:
-            s.type = s.unanalyzed_type.args[0]
+            s.type = final_type.args[0]
 
         if s.type is not None and self.is_classvar(s.type):
             self.fail("Variable should not be annotated with both ClassVar and Final", s)
@@ -4713,13 +4714,17 @@ class SemanticAnalyzer(
             return False
         return sym.node.fullname == "typing.ClassVar"
 
-    def is_final_type(self, typ: Type | None) -> bool:
+    def unwrap_final_type(self, typ: Type | None) -> UnboundType | None:
+        if isinstance(typ, RawExpressionType) and typ.node is not None:
+            typ = typ.node
         if not isinstance(typ, UnboundType):
-            return False
+            return None
         sym = self.lookup_qualified(typ.name, typ)
         if not sym or not sym.node:
-            return False
-        return sym.node.fullname in FINAL_TYPE_NAMES
+            return None
+        if sym.node.fullname in FINAL_TYPE_NAMES:
+            return typ
+        return None
 
     def fail_invalid_classvar(self, context: Context) -> None:
         self.fail(message_registry.CLASS_VAR_OUTSIDE_OF_CLASS, context)

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -507,7 +507,8 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
         typ.fallback.accept(self)
 
     def visit_raw_expression_type(self, t: RawExpressionType) -> None:
-        pass
+        if t.node is not None:
+            t.node.accept(self)
 
     def visit_literal_type(self, typ: LiteralType) -> None:
         typ.fallback.accept(self)

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -17,7 +17,7 @@ import mypy.options
 from mypy.modulefinder import ModuleNotFoundReason
 from mypy.moduleinspect import InspectError, ModuleInspect
 from mypy.stubdoc import ArgSig, FunctionSig
-from mypy.types import AnyType, NoneType, Type, TypeList, TypeStrVisitor, UnboundType, UnionType
+from mypy.types import AnyType, NoneType, RawExpressionType, Type, TypeList, TypeStrVisitor, UnboundType, UnionType
 
 # Modules that may fail when imported, or that may have side effects (fully qualified).
 NOT_IMPORTABLE_MODULES = ()
@@ -291,12 +291,11 @@ class AnnotationPrinter(TypeStrVisitor):
         The main difference from list_str is the preservation of quotes for string
         arguments
         """
-        types = ["builtins.bytes", "builtins.str"]
         res = []
         for arg in args:
             arg_str = arg.accept(self)
-            if isinstance(arg, UnboundType) and arg.original_str_fallback in types:
-                res.append(f"'{arg_str}'")
+            if isinstance(arg, RawExpressionType):
+                res.append(repr(arg.literal_value))
             else:
                 res.append(arg_str)
         return ", ".join(res)

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -17,7 +17,16 @@ import mypy.options
 from mypy.modulefinder import ModuleNotFoundReason
 from mypy.moduleinspect import InspectError, ModuleInspect
 from mypy.stubdoc import ArgSig, FunctionSig
-from mypy.types import AnyType, NoneType, RawExpressionType, Type, TypeList, TypeStrVisitor, UnboundType, UnionType
+from mypy.types import (
+    AnyType,
+    NoneType,
+    RawExpressionType,
+    Type,
+    TypeList,
+    TypeStrVisitor,
+    UnboundType,
+    UnionType,
+)
 
 # Modules that may fail when imported, or that may have side effects (fully qualified).
 NOT_IMPORTABLE_MODULES = ()

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -376,6 +376,8 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return self.query_types(t.items.values())
 
     def visit_raw_expression_type(self, t: RawExpressionType) -> T:
+        if t.node is not None:
+            return t.node.accept(self)
         return self.strategy([])
 
     def visit_literal_type(self, t: LiteralType) -> T:
@@ -516,6 +518,8 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         return self.query_types(list(t.items.values()))
 
     def visit_raw_expression_type(self, t: RawExpressionType) -> bool:
+        if t.node is not None:
+            return t.node.accept(self)
         return self.default
 
     def visit_literal_type(self, t: LiteralType) -> bool:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1537,18 +1537,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         return UnionType.make_union(output, line=t.line)
 
     def analyze_literal_param(self, idx: int, arg: Type, ctx: Context) -> list[Type] | None:
-        # This UnboundType was originally defined as a string.
-        if isinstance(arg, UnboundType) and arg.original_str_expr is not None:
-            assert arg.original_str_fallback is not None
-            return [
-                LiteralType(
-                    value=arg.original_str_expr,
-                    fallback=self.named_type(arg.original_str_fallback),
-                    line=arg.line,
-                    column=arg.column,
-                )
-            ]
-
         # If arg is an UnboundType that was *not* originally defined as
         # a string, try expanding it in case it's a type alias or something.
         if isinstance(arg, UnboundType):

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1460,6 +1460,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         invalid_unpacks: list[Type] = []
         second_unpack_last = False
         for i, arg in enumerate(arglist.items):
+            arg = arg.resolve_string_annotation()
             if isinstance(arg, CallableArgument):
                 args.append(arg.typ)
                 names.append(arg.name)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1195,6 +1195,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # make signatures like "foo(x: 20) -> None" legal, we can change
         # this method so it generates and returns an actual LiteralType
         # instead.
+        if t.node is not None:
+            return t.node.accept(self)
 
         if self.report_invalid_types:
             if t.base_type_name in ("builtins.int", "builtins.bool"):
@@ -2528,7 +2530,8 @@ class FindTypeVarVisitor(SyntheticTypeVisitor[None]):
         self.process_types(list(t.items.values()))
 
     def visit_raw_expression_type(self, t: RawExpressionType) -> None:
-        pass
+        if t.node is not None:
+            t.node.accept(self)
 
     def visit_literal_type(self, t: LiteralType) -> None:
         pass

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1070,6 +1070,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         return ret
 
     def anal_type_guard(self, t: Type) -> Type | None:
+        t = t.resolve_string_annotation()
         if isinstance(t, UnboundType):
             sym = self.lookup_qualified(t.name, t)
             if sym is not None and sym.node is not None:
@@ -1088,6 +1089,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         return None
 
     def anal_type_is(self, t: Type) -> Type | None:
+        t = t.resolve_string_annotation()
         if isinstance(t, UnboundType):
             sym = self.lookup_qualified(t.name, t)
             if sym is not None and sym.node is not None:
@@ -1105,6 +1107,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def anal_star_arg_type(self, t: Type, kind: ArgKind, nested: bool) -> Type:
         """Analyze signature argument type for *args and **kwargs argument."""
+        t = t.resolve_string_annotation()
         if isinstance(t, UnboundType) and t.name and "." in t.name and not t.args:
             components = t.name.split(".")
             tvar_name = ".".join(components[:-1])

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3400,7 +3400,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 
     def visit_raw_expression_type(self, t: RawExpressionType) -> str:
         if t.node is not None:
-            return f"{t.literal_value!r}={t.node.accept(self)}"
+            return t.node.accept(self)
         return repr(t.literal_value)
 
     def visit_literal_type(self, t: LiteralType) -> str:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -271,6 +271,9 @@ class Type(mypy.nodes.Context):
     def can_be_false_default(self) -> bool:
         return True
 
+    def resolve_string_annotation(self) -> Type:
+        return self
+
     def accept(self, visitor: TypeVisitor[T]) -> T:
         raise RuntimeError("Not implemented", type(self))
 
@@ -2681,6 +2684,11 @@ class RawExpressionType(ProperType):
             note=self.note,
             node=node,
         )
+
+    def resolve_string_annotation(self) -> Type:
+        if self.node is not None:
+            return self.node.resolve_string_annotation()
+        return self
 
     def serialize(self) -> JsonDict:
         assert False, "Synthetic types don't serialize"

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2656,7 +2656,7 @@ class RawExpressionType(ProperType):
         line: int = -1,
         column: int = -1,
         note: str | None = None,
-        node: ProperType | None = None,
+        node: Type | None = None,
     ) -> None:
         super().__init__(line, column)
         self.literal_value = literal_value
@@ -2672,7 +2672,7 @@ class RawExpressionType(ProperType):
         ret: T = visitor.visit_raw_expression_type(self)
         return ret
 
-    def copy_modified(self, node: ProperType | None) -> RawExpressionType:
+    def copy_modified(self, node: Type | None) -> RawExpressionType:
         return RawExpressionType(
             literal_value=self.literal_value,
             base_type_name=self.base_type_name,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -13,7 +13,6 @@ from typing import (
     Iterable,
     NamedTuple,
     NewType,
-    Optional,
     Sequence,
     TypeVar,
     Union,
@@ -901,12 +900,7 @@ class TypeVarTupleType(TypeVarLikeType):
 class UnboundType(ProperType):
     """Instance type that has not been bound during semantic analysis."""
 
-    __slots__ = (
-        "name",
-        "args",
-        "optional",
-        "empty_tuple_index",
-    )
+    __slots__ = ("name", "args", "optional", "empty_tuple_index")
 
     def __init__(
         self,
@@ -950,9 +944,7 @@ class UnboundType(ProperType):
         if not isinstance(other, UnboundType):
             return NotImplemented
         return (
-            self.name == other.name
-            and self.optional == other.optional
-            and self.args == other.args
+            self.name == other.name and self.optional == other.optional and self.args == other.args
         )
 
     def serialize(self) -> JsonDict:
@@ -965,10 +957,7 @@ class UnboundType(ProperType):
     @classmethod
     def deserialize(cls, data: JsonDict) -> UnboundType:
         assert data[".class"] == "UnboundType"
-        return UnboundType(
-            data["name"],
-            [deserialize_type(a) for a in data["args"]],
-        )
+        return UnboundType(data["name"], [deserialize_type(a) for a in data["args"]])
 
 
 class CallableArgument(ProperType):

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -130,7 +130,8 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
         pass
 
     def visit_raw_expression_type(self, t: RawExpressionType) -> None:
-        pass
+        if t.node is not None:
+            t.node.accept(self)
 
     def visit_type_alias_type(self, t: TypeAliasType) -> None:
         # TODO: sometimes we want to traverse target as well

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -24,7 +24,7 @@ from mypy.nodes import (
     TypeInfo,
     is_class_var,
 )
-from mypy.types import ENUM_REMOVED_PROPS, Instance, UnboundType, get_proper_type
+from mypy.types import ENUM_REMOVED_PROPS, Instance, RawExpressionType, UnboundType, get_proper_type
 from mypyc.common import PROPSET_PREFIX
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
@@ -602,15 +602,15 @@ def add_non_ext_class_attr_ann(
         # FIXME: if get_type_info is not provided, don't fall back to stmt.type?
         ann_type = get_proper_type(stmt.type)
         if (
-            isinstance(stmt.unanalyzed_type, UnboundType)
-            and stmt.unanalyzed_type.original_str_expr is not None
+            isinstance(stmt.unanalyzed_type, RawExpressionType)
+            and isinstance(stmt.unanalyzed_type.literal_value, str)
         ):
             # Annotation is a forward reference, so don't attempt to load the actual
             # type and load the string instead.
             #
             # TODO: is it possible to determine whether a non-string annotation is
             # actually a forward reference due to the __annotations__ future?
-            typ = builder.load_str(stmt.unanalyzed_type.original_str_expr)
+            typ = builder.load_str(stmt.unanalyzed_type.literal_value)
         elif isinstance(ann_type, Instance):
             typ = load_type(builder, ann_type.type, stmt.line)
         else:

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -24,7 +24,7 @@ from mypy.nodes import (
     TypeInfo,
     is_class_var,
 )
-from mypy.types import ENUM_REMOVED_PROPS, Instance, RawExpressionType, UnboundType, get_proper_type
+from mypy.types import ENUM_REMOVED_PROPS, Instance, RawExpressionType, get_proper_type
 from mypyc.common import PROPSET_PREFIX
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
 from mypyc.ir.func_ir import FuncDecl, FuncSignature
@@ -601,9 +601,8 @@ def add_non_ext_class_attr_ann(
     if typ is None:
         # FIXME: if get_type_info is not provided, don't fall back to stmt.type?
         ann_type = get_proper_type(stmt.type)
-        if (
-            isinstance(stmt.unanalyzed_type, RawExpressionType)
-            and isinstance(stmt.unanalyzed_type.literal_value, str)
+        if isinstance(stmt.unanalyzed_type, RawExpressionType) and isinstance(
+            stmt.unanalyzed_type.literal_value, str
         ):
             # Annotation is a forward reference, so don't attempt to load the actual
             # type and load the string instead.

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -6,11 +6,13 @@
 [case testFinalDefiningModuleVar]
 from typing import Final
 
+w: 'Final' = int()
 x: Final = int()
 y: Final[float] = int()
 z: Final[int] = int()
 bad: Final[str] = int()  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
+reveal_type(w)  # N: Revealed type is "builtins.int"
 reveal_type(x)  # N: Revealed type is "builtins.int"
 reveal_type(y)  # N: Revealed type is "builtins.float"
 reveal_type(z)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -12,8 +12,12 @@ reveal_type(g1)  # N: Revealed type is "def (x: Literal['A['])"
 
 def f2(x: 'A B') -> None: pass  # E: Invalid type comment or annotation
 def g2(x: Literal['A B']) -> None: pass
+def h2(x: 'A|int') -> None: pass  # E: Name "A" is not defined
+def i2(x: Literal['A|B']) -> None: pass
 reveal_type(f2)  # N: Revealed type is "def (x: Any)"
 reveal_type(g2)  # N: Revealed type is "def (x: Literal['A B'])"
+reveal_type(h2)  # N: Revealed type is "def (x: Union[Any, builtins.int])"
+reveal_type(i2)  # N: Revealed type is "def (x: Literal['A|B'])"
 [builtins fixtures/tuple.pyi]
 [out]
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -802,14 +802,20 @@ class Fraction(Real):
 [builtins fixtures/tuple.pyi]
 
 [case testForwardReferenceInNamedTuple]
-from typing import NamedTuple
+from typing import List, NamedTuple
 
 class A(NamedTuple):
     b: 'B'
     x: int
+    y: List['B']
 
 class B:
     pass
+
+def f(a: A):
+    reveal_type(a.b)  # N: Revealed type is "__main__.B"
+    reveal_type(a.x)  # N: Revealed type is "builtins.int"
+    reveal_type(a.y)  # N: Revealed type is "builtins.list[__main__.B]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeNamedTupleClassmethod]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1193,7 +1193,28 @@ def func(callback: Callable[P, str]) -> Callable[P, str]:
     return inner
 [builtins fixtures/paramspec.pyi]
 
-[case testParamSpecArgsAndKwargsMissmatch]
+[case testParamSpecArgsAndKwargsStringified]
+from typing import Callable
+from typing_extensions import ParamSpec
+
+P1 = ParamSpec("P1")
+
+def func(callback: Callable[P1, str]) -> Callable[P1, str]:
+    def inner(*args: "P1.args", **kwargs: "P1.kwargs") -> str:
+        return "foo"
+    return inner
+
+@func
+def outer(a: int) -> str:
+    return ""
+
+outer(1)  # OK
+outer("x")  # E: Argument 1 to "outer" has incompatible type "str"; expected "int"
+outer(a=1)  # OK
+outer(b=1)  # E: Unexpected keyword argument "b" for "outer"
+[builtins fixtures/paramspec.pyi]
+
+[case testParamSpecArgsAndKwargsMismatch]
 from typing import Callable
 from typing_extensions import ParamSpec
 

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -9,6 +9,17 @@ def main(a: object) -> None:
         reveal_type(a)  # N: Revealed type is "builtins.object"
 [builtins fixtures/tuple.pyi]
 
+[case testTypeGuardStringified]
+from typing_extensions import TypeGuard
+class Point: pass
+def is_point(a: object) -> "TypeGuard[Point]": pass
+def main(a: object) -> None:
+    if is_point(a):
+        reveal_type(a)  # N: Revealed type is "__main__.Point"
+    else:
+        reveal_type(a)  # N: Revealed type is "builtins.object"
+[builtins fixtures/tuple.pyi]
+
 [case testTypeGuardTypeArgsNone]
 from typing_extensions import TypeGuard
 def foo(a: object) -> TypeGuard:  # E: TypeGuard must have exactly one type argument

--- a/test-data/unit/check-typeis.test
+++ b/test-data/unit/check-typeis.test
@@ -9,6 +9,17 @@ def main(a: object) -> None:
         reveal_type(a)  # N: Revealed type is "builtins.object"
 [builtins fixtures/tuple.pyi]
 
+[case testTypeIsStringified]
+from typing_extensions import TypeIs
+class Point: pass
+def is_point(a: object) -> "TypeIs[Point]": pass
+def main(a: object) -> None:
+    if is_point(a):
+        reveal_type(a)  # N: Revealed type is "__main__.Point"
+    else:
+        reveal_type(a)  # N: Revealed type is "builtins.object"
+[builtins fixtures/tuple.pyi]
+
 [case testTypeIsElif]
 from typing_extensions import TypeIs
 from typing import Union


### PR DESCRIPTION
Fixes #16367

During semantic analysis, we try to parse all strings as types, including those inside Literal[]. Previously, we preserved the original string in the `UnboundType.original_str_expr` attribute, but if a type is parsed as a Union, we didn't have a place to put the value.

This PR instead always wraps string types in a RawExpressionType node, which now optionally includes a `.node` attribute containing the parsed type. This way, we don't need to worry about preserving the original string as a custom attribute on different kinds of types that can appear in this context.

The downside is that more code needs to be aware of RawExpressionType.