### PR TITLE
Emit warning for invalid use of quoted types in union syntax

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1354,7 +1354,49 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             and not self.options.python_version >= (3, 10)
         ):
             self.fail("X | Y syntax for unions requires Python 3.10", t, code=codes.SYNTAX)
-        return UnionType(self.anal_array(t.items), t.line, uses_pep604_syntax=t.uses_pep604_syntax)
+        items = self.anal_array(t.items)
+        # Check for invalid quoted type inside union syntax.
+        if (
+            t.original_str_expr is None
+            and not self.api.is_stub_file
+            and (not self.api.is_future_flag_set("annotations") or self.defining_alias)
+        ):
+            # Whether each type can be OR'd with a string.
+            item_ors_with_str = [
+                # Is a TypeVar?
+                isinstance(typ, (TypeVarType, UnboundType))
+                # Is a 'typing._UnionGenericAlias'?
+                or (
+                    isinstance(typ, TypeAliasType)
+                    and typ.alias is not None
+                    # "type: ignore" comment needed to satisfy the ProperTypePlugin.
+                    # Calling get_proper_type here would give the wrong result in the edge
+                    # case where a non-PEP-695 alias has a PEP-695 alias as its target.
+                    and isinstance(typ.alias.target, UnionType)  # type: ignore[misc]
+                    and typ.alias.alias_tvars
+                    and not typ.alias.python_3_12_type_alias
+                )
+                for typ in items
+            ]
+            for idx, itm in enumerate(t.items):
+                if (
+                    isinstance(itm, UnboundType)
+                    # Comes from a quoted expression.
+                    and itm.original_str_expr is not None
+                    # Not preceded by type that makes OR-ing with string valid.
+                    and not any(item_ors_with_str[:idx])
+                    # Not the first item immediately followed by a type that
+                    # can be OR'd with a string.
+                    # Accessing index 1 is safe because union syntax guarantees
+                    # that there are at least 2 items.
+                    and not (idx == 0 and item_ors_with_str[1])
+                ):
+                    self.fail(
+                        "X | Y syntax for unions cannot use quoted operands; use quotes"
+                        " around the entire expression instead",
+                        itm,
+                    )
+        return UnionType(items, t.line, uses_pep604_syntax=t.uses_pep604_syntax)
 
     def visit_partial_type(self, t: PartialType) -> Type:
         assert False, "Internal error: Unexpected partial type"

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1949,3 +1949,31 @@ class D:
             class G[Q]:
                 def g(self, x: Q): ...
             d: G[str]
+
+[case testPEP695TypeAliasInUnionOrSyntaxWithQuotedOperands]
+import types
+
+type A1 = int
+type A2 = int | str
+type A3[T] = list[T]
+type A4[T] = T | str
+
+x1: A1 | "bytes"        # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+x2: A2 | "bytes"        # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+x3: A3[int] | "bytes"   # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+x4: A4[int] | "bytes"   # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testPEP695TypeAliasInUnionOrSyntaxWithQuotedOperandsNestedAlias]
+import types
+from typing import TypeVar
+from typing_extensions import TypeAlias
+
+T = TypeVar("T")
+type A1[T] = T | str
+A2: TypeAlias = A1[T]
+
+x: A2[int] | "bytes"  # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -251,3 +251,65 @@ foo: ReadableBuffer
 [file was_mmap.py]
 from was_builtins import *
 class mmap: ...
+
+[case testUnionOrSyntaxWithQuotedOperandsNotAllowed]
+# flags: --python-version 3.10
+from typing import Union, assert_type
+
+x1: "int" | str          # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+x2: int | "str"          # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+x3: int | str | "bytes"  # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+assert_type(x1, Union[int, str])
+assert_type(x2, Union[int, str])
+assert_type(x3, Union[int, str, bytes])
+
+[case testUnionOrSyntaxWithQuotedOperandsWithTypeVar]
+# flags: --python-version 3.10
+import types
+from typing import TypeVar, Union, assert_type
+from typing_extensions import TypeAlias
+
+T = TypeVar("T")
+
+ok1: TypeAlias =  T | "int"
+ok2: TypeAlias = "int" | T
+ok3: TypeAlias = int | T | "str"
+ok4: TypeAlias = "int" | T | "str"
+ok5: TypeAlias = T | "int" | str
+ok6: TypeAlias = T | int | "str"
+ok7: TypeAlias = list["str" | T]
+
+bad1: TypeAlias = "T" | "int"       # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+bad2: TypeAlias = int | "str" | T   # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+bad3: TypeAlias = list["str" | int] # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+[builtins fixtures/tuple.pyi]
+
+[case testUnionOrSyntaxWithQuotedOperandsWithAlias]
+# flags: --python-version 3.10
+import types
+from typing import TypeVar
+from typing_extensions import TypeAlias
+
+T = TypeVar("T")
+
+A1: TypeAlias = int
+A2: TypeAlias = int | str
+A3: TypeAlias = list[T]
+A4: TypeAlias = T | str
+
+x1: A1 | "bytes"        # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+x2: A2 | "bytes"        # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+x3: A3[int] | "bytes"   # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+x4: A4[int] | "bytes"   # ok
+[builtins fixtures/tuple.pyi]
+
+[case testUnionOrSyntaxWithQuotedOperandsFutureAnnotations]
+# flags: --python-version 3.10
+from __future__ import annotations
+import types
+from typing_extensions import TypeAlias
+
+x1: int | "str"              # ok
+def f(x: int | "str"): pass  # ok
+x2: TypeAlias = int | "str"  # E: X | Y syntax for unions cannot use quoted operands; use quotes around the entire expression instead
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Using quoted types in PEP 604 union syntax can be problematic, since at runtime, using `|` between a type and string produces an error:
```python
>>> x: int | "str"
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    x: int | "str"
       ~~~~^~~~~~~
TypeError: unsupported operand type(s) for |: 'type' and 'str'


>>> U = int | float
>>> x: U | "str"
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    x: U | "str"
       ~~^~~~~~~
TypeError: unsupported operand type(s) for |: 'types.UnionType' and 'str'
```
The exception is when the type is a  `TypeVar` or a `_UnionGenericAlias`, which can both be safely `|`'d with strings:
```python
>>> T = TypeVar("T")
>>> U = T | int

>>> T | "str"
typing.Union[~T, ForwardRef('str')]
>>> U | "str"
typing.Union[~T, int, ForwardRef('str')]
```

This PR makes mypy emit a warning for the former cases (where using `|` with a string will produce a runtime error) while permitting the latter cases (where using `|` with a string is safe).

A few notes about the implementation:
* No errors are emitted inside stub files (where quoted types are redundant but harmless).
* No errors are emitted for annotations inside files that use `from __future__ import annotations`. Like in stubs, quoted types in these cases are redundant but mostly harmless (aside from issues with runtime inspection). It might be a good idea to emit errors for these cases too (pyright does), but I wasn't sure if the benefit is enough to justify the churn. Without this exception, this PR has ~20 mypy_primer hits across 4 projects.
* I've verified that all test cases that emit errors do indeed raise exceptions at runtime, and all cases that don't, don't. (checked with 3.10.12 and 3.13.0).

