### PR TITLE
Remove TypeType exception for protocol instantiation

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1668,12 +1668,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             # An Enum() call that failed SemanticAnalyzerPass2.check_enum_call().
             return callee.ret_type, callee
 
-        if (
-            callee.is_type_obj()
-            and callee.type_object().is_protocol
-            # Exception for Type[...]
-            and not callee.from_type_type
-        ):
+        if callee.is_type_obj() and callee.type_object().is_protocol:
             self.chk.fail(
                 message_registry.CANNOT_INSTANTIATE_PROTOCOL.format(callee.type_object().name),
                 context,

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1603,7 +1603,7 @@ class C:
         pass
 
 def f(cls: Type[P]) -> P:
-    return cls()  # OK
+    return cls()  # E: Cannot instantiate protocol class "P"
 def g() -> P:
     return P()  # E: Cannot instantiate protocol class "P"
 
@@ -1625,7 +1625,7 @@ class C:
         pass
 
 def f(cls: Type[P]) -> P:
-    return cls()  # OK
+    return cls()  # E: Cannot instantiate protocol class "P"
 
 Alias = P
 GoodAlias = C
@@ -1646,14 +1646,14 @@ class C:
         pass
 
 var: Type[P]
-var()
+var()  # E: Cannot instantiate protocol class "P"
 if int():
     var = P # E: Can only assign concrete classes to a variable of type "Type[P]"
     var = B # OK
     var = C # OK
 
 var_old = None # type: Type[P] # Old syntax for variable annotations
-var_old()
+var_old()  # E: Cannot instantiate protocol class "P"
 if int():
     var_old = P # E: Can only assign concrete classes to a variable of type "Type[P]"
     var_old = B # OK
@@ -1669,7 +1669,7 @@ class Logger:
 class C(Protocol):
     @classmethod
     def action(cls) -> None:
-        cls() #OK for classmethods
+        cls()  # E: Cannot instantiate protocol class "C"
         Logger.log(cls)  #OK for classmethods
 [builtins fixtures/classmethod.pyi]
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -1023,7 +1023,7 @@ T = TypeVar('T', bound=HasX)
 class Meta(type):
     def do_x(cls: Type[T]) -> T:
         cls.x
-        return cls()
+        return cls()  # E: Cannot instantiate protocol class "HasX"
 
 class Good(metaclass=Meta):
     x: int


### PR DESCRIPTION
This disallows direct instantiation of `cls: type[Proto]`

Discussed in https://discuss.python.org/t/compatibility-of-protocol-class-object-with-type-t-and-type-any/48442/2

Users should use `Callable[..., Proto]` instead. This helps with `__init__` unsoundness.

Subset of https://github.com/python/mypy/pull/18094, which also touched abstract classes.