### PR TITLE
[mypyc] Optimize calls to final classes

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -563,15 +563,14 @@ def generate_setup_for_class(
     emitter.emit_line("if (self == NULL)")
     emitter.emit_line("    return NULL;")
 
-    if not cl.is_final_class:
-        if shadow_vtable_name:
-            emitter.emit_line(f"if (type != {emitter.type_struct_name(cl)}) {{")
-            emitter.emit_line(f"self->vtable = {shadow_vtable_name};")
-            emitter.emit_line("} else {")
-            emitter.emit_line(f"self->vtable = {vtable_name};")
-            emitter.emit_line("}")
-        else:
-            emitter.emit_line(f"self->vtable = {vtable_name};")
+    if shadow_vtable_name:
+        emitter.emit_line(f"if (type != {emitter.type_struct_name(cl)}) {{")
+        emitter.emit_line(f"self->vtable = {shadow_vtable_name};")
+        emitter.emit_line("} else {")
+        emitter.emit_line(f"self->vtable = {vtable_name};")
+        emitter.emit_line("}")
+    else:
+        emitter.emit_line(f"self->vtable = {vtable_name};")
 
     for i in range(0, len(cl.bitmap_attrs), BITMAP_BITS):
         field = emitter.bitmap_field(i)

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -380,9 +380,7 @@ def setter_name(cl: ClassIR, attribute: str, names: NameGenerator) -> str:
 def generate_object_struct(cl: ClassIR, emitter: Emitter) -> None:
     seen_attrs: set[tuple[str, RType]] = set()
     lines: list[str] = []
-    lines += ["typedef struct {", "PyObject_HEAD"]
-    if not cl.is_final_class:
-        lines.append("CPyVTableItem *vtable;")
+    lines += ["typedef struct {", "PyObject_HEAD", "CPyVTableItem *vtable;"]
     if cl.has_method("__call__") and emitter.use_vectorcall():
         lines.append("vectorcallfunc vectorcall;")
     bitmap_attrs = []

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -362,10 +362,10 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         attr_rtype, decl_cl = cl.attr_details(op.attr)
         prefer_method = cl.is_trait and attr_rtype.error_overlap
         if cl.get_method(op.attr, prefer_method=prefer_method):
+            # Properties are essentially methods, so use vtable access for them.
             if cl.is_method_final(op.attr):
                 self.emit_method_call(f"{dest} = ", op.obj, op.attr, [])
             else:
-                # Properties are essentially methods, so use vtable access for them.
                 version = "_TRAIT" if cl.is_trait else ""
                 self.emit_line(
                     "%s = CPY_GET_ATTR%s(%s, %s, %d, %s, %s); /* %s */"

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -72,8 +72,8 @@ from mypyc.ir.ops import (
 from mypyc.ir.pprint import generate_names_for_ir
 from mypyc.ir.rtypes import (
     RArray,
-    RStruct,
     RInstance,
+    RStruct,
     RTuple,
     RType,
     is_int32_rprimitive,

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -73,6 +73,7 @@ from mypyc.ir.pprint import generate_names_for_ir
 from mypyc.ir.rtypes import (
     RArray,
     RStruct,
+    RInstance,
     RTuple,
     RType,
     is_int32_rprimitive,
@@ -537,6 +538,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
     def emit_method_call(self, dest: str, op_obj: Value, name: str, op_args: list[Value]) -> None:
         obj = self.reg(op_obj)
         rtype = op_obj.type
+        assert isinstance(rtype, RInstance)
         class_ir = rtype.class_ir
         method = rtype.class_ir.get_method(name)
         assert method is not None

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -361,21 +361,24 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         attr_rtype, decl_cl = cl.attr_details(op.attr)
         prefer_method = cl.is_trait and attr_rtype.error_overlap
         if cl.get_method(op.attr, prefer_method=prefer_method):
-            # Properties are essentially methods, so use vtable access for them.
-            version = "_TRAIT" if cl.is_trait else ""
-            self.emit_line(
-                "%s = CPY_GET_ATTR%s(%s, %s, %d, %s, %s); /* %s */"
-                % (
-                    dest,
-                    version,
-                    obj,
-                    self.emitter.type_struct_name(rtype.class_ir),
-                    rtype.getter_index(op.attr),
-                    rtype.struct_name(self.names),
-                    self.ctype(rtype.attr_type(op.attr)),
-                    op.attr,
+            if cl.is_method_final(op.attr):
+                self.emit_method_call(f"{dest} = ", op.obj, op.attr, [])
+            else:
+                # Properties are essentially methods, so use vtable access for them.
+                version = "_TRAIT" if cl.is_trait else ""
+                self.emit_line(
+                    "%s = CPY_GET_ATTR%s(%s, %s, %d, %s, %s); /* %s */"
+                    % (
+                        dest,
+                        version,
+                        obj,
+                        self.emitter.type_struct_name(rtype.class_ir),
+                        rtype.getter_index(op.attr),
+                        rtype.struct_name(self.names),
+                        self.ctype(rtype.attr_type(op.attr)),
+                        op.attr,
+                    )
                 )
-            )
         else:
             # Otherwise, use direct or offset struct access.
             attr_expr = self.get_attr_expr(obj, op, decl_cl)
@@ -529,11 +532,12 @@ class FunctionEmitterVisitor(OpVisitor[None]):
     def visit_method_call(self, op: MethodCall) -> None:
         """Call native method."""
         dest = self.get_dest_assign(op)
-        obj = self.reg(op.obj)
+        self.emit_method_call(dest, op.obj, op.method, op.args)
 
-        rtype = op.receiver_type
+    def emit_method_call(self, dest: str, op_obj: Value, name: str, op_args: list[Value]) -> None:
+        obj = self.reg(op_obj)
+        rtype = op_obj.type
         class_ir = rtype.class_ir
-        name = op.method
         method = rtype.class_ir.get_method(name)
         assert method is not None
 
@@ -547,7 +551,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             if method.decl.kind == FUNC_STATICMETHOD
             else [f"(PyObject *)Py_TYPE({obj})"] if method.decl.kind == FUNC_CLASSMETHOD else [obj]
         )
-        args = ", ".join(obj_args + [self.reg(arg) for arg in op.args])
+        args = ", ".join(obj_args + [self.reg(arg) for arg in op_args])
         mtype = native_function_type(method, self.emitter)
         version = "_TRAIT" if rtype.class_ir.is_trait else ""
         if is_direct:
@@ -567,7 +571,7 @@ class FunctionEmitterVisitor(OpVisitor[None]):
                     rtype.struct_name(self.names),
                     mtype,
                     args,
-                    op.method,
+                    name,
                 )
             )
 

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -407,6 +407,7 @@ class ClassIR:
         ir.is_abstract = data["is_abstract"]
         ir.is_ext_class = data["is_ext_class"]
         ir.is_augmented = data["is_augmented"]
+        ir.is_final_class = data["is_final_class"]
         ir.inherits_python = data["inherits_python"]
         ir.has_dict = data["has_dict"]
         ir.allow_interpreted_subclasses = data["allow_interpreted_subclasses"]

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -93,6 +93,7 @@ class ClassIR:
         is_generated: bool = False,
         is_abstract: bool = False,
         is_ext_class: bool = True,
+        is_final_class: bool = False,
     ) -> None:
         self.name = name
         self.module_name = module_name
@@ -100,6 +101,7 @@ class ClassIR:
         self.is_generated = is_generated
         self.is_abstract = is_abstract
         self.is_ext_class = is_ext_class
+        self.is_final_class = is_final_class
         # An augmented class has additional methods separate from what mypyc generates.
         # Right now the only one is dataclasses.
         self.is_augmented = False
@@ -248,8 +250,7 @@ class ClassIR:
     def is_method_final(self, name: str) -> bool:
         subs = self.subclasses()
         if subs is None:
-            # TODO: Look at the final attribute!
-            return False
+            return self.is_final_class
 
         if self.has_method(name):
             method_decl = self.method_decl(name)

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -201,7 +201,8 @@ class ClassIR:
             "ClassIR("
             "name={self.name}, module_name={self.module_name}, "
             "is_trait={self.is_trait}, is_generated={self.is_generated}, "
-            "is_abstract={self.is_abstract}, is_ext_class={self.is_ext_class}"
+            "is_abstract={self.is_abstract}, is_ext_class={self.is_ext_class}, "
+            "is_final_class={self.is_final_class}"
             ")".format(self=self)
         )
 
@@ -350,6 +351,7 @@ class ClassIR:
             "is_abstract": self.is_abstract,
             "is_generated": self.is_generated,
             "is_augmented": self.is_augmented,
+            "is_final_class": self.is_final_class,
             "inherits_python": self.inherits_python,
             "has_dict": self.has_dict,
             "allow_interpreted_subclasses": self.allow_interpreted_subclasses,

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -64,7 +64,7 @@ class RType:
 
     @abstractmethod
     def accept(self, visitor: RTypeVisitor[T]) -> T:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def short_name(self) -> str:
         return short_name(self.name)

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -63,12 +63,7 @@ from mypyc.irbuild.function import (
     handle_non_ext_method,
     load_type,
 )
-from mypyc.irbuild.util import (
-    dataclass_type,
-    get_func_def,
-    is_constant,
-    is_dataclass_decorator,
-)
+from mypyc.irbuild.util import dataclass_type, get_func_def, is_constant, is_dataclass_decorator
 from mypyc.primitives.dict_ops import dict_new_op, dict_set_item_op
 from mypyc.primitives.generic_ops import (
     iter_op,

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -63,7 +63,13 @@ from mypyc.irbuild.function import (
     handle_non_ext_method,
     load_type,
 )
-from mypyc.irbuild.util import dataclass_type, get_func_def, is_constant, is_dataclass_decorator, is_final_class
+from mypyc.irbuild.util import (
+    dataclass_type,
+    get_func_def,
+    is_constant,
+    is_dataclass_decorator,
+    is_final_class,
+)
 from mypyc.primitives.dict_ops import dict_new_op, dict_set_item_op
 from mypyc.primitives.generic_ops import (
     iter_op,

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -63,7 +63,7 @@ from mypyc.irbuild.function import (
     handle_non_ext_method,
     load_type,
 )
-from mypyc.irbuild.util import dataclass_type, get_func_def, is_constant, is_dataclass_decorator
+from mypyc.irbuild.util import dataclass_type, get_func_def, is_constant, is_dataclass_decorator, is_final_class
 from mypyc.primitives.dict_ops import dict_new_op, dict_set_item_op
 from mypyc.primitives.generic_ops import (
     iter_op,
@@ -294,6 +294,7 @@ class ExtClassBuilder(ClassBuilder):
             self.builder.init_final_static(lvalue, value, self.cdef.name)
 
     def finalize(self, ir: ClassIR) -> None:
+        ir.is_final_class = is_final_class(self.cdef)
         attrs_with_defaults, default_assignments = find_attr_initializers(
             self.builder, self.cdef, self.skip_attr_default
         )

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -68,7 +68,6 @@ from mypyc.irbuild.util import (
     get_func_def,
     is_constant,
     is_dataclass_decorator,
-    is_final_class,
 )
 from mypyc.primitives.dict_ops import dict_new_op, dict_set_item_op
 from mypyc.primitives.generic_ops import (
@@ -300,7 +299,6 @@ class ExtClassBuilder(ClassBuilder):
             self.builder.init_final_static(lvalue, value, self.cdef.name)
 
     def finalize(self, ir: ClassIR) -> None:
-        ir.is_final_class = is_final_class(self.cdef)
         attrs_with_defaults, default_assignments = find_attr_initializers(
             self.builder, self.cdef, self.skip_attr_default
         )

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1889,8 +1889,9 @@ class LowLevelIRBuilder:
         # Does this primitive map into calling a Python C API
         # or an internal mypyc C API function?
         if desc.c_function_name:
-            # TODO: Generate PrimitiOps here and transform them into CallC
+            # TODO: Generate PrimitiveOps here and transform them into CallC
             # ops only later in the lowering pass
+            print(f"primitive_op: {desc.name} {desc.c_function_name} {desc.is_pure} -> {result_type}")
             c_desc = CFunctionDescription(
                 desc.name,
                 desc.arg_types,
@@ -1908,7 +1909,7 @@ class LowLevelIRBuilder:
             )
             return self.call_c(c_desc, args, line, result_type)
 
-        # This primitve gets transformed in a lowering pass to
+        # This primitive gets transformed in a lowering pass to
         # lower-level IR ops using a custom transform function.
 
         coerced = []

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1891,9 +1891,6 @@ class LowLevelIRBuilder:
         if desc.c_function_name:
             # TODO: Generate PrimitiveOps here and transform them into CallC
             # ops only later in the lowering pass
-            print(
-                f"primitive_op: {desc.name} {desc.c_function_name} {desc.is_pure} -> {result_type}"
-            )
             c_desc = CFunctionDescription(
                 desc.name,
                 desc.arg_types,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1891,7 +1891,9 @@ class LowLevelIRBuilder:
         if desc.c_function_name:
             # TODO: Generate PrimitiveOps here and transform them into CallC
             # ops only later in the lowering pass
-            print(f"primitive_op: {desc.name} {desc.c_function_name} {desc.is_pure} -> {result_type}")
+            print(
+                f"primitive_op: {desc.name} {desc.c_function_name} {desc.is_pure} -> {result_type}"
+            )
             c_desc = CFunctionDescription(
                 desc.name,
                 desc.arg_types,

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -81,7 +81,11 @@ def build_type_map(
     # references even if there are import cycles.
     for module, cdef in classes:
         class_ir = ClassIR(
-            cdef.name, module.fullname, is_trait(cdef), is_abstract=cdef.info.is_abstract
+            cdef.name,
+            module.fullname,
+            is_trait(cdef),
+            is_abstract=cdef.info.is_abstract,
+            is_final_class=cdef.info.is_final,
         )
         class_ir.is_ext_class = is_extension_class(cdef)
         if class_ir.is_ext_class:

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -31,6 +31,14 @@ from mypy.nodes import (
 DATACLASS_DECORATORS = {"dataclasses.dataclass", "attr.s", "attr.attrs"}
 
 
+def is_final_decorator(d: Expression) -> bool:
+    return isinstance(d, RefExpr) and d.fullname == "typing.final"
+
+
+def is_final_class(cdef: ClassDef) -> bool:
+    return any(is_final_decorator(d) for d in cdef.decorators)
+
+
 def is_trait_decorator(d: Expression) -> bool:
     return isinstance(d, RefExpr) and d.fullname == "mypy_extensions.trait"
 
@@ -119,7 +127,7 @@ def get_mypyc_attrs(stmt: ClassDef | Decorator) -> dict[str, Any]:
 
 def is_extension_class(cdef: ClassDef) -> bool:
     if any(
-        not is_trait_decorator(d) and not is_dataclass_decorator(d) and not get_mypyc_attr_call(d)
+        not is_trait_decorator(d) and not is_dataclass_decorator(d) and not get_mypyc_attr_call(d) and not is_final_decorator(d)
         for d in cdef.decorators
     ):
         return False

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -127,7 +127,10 @@ def get_mypyc_attrs(stmt: ClassDef | Decorator) -> dict[str, Any]:
 
 def is_extension_class(cdef: ClassDef) -> bool:
     if any(
-        not is_trait_decorator(d) and not is_dataclass_decorator(d) and not get_mypyc_attr_call(d) and not is_final_decorator(d)
+        not is_trait_decorator(d)
+        and not is_dataclass_decorator(d)
+        and not get_mypyc_attr_call(d)
+        and not is_final_decorator(d)
         for d in cdef.decorators
     ):
         return False

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -27,16 +27,14 @@ from mypy.nodes import (
     UnaryExpr,
     Var,
 )
+from mypy.semanal import refers_to_fullname
+from mypy.types import FINAL_DECORATOR_NAMES
 
 DATACLASS_DECORATORS = {"dataclasses.dataclass", "attr.s", "attr.attrs"}
 
 
 def is_final_decorator(d: Expression) -> bool:
-    return isinstance(d, RefExpr) and d.fullname == "typing.final"
-
-
-def is_final_class(cdef: ClassDef) -> bool:
-    return any(is_final_decorator(d) for d in cdef.decorators)
+    return refers_to_fullname(d, FINAL_DECORATOR_NAMES)
 
 
 def is_trait_decorator(d: Expression) -> bool:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2503,3 +2503,29 @@ class C:
 def test_final_attribute() -> None:
     assert C.A == -1
     assert C.a == [-1]
+
+[case testClassWithFinalAttribute]
+from typing import final
+
+@final
+class C:
+    def a(self) -> int:
+        return 1
+
+def test_class_final_attribute() -> None:
+    assert C().a() == 1
+
+[case testClassWithFinalAttributeInherited]
+from typing import final
+
+class B:
+    def a(self) -> int:
+        return 2
+
+@final
+class C(B):
+    def a(self) -> int:
+        return 1
+
+def test_class_final_attribute_inherited() -> None:
+    assert C().a() == 1

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2504,7 +2504,7 @@ def test_final_attribute() -> None:
     assert C.A == -1
     assert C.a == [-1]
 
-[case testClassWithFinalTypingAttribute]
+[case testClassWithFinalDecorator]
 from typing import final
 
 @final
@@ -2515,7 +2515,28 @@ class C:
 def test_class_final_attribute() -> None:
     assert C().a() == 1
 
-[case testClassWithFinalTypingAttributeInherited]
+
+[case testClassWithFinalDecoratorCtor]
+from typing import final
+
+@final
+class C:
+    def __init__(self) -> None:
+        self.a = 1
+
+    def b(self) -> int:
+        return 2
+
+    @property
+    def c(self) -> int:
+        return 3
+
+def test_class_final_attribute() -> None:
+    assert C().a == 1
+    assert C().b() == 2
+    assert C().c == 3
+
+[case testClassWithFinalDecoratorInheritedWithProperties]
 from typing import final
 
 class B:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2504,7 +2504,7 @@ def test_final_attribute() -> None:
     assert C.A == -1
     assert C.a == [-1]
 
-[case testClassWithFinalAttribute]
+[case testClassWithFinalTypingAttribute]
 from typing import final
 
 @final
@@ -2515,7 +2515,7 @@ class C:
 def test_class_final_attribute() -> None:
     assert C().a() == 1
 
-[case testClassWithFinalAttributeInherited]
+[case testClassWithFinalTypingAttributeInherited]
 from typing import final
 
 class B:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2527,5 +2527,11 @@ class C(B):
     def a(self) -> int:
         return 1
 
+def fn(cl: B) -> int:
+    return cl.a()
+
 def test_class_final_attribute_inherited() -> None:
     assert C().a() == 1
+    assert fn(C()) == 1
+    assert B().a() == 2
+    assert fn(B()) == 2

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2522,10 +2522,27 @@ class B:
     def a(self) -> int:
         return 2
 
+    @property
+    def b(self) -> int:
+        return self.a() + 2
+
+    @property
+    def c(self) -> int:
+        return 3
+
+def test_class_final_attribute_basic() -> None:
+    assert B().a() == 2
+    assert B().b == 4
+    assert B().c == 3
+
 @final
 class C(B):
     def a(self) -> int:
         return 1
+
+    @property
+    def b(self) -> int:
+        return self.a() + 1
 
 def fn(cl: B) -> int:
     return cl.a()
@@ -2535,3 +2552,8 @@ def test_class_final_attribute_inherited() -> None:
     assert fn(C()) == 1
     assert B().a() == 2
     assert fn(B()) == 2
+
+    assert B().b == 4
+    assert C().b == 2
+    assert B().c == 3
+    assert C().c == 3


### PR DESCRIPTION
Fixes #9612

This change allows to gain more efficiency where classes are annotated with `@final` bypassing entirely the vtable for method calls and property accessors.

For example:
In
```python
@final
class Vector:
    __slots__ = ("_x", "_y")
    def __init__(self, x: i32, y: i32) -> None:
        self._x = x
        self._y = y

    @property
    def y(self) -> i32:
        return self._y

def test_vector() -> None:
    v3 = Vector(1, 2)
    assert v3.y == 2
```

The call will produce:

```c
...
cpy_r_r6 = CPyDef_Vector___y(cpy_r_r0);
...
```

Instead of:

```c
...
cpy_r_r1 = CPY_GET_ATTR(cpy_r_r0, CPyType_Vector, 2, farm_rush___engine___vectors2___VectorObject, int32_t); /* y */
...
```
(which uses vtable)