### PR TITLE
[mypyc] Use PyGen_GetCode in gen_is_coroutine

### DIFF
--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -405,45 +405,15 @@ _CPyObject_HasAttrId(PyObject *v, _Py_Identifier *name) {
     PyObject_CallMethodObjArgs((self), (name), (arg), NULL)
 #endif
 
-#if CPY_3_13_FEATURES
-
-// These are copied from genobject.c in Python 3.13
-
-/* Returns a borrowed reference */
-static inline PyCodeObject *
-_PyGen_GetCode(PyGenObject *gen) {
-    _PyInterpreterFrame *frame = (_PyInterpreterFrame *)(gen->gi_iframe);
-    return _PyFrame_GetCode(frame);
-}
-
-static int
-gen_is_coroutine(PyObject *o)
-{
-    if (PyGen_CheckExact(o)) {
-        PyCodeObject *code = _PyGen_GetCode((PyGenObject*)o);
-        if (code->co_flags & CO_ITERABLE_COROUTINE) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
-#elif CPY_3_12_FEATURES
+#if CPY_3_12_FEATURES
 
 // These are copied from genobject.c in Python 3.12
 
-/* Returns a borrowed reference */
-static inline PyCodeObject *
-_PyGen_GetCode(PyGenObject *gen) {
-    _PyInterpreterFrame *frame = (_PyInterpreterFrame *)(gen->gi_iframe);
-    return frame->f_code;
-}
-
 static int
 gen_is_coroutine(PyObject *o)
 {
     if (PyGen_CheckExact(o)) {
-        PyCodeObject *code = _PyGen_GetCode((PyGenObject*)o);
+        PyCodeObject *code = PyGen_GetCode((PyGenObject*)o);
         if (code->co_flags & CO_ITERABLE_COROUTINE) {
             return 1;
         }


### PR DESCRIPTION
Instead of copying the implementation of `_PyGen_GetCode` every time it changes in cpython, use the public `PyGen_GetCode` function. The current implementation would break for Python 3.14 as it has been changed upstream in https://github.com/python/cpython/pull/120835.