### PR TITLE
Fix crash involving recursive union of tuples

### DIFF
--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -958,3 +958,39 @@ z: Z
 x: X
 reveal_type(z)  # N: Revealed type is "Union[__main__.A[...], __main__.B[Union[..., None]]]"
 reveal_type(x)  # N: Revealed type is "Union[__main__.A[Union[..., None]], __main__.B[Union[..., None]]]"
+
+[case testRecursiveTupleFallback1]
+from typing import NewType, Tuple, Union
+
+T1 = NewType("T1", str)
+T2 = Tuple[T1, "T4", "T4"]
+T3 = Tuple[str, "T4", "T4"]
+T4 = Union[T2, T3]
+[builtins fixtures/tuple.pyi]
+
+[case testRecursiveTupleFallback2]
+from typing import NewType, Tuple, Union
+
+T1 = NewType("T1", str)
+class T2(Tuple[T1, "T4", "T4"]): ...
+T3 = Tuple[str, "T4", "T4"]
+T4 = Union[T2, T3]
+[builtins fixtures/tuple.pyi]
+
+[case testRecursiveTupleFallback3]
+from typing import NewType, Tuple, Union
+
+T1 = NewType("T1", str)
+T2 = Tuple[T1, "T4", "T4"]
+class T3(Tuple[str, "T4", "T4"]): ...
+T4 = Union[T2, T3]
+[builtins fixtures/tuple.pyi]
+
+[case testRecursiveTupleFallback4]
+from typing import NewType, Tuple, Union
+
+T1 = NewType("T1", str)
+class T2(Tuple[T1, "T4", "T4"]): ...
+class T3(Tuple[str, "T4", "T4"]): ...
+T4 = Union[T2, T3]
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/17236

It turns out we were calculating tuple fallbacks where we don't really need to. We can rely on the fact that tuple fallback is trivial for non-trivial partial fallbacks to simplify the logic and avoid the infinite recursion.
