### PR TITLE
allow the use of --show-traceback and --pdb with stubtest

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1938,10 +1938,8 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
         options.abs_custom_typeshed_dir = os.path.abspath(options.custom_typeshed_dir)
     options.config_file = args.mypy_config_file
     options.use_builtins_fixtures = use_builtins_fixtures
-    if args.show_traceback:
-        options.show_traceback = True
-    if args.pdb:
-        options.pdb = True
+    options.show_traceback = args.show_traceback
+    options.pdb = args.pdb
 
     if options.config_file:
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1938,6 +1938,10 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
         options.abs_custom_typeshed_dir = os.path.abspath(options.custom_typeshed_dir)
     options.config_file = args.mypy_config_file
     options.use_builtins_fixtures = use_builtins_fixtures
+    if args.show_traceback:
+        options.show_traceback = True
+    if args.pdb:
+        options.pdb = True
 
     if options.config_file:
 
@@ -2090,6 +2094,10 @@ def parse_options(args: list[str]) -> _Arguments:
     )
     parser.add_argument(
         "--version", action="version", version="%(prog)s " + mypy.version.__version__
+    )
+    parser.add_argument("--pdb", action="store_true", help="Invoke pdb on fatal error")
+    parser.add_argument(
+        "--show-traceback", "--tb", action="store_true", help="Show traceback on fatal error"
     )
 
     return parser.parse_args(args, namespace=_Arguments())

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1893,6 +1893,8 @@ class _Arguments:
     custom_typeshed_dir: str | None
     check_typeshed: bool
     version: str
+    show_traceback: bool
+    pdb: bool
 
 
 # typeshed added a stub for __main__, but that causes stubtest to check itself


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Mypy's error handling suggests using -`-show-traceback` and `--pdb` for more information, and this can occur while running stubtest. This MR adds support for both flags to stubtest so that the suggestions can be followed without needing to figure out the equivalent mypy invocation first.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
