### PR TITLE
[PEP 695] Detect errors related to mixing old and new style features

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2421,6 +2421,10 @@ class MessageBuilder:
             code=codes.ANNOTATION_UNCHECKED,
         )
 
+    def type_parameters_should_be_declared(self, undeclared: list[str], context: Context) -> None:
+        names = ", ".join('"' + n + '"' for n in undeclared)
+        self.fail(f"All type parameters should be declared ({names} not declared)", context)
+
 
 def quote_type_string(type_string: str) -> str:
     """Quotes a type representation for use in messages."""

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1164,7 +1164,6 @@ class C[T]:
 
 [case testPEP695InvalidGenericOrProtocolBaseClass]
 # mypy: enable-incomplete-feature=NewGenericSyntax
-
 from typing import Generic, Protocol, TypeVar
 
 S = TypeVar("S")
@@ -1180,4 +1179,25 @@ b: C2[int, str]
 class P[T](Protocol[T]):  # E: No arguments expected for "Protocol" base class
     pass
 class P2[T](Protocol[S]):  # E: No arguments expected for "Protocol" base class
+    pass
+
+[case testPEP695MixNewAndOldStyleGenerics]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+from typing import TypeVar
+
+S = TypeVar("S")
+U = TypeVar("U")
+
+def f[T](x: T, y: S) -> T | S: ...  # E: All type parameters should be declared ("S" not declared)
+def g[T](x: S, y: U) -> T | S | U: ...  # E: All type parameters should be declared ("S", "U" not declared)
+
+def h[S: int](x: S) -> S:
+   a: int = x
+   return x
+
+class C[T]:
+    def m[X, S](self, x: S, y: U) -> X | S | U: ...  # E: All type parameters should be declared ("U" not declared)
+    def m2(self, x: T, y: S) -> T | S: ...
+
+class D[T](C[S]):  # E: All type parameters should be declared ("S" not declared)
     pass

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1161,3 +1161,23 @@ def decorator(x: str) -> Any: ...
 @decorator(T)  # E: Argument 1 to "decorator" has incompatible type "int"; expected "str"
 class C[T]:
     pass
+
+[case testPEP695InvalidGenericOrProtocolBaseClass]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+
+from typing import Generic, Protocol, TypeVar
+
+S = TypeVar("S")
+
+class C[T](Generic[T]):  # E: Generic[...] base class is redundant
+    pass
+class C2[T](Generic[S]): # E: Generic[...] base class is redundant
+    pass
+
+a: C[int]
+b: C2[int, str]
+
+class P[T](Protocol[T]):  # E: No arguments expected for "Protocol" base class
+    pass
+class P2[T](Protocol[S]):  # E: No arguments expected for "Protocol" base class
+    pass


### PR DESCRIPTION
`Generic[...]` or `Protocol[...]` shouldn't be used with new-style syntax.

Generic functions and classes using the new syntax shouldn't mix new-style and
old-style type parameters.

Work on #15238.