### PR TITLE
fix: mark mypyc package with `py.typed`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ recursive-include mypy/typeshed *.pyi
 
 # mypy and mypyc
 include mypy/py.typed
+include mypyc/py.typed
 recursive-include mypy *.py
 recursive-include mypyc *.py
 


### PR DESCRIPTION
mypyc is fully typed, so it'd be nice to get rid of mypy errors to do with missing `py.typed` markers when writing `setup.py`s or similar.

```python
import mypyc  # E: Skipping analyzing "mypyc": module is installed, but missing library stubs or py. typed marker  [import-untyped]
```

