### PR TITLE
Do not require explicit override for plugin-generated methods

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1924,11 +1924,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         found_method_base_classes: list[TypeInfo] | None,
         context: Context | None = None,
     ) -> None:
+        sym = defn.info.get(defn.name)
         if (
             found_method_base_classes
             and not defn.is_explicit_override
             and defn.name not in ("__init__", "__new__")
             and not is_private(defn.name)
+            and sym is not None
+            and not sym.plugin_generated
         ):
             self.msg.explicit_override_decorator_missing(
                 defn.name, found_method_base_classes[0].fullname, context or defn

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2465,13 +2465,26 @@ class Foo:
 
 [case testDataclassInheritanceWorksWithExplicitOverrides]
 # flags: --enable-error-code explicit-override
-from dataclasses  import dataclass
+from dataclasses import dataclass
 
 @dataclass
 class Base:
     x: int
 
 @dataclass
+class Child(Base):
+    y: int
+[builtins fixtures/dataclasses.pyi]
+
+[case testDataclassInheritanceWorksWithExplicitOverridesAndOrdering]
+# flags: --enable-error-code explicit-override
+from dataclasses import dataclass
+
+@dataclass(order=True)
+class Base:
+    x: int
+
+@dataclass(order=True)
 class Child(Base):
     y: int
 [builtins fixtures/dataclasses.pyi]


### PR DESCRIPTION
Closes #17224. 

Ensure that `explicit-override` error is never applied to functions which are not present in source code (generated by plugin), because there is no place to apply `override`.