### PR TITLE
Do not include non-init fields in the synthesized `__replace__` method for dataclasses

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -400,7 +400,11 @@ class DataclassTransformer:
 
     def _add_dunder_replace(self, attributes: list[DataclassAttribute]) -> None:
         """Add a `__replace__` method to the class, which is used to replace attributes in the `copy` module."""
-        args = [attr.to_argument(self._cls.info, of="replace") for attr in attributes if attr.is_in_init]
+        args = [
+            attr.to_argument(self._cls.info, of="replace")
+            for attr in attributes
+            if attr.is_in_init
+        ]
         type_vars = [tv for tv in self._cls.type_vars]
         add_method_to_class(
             self._api,

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -400,7 +400,7 @@ class DataclassTransformer:
 
     def _add_dunder_replace(self, attributes: list[DataclassAttribute]) -> None:
         """Add a `__replace__` method to the class, which is used to replace attributes in the `copy` module."""
-        args = [attr.to_argument(self._cls.info, of="replace") for attr in attributes]
+        args = [attr.to_argument(self._cls.info, of="replace") for attr in attributes if attr.is_in_init]
         type_vars = [tv for tv in self._cls.type_vars]
         add_method_to_class(
             self._api,

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2492,12 +2492,14 @@ class Child(Base):
 
 [case testDunderReplacePresent]
 # flags: --python-version 3.13
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 @dataclass
 class Coords:
     x: int
     y: int
+    # non-init fields are not allowed with replace:
+    z: int = field(init=False)
 
 
 replaced = Coords(2, 4).__replace__(x=2, y=5)


### PR DESCRIPTION
At runtime, non init fields are not allowed when using replace. See [the source code](https://github.com/python/cpython/blob/1bc4f076d193ad157bdc69a1d62685a15f95113f/Lib/dataclasses.py#L1671-L1676) of the CPython implementation.