### PR TITLE
[mypyc] Replace deprecated _PyDict_GetItemStringWithError

### DIFF
--- a/mypyc/lib-rt/getargs.c
+++ b/mypyc/lib-rt/getargs.c
@@ -250,11 +250,11 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
                 current_arg = PyTuple_GET_ITEM(args, i);
             }
             else if (nkwargs && i >= pos) {
-                current_arg = _PyDict_GetItemStringWithError(kwargs, kwlist[i]);
-                if (current_arg) {
+                int res = PyDict_GetItemStringRef(kwargs, kwlist[i], &current_arg);
+                if (res == 1) {
                     --nkwargs;
                 }
-                else if (PyErr_Occurred()) {
+                else if (res == -1) {
                     return 0;
                 }
             }
@@ -370,8 +370,8 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
         Py_ssize_t j;
         /* make sure there are no arguments given by name and position */
         for (i = pos; i < bound_pos_args && i < len; i++) {
-            current_arg = _PyDict_GetItemStringWithError(kwargs, kwlist[i]);
-            if (unlikely(current_arg != NULL)) {
+            int res = PyDict_GetItemStringRef(kwargs, kwlist[i], &current_arg);
+            if (unlikely(res == 0)) {
                 /* arg present in tuple and in dict */
                 PyErr_Format(PyExc_TypeError,
                              "argument for %.200s%s given by name ('%s') "
@@ -381,7 +381,7 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
                              kwlist[i], i+1);
                 goto latefail;
             }
-            else if (unlikely(PyErr_Occurred() != NULL)) {
+            else if (unlikely(res == -1)) {
                 goto latefail;
             }
         }


### PR DESCRIPTION
`_PyDict_GetItemStringWithError ` was deprecated for Python 3.14 in https://github.com/python/cpython/pull/119855.
Use `PyDict_GetItemStringRef` instead. It was added in 3.13 but is available via `pythoncapi_compat.h`.

https://docs.python.org/3/c-api/dict.html#c.PyDict_GetItemStringRef