### PR TITLE
[chore] Remove black and ruff from test-requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 exclude: '^(mypyc/external/)|(mypy/typeshed/)|misc/typeshed_patches'  # Exclude all vendored code from lints
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0  # must match test-requirements.txt
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0  # must match test-requirements.txt
+    rev: 24.8.0
     hooks:
       - id: black
         exclude: '^(test-data/)'
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9  # must match test-requirements.txt
+    rev: v0.6.9
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]

--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -159,7 +159,7 @@ To run mypy on itself:
 
 To run the linter:
 
-    ruff .
+    python3 runtests.py lint
 
 You can also run all of the above tests using `runtests.py` (this includes
 type checking mypy and linting):

--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -100,6 +100,10 @@ First install any additional dependencies needed for testing:
 
     python3 -m pip install -U -r test-requirements.txt
 
+Configure `pre-commit` to run the linters automatically when you commit:
+
+    pre-commit install
+
 The unit test suites are driven by the `pytest` framework. To run all mypy tests,
 run `pytest` in the mypy repository:
 
@@ -157,7 +161,9 @@ To run mypy on itself:
 
     python3 -m mypy --config-file mypy_self_check.ini -p mypy
 
-To run the linter:
+To run the linter (this commands just wraps `pre-commit`, so you can also
+invoke it directly like `pre-commit run -a`, and this will also run when you
+`git commit` if enabled):
 
     python3 runtests.py lint
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -4,7 +4,6 @@
 -r mypy-requirements.txt
 -r build-requirements.txt
 attrs>=18.0
-black==24.8.0  # must match version in .pre-commit-config.yaml
 filelock>=3.3.0
 # lxml 4.9.3 switched to manylinux_2_28, the wheel builder still uses manylinux2014
 lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
@@ -12,7 +11,6 @@ psutil>=4.0
 pytest>=8.1.0
 pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
-ruff==0.6.9  # must match version in .pre-commit-config.yaml
 setuptools>=75.1.0
 tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.8
 pre_commit>=3.5.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,12 +6,8 @@
 #
 attrs==24.2.0
     # via -r test-requirements.in
-black==24.8.0
-    # via -r test-requirements.in
 cfgv==3.4.0
     # via pre-commit
-click==8.1.7
-    # via black
 coverage==7.6.1
     # via pytest-cov
 distlib==0.3.9
@@ -29,21 +25,13 @@ iniconfig==2.0.0
 lxml==4.9.2 ; (python_version < "3.11" or sys_platform != "win32") and python_version < "3.12"
     # via -r test-requirements.in
 mypy-extensions==1.0.0
-    # via
-    #   -r mypy-requirements.txt
-    #   black
+    # via -r mypy-requirements.txt
 nodeenv==1.9.1
     # via pre-commit
 packaging==24.1
-    # via
-    #   black
-    #   pytest
-pathspec==0.12.1
-    # via black
+    # via pytest
 platformdirs==4.3.6
-    # via
-    #   black
-    #   virtualenv
+    # via virtualenv
 pluggy==1.5.0
     # via pytest
 pre-commit==3.5.0
@@ -61,8 +49,6 @@ pytest-xdist==3.6.1
     # via -r test-requirements.in
 pyyaml==6.0.2
     # via pre-commit
-ruff==0.6.9
-    # via -r test-requirements.in
 tomli==2.0.2
     # via -r test-requirements.in
 types-psutil==6.0.0.20241011


### PR DESCRIPTION
#15210 standardized lint hooks invocations with pre-commit, but did not remove test requirements that became unneeded. Grepping for `ruff` and `black` revealed that they are never used directly any longer except for one outdated README notice.

Remove direct dependency on `black` and `ruff`, retaining them only in pre-commit configuration. pre-commit does not use local package installations and manages all virtual environments internally.