### PR TITLE
Validate more about overrides on untyped methods

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -615,6 +615,9 @@ class OverloadedFuncDef(FuncBase, SymbolNode, Statement):
         # NOTE: res.info will be set in the fixup phase.
         return res
 
+    def is_dynamic(self) -> bool:
+        return all(item.is_dynamic() for item in self.items)
+
 
 class Argument(Node):
     """A single argument in a FuncItem."""
@@ -936,6 +939,9 @@ class Decorator(SymbolNode, Statement):
         dec = Decorator(FuncDef.deserialize(data["func"]), [], Var.deserialize(data["var"]))
         dec.is_overload = data["is_overload"]
         return dec
+
+    def is_dynamic(self) -> bool:
+        return self.func.is_dynamic()
 
 
 VAR_FLAGS: Final = [

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -756,6 +756,21 @@ main:5: note:          def f(self, x: A) -> None
 main:5: note:      Subclass:
 main:5: note:          def f(self, x: Any, y: Any) -> None
 
+[case testInvalidOverrideArgumentCountWithImplicitSignature4]
+# flags: --check-untyped-defs
+import typing
+class B:
+    def f(self, x: A) -> None: pass
+class A(B):
+    def f(self, x, y): # dynamic function not type checked
+        x()
+[out]
+main:6: error: Signature of "f" incompatible with supertype "B"
+main:6: note:      Superclass:
+main:6: note:          def f(self, x: A) -> None
+main:6: note:      Subclass:
+main:6: note:          def f(self, x: Any, y: Any) -> Any
+
 [case testInvalidOverrideWithImplicitSignatureAndClassMethod1]
 class B:
     @classmethod

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -762,7 +762,7 @@ import typing
 class B:
     def f(self, x: A) -> None: pass
 class A(B):
-    def f(self, x, y): # dynamic function not type checked
+    def f(self, x, y):
         x()
 [out]
 main:6: error: Signature of "f" incompatible with supertype "B"

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3228,3 +3228,15 @@ class A:
 reveal_type(A.f)  # N: Revealed type is "__main__.something_callable"
 reveal_type(A().f)  # N: Revealed type is "builtins.str"
 [builtins fixtures/property.pyi]
+
+[case testFinalOverrideOnUntypedDef]
+from typing import final
+
+class Base:
+    @final
+    def foo(self):
+        pass
+
+class Derived(Base):
+    def foo(self):  # E: Cannot override final attribute "foo" (previously declared in base class "Base")
+        pass


### PR DESCRIPTION
This commit fixes #9618 by making MyPy always complain if a method overrides a base class method marked as `@final`.

In the process, it also adds a few additional validations:
- Always verify the `@override` decorator, which ought to be pretty backward-compatible for most projects assuming that strict override checks aren't enabled by default (and it appears to me that `--enable-error-code explicit-override` is off by default)
- Verify that the method signature is compatible (which in practice means only arity and argument name checks) *if* the `--check-untyped-defs` flag is set; it seems unlikely that a user would want mypy to validate the bodies of untyped functions but wouldn't want to be alerted about incompatible overrides.

Note: I did also explore enabling the signature compatibility check for all code, which in principle makes sense. But the mypy_primer results indicated that there would be backward compability issues because too many libraries rely on us not validating this: https://github.com/python/mypy/pull/17274