### PR TITLE
Preserve block unreachablility when checking function definitions with constrained TypeVars

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1263,7 +1263,7 @@ class Block(Statement):
 
     __match_args__ = ("body", "is_unreachable")
 
-    def __init__(self, body: list[Statement]) -> None:
+    def __init__(self, body: list[Statement], *, is_unreachable: bool = False) -> None:
         super().__init__()
         self.body = body
         # True if we can determine that this block is not executed during semantic
@@ -1271,7 +1271,7 @@ class Block(Statement):
         # something like "if PY3:" when using Python 2. However, some code is
         # only considered unreachable during type checking and this is not true
         # in those cases.
-        self.is_unreachable = False
+        self.is_unreachable = is_unreachable
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_block(self)

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -276,7 +276,9 @@ class TransformVisitor(NodeVisitor[Node]):
         return NonlocalDecl(node.names.copy())
 
     def visit_block(self, node: Block) -> Block:
-        return Block(self.statements(node.body))
+        new = Block(self.statements(node.body))
+        new.is_unreachable = node.is_unreachable
+        return new
 
     def visit_decorator(self, node: Decorator) -> Decorator:
         # Note that a Decorator must be transformed to a Decorator.

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -276,9 +276,7 @@ class TransformVisitor(NodeVisitor[Node]):
         return NonlocalDecl(node.names.copy())
 
     def visit_block(self, node: Block) -> Block:
-        new = Block(self.statements(node.body))
-        new.is_unreachable = node.is_unreachable
-        return new
+        return Block(self.statements(node.body), is_unreachable=node.is_unreachable)
 
     def visit_decorator(self, node: Decorator) -> Decorator:
         # Note that a Decorator must be transformed to a Decorator.

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1000,6 +1000,16 @@ class Test4(Generic[T3]):
 
 [builtins fixtures/isinstancelist.pyi]
 
+[case testUnreachableBlockStaysUnreachableWithTypeVarConstraints]
+# flags: --always-false COMPILE_TIME_FALSE
+from typing import TypeVar
+COMPILE_TIME_FALSE = False
+T = TypeVar("T", int, str)
+def foo(x: T) -> T:
+    if COMPILE_TIME_FALSE:
+        return "bad"
+    return x
+
 [case testUnreachableFlagContextManagersNoSuppress]
 # flags: --warn-unreachable
 from contextlib import contextmanager


### PR DESCRIPTION
Fixes #18210

When checking function definitions with constrained type variables (i.e. type variables with value restrictions), mypy expands the function definition for each possible type variable value. However, blocks in the expanded function definitions have their `is_unreachable` reset to `False`, which leads to spurious errors in blocks that were marked as unreachable during semantic analysis.

This PR preserves the value of `is_unreachable` on blocks in the expanded function definitions.