### PR TITLE
Use D drive to speed up test runs on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,12 @@ jobs:
       PYTEST_ADDOPTS: --color=yes
 
     steps:
+
+    - name: Set TEMP to D:\ on Windows pytest runs
+      if: ${{startsWith(matrix.os, 'windows-') && startsWith(matrix.toxenv, 'py')}}
+      run: |
+        mkdir "D:\\Temp"
+        echo "TEMP=D:\\Temp" >> $env:GITHUB_ENV
     - uses: actions/checkout@v4
 
     - name: Debug build


### PR DESCRIPTION
This PR changes the Windows pytest tests to put the temp directory on the `D:\` drive, which is faster than the `C:\` drive.

h/t to @ichard26 in this pip PR: https://github.com/pypa/pip/pull/13129 for the idea

