### PR TITLE
Allow bytearray/bytes comparisons with --disable-bytearray-promotion

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3790,6 +3790,18 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             if isinstance(left.value, bool) and isinstance(right.value, bool):
                 # Comparing different booleans is not dangerous.
                 return False
+        if isinstance(left, LiteralType) and isinstance(right, Instance):
+            # bytes/bytearray comparisons are supported
+            if left.fallback.type.fullname == "builtins.bytes" and right.type.has_base(
+                "builtins.bytearray"
+            ):
+                return False
+        if isinstance(right, LiteralType) and isinstance(left, Instance):
+            # bytes/bytearray comparisons are supported
+            if right.fallback.type.fullname == "builtins.bytes" and left.type.has_base(
+                "builtins.bytearray"
+            ):
+                return False
         return not is_overlapping_types(left, right, ignore_promotions=False)
 
     def check_method_call_by_name(

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2345,10 +2345,19 @@ x: int = ""  # E: Incompatible types in assignment (expression has type "str", v
 x: int = ""  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
 [case testDisableBytearrayPromotion]
-# flags: --disable-bytearray-promotion
+# flags: --disable-bytearray-promotion --strict-equality
 def f(x: bytes) -> None: ...
 f(bytearray(b"asdf"))  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
 f(memoryview(b"asdf"))
+ba = bytearray(b"")
+if ba == b"":
+    f(ba)  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
+if b"" == ba:
+    f(ba)  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
+if ba == bytes():
+    f(ba)  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
+if bytes() == ba:
+    f(ba)  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
 [builtins fixtures/primitives.pyi]
 
 [case testDisableMemoryviewPromotion]


### PR DESCRIPTION
Previously comparing a bytearray against a bytes literal was reported as a non-overlapping comparison when using `--strict-equality`. This was a false positive.

This is in preparation for disabling bytearray to bytes promotion by default in mypy 2.0.