### PR TITLE
Speed up SCC dependency inference

### DIFF
--- a/mypy/graph_utils.py
+++ b/mypy/graph_utils.py
@@ -57,7 +57,11 @@ def prepare_sccs(
     sccs: list[set[T]], edges: dict[T, list[T]]
 ) -> dict[AbstractSet[T], set[AbstractSet[T]]]:
     """Use original edges to organize SCCs in a graph by dependencies between them."""
-    sccsmap = {v: frozenset(scc) for scc in sccs for v in scc}
+    sccsmap = {}
+    for scc in sccs:
+        scc_frozen = frozenset(scc)
+        for v in scc:
+            sccsmap[v] = scc_frozen
     data: dict[AbstractSet[T], set[AbstractSet[T]]] = {}
     for scc in sccs:
         deps: set[AbstractSet[T]] = set()


### PR DESCRIPTION
Avoid redundant computation of `frozenset(scc)`.

This helps with incremental type checking of torch, since it has a big SCC. In my measurements this speeds up incremental checking of `-c "import torch"` by about 11%.