### PR TITLE
Automatically set -n=0 when running tests with --update-data

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -620,11 +620,13 @@ def pytest_addoption(parser: Any) -> None:
     )
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    if config.getoption("--update-data") and config.getoption("--numprocesses", default=1) > 1:
-        raise pytest.UsageError(
-            "--update-data incompatible with parallelized tests; re-run with -n 1"
-        )
+@pytest.hookimpl(tryfirst=True)
+def pytest_cmdline_main(config: pytest.Config) -> None:
+    if config.getoption("--collectonly"):
+        return
+    # --update-data is not compatible with parallelized tests, disable parallelization
+    if config.getoption("--update-data"):
+        config.option.numprocesses = 0
 
 
 # This function name is special to pytest.  See

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -133,8 +133,8 @@ def assert_string_arrays_equal(expected: list[str], actual: list[str], msg: str)
             show_align_message(expected[first_diff], actual[first_diff])
 
         sys.stderr.write(
-            "Update the test output using --update-data -n0 "
-            "(you can additionally use the -k selector to update only specific tests)\n"
+            "Update the test output using --update-data "
+            "(implies -n0; you can additionally use the -k selector to update only specific tests)\n"
         )
         pytest.fail(msg, pytrace=False)
 


### PR DESCRIPTION
Unless there is a reason to have the error, I think this improves the developer experience.