### PR TITLE
[PEP 695] Don't crash when redefining something as a type alias

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5318,6 +5318,11 @@ class SemanticAnalyzer(
         all_type_params_names = [p.name for p in s.type_args]
 
         try:
+            existing = self.current_symbol_table().get(s.name.name)
+            if existing and not isinstance(existing.node, (PlaceholderNode, TypeAlias)):
+                self.already_defined(s.name.name, s, existing, "Name")
+                return
+
             tag = self.track_incomplete_refs()
             res, alias_tvars, depends_on, qualified_tvars, empty_tuple_index = self.analyze_alias(
                 s.name.name,
@@ -5373,7 +5378,6 @@ class SemanticAnalyzer(
                 python_3_12_type_alias=True,
             )
 
-            existing = self.current_symbol_table().get(s.name.name)
             if (
                 existing
                 and isinstance(existing.node, (PlaceholderNode, TypeAlias))

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5319,7 +5319,10 @@ class SemanticAnalyzer(
 
         try:
             existing = self.current_symbol_table().get(s.name.name)
-            if existing and not isinstance(existing.node, (PlaceholderNode, TypeAlias)):
+            if existing and not (
+                isinstance(existing.node, TypeAlias)
+                or (isinstance(existing.node, PlaceholderNode) and existing.node.line == s.line)
+            ):
                 self.already_defined(s.name.name, s, existing, "Name")
                 return
 

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1453,3 +1453,30 @@ class E[T]:
 reveal_type(E[str]().a)  # N: Revealed type is "builtins.list[Any]"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testPEP695RedefineAsTypeAlias1]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+class C: pass
+type C = int  # E: Name "C" already defined on line 2
+
+A = 0
+type A = str  # E: Name "A" already defined on line 5
+reveal_type(A)  # N: Revealed type is "builtins.int"
+
+[case testPEP695RedefineAsTypeAlias2]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+from m import D
+type D = int  # E: Name "D" already defined (possibly by an import)
+a: D
+reveal_type(a)  # N: Revealed type is "m.D"
+[file m.py]
+class D: pass
+
+[case testPEP695MultiDefinitionsForTypeAlias]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+if int():
+    type A[T] = list[T]
+else:
+    type A[T] = str  # E: Name "A" already defined on line 3
+a: A[int]
+reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int]"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1477,6 +1477,8 @@ class D: pass
 D = list["Forward"]
 type D = int  # E: Name "D" already defined on line 2
 Forward = str
+x: D
+reveal_type(x)  # N: Revealed type is "builtins.list[builtins.str]"
 
 [case testPEP695MultiDefinitionsForTypeAlias]
 # flags: --enable-incomplete-feature=NewGenericSyntax
@@ -1484,5 +1486,6 @@ if int():
     type A[T] = list[T]
 else:
     type A[T] = str  # E: Name "A" already defined on line 3
+x: T  # E: Name "T" is not defined
 a: A[int]
 reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int]"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1472,6 +1472,12 @@ reveal_type(a)  # N: Revealed type is "m.D"
 [file m.py]
 class D: pass
 
+[case testPEP695RedefineAsTypeAlias3]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+D = list["Forward"]
+type D = int  # E: Name "D" already defined on line 2
+Forward = str
+
 [case testPEP695MultiDefinitionsForTypeAlias]
 # flags: --enable-incomplete-feature=NewGenericSyntax
 if int():


### PR DESCRIPTION
Generate an error instead.

Work on #15238.