### PR TITLE
[PEP 695] Support recursive type aliases

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1640,19 +1640,21 @@ class MatchStmt(Statement):
 
 
 class TypeAliasStmt(Statement):
-    __slots__ = ("name", "type_args", "value")
+    __slots__ = ("name", "type_args", "value", "invalid_recursive_alias")
 
     __match_args__ = ("name", "type_args", "value")
 
     name: NameExpr
     type_args: list[TypeParam]
     value: Expression  # Will get translated into a type
+    invalid_recursive_alias: bool
 
     def __init__(self, name: NameExpr, type_args: list[TypeParam], value: Expression) -> None:
         super().__init__()
         self.name = name
         self.type_args = type_args
         self.value = value
+        self.invalid_recursive_alias = False
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_type_alias_stmt(self)

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1184,3 +1184,23 @@ a: A
 reveal_type(a)  # N: Revealed type is "Any"
 b: B
 reveal_type(b)  # N: Revealed type is "Any"
+
+[case testPEP695RecursiveTypeAliasForwardReference]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+
+def f(a: A) -> None:
+    if isinstance(a, str):
+        reveal_type(a)  # N: Revealed type is "builtins.str"
+    else:
+        reveal_type(a)  # N: Revealed type is "__main__.C[Union[builtins.str, __main__.C[...]]]"
+
+type A = str | C[A]
+
+class C[T]: pass
+
+f('x')
+f(C[str]())
+f(C[C[str]]())
+f(1)  # E: Argument 1 to "f" has incompatible type "int"; expected "A"
+f(C[int]())  # E: Argument 1 to "f" has incompatible type "C[int]"; expected "A"
+[builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1174,3 +1174,13 @@ class C[T]: pass
 type B[T] = C[T] | list[B[T]]
 b: B[int]
 reveal_type(b)  # N: Revealed type is "Union[__main__.C[builtins.int], builtins.list[...]]"
+
+[case testPEP695BadRecursiveTypeAlias]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+
+type A = A  # E: Cannot resolve name "A" (possible cyclic definition)
+type B = B | int  # E: Invalid recursive alias: a union item of itself
+a: A
+reveal_type(a)  # N: Revealed type is "Any"
+b: B
+reveal_type(b)  # N: Revealed type is "Any"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1161,3 +1161,16 @@ def decorator(x: str) -> Any: ...
 @decorator(T)  # E: Argument 1 to "decorator" has incompatible type "int"; expected "str"
 class C[T]:
     pass
+
+[case testPEP695RecursiceTypeAlias]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+
+type A = str | list[A]
+a: A
+reveal_type(a)  # N: Revealed type is "Union[builtins.str, builtins.list[...]]"
+
+class C[T]: pass
+
+type B[T] = C[T] | list[B[T]]
+b: B[int]
+reveal_type(b)  # N: Revealed type is "Union[__main__.C[builtins.int], builtins.list[...]]"


### PR DESCRIPTION
The implementation follows the approach used for old-style type aliases.

Work on #15238.