### PR TITLE
Fallback to stdlib json if integer exceeds 64-bit range

### DIFF
--- a/mypy/util.py
+++ b/mypy/util.py
@@ -937,10 +937,8 @@ def json_dumps(obj: object, debug: bool = False) -> bytes:
         try:
             return orjson.dumps(obj, option=dumps_option) # type: ignore[no-any-return]
         except TypeError as e:
-            if str(e) == 'Integer exceeds 64-bit range':
-                # use stdlib json below
-                pass
-            raise
+            if str(e) != 'Integer exceeds 64-bit range':
+                raise
 
     if debug:
         return json.dumps(obj, indent=2, sort_keys=True).encode("utf-8")

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -935,7 +935,7 @@ def json_dumps(obj: object, debug: bool = False) -> bytes:
             dumps_option = orjson.OPT_SORT_KEYS
 
         try:
-            return orjson.dumps(obj, option=dumps_option)
+            return orjson.dumps(obj, option=dumps_option) # type: ignore[no-any-return]
         except TypeError as e:
             if str(e) == 'Integer exceeds 64-bit range':
                 # use stdlib json below

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -928,11 +928,19 @@ def quote_docstring(docstr: str) -> str:
 def json_dumps(obj: object, debug: bool = False) -> bytes:
     if orjson is not None:
         if debug:
-            return orjson.dumps(obj, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)  # type: ignore[no-any-return]
+            dumps_option = orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS
         else:
             # TODO: If we don't sort keys here, testIncrementalInternalScramble fails
             # We should document exactly what is going on there
-            return orjson.dumps(obj, option=orjson.OPT_SORT_KEYS)  # type: ignore[no-any-return]
+            dumps_option = orjson.OPT_SORT_KEYS
+
+        try:
+            return orjson.dumps(obj, option=dumps_option)
+        except TypeError as e:
+            if str(e) == 'Integer exceeds 64-bit range':
+                # use stdlib json below
+                pass
+            raise
 
     if debug:
         return json.dumps(obj, indent=2, sort_keys=True).encode("utf-8")

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -935,9 +935,9 @@ def json_dumps(obj: object, debug: bool = False) -> bytes:
             dumps_option = orjson.OPT_SORT_KEYS
 
         try:
-            return orjson.dumps(obj, option=dumps_option) # type: ignore[no-any-return]
+            return orjson.dumps(obj, option=dumps_option)  # type: ignore[no-any-return]
         except TypeError as e:
-            if str(e) != 'Integer exceeds 64-bit range':
+            if str(e) != "Integer exceeds 64-bit range":
                 raise
 
     if debug:


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes the error below:
```python
 File "mypy/main.py", line 102, in main
  File "mypy/main.py", line 186, in run_build
  File "mypy/build.py", line 194, in build
  File "mypy/build.py", line 269, in _build
  File "mypy/build.py", line 2935, in dispatch
  File "mypy/build.py", line 3333, in process_graph
  File "mypy/build.py", line 3460, in process_stale_scc
  File "mypy/build.py", line 2497, in write_cache
  File "mypy/build.py", line 1560, in write_cache
  File "mypy/util.py", line 924, in json_dumps
TypeError: Integer exceeds 64-bit range
```

Related: https://github.com/ijl/orjson/issues/116
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
