### PR TITLE
Allow nesting of Annotated with TypedDict special forms inside TypedDicts

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -688,7 +688,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     code=codes.VALID_TYPE,
                 )
                 return AnyType(TypeOfAny.from_error)
-            return self.anal_type(t.args[0])
+            return self.anal_type(
+                t.args[0], allow_typed_dict_special_forms=self.allow_typed_dict_special_forms
+            )
         elif fullname in ("typing_extensions.Required", "typing.Required"):
             if not self.allow_typed_dict_special_forms:
                 self.fail(

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3989,6 +3989,15 @@ class TP(TypedDict):
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictAnnotatedWithSpecialForms]
+from typing import NotRequired, ReadOnly, Required, TypedDict
+
+class A(TypedDict):
+    a: Annotated[NotRequired[ReadOnly[int]], ""]  # ok
+    b: NotRequired[ReadOnly[Annotated[int, ""]]]  # ok
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testTypedDictReadOnlyCovariant]
 from typing import ReadOnly, TypedDict, Union
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3991,6 +3991,7 @@ class TP(TypedDict):
 
 [case testTypedDictAnnotatedWithSpecialForms]
 from typing import NotRequired, ReadOnly, Required, TypedDict
+from typing_extensions import Annotated
 
 class A(TypedDict):
     a: Annotated[NotRequired[ReadOnly[int]], ""]  # ok


### PR DESCRIPTION
This is allowed per the [typing spec](https://typing.readthedocs.io/en/latest/spec/typeddict.html#interaction-with-other-special-types).

Updates the TypeAnalyzer to remember whether TypedDict special forms are allowed when visiting `Annotated` types.