### PR TITLE
fix: Allow `ClassVar` descriptors to be assigned to from instances

### DIFF
--- a/test-data/unit/check-classvar.test
+++ b/test-data/unit/check-classvar.test
@@ -12,6 +12,41 @@ A().x = 2
 [out]
 main:4: error: Cannot assign to class variable "x" via instance
 
+[case testAssignmentOnInstanceToClassVarDescriptor]
+from typing import Any, ClassVar
+class D:
+    def __set__(self, inst: Any, value: int) -> None: pass
+class A:
+    x: ClassVar[D] = D()
+a = A()
+a.x = 0
+a.x = '0'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testAssignmentOnInstanceToClassVarPartialDescriptor]
+from typing import Any, ClassVar, Self, Union
+class D:
+    def __set__(self, inst: Any, value: int) -> None: pass
+class A:
+    x: ClassVar[Union[str, D, Self, int]] = D()
+a = A()
+a.x = 0  # E: Item "str" of "Union[str, D, Self, int]" has no attribute "__set__" \
+         # E: Item "A" of "Union[str, D, Self, int]" has no attribute "__set__" \
+         # E: Item "int" of "Union[str, D, Self, int]" has no attribute "__set__" \
+         # E: Cannot assign to class variable "x" via instance
+
+[case testAssignmentOnInstanceToClassVarSelfDescriptor]
+from typing import Any, ClassVar, Self, Union
+class D:
+    d1: ClassVar[Self]
+    d2: ClassVar[Union[int, Self, str]]
+    def __set__(self, inst: Any, value: int) -> None: pass
+inst = D()
+inst.d1 = 0
+inst.d1 = '0'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+inst.d2 = 0  # E: Item "int" of "Union[int, Self, str]" has no attribute "__set__" \
+             # E: Item "str" of "Union[int, Self, str]" has no attribute "__set__" \
+             # E: Cannot assign to class variable "d2" via instance
+
 [case testAssignmentOnSubclassInstance]
 from typing import ClassVar
 class A:


### PR DESCRIPTION
Fixes #14969. Allows the following:

```python
from typing import Any, ClassVar

class D:
    def __set__(self, inst: Any, value: int) -> None: pass

class A:
    x: ClassVar[D] = D()

a = A()
a.x = 0  # OK
a.x = '0'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
```

Currently, `a.x = 0` errors with `Cannot assign to class variable "x" via instance  [misc]` (see [mypy Playground)](https://mypy-play.net/?mypy=latest&python=3.12&gist=71f9366c14ce1bde78429bcf2f63757f).

- The example in #14969 will still error because `ClassVar` there is not specified with a type (an unannotated `ClassVar` is equivalent to `ClassVar[Any]`).
- Unlike in other annotation contexts, I didn't think it was a good idea to be permissive with `Any`, due to the potential creep of false negatives.

<sub>Originally created as part of PR #17170, but I forgot about that PR and deleted the fork.</sub>