### PR TITLE
Fix type application for classes with generic constructors

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -101,8 +101,6 @@ def apply_generic_arguments(
     bound or constraints, instead of giving an error.
     """
     tvars = callable.variables
-    min_arg_count = sum(not tv.has_default() for tv in tvars)
-    assert min_arg_count <= len(orig_types) <= len(tvars)
     # Check that inferred type variable values are compatible with allowed
     # values and bounds.  Also, promote subtype values to allowed values.
     # Create a map from type variable id to target type.
@@ -156,7 +154,7 @@ def apply_generic_arguments(
         type_is = None
 
     # The callable may retain some type vars if only some were applied.
-    # TODO: move apply_poly() logic from checkexpr.py here when new inference
+    # TODO: move apply_poly() logic here when new inference
     # becomes universally used (i.e. in all passes + in unification).
     # With this new logic we can actually *add* some new free variables.
     remaining_tvars: list[TypeVarLikeType] = []

--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -101,6 +101,7 @@ def apply_generic_arguments(
     bound or constraints, instead of giving an error.
     """
     tvars = callable.variables
+    assert len(orig_types) <= len(tvars)
     # Check that inferred type variable values are compatible with allowed
     # values and bounds.  Also, promote subtype values to allowed values.
     # Create a map from type variable id to target type.

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -2367,6 +2367,12 @@ def validate_instance(t: Instance, fail: MsgCallback, empty_tuple_index: bool) -
         if not t.args:
             if not (empty_tuple_index and len(t.type.type_vars) == 1):
                 # The Any arguments should be set by the caller.
+                if empty_tuple_index and min_tv_count:
+                    fail(
+                        f"At least {min_tv_count} type argument(s) expected, none given",
+                        t,
+                        code=codes.TYPE_ARG,
+                    )
                 return False
         elif not correct:
             fail(

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3454,3 +3454,4 @@ class C(Generic[T]):
 
 reveal_type(C[int])  # N: Revealed type is "def [S] (f: def (S`-1) -> builtins.int, x: S`-1) -> __main__.C[builtins.int]"
 Alias = C[int]
+C[int, str]  # E: Type application has too many types (1 expected)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3442,3 +3442,15 @@ reveal_type(dec(g))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[b
 h: Callable[[Unpack[Us]], Foo[int]]
 reveal_type(dec(h))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[builtins.int]"
 [builtins fixtures/list.pyi]
+
+[case testTypeApplicationGenericConstructor]
+from typing import Generic, TypeVar, Callable
+
+T = TypeVar("T")
+S = TypeVar("S")
+class C(Generic[T]):
+    def __init__(self, f: Callable[[S], T], x: S) -> None:
+        self.x = f(x)
+
+reveal_type(C[int])  # N: Revealed type is "def [S] (f: def (S`-1) -> builtins.int, x: S`-1) -> __main__.C[builtins.int]"
+Alias = C[int]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2346,4 +2346,5 @@ def f(x: int, y: int, z: int, t: int) -> str: ...
 x = C(f, 0, 0, "hm")  # E: Argument 1 to "C" has incompatible type "Callable[[int, int, int, int], str]"; expected "Callable[[int, int, str, int], str]"
 reveal_type(x)  # N: Revealed type is "__main__.C[builtins.str, builtins.int]"
 reveal_type(C(f))  # N: Revealed type is "__main__.C[builtins.str, builtins.int, builtins.int, builtins.int, builtins.int]"
+C[()]  # E: At least 1 type argument(s) expected, none given
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2321,3 +2321,29 @@ def a2(x: Array[int, str]) -> None:
     reveal_type(func(x, 2, "Hello", True))   # E: Cannot infer type argument 1 of "func" \
                                              # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleTypeApplicationOverload]
+from typing import Generic, TypeVar, TypeVarTuple, Unpack, overload, Callable
+
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+Ts = TypeVarTuple("Ts")
+
+class C(Generic[T, Unpack[Ts]]):
+    @overload
+    def __init__(self, f: Callable[[Unpack[Ts]], T]) -> None: ...
+    @overload
+    def __init__(self, f: Callable[[T1, T2, T3, Unpack[Ts]], T], a: T1, b: T2, c: T3) -> None: ...
+    def __init__(self, f, *args, **kwargs) -> None:
+        ...
+
+reveal_type(C[int, str])  # N: Revealed type is "Overload(def (f: def (builtins.str) -> builtins.int) -> __main__.C[builtins.int, builtins.str], def [T1, T2, T3] (f: def (T1`-1, T2`-2, T3`-3, builtins.str) -> builtins.int, a: T1`-1, b: T2`-2, c: T3`-3) -> __main__.C[builtins.int, builtins.str])"
+Alias = C[int, str]
+
+def f(x: int, y: int, z: int, t: int) -> str: ...
+x = C(f, 0, 0, "hm")  # E: Argument 1 to "C" has incompatible type "Callable[[int, int, int, int], str]"; expected "Callable[[int, int, str, int], str]"
+reveal_type(x)  # N: Revealed type is "__main__.C[builtins.str, builtins.int]"
+reveal_type(C(f))  # N: Revealed type is "__main__.C[builtins.str, builtins.int, builtins.int, builtins.int, builtins.int]"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/17212

Note I removed the problematic asset after all. It is hard to maintain it, since this function may be called from both explicit application, and from type inference code paths. And these two cases may have different min/max type argument count (see tests and comments for examples).
