### PR TITLE
Fix handling of typing.Optional in stubgen 

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -309,7 +309,7 @@ class InspectionStubGenerator(BaseStubGenerator):
             if defaults and i >= len(args) - len(defaults):
                 default_value = defaults[i - (len(args) - len(defaults))]
                 if arg in annotations:
-                    argtype = annotations[arg]
+                    argtype = get_annotation(arg)
                 else:
                     argtype = self.get_type_annotation(default_value)
                     if argtype == "None":
@@ -735,7 +735,9 @@ class InspectionStubGenerator(BaseStubGenerator):
         typename = getattr(typ, "__qualname__", typ.__name__)
         module_name = self.get_obj_module(typ)
         assert module_name is not None, typ
-        if module_name != "builtins":
+        if module_name == "typing" and typename == "Optional":
+            typename = str(typ)
+        elif module_name != "builtins":
             typename = f"{module_name}.{typename}"
         return typename
 


### PR DESCRIPTION
When running stubgen on my local repository I noticed a couple of errors occurring notably around the handling of typing.Union / typing.Optional when `--inspect-mode` was being used.

I am running Python 3.10.14 on Linux.

I put together a mre:

```python
from typing import Optional

def func0(left: int, right: Optional[int]) -> int:
    """Add 2 numbers together"""
    if right:
        return left + right
    return left

def func1(left: int, right: Optional[int] = None) -> int:
    """Add 2 numbers together"""
    if right:
        return left + right
    return left
```

I put this in `mre.py` then ran:

```bash
stubgen ./mre.py --include-docstrings --inspect-mode
```

I would get:
```
TypeError: compile() arg 1 must be a string, bytes or AST object
```
calling `get_annotations(arg)` fixed this as the object being passed through was <class 'int'> and not the string version

```
return f"{t.args[0].accept(self)} | None"
IndexError: tuple index out of range
```
this was because `Optional[int]` was becoming `typing.Optional` and not `typing.Optional[int]` I updated handling to pass the `[int]` through (this may be incorrect though)


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
