### PR TITLE
Support `enum.member` for python3.11+

### DIFF
--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -41,7 +41,7 @@ class DefaultPlugin(Plugin):
     """Type checker plugin that is enabled by default."""
 
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
-        from mypy.plugins import ctypes, singledispatch
+        from mypy.plugins import ctypes, enums, singledispatch
 
         if fullname == "_ctypes.Array":
             return ctypes.array_constructor_callback
@@ -51,6 +51,8 @@ class DefaultPlugin(Plugin):
             import mypy.plugins.functools
 
             return mypy.plugins.functools.partial_new_callback
+        elif fullname == "enum.member":
+            return enums.enum_member_callback
 
         return None
 

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -136,6 +136,7 @@ def enum_member_callback(ctx: mypy.plugin.FunctionContext) -> Type:
         if (
             isinstance(arg, Instance)
             and arg.last_known_value
+            and isinstance(ctx.default_return_type, Instance)
             and len(ctx.default_return_type.args) == 1
         ):
             return ctx.default_return_type.copy_modified(args=[arg])

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -133,13 +133,14 @@ def enum_member_callback(ctx: mypy.plugin.FunctionContext) -> Type:
     we want to improve the inference to have `member[Literal[1]]` here."""
     if ctx.arg_types or ctx.arg_types[0]:
         arg = get_proper_type(ctx.arg_types[0][0])
+        proper_return = get_proper_type(ctx.default_return_type)
         if (
             isinstance(arg, Instance)
             and arg.last_known_value
-            and isinstance(ctx.default_return_type, Instance)
-            and len(ctx.default_return_type.args) == 1
+            and isinstance(proper_return, Instance)
+            and len(proper_return.args) == 1
         ):
-            return ctx.default_return_type.copy_modified(args=[arg])
+            return proper_return.copy_modified(args=[arg])
     return ctx.default_return_type
 
 

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -130,7 +130,7 @@ def _implements_new(info: TypeInfo) -> bool:
 
 def enum_member_callback(ctx: mypy.plugin.FunctionContext) -> Type:
     """By default `member(1)` will be infered as `member[int]`,
-    we want to improve the inference to have `member[Literal[1]]` here."""
+    we want to improve the inference to be `Literal[1]` here."""
     if ctx.arg_types or ctx.arg_types[0]:
         arg = get_proper_type(ctx.arg_types[0][0])
         proper_return = get_proper_type(ctx.default_return_type)

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2166,3 +2166,22 @@ class Other(Enum):
 reveal_type(Other.a)  # N: Revealed type is "Literal[__main__.Other.a]?"
 reveal_type(Other.Support.b)  # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
+
+
+[case testEnumMemberSupport]
+# flags: --python-version 3.11
+# This was added in 3.11
+from enum import Enum, member
+
+class A(Enum):
+    x = member(1)
+    y = 2
+
+reveal_type(A.x)  # N: Revealed type is "Literal[__main__.A.x]?"
+reveal_type(A.x.value)  # N: Revealed type is "Literal[1]?"
+reveal_type(A.y)  # N: Revealed type is "Literal[__main__.A.y]?"
+reveal_type(A.y.value)  # N: Revealed type is "Literal[2]?"
+
+def some_a(a: A):
+    reveal_type(a.value)  # N: Revealed type is "Union[Literal[1]?, Literal[2]?]"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/lib-stub/enum.pyi
+++ b/test-data/unit/lib-stub/enum.pyi
@@ -53,3 +53,8 @@ class StrEnum(str, Enum):
 class nonmember(Generic[_T]):
     value: _T
     def __init__(self, value: _T) -> None: ...
+
+# It is python-3.11+ only:
+class member(Generic[_T]):
+    value: _T
+    def __init__(self, value: _T) -> None: ...


### PR DESCRIPTION
There are no tests for `@enum.member` used as a decorator, because I can only decorate classes and functions, which are not supported right now: https://mypy-play.net/?mypy=latest&python=3.12&gist=449ee8c12eba9f807cfc7832f1ea2c49

```python
import enum

class A(enum.Enum):
    class x: ...

reveal_type(A.x)  # Revealed type is "def () -> __main__.A.x"
```

This issue is separate and rather complex, so I would prefer to solve it independently.

Refs https://github.com/python/mypy/pull/17376