### PR TITLE
Clarify status in `dmypy status` output

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -436,7 +436,7 @@ def do_status(args: argparse.Namespace) -> None:
     if args.verbose or "error" in response:
         show_stats(response)
     if "error" in response:
-        fail(f"Daemon is stuck; consider {sys.argv[0]} kill")
+        fail(f"Daemon may be busy processing; if this persists, consider {sys.argv[0]} kill")
     print("Daemon is up and running")
 
 
@@ -447,7 +447,7 @@ def do_stop(args: argparse.Namespace) -> None:
     response = request(args.status_file, "stop", timeout=5)
     if "error" in response:
         show_stats(response)
-        fail(f"Daemon is stuck; consider {sys.argv[0]} kill")
+        fail(f"Daemon may be busy processing; if this persists, consider {sys.argv[0]} kill")
     else:
         print("Daemon stopped")
 


### PR DESCRIPTION
Revised the status message output from the `dmypy status` command to eliminate potential misunderstandings about the daemon's operational state.

Given the daemon’s synchronous design, the server may appear unresponsive during periods of heavy processing. When encountering a timeout, the status message could suggest that the daemon was "stuck", prompting users to prematurely consider stopping it.

Fixes #18008