### PR TITLE
Remove unnecessary assertion during `recheck`

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -403,7 +403,6 @@ class Server:
                 sources, remove, update, explicit_export_types=export_types
             )
         else:
-            assert remove is None and update is None
             messages = self.fine_grained_increment_follow_imports(
                 sources, explicit_export_types=export_types
             )


### PR DESCRIPTION
Fixes #15795

In [`cmd_recheck` function of `dmypy_server.py`](https://github.com/python/mypy/blob/v1.14.0/mypy/dmypy_server.py#L365), when `remove` or `update` is provided, the sources list is altered appropriately. After that, however, there is no mechanism (nor should there be) to reset `remove` and `update` to `None`. The presence of `remove` or `update` being non-`None` is expected in scenarios where files are specifically being removed or updated. Thus, asserting them to be `None` contradicts their usage.