### PR TITLE
Fix re-processing cross-reference when node kind changes

### DIFF
--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -219,7 +219,9 @@ def snapshot_symbol_table(name_prefix: str, table: SymbolTable) -> dict[str, Sym
             assert symbol.kind != UNBOUND_IMPORTED
             if node and get_prefix(node.fullname) != name_prefix:
                 # This is a cross-reference to a node defined in another module.
-                result[name] = ("CrossRef", common)
+                # Include the node kind (FuncDef, Decorator, TypeInfo, ...), so that we will
+                # reprocess when a *new* node is created instead of merging an existing one.
+                result[name] = ("CrossRef", common, type(node).__name__)
             else:
                 result[name] = snapshot_definition(node, common)
     return result

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10573,3 +10573,101 @@ m.py:9: error: Argument 1 to "foo" has incompatible type "int"; expected "str"
 m.py:9: error: Argument 2 to "foo" has incompatible type "str"; expected "int"
 m.py:10: error: Unexpected keyword argument "a" for "foo"
 partial.py:4: note: "foo" defined here
+
+[case testReplaceFunctionWithDecoratedFunctionIndirect]
+from b import f
+x: int = f()
+import b
+y: int = b.f()
+
+[file b.py]
+from a import f
+
+[file a.py]
+def f() -> int: ...
+
+[file a.py.2]
+from typing import Callable
+def d(t: Callable[[], str]) -> Callable[[], str]: ...
+
+@d
+def f() -> str: ...
+
+[builtins fixtures/tuple.pyi]
+[out]
+==
+main:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testReplaceFunctionWithDecoratedFunctionIndirect2]
+from c import f
+x: int = f()
+import c
+y: int = c.f()
+
+[file c.py]
+from b import f
+
+[file b.py]
+from a import f
+
+[file a.py]
+def f() -> int: ...
+
+[file a.py.2]
+from typing import Callable
+def d(t: Callable[[], str]) -> Callable[[], str]: ...
+
+@d
+def f() -> str: ...
+
+[builtins fixtures/tuple.pyi]
+[out]
+==
+main:2: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+main:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+[case testReplaceFunctionWithClassIndirect]
+from b import f
+x: int = f()
+import b
+y: int = b.f()
+
+[file b.py]
+from a import f
+
+[file a.py]
+def f() -> int: ...
+
+[file a.py.2]
+class f: ...
+
+[builtins fixtures/tuple.pyi]
+[out]
+==
+main:2: error: Incompatible types in assignment (expression has type "f", variable has type "int")
+main:4: error: Incompatible types in assignment (expression has type "f", variable has type "int")
+
+[case testReplaceFunctionWithClassIndirect2]
+from c import f
+x: int = f()
+import c
+y: int = c.f()
+
+[file c.py]
+from b import f
+
+[file b.py]
+from a import f
+
+[file a.py]
+def f() -> int: ...
+
+[file a.py.2]
+class f: ...
+
+[builtins fixtures/tuple.pyi]
+[out]
+==
+main:2: error: Incompatible types in assignment (expression has type "f", variable has type "int")
+main:4: error: Incompatible types in assignment (expression has type "f", variable has type "int")


### PR DESCRIPTION
This is quite a bad bug. Currently we rely on `SymbolNode` being updated in-place for all indirect references, but this is not the case when node kind (`FuncDef`, `Decorator`, etc.) changes, in this case a _new_ `SymbolNode` is created. I fix this by forcing reprocessing if the node kind changes.

This currently blocks support for PEP 702, see https://github.com/python/mypy/pull/17476, so I will not wait for long before merging.

cc @JukkaL @hauntsaninja 
