### PR TITLE
Join meet symmetric

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -317,7 +317,7 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
         if state.strict_optional:
             if isinstance(self.s, (NoneType, UninhabitedType)):
                 return t
-            elif isinstance(self.s, UnboundType):
+            elif isinstance(self.s, (UnboundType, AnyType)):
                 return AnyType(TypeOfAny.special_form)
             else:
                 return mypy.typeops.make_simplified_union([self.s, t])

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -691,7 +691,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
     def visit_unbound_type(self, t: UnboundType) -> ProperType:
         if isinstance(self.s, NoneType):
             if state.strict_optional:
-                return AnyType(TypeOfAny.special_form)
+                return UninhabitedType()
             else:
                 return self.s
         elif isinstance(self.s, UninhabitedType):

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -806,8 +806,7 @@ class JoinSuite(Suite):
             self.fx.anyt,
             self.fx.a,
             self.fx.o,
-            # TODO: fix this is not currently symmetric
-            # NoneType(),
+            NoneType(),
             UnboundType("x"),
             self.fx.t,
             self.tuple(),
@@ -1177,8 +1176,7 @@ class MeetSuite(Suite):
             self.assert_meet(self.fx.o, NoneType(), NoneType())
             for t in [
                 self.fx.a,
-                # TODO: fix this is not currently symmetric
-                # UnboundType("x"),
+                UnboundType("x"),
                 self.fx.t,
                 self.tuple(),
                 self.callable(self.fx.a, self.fx.b),


### PR DESCRIPTION
Fixes #18199 

Updated `join.py`  to return `AnyType(TypeOfAny.special_form)` for both `UnboundType` and `AnyType`.

Updated `meet.py` to return `UninhabitedType()` when visiting a `UnboundType` as a `NoneType` when `state.strict_optional` is true. 
