### PR TITLE
[mypyc] Loading type from imported modules.

### DIFF
--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -806,6 +806,11 @@ def load_type(builder: IRBuilder, typ: TypeInfo, line: int) -> Value:
     elif typ.fullname in builtin_names:
         builtin_addr_type, src = builtin_names[typ.fullname]
         class_obj = builder.add(LoadAddress(builtin_addr_type, src, line))
+    elif typ.module_name in builder.imports:
+        loaded_module = builder.load_module(typ.module_name)
+        class_obj = builder.builder.get_attr(
+            loaded_module, typ.name, object_rprimitive, line, borrow=False
+        )
     else:
         class_obj = builder.load_global_str(typ.name, line)
 

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -76,6 +76,19 @@ assert hasattr(c, 'x')
 1000000000000000000000000000001
 1000000000000000000000000000002
 
+[case testTypedDictWithFields]
+import collections
+from typing_extensions import TypedDict
+class C(TypedDict):
+    x: collections.deque
+[file driver.py]
+from native import C
+from collections import deque
+
+print(C.__annotations__["x"] is deque)
+[out]
+True
+
 [case testClassWithDeletableAttributes]
 from typing import Any, cast
 from testutil import assertRaises


### PR DESCRIPTION
Fixes [#1075](https://github.com/mypyc/mypyc/issues/1075)

Previously, this compiled but failed to run:
```python
import collections
from typing_extensions import TypedDict
class C(TypedDict):
    x: collections.deque
```
Although type of `x` was being inferred correctly, it was not looking for `collections.deque` in imported modules.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
