### PR TITLE
Add timeout-minutes to ci config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ concurrency:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       TOXENV: docs
       TOX_SKIP_MISSING_INTERPRETERS: False

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         shard-index: [0, 1, 2, 3, 4]
       fail-fast: false
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sync_typeshed.yml
+++ b/.github/workflows/sync_typeshed.yml
@@ -14,6 +14,7 @@ jobs:
     name: Sync typeshed
     if: github.repository == 'python/mypy'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,7 @@ jobs:
           toxenv: lint
 
     name: ${{ matrix.name }}
+    timeout-minutes: 60
     env:
       TOX_SKIP_MISSING_INTERPRETERS: False
       # Rich (pip) -- Disable color for windows + pytest
@@ -205,6 +206,7 @@ jobs:
   python_32bits:
     runs-on: ubuntu-latest
     name: Test mypyc suite with 32-bit Python
+    timeout-minutes: 60
     env:
       TOX_SKIP_MISSING_INTERPRETERS: False
       # Rich (pip)

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -25,6 +25,7 @@ jobs:
     # Check stub file generation for a small pybind11 project
     # (full text match is required to pass)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
 
     - uses: actions/checkout@v4


### PR DESCRIPTION
Prevent blocking resources unnecessarily if something goes wrong and a CI task doesn't terminate. The default timeout would be 360 minutes.