### PR TITLE
Show the signature of __call__ for arguments with incompatible types …

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -872,11 +872,8 @@ class MessageBuilder:
                 self.note_call(original_caller_type, call, context, code=code)
         if isinstance(callee_type, Instance) and callee_type.type.is_protocol:
             call = find_member("__call__", callee_type, callee_type, is_operator=True)
-            if call is not None:
-                item = get_proper_type(call)
-                # should we print out all possible overloadings?
-                if not (isinstance(item, Overloaded)):
-                    self.note_call(callee_type, call, context, code=code)
+            if call:
+                self.note_call(callee_type, call, context, code=code)
         self.maybe_note_concatenate_pos_args(original_caller_type, callee_type, context, code)
 
     def maybe_note_concatenate_pos_args(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -870,7 +870,13 @@ class MessageBuilder:
             )
             if call:
                 self.note_call(original_caller_type, call, context, code=code)
-
+        if isinstance(callee_type, Instance) and callee_type.type.is_protocol:
+            call = find_member("__call__", callee_type, callee_type, is_operator=True)
+            if call is not None:
+                item = get_proper_type(call)
+                # should we print out all possible overloadings?
+                if not (isinstance(item, Overloaded)):
+                    self.note_call(callee_type, call, context, code=code)
         self.maybe_note_concatenate_pos_args(original_caller_type, callee_type, context, code)
 
     def maybe_note_concatenate_pos_args(

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3677,7 +3677,8 @@ def f(x: Call[T]) -> Tuple[T, T]: ...
 
 def g(__x: str) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "Tuple[Never, Never]" \
-                   # E: Argument 1 to "f" has incompatible type "Callable[[str], None]"; expected "Call[Never]"
+                   # E: Argument 1 to "f" has incompatible type "Callable[[str], None]"; expected "Call[Never]" \
+                   # N: "Call[Never].__call__" has type "Callable[[NamedArg(Never, 'x')], None]"
 [builtins fixtures/list.pyi]
 
 [case testCallableInferenceAgainstCallableNamedVsPosOnly]
@@ -3693,7 +3694,8 @@ def f(x: Call[T]) -> Tuple[T, T]: ...
 
 def g(*, x: str) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "Tuple[Never, Never]" \
-                   # E: Argument 1 to "f" has incompatible type "Callable[[NamedArg(str, 'x')], None]"; expected "Call[Never]"
+                   # E: Argument 1 to "f" has incompatible type "Callable[[NamedArg(str, 'x')], None]"; expected "Call[Never]" \
+                   # N: "Call[Never].__call__" has type "Callable[[Never], None]"
 [builtins fixtures/list.pyi]
 
 [case testCallableInferenceAgainstCallablePosOnlyVsKwargs]
@@ -3709,7 +3711,8 @@ def f(x: Call[T]) -> Tuple[T, T]: ...
 
 def g(**x: str) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "Tuple[Never, Never]" \
-                   # E: Argument 1 to "f" has incompatible type "Callable[[KwArg(str)], None]"; expected "Call[Never]"
+                   # E: Argument 1 to "f" has incompatible type "Callable[[KwArg(str)], None]"; expected "Call[Never]" \
+                   # N: "Call[Never].__call__" has type "Callable[[Never], None]"
 [builtins fixtures/list.pyi]
 
 [case testCallableInferenceAgainstCallableNamedVsArgs]
@@ -3725,7 +3728,8 @@ def f(x: Call[T]) -> Tuple[T, T]: ...
 
 def g(*args: str) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "Tuple[Never, Never]" \
-                   # E: Argument 1 to "f" has incompatible type "Callable[[VarArg(str)], None]"; expected "Call[Never]"
+                   # E: Argument 1 to "f" has incompatible type "Callable[[VarArg(str)], None]"; expected "Call[Never]" \
+                   # N: "Call[Never].__call__" has type "Callable[[NamedArg(Never, 'x')], None]"
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstTypeVarActualBound]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2473,7 +2473,8 @@ def func(caller: Caller) -> None:
     pass
 
 func(call)
-func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[int, VarArg(str)], None]"; expected "Caller"
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[int, VarArg(str)], None]"; expected "Caller" \
+           # N: "Caller.__call__" has type "Callable[[Arg(str, 'x'), VarArg(int)], None]"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -2510,7 +2511,8 @@ def func(caller: Caller) -> None:
     pass
 
 func(call)
-func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[int], int]"; expected "Caller"
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[int], int]"; expected "Caller" \
+           # N: "Caller.__call__" has type "Callable[[Arg(T, 'x')], T]"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -2530,7 +2532,8 @@ def func(caller: Caller) -> None:
     pass
 
 func(call)
-func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[T], Tuple[T, T]]"; expected "Caller"
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[T], Tuple[T, T]]"; expected "Caller" \
+           # N: "Caller.__call__" has type "Callable[[Arg(int, 'x')], int]"
 [builtins fixtures/tuple.pyi]
 [out]
 
@@ -2596,7 +2599,8 @@ def anon(caller: CallerAnon) -> None:
 
 
 func(call)
-func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[str], None]"; expected "Caller"
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[str], None]"; expected "Caller" \
+           # N: "Caller.__call__" has type "Callable[[Arg(str, 'x')], None]"
 anon(bad)
 [out]
 
@@ -2619,7 +2623,8 @@ a: Other
 b: Bad
 
 func(a)
-func(b)  # E: Argument 1 to "func" has incompatible type "Bad"; expected "One"
+func(b)  # E: Argument 1 to "func" has incompatible type "Bad"; expected "One" \
+         # N: "One.__call__" has type "Callable[[Arg(str, 'x')], None]"
 [out]
 
 [case testJoinProtocolCallback]
@@ -3589,7 +3594,8 @@ test(C)  # E: Argument 1 to "test" has incompatible type "Type[C]"; expected "P"
          # N:     Expected: \
          # N:         def __call__(x: int, y: int) -> Any \
          # N:     Got: \
-         # N:         def __init__(x: int, y: str) -> C
+         # N:         def __init__(x: int, y: str) -> C \
+         # N: "P.__call__" has type "Callable[[Arg(int, 'x'), Arg(int, 'y')], Any]"
 
 [case testProtocolClassObjectPureCallback]
 from typing import Any, ClassVar, Protocol
@@ -3610,7 +3616,8 @@ test(C)  # E: Argument 1 to "test" has incompatible type "Type[C]"; expected "P"
          # N:     Expected: \
          # N:         def __call__(x: int, y: int) -> Any \
          # N:     Got: \
-         # N:         def __init__(x: int, y: str) -> C
+         # N:         def __init__(x: int, y: str) -> C \
+         # N: "P.__call__" has type "Callable[[Arg(int, 'x'), Arg(int, 'y')], Any]"
 [builtins fixtures/type.pyi]
 
 [case testProtocolClassObjectCallableError]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2560,7 +2560,8 @@ def func(caller: Caller) -> None:
     pass
 
 func(call)
-func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[Union[int, str]], Union[int, str]]"; expected "Caller"
+func(bad)  # E: Argument 1 to "func" has incompatible type "Callable[[Union[int, str]], Union[int, str]]"; expected "Caller" \
+           # N: "Caller.__call__" has type overloaded function
 [out]
 
 [case testCallableImplementsProtocolExtraNote]


### PR DESCRIPTION
fixes issue #17840 
Check if callee_type.is_protocol if so calls find_member like before on the callee_type and then calls self.note_call() to report the note.
Checks if isinstance(Overloaded) and does nothing for now since it returns 
```
note: "C.__call__" has type overloaded function
``` 
which in my opinion is unhelpful.
Updated test cases to reflect all of the changes.