### PR TITLE
Docs: import reveal_type

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -222,7 +222,7 @@ When you're puzzled or when things are complicated
 
 .. code-block:: python
 
-   from typing import Union, Any, Optional, TYPE_CHECKING, cast
+   from typing import Any, TYPE_CHECKING, cast, reveal_type
 
    # To find out what type mypy infers for an expression anywhere in
    # your program, wrap it in reveal_type().  Mypy will print an error


### PR DESCRIPTION
In cheat sheet added import of reveal_type used in sample code

Also removed unused imports Union and Optional.

This is a tiny change but I was confused about where reveal_type was coming from and had to google it, so I figure it could be easier to understand for somebody else, too.
