### PR TITLE
Disallow no-args generic aliases when using PEP 613 explicit aliases

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3593,7 +3593,7 @@ class TypeAlias(SymbolNode):
     type will be initially an instance type with wrong number of type arguments.
     Such instances are all fixed either during or after main semantic analysis passes.
     We therefore store the difference between `List` and `List[Any]` rvalues (targets)
-    using the `no_args` flag. See also TypeAliasExpr.no_args.
+    using the `no_args` flag.
 
     Meaning of other fields:
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2765,15 +2765,15 @@ class SemanticAnalyzer(
                 return None, True, False  # defer later in the caller
 
             # Support type aliases, like `_Meta: TypeAlias = type`
+            metaclass_info: Node | None = sym.node
             if (
                 isinstance(sym.node, TypeAlias)
-                and sym.node.no_args
-                and isinstance(sym.node.target, ProperType)
-                and isinstance(sym.node.target, Instance)
+                and not sym.node.python_3_12_type_alias
+                and not sym.node.alias_tvars
             ):
-                metaclass_info: Node | None = sym.node.target.type
-            else:
-                metaclass_info = sym.node
+                target = get_proper_type(sym.node.target)
+                if isinstance(target, Instance):
+                    metaclass_info = target.type
 
             if not isinstance(metaclass_info, TypeInfo) or metaclass_info.tuple_type is not None:
                 self.fail(f'Invalid metaclass "{metaclass_name}"', metaclass_expr)
@@ -4040,6 +4040,7 @@ class SemanticAnalyzer(
             and not res.args
             and not empty_tuple_index
             and not pep_695
+            and not pep_613
         )
         if isinstance(res, ProperType) and isinstance(res, Instance):
             if not validate_instance(res, self.fail, empty_tuple_index):

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1239,8 +1239,8 @@ A = Union[int, List[A]]
 def func(x: A) -> int: ...
 [builtins fixtures/tuple.pyi]
 
-[case testAliasExplicitNoArgsNotGeneric]
-from typing import List, assert_type
+[case testAliasExplicitNoArgsBasic]
+from typing import Any, List, assert_type
 from typing_extensions import TypeAlias
 
 Implicit = List
@@ -1249,4 +1249,45 @@ Explicit: TypeAlias = List
 x1: Implicit[str]
 x2: Explicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
 assert_type(x1, List[str])
+assert_type(x2, List[Any])
+[builtins fixtures/tuple.pyi]
+
+[case testAliasExplicitNoArgsGenericClass]
+# flags: --python-version 3.9
+from typing import Any, assert_type
+from typing_extensions import TypeAlias
+
+Implicit = list
+Explicit: TypeAlias = list
+
+x1: Implicit[str]
+x2: Explicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
+assert_type(x1, list[str])
+assert_type(x2, list[Any])
+[builtins fixtures/tuple.pyi]
+
+[case testAliasExplicitNoArgsTuple]
+from typing import Any, Tuple, assert_type
+from typing_extensions import TypeAlias
+
+Implicit = Tuple
+Explicit: TypeAlias = Tuple
+
+x1: Implicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
+x2: Explicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
+assert_type(x1, Tuple[Any, ...])
+assert_type(x2, Tuple[Any, ...])
+[builtins fixtures/tuple.pyi]
+
+[case testAliasExplicitNoArgsCallable]
+from typing import Any, Callable, assert_type
+from typing_extensions import TypeAlias
+
+Implicit = Callable
+Explicit: TypeAlias = Callable
+
+x1: Implicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
+x2: Explicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
+assert_type(x1, Callable[..., Any])
+assert_type(x2, Callable[..., Any])
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1238,3 +1238,15 @@ from typing import List, Union
 A = Union[int, List[A]]
 def func(x: A) -> int: ...
 [builtins fixtures/tuple.pyi]
+
+[case testAliasExplicitNoArgsNotGeneric]
+from typing import List, assert_type
+from typing_extensions import TypeAlias
+
+Implicit = List
+Explicit: TypeAlias = List
+
+x1: Implicit[str]
+x2: Explicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
+assert_type(x1, List[str])
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -1563,7 +1563,6 @@ type H[T] = int
 __main__.A
 __main__.C
 __main__.D
-__main__.E
 __main__.G
 __main__.H
 


### PR DESCRIPTION
Per the type system conformance tests, [this is ok](https://github.com/python/typing/blob/46b05a4c10ed3841c9bc5126ba9f31dd8ae061e7/conformance/tests/aliases_implicit.py#L130):

```python
ListAlias = list
x = ListAlias[int]()  # OK
```

While [this is not](https://github.com/python/typing/blob/46b05a4c10ed3841c9bc5126ba9f31dd8ae061e7/conformance/tests/aliases_explicit.py#L100):
```python
ListAlias: TypeAlias = list
x: ListAlias[int]  # E: already specialized
```

Mypy currently permits both. This PR makes mypy reject the latter case, improving conformance.

As part of this, no-args PEP 613 explicit aliases are no longer eagerly expanded.

(Also removed a stale comment referencing `TypeAliasExpr.no_args`, which was removed in #15924)