### PR TITLE
Add plugin ability to defer to default type analyzer

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -598,7 +598,8 @@ class Plugin(CommonPluginApi):
 
         this method will be called with 'lib.Special', and then with 'lib.Other'.
         The callback returned by plugin must return an analyzed type,
-        i.e. an instance of `mypy.types.Type`.
+        i.e. an instance of `mypy.types.Type`, or `NotImplemented` to continue
+        default analysis.
         """
         return None
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -336,7 +336,12 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             fullname = node.fullname
             hook = self.plugin.get_type_analyze_hook(fullname)
             if hook is not None:
-                return hook(AnalyzeTypeContext(t, t, self))
+                hook_out = hook(AnalyzeTypeContext(t, t, self))
+                # allow deferring to default
+
+                if hook_out is not NotImplemented:
+                  return hook_out
+
             if (
                 fullname in get_nongen_builtins(self.options.python_version)
                 and t.args

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -337,10 +337,10 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             hook = self.plugin.get_type_analyze_hook(fullname)
             if hook is not None:
                 hook_out = hook(AnalyzeTypeContext(t, t, self))
-                # allow deferring to default
+                # Allow deferring to default
 
                 if hook_out is not NotImplemented:
-                  return hook_out
+                    return hook_out
 
             if (
                 fullname in get_nongen_builtins(self.options.python_version)


### PR DESCRIPTION
* The essence of this PR is to allow a Plugin's callback for `get_type_analyze_hook` to defer back to the default implementation.
* The motivating use-case that lead to needing this was specifically to help customizing type analysis for a variadic generic class which could be used in contexts (like inheritance) where the arguments would be an unpacked TypeVarTuple. The mechanisms for dealing with this seem complicated, and not exposed via the plugin API (but I could be mistaken on that). As far as I could tell it requires specialized logic for enabling/handling the unpacking etc, and besides these are not the instances that need to be customized in this case.
* The approach here is to return `NotImplemented` as a sentinel to indicate the intention. This appears to not require altering the annotated return `Type` (but I'm not familiar with why that is the case), but it seems that for example returning `None` would require the callback signature to change, which might be an irritation. Also, in my personal experience this is preferable to raising say NotImplementError since the intent can be less clear as to where exactly the error was raised  compared to a return value. 
* The included change appears to be the only place where the hook is called, and seems to not alter the succeeding logic if it was simply ignored.
* I am somewhat new to the mypy source style, so I  apologize if this PR doesn't conform to conventions. 


Following is an example of the use-case mentioned above...

```python
# example use case
def _analyze_type(ctx: AnalyzeTypeContext) -> Type:
  for arg in ctx.type.args:
    if isinstance(arg, UnboundType) and arg.name == 'Unpack':
      return NotImplemented
    ...
```

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
