### PR TITLE
Add initial support for new style TypeVar defaults (PEP 696)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1159,6 +1159,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     ) -> None:
         """Type check a function definition."""
         # Expand type variables with value restrictions to ordinary types.
+        self.check_typevar_defaults(typ.variables)
         expanded = self.expand_typevars(defn, typ)
         original_typ = typ
         for item, typ in expanded:
@@ -2548,7 +2549,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # all other bases have already been checked.
             break
 
-    def check_typevar_defaults(self, tvars: list[TypeVarLikeType]) -> None:
+    def check_typevar_defaults(self, tvars: Sequence[TypeVarLikeType]) -> None:
         for tv in tvars:
             if not (isinstance(tv, TypeVarType) and tv.has_default()):
                 continue

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5376,9 +5376,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         del type_map[expr]
 
     def visit_type_alias_stmt(self, o: TypeAliasStmt) -> None:
-        sym = self.lookup_qualified(o.name.fullname)
-        if isinstance(sym.node, TypeAlias):
-            self.check_typevar_defaults(sym.node.alias_tvars)
+        if o.alias_node:
+            self.check_typevar_defaults(o.alias_node.alias_tvars)
 
         with self.msg.filter_errors():
             self.expr_checker.accept(o.value)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2483,6 +2483,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             context=defn,
                             code=codes.TYPE_VAR,
                         )
+        if typ.defn.type_vars:
+            self.check_typevar_defaults(typ.defn.type_vars)
 
         if typ.is_protocol and typ.defn.type_vars:
             self.check_protocol_variance(defn)
@@ -2545,6 +2547,15 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # We are only interested in the first Base having __init_subclass__,
             # all other bases have already been checked.
             break
+
+    def check_typevar_defaults(self, tvars: list[TypeVarLikeType]) -> None:
+        for tv in tvars:
+            if not (isinstance(tv, TypeVarType) and tv.has_default()):
+                continue
+            if not is_subtype(tv.default, tv.upper_bound):
+                self.fail("TypeVar default must be a subtype of the bound type", tv)
+            if tv.values and not any(tv.default == value for value in tv.values):
+                self.fail("TypeVar default must be one of the constraint types", tv)
 
     def check_enum(self, defn: ClassDef) -> None:
         assert defn.info.is_enum
@@ -5365,6 +5376,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         del type_map[expr]
 
     def visit_type_alias_stmt(self, o: TypeAliasStmt) -> None:
+        sym = self.lookup_qualified(o.name.fullname)
+        if isinstance(sym.node, TypeAlias):
+            self.check_typevar_defaults(sym.node.alias_tvars)
+
         with self.msg.filter_errors():
             self.expr_checker.accept(o.value)
 

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1198,17 +1198,15 @@ class ASTConverter:
         for p in type_params:
             bound = None
             values: list[Type] = []
-            if sys.version_info >= (3, 13) and p.default_value is not None:
-                self.fail(
-                    message_registry.TYPE_PARAM_DEFAULT_NOT_SUPPORTED,
-                    p.lineno,
-                    p.col_offset,
-                    blocker=False,
-                )
+            default = None
+            if sys.version_info >= (3, 13):
+                default = TypeConverter(self.errors, line=p.lineno).visit(p.default_value)
             if isinstance(p, ast_ParamSpec):  # type: ignore[misc]
-                explicit_type_params.append(TypeParam(p.name, PARAM_SPEC_KIND, None, []))
+                explicit_type_params.append(TypeParam(p.name, PARAM_SPEC_KIND, None, [], default))
             elif isinstance(p, ast_TypeVarTuple):  # type: ignore[misc]
-                explicit_type_params.append(TypeParam(p.name, TYPE_VAR_TUPLE_KIND, None, []))
+                explicit_type_params.append(
+                    TypeParam(p.name, TYPE_VAR_TUPLE_KIND, None, [], default)
+                )
             else:
                 if isinstance(p.bound, ast3.Tuple):
                     if len(p.bound.elts) < 2:
@@ -1224,7 +1222,9 @@ class ASTConverter:
                 elif p.bound is not None:
                     self.validate_type_param(p)
                     bound = TypeConverter(self.errors, line=p.lineno).visit(p.bound)
-                explicit_type_params.append(TypeParam(p.name, TYPE_VAR_KIND, bound, values))
+                explicit_type_params.append(
+                    TypeParam(p.name, TYPE_VAR_KIND, bound, values, default)
+                )
         return explicit_type_params
 
     # Return(expr? value)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1196,9 +1196,9 @@ class ASTConverter:
     def translate_type_params(self, type_params: list[Any]) -> list[TypeParam]:
         explicit_type_params = []
         for p in type_params:
-            bound = None
+            bound: Type | None = None
             values: list[Type] = []
-            default = None
+            default: Type | None = None
             if sys.version_info >= (3, 13):
                 default = TypeConverter(self.errors, line=p.lineno).visit(p.default_value)
             if isinstance(p, ast_ParamSpec):  # type: ignore[misc]

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -362,8 +362,3 @@ TYPE_ALIAS_WITH_NAMED_EXPRESSION: Final = ErrorMessage(
 TYPE_ALIAS_WITH_AWAIT_EXPRESSION: Final = ErrorMessage(
     "Await expression cannot be used within a type alias", codes.SYNTAX
 )
-
-TYPE_PARAM_DEFAULT_NOT_SUPPORTED: Final = ErrorMessage(
-    "Type parameter default types not supported when using Python 3.12 type parameter syntax",
-    codes.MISC,
-)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -670,7 +670,7 @@ TYPE_VAR_TUPLE_KIND: Final = 2
 
 
 class TypeParam:
-    __slots__ = ("name", "kind", "upper_bound", "values")
+    __slots__ = ("name", "kind", "upper_bound", "values", "default")
 
     def __init__(
         self,
@@ -678,11 +678,13 @@ class TypeParam:
         kind: int,
         upper_bound: mypy.types.Type | None,
         values: list[mypy.types.Type],
+        default: mypy.types.Type | None,
     ) -> None:
         self.name = name
         self.kind = kind
         self.upper_bound = upper_bound
         self.values = values
+        self.default = default
 
 
 FUNCITEM_FLAGS: Final = FUNCBASE_FLAGS + [

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1659,7 +1659,7 @@ class MatchStmt(Statement):
 
 
 class TypeAliasStmt(Statement):
-    __slots__ = ("name", "type_args", "value", "invalid_recursive_alias")
+    __slots__ = ("name", "type_args", "value", "invalid_recursive_alias", "alias_node")
 
     __match_args__ = ("name", "type_args", "value")
 
@@ -1667,6 +1667,7 @@ class TypeAliasStmt(Statement):
     type_args: list[TypeParam]
     value: LambdaExpr  # Return value will get translated into a type
     invalid_recursive_alias: bool
+    alias_node: TypeAlias | None
 
     def __init__(self, name: NameExpr, type_args: list[TypeParam], value: LambdaExpr) -> None:
         super().__init__()
@@ -1674,6 +1675,7 @@ class TypeAliasStmt(Statement):
         self.type_args = type_args
         self.value = value
         self.invalid_recursive_alias = False
+        self.alias_node = None
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_type_alias_stmt(self)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -782,7 +782,7 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         "deco_line",
         "is_trivial_body",
         "is_mypy_only",
-        # Present only when a function is decorated with @typing.datasclass_transform or similar
+        # Present only when a function is decorated with @typing.dataclass_transform or similar
         "dataclass_transform_spec",
         "docstring",
         "deprecated",

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5535,6 +5535,7 @@ class SemanticAnalyzer(
                 eager=eager,
                 python_3_12_type_alias=True,
             )
+            s.alias_node = alias_node
 
             if (
                 existing

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -349,6 +349,8 @@ class StrConv(NodeVisitor[str]):
             a.append(p.upper_bound)
         if p.values:
             a.append(("Values", p.values))
+        if p.default:
+            a.append(("Default", [p.default]))
         return [("TypeParam", a)]
 
     # Expressions

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -25,6 +25,8 @@ class ParserSuite(DataSuite):
         files.remove("parse-python310.test")
     if sys.version_info < (3, 12):
         files.remove("parse-python312.test")
+    if sys.version_info < (3, 13):
+        files.remove("parse-python313.test")
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         test_parser(testcase)
@@ -43,6 +45,8 @@ def test_parser(testcase: DataDrivenTestCase) -> None:
         options.python_version = (3, 10)
     elif testcase.file.endswith("python312.test"):
         options.python_version = (3, 12)
+    elif testcase.file.endswith("python313.test"):
+        options.python_version = (3, 13)
     else:
         options.python_version = defaults.PYTHON3_VERSION
 

--- a/test-data/unit/check-python313.test
+++ b/test-data/unit/check-python313.test
@@ -64,6 +64,34 @@ class ClassTs3[*Ts = tuple[int]]: ...  # E: The default argument to TypeVarTuple
 [builtins fixtures/tuple.pyi]
 
 [case testPEP695TypeParameterDefaultInvalid2]
+from typing import overload
+def f1[T = 2]() -> None: ...  # E: TypeVar "default" must be a type
+def f2[T = [int]]() -> None: ...  # E: Bracketed expression "[...]" is not valid as a type \
+                                  # N: Did you mean "List[...]"? \
+                                  # E: TypeVar "default" must be a type
+def f3[T: str = int](x: T) -> T: ...               # E: TypeVar default must be a subtype of the bound type
+def f4[T: list[str] = list[int]](x: T) -> T: ...   # E: TypeVar default must be a subtype of the bound type
+def f5[T: (int, str) = bytes](x: T) -> T: ...      # E: TypeVar default must be one of the constraint types
+def f6[T: (int, str) = int | str](x: T) -> T: ...  # E: TypeVar default must be one of the constraint types
+def f7[T: (float, str) = int](x: T) -> T: ...      # E: TypeVar default must be one of the constraint types
+def f8[T: str = int]() -> None: ...                # TODO check unused TypeVars
+@overload
+def f9[T: str = int](x: T) -> T: ...               # E: TypeVar default must be a subtype of the bound type
+@overload
+def f9[T: (int, str) = bytes](x: T) -> T: ...      # E: TypeVar default must be one of the constraint types
+def f9() -> None: ...  # type: ignore[misc]
+
+def g1[**P = int]() -> None: ...       # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+def g2[**P = 2]() -> None: ...         # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+def g3[**P = (2, int)]() -> None: ...  # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+def g4[**P = [2, int]]() -> None: ...  # E: Argument 0 of ParamSpec default must be a type
+
+def h1[*Ts = 2]() -> None: ...           # E: The default argument to TypeVarTuple must be an Unpacked tuple
+def h2[*Ts = int]() -> None: ...         # E: The default argument to TypeVarTuple must be an Unpacked tuple
+def h3[*Ts = tuple[int]]() -> None: ...  # E: The default argument to TypeVarTuple must be an Unpacked tuple
+[builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeParameterDefaultInvalid3]
 from typing import Callable
 
 type TA1[T: str = 1] = list[T]  # E: TypeVar "default" must be a type

--- a/test-data/unit/check-python313.test
+++ b/test-data/unit/check-python313.test
@@ -1,11 +1,229 @@
-[case testPEP695TypeParameterDefaultNotSupported]
-class C[T = None]:  # E: Type parameter default types not supported when using Python 3.12 type parameter syntax
-    pass
+[case testPEP695TypeParameterDefaultSupported]
+class C[T = None]: ...
+def f[T = list[int]]() -> None: ...
+def g[**P = [int, str]]() -> None: ...
+type A[T, S = int, U = str] = list[T]
 
-def f[T = list[int]]() -> None:  # E: Type parameter default types not supported when using Python 3.12 type parameter syntax
-    pass
+[case testPEP695TypeParameterDefaultBasic]
+from typing import Callable
 
-def g[**P = [int, str]]() -> None:  # E: Type parameter default types not supported when using Python 3.12 type parameter syntax
-    pass
+def f1[T1 = int](a: T1) -> list[T1]: ...
+reveal_type(f1)  # N: Revealed type is "def [T1 = builtins.int] (a: T1`-1 = builtins.int) -> builtins.list[T1`-1 = builtins.int]"
 
-type A[T, S = int, U = str] = list[T]  # E: Type parameter default types not supported when using Python 3.12 type parameter syntax
+def f2[**P1 = [int, str]](a: Callable[P1, None]) -> Callable[P1, None]: ...
+reveal_type(f2)  # N: Revealed type is "def [P1 = [builtins.int, builtins.str]] (a: def (*P1.args, **P1.kwargs)) -> def (*P1.args, **P1.kwargs)"
+
+def f3[*Ts1 = *tuple[int, str]](a: tuple[*Ts1]) -> tuple[*Ts1]: ...
+reveal_type(f3)  # N: Revealed type is "def [Ts1 = Unpack[Tuple[builtins.int, builtins.str]]] (a: Tuple[Unpack[Ts1`-1 = Unpack[Tuple[builtins.int, builtins.str]]]]) -> Tuple[Unpack[Ts1`-1 = Unpack[Tuple[builtins.int, builtins.str]]]]"
+
+
+class ClassA1[T1 = int]: ...
+class ClassA2[**P1 = [int, str]]: ...
+class ClassA3[*Ts1 = *tuple[int, str]]: ...
+
+reveal_type(ClassA1)  # N: Revealed type is "def [T1 = builtins.int] () -> __main__.ClassA1[T1`1 = builtins.int]"
+reveal_type(ClassA2)  # N: Revealed type is "def [P1 = [builtins.int, builtins.str]] () -> __main__.ClassA2[P1`1 = [builtins.int, builtins.str]]"
+reveal_type(ClassA3)  # N: Revealed type is "def [Ts1 = Unpack[Tuple[builtins.int, builtins.str]]] () -> __main__.ClassA3[Unpack[Ts1`1 = Unpack[Tuple[builtins.int, builtins.str]]]]"
+[builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeParameterDefaultValid]
+from typing import Any
+
+class ClassT1[T = int]: ...
+class ClassT2[T: float = int]: ...
+class ClassT3[T: list[Any] = list[int]]: ...
+class ClassT4[T: (int, str) = int]: ...
+
+class ClassP1[**P = []]: ...
+class ClassP2[**P = ...]: ...
+class ClassP3[**P = [int, str]]: ...
+
+class ClassTs1[*Ts = *tuple[int]]: ...
+class ClassTs2[*Ts = *tuple[int, ...]]: ...
+[builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeParameterDefaultInvalid]
+class ClassT1[T = 2]: ...  # E: TypeVar "default" must be a type
+class ClassT2[T = [int]]: ...  # E: Bracketed expression "[...]" is not valid as a type \
+                               # N: Did you mean "List[...]"? \
+                               # E: TypeVar "default" must be a type
+class ClassT3[T: str = int]: ...               # E: TypeVar default must be a subtype of the bound type
+class ClassT4[T: list[str] = list[int]]: ...   # E: TypeVar default must be a subtype of the bound type
+class ClassT5[T: (int, str) = bytes]: ...      # E: TypeVar default must be one of the constraint types
+class ClassT6[T: (int, str) = int | str]: ...  # E: TypeVar default must be one of the constraint types
+class ClassT7[T: (float, str) = int]: ...      # E: TypeVar default must be one of the constraint types
+
+class ClassP1[**P = int]: ...       # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+class ClassP2[**P = 2]: ...         # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+class ClassP3[**P = (2, int)]: ...  # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+class ClassP4[**P = [2, int]]: ...  # E: Argument 0 of ParamSpec default must be a type
+
+class ClassTs1[*Ts = 2]: ...           # E: The default argument to TypeVarTuple must be an Unpacked tuple
+class ClassTs2[*Ts = int]: ...         # E: The default argument to TypeVarTuple must be an Unpacked tuple
+class ClassTs3[*Ts = tuple[int]]: ...  # E: The default argument to TypeVarTuple must be an Unpacked tuple
+[builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeParameterDefaultInvalid2]
+from typing import Callable
+
+type TA1[T: str = 1] = list[T]  # E: TypeVar "default" must be a type
+type TA2[T: str = [int]] = list[T]  # E: Bracketed expression "[...]" is not valid as a type \
+                                    # N: Did you mean "List[...]"? \
+                                    # E: TypeVar "default" must be a type
+type TA3[T: str = int] = list[T]               # E: TypeVar default must be a subtype of the bound type
+type TA4[T: list[str] = list[int]] = list[T]   # E: TypeVar default must be a subtype of the bound type
+type TA5[T: (int, str) = bytes] = list[T]      # E: TypeVar default must be one of the constraint types
+type TA6[T: (int, str) = int | str] = list[T]  # E: TypeVar default must be one of the constraint types
+type TA7[T: (float, str) = int] = list[T]      # E: TypeVar default must be one of the constraint types
+
+type TB1[**P = int] = Callable[P, None]       # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+type TB2[**P = 2] = Callable[P, None]         # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+type TB3[**P = (2, int)] = Callable[P, None]  # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
+type TB4[**P = [2, int]] = Callable[P, None]  # E: Argument 0 of ParamSpec default must be a type
+
+type TC1[*Ts = 2] = tuple[*Ts]           # E: The default argument to TypeVarTuple must be an Unpacked tuple
+type TC2[*Ts = int] = tuple[*Ts]         # E: The default argument to TypeVarTuple must be an Unpacked tuple
+type TC3[*Ts = tuple[int]] = tuple[*Ts]  # E: The default argument to TypeVarTuple must be an Unpacked tuple
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testPEP695TypeParameterDefaultFunctions]
+from typing import Callable
+
+def callback1(x: str) -> None: ...
+
+def func_a1[T = str](x: int | T) -> T: ...
+reveal_type(func_a1(2))  # N: Revealed type is "builtins.str"
+reveal_type(func_a1(2.1))  # N: Revealed type is "builtins.float"
+
+def func_a2[T = str](x: int | T) -> list[T]: ...
+reveal_type(func_a2(2))  # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type(func_a2(2.1))  # N: Revealed type is "builtins.list[builtins.float]"
+
+
+def func_a3[T: str = str](x: int | T) -> T: ...
+reveal_type(func_a3(2))  # N: Revealed type is "builtins.str"
+
+def func_a4[T: (bytes, str) = str](x: int | T) -> T: ...
+reveal_type(func_a4(2))  # N: Revealed type is "builtins.str"
+
+def func_b1[**P = [int, str]](x: int | Callable[P, None]) -> Callable[P, None]: ...
+reveal_type(func_b1(callback1))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(func_b1(2))  # N: Revealed type is "def (builtins.int, builtins.str)"
+
+def func_c1[*Ts = *tuple[int, str]](x: int | Callable[[*Ts], None]) -> tuple[*Ts]: ...
+# reveal_type(func_c1(callback1))  # Revealed type is "Tuple[str]"  # TODO
+reveal_type(func_c1(2))  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
+[builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeParameterDefaultClass1]
+# flags: --disallow-any-generics
+
+class ClassA1[T2 = int, T3 = str]: ...
+
+def func_a1(
+    a: ClassA1,
+    b: ClassA1[float],
+    c: ClassA1[float, float],
+    d: ClassA1[float, float, float],  # E: "ClassA1" expects between 0 and 2 type arguments, but 3 given
+) -> None:
+    reveal_type(a)  # N: Revealed type is "__main__.ClassA1[builtins.int, builtins.str]"
+    reveal_type(b)  # N: Revealed type is "__main__.ClassA1[builtins.float, builtins.str]"
+    reveal_type(c)  # N: Revealed type is "__main__.ClassA1[builtins.float, builtins.float]"
+    reveal_type(d)  # N: Revealed type is "__main__.ClassA1[builtins.int, builtins.str]"
+[builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeParameterDefaultClass2]
+# flags: --disallow-any-generics
+
+class ClassB1[**P2 = [int, str], **P3 = ...]: ...
+
+def func_b1(
+    a: ClassB1,
+    b: ClassB1[[float]],
+    c: ClassB1[[float], [float]],
+    d: ClassB1[[float], [float], [float]],  # E: "ClassB1" expects between 0 and 2 type arguments, but 3 given
+) -> None:
+    reveal_type(a)  # N: Revealed type is "__main__.ClassB1[[builtins.int, builtins.str], ...]"
+    reveal_type(b)  # N: Revealed type is "__main__.ClassB1[[builtins.float], ...]"
+    reveal_type(c)  # N: Revealed type is "__main__.ClassB1[[builtins.float], [builtins.float]]"
+    reveal_type(d)  # N: Revealed type is "__main__.ClassB1[[builtins.int, builtins.str], ...]"
+
+    k = ClassB1()
+    reveal_type(k)  # N: Revealed type is "__main__.ClassB1[[builtins.int, builtins.str], [*Any, **Any]]"
+    l = ClassB1[[float]]()
+    reveal_type(l)  # N: Revealed type is "__main__.ClassB1[[builtins.float], [*Any, **Any]]"
+    m = ClassB1[[float], [float]]()
+    reveal_type(m)  # N: Revealed type is "__main__.ClassB1[[builtins.float], [builtins.float]]"
+    n = ClassB1[[float], [float], [float]]()  # E: Type application has too many types (expected between 0 and 2)
+    reveal_type(n)  # N: Revealed type is "Any"
+
+[case testPEP695TypeParameterDefaultClass3]
+# flags: --disallow-any-generics
+
+class ClassC1[*Ts = *tuple[int, str]]: ...
+
+def func_c1(
+    a: ClassC1,
+    b: ClassC1[float],
+) -> None:
+    # reveal_type(a)  # Revealed type is "__main__.ClassC1[builtins.int, builtins.str]"  # TODO
+    reveal_type(b)  # N: Revealed type is "__main__.ClassC1[builtins.float]"
+
+    k = ClassC1()
+    reveal_type(k)  # N: Revealed type is "__main__.ClassC1[builtins.int, builtins.str]"
+    l = ClassC1[float]()
+    reveal_type(l)  # N: Revealed type is "__main__.ClassC1[builtins.float]"
+[builtins fixtures/tuple.pyi]
+
+[case testPEP695TypeParameterDefaultTypeAlias1]
+# flags: --disallow-any-generics
+
+type TA1[T2 = int, T3 = str] = dict[T2, T3]
+
+def func_a1(
+    a: TA1,
+    b: TA1[float],
+    c: TA1[float, float],
+    d: TA1[float, float, float],  # E: Bad number of arguments for type alias, expected between 0 and 2, given 3
+) -> None:
+    reveal_type(a)  # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
+    reveal_type(b)  # N: Revealed type is "builtins.dict[builtins.float, builtins.str]"
+    reveal_type(c)  # N: Revealed type is "builtins.dict[builtins.float, builtins.float]"
+    reveal_type(d)  # N: Revealed type is "builtins.dict[builtins.int, builtins.str]"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testPEP695TypeParameterDefaultTypeAlias2]
+# flags: --disallow-any-generics
+
+class ClassB1[**P2, **P3]: ...
+type TB1[**P2 = [int, str], **P3 = ...] = ClassB1[P2, P3]
+
+def func_b1(
+    a: TB1,
+    b: TB1[[float]],
+    c: TB1[[float], [float]],
+    d: TB1[[float], [float], [float]],  # E: Bad number of arguments for type alias, expected between 0 and 2, given 3
+) -> None:
+    reveal_type(a)  # N: Revealed type is "__main__.ClassB1[[builtins.int, builtins.str], [*Any, **Any]]"
+    reveal_type(b)  # N: Revealed type is "__main__.ClassB1[[builtins.float], [*Any, **Any]]"
+    reveal_type(c)  # N: Revealed type is "__main__.ClassB1[[builtins.float], [builtins.float]]"
+    reveal_type(d)  # N: Revealed type is "__main__.ClassB1[[builtins.int, builtins.str], [*Any, **Any]]"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testPEP695TypeParameterDefaultTypeAlias3]
+# flags: --disallow-any-generics
+
+type TC1[*Ts = *tuple[int, str]] = tuple[*Ts]
+
+def func_c1(
+    a: TC1,
+    b: TC1[float],
+) -> None:
+    # reveal_type(a)  # Revealed type is "Tuple[builtins.int, builtins.str]"  # TODO
+    reveal_type(b)  # N: Revealed type is "Tuple[builtins.float]"
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -1,5 +1,4 @@
 [case testTypeVarDefaultsBasic]
-import builtins
 from typing import Generic, TypeVar, ParamSpec, Callable, Tuple, List
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -10,7 +9,7 @@ Ts1 = TypeVarTuple("Ts1", default=Unpack[Tuple[int, str]])
 def f1(a: T1) -> List[T1]: ...
 reveal_type(f1)  # N: Revealed type is "def [T1 = builtins.int] (a: T1`-1 = builtins.int) -> builtins.list[T1`-1 = builtins.int]"
 
-def f2(a: Callable[P1, None] ) -> Callable[P1, None]: ...
+def f2(a: Callable[P1, None]) -> Callable[P1, None]: ...
 reveal_type(f2)  # N: Revealed type is "def [P1 = [builtins.int, builtins.str]] (a: def (*P1.args, **P1.kwargs)) -> def (*P1.args, **P1.kwargs)"
 
 def f3(a: Tuple[Unpack[Ts1]]) -> Tuple[Unpack[Ts1]]: ...
@@ -68,7 +67,7 @@ P2 = ParamSpec("P2", default=2)  # E: The default argument to ParamSpec must be 
 P3 = ParamSpec("P3", default=(2, int))  # E: The default argument to ParamSpec must be a list expression, ellipsis, or a ParamSpec
 P4 = ParamSpec("P4", default=[2, int])  # E: Argument 0 of ParamSpec default must be a type
 
-Ts1 = TypeVarTuple("Ts1", default=2) # E: The default argument to TypeVarTuple must be an Unpacked tuple
+Ts1 = TypeVarTuple("Ts1", default=2)  # E: The default argument to TypeVarTuple must be an Unpacked tuple
 Ts2 = TypeVarTuple("Ts2", default=int)  # E: The default argument to TypeVarTuple must be an Unpacked tuple
 Ts3 = TypeVarTuple("Ts3", default=Tuple[int])  # E: The default argument to TypeVarTuple must be an Unpacked tuple
 [builtins fixtures/tuple.pyi]
@@ -181,8 +180,8 @@ reveal_type(func_b1(callback1))  # N: Revealed type is "def (x: builtins.str)"
 reveal_type(func_b1(2))  # N: Revealed type is "def (builtins.int, builtins.str)"
 
 def func_c1(x: Union[int, Callable[[Unpack[Ts1]], None]]) -> Tuple[Unpack[Ts1]]: ...
-# reveal_type(func_c1(callback1))  # Revealed type is "builtins.tuple[str]"  # TODO
-# reveal_type(func_c1(2))  # Revealed type is "builtins.tuple[builtins.int, builtins.str]"  # TODO
+# reveal_type(func_c1(callback1))  # Revealed type is "Tuple[str]"  # TODO
+reveal_type(func_c1(2))  # N: Revealed type is "Tuple[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarDefaultsClass1]

--- a/test-data/unit/parse-python313.test
+++ b/test-data/unit/parse-python313.test
@@ -1,0 +1,80 @@
+[case testPEP696TypeAlias]
+type A[T = int] = C[T]
+[out]
+MypyFile:1(
+  TypeAliasStmt:1(
+    NameExpr(A)
+    TypeParam(
+      T
+      Default(
+        int?))
+    LambdaExpr:1(
+      Block:-1(
+        ReturnStmt:1(
+          IndexExpr:1(
+            NameExpr(C)
+            NameExpr(T)))))))
+
+[case testPEP696GenericFunction]
+def f[T = int](): pass
+class C[T = int]: pass
+[out]
+MypyFile:1(
+  FuncDef:1(
+    f
+    TypeParam(
+      T
+      Default(
+        int?))
+    Block:1(
+      PassStmt:1()))
+  ClassDef:2(
+    C
+    TypeParam(
+      T
+      Default(
+        int?))
+    PassStmt:2()))
+
+[case testPEP696ParamSpec]
+def f[**P = [int, str]](): pass
+class C[**P = [int, str]]: pass
+[out]
+[out]
+MypyFile:1(
+  FuncDef:1(
+    f
+    TypeParam(
+      **P
+      Default(
+        <TypeList int?, str?>))
+    Block:1(
+      PassStmt:1()))
+  ClassDef:2(
+    C
+    TypeParam(
+      **P
+      Default(
+        <TypeList int?, str?>))
+    PassStmt:2()))
+
+[case testPEP696TypeVarTuple]
+def f[*Ts = *tuple[str, int]](): pass
+class C[*Ts = *tuple[str, int]]: pass
+[out]
+MypyFile:1(
+  FuncDef:1(
+    f
+    TypeParam(
+      *Ts
+      Default(
+        Unpack[tuple?[str?, int?]]))
+    Block:1(
+      PassStmt:1()))
+  ClassDef:2(
+    C
+    TypeParam(
+      *Ts
+      Default(
+        Unpack[tuple?[str?, int?]]))
+    PassStmt:2()))


### PR DESCRIPTION
Add initial support for TypeVar defaults using the new syntax. Similar to the old syntax, it doesn't fully work yet for ParamSpec, TypeVarTuple and recursive TypeVar defaults.

Refs: #14851