### PR TITLE
[misc] Properly format subheadings and code in gen_blog_post_html.py

### DIFF
--- a/misc/gen_blog_post_html.py
+++ b/misc/gen_blog_post_html.py
@@ -46,7 +46,7 @@ def format_code(h: str) -> str:
             indent = a[i].startswith("    ")
             if not indent:
                 i += 1
-            r.append("<pre>")
+            r.append("<pre><code>")
             while i < len(a) and (
                 (indent and a[i].startswith("    ")) or (not indent and not a[i].startswith("```"))
             ):
@@ -56,7 +56,7 @@ def format_code(h: str) -> str:
                     line = "    " + line
                 r.append(html.escape(line))
                 i += 1
-            r.append("</pre>")
+            r.append("</code></pre>")
             if not indent and a[i].startswith("```"):
                 i += 1
         else:
@@ -76,7 +76,7 @@ def convert(src: str) -> str:
     h = re.sub(r"^## (Mypy [0-9.]+)", r"<h1>\1 Released</h1>", h, flags=re.MULTILINE)
 
     # Subheadings
-    h = re.sub(r"\n#### ([A-Z`].*)\n", r"\n<h2>\1</h2>\n", h)
+    h = re.sub(r"\n### ([A-Z`].*)\n", r"\n<h2>\1</h2>\n", h)
 
     # Sub-subheadings
     h = re.sub(r"\n\*\*([A-Z_`].*)\*\*\n", r"\n<h3>\1</h3>\n", h)


### PR DESCRIPTION
Our Changelog uses 3 number signs (#) for subheadings, not 4. This should generate proper `<h3>` in the blog post.

Also, code blocks are generated with just `<pre>` tags. Let's also add `<code>` tags so we can potentially apply syntax highlighting with js like highlight.js in the future, if we want to.
highlight.js detects `<pre><code> ... </code></pre>`. We can also put the language, but it detects it automatically: https://highlightjs.readthedocs.io/en/latest/readme.html#in-the-browser
