### PR TITLE
Fix crash on unimported `Any` with `Required`/`NotRequired`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -198,6 +198,7 @@ from mypy.types import (
     Overloaded,
     PartialType,
     ProperType,
+    RequiredType,
     TupleType,
     Type,
     TypeAliasType,
@@ -2945,7 +2946,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     "A type on this line", AnyType(TypeOfAny.special_form), s
                 )
             else:
-                self.msg.unimported_type_becomes_any("Type of variable", s.type, s)
+                self.msg.unimported_type_becomes_any(
+                    "Type of variable",
+                    s.type.item if isinstance(s.type, RequiredType) else s.type,
+                    s,
+                )
         check_for_explicit_any(s.type, self.options, self.is_typeshed_stub, self.msg, context=s)
 
         if len(s.lvalues) > 1:

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -48,6 +48,7 @@ from mypy.types import (
     CallableType,
     FunctionLike,
     Instance,
+    RequiredType,
     TupleType,
     Type,
     TypeOfAny,
@@ -205,7 +206,7 @@ class StatisticsVisitor(TraverserVisitor):
         if o.type:
             # If there is an explicit type, don't visit the l.h.s. as an expression
             # to avoid double-counting and mishandling special forms.
-            self.type(o.type)
+            self.type(o.type.item if isinstance(o.type, RequiredType) else o.type)
             o.rvalue.accept(self)
             return
         elif self.inferred and not self.all_nodes:

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2394,6 +2394,14 @@ class ForceDeferredEval: pass
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictRequiredUnimportedAny]
+# flags: --disallow-any-unimported
+from typing import NotRequired, TypedDict
+from nonexistent import Foo  # type: ignore[import-not-found]
+class Bar(TypedDict):
+    foo: NotRequired[Foo]  # E: Type of variable becomes "Any" due to an unfollowed import
+[typing fixtures/typing-typeddict.pyi]
+
 -- Required[]
 
 [case testDoesRecognizeRequiredInTypedDictWithClass]


### PR DESCRIPTION
- Fixes #17604.
- Fixes #17608.

(To reproduce the crash without mypyc, replace `cast(ProperType, typ)` with an assertion in `get_proper_type`.)