### PR TITLE
stubtest: changes for py313

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -634,6 +634,10 @@ def _verify_arg_name(
     if strip_prefix(stub_arg.variable.name, "__") == runtime_arg.name:
         return
 
+    nonspecific_names = {"object", "args"}
+    if runtime_arg.name in nonspecific_names:
+        return
+
     def names_approx_match(a: str, b: str) -> bool:
         a = a.strip("_")
         b = b.strip("_")
@@ -1455,6 +1459,8 @@ IGNORABLE_CLASS_DUNDERS: typing_extensions.Final = frozenset(
         "__getattr__",  # resulting behaviour might be typed explicitly
         "__setattr__",  # defining this on a class can cause worse type checking
         "__vectorcalloffset__",  # undocumented implementation detail of the vectorcall protocol
+        "__firstlineno__",
+        "__static_attributes__",
         # isinstance/issubclass hooks that type-checkers don't usually care about
         "__instancecheck__",
         "__subclasshook__",


### PR DESCRIPTION
Technically it feels like we should be able to put the new dunders on `type` or something, but that wasn't enough to make false positives go away. But also we might not want to do that because it only applies to pure Python types