### PR TITLE
[PEP 695] Add more error checks and tests for error conditions

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -271,7 +271,7 @@ FILE: Final = ErrorCode("file", "Internal marker for a whole file being ignored"
 del error_codes[FILE.code]
 
 # This is a catch-all for remaining uncategorized errors.
-MISC: Final = ErrorCode("misc", "Miscellaneous other checks", "General")
+MISC: Final[ErrorCode] = ErrorCode("misc", "Miscellaneous other checks", "General")
 
 OVERLOAD_OVERLAP: Final[ErrorCode] = ErrorCode(
     "overload-overlap",

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1185,8 +1185,12 @@ class ASTConverter:
                 explicit_type_params.append(TypeParam(p.name, TYPE_VAR_TUPLE_KIND, None, []))
             else:
                 if isinstance(p.bound, ast3.Tuple):
-                    conv = TypeConverter(self.errors, line=p.lineno)
-                    values = [conv.visit(t) for t in p.bound.elts]
+                    if len(p.bound.elts) < 2:
+                        self.fail(message_registry.TYPE_VAR_TOO_FEW_CONSTRAINED_TYPES,
+                                  p.lineno, p.col_offset, blocker=False)
+                    else:
+                        conv = TypeConverter(self.errors, line=p.lineno)
+                        values = [conv.visit(t) for t in p.bound.elts]
                 elif p.bound is not None:
                     bound = TypeConverter(self.errors, line=p.lineno).visit(p.bound)
                 explicit_type_params.append(TypeParam(p.name, TYPE_VAR_KIND, bound, values))

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1186,8 +1186,12 @@ class ASTConverter:
             else:
                 if isinstance(p.bound, ast3.Tuple):
                     if len(p.bound.elts) < 2:
-                        self.fail(message_registry.TYPE_VAR_TOO_FEW_CONSTRAINED_TYPES,
-                                  p.lineno, p.col_offset, blocker=False)
+                        self.fail(
+                            message_registry.TYPE_VAR_TOO_FEW_CONSTRAINED_TYPES,
+                            p.lineno,
+                            p.col_offset,
+                            blocker=False,
+                        )
                     else:
                         conv = TypeConverter(self.errors, line=p.lineno)
                         values = [conv.visit(t) for t in p.bound.elts]

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -330,3 +330,6 @@ ARG_NAME_EXPECTED_STRING_LITERAL: Final = ErrorMessage(
 NARROWED_TYPE_NOT_SUBTYPE: Final = ErrorMessage(
     "Narrowed type {} is not a subtype of input type {}", codes.NARROWED_TYPE_NOT_SUBTYPE
 )
+TYPE_VAR_TOO_FEW_CONSTRAINED_TYPES: Final = ErrorMessage(
+    "Type variable must have at least two constrained types", codes.MISC
+)

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1494,3 +1494,13 @@ reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int]"
 # flags: --enable-incomplete-feature=NewGenericSyntax
 def f[T](x: foobar, y: T) -> T: ...  # E: Name "foobar" is not defined
 reveal_type(f)  # N: Revealed type is "def [T] (x: Any, y: T`-1) -> T`-1"
+
+[case testPEP695WrongNumberOfConstrainedTypes]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+type A[T: ()] = list[T]  # E: Type variable must have at least two constrained types
+a: A[int]
+reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int]"
+
+type B[T: (int,)] = list[T]  # E: Type variable must have at least two constrained types
+b: B[str]
+reveal_type(b)  # N: Revealed type is "builtins.list[builtins.str]"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1504,3 +1504,24 @@ reveal_type(a)  # N: Revealed type is "builtins.list[builtins.int]"
 type B[T: (int,)] = list[T]  # E: Type variable must have at least two constrained types
 b: B[str]
 reveal_type(b)  # N: Revealed type is "builtins.list[builtins.str]"
+
+[case testPEP695UsingTypeVariableInOwnBoundOrConstraint]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+type A[T: list[T]] = str  # E: Name "T" is not defined
+type B[S: (list[S], str)] = str  # E: Name "S" is not defined
+type C[T, S: list[T]] = str  # E: Name "T" is not defined
+
+def f[T: T](x: T) -> T: ...  # E: Name "T" is not defined
+class D[T: T]:  # E: Name "T" is not defined
+    pass
+
+[case testPEP695InvalidType]
+# flags: --enable-incomplete-feature=NewGenericSyntax
+def f[T: 1](x: T) -> T: ...  # E: Invalid type: try using Literal[1] instead?
+class C[T: (int, (1 + 2))]: pass  # E: Invalid type comment or annotation
+type A = list[1]  # E: Invalid type: try using Literal[1] instead?
+type B = (1 + 2)  # E: Invalid type alias: expression is not a valid type
+a: A
+reveal_type(a)  # N: Revealed type is "builtins.list[Any]"
+b: B
+reveal_type(b)  # N: Revealed type is "Any"

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1046,7 +1046,7 @@ T = TypeVar(b'T')      # E: TypeVar() expects a string literal as first argument
 d = TypeVar('D')    # E: String argument 1 "D" to TypeVar(...) does not match variable name "d"
 e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to "TypeVar()": "x"
 f = TypeVar('f', (int, str), int) # E: Type expected
-g = TypeVar('g', int)             # E: TypeVar cannot have only a single constraint
+g = TypeVar('g', int)             # E: Type variable must have at least two constrained types
 h = TypeVar('h', x=(int, str))    # E: Unexpected argument to "TypeVar()": "x"
 i = TypeVar('i', bound=1)         # E: TypeVar "bound" must be a type
 j = TypeVar('j', covariant=None)  # E: TypeVar "covariant" may only be a literal bool


### PR DESCRIPTION
Detect invalid number of constrained types. At least two are required, according do PEP 695.

Add tests for other simple errors.

Work on #15238.