### PR TITLE
Improve error handling for missing source files

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -346,11 +346,11 @@ class Server:
                 )
                 if current_plugins_snapshot != start_plugins_snapshot:
                     return {"restart": "plugins changed"}
+            return self.check(sources, export_types, is_tty, terminal_width)
         except InvalidSourceList as err:
             return {"out": "", "err": str(err), "status": 2}
         except SystemExit as e:
             return {"out": stdout.getvalue(), "err": stderr.getvalue(), "status": e.code}
-        return self.check(sources, export_types, is_tty, terminal_width)
 
     def cmd_check(
         self, files: Sequence[str], export_types: bool, is_tty: bool, terminal_width: int
@@ -856,6 +856,13 @@ class Server:
 
     def update_sources(self, sources: list[BuildSource]) -> None:
         paths = [source.path for source in sources if source.path is not None]
+        for path in paths:
+            if not self.fscache.exists(path):
+                raise InvalidSourceList(
+                    "mypy: can't read file '{}': No such file or directory\n".format(
+                        path.replace(os.getcwd() + os.sep, "")
+                    )
+                )
         if self.following_imports():
             # Filter out directories (used for namespace packages).
             paths = [path for path in paths if self.fscache.isfile(path)]


### PR DESCRIPTION
Raise `InvalidSourceList` error if new source file is not found. `dmypy` now correctly reflects the absence of non-existent files, which was previously not reported.

Fixes #18111

---

### Testing

I manually tested the changes and confirmed that `dmypy` now correctly reports errors when attempting to check non-existent files:

```
$ dmypy run -- a.py
Success: no issues found in 1 source file
$ dmypy run -- nonexistent.py
mypy: can't read file 'nonexistent.py': No such file or directory
```

I haven't added tests yet, as I'm still familiarizing myself with the testing framework used in the project. If this change is deemed appropriate, I will add the necessary test cases soon to ensure it is thoroughly validated.

I’m eager to contribute further and ensure this fix is robust. Thank you for your support and feedback!