### PR TITLE
fix: preserve generator error context

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1223,11 +1223,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     if defn.is_async_generator:
                         if not self.is_async_generator_return_type(typ.ret_type):
                             self.fail(
-                                message_registry.INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR, typ
+                                message_registry.INVALID_RETURN_TYPE_FOR_ASYNC_GENERATOR,
+                                typ.ret_type,
                             )
                     else:
                         if not self.is_generator_return_type(typ.ret_type, defn.is_coroutine):
-                            self.fail(message_registry.INVALID_RETURN_TYPE_FOR_GENERATOR, typ)
+                            self.fail(
+                                message_registry.INVALID_RETURN_TYPE_FOR_GENERATOR, typ.ret_type
+                            )
 
                 # Fix the type if decorated with `@types.coroutine` or `@asyncio.coroutine`.
                 if defn.is_awaitable_coroutine:


### PR DESCRIPTION
Fixes #12498.

The callable return type's line number is preserved across `dmypy run` invocations, while the callable type is not.

The reporting context imitates the following:

https://github.com/python/mypy/blob/8ef21976cfd190d0b1974f438a7d30e8eaea5272/mypy/checker.py#L1210-L1212
