### PR TITLE
[docs]: fix the edit page buttton link in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,6 +107,12 @@ exclude_patterns = []
 # a list of builtin themes.
 html_theme = "furo"
 
+html_theme_options = {
+    "source_repository": "https://github.com/python/mypy",
+    "source_branch": "master",
+    "source_directory": "docs/source",
+}
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

fix: #17870 

# Issue
The current docs `edit` the page button gives a 404.

# What changes this PR does
This PR edits the sphinx `config.py` and configures the edit button url to the `master` branch of this repository.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
