### PR TITLE
Fix `OR` pattern structural matching exhaustiveness

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -158,7 +158,8 @@ class PatternChecker(PatternVisitor[PatternType]):
         for pattern in o.patterns:
             pattern_type = self.accept(pattern, current_type)
             pattern_types.append(pattern_type)
-            current_type = pattern_type.rest_type
+            if not is_uninhabited(pattern_type.type):
+                current_type = pattern_type.rest_type
 
         #
         # Collect the final type

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1702,6 +1702,22 @@ def f(x: int | str) -> int:
         case str() as s:
             return 1
 
+[case testMatchOrPatternExhaustiveness]
+from typing import NoReturn, Literal
+def assert_never(x: NoReturn) -> None: ...
+
+Color = Literal["blue", "green", "red"]
+c: Color
+
+match c:
+    case "blue":
+        reveal_type(c) # N: Revealed type is "Literal['blue']"
+    case "green" | "notColor":
+        reveal_type(c) # N: Revealed type is "Literal['green']"
+    case _:
+        assert_never(c) # E: Argument 1 to "assert_never" has incompatible type "Literal['red']"; expected "Never"
+[typing fixtures/typing-typeddict.pyi]
+
 [case testMatchAsPatternIntersection-skip]
 class A: pass
 class B: pass


### PR DESCRIPTION
Fixes #18108

This PR fixes the issue of missing value comparisons in a `MatchStmt` due to `OrPattern` incorrectly narrowing down the type of the subject.

