### PR TITLE
Emit error for "raise NotImplemented"

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4746,6 +4746,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # https://github.com/python/mypy/issues/11089
             self.expr_checker.check_call(typ, [], [], e)
 
+        if isinstance(typ, Instance) and typ.type.fullname == "builtins._NotImplementedType":
+            self.fail(
+                message_registry.INVALID_EXCEPTION.with_additional_msg(
+                    '; did you mean "NotImplementedError"?'
+                ),
+                s,
+            )
+
     def visit_try_stmt(self, s: TryStmt) -> None:
         """Type check a try statement."""
         # Our enclosing frame will get the result if the try/except falls through.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4581,6 +4581,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         s.expr, return_type, allow_none_return=allow_none_func_call
                     )
                 )
+                # Treat NotImplemented as having type Any, consistent with its
+                # definition in typeshed prior to python/typeshed#4222.
+                if (
+                    isinstance(typ, Instance)
+                    and typ.type.fullname == "builtins._NotImplementedType"
+                ):
+                    typ = AnyType(TypeOfAny.special_form)
 
                 if defn.is_async_generator:
                     self.fail(message_registry.RETURN_IN_ASYNC_GENERATOR, s)

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -519,6 +519,13 @@ if object():
     raise BaseException from f # E: Exception must be derived from BaseException
 [builtins fixtures/exception.pyi]
 
+[case testRaiseNotImplementedFails]
+if object():
+    raise NotImplemented    # E: Exception must be derived from BaseException; did you mean "NotImplementedError"?
+if object():
+    raise NotImplemented()  # E: NotImplemented? not callable
+[builtins fixtures/notimplemented.pyi]
+
 [case testTryFinallyStatement]
 import typing
 try:

--- a/test-data/unit/fixtures/notimplemented.pyi
+++ b/test-data/unit/fixtures/notimplemented.pyi
@@ -1,6 +1,5 @@
 # builtins stub used in NotImplemented related cases.
-from typing import Any, cast
-
+from typing import Any
 
 class object:
     def __init__(self) -> None: pass
@@ -10,5 +9,10 @@ class function: pass
 class bool: pass
 class int: pass
 class str: pass
-NotImplemented = cast(Any, None)
 class dict: pass
+
+class _NotImplementedType(Any):
+    __call__: NotImplemented  # type: ignore
+NotImplemented = _NotImplementedType()
+
+class BaseException: pass

--- a/test-data/unit/fixtures/notimplemented.pyi
+++ b/test-data/unit/fixtures/notimplemented.pyi
@@ -13,6 +13,6 @@ class dict: pass
 
 class _NotImplementedType(Any):
     __call__: NotImplemented  # type: ignore
-NotImplemented = _NotImplementedType()
+NotImplemented: _NotImplementedType
 
 class BaseException: pass


### PR DESCRIPTION
Refs #5710

Adds special-case handling for raising `NotImplemented`:
```python
raise NotImplemented  # E: Exception must be derived from BaseException; did you mean "NotImplementedError"?
```

Per the linked issue, there's some debate as to how to best handle `NotImplemented`.  This PR special-cases its behavior in `raise` statements, whereas the leaning in the issue (at the time it was opened) was towards updating its definition in typeshed and possibly special-casing its use in the relevant dunder methods. 

Going the typeshed/special-dunder route may still happen, but it hasn't in the six years since the issue was opened. It would be nice to at least catch errors from raising `NotImplemented` in the interim.

Making this change also uncovered a regression introduced in python/typeshed#4222. Previously, `NotImplemented` was annotated as `Any` in typeshed, so returning `NotImplemented` from a non-dunder would emit an error when `--warn-return-any` was used:
```python
class A:
    def some(self) -> bool: return NotImplemented  # E: Returning Any from function declared to return "bool"
```
However, in python/typeshed#4222, the type of `NotImplemented` was updated to be a subclass of `Any`. This broke the handling of `--warn-return-any`, but it wasn't caught since the definition of `NotImplemented` in `fixtures/notimplemented.pyi` wasn't updated along with the definition in typeshed. As a result, current mypy doesn't emit an error here ([playground](https://mypy-play.net/?mypy=1.11.2&python=3.12&flags=strict%2Cwarn-return-any&gist=8a78e3eb68b0b738f73fdd326f0bfca1)), despite having a test case saying that it should. As a bandaid, this PR add special handling for `NotImplemented` in return statements to treat it like an explicit `Any`, restoring the pre- python/typeshed#4222 behavior.

 
