### PR TITLE
Add more known types for better generation with pybind11

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -264,7 +264,7 @@ class InspectionStubGenerator(BaseStubGenerator):
                         "TypeGuard",
                         "Union",
                     ],
-                    "os" [:"PathLike"],
+                    "os": ["PathLike"],
                     "pathlib": ["Path"]
                 }
             )

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -254,10 +254,18 @@ class InspectionStubGenerator(BaseStubGenerator):
                         "List",
                         "Literal",
                         "NamedTuple",
+                        "Never",
+                        "NoReturn",
+                        "Set",
                         "Optional",
                         "Tuple",
+                        "Type",
+                        "TypeIs",
+                        "TypeGuard",
                         "Union",
-                    ]
+                    ],
+                    "os" [:"PathLike"],
+                    "pathlib": ["Path"]
                 }
             )
 

--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -265,7 +265,7 @@ class InspectionStubGenerator(BaseStubGenerator):
                         "Union",
                     ],
                     "os": ["PathLike"],
-                    "pathlib": ["Path"]
+                    "pathlib": ["Path"],
                 }
             )
 


### PR DESCRIPTION
Adds more known types for stubgenc when it is a c module.