### PR TITLE
Fix crash on invalid callable property override

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2279,7 +2279,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     ):
                         arg_type_in_super = original.arg_types[i]
 
-                        if isinstance(node, FuncDef):
+                        if isinstance(node, FuncDef) and not node.is_property:
                             context: Context = node.arguments[i + len(override.bound_args)]
                         else:
                             context = node

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3302,3 +3302,25 @@ class C:  # Note: Generic[T] missing
 
     def nope(self, x: T) -> None:
         self.x = x  # E: Incompatible types in assignment (expression has type "T@nope", variable has type "T@bad_idea")
+
+[case testNoCrashOnBadCallablePropertyOverride]
+from typing import Callable, Union
+
+class C: ...
+class D: ...
+
+A = Callable[[C], None]
+B = Callable[[D], None]
+
+class Foo:
+    @property
+    def method(self) -> Callable[[int, Union[A, B]], None]:
+        ...
+
+class Bar(Foo):
+    @property
+    def method(self) -> Callable[[int, A], None]:  # E: Argument 2 of "method" is incompatible with supertype "Foo"; supertype defines the argument type as "Union[Callable[[C], None], Callable[[D], None]]" \
+                                                   # N: This violates the Liskov substitution principle \
+                                                   # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+        ...
+[builtins fixtures/property.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16896

Fix is simple, do not assume that an error context given by the caller of the override check for callable type is a method defining such type, because it may be a property.
