### PR TITLE
[nit] conf.py: annotate the type, instead of ignoring the error

### DIFF
--- a/mypyc/doc/conf.py
+++ b/mypyc/doc/conf.py
@@ -36,7 +36,7 @@ release = mypy_version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []  # type: ignore[var-annotated]
+extensions: list[str] = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
There was a type-ignore here. But we can simply do what mypy is asking us to do; in fact, the comment even already tells us these have to be strings, (like the other arrays).