### PR TITLE
Do not prioritize ParamSpec signatures during overload resolution

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2781,7 +2781,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     ) -> list[CallableType]:
         """Returns all overload call targets that having matching argument counts.
 
-        If the given args contains a star-arg (*arg or **kwarg argument, including
+        If the given args contains a star-arg (*arg or **kwarg argument, except for
         ParamSpec), this method will ensure all star-arg overloads appear at the start
         of the list, instead of their usual location.
 
@@ -2816,7 +2816,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     # ParamSpec can be expanded in a lot of different ways. We may try
                     # to expand it here instead, but picking an impossible overload
                     # is safe: it will be filtered out later.
-                    star_matches.append(typ)
+                    # Unlike other var-args signatures, ParamSpec produces essentially
+                    # a fixed signature, so there's no need to push them to the top.
+                    matches.append(typ)
                 elif self.check_argument_count(
                     typ, arg_types, arg_kinds, arg_names, formal_to_actual, None
                 ):

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -2303,3 +2303,38 @@ reveal_type(capture(fn))  # N: Revealed type is "Union[builtins.str, builtins.in
 reveal_type(capture(err))  # N: Revealed type is "builtins.int"
 
 [builtins fixtures/paramspec.pyi]
+
+[case testRunParamSpecOverlappingOverloadsOrder]
+from typing import Any, Callable, overload
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+
+class Base:
+    pass
+class Child(Base):
+    def __call__(self) -> str: ...
+class NotChild:
+    def __call__(self) -> str: ...
+
+@overload
+def handle(func: Base) -> int: ...
+@overload
+def handle(func: Callable[P, str], *args: P.args, **kwargs: P.kwargs) -> str: ...
+def handle(func: Any, *args: Any, **kwargs: Any) -> Any:
+    return func(*args, **kwargs)
+
+@overload
+def handle_reversed(func: Callable[P, str], *args: P.args, **kwargs: P.kwargs) -> str: ...
+@overload
+def handle_reversed(func: Base) -> int: ...
+def handle_reversed(func: Any, *args: Any, **kwargs: Any) -> Any:
+    return func(*args, **kwargs)
+
+reveal_type(handle(Child()))  # N: Revealed type is "builtins.int"
+reveal_type(handle(NotChild()))  # N: Revealed type is "builtins.str"
+
+reveal_type(handle_reversed(Child()))  # N: Revealed type is "builtins.str"
+reveal_type(handle_reversed(NotChild()))  # N: Revealed type is "builtins.str"
+
+[builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
Closes #18027.

Var-args and star-args overloads are handled first to handle functions like `zip` correctly in cases like `zip(*[[1],[2],[3]])`. That does not seem to be necessary in case of `ParamSpec` overloads (or at least such use case is much less obvious).

So this PR prevents `ParamSpec` overloads from floating up in the list of overload targets.