### PR TITLE
[PEP 695] Partial support for new type parameter syntax in Python 3.12

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3417,8 +3417,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if (
                     lv.node.final_unset_in_class
                     and not lv.node.final_set_in_init
-                    and not self.is_stub
-                    and  # It is OK to skip initializer in stub files.
+                    and not self.is_stub  # It is OK to skip initializer in stub files.
+                    and
                     # Avoid extra error messages, if there is no type in Final[...],
                     # then we already reported the error about missing r.h.s.
                     isinstance(s, AssignmentStmt)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2567,6 +2567,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if they are actually covariant/contravariant, since this may break
         transitivity of subtyping, see PEP 544.
         """
+        if defn.type_args is not None:
+            # Using new-style syntax (PEP 695), so variance will be inferred
+            return
         info = defn.info
         object_type = Instance(info.mro[-1], [])
         tvars = info.defn.type_vars

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -146,6 +146,7 @@ from mypy.sharedparse import BINARY_MAGIC_METHODS
 from mypy.state import state
 from mypy.subtypes import (
     find_member,
+    infer_class_variances,
     is_callable_compatible,
     is_equivalent,
     is_more_precise,
@@ -153,7 +154,7 @@ from mypy.subtypes import (
     is_same_type,
     is_subtype,
     restrict_subtype_away,
-    unify_generic_callable, infer_class_variances,
+    unify_generic_callable,
 )
 from mypy.traverser import TraverserVisitor, all_return_statements, has_return_statement
 from mypy.treetransform import TransformVisitor

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2374,7 +2374,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     self.allow_abstract_call = old_allow_abstract_call
                 # TODO: Apply the sig to the actual TypeInfo so we can handle decorators
                 # that completely swap out the type.  (e.g. Callable[[Type[A]], Type[B]])
-        if typ.defn.type_vars:
+        if typ.defn.type_vars and typ.defn.type_args is None:
             for base_inst in typ.bases:
                 for base_tvar, base_decl_tvar in zip(
                     base_inst.args, base_inst.type.defn.type_vars

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2396,6 +2396,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             self.check_protocol_variance(defn)
         if not defn.has_incompatible_baseclass and defn.info.is_enum:
             self.check_enum(defn)
+        infer_class_variances(defn, self.named_type("builtins.object"))
 
     def check_final_deletable(self, typ: TypeInfo) -> None:
         # These checks are only for mypyc. Only perform some checks that are easier
@@ -8443,3 +8444,47 @@ class VarAssignVisitor(TraverserVisitor):
             self.lvalue = True
             p.capture.accept(self)
             self.lvalue = False
+
+
+def infer_variance(info: TypeInfo, i: int, object_type: ProperType) -> None:
+    """Infer the variance of the ith type variable of a generic class."""
+    for variance in COVARIANT, CONTRAVARIANT, INVARIANT:
+        tv = info.defn.type_vars[i]
+        assert isinstance(tv, TypeVarType)
+        tv.variance = variance
+        co = True
+        contra = True
+        tvar = info.defn.type_vars[i]
+        for member, sym in info.names.items():
+            node = sym.node
+            typ = None
+            if isinstance(node, FuncDef):
+                typ = node.type
+                if isinstance(typ, FunctionLike):
+                    typ = bind_self(typ)
+
+            if typ:
+                typ2 = expand_type(typ, {tvar.id: object_type})
+                print(member, typ, typ2)
+                if not is_subtype(typ, typ2):
+                    co = False
+                if not is_subtype(typ2, typ):
+                    contra = False
+        if co:
+            v = COVARIANT
+        elif contra:
+            v = CONTRAVARIANT
+        else:
+            v = INVARIANT
+        if v == variance:
+            break
+        tv.variance = INVARIANT
+
+
+def infer_class_variances(defn: ClassDef, obj: ProperType) -> None:
+    if not defn.type_args:
+        return
+    tvs = defn.type_vars
+    for i, tv in enumerate(tvs):
+        if isinstance(tv, TypeVarType):
+            infer_variance(defn.info, i, obj)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -80,6 +80,8 @@ from mypy.nodes import (
     TryStmt,
     TupleExpr,
     TypeAliasStmt,
+    TypeParam,
+    TypeVarExpr,
     UnaryExpr,
     Var,
     WhileStmt,
@@ -886,7 +888,7 @@ class ASTConverter:
         arg_kinds = [arg.kind for arg in args]
         arg_names = [None if arg.pos_only else arg.variable.name for arg in args]
         # Type parameters, if using new syntax for generics (PEP 695)
-        explicit_type_params: list[tuple[str, Type | None]] | None = None
+        explicit_type_params: list[TypeParam] | None = None
 
         arg_types: list[Type | None] = []
         if no_type_check:
@@ -1129,7 +1131,7 @@ class ASTConverter:
         keywords = [(kw.arg, self.visit(kw.value)) for kw in n.keywords if kw.arg]
 
         # Type parameters, if using new syntax for generics (PEP 695)
-        explicit_type_params: list[tuple[str, Type | None]] | None = None
+        explicit_type_params: list[TypeParam] | None = None
 
         if sys.version_info >= (3, 12) and n.type_params:
             if NEW_GENERIC_SYNTAX in self.options.enable_incomplete_feature:
@@ -1165,14 +1167,14 @@ class ASTConverter:
         self.class_and_function_stack.pop()
         return cdef
 
-    def translate_type_params(self, type_params: Any) -> list[tuple[str, Type | None]]:
+    def translate_type_params(self, type_params: list[Any]) -> list[TypeParam]:
         explicit_type_params = []
         for p in type_params:
             if p.bound is None:
                 bound = None
             else:
                 bound = TypeConverter(self.errors, line=p.lineno).visit(p.bound)
-            explicit_type_params.append((p.name, bound))
+            explicit_type_params.append(TypeParam(p.name, bound, []))
         return explicit_type_params
 
     # Return(expr? value)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -88,7 +88,7 @@ from mypy.nodes import (
     YieldFromExpr,
     check_arg_names,
 )
-from mypy.options import Options, NEW_GENERIC_SYNTAX
+from mypy.options import NEW_GENERIC_SYNTAX, Options
 from mypy.patterns import (
     AsPattern,
     ClassPattern,
@@ -944,8 +944,9 @@ class ASTConverter:
                     explicit_type_params = self.translate_type_params(n.type_params)
                 else:
                     self.fail(
-                        ErrorMessage("PEP 695 generics are not yet supported",
-                                     code=codes.VALID_TYPE),
+                        ErrorMessage(
+                            "PEP 695 generics are not yet supported", code=codes.VALID_TYPE
+                        ),
                         n.type_params[0].lineno,
                         n.type_params[0].col_offset,
                         blocker=False,

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1170,11 +1170,14 @@ class ASTConverter:
     def translate_type_params(self, type_params: list[Any]) -> list[TypeParam]:
         explicit_type_params = []
         for p in type_params:
-            if p.bound is None:
-                bound = None
-            else:
+            bound = None
+            values: list[Type] = []
+            if isinstance(p.bound, ast3.Tuple):
+                conv = TypeConverter(self.errors, line=p.lineno)
+                values = [conv.visit(t) for t in p.bound.elts]
+            elif p.bound is not None:
                 bound = TypeConverter(self.errors, line=p.lineno).visit(p.bound)
-            explicit_type_params.append(TypeParam(p.name, bound, []))
+            explicit_type_params.append(TypeParam(p.name, bound, values))
         return explicit_type_params
 
     # Return(expr? value)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -179,12 +179,12 @@ else:
 
 if sys.version_info >= (3, 12):
     ast_TypeAlias = ast3.TypeAlias
-    ParamSpec = ast3.ParamSpec
-    TypeVarTuple = ast3.TypeVarTuple
+    ast_ParamSpec = ast3.ParamSpec
+    ast_TypeVarTuple = ast3.TypeVarTuple
 else:
     ast_TypeAlias = Any
-    ParamSpec = Any
-    TypeVarTuple = Any
+    ast_ParamSpec = Any
+    ast_TypeVarTuple = Any
 
 N = TypeVar("N", bound=Node)
 
@@ -1179,9 +1179,9 @@ class ASTConverter:
         for p in type_params:
             bound = None
             values: list[Type] = []
-            if isinstance(p, ParamSpec):  # type: ignore[misc]
+            if isinstance(p, ast_ParamSpec):  # type: ignore[misc]
                 explicit_type_params.append(TypeParam(p.name, PARAM_SPEC_KIND, None, []))
-            elif isinstance(p, TypeVarTuple):  # type: ignore[misc]
+            elif isinstance(p, ast_TypeVarTuple):  # type: ignore[misc]
                 explicit_type_params.append(TypeParam(p.name, TYPE_VAR_TUPLE_KIND, None, []))
             else:
                 if isinstance(p.bound, ast3.Tuple):

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -19,6 +19,7 @@ from mypy.nodes import (
     ARG_STAR2,
     PARAM_SPEC_KIND,
     TYPE_VAR_KIND,
+    TYPE_VAR_TUPLE_KIND,
     ArgKind,
     Argument,
     AssertStmt,
@@ -148,11 +149,6 @@ def ast3_parse(
 NamedExpr = ast3.NamedExpr
 Constant = ast3.Constant
 
-if sys.version_info >= (3, 12):
-    ast_TypeAlias = ast3.TypeAlias
-else:
-    ast_TypeAlias = Any
-
 if sys.version_info >= (3, 10):
     Match = ast3.Match
     MatchValue = ast3.MatchValue
@@ -175,14 +171,20 @@ else:
     MatchAs = Any
     MatchOr = Any
     AstNode = Union[ast3.expr, ast3.stmt, ast3.ExceptHandler]
+
 if sys.version_info >= (3, 11):
     TryStar = ast3.TryStar
 else:
     TryStar = Any
+
 if sys.version_info >= (3, 12):
+    ast_TypeAlias = ast3.TypeAlias
     ParamSpec = ast3.ParamSpec
+    TypeVarTuple = ast3.TypeVarTuple
 else:
+    ast_TypeAlias = Any
     ParamSpec = Any
+    TypeVarTuple = Any
 
 N = TypeVar("N", bound=Node)
 
@@ -1179,6 +1181,8 @@ class ASTConverter:
             values: list[Type] = []
             if isinstance(p, ParamSpec):  # type: ignore[misc]
                 explicit_type_params.append(TypeParam(p.name, PARAM_SPEC_KIND, None, []))
+            elif isinstance(p, TypeVarTuple):  # type: ignore[misc]
+                explicit_type_params.append(TypeParam(p.name, TYPE_VAR_TUPLE_KIND, None, []))
             else:
                 if isinstance(p.bound, ast3.Tuple):
                     conv = TypeConverter(self.errors, line=p.lineno)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1761,6 +1761,7 @@ class ASTConverter:
 
     # TypeAlias(identifier name, type_param* type_params, expr value)
     def visit_TypeAlias(self, n: ast_TypeAlias) -> TypeAliasStmt | AssignmentStmt:
+        node: TypeAliasStmt | AssignmentStmt
         if NEW_GENERIC_SYNTAX in self.options.enable_incomplete_feature:
             type_params = self.translate_type_params(n.type_params)
             value = self.visit(n.value)

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -6,7 +6,7 @@ from typing import overload
 
 import mypy.typeops
 from mypy.maptype import map_instance_to_supertype
-from mypy.nodes import CONTRAVARIANT, COVARIANT, INVARIANT
+from mypy.nodes import CONTRAVARIANT, COVARIANT, INVARIANT, VARIANCE_NOT_READY
 from mypy.state import state
 from mypy.subtypes import (
     SubtypeContext,
@@ -97,7 +97,7 @@ class InstanceJoiner:
                 elif isinstance(sa_proper, AnyType):
                     new_type = AnyType(TypeOfAny.from_another_any, sa_proper)
                 elif isinstance(type_var, TypeVarType):
-                    if type_var.variance == COVARIANT:
+                    if type_var.variance in (COVARIANT, VARIANCE_NOT_READY):
                         new_type = join_types(ta, sa, self)
                         if len(type_var.values) != 0 and new_type not in type_var.values:
                             self.seen_instances.pop()

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2453,6 +2453,7 @@ class TypeApplication(Expression):
 INVARIANT: Final = 0
 COVARIANT: Final = 1
 CONTRAVARIANT: Final = 2
+VARIANCE_NOT_READY: Final = 3  # Variance hasn't been inferred (using Python 3.12 syntax)
 
 
 class TypeVarLikeExpr(SymbolNode, Expression):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1120,7 +1120,7 @@ class ClassDef(Statement):
         base_type_exprs: list[Expression] | None = None,
         metaclass: Expression | None = None,
         keywords: list[tuple[str, Expression]] | None = None,
-        type_args: list[tuple[str, mypy.types.Type | None]] | None = None
+        type_args: list[tuple[str, mypy.types.Type | None]] | None = None,
     ) -> None:
         super().__init__()
         self.name = name
@@ -1625,9 +1625,14 @@ class TypeAliasStmt(Statement):
 
     name: NameExpr
     type_args: list[tuple[str, mypy.types.Type | None]]
-    value: Expression # mypy.types.Type
+    value: Expression  # mypy.types.Type
 
-    def __init__(self, name: NameExpr, type_args: list[tuple[str, mypy.types.Type | None]], value: Expression) -> None:
+    def __init__(
+        self,
+        name: NameExpr,
+        type_args: list[tuple[str, mypy.types.Type | None]],
+        value: Expression,
+    ) -> None:
         super().__init__()
         self.name = name
         self.type_args = type_args

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1618,6 +1618,25 @@ class MatchStmt(Statement):
         return visitor.visit_match_stmt(self)
 
 
+class TypeAliasStmt(Statement):
+    __slots__ = ("name", "type_args", "value")
+
+    __match_args__ = ("name", "type_args", "value")
+
+    name: NameExpr
+    type_args: list[tuple[str, mypy.types.Type | None]]
+    value: Expression # mypy.types.Type
+
+    def __init__(self, name: NameExpr, type_args: list[tuple[str, mypy.types.Type | None]], value: Expression) -> None:
+        super().__init__()
+        self.name = name
+        self.type_args = type_args
+        self.value = value
+
+    def accept(self, visitor: StatementVisitor[T]) -> T:
+        return visitor.visit_type_alias_stmt(self)
+
+
 # Expressions
 
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -689,8 +689,8 @@ class FuncItem(FuncBase):
 
     __slots__ = (
         "arguments",  # Note that can be unset if deserialized (type is a lie!)
-        "arg_names",  # Names of parameters
-        "arg_kinds",  # Kinds of parameters
+        "arg_names",  # Names of arguments
+        "arg_kinds",  # Kinds of arguments
         "min_args",  # Minimum number of arguments
         "max_pos",  # Maximum number of positional arguments, -1 if no explicit
         # limit (*args not included)
@@ -719,7 +719,7 @@ class FuncItem(FuncBase):
         self.arg_names = [None if arg.pos_only else arg.variable.name for arg in self.arguments]
         self.arg_kinds: list[ArgKind] = [arg.kind for arg in self.arguments]
         self.max_pos: int = self.arg_kinds.count(ARG_POS) + self.arg_kinds.count(ARG_OPT)
-        self.type_args = type_args
+        self.type_args: list[TypeParam] | None = type_args
         self.body: Block = body or Block([])
         self.type = typ
         self.unanalyzed_type = typ
@@ -1119,7 +1119,6 @@ class ClassDef(Statement):
     # New-style type parameters (PEP 695), unanalyzed
     type_args: list[TypeParam] | None
     # Semantically analyzed type parameters (all syntax variants)
-    # TODO: Move these to TypeInfo? These partially duplicate type_args.
     type_vars: list[mypy.types.TypeVarLikeType]
     # Base class expressions (not semantically analyzed -- can be arbitrary expressions)
     base_type_exprs: list[Expression]
@@ -1647,7 +1646,7 @@ class TypeAliasStmt(Statement):
 
     name: NameExpr
     type_args: list[TypeParam]
-    value: Expression  # mypy.types.Type
+    value: Expression  # Will get translated into a type
 
     def __init__(self, name: NameExpr, type_args: list[TypeParam], value: Expression) -> None:
         super().__init__()

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -653,6 +653,15 @@ class Argument(Node):
         self.variable.set_line(self.line, self.column, self.end_line, self.end_column)
 
 
+class TypeParam:
+    __slots__ = ("name", "upper_bound", "values")
+
+    def __init__(self, name: str, upper_bound: mypy.types.Type | None, values: list[mypy.types.Type]) -> None:
+        self.name = name
+        self.upper_bound = upper_bound
+        self.values = values
+
+
 FUNCITEM_FLAGS: Final = FUNCBASE_FLAGS + [
     "is_overload",
     "is_generator",
@@ -690,7 +699,7 @@ class FuncItem(FuncBase):
         arguments: list[Argument] | None = None,
         body: Block | None = None,
         typ: mypy.types.FunctionLike | None = None,
-        type_args: list[tuple[str, mypy.types.Type | None]] | None = None,
+        type_args: list[TypeParam] | None = None,
     ) -> None:
         super().__init__()
         self.arguments = arguments or []
@@ -764,7 +773,7 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         arguments: list[Argument] | None = None,
         body: Block | None = None,
         typ: mypy.types.FunctionLike | None = None,
-        type_args: list[tuple[str, mypy.types.Type | None]] | None = None,
+        type_args: list[TypeParam] | None = None,
     ) -> None:
         super().__init__(arguments, body, typ, type_args)
         self._name = name
@@ -1095,7 +1104,7 @@ class ClassDef(Statement):
     _fullname: str  # Fully qualified name of the class
     defs: Block
     # New-style type parameters (PEP 695), unanalyzed
-    type_args: list[tuple[str, mypy.types.Type | None]] | None
+    type_args: list[TypeParam] | None
     # Semantically analyzed type parameters (all syntax variants)
     # TODO: Move these to TypeInfo? These partially duplicate type_args.
     type_vars: list[mypy.types.TypeVarLikeType]
@@ -1120,7 +1129,7 @@ class ClassDef(Statement):
         base_type_exprs: list[Expression] | None = None,
         metaclass: Expression | None = None,
         keywords: list[tuple[str, Expression]] | None = None,
-        type_args: list[tuple[str, mypy.types.Type | None]] | None = None,
+        type_args: list[TypeParam] | None = None,
     ) -> None:
         super().__init__()
         self.name = name
@@ -1624,13 +1633,13 @@ class TypeAliasStmt(Statement):
     __match_args__ = ("name", "type_args", "value")
 
     name: NameExpr
-    type_args: list[tuple[str, mypy.types.Type | None]]
+    type_args: list[TypeParam]
     value: Expression  # mypy.types.Type
 
     def __init__(
         self,
         name: NameExpr,
-        type_args: list[tuple[str, mypy.types.Type | None]],
+        type_args: list[TypeParam],
         value: Expression,
     ) -> None:
         super().__init__()

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1074,6 +1074,7 @@ class ClassDef(Statement):
         "name",
         "_fullname",
         "defs",
+        "type_args",
         "type_vars",
         "base_type_exprs",
         "removed_base_type_exprs",
@@ -1093,6 +1094,10 @@ class ClassDef(Statement):
     name: str  # Name of the class without module prefix
     _fullname: str  # Fully qualified name of the class
     defs: Block
+    # New-style type parameters (PEP 695), unanalyzed
+    type_args: list[tuple[str, mypy.types.Type | None]] | None
+    # Semantically analyzed type parameters (all syntax variants)
+    # TODO: Move these to TypeInfo? These partially duplicate type_args.
     type_vars: list[mypy.types.TypeVarLikeType]
     # Base class expressions (not semantically analyzed -- can be arbitrary expressions)
     base_type_exprs: list[Expression]
@@ -1115,12 +1120,14 @@ class ClassDef(Statement):
         base_type_exprs: list[Expression] | None = None,
         metaclass: Expression | None = None,
         keywords: list[tuple[str, Expression]] | None = None,
+        type_args: list[tuple[str, mypy.types.Type | None]] | None = None
     ) -> None:
         super().__init__()
         self.name = name
         self._fullname = ""
         self.defs = defs
         self.type_vars = type_vars or []
+        self.type_args = type_args
         self.base_type_exprs = base_type_exprs or []
         self.removed_base_type_exprs = []
         self.info = CLASSDEF_NO_INFO

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -667,11 +667,12 @@ class FuncItem(FuncBase):
 
     __slots__ = (
         "arguments",  # Note that can be unset if deserialized (type is a lie!)
-        "arg_names",  # Names of arguments
-        "arg_kinds",  # Kinds of arguments
+        "arg_names",  # Names of parameters
+        "arg_kinds",  # Kinds of parameters
         "min_args",  # Minimum number of arguments
         "max_pos",  # Maximum number of positional arguments, -1 if no explicit
         # limit (*args not included)
+        "type_args",  # New-style type parameters (PEP 695)
         "body",  # Body of the function
         "is_overload",  # Is this an overload variant of function with more than
         # one overload variant?
@@ -689,12 +690,14 @@ class FuncItem(FuncBase):
         arguments: list[Argument] | None = None,
         body: Block | None = None,
         typ: mypy.types.FunctionLike | None = None,
+        type_args: list[tuple[str, mypy.types.Type | None]] | None = None,
     ) -> None:
         super().__init__()
         self.arguments = arguments or []
         self.arg_names = [None if arg.pos_only else arg.variable.name for arg in self.arguments]
         self.arg_kinds: list[ArgKind] = [arg.kind for arg in self.arguments]
         self.max_pos: int = self.arg_kinds.count(ARG_POS) + self.arg_kinds.count(ARG_OPT)
+        self.type_args = type_args
         self.body: Block = body or Block([])
         self.type = typ
         self.unanalyzed_type = typ
@@ -761,8 +764,9 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         arguments: list[Argument] | None = None,
         body: Block | None = None,
         typ: mypy.types.FunctionLike | None = None,
+        type_args: list[tuple[str, mypy.types.Type | None]] | None = None,
     ) -> None:
-        super().__init__(arguments, body, typ)
+        super().__init__(arguments, body, typ, type_args)
         self._name = name
         self.is_decorated = False
         self.is_conditional = False  # Defined conditionally (within block)?

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -653,11 +653,24 @@ class Argument(Node):
         self.variable.set_line(self.line, self.column, self.end_line, self.end_column)
 
 
-class TypeParam:
-    __slots__ = ("name", "upper_bound", "values")
+# These specify the kind of a TypeParam
+TYPE_VAR_KIND: Final = 0
+PARAM_SPEC_KIND: Final = 1
+TYPE_VAR_TUPLE_KIND: Final = 2
 
-    def __init__(self, name: str, upper_bound: mypy.types.Type | None, values: list[mypy.types.Type]) -> None:
+
+class TypeParam:
+    __slots__ = ("name", "kind", "upper_bound", "values")
+
+    def __init__(
+        self,
+        name: str,
+        kind: int,
+        upper_bound: mypy.types.Type | None,
+        values: list[mypy.types.Type],
+    ) -> None:
         self.name = name
+        self.kind = kind
         self.upper_bound = upper_bound
         self.values = values
 
@@ -1636,12 +1649,7 @@ class TypeAliasStmt(Statement):
     type_args: list[TypeParam]
     value: Expression  # mypy.types.Type
 
-    def __init__(
-        self,
-        name: NameExpr,
-        type_args: list[TypeParam],
-        value: Expression,
-    ) -> None:
+    def __init__(self, name: NameExpr, type_args: list[TypeParam], value: Expression) -> None:
         super().__init__()
         self.name = name
         self.type_args = type_args

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -73,7 +73,8 @@ OPTIONS_AFFECTING_CACHE: Final = (
 TYPE_VAR_TUPLE: Final = "TypeVarTuple"
 UNPACK: Final = "Unpack"
 PRECISE_TUPLE_TYPES: Final = "PreciseTupleTypes"
-INCOMPLETE_FEATURES: Final = frozenset((PRECISE_TUPLE_TYPES,))
+NEW_GENERIC_SYNTAX: Final = "NewGenericSyntax"
+INCOMPLETE_FEATURES: Final = frozenset((PRECISE_TUPLE_TYPES, NEW_GENERIC_SYNTAX))
 COMPLETE_FEATURES: Final = frozenset((TYPE_VAR_TUPLE, UNPACK))
 
 

--- a/mypy/partially_defined.py
+++ b/mypy/partially_defined.py
@@ -36,6 +36,7 @@ from mypy.nodes import (
     SymbolTable,
     TryStmt,
     TupleExpr,
+    TypeAliasStmt,
     WhileStmt,
     WithStmt,
     implicit_module_attrs,
@@ -673,3 +674,7 @@ class PossiblyUndefinedVariableVisitor(ExtendedTraverserVisitor):
                 name = mod
             self.tracker.record_definition(name)
         super().visit_import_from(o)
+
+    def visit_type_alias_stmt(self, o: TypeAliasStmt) -> None:
+        # Type alias target may contain forward references
+        self.tracker.record_definition(o.name.name)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5289,9 +5289,6 @@ class SemanticAnalyzer(
             # When this type alias gets "inlined", the Any is not explicit anymore,
             # so we need to replace it with non-explicit Anys.
             res = make_any_non_explicit(res)
-            # if isinstance(res, ProperType) and isinstance(res, Instance):
-            #    if not validate_instance(res, self.fail, empty_tuple_index):
-            #        fix_instance(res, self.fail, self.note, disallow_any=False, options=self.options)
             eager = self.is_func_scope()
             alias_node = TypeAlias(
                 res,
@@ -5303,9 +5300,12 @@ class SemanticAnalyzer(
                 eager=eager,
             )
 
-            self.add_symbol(s.name.name, alias_node, s)
+            existing = self.current_symbol_table().get(s.name.name)
+            if existing and isinstance(existing.node, (PlaceholderNode, TypeAlias)) and existing.node.line == s.line:
+                existing.node = alias_node
+            else:
+                self.add_symbol(s.name.name, alias_node, s)
 
-            # TODO: Check if existing
         finally:
             self.pop_type_args(s.type_args)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -86,6 +86,7 @@ from mypy.nodes import (
     REVEAL_TYPE,
     RUNTIME_PROTOCOL_DECOS,
     TYPE_VAR_KIND,
+    TYPE_VAR_TUPLE_KIND,
     VARIANCE_NOT_READY,
     ArgKind,
     AssertStmt,
@@ -1681,6 +1682,22 @@ class SemanticAnalyzer(
                             name=p.name,
                             fullname=fullname,
                             upper_bound=upper_bound,
+                            default=default,
+                        ),
+                    )
+                )
+            else:
+                assert p.kind == TYPE_VAR_TUPLE_KIND
+                tuple_fallback = self.named_type("builtins.tuple", [self.object_type()])
+                tvs.append(
+                    (
+                        p.name,
+                        TypeVarTupleExpr(
+                            name=p.name,
+                            fullname=fullname,
+                            # Upper bound for *Ts is *tuple[object, ...], it can never be object.
+                            upper_bound=tuple_fallback.copy_modified(),
+                            tuple_fallback=tuple_fallback,
                             default=default,
                         ),
                     )

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -838,9 +838,11 @@ class SemanticAnalyzer(
             self.analyze_func_def(defn)
 
     def analyze_func_def(self, defn: FuncDef) -> None:
-        self.function_stack.append(defn)
+        if not self.push_type_args(defn.type_args, defn):
+            self.defer(defn)
+            return
 
-        self.push_type_args(defn.type_args, defn)
+        self.function_stack.append(defn)
 
         if defn.type:
             assert isinstance(defn.type, CallableType)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -177,7 +177,7 @@ from mypy.nodes import (
     is_final_node,
     type_aliases,
     type_aliases_source_versions,
-    typing_extensions_aliases,
+    typing_extensions_aliases, VARIANCE_NOT_READY,
 )
 from mypy.options import Options
 from mypy.patterns import (
@@ -1640,6 +1640,7 @@ class SemanticAnalyzer(
                 values=[],
                 upper_bound=self.named_type("builtins.object"),
                 default=AnyType(TypeOfAny.from_omitted_generics),
+                variance=VARIANCE_NOT_READY,
             )
             self.add_symbol(tv[0], tve, context)
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1644,12 +1644,19 @@ class SemanticAnalyzer(
             return True
         tvs = []
         for p in type_args:
+            values = []
             if p.upper_bound:
                 upper_bound = self.anal_type(p.upper_bound)
                 if upper_bound is None:
                     return False
             else:
                 upper_bound = self.named_type("builtins.object")
+                if p.values:
+                    for value in p.values:
+                        analyzed = self.anal_type(value)
+                        if analyzed is None:
+                            return False
+                        values.append(analyzed)
 
             tvs.append(
                 (
@@ -1657,7 +1664,7 @@ class SemanticAnalyzer(
                     TypeVarExpr(
                         name=p.name,
                         fullname=self.qualified_name(p.name),
-                        values=[],
+                        values=values,
                         upper_bound=upper_bound,
                         default=AnyType(TypeOfAny.from_omitted_generics),
                         variance=VARIANCE_NOT_READY,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1653,7 +1653,7 @@ class SemanticAnalyzer(
             tvs.append((p.name, tv))
 
         for name, tv in tvs:
-            self.add_symbol(name, tv, context)
+            self.add_symbol(name, tv, context, no_progress=True)
 
         return tvs
 
@@ -5967,6 +5967,7 @@ class SemanticAnalyzer(
         for table in reversed(self.locals):
             if table is not None and name in table:
                 return table[name]
+
         # 4. Current file global scope
         if name in self.globals:
             return self.globals[name]
@@ -6279,6 +6280,7 @@ class SemanticAnalyzer(
         module_hidden: bool = False,
         can_defer: bool = True,
         escape_comprehensions: bool = False,
+        no_progress: bool = False,
     ) -> bool:
         """Add symbol to the currently active symbol table.
 
@@ -6300,7 +6302,9 @@ class SemanticAnalyzer(
         symbol = SymbolTableNode(
             kind, node, module_public=module_public, module_hidden=module_hidden
         )
-        return self.add_symbol_table_node(name, symbol, context, can_defer, escape_comprehensions)
+        return self.add_symbol_table_node(
+            name, symbol, context, can_defer, escape_comprehensions, no_progress
+        )
 
     def add_symbol_skip_local(self, name: str, node: SymbolNode) -> None:
         """Same as above, but skipping the local namespace.
@@ -6331,6 +6335,7 @@ class SemanticAnalyzer(
         context: Context | None = None,
         can_defer: bool = True,
         escape_comprehensions: bool = False,
+        no_progress: bool = False,
     ) -> bool:
         """Add symbol table node to the currently active symbol table.
 
@@ -6379,7 +6384,8 @@ class SemanticAnalyzer(
                     self.name_already_defined(name, context, existing)
         elif name not in self.missing_names[-1] and "*" not in self.missing_names[-1]:
             names[name] = symbol
-            self.progress = True
+            if not no_progress:
+                self.progress = True
             return True
         return False
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5301,7 +5301,11 @@ class SemanticAnalyzer(
             )
 
             existing = self.current_symbol_table().get(s.name.name)
-            if existing and isinstance(existing.node, (PlaceholderNode, TypeAlias)) and existing.node.line == s.line:
+            if (
+                existing
+                and isinstance(existing.node, (PlaceholderNode, TypeAlias))
+                and existing.node.line == s.line
+            ):
                 existing.node = alias_node
             else:
                 self.add_symbol(s.name.name, alias_node, s)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5219,8 +5219,9 @@ class SemanticAnalyzer(
     def visit_type_alias_stmt(self, s: TypeAliasStmt) -> None:
         self.statement = s
         type_params = self.push_type_args(s.type_args, s)
-        # TODO: defer as needed
-        assert type_params is not None, "forward references in type aliases not implemented"
+        if type_params is None:
+            self.defer(s)
+            return
         all_type_params_names = [p.name for p in s.type_args]
 
         try:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1634,16 +1634,21 @@ class SemanticAnalyzer(
                        context: Context) -> None:
         if not type_args:
             return
-        for tv in type_args:
+        for name, upper_bound in type_args:
+            if upper_bound:
+                upper_bound = self.anal_type(upper_bound)
+            else:
+                upper_bound = self.named_type("builtins.object")
+
             tve = TypeVarExpr(
-                name=tv[0],
-                fullname=self.qualified_name(tv[0]),
+                name=name,
+                fullname=self.qualified_name(name),
                 values=[],
-                upper_bound=self.named_type("builtins.object"),
+                upper_bound=upper_bound,
                 default=AnyType(TypeOfAny.from_omitted_generics),
                 variance=VARIANCE_NOT_READY,
             )
-            self.add_symbol(tv[0], tve, context)
+            self.add_symbol(name, tve, context)
 
     def pop_type_args(self, type_args: list[tuple[str, Type | None]] | None) -> None:
         if not type_args:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -323,6 +323,17 @@ class StrConv(NodeVisitor[str]):
             a.append(("Body", o.bodies[i].body))
         return self.dump(a, o)
 
+    def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt) -> str:
+        a: list[Any] = [o.name]
+        for n, t in o.type_args:
+            aa = [n]
+            if t:
+                aa.append(t)
+            a.append(("TypeArg", aa))
+        a.append(o.value)
+
+        return self.dump(a, o)
+
     # Expressions
 
     # Simple expressions

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -86,6 +86,9 @@ class StrConv(NodeVisitor[str]):
             elif kind == mypy.nodes.ARG_STAR2:
                 extra.append(("DictVarArg", [arg.variable]))
         a: list[Any] = []
+        if o.type_args:
+            for p in o.type_args:
+                self.type_param(a, p)
         if args:
             a.append(("Args", args))
         if o.type:
@@ -325,14 +328,18 @@ class StrConv(NodeVisitor[str]):
 
     def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt) -> str:
         a: list[Any] = [o.name]
-        for n, t in o.type_args:
-            aa: list[Any] = [n]
-            if t:
-                aa.append(t)
-            a.append(("TypeArg", aa))
+        for p in o.type_args:
+            self.type_param(a, p)
         a.append(o.value)
 
         return self.dump(a, o)
+
+    def type_param(self, a: list[Any], p: mypy.nodes.TypeParam) -> None:
+        aa: list[Any] = []
+        aa.append(p.name)
+        if p.upper_bound:
+            aa.append(p.upper_bound)
+        a.append(("TypeParam", aa))
 
     # Expressions
 

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -334,7 +334,6 @@ class StrConv(NodeVisitor[str]):
         for p in o.type_args:
             a.append(self.type_param(p))
         a.append(o.value)
-
         return self.dump(a, o)
 
     def type_param(self, p: mypy.nodes.TypeParam) -> list[Any]:

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -339,6 +339,8 @@ class StrConv(NodeVisitor[str]):
         aa.append(p.name)
         if p.upper_bound:
             aa.append(p.upper_bound)
+        if p.values:
+            aa.append(("Values", p.values))
         a.append(("TypeParam", aa))
 
     # Expressions

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -326,7 +326,7 @@ class StrConv(NodeVisitor[str]):
     def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt) -> str:
         a: list[Any] = [o.name]
         for n, t in o.type_args:
-            aa = [n]
+            aa: list[Any] = [n]
             if t:
                 aa.append(t)
             a.append(("TypeArg", aa))

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -8,9 +8,8 @@ import mypy.applytype
 import mypy.constraints
 import mypy.typeops
 from mypy.erasetype import erase_type
-from mypy.expandtype import expand_self_type, expand_type_by_instance, expand_type
+from mypy.expandtype import expand_self_type, expand_type, expand_type_by_instance
 from mypy.maptype import map_instance_to_supertype
-from mypy.typevars import fill_typevars
 
 # Circular import; done in the function instead.
 # import mypy.solve
@@ -20,11 +19,12 @@ from mypy.nodes import (
     CONTRAVARIANT,
     COVARIANT,
     INVARIANT,
+    VARIANCE_NOT_READY,
     Decorator,
     FuncBase,
     OverloadedFuncDef,
     TypeInfo,
-    Var, VARIANCE_NOT_READY,
+    Var,
 )
 from mypy.options import Options
 from mypy.state import state
@@ -67,7 +67,7 @@ from mypy.types import (
 )
 from mypy.types_utils import flatten_types
 from mypy.typestate import SubtypeKind, type_state
-from mypy.typevars import fill_typevars_with_any
+from mypy.typevars import fill_typevars, fill_typevars_with_any
 
 # Flags for detected protocol members
 IS_SETTABLE: Final = 1
@@ -2020,7 +2020,7 @@ def infer_variance(info: TypeInfo, i: int) -> bool:
                 tv.variance = VARIANCE_NOT_READY
                 return False
             if isinstance(self_type, TupleType):
-                self_type =mypy.typeops.tuple_fallback(self_type)
+                self_type = mypy.typeops.tuple_fallback(self_type)
 
             flags = get_member_flags(member, self_type)
             typ = find_member(member, self_type, self_type)

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2044,7 +2044,7 @@ def infer_variance(info: TypeInfo, i: int) -> bool:
 
 def infer_class_variances(info: TypeInfo) -> bool:
     if not info.defn.type_args:
-        return
+        return True
     tvs = info.defn.type_vars
     for i, tv in enumerate(tvs):
         if isinstance(tv, TypeVarType):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1988,9 +1988,9 @@ def is_more_precise(left: Type, right: Type, *, ignore_promotions: bool = False)
     return is_proper_subtype(left, right, ignore_promotions=ignore_promotions)
 
 
-def all_members(info: TypeInfo) -> set[str]:
+def all_non_object_members(info: TypeInfo) -> set[str]:
     members = set(info.names)
-    for base in info.mro[1:]:
+    for base in info.mro[1:-1]:
         members.update(base.names)
     return members
 
@@ -2012,7 +2012,7 @@ def infer_variance(info: TypeInfo, i: int) -> bool:
         contra = True
         tvar = info.defn.type_vars[i]
         self_type = fill_typevars(info)
-        for member in all_members(info):
+        for member in all_non_object_members(info):
             if member in ("__init__", "__new__"):
                 continue
             node = info[member].node

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2019,6 +2019,9 @@ def infer_variance(info: TypeInfo, i: int) -> bool:
             if isinstance(node, Var) and node.type is None:
                 tv.variance = VARIANCE_NOT_READY
                 return False
+            if isinstance(self_type, TupleType):
+                self_type =mypy.typeops.tuple_fallback(self_type)
+
             flags = get_member_flags(member, self_type)
             typ = find_member(member, self_type, self_type)
             settable = IS_SETTABLE in flags

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2049,8 +2049,9 @@ def infer_class_variances(info: TypeInfo) -> bool:
     if not info.defn.type_args:
         return True
     tvs = info.defn.type_vars
+    success = True
     for i, tv in enumerate(tvs):
-        if isinstance(tv, TypeVarType):
+        if isinstance(tv, TypeVarType) and tv.variance == VARIANCE_NOT_READY:
             if not infer_variance(info, i):
-                return False
-    return True
+                success = False
+    return success

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -23,6 +23,8 @@ class ParserSuite(DataSuite):
 
     if sys.version_info < (3, 10):
         files.remove("parse-python310.test")
+    if sys.version_info < (3, 12):
+        files.remove("parse-python312.test")
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         test_parser(testcase)
@@ -39,6 +41,8 @@ def test_parser(testcase: DataDrivenTestCase) -> None:
 
     if testcase.file.endswith("python310.test"):
         options.python_version = (3, 10)
+    elif testcase.file.endswith("python312.test"):
+        options.python_version = (3, 12)
     else:
         options.python_version = defaults.PYTHON3_VERSION
 

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -71,6 +71,7 @@ from mypy.nodes import (
     TupleExpr,
     TypeAlias,
     TypeAliasExpr,
+    TypeAliasStmt,
     TypeApplication,
     TypedDictExpr,
     TypeVarExpr,
@@ -242,6 +243,11 @@ class TraverserVisitor(NodeVisitor[None]):
             if guard is not None:
                 guard.accept(self)
             o.bodies[i].accept(self)
+
+    def visit_type_alias_stmt(self, o: TypeAliasStmt) -> None:
+        o.name.accept(self)
+        # TODO: params
+        o.value.accept(self)
 
     def visit_member_expr(self, o: MemberExpr) -> None:
         o.expr.accept(self)

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -10,7 +10,7 @@ from typing_extensions import TypeAlias as _TypeAlias
 
 from mypy.nodes import TypeInfo, VARIANCE_NOT_READY
 from mypy.server.trigger import make_trigger
-from mypy.types import Instance, Type, TypeVarId, get_proper_type
+from mypy.types import Instance, Type, TypeVarId, TypeVarType, get_proper_type
 
 MAX_NEGATIVE_CACHE_TYPES: Final = 1000
 MAX_NEGATIVE_CACHE_ENTRIES: Final = 10000
@@ -192,7 +192,7 @@ class TypeState:
             # These are unlikely to match, due to the large space of
             # possible values.  Avoid uselessly increasing cache sizes.
             return
-        if any(tv.variance == VARIANCE_NOT_READY for tv in right.type.defn.type_vars):
+        if any((isinstance(tv, TypeVarType) and tv.variance == VARIANCE_NOT_READY) for tv in right.type.defn.type_vars):
             # Variance indeterminate -- don't know the result
             return
         cache = self._subtype_caches.setdefault(right.type, {})

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Dict, Final, Set, Tuple
 from typing_extensions import TypeAlias as _TypeAlias
 
-from mypy.nodes import TypeInfo
+from mypy.nodes import TypeInfo, VARIANCE_NOT_READY
 from mypy.server.trigger import make_trigger
 from mypy.types import Instance, Type, TypeVarId, get_proper_type
 
@@ -191,6 +191,9 @@ class TypeState:
         if left.last_known_value is not None or right.last_known_value is not None:
             # These are unlikely to match, due to the large space of
             # possible values.  Avoid uselessly increasing cache sizes.
+            return
+        if any(tv.variance == VARIANCE_NOT_READY for tv in right.type.defn.type_vars):
+            # Variance indeterminate -- don't know the result
             return
         cache = self._subtype_caches.setdefault(right.type, {})
         cache.setdefault(kind, set()).add((left, right))

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Dict, Final, Set, Tuple
 from typing_extensions import TypeAlias as _TypeAlias
 
-from mypy.nodes import TypeInfo, VARIANCE_NOT_READY
+from mypy.nodes import VARIANCE_NOT_READY, TypeInfo
 from mypy.server.trigger import make_trigger
 from mypy.types import Instance, Type, TypeVarId, TypeVarType, get_proper_type
 
@@ -192,7 +192,10 @@ class TypeState:
             # These are unlikely to match, due to the large space of
             # possible values.  Avoid uselessly increasing cache sizes.
             return
-        if any((isinstance(tv, TypeVarType) and tv.variance == VARIANCE_NOT_READY) for tv in right.type.defn.type_vars):
+        if any(
+            (isinstance(tv, TypeVarType) and tv.variance == VARIANCE_NOT_READY)
+            for tv in right.type.defn.type_vars
+        ):
             # Variance indeterminate -- don't know the result
             return
         cache = self._subtype_caches.setdefault(right.type, {})

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -464,6 +464,9 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T], Pattern
     def visit_match_stmt(self, o: mypy.nodes.MatchStmt) -> T:
         pass
 
+    def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt) -> T:
+        pass
+
     # Expressions (default no-op implementation)
 
     def visit_int_expr(self, o: mypy.nodes.IntExpr) -> T:

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -309,6 +309,10 @@ class StatementVisitor(Generic[T]):
     def visit_match_stmt(self, o: mypy.nodes.MatchStmt) -> T:
         pass
 
+    @abstractmethod
+    def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt) -> T:
+        pass
+
 
 @trait
 @mypyc_attr(allow_interpreted_subclasses=True)

--- a/mypyc/irbuild/visitor.py
+++ b/mypyc/irbuild/visitor.py
@@ -70,6 +70,7 @@ from mypy.nodes import (
     TryStmt,
     TupleExpr,
     TypeAliasExpr,
+    TypeAliasStmt,
     TypeApplication,
     TypedDictExpr,
     TypeVarExpr,
@@ -248,6 +249,9 @@ class IRBuilderVisitor(IRVisitor):
 
     def visit_match_stmt(self, stmt: MatchStmt) -> None:
         transform_match_stmt(self.builder, stmt)
+
+    def visit_type_alias_stmt(self, stmt: TypeAliasStmt) -> None:
+        self.bail('The "type" statement is not yet supported by mypyc', stmt.line)
 
     # Expressions
 

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -115,3 +115,42 @@ reveal_type(C("x"))  # N: Revealed type is "__main__.C[builtins.str]"
 c: C[int] = C(1)
 reveal_type(c.x)  # N: Revealed type is "builtins.int"
 reveal_type(c.ident(1))  # N: Revealed type is "builtins.int"
+
+[case testPEP695InferVarianceSimple]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class Invariant[T]:
+    def f(self, x: T) -> None:
+        pass
+
+    def g(self) -> T | None:
+        return None
+
+a: Invariant[object]
+b: Invariant[int]
+if int():
+    a = b  # E: Incompatible types in assignment (expression has type "Invariant[int]", variable has type "Invariant[object]")
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "Invariant[object]", variable has type "Invariant[int]")
+
+class Covariant[T]:
+    def g(self) -> T | None:
+        return None
+
+c: Covariant[object]
+d: Covariant[int]
+if int():
+    c = d
+if int():
+    d = c  # E: Incompatible types in assignment (expression has type "Covariant[object]", variable has type "Covariant[int]")
+
+class Contravariant[T]:
+    def f(self, x: T) -> None:
+        pass
+
+e: Contravariant[object]
+f: Contravariant[int]
+if int():
+    e = f  # E: Incompatible types in assignment (expression has type "Contravariant[int]", variable has type "Contravariant[object]")
+if int():
+    f = e

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -116,7 +116,7 @@ c: C[int] = C(1)
 reveal_type(c.x)  # N: Revealed type is "builtins.int"
 reveal_type(c.ident(1))  # N: Revealed type is "builtins.int"
 
-[case testPEP695InferVarianceSimple]
+[case testPEP695InferVarianceSimpleFromMethod]
 # flags: --enable-incomplete-feature=NewGenericSyntax
 
 class Invariant[T]:
@@ -154,6 +154,42 @@ if int():
     e = f  # E: Incompatible types in assignment (expression has type "Contravariant[int]", variable has type "Contravariant[object]")
 if int():
     f = e
+
+[case testPEP695InferVarianceSimpleFromAttribute]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class Invariant1[T]:
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+a: Invariant1[object]
+b: Invariant1[int]
+if int():
+    a = b  # E: Incompatible types in assignment (expression has type "Invariant1[int]", variable has type "Invariant1[object]")
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "Invariant1[object]", variable has type "Invariant1[int]")
+
+class Invariant2[T]:
+    def __init__(self) -> None:
+        self.x: list[T] = []
+
+a2: Invariant2[object]
+b2: Invariant2[int]
+if int():
+    a2 = b2  # E: Incompatible types in assignment (expression has type "Invariant2[int]", variable has type "Invariant2[object]")
+if int():
+    b2 = a2  # E: Incompatible types in assignment (expression has type "Invariant2[object]", variable has type "Invariant2[int]")
+
+class Invariant3[T]:
+    def __init__(self) -> None:
+        self.x: T | None = None
+
+a3: Invariant3[object]
+b3: Invariant3[int]
+if int():
+    a3 = b3  # E: Incompatible types in assignment (expression has type "Invariant3[int]", variable has type "Invariant3[object]")
+if int():
+    b3 = a3  # E: Incompatible types in assignment (expression has type "Invariant3[object]", variable has type "Invariant3[int]")
 
 [case testPEP695InferVarianceRecursive]
 # flags: --enable-incomplete-feature=NewGenericSyntax
@@ -207,3 +243,45 @@ class Covariant[T]:
 
     def g(self, x: Covariant[object]) -> None: pass
     def h(self, x: Covariant[int]) -> None: pass
+
+[case testPEP695InferVarianceNotReadyWhenNeeded]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class Covariant[T]:
+    def f(self) -> None:
+        c = Covariant[int]()
+        # We need to know that T is covariant here
+        self.g(c)
+        c2 = Covariant[object]()
+        self.h(c2)  # E: Argument 1 to "h" of "Covariant" has incompatible type "Covariant[object]"; expected "Covariant[int]"
+
+    def g(self, x: Covariant[object]) -> None: pass
+    def h(self, x: Covariant[int]) -> None: pass
+
+    def __init__(self) -> None:
+        self.x = [1]
+
+class Invariant[T]:
+    def f(self) -> None:
+        c = Invariant(1)
+        # We need to know that T is invariant here, and for this we need the type
+        # of self.x, which won't be available on the first type checking pass,
+        # since __init__ is defined later in the file. In this case we fall back
+        # covariance.
+        self.g(c)
+        c2 = Invariant(object())
+        self.h(c2)  # E: Argument 1 to "h" of "Invariant" has incompatible type "Invariant[object]"; expected "Invariant[int]"
+
+    def g(self, x: Invariant[object]) -> None: pass
+    def h(self, x: Invariant[int]) -> None: pass
+
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+# Now we should have the variance correct.
+a: Invariant[object]
+b: Invariant[int]
+if int():
+    a = b  # E: Incompatible types in assignment (expression has type "Invariant[int]", variable has type "Invariant[object]")
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "Invariant[object]", variable has type "Invariant[int]")

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -481,3 +481,95 @@ if int():
     e = f  # E: Incompatible types in assignment (expression has type "PInv[object]", variable has type "PInv[int]")
 if int():
     f = e  # E: Incompatible types in assignment (expression has type "PInv[int]", variable has type "PInv[object]")
+
+[case testPEP695TypeAlias]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T]: pass
+class D[T, S]: pass
+
+type A[S] = C[S]
+
+a: A[int]
+reveal_type(a)  # N: Revealed type is "__main__.C[builtins.int]"
+
+type A2[T] = C[C[T]]
+a2: A2[str]
+reveal_type(a2)  # N: Revealed type is "__main__.C[__main__.C[builtins.str]]"
+
+type A3[T, S] = D[S, C[T]]
+a3: A3[int, str]
+reveal_type(a3)  # N: Revealed type is "__main__.D[builtins.str, __main__.C[builtins.int]]"
+
+type A4 = int | str
+a4: A4
+reveal_type(a4)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+[case testPEP695TypeAliasWithUnusedTypeParams]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+type A[T] = int
+a: A[str]
+reveal_type(a)  # N: Revealed type is "builtins.int"
+
+[case testPEP695TypeAliasForwardReference1]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+type A[T] = C[T]
+
+a: A[int]
+reveal_type(a)  # N: Revealed type is "__main__.C[builtins.int]"
+
+class C[T]: pass
+
+[case testPEP695TypeAliasForwardReference2]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+type X = C
+type A = X
+
+a: A
+reveal_type(a)  # N: Revealed type is "__main__.C"
+
+class C: pass
+
+[case testPEP695TypeAliasForwardReference3]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+type X = D
+type A = C[X]
+
+a: A
+reveal_type(a)  # N: Revealed type is "__main__.C[__main__.D]"
+
+class C[T]: pass
+class D: pass
+
+[case testPEP695TypeAliasForwardReference4]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+type A = C
+
+# Note that this doesn't actually work at runtime, but we currently don't
+# keep track whether a type alias is valid in various runtime type contexts.
+class D(A):
+    pass
+
+class C: pass
+
+x: C = D()
+y: D = C()  # E: Incompatible types in assignment (expression has type "C", variable has type "D")
+
+[case testPEP695TypeAliasWithUndefineName]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+type A[T] = XXX  # E: Name "XXX" is not defined
+a: A[int]
+reveal_type(a)  # N: Revealed type is "Any"
+
+[case testPEP695TypeAliasInvalidType]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+type A = int | 1  # E: Invalid type: try using Literal[1] instead?
+a: A
+reveal_type(a)  # N: Revealed type is "Union[builtins.int, Any]"
+type B = int + str  # E: Invalid type alias: expression is not a valid type
+b: B
+reveal_type(b)  # N: Revealed type is "Any"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -285,3 +285,16 @@ if int():
     a = b  # E: Incompatible types in assignment (expression has type "Invariant[int]", variable has type "Invariant[object]")
 if int():
     b = a  # E: Incompatible types in assignment (expression has type "Invariant[object]", variable has type "Invariant[int]")
+
+[case testPEP695InferVarianceNotReadyForJoin]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class Invariant[T]:
+    def f(self) -> None:
+        reveal_type([Invariant(1), Invariant(object())]) \
+            # N: Revealed type is "builtins.list[__main__.Invariant[builtins.object]]"
+
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+reveal_type([Invariant(1), Invariant(object())])   # N: Revealed type is "builtins.list[builtins.object]"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -782,3 +782,23 @@ a: C[[int, str], None]
 reveal_type(a)  # N: Revealed type is "__main__.C[[builtins.int, builtins.str], None]"
 reveal_type(a.m)  # N: Revealed type is "def (builtins.int, builtins.str)"
 [builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeVarTuple]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+def f[*Ts](t: tuple[*Ts]) -> tuple[*Ts]:
+    reveal_type(t)  # N: Revealed type is "Tuple[Unpack[Ts`-1]]"
+    return t
+
+reveal_type(f((1, 'x')))  # N: Revealed type is "Tuple[Literal[1]?, Literal['x']?]"
+a: tuple[int, ...]
+reveal_type(f(a))  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
+
+class C[T, *Ts]:
+    pass
+
+b: C[int, str, None]
+reveal_type(b)  # N: Revealed type is "__main__.C[builtins.int, builtins.str, None]"
+c: C[str]
+reveal_type(c)  # N: Revealed type is "__main__.C[builtins.str]"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -86,14 +86,22 @@ reveal_type(ba2)  # N: Revealed type is "def (*Any) -> builtins.str"
 [case testPEP695GenericFunctionSyntax]
 # flags: --enable-incomplete-feature=NewGenericSyntax
 
-def ident[T](x: T) -> T:
-    y: T = x
-    y = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "T")
+def ident[TV](x: TV) -> TV:
+    y: TV = x
+    y = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "TV")
     return x
 
 reveal_type(ident(1))  # N: Revealed type is "builtins.int"
+reveal_type(ident('x'))  # N: Revealed type is "builtins.str"
 
-a: T  # E: Name "T" is not defined
+a: TV  # E: Name "TV" is not defined
+
+def tup[T, S](x: T, y: S) -> tuple[T, S]:
+    reveal_type((x, y))  # N: Revealed type is "Tuple[T`-1, S`-2]"
+    return (x, y)
+
+reveal_type(tup(1, 'x'))  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
+[builtins fixtures/tuple.pyi]
 
 [case testPEP695GenericClassSyntax]
 # flags: --enable-incomplete-feature=NewGenericSyntax
@@ -115,6 +123,17 @@ reveal_type(C("x"))  # N: Revealed type is "__main__.C[builtins.str]"
 c: C[int] = C(1)
 reveal_type(c.x)  # N: Revealed type is "builtins.int"
 reveal_type(c.ident(1))  # N: Revealed type is "builtins.int"
+
+[case testPEP695GenericMethodInGenericClass]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T]:
+    def m[S](self, x: S) -> T: ...
+
+a: C[int] = C[object]()  # E: Incompatible types in assignment (expression has type "C[object]", variable has type "C[int]")
+b: C[object] = C[int]()
+
+reveal_type(C[str]().m(1))  # N: Revealed type is "builtins.str"
 
 [case testPEP695InferVarianceSimpleFromMethod]
 # flags: --enable-incomplete-feature=NewGenericSyntax

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -802,3 +802,111 @@ reveal_type(b)  # N: Revealed type is "__main__.C[builtins.int, builtins.str, No
 c: C[str]
 reveal_type(c)  # N: Revealed type is "__main__.C[builtins.str]"
 [builtins fixtures/tuple.pyi]
+
+[case testPEP695IncrementalFunction]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+import b
+reveal_type(b.f(1))
+reveal_type(b.g(1, 'x'))
+b.g('x', 'x')
+b.g(1, 2)
+
+[file b.py]
+def f[T](x: T) -> T:
+    return x
+
+def g[T: int, S: (str, None)](x: T, y: S) -> T | S:
+    return x
+
+[out2]
+tmp/a.py:2: note: Revealed type is "builtins.int"
+tmp/a.py:3: note: Revealed type is "Union[builtins.int, builtins.str]"
+tmp/a.py:4: error: Value of type variable "T" of "g" cannot be "str"
+tmp/a.py:5: error: Value of type variable "S" of "g" cannot be "int"
+
+[case testPEP695IncrementalClass]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+from b import C, D
+x: C[int]
+reveal_type(x)
+
+class N(int): pass
+class SS(str): pass
+
+y1: D[int, str]
+y2: D[N, str]
+y3: D[int, None]
+y4: D[int, None]
+y5: D[int, SS]  # Error
+y6: D[object, str]  # Error
+
+[file b.py]
+class C[T]: pass
+
+class D[T: int, S: (str, None)]:
+    pass
+
+[out2]
+tmp/a.py:3: note: Revealed type is "b.C[builtins.int]"
+tmp/a.py:12: error: Value of type variable "S" of "D" cannot be "SS"
+tmp/a.py:13: error: Type argument "object" of "D" must be a subtype of "int"
+
+[case testPEP695IncrementalParamSpecAndTypeVarTuple]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+from b import C, D
+x1: C[()]
+x2: C[int]
+x3: C[int, str]
+y: D[[int, str]]
+reveal_type(y.m)
+
+[file b.py]
+class C[*Ts]: pass
+class D[**P]:
+    def m(self, *args: P.args, **kwargs: P.kwargs) -> None: pass
+
+[builtins fixtures/tuple.pyi]
+[out2]
+tmp/a.py:6: note: Revealed type is "def (builtins.int, builtins.str)"
+
+[case testPEP695IncrementalTypeAlias]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+import a
+
+[file a.py]
+import b
+
+[file a.py.2]
+from b import A, B
+a: A
+reveal_type(a)
+b: B[int]
+reveal_type(b)
+
+[file b.py]
+type A = str
+class Foo[T]: pass
+type B[T] = Foo[T]
+
+[builtins fixtures/tuple.pyi]
+[out2]
+tmp/a.py:3: note: Revealed type is "builtins.str"
+tmp/a.py:5: note: Revealed type is "b.Foo[builtins.int]"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -693,3 +693,25 @@ u: int | str
 f(1, u)
 f('x', None)  # E: Value of type variable "T" of "f" cannot be "str" \
               # E: Value of type variable "S" of "f" cannot be "None"
+
+[case testPEP695InferVarianceOfTupleType]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class Cov[T](tuple[int, str]):
+    def f(self) -> T: pass
+
+class Cov2[T](tuple[T, T]):
+    pass
+
+class Contra[T](tuple[int, str]):
+    def f(self, x: T) -> None: pass
+
+a: Cov[object] = Cov[int]()
+b: Cov[int] = Cov[object]()  # E: Incompatible types in assignment (expression has type "Cov[object]", variable has type "Cov[int]")
+
+c: Cov2[object] = Cov2[int]()
+d: Cov2[int] = Cov2[object]()  # E: Incompatible types in assignment (expression has type "Cov2[object]", variable has type "Cov2[int]")
+
+e: Contra[int] = Contra[object]()
+f: Contra[object] = Contra[int]()  # E: Incompatible types in assignment (expression has type "Contra[int]", variable has type "Contra[object]")
+[builtins fixtures/tuple-simple.pyi]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -383,3 +383,45 @@ class InvSubclass[T](Covariant[T]):
 
 e: InvSubclass[int] = InvSubclass[object]()  # E: Incompatible types in assignment (expression has type "InvSubclass[object]", variable has type "InvSubclass[int]")
 f: InvSubclass[object] = InvSubclass[int]()  # E: Incompatible types in assignment (expression has type "InvSubclass[int]", variable has type "InvSubclass[object]")
+
+[case testPEP695FinalAttribute]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+from typing import Final
+
+class C[T]:
+    def __init__(self, x: T) -> None:
+        self.x: Final = x
+
+a: C[int] = C[object](1)  # E: Incompatible types in assignment (expression has type "C[object]", variable has type "C[int]")
+b: C[object] = C[int](1)
+
+[case testPEP695TwoTypeVariables]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T, S]:
+    def f(self, x: T) -> None: ...
+    def g(self) -> S: ...
+
+a: C[int, int] = C[object, int]()
+b: C[object, int] = C[int, int]()  # E: Incompatible types in assignment (expression has type "C[int, int]", variable has type "C[object, int]")
+c: C[int, int] = C[int, object]()  # E: Incompatible types in assignment (expression has type "C[int, object]", variable has type "C[int, int]")
+d: C[int, object] = C[int, int]()
+
+[case testPEP695Properties]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class R[T]:
+    @property
+    def p(self) -> T: ...
+
+class RW[T]:
+    @property
+    def p(self) -> T: ...
+    @p.setter
+    def p(self, x: T) -> None: ...
+
+a: R[int] = R[object]()  # E: Incompatible types in assignment (expression has type "R[object]", variable has type "R[int]")
+b: R[object] = R[int]()
+c: RW[int] = RW[object]()  # E: Incompatible types in assignment (expression has type "RW[object]", variable has type "RW[int]")
+d: RW[object] = RW[int]()  # E: Incompatible types in assignment (expression has type "RW[int]", variable has type "RW[object]")
+[builtins fixtures/property.pyi]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -94,3 +94,24 @@ def ident[T](x: T) -> T:
 reveal_type(ident(1))  # N: Revealed type is "builtins.int"
 
 a: T  # E: Name "T" is not defined
+
+[case testPEP695GenericClassSyntax]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T]:
+    x: T
+
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+    def ident(self, x: T) -> T:
+        y: T = x
+        if int():
+            return self.x
+        else:
+            return y
+
+reveal_type(C("x"))  # N: Revealed type is "__main__.C[builtins.str]"
+c: C[int] = C(1)
+reveal_type(c.x)  # N: Revealed type is "builtins.int"
+reveal_type(c.ident(1))  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -795,6 +795,16 @@ reveal_type(a)  # N: Revealed type is "__main__.C[[builtins.int, builtins.str], 
 reveal_type(a.m)  # N: Revealed type is "def (builtins.int, builtins.str)"
 [builtins fixtures/tuple.pyi]
 
+[case testPEP695ParamSpecTypeAlias]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+from typing import Callable
+
+type C[**P] = Callable[P, int]
+
+f: C[[str, int | None]]
+reveal_type(f)  # N: Revealed type is "def (builtins.str, Union[builtins.int, None]) -> builtins.int"
+[builtins fixtures/tuple.pyi]
+
 [case testPEP695TypeVarTuple]
 # flags: --enable-incomplete-feature=NewGenericSyntax
 
@@ -814,6 +824,16 @@ reveal_type(b)  # N: Revealed type is "__main__.C[builtins.int, builtins.str, No
 c: C[str]
 reveal_type(c)  # N: Revealed type is "__main__.C[builtins.str]"
 b = c  # E: Incompatible types in assignment (expression has type "C[str]", variable has type "C[int, str, None]")
+[builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeVarTupleAlias]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+from typing import Callable
+
+type C[*Ts] = tuple[*Ts, int]
+
+a: C[str, None]
+reveal_type(a)  # N: Revealed type is "Tuple[builtins.str, None, builtins.int]"
 [builtins fixtures/tuple.pyi]
 
 [case testPEP695IncrementalFunction]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -948,3 +948,13 @@ type B[T] = Foo[T]
 [out2]
 tmp/a.py:3: note: Revealed type is "builtins.str"
 tmp/a.py:5: note: Revealed type is "b.Foo[builtins.int]"
+
+[case testPEP695UndefinedNameInGenericFunction]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+
+def f[T](x: T) -> T:
+    return unknown()  # E: Name "unknown" is not defined
+
+class C:
+    def m[T](self, x: T) -> T:
+        return unknown()  # E: Name "unknown" is not defined

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -760,3 +760,25 @@ class C[T: (int, XX)]:  # E: Name "XX" is not defined
 
 def f[S: (int, YY)](x: S) -> S:  # E: Name "YY" is not defined
     return x
+
+[case testPEP695ParamSpec]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+from typing import Callable
+
+def g[**P](f: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None:
+    f(*args, **kwargs)
+    f(1, *args, **kwargs)  # E: Argument 1 has incompatible type "int"; expected "P.args"
+
+def h(x: int, y: str) -> None: pass
+
+g(h, 1, y='x')
+g(h, 1, x=1)  # E: "g" gets multiple values for keyword argument "x" \
+              # E: Missing positional argument "y" in call to "g"
+
+class C[**P, T]:
+    def m(self, *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+a: C[[int, str], None]
+reveal_type(a)  # N: Revealed type is "__main__.C[[builtins.int, builtins.str], None]"
+reveal_type(a.m)  # N: Revealed type is "def (builtins.int, builtins.str)"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -813,6 +813,7 @@ b: C[int, str, None]
 reveal_type(b)  # N: Revealed type is "__main__.C[builtins.int, builtins.str, None]"
 c: C[str]
 reveal_type(c)  # N: Revealed type is "__main__.C[builtins.str]"
+b = c  # E: Incompatible types in assignment (expression has type "C[str]", variable has type "C[int, str, None]")
 [builtins fixtures/tuple.pyi]
 
 [case testPEP695IncrementalFunction]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -674,3 +674,22 @@ a: C[int]
 def f[T: YY](x: T) -> T:  # E: Name "YY" is not defined
     return x
 reveal_type(f)  # N: Revealed type is "def [T <: Any] (x: T`-1) -> T`-1"
+
+[case testPEP695UpperBoundWithMultipleParams]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T, S: int]: pass
+class D[A: int, B]: pass
+
+def f[T: int, S: int | str](x: T, y: S) -> T | S:
+    return x
+
+C[str, int]()
+C[str, str]()  # E: Value of type variable "S" of "C" cannot be "str"
+D[int, str]()
+D[str, str]()  # E: Value of type variable "A" of "D" cannot be "str"
+f(1, 1)
+u: int | str
+f(1, u)
+f('x', None)  # E: Value of type variable "T" of "f" cannot be "str" \
+              # E: Value of type variable "S" of "f" cannot be "None"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -82,3 +82,15 @@ reveal_type(ba2)  # N: Revealed type is "def (*Any) -> builtins.str"
 
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testPEP695GenericFunctionSyntax]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+def ident[T](x: T) -> T:
+    y: T = x
+    y = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "T")
+    return x
+
+reveal_type(ident(1))  # N: Revealed type is "builtins.int"
+
+a: T  # E: Name "T" is not defined

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -648,6 +648,21 @@ reveal_type(b)  # N: Revealed type is "__main__.C[__main__.E[__main__.X]]"
 
 c: C[D[int]]  # E: Type argument "D[int]" of "C" must be a subtype of "D[X]"
 
+[case testPEP695UpperBoundForwardReference4]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+def f[T: D](a: T) -> T:
+    reveal_type(a.x)  # N: Revealed type is "builtins.int"
+    return a
+
+class D:
+    x: int
+class E(D): pass
+
+reveal_type(f(D()))  # N: Revealed type is "__main__.D"
+reveal_type(f(E()))  # N: Revealed type is "__main__.E"
+f(1)  # E: Value of type variable "T" of "f" cannot be "int"
+
 [case testPEP695UpperBoundUndefinedName]
 # flags: --enable-incomplete-feature=NewGenericSyntax
 
@@ -656,3 +671,6 @@ class C[T: XX]:  # E: Name "XX" is not defined
 
 a: C[int]
 
+def f[T: YY](x: T) -> T:  # E: Name "YY" is not defined
+    return x
+reveal_type(f)  # N: Revealed type is "def [T <: Any] (x: T`-1) -> T`-1"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -586,6 +586,11 @@ type B = int + str  # E: Invalid type alias: expression is not a valid type
 b: B
 reveal_type(b)  # N: Revealed type is "Any"
 
+[case testPEP695TypeAliasBoundForwardReference]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+type B[T: Foo] = list[T]
+class Foo: pass
+
 [case testPEP695UpperBound]
 # flags: --enable-incomplete-feature=NewGenericSyntax
 

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -342,3 +342,44 @@ if int():
     a = b  # E: Incompatible types in assignment (expression has type "Subclass[object]", variable has type "Subclass[int]")
 if int():
     b = a  # E: Incompatible types in assignment (expression has type "Subclass[int]", variable has type "Subclass[object]")
+
+[case testPEP695InheritanceMakesInvariant]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+class Covariant[T]:
+    def f(self) -> T:
+        ...
+
+class Subclass[T](Covariant[list[T]]):
+    pass
+
+x: Covariant[int] = Covariant[object]()  # E: Incompatible types in assignment (expression has type "Covariant[object]", variable has type "Covariant[int]")
+y: Covariant[object] = Covariant[int]()
+
+a: Subclass[int] = Subclass[object]()  # E: Incompatible types in assignment (expression has type "Subclass[object]", variable has type "Subclass[int]")
+b: Subclass[object] = Subclass[int]()  # E: Incompatible types in assignment (expression has type "Subclass[int]", variable has type "Subclass[object]")
+
+[case testPEP695InheritCoOrContravariant]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+class Contravariant[T]:
+    def f(self, x: T) -> None: pass
+
+class CovSubclass[T](Contravariant[T]):
+    pass
+
+a: CovSubclass[int] = CovSubclass[object]()
+b: CovSubclass[object] = CovSubclass[int]()  # E: Incompatible types in assignment (expression has type "CovSubclass[int]", variable has type "CovSubclass[object]")
+
+class Covariant[T]:
+    def f(self) -> T: ...
+
+class CoSubclass[T](Covariant[T]):
+    pass
+
+c: CoSubclass[int] = CoSubclass[object]()  # E: Incompatible types in assignment (expression has type "CoSubclass[object]", variable has type "CoSubclass[int]")
+d: CoSubclass[object] = CoSubclass[int]()
+
+class InvSubclass[T](Covariant[T]):
+    def g(self, x: T) -> None: pass
+
+e: InvSubclass[int] = InvSubclass[object]()  # E: Incompatible types in assignment (expression has type "InvSubclass[object]", variable has type "InvSubclass[int]")
+f: InvSubclass[object] = InvSubclass[int]()  # E: Incompatible types in assignment (expression has type "InvSubclass[int]", variable has type "InvSubclass[object]")

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -597,3 +597,62 @@ def f[T: D](a: T) -> T:
 reveal_type(f(D()))  # N: Revealed type is "__main__.D"
 reveal_type(f(E()))  # N: Revealed type is "__main__.E"
 f(1)  # E: Value of type variable "T" of "f" cannot be "int"
+
+[case testPEP695UpperBoundForwardReference1]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T: D]: pass
+
+a: C[D]
+b: C[E]
+reveal_type(a)  # N: Revealed type is "__main__.C[__main__.D]"
+reveal_type(b)  # N: Revealed type is "__main__.C[__main__.E]"
+
+c: C[int]  # E: Type argument "int" of "C" must be a subtype of "D"
+
+class D: pass
+class E(D): pass
+
+[case testPEP695UpperBoundForwardReference2]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+type A = D
+class C[T: A]: pass
+
+class D: pass
+class E(D): pass
+
+a: C[D]
+b: C[E]
+reveal_type(a)  # N: Revealed type is "__main__.C[__main__.D]"
+reveal_type(b)  # N: Revealed type is "__main__.C[__main__.E]"
+
+c: C[int]  # E: Type argument "int" of "C" must be a subtype of "D"
+
+[case testPEP695UpperBoundForwardReference3]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class D[T]: pass
+class E[T](D[T]): pass
+
+type A = D[X]
+
+class C[T: A]: pass
+
+class X: pass
+
+a: C[D[X]]
+b: C[E[X]]
+reveal_type(a)  # N: Revealed type is "__main__.C[__main__.D[__main__.X]]"
+reveal_type(b)  # N: Revealed type is "__main__.C[__main__.E[__main__.X]]"
+
+c: C[D[int]]  # E: Type argument "D[int]" of "C" must be a subtype of "D[X]"
+
+[case testPEP695UpperBoundUndefinedName]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T: XX]:  # E: Name "XX" is not defined
+    pass
+
+a: C[int]
+

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -190,3 +190,20 @@ if int():
     e = f  # E: Incompatible types in assignment (expression has type "Contravariant[int]", variable has type "Contravariant[object]")
 if int():
     f = e
+
+[case testPEP695InferVarianceCalculateOnDemand]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class Covariant[T]:
+    def __init__(self) -> None:
+        self.x = [1]
+
+    def f(self) -> None:
+        c = Covariant[int]()
+        # We need to know that T is covariant here
+        self.g(c)
+        c2 = Covariant[object]()
+        self.h(c2)  # E: Argument 1 to "h" of "Covariant" has incompatible type "Covariant[object]"; expected "Covariant[int]"
+
+    def g(self, x: Covariant[object]) -> None: pass
+    def h(self, x: Covariant[int]) -> None: pass

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -154,3 +154,39 @@ if int():
     e = f  # E: Incompatible types in assignment (expression has type "Contravariant[int]", variable has type "Contravariant[object]")
 if int():
     f = e
+
+[case testPEP695InferVarianceRecursive]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class Invariant[T]:
+    def f(self, x: Invariant[T]) -> Invariant[T]:
+        return x
+
+class Covariant[T]:
+    def f(self) -> Covariant[T]:
+        return self
+
+class Contravariant[T]:
+    def f(self, x: Contravariant[T]) -> None:
+        pass
+
+a: Invariant[object]
+b: Invariant[int]
+if int():
+    a = b  # E: Incompatible types in assignment (expression has type "Invariant[int]", variable has type "Invariant[object]")
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "Invariant[object]", variable has type "Invariant[int]")
+
+c: Covariant[object]
+d: Covariant[int]
+if int():
+    c = d
+if int():
+    d = c  # E: Incompatible types in assignment (expression has type "Covariant[object]", variable has type "Covariant[int]")
+
+e: Contravariant[object]
+f: Contravariant[int]
+if int():
+    e = f  # E: Incompatible types in assignment (expression has type "Contravariant[int]", variable has type "Contravariant[object]")
+if int():
+    f = e

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -319,3 +319,26 @@ class Invariant[T]:
         self.x = x
 
 reveal_type(c(a1, a2))  # N: Revealed type is "Never"
+
+[case testPEP695InheritInvariant]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class Invariant[T]:
+    x: T
+
+class Subclass[T](Invariant[T]):
+    pass
+
+x: Invariant[int]
+y: Invariant[object]
+if int():
+    x = y  # E: Incompatible types in assignment (expression has type "Invariant[object]", variable has type "Invariant[int]")
+if int():
+    y = x  # E: Incompatible types in assignment (expression has type "Invariant[int]", variable has type "Invariant[object]")
+
+a: Subclass[int]
+b: Subclass[object]
+if int():
+    a = b  # E: Incompatible types in assignment (expression has type "Subclass[object]", variable has type "Subclass[int]")
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "Subclass[int]", variable has type "Subclass[object]")

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -291,6 +291,7 @@ if int():
 
 class Invariant[T]:
     def f(self) -> None:
+        # Assume covariance if variance us not ready
         reveal_type([Invariant(1), Invariant(object())]) \
             # N: Revealed type is "builtins.list[__main__.Invariant[builtins.object]]"
 
@@ -298,3 +299,23 @@ class Invariant[T]:
         self.x = x
 
 reveal_type([Invariant(1), Invariant(object())])   # N: Revealed type is "builtins.list[builtins.object]"
+
+[case testPEP695InferVarianceNotReadyForMeet]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+from typing import TypeVar, Callable
+
+S = TypeVar("S")
+def c(a: Callable[[S], None], b: Callable[[S], None]) -> S: ...
+
+def a1(x: Invariant[int]) -> None: pass
+def a2(x: Invariant[object]) -> None: pass
+
+class Invariant[T]:
+    def f(self) -> None:
+        reveal_type(c(a1, a2))  # N: Revealed type is "__main__.Invariant[builtins.int]"
+
+    def __init__(self, x: T) -> None:
+        self.x = x
+
+reveal_type(c(a1, a2))  # N: Revealed type is "Never"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -573,3 +573,27 @@ reveal_type(a)  # N: Revealed type is "Union[builtins.int, Any]"
 type B = int + str  # E: Invalid type alias: expression is not a valid type
 b: B
 reveal_type(b)  # N: Revealed type is "Any"
+
+[case testPEP695UpperBound]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class D:
+    x: int
+class E(D): pass
+
+class C[T: D]: pass
+
+a: C[D]
+b: C[E]
+reveal_type(a)  # N: Revealed type is "__main__.C[__main__.D]"
+reveal_type(b)  # N: Revealed type is "__main__.C[__main__.E]"
+
+c: C[int]  # E: Type argument "int" of "C" must be a subtype of "D"
+
+def f[T: D](a: T) -> T:
+    reveal_type(a.x)  # N: Revealed type is "builtins.int"
+    return a
+
+reveal_type(f(D()))  # N: Revealed type is "__main__.D"
+reveal_type(f(E()))  # N: Revealed type is "__main__.E"
+f(1)  # E: Value of type variable "T" of "f" cannot be "int"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -128,12 +128,12 @@ reveal_type(c.ident(1))  # N: Revealed type is "builtins.int"
 # flags: --enable-incomplete-feature=NewGenericSyntax
 
 class C[T]:
-    def m[S](self, x: S) -> T: ...
+    def m[S](self, x: S) -> T | S: ...
 
 a: C[int] = C[object]()  # E: Incompatible types in assignment (expression has type "C[object]", variable has type "C[int]")
 b: C[object] = C[int]()
 
-reveal_type(C[str]().m(1))  # N: Revealed type is "builtins.str"
+reveal_type(C[str]().m(1))  # N: Revealed type is "Union[builtins.str, builtins.int]"
 
 [case testPEP695InferVarianceSimpleFromMethod]
 # flags: --enable-incomplete-feature=NewGenericSyntax

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -715,3 +715,48 @@ d: Cov2[int] = Cov2[object]()  # E: Incompatible types in assignment (expression
 e: Contra[int] = Contra[object]()
 f: Contra[object] = Contra[int]()  # E: Incompatible types in assignment (expression has type "Contra[int]", variable has type "Contra[object]")
 [builtins fixtures/tuple-simple.pyi]
+
+[case testPEP695ValueRestiction]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+def f[T: (int, str)](x: T) -> T:
+    reveal_type(x)  # N: Revealed type is "builtins.int" \
+                    # N: Revealed type is "builtins.str"
+    return x
+
+reveal_type(f(1))  # N: Revealed type is "builtins.int"
+reveal_type(f('x'))  # N: Revealed type is "builtins.str"
+f(None)  # E: Value of type variable "T" of "f" cannot be "None"
+
+class C[T: (object, None)]: pass
+
+a: C[object]
+b: C[None]
+c: C[int]  # E: Value of type variable "T" of "C" cannot be "int"
+
+[case testPEP695ValueRestictionForwardReference]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T: (int, D)]:
+    def __init__(self, x: T) -> None:
+        a = x
+        if int():
+            a = 'x'  # E: Incompatible types in assignment (expression has type "str", variable has type "int") \
+                     # E: Incompatible types in assignment (expression has type "str", variable has type "D")
+        self.x: T = x
+
+reveal_type(C(1).x)  # N: Revealed type is "builtins.int"
+C(None)  # E: Value of type variable "T" of "C" cannot be "None"
+
+class D: pass
+
+C(D())
+
+[case testPEP695ValueRestictionUndefinedName]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+
+class C[T: (int, XX)]:  # E: Name "XX" is not defined
+    pass
+
+def f[S: (int, YY)](x: S) -> S:  # E: Name "YY" is not defined
+    return x

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -425,3 +425,40 @@ b: R[object] = R[int]()
 c: RW[int] = RW[object]()  # E: Incompatible types in assignment (expression has type "RW[object]", variable has type "RW[int]")
 d: RW[object] = RW[int]()  # E: Incompatible types in assignment (expression has type "RW[int]", variable has type "RW[object]")
 [builtins fixtures/property.pyi]
+
+[case testPEP695Protocol]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+from typing import Protocol
+
+class PContra[T](Protocol):
+    def f(self, x: T) -> None: ...
+
+PContra()  # E: Cannot instantiate protocol class "PContra"
+a: PContra[int]
+b: PContra[object]
+if int():
+    a = b
+if int():
+    b = a  # E: Incompatible types in assignment (expression has type "PContra[int]", variable has type "PContra[object]")
+
+class PCov[T](Protocol):
+    def f(self) -> T: ...
+
+PCov()  # E: Cannot instantiate protocol class "PCov"
+c: PCov[int]
+d: PCov[object]
+if int():
+    c = d  # E: Incompatible types in assignment (expression has type "PCov[object]", variable has type "PCov[int]")
+if int():
+    d = c
+
+class PInv[T](Protocol):
+    def f(self, x: T) -> T: ...
+
+PInv()  # E: Cannot instantiate protocol class "PInv"
+e: PInv[int]
+f: PInv[object]
+if int():
+    e = f  # E: Incompatible types in assignment (expression has type "PInv[object]", variable has type "PInv[int]")
+if int():
+    f = e  # E: Incompatible types in assignment (expression has type "PInv[int]", variable has type "PInv[object]")

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -559,6 +559,18 @@ class C: pass
 x: C = D()
 y: D = C()  # E: Incompatible types in assignment (expression has type "C", variable has type "D")
 
+[case testPEP695TypeAliasForwardReference5]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+type A = str
+type B[T] = C[T]
+class C[T]: pass
+a: A
+b: B[int]
+c: C[str]
+reveal_type(a)  # N: Revealed type is "builtins.str"
+reveal_type(b)  # N: Revealed type is "__main__.C[builtins.int]"
+reveal_type(c)  # N: Revealed type is "__main__.C[builtins.str]"
+
 [case testPEP695TypeAliasWithUndefineName]
 # flags: --enable-incomplete-feature=NewGenericSyntax
 type A[T] = XXX  # E: Name "XXX" is not defined

--- a/test-data/unit/parse-python312.test
+++ b/test-data/unit/parse-python312.test
@@ -5,8 +5,29 @@ type A[T] = C[T]
 MypyFile:1(
   TypeAliasStmt:2(
     NameExpr(A)
-    TypeArg(
+    TypeParam(
       T)
     IndexExpr:2(
       NameExpr(C)
       NameExpr(T))))
+
+[case testPEP695GenericFunction]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+
+def f[T](): pass
+def g[T: str](): pass
+[out]
+MypyFile:1(
+  FuncDef:3(
+    f
+    TypeParam(
+      T)
+    Block:3(
+      PassStmt:3()))
+  FuncDef:4(
+    g
+    TypeParam(
+      T
+      str?)
+    Block:4(
+      PassStmt:4())))

--- a/test-data/unit/parse-python312.test
+++ b/test-data/unit/parse-python312.test
@@ -16,6 +16,7 @@ MypyFile:1(
 
 def f[T](): pass
 def g[T: str](): pass
+def h[T: (int, str)](): pass
 [out]
 MypyFile:1(
   FuncDef:3(
@@ -30,4 +31,13 @@ MypyFile:1(
       T
       str?)
     Block:4(
-      PassStmt:4())))
+      PassStmt:4()))
+  FuncDef:5(
+    h
+    TypeParam(
+      T
+      Values(
+        int?
+        str?))
+    Block:5(
+      PassStmt:5())))

--- a/test-data/unit/parse-python312.test
+++ b/test-data/unit/parse-python312.test
@@ -1,0 +1,12 @@
+[case testPEP695TypeAlias]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+type A[T] = C[T]
+[out]
+MypyFile:1(
+  TypeAliasStmt:2(
+    NameExpr(A)
+    TypeArg(
+      T)
+    IndexExpr:2(
+      NameExpr(C)
+      NameExpr(T))))

--- a/test-data/unit/parse-python312.test
+++ b/test-data/unit/parse-python312.test
@@ -63,3 +63,25 @@ MypyFile:1(
     TypeParam(
       **P)
     PassStmt:4()))
+
+[case testPEP695TypeVarTuple]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+
+def f[*Ts](): pass
+class C[T: int, *Ts]: pass
+[out]
+MypyFile:1(
+  FuncDef:3(
+    f
+    TypeParam(
+      *Ts)
+    Block:3(
+      PassStmt:3()))
+  ClassDef:4(
+    C
+    TypeParam(
+      T
+      int?)
+    TypeParam(
+      *Ts)
+    PassStmt:4()))

--- a/test-data/unit/parse-python312.test
+++ b/test-data/unit/parse-python312.test
@@ -41,3 +41,25 @@ MypyFile:1(
         str?))
     Block:5(
       PassStmt:5())))
+
+[case testPEP695ParamSpec]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+
+def f[**P](): pass
+class C[T: int, **P]: pass
+[out]
+MypyFile:1(
+  FuncDef:3(
+    f
+    TypeParam(
+      **P)
+    Block:3(
+      PassStmt:3()))
+  ClassDef:4(
+    C
+    TypeParam(
+      T
+      int?)
+    TypeParam(
+      **P)
+    PassStmt:4()))

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2091,3 +2091,24 @@ def f(d: Description) -> None:
     reveal_type(d.name_fn)
 [out]
 _testDataclassStrictOptionalAlwaysSet.py:9: note: Revealed type is "def (Union[builtins.int, None]) -> Union[builtins.str, None]"
+
+[case testPEP695VarianceInference]
+# flags: --python-version=3.12 --enable-incomplete-feature=NewGenericSyntax
+from typing import Callable, Final
+
+class Job[_R_co]:
+    def __init__(self, target: Callable[[], _R_co]) -> None:
+        self.target: Final = target
+
+def func(
+    action: Job[int | None],
+    a1: Job[int | None],
+    a2: Job[int],
+    a3: Job[None],
+) -> None:
+    action = a1
+    action = a2
+    action = a3
+    a2 = action  # Error
+[out]
+_testPEP695VarianceInference.py:17: error: Incompatible types in assignment (expression has type "Job[None]", variable has type "Job[int]")


### PR DESCRIPTION
Add basic support for most features of PEP 695. It's still not generally useful, but it
should be enough for experimentation and testing. I will continue working on 
follow-up PRs after this has been merged.

This is currently behind a feature flag: `--enable-incomplete-feature=NewGenericSyntax`

These features, among other things, are unimplemented (or at least untested):
* Recursive type aliases
* Checking for various errors
* Inference of variance in complex cases
* Dealing with unknown variance consistently
* Scoping
* Mypy daemon
* Compilation using mypyc

The trickiest remaining thing is probably variance inference in cases where some types
aren't ready (i.e. not inferred) when we need variance. I have some ideas about how to
tackle this, but it might need significant work. Currently the idea is to infer variance
on demand when we need it, but we may need to defer if variance can't be calculated,
for example if a type of an attribute is not yet ready. The current approach is to fall
back to covariance in some cases, which is not ideal.

Work on #15238.