### PR TITLE
Fix `gen_is_coroutine` for Python 3.13

### DIFF
--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -115,4 +115,7 @@ static inline void CPyLong_SetUnsignedSize(PyLongObject *o, Py_ssize_t n) {
 
 #endif
 
+// Are we targeting Python 3.13 or newer?
+#define CPY_3_13_FEATURES (PY_VERSION_HEX >= 0x030d0000)
+
 #endif

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -392,7 +392,30 @@ _CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
     _PyObject_CallMethodIdObjArgs((self), (name), (arg), NULL)
 #endif
 
-#if CPY_3_12_FEATURES
+#if CPY_3_13_FEATURES
+
+// These are copied from genobject.c in Python 3.13
+
+/* Returns a borrowed reference */
+static inline PyCodeObject *
+_PyGen_GetCode(PyGenObject *gen) {
+    _PyInterpreterFrame *frame = (_PyInterpreterFrame *)(gen->gi_iframe);
+    return _PyFrame_GetCode(frame);
+}
+
+static int
+gen_is_coroutine(PyObject *o)
+{
+    if (PyGen_CheckExact(o)) {
+        PyCodeObject *code = _PyGen_GetCode((PyGenObject*)o);
+        if (code->co_flags & CO_ITERABLE_COROUTINE) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+#elif CPY_3_12_FEATURES
 
 // These are copied from genobject.c in Python 3.12
 


### PR DESCRIPTION
The `_PyInterpreterFrame` struct was changed in https://github.com/python/cpython/pull/105727 to store the code object in `f_executable` instead of `f_code`.

Fixes
```cpp
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h: In function ‘_PyGen_GetCode’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h:403:17: error: ‘_PyInterpreterFrame’ has no member named ‘f_code’ (diff)
    403 |     return frame->f_code; (diff)
        |                 ^~ (diff)
```