### PR TITLE
Fix another crash scenario on recursive tuple types

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3629,10 +3629,7 @@ def extend_args_for_prefix_and_suffix(
 
 
 def flatten_nested_unions(
-    types: Sequence[Type],
-    *,
-    handle_type_alias_type: bool = True,
-    handle_recursive: bool = True,
+    types: Sequence[Type], *, handle_type_alias_type: bool = True, handle_recursive: bool = True
 ) -> list[Type]:
     """Flatten nested unions in a type list."""
     if not isinstance(types, list):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3629,7 +3629,10 @@ def extend_args_for_prefix_and_suffix(
 
 
 def flatten_nested_unions(
-    types: Sequence[Type], handle_type_alias_type: bool = True
+    types: Sequence[Type],
+    *,
+    handle_type_alias_type: bool = True,
+    handle_recursive: bool = True,
 ) -> list[Type]:
     """Flatten nested unions in a type list."""
     if not isinstance(types, list):
@@ -3643,7 +3646,13 @@ def flatten_nested_unions(
 
     flat_items: list[Type] = []
     for t in typelist:
-        tp = get_proper_type(t) if handle_type_alias_type else t
+        if handle_type_alias_type:
+            if not handle_recursive and isinstance(t, TypeAliasType) and t.is_recursive:
+                tp: Type = t
+            else:
+                tp = get_proper_type(t)
+        else:
+            tp = t
         if isinstance(tp, ProperType) and isinstance(tp, UnionType):
             flat_items.extend(
                 flatten_nested_unions(tp.items, handle_type_alias_type=handle_type_alias_type)

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -994,3 +994,15 @@ class T2(Tuple[T1, "T4", "T4"]): ...
 class T3(Tuple[str, "T4", "T4"]): ...
 T4 = Union[T2, T3]
 [builtins fixtures/tuple.pyi]
+
+[case testRecursiveTupleFallback5]
+from typing import Protocol, Tuple, Union
+
+class Proto(Protocol):
+    def __len__(self) -> int: ...
+
+A = Union[Proto, Tuple[A]]
+ta: Tuple[A]
+p: Proto
+p = ta
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/17691

This looks quite ad-hoc, but the only clean alternative is to remove the existing recursive types optimization we have in `subtypes.py`. But the best I can get without that optimization is -7% performance penalty (on self-check). So I think it is not worth it, since it is still a corner case.

cc @JukkaL 
