### PR TITLE
Fix stub generation false reporting

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -180,6 +180,16 @@ class DocStringParser:
 
     def add_token(self, token: tokenize.TokenInfo) -> None:
         """Process next token from the token stream."""
+
+        if (
+            self.state[-1] == STATE_ARGUMENT_TYPE
+            and token.type != tokenize.NAME
+            and len(self.accumulator) == 0
+        ):
+            # the next token after : must be a name
+            self.reset()
+            return
+
         if (
             token.type == tokenize.NAME
             and token.string == self.function_name
@@ -282,8 +292,13 @@ class DocStringParser:
             self.accumulator = ""
 
         elif token.type == tokenize.OP and token.string == "->" and self.state[-1] == STATE_INIT:
+            if len(self.accumulator) == 0:
+                self.state.append(STATE_RETURN_VALUE)
+            else:
+                # ) is not directly followed by ->
+                self.reset()
+                return
             self.accumulator = ""
-            self.state.append(STATE_RETURN_VALUE)
 
         # ENDMAKER is necessary for python 3.4 and 3.5.
         elif token.type in (tokenize.NEWLINE, tokenize.ENDMARKER) and self.state[-1] in (
@@ -306,6 +321,14 @@ class DocStringParser:
             self.args = []
             self.ret_type = "Any"
             # Leave state as INIT.
+        elif (
+            token.type == tokenize.NAME
+            and self.state[-1] == STATE_ARGUMENT_LIST
+            and len(self.accumulator) != 0
+        ):
+            # not the first name in a row
+            self.reset()
+            return
         else:
             self.accumulator += token.string
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -398,6 +398,85 @@ class StubgenUtilSuite(unittest.TestCase):
             None,
         )
 
+    def test_infer_sig_from_docstring_invalid_signature(self) -> None:
+
+        assert_equal(infer_sig_from_docstring("\nfunc() --> None", "func"), [])
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(name1 name2) -> None", "func"), []
+        )
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(name1, name2 name3) -> None", "func"), []
+        )
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(name2, name3) -> None, None", "func"),
+            [],
+        )
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(invalid::name) -> None", "func"),
+            [],
+        )
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(invalid: [type]) -> None", "func"),
+            [],
+        )
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(invalid: (type)) -> None", "func"),
+            [],
+        )
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(invalid: -type) -> None", "func"),
+            [],
+        )
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(invalid<name) -> None", "func"),
+            [],
+        )
+
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(cpp::type name) -> None", "func"),
+            [],
+        )
+        assert_equal(
+            infer_sig_from_docstring("\nfunc(name) -> cpp::type", "func"),
+            [],
+        )
+        assert_equal(
+            infer_sig_from_docstring("\nvoid func(int name) {", "func"),
+            [],
+        )
+        assert_equal(
+            infer_sig_from_docstring("\nvoid func(std::vector<int> name)", "func"),
+            [],
+        )
+
+    def test_infer_sig_from_docstring_deeply_nested_types(self) -> None:
+        assert_equal(
+            infer_sig_from_docstring(
+                "\nfunc(name: dict[str, dict[str, list[tuple[int, float]]]]) -> None",
+                "func",
+            ),
+            [
+                FunctionSig(
+                    name="func",
+                    args=[
+                        ArgSig(
+                            name="name",
+                            type="dict[str,dict[str,list[tuple[int,float]]]]",
+                        )
+                    ],
+                    ret_type="None",
+                )
+            ],
+        )
+
     def test_infer_arg_sig_from_anon_docstring(self) -> None:
         assert_equal(
             infer_arg_sig_from_anon_docstring("(*args, **kwargs)"),


### PR DESCRIPTION
A number of false function signatures were being detected by the `DocStringParser`. This PR fixes them that issue. The main problem I was getting was because my doc strings would have both the python and c++ signature, and the stub generator would grab parts from the c++ signature.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
