### PR TITLE
Fix `_PyObject_LookupAttrId` for Python 3.13

### DIFF
--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -48,7 +48,7 @@ update_bases(PyObject *bases)
             }
             continue;
         }
-        if (_PyObject_LookupAttrId(base, &PyId___mro_entries__, &meth) < 0) {
+        if (PyObject_GetOptionalAttrString(base, PyId___mro_entries__.string, &meth) < 0) {
             goto error;
         }
         if (!meth) {
@@ -374,7 +374,7 @@ _CPyDictView_New(PyObject *dict, PyTypeObject *type)
 static int
 _CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
     PyObject *tmp = NULL;
-    int result = _PyObject_LookupAttrId(v, name, &tmp);
+    int result = PyObject_GetOptionalAttrString(v, name->string, &tmp);
     if (tmp) {
         Py_DECREF(tmp);
     }


### PR DESCRIPTION
`_PyObject_LookupAttrId` was removed / replaced with `PyObject_GetOptionalAttrString` in https://github.com/python/cpython/pull/106522.
https://docs.python.org/dev/c-api/object.html#c.PyObject_GetOptionalAttrString

Fixes
```cpp
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h: In function ‘update_bases’: (diff)
  /home/runner/work/mypy/mypy/mypyc/lib-rt/pythonsupport.h:51:13: error: implicit declaration of function ‘_PyObject_LookupAttrId’; did you mean ‘_PyObject_GetAttrId’? [-Werror=implicit-function-declaration] (diff)
     51 |         if (_PyObject_LookupAttrId(base, &PyId___mro_entries__, &meth) < 0) { (diff)
        |             ^~~~~~~~~~~~~~~~~~~~~~ (diff)
        |             _PyObject_GetAttrId (diff)
```