### PR TITLE
Revert "Fix `RawExpressionType.accept` crash with `--cache-fine-grained`"

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2705,8 +2705,6 @@ class RawExpressionType(ProperType):
         return self.base_type_name.replace("builtins.", "")
 
     def accept(self, visitor: TypeVisitor[T]) -> T:
-        if self.node is not None:
-            return self.node.accept(visitor)
         assert isinstance(visitor, SyntheticTypeVisitor)
         ret: T = visitor.visit_raw_expression_type(self)
         return ret

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1442,18 +1442,6 @@ reveal_type(x) # N: Revealed type is "TypedDict('__main__.X', {'a': TypedDict('_
 reveal_type(x['a']['b']) # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
 
-[case testTypedDictForwardReferenceCacheFineGrained]
-# flags: --cache-fine-grained
-from mypy_extensions import TypedDict
-class A(TypedDict):
-    b: "B"
-class B(TypedDict):
-    c: "C"
-class C(TypedDict):
-    d: "D"
-class D:
-    pass
-
 [case testSelfRecursiveTypedDictInheriting]
 from mypy_extensions import TypedDict
 


### PR DESCRIPTION
Reverts python/mypy#17588