### PR TITLE
disabled overlap checks in assert

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4725,6 +4725,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.check_final(s)
 
     def visit_assert_stmt(self, s: AssertStmt) -> None:
+        # Disable comparison overlap checks on assert statements to prevent false positives
         with self.msg.filter_errors(
                 filter_errors=lambda name, info: info.code == codes.COMPARISON_OVERLAP,
             ):
@@ -4738,6 +4739,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if s.msg is not None:
             self.expr_checker.analyze_cond_branch(else_map, s.msg, None)
         self.push_type_map(true_map)
+
+        # Disable unreachable warning on assert statements to prevent false positives
         if not true_map:
             self.binder.suppress_unreachable_warnings()
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4727,8 +4727,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def visit_assert_stmt(self, s: AssertStmt) -> None:
         # Disable comparison overlap checks on assert statements to prevent false positives
         with self.msg.filter_errors(
-                filter_errors=lambda name, info: info.code == codes.COMPARISON_OVERLAP,
-            ):
+            filter_errors=lambda name, info: info.code == codes.COMPARISON_OVERLAP
+        ):
             self.expr_checker.accept(s.expr)
 
         if isinstance(s.expr, TupleExpr) and len(s.expr.items) > 0:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2388,7 +2388,7 @@ assert a == b
 
 R2 = Dict[int, R2]
 c: R2
-assert a == c  # E: Non-overlapping equality check (left operand type: "Dict[str, R]", right operand type: "Dict[int, R2]")
+assert a == c
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -727,8 +727,8 @@ def test2(switch: FlipFlopEnum) -> None:
 
     switch.mutate()
 
-    assert switch.state == State.B     # E: Non-overlapping equality check (left operand type: "Literal[State.A]", right operand type: "Literal[State.B]")
-    reveal_type(switch.state)          # E: Statement is unreachable
+    assert switch.state == State.B
+    reveal_type(switch.state)
 
 def test3(switch: FlipFlopEnum) -> None:
     # Same thing, but using 'is' comparisons. Previously mypy's behaviour differed
@@ -739,8 +739,8 @@ def test3(switch: FlipFlopEnum) -> None:
 
     switch.mutate()
 
-    assert switch.state is State.B     # E: Non-overlapping identity check (left operand type: "Literal[State.A]", right operand type: "Literal[State.B]")
-    reveal_type(switch.state)          # E: Statement is unreachable
+    assert switch.state is State.B
+    reveal_type(switch.state)
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityRequiresExplicitStrLiteral]

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -733,7 +733,7 @@ else:
 def foo(c: int) -> None:
     reveal_type(c)  # N: Revealed type is "builtins.int"
     assert not isinstance(c, int)
-    reveal_type(c)  # E: Statement is unreachable
+    reveal_type(c)
 [builtins fixtures/isinstancelist.pyi]
 
 [case testUnreachableFlagWithBadControlFlow4]
@@ -1338,7 +1338,7 @@ def test_typed_fn(obj) -> None:
     obj.reload()
 
     assert obj.prop is False
-    reveal_type(obj.prop)  # E: Statement is unreachable
+    reveal_type(obj.prop)
 
 [case testUnreachableCheckedUntypedFunction]
 # flags: --warn-unreachable --check-untyped-defs
@@ -1350,7 +1350,7 @@ def test_untyped_fn(obj):
     obj.reload()
 
     assert obj.prop is False
-    reveal_type(obj.prop)  # E: Statement is unreachable
+    reveal_type(obj.prop)
 
 [case testConditionalTypeVarException]
 # every part of this test case was necessary to trigger the crash


### PR DESCRIPTION
Fixes #17896 

### Changes

1. `COMPARISON_OVERLAP` errors are being filtered on the assert statement
2. Regarding the reachability issue, I have also implemented `suppress_unreachable_warnings()` after assert statements. 

I'm not sure if this is the best approach, particularly on `suppress_unreachable_warnings()`. Any feedback on this would be great.