### PR TITLE
Propagate is_async_generator down to overloads

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1286,7 +1286,7 @@ class SemanticAnalyzer(
         """
         for fdef in defn.items:
             assert isinstance(fdef, Decorator)
-            if not fdef.func.is_async_generator:
+            if not fdef.func.is_async_generator and fdef.func.is_coroutine:
                 # If it was *not* identified as an async generator, then we wrapped it
                 # with erroneous Coroutine before. Remove this wrapper and record that.
                 fdef.func.is_async_generator = True

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3383,23 +3383,25 @@ for factory in (
     var = factory()
 [builtins fixtures/tuple.pyi]
 
-[case testAyncContextManagerOverload]
-from contextlib import asynccontextmanager
-from typing import AsyncIterator, Iterator, Union, overload
+[case testAsyncIteratorOverload]
+from typing import AsyncIterator, Callable, Iterator, TypeVar, Union, overload
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def deco(fn: Callable[[T], AsyncIterator[U]]) -> Callable[[T], U]:
+    ...
 
 @overload
-@asynccontextmanager
+@deco
 async def test_async(val: int) -> AsyncIterator[int]: ...
 
 @overload
-@asynccontextmanager
-async def test_async(val: str) -> AsyncIterator[str]: ...  # E: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
+@deco
+async def test_async(val: str) -> AsyncIterator[str]: ...
 
-# NB: the error above is caused by naive `asynccontextmanager` definition in test stubs.
-
-@asynccontextmanager
+@deco
 async def test_async(val: Union[int, str]) -> AsyncIterator[Union[int, str]]:
     yield val
 
-[typing fixtures/typing-full.pyi]
-[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3405,3 +3405,26 @@ async def test_async(val: Union[int, str]) -> AsyncIterator[Union[int, str]]:
     yield val
 
 [typing fixtures/typing-async.pyi]
+
+[case testAsyncIteratorOverloadMixedAsync]
+from typing import AsyncIterator, Callable, Iterator, TypeVar, Union, overload
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def deco(fn: Callable[[T], AsyncIterator[U]]) -> Callable[[T], U]:
+    ...
+
+@overload
+@deco
+def test_async(val: int) -> AsyncIterator[int]: ...
+
+@overload
+@deco
+def test_async(val: str) -> AsyncIterator[str]: ...
+
+@deco
+async def test_async(val: Union[int, str]) -> AsyncIterator[Union[int, str]]:
+    yield val
+
+[typing fixtures/typing-async.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3382,3 +3382,24 @@ for factory in (
     reveal_type(factory)  # N: Revealed type is "def () -> Union[builtins.str, None]"
     var = factory()
 [builtins fixtures/tuple.pyi]
+
+[case testAyncContextManagerOverload]
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Iterator, Union, overload
+
+@overload
+@asynccontextmanager
+async def test_async(val: int) -> AsyncIterator[int]: ...
+
+@overload
+@asynccontextmanager
+async def test_async(val: str) -> AsyncIterator[str]: ...  # E: Overloaded function signature 2 will never be matched: signature 1's parameter type(s) are the same or broader
+
+# NB: the error above is caused by naive `asynccontextmanager` definition in test stubs.
+
+@asynccontextmanager
+async def test_async(val: Union[int, str]) -> AsyncIterator[Union[int, str]]:
+    yield val
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Closes #17340 

When an overloaded definition is checked, overloads usually have a trivial body. As a result, the return type of async overloads is wrapped with `Coroutine`, while the implementation is not - all this happens during semanal based solely on `yield` presence.

When such situation is encountered, we should unwrap the return type and mark the functions as async generators.
