### PR TITLE
Defer type analysis of integer Literal when builtins.int is slow to resolve

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -297,40 +297,43 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             and tvar_name not in self.alias_type_params_names
         )
 
+    def handle_placeholder_node(self, node: PlaceholderNode, t: UnboundType) -> Type:
+        if node.becomes_typeinfo:
+            # Reference to placeholder type.
+            if self.api.final_iteration:
+                self.cannot_resolve_type(t)
+                return AnyType(TypeOfAny.from_error)
+            elif self.allow_placeholder:
+                self.api.defer()
+            else:
+                self.api.record_incomplete_ref()
+            # Always allow ParamSpec for placeholders, if they are actually not valid,
+            # they will be reported later, after we resolve placeholders.
+            return PlaceholderType(
+                node.fullname,
+                self.anal_array(
+                    t.args,
+                    allow_param_spec=True,
+                    allow_param_spec_literals=True,
+                    allow_unpack=True,
+                ),
+                t.line,
+            )
+        else:
+            if self.api.final_iteration:
+                self.cannot_resolve_type(t)
+                return AnyType(TypeOfAny.from_error)
+            else:
+                # Reference to an unknown placeholder node.
+                self.api.record_incomplete_ref()
+                return AnyType(TypeOfAny.special_form)
+
     def visit_unbound_type_nonoptional(self, t: UnboundType, defining_literal: bool) -> Type:
         sym = self.lookup_qualified(t.name, t)
         if sym is not None:
             node = sym.node
             if isinstance(node, PlaceholderNode):
-                if node.becomes_typeinfo:
-                    # Reference to placeholder type.
-                    if self.api.final_iteration:
-                        self.cannot_resolve_type(t)
-                        return AnyType(TypeOfAny.from_error)
-                    elif self.allow_placeholder:
-                        self.api.defer()
-                    else:
-                        self.api.record_incomplete_ref()
-                    # Always allow ParamSpec for placeholders, if they are actually not valid,
-                    # they will be reported later, after we resolve placeholders.
-                    return PlaceholderType(
-                        node.fullname,
-                        self.anal_array(
-                            t.args,
-                            allow_param_spec=True,
-                            allow_param_spec_literals=True,
-                            allow_unpack=True,
-                        ),
-                        t.line,
-                    )
-                else:
-                    if self.api.final_iteration:
-                        self.cannot_resolve_type(t)
-                        return AnyType(TypeOfAny.from_error)
-                    else:
-                        # Reference to an unknown placeholder node.
-                        self.api.record_incomplete_ref()
-                        return AnyType(TypeOfAny.special_form)
+                return self.handle_placeholder_node(node, t)
             if node is None:
                 self.fail(f"Internal error (node is None, kind={sym.kind})", t)
                 return AnyType(TypeOfAny.special_form)
@@ -1700,6 +1703,11 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 # Note: we deliberately ignore arg.note here: the extra info might normally be
                 # helpful, but it generally won't make sense in the context of a Literal[...].
                 return None
+
+            # Make sure the literal's class is ready
+            sym = self.lookup_fully_qualified(arg.base_type_name)
+            if isinstance(sym.node, PlaceholderNode):
+                return [self.handle_placeholder_node(sym.node, UnboundType(arg.base_type_name))]
 
             # Remap bytes and unicode into the appropriate type for the correct Python version
             fallback = self.named_type(arg.base_type_name)

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2984,3 +2984,40 @@ class C(Base):
             reveal_type(sep)  # N: Revealed type is "Union[Literal['a'], Literal['b']]"
         return super().feed_data(sep)
 [builtins fixtures/tuple.pyi]
+
+
+-- This is constructed so that when mypy performs first pass
+-- type analysis on _LiteralInteger, builtins.int is still a
+-- placeholder, and the analysis must defer to avoid an error.
+[case testDeferIntLiteral]
+[file typing.py]
+import abc
+
+[file abc.py]
+import collections.abc
+
+[file collections/__init__.py]
+
+[file collections/abc.py]
+from _collections_abc import *
+
+[file _collections_abc.py]
+
+[file typing_extensions.py]
+Literal: object
+
+[file numbers.py]
+class Number: ...
+
+[file builtins.py]
+import numbers
+import typing
+from typing_extensions import Literal
+
+_LiteralInteger: Literal[0]
+
+class int(numbers.Number): ...
+class str: ...
+class list: ...
+class dict: ...
+class ellipsis: ...


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
This fixes a crash that can occur when working with experimental versions of typeshed.
Type analysis of a literal integer calls `TypeAnalyser.named_type` to lookup `builtins.int`
which is expected to lookup the TypeInfo node and return it as an Instance type. If the lookup returns
an unexpected `PlaceholderNode` node instead, mypy currently crashes.

In this MR I took the existing logic around deferring for a `PlaceholderNode` from within `TypeAnalyser.visit_unbound_type_nonoptional` and moved it to a reusable method, `TypeAnalyser.handle_placeholder_node` (method name could probably be better). There are no modifications to this block of code, just isolating it into its own method. Then I added a check within `TypeAnalyser.analyze_literal_param` which calls `handle_placeholder_node` if needed.

In the current version of the MR, this does mean that `self.lookup_fully_qualified(arg.base_type_name)` is called basically twice in a row in the normal case of integer `Literal` analysis - once to check that it's not a placeholder, and then again after calling `TypeAnalyser.named_type`. These could be consolidated by making `named_type` handle the check for placeholder nodes, but I was nervous about that due to the variety of different places where `named_type` is called. Possibly a flag could be added to `named_type` to indicate that the calling site is prepared to handle a defer situation. I wasn't sure what would be the best approach overall, and I wasn't sure how much calling `lookup_fully_qualified` twice in a row was really worth worrying about. This version is probably best for keeping different concerns separated from each other.

The test case added is a distilled version of the crashing scenario from typeshed. The long import chain seems necessary, otherwise a different but related crash occurs (`lookup_fully_qualified_or_none` returns `None` instead of `PlaceholderNode`, which causes a failed assertion in a slightly different location).

Was it really necessary to fix this crash? Maybe not. But it is nice to be able to experiment more freely.
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
