### PR TITLE
Fix `PyUnicode` functions for Python 3.13

### DIFF
--- a/mypyc/lib-rt/getargs.c
+++ b/mypyc/lib-rt/getargs.c
@@ -395,7 +395,7 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
                 goto latefail;
             }
             for (i = pos; i < len; i++) {
-                if (CPyUnicode_EqualToASCIIString(key, kwlist[i])) {
+                if (PyUnicode_EqualToUTF8(key, kwlist[i])) {
                     match = 1;
                     break;
                 }

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -307,8 +307,6 @@ list_count(PyListObject *self, PyObject *value)
     return CPyTagged_ShortFromSsize_t(count);
 }
 
-#define CPyUnicode_EqualToASCIIString(x, y) _PyUnicode_EqualToASCIIString(x, y)
-
 // Adapted from genobject.c in Python 3.7.2
 // Copied because it wasn't in 3.5.2 and it is undocumented anyways.
 /*

--- a/mypyc/lib-rt/str_ops.c
+++ b/mypyc/lib-rt/str_ops.c
@@ -80,7 +80,7 @@ PyObject *CPyStr_Build(Py_ssize_t len, ...) {
         sz += add_sz;
 
         // If these strings have different kind, we would call
-        // _PyUnicode_FastCopyCharacters() in the following part.
+        // PyUnicode_CopyCharacters() in the following part.
         if (use_memcpy && last_obj != NULL) {
             if (PyUnicode_KIND(last_obj) != PyUnicode_KIND(item))
                 use_memcpy = 0;

--- a/mypyc/lib-rt/str_ops.c
+++ b/mypyc/lib-rt/str_ops.c
@@ -117,7 +117,7 @@ PyObject *CPyStr_Build(Py_ssize_t len, ...) {
             PyObject *item = va_arg(args, PyObject *);
             Py_ssize_t itemlen = PyUnicode_GET_LENGTH(item);
             if (itemlen != 0) {
-                _PyUnicode_FastCopyCharacters(res, res_offset, item, 0, itemlen);
+                PyUnicode_CopyCharacters(res, res_offset, item, 0, itemlen);
                 res_offset += itemlen;
             }
         }

--- a/mypyc/lib-rt/str_ops.c
+++ b/mypyc/lib-rt/str_ops.c
@@ -80,7 +80,7 @@ PyObject *CPyStr_Build(Py_ssize_t len, ...) {
         sz += add_sz;
 
         // If these strings have different kind, we would call
-        // PyUnicode_CopyCharacters() in the following part.
+        // _PyUnicode_FastCopyCharacters() in the following part.
         if (use_memcpy && last_obj != NULL) {
             if (PyUnicode_KIND(last_obj) != PyUnicode_KIND(item))
                 use_memcpy = 0;
@@ -117,7 +117,7 @@ PyObject *CPyStr_Build(Py_ssize_t len, ...) {
             PyObject *item = va_arg(args, PyObject *);
             Py_ssize_t itemlen = PyUnicode_GET_LENGTH(item);
             if (itemlen != 0) {
-                PyUnicode_CopyCharacters(res, res_offset, item, 0, itemlen);
+                _PyUnicode_FastCopyCharacters(res, res_offset, item, 0, itemlen);
                 res_offset += itemlen;
             }
         }


### PR DESCRIPTION
Replace `_PyUnicode_EqualToASCIIString` with `PyUnicode_EqualToUTF8`.

https://docs.python.org/dev/c-api/unicode.html#c.PyUnicode_EqualToUTF8
https://github.com/python/cpython/issues/110289

Fixes
```cpp
  /home/runner/work/mypy/mypy/mypyc/lib-rt/getargs.c: In function ‘vgetargskeywords’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h:310:45: error: implicit declaration of function ‘_PyUnicode_EqualToASCIIString’; did you mean ‘CPyUnicode_EqualToASCIIString’? [-Werror=implicit-function-declaration] (diff)
    310 | #define CPyUnicode_EqualToASCIIString(x, y) _PyUnicode_EqualToASCIIString(x, y) (diff)
        |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~ (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/getargs.c:398:21: note: in expansion of macro ‘CPyUnicode_EqualToASCIIString’ (diff)
    398 |                 if (CPyUnicode_EqualToASCIIString(key, kwlist[i])) { (diff)
        |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~ (diff)
```