### PR TITLE
Support rename=True in collections.namedtuple

### DIFF
--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -378,7 +378,7 @@ class NamedTupleAnalyzer:
                         rename = arg.name == "True"
                     else:
                         self.fail(
-                            "Boolean literal expected as the \"rename\" argument to "
+                            'Boolean literal expected as the "rename" argument to '
                             f"{type_name}()",
                             arg,
                         )
@@ -691,7 +691,7 @@ class NamedTupleAnalyzer:
     def check_namedtuple_field_name(self, field: str, seen_names: Container[str]) -> Optional[str]:
         """Return None for valid fields, a string description for invalid ones."""
         if field in seen_names:
-            return f"has duplicate field name \"{field}\""
+            return f'has duplicate field name "{field}"'
         elif not field.isidentifier():
             return f'field name "{field}" is not a valid identifier'
         elif field.startswith("_"):

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -429,7 +429,7 @@ class NamedTupleAnalyzer:
         if not types:
             types = [AnyType(TypeOfAny.unannotated) for _ in items]
         processed_items = []
-        seen_names = set()
+        seen_names: set[str] = set()
         for i, item in enumerate(items):
             problem = self.check_namedtuple_field_name(item, seen_names)
             if problem is None:

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -9,6 +9,7 @@ import keyword
 from contextlib import contextmanager
 from typing import Container, Final, Iterator, List, Mapping, cast
 
+from mypy.errorcodes import ARG_TYPE, ErrorCode
 from mypy.exprtotype import TypeTranslationError, expr_to_unanalyzed_type
 from mypy.messages import MessageBuilder
 from mypy.nodes import (
@@ -381,6 +382,7 @@ class NamedTupleAnalyzer:
                             'Boolean literal expected as the "rename" argument to '
                             f"{type_name}()",
                             arg,
+                            code=ARG_TYPE,
                         )
         if call.arg_kinds[:2] != [ARG_POS, ARG_POS]:
             self.fail(f'Unexpected arguments to "{type_name}()"', call)
@@ -700,5 +702,5 @@ class NamedTupleAnalyzer:
             return f'field name "{field}" is a keyword'
         return None
 
-    def fail(self, msg: str, ctx: Context) -> None:
-        self.api.fail(msg, ctx)
+    def fail(self, msg: str, ctx: Context, code: ErrorCode | None = None) -> None:
+        self.api.fail(msg, ctx, code=code)

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import keyword
 from contextlib import contextmanager
-from typing import Container, Final, Iterator, List, Mapping, Optional, cast
+from typing import Container, Final, Iterator, List, Mapping, cast
 
 from mypy.exprtotype import TypeTranslationError, expr_to_unanalyzed_type
 from mypy.messages import MessageBuilder
@@ -688,7 +688,7 @@ class NamedTupleAnalyzer:
 
     # Helpers
 
-    def check_namedtuple_field_name(self, field: str, seen_names: Container[str]) -> Optional[str]:
+    def check_namedtuple_field_name(self, field: str, seen_names: Container[str]) -> str | None:
         """Return None for valid fields, a string description for invalid ones."""
         if field in seen_names:
             return f'has duplicate field name "{field}"'

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -22,10 +22,13 @@ a, b, c = x # E: Need more than 2 values to unpack (3 expected)
 x[2] # E: Tuple index out of range
 [builtins fixtures/tuple.pyi]
 
-[case testNamedTupleNoUnderscoreFields]
+[case testNamedTupleInvalidFields]
 from collections import namedtuple
 
-X = namedtuple('X', 'x, _y, _z')  # E: "namedtuple()" field names cannot start with an underscore: _y, _z
+X = namedtuple('X', 'x, _y')  # E: "namedtuple()" field name "_y" starts with an underscore
+Y = namedtuple('Y', ['x', '1'])  # E: "namedtuple()" field name "1" is not a valid identifier
+Z = namedtuple('Z', ['x', 'def'])  # E: "namedtuple()" field name "def" is a keyword
+A = namedtuple('A', ['x', 'x'])  # E: "namedtuple()" has duplicate field name "x"
 [builtins fixtures/tuple.pyi]
 
 [case testNamedTupleAccessingAttributes]
@@ -125,6 +128,8 @@ E = namedtuple('E', 'a b', 0)
 [builtins fixtures/bool.pyi]
 
 [out]
+main:4: error: Boolean literal expected as the "rename" argument to namedtuple()
+main:5: error: Boolean literal expected as the "rename" argument to namedtuple()
 main:5: error: Argument "rename" to "namedtuple" has incompatible type "str"; expected "int"
 main:6: error: Unexpected keyword argument "unrecognized_arg" for "namedtuple"
 <ROOT>/test-data/unit/lib-stub/collections.pyi:3: note: "namedtuple" defined here
@@ -142,6 +147,23 @@ X(0, 1, 2)  # E: Too many arguments for "X"
 
 Y = namedtuple('Y', ['x', 'y'], defaults=(1, 2, 3))  # E: Too many defaults given in call to "namedtuple()"
 Z = namedtuple('Z', ['x', 'y'], defaults='not a tuple')  # E: List or tuple literal expected as the defaults argument to namedtuple()  # E: Argument "defaults" to "namedtuple" has incompatible type "str"; expected "Optional[Iterable[Any]]"
+
+[builtins fixtures/list.pyi]
+
+[case testNamedTupleRename]
+from collections import namedtuple
+
+X = namedtuple('X', ['abc', 'def'], rename=False)  # E: "namedtuple()" field name "def" is a keyword
+Y = namedtuple('Y', ['x', 'x', 'def', '42', '_x'], rename=True)
+y = Y(x=0, _1=1, _2=2, _3=3, _4=4)
+reveal_type(y.x)  # N: Revealed type is "Any"
+reveal_type(y._1)  # N: Revealed type is "Any"
+reveal_type(y._2)  # N: Revealed type is "Any"
+reveal_type(y._3)  # N: Revealed type is "Any"
+reveal_type(y._4)  # N: Revealed type is "Any"
+y._0  # E: "Y" has no attribute "_0"
+y._5  # E: "Y" has no attribute "_5"
+y._x  # E: "Y" has no attribute "_x"
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/semanal-namedtuple.test
+++ b/test-data/unit/semanal-namedtuple.test
@@ -165,7 +165,7 @@ N = namedtuple('N', ['x', 1]) # E: String literal expected as "namedtuple()" ite
 
 [case testNamedTupleWithUnderscoreItemName]
 from collections import namedtuple
-N = namedtuple('N', ['_fallback']) # E: "namedtuple()" field names cannot start with an underscore: _fallback
+N = namedtuple('N', ['_fallback']) # E: "namedtuple()" field name "_fallback" starts with an underscore
 [builtins fixtures/tuple.pyi]
 
 -- NOTE: The following code works at runtime but is not yet supported by mypy.
@@ -197,7 +197,7 @@ N = NamedTuple('N', 1) # E: List or tuple literal expected as the second argumen
 
 [case testTypingNamedTupleWithUnderscoreItemName]
 from typing import NamedTuple
-N = NamedTuple('N', [('_fallback', int)]) # E: "NamedTuple()" field names cannot start with an underscore: _fallback
+N = NamedTuple('N', [('_fallback', int)]) # E: "NamedTuple()" field name "_fallback" starts with an underscore
 [builtins fixtures/tuple.pyi]
 
 [case testTypingNamedTupleWithUnexpectedNames]


### PR DESCRIPTION
A pretty marginal feature but it's now tested in the typing conformance suite,
and it was easy to add support.

For reference: https://github.com/python/typing/blob/9f7f400bb7c4c79f1fb938402e0bb3198dac0054/conformance/tests/namedtuples_define_functional.py#L46, https://github.com/python/cpython/blob/7d8725ac6f3304677d71dabdb7c184e98a62d864/Lib/collections/__init__.py#L389