### PR TITLE
Print InspectError traceback in stubgen `walk_packages` when verbose is specified

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1524,7 +1524,7 @@ def find_module_paths_using_imports(
             except CantImport as e:
                 tb = traceback.format_exc()
                 if verbose:
-                    sys.stdout.write(tb)
+                    sys.stderr.write(tb)
                 if not quiet:
                     report_missing(mod, e.message, tb)
                 continue

--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os.path
 import re
 import sys
+import traceback
 from abc import abstractmethod
 from collections import defaultdict
 from contextlib import contextmanager
@@ -70,6 +71,9 @@ def walk_packages(
         try:
             prop = inspect.get_package_properties(package_name)
         except InspectError:
+            if verbose:
+                tb = traceback.format_exc()
+                sys.stderr.write(tb)
             report_missing(package_name)
             continue
         yield prop.name


### PR DESCRIPTION
This change modifies `walk_packages` such that the full `ImporError` traceback is printed when a module cannot be imported. The goal is to provide the user with more context to debug the error.

I implemented this change by mirroring existing behavior in `find_module_paths_using_imports`: https://github.com/python/mypy/blob/9405bfd9205ea369c11150907764fa46c03cb1f7/mypy/stubgen.py#L1522-L1529

