### PR TITLE
Disallow bare `ParamSpec` in type aliases

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -180,7 +180,7 @@ def analyze_type_alias(
     )
     analyzer.in_dynamic_func = in_dynamic_func
     analyzer.global_scope = global_scope
-    res = type.accept(analyzer)
+    res = analyzer.anal_type(type, nested=False)
     return res, analyzer.aliases_used
 
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1452,6 +1452,17 @@ y: C[int, str]
 reveal_type(y)  # N: Revealed type is "def (builtins.int, builtins.int, builtins.str) -> builtins.int"
 [builtins fixtures/paramspec.pyi]
 
+[case testParamSpecInTypeAliasIllegalBare]
+from typing import ParamSpec
+from typing_extensions import Concatenate, TypeAlias
+
+P = ParamSpec("P")
+Bad1: TypeAlias = P                     # E: Invalid location for ParamSpec "P" \
+                                        # N: You can use ParamSpec as the first argument to Callable, e.g., "Callable[P, int]"
+Bad2: TypeAlias = Concatenate[int, P]   # E: Invalid location for Concatenate \
+                                        # N: You can use Concatenate as the first argument to Callable
+[builtins fixtures/paramspec.pyi]
+
 [case testParamSpecInTypeAliasRecursive]
 from typing import ParamSpec, Callable, Union
 


### PR DESCRIPTION
Emit errors for both of the following aliases:
```python
P = ParamSpec("P")
Bad1: TypeAlias = P
Bad2: TypeAlias = Concatenate[int, P]
```
This is done by swapping a top-level call to `type.accept(analyzer)` with `analyzer.anal_type(type)`, the latter of which simply calls the former and then performs some checks.