### PR TITLE
Speed up State.finish_passes

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2373,23 +2373,20 @@ class State:
             # We should always patch indirect dependencies, even in full (non-incremental) builds,
             # because the cache still may be written, and it must be correct.
             # TODO: find a more robust way to traverse *all* relevant types?
-            expr_types = set(self.type_map().values())
-            symbol_types = set()
+            all_types = list(self.type_map().values())
             for _, sym, _ in self.tree.local_definitions():
                 if sym.type is not None:
-                    symbol_types.add(sym.type)
+                    all_types.append(sym.type)
                 if isinstance(sym.node, TypeInfo):
                     # TypeInfo symbols have some extra relevant types.
-                    symbol_types.update(sym.node.bases)
+                    all_types.extend(sym.node.bases)
                     if sym.node.metaclass_type:
-                        symbol_types.add(sym.node.metaclass_type)
+                        all_types.append(sym.node.metaclass_type)
                     if sym.node.typeddict_type:
-                        symbol_types.add(sym.node.typeddict_type)
+                        all_types.append(sym.node.typeddict_type)
                     if sym.node.tuple_type:
-                        symbol_types.add(sym.node.tuple_type)
-            self._patch_indirect_dependencies(
-                self.type_checker().module_refs, expr_types | symbol_types
-            )
+                        all_types.append(sym.node.tuple_type)
+            self._patch_indirect_dependencies(self.type_checker().module_refs, all_types)
 
             if self.options.dump_inference_stats:
                 dump_type_stats(
@@ -2418,7 +2415,7 @@ class State:
             self._type_checker.reset()
             self._type_checker = None
 
-    def _patch_indirect_dependencies(self, module_refs: set[str], types: set[Type]) -> None:
+    def _patch_indirect_dependencies(self, module_refs: set[str], types: list[Type]) -> None:
         assert None not in types
         valid = self.valid_references()
 


### PR DESCRIPTION
Don't use a set to deduplicate mypy `Type` objects, since taking the hash of a type, and possibly comparing for equality (which is needed to add a type to a set) is more expensive than processing duplicates in TypeIndirectionVisitor. Many of the most expensive types to process are complex types such as callables, which often don't have many duplicates and have complex `__hash__` methods.

This seems to speed up type checking torch slightly, by about 0.5% (average of 100 runs).