### PR TITLE
Replace lru_cache with functools.cache

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -751,7 +751,7 @@ def default_lib_path(
     return path
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def get_search_dirs(python_executable: str | None) -> tuple[list[str], list[str]]:
     """Find package directories for given python. Guaranteed to return absolute paths.
 


### PR DESCRIPTION
Python 3.9 added `functools.cache` which can replace `lru_cache(maxsize=None)`.
https://docs.python.org/3/library/functools.html#functools.cache