### PR TITLE
Support `enum.nonmember` for python3.11+

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1143,6 +1143,17 @@ def analyze_enum_class_attribute_access(
     if name.startswith("__") and name.replace("_", "") != "":
         return None
 
+    node = itype.type.get(name)
+    if node.type:
+        proper = get_proper_type(node.type)
+        # Support `A = nonmember(1)` function call and decorator.
+        if (
+            isinstance(proper, Instance)
+            and proper.type.fullname == "enum.nonmember"
+            and proper.args
+        ):
+            return proper.args[0]
+
     enum_literal = LiteralType(name, fallback=itype)
     return itype.copy_modified(last_known_value=enum_literal)
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1144,7 +1144,7 @@ def analyze_enum_class_attribute_access(
         return None
 
     node = itype.type.get(name)
-    if node.type:
+    if node and node.type:
         proper = get_proper_type(node.type)
         # Support `A = nonmember(1)` function call and decorator.
         if (

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2138,3 +2138,31 @@ elif e == MyEnum.B:
 else:
     reveal_type(e)  # E: Statement is unreachable
 [builtins fixtures/dict.pyi]
+
+
+[case testEnumNonMemberSupport]
+# flags: --python-version 3.11
+# This was added in 3.11
+from enum import Enum, nonmember
+
+class My(Enum):
+    a = 1
+    b = 2
+    c = nonmember(3)
+
+reveal_type(My.a)  # N: Revealed type is "Literal[__main__.My.a]?"
+reveal_type(My.b)  # N: Revealed type is "Literal[__main__.My.b]?"
+reveal_type(My.c)  # N: Revealed type is "builtins.int"
+
+def accepts_my(my: My):
+    reveal_type(my.value)  # N: Revealed type is "Union[Literal[1]?, Literal[2]?]"
+
+class Other(Enum):
+    a = 1
+    @nonmember
+    class Support:
+        b = 2
+
+reveal_type(Other.a)  # N: Revealed type is "Literal[__main__.Other.a]?"
+reveal_type(Other.Support.b)  # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/lib-stub/enum.pyi
+++ b/test-data/unit/lib-stub/enum.pyi
@@ -48,3 +48,8 @@ class auto(IntFlag):
 # It is python-3.11+ only:
 class StrEnum(str, Enum):
     def __new__(cls: Type[_T], value: str | _T) -> _T: ...
+
+# It is python-3.11+ only:
+class nonmember(Generic[_T]):
+    value: _T
+    def __init__(self, value: _T) -> None: ...


### PR DESCRIPTION
This PR adds support for https://docs.python.org/3.11/library/enum.html#enum.nonmember

Refs https://github.com/python/mypy/issues/12841