### PR TITLE
special case types.DynamicClassAttribute as property-like

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1684,6 +1684,7 @@ class SemanticAnalyzer(
                     "abc.abstractproperty",
                     "functools.cached_property",
                     "enum.property",
+                    "types.DynamicClassAttribute",
                 ),
             ):
                 removed.append(i)

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2163,3 +2163,21 @@ class C3[T1, T2](tuple[T1, ...]):
 
 def func3(p: C3[int, object]):
     x: C3[int, int] = p
+
+
+[case testDynamicClassAttribute]
+# Some things that can break if DynamicClassAttribute isn't handled properly
+from types import DynamicClassAttribute
+from enum import Enum
+
+class TestClass:
+    @DynamicClassAttribute
+    def name(self) -> str: ...
+
+class TestClass2(TestClass, Enum): ...
+
+class Status(Enum):
+    ABORTED = -1
+
+def imperfect(status: Status) -> str:
+    return status.name.lower()


### PR DESCRIPTION
This enables typeshed to define types.DynamicClassAttribute as a different class from builtins.property without breakage.

Would enable https://github.com/python/typeshed/pull/12762
see also https://github.com/python/mypy/pull/14133

Let me know if a test case is desired for this.