### PR TITLE
Update for Windows platform. Resolves #18096

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,16 +65,16 @@ However, if you wish to do so, you can run the full test suite
 like this:
 
 ```bash
-python3 runtests.py
+python runtests.py
 ```
 
 Some useful commands for running specific tests include:
 
 ```bash
 # Use mypy to check mypy's own code
-python3 runtests.py self
+python runtests.py self
 # or equivalently:
-python3 -m mypy --config-file mypy_self_check.ini -p mypy
+python -m mypy --config-file mypy_self_check.ini -p mypy
 
 # Run a single test from the test suite
 pytest -n0 -k 'test_name'
@@ -117,7 +117,7 @@ tox -e dev --override testenv:dev.allowlist_externals+=env -- env  # inspect the
 ```
 
 If you don't already have `tox` installed, you can use a virtual environment as
-described above to install `tox` via `pip` (e.g., ``python3 -m pip install tox``).
+described above to install `tox` via `pip` (e.g., ``python -m pip install tox``).
 
 ## First time contributors
 


### PR DESCRIPTION
Fixes #18096

Update of CONTRIBUTING.md document to be able to run tests using Windows OS.

```bash
python3 runtests.py
```


Change to:

```bash
python runtests.py
```



```bash
# Use mypy to check mypy's own code
python3 runtests.py self
# or equivalently:
python3 -m mypy --config-file mypy_self_check.ini -p mypy
```

Change to:

```bash
# Use mypy to check mypy's own code
python runtests.py self
# or equivalently:
python -m mypy --config-file mypy_self_check.ini -p mypy
```


described above to install `tox` via `pip` (e.g., ``python3 -m pip install tox``).

Change to:
described above to install `tox` via `pip` (e.g., ``python -m pip install tox``).