### PR TITLE
Improve match statement union narrowing/inference

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -244,6 +244,22 @@ class PatternChecker(PatternVisitor[PatternType]):
         # get inner types of original type
         #
         unpack_index = None
+
+        if isinstance(current_type, UnionType):
+            captures = {}
+            items = []
+            for t in current_type.items:
+                typ, _, capture = self.accept(o, t)
+                if not isinstance(typ, UninhabitedType):
+                    items.append(typ)
+                    captures.update(capture)
+            if len(items) == 0:
+                typ = UninhabitedType()
+            elif len(items) == 1:
+                typ = items[0]
+            else:
+                typ = UnionType(items=items)
+            return PatternType(type=typ, rest_type=current_type, captures=captures)
         if isinstance(current_type, TupleType):
             inner_types = current_type.items
             unpack_index = find_unpack_in_list(inner_types)

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1777,12 +1777,11 @@ match foo:
 [case testMatchUnionTwoTuplesNoCrash]
 var: tuple[int, int] | tuple[str, str]
 
-# TODO: we can infer better here.
 match var:
     case (42, a):
-        reveal_type(a)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+        reveal_type(a)  # N: Revealed type is "builtins.int"
     case ("yes", b):
-        reveal_type(b)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+        reveal_type(b)  # N: Revealed type is "builtins.str"
 [builtins fixtures/tuple.pyi]
 
 [case testMatchNamedAndKeywordsAreTheSame]


### PR DESCRIPTION
### This PR improves inference/narrowing support for union types in match statements.

Fixes #17549


Before:
```py
var: tuple[int, int] | tuple[str, str]

# TODO: we can infer better here.
match var:
    case (42, a):
        reveal_type(a)  # N: Revealed type is "Union[builtins.int, builtins.str]"
    case ("yes", b):
        reveal_type(b)  # N: Revealed type is "Union[builtins.int, builtins.str]"
```
After:
```py
var: tuple[int, int] | tuple[str, str]

match var:
    case (42, a):
        reveal_type(a)  # N: Revealed type is "builtins.int"
    case ("yes", b):
        reveal_type(b)  # N: Revealed type is "builtins.str"
```


