### PR TITLE
stubgen: Add flagfile support

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1793,7 +1793,9 @@ manual changes.  This directory is assumed to exist.
 
 
 def parse_options(args: list[str]) -> Options:
-    parser = argparse.ArgumentParser(prog="stubgen", usage=HEADER, description=DESCRIPTION)
+    parser = argparse.ArgumentParser(
+        prog="stubgen", usage=HEADER, description=DESCRIPTION, fromfile_prefix_chars="@"
+    )
 
     parser.add_argument(
         "--ignore-errors",


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->

## Description

This is already supported by main `mypy` binary and `dmypy` but not by `stubgen`.

## Context
I maintain https://github.com/KapJI/homeassistant-stubs which automatically generates typing stubs. Currently list of arguments there is 50 KB long and this can be longer that supported by OS (depending on configuration). It'd help to write these args to flagfile.
