### PR TITLE
stubtest: distinguish metaclass attributes from class attributes

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -568,6 +568,13 @@ def verify_typeinfo(
             # Catch all exceptions in case the runtime raises an unexpected exception
             # from __getattr__ or similar.
             continue
+
+        # If it came from the metaclass, consider the runtime_attr to be MISSING
+        # for a more accurate message
+        if runtime_attr is not MISSING and type(runtime) != runtime:
+            if getattr(runtime_attr, "__objclass__", None) is type(runtime):
+                runtime_attr = MISSING
+
         # Do not error for an object missing from the stub
         # If the runtime object is a types.WrapperDescriptorType object
         # and has a non-special dunder name.

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1526,7 +1526,7 @@ def is_probably_a_function(runtime: Any) -> bool:
         isinstance(runtime, (types.FunctionType, types.BuiltinFunctionType))
         or isinstance(runtime, (types.MethodType, types.BuiltinMethodType))
         or (inspect.ismethoddescriptor(runtime) and callable(runtime))
-        or (inspect.ismethodwrapper(runtime) and callable(runtime))
+        or (isinstance(runtime, types.MethodWrapperType) and callable(runtime))
     )
 
 

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -571,7 +571,7 @@ def verify_typeinfo(
 
         # If it came from the metaclass, consider the runtime_attr to be MISSING
         # for a more accurate message
-        if runtime_attr is not MISSING and type(runtime) != runtime:
+        if runtime_attr is not MISSING and type(runtime) is not runtime:
             if getattr(runtime_attr, "__objclass__", None) is type(runtime):
                 runtime_attr = MISSING
 
@@ -1526,6 +1526,7 @@ def is_probably_a_function(runtime: Any) -> bool:
         isinstance(runtime, (types.FunctionType, types.BuiltinFunctionType))
         or isinstance(runtime, (types.MethodType, types.BuiltinMethodType))
         or (inspect.ismethoddescriptor(runtime) and callable(runtime))
+        or (inspect.ismethodwrapper(runtime) and callable(runtime))
     )
 
 

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1460,6 +1460,16 @@ class StubtestUnit(unittest.TestCase):
             runtime="__all__ += ['Z']\nclass Z:\n  def __reduce__(self): return (Z,)",
             error=None,
         )
+        # __call__ exists on type, so it appears to exist on the class.
+        # This checks that we identify it as missing at runtime anyway.
+        yield Case(
+            stub="""
+            class ClassWithMetaclassOverride:
+                def __call__(*args, **kwds): ...
+            """,
+            runtime="class ClassWithMetaclassOverride: ...",
+            error="ClassWithMetaclassOverride.__call__",
+        )
 
     @collect_cases
     def test_missing_no_runtime_all(self) -> Iterator[Case]:


### PR DESCRIPTION
If the runtime attribute of a class is actually from the metaclass, consider it to be MISSING at runtime.

This only occurs a couple times in the stdlib: it shows up when a descriptor is present on the metaclass but not the class, and we want to lie in the stub and say it's a thing on the class anyway.

I found this after noticing that `enum.auto.__or__` had a comment that said it
didn't exist at runtime, but stubtest thought that it actually did. The issue is that on 3.10+, `type.__or__` is defined for the purpose of Union types, and stubtest doesn't know the difference between `type.__or__` and `__or__` on the actual class.

Currently this matches on these things in typeshed's stdlib:

```
abc.ABCMeta.__abstractmethods__
builtins.object.__annotations__
enum.auto.__or__
enum.auto.__ror__
types.NotImplementedType.__call__
```

This MR doesn't resolve any allowlist entries for typeshed, and it doesn't create any new ones either, but should generate more accurate error messages in this particular edge case.