### PR TITLE
Fix union inference of generic class and its generic type

### DIFF
--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -873,13 +873,7 @@ def g(x: Union[T, List[T]]) -> List[T]: pass
 def h(x: List[str]) -> None: pass
 g('a')() # E: "List[str]" not callable
 
-# The next line is a case where there are multiple ways to satisfy a constraint
-# involving a Union. Either T = List[str] or T = str would turn out to be valid,
-# but mypy doesn't know how to branch on these two options (and potentially have
-# to backtrack later) and defaults to T = Never. The result is an
-# awkward error message. Either a better error message, or simply accepting the
-# call, would be preferable here.
-g(['a']) # E: Argument 1 to "g" has incompatible type "List[str]"; expected "List[Never]"
+g(['a'])
 
 h(g(['a']))
 
@@ -890,6 +884,28 @@ i(a, a, b)
 i(b, a, b)
 i(a, b, b) # E: Argument 1 to "i" has incompatible type "List[int]"; expected "List[str]"
 [builtins fixtures/list.pyi]
+
+[case testUnionInferenceOfGenericClassAndItsGenericType]
+from typing import Generic, TypeVar, Union
+
+T = TypeVar('T')
+
+class GenericClass(Generic[T]):
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+def method_with_union(arg: Union[GenericClass[T], T]) -> GenericClass[T]:
+    if not isinstance(arg, GenericClass):
+        arg = GenericClass(arg)
+    return arg
+
+result_1 = method_with_union(GenericClass("test"))
+reveal_type(result_1) # N: Revealed type is "__main__.GenericClass[builtins.str]"
+
+result_2 = method_with_union("test")
+reveal_type(result_2) # N: Revealed type is "__main__.GenericClass[builtins.str]"
+
+[builtins fixtures/isinstance.pyi]
 
 [case testCallableListJoinInference]
 from typing import Any, Callable


### PR DESCRIPTION
Fixes #16788

The fix consists in discarding one possible type item of the union if it is an argument of other item that is subtype of the actual type.

Code examples:
- Example 1:
```py
from typing import List, Iterable, TypeVar, Union, reveal_type

T = TypeVar("T")


def coerce_list(x: Union[T, Iterable[T]]) -> List[T]:
    reveal_type(x)
    raise NotImplementedError()


def test() -> None:
    reveal_type(coerce_list(1))
    reveal_type(coerce_list([1, 2]))
```

Output before the fix:
```
file.py:7: note: Revealed type is "Union[T`-1, typing.Iterable[T`-1]]"
file.py:12: note: Revealed type is "builtins.list[builtins.int]"
file.py:13: note: Revealed type is "builtins.list[Never]"
file.py:13: error: Argument 1 to "coerce_list" has incompatible type "list[int]"; expected "Iterable[Never]"
```

Output after the fix:
```
file.py:7: note: Revealed type is "Union[T`-1, typing.Iterable[T`-1]]"
file.py:12: note: Revealed type is "builtins.list[builtins.int]"
file.py:13: note: Revealed type is "builtins.list[builtins.int]"
```

- Example 2:
```py
from typing import Generic, TypeVar, Union, reveal_type

T = TypeVar("T")


class GenericClass(Generic[T]):
    def __init__(self, value: T) -> None:
        self.value = value


def method_with_union(arg: Union[GenericClass[T], T]) -> GenericClass[T]:
    if not isinstance(arg, GenericClass):
        arg = GenericClass(arg)
    return arg


result_1 = method_with_union(GenericClass("test"))
reveal_type(result_1)

result_2 = method_with_union("test")
reveal_type(result_2)
```

Output before the fix:
```
file.py:17: error: Need type annotation for "result_1"  [var-annotated]
file.py:17: error: Argument 1 to "method_with_union" has incompatible type "GenericClass[str]"; expected "GenericClass[Never]"  [arg-type]
file.py:18: note: Revealed type is "file.GenericClass[Any]"
file.py:21: note: Revealed type is "file.GenericClass[builtins.str]"
```

Output after the fix:
```
file.py:18: note: Revealed type is "file.GenericClass[builtins.str]"
file.py:21: note: Revealed type is "file.GenericClass[builtins.str]"
```