### PR TITLE
[Documentation] Minor change: Unify indexes in Variance of generic types description

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -630,7 +630,7 @@ Let us illustrate this by few simple examples:
 
      my_circles: list[Circle] = []
      add_one(my_circles)     # This may appear safe, but...
-     my_circles[-1].rotate()  # ...this will fail, since my_circles[0] is now a Shape, not a Circle
+     my_circles[0].rotate()  # ...this will fail, since my_circles[0] is now a Shape, not a Circle
 
   Another example of invariant type is ``dict``. Most mutable containers
   are invariant.


### PR DESCRIPTION
This is a very minor fix.

The last comment in this code block:

```
my_circles: list[Circle] = []
add_one(my_circles)     # This may appear safe, but...
my_circles[-1].rotate()  # ...this will fail, since my_circles[0] is now a Shape, not a Circle
```
uses a different index 0 instead of the one used in the code -1. I think these should be same to avoid confusion. I went for 0.