### PR TITLE
Fix narrowing of IntEnum and StrEnum types

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -1078,14 +1078,6 @@ def custom_special_method(typ: Type, name: str, check_all: bool = False) -> bool
     """
     typ = get_proper_type(typ)
     if isinstance(typ, Instance):
-        if (
-            typ.type.is_enum
-            and name in ("__eq__", "__ne__")
-            and any(base.fullname in ("enum.IntEnum", "enum.StrEnum") for base in typ.type.mro)
-        ):
-            # IntEnum and StrEnum values have non-straightfoward equality, so treat them
-            # as if they had custom __eq__ and __ne__
-            return True
         method = typ.type.get(name)
         if method and isinstance(method.node, (SYMBOL_FUNCBASE_TYPES, Decorator, Var)):
             if method.node.info:

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2135,7 +2135,7 @@ else:
 # mypy: strict-equality
 from __future__ import annotations
 from typing import Any
-from enum import IntEnum, StrEnum
+from enum import IntEnum
 
 class IE(IntEnum):
     X = 1
@@ -2178,6 +2178,71 @@ def f5(x: int) -> None:
         reveal_type(x)  # N: Revealed type is "builtins.int"
     else:
         reveal_type(x)  # N: Revealed type is "Literal[__main__.IE.X]"
+
+def f6(x: IE) -> None:
+     if x == IE.X:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.IE.X]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.IE.Y]"
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingWithIntEnum2]
+# mypy: strict-equality
+from __future__ import annotations
+from typing import Any
+from enum import IntEnum, Enum
+
+class MyDecimal: ...
+
+class IE(IntEnum):
+    X = 1
+    Y = 2
+
+class IE2(IntEnum):
+    X = 1
+    Y = 2
+
+class E(Enum):
+    X = 1
+    Y = 2
+
+def f1(x: IE | MyDecimal) -> None:
+     if x == IE.X:
+         reveal_type(x)  # N: Revealed type is "Union[__main__.IE, __main__.MyDecimal]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Union[__main__.IE, __main__.MyDecimal]"
+
+def f2(x: E | bytes) -> None:
+     if x == E.X:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.E.X]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Union[Literal[__main__.E.Y], builtins.bytes]"
+
+def f3(x: IE | IE2) -> None:
+     if x == IE.X:
+         reveal_type(x)  # N: Revealed type is "Union[__main__.IE, __main__.IE2]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Union[__main__.IE, __main__.IE2]"
+
+def f4(x: IE | E) -> None:
+     if x == IE.X:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.IE.X]"
+     elif x == E.X:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.E.X]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Union[Literal[__main__.IE.Y], Literal[__main__.E.Y]]"
+
+def f5(x: E | str | int) -> None:
+     if x == E.X:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.E.X]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Union[Literal[__main__.E.Y], builtins.str, builtins.int]"
+
+def f6(x: IE | Any) -> None:
+     if x == IE.X:
+         reveal_type(x)  # N: Revealed type is "Union[__main__.IE, Any]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Union[__main__.IE, Any]"
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingWithStrEnum]
@@ -2205,4 +2270,10 @@ def f3(x: object) -> None:
         reveal_type(x)  # N: Revealed type is "builtins.object"
     else:
         reveal_type(x)  # N: Revealed type is "builtins.object"
+
+def f4(x: SE) -> None:
+     if x == SE.A:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.SE.A]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.SE.B]"
 [builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Fix regression introduced in #17866. It should still be possible to narrow IntEnum and StrEnum types, but only when types match or are disjoint. Add more logic to rule out narrowing when types are ambigous.