### PR TITLE
Remove unnecessary concatenated strings

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -393,8 +393,10 @@ class StringFormatterChecker:
                 # If the explicit conversion is given, then explicit conversion is called _first_.
                 if spec.conversion[1] not in "rsa":
                     self.msg.fail(
-                        'Invalid conversion type "{}",'
-                        ' must be one of "r", "s" or "a"'.format(spec.conversion[1]),
+                        (
+                            f'Invalid conversion type "{spec.conversion[1]}", '
+                            f'must be one of "r", "s" or "a"'
+                        ),
                         call,
                         code=codes.STRING_FORMATTING,
                     )
@@ -472,8 +474,7 @@ class StringFormatterChecker:
                 expr = self.get_expr_by_position(int(key), call)
                 if not expr:
                     self.msg.fail(
-                        "Cannot find replacement for positional"
-                        " format specifier {}".format(key),
+                        f"Cannot find replacement for positional format specifier {key}",
                         call,
                         code=codes.STRING_FORMATTING,
                     )
@@ -654,8 +655,9 @@ class StringFormatterChecker:
                 assert spec.key, "Call this method only after auto-generating keys!"
                 assert spec.field
                 self.msg.fail(
-                    "Invalid index expression in format field"
-                    ' accessor "{}"'.format(spec.field[len(spec.key) :]),
+                    'Invalid index expression in format field accessor "{}"'.format(
+                        spec.field[len(spec.key) :]
+                    ),
                     ctx,
                     code=codes.STRING_FORMATTING,
                 )

--- a/mypy/inspections.py
+++ b/mypy/inspections.py
@@ -469,8 +469,7 @@ class InspectionEngine:
 
     def missing_node(self, expression: Expression) -> str:
         return (
-            f'Cannot find definition for "{type(expression).__name__}"'
-            f" at {expr_span(expression)}"
+            f'Cannot find definition for "{type(expression).__name__}" at {expr_span(expression)}'
         )
 
     def add_prefixes(self, result: str, expression: Expression) -> str:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -552,15 +552,16 @@ def process_options(
     )
     config_group.add_argument(
         "--config-file",
-        help="Configuration file, must have a [mypy] section "
-        "(defaults to {})".format(", ".join(defaults.CONFIG_FILES)),
+        help=(
+            f"Configuration file, must have a [mypy] section "
+            f"(defaults to {', '.join(defaults.CONFIG_FILES)})"
+        ),
     )
     add_invertible_flag(
         "--warn-unused-configs",
         default=False,
         strict_flag=True,
-        help="Warn about unused '[mypy-<pattern>]' or '[[tool.mypy.overrides]]' "
-        "config sections",
+        help="Warn about unused '[mypy-<pattern>]' or '[[tool.mypy.overrides]]' config sections",
         group=config_group,
     )
 
@@ -589,8 +590,7 @@ def process_options(
         "--python-executable",
         action="store",
         metavar="EXECUTABLE",
-        help="Python executable used for finding PEP 561 compliant installed"
-        " packages and stubs",
+        help="Python executable used for finding PEP 561 compliant installed packages and stubs",
         dest="special-opts:python_executable",
     )
     imports_group.add_argument(
@@ -623,8 +623,7 @@ def process_options(
         "--platform",
         action="store",
         metavar="PLATFORM",
-        help="Type check special-cased code for the given OS platform "
-        "(defaults to sys.platform)",
+        help="Type check special-cased code for the given OS platform (defaults to sys.platform)",
     )
     platform_group.add_argument(
         "--always-true",
@@ -661,8 +660,7 @@ def process_options(
         "--disallow-any-decorated",
         default=False,
         action="store_true",
-        help="Disallow functions that have Any in their signature "
-        "after decorator transformation",
+        help="Disallow functions that have Any in their signature after decorator transformation",
     )
     disallow_any_group.add_argument(
         "--disallow-any-explicit",

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -196,8 +196,7 @@ TYPEVAR_VARIANCE_DEF: Final = 'TypeVar "{}" may only be a literal bool'
 TYPEVAR_ARG_MUST_BE_TYPE: Final = '{} "{}" must be a type'
 TYPEVAR_UNEXPECTED_ARGUMENT: Final = 'Unexpected argument to "TypeVar()"'
 UNBOUND_TYPEVAR: Final = (
-    "A function returning TypeVar should receive at least "
-    "one argument containing the same TypeVar"
+    "A function returning TypeVar should receive at least one argument containing the same TypeVar"
 )
 TYPE_PARAMETERS_SHOULD_BE_DECLARED: Final = (
     "All type parameters should be declared ({} not declared)"

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1685,7 +1685,7 @@ class MessageBuilder:
 
     def overloaded_signatures_ret_specific(self, index: int, context: Context) -> None:
         self.fail(
-            "Overloaded function implementation cannot produce return type of signature {index}",
+            f"Overloaded function implementation cannot produce return type of signature {index}",
             context,
         )
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -675,8 +675,7 @@ class MessageBuilder:
                         arg_type, callee.arg_types[n - 1], options=self.options
                     )
                     info = (
-                        f" (expression has type {arg_type_str}, "
-                        f"target has type {callee_type_str})"
+                        f" (expression has type {arg_type_str}, target has type {callee_type_str})"
                     )
                     error_msg = (
                         message_registry.INCOMPATIBLE_TYPES_IN_ASSIGNMENT.with_additional_msg(info)
@@ -1433,8 +1432,7 @@ class MessageBuilder:
 
     def unsafe_super(self, method: str, cls: str, ctx: Context) -> None:
         self.fail(
-            'Call to abstract method "{}" of "{}" with trivial body'
-            " via super() is unsafe".format(method, cls),
+            f'Call to abstract method "{method}" of "{cls}" with trivial body via super() is unsafe',
             ctx,
             code=codes.SAFE_SUPER,
         )
@@ -1588,8 +1586,10 @@ class MessageBuilder:
 
     def cant_override_final(self, name: str, base_name: str, ctx: Context) -> None:
         self.fail(
-            'Cannot override final attribute "{}"'
-            ' (previously declared in base class "{}")'.format(name, base_name),
+            (
+                f'Cannot override final attribute "{name}" '
+                f'(previously declared in base class "{base_name}")'
+            ),
             ctx,
         )
 
@@ -1676,15 +1676,16 @@ class MessageBuilder:
 
     def overloaded_signatures_arg_specific(self, index: int, context: Context) -> None:
         self.fail(
-            "Overloaded function implementation does not accept all possible arguments "
-            "of signature {}".format(index),
+            (
+                f"Overloaded function implementation does not accept all possible arguments "
+                f"of signature {index}"
+            ),
             context,
         )
 
     def overloaded_signatures_ret_specific(self, index: int, context: Context) -> None:
         self.fail(
-            "Overloaded function implementation cannot produce return type "
-            "of signature {}".format(index),
+            "Overloaded function implementation cannot produce return type of signature {index}",
             context,
         )
 
@@ -1707,8 +1708,7 @@ class MessageBuilder:
         context: Context,
     ) -> None:
         self.fail(
-            'Signatures of "{}" of "{}" and "{}" of {} '
-            "are unsafely overlapping".format(
+            'Signatures of "{}" of "{}" and "{}" of {} are unsafely overlapping'.format(
                 reverse_method,
                 reverse_class.name,
                 forward_method,
@@ -1997,8 +1997,7 @@ class MessageBuilder:
         self, actual: int, tvar_name: str, expected: int, context: Context
     ) -> None:
         msg = capitalize(
-            '{} type variable "{}" used in protocol where'
-            " {} one is expected".format(
+            '{} type variable "{}" used in protocol where {} one is expected'.format(
                 variance_string(actual), tvar_name, variance_string(expected)
             )
         )
@@ -2246,15 +2245,17 @@ class MessageBuilder:
         for name, subflags, superflags in conflict_flags[:MAX_ITEMS]:
             if not class_obj and IS_CLASSVAR in subflags and IS_CLASSVAR not in superflags:
                 self.note(
-                    "Protocol member {}.{} expected instance variable,"
-                    " got class variable".format(supertype.type.name, name),
+                    "Protocol member {}.{} expected instance variable, got class variable".format(
+                        supertype.type.name, name
+                    ),
                     context,
                     code=code,
                 )
             if not class_obj and IS_CLASSVAR in superflags and IS_CLASSVAR not in subflags:
                 self.note(
-                    "Protocol member {}.{} expected class variable,"
-                    " got instance variable".format(supertype.type.name, name),
+                    "Protocol member {}.{} expected class variable, got instance variable".format(
+                        supertype.type.name, name
+                    ),
                     context,
                     code=code,
                 )

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -73,8 +73,7 @@ class ModuleNotFoundReason(Enum):
         elif self is ModuleNotFoundReason.WRONG_WORKING_DIRECTORY:
             msg = 'Cannot find implementation or library stub for module named "{module}"'
             notes = [
-                "You may be running mypy in a subpackage, "
-                "mypy should be run on the package root"
+                "You may be running mypy in a subpackage, mypy should be run on the package root"
             ]
         elif self is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
             msg = (

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -444,8 +444,7 @@ class DataclassTransformer:
             # This means that version is lower than `3.10`,
             # it is just a non-existent argument for `dataclass` function.
             self._api.fail(
-                'Keyword argument "slots" for "dataclass" '
-                "is only valid in Python 3.10 and higher",
+                'Keyword argument "slots" for "dataclass" is only valid in Python 3.10 and higher',
                 self._reason,
             )
             return

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2636,8 +2636,7 @@ class SemanticAnalyzer(
             calculate_mro(defn.info, obj_type)
         except MroError:
             self.fail(
-                "Cannot determine consistent method resolution "
-                'order (MRO) for "%s"' % defn.name,
+                f'Cannot determine consistent method resolution order (MRO) for "{defn.name}"',
                 defn,
             )
             self.set_dummy_mro(defn.info)

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -380,8 +380,7 @@ class NamedTupleAnalyzer:
                         rename = arg.name == "True"
                     else:
                         self.fail(
-                            'Boolean literal expected as the "rename" argument to '
-                            f"{type_name}()",
+                            f'Boolean literal expected as the "rename" argument to {type_name}()',
                             arg,
                             code=ARG_TYPE,
                         )

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -968,14 +968,12 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 message = 'Type variable "{}" is unbound'
                 short = name.split(".")[-1]
                 notes.append(
-                    (
-                        '(Hint: Use "Generic[{}]" or "Protocol[{}]" base class'
-                        ' to bind "{}" inside a class)'
-                    ).format(short, short, short)
+                    f'(Hint: Use "Generic[{short}]" or "Protocol[{short}]" base class'
+                    f' to bind "{short}" inside a class)'
                 )
                 notes.append(
-                    '(Hint: Use "{}" in function signature to bind "{}"'
-                    " inside a function)".format(short, short)
+                    f'(Hint: Use "{short}" in function signature '
+                    f'to bind "{short}" inside a function)'
                 )
         else:
             message = 'Cannot interpret reference "{}" as a type'


### PR DESCRIPTION
We have some strings which use implicit concatenation unnecessarily (where the whole string can fit on a single line without implicit concatenation). This PR removes them.

For some of the changed lines here, I also did some driveby modernisations to use f-strings, since I was touching those lines anyway.