### PR TITLE
Remove union simplification during inference

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -324,14 +324,6 @@ def _infer_constraints(
     template = get_proper_type(template)
     actual = get_proper_type(actual)
 
-    # Type inference shouldn't be affected by whether union types have been simplified.
-    # We however keep any ErasedType items, so that the caller will see it when using
-    # checkexpr.has_erased_component().
-    if isinstance(template, UnionType):
-        template = mypy.typeops.make_simplified_union(template.items, keep_erased=True)
-    if isinstance(actual, UnionType):
-        actual = mypy.typeops.make_simplified_union(actual.items, keep_erased=True)
-
     # Ignore Any types from the type suggestion engine to avoid them
     # causing us to infer Any in situations where a better job could
     # be done otherwise. (This can produce false positives but that


### PR DESCRIPTION
This is very hot and I'm curious how necessary it is, especially given the comment