### PR TITLE
Fix crash when checking slice expression with step 0 in tuple index

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2502,6 +2502,9 @@ class TupleType(ProperType):
         if fallback is None:
             fallback = self.partial_fallback
 
+        if stride == 0:
+            return None
+
         if any(isinstance(t, UnpackType) for t in self.items):
             total = len(self.items)
             unpack_index = find_unpack_in_list(self.items)

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1438,6 +1438,12 @@ reveal_type(t[x:])  # N: Revealed type is "builtins.tuple[Union[builtins.int, bu
 t[y:]  # E: Slice index must be an integer, SupportsIndex or None
 [builtins fixtures/tuple.pyi]
 
+[case testTupleSliceStepZeroNoCrash]
+# This was crashing: https://github.com/python/mypy/issues/18062
+# TODO: emit better error when 0 is used for step
+()[::0]  # E: Ambiguous slice of a variadic tuple
+[builtins fixtures/tuple.pyi]
+
 [case testInferTupleTypeFallbackAgainstInstance]
 from typing import TypeVar, Generic, Tuple
 T = TypeVar('T')


### PR DESCRIPTION
Fixes #18062

I plan to follow up with another PR that adds a better error messages for  slice expressions with `step=0` when indexing standard containers that disallow that.