### PR TITLE
[mypyc] Fixing check for enum classes.

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -513,7 +513,7 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
     is_named_tuple = cdef.info.is_named_tuple
     ir = builder.mapper.type_to_ir[cdef.info]
     bases = []
-    for cls in cdef.info.mro[1:]:
+    for cls in (b.type for b in cdef.info.bases):
         if cls.fullname == "builtins.object":
             continue
         if is_named_tuple and cls.fullname in (

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -682,7 +682,7 @@ def add_non_ext_class_attr(
         # are final.
         if (
             cdef.info.bases
-            and cdef.info.bases[0].type.fullname == "enum.Enum"
+            and cdef.info.bases[0].type.is_enum
             # Skip these since Enum will remove it
             and lvalue.name not in EXCLUDED_ENUM_ATTRIBUTES
         ):

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2619,3 +2619,15 @@ def test_final_attribute() -> None:
     assert C.a['x'] == 'y'
     assert C.b['x'] == 'y'
     assert C.a is C.b
+
+[case testClassDerivedFromIntEnum]
+from enum import IntEnum, auto
+
+class Player(IntEnum):
+    MIN = auto()
+
+print(f'{Player.MIN = }')
+[file driver.py]
+from native import Player
+[out]
+Player.MIN = <Player.MIN: 1>


### PR DESCRIPTION
Fixes [mypyc/mypyc#1065](https://github.com/mypyc/mypyc/issues/1065)
Fixes [mypyc/mypyc#1059](https://github.com/mypyc/mypyc/issues/1059)
Fixes [mypyc/mypyc#1022](https://github.com/mypyc/mypyc/issues/1022)

* Checking for enum classes using `is_enum` flag instead of `fullname` of base class. That way, mypyc recognizes classes derived from `IntEnum` as enum classes too.
* After fixing the above bug, test failures revealed that mypyc was sending all MRO classes to `__prepare__` function. For example, for the `Player` test class added in this PR, mypyc was generating C code to call `__prepare__` of the base class with `(IntEnum, int, Enum)` instead of just `(IntEnum,)`. This bug has been fixed in `classdef.py:populate_non_ext_bases`.