### PR TITLE
Disallow literal `0` step in slice expressions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5616,6 +5616,13 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if index:
                 t = self.accept(index)
                 self.chk.check_subtype(t, expected, index, message_registry.INVALID_SLICE_INDEX)
+
+        if e.stride:
+            stride_literals = self.try_getting_int_literals(e.stride)
+            if stride_literals is not None and 0 in stride_literals:
+                self.msg.fail("Slice step cannot be 0", index)
+                return AnyType(TypeOfAny.from_error)
+
         return self.named_type("builtins.slice")
 
     def visit_list_comprehension(self, e: ListComprehension) -> Type:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1235,6 +1235,19 @@ a[None:]
 a[:None]
 [builtins fixtures/slice.pyi]
 
+[case testSliceStepZero]
+from typing import Any
+from typing_extensions import Literal
+n1: Literal[0]
+n2: Literal[0, 1]
+a: Any
+a[::0]      # E: Slice step cannot be 0
+a[::-0]     # E: Slice step cannot be 0
+a[::+0]     # E: Slice step cannot be 0
+a[::n1]     # E: Slice step cannot be 0
+a[::n2]     # E: Slice step cannot be 0
+[builtins fixtures/tuple.pyi]
+
 
 -- Lambdas
 -- -------


### PR DESCRIPTION
Follow up to #18063

Using a step of `0` when slicing a sequence is often a runtime error:
```python
>>> ()[::0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: slice step cannot be zero
```
This applies to standard library sequences types (tuple, list, str, memoryview, array.array, etc.), as well as to numpy arrays, pandas series, and many other third-party sequence types (including all that use `slice.indices` internally).

This PR takes a slightly aggressive stance by disallowing any expressions with a literal-`0` type (or unions including literal `0`) in the step position of a slice expression. Depending on how significant the mypy_primer hit is, I may relax this a bit.

