### PR TITLE
Better error for `mypy -p package` without py.typed

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1413,7 +1413,11 @@ def process_options(
                 fail(f"Package name '{p}' cannot have a slash in it.", stderr, options)
             p_targets = cache.find_modules_recursive(p)
             if not p_targets:
-                fail(f"Can't find package '{p}'", stderr, options)
+                fail(
+                    f"Can't find package '{p}'. This can happen when py.typed is missing. See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
+                    stderr,
+                    options,
+                )
             targets.extend(p_targets)
         for m in special_opts.modules:
             targets.append(BuildSource(None, m, None))

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -22,7 +22,14 @@ from mypy.error_formatter import OUTPUT_CHOICES
 from mypy.errors import CompileError
 from mypy.find_sources import InvalidSourceList, create_source_list
 from mypy.fscache import FileSystemCache
-from mypy.modulefinder import BuildSource, FindModuleCache, SearchPaths, get_search_dirs, mypy_path
+from mypy.modulefinder import (
+    BuildSource,
+    FindModuleCache,
+    SearchPaths,
+    get_search_dirs,
+    mypy_path,
+    ModuleNotFoundReason,
+)
 from mypy.options import INCOMPLETE_FEATURES, BuildType, Options
 from mypy.split_namespace import SplitNamespace
 from mypy.version import __version__
@@ -1413,11 +1420,15 @@ def process_options(
                 fail(f"Package name '{p}' cannot have a slash in it.", stderr, options)
             p_targets = cache.find_modules_recursive(p)
             if not p_targets:
-                fail(
-                    f"Can't find package '{p}'. This can happen when py.typed is missing. See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
-                    stderr,
-                    options,
-                )
+                reason = cache.find_module(p)
+                if reason is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
+                    fail(
+                        f"package '{p}' is skipping due to missing py.typed marker. See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
+                        stderr,
+                        options,
+                    )
+                else:
+                    fail(f"Can't find package '{p}'", stderr, options)
             targets.extend(p_targets)
         for m in special_opts.modules:
             targets.append(BuildSource(None, m, None))

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1423,7 +1423,7 @@ def process_options(
                 reason = cache.find_module(p)
                 if reason is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
                     fail(
-                        f"package '{p}' is skipping due to missing py.typed marker. See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
+                        f"Package '{p}' cannot be type checked due to missing py.typed marker. See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
                         stderr,
                         options,
                     )

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -25,10 +25,10 @@ from mypy.fscache import FileSystemCache
 from mypy.modulefinder import (
     BuildSource,
     FindModuleCache,
+    ModuleNotFoundReason,
     SearchPaths,
     get_search_dirs,
     mypy_path,
-    ModuleNotFoundReason,
 )
 from mypy.options import INCOMPLETE_FEATURES, BuildType, Options
 from mypy.split_namespace import SplitNamespace


### PR DESCRIPTION
Improve the error message when running `mypy -p packagename` with a
package that doesn't have py.typed set.

> package 'example' is skipping due to missing py.typed marker. See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details

Fix #17048