### PR TITLE
stubgen:  fix FunctionContext.fullname for nested classes

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -468,13 +468,17 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
         self._vars: list[list[str]] = [[]]
         # What was generated previously in the stub file.
         self._state = EMPTY
-        self._current_class: ClassDef | None = None
+        self._class_stack: list[ClassDef] = []
         # Was the tree semantically analysed before?
         self.analyzed = analyzed
         # Short names of methods defined in the body of the current class
         self.method_names: set[str] = set()
         self.processing_enum = False
         self.processing_dataclass = False
+
+    @property
+    def _current_class(self) -> ClassDef | None:
+        return self._class_stack[-1] if self._class_stack else None
 
     def visit_mypy_file(self, o: MypyFile) -> None:
         self.module_name = o.fullname  # Current module being processed
@@ -646,12 +650,14 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
                 if init_code:
                     self.add(init_code)
 
-        if self._current_class is not None:
+        if self._class_stack:
             if len(o.arguments):
                 self_var = o.arguments[0].variable.name
             else:
                 self_var = "self"
-            class_info = ClassInfo(self._current_class.name, self_var)
+            class_info: ClassInfo | None = None
+            for class_def in self._class_stack:
+                class_info = ClassInfo(class_def.name, self_var, parent=class_info)
         else:
             class_info = None
 
@@ -741,7 +747,7 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
         return self.resolve_name(name)
 
     def visit_class_def(self, o: ClassDef) -> None:
-        self._current_class = o
+        self._class_stack.append(o)
         self.method_names = find_method_names(o.defs.body)
         sep: int | None = None
         if self.is_top_level() and self._state != EMPTY:
@@ -786,8 +792,8 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
             self._state = CLASS
         self.method_names = set()
         self.processing_dataclass = False
+        self._class_stack.pop(-1)
         self.processing_enum = False
-        self._current_class = None
 
     def get_base_types(self, cdef: ClassDef) -> list[str]:
         """Get list of base classes for a class."""

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -787,7 +787,9 @@ class InspectionStubGenerator(BaseStubGenerator):
                 bases.append(base)
         return [self.strip_or_import(self.get_type_fullname(base)) for base in bases]
 
-    def generate_class_stub(self, class_name: str, cls: type, output: list[str]) -> None:
+    def generate_class_stub(
+        self, class_name: str, cls: type, output: list[str], parent_class: ClassInfo | None = None
+    ) -> None:
         """Generate stub for a single class using runtime introspection.
 
         The result lines will be appended to 'output'. If necessary, any
@@ -808,7 +810,9 @@ class InspectionStubGenerator(BaseStubGenerator):
         self.record_name(class_name)
         self.indent()
 
-        class_info = ClassInfo(class_name, "", getattr(cls, "__doc__", None), cls)
+        class_info = ClassInfo(
+            class_name, "", getattr(cls, "__doc__", None), cls, parent=parent_class
+        )
 
         for attr, value in items:
             # use unevaluated descriptors when dealing with property inspection
@@ -843,7 +847,7 @@ class InspectionStubGenerator(BaseStubGenerator):
                     class_info,
                 )
             elif inspect.isclass(value) and self.is_defined_in_module(value):
-                self.generate_class_stub(attr, value, types)
+                self.generate_class_stub(attr, value, types, parent_class=class_info)
             else:
                 attrs.append((attr, value))
 

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -306,12 +306,18 @@ class AnnotationPrinter(TypeStrVisitor):
 
 class ClassInfo:
     def __init__(
-        self, name: str, self_var: str, docstring: str | None = None, cls: type | None = None
+        self,
+        name: str,
+        self_var: str,
+        docstring: str | None = None,
+        cls: type | None = None,
+        parent: ClassInfo | None = None,
     ) -> None:
         self.name = name
         self.self_var = self_var
         self.docstring = docstring
         self.cls = cls
+        self.parent = parent
 
 
 class FunctionContext:
@@ -334,7 +340,13 @@ class FunctionContext:
     def fullname(self) -> str:
         if self._fullname is None:
             if self.class_info:
-                self._fullname = f"{self.module_name}.{self.class_info.name}.{self.name}"
+                parents = []
+                class_info: ClassInfo | None = self.class_info
+                while class_info is not None:
+                    parents.append(class_info.name)
+                    class_info = class_info.parent
+                namespace = ".".join(reversed(parents))
+                self._fullname = f"{self.module_name}.{namespace}.{self.name}"
             else:
                 self._fullname = f"{self.module_name}.{self.name}"
         return self._fullname

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -38,6 +38,7 @@ from mypy.stubgen import (
 from mypy.stubgenc import InspectionStubGenerator, infer_c_method_args
 from mypy.stubutil import (
     ClassInfo,
+    FunctionContext,
     common_dir_prefix,
     infer_method_ret_type,
     remove_misplaced_type_comments,
@@ -611,6 +612,16 @@ class StubgenUtilSuite(unittest.TestCase):
         assert common_dir_prefix([r"foo/bar\x.pyi"]) == r"foo\bar"
         assert common_dir_prefix([r"foo\bar/x.pyi"]) == r"foo\bar"
         assert common_dir_prefix([r"foo/bar/x.pyi"]) == r"foo\bar"
+
+    def test_function_context_nested_classes(self) -> None:
+        ctx = FunctionContext(
+            module_name="spangle",
+            name="foo",
+            class_info=ClassInfo(
+                name="Nested", self_var="self", parent=ClassInfo(name="Parent", self_var="self")
+            ),
+        )
+        assert ctx.fullname == "spangle.Parent.Nested.foo"
 
 
 class StubgenHelpersSuite(unittest.TestCase):


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This fixes an issue with the computation of `FunctionContext.fullname` for nested classes.  

For a module named `spangle`, with the following classes:

```python
class Foo:
    class Bar:
        pass
```

The previous output for the class `Bar` was `"spangle.Bar"` and with this fix it is now `"spangle.Foo.Bar"`.



<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
