### PR TITLE
Move some tests from cmdline.test (#5966 )

### DIFF
--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -79,6 +79,13 @@ async def g(x: int) -> Any:
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
 
+[case testDisallowUntypedDefsAndGeneric]
+# flags: --disallow-untyped-defs --disallow-any-generics
+def get_tasks(self):
+    return 'whatever'
+[out]
+main:2: error: Function is missing a return type annotation
+
 [case testDisallowUntypedDefsUntypedDecorator]
 # flags: --disallow-untyped-decorators
 def d(p):
@@ -540,21 +547,30 @@ tmp/b.py:1: error: Unsupported operand types for + ("int" and "str")
 [case testFollowImportsNormal]
 # flags: --follow-imports=normal
 from mod import x
-x + ""
+x + 0
+x + ""  # E: Unsupported operand types for + ("int" and "str")
+import mod
+mod.x + 0
+mod.x + ""  # E: Unsupported operand types for + ("int" and "str")
+mod.y  # E: "object" has no attribute "y"
+mod + 0  # E: Unsupported left operand type for + ("object")
 [file mod.py]
-1 + ""
+1 + ""  # E: Unsupported operand types for + ("int" and "str")
 x = 0
-[out]
-tmp/mod.py:1: error: Unsupported operand types for + ("int" and "str")
-main:3: error: Unsupported operand types for + ("int" and "str")
+x += ""  # E: Unsupported operand types for + ("int" and "str")
 
 [case testFollowImportsSilent]
 # flags: --follow-imports=silent
 from mod import x
 x + ""  # E: Unsupported operand types for + ("int" and "str")
+import mod
+mod.x + ""  # E: Unsupported operand types for + ("int" and "str")
+mod.y  # E: "object" has no attribute "y"
+mod + 0  # E: Unsupported left operand type for + ("object")
 [file mod.py]
 1 + ""
 x = 0
+x += ""
 
 [case testFollowImportsSilentTypeIgnore]
 # flags: --warn-unused-ignores --follow-imports=silent
@@ -565,20 +581,55 @@ x = 3  # type: ignore
 [case testFollowImportsSkip]
 # flags: --follow-imports=skip
 from mod import x
+reveal_type(x)  # N: Revealed type is "Any"
 x + ""
+import mod
+reveal_type(mod.x)  # N: Revealed type is "Any"
 [file mod.py]
 this deliberate syntax error will not be reported
-[out]
 
 [case testFollowImportsError]
 # flags: --follow-imports=error
-from mod import x
+from mod import x  # E: Import of "mod" ignored \
+                   # N: (Using --follow-imports=error, module not passed on command line)
 x + ""
+reveal_type(x)  # N: Revealed type is "Any"
+import mod
+reveal_type(mod.x) # N: Revealed type is "Any"
 [file mod.py]
 deliberate syntax error
-[out]
-main:2: error: Import of "mod" ignored
-main:2: note: (Using --follow-imports=error, module not passed on command line)
+
+[case testFollowImportsSelective]
+# flags: --config-file tmp/mypy.ini
+import normal
+import silent
+import skip
+import error  # E: Import of "error" ignored \
+              # N: (Using --follow-imports=error, module not passed on command line)
+reveal_type(normal.x)  # N: Revealed type is "builtins.int"
+reveal_type(silent.x)  # N: Revealed type is "builtins.int"
+reveal_type(skip)  # N: Revealed type is "Any"
+reveal_type(error)  # N: Revealed type is "Any"
+[file mypy.ini]
+\[mypy]
+\[mypy-normal]
+follow_imports = normal
+\[mypy-silent]
+follow_imports = silent
+\[mypy-skip]
+follow_imports = skip
+\[mypy-error]
+follow_imports = error
+[file normal.py]
+x = 0
+x += ''  # E: Unsupported operand types for + ("int" and "str")
+[file silent.py]
+x = 0
+x += ''
+[file skip.py]
+bla bla
+[file error.py]
+bla bla
 
 [case testIgnoreMissingImportsFalse]
 from mod import x
@@ -589,6 +640,15 @@ main:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missin
 [case testIgnoreMissingImportsTrue]
 # flags: --ignore-missing-imports
 from mod import x
+[out]
+
+[case testNoConfigFile]
+# flags: --config-file=
+# type: ignore
+
+[file mypy.ini]
+\[mypy]
+warn_unused_ignores = True
 [out]
 
 [case testPerFileIncompleteDefsBasic]
@@ -868,6 +928,16 @@ implicit_optional = true
 module = 'optional'
 strict_optional = true
 
+[case testSilentMissingImportsOff]
+-- ignore_missing_imports is False by default.
+import missing  # E: Cannot find implementation or library stub for module named "missing" \
+                # N: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+reveal_type(missing.x)  # N: Revealed type is "Any"
+
+[case testSilentMissingImportsOn]
+# flags: --ignore-missing-imports
+import missing
+reveal_type(missing.x)  # N: Revealed type is "Any"
 
 [case testDisallowImplicitTypesIgnoreMissingTypes]
 # flags: --ignore-missing-imports --disallow-any-unimported
@@ -1447,6 +1517,29 @@ class Queue(Generic[_T]): ...
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testDisallowAnyGenericsBuiltinTuplePre39]
+# flags: --disallow-any-generics --python-version 3.8
+s = tuple([1, 2, 3])
+def f(t: tuple) -> None: pass  # E: Implicit generic "Any". Use "typing.Tuple" and specify generic parameters
+[builtins fixtures/tuple.pyi]
+
+[case testDisallowAnyGenericsBuiltinListPre39]
+# flags: --disallow-any-generics --python-version 3.8
+l = list([1, 2, 3])
+def f(t: list) -> None: pass  # E: Implicit generic "Any". Use "typing.List" and specify generic parameters
+[builtins fixtures/list.pyi]
+
+[case testDisallowAnyGenericsBuiltinSetPre39]
+# flags: --disallow-any-generics --python-version 3.8
+l = set({1, 2, 3})
+def f(s: set) -> None: pass  # E: Implicit generic "Any". Use "typing.Set" and specify generic parameters
+[builtins fixtures/set.pyi]
+
+[case testDisallowAnyGenericsBuiltinDictPre39]
+# flags: --disallow-any-generics --python-version 3.8
+l = dict([('a', 1)])
+def f(d: dict) -> None: pass  # E: Implicit generic "Any". Use "typing.Dict" and specify generic parameters
+[builtins fixtures/dict.pyi]
 
 [case testCheckDefaultAllowAnyGeneric]
 from typing import TypeVar, Callable
@@ -1863,8 +1956,9 @@ x: Tuple = ()  # E: Missing type parameters for generic type "Tuple"
 # flags: --disallow-any-generics
 from typing import Tuple, List
 
-def f(s: List[Tuple]) -> None: pass  # E: Missing type parameters for generic type "Tuple"
-def g(s: List[Tuple[str, str]]) -> None: pass  # no error
+def f(s: Tuple) -> None: pass  # E: Missing type parameters for generic type "Tuple"
+def g(s: List[Tuple]) -> None: pass  # E: Missing type parameters for generic type "Tuple"
+def h(s: List[Tuple[str, str]]) -> None: pass  # no error
 [builtins fixtures/list.pyi]
 
 [case testDisallowAnyGenericsTypeType]
@@ -1908,13 +2002,35 @@ x: A = ('a', 'b', 1)  # E: Missing type parameters for generic type "A"
 from typing import List
 
 def f(l: List) -> None: pass  # E: Missing type parameters for generic type "List"
-def g(l: List[str]) -> None: pass  # no error
+def g(l: List[str]) -> None: pass
 def h(l: List[List]) -> None: pass   # E: Missing type parameters for generic type "List"
 def i(l: List[List[List[List]]]) -> None: pass  # E: Missing type parameters for generic type "List"
+def j() -> List: pass  # E: Missing type parameters for generic type "List"
 
 x = []  # E: Need type annotation for "x" (hint: "x: List[<type>] = ...")
 y: List = []  # E: Missing type parameters for generic type "List"
 [builtins fixtures/list.pyi]
+
+[case testDisallowAnyGenericsPlainDict]
+# flags: --disallow-any-generics
+from typing import List, Dict
+
+def f(d: Dict) -> None: pass  # E: Missing type parameters for generic type "Dict"
+def g(d: Dict[str, Dict]) -> None: pass  # E: Missing type parameters for generic type "Dict"
+def h(d: List[Dict]) -> None: pass  # E: Missing type parameters for generic type "Dict"
+
+d: Dict = {}  # E: Missing type parameters for generic type "Dict"
+[builtins fixtures/dict.pyi]
+
+[case testDisallowAnyGenericsPlainSet]
+# flags: --disallow-any-generics
+from typing import Set
+
+def f(s: Set) -> None: pass  # E: Missing type parameters for generic type "Set"
+def g(s: Set[Set]) -> None: pass  # E: Missing type parameters for generic type "Set"
+
+s: Set = set()  # E: Missing type parameters for generic type "Set"
+[builtins fixtures/set.pyi]
 
 [case testDisallowAnyGenericsCustomGenericClass]
 # flags: --disallow-any-generics
@@ -2162,6 +2278,38 @@ allow_untyped_defs = True
 allow_untyped_calls = True
 disable_error_code = var-annotated
 
+[case testPerFileIgnoreErrors]
+# flags: --config-file tmp/mypy.ini
+import foo, bar
+[file foo.py]
+x: str = 5
+[file bar.py]
+x: str = 5  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+[file mypy.ini]
+\[mypy]
+\[mypy-foo]
+ignore_errors = True
+
+[case testPerFileUntypedDefs]
+# flags: --config-file tmp/mypy.ini
+import x, y, z
+[file x.py]
+def f(a): ...  # E: Function is missing a type annotation
+def g(a: int) -> int: return f(a)
+[file y.py]
+def f(a): pass
+def g(a: int) -> int: return f(a)
+[file z.py]
+def f(a): pass  # E: Function is missing a type annotation
+def g(a: int) -> int: return f(a)  # E: Call to untyped function "f" in typed context
+[file mypy.ini]
+\[mypy]
+disallow_untyped_defs = True
+\[mypy-y]
+disallow_untyped_defs = False
+\[mypy-z]
+disallow_untyped_calls = True
+
 [case testPerModuleErrorCodesOverride]
 # flags: --config-file tmp/mypy.ini
 import tests.foo
@@ -2284,3 +2432,8 @@ class C(Generic[T]): ...
 
 A = Union[C, List]  # OK
 [builtins fixtures/list.pyi]
+
+[case testNotesOnlyResultInExitSuccess]
+-- check_untyped_defs is False by default.
+def f():
+    x: int = "no"  # N: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -153,18 +153,6 @@ FLAG = False
 if not FLAG:
     x = "unreachable"
 
-[case testErrorContextConfig]
-# cmd: mypy main.py
-[file mypy.ini]
-\[mypy]
-show_error_context=True
-[file main.py]
-def f() -> None:
-  0 + ""
-[out]
-main.py: note: In function "f":
-main.py:2: error: Unsupported operand types for + ("int" and "str")
-
 [case testAltConfigFile]
 # cmd: mypy --config-file config.ini main.py
 [file config.ini]
@@ -175,43 +163,6 @@ x: int
 FLAG = False
 if not FLAG:
     x = "unreachable"
-
-[case testNoConfigFile]
-# cmd: mypy main.py --config-file=
-[file mypy.ini]
-\[mypy]
-warn_unused_ignores = True
-[file main.py]
-# type: ignore
-
-[case testPerFileConfigSection]
-# cmd: mypy x.py y.py z.py
-[file mypy.ini]
-\[mypy]
-disallow_untyped_defs = True
-\[mypy-y]
-disallow_untyped_defs = False
-\[mypy-z]
-disallow_untyped_calls = True
-[file x.py]
-def f(a):
-    pass
-def g(a: int) -> int:
-    return f(a)
-[file y.py]
-def f(a):
-    pass
-def g(a: int) -> int:
-    return f(a)
-[file z.py]
-def f(a):
-    pass
-def g(a: int) -> int:
-    return f(a)
-[out]
-z.py:1: error: Function is missing a type annotation
-z.py:4: error: Call to untyped function "f" in typed context
-x.py:1: error: Function is missing a type annotation
 
 [case testPerFileConfigSectionMultipleMatchesDisallowed]
 # cmd: mypy xx.py xy.py yx.py yy.py
@@ -326,43 +277,6 @@ file.py:1: error: Cannot find implementation or library stub for module named "n
 file.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 file.py:6: error: Argument 1 to "foo" has incompatible type "str"; expected "int"
 
-[case testIgnoreErrorsConfig]
-# cmd: mypy x.py y.py
-[file mypy.ini]
-\[mypy]
-\[mypy-x]
-ignore_errors = True
-[file x.py]
-x: str = 5
-[file y.py]
-x: str = 5
-[out]
-y.py:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
-
-[case testConfigFollowImportsNormal]
-# cmd: mypy main.py
-[file main.py]
-from a import x
-x + 0
-x + ''  # E
-import a
-a.x + 0
-a.x + ''  # E
-a.y  # E
-a + 0  # E
-[file mypy.ini]
-\[mypy]
-follow_imports = normal
-[file a.py]
-x = 0
-x += ''  # Error reported here
-[out]
-a.py:2: error: Unsupported operand types for + ("int" and "str")
-main.py:3: error: Unsupported operand types for + ("int" and "str")
-main.py:6: error: Unsupported operand types for + ("int" and "str")
-main.py:7: error: Module has no attribute "y"
-main.py:8: error: Unsupported operand types for + (Module and "int")
-
 [case testConfigFollowImportsSysPath]
 # cmd: mypy main.py
 [file main.py]
@@ -389,102 +303,6 @@ main.py:6: error: Unsupported operand types for + ("int" and "str")
 main.py:7: error: Module has no attribute "y"
 main.py:8: error: Unsupported operand types for + (Module and "int")
 
-[case testConfigFollowImportsSilent]
-# cmd: mypy main.py
-[file main.py]
-from a import x
-x + ''
-import a
-a.x + ''
-a.y
-a + 0
-[file mypy.ini]
-\[mypy]
-follow_imports = silent
-[file a.py]
-x = 0
-x += ''  # No error reported
-[out]
-main.py:2: error: Unsupported operand types for + ("int" and "str")
-main.py:4: error: Unsupported operand types for + ("int" and "str")
-main.py:5: error: Module has no attribute "y"
-main.py:6: error: Unsupported operand types for + (Module and "int")
-
-[case testConfigFollowImportsSkip]
-# cmd: mypy main.py
-[file main.py]
-from a import x
-reveal_type(x)  # Expect Any
-import a
-reveal_type(a.x)  # Expect Any
-[file mypy.ini]
-\[mypy]
-follow_imports = skip
-[file a.py]
-/  # No error reported
-[out]
-main.py:2: note: Revealed type is "Any"
-main.py:4: note: Revealed type is "Any"
-== Return code: 0
-
-[case testConfigFollowImportsError]
-# cmd: mypy main.py
-[file main.py]
-from a import x  # Error reported here
-reveal_type(x)  # Expect Any
-import a
-reveal_type(a.x)  # Expect Any
-[file mypy.ini]
-\[mypy]
-follow_imports = error
-[file a.py]
-/  # No error reported
-[out]
-main.py:1: error: Import of "a" ignored
-main.py:1: note: (Using --follow-imports=error, module not passed on command line)
-main.py:2: note: Revealed type is "Any"
-main.py:4: note: Revealed type is "Any"
-
-[case testConfigFollowImportsSelective]
-# cmd: mypy main.py
-[file mypy.ini]
-\[mypy]
-\[mypy-normal]
-follow_imports = normal
-\[mypy-silent]
-follow_imports = silent
-\[mypy-skip]
-follow_imports = skip
-\[mypy-error]
-follow_imports = error
-[file main.py]
-import normal
-import silent
-import skip
-import error
-reveal_type(normal.x)
-reveal_type(silent.x)
-reveal_type(skip)
-reveal_type(error)
-[file normal.py]
-x = 0
-x += ''
-[file silent.py]
-x = 0
-x += ''
-[file skip.py]
-bla bla
-[file error.py]
-bla bla
-[out]
-normal.py:2: error: Unsupported operand types for + ("int" and "str")
-main.py:4: error: Import of "error" ignored
-main.py:4: note: (Using --follow-imports=error, module not passed on command line)
-main.py:5: note: Revealed type is "builtins.int"
-main.py:6: note: Revealed type is "builtins.int"
-main.py:7: note: Revealed type is "Any"
-main.py:8: note: Revealed type is "Any"
-
 [case testConfigFollowImportsInvalid]
 # cmd: mypy main.py
 [file mypy.ini]
@@ -493,31 +311,6 @@ follow_imports =True
 [file main.py]
 [out]
 mypy.ini: [mypy]: follow_imports: invalid choice 'True' (choose from 'normal', 'silent', 'skip', 'error')
-== Return code: 0
-
-[case testConfigSilentMissingImportsOff]
-# cmd: mypy main.py
-[file main.py]
-import missing  # Expect error here
-reveal_type(missing.x)  # Expect Any
-[file mypy.ini]
-\[mypy]
-ignore_missing_imports = False
-[out]
-main.py:1: error: Cannot find implementation or library stub for module named "missing"
-main.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-main.py:2: note: Revealed type is "Any"
-
-[case testConfigSilentMissingImportsOn]
-# cmd: mypy main.py
-[file main.py]
-import missing  # No error here
-reveal_type(missing.x)  # Expect Any
-[file mypy.ini]
-\[mypy]
-ignore_missing_imports = True
-[out]
-main.py:2: note: Revealed type is "Any"
 == Return code: 0
 
 [case testFailedImportOnWrongCWD]
@@ -683,21 +476,10 @@ int_pow.py:11: note: Revealed type is "Any"
 python_version = 3.8
 \[mypy-m]
 disallow_any_generics = True
-
 [file m.py]
-s = tuple([1, 2, 3])  # no error
-
-def f(t: tuple) -> None: pass
-def g() -> list: pass
-def h(s: dict) -> None: pass
-def i(s: set) -> None: pass
 def j(s: frozenset) -> None: pass
 [out]
-m.py:3: error: Implicit generic "Any". Use "typing.Tuple" and specify generic parameters
-m.py:4: error: Implicit generic "Any". Use "typing.List" and specify generic parameters
-m.py:5: error: Implicit generic "Any". Use "typing.Dict" and specify generic parameters
-m.py:6: error: Implicit generic "Any". Use "typing.Set" and specify generic parameters
-m.py:7: error: Implicit generic "Any". Use "typing.FrozenSet" and specify generic parameters
+m.py:1: error: Implicit generic "Any". Use "typing.FrozenSet" and specify generic parameters
 
 [case testDisallowAnyGenericsTypingCollections]
 # cmd: mypy m.py
@@ -705,21 +487,11 @@ m.py:7: error: Implicit generic "Any". Use "typing.FrozenSet" and specify generi
 \[mypy]
 \[mypy-m]
 disallow_any_generics = True
-
 [file m.py]
-from typing import Tuple, List, Dict, Set, FrozenSet
-
-def f(t: Tuple) -> None: pass
-def g() -> List: pass
-def h(s: Dict) -> None: pass
-def i(s: Set) -> None: pass
+from typing import FrozenSet
 def j(s: FrozenSet) -> None: pass
 [out]
-m.py:3: error: Missing type parameters for generic type "Tuple"
-m.py:4: error: Missing type parameters for generic type "List"
-m.py:5: error: Missing type parameters for generic type "Dict"
-m.py:6: error: Missing type parameters for generic type "Set"
-m.py:7: error: Missing type parameters for generic type "FrozenSet"
+m.py:2: error: Missing type parameters for generic type "FrozenSet"
 
 [case testSectionInheritance]
 # cmd: mypy a
@@ -756,44 +528,12 @@ ignore_errors = False
 a/b/c/d/e/__init__.py:2: error: Missing type parameters for generic type "List"
 a/b/c/d/e/__init__.py:3: error: Argument 1 to "g" has incompatible type "None"; expected "List[Any]"
 
-[case testDisallowUntypedDefsAndGenerics]
-# cmd: mypy a.py
-[file mypy.ini]
-\[mypy]
-disallow_untyped_defs = True
-disallow_any_generics = True
-[file a.py]
-def get_tasks(self):
-    return 'whatever'
-[out]
-a.py:1: error: Function is missing a return type annotation
-
 [case testMissingFile]
 # cmd: mypy nope.py
 [out]
 mypy: can't read file 'nope.py': No such file or directory
 == Return code: 2
 --'
-
-[case testParseError]
-# cmd: mypy a.py
-[file a.py]
-def foo(
-[out]
-a.py:1: error: unexpected EOF while parsing
-== Return code: 2
-[out version>=3.10]
-a.py:1: error: '(' was never closed
-== Return code: 2
-
-[case testParseErrorAnnots]
-# cmd: mypy a.py
-[file a.py]
-def foo(x):
-    # type: (str, int) -> None
-    return
-[out]
-a.py:1: error: Type signature has too many arguments
 
 [case testModulesAndPackages]
 # cmd: mypy --package p.a --package p.b --module c
@@ -1470,15 +1210,6 @@ Failed to find builtin module mypy_extensions, perhaps typeshed is broken?
 pass
 [out]
 Warning: --new-type-inference flag is deprecated; new type inference algorithm is already enabled by default
-== Return code: 0
-
-[case testNotesOnlyResultInExitSuccess]
-# cmd: mypy a.py
-[file a.py]
-def f():
-    x: int = "no"
-[out]
-a.py:2: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs
 == Return code: 0
 
 [case testCustomTypeshedDirFilePassedExplicitly]

--- a/test-data/unit/parse-errors.test
+++ b/test-data/unit/parse-errors.test
@@ -151,6 +151,13 @@ x = 0 # type: A B #comment #7
 [out]
 file:2: error: Syntax error in type comment "A B"
 
+[case testMissingBracket]
+def foo(
+[out]
+file:1: error: unexpected EOF while parsing
+[out version>=3.10]
+file:1: error: '(' was never closed
+
 [case testInvalidSignatureInComment1]
 def f(): # type: x
   pass


### PR DESCRIPTION
Relates #5966.

Below is the info what happened with the concrete test from `cmdline.test`:

1. `testErrorContextConfig` => check-flags.test (`testShowErrorContextFunction`) [duplicate]
2. `testNoConfigFile` => check-flags.test (`testNoConfigFile`) [move]
3. `testPerFileConfigSection` => check-flags.test (`testPerFileUntypedDefs`) [move]
4. `testIgnoreErrorsConfig` => check-flags.test (`testPerFileIgnoreErrors`) [move]
5. `testConfigFollowImportsNormal` => check-flags.test (`testFollowImportsNormal`) [move + modified]
6. `testConfigFollowImportsSilent` => check-flags (`testFollowImportsSilent`) [move + modified]
7. `testConfigFollowImportsSkip` => check-flags (`testFollowImportsSkip`) [move + modified]
8. `testConfigFollowImportsError` => check-flags.test (`testFollowImportsError`) [move + modified]
9. `testConfigFollowImportsSelective` => check-flags.test (`testFollowImportsSelective`) [move]
10. `testConfigSilentMissingImportsOff` => check-flags.test (`testSilentMissingImportsOff`) [move]
11. `testConfigSilentMissingImportsOn` => check-flags.test (`testSilentMissingImportsOn`) [move]
12. `testDisallowAnyGenericsBuiltinCollectionsPre39` => check-flags.test (`testDisallowAnyGenericsBuiltinTuplePre39`, `testDisallowAnyGenericsBuiltinListPre39`, `testDisallowAnyGenericsBuiltinSetPre39`, `testDisallowAnyGenericsBuiltinDictPre39`) [split]
13. `testDisallowAnyGenericsTypingCollections` => check-flags.test (`testDisallowAnyGenericsTupleWithNoTypeParamsGeneric`, `testDisallowAnyGenericsPlainList`, `testDisallowAnyGenericsPlainDict`, `testDisallowAnyGenericsPlainSet`) [split]
14. `testDisallowUntypedDefsAndGeneric` => check-flags.test (`testDisallowUntypedDefsAndGeneric`) [move]
15. `testParseError` => parse-errors.test (`testMissingBracket`) [move]
16. `testParseErrorAnnots` => check-fastparse.test (`testFasterParseTooManyArgumentsAnnotation`) [duplicate]
17. `testNotesOnlyResultInExitSuccess` => check-flags.test (`testNotesOnlyResultInExitSuccess`) [move]

Let's compare test execution time. I've run `pytest -n 4 mypy/test/testcmdline.py` 3 times on my machine and calculated the average time.
- Before: 130 tests, 1m 02s
- After: 115 tests, 0m 55s

Also, if it's possible to use fixture `FrozenSet` in `check-flags.test`, we'd be able to totally split items 12 and 13 from the above list.

And `testMissingBracket` is skipped by pytest in the `parse-errors.test`-file, but, probably, this file is the best variant for it (not sure about it).
