### PR TITLE
Fix get_member_expr_fullname returning strings with embedded "None"

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -4090,7 +4090,7 @@ def get_member_expr_fullname(expr: MemberExpr) -> str | None:
         initial = expr.expr.name
     elif isinstance(expr.expr, MemberExpr):
         initial = get_member_expr_fullname(expr.expr)
-    else:
+    if initial is None:
         return None
     return f"{initial}.{expr.name}"
 


### PR DESCRIPTION
Fixes #17847

### Before
```python
from mypy.nodes import CallExpr, MemberExpr, NameExpr, get_member_expr_fullname
m3 = MemberExpr(MemberExpr(CallExpr(NameExpr("a"), [], [], []), "b"), "c")  # a().b.c

>>> get_member_expr_fullname(m3)
'None.c'
```
### After
```python
from mypy.nodes import CallExpr, MemberExpr, NameExpr, get_member_expr_fullname
m3 = MemberExpr(MemberExpr(CallExpr(NameExpr("a"), [], [], []), "b"), "c")  # a().b.c

>>> get_member_expr_fullname(m3) is None
True
```
