### PR TITLE
Preserve typevar default None in type alias

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -2277,7 +2277,8 @@ def set_any_tvars(
         env[tv.id] = arg
     t = TypeAliasType(node, args, newline, newcolumn)
     if not has_type_var_tuple_type:
-        fixed = expand_type(t, env)
+        with state.strict_optional_set(options.strict_optional):
+            fixed = expand_type(t, env)
         assert isinstance(fixed, TypeAliasType)
         t.args = fixed.args
 

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -728,3 +728,24 @@ class C(Generic[_I]): pass
 
 t: type[C] | int = C
 [builtins fixtures/tuple.pyi]
+
+
+
+[case testGenericTypeAliasWithDefaultTypeVarPreservesNoneInDefault]
+from typing_extensions import TypeVar
+from typing import Generic, Union
+
+T1 = TypeVar("T1", default=Union[int, None])
+T2 = TypeVar("T2", default=Union[int, None])
+
+
+class A(Generic[T1, T2]):
+    def __init__(self, a: T1, b: T2) -> None:
+        self.a = a
+        self.b = b
+
+
+MyA = A[T1, int]
+a: MyA = A(None, 10)
+reveal_type(a.a)  # N: Revealed type is "Union[builtins.int, None]"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #18188 

Currently it seems that `None` is dropped from type variable defaults when assigning generic class to a type alias.

<details>
  <summary>Example</summary>

```python
from typing_extensions import TypeVar
from typing import Generic, Union

T1 = TypeVar("T1", default=Union[int, None])
T2 = TypeVar("T2", default=Union[int, None])


class A(Generic[T1, T2]):
    def __init__(self, a: T1, b: T2) -> None:
        self.a = a
        self.b = b


MyA = A[T1, int]
a: MyA = A(None, 10)  # error: Argument 1 to "A" has incompatible type "None"; expected "int"  [arg-type]
reveal_type(a.a)
```
</details>

The change is similar to https://github.com/python/mypy/pull/16859

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
