### PR TITLE
Fix - Allow @final decorator on Protocol Classes with abstract attributes

### DIFF
--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -110,7 +110,7 @@ def calculate_class_abstract_status(typ: TypeInfo, is_stub_file: bool, errors: E
             report(
                 "If it is meant to be abstract, add 'abc.ABCMeta' as an explicit metaclass", "note"
             )
-    if typ.is_final and abstract:
+    if typ.is_final and abstract and not typ.is_protocol:
         attrs = ", ".join(f'"{attr}"' for attr, _ in sorted(abstract))
         errors.report(
             typ.line, typ.column, f"Final class {typ.fullname} has abstract attributes {attrs}"

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7510,6 +7510,22 @@ class A(metaclass=ABCMeta):  # E: Final class __main__.A has abstract attributes
 
 [builtins fixtures/property.pyi]
 
+[case testFinalProtocolWithAbstractAttributes]
+from typing import Protocol, final
+
+@final #OK
+class Inter(Protocol):
+    x: int
+
+    def y(self) -> int:
+        ...
+
+    @property
+    def z(self) -> int:
+        ...
+
+[builtins fixtures/property.pyi]
+
 [case testFinalClassWithoutABCMeta]
 from abc import abstractmethod
 from typing import final


### PR DESCRIPTION
This PR implements and closes #17288. Previously, mypy raised an error for all classes that use the @final decorator and have abstract attributes.

With this change:
- The error check now excludes @final classes that inherit from the Protocol class.
- All other @final classes still cannot have abstract attributes, maintaining the original behavior.
