### PR TITLE
Allow mixing ParamSpec and TypeVarTuple in Generic

### DIFF
--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -34,6 +34,7 @@ from mypy.types import (
     get_proper_type,
     get_proper_types,
 )
+from mypy.typevartuples import erased_vars
 
 
 def erase_type(typ: Type) -> ProperType:
@@ -77,17 +78,7 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
         return t
 
     def visit_instance(self, t: Instance) -> ProperType:
-        args: list[Type] = []
-        for tv in t.type.defn.type_vars:
-            # Valid erasure for *Ts is *tuple[Any, ...], not just Any.
-            if isinstance(tv, TypeVarTupleType):
-                args.append(
-                    UnpackType(
-                        tv.tuple_fallback.copy_modified(args=[AnyType(TypeOfAny.special_form)])
-                    )
-                )
-            else:
-                args.append(AnyType(TypeOfAny.special_form))
+        args = erased_vars(t.type.defn.type_vars, TypeOfAny.special_form)
         return Instance(t.type, args, t.line)
 
     def visit_type_var(self, t: TypeVarType) -> ProperType:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3165,9 +3165,6 @@ class TypeInfo(SymbolNode):
                     self.type_var_tuple_prefix = i
                     self.type_var_tuple_suffix = len(self.defn.type_vars) - i - 1
                 self.type_vars.append(vd.name)
-        assert not (
-            self.has_param_spec_type and self.has_type_var_tuple_type
-        ), "Mixing type var tuples and param specs not supported yet"
 
     @property
     def name(self) -> str:

--- a/mypy/typevartuples.py
+++ b/mypy/typevartuples.py
@@ -40,11 +40,7 @@ def erased_vars(type_vars: Sequence[TypeVarLikeType], type_of_any: int) -> list[
     for tv in type_vars:
         # Valid erasure for *Ts is *tuple[Any, ...], not just Any.
         if isinstance(tv, TypeVarTupleType):
-            args.append(
-                UnpackType(
-                    tv.tuple_fallback.copy_modified(args=[AnyType(type_of_any)])
-                )
-            )
+            args.append(UnpackType(tv.tuple_fallback.copy_modified(args=[AnyType(type_of_any)])))
         else:
             args.append(AnyType(type_of_any))
     return args

--- a/mypy/typevartuples.py
+++ b/mypy/typevartuples.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from typing import Sequence
 
 from mypy.types import (
+    AnyType,
     Instance,
     ProperType,
     Type,
+    TypeVarLikeType,
+    TypeVarTupleType,
     UnpackType,
     get_proper_type,
     split_with_prefix_and_suffix,
@@ -30,3 +33,18 @@ def extract_unpack(types: Sequence[Type]) -> ProperType | None:
         if isinstance(types[0], UnpackType):
             return get_proper_type(types[0].type)
     return None
+
+
+def erased_vars(type_vars: Sequence[TypeVarLikeType], type_of_any: int) -> list[Type]:
+    args: list[Type] = []
+    for tv in type_vars:
+        # Valid erasure for *Ts is *tuple[Any, ...], not just Any.
+        if isinstance(tv, TypeVarTupleType):
+            args.append(
+                UnpackType(
+                    tv.tuple_fallback.copy_modified(args=[AnyType(type_of_any)])
+                )
+            )
+        else:
+            args.append(AnyType(type_of_any))
+    return args

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2460,3 +2460,30 @@ def test(x: T, *args: Unpack[Ts]) -> Tuple[T, Unpack[Ts]]: ...
 
 reveal_type(test)  # N: Revealed type is "def [T, Ts] (builtins.list[T`2], *args: Unpack[Ts`-2]) -> __main__.CM[Tuple[T`2, Unpack[Ts`-2]]]"
 [builtins fixtures/tuple.pyi]
+
+[case testMixingTypeVarTupleAndParamSpec]
+from typing import Generic, ParamSpec, TypeVarTuple, Unpack, Callable, TypeVar
+
+P = ParamSpec("P")
+Ts = TypeVarTuple("Ts")
+
+class A(Generic[P, Unpack[Ts]]): ...
+class B(Generic[Unpack[Ts], P]): ...
+
+a: A[[int, str], int, str]
+reveal_type(a)  # N: Revealed type is "__main__.A[[builtins.int, builtins.str], builtins.int, builtins.str]"
+b: B[int, str, [int, str]]
+reveal_type(b)  # N: Revealed type is "__main__.B[builtins.int, builtins.str, [builtins.int, builtins.str]]"
+
+x: A[int, str, [int, str]]  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "int"
+reveal_type(x)  # N: Revealed type is "__main__.A[Any, Unpack[builtins.tuple[Any, ...]]]"
+y: B[[int, str], int, str]  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "str"
+reveal_type(y)  # N: Revealed type is "__main__.B[Unpack[builtins.tuple[Any, ...]], Any]"
+
+R = TypeVar("R")
+class C(Generic[P, R]):
+    fn: Callable[P, None]
+
+c: C[int, str]  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "int"
+reveal_type(c.fn)  # N: Revealed type is "def (*Any, **Any)"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16696
Fixes https://github.com/python/mypy/issues/16695

I think there are no good reasons to not allow this anymore. Also I am using this opportunity to tighten a bit invalid instances/aliases where a regular type variable is replaced with parameters and vice versa.