### PR TITLE
Don't consider None vs IntEnum comparison ambiguous

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8645,6 +8645,8 @@ def _ambiguous_enum_variants(types: list[Type]) -> set[str]:
                 result.add("<other>")
         elif isinstance(t, LiteralType):
             result.update(_ambiguous_enum_variants([t.fallback]))
+        elif isinstance(t, NoneType):
+            pass
         else:
             result.add("<other>")
     return result

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2243,6 +2243,12 @@ def f6(x: IE | Any) -> None:
          reveal_type(x)  # N: Revealed type is "Union[__main__.IE, Any]"
      else:
          reveal_type(x)  # N: Revealed type is "Union[__main__.IE, Any]"
+
+def f7(x: IE | None) -> None:
+     if x == IE.X:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.IE.X]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Union[Literal[__main__.IE.Y], None]"
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingWithStrEnum]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2249,6 +2249,14 @@ def f7(x: IE | None) -> None:
          reveal_type(x)  # N: Revealed type is "Literal[__main__.IE.X]"
      else:
          reveal_type(x)  # N: Revealed type is "Union[Literal[__main__.IE.Y], None]"
+
+def f8(x: IE | None) -> None:
+     if x is None:
+         reveal_type(x)  # N: Revealed type is "None"
+     elif x == IE.X:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.IE.X]"
+     else:
+         reveal_type(x)  # N: Revealed type is "Literal[__main__.IE.Y]"
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingWithStrEnum]


### PR DESCRIPTION
We can assume that None doesn't compare equal to an enum.