### PR TITLE
Add additional includes for Python 3.13

### DIFF
--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -13,6 +13,17 @@
 #include <assert.h>
 #include "mypyc_util.h"
 
+#if CPY_3_13_FEATURES
+#ifndef Py_BUILD_CORE
+#define Py_BUILD_CORE
+#endif
+#include "internal/pycore_bytesobject.h"  // _PyBytes_Join
+#include "internal/pycore_call.h"  // _PyObject_CallMethodIdNoArgs, _PyObject_CallMethodIdObjArgs, _PyObject_CallMethodIdOneArg
+#include "internal/pycore_genobject.h"  // _PyGen_FetchStopIterationValue
+#include "internal/pycore_object.h"  // _PyType_CalculateMetaclass
+#include "internal/pycore_pyerrors.h"  // _PyErr_FormatFromCause, _PyErr_SetKeyError
+#endif
+
 #if CPY_3_12_FEATURES
 #include "internal/pycore_frame.h"
 #endif

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -22,7 +22,7 @@
 #include "internal/pycore_genobject.h"  // _PyGen_FetchStopIterationValue
 #include "internal/pycore_object.h"  // _PyType_CalculateMetaclass
 #include "internal/pycore_pyerrors.h"  // _PyErr_FormatFromCause, _PyErr_SetKeyError
-#include "internal/pycore_unicodeobject.h"  // _PyUnicode_EQ
+#include "internal/pycore_unicodeobject.h"  // _PyUnicode_EQ, _PyUnicode_FastCopyCharacters
 #endif
 
 #if CPY_3_12_FEATURES

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -22,6 +22,7 @@
 #include "internal/pycore_genobject.h"  // _PyGen_FetchStopIterationValue
 #include "internal/pycore_object.h"  // _PyType_CalculateMetaclass
 #include "internal/pycore_pyerrors.h"  // _PyErr_FormatFromCause, _PyErr_SetKeyError
+#include "internal/pycore_unicodeobject.h"  // _PyUnicode_EQ
 #endif
 
 #if CPY_3_12_FEATURES


### PR DESCRIPTION
Define `Py_BUILD_CORE` required by `internal/...` header files. Include additional headers for moved private functions.

```cpp
  /opt/hostedtoolcache/Python/3.13.0-beta.3/x64/include/python3.13/internal/pycore_frame.h:8:4: error: #error "this header requires Py_BUILD_CORE define" (diff)
      8 | #  error "this header requires Py_BUILD_CORE define" (diff)
```