### PR TITLE
Update black to 24.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1  # must match test-requirements.txt
+    rev: 24.8.0  # must match test-requirements.txt
     hooks:
       - id: black
         exclude: '^(test-data/)'

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -4,7 +4,7 @@
 -r mypy-requirements.txt
 -r build-requirements.txt
 attrs>=18.0
-black==24.3.0  # must match version in .pre-commit-config.yaml
+black==24.8.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
 # lxml 4.9.3 switched to manylinux_2_28, the wheel builder still uses manylinux2014
 lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@
 #
 attrs==23.1.0
     # via -r test-requirements.in
-black==24.3.0
+black==24.8.0
     # via -r test-requirements.in
 click==8.1.7
     # via black


### PR DESCRIPTION
Update to 24.8.0 the last release with support for Python 3.8.
https://github.com/psf/black/blob/24.8.0/CHANGES.md