### PR TITLE
Update setuptools to 75.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
         echo debug build; python -c 'import sysconfig; print(bool(sysconfig.get_config_var("Py_DEBUG")))'
         echo os.cpu_count; python -c 'import os; print(os.cpu_count())'
         echo os.sched_getaffinity; python -c 'import os; print(len(getattr(os, "sched_getaffinity", lambda *args: [])(0)))'
-        pip install setuptools==68.2.2 tox==4.11.0
+        pip install setuptools==75.1.0 tox==4.11.0
 
     - name: Compiled with mypyc
       if: ${{ matrix.test_mypyc }}
@@ -243,7 +243,7 @@ jobs:
           default: 3.11.1
           command: python -c "import platform; print(f'{platform.architecture()=} {platform.machine()=}');"
       - name: Install tox
-        run: pip install setuptools==68.2.2 tox==4.11.0
+        run: pip install setuptools==75.1.0 tox==4.11.0
       - name: Setup tox environment
         run: tox run -e py --notest
       - name: Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,7 @@ requires = [
     # NOTE: this needs to be kept in sync with mypy-requirements.txt
     # and build-requirements.txt, because those are both needed for
     # self-typechecking :/
-    "setuptools >= 40.6.2",
-    "wheel >= 0.30.0",
+    "setuptools >= 75.1.0",
     # the following is from mypy-requirements.txt/setup.py
     "typing_extensions>=4.6.0",
     "mypy_extensions>=1.0.0",

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -13,6 +13,6 @@ pytest>=8.1.0
 pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
 ruff==0.6.9  # must match version in .pre-commit-config.yaml
-setuptools>=65.5.1
+setuptools>=75.1.0
 tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.8
 pre_commit>=3.5.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -67,7 +67,7 @@ tomli==2.0.1
     # via -r test-requirements.in
 types-psutil==5.9.5.17
     # via -r build-requirements.txt
-types-setuptools==68.2.0.0
+types-setuptools==75.1.0.20241014
     # via -r build-requirements.txt
 typing-extensions==4.12.2
     # via -r mypy-requirements.txt
@@ -75,5 +75,5 @@ virtualenv==20.26.6
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==70.0.0
+setuptools==75.1.0
     # via -r test-requirements.in


### PR DESCRIPTION
https://setuptools.pypa.io/en/stable/history.html#v75-1-0

Since setuptools `70.1` the `bdist_wheel` command is shipped with setuptools directly. It's no longer necessary to specify `wheel` as a build system requirement.