### PR TITLE
Fix stubgen for Python 3.13

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -466,6 +466,9 @@ class InspectionStubGenerator(BaseStubGenerator):
                 "__module__",
                 "__weakref__",
                 "__annotations__",
+                "__firstlineno__",
+                "__static_attributes__",
+                "__annotate__",
             )
             or attr in self.IGNORED_DUNDERS
             or is_pybind_skipped_attribute(attr)  # For pickling


### PR DESCRIPTION
__firstlineno__ and __static_attributes__ are new in 3.13.
__annotate__ will be new in 3.14, so we might as well add it now.

I tried to run the test suite on 3.13. There are a ton of compilation failures from mypyc, and a number of stubgen failures that this PR will fix.