### PR TITLE
TEST: Show that value restricted generic functions handle ambiguous types

### DIFF
--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -48,6 +48,16 @@ class S(str): pass
 f(S())
 [out]
 
+[case testCallGenericFunctionWithTypeVarValueRestrictionUsingAmbiguousType]
+from typing import TypeVar
+T = TypeVar('T', int, str)
+def noop(l: list[TV]) -> list[TV]:
+    return l
+x: list[int] = noop([])
+x: list[str] = noop([])
+x: list[int] | str = noop([])
+[out]
+
 [case testCheckGenericFunctionBodyWithTypeVarValues]
 from typing import TypeVar
 class A:


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #13083, or rather shows that the issue is not in fact an issue, by showing that even though the output from `reveal_type` is misleadingly narrow, the actual inferred type is as general as can be expected.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
