### PR TITLE
Micro-optimize cache deserialization (fixup)

### DIFF
--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -117,7 +117,8 @@ class NodeFixer(NodeVisitor[None]):
     # NOTE: This method *definitely* isn't part of the NodeVisitor API.
     def visit_symbol_table(self, symtab: SymbolTable, table_fullname: str) -> None:
         # Copy the items because we may mutate symtab.
-        for key, value in list(symtab.items()):
+        for key in list(symtab):
+            value = symtab[key]
             cross_ref = value.cross_ref
             if cross_ref is not None:  # Fix up cross-reference.
                 value.cross_ref = None


### PR DESCRIPTION
Mypyc is bad at compiling tuple unpacking, so this should be faster, based on a microbenchmark I created. Also fewer tuple objects need to be allocated and freed.

The impact is probably too small to be measured in a real workload, but every little helps.