### PR TITLE
Sync typing_extensions pin in setup.py with the pin in the other two places

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,4 +1,5 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
+# and the pins in setup.py
 typing_extensions>=4.6.0
 mypy_extensions>=1.0.0
 tomli>=1.1.0; python_version<'3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     # self-typechecking :/
     "setuptools >= 40.6.2",
     "wheel >= 0.30.0",
-    # the following is from mypy-requirements.txt
+    # the following is from mypy-requirements.txt/setup.py
     "typing_extensions>=4.6.0",
     "mypy_extensions>=1.0.0",
     "tomli>=1.1.0; python_version<'3.11'",

--- a/setup.py
+++ b/setup.py
@@ -218,9 +218,9 @@ setup(
     },
     classifiers=classifiers,
     cmdclass=cmdclass,
-    # When changing this, also update mypy-requirements.txt.
+    # When changing this, also update mypy-requirements.txt and pyproject.toml
     install_requires=[
-        "typing_extensions>=4.1.0",
+        "typing_extensions>=4.6.0",
         "mypy_extensions >= 1.0.0",
         "tomli>=1.1.0; python_version<'3.11'",
     ],


### PR DESCRIPTION
Followup to #17312. (Can't say I fully understand why we have to have this pin in three places :)