### PR TITLE
[stubgenc] Generate Inline generics from `__type_params__`

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -108,7 +108,7 @@ class FunctionSig(NamedTuple):
         is_async: bool = False,
         any_val: str | None = None,
         docstring: str | None = None,
-        generic: str = ""
+        generic: str = "",
     ) -> str:
         args: list[str] = []
         for arg in self.args:
@@ -143,7 +143,12 @@ class FunctionSig(NamedTuple):
 
         prefix = "async " if is_async else ""
         sig = "{indent}{prefix}def {name}{generic}({args}){ret}:".format(
-            indent=indent, prefix=prefix, name=self.name, args=", ".join(args), ret=retfield, generic=generic
+            indent=indent,
+            prefix=prefix,
+            name=self.name,
+            args=", ".join(args),
+            ret=retfield,
+            generic=generic,
         )
         if docstring:
             suffix = f"\n{indent}    {mypy.util.quote_docstring(docstring)}"

--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -108,6 +108,7 @@ class FunctionSig(NamedTuple):
         is_async: bool = False,
         any_val: str | None = None,
         docstring: str | None = None,
+        generic: str = ""
     ) -> str:
         args: list[str] = []
         for arg in self.args:
@@ -141,8 +142,8 @@ class FunctionSig(NamedTuple):
             retfield = " -> " + ret_type
 
         prefix = "async " if is_async else ""
-        sig = "{indent}{prefix}def {name}({args}){ret}:".format(
-            indent=indent, prefix=prefix, name=self.name, args=", ".join(args), ret=retfield
+        sig = "{indent}{prefix}def {name}{generic}({args}){ret}:".format(
+            indent=indent, prefix=prefix, name=self.name, args=", ".join(args), ret=retfield, generic=generic
         )
         if docstring:
             suffix = f"\n{indent}    {mypy.util.quote_docstring(docstring)}"

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -653,7 +653,11 @@ class InspectionStubGenerator(BaseStubGenerator):
         else:
             generic = ""
 
-        output.extend(self.format_func_def(inferred, decorators=decorators, docstring=docstring, generic=generic))
+        output.extend(
+            self.format_func_def(
+                inferred, decorators=decorators, docstring=docstring, generic=generic
+            )
+        )
         self._fix_iter(ctx, inferred, output)
 
     def _indent_docstring(self, docstring: str) -> str:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -856,6 +856,7 @@ class InspectionStubGenerator(BaseStubGenerator):
                 continue
             elif attr == "__type_params__":
                 inline_generic = generate_inline_generic(value)
+                continue
 
             prop_type_name = self.strip_or_import(self.get_type_annotation(value))
             classvar = self.add_name("typing.ClassVar")

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -647,7 +647,13 @@ class InspectionStubGenerator(BaseStubGenerator):
 
         if docstring:
             docstring = self._indent_docstring(docstring)
-        output.extend(self.format_func_def(inferred, decorators=decorators, docstring=docstring))
+
+        if hasattr(obj, "__type_params__"):
+            generic = generate_inline_generic(obj.__type_params__)
+        else:
+            generic = ""
+
+        output.extend(self.format_func_def(inferred, decorators=decorators, docstring=docstring, generic=generic))
         self._fix_iter(ctx, inferred, output)
 
     def _indent_docstring(self, docstring: str) -> str:

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -880,7 +880,7 @@ class InspectionStubGenerator(BaseStubGenerator):
         else:
             bases_str = ""
         if types or static_properties or rw_properties or methods or ro_properties:
-            output.append(f"{self._indent}class {class_name}{bases_str}:")
+            output.append(f"{self._indent}class {class_name}{inline_generic}{bases_str}:")
             for line in types:
                 if (
                     output

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -11,6 +11,7 @@ import importlib
 import inspect
 import keyword
 import os.path
+from contextlib import suppress
 from types import FunctionType, ModuleType
 from typing import Any, Callable, Mapping
 
@@ -497,6 +498,8 @@ class InspectionStubGenerator(BaseStubGenerator):
                 "__firstlineno__",
                 "__static_attributes__",
                 "__annotate__",
+                "__orig_bases__",
+                "__parameters__",
             )
             or attr in self.IGNORED_DUNDERS
             or is_pybind_skipped_attribute(attr)  # For pickling
@@ -875,6 +878,10 @@ class InspectionStubGenerator(BaseStubGenerator):
         self.dedent()
 
         bases = self.get_base_types(cls)
+        if inline_generic != "":
+            # Removes typing.Generic form bases if it exists for python3.12 inline generics
+            with suppress(ValueError):
+                bases.remove("typing.Generic")
         if bases:
             bases_str = "(%s)" % ", ".join(bases)
         else:

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -8,8 +8,8 @@ import sys
 from abc import abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import Final, Iterable, Iterator, Mapping, ParamSpec, TypeVar, TypeVarTuple, cast
-from typing_extensions import overload
+from typing import Final, Iterable, Iterator, Mapping, TypeVar, cast
+from typing_extensions import ParamSpec, TypeVarTuple, overload
 
 from mypy_extensions import mypyc_attr
 
@@ -845,28 +845,31 @@ class BaseStubGenerator:
 
 
 def generate_inline_generic(type_params: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]) -> str:
-        """Generate stub for inline generic from __type_params__"""
+    """Generate stub for inline generic from __type_params__"""
 
-        generic_arg_list: list[str] = []
+    generic_arg_list: list[str] = []
 
-        for type_param in type_params:
-            # Not done with isinstance checks so compiled code doesn't necessarily need to use
-            # typing.TypeVar, just something with similar duck typing.
-            if hasattr(type_param, "__constraints__"):
-                # Is TypeVar
-                typevar = cast(TypeVar, type_param)
-                if typevar.__bound__:
-                    generic_arg_list.append(f'{typevar.__name__}: {typevar.__bound__}')
-                else:
-                    generic_arg_list.append(f'{typevar.__name__}: {typevar.__constraints__}')
-            elif hasattr(type_param, "__bounds__"):
-                # Is ParamSpec
-                param_spec = cast(ParamSpec, type_param)
-                generic_arg_list.append(f'**{param_spec.__name__}')
+    for type_param in type_params:
+        # Not done with isinstance checks so compiled code doesn't necessarily need to use
+        # typing.TypeVar, just something with similar duck typing.
+        if hasattr(type_param, "__constraints__"):
+            # Is TypeVar
+            typevar = cast(TypeVar, type_param)
+            if typevar.__bound__:
+                generic_arg_list.append(f"{typevar.__name__}: {typevar.__bound__.__name__}")
+            elif typevar.__constraints__ != ():
+                generic_arg_list.append(
+                    f"{typevar.__name__}: ({', '.join([constraint.__name__ for constraint in typevar.__constraints__])})"
+                )
             else:
-                # Is TypeVarTuple
-                typevar_tuple = cast(TypeVarTuple, type_param)
-                generic_arg_list.append(f'*{typevar_tuple.__name__}')
+                generic_arg_list.append(f"{typevar.__name__}")
+        elif hasattr(type_param, "__bound__"):
+            # Is ParamSpec
+            param_spec = cast(ParamSpec, type_param)
+            generic_arg_list.append(f"**{param_spec.__name__}")
+        else:
+            # Is TypeVarTuple
+            generic_arg_list.append(f"*{type_param.__name__}")
 
-        flat_internals = ",".join(generic_arg_list)
-        return f"[{flat_internals}]"
+    flat_internals = ", ".join(generic_arg_list)
+    return f"[{flat_internals}]"

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -766,6 +766,7 @@ class BaseStubGenerator:
         is_coroutine: bool = False,
         decorators: list[str] | None = None,
         docstring: str | None = None,
+        generic: str = "",
     ) -> list[str]:
         lines: list[str] = []
         if decorators is None:
@@ -781,6 +782,7 @@ class BaseStubGenerator:
                     indent=self._indent,
                     is_async=is_coroutine,
                     docstring=docstring if self._include_docstrings else None,
+                    generic=generic
                 )
             )
         return lines
@@ -846,6 +848,9 @@ class BaseStubGenerator:
 
 def generate_inline_generic(type_params: tuple[TypeVar | ParamSpec | TypeVarTuple, ...]) -> str:
     """Generate stub for inline generic from __type_params__"""
+
+    if len(type_params) == 0:
+        return ""
 
     generic_arg_list: list[str] = []
 

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -782,7 +782,7 @@ class BaseStubGenerator:
                     indent=self._indent,
                     is_async=is_coroutine,
                     docstring=docstring if self._include_docstrings else None,
-                    generic=generic
+                    generic=generic,
                 )
             )
         return lines

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -946,7 +946,7 @@ class StubgencSuite(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_generic_class(self) -> None:
-        # This test lives in the exec block to avoid syntax version on python versions < 3.12
+        # This test lives in the exec block to avoid syntax errors on python versions < 3.12
         code = """
 class Test[A]: ...
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -946,17 +946,15 @@ class StubgencSuite(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_generic_class(self) -> None:
-        # This test lives in the exec block to avoid syntax errors on python versions < 3.12
-        code = """
-class Test[A]: ...
+        # This class declaration lives in exec to avoid syntax version on python versions < 3.12
+        local: dict[str, Any] = {}
+        exec("class Test[A]: ...", globals(), local)
 
-output: list[str] = []
-mod = ModuleType("module", "")
-gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
-gen.generate_class_stub("C", Test, output)
-assert_equal(output, ["class C[A]: ..."])
-        """
-        exec(code)
+        output: list[str] = []
+        mod = ModuleType("module", "")
+        gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
+        gen.generate_class_stub("C", local['Test'], output)
+        assert_equal(output, ["class C[A]: ..."])
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_function(self) -> None:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -945,6 +945,7 @@ class StubgencSuite(unittest.TestCase):
 
     def test_inline_generic_function(self) -> None:
         T = TypeVar("T", bound=int)
+
         class TestClass:
             def test(self, arg0: T) -> T:
                 """
@@ -952,7 +953,7 @@ class StubgencSuite(unittest.TestCase):
                 """
                 return arg0
 
-            test.__type_params__ = (T, )
+            test.__type_params__ = (T,)
 
         output: list[str] = []
         mod = ModuleType(TestClass.__module__, "")

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -948,6 +948,14 @@ class StubgencSuite(unittest.TestCase):
     def test_generic_class(self) -> None:
         exec("class Test[A]: ...")
 
+        class TestClass[A]: ...
+
+        output: list[str] = []
+        mod = ModuleType("module", "")
+        gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
+        gen.generate_class_stub("C", TestClass, output)
+        assert_equal(output, ["class C[A]: ..."])
+
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_function(self) -> None:
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -948,7 +948,7 @@ class StubgencSuite(unittest.TestCase):
     def test_generic_class(self) -> None:
         # This class declaration lives in exec to avoid syntax version on python versions < 3.12
         local: dict[str, Any] = {}
-        exec("class Test[A]: ...", globals(), local)
+        exec("class Test[A]: ...", None, local)
 
         output: list[str] = []
         mod = ModuleType("module", "")

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -946,15 +946,10 @@ class StubgencSuite(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_generic_class(self) -> None:
-        if sys.version_info < (
-            3,
-            12,
-        ):  # Done to prevent mypy [syntax] error on inline Generics in older versions of python
-            return
-
         exec("class Test[A]: ...")
 
-        class TestClass[A]: ...
+        # type: ignore used for older versions of python type checking
+        class TestClass[A]: ...  # type: ignore[invalid-syntax]
 
         output: list[str] = []
         mod = ModuleType("module", "")

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -949,7 +949,7 @@ class StubgencSuite(unittest.TestCase):
         exec("class Test[A]: ...")
 
         # type: ignore used for older versions of python type checking
-        class TestClass[A]: ...  # type: ignore[syntax]
+        class TestClass[A]: ...  # type: ignore
 
         output: list[str] = []
         mod = ModuleType("module", "")

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -946,6 +946,13 @@ class StubgencSuite(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_function(self) -> None:
+
+        if sys.version_info < (
+            3,
+            12,
+        ):  # Done to prevent mypy [attr-defined] error on __type_params__ in older versions of python
+            return
+
         T = TypeVar("T", bound=int)
 
         class TestClass:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -931,6 +931,9 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ["class C(argparse.Action): ..."])
         assert_equal(gen.get_imports().splitlines(), ["import argparse"])
 
+    @unittest.skipIf(
+        sys.version < (3, 12), "Inline Generics not supported before Python3.12"
+    )
     def test_inline_generic_class(self) -> None:
         T = TypeVar("T")
 
@@ -943,6 +946,9 @@ class StubgencSuite(unittest.TestCase):
         gen.generate_class_stub("C", TestClass, output)
         assert_equal(output, ["class C[T]: ..."])
 
+    @unittest.skipIf(
+        sys.version < (3, 12), "Inline Generics not supported before Python3.12"
+    )
     def test_inline_generic_function(self) -> None:
         T = TypeVar("T", bound=int)
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -953,7 +953,7 @@ class StubgencSuite(unittest.TestCase):
         output: list[str] = []
         mod = ModuleType("module", "")
         gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
-        gen.generate_class_stub("C", local['Test'], output)
+        gen.generate_class_stub("C", local["Test"], output)
         assert_equal(output, ["class C[A]: ..."])
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import unittest
 from types import ModuleType
-from typing import Any, Tuple, TypeVar, cast
+from typing import Any, Tuple, TypeVar, cast, no_type_check
 from typing_extensions import ParamSpec, TypeVarTuple
 
 import pytest
@@ -944,12 +944,13 @@ class StubgencSuite(unittest.TestCase):
         gen.generate_class_stub("C", TestClass, output)
         assert_equal(output, ["class C[T]: ..."])
 
+    # type: ignore used for older versions of python type checking inline generics.
+    @no_type_check
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_generic_class(self) -> None:
         exec("class Test[A]: ...")
 
-        # type: ignore used for older versions of python type checking
-        class TestClass[A]: ...  # type: ignore
+        class TestClass[A]: ...
 
         output: list[str] = []
         mod = ModuleType("module", "")

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -945,6 +945,10 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ["class C[T]: ..."])
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
+    def test_generic_class(self) -> None:
+        exec("class Test[A]: ...")
+
+    @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_function(self) -> None:
 
         if sys.version_info < (

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -949,7 +949,7 @@ class StubgencSuite(unittest.TestCase):
         exec("class Test[A]: ...")
 
         # type: ignore used for older versions of python type checking
-        class TestClass[A]: ...  # type: ignore[invalid-syntax]
+        class TestClass[A]: ...  # type: ignore[syntax]
 
         output: list[str] = []
         mod = ModuleType("module", "")

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -931,9 +931,7 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ["class C(argparse.Action): ..."])
         assert_equal(gen.get_imports().splitlines(), ["import argparse"])
 
-    @unittest.skipIf(
-        sys.version < (3, 12), "Inline Generics not supported before Python3.12"
-    )
+    @unittest.skipIf(sys.version < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_class(self) -> None:
         T = TypeVar("T")
 
@@ -946,9 +944,7 @@ class StubgencSuite(unittest.TestCase):
         gen.generate_class_stub("C", TestClass, output)
         assert_equal(output, ["class C[T]: ..."])
 
-    @unittest.skipIf(
-        sys.version < (3, 12), "Inline Generics not supported before Python3.12"
-    )
+    @unittest.skipIf(sys.version < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_function(self) -> None:
         T = TypeVar("T", bound=int)
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -946,6 +946,12 @@ class StubgencSuite(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_generic_class(self) -> None:
+        if sys.version_info < (
+            3,
+            12,
+        ):  # Done to prevent mypy [syntax] error on inline Generics in older versions of python
+            return
+
         exec("class Test[A]: ...")
 
         class TestClass[A]: ...

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import unittest
 from types import ModuleType
-from typing import Any, TypeVar, cast
+from typing import Any, Tuple, TypeVar, cast
 from typing_extensions import ParamSpec, TypeVarTuple
 
 import pytest
@@ -623,13 +623,13 @@ class StubgenUtilSuite(unittest.TestCase):
         TBoundTuple = TypeVar("TBoundTuple", int, str)
         assert generate_inline_generic((TBoundTuple,)) == "[TBoundTuple: (int, str)]"
         P = ParamSpec("P")
-        p_tuple = cast(tuple[ParamSpec], (P,))
+        p_tuple = cast(Tuple[ParamSpec], (P,))
         assert generate_inline_generic(p_tuple) == "[**P]"
         U = TypeVarTuple("U")
-        u_tuple = cast(tuple[TypeVarTuple], (U,))
+        u_tuple = cast(Tuple[TypeVarTuple], (U,))
         assert generate_inline_generic(u_tuple) == "[*U]"
         all_tuple = cast(
-            tuple[TypeVar, TypeVar, TypeVar, ParamSpec, TypeVarTuple],
+            Tuple[TypeVar, TypeVar, TypeVar, ParamSpec, TypeVarTuple],
             (T, TBound, TBoundTuple, P, U),
         )
         assert (

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -946,16 +946,17 @@ class StubgencSuite(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_generic_class(self) -> None:
-        # mypy: enable-incomplete-feature=NewGenericSyntax
-        exec("class Test[A]: ...")
+        # This test lives in the exec block to avoid syntax version on python versions < 3.12
+        code = """
+class Test[A]: ...
 
-        class TestClass[A]: ...
-
-        output: list[str] = []
-        mod = ModuleType("module", "")
-        gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
-        gen.generate_class_stub("C", TestClass, output)
-        assert_equal(output, ["class C[A]: ..."])
+output: list[str] = []
+mod = ModuleType("module", "")
+gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
+gen.generate_class_stub("C", Test, output)
+assert_equal(output, ["class C[A]: ..."])
+        """
+        exec(code)
 
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_function(self) -> None:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import unittest
 from types import ModuleType
-from typing import Any, Tuple, TypeVar, cast, no_type_check
+from typing import Any, Tuple, TypeVar, cast
 from typing_extensions import ParamSpec, TypeVarTuple
 
 import pytest
@@ -944,10 +944,9 @@ class StubgencSuite(unittest.TestCase):
         gen.generate_class_stub("C", TestClass, output)
         assert_equal(output, ["class C[T]: ..."])
 
-    # type: ignore used for older versions of python type checking inline generics.
-    @no_type_check
     @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_generic_class(self) -> None:
+        # mypy: enable-incomplete-feature=NewGenericSyntax
         exec("class Test[A]: ...")
 
         class TestClass[A]: ...

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -931,7 +931,7 @@ class StubgencSuite(unittest.TestCase):
         assert_equal(output, ["class C(argparse.Action): ..."])
         assert_equal(gen.get_imports().splitlines(), ["import argparse"])
 
-    @unittest.skipIf(sys.version < (3, 12), "Inline Generics not supported before Python3.12")
+    @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_class(self) -> None:
         T = TypeVar("T")
 
@@ -944,7 +944,7 @@ class StubgencSuite(unittest.TestCase):
         gen.generate_class_stub("C", TestClass, output)
         assert_equal(output, ["class C[T]: ..."])
 
-    @unittest.skipIf(sys.version < (3, 12), "Inline Generics not supported before Python3.12")
+    @unittest.skipIf(sys.version_info < (3, 12), "Inline Generics not supported before Python3.12")
     def test_inline_generic_function(self) -> None:
         T = TypeVar("T", bound=int)
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Fixes #17447 

This allows generating inline generics for stubgenc by using `__type_params__`.

Similar to #17463 but for `__type_params__` instead of `__annotations__`

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
