### PR TITLE
Fix `_PyList_Extend` for Python 3.13

### DIFF
--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -230,12 +230,11 @@ PyObject *CPyDict_Keys(PyObject *dict) {
     if (view == NULL) {
         return NULL;
     }
-    PyObject *res = _PyList_Extend((PyListObject *)list, view);
+    int res = PyList_Extend(list, view);
     Py_DECREF(view);
-    if (res == NULL) {
+    if (res < 0) {
         return NULL;
     }
-    Py_DECREF(res);
     return list;
 }
 
@@ -250,12 +249,11 @@ PyObject *CPyDict_Values(PyObject *dict) {
     if (view == NULL) {
         return NULL;
     }
-    PyObject *res = _PyList_Extend((PyListObject *)list, view);
+    int res = PyList_Extend(list, view);
     Py_DECREF(view);
-    if (res == NULL) {
+    if (res < 0) {
         return NULL;
     }
-    Py_DECREF(res);
     return list;
 }
 
@@ -270,12 +268,11 @@ PyObject *CPyDict_Items(PyObject *dict) {
     if (view == NULL) {
         return NULL;
     }
-    PyObject *res = _PyList_Extend((PyListObject *)list, view);
+    int res = PyList_Extend(list, view);
     Py_DECREF(view);
-    if (res == NULL) {
+    if (res < 0) {
         return NULL;
     }
-    Py_DECREF(res);
     return list;
 }
 

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -256,7 +256,10 @@ int CPyList_Insert(PyObject *list, CPyTagged index, PyObject *value)
 }
 
 PyObject *CPyList_Extend(PyObject *o1, PyObject *o2) {
-    return _PyList_Extend((PyListObject *)o1, o2);
+    if (PyList_Extend(o1, o2) < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
 }
 
 // Return -2 or error, -1 if not found, or index of first match otherwise.


### PR DESCRIPTION
Replace `_PyList_Extend` with `PyList_Extend` from `pythoncapi_compat.h`.

https://github.com/python/cpython/issues/111138
https://docs.python.org/dev/c-api/list.html#c.PyList_Extend

Fixes
```cpp
  /home/runner/work/mypy/mypy/mypyc/lib-rt/list_ops.c: In function ‘CPyList_Extend’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/list_ops.c:259:12: error: implicit declaration of function ‘_PyList_Extend’; did you mean ‘CPyList_Extend’? [-Werror=implicit-function-declaration] (diff)
    259 |     return _PyList_Extend((PyListObject *)o1, o2); (diff)
        |            ^~~~~~~~~~~~~~ (diff)
        |            CPyList_Extend (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/list_ops.c:259:12: error: returning ‘int’ from a function with return type ‘PyObject *’ {aka ‘struct _object *’} makes pointer from integer without a cast [-Werror=int-conversion] (diff)
    259 |     return _PyList_Extend((PyListObject *)o1, o2); (diff)
        |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/dict_ops.c: In function ‘CPyDict_Keys’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/dict_ops.c:233:21: error: initialization of ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion] (diff)
    233 |     PyObject *res = _PyList_Extend((PyListObject *)list, view); (diff)
        |                     ^~~~~~~~~~~~~~ (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/dict_ops.c: In function ‘CPyDict_Values’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/dict_ops.c:253:21: error: initialization of ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion] (diff)
    253 |     PyObject *res = _PyList_Extend((PyListObject *)list, view); (diff)
        |                     ^~~~~~~~~~~~~~ (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/dict_ops.c: In function ‘CPyDict_Items’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/dict_ops.c:273:21: error: initialization of ‘PyObject *’ {aka ‘struct _object *’} from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion] (diff)
    273 |     PyObject *res = _PyList_Extend((PyListObject *)list, view); (diff)
        |                     ^~~~~~~~~~~~~~ (diff)
```