### PR TITLE
Signal unreachability when narrowing with TypeGuard[Never] or TypeIs[Never]

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5889,9 +5889,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         # Also note that a care must be taken to unwrap this back at read places
                         # where we use this to narrow down declared type.
                         if node.callee.type_guard is not None:
+                            if isinstance(get_proper_type(node.callee.type_guard), UninhabitedType):
+                                return None, {}
                             return {expr: TypeGuardedType(node.callee.type_guard)}, {}
                         else:
                             assert node.callee.type_is is not None
+                            if isinstance(get_proper_type(node.callee.type_is), UninhabitedType):
+                                return None, {}
                             return conditional_types_to_typemaps(
                                 expr,
                                 *self.conditional_types_with_intersection(

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5889,7 +5889,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         # Also note that a care must be taken to unwrap this back at read places
                         # where we use this to narrow down declared type.
                         if node.callee.type_guard is not None:
-                            if isinstance(get_proper_type(node.callee.type_guard), UninhabitedType):
+                            if isinstance(
+                                get_proper_type(node.callee.type_guard), UninhabitedType
+                            ):
                                 return None, {}
                             return {expr: TypeGuardedType(node.callee.type_guard)}, {}
                         else:

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1507,3 +1507,41 @@ x = 0  # not unreachable
 
 f2: Callable[[], NoReturn] = lambda: foo()
 x = 0  # not unreachable
+
+[case testUnreachableTypeGuardNever]
+# flags: --warn-unreachable
+from typing_extensions import Never, TypeGuard
+
+def guard(x: object) -> TypeGuard[Never]:
+    pass
+
+a: object
+assert not guard(a)
+
+if guard(a):
+    reveal_type(a)  # E: Statement is unreachable
+else:
+    reveal_type(a)  # N: Revealed type is "builtins.object"
+
+assert guard(a)
+b = 0  # E: Statement is unreachable
+[builtins fixtures/tuple.pyi]
+
+[case testUnreachableTypeIsNever]
+# flags: --warn-unreachable
+from typing_extensions import Never, TypeIs
+
+def guard(x: object) -> TypeIs[Never]:
+    pass
+
+a: object
+assert not guard(a)
+
+if guard(a):
+    reveal_type(a)  # E: Statement is unreachable
+else:
+    reveal_type(a)  # N: Revealed type is "builtins.object"
+
+assert guard(a)
+b = 0  # E: Statement is unreachable
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Closes #16160

### Before
```python
from typing_extensions import Never, TypeGuard

def guard(x: object) -> TypeGuard[Never]:
    ...

a: object

if guard(a):
    reveal_type(a)  # N: Revealed type is "Never"
else:
    reveal_type(a)  # N: Revealed type is "builtins.object"

assert guard(a)
b = 0  # reachable
```

### After
```python
from typing_extensions import Never, TypeGuard

def guard(x: object) -> TypeGuard[Never]:
    ...

a: object

if guard(a):
    reveal_type(a)  # E: Statement is unreachable
else:
    reveal_type(a)  # N: Revealed type is "builtins.object"

assert guard(a)
b = 0  # E: Statement is unreachable
```