### PR TITLE
Refactor: remove temporary `def` from `semanal_classprop.check_protocol_status`

### DIFF
--- a/mypy/semanal_classprop.py
+++ b/mypy/semanal_classprop.py
@@ -122,11 +122,12 @@ def check_protocol_status(info: TypeInfo, errors: Errors) -> None:
     if info.is_protocol:
         for type in info.bases:
             if not type.type.is_protocol and type.type.fullname != "builtins.object":
-
-                def report(message: str, severity: str) -> None:
-                    errors.report(info.line, info.column, message, severity=severity)
-
-                report("All bases of a protocol must be protocols", "error")
+                errors.report(
+                    info.line,
+                    info.column,
+                    "All bases of a protocol must be protocols",
+                    severity="error",
+                )
 
 
 def calculate_class_vars(info: TypeInfo) -> None:


### PR DESCRIPTION
There's no need to create and call a temporary function, when we can just call an existing method: faster and simplier.