### PR TITLE
Fixes issue  #17840 (shows signature of __call__ for incompatible function argument)

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -831,6 +831,12 @@ class MessageBuilder:
                     if isinstance(arg_type, Instance) and isinstance(type, Instance):
                         notes = append_invariance_notes(notes, arg_type, type)
                         notes = append_numbers_notes(notes, arg_type, type)
+                    if isinstance(arg_type,CallableType) and isinstance(type,Instance):
+                        if type.type.is_protocol and "__call__" in type.type.protocol_members:
+                            call = find_member("__call__", type, arg_type, is_operator=True)
+                            assert call is not None
+                            notes.append(self.note_call_message(type,arg_type))
+
             object_type = get_proper_type(object_type)
             if isinstance(object_type, TypedDictType):
                 code = codes.TYPEDDICT_ITEM
@@ -2038,13 +2044,18 @@ class MessageBuilder:
         self, subtype: Type, call: Type, context: Context, *, code: ErrorCode | None
     ) -> None:
         self.note(
-            '"{}.__call__" has type {}'.format(
-                format_type_bare(subtype, self.options),
-                format_type(call, self.options, verbosity=1),
-            ),
+            self.note_call_message(subtype,call),
             context,
             code=code,
         )
+
+    def note_call_message(
+        self, subtype: Type, call: Type
+    ) -> str:
+        return '"{}.__call__" has type {}'.format(
+                format_type_bare(subtype, self.options),
+                format_type(call, self.options, verbosity=1),
+            )
 
     def unreachable_statement(self, context: Context) -> None:
         self.fail("Statement is unreachable", context, code=codes.UNREACHABLE)

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -599,7 +599,7 @@ a(a)
 a(lambda: None)
 
 [case testCallableSubtypingTrivialSuffix]
-from typing import Any, Protocol
+from typing import Any, Protocol, Callable
 
 class Call(Protocol):
     def __call__(self, x: int, *args: Any, **kwargs: Any) -> None: ...
@@ -627,4 +627,9 @@ a7: Call = f7
 
 def f8(x: int, *args: int, **kwargs: str) -> None: ...
 a8: Call = f8
+
+def f9(c: Call) -> None: ...
+a9: Callable[[int, str, bytes], None]
+f9(a9) # E: Argument 1 to "f9" has incompatible type "Callable[[int, str, bytes], None]"; expected "Call" \
+       # N: "Call.__call__" has type "Callable[[int, str, DefaultArg(bytes)], None]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-callable.test
+++ b/test-data/unit/check-callable.test
@@ -631,5 +631,5 @@ a8: Call = f8
 def f9(c: Call) -> None: ...
 a9: Callable[[int, str, bytes], None]
 f9(a9) # E: Argument 1 to "f9" has incompatible type "Callable[[int, str, bytes], None]"; expected "Call" \
-       # N: "Call.__call__" has type "Callable[[int, str, DefaultArg(bytes)], None]"
+       # N: "Call.__call__" has type "Callable[[int, str, bytes], None]"
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes issue  #17840 (shows signature of __call__ for incompatible function argument)
made modifications to messages.py
- created a note_call_message function to just return the note message for __call__  type  instead of emitting the note 
- implemented changes to fix issue   #17840 

wrote one unit test in check-callable:testCallableSubtypingTrivialSuffix