### PR TITLE
Gracefully handle encoding errors when writing to stdout

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -9,6 +9,7 @@ import sys
 import time
 from collections import defaultdict
 from gettext import gettext
+from io import TextIOWrapper
 from typing import IO, Any, Final, NoReturn, Sequence, TextIO
 
 from mypy import build, defaults, state, util
@@ -73,6 +74,10 @@ def main(
     sys.setrecursionlimit(2**14)
     if args is None:
         args = sys.argv[1:]
+
+    # Write an escape sequence instead of raising an exception on encoding errors.
+    if isinstance(stdout, TextIOWrapper) and stdout.errors == "strict":
+        stdout.reconfigure(errors="backslashreplace")
 
     fscache = FileSystemCache()
     sources, options = process_options(args, stdout=stdout, stderr=stderr, fscache=fscache)


### PR DESCRIPTION
Fixes #12692

Sets the [encoding error handler](https://docs.python.org/3/library/codecs.html#error-handlers) for `stdout` to `"backslashreplace"`. This prevents mypy from crashing if an error message has a character that can't be represented by the current I/O encoding.

No change is made to `stderr` since its default is already `"backslashreplace"`.


**Before**
```shell
$ PYTHONIOENCODING=ascii mypy -c "x=γ"
Traceback (most recent call last):
    ...
UnicodeEncodeError: 'ascii' codec can't encode character '\u03b3' in position 50: ordinal not in range(128)
```

**After:**
```shell
$ PYTHONIOENCODING=ascii mypy -c "x=γ"
<string>:1: error: Name "\u03b3" is not defined  [name-defined]
Found 1 error in 1 file (checked 1 source file)
```

Externally setting the error handler to something other than `"strict"` still works. For example:
```shell
$ PYTHONIOENCODING=ascii:namereplace mypy -c "x=γ"
<string>:1: error: Name "\N{GREEK SMALL LETTER GAMMA}" is not defined  [name-defined]
Found 1 error in 1 file (checked 1 source file)
```