### PR TITLE
[mypyc] Avoid uses of _PyObject_CallMethodOneArg on 3.13

### DIFF
--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -78,7 +78,11 @@ PyObject *CPyDict_SetDefault(PyObject *dict, PyObject *key, PyObject *value) {
         return ret;
     }
     _Py_IDENTIFIER(setdefault);
-    return _PyObject_CallMethodIdObjArgs(dict, &PyId_setdefault, key, value, NULL);
+    PyObject *name = _PyUnicode_FromId(&PyId_setdefault); /* borrowed */
+    if (name == NULL) {
+        return NULL;
+    }
+    return PyObject_CallMethodObjArgs(dict, name, key, value, NULL);
 }
 
 PyObject *CPyDict_SetDefaultWithNone(PyObject *dict, PyObject *key) {
@@ -133,7 +137,11 @@ static inline int CPy_ObjectToStatus(PyObject *obj) {
 
 static int CPyDict_UpdateGeneral(PyObject *dict, PyObject *stuff) {
     _Py_IDENTIFIER(update);
-    PyObject *res = _PyObject_CallMethodIdOneArg(dict, &PyId_update, stuff);
+    PyObject *name = _PyUnicode_FromId(&PyId_update); /* borrowed */
+    if (name == NULL) {
+        return -1;
+    }
+    PyObject *res = _PyObject_CallMethodOneArg(dict, name, stuff);
     return CPy_ObjectToStatus(res);
 }
 

--- a/mypyc/lib-rt/dict_ops.c
+++ b/mypyc/lib-rt/dict_ops.c
@@ -141,7 +141,7 @@ static int CPyDict_UpdateGeneral(PyObject *dict, PyObject *stuff) {
     if (name == NULL) {
         return -1;
     }
-    PyObject *res = _PyObject_CallMethodOneArg(dict, name, stuff);
+    PyObject *res = PyObject_CallMethodOneArg(dict, name, stuff);
     return CPy_ObjectToStatus(res);
 }
 

--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -401,6 +401,8 @@ _CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
     _PyObject_CallMethodIdObjArgs((self), (name), NULL)
 #define _PyObject_CallMethodIdOneArg(self, name, arg) \
     _PyObject_CallMethodIdObjArgs((self), (name), (arg), NULL)
+#define PyObject_CallMethodOneArg(self, name, arg) \
+    PyObject_CallMethodObjArgs((self), (name), (arg), NULL)
 #endif
 
 #if CPY_3_13_FEATURES


### PR DESCRIPTION
It's no longer available in CPython 3.13 betas.

This fixes some dict primitives on 3.13.

Work on mypyc/mypyc#1056.