### PR TITLE
Enable negative narrowing of Union TypeVar upper bounds

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1930,6 +1930,8 @@ def restrict_subtype_away(t: Type, s: Type) -> Type:
                 if (isinstance(get_proper_type(item), AnyType) or not covers_at_runtime(item, s))
             ]
         return UnionType.make_union(new_items)
+    elif isinstance(p_t, TypeVarType):
+        return p_t.copy_modified(upper_bound=restrict_subtype_away(p_t.upper_bound, s))
     elif covers_at_runtime(t, s):
         return UninhabitedType()
     else:

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1833,6 +1833,30 @@ def f(x: T) -> None:
     reveal_type(x) # N: Revealed type is "T`-1"
 [builtins fixtures/isinstance.pyi]
 
+[case testIsinstanceAndNegativeNarrowTypeVariableWithUnionBound]
+from typing import Union, TypeVar
+
+class A:
+    a: int
+class B:
+    b: int
+
+T = TypeVar("T", bound=Union[A, B])
+
+def f(x: T) -> T:
+    if isinstance(x, A):
+        reveal_type(x)      # N: Revealed type is "__main__.A"
+        x.a
+        x.b                 # E: "A" has no attribute "b"
+    else:
+        reveal_type(x)      # N: Revealed type is "T`-1"
+        x.a                 # E: "T" has no attribute "a"
+        x.b
+    x.a                     # E: Item "B" of the upper bound "Union[A, B]" of type variable "T" has no attribute "a"
+    x.b                     # E: Item "A" of the upper bound "Union[A, B]" of type variable "T" has no attribute "b"
+    return x
+[builtins fixtures/isinstance.pyi]
+
 [case testIsinstanceAndTypeType]
 from typing import Type
 def f(x: Type[int]) -> None:

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1305,6 +1305,53 @@ def f(t: Type[T], a: A, b: B) -> None:
     else:
         reveal_type(b)  # N: Revealed type is "__main__.B"
 
+[case testNarrowingTypeVarConstraints]
+from typing import TypeVar
+
+class A:
+    a: int
+class B:
+    b: int
+
+T = TypeVar("T", A, B)
+
+def f(x: T):
+    x.a                     # E: "B" has no attribute "a"
+    x.b                     # E: "A" has no attribute "b"
+    if isinstance(x, A):
+        reveal_type(x)      # N: Revealed type is "__main__.A" \
+                            # N: Revealed type is "__main__.<subclass of "B" and "A">"
+        x.a
+        x.b                 # E: "A" has no attribute "b"
+    else:
+        reveal_type(x)      # N: Revealed type is "__main__.B"
+        x.a                 # E: "B" has no attribute "a"
+        x.b
+[builtins fixtures/isinstance.pyi]
+
+[case testNarrowingTypeVarUnionBound]
+from typing import Union, TypeVar
+
+class A:
+    a: int
+class B:
+    b: int
+
+T = TypeVar("T", bound=Union[A, B])
+
+def f(x: T):
+    x.a                     # E: Item "B" of the upper bound "Union[A, B]" of type variable "T" has no attribute "a"
+    x.b                     # E: Item "A" of the upper bound "Union[A, B]" of type variable "T" has no attribute "b"
+    if isinstance(x, A):
+        reveal_type(x)      # N: Revealed type is "__main__.A"
+        x.a
+        x.b                 # E: "A" has no attribute "b"
+    else:
+        reveal_type(x)      # N: Revealed type is "T`-1"
+        x.a                 # E: "T" has no attribute "a"
+        x.b
+[builtins fixtures/isinstance.pyi]
+
 [case testNarrowingNestedUnionOfTypedDicts]
 from typing import Union
 from typing_extensions import Literal, TypedDict

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1305,53 +1305,6 @@ def f(t: Type[T], a: A, b: B) -> None:
     else:
         reveal_type(b)  # N: Revealed type is "__main__.B"
 
-[case testNarrowingTypeVarConstraints]
-from typing import TypeVar
-
-class A:
-    a: int
-class B:
-    b: int
-
-T = TypeVar("T", A, B)
-
-def f(x: T):
-    x.a                     # E: "B" has no attribute "a"
-    x.b                     # E: "A" has no attribute "b"
-    if isinstance(x, A):
-        reveal_type(x)      # N: Revealed type is "__main__.A" \
-                            # N: Revealed type is "__main__.<subclass of "B" and "A">"
-        x.a
-        x.b                 # E: "A" has no attribute "b"
-    else:
-        reveal_type(x)      # N: Revealed type is "__main__.B"
-        x.a                 # E: "B" has no attribute "a"
-        x.b
-[builtins fixtures/isinstance.pyi]
-
-[case testNarrowingTypeVarUnionBound]
-from typing import Union, TypeVar
-
-class A:
-    a: int
-class B:
-    b: int
-
-T = TypeVar("T", bound=Union[A, B])
-
-def f(x: T):
-    x.a                     # E: Item "B" of the upper bound "Union[A, B]" of type variable "T" has no attribute "a"
-    x.b                     # E: Item "A" of the upper bound "Union[A, B]" of type variable "T" has no attribute "b"
-    if isinstance(x, A):
-        reveal_type(x)      # N: Revealed type is "__main__.A"
-        x.a
-        x.b                 # E: "A" has no attribute "b"
-    else:
-        reveal_type(x)      # N: Revealed type is "T`-1"
-        x.a                 # E: "T" has no attribute "a"
-        x.b
-[builtins fixtures/isinstance.pyi]
-
 [case testNarrowingNestedUnionOfTypedDicts]
 from typing import Union
 from typing_extensions import Literal, TypedDict


### PR DESCRIPTION
Fixes #15235

### Before
```python
from typing import TypeVar

class A:
    pass
class B:
    b: int

T = TypeVar("T", bound=A | B)


def foo(x: T) -> T:
    if isinstance(x, A):
        reveal_type(x)      # N: Revealed type is "__main__.A"
    else:
        reveal_type(x)      # N: Revealed type is "T`-1"
        x.b                 # E: Item "A" of the upper bound "A | B" of type variable "T" has no attribute "b"
    return x
```
### After
```python
from typing import TypeVar

class A:
    pass
class B:
    b: int

T = TypeVar("T", bound=A | B)


def foo(x: T) -> T:
    if isinstance(x, A):
        reveal_type(x)      # N: Revealed type is "__main__.A"
    else:
        reveal_type(x)      # N: Revealed type is "T`-1"
        x.b                 # ok! Upper bound of T narrowed to B
    return x
```

