### PR TITLE
[mypyc] Add "runtests.py mypyc-fast" for running fast mypyc tests

### DIFF
--- a/mypyc/doc/dev-intro.md
+++ b/mypyc/doc/dev-intro.md
@@ -202,6 +202,10 @@ general overview of how things work. Test cases live under
 -q mypyc`. If you don't make changes to code under `mypy/`, it's not
 important to regularly run mypy tests during development.
 
+You can use `python runtests.py mypyc-fast` to run a subset of mypyc
+tests that covers most functionality but runs significantly quicker
+than the entire test suite.
+
 When you create a PR, we have Continuous Integration jobs set up that
 compile mypy using mypyc and run the mypy test suite using the
 compiled mypy. This will sometimes catch additional issues not caught

--- a/runtests.py
+++ b/runtests.py
@@ -17,6 +17,8 @@ MYPYC_RUN = "TestRun"
 MYPYC_RUN_MULTI = "TestRunMultiFile"
 MYPYC_EXTERNAL = "TestExternal"
 MYPYC_COMMAND_LINE = "TestCommandLine"
+MYPYC_SEPARATE = "TestRunSeparate"
+MYPYC_MULTIMODULE = "multimodule"  # Subset of mypyc run tests that are slow
 ERROR_STREAM = "ErrorStreamSuite"
 
 
@@ -31,6 +33,7 @@ ALL_NON_FAST = [
     MYPYC_RUN_MULTI,
     MYPYC_EXTERNAL,
     MYPYC_COMMAND_LINE,
+    MYPYC_SEPARATE,
     ERROR_STREAM,
 ]
 
@@ -40,7 +43,10 @@ PYTEST_OPT_IN = [PEP561]
 
 
 # These must be enabled by explicitly including 'mypyc-extra' on the command line.
-MYPYC_OPT_IN = [MYPYC_RUN, MYPYC_RUN_MULTI]
+MYPYC_OPT_IN = [MYPYC_RUN, MYPYC_RUN_MULTI, MYPYC_SEPARATE]
+
+# These mypyc test filters cover most slow test cases
+MYPYC_SLOW = [MYPYC_RUN_MULTI, MYPYC_COMMAND_LINE, MYPYC_SEPARATE, MYPYC_MULTIMODULE]
 
 
 # We split the pytest run into three parts to improve test
@@ -77,6 +83,7 @@ cmds = {
         "-k",
         " or ".join([DAEMON, MYPYC_EXTERNAL, MYPYC_COMMAND_LINE, ERROR_STREAM]),
     ],
+    "mypyc-fast": ["pytest", "-q", "mypyc", "-k", f"not ({' or '.join(MYPYC_SLOW)})"],
     # Test cases that might take minutes to run
     "pytest-extra": ["pytest", "-q", "-k", " or ".join(PYTEST_OPT_IN)],
     # Mypyc tests that aren't run by default, since they are slow and rarely
@@ -87,7 +94,7 @@ cmds = {
 # Stop run immediately if these commands fail
 FAST_FAIL = ["self", "lint"]
 
-EXTRA_COMMANDS = ("pytest-extra", "mypyc-extra")
+EXTRA_COMMANDS = ("pytest-extra", "mypyc-fast", "mypyc-extra")
 DEFAULT_COMMANDS = [cmd for cmd in cmds if cmd not in EXTRA_COMMANDS]
 
 assert all(cmd in cmds for cmd in FAST_FAIL)


### PR DESCRIPTION
Many tests are a bit slow and but don't increase test coverage by a lot. Running these fast tests should find the vast majority of issues while being significantly faster than running all mypyc tests.