### PR TITLE
Disallow `TypeVar` constraints parameterized by type variables

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -350,6 +350,10 @@ TYPE_VAR_AWAIT_EXPRESSION_IN_BOUND: Final = ErrorMessage(
     "Await expression cannot be used as a type variable bound", codes.SYNTAX
 )
 
+TYPE_VAR_GENERIC_CONSTRAINT_TYPE: Final = ErrorMessage(
+    "TypeVar constraint type cannot be parametrized by type variables", codes.MISC
+)
+
 TYPE_ALIAS_WITH_YIELD_EXPRESSION: Final = ErrorMessage(
     "Yield expression cannot be used within a type alias", codes.SYNTAX
 )

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1862,7 +1862,12 @@ class SemanticAnalyzer(
                     analyzed = self.anal_type(value, allow_placeholder=True)
                     if analyzed is None:
                         analyzed = PlaceholderType(None, [], context.line)
-                    values.append(analyzed)
+                    # has_no_typevars does not work with PlaceholderType.
+                    if not has_placeholder(analyzed) and not has_no_typevars(analyzed):
+                        self.fail(message_registry.TYPE_VAR_GENERIC_CONSTRAINT_TYPE, context)
+                        values.append(AnyType(TypeOfAny.from_error))
+                    else:
+                        values.append(analyzed)
             return TypeVarExpr(
                 name=type_param.name,
                 fullname=fullname,
@@ -5047,9 +5052,7 @@ class SemanticAnalyzer(
 
                 # has_no_typevars does not work with PlaceholderType.
                 if not has_placeholder(analyzed) and not has_no_typevars(analyzed):
-                    self.fail(
-                        "TypeVar constraint type cannot be parametrized by type variables", node
-                    )
+                    self.fail(message_registry.TYPE_VAR_GENERIC_CONSTRAINT_TYPE, node)
                     result.append(AnyType(TypeOfAny.from_error))
                 else:
                     result.append(analyzed)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5046,9 +5046,8 @@ class SemanticAnalyzer(
                     analyzed = PlaceholderType(None, [], node.line)
 
                 # has_no_typevars does not work with PlaceholderType.
-                if not isinstance(
-                    get_proper_type(analyzed), PlaceholderType
-                ) and not has_no_typevars(analyzed):
+                typ = get_proper_type(analyzed)
+                if not isinstance(typ, PlaceholderType) and not has_no_typevars(typ):
                     self.fail(
                         "TypeVar constraint type cannot be parametrized by type variables", node
                     )

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5046,8 +5046,7 @@ class SemanticAnalyzer(
                     analyzed = PlaceholderType(None, [], node.line)
 
                 # has_no_typevars does not work with PlaceholderType.
-                typ = get_proper_type(analyzed)
-                if not isinstance(typ, PlaceholderType) and not has_no_typevars(typ):
+                if not has_placeholder(analyzed) and not has_no_typevars(analyzed):
                     self.fail(
                         "TypeVar constraint type cannot be parametrized by type variables", node
                     )

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -2558,7 +2558,6 @@ class FindTypeVarVisitor(SyntheticTypeVisitor[None]):
         self.has_self_type = False
         self.seen_aliases: set[TypeAliasType] | None = None
         self.include_callables = True
-        self.include_bound_tvars = False
 
     def _seems_like_callable(self, type: UnboundType) -> bool:
         if not type.args:
@@ -2584,7 +2583,7 @@ class FindTypeVarVisitor(SyntheticTypeVisitor[None]):
         if (
             node
             and isinstance(node.node, TypeVarLikeExpr)
-            and (self.scope.get_binding(node) is None or self.include_bound_tvars)
+            and self.scope.get_binding(node) is None
         ):
             if (name, node.node) not in self.type_var_likes:
                 self.type_var_likes.append((name, node.node))

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -2558,6 +2558,7 @@ class FindTypeVarVisitor(SyntheticTypeVisitor[None]):
         self.has_self_type = False
         self.seen_aliases: set[TypeAliasType] | None = None
         self.include_callables = True
+        self.include_bound_tvars = False
 
     def _seems_like_callable(self, type: UnboundType) -> bool:
         if not type.args:
@@ -2583,7 +2584,7 @@ class FindTypeVarVisitor(SyntheticTypeVisitor[None]):
         if (
             node
             and isinstance(node.node, TypeVarLikeExpr)
-            and self.scope.get_binding(node) is None
+            and (self.scope.get_binding(node) is None or self.include_bound_tvars)
         ):
             if (name, node.node) not in self.type_var_likes:
                 self.type_var_likes.append((name, node.node))

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1525,6 +1525,29 @@ reveal_type(E[str]().a)  # N: Revealed type is "builtins.list[Any]"
 [builtins fixtures/type.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testPEP695TypeAliasInvalidGenericConstraint]
+class A[T]:
+    class a[S: (int, list[T])]: pass                # E: Name "T" is not defined
+    type b[S: (int, list[T])] = S                   # E: TypeVar constraint type cannot be parametrized by type variables
+    def c[S: (int, list[T])](self) -> None: ...     # E: TypeVar constraint type cannot be parametrized by type variables
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testPEP695TypeAliasUnboundTypeVarConstraint]
+from typing import TypeVar
+T = TypeVar("T")
+class a[S: (int, list[T])]: pass                # E: Type variable "__main__.T" is unbound \
+                                                # N: (Hint: Use "Generic[T]" or "Protocol[T]" base class to bind "T" inside a class) \
+                                                # N: (Hint: Use "T" in function signature to bind "T" inside a function)
+type b[S: (int, list[T])] = S                   # E: Type variable "__main__.T" is unbound \
+                                                # N: (Hint: Use "Generic[T]" or "Protocol[T]" base class to bind "T" inside a class) \
+                                                # N: (Hint: Use "T" in function signature to bind "T" inside a function)
+def c[S: (int, list[T])](self) -> None: ...     # E: Type variable "__main__.T" is unbound \
+                                                # N: (Hint: Use "Generic[T]" or "Protocol[T]" base class to bind "T" inside a class) \
+                                                # N: (Hint: Use "T" in function signature to bind "T" inside a function)
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
 [case testPEP695RedefineAsTypeAlias1]
 class C: pass
 type C = int  # E: Name "C" already defined on line 1

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1060,6 +1060,19 @@ S = TypeVar('S', covariant=True, contravariant=True) \
     # E: TypeVar cannot be both covariant and contravariant
 [builtins fixtures/bool.pyi]
 
+[case testInvalidTypevarArgumentsGenericConstraint]
+from typing import Generic, List, TypeVar
+
+T = TypeVar("T")
+
+Bad1 = TypeVar("Bad1", int, T)              # E: TypeVar constraint type cannot be parametrized by type variables
+Bad2 = TypeVar("Bad2", int, List[T])        # E: TypeVar constraint type cannot be parametrized by type variables
+Bad3 = TypeVar("Bad3", int, List[List[T]])  # E: TypeVar constraint type cannot be parametrized by type variables
+def f(x: T) -> None:
+    Bad4 = TypeVar("Bad4", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
+class C(Generic[T]):
+    Bad5 = TypeVar("Bad5", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
+
 [case testInvalidTypevarValues]
 from typing import TypeVar
 b = TypeVar('b', *[int]) # E: Unexpected argument to "TypeVar()"

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1072,6 +1072,9 @@ class C(Generic[T]):
     Bad = TypeVar("Bad", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
 class D:
     Bad = TypeVar("Bad", int, List[Self]) # E: TypeVar constraint type cannot be parametrized by type variables
+S = TypeVar("S", int, List[T])            # E: Type variable "__main__.T" is unbound \
+                                          # N: (Hint: Use "Generic[T]" or "Protocol[T]" base class to bind "T" inside a class) \
+                                          # N: (Hint: Use "T" in function signature to bind "T" inside a function)
 
 [case testInvalidTypevarValues]
 from typing import TypeVar

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1062,6 +1062,7 @@ S = TypeVar('S', covariant=True, contravariant=True) \
 
 [case testInvalidTypevarArgumentsGenericConstraint]
 from typing import Generic, List, TypeVar
+from typing_extensions import Self
 
 T = TypeVar("T")
 
@@ -1069,6 +1070,8 @@ def f(x: T) -> None:
     Bad = TypeVar("Bad", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
 class C(Generic[T]):
     Bad = TypeVar("Bad", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
+class D:
+    Bad = TypeVar("Bad", int, List[Self]) # E: TypeVar constraint type cannot be parametrized by type variables
 
 [case testInvalidTypevarValues]
 from typing import TypeVar

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1065,13 +1065,10 @@ from typing import Generic, List, TypeVar
 
 T = TypeVar("T")
 
-Bad1 = TypeVar("Bad1", int, T)              # E: TypeVar constraint type cannot be parametrized by type variables
-Bad2 = TypeVar("Bad2", int, List[T])        # E: TypeVar constraint type cannot be parametrized by type variables
-Bad3 = TypeVar("Bad3", int, List[List[T]])  # E: TypeVar constraint type cannot be parametrized by type variables
 def f(x: T) -> None:
-    Bad4 = TypeVar("Bad4", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
+    Bad = TypeVar("Bad", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
 class C(Generic[T]):
-    Bad5 = TypeVar("Bad5", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
+    Bad = TypeVar("Bad", int, List[T])    # E: TypeVar constraint type cannot be parametrized by type variables
 
 [case testInvalidTypevarValues]
 from typing import TypeVar


### PR DESCRIPTION
Emit an error for [this test case](https://github.com/python/typing/blob/46b05a4c10ed3841c9bc5126ba9f31dd8ae061e7/conformance/tests/generics_basic.py#L54-L55) from the conformance tests:
```python
class Test(Generic[T]):
    BadConstraint2 = TypeVar("BadConstraint2", str, list[T])  # E
```