### PR TITLE
Stubtest: ignore `_ios_support`

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1891,7 +1891,9 @@ class _Arguments:
 
 
 # typeshed added a stub for __main__, but that causes stubtest to check itself
-ANNOYING_STDLIB_MODULES: typing_extensions.Final = frozenset({"antigravity", "this", "__main__"})
+ANNOYING_STDLIB_MODULES: typing_extensions.Final = frozenset(
+    {"antigravity", "this", "__main__", "_ios_support"}
+)
 
 
 def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:


### PR DESCRIPTION
Trying to import this module on py313 raises RuntimeError on Windows, and it doesn't seem important