### PR TITLE
Fix tests on latest Python 3.13 (and 3.12)

### DIFF
--- a/mypyc/test-data/run-dicts.test
+++ b/mypyc/test-data/run-dicts.test
@@ -157,7 +157,11 @@ else:
 try:
     clear_during_iter(d)
 except RuntimeError as e:
-    assert str(e) == "OrderedDict changed size during iteration"
+    assert str(e) in (
+        "OrderedDict changed size during iteration",
+        # Error message changed in Python 3.13 and some 3.12 patch version
+        "OrderedDict mutated during iteration",
+    )
 else:
     assert False
 


### PR DESCRIPTION
Related to python/cpython@c6c3d970ba54f4ad4c4151bb262cef96d3299480 (python/cpython#121329), thanks to brianschubert for noticing