### PR TITLE
[dmypy] sort list of files for update by extension

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -383,6 +383,9 @@ class Server:
             removals = set(remove)
             sources = [s for s in sources if s.path and s.path not in removals]
         if update:
+            # Sort list of file updates by extension, so *.pyi files are first.
+            update.sort(key=lambda f: os.path.splitext(f)[1], reverse=True)
+
             known = {s.path for s in sources if s.path}
             added = [p for p in update if p not in known]
             try:


### PR DESCRIPTION
dmypy receives the list of updated files via `--update` flag. If this list contains both `foo.py` and `foo.pyi`, the order matters. It seems to process the first file in the list first. But if we have a `.pyi` file, we want this to be processed first since this one contains the typing information.
Let's reverse sort the list of updated files by the extension. This should be a simple enough fix to resolve this.

Though there might be some edge cases where the list of files to update contains just pyi files, but we might need to recheck the equivalent py files even if not explicitly updated.