### PR TITLE
Allow deeper recursion in mypy daemon, better error reporting

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -16,10 +16,10 @@ import time
 import traceback
 from typing import Any, Callable, Mapping, NoReturn
 
-from mypy.main import RECURSION_LIMIT
 from mypy.dmypy_os import alive, kill
 from mypy.dmypy_util import DEFAULT_STATUS_FILE, receive, send
 from mypy.ipc import IPCClient, IPCException
+from mypy.main import RECURSION_LIMIT
 from mypy.util import check_python_version, get_terminal_width, should_force_color
 from mypy.version import __version__
 

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -16,6 +16,7 @@ import time
 import traceback
 from typing import Any, Callable, Mapping, NoReturn
 
+from mypy.main import RECURSION_LIMIT
 from mypy.dmypy_os import alive, kill
 from mypy.dmypy_util import DEFAULT_STATUS_FILE, receive, send
 from mypy.ipc import IPCClient, IPCException
@@ -269,7 +270,7 @@ def main(argv: list[str]) -> None:
     check_python_version("dmypy")
 
     # set recursion limit consistent with mypy/main.py
-    sys.setrecursionlimit(2**14)
+    sys.setrecursionlimit(RECURSION_LIMIT)
 
     args = parser.parse_args(argv)
     if not args.action:

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -267,6 +267,10 @@ class BadStatus(Exception):
 def main(argv: list[str]) -> None:
     """The code is top-down."""
     check_python_version("dmypy")
+
+    # set recursion limit consistent with mypy/main.py
+    sys.setrecursionlimit(2**14)
+
     args = parser.parse_args(argv)
     if not args.action:
         parser.print_usage()

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -441,9 +441,9 @@ class ASTConverter:
                 return expr
 
             else:
-              # re-raise original recursion error if it *can* be unparsed,
-              # maybe this is some other issue that shouldn't be silenced/misdirected
-              raise e
+                # re-raise original recursion error if it *can* be unparsed,
+                # maybe this is some other issue that shouldn't be silenced/misdirected
+                raise e
 
     def set_line(self, node: N, n: AstNode) -> N:
         node.line = n.lineno

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -31,6 +31,7 @@ orig_stat: Final = os.stat
 MEM_PROFILE: Final = False  # If True, dump memory profile
 RECURSION_LIMIT: Final = 2**14
 
+
 def stat_proxy(path: str) -> os.stat_result:
     try:
         st = orig_stat(path)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -29,7 +29,7 @@ from mypy.version import __version__
 
 orig_stat: Final = os.stat
 MEM_PROFILE: Final = False  # If True, dump memory profile
-
+RECURSION_LIMIT: Final = 2**14
 
 def stat_proxy(path: str) -> os.stat_result:
     try:
@@ -63,7 +63,7 @@ def main(
     util.check_python_version("mypy")
     t0 = time.time()
     # To log stat() calls: os.stat = stat_proxy
-    sys.setrecursionlimit(2**14)
+    sys.setrecursionlimit(RECURSION_LIMIT)
     if args is None:
         args = sys.argv[1:]
 


### PR DESCRIPTION
Fixes #17706 

Handles recursion error during parse of too complex expressions, differentiates from internal recursion errors by attempting to unparse the ast. If builtin ast.unparse fails, then the error is ignored. Otherwise, re-raises.
