### PR TITLE
[PEP 695] Fix crash on invalid type var reference

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6955,6 +6955,7 @@ class SemanticAnalyzer(
             namespace is None
             and self.type
             and not self.is_func_scope()
+            and self.incomplete_type_stack
             and self.incomplete_type_stack[-1]
             and not self.final_iteration
         ):

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1320,6 +1320,14 @@ class P[T](Protocol[T]):  # E: No arguments expected for "Protocol" base class
 class P2[T](Protocol[S]):  # E: No arguments expected for "Protocol" base class
     pass
 
+[case testPEP695CannotUseTypeVarFromOuterClass]
+# mypy: enable-incomplete-feature=NewGenericSyntax
+class ClassG[V]:
+    # This used to crash
+    class ClassD[T: dict[str, V]]:  # E: Name "V" is not defined
+        ...
+[builtins fixtures/dict.pyi]
+
 [case testPEP695MixNewAndOldStyleGenerics]
 # mypy: enable-incomplete-feature=NewGenericSyntax
 from typing import TypeVar


### PR DESCRIPTION
Test case from typing conformance test suite:
https://github.com/python/typing/blob/main/conformance/tests/generics_syntax_declarations.py#L45