### PR TITLE
Fix `_PyObject_FastCall` for Python 3.13

### DIFF
--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -59,7 +59,7 @@ update_bases(PyObject *bases)
             }
             continue;
         }
-        new_base = _PyObject_FastCall(meth, stack, 1);
+        new_base = _PyObject_Vectorcall(meth, stack, 1, NULL);
         Py_DECREF(meth);
         if (!new_base) {
             goto error;
@@ -108,7 +108,7 @@ init_subclass(PyTypeObject *type, PyObject *kwds)
     PyObject *super, *func, *result;
     PyObject *args[2] = {(PyObject *)type, (PyObject *)type};
 
-    super = _PyObject_FastCall((PyObject *)&PySuper_Type, args, 2);
+    super = _PyObject_Vectorcall((PyObject *)&PySuper_Type, args, 2, NULL);
     if (super == NULL) {
         return -1;
     }


### PR DESCRIPTION
`_PyObject_FastCall` will be removed in 3.13. It can safely replaced by `PyObject_Vectorcall` (available since `3.9`) / `_PyObject_Vectorcall` (available since `3.8`). https://github.com/python/cpython/issues/106023#issuecomment-1613963489

https://peps.python.org/pep-0590/

Fixes
```cpp
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h: In function ‘update_bases’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h:62:20: error: implicit declaration of function ‘_PyObject_FastCall’; did you mean ‘PyObject_Call’? [-Werror=implicit-function-declaration] (diff)
     62 |         new_base = _PyObject_FastCall(meth, stack, 1); (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h:62:18: error: assignment to ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion] (diff)
     62 |         new_base = _PyObject_FastCall(meth, stack, 1); (diff)
        |                  ^ (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h: In function ‘init_subclass’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h:111:11: error: assignment to ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion] (diff)
    111 |     super = _PyObject_FastCall((PyObject *)&PySuper_Type, args, 2); (diff)
        |           ^ (diff)
```