### PR TITLE
stubgen: Gracefully handle invalid `Optional` and recognize aliases to PEP 604 unions

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -315,7 +315,7 @@ class AliasPrinter(NodeVisitor[str]):
             return node.index.accept(self)
         if base_fullname == "typing.Optional":
             if isinstance(node.index, TupleExpr):
-                return f"{self.stubgen.add_name('_typeshed.Incomplete')} | None"
+                return self.stubgen.add_name("_typeshed.Incomplete")
             return f"{node.index.accept(self)} | None"
         base = node.base.accept(self)
         index = node.index.accept(self)

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1062,6 +1062,10 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
                 else:
                     return False
             return all(self.is_alias_expression(i, top_level=False) for i in indices)
+        elif isinstance(expr, OpExpr) and expr.op == "|":
+            return self.is_alias_expression(
+                expr.left, top_level=False
+            ) and self.is_alias_expression(expr.right, top_level=False)
         else:
             return False
 

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -314,6 +314,8 @@ class AliasPrinter(NodeVisitor[str]):
                 return " | ".join([item.accept(self) for item in node.index.items])
             return node.index.accept(self)
         if base_fullname == "typing.Optional":
+            if isinstance(node.index, TupleExpr):
+                return " | ".join([item.accept(self) for item in node.index.items] + ["None"])
             return f"{node.index.accept(self)} | None"
         base = node.base.accept(self)
         index = node.index.accept(self)

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -315,7 +315,7 @@ class AliasPrinter(NodeVisitor[str]):
             return node.index.accept(self)
         if base_fullname == "typing.Optional":
             if isinstance(node.index, TupleExpr):
-                return " | ".join([item.accept(self) for item in node.index.items] + ["None"])
+                return f"{self.stubgen.add_name('_typeshed.Incomplete')} | None"
             return f"{node.index.accept(self)} | None"
         base = node.base.accept(self)
         index = node.index.accept(self)

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -257,7 +257,9 @@ class AnnotationPrinter(TypeStrVisitor):
         if fullname == "typing.Union":
             return " | ".join([item.accept(self) for item in t.args])
         if fullname == "typing.Optional":
-            return f"{t.args[0].accept(self)} | None"
+            if not t.args:
+                return self.stubgen.add_name("_typeshed.Incomplete")
+            return " | ".join([item.accept(self) for item in t.args] + ["None"])
         if fullname in TYPING_BUILTIN_REPLACEMENTS:
             s = self.stubgen.add_name(TYPING_BUILTIN_REPLACEMENTS[fullname], require=True)
         if self.known_modules is not None and "." in s:

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -258,7 +258,7 @@ class AnnotationPrinter(TypeStrVisitor):
             return " | ".join([item.accept(self) for item in t.args])
         if fullname == "typing.Optional":
             if not t.args:
-                return self.stubgen.add_name("_typeshed.Incomplete")
+                return f"{self.stubgen.add_name('_typeshed.Incomplete')} | None"
             return " | ".join([item.accept(self) for item in t.args] + ["None"])
         if fullname in TYPING_BUILTIN_REPLACEMENTS:
             s = self.stubgen.add_name(TYPING_BUILTIN_REPLACEMENTS[fullname], require=True)

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -257,9 +257,9 @@ class AnnotationPrinter(TypeStrVisitor):
         if fullname == "typing.Union":
             return " | ".join([item.accept(self) for item in t.args])
         if fullname == "typing.Optional":
-            if not t.args:
-                return f"{self.stubgen.add_name('_typeshed.Incomplete')} | None"
-            return " | ".join([item.accept(self) for item in t.args] + ["None"])
+            if len(t.args) == 1:
+                return f"{t.args[0].accept(self)} | None"
+            return f"{self.stubgen.add_name('_typeshed.Incomplete')} | None"
         if fullname in TYPING_BUILTIN_REPLACEMENTS:
             s = self.stubgen.add_name(TYPING_BUILTIN_REPLACEMENTS[fullname], require=True)
         if self.known_modules is not None and "." in s:

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -259,7 +259,7 @@ class AnnotationPrinter(TypeStrVisitor):
         if fullname == "typing.Optional":
             if len(t.args) == 1:
                 return f"{t.args[0].accept(self)} | None"
-            return f"{self.stubgen.add_name('_typeshed.Incomplete')} | None"
+            return self.stubgen.add_name("_typeshed.Incomplete")
         if fullname in TYPING_BUILTIN_REPLACEMENTS:
             s = self.stubgen.add_name(TYPING_BUILTIN_REPLACEMENTS[fullname], require=True)
         if self.known_modules is not None and "." in s:

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -4370,13 +4370,15 @@ class Bar(Enum):
 [case testGracefullyHandleInvalidOptionalUsage]
 from typing import Optional
 
-x: Optional
-y: Optional[int]
-z: Optional[int, str]
+x: Optional  # invalid
+y: Optional[int]  # valid
+z: Optional[int, str]  # invalid
+w: Optional[int | str]  # valid
 
 X = Optional
 Y = Optional[int]
 Z = Optional[int, str]
+W = Optional[int | str]
 
 [out]
 from _typeshed import Incomplete
@@ -4385,6 +4387,8 @@ from typing import Optional
 x: Incomplete | None
 y: int | None
 z: Incomplete | None
+w: int | str | None
 X = Optional
 Y = int | None
 Z = Incomplete | None
+W = int | str | None

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -4382,7 +4382,7 @@ Z = Optional[int, str]
 from _typeshed import Incomplete
 from typing import Optional
 
-x: Incomplete
+x: Incomplete | None
 y: int | None
 z: int | str | None
 X = Optional

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -4374,11 +4374,13 @@ x: Optional  # invalid
 y: Optional[int]  # valid
 z: Optional[int, str]  # invalid
 w: Optional[int | str]  # valid
+r: Optional[type[int | str]]
 
 X = Optional
 Y = Optional[int]
 Z = Optional[int, str]
 W = Optional[int | str]
+R = Optional[type[int | str]]
 
 [out]
 from _typeshed import Incomplete
@@ -4388,7 +4390,9 @@ x: Incomplete
 y: int | None
 z: Incomplete
 w: int | str | None
+r: type[int | str] | None
 X = Optional
 Y = int | None
 Z = Incomplete
 W = int | str | None
+R = type[int | str] | None

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -4384,7 +4384,7 @@ from typing import Optional
 
 x: Incomplete | None
 y: int | None
-z: int | str | None
+z: Incomplete | None
 X = Optional
 Y = int | None
-Z = int | str | None
+Z = Incomplete | None

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -4366,3 +4366,25 @@ class Foo(Enum):
 class Bar(Enum):
     A = ...
     B = ...
+
+[case testGracefullyHandleInvalidOptionalUsage]
+from typing import Optional
+
+x: Optional
+y: Optional[int]
+z: Optional[int, str]
+
+X = Optional
+Y = Optional[int]
+Z = Optional[int, str]
+
+[out]
+from _typeshed import Incomplete
+from typing import Optional
+
+x: Incomplete
+y: int | None
+z: int | str | None
+X = Optional
+Y = int | None
+Z = int | str | None

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -4384,11 +4384,11 @@ W = Optional[int | str]
 from _typeshed import Incomplete
 from typing import Optional
 
-x: Incomplete | None
+x: Incomplete
 y: int | None
-z: Incomplete | None
+z: Incomplete
 w: int | str | None
 X = Optional
 Y = int | None
-Z = Incomplete | None
+Z = Incomplete
 W = int | str | None


### PR DESCRIPTION
This Fixes 2 issues with invalid `Optional` (inspired by an error reported in #17197):
- do not crash on empty `Optional`
- treat `Optional` with more than one index as an unknown type instead of choosing the first type.

It also fixes PEP 604 unions not being recognized as type aliases.
