### PR TITLE
fix: annotated argument's `var` node type is explicit, not inferred

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1099,7 +1099,7 @@ class ASTConverter:
         if argument_elide_name(arg.arg):
             pos_only = True
 
-        argument = Argument(Var(arg.arg), arg_type, self.visit(default), kind, pos_only)
+        argument = Argument(Var(arg.arg, arg_type), arg_type, self.visit(default), kind, pos_only)
         argument.set_line(
             arg.lineno,
             arg.col_offset,


### PR DESCRIPTION
Fixes #17216

During conversion from a standard library AST to the mypy AST, `Var` nodes were being created inside `Argument` nodes  without acknowledging the presence of a type annotation, leading to the `Var` node's type as being always set as *inferred*:

https://github.com/python/mypy/blob/fb31409b392c5533b25173705d62ed385ee39cfb/mypy/nodes.py#L988

This causes an error at

https://github.com/python/mypy/blob/fb31409b392c5533b25173705d62ed385ee39cfb/mypyc/irbuild/expression.py#L161-L164

The fix simply acknowledges any presence of a type annotation, so the type of the relevant `Var` node is no longer considered inferred if an annotation is present.