### PR TITLE
[PEP 696] Report error if using unsupported type parameter defaults

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1198,6 +1198,13 @@ class ASTConverter:
         for p in type_params:
             bound = None
             values: list[Type] = []
+            if sys.version_info >= (3, 13) and p.default_value is not None:
+                self.fail(
+                    message_registry.TYPE_PARAM_DEFAULT_NOT_SUPPORTED,
+                    p.lineno,
+                    p.col_offset,
+                    blocker=False,
+                )
             if isinstance(p, ast_ParamSpec):  # type: ignore[misc]
                 explicit_type_params.append(TypeParam(p.name, PARAM_SPEC_KIND, None, []))
             elif isinstance(p, ast_TypeVarTuple):  # type: ignore[misc]

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -362,3 +362,8 @@ TYPE_ALIAS_WITH_NAMED_EXPRESSION: Final = ErrorMessage(
 TYPE_ALIAS_WITH_AWAIT_EXPRESSION: Final = ErrorMessage(
     "Await expression cannot be used within a type alias", codes.SYNTAX
 )
+
+TYPE_PARAM_DEFAULT_NOT_SUPPORTED: Final = ErrorMessage(
+    "Type parameter default types not supported when using Python 3.12 type parameter syntax",
+    codes.MISC,
+)

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -256,16 +256,9 @@ def local_sys_path_set() -> Iterator[None]:
 
 
 def testfile_pyversion(path: str) -> tuple[int, int]:
-    if path.endswith("python312.test"):
-        return 3, 12
-    elif path.endswith("python311.test"):
-        return 3, 11
-    elif path.endswith("python310.test"):
-        return 3, 10
-    elif path.endswith("python39.test"):
-        return 3, 9
-    elif path.endswith("python38.test"):
-        return 3, 8
+    m = re.search(r"python3([0-9]+)\.test$", path)
+    if m:
+        return 3, int(m.group(1))
     else:
         return defaults.PYTHON3_VERSION
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -45,6 +45,8 @@ if sys.version_info < (3, 11):
     typecheck_files.remove("check-python311.test")
 if sys.version_info < (3, 12):
     typecheck_files.remove("check-python312.test")
+if sys.version_info < (3, 13):
+    typecheck_files.remove("check-python313.test")
 
 # Special tests for platforms with case-insensitive filesystems.
 if sys.platform not in ("darwin", "win32"):

--- a/test-data/unit/check-python313.test
+++ b/test-data/unit/check-python313.test
@@ -1,0 +1,11 @@
+[case testPEP695TypeParameterDefaultNotSupported]
+class C[T = None]:  # E: Type parameter default types not supported when using Python 3.12 type parameter syntax
+    pass
+
+def f[T = list[int]]() -> None:  # E: Type parameter default types not supported when using Python 3.12 type parameter syntax
+    pass
+
+def g[**P = [int, str]]() -> None:  # E: Type parameter default types not supported when using Python 3.12 type parameter syntax
+    pass
+
+type A[T, S = int, U = str] = list[T]  # E: Type parameter default types not supported when using Python 3.12 type parameter syntax


### PR DESCRIPTION
We don't yet support default types for type parameters when using the new type parameter syntax. Generate an error instead of just ignoring them.

Also make it possible to write Python 3.13 specific tests.
