### PR TITLE
[PEP 695] Document Python 3.12 type parameter syntax

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -1187,11 +1187,10 @@ Here is the definition of ``Linked`` using the legacy syntax
 Generic type aliases
 ********************
 
-Type aliases can be generic. In this case they can be used in two ways:
-Subscripted aliases are equivalent to original types with substituted type
-variables, so the number of type arguments must match the number of free type variables
-in the generic type alias. Unsubscripted aliases are treated as original types with free
-variables replaced with ``Any``.
+Type aliases can be generic. In this case they can be used in two ways.
+First, subscripted aliases are equivalent to original types with substituted type
+variables. Second, unsubscripted aliases are treated as original types with type
+parameters replaced with ``Any``.
 
 The ``type`` statement introduced in Python 3.12 is used to define generic
 type aliases (it also supports non-generic type aliases):
@@ -1222,7 +1221,10 @@ type aliases (it also supports non-generic type aliases):
     v2: Vec = []           # Same as Iterable[tuple[Any, Any]]
     v3: Vec[int, int] = [] # Error: Invalid alias, too many type arguments!
 
-There is also a legacy syntax that relies on ``TypeVar`` (following
+There is also a legacy syntax that relies on ``TypeVar``.
+Here the number of type arguments must match the number of free type variables
+in the generic type alias definition. A type variables is free if it's not
+a type parameter of a surrounding class or function. Example (following
 :pep:`PEP 484: Type aliases <484#type-aliases>`, Python 3.11 and earlier):
 
 .. code-block:: python
@@ -1231,7 +1233,7 @@ There is also a legacy syntax that relies on ``TypeVar`` (following
 
     S = TypeVar('S')
 
-    TInt = tuple[int, S]
+    TInt = tuple[int, S]  # 1 type parameter, since only S is free
     UInt = Union[S, int]
     CBack = Callable[..., S]
 
@@ -1315,8 +1317,8 @@ Here are examples using the legacy syntax (Python 3.11 and earlier):
     for i, j in NewVec[int]():
         ...
 
-Using type variable bounds or values in generic aliases has the same effect
-as in generic classes/functions.
+Using type variable bounds or value restriction in generic aliases has
+the same effect as in generic classes and functions.
 
 
 Differences between the new and old syntax

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -38,9 +38,10 @@ Python 3.12):
            return not self.items
 
 There are two syntax variants for defining generic classes in Python.
-Python 3.12 introduced a new dedicated syntax for defining generic
-classes (and also functions and type aliases, which we will discuss
-later). The above example used the new syntax. Most examples are
+Python 3.12 introduced a
+`new dedicated syntax <https://docs.python.org/3/whatsnew/3.12.html#pep-695-type-parameter-syntax>`_
+for defining generic classes (and also functions and type aliases, which
+we will discuss later). The above example used the new syntax. Most examples are
 given using both the new and the old (or legacy) syntax variants.
 Unless mentioned otherwise, they work the same -- but the new syntax
 is more readable and more convenient.
@@ -72,7 +73,7 @@ and earlier, but also supported on newer Python versions):
 
     There are currently no plans to deprecate the legacy syntax.
     You can freely mix code using the new and old syntax variants,
-    even within a single file.
+    even within a single file (but *not* within a single class).
 
 The ``Stack`` class can be used to represent a stack of any type:
 ``Stack[int]``, ``Stack[tuple[int, str]]``, etc. You can think of
@@ -310,6 +311,9 @@ inferred by mypy. This is not valid:
 
     first[int]([1, 2])  # Error: can't use [...] with generic function
 
+If you really need this, you can define a generic class with a ``__call__``
+method.
+
 .. _generic-methods-and-generic-self:
 
 Generic methods and generic self
@@ -519,8 +523,8 @@ Let us illustrate this by few simple examples:
     class Triangle(Shape): ...
     class Square(Shape): ...
 
-* Most immutable containers, such as :py:class:`~typing.Sequence` and
-  :py:class:`~typing.FrozenSet` are covariant. :py:data:`~typing.Union` is
+* Most immutable container types, such as :py:class:`~collections.abc.Sequence`
+  and :py:class:`~frozenset` are covariant. :py:data:`~typing.Union` is
   also covariant in all variables: ``Union[Triangle, int]`` is
   a subtype of ``Union[Shape, int]``.
 

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -316,7 +316,7 @@ Generic methods and generic self
 ********************************
 
 You can also define generic methods. In
-particular, the ``self`` argument may also be generic, allowing a
+particular, the ``self`` parameter may also be generic, allowing a
 method to return the most precise type known at the point of access.
 In this way, for example, you can type check a chain of setter
 methods (Python 3.12 syntax):
@@ -347,7 +347,7 @@ checked properly, since the return type of ``set_scale`` would be
 
 When using the legacy syntax, just use a type variable in the
 method signature that is different from class type parameters (if any
-are defined). Here is the abaove example using the legacy
+are defined). Here is the above example using the legacy
 syntax (3.11 and earlier):
 
 .. code-block:: python
@@ -584,7 +584,7 @@ Let us illustrate this by few simple examples:
   Another example of invariant type is ``dict``. Most mutable containers
   are invariant.
 
-When using the Python 3.12 syntax for generics, mypy will be automatically
+When using the Python 3.12 syntax for generics, mypy will automatically
 infer the most flexible variance for each class type variable. Here
 ``Box`` will be inferred as covariant:
 
@@ -1028,13 +1028,13 @@ achieved by combining with :py:func:`@overload <typing.overload>` (Python 3.12 s
 
     # Bare decorator usage
     @overload
-    def atomic[F: Callable[..., Any]](__func: F) -> F: ...
+    def atomic[F: Callable[..., Any]](func: F, /) -> F: ...
     # Decorator with arguments
     @overload
     def atomic[F: Callable[..., Any]](*, savepoint: bool = True) -> Callable[[F], F]: ...
 
     # Implementation
-    def atomic(__func: Callable[..., Any] | None = None, *, savepoint: bool = True):
+    def atomic(func: Callable[..., Any] | None = None, /, *, savepoint: bool = True):
         def decorator(func: Callable[..., Any]):
             ...  # Code goes here
         if __func is not None:
@@ -1060,13 +1060,13 @@ Here is the decorator from the example using the legacy syntax
 
     # Bare decorator usage
     @overload
-    def atomic(__func: F) -> F: ...
+    def atomic(func: F, /) -> F: ...
     # Decorator with arguments
     @overload
     def atomic(*, savepoint: bool = True) -> Callable[[F], F]: ...
 
     # Implementation
-    def atomic(__func: Optional[Callable[..., Any]] = None, *, savepoint: bool = True):
+    def atomic(func: Optional[Callable[..., Any]] = None, /, *, savepoint: bool = True):
         ...  # Same as above
 
 Generic protocols
@@ -1337,7 +1337,8 @@ the obvious syntactic differences:
  * When using the new syntax, the variance of class type variables is always
    inferred.
  * Type aliases defined using the new syntax can contain forward references
-   and recursive references without using string literal escaping.
+   and recursive references without using string literal escaping. The
+   same is true for the bounds and constraints of type variables.
  * The new syntax lets you define a generic alias where the definition doesn't
    contain a reference to a type parameter. This is occasionally useful, at
    least when conditionally defining type aliases.

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -2,7 +2,7 @@ Generics
 ========
 
 This section explains how you can define your own generic classes that take
-one or more type parameters, similar to built-in types such as ``list[X]``.
+one or more type arguments, similar to built-in types such as ``list[T]``.
 User-defined generics are a moderately advanced feature and you can get far
 without ever using them -- feel free to skip this section and come back later.
 
@@ -12,27 +12,14 @@ Defining generic classes
 ************************
 
 The built-in collection classes are generic classes. Generic types
-have one or more type parameters, which can be arbitrary types. For
-example, ``dict[int, str]`` has the type parameters ``int`` and
-``str``, and ``list[int]`` has a type parameter ``int``.
+accept one or more type arguments within ``[...]``, which can be
+arbitrary types. For example, the type ``dict[int, str]`` has the
+type arguments ``int`` and ``str``, and ``list[int]`` has the type
+argument ``int``.
 
-Programs can also define new generic classes. There are two syntax
-variants for defining generic classes in Python.
-Python 3.12 introduced a new dedicated syntax for defining generic
-classes (and also functions and type aliases, which we will discuss
-later). Most examples are given using both the new and
-the old (or legacy) syntax variants. Unless explicitly mentioned otherwise,
-they behave identically -- but the new syntax is more readable and
-convenient to use.
-
-.. note::
-
-    There are no plans to deprecate the legacy syntax in the future.
-    You can freely mix code using the new and old syntax variants,
-    even within a single file.
-
-Here is a very simple generic class that represents a stack
-(Python 3.12 syntax):
+Programs can also define new generic classes. Here is a very simple
+generic class that represents a stack (using the syntax introduced in
+Python 3.12):
 
 .. code-block:: python
 
@@ -50,6 +37,14 @@ Here is a very simple generic class that represents a stack
        def empty(self) -> bool:
            return not self.items
 
+There are two syntax variants for defining generic classes in Python.
+Python 3.12 introduced a new dedicated syntax for defining generic
+classes (and also functions and type aliases, which we will discuss
+later). The above example used the new syntax. Most examples are
+given using both the new and the old (or legacy) syntax variants.
+Unless mentioned otherwise, they work the same -- but the new syntax
+is more readable and more convenient.
+
 Here is the same example using the old syntax (required for Python 3.11
 and earlier, but also supported on newer Python versions):
 
@@ -57,7 +52,7 @@ and earlier, but also supported on newer Python versions):
 
    from typing import TypeVar, Generic
 
-   T = TypeVar('T')
+   T = TypeVar('T')  # Define type variable "T"
 
    class Stack(Generic[T]):
        def __init__(self) -> None:
@@ -73,8 +68,16 @@ and earlier, but also supported on newer Python versions):
        def empty(self) -> bool:
            return not self.items
 
+.. note::
+
+    There are currently no plans to deprecate the legacy syntax.
+    You can freely mix code using the new and old syntax variants,
+    even within a single file.
+
 The ``Stack`` class can be used to represent a stack of any type:
-``Stack[int]``, ``Stack[tuple[int, str]]``, etc.
+``Stack[int]``, ``Stack[tuple[int, str]]``, etc. You can think of
+``Stack[int]`` as referring to the definition of ``Stack`` above,
+but with all instances of ``T`` replaced with ``int``.
 
 Using ``Stack`` is similar to built-in container types:
 
@@ -87,6 +90,9 @@ Using ``Stack`` is similar to built-in container types:
 
    # error: Argument 1 to "push" of "Stack" has incompatible type "str"; expected "int"
    stack.push('x')
+
+   stack2: Stack[str] = Stack()
+   stack2.append('x')
 
 Construction of instances of generic types is type checked (Python 3.12 syntax):
 
@@ -102,7 +108,7 @@ Construction of instances of generic types is type checked (Python 3.12 syntax):
    # error: Argument 1 to "Box" has incompatible type "str"; expected "int"
    Box[int]('some string')
 
-Here is the class definition using the legacy syntax (Python 3.11 and earlier):
+Here is the definition of ``Box`` using the legacy syntax (Python 3.11 and earlier):
 
 .. code-block:: python
 
@@ -113,6 +119,17 @@ Here is the class definition using the legacy syntax (Python 3.11 and earlier):
    class Box(Generic[T]):
        def __init__(self, content: T) -> None:
            self.content = content
+
+.. note::
+
+    Before moving on, let's clarify some terminology.
+    The name ``T`` in ``class Stack[T]`` or ``class Stack(Generic[T])``
+    declares a *type parameter* ``T`` (of class ``Stack``).
+    ``T`` is also called a *type variable*, especially in a type annotation,
+    such as in the signature of ``push`` above.
+    When the type ``Stack[...]`` is used in a type annotation, the type
+    within square brackets is called a *type argument*.
+    This is similar to the distinction between function parameters and arguments.
 
 .. _generic-subclasses:
 
@@ -195,15 +212,15 @@ from bases if there are
 other base classes that include type variables, such as ``Mapping[KT, VT]``
 in the above example. If you include ``Generic[...]`` in bases, then
 it should list all type variables present in other bases (or more,
-if needed). The order of type variables is defined by the following
+if needed). The order of type parameters is defined by the following
 rules:
 
-* If ``Generic[...]`` is present, then the order of variables is
+* If ``Generic[...]`` is present, then the order of parameters is
   always determined by their order in ``Generic[...]``.
-* If there are no ``Generic[...]`` in bases, then all type variables
+* If there are no ``Generic[...]`` in bases, then all type parameters
   are collected in the lexicographic order (i.e. by first appearance).
 
-For example:
+Example:
 
 .. code-block:: python
 
@@ -223,14 +240,15 @@ For example:
    y: Second[int, str, Any]  # Here T is Any, S is int, and U is str
 
 When using the Python 3.12 syntax, all type parameters must always be
-explicitly defined, and the ``Generic[...]`` base class is never used.
+explicitly defined immediately after the class name within ``[...]``, and the
+``Generic[...]`` base class is never used.
 
 .. _generic-functions:
 
 Generic functions
 *****************
 
-Type variables can be used to define generic functions (Python 3.12 syntax):
+Functions can also be generic, i.e. they can have type parameters (Python 3.12 syntax):
 
 .. code-block:: python
 
@@ -252,25 +270,25 @@ Here is the same example using the legacy syntax (Python 3.11 and earlier):
    def first(seq: Sequence[T]) -> T:
        return seq[0]
 
-As with generic classes, the type variable can be replaced with any
-type. That means ``first`` can be used with any sequence type, and the
-return type is derived from the sequence item type. For example:
+As with generic classes, the type parameter ``T`` can be replaced with any
+type. That means ``first`` can be passed an argument with any sequence type,
+and the return type is derived from the sequence item type. Example:
 
 .. code-block:: python
 
    reveal_type(first([1, 2, 3]))   # Revealed type is "builtins.int"
-   reveal_type(first(['a', 'b']))  # Revealed type is "builtins.str"
+   reveal_type(first(('a', 'b')))  # Revealed type is "builtins.str"
 
 When using the legacy syntax, a single definition of a type variable
 (such as ``T`` above) can be used in multiple generic functions or
 classes. In this example we use the same type variable in two generic
-functions:
+functions to declarare type parameters:
 
 .. code-block:: python
 
    from typing import TypeVar, Sequence
 
-   T = TypeVar('T')      # Declare type variable
+   T = TypeVar('T')      # Define type variable
 
    def first(seq: Sequence[T]) -> T:
        return seq[0]
@@ -284,13 +302,20 @@ an equivalent way of sharing type parameter definitions.
 A variable cannot have a type variable in its type unless the type
 variable is bound in a containing generic class or function.
 
+When calling a generic function, you can't explicitly pass the values of
+type parameters as type arguments. The values of type parameters are always
+inferred by mypy. This is not valid:
+
+.. code-block:: python
+
+    first[int]([1, 2])  # Error: can't use [...] with generic function
+
 .. _generic-methods-and-generic-self:
 
 Generic methods and generic self
 ********************************
 
-You can also define generic methods — just use a type variable in the
-method signature that is different from class type variables. In
+You can also define generic methods. In
 particular, the ``self`` argument may also be generic, allowing a
 method to return the most precise type known at the point of access.
 In this way, for example, you can type check a chain of setter
@@ -299,7 +324,7 @@ methods (Python 3.12 syntax):
 .. code-block:: python
 
    class Shape:
-       def set_scale[T](self: T, scale: float) -> T:
+       def set_scale[T: Shape](self: T, scale: float) -> T:
            self.scale = scale
            return self
 
@@ -316,7 +341,14 @@ methods (Python 3.12 syntax):
    circle: Circle = Circle().set_scale(0.5).set_radius(2.7)
    square: Square = Square().set_scale(0.5).set_width(3.2)
 
-Here is the same example using the legacy syntax (3.11 and earlier):
+Without using generic ``self``, the last two lines could not be type
+checked properly, since the return type of ``set_scale`` would be
+``Shape``, which doesn't define ``set_radius`` or ``set_width``.
+
+When using the legacy syntax, just use a type variable in the
+method signature that is different from class type parameters (if any
+are defined). Here is the abaove example using the legacy
+syntax (3.11 and earlier):
 
 .. code-block:: python
 
@@ -342,18 +374,14 @@ Here is the same example using the legacy syntax (3.11 and earlier):
    circle: Circle = Circle().set_scale(0.5).set_radius(2.7)
    square: Square = Square().set_scale(0.5).set_width(3.2)
 
-Without using generic ``self``, the last two lines could not be type
-checked properly, since the return type of ``set_scale`` would be
-``Shape``, which doesn't define ``set_radius`` or ``set_width``.
-
-Other uses are factory methods, such as copy and deserialization.
+Other uses include factory methods, such as copy and deserialization methods.
 For class methods, you can also define generic ``cls``, using ``type[T]``
 or :py:class:`Type[T] <typing.Type>` (Python 3.12 syntax):
 
 .. code-block:: python
 
    class Friend:
-       other: "Friend" = None
+       other: "Friend | None" = None
 
        @classmethod
        def make_pair[T: Friend](cls: type[T]) -> tuple[T, T]:
@@ -372,15 +400,15 @@ Here is the same example using the legacy syntax (3.11 and earlier, though
 
 .. code-block:: python
 
-   from typing import TypeVar, Type
+   from typing import TypeVar
 
    T = TypeVar('T', bound='Friend')
 
    class Friend:
-       other: "Friend" = None
+       other: "Friend | None" = None
 
        @classmethod
-       def make_pair(cls: Type[T]) -> tuple[T, T]:
+       def make_pair(cls: type[T]) -> tuple[T, T]:
            a, b = cls(), cls()
            a.other = b
            b.other = a
@@ -408,7 +436,7 @@ syntax):
 .. code-block:: python
 
    class Base:
-       def compare[T](self: T, other: T) -> bool:
+       def compare[T: Base](self: T, other: T) -> bool:
            return False
 
    class Sub(Base):
@@ -430,12 +458,12 @@ Automatic self types using typing.Self
 
 Since the patterns described above are quite common, mypy supports a
 simpler syntax, introduced in :pep:`673`, to make them easier to use.
-Instead of introducing a type variable and using an explicit annotation
+Instead of introducing a type parameter and using an explicit annotation
 for ``self``, you can import the special type ``typing.Self`` that is
-automatically transformed into a type variable with the current class
-as the upper bound, and you don't need an annotation for ``self`` (or
-``cls`` in class methods). The example from the previous section can
-be made simpler by using ``Self``:
+automatically transformed into a method-level type parameter with the
+current class as the upper bound, and you don't need an annotation for
+``self`` (or ``cls`` in class methods). The example from the previous
+section can be made simpler by using ``Self``:
 
 .. code-block:: python
 
@@ -456,7 +484,7 @@ be made simpler by using ``Self``:
 
    a, b = SuperFriend.make_pair()
 
-This is more compact than using explicit type variables. Also, you can
+This is more compact than using explicit type parameters. Also, you can
 use ``Self`` in attribute annotations in addition to methods.
 
 .. note::

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -597,16 +597,16 @@ infer the most flexible variance for each class type variable. Here
        def get_content(self) -> T:
            return self._content
 
-   def look_into(box: Box[Animal]): ...
+   def look_into(box: Box[Shape]): ...
 
-   my_box = Box(Cat())
+   my_box = Box(Square())
    look_into(my_box)  # OK, but mypy would complain here for an invariant type
 
 Here the underscore prefix for ``_content`` is significant. Without an
 underscore prefix, the class would be invariant, as the attribute would
 be understood as a public, mutable attribute (a single underscore prefix
-has no special significance in other contexts). By declaring the attribute
-as ``Final``, the class could still be made covariant:
+has no special significance for mypy in most other contexts). By declaring
+the attribute as ``Final``, the class could still be made covariant:
 
 .. code-block:: python
 
@@ -637,9 +637,9 @@ contravariant, use type variables defined with special keyword arguments
        def get_content(self) -> T_co:
            return self._content
 
-   def look_into(box: Box[Animal]): ...
+   def look_into(box: Box[Shape]): ...
 
-   my_box = Box(Cat())
+   my_box = Box(Square())
    look_into(my_box)  # OK, but mypy would complain here for an invariant type
 
 .. _type-variable-upper-bound:
@@ -722,9 +722,9 @@ The same thing is also possibly using the legacy syntax (Python 3.11 or earlier)
    def concat(x: AnyStr, y: AnyStr) -> AnyStr:
        return x + y
 
-No matter which syntax you use, this is called a type variable with a value
-restriction. Importantly, this is different from a union type, since combinations
-of ``str`` and ``bytes`` are not accepted:
+No matter which syntax you use, such a type variable is called a type variable
+with a value restriction. Importantly, this is different from a union type,
+since combinations of ``str`` and ``bytes`` are not accepted:
 
 .. code-block:: python
 
@@ -774,16 +774,9 @@ bytes pattern.
 A type variable may not have both a value restriction and an upper bound
 (see :ref:`type-variable-upper-bound`).
 
-Note that if you use the legacy syntax, :py:data:`~typing.AnyStr` as we defined
-it above is predefined in :py:mod:`typing`, and it isn't necessary to define it:
-
-.. code-block:: python
-
-   from typing import AnyStr
-
-   def concat(x: AnyStr, y: AnyStr) -> AnyStr:
-       return x + y
-
+Note that you may come across :py:data:`~typing.AnyStr` imported from
+:py:mod:`typing`. This feature is now deprecated, but it means the same
+as our definition of ``AnyStr`` above.
 
 .. _declaring-decorators:
 
@@ -923,7 +916,7 @@ alter the signature of the input function (Python 3.12 syntax):
 
    from typing import Callable
 
-    # We reuse 'P' in the return type, but replace 'T' with 'str'
+   # We reuse 'P' in the return type, but replace 'T' with 'str'
    def stringify[**P, T](func: Callable[P, T]) -> Callable[P, str]:
        def wrapper(*args: P.args, **kwds: P.kwargs) -> str:
            return str(func(*args, **kwds))
@@ -947,7 +940,7 @@ Here is the above example using the legacy syntax (Python 3.11 and earlier):
    P = ParamSpec('P')
    T = TypeVar('T')
 
-    # We reuse 'P' in the return type, but replace 'T' with 'str'
+   # We reuse 'P' in the return type, but replace 'T' with 'str'
    def stringify(func: Callable[P, T]) -> Callable[P, str]:
        def wrapper(*args: P.args, **kwds: P.kwargs) -> str:
            return str(func(*args, **kwds))
@@ -1027,11 +1020,11 @@ Here is the example using the legacy syntax (Python 3.11 and earlier):
         return 'Hello world'
 
 Sometimes the same decorator supports both bare calls and calls with arguments. This can be
-achieved by combining with :py:func:`@overload <typing.overload>` (Python 3.12):
+achieved by combining with :py:func:`@overload <typing.overload>` (Python 3.12 syntax):
 
 .. code-block:: python
 
-    from typing import Any, Callable, Optional, overload
+    from typing import Any, Callable, overload
 
     # Bare decorator usage
     @overload
@@ -1041,7 +1034,7 @@ achieved by combining with :py:func:`@overload <typing.overload>` (Python 3.12):
     def atomic[F: Callable[..., Any]](*, savepoint: bool = True) -> Callable[[F], F]: ...
 
     # Implementation
-    def atomic(__func: Optional[Callable[..., Any]] = None, *, savepoint: bool = True):
+    def atomic(__func: Callable[..., Any] | None = None, *, savepoint: bool = True):
         def decorator(func: Callable[..., Any]):
             ...  # Code goes here
         if __func is not None:

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -84,7 +84,9 @@ Using ``Stack`` is similar to built-in container types:
    stack = Stack[int]()
    stack.push(2)
    stack.pop()
-   stack.push('x')  # error: Argument 1 to "push" of "Stack" has incompatible type "str"; expected "int"
+
+   # error: Argument 1 to "push" of "Stack" has incompatible type "str"; expected "int"
+   stack.push('x')
 
 Construction of instances of generic types is type checked (Python 3.12 syntax):
 
@@ -96,11 +98,17 @@ Construction of instances of generic types is type checked (Python 3.12 syntax):
 
    Box(1)       # OK, inferred type is Box[int]
    Box[int](1)  # Also OK
-   Box[int]('some string')  # error: Argument 1 to "Box" has incompatible type "str"; expected "int"
+
+   # error: Argument 1 to "Box" has incompatible type "str"; expected "int"
+   Box[int]('some string')
 
 Here is the class definition using the legacy syntax (Python 3.11 and earlier):
 
 .. code-block:: python
+
+   from typing import TypeVar, Generic
+
+   T = TypeVar('T')
 
    class Box(Generic[T]):
        def __init__(self, content: T) -> None:
@@ -222,7 +230,7 @@ explicitly defined, and the ``Generic[...]`` base class is never used.
 Generic functions
 *****************
 
-Type variables can be used to define generic functions (Python 3.12):
+Type variables can be used to define generic functions (Python 3.12 syntax):
 
 .. code-block:: python
 
@@ -270,8 +278,8 @@ functions:
    def last(seq: Sequence[T]) -> T:
        return seq[-1]
 
-Since the Python 3.12 syntax is more concise, it doesn't have an
-equivalent way of sharing type parameter definitions.
+Since the Python 3.12 syntax is more concise, it doesn't need (or have)
+an equivalent way of sharing type parameter definitions.
 
 A variable cannot have a type variable in its type unless the type
 variable is bound in a containing generic class or function.
@@ -646,9 +654,9 @@ above:
 
 .. code-block:: python
 
-   largest_in_absolute_value(-3.5, 2)   # Okay, has type float.
-   largest_in_absolute_value(5+6j, 7)   # Okay, has type complex.
-   largest_in_absolute_value('a', 'b')  # Error: 'str' is not a subtype of SupportsAbs[float].
+   max_by_abs(-3.5, 2)   # Okay, has type float.
+   max_by_abs(5+6j, 7)   # Okay, has type complex.
+   max_by_abs('a', 'b')  # Error: 'str' is not a subtype of SupportsAbs[float].
 
 Type parameters of generic classes may also have upper bounds, which
 restrict the valid values for the type parameter in the same way.

--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -202,11 +202,12 @@ Here is the above example using the legacy syntax (Python 3.11 and earlier):
 
 .. note::
 
-    You have to add an explicit :py:class:`~typing.Mapping` base class
+    You have to add an explicit :py:class:`~collections.abc.Mapping` base class
     if you want mypy to consider a user-defined class as a mapping (and
-    :py:class:`~typing.Sequence` for sequences, etc.). This is because mypy doesn't use
-    *structural subtyping* for these ABCs, unlike simpler protocols
-    like :py:class:`~typing.Iterable`, which use :ref:`structural subtyping <protocol-types>`.
+    :py:class:`~collections.abc.Sequence` for sequences, etc.). This is because
+    mypy doesn't use *structural subtyping* for these ABCs, unlike simpler protocols
+    like :py:class:`~collections.abc.Iterable`, which use
+    :ref:`structural subtyping <protocol-types>`.
 
 When using the legacy syntax, :py:class:`Generic <typing.Generic>` can be omitted
 from bases if there are
@@ -253,7 +254,7 @@ Functions can also be generic, i.e. they can have type parameters (Python 3.12 s
 
 .. code-block:: python
 
-   from typing Sequence
+   from collections.abc import Sequence
 
    # A generic function!
    def first[T](seq: Sequence[T]) -> T:
@@ -570,7 +571,7 @@ Let us illustrate this by few simple examples:
   arbitrary shape (not just triangles), everything still works.
 
 * ``list`` is an invariant generic type. Naively, one would think
-  that it is covariant, like :py:class:`~typing.Sequence` above, but consider this code:
+  that it is covariant, like :py:class:`~collections.abc.Sequence` above, but consider this code:
 
   .. code-block:: python
 


### PR DESCRIPTION
Provide examples using both syntax variants, and give both of the syntax variants similar prominence. It's likely that both syntax variants will continue to be widely used for a long time.

Also adjust terminology (e.g. use 'type parameter' / 'type argument' more consistently), since otherwise some descriptions would be unclear.

I didn't update examples outside the generics chapter. I'll do this in a follow-up PR.

Work on #17810.