### PR TITLE
[docs] fix broken markup in `type_narrowing.rst`

### DIFF
--- a/docs/source/type_narrowing.rst
+++ b/docs/source/type_narrowing.rst
@@ -400,11 +400,11 @@ Mypy supports TypeIs (:pep:`742`).
 
 A `TypeIs narrowing function <https://typing.readthedocs.io/en/latest/spec/narrowing.html#typeis>`_
 allows you to define custom type checks that can narrow the type of a variable
-in `both the if and else <https://docs.python.org/3.13/library/typing.html#typing.TypeIs>_`
+in `both the if and else <https://docs.python.org/3.13/library/typing.html#typing.TypeIs>`_
 branches of a conditional, similar to how the built-in isinstance() function works.
 
 TypeIs is new in Python 3.13 — for use in older Python versions, use the backport
-from `typing_extensions <https://typing-extensions.readthedocs.io/en/latest/>_`
+from `typing_extensions <https://typing-extensions.readthedocs.io/en/latest/>`_
 
 Consider the following example using TypeIs:
 


### PR DESCRIPTION
[Here](https://mypy.readthedocs.io/en/stable/type_narrowing.html#typeis), the markup is broken:

![Screenshot from 2024-10-24 14-46-10](https://github.com/user-attachments/assets/d3b2f6ee-a114-4a2b-b000-49667db50daf)

After applying the changes:

![Screenshot from 2024-10-24 14-49-27](https://github.com/user-attachments/assets/2e362f88-5cc1-4e4e-852f-d1917a2d4ede)
