### PR TITLE
Suggest is not None Checks for Optional Attributes in Type Annotations

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -534,6 +534,11 @@ class MessageBuilder:
                     context,
                     code=codes.UNION_ATTR,
                 )
+                self.note(
+                    'You can use "if <variable_name> is not None" check to guard against a None value',
+                    context,
+                    code=codes.UNION_ATTR,
+                )
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):
                 bound = get_proper_type(original_type.upper_bound)


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #17036
The added note makes it easier for new mypy users to understand where the errors are coming from and suggests a potentially simple fix.
Note: 'You can use "if <variable_name> is not None" check to guard against a None value'
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
