### PR TITLE
Sketch implementation of "optional-non-truthy" check for `if x` with `x: None | str`

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -372,6 +372,32 @@ items`` check is actually valid. If that is the case, it is
 recommended to annotate ``items`` as ``Collection[int]`` instead of
 ``Iterable[int]``.
 
+.. _code-optional-non-truthy:
+
+Check that expression doesn't conflate None with other false expressions [optional-non-truthy]
+-----------------------------------------------------------------------------
+
+Warn when the type of an expression in a boolean context is optional
+(union with `None`) and also has other types that are boolean-like
+(implement ``__bool__`` or ``__len__``), such as `int`, `str` or `list`.
+
+In this case, the `if` block is likely to to be intending to just
+guard the `None` case, but falsey values like `0`, `""` or `[]` will
+behave the same as `None`. Instead `... is None` or `... is not None`
+if one is wanting to only guard `None`, or `bool(...)` if the falsey
+values should indeed behave like `None`.
+
+.. code-block:: python
+
+    # Use "mypy --enable-error-code optional-non-truthy ..."
+
+    foo: None | int = 0
+    # Error: FIXME
+    if foo:
+        ... # executes when foo is an int != 0
+    else:
+        ... # executes when foo is None or 0
+
 .. _code-ignore-without-code:
 
 Check that ``# type: ignore`` include an error code [ignore-without-code]

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4296,7 +4296,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         op = e.op
         if op == "not":
             result: Type = self.bool_type()
+            # FIXME: make this a single call again
             self.chk.check_for_truthy_type(operand_type, e.expr)
+            self.chk.check_for_optional_non_truthy_type(operand_type, e.expr)
         else:
             method = operators.unary_op_methods[op]
             result, method_type = self.check_method_call_by_name(method, operand_type, [], [], e)

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -214,6 +214,12 @@ TRUTHY_ITERABLE: Final[ErrorCode] = ErrorCode(
     "General",
     default_enabled=False,
 )
+OPTIONAL_NON_TRUTHY: Final[ErrorCode] = ErrorCode(
+    "optional-non-truthy",
+    "Warn about expressions involving both None and a non-always-true value in boolean contexts",
+    "General",
+    default_enabled=False,
+)
 NAME_MATCH: Final = ErrorCode(
     "name-match", "Check that type definition has consistent naming", "General"
 )

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -167,6 +167,7 @@ ITERABLE_ALWAYS_TRUE: Final = ErrorMessage(
     "{} which can always be true in boolean context. Consider using {} instead.",
     code=codes.TRUTHY_ITERABLE,
 )
+OPTIONAL_WITH_NON_TRUTHY: Final = ErrorMessage("FIXME {}", code=codes.OPTIONAL_NON_TRUTHY)
 NOT_CALLABLE: Final = "{} not callable"
 TYPE_MUST_BE_USED: Final = "Value of type {} must be used"
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -942,6 +942,80 @@ def func(var: Iterable[str]) -> None:
 
     not var  # E: "var" has type "Iterable[str]" which can always be true in boolean context. Consider using "Collection[str]" instead.  [truthy-iterable]
 
+[case testOptionalNonTruthy]
+# flags: --enable-error-code optional-non-truthy
+from __future__ import annotations
+
+from typing import TypeVar
+
+class Truthy: pass
+class Truthy2: pass
+
+class NonTruthy:
+    def __bool__(self) -> bool: return False
+
+def no_error_direct(var: None | Truthy) -> None:
+    if var:
+        ...
+
+    not var
+
+OnlyTruthy = TypeVar("OnlyTruthy", Truthy, Truthy2)
+
+def no_error_typevar(var: None | OnlyTruthy) -> None:
+    if var:
+        ...
+
+    not var
+
+def error_int(var: None | int) -> None:
+    if var:  # E: FIXME x  [optional-non-truthy]
+        ...
+
+    not var  # E: FIXME x  [optional-non-truthy]
+
+def error_bool(var: None | bool) -> None:
+    if var:  # E: FIXME x  [optional-non-truthy]
+        ...
+
+    not var  # E: FIXME x  [optional-non-truthy]
+
+def error_list(var: None | list[Truthy]) -> None:
+    if var:  # E: FIXME x  [optional-non-truthy]
+        ...
+
+    not var  # E: FIXME x  [optional-non-truthy]
+
+def error_user_defined(var: None | NonTruthy) -> None:
+    if var:  # E: FIXME x  [optional-non-truthy]
+        ...
+
+    not var  # E: FIXME x  [optional-non-truthy]
+
+def error_union(var: None | int | Truthy | NonTruthy) -> None:
+    if var:  # E: FIXME x  [optional-non-truthy]
+        ...
+
+    not var  # E: FIXME x  [optional-non-truthy]
+
+Unconstrained = TypeVar("Unconstrained")
+
+def error_unconstrained_var(var: None | Unconstrained) -> None:
+    if var:  # E: FIXME x  [optional-non-truthy]
+        ...
+
+    not var  # E: FIXME x  [optional-non-truthy]
+
+Constrained = TypeVar("Constrained", str, int, Truthy, NonTruthy)
+
+def error_constrained_var(var: None | Constrained) -> None:
+    if var:  # E: FIXME x  [optional-non-truthy]
+        ...
+
+    not var  # E: FIXME x  [optional-non-truthy]
+
+[builtins fixtures/list.pyi]
+
 [case testNoOverloadImplementation]
 from typing import overload
 


### PR DESCRIPTION
Fixed #17892 

This is a sketch of an implementation of a check that catches bugs like

```python
def bug(x: None | str):
    if x:
        print(f"the str value is {x}") 
    else:
        print("the value is None") # oops! x could also be `""`
```

This is heavily inspired by the checks done in `check_for_truthy_type` for `truthy-iterable`, `truthy-bool` etc.

This isn't complete, but is designed to be a proof of concept. If I have agreement on the direction, I'll at least fix these:

- [ ] an actual error message (currently just `FIXME`)
- [ ] maybe put `check_for_truthy_type` and `check_for_optional_non_truthy_type` behind a single `check_for_type_truthiness` call, instead of having two calls sites that call both
