### PR TITLE
docs: remove six from the intersphinx mappings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -266,7 +266,6 @@ rst_prolog = ".. |...| unicode:: U+2026   .. ellipsis\n"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "six": ("https://six.readthedocs.io", None),
     "attrs": ("https://www.attrs.org/en/stable/", None),
     "cython": ("https://docs.cython.org/en/latest", None),
     "monkeytype": ("https://monkeytype.readthedocs.io/en/latest", None),


### PR DESCRIPTION
002f77cedc9a5c772ebcfb0c5d245a98044c8b21 removed the last reference to six, so there is no need to pull down the six docs inventory