### PR TITLE
[mypyc] fix name generation for modules with similar full names

### DIFF
--- a/mypyc/namegen.py
+++ b/mypyc/namegen.py
@@ -100,10 +100,9 @@ def make_module_translation_map(names: list[str]) -> dict[str, str]:
     for name in names:
         for suffix in candidate_suffixes(name):
             if num_instances[suffix] == 1:
-                result[name] = suffix
                 break
-        else:
-            assert False, names
+        # Takes the last suffix if none are unique
+        result[name] = suffix
     return result
 
 

--- a/mypyc/test/test_namegen.py
+++ b/mypyc/test/test_namegen.py
@@ -35,6 +35,12 @@ class TestNameGen(unittest.TestCase):
             "fu.bar": "fu.bar.",
             "foo.baz": "baz.",
         }
+        assert make_module_translation_map(["foo", "foo.foo", "bar.foo", "bar.foo.bar.foo"]) == {
+            "foo": "foo.",
+            "foo.foo": "foo.foo.",
+            "bar.foo": "bar.foo.",
+            "bar.foo.bar.foo": "foo.bar.foo.",
+        }
 
     def test_name_generator(self) -> None:
         g = NameGenerator([["foo", "foo.zar"]])


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes https://github.com/mypyc/mypyc/issues/1071
Adds a test to cover this case

Building certain package layouts now succeeds instead of failing. The behavior for all package layouts not affected by the error is unchanged.

In `namegen.make_module_translation_map(names)`, if argument `names` have `"foo"` and `"foo.foo"`, all suffixes found for `"foo"` are also found for `"foo.foo"`. This means that module `foo` has no unique suffixes, which currently causes an `AssertionError`.
The fix forces a module to take the last, fullest suffix if none are unique. It is guaranteed that no other module will also take the same suffix because they either will have a unique suffix to take, or they will take the fullest suffix for their name which is always going to be different.

P.S. 'suffix' or 'prefix'?

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
