### PR TITLE
ruff: enable pep8-naming rules

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1727,7 +1727,7 @@ class StrExpr(Expression):
         return visitor.visit_str_expr(self)
 
 
-def is_StrExpr_list(seq: list[Expression]) -> TypeGuard[list[StrExpr]]:
+def is_StrExpr_list(seq: list[Expression]) -> TypeGuard[list[StrExpr]]:  # noqa: N802
     return all(isinstance(item, StrExpr) for item in seq)
 
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -987,7 +987,7 @@ class StubgencSuite(unittest.TestCase):
     def test_generate_c_type_classmethod_with_overloads(self) -> None:
         class TestClass:
             @classmethod
-            def test(self, arg0: str) -> None:
+            def test(cls, arg0: str) -> None:
                 """
                 test(cls, arg0: str)
                 test(cls, arg0: int)

--- a/mypyc/lib-rt/setup.py
+++ b/mypyc/lib-rt/setup.py
@@ -21,7 +21,7 @@ else:
     compile_args = ["--std=c++11"]
 
 
-class build_ext_custom(build_ext):
+class build_ext_custom(build_ext):  # noqa: N801
     def get_library_names(self):
         return ["gtest"]
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -134,7 +134,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
     def test_tuple_get(self) -> None:
         self.assert_emit(TupleGet(self.t, 1, 0), "cpy_r_r0 = cpy_r_t.f1;")
 
-    def test_load_None(self) -> None:
+    def test_load_None(self) -> None:  # noqa: N802
         self.assert_emit(
             LoadAddress(none_object_op.type, none_object_op.src, 0),
             "cpy_r_r0 = (PyObject *)&_Py_NoneStruct;",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ select = [
   "W",       # pycodestyle (warning)
   "B",       # flake8-bugbear
   "I",       # isort
+  "N",       # pep8-naming
   "RUF100",  # Unused noqa comments
   "PGH004",  # blanket noqa comments
   "UP",      # pyupgrade
@@ -68,6 +69,8 @@ ignore = [
   "E721",  # Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   "E731",  # Do not assign a `lambda` expression, use a `def`
   "E741",  # Ambiguous variable name
+  "N818",  # Exception should be named with an Error suffix
+  "N806",  # UPPER_CASE used for constant local variables
   "UP031", # Use format specifiers instead of percent format
   "UP032", # 'f-string always preferable to format' is controversial
   "C416",  # There are a few cases where it's nice to have names for the dict items
@@ -80,6 +83,10 @@ unfixable = [
     "B018",  # automatic fix might obscure issue
     "UP036", # sometimes it's better to just noqa this
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Mixed case variable and function names.
+"mypy/fastparse.py" = ["N802", "N816"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true


### PR DESCRIPTION
The vast majority of mypy's code follows PEP 8 naming conventions. However, we currently don't enforce this in the linter config. I noticed this in a recent PR which included a `camelCase` name: https://github.com/python/mypy/pull/18132#discussion_r1836870819.

Ruff has some rules to enforce PEP 8 naming style ([pep8-naming](https://docs.astral.sh/ruff/rules/#pep8-naming-n)). I think it would be a good idea to enable some of these to help contributors catch naming discrepancies before PR review.

We have a few notable exceptions to PEP 8 naming (e.g. functions named to match ast node names), but these are easily accounted for with some config file ignores and handful of `# noqa`'s.