### PR TITLE
Improvements to descriptor `__set__`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2994,7 +2994,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 ):  # Ignore member access to modules
                     instance_type = self.expr_checker.accept(lvalue.expr)
                     rvalue_type, lvalue_type, infer_lvalue_type = self.check_member_assignment(
-                        instance_type, lvalue_type, rvalue, context=rvalue
+                        instance_type, lvalue_type, rvalue, context=lvalue
                     )
                 else:
                     # Hacky special case for assigning a literal None
@@ -4236,8 +4236,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         Return the inferred rvalue_type, inferred lvalue_type, and whether to use the binder
         for this assignment.
 
-        Note: this method exists here and not in checkmember.py, because we need to take
-        care about interaction between binder and __set__().
+        Notes:
+         * The argument passed to `context` should be at the lvalue.
+         * This method exists here and not in checkmember.py, because we need to take
+           care about interaction between binder and __set__().
         """
         instance_type = get_proper_type(instance_type)
         attribute_type = get_proper_type(attribute_type)
@@ -4245,12 +4247,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if (isinstance(instance_type, FunctionLike) and instance_type.is_type_obj()) or isinstance(
             instance_type, TypeType
         ):
-            rvalue_type = self.check_simple_assignment(attribute_type, rvalue, context)
+            rvalue_type = self.check_simple_assignment(attribute_type, rvalue, rvalue)
             return rvalue_type, attribute_type, True
 
         if not isinstance(attribute_type, Instance):
             # TODO: support __set__() for union types.
-            rvalue_type = self.check_simple_assignment(attribute_type, rvalue, context)
+            rvalue_type = self.check_simple_assignment(attribute_type, rvalue, rvalue)
             return rvalue_type, attribute_type, True
 
         mx = MemberContext(
@@ -4269,7 +4271,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # the return type of __get__. This doesn't match the python semantics,
             # (which allow you to override the descriptor with any value), but preserves
             # the type of accessing the attribute (even after the override).
-            rvalue_type = self.check_simple_assignment(get_type, rvalue, context)
+            rvalue_type = self.check_simple_assignment(get_type, rvalue, rvalue)
             return rvalue_type, get_type, True
 
         dunder_set = attribute_type.type.get_method("__set__")
@@ -4341,7 +4343,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # and '__get__' type is narrower than '__set__', then we invoke the binder to narrow type
         # by this assignment. Technically, this is not safe, but in practice this is
         # what a user expects.
-        rvalue_type = self.check_simple_assignment(set_type, rvalue, context)
+        rvalue_type = self.check_simple_assignment(set_type, rvalue, rvalue)
         infer = is_subtype(rvalue_type, get_type) and is_subtype(get_type, set_type)
         return rvalue_type if infer else set_type, get_type, infer
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Sequence, cast
+from typing import TYPE_CHECKING, Callable, Literal, Sequence, cast
 
 from mypy import meet, message_registry, subtypes
 from mypy.erasetype import erase_typevars
@@ -748,6 +748,37 @@ def is_instance_var(var: Var) -> bool:
     )
 
 
+def _partially_supports_classvar_descriptor(
+    typ: Type,
+    descriptor_name: Literal["__get__", "__set__", "__delete__"],
+    non_supporting_types: list[Type],
+    /,
+) -> bool:
+    """
+    For a ClassVar's type, gets whether it (or any item in a union) supports a named
+    descriptor method member.
+
+    Accumulates a list of non-supporting types to be reported.
+    """
+    typ = get_proper_type(typ)
+    has_desc_member = False
+    if isinstance(typ, Instance):
+        has_desc_member = typ.type.has_readable_member(descriptor_name)
+        if not has_desc_member:
+            non_supporting_types.append(typ)
+    elif isinstance(typ, UnionType):
+        for item_type in typ.relevant_items():
+            has_desc_member = (
+                _partially_supports_classvar_descriptor(
+                    item_type, descriptor_name, non_supporting_types
+                )
+                or has_desc_member
+            )
+    else:  # Unhandled type in ClassVar
+        non_supporting_types.append(typ)
+    return has_desc_member
+
+
 def analyze_var(
     name: str,
     var: Var,
@@ -774,8 +805,6 @@ def analyze_var(
         if mx.is_lvalue and var.is_property and not var.is_settable_property:
             # TODO allow setting attributes in subclass (although it is probably an error)
             mx.msg.read_only_property(name, itype.type, mx.context)
-        if mx.is_lvalue and var.is_classvar:
-            mx.msg.cant_assign_to_classvar(name, mx.context)
         t = freshen_all_functions_type_vars(typ)
         if not (mx.is_self or mx.is_super) or supported_self_type(
             get_proper_type(mx.original_type)
@@ -795,6 +824,21 @@ def analyze_var(
         freeze_all_type_vars(t)
         result: Type = t
         typ = get_proper_type(typ)
+
+        if mx.is_lvalue and var.is_classvar:
+            # Warn any class variable assignments from an instance if the lvalue doesn't
+            # support `__set__`
+            non__set__types: list[Type] = []
+            partial__set__support = _partially_supports_classvar_descriptor(
+                result, "__set__", non__set__types
+            )
+            full__set__support = partial__set__support and not non__set__types
+            if not full__set__support:
+                if partial__set__support:
+                    with mx.msg.disable_type_names():
+                        for non_desc_type in non__set__types:
+                            mx.msg.has_no_attr(typ, non_desc_type, "__set__", context=mx.context)
+                mx.msg.cant_assign_to_classvar(name, mx.context)
 
         call_type: ProperType | None = None
         if var.is_initialized_in_class and (not is_instance_var(var) or mx.is_operator):

--- a/test-data/unit/check-classvar.test
+++ b/test-data/unit/check-classvar.test
@@ -12,6 +12,41 @@ A().x = 2
 [out]
 main:4: error: Cannot assign to class variable "x" via instance
 
+[case testAssignmentOnInstanceToClassVarDescriptor]
+from typing import Any, ClassVar
+class D:
+    def __set__(self, inst: Any, value: int) -> None: pass
+class A:
+    x: ClassVar[D] = D()
+a = A()
+a.x = 0
+a.x = '0'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testAssignmentOnInstanceToClassVarPartialDescriptor]
+from typing import Any, ClassVar, Self, Union
+class D:
+    def __set__(self, inst: Any, value: int) -> None: pass
+class A:
+    x: ClassVar[Union[str, D, Self, int]] = D()
+a = A()
+a.x = 0  # E: Item "str" of "Union[str, D, Self, int]" has no attribute "__set__" \
+         # E: Item "A" of "Union[str, D, Self, int]" has no attribute "__set__" \
+         # E: Item "int" of "Union[str, D, Self, int]" has no attribute "__set__" \
+         # E: Cannot assign to class variable "x" via instance
+
+[case testAssignmentOnInstanceToClassVarSelfDescriptor]
+from typing import Any, ClassVar, Self, Union
+class D:
+    d1: ClassVar[Self]
+    d2: ClassVar[Union[int, Self, str]]
+    def __set__(self, inst: Any, value: int) -> None: pass
+inst = D()
+inst.d1 = 0
+inst.d1 = '0'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+inst.d2 = 0  # E: Item "int" of "Union[int, Self, str]" has no attribute "__set__" \
+             # E: Item "str" of "Union[int, Self, str]" has no attribute "__set__" \
+             # E: Cannot assign to class variable "d2" via instance
+
 [case testAssignmentOnSubclassInstance]
 from typing import ClassVar
 class A:

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -85,10 +85,23 @@ main:4:16: error: Incompatible types in assignment (expression has type "int", v
 main:4:24: error: Unsupported operand types for + ("str" and "int")
 
 [case testColumnsAssignment]
+from typing import Any
+
+class GoodDesc:
+    def __set__(self, inst: Any, val: int) -> None: pass
+
+class BadDesc:
+    __set__ = None
+
 class A:
     x = 0
+    y = GoodDesc()
+    z = BadDesc()
 
 A().x = ''  # E:9: Incompatible types in assignment (expression has type "str", variable has type "int")
+A().y = ''  # E:9: Incompatible types in assignment (expression has type "str", variable has type "int")
+A().z = ''  # E:1: __main__.BadDesc.__set__ is not callable
+
 a = [0]
 a[0] = ''  # E:8: Incompatible types in assignment (expression has type "str", target has type "int")
 b = 0


### PR DESCRIPTION
1. Fix wrong error location when assignment errors is due to `__set__`. Presently, the error location appears on the right:
    ```python
    # mypy: pretty=True
    
    import typing as t
    
    class desc:
        __set__ = None
        
    class A:
        prop = desc()
    ```
    ```pycon
    >>> abc: A = A()
    >>> abc.prop = 123
                   ^~~
                   E
    ```
    https://github.com/python/mypy/commit/e570aa1cd8b964a7c32b8a6d1bcefd8d8da4d4db will change the error location to be on the left:
    ```pycon
    >>> abc: A = A()
    >>> abc.prop = 123
        ^~~~~~~~
        E
    ```

2. Fixes #14969
   - The example in the issue will still error because `ClassVar` there is not specified with a type (an unannotated `ClassVar` is equivalent to `ClassVar[Any]`).
   - Unlike in other annotation contexts, I didn't think it was a good idea to be permissive with `Any`, due to the potential creep of false negatives.
