### PR TITLE
Update 'typing_extensions' to >=4.6.0 to fix python 3.12 error

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,4 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
-typing_extensions>=4.1.0
+typing_extensions>=4.6.0
 mypy_extensions>=1.0.0
 tomli>=1.1.0; python_version<'3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "setuptools >= 40.6.2",
     "wheel >= 0.30.0",
     # the following is from mypy-requirements.txt
-    "typing_extensions>=4.1.0",
+    "typing_extensions>=4.6.0",
     "mypy_extensions>=1.0.0",
     "tomli>=1.1.0; python_version<'3.11'",
     # the following is from build-requirements.txt


### PR DESCRIPTION
With earlier versions of typing_extensions, the following traceback is seen:

```
Traceback (most recent call last):
  File ".../bin/mypy", line 5, in <module>
    from mypy.__main__ import console_entry
  File ".../lib/python3.12/site-packages/mypy/__main__.py", line 9, in <module>
    from mypy.main import main, process_options
  File ".../lib/python3.12/site-packages/mypy/main.py", line 12, in <module>
    from typing_extensions import Final
  File ".../lib/python3.12/site-packages/typing_extensions.py", line 1174, in <module>
    class TypeVar(typing.TypeVar, _DefaultMixin, _root=True):
TypeError: type 'typing.TypeVar' is not an acceptable base type
```

The error is addressed in typing_extensions in
 https://github.com/python/typing_extensions/pull/162, which is included
in the 4.6.0 release.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
