### PR TITLE
Improve for loop index variable type narrowing

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -969,6 +969,7 @@ VAR_FLAGS: Final = [
     "is_classvar",
     "is_abstract_var",
     "is_final",
+    "is_index_var",
     "final_unset_in_class",
     "final_set_in_init",
     "explicit_self_type",
@@ -1005,6 +1006,7 @@ class Var(SymbolNode):
         "is_classvar",
         "is_abstract_var",
         "is_final",
+        "is_index_var",
         "final_unset_in_class",
         "final_set_in_init",
         "is_suppressed_import",
@@ -1039,6 +1041,7 @@ class Var(SymbolNode):
         self.is_settable_property = False
         self.is_classvar = False
         self.is_abstract_var = False
+        self.is_index_var = False
         # Set to true when this variable refers to a module we were unable to
         # parse for some reason (eg a silenced module)
         self.is_suppressed_import = False

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1250,12 +1250,16 @@ for a in ("hourly", "daily"):
     reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
     reveal_type(x[a])  # N: Revealed type is "builtins.int"
     reveal_type(a.upper())  # N: Revealed type is "builtins.str"
+    c = a
+    reveal_type(c)  # N: Revealed type is "builtins.str"
     a = "monthly"
     reveal_type(a)  # N: Revealed type is "builtins.str"
     a = "yearly"
     reveal_type(a)  # N: Revealed type is "builtins.str"
     a = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
     reveal_type(a)  # N: Revealed type is "builtins.str"
+    d = a
+    reveal_type(d)  # N: Revealed type is "builtins.str"
 
 b: str
 for b in ("hourly", "daily"):

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1238,6 +1238,31 @@ class B: pass
 [builtins fixtures/for.pyi]
 [out]
 
+[case testForStatementIndexNarrowing]
+from typing_extensions import TypedDict
+
+class X(TypedDict):
+    hourly: int
+    daily: int
+
+x: X
+for a in ("hourly", "daily"):
+    reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
+    reveal_type(x[a])  # N: Revealed type is "builtins.int"
+    reveal_type(a.upper())  # N: Revealed type is "builtins.str"
+    a = "monthly"
+    reveal_type(a)  # N: Revealed type is "builtins.str"
+    a = "yearly"
+    reveal_type(a)  # N: Revealed type is "builtins.str"
+    a = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+    reveal_type(a)  # N: Revealed type is "builtins.str"
+
+b: str
+for b in ("hourly", "daily"):
+    reveal_type(b)  # N: Revealed type is "builtins.str"
+    reveal_type(b.upper())  # N: Revealed type is "builtins.str"
+[builtins fixtures/for.pyi]
+
 
 -- Regression tests
 -- ----------------

--- a/test-data/unit/fixtures/for.pyi
+++ b/test-data/unit/fixtures/for.pyi
@@ -12,9 +12,11 @@ class type: pass
 class tuple(Generic[t]):
     def __iter__(self) -> Iterator[t]: pass
 class function: pass
+class ellipsis: pass
 class bool: pass
 class int: pass # for convenience
-class str: pass # for convenience
+class str:  # for convenience
+    def upper(self) -> str: ...
 
 class list(Iterable[t], Generic[t]):
     def __iter__(self) -> Iterator[t]: pass


### PR DESCRIPTION
Preserve the literal type of index expressions a bit longer (until the next assignment) to support TypedDict lookups.

```py
from typing import TypedDict

class X(TypedDict):
    hourly: int
    daily: int

def func(x: X) -> None:
    for var in ("hourly", "daily"):
        print(x[var])
```

Closes #9230