### PR TITLE
Make `disallow-any-unimported` flag invertible

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -646,12 +646,6 @@ def process_options(
         description="Disallow the use of the dynamic 'Any' type under certain conditions.",
     )
     disallow_any_group.add_argument(
-        "--disallow-any-unimported",
-        default=False,
-        action="store_true",
-        help="Disallow Any types resulting from unfollowed imports",
-    )
-    disallow_any_group.add_argument(
         "--disallow-any-expr",
         default=False,
         action="store_true",
@@ -675,6 +669,12 @@ def process_options(
         default=False,
         strict_flag=True,
         help="Disallow usage of generic types that do not specify explicit type parameters",
+        group=disallow_any_group,
+    )
+    add_invertible_flag(
+        "--disallow-any-unimported",
+        default=False,
+        help="Disallow Any types resulting from unfollowed imports",
         group=disallow_any_group,
     )
     add_invertible_flag(

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -963,6 +963,12 @@ from missing import Unchecked
 
 t: Unchecked = 12  # E: Type of variable becomes "Any" due to an unfollowed import
 
+[case testAllowImplicitAnyVariableDefinition]
+# flags: --ignore-missing-imports --allow-any-unimported
+from missing import Unchecked
+
+t: Unchecked = 12
+
 [case testDisallowImplicitAnyGeneric]
 # flags: --ignore-missing-imports --disallow-any-unimported
 from missing import Unchecked


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

The `--follow-imports=skip` CLI option is pretty much unusable in a project where `disallow_any_unimported` is set to true in the configuration file, as this results in a large number of errors (due to both flags being incompatible). We have a pretty standard project configuration file (with `disallow_any_unimported = true` and `follow_imports = 'normal'`), but for specific local development cases where we want to run the mypy CLI with `--follow-imports=skip` it's incredibly noisy due to the number of errors produced.

This change proposes making the `disallow-any-unimported` invertible, so that the CLI can be used with `--follow-imports=skip` in a less noisy way by using:
```bash
mypy --follow-imports=skip --allow-any-unimported path/to/my/file.py
```

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
