### PR TITLE
Use Python 3.12 for mypy_primer

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install -U pip


### PR DESCRIPTION
I'd like for us to cover projects that use Python 3.12 only syntax, like homeassistant