### PR TITLE
Have namedtuple `__replace__` return `Self`

### DIFF
--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -632,9 +632,10 @@ class NamedTupleAnalyzer:
             args=[Argument(var, var.type, EllipsisExpr(), ARG_NAMED_OPT) for var in vars],
         )
         if self.options.python_version >= (3, 13):
+            type_vars = [tv for tv in info.defn.type_vars]
             add_method(
                 "__replace__",
-                ret=Instance(info, []),
+                ret=Instance(info, type_vars),
                 args=[Argument(var, var.type, EllipsisExpr(), ARG_NAMED_OPT) for var in vars],
             )
 

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -57,6 +57,7 @@ from mypy.types import (
     TYPED_NAMEDTUPLE_NAMES,
     AnyType,
     CallableType,
+    Instance,
     LiteralType,
     TupleType,
     Type,
@@ -633,7 +634,7 @@ class NamedTupleAnalyzer:
         if self.options.python_version >= (3, 13):
             add_method(
                 "__replace__",
-                ret=None,
+                ret=Instance(info, []),
                 args=[Argument(var, var.type, EllipsisExpr(), ARG_NAMED_OPT) for var in vars],
             )
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1408,7 +1408,7 @@ class A(NamedTuple):
     x: int
 
 replaced = A(x=0).__replace__(x=1)
-reveal_type(replaced)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.A]"
+reveal_type(replaced)  # N: Revealed type is "__main__.A"
 
 A(x=0).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "A" has incompatible type "str"; expected "int"
 A(x=0).__replace__(y=1)  # E: Unexpected keyword argument "y" for "__replace__" of "A"
@@ -1421,7 +1421,7 @@ class GenericA(NamedTuple, Generic[T]):
     x: T
 
 replaced_2 = GenericA(x=0).__replace__(x=1)
-reveal_type(replaced_2)  # N: Revealed type is "__main__.GenericA[builtins.int]"
+reveal_type(replaced_2)  # N: Revealed type is "__main__.GenericA"
 GenericA(x=0).__replace__(x="abc") # E: Argument "x" to "__replace__" of "GenericA" has incompatible type "str"; expected "int"
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1408,7 +1408,7 @@ class A(NamedTuple):
     x: int
 
 replaced = A(x=0).__replace__(x=1)
-reveal_type(replaced)  # N: Revealed type is "__main__.A"
+reveal_type(replaced)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.A]"
 
 A(x=0).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "A" has incompatible type "str"; expected "int"
 A(x=0).__replace__(y=1)  # E: Unexpected keyword argument "y" for "__replace__" of "A"

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1407,9 +1407,12 @@ from typing import NamedTuple
 class A(NamedTuple):
     x: int
 
-A(x=0).__replace__(x=1)
+replaced = A(x=0).__replace__(x=1)
+reveal_type(replaced)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.A]"
+
 A(x=0).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "A" has incompatible type "str"; expected "int"
 A(x=0).__replace__(y=1)  # E: Unexpected keyword argument "y" for "__replace__" of "A"
+
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1408,10 +1408,21 @@ class A(NamedTuple):
     x: int
 
 replaced = A(x=0).__replace__(x=1)
-reveal_type(replaced)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.A]"
+reveal_type(replaced)  # N: Revealed type is "__main__.A"
 
 A(x=0).__replace__(x="asdf")  # E: Argument "x" to "__replace__" of "A" has incompatible type "str"; expected "int"
 A(x=0).__replace__(y=1)  # E: Unexpected keyword argument "y" for "__replace__" of "A"
+
+from typing import TypeVar, Generic
+
+T = TypeVar("T")
+
+class GenericA(NamedTuple, Generic[T]):
+    x: T
+
+replaced_2 = GenericA(x=0).__replace__(x=1)
+reveal_type(replaced_2)  # N: Revealed type is "__main__.GenericA[builtins.int]"
+GenericA(x=0).__replace__(x="abc") # E: Argument "x" to "__replace__" of "GenericA" has incompatible type "str"; expected "int"
 
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]


### PR DESCRIPTION
Have `__replace__` for named tuples return `Self` to ensure protocol compatibility with `copy.replace` in the typeshed, and to be accurate to the actual dunder.
