### PR TITLE
Don’t leak unreachability from lambda body to surrounding scope

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5223,15 +5223,16 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.chk.return_types.append(AnyType(TypeOfAny.special_form))
             # Type check everything in the body except for the final return
             # statement (it can contain tuple unpacking before return).
-            with self.chk.scope.push_function(e):
+            with self.chk.binder.frame_context(
+                can_skip=True, fall_through=0
+            ), self.chk.scope.push_function(e):
                 # Lambdas can have more than one element in body,
                 # when we add "fictional" AssigmentStatement nodes, like in:
                 # `lambda (a, b): a`
                 for stmt in e.body.body[:-1]:
                     stmt.accept(self.chk)
                 # Only type check the return expression, not the return statement.
-                # This is important as otherwise the following statements would be
-                # considered unreachable. There's no useful type context.
+                # There's no useful type context.
                 ret_type = self.accept(e.expr(), allow_none_return=True)
             fallback = self.named_type("builtins.function")
             self.chk.return_types.pop()
@@ -5243,7 +5244,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 self.chk.check_func_item(e, type_override=type_override)
             if not self.chk.has_type(e.expr()):
                 # TODO: return expression must be accepted before exiting function scope.
-                self.accept(e.expr(), allow_none_return=True)
+                with self.chk.binder.frame_context(can_skip=True, fall_through=0):
+                    self.accept(e.expr(), allow_none_return=True)
             ret_type = self.chk.lookup_type(e.expr())
             self.chk.return_types.pop()
             return replace_callable_return_type(inferred_type, ret_type)

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1494,3 +1494,23 @@ from typing import Generator
 def f() -> Generator[None, None, None]:
     return None
     yield None
+
+[case testLambdaNoReturn]
+# flags: --warn-unreachable
+from typing import Callable, NoReturn
+
+def foo() -> NoReturn:
+    raise
+
+f = lambda: foo()
+x = 0  # not unreachable
+
+[case testLambdaNoReturnAnnotated]
+# flags: --warn-unreachable
+from typing import Callable, NoReturn
+
+def foo() -> NoReturn:
+    raise
+
+f: Callable[[], NoReturn] = lambda: foo()  # E: Return statement in function which does not return # (false positive: https://github.com/python/mypy/issues/17254)
+x = 0  # not unreachable


### PR DESCRIPTION
- Fixes #17254.