### PR TITLE
Add missing lines-covered and lines-valid attributes

### DIFF
--- a/mypy/report.py
+++ b/mypy/report.py
@@ -689,6 +689,8 @@ class CoberturaXmlReporter(AbstractReporter):
             self.root_package.covered_lines, self.root_package.total_lines
         )
         self.root.attrib["branch-rate"] = "0"
+        self.root.attrib["lines-covered"] = str(self.root_package.covered_lines)
+        self.root.attrib["lines-valid"] = str(self.root_package.total_lines)
         sources = etree.SubElement(self.root, "sources")
         source_element = etree.SubElement(sources, "source")
         source_element.text = os.getcwd()

--- a/mypy/test/testreports.py
+++ b/mypy/test/testreports.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import tempfile
 import textwrap
 
-from mypy.report import CoberturaPackage, CoberturaXmlReporter, Reports, get_line_rate
+from mypy.report import CoberturaPackage, get_line_rate
 from mypy.test.helpers import Suite, assert_equal
 
 try:

--- a/mypy/test/testreports.py
+++ b/mypy/test/testreports.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import textwrap
 import tempfile
-from mypy.report import CoberturaPackage, get_line_rate, CoberturaXmlReporter, Reports
+import textwrap
+
+from mypy.report import CoberturaPackage, CoberturaXmlReporter, Reports, get_line_rate
 from mypy.test.helpers import Suite, assert_equal
 
 try:
@@ -66,4 +67,3 @@ class CoberturaReportSuite(Suite):
         # Check that the required attributes are present
         assert f'lines-covered="{cobertura_package.covered_lines}"' in xml_str
         assert f'lines-valid="{cobertura_package.total_lines}"' in xml_str
-

--- a/mypy/test/testreports.py
+++ b/mypy/test/testreports.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import textwrap
-
-from mypy.report import CoberturaPackage, get_line_rate, CoberturaXmlReporter
+import tempfile
+from mypy.report import CoberturaPackage, get_line_rate, CoberturaXmlReporter, Reports
 from mypy.test.helpers import Suite, assert_equal
 
 try:
@@ -53,7 +53,10 @@ class CoberturaReportSuite(Suite):
         assert_equal(
             expected_output, etree.tostring(cobertura_package.as_xml(), pretty_print=True)
         )
-        cobertura_reporter = CoberturaXmlReporter(None, ".")
+        with tempfile.TemporaryDirectory() as tempdir:
+            reports = Reports(data_dir=tempdir, report_dirs={"dummy_report": tempdir})
+
+        cobertura_reporter = CoberturaXmlReporter(reports, ".")
         cobertura_reporter.root_package = cobertura_package
         cobertura_reporter.on_finish()
 

--- a/mypy/test/testreports.py
+++ b/mypy/test/testreports.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import textwrap
 
-from mypy.report import CoberturaPackage, get_line_rate
+from mypy.report import CoberturaPackage, get_line_rate, CoberturaXmlReporter
 from mypy.test.helpers import Suite, assert_equal
 
 try:
@@ -53,3 +53,14 @@ class CoberturaReportSuite(Suite):
         assert_equal(
             expected_output, etree.tostring(cobertura_package.as_xml(), pretty_print=True)
         )
+        cobertura_reporter = CoberturaXmlReporter(None, ".")
+        cobertura_reporter.root_package = cobertura_package
+        cobertura_reporter.on_finish()
+
+        # Convert the XML document to a string
+        xml_str = etree.tostring(cobertura_reporter.doc, pretty_print=True).decode("utf-8")
+
+        # Check that the required attributes are present
+        assert f'lines-covered="{cobertura_package.covered_lines}"' in xml_str
+        assert f'lines-valid="{cobertura_package.total_lines}"' in xml_str
+

--- a/mypy/test/testreports.py
+++ b/mypy/test/testreports.py
@@ -54,16 +54,3 @@ class CoberturaReportSuite(Suite):
         assert_equal(
             expected_output, etree.tostring(cobertura_package.as_xml(), pretty_print=True)
         )
-        with tempfile.TemporaryDirectory() as tempdir:
-            reports = Reports(data_dir=tempdir, report_dirs={"dummy_report": tempdir})
-
-        cobertura_reporter = CoberturaXmlReporter(reports, ".")
-        cobertura_reporter.root_package = cobertura_package
-        cobertura_reporter.on_finish()
-
-        # Convert the XML document to a string
-        xml_str = etree.tostring(cobertura_reporter.doc, pretty_print=True).decode("utf-8")
-
-        # Check that the required attributes are present
-        assert f'lines-covered="{cobertura_package.covered_lines}"' in xml_str
-        assert f'lines-valid="{cobertura_package.total_lines}"' in xml_str

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -27,7 +27,7 @@ def bar() -> str:
 def untyped_function():
   return 42
 [outfile build/cobertura.xml]
-<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="0.7500" branch-rate="0">
+<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="0.7500" branch-rate="0" lines-covered="6" lines-valid="8">
   <sources>
     <source>$PWD</source>
   </sources>
@@ -81,7 +81,7 @@ def foo(a: int) -> MyDict:
     return {"a": a}
 md: MyDict = MyDict(**foo(42))
 [outfile build/cobertura.xml]
-<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="1.0000" branch-rate="0">
+<coverage timestamp="$TIMESTAMP" version="$VERSION" line-rate="1.0000" branch-rate="0" lines-covered="6" lines-valid="6">
   <sources>
     <source>$PWD</source>
   </sources>


### PR DESCRIPTION
This PR resolves an issue where the Cobertura XML report generated by MyPy was missing the lines-covered and lines-valid attributes in the <coverage> element.

Changes made:

- Added the lines-covered and lines-valid attributes to the <coverage> element in the Cobertura XML report.
- Updated the CoberturaReportSuite test suite to validate that these attributes are correctly included in the generated XML.

Fixes #17689
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
