### PR TITLE
Update `config_file` docs

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -717,6 +717,14 @@ section of the command line docs.
 
     Note: This option will override disabled error codes from the disable_error_code option.
 
+.. confval:: extra_checks
+
+   :type: boolean
+   :default: False
+
+   This flag enables additional checks that are technically correct but may be impractical in real code.
+   See :option:`--extra-checks` for more info.
+
 .. confval:: implicit_reexport
 
     :type: boolean
@@ -744,25 +752,28 @@ section of the command line docs.
 
     Make arguments prepended via ``Concatenate`` be truly positional-only.
 
+    .. warning::
+       Deprecated: use :confval:`extra_checks` instead.
+
 .. confval:: strict_equality
 
     :type: boolean
     :default: False
 
-   Prohibit equality checks, identity checks, and container checks between
-   non-overlapping types.
+    Prohibit equality checks, identity checks, and container checks between
+    non-overlapping types.
 
 .. confval:: strict
 
     :type: boolean
     :default: False
 
-   Enable all optional error checking flags.  You can see the list of
-   flags enabled by strict mode in the full :option:`mypy --help`
-   output.
+    Enable all optional error checking flags.  You can see the list of
+    flags enabled by strict mode in the full :option:`mypy --help`
+    output.
 
-   Note: the exact list of flags enabled by :confval:`strict` may
-   change over time.
+    Note: the exact list of flags enabled by :confval:`strict` may
+    change over time.
 
 
 Configuring error messages

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -723,7 +723,7 @@ section of the command line docs.
    :default: False
 
    This flag enables additional checks that are technically correct but may be impractical in real code.
-   See :option:`--extra-checks` for more info.
+   See :option:`mypy --extra-checks` for more info.
 
 .. confval:: implicit_reexport
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -747,33 +747,30 @@ section of the command line docs.
 
 .. confval:: strict_concatenate
 
-    :type: boolean
-    :default: False
+   :type: boolean
+   :default: False
 
-    Make arguments prepended via ``Concatenate`` be truly positional-only.
-
-    .. warning::
-       Deprecated: use :confval:`extra_checks` instead.
+   Make arguments prepended via ``Concatenate`` be truly positional-only.
 
 .. confval:: strict_equality
 
-    :type: boolean
-    :default: False
+   :type: boolean
+   :default: False
 
-    Prohibit equality checks, identity checks, and container checks between
-    non-overlapping types.
+   Prohibit equality checks, identity checks, and container checks between
+   non-overlapping types.
 
 .. confval:: strict
 
-    :type: boolean
-    :default: False
+   :type: boolean
+   :default: False
 
-    Enable all optional error checking flags.  You can see the list of
-    flags enabled by strict mode in the full :option:`mypy --help`
-    output.
+   Enable all optional error checking flags.  You can see the list of
+   flags enabled by strict mode in the full :option:`mypy --help`
+   output.
 
-    Note: the exact list of flags enabled by :confval:`strict` may
-    change over time.
+   Note: the exact list of flags enabled by :confval:`strict` may
+   change over time.
 
 
 Configuring error messages


### PR DESCRIPTION
Changes:
- Fix `strict_equality` markup. It used to be like this:
<img width="760" alt="Снимок экрана 2024-11-04 в 13 47 35" src="https://github.com/user-attachments/assets/d3e99a72-5216-4dda-8cca-2e30f6d705dc">

- Mark `strict_concatenate` as deprecated
- Add `extra_checks` confval