### PR TITLE
Pin MacOS version in GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         - name: mypyc runtime tests with py39-macos
           python: '3.9.18'
           arch: x64
-          # TODO: macos-13 is the latest to support Python 3.9, change it to macos-latest when updating the Python version
+          # TODO: macos-13 is the last one to support Python 3.9, change it to macos-latest when updating the Python version
           os: macos-13
           toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,6 @@ jobs:
 
         - name: mypyc runtime tests with py39-macos
           python: '3.9.19'
-          arch: x64
           os: macos-latest
           toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,9 @@ jobs:
           test_mypyc: true
 
         - name: mypyc runtime tests with py39-macos
-          python: '3.9.19'
-          os: macos-latest
+          python: '3.9.18'
+          arch: x64
+          os: macos-13
           toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"
         - name: mypyc runtime tests with py38-debug-build-ubuntu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           test_mypyc: true
 
         - name: mypyc runtime tests with py39-macos
-          python: '3.9.18'
+          python: '3.9.19'
           arch: x64
           os: macos-latest
           toxenv: py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
         - name: mypyc runtime tests with py39-macos
           python: '3.9.18'
           arch: x64
+          # TODO: macos-13 is the latest to support Python 3.9, change it to macos-latest when updating the Python version
           os: macos-13
           toxenv: py
           tox_extra_args: "-n 2 mypyc/test/test_run.py mypyc/test/test_external.py"


### PR DESCRIPTION
Fix failing MacOS tests in CI

Python 3.9 is not available on the latest MacOS images https://github.com/actions/setup-python/issues/850