### PR TITLE
Infer generic type arguments for slice expressions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5616,7 +5616,11 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if index:
                 t = self.accept(index)
                 self.chk.check_subtype(t, expected, index, message_registry.INVALID_SLICE_INDEX)
-        return self.named_type("builtins.slice")
+        type_args = [
+            NoneType() if arg is None else self.accept(arg)
+            for arg in [e.begin_index, e.end_index, e.stride]
+        ]
+        return self.chk.named_generic_type("builtins.slice", type_args)
 
     def visit_list_comprehension(self, e: ListComprehension) -> Type:
         return self.check_generator_or_comprehension(

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5612,14 +5612,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         except KeyError:
             supports_index = self.chk.named_type("builtins.int")  # thanks, fixture life
         expected = make_optional_type(supports_index)
+        type_args = []
         for index in [e.begin_index, e.end_index, e.stride]:
             if index:
                 t = self.accept(index)
                 self.chk.check_subtype(t, expected, index, message_registry.INVALID_SLICE_INDEX)
-        type_args = [
-            NoneType() if arg is None else self.accept(arg)
-            for arg in [e.begin_index, e.end_index, e.stride]
-        ]
+                type_args.append(t)
+            else:
+                type_args.append(NoneType())
         return self.chk.named_generic_type("builtins.slice", type_args)
 
     def visit_list_comprehension(self, e: ListComprehension) -> Type:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1178,8 +1178,8 @@ class B: pass
 [case testSlicingWithInvalidBase]
 
 a: A
-a[1:2] # E: Invalid index type "slice" for "A"; expected type "int"
-a[:]   # E: Invalid index type "slice" for "A"; expected type "int"
+a[1:2] # E: Invalid index type "slice[int, int, None]" for "A"; expected type "int"
+a[:]   # E: Invalid index type "slice[None, None, None]" for "A"; expected type "int"
 class A:
   def __getitem__(self, n: int) -> 'A': pass
 [builtins fixtures/slice.pyi]


### PR DESCRIPTION
Fixes  #18149

Slices were made generic in https://github.com/python/typeshed/pull/11637. Currently, all slice expressions are inferred to have type `slice[Any, Any, Any]`. This PR fills in the generic type arguments more appropriately using start/stop/stride expression types.

Given
```python
class Foo:
    def __getitem__[T](self, item: T) -> T: return item

x = Foo()
reveal_type(x[1:])
```
Before:
```none
main.py:5: note: Revealed type is "builtins.slice[Any, Any, Any]"
```
After:
```none
main.py:5: note: Revealed type is "builtins.slice[builtins.int, None, None]"
```