### PR TITLE
[mypyc] Make C unit tests faster by compiling with -O0

### DIFF
--- a/mypyc/test/test_external.py
+++ b/mypyc/test/test_external.py
@@ -20,7 +20,9 @@ class TestExternal(unittest.TestCase):
         cppflags: list[str] = []
         env = os.environ.copy()
         if sys.platform == "darwin":
-            cppflags += ["-mmacosx-version-min=10.10", "-stdlib=libc++"]
+            cppflags += ["-O0", "-mmacosx-version-min=10.10", "-stdlib=libc++"]
+        elif sys.platform == "linux":
+            cppflags += ["-O0"]
         env["CPPFLAGS"] = " ".join(cppflags)
         # Build Python wrapper for C unit tests.
 


### PR DESCRIPTION
Most time is spent in compilation, so runtime performance doesn't really matter.