### PR TITLE
stubtest: handle overloads with mixed pos-only params

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -824,6 +824,21 @@ class Signature(Generic[T]):
         # For most dunder methods, just assume all args are positional-only
         assume_positional_only = is_dunder(stub.name, exclude_special=True)
 
+        is_arg_pos_only: defaultdict[str, set[bool]] = defaultdict(set)
+        for func in map(_resolve_funcitem_from_decorator, stub.items):
+            assert func is not None
+            args = maybe_strip_cls(stub.name, func.arguments)
+            for arg in args:
+                if (
+                    arg.variable.name.startswith("__")
+                    or arg.pos_only
+                    or assume_positional_only
+                    or arg.variable.name.strip("_") == "self"
+                ):
+                    is_arg_pos_only[arg.variable.name].add(True)
+                else:
+                    is_arg_pos_only[arg.variable.name].add(False)
+
         all_args: dict[str, list[tuple[nodes.Argument, int]]] = {}
         for func in map(_resolve_funcitem_from_decorator, stub.items):
             assert func is not None
@@ -831,14 +846,13 @@ class Signature(Generic[T]):
             for index, arg in enumerate(args):
                 # For positional-only args, we allow overloads to have different names for the same
                 # argument. To accomplish this, we just make up a fake index-based name.
-                name = (
-                    f"__{index}"
-                    if arg.variable.name.startswith("__")
-                    or arg.pos_only
-                    or assume_positional_only
-                    or arg.variable.name.strip("_") == "self"
-                    else arg.variable.name
-                )
+                # We can only use the index-based name if the argument is always
+                # positional only. Sometimes overloads have an arg as positional-only
+                # in some but not all branches of the overload.
+                name = arg.variable.name
+                if is_arg_pos_only[name] == {True}:
+                    name = f"__{index}"
+
                 all_args.setdefault(name, []).append((arg, index))
 
         def get_position(arg_name: str) -> int:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -12,7 +12,11 @@ import unittest
 from typing import Any, Callable, Iterator
 
 import mypy.stubtest
+from mypy import build
+from mypy.modulefinder import BuildSource
+from mypy.options import Options
 from mypy.stubtest import parse_options, test_stubs
+from mypy.test.config import test_temp_dir
 from mypy.test.data import root_dir
 
 
@@ -142,6 +146,14 @@ class Flag(Enum):
         __rand__ = __and__
         __rxor__ = __xor__
 """
+
+
+def build_helper(source: str) -> build.BuildResult:
+    return build.build(
+        sources=[BuildSource("main.pyi", None, textwrap.dedent(source))],
+        options=Options(),
+        alt_lib_path=test_temp_dir,
+    )
 
 
 def run_stubtest_with_stderr(
@@ -798,6 +810,18 @@ class StubtestUnit(unittest.TestCase):
             class Bar:
                 def f1(self, *a) -> int: ...
                 def f2(self, *a) -> int: ...
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            @overload
+            def f(a: int) -> int: ...
+            @overload
+            def f(a: int, b: str, /) -> str: ...
+            """,
+            runtime="""
+            def f(a, *args): ...
             """,
             error=None,
         )
@@ -2576,6 +2600,21 @@ class StubtestMiscUnit(unittest.TestCase):
             str(mypy.stubtest.Signature.from_inspect_signature(sig))
             == "def (self, sep = ..., bytes_per_sep = ...)"
         )
+
+    def test_overload_signature(self) -> None:
+        # The same argument as both positional-only and pos-or-kw in
+        # different overloads used to produce incorrect signatures
+        source = """
+        from typing import overload
+        @overload
+        def myfunction(arg: int) -> None: ...
+        @overload
+        def myfunction(arg: str, /) -> None: ...
+        """
+        result = build_helper(source)
+        stub = result.files["__main__"].names["myfunction"].node
+        sig = mypy.stubtest.Signature.from_overloadedfuncdef(stub)
+        assert str(sig) == "def (arg: Union[builtins.int, builtins.str])"
 
     def test_config_file(self) -> None:
         runtime = "temp = 5\n"

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -12,7 +12,7 @@ import unittest
 from typing import Any, Callable, Iterator
 
 import mypy.stubtest
-from mypy import build
+from mypy import build, nodes
 from mypy.modulefinder import BuildSource
 from mypy.options import Options
 from mypy.stubtest import parse_options, test_stubs
@@ -2613,7 +2613,7 @@ class StubtestMiscUnit(unittest.TestCase):
         """
         result = build_helper(source)
         stub = result.files["__main__"].names["myfunction"].node
-        assert stub is not None
+        assert isinstance(stub, nodes.OverloadedFuncDef)
         sig = mypy.stubtest.Signature.from_overloadedfuncdef(stub)
         assert str(sig) == "def (arg: Union[builtins.int, builtins.str])"
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -2613,6 +2613,7 @@ class StubtestMiscUnit(unittest.TestCase):
         """
         result = build_helper(source)
         stub = result.files["__main__"].names["myfunction"].node
+        assert stub is not None
         sig = mypy.stubtest.Signature.from_overloadedfuncdef(stub)
         assert str(sig) == "def (arg: Union[builtins.int, builtins.str])"
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -2603,7 +2603,7 @@ class StubtestMiscUnit(unittest.TestCase):
 
     def test_overload_signature(self) -> None:
         # The same argument as both positional-only and pos-or-kw in
-        # different overloads used to produce incorrect signatures
+        # different overloads previously produced incorrect signatures
         source = """
         from typing import overload
         @overload


### PR DESCRIPTION
Fixes #17023 

Stubtest should only mangle positional-only parameter names if they're positional-only in all branches of the overload. The signatures get really ugly and wrong otherwise.

I'm not sure if I did the new `test_overload_signature` in the best way. I couldn't figure out a way to get covert a string into a `nodes.OverloadedFuncDef` object with any of the techniques in existing tests in `teststubtest.py`. Maybe the new test case is sufficient, but I wanted to test the signature generation directly.