### PR TITLE
Use sha1 for hashing

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -535,9 +535,7 @@ def hash_digest(data: bytes) -> str:
     accidental collision, but we don't really care about any of the
     cryptographic properties.
     """
-    # Once we drop Python 3.5 support, we should consider using
-    # blake2b, which is faster.
-    return hashlib.sha256(data).hexdigest()
+    return hashlib.sha1(data).hexdigest()
 
 
 def parse_gray_color(cup: bytes) -> str:


### PR DESCRIPTION
This is a pretty small win, it's below the noise floor on macrobenchmark, but if you time the hashing specifically it saves about 100ms (0.5%) on `python -m mypy -c 'import torch' --no-incremental`. blake2b is slower