### PR TITLE
[Documentation] Update repository clone method. Fixes issue 18050

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,15 @@ Within Github, navigate to <https://github.com/python/mypy> and fork the reposit
 #### (2) Clone the mypy repository and enter into it
 
 ```bash
-git clone git@github.com:<your_username>/mypy.git
+git clone https://github.com/<your_username>/mypy.git
 cd mypy
 ```
+
+If you use the following command to clone instead:
+```bash
+git clone git@github.com:<your_username>/mypy.git
+```
+then make sure to connect to GitHub first: [Connecting to github with ssh](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
 
 #### (3) Create then activate a virtual environment
 


### PR DESCRIPTION
Fixes #18050

Makes cloning of the repository easier for new starters. It allows to skip a complicated step of generating ssh keys, but provides a link to detailed instructions on how to do so.