### PR TITLE
[PEP 695] Fix handling of undefined name in generic function annotation

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -909,7 +909,7 @@ class SemanticAnalyzer(
                 # Don't store not ready types (including placeholders).
                 if self.found_incomplete_ref(tag) or has_placeholder(result):
                     self.defer(defn)
-                    # TODO: pop type args
+                    self.pop_type_args(defn.type_args)
                     return
                 assert isinstance(result, ProperType)
                 if isinstance(result, CallableType):

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1489,3 +1489,8 @@ else:
 x: T  # E: Name "T" is not defined
 a: A[int]
 reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int]"
+
+[case testPEP695UndefinedNameInAnnotation]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+def f[T](x: foobar, y: T) -> T: ...  # E: Name "foobar" is not defined
+reveal_type(f)  # N: Revealed type is "def [T] (x: Any, y: T`-1) -> T`-1"


### PR DESCRIPTION
This was generating a false positive.

Work on #15238.