### PR TITLE
Refactor: merge duplicate HasTypeVars query visitors

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -181,6 +181,7 @@ from mypy.types import (
     get_proper_type,
     get_proper_types,
     has_recursive_types,
+    has_type_vars,
     is_named_instance,
     split_with_prefix_and_suffix,
 )
@@ -6350,23 +6351,7 @@ class ArgInferSecondPassQuery(types.BoolTypeQuery):
 
     def visit_callable_type(self, t: CallableType) -> bool:
         # TODO: we need to check only for type variables of original callable.
-        return self.query_types(t.arg_types) or t.accept(HasTypeVarQuery())
-
-
-class HasTypeVarQuery(types.BoolTypeQuery):
-    """Visitor for querying whether a type has a type variable component."""
-
-    def __init__(self) -> None:
-        super().__init__(types.ANY_STRATEGY)
-
-    def visit_type_var(self, t: TypeVarType) -> bool:
-        return True
-
-    def visit_param_spec(self, t: ParamSpecType) -> bool:
-        return True
-
-    def visit_type_var_tuple(self, t: TypeVarTupleType) -> bool:
-        return True
+        return self.query_types(t.arg_types) or has_type_vars(t)
 
 
 def has_erased_component(t: Type | None) -> bool:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3612,6 +3612,8 @@ class LocationSetter(TypeTraverserVisitor):
 
 
 class HasTypeVars(BoolTypeQuery):
+    """Visitor for querying whether a type has a type variable component."""
+
     def __init__(self) -> None:
         super().__init__(ANY_STRATEGY)
         self.skip_alias_target = True


### PR DESCRIPTION
`mypy.checkexpr.HasTypeVarQuery` has only one usage and is virtually[^1] identical to `mypy.types.HasTypeVars`.  Merging them seems sensible. The latter has wider usage via `has_type_vars`, so it seems like the better one to keep.

Some history for the record:
* `mypy.checkexpr.HasTypeVarQuery` was added in 12 years ago a40efb48f0a40a5a4a6038960909ddec98965beb
* `mypy.types.HasTypeVars` was added 5 years ago in 59617e8f895ca12a6fb0ec46f378ce384a757118

[^1]: the only difference is that `HasTypeVars` sets `self.skip_alias_target = True`, but this seem to fit the usage of `HasTypeVarQuery` just as well.