### PR TITLE
fix misleading error message: MyPy should not suggest a syntactic error when function calls are included in type annotations

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1830,6 +1830,10 @@ class TypeConverter:
         f = e.func
         constructor = stringify_name(f)
 
+        if self.parent() is None:
+            return self.invalid_type(
+                e, note="Suggestion: Don't use function calls in type annotations"
+            )
         if not isinstance(self.parent(), ast3.List):
             note = None
             if constructor:

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -51,6 +51,33 @@ for v in x:  # type: int, int  # E: Syntax error in type annotation  [syntax] \
     # N: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
     pass
 
+[case testErrorCodeSyntaxError4]
+from typing import Dict
+from typing_extensions import Annotated
+
+class _EnvironmentVariables():
+    def __init__(self, variables: Dict) -> None:
+        self.__variables = variables
+
+def EnvironmentVariables(sort: bool):
+    return Annotated[_EnvironmentVariables, dict]
+
+def unsorted_env_variables(variables: EnvironmentVariables(sort=False)) -> None: # E: Invalid type comment or annotation  [valid-type] \
+    # N: Suggestion: Don't use function calls in type annotations
+    return variables.as_json_obj()
+
+[builtins fixtures/tuple.pyi]
+
+class _EnvironmentVariables():
+    def __init__(self, variables: dict[str, bytes]) -> None:
+        self.__variables = variables
+
+def EnvironmentVariables(sort: bool):
+    return Annotated[_EnvironmentVariables, dict]
+
+def unsorted_env_variables(variables: EnvironmentVariables(sort=False)) -> None:
+    return variables.as_json_obj()
+
 [case testErrorCodeSyntaxErrorIgnoreNote]
 # This is a bit inconsistent -- syntax error would be more logical?
 x: 'a b'  # type: ignore[valid-type]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -205,7 +205,7 @@ def f(a: Foo(int)) -> int:
     pass
 [out]
 main:7: error: Invalid type comment or annotation
-main:7: note: Suggestion: use Foo[...] instead of Foo(...)
+main:7: note: Suggestion: Don't use function calls in type annotations
 
 [case testFastParseMatMul]
 


### PR DESCRIPTION
#16506

This Pull request makes it obvious that function calls in type annotations are not allowed and gets rid of the previous misleading error that the function called should be changed too foo[...] instead of foo(...)