### PR TITLE
Now overloads with ambiguous `self` are handled properly, refs #11347

### DIFF
--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6693,3 +6693,65 @@ class B:
     def f(self, *args, **kwargs):
         pass
 [builtins fixtures/tuple.pyi]
+
+[case testOverloadSelfArgWithMultipleMatches]
+# https://github.com/python/mypy/issues/11347
+from typing import Generic, TypeVar, overload, Any
+
+T = TypeVar('T')
+
+class Some(Generic[T]):
+    @overload
+    def method(self: Some[int]) -> str: ...
+    @overload
+    def method(self: Some[str]) -> float: ...
+    def method(self): ...
+
+s1: Some[int]
+s2: Some[str]
+s3: Some[Any]
+reveal_type(s1.method())  # N: Revealed type is "builtins.str"
+reveal_type(s2.method())  # N: Revealed type is "builtins.float"
+reveal_type(s3.method()) # N: Revealed type is "Any"
+[builtins fixtures/dict.pyi]
+
+[case testOverloadSelfArgWithOtherSameArgAndMultipleMatches]
+from typing import Generic, TypeVar, overload, Any
+
+T = TypeVar('T')
+
+class Some(Generic[T]):
+    @overload
+    def method(self: Some[int], other: int) -> str: ...
+    @overload
+    def method(self: Some[str], other: int) -> float: ...
+    def method(self): ...
+
+# was ok
+s1: Some[int]
+s2: Some[str]
+s3: Some[Any]
+reveal_type(s1.method(1))  # N: Revealed type is "builtins.str"
+reveal_type(s2.method(1))  # N: Revealed type is "builtins.float"
+reveal_type(s3.method(1)) # N: Revealed type is "Any"
+[builtins fixtures/dict.pyi]
+
+[case testOverloadSelfArgWithOtherDifferentArgAndMultipleMatches]
+from typing import Generic, TypeVar, overload, Any
+
+T = TypeVar('T')
+
+class Some(Generic[T]):
+    @overload
+    def method(self: Some[int], other: int) -> str: ...
+    @overload
+    def method(self: Some[str], other: str) -> float: ...
+    def method(self): ...
+
+s1: Some[int]
+s2: Some[str]
+s3: Some[Any]
+reveal_type(s1.method(1))  # N: Revealed type is "builtins.str"
+reveal_type(s2.method('a'))  # N: Revealed type is "builtins.float"
+reveal_type(s3.method(1)) # N: Revealed type is "builtins.str"
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
- Fixes #11347 
- Supersedes #11366 

This is simply a rebase of #11366 (See https://github.com/python/mypy/pull/11366#issuecomment-2057205424 CC @sobolevn), I kept the changes intact.