### PR TITLE
[mypyc] Don't use _PyUnicode_EQ on 3.13, as it's no longer exported

### DIFF
--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -271,9 +271,16 @@ find_keyword(PyObject *kwnames, PyObject *const *kwstack, PyObject *key)
     for (i = 0; i < nkwargs; i++) {
         PyObject *kwname = PyTuple_GET_ITEM(kwnames, i);
         assert(PyUnicode_Check(kwname));
+#if CPY_3_13_FEATURES
+        if (_PyUnicode_Equal(kwname, key)) {
+            return kwstack[i];
+        }
+#else
         if (_PyUnicode_EQ(kwname, key)) {
             return kwstack[i];
         }
+#endif
+
     }
     return NULL;
 }


### PR DESCRIPTION
Work on mypyc/mypyc#1056.