### PR TITLE
Fix crash on unpacking self in NamedTuple

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3839,6 +3839,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     self.expr_checker.accept(rvalue, lvalue_type)
                 )
 
+                if isinstance(reinferred_rvalue_type, TypeVarLikeType):
+                    reinferred_rvalue_type = get_proper_type(reinferred_rvalue_type.upper_bound)
                 if isinstance(reinferred_rvalue_type, UnionType):
                     # If this is an Optional type in non-strict Optional code, unwrap it.
                     relevant_items = reinferred_rvalue_type.relevant_items()

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1419,7 +1419,7 @@ import typing
 class Foo(typing.NamedTuple):
     bar: int
     def baz(self: typing.Self) -> None:
-        x ,= self
+        x, = self
         reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1412,3 +1412,14 @@ A(x=0).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "A" has inco
 A(x=0).__replace__(y=1)  # E: Unexpected keyword argument "y" for "__replace__" of "A"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
+
+[case testUnpackSelfNamedTuple]
+import typing
+
+class Foo(typing.NamedTuple):
+    bar: int
+    def baz(self: typing.Self) -> None:
+        x ,= self
+        reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-namedtuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/17010

Fix is trivial: replicate the `TypeVar` handling logic in the caller.
