### PR TITLE
Fix typo in `error_code_list2.rst`

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -389,7 +389,7 @@ Example:
         #        Are you missing an await?
         asyncio.create_task(f())
 
-You can assign the value to a temporary, otherwise unused to variable to
+You can assign the value to a temporary, otherwise unused variable to
 silence the error:
 
 .. code-block:: python


### PR DESCRIPTION
Diff:

```diff
-You can assign the value to a temporary, otherwise unused to variable to silence the error
+You can assign the value to a temporary, otherwise unused variable to silence the error
```
