### PR TITLE
Fix `[func-returns-value]` not being trigged when calling decorated functions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -716,6 +716,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
 
     def defn_returns_none(self, defn: SymbolNode | None) -> bool:
         """Check if `defn` can _only_ return None."""
+        if isinstance(defn, Decorator):
+            defn = defn.func
         if isinstance(defn, FuncDef):
             return isinstance(defn.type, CallableType) and isinstance(
                 get_proper_type(defn.type.ret_type), NoneType

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1144,6 +1144,32 @@ f() and b  # E: "f" does not return a value (it only ever returns None)
 b or f()   # E: "f" does not return a value (it only ever returns None)
 [builtins fixtures/bool.pyi]
 
+[case testNoneReturnDecorated]
+from typing import Any, Callable, TypeVar
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+def deco(f: F) -> F:
+    pass
+
+@deco
+@deco
+def f() -> None:
+    pass
+
+class A:
+    @staticmethod
+    def s() -> None:
+        pass
+
+if int():
+    x = f()      # E: "f" does not return a value (it only ever returns None)
+if int():
+    x = A.s()    # E: "s" of "A" does not return a value (it only ever returns None)
+if int():
+    x = A().s()  # E: "s" of "A" does not return a value (it only ever returns None)
+[builtins fixtures/staticmethod.pyi]
+
 
 -- Slicing
 -- -------


### PR DESCRIPTION
Fixes #14179

@harahu previously wrote a unit test for this issue in #17834 (open). I wasn't sure how to best integrate that work, so this PR includes its own tests with @harahu added as co-author. (Happy to tweak if there's a better way to handle this)

