### PR TITLE
Fix `stubgen --no-analysis/--parse-only` docs

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1772,7 +1772,7 @@ def parse_options(args: list[str]) -> Options:
         action="store_true",
         help="don't perform semantic analysis of sources, just parse them "
         "(only applies to Python modules, might affect quality of stubs. "
-        "Not compatible with --inspect)",
+        "Not compatible with --inspect-mode)",
     )
     parser.add_argument(
         "--inspect-mode",


### PR DESCRIPTION
The option is called `--inspect-mode`, not `--inspect`


It used to be:

```
» stubgen --help
usage: stubgen [-h] [more options, see -h]
                     [-m MODULE] [-p PACKAGE] [files ...]

Generate draft stubs for modules. Stubs are generated in directory ./out, to avoid
overriding files with manual changes. This directory is assumed to exist.

positional arguments:
  files                 generate stubs for given files or directories

options:
  --no-analysis, --parse-only
                        don't perform semantic analysis of sources, just parse them (only
                        applies to Python modules, might affect quality of stubs. Not
                        compatible with --inspect)
  --inspect-mode        import and inspect modules instead of parsing source code.This is
                        the default behavior for c modules and pyc-only packages, but it
                        is also useful for pure python modules with dynamically generated
                        members.
```