### PR TITLE
Add `__replace__` for dataclasses

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -401,14 +401,13 @@ class DataclassTransformer:
     def _add_dunder_replace(self, attributes: list[DataclassAttribute]) -> None:
         """Add a `__replace__` method to the class, which is used to replace attributes in the `copy` module."""
         args = [attr.to_argument(self._cls.info, of="replace") for attr in attributes]
-        if self._cls.info.self_type:
-            add_method_to_class(
-                self._api,
-                self._cls,
-                "__replace__",
-                args=args,
-                return_type=self._cls.info.self_type,
-            )
+        add_method_to_class(
+            self._api,
+            self._cls,
+            "__replace__",
+            args=args,
+            return_type=NoneType(),
+        )
 
     def _add_internal_replace_method(self, attributes: list[DataclassAttribute]) -> None:
         """

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -385,6 +385,7 @@ class DataclassTransformer:
 
         self._add_dataclass_fields_magic_attribute()
         self._add_internal_replace_method(attributes)
+        self._add_dunder_replace(attributes)
         if "__post_init__" in info.names:
             self._add_internal_post_init_method(attributes)
 
@@ -394,6 +395,13 @@ class DataclassTransformer:
         }
 
         return True
+    
+    def _add_dunder_replace(self, attributes: list[DataclassAttribute]) -> None:
+        """Add a `__replace__` method to the class, which is used to replace attributes in the `copy` module."""
+        args = [attr.to_argument(self._cls.info, of="replace") for attr in attributes]
+        add_method_to_class(
+            self._api, self._cls, "__replace__", args=args, return_type=self._cls.info.self_type
+        )
 
     def _add_internal_replace_method(self, attributes: list[DataclassAttribute]) -> None:
         """

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -385,7 +385,9 @@ class DataclassTransformer:
 
         self._add_dataclass_fields_magic_attribute()
         self._add_internal_replace_method(attributes)
-        self._add_dunder_replace(attributes)
+        if self._api.options.python_version >= (3, 13):
+            self._add_dunder_replace(attributes)
+
         if "__post_init__" in info.names:
             self._add_internal_post_init_method(attributes)
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -401,9 +401,10 @@ class DataclassTransformer:
     def _add_dunder_replace(self, attributes: list[DataclassAttribute]) -> None:
         """Add a `__replace__` method to the class, which is used to replace attributes in the `copy` module."""
         args = [attr.to_argument(self._cls.info, of="replace") for attr in attributes]
-        add_method_to_class(
-            self._api, self._cls, "__replace__", args=args, return_type=self._cls.info.self_type
-        )
+        if self._cls.info.self_type:
+            add_method_to_class(
+                self._api, self._cls, "__replace__", args=args, return_type=self._cls.info.self_type
+            )
 
     def _add_internal_replace_method(self, attributes: list[DataclassAttribute]) -> None:
         """

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -406,7 +406,7 @@ class DataclassTransformer:
             self._cls,
             "__replace__",
             args=args,
-            return_type=NoneType(),
+            return_type=Instance(self._cls.info, []),
         )
 
     def _add_internal_replace_method(self, attributes: list[DataclassAttribute]) -> None:

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -403,7 +403,11 @@ class DataclassTransformer:
         args = [attr.to_argument(self._cls.info, of="replace") for attr in attributes]
         if self._cls.info.self_type:
             add_method_to_class(
-                self._api, self._cls, "__replace__", args=args, return_type=self._cls.info.self_type
+                self._api,
+                self._cls,
+                "__replace__",
+                args=args,
+                return_type=self._cls.info.self_type,
             )
 
     def _add_internal_replace_method(self, attributes: list[DataclassAttribute]) -> None:

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -401,12 +401,13 @@ class DataclassTransformer:
     def _add_dunder_replace(self, attributes: list[DataclassAttribute]) -> None:
         """Add a `__replace__` method to the class, which is used to replace attributes in the `copy` module."""
         args = [attr.to_argument(self._cls.info, of="replace") for attr in attributes]
+        type_vars = [tv for tv in self._cls.type_vars]
         add_method_to_class(
             self._api,
             self._cls,
             "__replace__",
             args=args,
-            return_type=Instance(self._cls.info, []),
+            return_type=Instance(self._cls.info, type_vars),
         )
 
     def _add_internal_replace_method(self, attributes: list[DataclassAttribute]) -> None:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2509,5 +2509,6 @@ reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
 Coords(2, 4).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "Coords" has incompatible type "str"; expected "int"
 Coords(2, 4).__replace__(23)          # E: Too many positional arguments for "Coords"
 Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments for "Coords"
+Coords(2, 4).__replace__(x=23, y=25, z=42)  # E: Unexpected keyword argument "z" for "__replace__" of "Coords"
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2511,7 +2511,7 @@ Coords(2, 4).__replace__(23)          # E: Too many positional arguments for "Co
 Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments for "Coords"
 Coords(2, 4).__replace__(x=23, y=25, z=42)  # E: Unexpected keyword argument "z" for "__replace__" of "Coords"
 
-from typing import Generic
+from typing import Generic, TypeVar
 T = TypeVar('T')
 
 @dataclass

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2507,7 +2507,7 @@ replaced = Coords(2, 4).__replace(x=2)
 reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
 
 Coords(2, 4).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "Coords" has incompatible type "str"; expected "int"
-Coords(2, 4).__replace(23)          # E: Too many positional arguments for "Coords"
-Coords(2, 4).__replace(23, 25)      # E: Too many positional arguments for "Coords"
+Coords(2, 4).__replace__(23)          # E: Too many positional arguments for "Coords"
+Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments for "Coords"
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2520,5 +2520,6 @@ class Gen(Generic[T]):
 
 replaced_2 = Gen(2).__replace__(x=2)
 reveal_type(replaced_2)  # N: Revealed type is "__main__.Gen[builtins.int]"
+Gen(2).__replace__(x="not an int")  # E: Argument "x" to "__replace__" of "Gen" has incompatible type "str"; expected "int"
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2503,7 +2503,7 @@ class Coords:
 replaced = Coords(2, 4).__replace__(x=2, y=5)
 reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
 
-replaced = Coords(2, 4).__replace(x=2)
+replaced = Coords(2, 4).__replace__(x=2)
 reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
 
 Coords(2, 4).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "Coords" has incompatible type "str"; expected "int"

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2508,7 +2508,7 @@ reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
 
 Coords(2, 4).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "Coords" has incompatible type "str"; expected "int"
 Coords(2, 4).__replace__(23)          # E: Too many positional arguments for "__replace__" of "Coords"
-Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments "__replace__" of "Coords"
+Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments for "__replace__" of "Coords"
 Coords(2, 4).__replace__(x=23, y=25, z=42)  # E: Unexpected keyword argument "z" for "__replace__" of "Coords"
 
 from typing import Generic, TypeVar

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2491,6 +2491,7 @@ class Child(Base):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDunderReplacePresent]
+# flags: --python-version 3.13
 from dataclasses import dataclass
 
 @dataclass

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2507,8 +2507,8 @@ replaced = Coords(2, 4).__replace__(x=2)
 reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
 
 Coords(2, 4).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "Coords" has incompatible type "str"; expected "int"
-Coords(2, 4).__replace__(23)          # E: Too many positional arguments for "Coords"
-Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments for "Coords"
+Coords(2, 4).__replace__(23)          # E: Too many positional arguments for "__replace__" of "Coords"
+Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments "__replace__" of "Coords"
 Coords(2, 4).__replace__(x=23, y=25, z=42)  # E: Unexpected keyword argument "z" for "__replace__" of "Coords"
 
 from typing import Generic, TypeVar
@@ -2518,7 +2518,7 @@ T = TypeVar('T')
 class Gen(Generic[T]):
     x: T
 
-replaced = Gen(2).__replace__(x=2)
-reveal_type(replaced)  # N: Revealed type is "__main__.Gen[builtins.int]"
+replaced_2 = Gen(2).__replace__(x=2)
+reveal_type(replaced_2)  # N: Revealed type is "__main__.Gen[builtins.int]"
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2512,6 +2512,7 @@ Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments for "Co
 Coords(2, 4).__replace__(x=23, y=25, z=42)  # E: Unexpected keyword argument "z" for "__replace__" of "Coords"
 
 from typing import Generic
+T = TypeVar('T')
 
 @dataclass
 class Gen(Generic[T]):

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2500,5 +2500,5 @@ class Coords:
     y: int
 
 
-replaced = Coords(2, 4).__replace__(x=2, y=5)
-reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
+Coords(2, 4).__replace__(x=2, y=5)
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2511,4 +2511,13 @@ Coords(2, 4).__replace__(23)          # E: Too many positional arguments for "Co
 Coords(2, 4).__replace__(23, 25)      # E: Too many positional arguments for "Coords"
 Coords(2, 4).__replace__(x=23, y=25, z=42)  # E: Unexpected keyword argument "z" for "__replace__" of "Coords"
 
+from typing import Generic
+
+@dataclass
+class Gen(Generic[T]):
+    x: T
+
+replaced = Gen(2).__replace__(x=2)
+reveal_type(replaced)  # N: Revealed type is "__main__.Gen[builtins.int]"
+
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2500,5 +2500,7 @@ class Coords:
     y: int
 
 
-Coords(2, 4).__replace__(x=2, y=5)
-[builtins fixtures/dataclasses.pyi]
+replaced = Coords(2, 4).__replace__(x=2, y=5)
+reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
+[builtins fixtures/tuple.pyi]
+

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2489,3 +2489,16 @@ class Base:
 class Child(Base):
     y: int
 [builtins fixtures/dataclasses.pyi]
+
+[case testDunderReplacePresent]
+from dataclasses import dataclass
+
+@dataclass
+class Coords:
+    x: int
+    y: int
+
+
+replaced = Coords(2, 4).__replace__(x=2, y=5)
+reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
+

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2502,4 +2502,12 @@ class Coords:
 
 replaced = Coords(2, 4).__replace__(x=2, y=5)
 reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
+
+replaced = Coords(2, 4).__replace(x=2)
+reveal_type(replaced)  # N: Revealed type is "__main__.Coords"
+
+Coords(2, 4).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "Coords" has incompatible type "str"; expected "int"
+Coords(2, 4).__replace(23)          # E: Too many positional arguments for "Coords"
+Coords(2, 4).__replace(23, 25)      # E: Too many positional arguments for "Coords"
+
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Add `__replace__`, which is now present on dataclasses in 3.13, which is creating false alarms in TypeShed on dataclasses, and is needed for `copy.replace` to work properly.

Fixes https://github.com/python/mypy/issues/17471

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
