### PR TITLE
Move static project metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,72 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "mypy"
+description = "Optional static typing for Python"
+authors = [{name = "Jukka Lehtosalo", email = "jukka.lehtosalo@iki.fi"}]
+license = {text = "MIT"}
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development",
+  "Typing :: Typed",
+]
+requires-python = ">=3.8"
+dependencies = [
+  # When changing this, also update build-system.requires and mypy-requirements.txt
+  "typing_extensions>=4.6.0",
+  "mypy_extensions>=1.0.0",
+  "tomli>=1.1.0; python_version<'3.11'",
+]
+dynamic = ["version", "readme"]
+
+[project.optional-dependencies]
+dmypy = ["psutil>=4.0"]
+mypyc = ["setuptools>=50"]
+python2 = []
+reports = ["lxml"]
+install-types = ["pip"]
+faster-cache = ["orjson"]
+
+[project.urls]
+Homepage = "https://www.mypy-lang.org/"
+Documentation = "https://mypy.readthedocs.io/en/stable/index.html"
+Repository = "https://github.com/python/mypy"
+Changelog = "https://github.com/python/mypy/blob/master/CHANGELOG.md"
+Issues = "https://github.com/python/mypy/issues"
+
+[project.scripts]
+mypy = "mypy.__main__:console_entry"
+stubgen = "mypy.stubgen:main"
+stubtest = "mypy.stubtest:main"
+dmypy = "mypy.dmypy.client:console_entry"
+mypyc = "mypyc.__main__:main"
+
+[tool.setuptools.packages.find]
+include = ["mypy*", "mypyc*", "*__mypyc*"]
+namespaces = false
+
+[tool.setuptools.package-data]
+mypy = [
+  "py.typed",
+  "typeshed/**/*.py",
+  "typeshed/**/*.pyi",
+  "typeshed/stdlib/VERSIONS",
+  "xml/*.xsd",
+  "xml/*.xslt",
+  "xml/*.css",
+]
+
 [tool.black]
 line-length = 99
 target-version = ["py38", "py39", "py310", "py311", "py312"]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 # This requires setuptools when building; setuptools is not needed
 # when installing from a wheel file (though it is still needed for
 # alternative forms of installing, as suggested by README.md).
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 from setuptools.command.build_py import build_py
 
 from mypy.version import __version__ as version
@@ -26,7 +26,6 @@ from mypy.version import __version__ as version
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
 
-description = "Optional static typing for Python"
 long_description = """
 Mypy -- Optional Static Typing for Python
 =========================================
@@ -77,13 +76,6 @@ class CustomPythonBuild(build_py):
 
 
 cmdclass = {"build_py": CustomPythonBuild}
-
-package_data = ["py.typed"]
-
-package_data += find_package_data(os.path.join("mypy", "typeshed"), ["*.py", "*.pyi"])
-package_data += [os.path.join("mypy", "typeshed", "stdlib", "VERSIONS")]
-
-package_data += find_package_data(os.path.join("mypy", "xml"), ["*.xsd", "*.xslt", "*.css"])
 
 USE_MYPYC = False
 # To compile with mypyc, a mypyc checkout must be present on the PYTHONPATH
@@ -179,67 +171,6 @@ else:
     ext_modules = []
 
 
-classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Topic :: Software Development",
-    "Typing :: Typed",
-]
-
 setup(
-    name="mypy",
-    version=version,
-    description=description,
-    long_description=long_description,
-    author="Jukka Lehtosalo",
-    author_email="jukka.lehtosalo@iki.fi",
-    url="https://www.mypy-lang.org/",
-    license="MIT",
-    py_modules=[],
-    ext_modules=ext_modules,
-    packages=find_packages(),
-    package_data={"mypy": package_data},
-    entry_points={
-        "console_scripts": [
-            "mypy=mypy.__main__:console_entry",
-            "stubgen=mypy.stubgen:main",
-            "stubtest=mypy.stubtest:main",
-            "dmypy=mypy.dmypy.client:console_entry",
-            "mypyc=mypyc.__main__:main",
-        ]
-    },
-    classifiers=classifiers,
-    cmdclass=cmdclass,
-    # When changing this, also update mypy-requirements.txt and pyproject.toml
-    install_requires=[
-        "typing_extensions>=4.6.0",
-        "mypy_extensions >= 1.0.0",
-        "tomli>=1.1.0; python_version<'3.11'",
-    ],
-    # Same here.
-    extras_require={
-        "dmypy": "psutil >= 4.0",
-        "mypyc": "setuptools >= 50",
-        "python2": "",
-        "reports": "lxml",
-        "install-types": "pip",
-        "faster-cache": "orjson",
-    },
-    python_requires=">=3.8",
-    include_package_data=True,
-    project_urls={
-        "Documentation": "https://mypy.readthedocs.io/en/stable/index.html",
-        "Repository": "https://github.com/python/mypy",
-        "Changelog": "https://github.com/python/mypy/blob/master/CHANGELOG.md",
-        "Issues": "https://github.com/python/mypy/issues",
-    },
+    version=version, long_description=long_description, ext_modules=ext_modules, cmdclass=cmdclass
 )


### PR DESCRIPTION
Setuptools supports using `setup.py` and `pyproject.toml` simultaneously. This PR moves most of the static project metadata to `pyproject.toml`.

Diff for **`.dist-info/METADATA`**
```diff
 Metadata-Version: 2.1
 Name: mypy
 Version: 1.14.0+dev
 Summary: Optional static typing for Python
-Home-page: https://www.mypy-lang.org/
+Author-email: Jukka Lehtosalo <jukka.lehtosalo@iki.fi>
-Author: Jukka Lehtosalo
-Author-email: jukka.lehtosalo@iki.fi
 License: MIT
+Project-URL: Homepage, https://www.mypy-lang.org/
 Project-URL: Documentation, https://mypy.readthedocs.io/en/stable/index.html
 ...
```

**`dist-info/RECORD`** is the same (except for the changed hash for `.dist-info/METADATA`).

https://packaging.python.org/en/latest/specifications/core-metadata/