### PR TITLE
Fix False positive - Final local scope variable in Protocol

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3505,7 +3505,8 @@ class SemanticAnalyzer(
         if self.loop_depth[-1] > 0:
             self.fail("Cannot use Final inside a loop", s)
         if self.type and self.type.is_protocol:
-            self.msg.protocol_members_cant_be_final(s)
+            if self.is_class_scope():
+                self.msg.protocol_members_cant_be_final(s)
         if (
             isinstance(s.rvalue, TempNode)
             and s.rvalue.no_rhs

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -301,6 +301,37 @@ class P(Protocol):
         pass
 [out]
 
+[case testFinalInProtocol]
+from typing import Protocol, Final, final, ClassVar
+
+class P(Protocol):
+    var1 : Final[int] = 0 # E: Protocol member cannot be final
+
+    @final # E: Protocol member cannot be final
+    def meth1(self) -> None:
+        var2: Final = 0
+
+    def meth2(self) -> None:
+        var3: Final = 0
+
+[out]
+
+[case testFinalWithClassVarInProtocol]
+from typing import Protocol, Final, final, ClassVar
+
+class P(Protocol):
+    var1 : Final[ClassVar[int]] = 0 # E: Variable should not be annotated with both ClassVar and Final
+    var2: ClassVar[int] = 1
+
+    @final # E: Protocol member cannot be final
+    def meth1(self) -> None:
+        ...
+
+    def meth2(self) -> None:
+        var3: Final[ClassVar[int]] = 0 # E: Variable should not be annotated with both ClassVar and Final # E: ClassVar can only be used for assignments in class body
+
+[out]
+
 [case testFinalNotInLoops]
 from typing import Final
 

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -302,7 +302,7 @@ class P(Protocol):
 [out]
 
 [case testFinalInProtocol]
-from typing import Protocol, Final, final, ClassVar
+from typing import Final, Protocol, final
 
 class P(Protocol):
     var1 : Final[int] = 0 # E: Protocol member cannot be final
@@ -313,6 +313,19 @@ class P(Protocol):
 
     def meth2(self) -> None:
         var3: Final = 0
+
+    def meth3(self) -> None:
+        class Inner:
+            var3: Final = 0  # OK
+
+            @final
+            def inner(self) -> None: ...
+
+    class Inner:
+        var3: Final = 0  # OK
+
+        @final
+        def inner(self) -> None: ...
 
 [out]
 


### PR DESCRIPTION
This PR fixes and closes #17281 ,which reported a false positive when using Final within the local function scope of a protocol method.

With these changes:
- Local variables within protocol methods can be marked as Final.
- Protocol members still cannot be marked as Final

Modified ``semanal.py`` file and added a unit test in ``test-data/unit/check.final.test``

