### PR TITLE
[mypyc] Fixing condition to fall back to PyCall for staticmethod and classmethod

### DIFF
--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -10,6 +10,7 @@ import math
 from typing import Callable, Sequence
 
 from mypy.nodes import (
+    ARG_NAMED,
     ARG_POS,
     LDEF,
     AssertTypeExpr,
@@ -355,6 +356,7 @@ def translate_method_call(builder: IRBuilder, expr: CallExpr, callee: MemberExpr
         and isinstance(callee.expr.node, TypeInfo)
         and callee.expr.node in builder.mapper.type_to_ir
         and builder.mapper.type_to_ir[callee.expr.node].has_method(callee.name)
+        and all(kind in (ARG_POS, ARG_NAMED) for kind in expr.arg_kinds)
     ):
         # Call a method via the *class*
         assert isinstance(callee.expr.node, TypeInfo)

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2631,3 +2631,27 @@ print(f'{Player.MIN = }')
 from native import Player
 [out]
 Player.MIN = <Player.MIN: 1>
+
+[case testStaticCallsWithUnpackingArgs]
+from typing import Tuple
+
+class Foo:
+  @staticmethod
+  def static(a: int, b: int, c: int) -> Tuple[int, int, int]:
+    return (c+1, a+2, b+3)
+
+  @classmethod
+  def clsmethod(cls, a: int, b: int, c: int) -> Tuple[int, int, int]:
+    return (c+1, a+2, b+3)
+
+
+print(Foo.static(*[10, 20, 30]))
+print(Foo.static(*(40, 50), *[60]))
+assert Foo.static(70, 80, *[90]) == Foo.clsmethod(70, *(80, 90))
+
+[file driver.py]
+import native
+
+[out]
+(31, 12, 23)
+(61, 42, 53)


### PR DESCRIPTION
Fixes mypyc/mypyc#1076

This change has been copied from [mypyc/irbuild/builder.py#1084](https://github.com/advait-dixit/mypy/blob/1a9596453bf6377b8fee822cf0bf74350993ec28/mypyc/irbuild/builder.py#L1084).