### PR TITLE
Check override compatibility for dynamically typed methods

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1004,7 +1004,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         """Type check a function definition."""
         self.check_func_item(defn, name=defn.name)
         if defn.info:
-            if not defn.is_dynamic() and not defn.is_overload and not defn.is_decorated:
+            if not defn.is_overload and not defn.is_decorated:
                 # If the definition is the implementation for an
                 # overload, the legality of the override has already
                 # been typechecked, and decorated methods will be

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -516,7 +516,7 @@ class A(I):
 [out]
 main:10: error: Signature of "g" incompatible with supertype "I"
 main:10: note:      Superclass:
-main:10: note:          def g(self, x: Any) -> Any
+main:10: note:          def g(self, x: int) -> None
 main:10: note:      Subclass:
 main:10: note:          def g(self, x: Any, y: Any) -> Any
 

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -494,8 +494,13 @@ class I(metaclass=ABCMeta):
     def g(self, x): pass
 class A(I):
     def f(self, x): pass
-    def g(self, x, y): pass
+    def g(self, x, y): pass  # Fail
 [out]
+main:10: error: Signature of "g" incompatible with supertype "I"
+main:10: note:      Superclass:
+main:10: note:          def g(self, x: Any) -> Any
+main:10: note:      Subclass:
+main:10: note:          def g(self, x: Any, y: Any) -> Any
 
 [case testAbstractClassWithImplementationUsingDynamicTypes]
 from abc import abstractmethod, ABCMeta
@@ -507,8 +512,13 @@ class I(metaclass=ABCMeta):
     def g(self, x: int) -> None: pass
 class A(I):
     def f(self, x): pass
-    def g(self, x, y): pass
+    def g(self, x, y): pass  # Fail
 [out]
+main:10: error: Signature of "g" incompatible with supertype "I"
+main:10: note:      Superclass:
+main:10: note:          def g(self, x: Any) -> Any
+main:10: note:      Subclass:
+main:10: note:          def g(self, x: Any, y: Any) -> Any
 
 
 -- Special cases

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -727,6 +727,11 @@ class A(B):
     def f(self, x, y): # dynamic function not type checked
         x()
 [out]
+main:5: error: Signature of "f" incompatible with supertype "B"
+main:5: note:      Superclass:
+main:5: note:          def f(self, x: A) -> None
+main:5: note:      Subclass:
+main:5: note:          def f(self, x: Any, y: Any) -> Any
 
 [case testInvalidOverrideArgumentCountWithImplicitSignature2]
 import typing

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3228,3 +3228,19 @@ class A:
 reveal_type(A.f)  # N: Revealed type is "__main__.something_callable"
 reveal_type(A().f)  # N: Revealed type is "builtins.str"
 [builtins fixtures/property.pyi]
+
+[case testFinalOverrideOnUntypedDef]
+# flags: --python-version 3.12
+
+from typing import final
+
+class Base:
+    @final
+    def foo(self):
+        pass
+
+class Derived(Base):
+    def foo(self):  # E: Cannot override final attribute "foo" (previously declared in base class "Base")
+        pass
+
+        

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3242,5 +3242,3 @@ class Base:
 class Derived(Base):
     def foo(self):  # E: Cannot override final attribute "foo" (previously declared in base class "Base")
         pass
-
-        


### PR DESCRIPTION
This fixes #9618 in a fairly aggressive way, by turning on all override checks for all methods. This means that with this change, MyPy will complain in cases where just inspecting type signatures involving `Any` is enough to establish that an override is a type error:
- This includes the case of overriding `@final` as listed in #9618
- But it also includes arity mismatches, for example when an untyped subclass method adds a required attribute not in the parent class method.

The tests illustrate this, I added a test case to `check-functions.test` (is this a good place for it?) for the `@final` check specifically but also updated a few existing tests of dynamic logic.

The resulting code change is very simple (since all override checks happen in the same place), and I think conceptually it is right to enable all these checks because the contract is that MyPy won't generally type check *bodies* of functions, but the function signatures are actually part of the *class* type definition which is (in other cases) sanity-checked even when there are no annotations.

If we think that the arity checks are too big a change, I can work on a refactor that would let us validate *only* `@final` but not other properties. I think we should give it a shot and see if `mypy_primer` indicates a big blast radius.
