### PR TITLE
[misc] Fix previous change to `<pre><code>`

### DIFF
--- a/misc/gen_blog_post_html.py
+++ b/misc/gen_blog_post_html.py
@@ -62,7 +62,9 @@ def format_code(h: str) -> str:
         else:
             r.append(a[i])
             i += 1
-    return "\n".join(r)
+    formatted = "\n".join(r)
+    # remove empty first line for code blocks
+    return re.sub(r"<code>\n", r"<code>", formatted)
 
 
 def convert(src: str) -> str:


### PR DESCRIPTION
Turns out that `<pre>...</pre>` blocks ignore the first empty line, but `<pre><code>...</code></pre>` blocks don't. So if we put the first real line of code on the html line after the tags, it will render as an empty line. (a problem that didn't exist for just pre tags) Let's remove those extra newlines after code tags.

(I still think it's nice to have code tags for future syntax highlighting on the blog posts)
