### PR TITLE
Fix compatibility checks for conditional function definitions using decorators

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5124,7 +5124,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if e.type and not isinstance(get_proper_type(e.type), (FunctionLike, AnyType)):
                 self.fail(message_registry.BAD_CONSTRUCTOR_TYPE, e)
 
-        if e.func.original_def:
+        if e.func.original_def and isinstance(sig, FunctionLike):
             # Function definition overrides function definition.
             self.check_func_def_override(e.func, sig)
 

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1474,7 +1474,7 @@ def dec(f) -> Callable[[int], None]: pass
 
 x = int()
 if x:
-    def f(x: int) -> None: pass
+    def f(x: int, /) -> None: pass
 else:
     @dec
     def f(): pass
@@ -1489,9 +1489,12 @@ x = int()
 if x:
     def f(x: str) -> None: pass
 else:
-    # TODO: Complain about incompatible redefinition
     @dec
-    def f(): pass
+    def f(): pass   # E: All conditional function variants must have identical signatures \
+                    # N: Original: \
+                    # N:     def f(x: str) -> None \
+                    # N: Redefinition: \
+                    # N:     def f(int, /) -> None
 
 [case testConditionalFunctionDefinitionUnreachable]
 def bar() -> None:
@@ -1599,7 +1602,7 @@ else:
     def f():
         yield
 [file m.py]
-def f(): pass
+def f() -> None: pass
 
 [case testDefineConditionallyAsImportedAndDecoratedWithInference]
 if int():

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1908,9 +1908,9 @@ else:
     @dec
     def f(x: int) -> None:
         1()  # E: "int" not callable
-reveal_type(f) # N: Revealed type is "def (x: builtins.str)"
+reveal_type(f) # N: Revealed type is "def (builtins.str)"
 [file m.py]
-def f(x: str) -> None: pass
+def f(x: str, /) -> None: pass
 
 [case testNewAnalyzerConditionallyDefineFuncOverVar]
 from typing import Callable

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6463,7 +6463,7 @@ class D: ...
 def f1(g: A) -> A: ...
 if True:
     @overload  # E: Single overload definition, multiple required
-    def f1(g: B) -> B: ...
+    def f1(g: B) -> B: ...  # E: Incompatible redefinition (redefinition with type "Callable[[B], B]", original type "Callable[[A], A]")
     if maybe_true:  # E: Condition can't be inferred, unable to merge overloads \
                     # E: Name "maybe_true" is not defined
         @overload
@@ -6480,14 +6480,14 @@ if True:
         def f2(g: B) -> B: ...
     elif maybe_true:  # E: Name "maybe_true" is not defined
         @overload  # E: Single overload definition, multiple required
-        def f2(g: C) -> C: ...
+        def f2(g: C) -> C: ...  # E: Incompatible redefinition (redefinition with type "Callable[[C], C]", original type "Callable[[A], A]")
 def f2(g): ...  # E: Name "f2" already defined on line 21
 
 @overload  # E: Single overload definition, multiple required
 def f3(g: A) -> A: ...
 if True:
     @overload  # E: Single overload definition, multiple required
-    def f3(g: B) -> B: ...
+    def f3(g: B) -> B: ...  # E: Incompatible redefinition (redefinition with type "Callable[[B], B]", original type "Callable[[A], A]")
     if True:
         pass  # Some other node
         @overload  # E: Name "f3" already defined on line 32 \


### PR DESCRIPTION
Fixes #17211, resolves this `# TODO`:
https://github.com/python/mypy/blob/e106dd7a0653c24d67597adf3ae6939d7ff9a376/test-data/unit/check-functions.test#L1486-L1494

### Before
```python
from typing import Callable

def dec(f: object) -> Callable[[int], None]: raise NotImplementedError

if int():
    def f(x: str) -> None: pass
else:
    @dec
    def f() -> None: pass  # uh oh! passes without error
```
### After
```python
from typing import Callable

def dec(f: object) -> Callable[[int], None]: raise NotImplementedError

if int():
    def f(x: str) -> None: pass
else:
    @dec
    def f() -> None: pass  # E: All conditional function variants must have identical signatures \
                           # N: Original: \
                           # N:     def f(x: str) -> None \
                           # N: Redefinition: \
                           # N:     def f(int, /) -> None
```

