### PR TITLE
[stubtest] Verify __all__ exists in stub

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -349,7 +349,7 @@ def verify_mypyfile(
             # if the stub actually defines __all__
             yield from _verify_exported_names(object_path, stub, runtime_all_as_set)
         else:
-            yield Error(object_path + ["__all__"], "is not present in stub", stub, runtime)
+            yield Error(object_path + ["__all__"], "is not present in stub", MISSING, runtime)
     else:
         runtime_all_as_set = None
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -348,6 +348,8 @@ def verify_mypyfile(
             # Only verify the contents of the stub's __all__
             # if the stub actually defines __all__
             yield from _verify_exported_names(object_path, stub, runtime_all_as_set)
+        else:
+            yield Error(object_path + ["__all__"], "is not present in stub", stub, runtime)
     else:
         runtime_all_as_set = None
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -169,14 +169,12 @@ def run_stubtest_with_stderr(
     filtered_output = remove_color_code(
         output.getvalue()
         # remove cwd as it's not available from outside
-        .replace(os.path.realpath(tmp_dir) + os.sep, "")
-        .replace(tmp_dir + os.sep, "")
+        .replace(os.path.realpath(tmp_dir) + os.sep, "").replace(tmp_dir + os.sep, "")
     )
     filtered_outerr = remove_color_code(
         outerr.getvalue()
         # remove cwd as it's not available from outside
-        .replace(os.path.realpath(tmp_dir) + os.sep, "")
-        .replace(tmp_dir + os.sep, "")
+        .replace(os.path.realpath(tmp_dir) + os.sep, "").replace(tmp_dir + os.sep, "")
     )
     return filtered_output, filtered_outerr
 
@@ -2485,14 +2483,18 @@ class StubtestMiscUnit(unittest.TestCase):
                     def good() -> None: ...
                     def bad(number: int) -> None: ...
                     def also_bad(number: int) -> None: ...
-                    """.lstrip("\n")
+                    """.lstrip(
+                        "\n"
+                    )
                 ),
                 runtime=textwrap.dedent(
                     """
                     def good(): pass
                     def bad(asdf): pass
                     def also_bad(asdf): pass
-                    """.lstrip("\n")
+                    """.lstrip(
+                        "\n"
+                    )
                 ),
                 options=["--allowlist", allowlist.name, "--generate-allowlist"],
             )

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -169,12 +169,14 @@ def run_stubtest_with_stderr(
     filtered_output = remove_color_code(
         output.getvalue()
         # remove cwd as it's not available from outside
-        .replace(os.path.realpath(tmp_dir) + os.sep, "").replace(tmp_dir + os.sep, "")
+        .replace(os.path.realpath(tmp_dir) + os.sep, "")
+        .replace(tmp_dir + os.sep, "")
     )
     filtered_outerr = remove_color_code(
         outerr.getvalue()
         # remove cwd as it's not available from outside
-        .replace(os.path.realpath(tmp_dir) + os.sep, "").replace(tmp_dir + os.sep, "")
+        .replace(os.path.realpath(tmp_dir) + os.sep, "")
+        .replace(tmp_dir + os.sep, "")
     )
     return filtered_output, filtered_outerr
 
@@ -2435,6 +2437,11 @@ class StubtestMiscUnit(unittest.TestCase):
         assert output == expected
 
     def test_ignore_flags(self) -> None:
+        output = run_stubtest(
+            stub="", runtime="__all__ = ['f']\ndef f(): pass", options=["--ignore-missing-stub"]
+        )
+        assert output == "Success: no issues found in 1 module\n"
+
         output = run_stubtest(stub="", runtime="def f(): pass", options=["--ignore-missing-stub"])
         assert output == "Success: no issues found in 1 module\n"
 
@@ -2483,18 +2490,14 @@ class StubtestMiscUnit(unittest.TestCase):
                     def good() -> None: ...
                     def bad(number: int) -> None: ...
                     def also_bad(number: int) -> None: ...
-                    """.lstrip(
-                        "\n"
-                    )
+                    """.lstrip("\n")
                 ),
                 runtime=textwrap.dedent(
                     """
                     def good(): pass
                     def bad(asdf): pass
                     def also_bad(asdf): pass
-                    """.lstrip(
-                        "\n"
-                    )
+                    """.lstrip("\n")
                 ),
                 options=["--allowlist", allowlist.name, "--generate-allowlist"],
             )

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -169,14 +169,12 @@ def run_stubtest_with_stderr(
     filtered_output = remove_color_code(
         output.getvalue()
         # remove cwd as it's not available from outside
-        .replace(os.path.realpath(tmp_dir) + os.sep, "")
-        .replace(tmp_dir + os.sep, "")
+        .replace(os.path.realpath(tmp_dir) + os.sep, "").replace(tmp_dir + os.sep, "")
     )
     filtered_outerr = remove_color_code(
         outerr.getvalue()
         # remove cwd as it's not available from outside
-        .replace(os.path.realpath(tmp_dir) + os.sep, "")
-        .replace(tmp_dir + os.sep, "")
+        .replace(os.path.realpath(tmp_dir) + os.sep, "").replace(tmp_dir + os.sep, "")
     )
     return filtered_output, filtered_outerr
 
@@ -2490,14 +2488,18 @@ class StubtestMiscUnit(unittest.TestCase):
                     def good() -> None: ...
                     def bad(number: int) -> None: ...
                     def also_bad(number: int) -> None: ...
-                    """.lstrip("\n")
+                    """.lstrip(
+                        "\n"
+                    )
                 ),
                 runtime=textwrap.dedent(
                     """
                     def good(): pass
                     def bad(asdf): pass
                     def also_bad(asdf): pass
-                    """.lstrip("\n")
+                    """.lstrip(
+                        "\n"
+                    )
                 ),
                 options=["--allowlist", allowlist.name, "--generate-allowlist"],
             )

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -169,12 +169,14 @@ def run_stubtest_with_stderr(
     filtered_output = remove_color_code(
         output.getvalue()
         # remove cwd as it's not available from outside
-        .replace(os.path.realpath(tmp_dir) + os.sep, "").replace(tmp_dir + os.sep, "")
+        .replace(os.path.realpath(tmp_dir) + os.sep, "")
+        .replace(tmp_dir + os.sep, "")
     )
     filtered_outerr = remove_color_code(
         outerr.getvalue()
         # remove cwd as it's not available from outside
-        .replace(os.path.realpath(tmp_dir) + os.sep, "").replace(tmp_dir + os.sep, "")
+        .replace(os.path.realpath(tmp_dir) + os.sep, "")
+        .replace(tmp_dir + os.sep, "")
     )
     return filtered_output, filtered_outerr
 
@@ -1403,7 +1405,7 @@ class StubtestUnit(unittest.TestCase):
             runtime="""
             __all__ = []
             Z = 5""",
-            error=None,
+            error="__all__",
         )
 
     @collect_cases
@@ -1443,7 +1445,7 @@ class StubtestUnit(unittest.TestCase):
             runtime="",
             error="h",
         )
-        yield Case(stub="", runtime="__all__ = []", error=None)  # dummy case
+        yield Case(stub="", runtime="__all__ = []", error="__all__")  # dummy case
         yield Case(stub="", runtime="__all__ += ['y']\ny = 5", error="y")
         yield Case(stub="", runtime="__all__ += ['g']\ndef g(): pass", error="g")
         # Here we should only check that runtime has B, since the stub explicitly re-exports it
@@ -2435,11 +2437,6 @@ class StubtestMiscUnit(unittest.TestCase):
         assert output == expected
 
     def test_ignore_flags(self) -> None:
-        output = run_stubtest(
-            stub="", runtime="__all__ = ['f']\ndef f(): pass", options=["--ignore-missing-stub"]
-        )
-        assert output == "Success: no issues found in 1 module\n"
-
         output = run_stubtest(stub="", runtime="def f(): pass", options=["--ignore-missing-stub"])
         assert output == "Success: no issues found in 1 module\n"
 
@@ -2488,18 +2485,14 @@ class StubtestMiscUnit(unittest.TestCase):
                     def good() -> None: ...
                     def bad(number: int) -> None: ...
                     def also_bad(number: int) -> None: ...
-                    """.lstrip(
-                        "\n"
-                    )
+                    """.lstrip("\n")
                 ),
                 runtime=textwrap.dedent(
                     """
                     def good(): pass
                     def bad(asdf): pass
                     def also_bad(asdf): pass
-                    """.lstrip(
-                        "\n"
-                    )
+                    """.lstrip("\n")
                 ),
                 options=["--allowlist", allowlist.name, "--generate-allowlist"],
             )


### PR DESCRIPTION
Previously it wasn't an error if runtime included an
`__all__` declaration, but the stubs did not. This PR
changes this to reflect the consensus that it would
be a good idea to ensure consistency in this case.

Fixes #13300


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
