### PR TITLE
Shorter reporting (i.e. don't highlight entire functions for certain errors)

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -985,45 +985,9 @@ class ASTConverter:
                     _dummy_fallback,
                 )
 
-        # We don't want the end positions for functions to include the entire
-        # body, which is what `ast` gives us; we want to highlight only the
-        # function signature as the error / note.
-
-        # First, check for return typehint
-        ret = n.returns
-        if ret is not None:
-            # There is a return typehint; highlight to the end of it.
-            end_line = ret.end_lineno
-            end_column = ret.end_col_offset
-        elif len(n.body) > 0:
-            # There's no return type, but there is a body (which includes
-            # docstrings).
-            def_line = n.lineno
-            body_line = n.body[0].lineno
-            if def_line == body_line:
-                # Single line definition, e.g. `def foo(): pass`
-                # NOTE: this will not highlight the colon in the nonstandard
-                # case of `def foo():pass`
-                end_line = def_line
-                end_column = n.body[0].col_offset - 1
-            else:
-                # "Proper" body starting on a different line after `:`
-                # We highlight up to the line in which the body starts
-                # but at column 0, effectively ending at the end of the
-                # previous line.
-                # NOTE: this causes funny highlighting in the non-standard
-                # case below:
-                #
-                # def foo(x: int
-                #          ): pass
-                #
-                # The error will show from `d` of `def to `t` of `int`.
-                end_line = n.body[0].lineno
-                end_column = 0
-        else:
-            # Fall back to whole function.
-            end_line = getattr(n, "end_lineno", None)
-            end_column = getattr(n, "end_col_offset", None)
+        # End position is always the same.
+        end_line = getattr(n, "end_lineno", None)
+        end_column = getattr(n, "end_col_offset", None)
 
         self.class_and_function_stack.pop()
         self.class_and_function_stack.append("F")

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -985,9 +985,45 @@ class ASTConverter:
                     _dummy_fallback,
                 )
 
-        # End position is always the same.
-        end_line = getattr(n, "end_lineno", None)
-        end_column = getattr(n, "end_col_offset", None)
+        # We don't want the end positions for functions to include the entire
+        # body, which is what `ast` gives us; we want to highlight only the
+        # function signature as the error / note.
+
+        # First, check for return typehint
+        ret = n.returns
+        if ret is not None:
+            # There is a return typehint; highlight to the end of it.
+            end_line = ret.end_lineno
+            end_column = ret.end_col_offset
+        elif len(n.body) > 0:
+            # There's no return type, but there is a body (which includes
+            # docstrings).
+            def_line = n.lineno
+            body_line = n.body[0].lineno
+            if def_line == body_line:
+                # Single line definition, e.g. `def foo(): pass`
+                # NOTE: this will not highlight the colon in the nonstandard
+                # case of `def foo():pass`
+                end_line = def_line
+                end_column = n.body[0].col_offset - 1
+            else:
+                # "Proper" body starting on a different line after `:`
+                # We highlight up to the line in which the body starts
+                # but at column 0, effectively ending at the end of the
+                # previous line.
+                # NOTE: this causes funny highlighting in the non-standard
+                # case below:
+                #
+                # def foo(x: int
+                #          ): pass
+                #
+                # The error will show from `d` of `def to `t` of `int`.
+                end_line = n.body[0].lineno
+                end_column = 0
+        else:
+            # Fall back to whole function.
+            end_line = getattr(n, "end_lineno", None)
+            end_column = getattr(n, "end_col_offset", None)
 
         self.class_and_function_stack.pop()
         self.class_and_function_stack.append("F")

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6520,12 +6520,28 @@ class SemanticAnalyzer(
             return
         # In case it's a bug and we don't really have context
         assert ctx is not None, msg
-        self.errors.report(ctx.line, ctx.column, msg, blocker=blocker, code=code)
+        self.errors.report(
+            ctx.line,
+            ctx.column,
+            msg,
+            blocker=blocker,
+            end_line=ctx.end_line,
+            end_column=ctx.end_column,
+            code=code,
+        )
 
     def note(self, msg: str, ctx: Context, code: ErrorCode | None = None) -> None:
         if not self.in_checked_function():
             return
-        self.errors.report(ctx.line, ctx.column, msg, severity="note", code=code)
+        self.errors.report(
+            ctx.line,
+            ctx.column,
+            msg,
+            severity="note",
+            end_line=ctx.end_line,
+            end_column=ctx.end_column,
+            code=code,
+        )
 
     def incomplete_feature_enabled(self, feature: str, ctx: Context) -> bool:
         if feature not in self.options.enable_incomplete_feature:


### PR DESCRIPTION
This pertains to #16746, and is a work in progress. Most likely, I'll work into #17006 instead. But since it's been a while, I wanted to have this here to comment on what I learned.

The goal is to avoid highlighting entire functions as the error for things like missing return statement, forgotten `self`, etc. I'm not sure we have an exhaustive list of the errors which do this, but perhaps we can find an approach where the entire function is *never* highlighted as an error.