### PR TITLE
Fix error on instance property and init-only variable with the same name in a dataclass

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3165,12 +3165,18 @@ class TypeInfo(SymbolNode):
         for cls in self.mro:
             if name in cls.names:
                 node = cls.names[name].node
-                if isinstance(node, FuncBase):
-                    return node
-                elif isinstance(node, Decorator):  # Two `if`s make `mypyc` happy
-                    return node
-                else:
-                    return None
+            elif possible_redefinitions := sorted(
+                [n for n in cls.names.keys() if n.startswith(f"{name}-redefinition")]
+            ):
+                node = cls.names[possible_redefinitions[-1]].node
+            else:
+                continue
+            if isinstance(node, FuncBase):
+                return node
+            elif isinstance(node, Decorator):  # Two `if`s make `mypyc` happy
+                return node
+            else:
+                return None
         return None
 
     def calculate_metaclass_type(self) -> mypy.types.Instance | None:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2475,3 +2475,42 @@ class Base:
 class Child(Base):
     y: int
 [builtins fixtures/dataclasses.pyi]
+
+[case testDataclassesInitVarsWithProperty]
+from dataclasses import InitVar, dataclass, field
+
+@dataclass
+class Test:
+    foo: InitVar[str]
+    _foo: str = field(init=False)
+
+    def __post_init__(self, foo: str) -> None:
+        self._foo = foo
+
+    @property
+    def foo(self) -> str:
+        return self._foo
+
+    @foo.setter
+    def foo(self, value: str) -> None:
+        self._foo = value
+
+reveal_type(Test)  # N: Revealed type is "def (foo: builtins.str) -> __main__.Test"
+test = Test(42)  # E: Argument 1 to "Test" has incompatible type "int"; expected "str"
+test = Test("foo")
+test.foo
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassesWithProperty]
+from dataclasses import dataclass
+
+@dataclass
+class Test:
+    @property
+    def foo(self) -> str:
+        return "a"
+
+    @foo.setter
+    def foo(self, value: str) -> None:
+        pass
+[builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
Fixes #12046

It does not raise "already defined" fail if already existing node is `InitVar`, so name of the property will be redefined. Then, when getting the method of that property, it looks for a possible redefinition.