### PR TITLE
expand Self type using method context's self_type

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1064,7 +1064,14 @@ def analyze_class_attribute_access(
             # In the above example this means that we infer following types:
             #     C.x -> Any
             #     C[int].x -> int
-            t = get_proper_type(expand_self_type(node.node, t, itype))
+            mx_self_type = get_proper_type(mx.self_type)
+            if isinstance(mx_self_type, CallableType):
+                self_type = mx_self_type.ret_type
+            elif isinstance(mx_self_type, TypeType):
+                self_type = mx_self_type.item
+            else:
+                self_type = itype
+            t = get_proper_type(expand_self_type(node.node, t, self_type))
             t = erase_typevars(expand_type_by_instance(t, isuper), {tv.id for tv in def_vars})
 
         is_classmethod = (is_decorated and cast(Decorator, node.node).func.is_class) or (

--- a/test-data/unit/check-classvar.test
+++ b/test-data/unit/check-classvar.test
@@ -334,3 +334,21 @@ class C:
 c:C
 c.foo()  # E: Too few arguments \
          # N: "foo" is considered instance variable, to make it class variable use ClassVar[...]
+[case testClassVarSelfThroughTypeVar]
+from typing import TypeVar, Generic, ClassVar, Self, Type
+
+M = TypeVar("M", bound="B", covariant=True)
+
+class Related(Generic[M]):
+    def get(self) -> M: ...
+
+class B:
+    objects: ClassVar[Related[Self]] = Related()
+
+def of_m(cls: Type[M]) -> M:
+    return cls.objects.get()
+
+class C(B): pass
+
+reveal_type(of_m(C))  # N: Revealed type is "__main__.C"
+[builtins fixtures/type.pyi]


### PR DESCRIPTION
this better preserves attributes through generic bounds

Resolves #17395 

