### PR TITLE
PEP 702 (@deprecated): improve the handling of explicit type annotations of assignment statements

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -160,6 +160,7 @@ from mypy.subtypes import (
 )
 from mypy.traverser import TraverserVisitor, all_return_statements, has_return_statement
 from mypy.treetransform import TransformVisitor
+from mypy.type_visitor import TypeVisitor
 from mypy.typeanal import check_for_explicit_any, has_any_from_unimported_type, make_optional_type
 from mypy.typeops import (
     bind_self,
@@ -226,7 +227,6 @@ from mypy.types import (
 from mypy.types_utils import is_overlapping_none, remove_optional, store_argument_type, strip_type
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.typevars import fill_typevars, fill_typevars_with_any, has_no_typevars
-from mypy.type_visitor import TypeVisitor
 from mypy.util import is_dunder, is_sunder
 from mypy.visitor import NodeVisitor
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -196,8 +196,6 @@ from mypy.types import (
     LiteralType,
     NoneType,
     Overloaded,
-    Parameters,
-    ParamSpecType,
     PartialType,
     ProperType,
     TupleType,

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7582,12 +7582,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if typ not in visited:
             visited.add(typ)
             if isinstance(typ := get_proper_type(typ), Instance):
-                    self.check_deprecated(typ.type, s)
-                    for arg in typ.args:
-                        self.search_deprecated(arg, s, visited)
+                self.check_deprecated(typ.type, s)
+                for arg in typ.args:
+                    self.search_deprecated(arg, s, visited)
             elif isinstance(typ, (UnionType, TupleType)):
                 for item in typ.items:
-                     self.search_deprecated(item, s, visited)
+                    self.search_deprecated(item, s, visited)
 
 
 class CollectArgTypeVarTypes(TypeTraverserVisitor):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7577,7 +7577,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             warn = self.msg.fail if self.options.report_deprecated_as_error else self.msg.note
             warn(deprecated, context, code=codes.DEPRECATED)
 
-    def search_deprecated(self, typ: Type | None, s: AssignmentStmt, visited: set[Type]) -> None:
+    def search_deprecated(
+        self, typ: Type | None, s: AssignmentStmt, visited: set[Type | None]
+    ) -> None:
 
         if typ not in visited:
             visited.add(typ)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -293,18 +293,10 @@ class InstanceDeprecatedVisitor(TypeTraverserVisitor):
     def __init__(self, typechecker: TypeChecker, context: Context) -> None:
         self.typechecker = typechecker
         self.context = context
-        self.seen_aliases: set[TypeAliasType] = set()
 
     def visit_instance(self, t: Instance) -> None:
         super().visit_instance(t)
         self.typechecker.check_deprecated(t.type, self.context)
-
-    def visit_type_alias_type(self, t: TypeAliasType) -> None:
-        super().visit_type_alias_type(t)
-        if t not in self.seen_aliases:
-            self.seen_aliases.add(t)
-            if ((alias := t.alias) is not None) and ((target := alias.target) is not None):
-                target.accept(self)
 
 
 class TypeChecker(NodeVisitor[None], CheckerPluginInterface):

--- a/test-data/unit/check-deprecated.test
+++ b/test-data/unit/check-deprecated.test
@@ -102,6 +102,7 @@ def h() -> None: ...
 
 [case testDeprecatedClass]
 
+from typing import List, Optional, Tuple, Union
 from typing_extensions import deprecated
 
 @deprecated("use C2 instead")
@@ -114,9 +115,29 @@ C.missing()  # N: class __main__.C is deprecated: use C2 instead \
 C.__init__(c)  # N: class __main__.C is deprecated: use C2 instead
 C(1)  # N: class __main__.C is deprecated: use C2 instead \
       # E: Too many arguments for "C"
+
 D = C  # N: class __main__.C is deprecated: use C2 instead
 D()
 t = (C, C, D)  # N: class __main__.C is deprecated: use C2 instead
+
+u1: Union[C, int] = 1  # N: class __main__.C is deprecated: use C2 instead
+u1 = 1
+u2 = 1  # type: Union[C, int]  # N: class __main__.C is deprecated: use C2 instead
+u2 = 1
+
+c1 = c2 = C()  # N: class __main__.C is deprecated: use C2 instead
+i, c3 = 1, C()  # N: class __main__.C is deprecated: use C2 instead
+
+class E: ...
+
+x1: Optional[C]  # N: class __main__.C is deprecated: use C2 instead
+x2: Union[D, C, E]  # N: class __main__.C is deprecated: use C2 instead
+x3: Union[D, Optional[C], E]  # N: class __main__.C is deprecated: use C2 instead
+x4: Tuple[D, C, E]  # N: class __main__.C is deprecated: use C2 instead
+x5: Tuple[Tuple[D, C], E]  # N: class __main__.C is deprecated: use C2 instead
+x6: List[C]  # N: class __main__.C is deprecated: use C2 instead
+x7: List[List[C]]  # N: class __main__.C is deprecated: use C2 instead
+x8: List[Optional[Tuple[Union[List[C], int]]]]  # N: class __main__.C is deprecated: use C2 instead
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-deprecated.test
+++ b/test-data/unit/check-deprecated.test
@@ -103,7 +103,7 @@ def h() -> None: ...
 [case testDeprecatedClass]
 
 from typing import Callable, List, Optional, Tuple, Union
-from typing_extensions import deprecated, TypeAlias
+from typing_extensions import deprecated, TypeAlias, TypeVar
 
 @deprecated("use C2 instead")
 class C: ...
@@ -141,11 +141,13 @@ x8: List[Optional[Tuple[Union[List[C], int]]]]  # N: class __main__.C is depreca
 x9: Callable[[int], C]  # N: class __main__.C is deprecated: use C2 instead
 x10: Callable[[int, C, int], int]  # N: class __main__.C is deprecated: use C2 instead
 
+T = TypeVar("T")
 A1: TypeAlias = Optional[C]  # ToDo
-x11: A1  # N: class __main__.C is deprecated: use C2 instead
-
+x11: A1
 A2: TypeAlias = List[Union[A2, C]]  # ToDo
-x12: A2  # N: class __main__.C is deprecated: use C2 instead
+x12: A2
+A3: TypeAlias = List[Optional[T]]
+x13: A3[C]  # N: class __main__.C is deprecated: use C2 instead
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-deprecated.test
+++ b/test-data/unit/check-deprecated.test
@@ -141,8 +141,11 @@ x8: List[Optional[Tuple[Union[List[C], int]]]]  # N: class __main__.C is depreca
 x9: Callable[[int], C]  # N: class __main__.C is deprecated: use C2 instead
 x10: Callable[[int, C, int], int]  # N: class __main__.C is deprecated: use C2 instead
 
-A: TypeAlias = Optional[C]  # ToDo
-x11: A  # N: class __main__.C is deprecated: use C2 instead
+A1: TypeAlias = Optional[C]  # ToDo
+x11: A1  # N: class __main__.C is deprecated: use C2 instead
+
+A2: TypeAlias = List[Union[A2, C]]  # ToDo
+x12: A2  # N: class __main__.C is deprecated: use C2 instead
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-deprecated.test
+++ b/test-data/unit/check-deprecated.test
@@ -102,8 +102,8 @@ def h() -> None: ...
 
 [case testDeprecatedClass]
 
-from typing import List, Optional, Tuple, Union
-from typing_extensions import deprecated
+from typing import Callable, List, Optional, Tuple, Union
+from typing_extensions import deprecated, TypeAlias
 
 @deprecated("use C2 instead")
 class C: ...
@@ -138,6 +138,11 @@ x5: Tuple[Tuple[D, C], E]  # N: class __main__.C is deprecated: use C2 instead
 x6: List[C]  # N: class __main__.C is deprecated: use C2 instead
 x7: List[List[C]]  # N: class __main__.C is deprecated: use C2 instead
 x8: List[Optional[Tuple[Union[List[C], int]]]]  # N: class __main__.C is deprecated: use C2 instead
+x9: Callable[[int], C]  # N: class __main__.C is deprecated: use C2 instead
+x10: Callable[[int, C, int], int]  # N: class __main__.C is deprecated: use C2 instead
+
+A: TypeAlias = Optional[C]  # ToDo
+x11: A  # N: class __main__.C is deprecated: use C2 instead
 
 [builtins fixtures/tuple.pyi]
 


### PR DESCRIPTION
Two improvements of the current PEP 702 implementation (deprecated):

* Analyse the explicit type annotations of "normal" assignment statements (that have an rvalue).
* Dive into nested type annotations of assignment statements.

(I intend to continue working on PEP 702 and would prefer to do so in small steps if this is okay for the maintainers/reviewers.)