### PR TITLE
Update capi_version for mypyc tests to 3.8

### DIFF
--- a/mypyc/lib-rt/pythonsupport.h
+++ b/mypyc/lib-rt/pythonsupport.h
@@ -69,7 +69,7 @@ update_bases(PyObject *bases)
             }
             continue;
         }
-        new_base = _PyObject_Vectorcall(meth, stack, 1, NULL);
+        new_base = PyObject_Vectorcall(meth, stack, 1, NULL);
         Py_DECREF(meth);
         if (!new_base) {
             goto error;
@@ -118,7 +118,7 @@ init_subclass(PyTypeObject *type, PyObject *kwds)
     PyObject *super, *func, *result;
     PyObject *args[2] = {(PyObject *)type, (PyObject *)type};
 
-    super = _PyObject_Vectorcall((PyObject *)&PySuper_Type, args, 2, NULL);
+    super = PyObject_Vectorcall((PyObject *)&PySuper_Type, args, 2, NULL);
     if (super == NULL) {
         return -1;
     }

--- a/mypyc/primitives/generic_ops.py
+++ b/mypyc/primitives/generic_ops.py
@@ -281,7 +281,7 @@ py_vectorcall_op = custom_op(
         object_rprimitive,
     ],  # Keyword arg names tuple (or NULL)
     return_type=object_rprimitive,
-    c_function_name="_PyObject_Vectorcall",
+    c_function_name="PyObject_Vectorcall",
     error_kind=ERR_MAGIC,
 )
 

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -163,9 +163,12 @@ def g():
     r5 :: str
     r6 :: object
     r7 :: str
-    r8, r9 :: object
-    r10 :: bit
-    r11 :: None
+    r8 :: object
+    r9 :: object[1]
+    r10 :: object_ptr
+    r11 :: object
+    r12 :: bit
+    r13 :: None
 L0:
 L1:
     r0 = builtins :: module
@@ -173,7 +176,7 @@ L1:
     r2 = CPyObject_GetAttr(r0, r1)
     if is_error(r2) goto L3 (error at g:3) else goto L2
 L2:
-    r3 = PyObject_CallFunctionObjArgs(r2, 0)
+    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
     dec_ref r2
     if is_error(r3) goto L3 (error at g:3) else goto L10
 L3:
@@ -184,9 +187,11 @@ L3:
     r8 = CPyObject_GetAttr(r6, r7)
     if is_error(r8) goto L6 (error at g:5) else goto L4
 L4:
-    r9 = PyObject_CallFunctionObjArgs(r8, r5, 0)
+    r9 = [r5]
+    r10 = load_address r9
+    r11 = _PyObject_Vectorcall(r8, r10, 1, 0)
     dec_ref r8
-    if is_error(r9) goto L6 (error at g:5) else goto L11
+    if is_error(r11) goto L6 (error at g:5) else goto L11
 L5:
     CPy_RestoreExcInfo(r4)
     dec_ref r4
@@ -194,20 +199,20 @@ L5:
 L6:
     CPy_RestoreExcInfo(r4)
     dec_ref r4
-    r10 = CPy_KeepPropagating()
-    if not r10 goto L9 else goto L7 :: bool
+    r12 = CPy_KeepPropagating()
+    if not r12 goto L9 else goto L7 :: bool
 L7:
     unreachable
 L8:
     return 1
 L9:
-    r11 = <error> :: None
-    return r11
+    r13 = <error> :: None
+    return r13
 L10:
     dec_ref r3
     goto L8
 L11:
-    dec_ref r9
+    dec_ref r11
     goto L5
 
 [case testGenopsTryFinally]
@@ -229,9 +234,12 @@ def a():
     r10 :: str
     r11 :: object
     r12 :: str
-    r13, r14 :: object
-    r15 :: bit
-    r16 :: str
+    r13 :: object
+    r14 :: object[1]
+    r15 :: object_ptr
+    r16 :: object
+    r17 :: bit
+    r18 :: str
 L0:
 L1:
     r0 = builtins :: module
@@ -239,7 +247,7 @@ L1:
     r2 = CPyObject_GetAttr(r0, r1)
     if is_error(r2) goto L5 (error at a:3) else goto L2
 L2:
-    r3 = PyObject_CallFunctionObjArgs(r2, 0)
+    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
     dec_ref r2
     if is_error(r3) goto L5 (error at a:3) else goto L19
 L3:
@@ -262,9 +270,11 @@ L6:
     r13 = CPyObject_GetAttr(r11, r12)
     if is_error(r13) goto L20 (error at a:6) else goto L7
 L7:
-    r14 = PyObject_CallFunctionObjArgs(r13, r10, 0)
+    r14 = [r10]
+    r15 = load_address r14
+    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
     dec_ref r13
-    if is_error(r14) goto L20 (error at a:6) else goto L21
+    if is_error(r16) goto L20 (error at a:6) else goto L21
 L8:
     if is_error(r7) goto L11 else goto L22
 L9:
@@ -282,15 +292,15 @@ L14:
     CPy_RestoreExcInfo(r7)
     xdec_ref r7
 L15:
-    r15 = CPy_KeepPropagating()
-    if not r15 goto L18 else goto L16 :: bool
+    r17 = CPy_KeepPropagating()
+    if not r17 goto L18 else goto L16 :: bool
 L16:
     unreachable
 L17:
     unreachable
 L18:
-    r16 = <error> :: str
-    return r16
+    r18 = <error> :: str
+    return r18
 L19:
     dec_ref r3
     goto L3
@@ -298,7 +308,7 @@ L20:
     xdec_ref r5
     goto L13
 L21:
-    dec_ref r14
+    dec_ref r16
     goto L8
 L22:
     xdec_ref r5
@@ -446,8 +456,11 @@ def f(b):
     r6 :: str
     r7 :: object
     r8 :: bool
-    r9 :: object
-    r10 :: None
+    r9 :: object[1]
+    r10 :: object_ptr
+    r11 :: object
+    r12 :: bool
+    r13 :: None
 L0:
     r0 = <error> :: str
     v = r0
@@ -455,50 +468,59 @@ L0:
     inc_ref r1
     u = r1
 L1:
-    if b goto L10 else goto L11 :: bool
+    if b goto L13 else goto L14 :: bool
 L2:
     r2 = 'b'
     inc_ref r2
     v = r2
     r3 = v == u
     r4 = r3 ^ 1
-    if r4 goto L11 else goto L1 :: bool
+    if r4 goto L14 else goto L1 :: bool
 L3:
     r5 = builtins :: module
     r6 = 'print'
     r7 = CPyObject_GetAttr(r5, r6)
-    if is_error(r7) goto L12 (error at f:7) else goto L4
+    if is_error(r7) goto L15 (error at f:7) else goto L4
 L4:
-    if is_error(v) goto L13 else goto L7
+    if is_error(v) goto L16 else goto L7
 L5:
     r8 = raise UnboundLocalError('local variable "v" referenced before assignment')
-    if not r8 goto L9 (error at f:7) else goto L6 :: bool
+    if not r8 goto L12 (error at f:-1) else goto L6 :: bool
 L6:
     unreachable
 L7:
-    r9 = PyObject_CallFunctionObjArgs(r7, v, 0)
+    r9 = [v]
+    r10 = load_address r9
+    r11 = _PyObject_Vectorcall(r7, r10, 1, 0)
     dec_ref r7
-    xdec_ref v
-    if is_error(r9) goto L9 (error at f:7) else goto L14
+    if is_error(r11) goto L15 (error at f:7) else goto L17
 L8:
-    return 1
+    if is_error(v) goto L9 else goto L11
 L9:
-    r10 = <error> :: None
-    return r10
+    r12 = raise UnboundLocalError('local variable "v" referenced before assignment')
+    if not r12 goto L12 (error at f:-1) else goto L10 :: bool
 L10:
+    unreachable
+L11:
+    xdec_ref v
+    return 1
+L12:
+    r13 = <error> :: None
+    return r13
+L13:
     xdec_ref v
     goto L2
-L11:
+L14:
     dec_ref u
     goto L3
-L12:
+L15:
     xdec_ref v
-    goto L9
-L13:
+    goto L12
+L16:
     dec_ref r7
     goto L5
-L14:
-    dec_ref r9
+L17:
+    dec_ref r11
     goto L8
 
 [case testExceptionWithOverlappingErrorValue]

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -176,7 +176,7 @@ L1:
     r2 = CPyObject_GetAttr(r0, r1)
     if is_error(r2) goto L3 (error at g:3) else goto L2
 L2:
-    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
+    r3 = PyObject_Vectorcall(r2, 0, 0, 0)
     dec_ref r2
     if is_error(r3) goto L3 (error at g:3) else goto L10
 L3:
@@ -189,7 +189,7 @@ L3:
 L4:
     r9 = [r5]
     r10 = load_address r9
-    r11 = _PyObject_Vectorcall(r8, r10, 1, 0)
+    r11 = PyObject_Vectorcall(r8, r10, 1, 0)
     dec_ref r8
     if is_error(r11) goto L6 (error at g:5) else goto L11
 L5:
@@ -247,7 +247,7 @@ L1:
     r2 = CPyObject_GetAttr(r0, r1)
     if is_error(r2) goto L5 (error at a:3) else goto L2
 L2:
-    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
+    r3 = PyObject_Vectorcall(r2, 0, 0, 0)
     dec_ref r2
     if is_error(r3) goto L5 (error at a:3) else goto L19
 L3:
@@ -272,7 +272,7 @@ L6:
 L7:
     r14 = [r10]
     r15 = load_address r14
-    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
     dec_ref r13
     if is_error(r16) goto L20 (error at a:6) else goto L21
 L8:
@@ -491,7 +491,7 @@ L6:
 L7:
     r9 = [v]
     r10 = load_address r9
-    r11 = _PyObject_Vectorcall(r7, r10, 1, 0)
+    r11 = PyObject_Vectorcall(r7, r10, 1, 0)
     dec_ref r7
     if is_error(r11) goto L15 (error at f:7) else goto L17
 L8:

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -484,16 +484,22 @@ def f(x):
     x :: int
     r0 :: object
     r1 :: str
-    r2, r3, r4 :: object
-    r5 :: int
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
+    r7 :: int
 L0:
     r0 = testmodule :: module
     r1 = 'factorial'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(int, x)
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
-    r5 = unbox(int, r4)
-    return r5
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
+    r7 = unbox(int, r6)
+    return r7
 
 [case testImport_toplevel]
 import sys
@@ -581,7 +587,7 @@ L2:
     r33 = single :: module
     r34 = 'hello'
     r35 = CPyObject_GetAttr(r33, r34)
-    r36 = PyObject_CallFunctionObjArgs(r35, 0)
+    r36 = _PyObject_Vectorcall(r35, 0, 0, 0)
     return 1
 
 [case testFromImport_toplevel]
@@ -600,36 +606,42 @@ def f(x):
     x :: int
     r0 :: dict
     r1 :: str
-    r2, r3, r4 :: object
-    r5 :: int
-    r6 :: dict
-    r7 :: str
-    r8, r9 :: object
-    r10, r11 :: int
-    r12 :: dict
-    r13 :: str
-    r14, r15 :: object
-    r16, r17 :: int
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
+    r7 :: int
+    r8 :: dict
+    r9 :: str
+    r10, r11 :: object
+    r12, r13 :: int
+    r14 :: dict
+    r15 :: str
+    r16, r17 :: object
+    r18, r19 :: int
 L0:
     r0 = __main__.globals :: static
     r1 = 'g'
     r2 = CPyDict_GetItem(r0, r1)
     r3 = box(int, x)
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
-    r5 = unbox(int, r4)
-    r6 = __main__.globals :: static
-    r7 = 'h'
-    r8 = CPyDict_GetItem(r6, r7)
-    r9 = PyObject_CallFunctionObjArgs(r8, 0)
-    r10 = unbox(int, r9)
-    r11 = CPyTagged_Add(r5, r10)
-    r12 = __main__.globals :: static
-    r13 = 'two'
-    r14 = CPyDict_GetItem(r12, r13)
-    r15 = PyObject_CallFunctionObjArgs(r14, 0)
-    r16 = unbox(int, r15)
-    r17 = CPyTagged_Add(r11, r16)
-    return r17
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
+    r7 = unbox(int, r6)
+    r8 = __main__.globals :: static
+    r9 = 'h'
+    r10 = CPyDict_GetItem(r8, r9)
+    r11 = _PyObject_Vectorcall(r10, 0, 0, 0)
+    r12 = unbox(int, r11)
+    r13 = CPyTagged_Add(r7, r12)
+    r14 = __main__.globals :: static
+    r15 = 'two'
+    r16 = CPyDict_GetItem(r14, r15)
+    r17 = _PyObject_Vectorcall(r16, 0, 0, 0)
+    r18 = unbox(int, r17)
+    r19 = CPyTagged_Add(r13, r18)
+    return r19
 def __top_level__():
     r0, r1 :: object
     r2 :: bit
@@ -673,13 +685,19 @@ def f(x):
     x :: int
     r0 :: object
     r1 :: str
-    r2, r3, r4 :: object
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
 L0:
     r0 = builtins :: module
     r1 = 'print'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = object 5
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
     return 1
 
 [case testPrint]
@@ -691,13 +709,19 @@ def f(x):
     x :: int
     r0 :: object
     r1 :: str
-    r2, r3, r4 :: object
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
 L0:
     r0 = builtins :: module
     r1 = 'print'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = object 5
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
     return 1
 
 [case testUnicodeLiteral]
@@ -1105,16 +1129,22 @@ def call_python_function(x):
     x :: int
     r0 :: dict
     r1 :: str
-    r2, r3, r4 :: object
-    r5 :: int
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
+    r7 :: int
 L0:
     r0 = __main__.globals :: static
     r1 = 'f'
     r2 = CPyDict_GetItem(r0, r1)
     r3 = box(int, x)
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
-    r5 = unbox(int, r4)
-    return r5
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
+    r7 = unbox(int, r6)
+    return r7
 def return_float():
 L0:
     return 5.0
@@ -1133,7 +1163,7 @@ def call_callable_type():
 L0:
     r0 = return_callable_type()
     f = r0
-    r1 = PyObject_CallFunctionObjArgs(f, 0)
+    r1 = _PyObject_Vectorcall(f, 0, 0, 0)
     r2 = unbox(float, r1)
     return r2
 
@@ -1151,58 +1181,53 @@ def call_python_method_with_keyword_args(xs: List[int], first: int, second: int)
 [out]
 def call_python_function_with_keyword_arg(x):
     x :: str
-    r0 :: object
-    r1 :: str
-    r2 :: tuple
-    r3 :: object
-    r4 :: dict
-    r5 :: object
+    r0, r1 :: object
+    r2 :: object[2]
+    r3 :: object_ptr
+    r4, r5 :: object
     r6 :: int
 L0:
     r0 = load_address PyLong_Type
-    r1 = 'base'
-    r2 = PyTuple_Pack(1, x)
-    r3 = object 2
-    r4 = CPyDict_Build(1, r1, r3)
-    r5 = PyObject_Call(r0, r2, r4)
+    r1 = object 2
+    r2 = [x, r1]
+    r3 = load_address r2
+    r4 = ('base',)
+    r5 = _PyObject_Vectorcall(r0, r3, 1, r4)
+    keep_alive x, r1
     r6 = unbox(int, r5)
     return r6
 def call_python_method_with_keyword_args(xs, first, second):
     xs :: list
     first, second :: int
     r0 :: str
-    r1 :: object
-    r2 :: str
-    r3 :: object
-    r4 :: tuple
-    r5 :: object
-    r6 :: dict
-    r7 :: object
+    r1, r2, r3 :: object
+    r4 :: object[2]
+    r5 :: object_ptr
+    r6, r7 :: object
     r8 :: str
-    r9 :: object
-    r10, r11 :: str
-    r12 :: tuple
-    r13, r14 :: object
-    r15 :: dict
-    r16 :: object
+    r9, r10, r11 :: object
+    r12 :: object[2]
+    r13 :: object_ptr
+    r14, r15 :: object
 L0:
     r0 = 'insert'
     r1 = CPyObject_GetAttr(xs, r0)
-    r2 = 'x'
-    r3 = object 0
-    r4 = PyTuple_Pack(1, r3)
-    r5 = box(int, first)
-    r6 = CPyDict_Build(1, r2, r5)
-    r7 = PyObject_Call(r1, r4, r6)
+    r2 = object 0
+    r3 = box(int, first)
+    r4 = [r2, r3]
+    r5 = load_address r4
+    r6 = ('x',)
+    r7 = _PyObject_Vectorcall(r1, r5, 1, r6)
+    keep_alive r2, r3
     r8 = 'insert'
     r9 = CPyObject_GetAttr(xs, r8)
-    r10 = 'x'
-    r11 = 'i'
-    r12 = PyTuple_Pack(0)
-    r13 = box(int, second)
-    r14 = object 1
-    r15 = CPyDict_Build(2, r10, r13, r11, r14)
-    r16 = PyObject_Call(r9, r12, r15)
+    r10 = box(int, second)
+    r11 = object 1
+    r12 = [r10, r11]
+    r13 = load_address r12
+    r14 = ('x', 'i')
+    r15 = _PyObject_Vectorcall(r9, r13, 0, r14)
+    keep_alive r10, r11
     return xs
 
 [case testObjectAsBoolean]
@@ -1368,7 +1393,7 @@ L0:
     r0 = builtins :: module
     r1 = 'Exception'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = PyObject_CallFunctionObjArgs(r2, 0)
+    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
     CPy_Raise(r3)
     unreachable
 def bar():
@@ -1396,7 +1421,10 @@ def f():
     r3 :: int
     r4 :: object
     r5 :: str
-    r6, r7, r8 :: object
+    r6, r7 :: object
+    r8 :: object[1]
+    r9 :: object_ptr
+    r10 :: object
 L0:
     r0 = __main__.globals :: static
     r1 = 'x'
@@ -1406,7 +1434,10 @@ L0:
     r5 = 'print'
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = box(int, r3)
-    r8 = PyObject_CallFunctionObjArgs(r6, r7, 0)
+    r8 = [r7]
+    r9 = load_address r8
+    r10 = _PyObject_Vectorcall(r6, r9, 1, 0)
+    keep_alive r7
     return 1
 def __top_level__():
     r0, r1 :: object
@@ -1424,7 +1455,10 @@ def __top_level__():
     r13 :: int
     r14 :: object
     r15 :: str
-    r16, r17, r18 :: object
+    r16, r17 :: object
+    r18 :: object[1]
+    r19 :: object_ptr
+    r20 :: object
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -1448,7 +1482,10 @@ L2:
     r15 = 'print'
     r16 = CPyObject_GetAttr(r14, r15)
     r17 = box(int, r13)
-    r18 = PyObject_CallFunctionObjArgs(r16, r17, 0)
+    r18 = [r17]
+    r19 = load_address r18
+    r20 = _PyObject_Vectorcall(r16, r19, 1, 0)
+    keep_alive r17
     return 1
 
 [case testCallOverloaded]
@@ -1465,16 +1502,22 @@ def f(x: str) -> int: ...
 def f():
     r0 :: object
     r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
+    r7 :: str
 L0:
     r0 = m :: module
     r1 = 'f'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = object 1
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
-    r5 = cast(str, r4)
-    return r5
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
+    r7 = cast(str, r6)
+    return r7
 
 [case testCallOverloadedNative]
 from typing import overload, Union
@@ -2147,45 +2190,54 @@ def __top_level__():
     r19 :: object
     r20 :: dict
     r21 :: str
-    r22, r23 :: object
-    r24 :: dict
-    r25 :: str
-    r26 :: i32
-    r27 :: bit
-    r28 :: str
-    r29 :: dict
+    r22 :: object
+    r23 :: object[2]
+    r24 :: object_ptr
+    r25 :: object
+    r26 :: dict
+    r27 :: str
+    r28 :: i32
+    r29 :: bit
     r30 :: str
-    r31, r32, r33 :: object
-    r34 :: tuple
-    r35 :: dict
-    r36 :: str
-    r37 :: i32
-    r38 :: bit
+    r31 :: dict
+    r32 :: str
+    r33, r34 :: object
+    r35 :: object[2]
+    r36 :: object_ptr
+    r37 :: object
+    r38 :: tuple
     r39 :: dict
     r40 :: str
-    r41, r42, r43 :: object
-    r44 :: dict
-    r45 :: str
-    r46 :: i32
-    r47 :: bit
-    r48 :: str
-    r49 :: dict
-    r50 :: str
-    r51 :: object
-    r52 :: dict
-    r53 :: str
-    r54, r55 :: object
+    r41 :: i32
+    r42 :: bit
+    r43 :: dict
+    r44 :: str
+    r45, r46, r47 :: object
+    r48 :: dict
+    r49 :: str
+    r50 :: i32
+    r51 :: bit
+    r52 :: str
+    r53 :: dict
+    r54 :: str
+    r55 :: object
     r56 :: dict
     r57 :: str
-    r58 :: i32
-    r59 :: bit
-    r60 :: list
-    r61, r62, r63 :: object
-    r64 :: ptr
-    r65 :: dict
-    r66 :: str
-    r67 :: i32
-    r68 :: bit
+    r58 :: object
+    r59 :: object[2]
+    r60 :: object_ptr
+    r61 :: object
+    r62 :: dict
+    r63 :: str
+    r64 :: i32
+    r65 :: bit
+    r66 :: list
+    r67, r68, r69 :: object
+    r70 :: ptr
+    r71 :: dict
+    r72 :: str
+    r73 :: i32
+    r74 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -2215,56 +2267,65 @@ L2:
     r20 = __main__.globals :: static
     r21 = 'NamedTuple'
     r22 = CPyDict_GetItem(r20, r21)
-    r23 = PyObject_CallFunctionObjArgs(r22, r9, r19, 0)
-    r24 = __main__.globals :: static
-    r25 = 'Lol'
-    r26 = CPyDict_SetItem(r24, r25, r23)
-    r27 = r26 >= 0 :: signed
-    r28 = ''
-    r29 = __main__.globals :: static
-    r30 = 'Lol'
-    r31 = CPyDict_GetItem(r29, r30)
-    r32 = object 1
-    r33 = PyObject_CallFunctionObjArgs(r31, r32, r28, 0)
-    r34 = cast(tuple, r33)
-    r35 = __main__.globals :: static
-    r36 = 'x'
-    r37 = CPyDict_SetItem(r35, r36, r34)
-    r38 = r37 >= 0 :: signed
+    r23 = [r9, r19]
+    r24 = load_address r23
+    r25 = _PyObject_Vectorcall(r22, r24, 2, 0)
+    keep_alive r9, r19
+    r26 = __main__.globals :: static
+    r27 = 'Lol'
+    r28 = CPyDict_SetItem(r26, r27, r25)
+    r29 = r28 >= 0 :: signed
+    r30 = ''
+    r31 = __main__.globals :: static
+    r32 = 'Lol'
+    r33 = CPyDict_GetItem(r31, r32)
+    r34 = object 1
+    r35 = [r34, r30]
+    r36 = load_address r35
+    r37 = _PyObject_Vectorcall(r33, r36, 2, 0)
+    keep_alive r34, r30
+    r38 = cast(tuple, r37)
     r39 = __main__.globals :: static
-    r40 = 'List'
-    r41 = CPyDict_GetItem(r39, r40)
-    r42 = load_address PyLong_Type
-    r43 = PyObject_GetItem(r41, r42)
-    r44 = __main__.globals :: static
-    r45 = 'Foo'
-    r46 = CPyDict_SetItem(r44, r45, r43)
-    r47 = r46 >= 0 :: signed
-    r48 = 'Bar'
-    r49 = __main__.globals :: static
-    r50 = 'Foo'
-    r51 = CPyDict_GetItem(r49, r50)
-    r52 = __main__.globals :: static
-    r53 = 'NewType'
-    r54 = CPyDict_GetItem(r52, r53)
-    r55 = PyObject_CallFunctionObjArgs(r54, r48, r51, 0)
+    r40 = 'x'
+    r41 = CPyDict_SetItem(r39, r40, r38)
+    r42 = r41 >= 0 :: signed
+    r43 = __main__.globals :: static
+    r44 = 'List'
+    r45 = CPyDict_GetItem(r43, r44)
+    r46 = load_address PyLong_Type
+    r47 = PyObject_GetItem(r45, r46)
+    r48 = __main__.globals :: static
+    r49 = 'Foo'
+    r50 = CPyDict_SetItem(r48, r49, r47)
+    r51 = r50 >= 0 :: signed
+    r52 = 'Bar'
+    r53 = __main__.globals :: static
+    r54 = 'Foo'
+    r55 = CPyDict_GetItem(r53, r54)
     r56 = __main__.globals :: static
-    r57 = 'Bar'
-    r58 = CPyDict_SetItem(r56, r57, r55)
-    r59 = r58 >= 0 :: signed
-    r60 = PyList_New(3)
-    r61 = object 1
-    r62 = object 2
-    r63 = object 3
-    r64 = list_items r60
-    buf_init_item r64, 0, r61
-    buf_init_item r64, 1, r62
-    buf_init_item r64, 2, r63
-    keep_alive r60
-    r65 = __main__.globals :: static
-    r66 = 'y'
-    r67 = CPyDict_SetItem(r65, r66, r60)
-    r68 = r67 >= 0 :: signed
+    r57 = 'NewType'
+    r58 = CPyDict_GetItem(r56, r57)
+    r59 = [r52, r55]
+    r60 = load_address r59
+    r61 = _PyObject_Vectorcall(r58, r60, 2, 0)
+    keep_alive r52, r55
+    r62 = __main__.globals :: static
+    r63 = 'Bar'
+    r64 = CPyDict_SetItem(r62, r63, r61)
+    r65 = r64 >= 0 :: signed
+    r66 = PyList_New(3)
+    r67 = object 1
+    r68 = object 2
+    r69 = object 3
+    r70 = list_items r66
+    buf_init_item r70, 0, r67
+    buf_init_item r70, 1, r68
+    buf_init_item r70, 2, r69
+    keep_alive r66
+    r71 = __main__.globals :: static
+    r72 = 'y'
+    r73 = CPyDict_SetItem(r71, r72, r66)
+    r74 = r73 >= 0 :: signed
     return 1
 
 [case testChainedConditional]
@@ -2378,25 +2439,37 @@ def g_a_obj.__call__(__mypyc_self__):
     r1 :: str
     r2 :: object
     r3 :: str
-    r4, r5, r6, r7 :: object
-    r8 :: str
-    r9 :: object
+    r4 :: object
+    r5 :: object[1]
+    r6 :: object_ptr
+    r7, r8, r9 :: object
     r10 :: str
-    r11, r12 :: object
+    r11 :: object
+    r12 :: str
+    r13 :: object
+    r14 :: object[1]
+    r15 :: object_ptr
+    r16 :: object
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = 'Entering'
     r2 = builtins :: module
     r3 = 'print'
     r4 = CPyObject_GetAttr(r2, r3)
-    r5 = PyObject_CallFunctionObjArgs(r4, r1, 0)
-    r6 = r0.f
-    r7 = PyObject_CallFunctionObjArgs(r6, 0)
-    r8 = 'Exited'
-    r9 = builtins :: module
-    r10 = 'print'
-    r11 = CPyObject_GetAttr(r9, r10)
-    r12 = PyObject_CallFunctionObjArgs(r11, r8, 0)
+    r5 = [r1]
+    r6 = load_address r5
+    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    keep_alive r1
+    r8 = r0.f
+    r9 = _PyObject_Vectorcall(r8, 0, 0, 0)
+    r10 = 'Exited'
+    r11 = builtins :: module
+    r12 = 'print'
+    r13 = CPyObject_GetAttr(r11, r12)
+    r14 = [r10]
+    r15 = load_address r14
+    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    keep_alive r10
     return 1
 def a(f):
     f :: object
@@ -2431,25 +2504,37 @@ def g_b_obj.__call__(__mypyc_self__):
     r1 :: str
     r2 :: object
     r3 :: str
-    r4, r5, r6, r7 :: object
-    r8 :: str
-    r9 :: object
+    r4 :: object
+    r5 :: object[1]
+    r6 :: object_ptr
+    r7, r8, r9 :: object
     r10 :: str
-    r11, r12 :: object
+    r11 :: object
+    r12 :: str
+    r13 :: object
+    r14 :: object[1]
+    r15 :: object_ptr
+    r16 :: object
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = '---'
     r2 = builtins :: module
     r3 = 'print'
     r4 = CPyObject_GetAttr(r2, r3)
-    r5 = PyObject_CallFunctionObjArgs(r4, r1, 0)
-    r6 = r0.f
-    r7 = PyObject_CallFunctionObjArgs(r6, 0)
-    r8 = '---'
-    r9 = builtins :: module
-    r10 = 'print'
-    r11 = CPyObject_GetAttr(r9, r10)
-    r12 = PyObject_CallFunctionObjArgs(r11, r8, 0)
+    r5 = [r1]
+    r6 = load_address r5
+    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    keep_alive r1
+    r8 = r0.f
+    r9 = _PyObject_Vectorcall(r8, 0, 0, 0)
+    r10 = '---'
+    r11 = builtins :: module
+    r12 = 'print'
+    r13 = CPyObject_GetAttr(r11, r12)
+    r14 = [r10]
+    r15 = load_address r14
+    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    keep_alive r10
     return 1
 def b(f):
     f :: object
@@ -2484,14 +2569,20 @@ def d_c_obj.__call__(__mypyc_self__):
     r1 :: str
     r2 :: object
     r3 :: str
-    r4, r5 :: object
+    r4 :: object
+    r5 :: object[1]
+    r6 :: object_ptr
+    r7 :: object
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = 'd'
     r2 = builtins :: module
     r3 = 'print'
     r4 = CPyObject_GetAttr(r2, r3)
-    r5 = PyObject_CallFunctionObjArgs(r4, r1, 0)
+    r5 = [r1]
+    r6 = load_address r5
+    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    keep_alive r1
     return 1
 def c():
     r0 :: __main__.c_env
@@ -2499,18 +2590,27 @@ def c():
     r2 :: bool
     r3 :: dict
     r4 :: str
-    r5, r6 :: object
-    r7 :: dict
-    r8 :: str
-    r9, r10, d :: object
-    r11 :: dict
-    r12 :: str
-    r13 :: i32
-    r14 :: bit
-    r15 :: str
-    r16 :: object
-    r17 :: str
-    r18, r19, r20 :: object
+    r5 :: object
+    r6 :: object[1]
+    r7 :: object_ptr
+    r8 :: object
+    r9 :: dict
+    r10 :: str
+    r11 :: object
+    r12 :: object[1]
+    r13 :: object_ptr
+    r14, d :: object
+    r15 :: dict
+    r16 :: str
+    r17 :: i32
+    r18 :: bit
+    r19 :: str
+    r20 :: object
+    r21 :: str
+    r22 :: object
+    r23 :: object[1]
+    r24 :: object_ptr
+    r25, r26 :: object
 L0:
     r0 = c_env()
     r1 = d_c_obj()
@@ -2518,22 +2618,31 @@ L0:
     r3 = __main__.globals :: static
     r4 = 'b'
     r5 = CPyDict_GetItem(r3, r4)
-    r6 = PyObject_CallFunctionObjArgs(r5, r1, 0)
-    r7 = __main__.globals :: static
-    r8 = 'a'
-    r9 = CPyDict_GetItem(r7, r8)
-    r10 = PyObject_CallFunctionObjArgs(r9, r6, 0)
-    d = r10
-    r11 = __main__.globals :: static
-    r12 = 'd'
-    r13 = CPyDict_SetItem(r11, r12, r10)
-    r14 = r13 >= 0 :: signed
-    r15 = 'c'
-    r16 = builtins :: module
-    r17 = 'print'
-    r18 = CPyObject_GetAttr(r16, r17)
-    r19 = PyObject_CallFunctionObjArgs(r18, r15, 0)
-    r20 = PyObject_CallFunctionObjArgs(d, 0)
+    r6 = [r1]
+    r7 = load_address r6
+    r8 = _PyObject_Vectorcall(r5, r7, 1, 0)
+    keep_alive r1
+    r9 = __main__.globals :: static
+    r10 = 'a'
+    r11 = CPyDict_GetItem(r9, r10)
+    r12 = [r8]
+    r13 = load_address r12
+    r14 = _PyObject_Vectorcall(r11, r13, 1, 0)
+    keep_alive r8
+    d = r14
+    r15 = __main__.globals :: static
+    r16 = 'd'
+    r17 = CPyDict_SetItem(r15, r16, r14)
+    r18 = r17 >= 0 :: signed
+    r19 = 'c'
+    r20 = builtins :: module
+    r21 = 'print'
+    r22 = CPyObject_GetAttr(r20, r21)
+    r23 = [r19]
+    r24 = load_address r23
+    r25 = _PyObject_Vectorcall(r22, r24, 1, 0)
+    keep_alive r19
+    r26 = _PyObject_Vectorcall(d, 0, 0, 0)
     return 1
 def __top_level__():
     r0, r1 :: object
@@ -2548,14 +2657,20 @@ def __top_level__():
     r11 :: object
     r12 :: dict
     r13 :: str
-    r14, r15 :: object
-    r16 :: dict
-    r17 :: str
-    r18, r19 :: object
-    r20 :: dict
-    r21 :: str
-    r22 :: i32
-    r23 :: bit
+    r14 :: object
+    r15 :: object[1]
+    r16 :: object_ptr
+    r17 :: object
+    r18 :: dict
+    r19 :: str
+    r20 :: object
+    r21 :: object[1]
+    r22 :: object_ptr
+    r23 :: object
+    r24 :: dict
+    r25 :: str
+    r26 :: i32
+    r27 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -2577,15 +2692,21 @@ L2:
     r12 = __main__.globals :: static
     r13 = 'b'
     r14 = CPyDict_GetItem(r12, r13)
-    r15 = PyObject_CallFunctionObjArgs(r14, r11, 0)
-    r16 = __main__.globals :: static
-    r17 = 'a'
-    r18 = CPyDict_GetItem(r16, r17)
-    r19 = PyObject_CallFunctionObjArgs(r18, r15, 0)
-    r20 = __main__.globals :: static
-    r21 = 'c'
-    r22 = CPyDict_SetItem(r20, r21, r19)
-    r23 = r22 >= 0 :: signed
+    r15 = [r11]
+    r16 = load_address r15
+    r17 = _PyObject_Vectorcall(r14, r16, 1, 0)
+    keep_alive r11
+    r18 = __main__.globals :: static
+    r19 = 'a'
+    r20 = CPyDict_GetItem(r18, r19)
+    r21 = [r17]
+    r22 = load_address r21
+    r23 = _PyObject_Vectorcall(r20, r22, 1, 0)
+    keep_alive r17
+    r24 = __main__.globals :: static
+    r25 = 'c'
+    r26 = CPyDict_SetItem(r24, r25, r23)
+    r27 = r26 >= 0 :: signed
     return 1
 
 [case testDecoratorsSimple_toplevel]
@@ -2618,25 +2739,37 @@ def g_a_obj.__call__(__mypyc_self__):
     r1 :: str
     r2 :: object
     r3 :: str
-    r4, r5, r6, r7 :: object
-    r8 :: str
-    r9 :: object
+    r4 :: object
+    r5 :: object[1]
+    r6 :: object_ptr
+    r7, r8, r9 :: object
     r10 :: str
-    r11, r12 :: object
+    r11 :: object
+    r12 :: str
+    r13 :: object
+    r14 :: object[1]
+    r15 :: object_ptr
+    r16 :: object
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = 'Entering'
     r2 = builtins :: module
     r3 = 'print'
     r4 = CPyObject_GetAttr(r2, r3)
-    r5 = PyObject_CallFunctionObjArgs(r4, r1, 0)
-    r6 = r0.f
-    r7 = PyObject_CallFunctionObjArgs(r6, 0)
-    r8 = 'Exited'
-    r9 = builtins :: module
-    r10 = 'print'
-    r11 = CPyObject_GetAttr(r9, r10)
-    r12 = PyObject_CallFunctionObjArgs(r11, r8, 0)
+    r5 = [r1]
+    r6 = load_address r5
+    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    keep_alive r1
+    r8 = r0.f
+    r9 = _PyObject_Vectorcall(r8, 0, 0, 0)
+    r10 = 'Exited'
+    r11 = builtins :: module
+    r12 = 'print'
+    r13 = CPyObject_GetAttr(r11, r12)
+    r14 = [r10]
+    r15 = load_address r14
+    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    keep_alive r10
     return 1
 def a(f):
     f :: object
@@ -2757,10 +2890,13 @@ def call_sum(l, comparison):
     r0 :: int
     r1, r2 :: object
     r3, x :: int
-    r4, r5 :: object
-    r6, r7 :: bool
-    r8, r9 :: int
-    r10 :: bit
+    r4 :: object
+    r5 :: object[1]
+    r6 :: object_ptr
+    r7 :: object
+    r8, r9 :: bool
+    r10, r11 :: int
+    r12 :: bit
 L0:
     r0 = 0
     r1 = PyObject_GetIter(l)
@@ -2771,16 +2907,19 @@ L2:
     r3 = unbox(int, r2)
     x = r3
     r4 = box(int, x)
-    r5 = PyObject_CallFunctionObjArgs(comparison, r4, 0)
-    r6 = unbox(bool, r5)
-    r7 = r6 << 1
-    r8 = extend r7: builtins.bool to builtins.int
-    r9 = CPyTagged_Add(r0, r8)
-    r0 = r9
+    r5 = [r4]
+    r6 = load_address r5
+    r7 = _PyObject_Vectorcall(comparison, r6, 1, 0)
+    keep_alive r4
+    r8 = unbox(bool, r7)
+    r9 = r8 << 1
+    r10 = extend r9: builtins.bool to builtins.int
+    r11 = CPyTagged_Add(r0, r10)
+    r0 = r11
 L3:
     goto L1
 L4:
-    r10 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L5:
     return r0
 
@@ -3060,13 +3199,19 @@ def f(x):
     x :: int
     r0 :: object
     r1 :: str
-    r2, r3, r4 :: object
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
 L0:
     r0 = builtins :: module
     r1 = 'reveal_type'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = box(int, x)
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
     return 1
 
 [case testCallCWithStrJoinMethod]
@@ -3274,34 +3419,40 @@ def range_in_loop() -> None:
         sum += i
 [out]
 def range_object():
-    r0, r1, r2, r3, r4 :: object
-    r5, r :: range
+    r0, r1, r2, r3 :: object
+    r4 :: object[3]
+    r5 :: object_ptr
+    r6 :: object
+    r7, r :: range
     sum :: int
-    r6, r7 :: object
-    r8, i, r9 :: int
-    r10 :: bit
+    r8, r9 :: object
+    r10, i, r11 :: int
+    r12 :: bit
 L0:
     r0 = load_address PyRange_Type
     r1 = object 4
     r2 = object 12
     r3 = object 2
-    r4 = PyObject_CallFunctionObjArgs(r0, r1, r2, r3, 0)
-    r5 = cast(range, r4)
-    r = r5
+    r4 = [r1, r2, r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r0, r5, 3, 0)
+    keep_alive r1, r2, r3
+    r7 = cast(range, r6)
+    r = r7
     sum = 0
-    r6 = PyObject_GetIter(r)
+    r8 = PyObject_GetIter(r)
 L1:
-    r7 = PyIter_Next(r6)
-    if is_error(r7) goto L4 else goto L2
+    r9 = PyIter_Next(r8)
+    if is_error(r9) goto L4 else goto L2
 L2:
-    r8 = unbox(int, r7)
-    i = r8
-    r9 = CPyTagged_Add(sum, i)
-    sum = r9
+    r10 = unbox(int, r9)
+    i = r10
+    r11 = CPyTagged_Add(sum, i)
+    sum = r11
 L3:
     goto L1
 L4:
-    r10 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L5:
     return 1
 def range_in_loop():

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -496,7 +496,7 @@ L0:
     r3 = box(int, x)
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     r7 = unbox(int, r6)
     return r7
@@ -587,7 +587,7 @@ L2:
     r33 = single :: module
     r34 = 'hello'
     r35 = CPyObject_GetAttr(r33, r34)
-    r36 = _PyObject_Vectorcall(r35, 0, 0, 0)
+    r36 = PyObject_Vectorcall(r35, 0, 0, 0)
     return 1
 
 [case testFromImport_toplevel]
@@ -626,19 +626,19 @@ L0:
     r3 = box(int, x)
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     r7 = unbox(int, r6)
     r8 = __main__.globals :: static
     r9 = 'h'
     r10 = CPyDict_GetItem(r8, r9)
-    r11 = _PyObject_Vectorcall(r10, 0, 0, 0)
+    r11 = PyObject_Vectorcall(r10, 0, 0, 0)
     r12 = unbox(int, r11)
     r13 = CPyTagged_Add(r7, r12)
     r14 = __main__.globals :: static
     r15 = 'two'
     r16 = CPyDict_GetItem(r14, r15)
-    r17 = _PyObject_Vectorcall(r16, 0, 0, 0)
+    r17 = PyObject_Vectorcall(r16, 0, 0, 0)
     r18 = unbox(int, r17)
     r19 = CPyTagged_Add(r13, r18)
     return r19
@@ -696,7 +696,7 @@ L0:
     r3 = object 5
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     return 1
 
@@ -720,7 +720,7 @@ L0:
     r3 = object 5
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     return 1
 
@@ -1141,7 +1141,7 @@ L0:
     r3 = box(int, x)
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     r7 = unbox(int, r6)
     return r7
@@ -1163,7 +1163,7 @@ def call_callable_type():
 L0:
     r0 = return_callable_type()
     f = r0
-    r1 = _PyObject_Vectorcall(f, 0, 0, 0)
+    r1 = PyObject_Vectorcall(f, 0, 0, 0)
     r2 = unbox(float, r1)
     return r2
 
@@ -1192,7 +1192,7 @@ L0:
     r2 = [x, r1]
     r3 = load_address r2
     r4 = ('base',)
-    r5 = _PyObject_Vectorcall(r0, r3, 1, r4)
+    r5 = PyObject_Vectorcall(r0, r3, 1, r4)
     keep_alive x, r1
     r6 = unbox(int, r5)
     return r6
@@ -1217,7 +1217,7 @@ L0:
     r4 = [r2, r3]
     r5 = load_address r4
     r6 = ('x',)
-    r7 = _PyObject_Vectorcall(r1, r5, 1, r6)
+    r7 = PyObject_Vectorcall(r1, r5, 1, r6)
     keep_alive r2, r3
     r8 = 'insert'
     r9 = CPyObject_GetAttr(xs, r8)
@@ -1226,7 +1226,7 @@ L0:
     r12 = [r10, r11]
     r13 = load_address r12
     r14 = ('x', 'i')
-    r15 = _PyObject_Vectorcall(r9, r13, 0, r14)
+    r15 = PyObject_Vectorcall(r9, r13, 0, r14)
     keep_alive r10, r11
     return xs
 
@@ -1393,7 +1393,7 @@ L0:
     r0 = builtins :: module
     r1 = 'Exception'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
+    r3 = PyObject_Vectorcall(r2, 0, 0, 0)
     CPy_Raise(r3)
     unreachable
 def bar():
@@ -1436,7 +1436,7 @@ L0:
     r7 = box(int, r3)
     r8 = [r7]
     r9 = load_address r8
-    r10 = _PyObject_Vectorcall(r6, r9, 1, 0)
+    r10 = PyObject_Vectorcall(r6, r9, 1, 0)
     keep_alive r7
     return 1
 def __top_level__():
@@ -1484,7 +1484,7 @@ L2:
     r17 = box(int, r13)
     r18 = [r17]
     r19 = load_address r18
-    r20 = _PyObject_Vectorcall(r16, r19, 1, 0)
+    r20 = PyObject_Vectorcall(r16, r19, 1, 0)
     keep_alive r17
     return 1
 
@@ -1514,7 +1514,7 @@ L0:
     r3 = object 1
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     r7 = cast(str, r6)
     return r7
@@ -2269,7 +2269,7 @@ L2:
     r22 = CPyDict_GetItem(r20, r21)
     r23 = [r9, r19]
     r24 = load_address r23
-    r25 = _PyObject_Vectorcall(r22, r24, 2, 0)
+    r25 = PyObject_Vectorcall(r22, r24, 2, 0)
     keep_alive r9, r19
     r26 = __main__.globals :: static
     r27 = 'Lol'
@@ -2282,7 +2282,7 @@ L2:
     r34 = object 1
     r35 = [r34, r30]
     r36 = load_address r35
-    r37 = _PyObject_Vectorcall(r33, r36, 2, 0)
+    r37 = PyObject_Vectorcall(r33, r36, 2, 0)
     keep_alive r34, r30
     r38 = cast(tuple, r37)
     r39 = __main__.globals :: static
@@ -2307,7 +2307,7 @@ L2:
     r58 = CPyDict_GetItem(r56, r57)
     r59 = [r52, r55]
     r60 = load_address r59
-    r61 = _PyObject_Vectorcall(r58, r60, 2, 0)
+    r61 = PyObject_Vectorcall(r58, r60, 2, 0)
     keep_alive r52, r55
     r62 = __main__.globals :: static
     r63 = 'Bar'
@@ -2458,17 +2458,17 @@ L0:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
     r8 = r0.f
-    r9 = _PyObject_Vectorcall(r8, 0, 0, 0)
+    r9 = PyObject_Vectorcall(r8, 0, 0, 0)
     r10 = 'Exited'
     r11 = builtins :: module
     r12 = 'print'
     r13 = CPyObject_GetAttr(r11, r12)
     r14 = [r10]
     r15 = load_address r14
-    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
     keep_alive r10
     return 1
 def a(f):
@@ -2523,17 +2523,17 @@ L0:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
     r8 = r0.f
-    r9 = _PyObject_Vectorcall(r8, 0, 0, 0)
+    r9 = PyObject_Vectorcall(r8, 0, 0, 0)
     r10 = '---'
     r11 = builtins :: module
     r12 = 'print'
     r13 = CPyObject_GetAttr(r11, r12)
     r14 = [r10]
     r15 = load_address r14
-    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
     keep_alive r10
     return 1
 def b(f):
@@ -2581,7 +2581,7 @@ L0:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
     return 1
 def c():
@@ -2620,14 +2620,14 @@ L0:
     r5 = CPyDict_GetItem(r3, r4)
     r6 = [r1]
     r7 = load_address r6
-    r8 = _PyObject_Vectorcall(r5, r7, 1, 0)
+    r8 = PyObject_Vectorcall(r5, r7, 1, 0)
     keep_alive r1
     r9 = __main__.globals :: static
     r10 = 'a'
     r11 = CPyDict_GetItem(r9, r10)
     r12 = [r8]
     r13 = load_address r12
-    r14 = _PyObject_Vectorcall(r11, r13, 1, 0)
+    r14 = PyObject_Vectorcall(r11, r13, 1, 0)
     keep_alive r8
     d = r14
     r15 = __main__.globals :: static
@@ -2640,9 +2640,9 @@ L0:
     r22 = CPyObject_GetAttr(r20, r21)
     r23 = [r19]
     r24 = load_address r23
-    r25 = _PyObject_Vectorcall(r22, r24, 1, 0)
+    r25 = PyObject_Vectorcall(r22, r24, 1, 0)
     keep_alive r19
-    r26 = _PyObject_Vectorcall(d, 0, 0, 0)
+    r26 = PyObject_Vectorcall(d, 0, 0, 0)
     return 1
 def __top_level__():
     r0, r1 :: object
@@ -2694,14 +2694,14 @@ L2:
     r14 = CPyDict_GetItem(r12, r13)
     r15 = [r11]
     r16 = load_address r15
-    r17 = _PyObject_Vectorcall(r14, r16, 1, 0)
+    r17 = PyObject_Vectorcall(r14, r16, 1, 0)
     keep_alive r11
     r18 = __main__.globals :: static
     r19 = 'a'
     r20 = CPyDict_GetItem(r18, r19)
     r21 = [r17]
     r22 = load_address r21
-    r23 = _PyObject_Vectorcall(r20, r22, 1, 0)
+    r23 = PyObject_Vectorcall(r20, r22, 1, 0)
     keep_alive r17
     r24 = __main__.globals :: static
     r25 = 'c'
@@ -2758,17 +2758,17 @@ L0:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
     r8 = r0.f
-    r9 = _PyObject_Vectorcall(r8, 0, 0, 0)
+    r9 = PyObject_Vectorcall(r8, 0, 0, 0)
     r10 = 'Exited'
     r11 = builtins :: module
     r12 = 'print'
     r13 = CPyObject_GetAttr(r11, r12)
     r14 = [r10]
     r15 = load_address r14
-    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
     keep_alive r10
     return 1
 def a(f):
@@ -2909,7 +2909,7 @@ L2:
     r4 = box(int, x)
     r5 = [r4]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(comparison, r6, 1, 0)
+    r7 = PyObject_Vectorcall(comparison, r6, 1, 0)
     keep_alive r4
     r8 = unbox(bool, r7)
     r9 = r8 << 1
@@ -3210,7 +3210,7 @@ L0:
     r3 = box(int, x)
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     return 1
 
@@ -3435,7 +3435,7 @@ L0:
     r3 = object 2
     r4 = [r1, r2, r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r0, r5, 3, 0)
+    r6 = PyObject_Vectorcall(r0, r5, 3, 0)
     keep_alive r1, r2, r3
     r7 = cast(range, r6)
     r = r7

--- a/mypyc/test-data/irbuild-bytes.test
+++ b/mypyc/test-data/irbuild-bytes.test
@@ -13,24 +13,30 @@ def f(num, l, d, s):
     s :: str
     r0, r1 :: object
     r2, b1 :: bytes
-    r3, r4, r5 :: object
-    r6, b2, r7, b3, r8, b4, r9, b5 :: bytes
+    r3, r4 :: object
+    r5 :: object[1]
+    r6 :: object_ptr
+    r7 :: object
+    r8, b2, r9, b3, r10, b4, r11, b5 :: bytes
 L0:
     r0 = load_address PyBytes_Type
-    r1 = PyObject_CallFunctionObjArgs(r0, 0)
+    r1 = _PyObject_Vectorcall(r0, 0, 0, 0)
     r2 = cast(bytes, r1)
     b1 = r2
     r3 = load_address PyBytes_Type
     r4 = box(int, num)
-    r5 = PyObject_CallFunctionObjArgs(r3, r4, 0)
-    r6 = cast(bytes, r5)
-    b2 = r6
-    r7 = PyBytes_FromObject(l)
-    b3 = r7
-    r8 = PyBytes_FromObject(d)
-    b4 = r8
-    r9 = PyBytes_FromObject(s)
-    b5 = r9
+    r5 = [r4]
+    r6 = load_address r5
+    r7 = _PyObject_Vectorcall(r3, r6, 1, 0)
+    keep_alive r4
+    r8 = cast(bytes, r7)
+    b2 = r8
+    r9 = PyBytes_FromObject(l)
+    b3 = r9
+    r10 = PyBytes_FromObject(d)
+    b4 = r10
+    r11 = PyBytes_FromObject(s)
+    b5 = r11
     return 1
 
 [case testBytearrayBasics]
@@ -53,7 +59,7 @@ L0:
     r0 = builtins :: module
     r1 = 'bytearray'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = PyObject_CallFunctionObjArgs(r2, 0)
+    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
     a = r3
     r4 = PyByteArray_FromObject(s)
     b = r4

--- a/mypyc/test-data/irbuild-bytes.test
+++ b/mypyc/test-data/irbuild-bytes.test
@@ -20,14 +20,14 @@ def f(num, l, d, s):
     r8, b2, r9, b3, r10, b4, r11, b5 :: bytes
 L0:
     r0 = load_address PyBytes_Type
-    r1 = _PyObject_Vectorcall(r0, 0, 0, 0)
+    r1 = PyObject_Vectorcall(r0, 0, 0, 0)
     r2 = cast(bytes, r1)
     b1 = r2
     r3 = load_address PyBytes_Type
     r4 = box(int, num)
     r5 = [r4]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r3, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r3, r6, 1, 0)
     keep_alive r4
     r8 = cast(bytes, r7)
     b2 = r8
@@ -59,7 +59,7 @@ L0:
     r0 = builtins :: module
     r1 = 'bytearray'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
+    r3 = PyObject_Vectorcall(r2, 0, 0, 0)
     a = r3
     r4 = PyByteArray_FromObject(s)
     b = r4

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -209,53 +209,56 @@ def __top_level__():
     r13 :: str
     r14 :: dict
     r15 :: str
-    r16, r17 :: object
-    r18 :: dict
-    r19 :: str
-    r20 :: i32
-    r21 :: bit
-    r22 :: object
-    r23 :: str
-    r24, r25 :: object
-    r26 :: bool
-    r27 :: str
-    r28 :: tuple
-    r29 :: i32
-    r30 :: bit
-    r31 :: dict
-    r32 :: str
-    r33 :: i32
-    r34 :: bit
-    r35 :: object
-    r36 :: str
-    r37, r38 :: object
-    r39 :: str
-    r40 :: tuple
-    r41 :: i32
-    r42 :: bit
-    r43 :: dict
-    r44 :: str
-    r45 :: i32
-    r46 :: bit
-    r47, r48 :: object
-    r49 :: dict
-    r50 :: str
-    r51 :: object
-    r52 :: dict
-    r53 :: str
-    r54, r55 :: object
-    r56 :: tuple
-    r57 :: str
-    r58, r59 :: object
-    r60 :: bool
-    r61, r62 :: str
-    r63 :: tuple
-    r64 :: i32
-    r65 :: bit
-    r66 :: dict
-    r67 :: str
-    r68 :: i32
-    r69 :: bit
+    r16 :: object
+    r17 :: object[1]
+    r18 :: object_ptr
+    r19 :: object
+    r20 :: dict
+    r21 :: str
+    r22 :: i32
+    r23 :: bit
+    r24 :: object
+    r25 :: str
+    r26, r27 :: object
+    r28 :: bool
+    r29 :: str
+    r30 :: tuple
+    r31 :: i32
+    r32 :: bit
+    r33 :: dict
+    r34 :: str
+    r35 :: i32
+    r36 :: bit
+    r37 :: object
+    r38 :: str
+    r39, r40 :: object
+    r41 :: str
+    r42 :: tuple
+    r43 :: i32
+    r44 :: bit
+    r45 :: dict
+    r46 :: str
+    r47 :: i32
+    r48 :: bit
+    r49, r50 :: object
+    r51 :: dict
+    r52 :: str
+    r53 :: object
+    r54 :: dict
+    r55 :: str
+    r56, r57 :: object
+    r58 :: tuple
+    r59 :: str
+    r60, r61 :: object
+    r62 :: bool
+    r63, r64 :: str
+    r65 :: tuple
+    r66 :: i32
+    r67 :: bit
+    r68 :: dict
+    r69 :: str
+    r70 :: i32
+    r71 :: bit
 L0:
     r0 = builtins :: module
     r1 = load_address _Py_NoneStruct
@@ -280,62 +283,65 @@ L2:
     r14 = __main__.globals :: static
     r15 = 'TypeVar'
     r16 = CPyDict_GetItem(r14, r15)
-    r17 = PyObject_CallFunctionObjArgs(r16, r13, 0)
-    r18 = __main__.globals :: static
-    r19 = 'T'
-    r20 = CPyDict_SetItem(r18, r19, r17)
-    r21 = r20 >= 0 :: signed
-    r22 = <error> :: object
-    r23 = '__main__'
-    r24 = __main__.C_template :: type
-    r25 = CPyType_FromTemplate(r24, r22, r23)
-    r26 = C_trait_vtable_setup()
-    r27 = '__mypyc_attrs__'
-    r28 = PyTuple_Pack(0)
-    r29 = PyObject_SetAttr(r25, r27, r28)
-    r30 = r29 >= 0 :: signed
-    __main__.C = r25 :: type
-    r31 = __main__.globals :: static
-    r32 = 'C'
-    r33 = CPyDict_SetItem(r31, r32, r25)
-    r34 = r33 >= 0 :: signed
-    r35 = <error> :: object
-    r36 = '__main__'
-    r37 = __main__.S_template :: type
-    r38 = CPyType_FromTemplate(r37, r35, r36)
-    r39 = '__mypyc_attrs__'
-    r40 = PyTuple_Pack(0)
-    r41 = PyObject_SetAttr(r38, r39, r40)
-    r42 = r41 >= 0 :: signed
-    __main__.S = r38 :: type
-    r43 = __main__.globals :: static
-    r44 = 'S'
-    r45 = CPyDict_SetItem(r43, r44, r38)
-    r46 = r45 >= 0 :: signed
-    r47 = __main__.C :: type
-    r48 = __main__.S :: type
-    r49 = __main__.globals :: static
-    r50 = 'Generic'
-    r51 = CPyDict_GetItem(r49, r50)
-    r52 = __main__.globals :: static
-    r53 = 'T'
-    r54 = CPyDict_GetItem(r52, r53)
-    r55 = PyObject_GetItem(r51, r54)
-    r56 = PyTuple_Pack(3, r47, r48, r55)
-    r57 = '__main__'
-    r58 = __main__.D_template :: type
-    r59 = CPyType_FromTemplate(r58, r56, r57)
-    r60 = D_trait_vtable_setup()
-    r61 = '__mypyc_attrs__'
-    r62 = '__dict__'
-    r63 = PyTuple_Pack(1, r62)
-    r64 = PyObject_SetAttr(r59, r61, r63)
-    r65 = r64 >= 0 :: signed
-    __main__.D = r59 :: type
-    r66 = __main__.globals :: static
-    r67 = 'D'
-    r68 = CPyDict_SetItem(r66, r67, r59)
-    r69 = r68 >= 0 :: signed
+    r17 = [r13]
+    r18 = load_address r17
+    r19 = _PyObject_Vectorcall(r16, r18, 1, 0)
+    keep_alive r13
+    r20 = __main__.globals :: static
+    r21 = 'T'
+    r22 = CPyDict_SetItem(r20, r21, r19)
+    r23 = r22 >= 0 :: signed
+    r24 = <error> :: object
+    r25 = '__main__'
+    r26 = __main__.C_template :: type
+    r27 = CPyType_FromTemplate(r26, r24, r25)
+    r28 = C_trait_vtable_setup()
+    r29 = '__mypyc_attrs__'
+    r30 = PyTuple_Pack(0)
+    r31 = PyObject_SetAttr(r27, r29, r30)
+    r32 = r31 >= 0 :: signed
+    __main__.C = r27 :: type
+    r33 = __main__.globals :: static
+    r34 = 'C'
+    r35 = CPyDict_SetItem(r33, r34, r27)
+    r36 = r35 >= 0 :: signed
+    r37 = <error> :: object
+    r38 = '__main__'
+    r39 = __main__.S_template :: type
+    r40 = CPyType_FromTemplate(r39, r37, r38)
+    r41 = '__mypyc_attrs__'
+    r42 = PyTuple_Pack(0)
+    r43 = PyObject_SetAttr(r40, r41, r42)
+    r44 = r43 >= 0 :: signed
+    __main__.S = r40 :: type
+    r45 = __main__.globals :: static
+    r46 = 'S'
+    r47 = CPyDict_SetItem(r45, r46, r40)
+    r48 = r47 >= 0 :: signed
+    r49 = __main__.C :: type
+    r50 = __main__.S :: type
+    r51 = __main__.globals :: static
+    r52 = 'Generic'
+    r53 = CPyDict_GetItem(r51, r52)
+    r54 = __main__.globals :: static
+    r55 = 'T'
+    r56 = CPyDict_GetItem(r54, r55)
+    r57 = PyObject_GetItem(r53, r56)
+    r58 = PyTuple_Pack(3, r49, r50, r57)
+    r59 = '__main__'
+    r60 = __main__.D_template :: type
+    r61 = CPyType_FromTemplate(r60, r58, r59)
+    r62 = D_trait_vtable_setup()
+    r63 = '__mypyc_attrs__'
+    r64 = '__dict__'
+    r65 = PyTuple_Pack(1, r64)
+    r66 = PyObject_SetAttr(r61, r63, r65)
+    r67 = r66 >= 0 :: signed
+    __main__.D = r61 :: type
+    r68 = __main__.globals :: static
+    r69 = 'D'
+    r70 = CPyDict_SetItem(r68, r69, r61)
+    r71 = r70 >= 0 :: signed
     return 1
 
 [case testIsInstance]
@@ -747,18 +753,24 @@ def DictSubclass.__init__(self):
     self :: dict
     r0 :: object
     r1 :: str
-    r2, r3, r4 :: object
-    r5 :: str
-    r6, r7 :: object
+    r2, r3 :: object
+    r4 :: object[2]
+    r5 :: object_ptr
+    r6 :: object
+    r7 :: str
+    r8, r9 :: object
 L0:
     r0 = builtins :: module
     r1 = 'super'
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = __main__.DictSubclass :: type
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, self, 0)
-    r5 = '__init__'
-    r6 = CPyObject_GetAttr(r4, r5)
-    r7 = PyObject_CallFunctionObjArgs(r6, 0)
+    r4 = [r3, self]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 2, 0)
+    keep_alive r3, self
+    r7 = '__init__'
+    r8 = CPyObject_GetAttr(r6, r7)
+    r9 = _PyObject_Vectorcall(r8, 0, 0, 0)
     return 1
 
 [case testClassVariable]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -285,7 +285,7 @@ L2:
     r16 = CPyDict_GetItem(r14, r15)
     r17 = [r13]
     r18 = load_address r17
-    r19 = _PyObject_Vectorcall(r16, r18, 1, 0)
+    r19 = PyObject_Vectorcall(r16, r18, 1, 0)
     keep_alive r13
     r20 = __main__.globals :: static
     r21 = 'T'
@@ -766,11 +766,11 @@ L0:
     r3 = __main__.DictSubclass :: type
     r4 = [r3, self]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 2, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 2, 0)
     keep_alive r3, self
     r7 = '__init__'
     r8 = CPyObject_GetAttr(r6, r7)
-    r9 = _PyObject_Vectorcall(r8, 0, 0, 0)
+    r9 = PyObject_Vectorcall(r8, 0, 0, 0)
     return 1
 
 [case testClassVariable]

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -373,7 +373,7 @@ L2:
     r12 = load_address PyLong_Type
     r13 = [v]
     r14 = load_address r13
-    r15 = _PyObject_Vectorcall(r12, r14, 1, 0)
+    r15 = PyObject_Vectorcall(r12, r14, 1, 0)
     keep_alive v
     r16 = unbox(int, r15)
     r17 = box(int, r16)

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -342,11 +342,14 @@ def union_of_dicts(d):
     r11 :: union[int, str]
     k :: str
     v :: union[int, str]
-    r12, r13 :: object
-    r14 :: int
+    r12 :: object
+    r13 :: object[1]
+    r14 :: object_ptr
     r15 :: object
-    r16 :: i32
-    r17, r18, r19 :: bit
+    r16 :: int
+    r17 :: object
+    r18 :: i32
+    r19, r20, r21 :: bit
 L0:
     r0 = PyDict_New()
     new = r0
@@ -368,16 +371,19 @@ L2:
     k = r10
     v = r11
     r12 = load_address PyLong_Type
-    r13 = PyObject_CallFunctionObjArgs(r12, v, 0)
-    r14 = unbox(int, r13)
-    r15 = box(int, r14)
-    r16 = CPyDict_SetItem(new, k, r15)
-    r17 = r16 >= 0 :: signed
+    r13 = [v]
+    r14 = load_address r13
+    r15 = _PyObject_Vectorcall(r12, r14, 1, 0)
+    keep_alive v
+    r16 = unbox(int, r15)
+    r17 = box(int, r16)
+    r18 = CPyDict_SetItem(new, k, r17)
+    r19 = r18 >= 0 :: signed
 L3:
-    r18 = CPyDict_CheckSize(d, r3)
+    r20 = CPyDict_CheckSize(d, r3)
     goto L1
 L4:
-    r19 = CPy_NoErrOccurred()
+    r21 = CPy_NoErrOccurred()
 L5:
     return 1
 def typeddict(d):

--- a/mypyc/test-data/irbuild-glue-methods.test
+++ b/mypyc/test-data/irbuild-glue-methods.test
@@ -194,18 +194,24 @@ def DerivedProperty.next(self):
     self :: __main__.DerivedProperty
     r0 :: object
     r1 :: int
-    r2, r3, r4 :: object
-    r5 :: int
-    r6 :: __main__.DerivedProperty
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
+    r7 :: int
+    r8 :: __main__.DerivedProperty
 L0:
     r0 = self._incr_func
     r1 = self.value
     r2 = self._incr_func
     r3 = box(int, r1)
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
-    r5 = unbox(int, r4)
-    r6 = DerivedProperty(r0, r5)
-    return r6
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
+    r7 = unbox(int, r6)
+    r8 = DerivedProperty(r0, r7)
+    return r8
 def DerivedProperty.next__BaseProperty_glue(__mypyc_self__):
     __mypyc_self__, r0 :: __main__.DerivedProperty
 L0:
@@ -224,24 +230,36 @@ def AgainProperty.next(self):
     self :: __main__.AgainProperty
     r0 :: object
     r1 :: int
-    r2, r3, r4 :: object
-    r5 :: int
-    r6, r7, r8 :: object
-    r9 :: int
-    r10 :: __main__.AgainProperty
+    r2, r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
+    r7 :: int
+    r8, r9 :: object
+    r10 :: object[1]
+    r11 :: object_ptr
+    r12 :: object
+    r13 :: int
+    r14 :: __main__.AgainProperty
 L0:
     r0 = self._incr_func
     r1 = self.value
     r2 = self._incr_func
     r3 = box(int, r1)
-    r4 = PyObject_CallFunctionObjArgs(r2, r3, 0)
-    r5 = unbox(int, r4)
-    r6 = self._incr_func
-    r7 = box(int, r5)
-    r8 = PyObject_CallFunctionObjArgs(r6, r7, 0)
-    r9 = unbox(int, r8)
-    r10 = AgainProperty(r0, r9)
-    return r10
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    keep_alive r3
+    r7 = unbox(int, r6)
+    r8 = self._incr_func
+    r9 = box(int, r7)
+    r10 = [r9]
+    r11 = load_address r10
+    r12 = _PyObject_Vectorcall(r8, r11, 1, 0)
+    keep_alive r9
+    r13 = unbox(int, r12)
+    r14 = AgainProperty(r0, r13)
+    return r14
 def AgainProperty.next__DerivedProperty_glue(__mypyc_self__):
     __mypyc_self__, r0 :: __main__.AgainProperty
 L0:

--- a/mypyc/test-data/irbuild-glue-methods.test
+++ b/mypyc/test-data/irbuild-glue-methods.test
@@ -207,7 +207,7 @@ L0:
     r3 = box(int, r1)
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     r7 = unbox(int, r6)
     r8 = DerivedProperty(r0, r7)
@@ -248,14 +248,14 @@ L0:
     r3 = box(int, r1)
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r2, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r2, r5, 1, 0)
     keep_alive r3
     r7 = unbox(int, r6)
     r8 = self._incr_func
     r9 = box(int, r7)
     r10 = [r9]
     r11 = load_address r10
-    r12 = _PyObject_Vectorcall(r8, r11, 1, 0)
+    r12 = PyObject_Vectorcall(r8, r11, 1, 0)
     keep_alive r9
     r13 = unbox(int, r12)
     r14 = AgainProperty(r0, r13)

--- a/mypyc/test-data/irbuild-match.test
+++ b/mypyc/test-data/irbuild-match.test
@@ -23,7 +23,7 @@ L1:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
     goto L3
 L2:
@@ -61,7 +61,7 @@ L3:
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = [r2]
     r7 = load_address r6
-    r8 = _PyObject_Vectorcall(r5, r7, 1, 0)
+    r8 = PyObject_Vectorcall(r5, r7, 1, 0)
     keep_alive r2
     goto L5
 L4:
@@ -105,7 +105,7 @@ L5:
     r7 = CPyObject_GetAttr(r5, r6)
     r8 = [r4]
     r9 = load_address r8
-    r10 = _PyObject_Vectorcall(r7, r9, 1, 0)
+    r10 = PyObject_Vectorcall(r7, r9, 1, 0)
     keep_alive r4
     goto L7
 L6:
@@ -141,7 +141,7 @@ L1:
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = [r3]
     r8 = load_address r7
-    r9 = _PyObject_Vectorcall(r6, r8, 1, 0)
+    r9 = PyObject_Vectorcall(r6, r8, 1, 0)
     keep_alive r3
     goto L3
 L2:
@@ -170,7 +170,7 @@ L1:
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = [r0]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r3, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r3, r5, 1, 0)
     keep_alive r0
     goto L3
 L2:
@@ -212,7 +212,7 @@ L1:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
     goto L5
 L2:
@@ -225,7 +225,7 @@ L3:
     r12 = CPyObject_GetAttr(r10, r11)
     r13 = [r9]
     r14 = load_address r13
-    r15 = _PyObject_Vectorcall(r12, r14, 1, 0)
+    r15 = PyObject_Vectorcall(r12, r14, 1, 0)
     keep_alive r9
     goto L5
 L4:
@@ -278,7 +278,7 @@ L1:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
     goto L9
 L2:
@@ -296,7 +296,7 @@ L5:
     r13 = CPyObject_GetAttr(r11, r12)
     r14 = [r10]
     r15 = load_address r14
-    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
     keep_alive r10
     goto L9
 L6:
@@ -309,7 +309,7 @@ L7:
     r21 = CPyObject_GetAttr(r19, r20)
     r22 = [r18]
     r23 = load_address r22
-    r24 = _PyObject_Vectorcall(r21, r23, 1, 0)
+    r24 = PyObject_Vectorcall(r21, r23, 1, 0)
     keep_alive r18
     goto L9
 L8:
@@ -344,7 +344,7 @@ L2:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
     goto L4
 L3:
@@ -400,7 +400,7 @@ L1:
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = [r3]
     r8 = load_address r7
-    r9 = _PyObject_Vectorcall(r6, r8, 1, 0)
+    r9 = PyObject_Vectorcall(r6, r8, 1, 0)
     keep_alive r3
     goto L7
 L2:
@@ -415,7 +415,7 @@ L3:
     r16 = CPyObject_GetAttr(r14, r15)
     r17 = [r13]
     r18 = load_address r17
-    r19 = _PyObject_Vectorcall(r16, r18, 1, 0)
+    r19 = PyObject_Vectorcall(r16, r18, 1, 0)
     keep_alive r13
     goto L7
 L4:
@@ -430,7 +430,7 @@ L5:
     r26 = CPyObject_GetAttr(r24, r25)
     r27 = [r23]
     r28 = load_address r27
-    r29 = _PyObject_Vectorcall(r26, r28, 1, 0)
+    r29 = PyObject_Vectorcall(r26, r28, 1, 0)
     keep_alive r23
     goto L7
 L6:
@@ -471,7 +471,7 @@ L3:
     r7 = CPyObject_GetAttr(r5, r6)
     r8 = [r4]
     r9 = load_address r8
-    r10 = _PyObject_Vectorcall(r7, r9, 1, 0)
+    r10 = PyObject_Vectorcall(r7, r9, 1, 0)
     keep_alive r4
     goto L5
 L4:
@@ -504,7 +504,7 @@ L1:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [x]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive x
     goto L3
 L2:
@@ -546,7 +546,7 @@ L3:
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = [x]
     r8 = load_address r7
-    r9 = _PyObject_Vectorcall(r6, r8, 1, 0)
+    r9 = PyObject_Vectorcall(r6, r8, 1, 0)
     keep_alive x
     goto L5
 L4:
@@ -584,7 +584,7 @@ L2:
     r6 = box(int, i)
     r7 = [r6]
     r8 = load_address r7
-    r9 = _PyObject_Vectorcall(r5, r8, 1, 0)
+    r9 = PyObject_Vectorcall(r5, r8, 1, 0)
     keep_alive r6
     goto L4
 L3:
@@ -682,7 +682,7 @@ L4:
     r28 = CPyObject_GetAttr(r26, r27)
     r29 = [r25]
     r30 = load_address r29
-    r31 = _PyObject_Vectorcall(r28, r30, 1, 0)
+    r31 = PyObject_Vectorcall(r28, r30, 1, 0)
     keep_alive r25
     goto L6
 L5:
@@ -767,7 +767,7 @@ L4:
     r28 = CPyObject_GetAttr(r26, r27)
     r29 = [r25]
     r30 = load_address r29
-    r31 = _PyObject_Vectorcall(r28, r30, 1, 0)
+    r31 = PyObject_Vectorcall(r28, r30, 1, 0)
     keep_alive r25
     goto L6
 L5:
@@ -835,7 +835,7 @@ L4:
     r19 = CPyObject_GetAttr(r17, r18)
     r20 = [r16]
     r21 = load_address r20
-    r22 = _PyObject_Vectorcall(r19, r21, 1, 0)
+    r22 = PyObject_Vectorcall(r19, r21, 1, 0)
     keep_alive r16
     goto L6
 L5:
@@ -920,7 +920,7 @@ L4:
     r22 = CPyObject_GetAttr(r20, r21)
     r23 = [r19]
     r24 = load_address r23
-    r25 = _PyObject_Vectorcall(r22, r24, 1, 0)
+    r25 = PyObject_Vectorcall(r22, r24, 1, 0)
     keep_alive r19
     goto L6
 L5:
@@ -980,7 +980,7 @@ L2:
     r10 = CPyObject_GetAttr(r8, r9)
     r11 = [r7]
     r12 = load_address r11
-    r13 = _PyObject_Vectorcall(r10, r12, 1, 0)
+    r13 = PyObject_Vectorcall(r10, r12, 1, 0)
     keep_alive r7
     goto L4
 L3:
@@ -1015,7 +1015,7 @@ L1:
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = [r2]
     r7 = load_address r6
-    r8 = _PyObject_Vectorcall(r5, r7, 1, 0)
+    r8 = PyObject_Vectorcall(r5, r7, 1, 0)
     keep_alive r2
     goto L3
 L2:
@@ -1072,7 +1072,7 @@ L3:
     r14 = CPyObject_GetAttr(r12, r13)
     r15 = [r11]
     r16 = load_address r15
-    r17 = _PyObject_Vectorcall(r14, r16, 1, 0)
+    r17 = PyObject_Vectorcall(r14, r16, 1, 0)
     keep_alive r11
     goto L5
 L4:
@@ -1111,7 +1111,7 @@ L2:
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = [r3]
     r8 = load_address r7
-    r9 = _PyObject_Vectorcall(r6, r8, 1, 0)
+    r9 = PyObject_Vectorcall(r6, r8, 1, 0)
     keep_alive r3
     goto L4
 L3:
@@ -1176,7 +1176,7 @@ L4:
     r17 = CPyObject_GetAttr(r15, r16)
     r18 = [r14]
     r19 = load_address r18
-    r20 = _PyObject_Vectorcall(r17, r19, 1, 0)
+    r20 = PyObject_Vectorcall(r17, r19, 1, 0)
     keep_alive r14
     goto L6
 L5:
@@ -1218,7 +1218,7 @@ L2:
     r8 = CPyObject_GetAttr(r6, r7)
     r9 = [r5]
     r10 = load_address r9
-    r11 = _PyObject_Vectorcall(r8, r10, 1, 0)
+    r11 = PyObject_Vectorcall(r8, r10, 1, 0)
     keep_alive r5
     goto L4
 L3:
@@ -1284,7 +1284,7 @@ L4:
     r20 = CPyObject_GetAttr(r18, r19)
     r21 = [r17]
     r22 = load_address r21
-    r23 = _PyObject_Vectorcall(r20, r22, 1, 0)
+    r23 = PyObject_Vectorcall(r20, r22, 1, 0)
     keep_alive r17
     goto L6
 L5:
@@ -1350,7 +1350,7 @@ L4:
     r20 = CPyObject_GetAttr(r18, r19)
     r21 = [r17]
     r22 = load_address r21
-    r23 = _PyObject_Vectorcall(r20, r22, 1, 0)
+    r23 = PyObject_Vectorcall(r20, r22, 1, 0)
     keep_alive r17
     goto L6
 L5:
@@ -1424,7 +1424,7 @@ L5:
     r23 = CPyObject_GetAttr(r21, r22)
     r24 = [r20]
     r25 = load_address r24
-    r26 = _PyObject_Vectorcall(r23, r25, 1, 0)
+    r26 = PyObject_Vectorcall(r23, r25, 1, 0)
     keep_alive r20
     goto L7
 L6:
@@ -1505,7 +1505,7 @@ L5:
     r24 = CPyObject_GetAttr(r22, r23)
     r25 = [r21]
     r26 = load_address r25
-    r27 = _PyObject_Vectorcall(r24, r26, 1, 0)
+    r27 = PyObject_Vectorcall(r24, r26, 1, 0)
     keep_alive r21
     goto L7
 L6:
@@ -1584,7 +1584,7 @@ L5:
     r25 = CPyObject_GetAttr(r23, r24)
     r26 = [r22]
     r27 = load_address r26
-    r28 = _PyObject_Vectorcall(r25, r27, 1, 0)
+    r28 = PyObject_Vectorcall(r25, r27, 1, 0)
     keep_alive r22
     goto L7
 L6:
@@ -1623,7 +1623,7 @@ L2:
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = [r3]
     r8 = load_address r7
-    r9 = _PyObject_Vectorcall(r6, r8, 1, 0)
+    r9 = PyObject_Vectorcall(r6, r8, 1, 0)
     keep_alive r3
     goto L4
 L3:
@@ -1673,7 +1673,7 @@ L3:
     r11 = CPyObject_GetAttr(r9, r10)
     r12 = [r8]
     r13 = load_address r12
-    r14 = _PyObject_Vectorcall(r11, r13, 1, 0)
+    r14 = PyObject_Vectorcall(r11, r13, 1, 0)
     keep_alive r8
     goto L5
 L4:

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -210,14 +210,14 @@ L0:
     r3 = 'one'
     r4 = [r3]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(inner, r5, 1, 0)
+    r6 = PyObject_Vectorcall(inner, r5, 1, 0)
     keep_alive r3
     r7 = cast(str, r6)
     a = r7
     r8 = 'two'
     r9 = [r8]
     r10 = load_address r9
-    r11 = _PyObject_Vectorcall(inner, r10, 1, 0)
+    r11 = PyObject_Vectorcall(inner, r10, 1, 0)
     keep_alive r8
     r12 = cast(str, r11)
     b = r12
@@ -300,7 +300,7 @@ L0:
     r2 = inner_a_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
     inner = r2
-    r4 = _PyObject_Vectorcall(inner, 0, 0, 0)
+    r4 = PyObject_Vectorcall(inner, 0, 0, 0)
     r5 = unbox(int, r4)
     return r5
 def inner_b_obj.__get__(__mypyc_self__, instance, owner):
@@ -340,7 +340,7 @@ L0:
     r2 = inner_b_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
     inner = r2
-    r4 = _PyObject_Vectorcall(inner, 0, 0, 0)
+    r4 = PyObject_Vectorcall(inner, 0, 0, 0)
     r5 = unbox(int, r4)
     r6 = r0.num
     r7 = CPyTagged_Add(r5, r6)
@@ -410,7 +410,7 @@ L2:
     r3.__mypyc_env__ = r0; r4 = is_error
     inner = r3
 L3:
-    r5 = _PyObject_Vectorcall(inner, 0, 0, 0)
+    r5 = PyObject_Vectorcall(inner, 0, 0, 0)
     r6 = cast(str, r5)
     return r6
 
@@ -482,7 +482,7 @@ L0:
     r6 = c_a_b_obj()
     r6.__mypyc_env__ = r1; r7 = is_error
     c = r6
-    r8 = _PyObject_Vectorcall(c, 0, 0, 0)
+    r8 = PyObject_Vectorcall(c, 0, 0, 0)
     r9 = unbox(int, r8)
     return r9
 def a():
@@ -498,7 +498,7 @@ L0:
     r2 = b_a_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
     b = r2
-    r4 = _PyObject_Vectorcall(b, 0, 0, 0)
+    r4 = PyObject_Vectorcall(b, 0, 0, 0)
     r5 = unbox(int, r4)
     return r5
 
@@ -577,7 +577,7 @@ L2:
     r3.__mypyc_env__ = r0; r4 = is_error
     inner = r3
 L3:
-    r5 = _PyObject_Vectorcall(inner, 0, 0, 0)
+    r5 = PyObject_Vectorcall(inner, 0, 0, 0)
     r6 = cast(str, r5)
     return r6
 
@@ -642,7 +642,7 @@ def bar_f_obj.__call__(__mypyc_self__):
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.foo
-    r2 = _PyObject_Vectorcall(r1, 0, 0, 0)
+    r2 = PyObject_Vectorcall(r1, 0, 0, 0)
     r3 = unbox(int, r2)
     return r3
 def baz_f_obj.__get__(__mypyc_self__, instance, owner):
@@ -681,7 +681,7 @@ L2:
     r4 = box(int, r2)
     r5 = [r4]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r3, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r3, r6, 1, 0)
     keep_alive r4
     r8 = unbox(int, r7)
     r9 = CPyTagged_Add(n, r8)
@@ -716,14 +716,14 @@ L0:
     r8.__mypyc_env__ = r0; r9 = is_error
     r0.baz = r8; r10 = is_error
     r11 = r0.bar
-    r12 = _PyObject_Vectorcall(r11, 0, 0, 0)
+    r12 = PyObject_Vectorcall(r11, 0, 0, 0)
     r13 = unbox(int, r12)
     r14 = r0.a
     r15 = r0.baz
     r16 = box(int, r14)
     r17 = [r16]
     r18 = load_address r17
-    r19 = _PyObject_Vectorcall(r15, r18, 1, 0)
+    r19 = PyObject_Vectorcall(r15, r18, 1, 0)
     keep_alive r16
     r20 = unbox(int, r19)
     r21 = CPyTagged_Add(r13, r20)
@@ -784,7 +784,7 @@ L0:
     r1 = r0.s
     r2 = [a, b]
     r3 = load_address r2
-    r4 = _PyObject_Vectorcall(r1, r3, 2, 0)
+    r4 = PyObject_Vectorcall(r1, r3, 2, 0)
     keep_alive a, b
     return r4
 def f(x, y):
@@ -811,7 +811,7 @@ L0:
     r7 = box(int, y)
     r8 = [r6, r7]
     r9 = load_address r8
-    r10 = _PyObject_Vectorcall(t, r9, 2, 0)
+    r10 = PyObject_Vectorcall(t, r9, 2, 0)
     keep_alive r6, r7
     r11 = unbox(None, r10)
     return r11

--- a/mypyc/test-data/irbuild-nested.test
+++ b/mypyc/test-data/irbuild-nested.test
@@ -194,23 +194,33 @@ def d(num):
     r2 :: bool
     inner :: object
     r3 :: str
-    r4 :: object
-    r5, a, r6 :: str
-    r7 :: object
-    r8, b :: str
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
+    r7, a, r8 :: str
+    r9 :: object[1]
+    r10 :: object_ptr
+    r11 :: object
+    r12, b :: str
 L0:
     r0 = d_env()
     r1 = inner_d_obj()
     r1.__mypyc_env__ = r0; r2 = is_error
     inner = r1
     r3 = 'one'
-    r4 = PyObject_CallFunctionObjArgs(inner, r3, 0)
-    r5 = cast(str, r4)
-    a = r5
-    r6 = 'two'
-    r7 = PyObject_CallFunctionObjArgs(inner, r6, 0)
-    r8 = cast(str, r7)
-    b = r8
+    r4 = [r3]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(inner, r5, 1, 0)
+    keep_alive r3
+    r7 = cast(str, r6)
+    a = r7
+    r8 = 'two'
+    r9 = [r8]
+    r10 = load_address r9
+    r11 = _PyObject_Vectorcall(inner, r10, 1, 0)
+    keep_alive r8
+    r12 = cast(str, r11)
+    b = r12
     return a
 def inner():
     r0 :: str
@@ -290,7 +300,7 @@ L0:
     r2 = inner_a_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
     inner = r2
-    r4 = PyObject_CallFunctionObjArgs(inner, 0)
+    r4 = _PyObject_Vectorcall(inner, 0, 0, 0)
     r5 = unbox(int, r4)
     return r5
 def inner_b_obj.__get__(__mypyc_self__, instance, owner):
@@ -330,7 +340,7 @@ L0:
     r2 = inner_b_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
     inner = r2
-    r4 = PyObject_CallFunctionObjArgs(inner, 0)
+    r4 = _PyObject_Vectorcall(inner, 0, 0, 0)
     r5 = unbox(int, r4)
     r6 = r0.num
     r7 = CPyTagged_Add(r5, r6)
@@ -400,7 +410,7 @@ L2:
     r3.__mypyc_env__ = r0; r4 = is_error
     inner = r3
 L3:
-    r5 = PyObject_CallFunctionObjArgs(inner, 0)
+    r5 = _PyObject_Vectorcall(inner, 0, 0, 0)
     r6 = cast(str, r5)
     return r6
 
@@ -472,7 +482,7 @@ L0:
     r6 = c_a_b_obj()
     r6.__mypyc_env__ = r1; r7 = is_error
     c = r6
-    r8 = PyObject_CallFunctionObjArgs(c, 0)
+    r8 = _PyObject_Vectorcall(c, 0, 0, 0)
     r9 = unbox(int, r8)
     return r9
 def a():
@@ -488,7 +498,7 @@ L0:
     r2 = b_a_obj()
     r2.__mypyc_env__ = r0; r3 = is_error
     b = r2
-    r4 = PyObject_CallFunctionObjArgs(b, 0)
+    r4 = _PyObject_Vectorcall(b, 0, 0, 0)
     r5 = unbox(int, r4)
     return r5
 
@@ -567,7 +577,7 @@ L2:
     r3.__mypyc_env__ = r0; r4 = is_error
     inner = r3
 L3:
-    r5 = PyObject_CallFunctionObjArgs(inner, 0)
+    r5 = _PyObject_Vectorcall(inner, 0, 0, 0)
     r6 = cast(str, r5)
     return r6
 
@@ -632,7 +642,7 @@ def bar_f_obj.__call__(__mypyc_self__):
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.foo
-    r2 = PyObject_CallFunctionObjArgs(r1, 0)
+    r2 = _PyObject_Vectorcall(r1, 0, 0, 0)
     r3 = unbox(int, r2)
     return r3
 def baz_f_obj.__get__(__mypyc_self__, instance, owner):
@@ -654,8 +664,11 @@ def baz_f_obj.__call__(__mypyc_self__, n):
     r0 :: __main__.f_env
     r1 :: bit
     r2 :: int
-    r3, r4, r5 :: object
-    r6, r7 :: int
+    r3, r4 :: object
+    r5 :: object[1]
+    r6 :: object_ptr
+    r7 :: object
+    r8, r9 :: int
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = int_eq n, 0
@@ -666,10 +679,13 @@ L2:
     r2 = CPyTagged_Subtract(n, 2)
     r3 = r0.baz
     r4 = box(int, r2)
-    r5 = PyObject_CallFunctionObjArgs(r3, r4, 0)
-    r6 = unbox(int, r5)
-    r7 = CPyTagged_Add(n, r6)
-    return r7
+    r5 = [r4]
+    r6 = load_address r5
+    r7 = _PyObject_Vectorcall(r3, r6, 1, 0)
+    keep_alive r4
+    r8 = unbox(int, r7)
+    r9 = CPyTagged_Add(n, r8)
+    return r9
 def f(a):
     a :: int
     r0 :: __main__.f_env
@@ -682,8 +698,11 @@ def f(a):
     r9, r10 :: bool
     r11, r12 :: object
     r13, r14 :: int
-    r15, r16, r17 :: object
-    r18, r19 :: int
+    r15, r16 :: object
+    r17 :: object[1]
+    r18 :: object_ptr
+    r19 :: object
+    r20, r21 :: int
 L0:
     r0 = f_env()
     r0.a = a; r1 = is_error
@@ -697,15 +716,18 @@ L0:
     r8.__mypyc_env__ = r0; r9 = is_error
     r0.baz = r8; r10 = is_error
     r11 = r0.bar
-    r12 = PyObject_CallFunctionObjArgs(r11, 0)
+    r12 = _PyObject_Vectorcall(r11, 0, 0, 0)
     r13 = unbox(int, r12)
     r14 = r0.a
     r15 = r0.baz
     r16 = box(int, r14)
-    r17 = PyObject_CallFunctionObjArgs(r15, r16, 0)
-    r18 = unbox(int, r17)
-    r19 = CPyTagged_Add(r13, r18)
-    return r19
+    r17 = [r16]
+    r18 = load_address r17
+    r19 = _PyObject_Vectorcall(r15, r18, 1, 0)
+    keep_alive r16
+    r20 = unbox(int, r19)
+    r21 = CPyTagged_Add(r13, r20)
+    return r21
 
 [case testLambdas]
 def f(x: int, y: int) -> None:
@@ -753,12 +775,18 @@ def __mypyc_lambda__1_f_obj.__call__(__mypyc_self__, a, b):
     __mypyc_self__ :: __main__.__mypyc_lambda__1_f_obj
     a, b :: object
     r0 :: __main__.f_env
-    r1, r2 :: object
+    r1 :: object
+    r2 :: object[2]
+    r3 :: object_ptr
+    r4 :: object
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = r0.s
-    r2 = PyObject_CallFunctionObjArgs(r1, a, b, 0)
-    return r2
+    r2 = [a, b]
+    r3 = load_address r2
+    r4 = _PyObject_Vectorcall(r1, r3, 2, 0)
+    keep_alive a, b
+    return r4
 def f(x, y):
     x, y :: int
     r0 :: __main__.f_env
@@ -766,8 +794,11 @@ def f(x, y):
     r2, r3 :: bool
     r4 :: __main__.__mypyc_lambda__1_f_obj
     r5 :: bool
-    t, r6, r7, r8 :: object
-    r9 :: None
+    t, r6, r7 :: object
+    r8 :: object[2]
+    r9 :: object_ptr
+    r10 :: object
+    r11 :: None
 L0:
     r0 = f_env()
     r1 = __mypyc_lambda__0_f_obj()
@@ -778,9 +809,12 @@ L0:
     t = r4
     r6 = box(int, x)
     r7 = box(int, y)
-    r8 = PyObject_CallFunctionObjArgs(t, r6, r7, 0)
-    r9 = unbox(None, r8)
-    return r9
+    r8 = [r6, r7]
+    r9 = load_address r8
+    r10 = _PyObject_Vectorcall(t, r9, 2, 0)
+    keep_alive r6, r7
+    r11 = unbox(None, r10)
+    return r11
 
 [case testRecursiveFunction]
 from typing import Callable

--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -38,19 +38,23 @@ def f_obj.__call__(__mypyc_self__, arg):
     r8 :: str
     r9 :: object
     r10 :: dict
-    r11 :: object
-    r12 :: i32
-    r13 :: bit
-    r14 :: object
-    r15 :: ptr
+    r11 :: object[2]
+    r12 :: object_ptr
+    r13 :: object
+    r14 :: i32
+    r15 :: bit
     r16 :: object
-    r17 :: bit
-    r18 :: int
+    r17 :: ptr
+    r18 :: object
     r19 :: bit
     r20 :: int
-    r21 :: bool
-    r22 :: object
+    r21 :: bit
+    r22 :: int
     r23 :: bool
+    r24 :: object[1]
+    r25 :: object_ptr
+    r26 :: object
+    r27 :: bool
 L0:
     r0 = get_element_ptr arg ob_type :: PyObject
     r1 = load_mem r0 :: builtins.object*
@@ -68,31 +72,37 @@ L2:
     r8 = '_find_impl'
     r9 = CPyObject_GetAttr(r7, r8)
     r10 = __mypyc_self__.registry
-    r11 = PyObject_CallFunctionObjArgs(r9, r1, r10, 0)
-    r12 = CPyDict_SetItem(r2, r1, r11)
-    r13 = r12 >= 0 :: signed
-    r6 = r11
+    r11 = [r1, r10]
+    r12 = load_address r11
+    r13 = _PyObject_Vectorcall(r9, r12, 2, 0)
+    keep_alive r1, r10
+    r14 = CPyDict_SetItem(r2, r1, r13)
+    r15 = r14 >= 0 :: signed
+    r6 = r13
 L3:
-    r14 = load_address PyLong_Type
-    r15 = get_element_ptr r6 ob_type :: PyObject
-    r16 = load_mem r15 :: builtins.object*
+    r16 = load_address PyLong_Type
+    r17 = get_element_ptr r6 ob_type :: PyObject
+    r18 = load_mem r17 :: builtins.object*
     keep_alive r6
-    r17 = r16 == r14
-    if r17 goto L4 else goto L7 :: bool
+    r19 = r18 == r16
+    if r19 goto L4 else goto L7 :: bool
 L4:
-    r18 = unbox(int, r6)
-    r19 = int_eq r18, 0
-    if r19 goto L5 else goto L6 :: bool
+    r20 = unbox(int, r6)
+    r21 = int_eq r20, 0
+    if r21 goto L5 else goto L6 :: bool
 L5:
-    r20 = unbox(int, arg)
-    r21 = g(r20)
-    return r21
+    r22 = unbox(int, arg)
+    r23 = g(r22)
+    return r23
 L6:
     unreachable
 L7:
-    r22 = PyObject_CallFunctionObjArgs(r6, arg, 0)
-    r23 = unbox(bool, r22)
-    return r23
+    r24 = [arg]
+    r25 = load_address r24
+    r26 = _PyObject_Vectorcall(r6, r25, 1, 0)
+    keep_alive arg
+    r27 = unbox(bool, r26)
+    return r27
 def f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
     r1 :: bit
@@ -128,7 +138,6 @@ def g(arg):
     arg :: int
 L0:
     return 1
-
 
 [case testCallsToSingledispatchFunctionsAreNative]
 from functools import singledispatch
@@ -170,16 +179,20 @@ def f_obj.__call__(__mypyc_self__, x):
     r8 :: str
     r9 :: object
     r10 :: dict
-    r11 :: object
-    r12 :: i32
-    r13 :: bit
-    r14 :: object
-    r15 :: ptr
+    r11 :: object[2]
+    r12 :: object_ptr
+    r13 :: object
+    r14 :: i32
+    r15 :: bit
     r16 :: object
-    r17 :: bit
-    r18 :: int
-    r19 :: object
-    r20 :: None
+    r17 :: ptr
+    r18 :: object
+    r19 :: bit
+    r20 :: int
+    r21 :: object[1]
+    r22 :: object_ptr
+    r23 :: object
+    r24 :: None
 L0:
     r0 = get_element_ptr x ob_type :: PyObject
     r1 = load_mem r0 :: builtins.object*
@@ -197,24 +210,30 @@ L2:
     r8 = '_find_impl'
     r9 = CPyObject_GetAttr(r7, r8)
     r10 = __mypyc_self__.registry
-    r11 = PyObject_CallFunctionObjArgs(r9, r1, r10, 0)
-    r12 = CPyDict_SetItem(r2, r1, r11)
-    r13 = r12 >= 0 :: signed
-    r6 = r11
+    r11 = [r1, r10]
+    r12 = load_address r11
+    r13 = _PyObject_Vectorcall(r9, r12, 2, 0)
+    keep_alive r1, r10
+    r14 = CPyDict_SetItem(r2, r1, r13)
+    r15 = r14 >= 0 :: signed
+    r6 = r13
 L3:
-    r14 = load_address PyLong_Type
-    r15 = get_element_ptr r6 ob_type :: PyObject
-    r16 = load_mem r15 :: builtins.object*
+    r16 = load_address PyLong_Type
+    r17 = get_element_ptr r6 ob_type :: PyObject
+    r18 = load_mem r17 :: builtins.object*
     keep_alive r6
-    r17 = r16 == r14
-    if r17 goto L4 else goto L5 :: bool
+    r19 = r18 == r16
+    if r19 goto L4 else goto L5 :: bool
 L4:
-    r18 = unbox(int, r6)
+    r20 = unbox(int, r6)
     unreachable
 L5:
-    r19 = PyObject_CallFunctionObjArgs(r6, x, 0)
-    r20 = unbox(None, r19)
-    return r20
+    r21 = [x]
+    r22 = load_address r21
+    r23 = _PyObject_Vectorcall(r6, r22, 1, 0)
+    keep_alive x
+    r24 = unbox(None, r23)
+    return r24
 def f_obj.__get__(__mypyc_self__, instance, owner):
     __mypyc_self__, instance, owner, r0 :: object
     r1 :: bit

--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -74,7 +74,7 @@ L2:
     r10 = __mypyc_self__.registry
     r11 = [r1, r10]
     r12 = load_address r11
-    r13 = _PyObject_Vectorcall(r9, r12, 2, 0)
+    r13 = PyObject_Vectorcall(r9, r12, 2, 0)
     keep_alive r1, r10
     r14 = CPyDict_SetItem(r2, r1, r13)
     r15 = r14 >= 0 :: signed
@@ -99,7 +99,7 @@ L6:
 L7:
     r24 = [arg]
     r25 = load_address r24
-    r26 = _PyObject_Vectorcall(r6, r25, 1, 0)
+    r26 = PyObject_Vectorcall(r6, r25, 1, 0)
     keep_alive arg
     r27 = unbox(bool, r26)
     return r27
@@ -212,7 +212,7 @@ L2:
     r10 = __mypyc_self__.registry
     r11 = [r1, r10]
     r12 = load_address r11
-    r13 = _PyObject_Vectorcall(r9, r12, 2, 0)
+    r13 = PyObject_Vectorcall(r9, r12, 2, 0)
     keep_alive r1, r10
     r14 = CPyDict_SetItem(r2, r1, r13)
     r15 = r14 >= 0 :: signed
@@ -230,7 +230,7 @@ L4:
 L5:
     r21 = [x]
     r22 = load_address r21
-    r23 = _PyObject_Vectorcall(r6, r22, 1, 0)
+    r23 = PyObject_Vectorcall(r6, r22, 1, 0)
     keep_alive x
     r24 = unbox(None, r23)
     return r24

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -655,7 +655,10 @@ def complex_msg(x, s):
     r3 :: bit
     r4 :: object
     r5 :: str
-    r6, r7 :: object
+    r6 :: object
+    r7 :: object[1]
+    r8 :: object_ptr
+    r9 :: object
 L0:
     r0 = load_address _Py_NoneStruct
     r1 = x != r0
@@ -668,8 +671,11 @@ L2:
     r4 = builtins :: module
     r5 = 'AssertionError'
     r6 = CPyObject_GetAttr(r4, r5)
-    r7 = PyObject_CallFunctionObjArgs(r6, s, 0)
-    CPy_Raise(r7)
+    r7 = [s]
+    r8 = load_address r7
+    r9 = _PyObject_Vectorcall(r6, r8, 1, 0)
+    keep_alive s
+    CPy_Raise(r9)
     unreachable
 L3:
     return 1

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -673,7 +673,7 @@ L2:
     r6 = CPyObject_GetAttr(r4, r5)
     r7 = [s]
     r8 = load_address r7
-    r9 = _PyObject_Vectorcall(r6, r8, 1, 0)
+    r9 = PyObject_Vectorcall(r6, r8, 1, 0)
     keep_alive s
     CPy_Raise(r9)
     unreachable

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -322,24 +322,21 @@ def f(s):
     r16 :: bytes
     r17, r18 :: str
     r19 :: object
-    r20 :: str
-    r21 :: tuple
-    r22 :: dict
-    r23 :: object
+    r20 :: object[2]
+    r21 :: object_ptr
+    r22, r23 :: object
     r24 :: str
     r25 :: object
-    r26 :: str
-    r27 :: tuple
-    r28 :: dict
-    r29 :: object
+    r26 :: object[1]
+    r27 :: object_ptr
+    r28, r29 :: object
     r30 :: str
     r31 :: object
-    r32, r33 :: str
-    r34 :: tuple
-    r35 :: dict
-    r36 :: object
-    r37 :: str
-    r38 :: bytes
+    r32 :: object[2]
+    r33 :: object_ptr
+    r34, r35 :: object
+    r36 :: str
+    r37 :: bytes
 L0:
     r0 = PyUnicode_AsUTF8String(s)
     r1 = PyUnicode_AsUTF8String(s)
@@ -363,25 +360,27 @@ L0:
     r17 = 'utf8'
     r18 = 'encode'
     r19 = CPyObject_GetAttr(s, r18)
-    r20 = 'errors'
-    r21 = PyTuple_Pack(1, r17)
-    r22 = CPyDict_Build(1, r20, errors)
-    r23 = PyObject_Call(r19, r21, r22)
+    r20 = [r17, errors]
+    r21 = load_address r20
+    r22 = ('errors',)
+    r23 = _PyObject_Vectorcall(r19, r21, 1, r22)
+    keep_alive r17, errors
     r24 = 'encode'
     r25 = CPyObject_GetAttr(s, r24)
-    r26 = 'errors'
-    r27 = PyTuple_Pack(0)
-    r28 = CPyDict_Build(1, r26, errors)
-    r29 = PyObject_Call(r25, r27, r28)
+    r26 = [errors]
+    r27 = load_address r26
+    r28 = ('errors',)
+    r29 = _PyObject_Vectorcall(r25, r27, 0, r28)
+    keep_alive errors
     r30 = 'encode'
     r31 = CPyObject_GetAttr(s, r30)
-    r32 = 'encoding'
-    r33 = 'errors'
-    r34 = PyTuple_Pack(0)
-    r35 = CPyDict_Build(2, r32, encoding, r33, errors)
-    r36 = PyObject_Call(r31, r34, r35)
-    r37 = 'latin2'
-    r38 = CPy_Encode(s, r37, 0)
+    r32 = [encoding, errors]
+    r33 = load_address r32
+    r34 = ('encoding', 'errors')
+    r35 = _PyObject_Vectorcall(r31, r33, 0, r34)
+    keep_alive encoding, errors
+    r36 = 'latin2'
+    r37 = CPy_Encode(s, r36, 0)
     return 1
 
 [case testOrd]
@@ -417,12 +416,18 @@ L0:
 def any_ord(x):
     x, r0 :: object
     r1 :: str
-    r2, r3 :: object
-    r4 :: int
+    r2 :: object
+    r3 :: object[1]
+    r4 :: object_ptr
+    r5 :: object
+    r6 :: int
 L0:
     r0 = builtins :: module
     r1 = 'ord'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = PyObject_CallFunctionObjArgs(r2, x, 0)
-    r4 = unbox(int, r3)
-    return r4
+    r3 = [x]
+    r4 = load_address r3
+    r5 = _PyObject_Vectorcall(r2, r4, 1, 0)
+    keep_alive x
+    r6 = unbox(int, r5)
+    return r6

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -363,21 +363,21 @@ L0:
     r20 = [r17, errors]
     r21 = load_address r20
     r22 = ('errors',)
-    r23 = _PyObject_Vectorcall(r19, r21, 1, r22)
+    r23 = PyObject_Vectorcall(r19, r21, 1, r22)
     keep_alive r17, errors
     r24 = 'encode'
     r25 = CPyObject_GetAttr(s, r24)
     r26 = [errors]
     r27 = load_address r26
     r28 = ('errors',)
-    r29 = _PyObject_Vectorcall(r25, r27, 0, r28)
+    r29 = PyObject_Vectorcall(r25, r27, 0, r28)
     keep_alive errors
     r30 = 'encode'
     r31 = CPyObject_GetAttr(s, r30)
     r32 = [encoding, errors]
     r33 = load_address r32
     r34 = ('encoding', 'errors')
-    r35 = _PyObject_Vectorcall(r31, r33, 0, r34)
+    r35 = PyObject_Vectorcall(r31, r33, 0, r34)
     keep_alive encoding, errors
     r36 = 'latin2'
     r37 = CPy_Encode(s, r36, 0)
@@ -427,7 +427,7 @@ L0:
     r2 = CPyObject_GetAttr(r0, r1)
     r3 = [x]
     r4 = load_address r3
-    r5 = _PyObject_Vectorcall(r2, r4, 1, 0)
+    r5 = PyObject_Vectorcall(r2, r4, 1, 0)
     keep_alive x
     r6 = unbox(int, r5)
     return r6

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -13,14 +13,17 @@ def g():
     r5 :: str
     r6 :: object
     r7 :: str
-    r8, r9 :: object
-    r10 :: bit
+    r8 :: object
+    r9 :: object[1]
+    r10 :: object_ptr
+    r11 :: object
+    r12 :: bit
 L0:
 L1:
     r0 = builtins :: module
     r1 = 'object'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = PyObject_CallFunctionObjArgs(r2, 0)
+    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
     goto L5
 L2: (handler for L1)
     r4 = CPy_CatchError()
@@ -28,13 +31,16 @@ L2: (handler for L1)
     r6 = builtins :: module
     r7 = 'print'
     r8 = CPyObject_GetAttr(r6, r7)
-    r9 = PyObject_CallFunctionObjArgs(r8, r5, 0)
+    r9 = [r5]
+    r10 = load_address r9
+    r11 = _PyObject_Vectorcall(r8, r10, 1, 0)
+    keep_alive r5
 L3:
     CPy_RestoreExcInfo(r4)
     goto L5
 L4: (handler for L2)
     CPy_RestoreExcInfo(r4)
-    r10 = CPy_KeepPropagating()
+    r12 = CPy_KeepPropagating()
     unreachable
 L5:
     return 1
@@ -59,8 +65,11 @@ def g(b):
     r7 :: str
     r8 :: object
     r9 :: str
-    r10, r11 :: object
-    r12 :: bit
+    r10 :: object
+    r11 :: object[1]
+    r12 :: object_ptr
+    r13 :: object
+    r14 :: bit
 L0:
 L1:
     if b goto L2 else goto L3 :: bool
@@ -68,7 +77,7 @@ L2:
     r0 = builtins :: module
     r1 = 'object'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = PyObject_CallFunctionObjArgs(r2, 0)
+    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
     goto L4
 L3:
     r4 = 'hi'
@@ -81,13 +90,16 @@ L5: (handler for L1, L2, L3, L4)
     r8 = builtins :: module
     r9 = 'print'
     r10 = CPyObject_GetAttr(r8, r9)
-    r11 = PyObject_CallFunctionObjArgs(r10, r7, 0)
+    r11 = [r7]
+    r12 = load_address r11
+    r13 = _PyObject_Vectorcall(r10, r12, 1, 0)
+    keep_alive r7
 L6:
     CPy_RestoreExcInfo(r6)
     goto L8
 L7: (handler for L5)
     CPy_RestoreExcInfo(r6)
-    r12 = CPy_KeepPropagating()
+    r14 = CPy_KeepPropagating()
     unreachable
 L8:
     return 1
@@ -107,80 +119,98 @@ def g():
     r0 :: str
     r1 :: object
     r2 :: str
-    r3, r4, r5 :: object
-    r6 :: str
-    r7, r8 :: object
-    r9 :: tuple[object, object, object]
-    r10 :: object
-    r11 :: str
+    r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6, r7 :: object
+    r8 :: str
+    r9, r10 :: object
+    r11 :: tuple[object, object, object]
     r12 :: object
-    r13 :: bit
-    r14, e :: object
-    r15 :: str
-    r16 :: object
+    r13 :: str
+    r14 :: object
+    r15 :: bit
+    r16, e :: object
     r17 :: str
-    r18, r19 :: object
-    r20 :: bit
-    r21 :: tuple[object, object, object]
-    r22 :: str
+    r18 :: object
+    r19 :: str
+    r20 :: object
+    r21 :: object[2]
+    r22 :: object_ptr
     r23 :: object
-    r24 :: str
-    r25, r26 :: object
-    r27 :: bit
+    r24 :: bit
+    r25 :: tuple[object, object, object]
+    r26 :: str
+    r27 :: object
+    r28 :: str
+    r29 :: object
+    r30 :: object[1]
+    r31 :: object_ptr
+    r32 :: object
+    r33 :: bit
 L0:
 L1:
     r0 = 'a'
     r1 = builtins :: module
     r2 = 'print'
     r3 = CPyObject_GetAttr(r1, r2)
-    r4 = PyObject_CallFunctionObjArgs(r3, r0, 0)
+    r4 = [r0]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r3, r5, 1, 0)
+    keep_alive r0
 L2:
-    r5 = builtins :: module
-    r6 = 'object'
-    r7 = CPyObject_GetAttr(r5, r6)
-    r8 = PyObject_CallFunctionObjArgs(r7, 0)
+    r7 = builtins :: module
+    r8 = 'object'
+    r9 = CPyObject_GetAttr(r7, r8)
+    r10 = _PyObject_Vectorcall(r9, 0, 0, 0)
     goto L8
 L3: (handler for L2)
-    r9 = CPy_CatchError()
-    r10 = builtins :: module
-    r11 = 'AttributeError'
-    r12 = CPyObject_GetAttr(r10, r11)
-    r13 = CPy_ExceptionMatches(r12)
-    if r13 goto L4 else goto L5 :: bool
+    r11 = CPy_CatchError()
+    r12 = builtins :: module
+    r13 = 'AttributeError'
+    r14 = CPyObject_GetAttr(r12, r13)
+    r15 = CPy_ExceptionMatches(r14)
+    if r15 goto L4 else goto L5 :: bool
 L4:
-    r14 = CPy_GetExcValue()
-    e = r14
-    r15 = 'b'
-    r16 = builtins :: module
-    r17 = 'print'
-    r18 = CPyObject_GetAttr(r16, r17)
-    r19 = PyObject_CallFunctionObjArgs(r18, r15, e, 0)
+    r16 = CPy_GetExcValue()
+    e = r16
+    r17 = 'b'
+    r18 = builtins :: module
+    r19 = 'print'
+    r20 = CPyObject_GetAttr(r18, r19)
+    r21 = [r17, e]
+    r22 = load_address r21
+    r23 = _PyObject_Vectorcall(r20, r22, 2, 0)
+    keep_alive r17, e
     goto L6
 L5:
     CPy_Reraise()
     unreachable
 L6:
-    CPy_RestoreExcInfo(r9)
+    CPy_RestoreExcInfo(r11)
     goto L8
 L7: (handler for L3, L4, L5)
-    CPy_RestoreExcInfo(r9)
-    r20 = CPy_KeepPropagating()
+    CPy_RestoreExcInfo(r11)
+    r24 = CPy_KeepPropagating()
     unreachable
 L8:
     goto L12
 L9: (handler for L1, L6, L7, L8)
-    r21 = CPy_CatchError()
-    r22 = 'weeee'
-    r23 = builtins :: module
-    r24 = 'print'
-    r25 = CPyObject_GetAttr(r23, r24)
-    r26 = PyObject_CallFunctionObjArgs(r25, r22, 0)
+    r25 = CPy_CatchError()
+    r26 = 'weeee'
+    r27 = builtins :: module
+    r28 = 'print'
+    r29 = CPyObject_GetAttr(r27, r28)
+    r30 = [r26]
+    r31 = load_address r30
+    r32 = _PyObject_Vectorcall(r29, r31, 1, 0)
+    keep_alive r26
 L10:
-    CPy_RestoreExcInfo(r21)
+    CPy_RestoreExcInfo(r25)
     goto L12
 L11: (handler for L9)
-    CPy_RestoreExcInfo(r21)
-    r27 = CPy_KeepPropagating()
+    CPy_RestoreExcInfo(r25)
+    r33 = CPy_KeepPropagating()
     unreachable
 L12:
     return 1
@@ -203,15 +233,21 @@ def g():
     r5 :: str
     r6 :: object
     r7 :: str
-    r8, r9, r10 :: object
-    r11 :: str
-    r12 :: object
-    r13 :: bit
-    r14 :: str
-    r15 :: object
+    r8 :: object
+    r9 :: object[1]
+    r10 :: object_ptr
+    r11, r12 :: object
+    r13 :: str
+    r14 :: object
+    r15 :: bit
     r16 :: str
-    r17, r18 :: object
-    r19 :: bit
+    r17 :: object
+    r18 :: str
+    r19 :: object
+    r20 :: object[1]
+    r21 :: object_ptr
+    r22 :: object
+    r23 :: bit
 L0:
 L1:
     goto L9
@@ -227,20 +263,26 @@ L3:
     r6 = builtins :: module
     r7 = 'print'
     r8 = CPyObject_GetAttr(r6, r7)
-    r9 = PyObject_CallFunctionObjArgs(r8, r5, 0)
+    r9 = [r5]
+    r10 = load_address r9
+    r11 = _PyObject_Vectorcall(r8, r10, 1, 0)
+    keep_alive r5
     goto L7
 L4:
-    r10 = builtins :: module
-    r11 = 'IndexError'
-    r12 = CPyObject_GetAttr(r10, r11)
-    r13 = CPy_ExceptionMatches(r12)
-    if r13 goto L5 else goto L6 :: bool
+    r12 = builtins :: module
+    r13 = 'IndexError'
+    r14 = CPyObject_GetAttr(r12, r13)
+    r15 = CPy_ExceptionMatches(r14)
+    if r15 goto L5 else goto L6 :: bool
 L5:
-    r14 = 'yo'
-    r15 = builtins :: module
-    r16 = 'print'
-    r17 = CPyObject_GetAttr(r15, r16)
-    r18 = PyObject_CallFunctionObjArgs(r17, r14, 0)
+    r16 = 'yo'
+    r17 = builtins :: module
+    r18 = 'print'
+    r19 = CPyObject_GetAttr(r17, r18)
+    r20 = [r16]
+    r21 = load_address r20
+    r22 = _PyObject_Vectorcall(r19, r21, 1, 0)
+    keep_alive r16
     goto L7
 L6:
     CPy_Reraise()
@@ -250,7 +292,7 @@ L7:
     goto L9
 L8: (handler for L2, L3, L4, L5, L6)
     CPy_RestoreExcInfo(r0)
-    r19 = CPy_KeepPropagating()
+    r23 = CPy_KeepPropagating()
     unreachable
 L9:
     return 1
@@ -268,13 +310,19 @@ def a(b):
     r0 :: str
     r1 :: object
     r2 :: str
-    r3, r4 :: object
-    r5, r6, r7 :: tuple[object, object, object]
-    r8 :: str
-    r9 :: object
+    r3 :: object
+    r4 :: object[1]
+    r5 :: object_ptr
+    r6 :: object
+    r7, r8, r9 :: tuple[object, object, object]
     r10 :: str
-    r11, r12 :: object
-    r13 :: bit
+    r11 :: object
+    r12 :: str
+    r13 :: object
+    r14 :: object[1]
+    r15 :: object_ptr
+    r16 :: object
+    r17 :: bit
 L0:
 L1:
     if b goto L2 else goto L3 :: bool
@@ -283,36 +331,42 @@ L2:
     r1 = builtins :: module
     r2 = 'Exception'
     r3 = CPyObject_GetAttr(r1, r2)
-    r4 = PyObject_CallFunctionObjArgs(r3, r0, 0)
-    CPy_Raise(r4)
+    r4 = [r0]
+    r5 = load_address r4
+    r6 = _PyObject_Vectorcall(r3, r5, 1, 0)
+    keep_alive r0
+    CPy_Raise(r6)
     unreachable
 L3:
 L4:
 L5:
-    r5 = <error> :: tuple[object, object, object]
-    r6 = r5
+    r7 = <error> :: tuple[object, object, object]
+    r8 = r7
     goto L7
 L6: (handler for L1, L2, L3)
-    r7 = CPy_CatchError()
-    r6 = r7
+    r9 = CPy_CatchError()
+    r8 = r9
 L7:
-    r8 = 'finally'
-    r9 = builtins :: module
-    r10 = 'print'
-    r11 = CPyObject_GetAttr(r9, r10)
-    r12 = PyObject_CallFunctionObjArgs(r11, r8, 0)
-    if is_error(r6) goto L9 else goto L8
+    r10 = 'finally'
+    r11 = builtins :: module
+    r12 = 'print'
+    r13 = CPyObject_GetAttr(r11, r12)
+    r14 = [r10]
+    r15 = load_address r14
+    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    keep_alive r10
+    if is_error(r8) goto L9 else goto L8
 L8:
     CPy_Reraise()
     unreachable
 L9:
     goto L13
 L10: (handler for L7, L8)
-    if is_error(r6) goto L12 else goto L11
+    if is_error(r8) goto L12 else goto L11
 L11:
-    CPy_RestoreExcInfo(r6)
+    CPy_RestoreExcInfo(r8)
 L12:
-    r13 = CPy_KeepPropagating()
+    r17 = CPy_KeepPropagating()
     unreachable
 L13:
     return 1
@@ -328,90 +382,114 @@ def foo(x):
     r2 :: str
     r3 :: object
     r4 :: str
-    r5, r6 :: object
-    r7 :: bool
+    r5 :: object
+    r6 :: object[1]
+    r7 :: object_ptr
+    r8 :: object
+    r9 :: bool
     y :: object
-    r8 :: str
-    r9 :: object
     r10 :: str
-    r11, r12 :: object
-    r13, r14 :: tuple[object, object, object]
-    r15, r16, r17, r18 :: object
-    r19 :: i32
-    r20 :: bit
-    r21 :: bool
-    r22 :: bit
-    r23, r24, r25 :: tuple[object, object, object]
-    r26, r27 :: object
+    r11 :: object
+    r12 :: str
+    r13 :: object
+    r14 :: object[1]
+    r15 :: object_ptr
+    r16 :: object
+    r17, r18 :: tuple[object, object, object]
+    r19, r20, r21 :: object
+    r22 :: object[4]
+    r23 :: object_ptr
+    r24 :: object
+    r25 :: i32
+    r26 :: bit
+    r27 :: bool
     r28 :: bit
+    r29, r30, r31 :: tuple[object, object, object]
+    r32 :: object
+    r33 :: object[4]
+    r34 :: object_ptr
+    r35 :: object
+    r36 :: bit
 L0:
-    r0 = PyObject_CallFunctionObjArgs(x, 0)
+    r0 = _PyObject_Vectorcall(x, 0, 0, 0)
     r1 = PyObject_Type(r0)
     r2 = '__exit__'
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = '__enter__'
     r5 = CPyObject_GetAttr(r1, r4)
-    r6 = PyObject_CallFunctionObjArgs(r5, r0, 0)
-    r7 = 1
+    r6 = [r0]
+    r7 = load_address r6
+    r8 = _PyObject_Vectorcall(r5, r7, 1, 0)
+    keep_alive r0
+    r9 = 1
 L1:
 L2:
-    y = r6
-    r8 = 'hello'
-    r9 = builtins :: module
-    r10 = 'print'
-    r11 = CPyObject_GetAttr(r9, r10)
-    r12 = PyObject_CallFunctionObjArgs(r11, r8, 0)
+    y = r8
+    r10 = 'hello'
+    r11 = builtins :: module
+    r12 = 'print'
+    r13 = CPyObject_GetAttr(r11, r12)
+    r14 = [r10]
+    r15 = load_address r14
+    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    keep_alive r10
     goto L8
 L3: (handler for L2)
-    r13 = CPy_CatchError()
-    r7 = 0
-    r14 = CPy_GetExcInfo()
-    r15 = r14[0]
-    r16 = r14[1]
-    r17 = r14[2]
-    r18 = PyObject_CallFunctionObjArgs(r3, r0, r15, r16, r17, 0)
-    r19 = PyObject_IsTrue(r18)
-    r20 = r19 >= 0 :: signed
-    r21 = truncate r19: i32 to builtins.bool
-    if r21 goto L5 else goto L4 :: bool
+    r17 = CPy_CatchError()
+    r9 = 0
+    r18 = CPy_GetExcInfo()
+    r19 = r18[0]
+    r20 = r18[1]
+    r21 = r18[2]
+    r22 = [r0, r19, r20, r21]
+    r23 = load_address r22
+    r24 = _PyObject_Vectorcall(r3, r23, 4, 0)
+    keep_alive r0, r19, r20, r21
+    r25 = PyObject_IsTrue(r24)
+    r26 = r25 >= 0 :: signed
+    r27 = truncate r25: i32 to builtins.bool
+    if r27 goto L5 else goto L4 :: bool
 L4:
     CPy_Reraise()
     unreachable
 L5:
 L6:
-    CPy_RestoreExcInfo(r13)
+    CPy_RestoreExcInfo(r17)
     goto L8
 L7: (handler for L3, L4, L5)
-    CPy_RestoreExcInfo(r13)
-    r22 = CPy_KeepPropagating()
+    CPy_RestoreExcInfo(r17)
+    r28 = CPy_KeepPropagating()
     unreachable
 L8:
 L9:
 L10:
-    r23 = <error> :: tuple[object, object, object]
-    r24 = r23
+    r29 = <error> :: tuple[object, object, object]
+    r30 = r29
     goto L12
 L11: (handler for L1, L6, L7, L8)
-    r25 = CPy_CatchError()
-    r24 = r25
+    r31 = CPy_CatchError()
+    r30 = r31
 L12:
-    if r7 goto L13 else goto L14 :: bool
+    if r9 goto L13 else goto L14 :: bool
 L13:
-    r26 = load_address _Py_NoneStruct
-    r27 = PyObject_CallFunctionObjArgs(r3, r0, r26, r26, r26, 0)
+    r32 = load_address _Py_NoneStruct
+    r33 = [r0, r32, r32, r32]
+    r34 = load_address r33
+    r35 = _PyObject_Vectorcall(r3, r34, 4, 0)
+    keep_alive r0, r32, r32, r32
 L14:
-    if is_error(r24) goto L16 else goto L15
+    if is_error(r30) goto L16 else goto L15
 L15:
     CPy_Reraise()
     unreachable
 L16:
     goto L20
 L17: (handler for L12, L13, L14, L15)
-    if is_error(r24) goto L19 else goto L18
+    if is_error(r30) goto L19 else goto L18
 L18:
-    CPy_RestoreExcInfo(r24)
+    CPy_RestoreExcInfo(r30)
 L19:
-    r28 = CPy_KeepPropagating()
+    r36 = CPy_KeepPropagating()
     unreachable
 L20:
     return 1
@@ -443,19 +521,22 @@ def foo(x):
     r2 :: str
     r3 :: object
     r4 :: str
-    r5, r6 :: object
-    r7, r8 :: tuple[object, object, object]
-    r9, r10, r11 :: object
-    r12 :: None
-    r13 :: object
-    r14 :: i32
-    r15 :: bit
-    r16 :: bool
+    r5 :: object
+    r6 :: object[1]
+    r7 :: object_ptr
+    r8 :: object
+    r9, r10 :: tuple[object, object, object]
+    r11, r12, r13 :: object
+    r14 :: None
+    r15 :: object
+    r16 :: i32
     r17 :: bit
-    r18, r19, r20 :: tuple[object, object, object]
-    r21 :: object
-    r22 :: None
-    r23 :: bit
+    r18 :: bool
+    r19 :: bit
+    r20, r21, r22 :: tuple[object, object, object]
+    r23 :: object
+    r24 :: None
+    r25 :: bit
 L0:
     r0 = x.__enter__()
     r1 = 1
@@ -465,59 +546,62 @@ L2:
     r3 = builtins :: module
     r4 = 'print'
     r5 = CPyObject_GetAttr(r3, r4)
-    r6 = PyObject_CallFunctionObjArgs(r5, r2, 0)
+    r6 = [r2]
+    r7 = load_address r6
+    r8 = _PyObject_Vectorcall(r5, r7, 1, 0)
+    keep_alive r2
     goto L8
 L3: (handler for L2)
-    r7 = CPy_CatchError()
+    r9 = CPy_CatchError()
     r1 = 0
-    r8 = CPy_GetExcInfo()
-    r9 = r8[0]
-    r10 = r8[1]
-    r11 = r8[2]
-    r12 = x.__exit__(r9, r10, r11)
-    r13 = box(None, r12)
-    r14 = PyObject_IsTrue(r13)
-    r15 = r14 >= 0 :: signed
-    r16 = truncate r14: i32 to builtins.bool
-    if r16 goto L5 else goto L4 :: bool
+    r10 = CPy_GetExcInfo()
+    r11 = r10[0]
+    r12 = r10[1]
+    r13 = r10[2]
+    r14 = x.__exit__(r11, r12, r13)
+    r15 = box(None, r14)
+    r16 = PyObject_IsTrue(r15)
+    r17 = r16 >= 0 :: signed
+    r18 = truncate r16: i32 to builtins.bool
+    if r18 goto L5 else goto L4 :: bool
 L4:
     CPy_Reraise()
     unreachable
 L5:
 L6:
-    CPy_RestoreExcInfo(r7)
+    CPy_RestoreExcInfo(r9)
     goto L8
 L7: (handler for L3, L4, L5)
-    CPy_RestoreExcInfo(r7)
-    r17 = CPy_KeepPropagating()
+    CPy_RestoreExcInfo(r9)
+    r19 = CPy_KeepPropagating()
     unreachable
 L8:
 L9:
 L10:
-    r18 = <error> :: tuple[object, object, object]
-    r19 = r18
+    r20 = <error> :: tuple[object, object, object]
+    r21 = r20
     goto L12
 L11: (handler for L1, L6, L7, L8)
-    r20 = CPy_CatchError()
-    r19 = r20
+    r22 = CPy_CatchError()
+    r21 = r22
 L12:
     if r1 goto L13 else goto L14 :: bool
 L13:
-    r21 = load_address _Py_NoneStruct
-    r22 = x.__exit__(r21, r21, r21)
+    r23 = load_address _Py_NoneStruct
+    r24 = x.__exit__(r23, r23, r23)
 L14:
-    if is_error(r19) goto L16 else goto L15
+    if is_error(r21) goto L16 else goto L15
 L15:
     CPy_Reraise()
     unreachable
 L16:
     goto L20
 L17: (handler for L12, L13, L14, L15)
-    if is_error(r19) goto L19 else goto L18
+    if is_error(r21) goto L19 else goto L18
 L18:
-    CPy_RestoreExcInfo(r19)
+    CPy_RestoreExcInfo(r21)
 L19:
-    r23 = CPy_KeepPropagating()
+    r25 = CPy_KeepPropagating()
     unreachable
 L20:
     return 1

--- a/mypyc/test-data/irbuild-try.test
+++ b/mypyc/test-data/irbuild-try.test
@@ -23,7 +23,7 @@ L1:
     r0 = builtins :: module
     r1 = 'object'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
+    r3 = PyObject_Vectorcall(r2, 0, 0, 0)
     goto L5
 L2: (handler for L1)
     r4 = CPy_CatchError()
@@ -33,7 +33,7 @@ L2: (handler for L1)
     r8 = CPyObject_GetAttr(r6, r7)
     r9 = [r5]
     r10 = load_address r9
-    r11 = _PyObject_Vectorcall(r8, r10, 1, 0)
+    r11 = PyObject_Vectorcall(r8, r10, 1, 0)
     keep_alive r5
 L3:
     CPy_RestoreExcInfo(r4)
@@ -77,7 +77,7 @@ L2:
     r0 = builtins :: module
     r1 = 'object'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
+    r3 = PyObject_Vectorcall(r2, 0, 0, 0)
     goto L4
 L3:
     r4 = 'hi'
@@ -92,7 +92,7 @@ L5: (handler for L1, L2, L3, L4)
     r10 = CPyObject_GetAttr(r8, r9)
     r11 = [r7]
     r12 = load_address r11
-    r13 = _PyObject_Vectorcall(r10, r12, 1, 0)
+    r13 = PyObject_Vectorcall(r10, r12, 1, 0)
     keep_alive r7
 L6:
     CPy_RestoreExcInfo(r6)
@@ -156,13 +156,13 @@ L1:
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = [r0]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r3, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r3, r5, 1, 0)
     keep_alive r0
 L2:
     r7 = builtins :: module
     r8 = 'object'
     r9 = CPyObject_GetAttr(r7, r8)
-    r10 = _PyObject_Vectorcall(r9, 0, 0, 0)
+    r10 = PyObject_Vectorcall(r9, 0, 0, 0)
     goto L8
 L3: (handler for L2)
     r11 = CPy_CatchError()
@@ -180,7 +180,7 @@ L4:
     r20 = CPyObject_GetAttr(r18, r19)
     r21 = [r17, e]
     r22 = load_address r21
-    r23 = _PyObject_Vectorcall(r20, r22, 2, 0)
+    r23 = PyObject_Vectorcall(r20, r22, 2, 0)
     keep_alive r17, e
     goto L6
 L5:
@@ -203,7 +203,7 @@ L9: (handler for L1, L6, L7, L8)
     r29 = CPyObject_GetAttr(r27, r28)
     r30 = [r26]
     r31 = load_address r30
-    r32 = _PyObject_Vectorcall(r29, r31, 1, 0)
+    r32 = PyObject_Vectorcall(r29, r31, 1, 0)
     keep_alive r26
 L10:
     CPy_RestoreExcInfo(r25)
@@ -265,7 +265,7 @@ L3:
     r8 = CPyObject_GetAttr(r6, r7)
     r9 = [r5]
     r10 = load_address r9
-    r11 = _PyObject_Vectorcall(r8, r10, 1, 0)
+    r11 = PyObject_Vectorcall(r8, r10, 1, 0)
     keep_alive r5
     goto L7
 L4:
@@ -281,7 +281,7 @@ L5:
     r19 = CPyObject_GetAttr(r17, r18)
     r20 = [r16]
     r21 = load_address r20
-    r22 = _PyObject_Vectorcall(r19, r21, 1, 0)
+    r22 = PyObject_Vectorcall(r19, r21, 1, 0)
     keep_alive r16
     goto L7
 L6:
@@ -333,7 +333,7 @@ L2:
     r3 = CPyObject_GetAttr(r1, r2)
     r4 = [r0]
     r5 = load_address r4
-    r6 = _PyObject_Vectorcall(r3, r5, 1, 0)
+    r6 = PyObject_Vectorcall(r3, r5, 1, 0)
     keep_alive r0
     CPy_Raise(r6)
     unreachable
@@ -353,7 +353,7 @@ L7:
     r13 = CPyObject_GetAttr(r11, r12)
     r14 = [r10]
     r15 = load_address r14
-    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
     keep_alive r10
     if is_error(r8) goto L9 else goto L8
 L8:
@@ -411,7 +411,7 @@ def foo(x):
     r35 :: object
     r36 :: bit
 L0:
-    r0 = _PyObject_Vectorcall(x, 0, 0, 0)
+    r0 = PyObject_Vectorcall(x, 0, 0, 0)
     r1 = PyObject_Type(r0)
     r2 = '__exit__'
     r3 = CPyObject_GetAttr(r1, r2)
@@ -419,7 +419,7 @@ L0:
     r5 = CPyObject_GetAttr(r1, r4)
     r6 = [r0]
     r7 = load_address r6
-    r8 = _PyObject_Vectorcall(r5, r7, 1, 0)
+    r8 = PyObject_Vectorcall(r5, r7, 1, 0)
     keep_alive r0
     r9 = 1
 L1:
@@ -431,7 +431,7 @@ L2:
     r13 = CPyObject_GetAttr(r11, r12)
     r14 = [r10]
     r15 = load_address r14
-    r16 = _PyObject_Vectorcall(r13, r15, 1, 0)
+    r16 = PyObject_Vectorcall(r13, r15, 1, 0)
     keep_alive r10
     goto L8
 L3: (handler for L2)
@@ -443,7 +443,7 @@ L3: (handler for L2)
     r21 = r18[2]
     r22 = [r0, r19, r20, r21]
     r23 = load_address r22
-    r24 = _PyObject_Vectorcall(r3, r23, 4, 0)
+    r24 = PyObject_Vectorcall(r3, r23, 4, 0)
     keep_alive r0, r19, r20, r21
     r25 = PyObject_IsTrue(r24)
     r26 = r25 >= 0 :: signed
@@ -475,7 +475,7 @@ L13:
     r32 = load_address _Py_NoneStruct
     r33 = [r0, r32, r32, r32]
     r34 = load_address r33
-    r35 = _PyObject_Vectorcall(r3, r34, 4, 0)
+    r35 = PyObject_Vectorcall(r3, r34, 4, 0)
     keep_alive r0, r32, r32, r32
 L14:
     if is_error(r30) goto L16 else goto L15
@@ -548,7 +548,7 @@ L2:
     r5 = CPyObject_GetAttr(r3, r4)
     r6 = [r2]
     r7 = load_address r6
-    r8 = _PyObject_Vectorcall(r5, r7, 1, 0)
+    r8 = PyObject_Vectorcall(r5, r7, 1, 0)
     keep_alive r2
     goto L8
 L3: (handler for L2)

--- a/mypyc/test-data/irbuild-unreachable.test
+++ b/mypyc/test-data/irbuild-unreachable.test
@@ -205,7 +205,7 @@ L1:
     r0 = builtins :: module
     r1 = 'ValueError'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = PyObject_CallFunctionObjArgs(r2, 0)
+    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
     CPy_Raise(r3)
     unreachable
 L2:
@@ -223,7 +223,10 @@ def f(x):
     r1 :: str
     r2 :: object
     r3 :: str
-    r4, r5 :: object
+    r4 :: object
+    r5 :: object[1]
+    r6 :: object_ptr
+    r7 :: object
 L0:
     if x goto L1 else goto L4 :: bool
 L1:
@@ -236,6 +239,9 @@ L3:
     r2 = builtins :: module
     r3 = 'print'
     r4 = CPyObject_GetAttr(r2, r3)
-    r5 = PyObject_CallFunctionObjArgs(r4, r1, 0)
+    r5 = [r1]
+    r6 = load_address r5
+    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    keep_alive r1
 L4:
     return 4

--- a/mypyc/test-data/irbuild-unreachable.test
+++ b/mypyc/test-data/irbuild-unreachable.test
@@ -205,7 +205,7 @@ L1:
     r0 = builtins :: module
     r1 = 'ValueError'
     r2 = CPyObject_GetAttr(r0, r1)
-    r3 = _PyObject_Vectorcall(r2, 0, 0, 0)
+    r3 = PyObject_Vectorcall(r2, 0, 0, 0)
     CPy_Raise(r3)
     unreachable
 L2:
@@ -241,7 +241,7 @@ L3:
     r4 = CPyObject_GetAttr(r2, r3)
     r5 = [r1]
     r6 = load_address r5
-    r7 = _PyObject_Vectorcall(r4, r6, 1, 0)
+    r7 = PyObject_Vectorcall(r4, r6, 1, 0)
     keep_alive r1
 L4:
     return 4

--- a/mypyc/test-data/irbuild-vectorcall.test
+++ b/mypyc/test-data/irbuild-vectorcall.test
@@ -3,7 +3,7 @@
 -- Vectorcalls are faster than the legacy API, especially with keyword arguments,
 -- since there is no need to allocate a temporary dictionary for keyword args.
 
-[case testeVectorcallBasic_python3_8]
+[case testeVectorcallBasic]
 from typing import Any
 
 def f(c: Any) -> None:
@@ -26,7 +26,7 @@ L0:
     keep_alive r1, r2
     return 1
 
-[case testVectorcallKeywords_python3_8]
+[case testVectorcallKeywords]
 from typing import Any
 
 def f(c: Any) -> None:
@@ -60,7 +60,7 @@ L0:
     keep_alive r5, r6, r7
     return 1
 
-[case testVectorcallMethod_python3_8]
+[case testVectorcallMethod]
 from typing import Any
 
 def f(o: Any) -> None:

--- a/mypyc/test-data/irbuild-vectorcall.test
+++ b/mypyc/test-data/irbuild-vectorcall.test
@@ -17,12 +17,12 @@ def f(c):
     r4 :: object_ptr
     r5 :: object
 L0:
-    r0 = _PyObject_Vectorcall(c, 0, 0, 0)
+    r0 = PyObject_Vectorcall(c, 0, 0, 0)
     r1 = 'x'
     r2 = 'y'
     r3 = [r1, r2]
     r4 = load_address r3
-    r5 = _PyObject_Vectorcall(c, r4, 2, 0)
+    r5 = PyObject_Vectorcall(c, r4, 2, 0)
     keep_alive r1, r2
     return 1
 
@@ -48,7 +48,7 @@ L0:
     r1 = [r0]
     r2 = load_address r1
     r3 = ('x',)
-    r4 = _PyObject_Vectorcall(c, r2, 0, r3)
+    r4 = PyObject_Vectorcall(c, r2, 0, r3)
     keep_alive r0
     r5 = 'x'
     r6 = 'y'
@@ -56,7 +56,7 @@ L0:
     r8 = [r5, r6, r7]
     r9 = load_address r8
     r10 = ('a', 'b')
-    r11 = _PyObject_Vectorcall(c, r9, 1, r10)
+    r11 = PyObject_Vectorcall(c, r9, 1, r10)
     keep_alive r5, r6, r7
     return 1
 
@@ -88,7 +88,7 @@ L0:
     r7 = [r3, r4]
     r8 = load_address r7
     r9 = ('a',)
-    r10 = _PyObject_Vectorcall(r6, r8, 1, r9)
+    r10 = PyObject_Vectorcall(r6, r8, 1, r9)
     keep_alive r3, r4
     return 1
 

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -695,7 +695,7 @@ L0:
     r2 = [x, r1]
     r3 = load_address r2
     r4 = ('base',)
-    r5 = _PyObject_Vectorcall(r0, r3, 1, r4)
+    r5 = PyObject_Vectorcall(r0, r3, 1, r4)
     r6 = unbox(int, r5)
     dec_ref r5
     return r6
@@ -890,7 +890,7 @@ L0:
     r0 = box(int, x)
     r1 = [r0]
     r2 = load_address r1
-    r3 = _PyObject_Vectorcall(f, r2, 1, 0)
+    r3 = PyObject_Vectorcall(f, r2, 1, 0)
     dec_ref r0
     r4 = unbox(int, r3)
     dec_ref r3

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -684,22 +684,18 @@ def g(x: str) -> int:
 [out]
 def g(x):
     x :: str
-    r0 :: object
-    r1 :: str
-    r2 :: tuple
-    r3 :: object
-    r4 :: dict
-    r5 :: object
+    r0, r1 :: object
+    r2 :: object[2]
+    r3 :: object_ptr
+    r4, r5 :: object
     r6 :: int
 L0:
     r0 = load_address PyLong_Type
-    r1 = 'base'
-    r2 = PyTuple_Pack(1, x)
-    r3 = object 2
-    r4 = CPyDict_Build(1, r1, r3)
-    r5 = PyObject_Call(r0, r2, r4)
-    dec_ref r2
-    dec_ref r4
+    r1 = object 2
+    r2 = [x, r1]
+    r3 = load_address r2
+    r4 = ('base',)
+    r5 = _PyObject_Vectorcall(r0, r3, 1, r4)
     r6 = unbox(int, r5)
     dec_ref r5
     return r6
@@ -875,7 +871,7 @@ L11:
     xdec_ref y :: int
     goto L6
 
-[case testVectorcall_python3_8]
+[case testVectorcall]
 from typing import Any
 
 def call(f: Any, x: int) -> int:

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -103,13 +103,13 @@ def build_ir_for_single_file2(
 
     # By default generate IR compatible with the earliest supported Python C API.
     # If a test needs more recent API features, this should be overridden.
-    compiler_options = compiler_options or CompilerOptions(capi_version=(3, 7))
+    compiler_options = compiler_options or CompilerOptions(capi_version=(3, 8))
     options = Options()
     options.show_traceback = True
     options.hide_error_codes = True
     options.use_builtins_fixtures = True
     options.strict_optional = True
-    options.python_version = compiler_options.python_version or (3, 6)
+    options.python_version = compiler_options.python_version or (3, 8)
     options.export_types = True
     options.preserve_asts = True
     options.allow_empty_bodies = True
@@ -273,8 +273,8 @@ def infer_ir_build_options_from_test_name(name: str) -> CompilerOptions | None:
         return None
     if "_32bit" in name and not IS_32_BIT_PLATFORM:
         return None
-    options = CompilerOptions(strip_asserts="StripAssert" in name, capi_version=(3, 7))
-    # A suffix like _python3.8 is used to set the target C API version.
+    options = CompilerOptions(strip_asserts="StripAssert" in name, capi_version=(3, 8))
+    # A suffix like _python3_8 is used to set the target C API version.
     m = re.search(r"_python([3-9]+)_([0-9]+)(_|\b)", name)
     if m:
         options.capi_version = (int(m.group(1)), int(m.group(2)))


### PR DESCRIPTION
This PR updates the `capi_version` used for mypyc tests to `3.8` (mypy / mypyc requires `>=3.9`). Test data updates done with `--update-data`. For Python 3.8+ mypyc uses `_PyObject_Vectorcall` instead of `PyObject_CallFunctionObjArgs` and `PyObject_Call` where ever possible.

Will remove the now unnecessary `use_vectorcall` check in a followup.
https://github.com/python/mypy/blob/aa0b6f0288e6a511b750f7fe8f49a0e321362105/mypyc/common.py#L103-L105