### PR TITLE
Add warn-unreachable to strict mode

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -802,7 +802,7 @@ def process_options(
     add_invertible_flag(
         "--warn-unreachable",
         default=False,
-        strict_flag=False,
+        strict_flag=True,
         help="Warn about statements or expressions inferred to be unreachable",
         group=lint_group,
     )


### PR DESCRIPTION
This is useful check for dead code analysis

Closes #11223 

This adds a useful check to the default list of strict arguments

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
