### PR TITLE
[mypyc] Support ellipsis (...) expressions in class bodies

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -12,6 +12,7 @@ from mypy.nodes import (
     CallExpr,
     ClassDef,
     Decorator,
+    EllipsisExpr,
     ExpressionStmt,
     FuncDef,
     Lvalue,
@@ -145,7 +146,11 @@ def transform_class_def(builder: IRBuilder, cdef: ClassDef) -> None:
                 continue
             with builder.catch_errors(stmt.line):
                 cls_builder.add_method(get_func_def(stmt))
-        elif isinstance(stmt, PassStmt):
+        elif (
+            isinstance(stmt, PassStmt)
+            or (isinstance(stmt, ExpressionStmt)
+            and isinstance(stmt.expr, EllipsisExpr))
+        ):
             continue
         elif isinstance(stmt, AssignmentStmt):
             if len(stmt.lvalues) != 1:

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -146,10 +146,8 @@ def transform_class_def(builder: IRBuilder, cdef: ClassDef) -> None:
                 continue
             with builder.catch_errors(stmt.line):
                 cls_builder.add_method(get_func_def(stmt))
-        elif (
-            isinstance(stmt, PassStmt)
-            or (isinstance(stmt, ExpressionStmt)
-            and isinstance(stmt.expr, EllipsisExpr))
+        elif isinstance(stmt, PassStmt) or (
+            isinstance(stmt, ExpressionStmt) and isinstance(stmt.expr, EllipsisExpr)
         ):
             continue
         elif isinstance(stmt, AssignmentStmt):

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -18,6 +18,26 @@ True
 <native.Empty object
 True
 
+[case testEmptyClassEllipsis]
+class Empty: ...
+
+def f(e: Empty) -> Empty:
+    return e
+[file driver.py]
+from native import Empty, f
+
+print(isinstance(Empty, type))
+print(Empty)
+print(str(Empty())[:20])
+
+e = Empty()
+print(f(e) is e)
+[out]
+True
+<class 'native.Empty'>
+<native.Empty object
+True
+
 [case testClassWithFields]
 class C:
     x: int

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -3,28 +3,13 @@ class Empty: pass
 
 def f(e: Empty) -> Empty:
     return e
-[file driver.py]
-from native import Empty, f
 
-print(isinstance(Empty, type))
-print(Empty)
-print(str(Empty())[:20])
+class EmptyEllipsis: ...
 
-e = Empty()
-print(f(e) is e)
-[out]
-True
-<class 'native.Empty'>
-<native.Empty object
-True
-
-[case testEmptyClassEllipsis]
-class Empty: ...
-
-def f(e: Empty) -> Empty:
+def g(e: EmptyEllipsis) -> EmptyEllipsis:
     return e
 [file driver.py]
-from native import Empty, f
+from native import Empty, EmptyEllipsis, f, g
 
 print(isinstance(Empty, type))
 print(Empty)
@@ -32,10 +17,21 @@ print(str(Empty())[:20])
 
 e = Empty()
 print(f(e) is e)
+
+print(isinstance(EmptyEllipsis, type))
+print(EmptyEllipsis)
+print(str(EmptyEllipsis())[:28])
+
+e2 = EmptyEllipsis()
+print(g(e2) is e2)
 [out]
 True
 <class 'native.Empty'>
 <native.Empty object
+True
+True
+<class 'native.EmptyEllipsis'>
+<native.EmptyEllipsis object
 True
 
 [case testClassWithFields]


### PR DESCRIPTION
This can be used to declare concise custom exceptions, e.g.

    class UnknownReleaseError(ValueError): ...

which otherwise probably would be written

    class UnknownReleaseError(ValueError):
        pass

and is supported by CPython.

Closes https://github.com/mypyc/mypyc/issues/1069
