### PR TITLE
Provide hint when Union type with None may not have been narrowed

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -522,12 +522,23 @@ class MessageBuilder:
                     type(item) == NoneType for item in original_type.items
                 ):
                     typ_format = '"None"'
-                self.fail(
-                    'Item {} of {} has no attribute "{}"{}'.format(
-                        typ_format, orig_type_format, member, extra
-                    ),
-                    context,
-                    code=codes.UNION_ATTR,
+                if typ_format == '"None"':(
+                    self.fail(
+                        'Item {} of {} has no attribute "{}"{}. ADD HINT HERE'.format(
+                            typ_format, orig_type_format, member, extra
+                        ),
+                        context,
+                        code=codes.UNION_ATTR,
+                    )
+                )
+                else:(
+                    self.fail(
+                        'Item {} of {} has no attribute "{}"{}'.format(
+                            typ_format, orig_type_format, member, extra
+                        ),
+                        context,
+                        code=codes.UNION_ATTR,
+                    )
                 )
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -530,8 +530,12 @@ class MessageBuilder:
                         code=codes.UNION_ATTR,
                 )
                 if typ_format == '"None"':(
+                    if typ.source is None:
+                        s = ""
+                    else:
+                        s = f' "{typ.source}"'
                     self.note(
-                        'You can use "if <variable name> is not None" to guard against a None value'
+                        f'You can use "if{s} is not None" to guard against a None value'
                     )
                 )
                 return codes.UNION_ATTR

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -523,21 +523,18 @@ class MessageBuilder:
                 ):
                     typ_format = '"None"'
                 self.fail(
-                        'Item {} of {} has no attribute "{}"{}'.format(
-                            typ_format, orig_type_format, member, extra
-                        ),
-                        context,
-                        code=codes.UNION_ATTR,
+                    'Item {} of {} has no attribute "{}"{}'.format(
+                        typ_format, orig_type_format, member, extra
+                    ),
+                    context,
+                    code=codes.UNION_ATTR,
                 )
-                if typ_format == '"None"':(
+                if typ_format == '"None"':
                     if typ.source is None:
                         s = ""
                     else:
                         s = f' "{typ.source}"'
-                    self.note(
-                        f'You can use "if{s} is not None" to guard against a None value'
-                    )
-                )
+                    self.note(f'You can use "if{s} is not None" to guard against a None value')
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):
                 bound = get_proper_type(original_type.upper_bound)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -532,7 +532,12 @@ class MessageBuilder:
                     code=codes.UNION_ATTR,
                 )
                 if typ_format == '"None"':
-                    var_name = f' {get_member_expr_fullname(context.expr)}'
+                    if isinstance(context, NameExpr):
+                        var_name = f' {context.name}'
+                    elif isinstance(context.expr, MemberExpr):
+                        var_name = f' {get_member_expr_fullname(context.expr)}'
+                    else:
+                        var_name = ' <variable name>'
                     self.note(f'You can use "if{var_name} is not None" to guard against a None value', context, code=codes.UNION_ATTR)
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -522,23 +522,12 @@ class MessageBuilder:
                     type(item) == NoneType for item in original_type.items
                 ):
                     typ_format = '"None"'
-                if typ_format == '"None"':(
-                    self.fail(
-                        'Item {} of {} has no attribute "{}"{}. ADD HINT HERE'.format(
-                            typ_format, orig_type_format, member, extra
-                        ),
-                        context,
-                        code=codes.UNION_ATTR,
-                    )
-                )
-                else:(
-                    self.fail(
-                        'Item {} of {} has no attribute "{}"{}'.format(
-                            typ_format, orig_type_format, member, extra
-                        ),
-                        context,
-                        code=codes.UNION_ATTR,
-                    )
+                self.fail(
+                    'Item {} of {} has no attribute "{}"{}'.format(
+                        typ_format, orig_type_format, member, extra
+                    ),
+                    context,
+                    code=codes.UNION_ATTR,
                 )
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -40,17 +40,17 @@ from mypy.nodes import (
     Expression,
     FuncDef,
     IndexExpr,
+    MemberExpr,
     MypyFile,
     NameExpr,
-    MemberExpr,
     ReturnStmt,
     StrExpr,
     SymbolNode,
     SymbolTable,
     TypeInfo,
     Var,
-    reverse_builtin_aliases,
     get_member_expr_fullname,
+    reverse_builtin_aliases,
 )
 from mypy.operators import op_methods, op_methods_to_symbols
 from mypy.options import Options
@@ -533,14 +533,18 @@ class MessageBuilder:
                 )
                 if typ_format == '"None"':
                     if isinstance(context, NameExpr):
-                        var_name = f' {context.name}'
+                        var_name = f" {context.name}"
                     elif isinstance(context.expr, NameExpr):
-                        var_name = f' {context.expr.name}'
+                        var_name = f" {context.expr.name}"
                     elif isinstance(context.expr, MemberExpr):
-                        var_name = f' {get_member_expr_fullname(context.expr)}'
+                        var_name = f" {get_member_expr_fullname(context.expr)}"
                     else:
-                        var_name = ' <variable name>'
-                    self.note(f'You can use "if{var_name} is not None" to guard against a None value', context, code=codes.UNION_ATTR)
+                        var_name = " <variable name>"
+                    self.note(
+                        f'You can use "if{var_name} is not None" to guard against a None value',
+                        context,
+                        code=codes.UNION_ATTR,
+                    )
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):
                 bound = get_proper_type(original_type.upper_bound)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -534,9 +534,9 @@ class MessageBuilder:
                 if typ_format == '"None"':
                     if isinstance(context, NameExpr):
                         var_name = f" {context.name}"
-                    elif isinstance(context.expr, NameExpr):
+                    elif isinstance(context, MemberExpr) and isinstance(context.expr, NameExpr):
                         var_name = f" {context.expr.name}"
-                    elif isinstance(context.expr, MemberExpr):
+                    elif isinstance(context, MemberExpr) and isinstance(context.expr, MemberExpr):
                         var_name = f" {get_member_expr_fullname(context.expr)}"
                     else:
                         var_name = " <variable name>"

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -42,6 +42,7 @@ from mypy.nodes import (
     IndexExpr,
     MypyFile,
     NameExpr,
+    MemberExpr,
     ReturnStmt,
     StrExpr,
     SymbolNode,
@@ -49,6 +50,7 @@ from mypy.nodes import (
     TypeInfo,
     Var,
     reverse_builtin_aliases,
+    get_member_expr_fullname,
 )
 from mypy.operators import op_methods, op_methods_to_symbols
 from mypy.options import Options
@@ -530,11 +532,8 @@ class MessageBuilder:
                     code=codes.UNION_ATTR,
                 )
                 if typ_format == '"None"':
-                    if typ.source is None:
-                        s = ""
-                    else:
-                        s = f' "{typ.source}"'
-                    self.note(f'You can use "if{s} is not None" to guard against a None value')
+                    var_name = f' {get_member_expr_fullname(context.expr)}'
+                    self.note(f'You can use "if{var_name} is not None" to guard against a None value', context, code=codes.UNION_ATTR)
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):
                 bound = get_proper_type(original_type.upper_bound)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -534,6 +534,8 @@ class MessageBuilder:
                 if typ_format == '"None"':
                     if isinstance(context, NameExpr):
                         var_name = f' {context.name}'
+                    elif isinstance(context.expr, NameExpr):
+                        var_name = f' {context.expr.name}'
                     elif isinstance(context.expr, MemberExpr):
                         var_name = f' {get_member_expr_fullname(context.expr)}'
                     else:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -522,22 +522,16 @@ class MessageBuilder:
                     type(item) == NoneType for item in original_type.items
                 ):
                     typ_format = '"None"'
-                if typ_format == '"None"':(
-                    self.fail(
-                        'Item {} of {} has no attribute "{}"{}. ADD HINT HERE'.format(
-                            typ_format, orig_type_format, member, extra
-                        ),
-                        context,
-                        code=codes.UNION_ATTR,
-                    )
-                )
-                else:(
-                    self.fail(
+                self.fail(
                         'Item {} of {} has no attribute "{}"{}'.format(
                             typ_format, orig_type_format, member, extra
                         ),
                         context,
                         code=codes.UNION_ATTR,
+                )
+                if typ_format == '"None"':(
+                    self.note(
+                        'You can use "if <variable name> is not None" to guard against a None value'
                     )
                 )
                 return codes.UNION_ATTR

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2828,7 +2828,8 @@ class C:
     a = None  # E: Need type annotation for "a" (hint: "a: Optional[<type>] = ...")
 
     def f(self, x) -> None:
-        C.a.y  # E: Item "None" of "Optional[Any]" has no attribute "y"
+        C.a.y # E: Item "None" of "Optional[Any]" has no attribute "y" \
+              # N: You can use "if C.a is not None" to guard against a None value
 
 [case testLocalPartialTypesAccessPartialNoneAttribute2]
 # flags: --local-partial-types
@@ -2836,7 +2837,8 @@ class C:
     a = None  # E: Need type annotation for "a" (hint: "a: Optional[<type>] = ...")
 
     def f(self, x) -> None:
-        self.a.y  # E: Item "None" of "Optional[Any]" has no attribute "y"
+        self.a.y  # E: Item "None" of "Optional[Any]" has no attribute "y" \
+                  # N: You can use "if self.a is not None" to guard against a None value
 
 -- Special case for assignment to '_'
 -- ----------------------------------

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -564,7 +564,8 @@ if int():
 if int():
     x = f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 
-x.x = 1 # E: Item "None" of "Optional[Node[int]]" has no attribute "x"
+x.x = 1 # E: Item "None" of "Optional[Node[int]]" has no attribute "x" \
+        # N: You can use "if x is not None" to guard against a None value
 if x is not None:
     x.x = 1 # OK here
 
@@ -617,7 +618,8 @@ A = None  # type: Any
 class C(A):
     pass
 x = None  # type: Optional[C]
-x.foo()  # E: Item "None" of "Optional[C]" has no attribute "foo"
+x.foo()   # E: Item "None" of "Optional[C]" has no attribute "foo" \
+          # N: You can use "if x is not None" to guard against a None value
 
 [case testIsinstanceAndOptionalAndAnyBase]
 from typing import Any, Optional

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -79,6 +79,16 @@ if int():
 
 [builtins fixtures/isinstance.pyi]
 
+[case testUnionAttributeAccessWithNoneItem]
+from typing import Union
+
+class A:
+    def foo(self) -> int: pass
+
+def f(x: Union[A, None]) -> int:
+    return x.foo()  # E: Item "None" of "Optional[A]" has no attribute "foo" \
+                              # N: You can use "if x is not None" to guard against a None value
+
 [case testUnionMethodCalls]
 from typing import Union
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -935,7 +935,8 @@ a: Any
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
 
-for y in x: pass # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__" (not iterable)
+for y in x: pass  # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__" (not iterable) \
+                  # N: You can use "if x is not None" to guard against a None value
 if x:
     for s, t in x:
         reveal_type(s) # N: Revealed type is "builtins.str"
@@ -950,7 +951,8 @@ x = None
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
 
-for y in x: pass # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__" (not iterable)
+for y in x: pass  # E: Item "None" of "Optional[List[Tuple[str, str]]]" has no attribute "__iter__" (not iterable) \
+                  # N: You can use "if x is not None" to guard against a None value
 if x:
     for s, t in x:
         reveal_type(s) # N: Revealed type is "builtins.str"


### PR DESCRIPTION
Fixes #17036

When a union includes `None`, new users may not know they need an `is not None` check before accessing attributes. For example, the following code: 
```
class A:
    def foo(self) -> int: pass

def f(x: Union[A, None]) -> int:
    return x.foo()
```
previously (on the master branch) generated this error message: 
```
main:7: error: Item "None" of "Optional[A]" has no attribute "foo"
```
which may be ambiguous since `x` is never explicitly defined as `None`. 

With this PR, the message remains, but we add a suggestion for how to fix the error:
```
main:7: error: Item "None" of "Optional[A]" has no attribute "foo"
main:7: note: You can use "if x is not None" to guard against a None value
```
This is possible by checking if `None` is part of the union when an error signaling a type doesn't have an attribute is triggered and displays the corresponding hint if it is.