### PR TITLE
Suppress errors for unreachable branches in conditional expressions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4793,7 +4793,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # If this is asserting some isinstance check, bind that type in the following code
         true_map, else_map = self.find_isinstance_check(s.expr)
         if s.msg is not None:
-            self.expr_checker.analyze_cond_branch(else_map, s.msg, None)
+            self.expr_checker.analyze_cond_branch(
+                else_map, s.msg, None, suppress_unreachable_errors=False
+            )
         self.push_type_map(true_map)
 
     def visit_raise_stmt(self, s: RaiseStmt) -> None:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1506,6 +1506,13 @@ x.append(y) if bool() else x.append(y)
 z = x.append(y) if bool() else x.append(y) # E: "append" of "list" does not return a value (it only ever returns None)
 [builtins fixtures/list.pyi]
 
+[case testConditionalExpressionWithUnreachableBranches]
+from typing import TypeVar
+T = TypeVar("T", int, str)
+def foo(x: T) -> T:
+    return x + 1 if isinstance(x, int) else x + "a"
+[builtins fixtures/isinstancelist.pyi]
+
 -- Special cases
 -- -------------
 


### PR DESCRIPTION
Fixes #4134
Fixes #9195

Suppress errors when analyzing unreachable conditional expression branches. Same idea as what's done when analyzing the right-hand operand of `and`/`or`:

https://github.com/python/mypy/blob/973618a6bfa88398e08dc250c8427b381b3a0fce/mypy/checkexpr.py#L4252-L4256

This PR originally added filters of the same form to the places where `analyze_cond_branch` is called in `ExpressionChecker.visit_conditional_expr`. However, since 5 out of the 6  `analyze_cond_branch` call sites now use `filter_errors` for the case when `map is None`, I decided to move the error filtering logic to inside `analyze_cond_branch`.

**Given:**
```python
from typing import TypeVar
T = TypeVar("T", int, str)

def foo(x: T) -> T:
    return x + 1 if isinstance(x, int) else x + "a"
```
**Before:**
```none
main.py:5:16: error: Unsupported operand types for + ("str" and "int")  [operator]
main.py:5:49: error: Unsupported operand types for + ("int" and "str")  [operator]
Found 2 errors in 1 file (checked 1 source file)
```
**After:**
```
Success: no issues found in 1 source file
```