### PR TITLE
Fix  --install-types masking failure details

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1549,7 +1549,6 @@ def read_types_packages_to_install(cache_dir: str, after_run: bool) -> list[str]
             )
         else:
             sys.stderr.write("error: --install-types failed (no mypy cache directory)\n")
-        sys.exit(2)
     fnam = build.missing_stubs_file(cache_dir)
     if not os.path.isfile(fnam):
         # No missing stubs.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1548,7 +1548,9 @@ def read_types_packages_to_install(cache_dir: str, after_run: bool) -> list[str]
                 + "(and no cache from previous mypy run)\n"
             )
         else:
-            sys.stderr.write("error: --install-types failed (an error blocked analysis of which types to install)\n")
+            sys.stderr.write(
+                "error: --install-types failed (an error blocked analysis of which types to install)\n"
+            )
     fnam = build.missing_stubs_file(cache_dir)
     if not os.path.isfile(fnam):
         # No missing stubs.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1548,7 +1548,7 @@ def read_types_packages_to_install(cache_dir: str, after_run: bool) -> list[str]
                 + "(and no cache from previous mypy run)\n"
             )
         else:
-            sys.stderr.write("error: --install-types failed (no mypy cache directory)\n")
+            sys.stderr.write("error: --install-types failed (an error blocked analysis of which types to install)\n")
     fnam = build.missing_stubs_file(cache_dir)
     if not os.path.isfile(fnam):
         # No missing stubs.


### PR DESCRIPTION
It seems that: if the mypy cache dir wasn't created, this code would do an exit, preventing the actual errors from being printed. So I've removed the exit. More information is available at the issue I claim this fixes.

Fixes #10768
