### PR TITLE
Add Python 3.13 to classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -190,6 +190,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
Mypy now supports 3.13 (though not all features yet).