### PR TITLE
Fix for type narrowing of negative integer literals

### DIFF
--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -489,7 +489,7 @@ def int_neg_callback(ctx: MethodContext, multiplier: int = -1) -> Type:
                 return ctx.type.copy_modified(
                     last_known_value=LiteralType(
                         value=multiplier * value,
-                        fallback=ctx.type,
+                        fallback=fallback,
                         line=ctx.type.line,
                         column=ctx.type.column,
                     )

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2089,3 +2089,28 @@ if isinstance(x, (Z, NoneType)):  # E: Subclass of "X" and "Z" cannot exist: "Z"
     reveal_type(x)  # E: Statement is unreachable
 
 [builtins fixtures/isinstance.pyi]
+
+[case testTypeNarrowingReachableNegative]
+# flags: --warn-unreachable
+from typing import Literal
+
+x: Literal[-1]
+
+if x == -1:
+    assert True
+
+[typing fixtures/typing-medium.pyi]
+[builtins fixtures/ops.pyi]
+
+[case testTypeNarrowingReachableNegativeUnion]
+from typing import Literal
+
+x: Literal[-1, 1]
+
+if x == -1:
+    reveal_type(x)  # N: Revealed type is "Literal[-1]"
+else:
+    reveal_type(x)  # N: Revealed type is "Literal[1]"
+
+[typing fixtures/typing-medium.pyi]
+[builtins fixtures/ops.pyi]


### PR DESCRIPTION
Fixes #10514
Fixes #17118

Negative integer literals were not being correctly handled in the type narrowing process, causing mypy errors such as "Statement is unreachable" despite the checked code being valid. This fix ensures that negative integer literals are properly considered in if-statements.
