### PR TITLE
Make visit method arguments pos-only

### DIFF
--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -30,14 +30,14 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
 
     # Symbol nodes
 
-    def visit_var(self, var: Var) -> None:
+    def visit_var(self, var: Var, /) -> None:
         self.visit_optional_type(var.type)
 
-    def visit_func(self, o: FuncItem) -> None:
+    def visit_func(self, o: FuncItem, /) -> None:
         super().visit_func(o)
         self.visit_optional_type(o.type)
 
-    def visit_class_def(self, o: ClassDef) -> None:
+    def visit_class_def(self, o: ClassDef, /) -> None:
         # TODO: Should we visit generated methods/variables as well, either here or in
         #       TraverserVisitor?
         super().visit_class_def(o)
@@ -46,67 +46,67 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
             for base in info.bases:
                 base.accept(self)
 
-    def visit_type_alias_expr(self, o: TypeAliasExpr) -> None:
+    def visit_type_alias_expr(self, o: TypeAliasExpr, /) -> None:
         super().visit_type_alias_expr(o)
         self.in_type_alias_expr = True
         o.node.target.accept(self)
         self.in_type_alias_expr = False
 
-    def visit_type_var_expr(self, o: TypeVarExpr) -> None:
+    def visit_type_var_expr(self, o: TypeVarExpr, /) -> None:
         super().visit_type_var_expr(o)
         o.upper_bound.accept(self)
         for value in o.values:
             value.accept(self)
 
-    def visit_typeddict_expr(self, o: TypedDictExpr) -> None:
+    def visit_typeddict_expr(self, o: TypedDictExpr, /) -> None:
         super().visit_typeddict_expr(o)
         self.visit_optional_type(o.info.typeddict_type)
 
-    def visit_namedtuple_expr(self, o: NamedTupleExpr) -> None:
+    def visit_namedtuple_expr(self, o: NamedTupleExpr, /) -> None:
         super().visit_namedtuple_expr(o)
         assert o.info.tuple_type
         o.info.tuple_type.accept(self)
 
-    def visit__promote_expr(self, o: PromoteExpr) -> None:
+    def visit__promote_expr(self, o: PromoteExpr, /) -> None:
         super().visit__promote_expr(o)
         o.type.accept(self)
 
-    def visit_newtype_expr(self, o: NewTypeExpr) -> None:
+    def visit_newtype_expr(self, o: NewTypeExpr, /) -> None:
         super().visit_newtype_expr(o)
         self.visit_optional_type(o.old_type)
 
     # Statements
 
-    def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, o: AssignmentStmt, /) -> None:
         super().visit_assignment_stmt(o)
         self.visit_optional_type(o.type)
 
-    def visit_for_stmt(self, o: ForStmt) -> None:
+    def visit_for_stmt(self, o: ForStmt, /) -> None:
         super().visit_for_stmt(o)
         self.visit_optional_type(o.index_type)
 
-    def visit_with_stmt(self, o: WithStmt) -> None:
+    def visit_with_stmt(self, o: WithStmt, /) -> None:
         super().visit_with_stmt(o)
         for typ in o.analyzed_types:
             typ.accept(self)
 
     # Expressions
 
-    def visit_cast_expr(self, o: CastExpr) -> None:
+    def visit_cast_expr(self, o: CastExpr, /) -> None:
         super().visit_cast_expr(o)
         o.type.accept(self)
 
-    def visit_assert_type_expr(self, o: AssertTypeExpr) -> None:
+    def visit_assert_type_expr(self, o: AssertTypeExpr, /) -> None:
         super().visit_assert_type_expr(o)
         o.type.accept(self)
 
-    def visit_type_application(self, o: TypeApplication) -> None:
+    def visit_type_application(self, o: TypeApplication, /) -> None:
         super().visit_type_application(o)
         for t in o.types:
             t.accept(self)
 
     # Helpers
 
-    def visit_optional_type(self, t: Type | None) -> None:
+    def visit_optional_type(self, t: Type | None, /) -> None:
         if t:
             t.accept(self)

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -111,15 +111,15 @@ class TraverserVisitor(NodeVisitor[None]):
 
     # Visit methods
 
-    def visit_mypy_file(self, o: MypyFile) -> None:
+    def visit_mypy_file(self, o: MypyFile, /) -> None:
         for d in o.defs:
             d.accept(self)
 
-    def visit_block(self, block: Block) -> None:
+    def visit_block(self, block: Block, /) -> None:
         for s in block.body:
             s.accept(self)
 
-    def visit_func(self, o: FuncItem) -> None:
+    def visit_func(self, o: FuncItem, /) -> None:
         if o.arguments is not None:
             for arg in o.arguments:
                 init = arg.initializer
@@ -131,16 +131,16 @@ class TraverserVisitor(NodeVisitor[None]):
 
         o.body.accept(self)
 
-    def visit_func_def(self, o: FuncDef) -> None:
+    def visit_func_def(self, o: FuncDef, /) -> None:
         self.visit_func(o)
 
-    def visit_overloaded_func_def(self, o: OverloadedFuncDef) -> None:
+    def visit_overloaded_func_def(self, o: OverloadedFuncDef, /) -> None:
         for item in o.items:
             item.accept(self)
         if o.impl:
             o.impl.accept(self)
 
-    def visit_class_def(self, o: ClassDef) -> None:
+    def visit_class_def(self, o: ClassDef, /) -> None:
         for d in o.decorators:
             d.accept(self)
         for base in o.base_type_exprs:
@@ -153,52 +153,52 @@ class TraverserVisitor(NodeVisitor[None]):
         if o.analyzed:
             o.analyzed.accept(self)
 
-    def visit_decorator(self, o: Decorator) -> None:
+    def visit_decorator(self, o: Decorator, /) -> None:
         o.func.accept(self)
         o.var.accept(self)
         for decorator in o.decorators:
             decorator.accept(self)
 
-    def visit_expression_stmt(self, o: ExpressionStmt) -> None:
+    def visit_expression_stmt(self, o: ExpressionStmt, /) -> None:
         o.expr.accept(self)
 
-    def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, o: AssignmentStmt, /) -> None:
         o.rvalue.accept(self)
         for l in o.lvalues:
             l.accept(self)
 
-    def visit_operator_assignment_stmt(self, o: OperatorAssignmentStmt) -> None:
+    def visit_operator_assignment_stmt(self, o: OperatorAssignmentStmt, /) -> None:
         o.rvalue.accept(self)
         o.lvalue.accept(self)
 
-    def visit_while_stmt(self, o: WhileStmt) -> None:
+    def visit_while_stmt(self, o: WhileStmt, /) -> None:
         o.expr.accept(self)
         o.body.accept(self)
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_for_stmt(self, o: ForStmt) -> None:
+    def visit_for_stmt(self, o: ForStmt, /) -> None:
         o.index.accept(self)
         o.expr.accept(self)
         o.body.accept(self)
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_return_stmt(self, o: ReturnStmt) -> None:
+    def visit_return_stmt(self, o: ReturnStmt, /) -> None:
         if o.expr is not None:
             o.expr.accept(self)
 
-    def visit_assert_stmt(self, o: AssertStmt) -> None:
+    def visit_assert_stmt(self, o: AssertStmt, /) -> None:
         if o.expr is not None:
             o.expr.accept(self)
         if o.msg is not None:
             o.msg.accept(self)
 
-    def visit_del_stmt(self, o: DelStmt) -> None:
+    def visit_del_stmt(self, o: DelStmt, /) -> None:
         if o.expr is not None:
             o.expr.accept(self)
 
-    def visit_if_stmt(self, o: IfStmt) -> None:
+    def visit_if_stmt(self, o: IfStmt, /) -> None:
         for e in o.expr:
             e.accept(self)
         for b in o.body:
@@ -206,13 +206,13 @@ class TraverserVisitor(NodeVisitor[None]):
         if o.else_body:
             o.else_body.accept(self)
 
-    def visit_raise_stmt(self, o: RaiseStmt) -> None:
+    def visit_raise_stmt(self, o: RaiseStmt, /) -> None:
         if o.expr is not None:
             o.expr.accept(self)
         if o.from_expr is not None:
             o.from_expr.accept(self)
 
-    def visit_try_stmt(self, o: TryStmt) -> None:
+    def visit_try_stmt(self, o: TryStmt, /) -> None:
         o.body.accept(self)
         for i in range(len(o.types)):
             tp = o.types[i]
@@ -227,7 +227,7 @@ class TraverserVisitor(NodeVisitor[None]):
         if o.finally_body is not None:
             o.finally_body.accept(self)
 
-    def visit_with_stmt(self, o: WithStmt) -> None:
+    def visit_with_stmt(self, o: WithStmt, /) -> None:
         for i in range(len(o.expr)):
             o.expr[i].accept(self)
             targ = o.target[i]
@@ -235,7 +235,7 @@ class TraverserVisitor(NodeVisitor[None]):
                 targ.accept(self)
         o.body.accept(self)
 
-    def visit_match_stmt(self, o: MatchStmt) -> None:
+    def visit_match_stmt(self, o: MatchStmt, /) -> None:
         o.subject.accept(self)
         for i in range(len(o.patterns)):
             o.patterns[i].accept(self)
@@ -244,38 +244,38 @@ class TraverserVisitor(NodeVisitor[None]):
                 guard.accept(self)
             o.bodies[i].accept(self)
 
-    def visit_type_alias_stmt(self, o: TypeAliasStmt) -> None:
+    def visit_type_alias_stmt(self, o: TypeAliasStmt, /) -> None:
         o.name.accept(self)
         o.value.accept(self)
 
-    def visit_member_expr(self, o: MemberExpr) -> None:
+    def visit_member_expr(self, o: MemberExpr, /) -> None:
         o.expr.accept(self)
 
-    def visit_yield_from_expr(self, o: YieldFromExpr) -> None:
+    def visit_yield_from_expr(self, o: YieldFromExpr, /) -> None:
         o.expr.accept(self)
 
-    def visit_yield_expr(self, o: YieldExpr) -> None:
+    def visit_yield_expr(self, o: YieldExpr, /) -> None:
         if o.expr:
             o.expr.accept(self)
 
-    def visit_call_expr(self, o: CallExpr) -> None:
+    def visit_call_expr(self, o: CallExpr, /) -> None:
         o.callee.accept(self)
         for a in o.args:
             a.accept(self)
         if o.analyzed:
             o.analyzed.accept(self)
 
-    def visit_op_expr(self, o: OpExpr) -> None:
+    def visit_op_expr(self, o: OpExpr, /) -> None:
         o.left.accept(self)
         o.right.accept(self)
         if o.analyzed is not None:
             o.analyzed.accept(self)
 
-    def visit_comparison_expr(self, o: ComparisonExpr) -> None:
+    def visit_comparison_expr(self, o: ComparisonExpr, /) -> None:
         for operand in o.operands:
             operand.accept(self)
 
-    def visit_slice_expr(self, o: SliceExpr) -> None:
+    def visit_slice_expr(self, o: SliceExpr, /) -> None:
         if o.begin_index is not None:
             o.begin_index.accept(self)
         if o.end_index is not None:
@@ -283,13 +283,13 @@ class TraverserVisitor(NodeVisitor[None]):
         if o.stride is not None:
             o.stride.accept(self)
 
-    def visit_cast_expr(self, o: CastExpr) -> None:
+    def visit_cast_expr(self, o: CastExpr, /) -> None:
         o.expr.accept(self)
 
-    def visit_assert_type_expr(self, o: AssertTypeExpr) -> None:
+    def visit_assert_type_expr(self, o: AssertTypeExpr, /) -> None:
         o.expr.accept(self)
 
-    def visit_reveal_expr(self, o: RevealExpr) -> None:
+    def visit_reveal_expr(self, o: RevealExpr, /) -> None:
         if o.kind == REVEAL_TYPE:
             assert o.expr is not None
             o.expr.accept(self)
@@ -297,38 +297,38 @@ class TraverserVisitor(NodeVisitor[None]):
             # RevealLocalsExpr doesn't have an inner expression
             pass
 
-    def visit_assignment_expr(self, o: AssignmentExpr) -> None:
+    def visit_assignment_expr(self, o: AssignmentExpr, /) -> None:
         o.target.accept(self)
         o.value.accept(self)
 
-    def visit_unary_expr(self, o: UnaryExpr) -> None:
+    def visit_unary_expr(self, o: UnaryExpr, /) -> None:
         o.expr.accept(self)
 
-    def visit_list_expr(self, o: ListExpr) -> None:
+    def visit_list_expr(self, o: ListExpr, /) -> None:
         for item in o.items:
             item.accept(self)
 
-    def visit_tuple_expr(self, o: TupleExpr) -> None:
+    def visit_tuple_expr(self, o: TupleExpr, /) -> None:
         for item in o.items:
             item.accept(self)
 
-    def visit_dict_expr(self, o: DictExpr) -> None:
+    def visit_dict_expr(self, o: DictExpr, /) -> None:
         for k, v in o.items:
             if k is not None:
                 k.accept(self)
             v.accept(self)
 
-    def visit_set_expr(self, o: SetExpr) -> None:
+    def visit_set_expr(self, o: SetExpr, /) -> None:
         for item in o.items:
             item.accept(self)
 
-    def visit_index_expr(self, o: IndexExpr) -> None:
+    def visit_index_expr(self, o: IndexExpr, /) -> None:
         o.base.accept(self)
         o.index.accept(self)
         if o.analyzed:
             o.analyzed.accept(self)
 
-    def visit_generator_expr(self, o: GeneratorExpr) -> None:
+    def visit_generator_expr(self, o: GeneratorExpr, /) -> None:
         for index, sequence, conditions in zip(o.indices, o.sequences, o.condlists):
             sequence.accept(self)
             index.accept(self)
@@ -336,7 +336,7 @@ class TraverserVisitor(NodeVisitor[None]):
                 cond.accept(self)
         o.left_expr.accept(self)
 
-    def visit_dictionary_comprehension(self, o: DictionaryComprehension) -> None:
+    def visit_dictionary_comprehension(self, o: DictionaryComprehension, /) -> None:
         for index, sequence, conditions in zip(o.indices, o.sequences, o.condlists):
             sequence.accept(self)
             index.accept(self)
@@ -345,54 +345,54 @@ class TraverserVisitor(NodeVisitor[None]):
         o.key.accept(self)
         o.value.accept(self)
 
-    def visit_list_comprehension(self, o: ListComprehension) -> None:
+    def visit_list_comprehension(self, o: ListComprehension, /) -> None:
         o.generator.accept(self)
 
-    def visit_set_comprehension(self, o: SetComprehension) -> None:
+    def visit_set_comprehension(self, o: SetComprehension, /) -> None:
         o.generator.accept(self)
 
-    def visit_conditional_expr(self, o: ConditionalExpr) -> None:
+    def visit_conditional_expr(self, o: ConditionalExpr, /) -> None:
         o.cond.accept(self)
         o.if_expr.accept(self)
         o.else_expr.accept(self)
 
-    def visit_type_application(self, o: TypeApplication) -> None:
+    def visit_type_application(self, o: TypeApplication, /) -> None:
         o.expr.accept(self)
 
-    def visit_lambda_expr(self, o: LambdaExpr) -> None:
+    def visit_lambda_expr(self, o: LambdaExpr, /) -> None:
         self.visit_func(o)
 
-    def visit_star_expr(self, o: StarExpr) -> None:
+    def visit_star_expr(self, o: StarExpr, /) -> None:
         o.expr.accept(self)
 
-    def visit_await_expr(self, o: AwaitExpr) -> None:
+    def visit_await_expr(self, o: AwaitExpr, /) -> None:
         o.expr.accept(self)
 
-    def visit_super_expr(self, o: SuperExpr) -> None:
+    def visit_super_expr(self, o: SuperExpr, /) -> None:
         o.call.accept(self)
 
-    def visit_as_pattern(self, o: AsPattern) -> None:
+    def visit_as_pattern(self, o: AsPattern, /) -> None:
         if o.pattern is not None:
             o.pattern.accept(self)
         if o.name is not None:
             o.name.accept(self)
 
-    def visit_or_pattern(self, o: OrPattern) -> None:
+    def visit_or_pattern(self, o: OrPattern, /) -> None:
         for p in o.patterns:
             p.accept(self)
 
-    def visit_value_pattern(self, o: ValuePattern) -> None:
+    def visit_value_pattern(self, o: ValuePattern, /) -> None:
         o.expr.accept(self)
 
-    def visit_sequence_pattern(self, o: SequencePattern) -> None:
+    def visit_sequence_pattern(self, o: SequencePattern, /) -> None:
         for p in o.patterns:
             p.accept(self)
 
-    def visit_starred_pattern(self, o: StarredPattern) -> None:
+    def visit_starred_pattern(self, o: StarredPattern, /) -> None:
         if o.capture is not None:
             o.capture.accept(self)
 
-    def visit_mapping_pattern(self, o: MappingPattern) -> None:
+    def visit_mapping_pattern(self, o: MappingPattern, /) -> None:
         for key in o.keys:
             key.accept(self)
         for value in o.values:
@@ -400,18 +400,18 @@ class TraverserVisitor(NodeVisitor[None]):
         if o.rest is not None:
             o.rest.accept(self)
 
-    def visit_class_pattern(self, o: ClassPattern) -> None:
+    def visit_class_pattern(self, o: ClassPattern, /) -> None:
         o.class_ref.accept(self)
         for p in o.positionals:
             p.accept(self)
         for v in o.keyword_values:
             v.accept(self)
 
-    def visit_import(self, o: Import) -> None:
+    def visit_import(self, o: Import, /) -> None:
         for a in o.assignments:
             a.accept(self)
 
-    def visit_import_from(self, o: ImportFrom) -> None:
+    def visit_import_from(self, o: ImportFrom, /) -> None:
         for a in o.assignments:
             a.accept(self)
 
@@ -432,402 +432,402 @@ class ExtendedTraverserVisitor(TraverserVisitor):
         # If returns True, will continue to nested nodes.
         return True
 
-    def visit_mypy_file(self, o: MypyFile) -> None:
+    def visit_mypy_file(self, o: MypyFile, /) -> None:
         if not self.visit(o):
             return
         super().visit_mypy_file(o)
 
     # Module structure
 
-    def visit_import(self, o: Import) -> None:
+    def visit_import(self, o: Import, /) -> None:
         if not self.visit(o):
             return
         super().visit_import(o)
 
-    def visit_import_from(self, o: ImportFrom) -> None:
+    def visit_import_from(self, o: ImportFrom, /) -> None:
         if not self.visit(o):
             return
         super().visit_import_from(o)
 
-    def visit_import_all(self, o: ImportAll) -> None:
+    def visit_import_all(self, o: ImportAll, /) -> None:
         if not self.visit(o):
             return
         super().visit_import_all(o)
 
     # Definitions
 
-    def visit_func_def(self, o: FuncDef) -> None:
+    def visit_func_def(self, o: FuncDef, /) -> None:
         if not self.visit(o):
             return
         super().visit_func_def(o)
 
-    def visit_overloaded_func_def(self, o: OverloadedFuncDef) -> None:
+    def visit_overloaded_func_def(self, o: OverloadedFuncDef, /) -> None:
         if not self.visit(o):
             return
         super().visit_overloaded_func_def(o)
 
-    def visit_class_def(self, o: ClassDef) -> None:
+    def visit_class_def(self, o: ClassDef, /) -> None:
         if not self.visit(o):
             return
         super().visit_class_def(o)
 
-    def visit_global_decl(self, o: GlobalDecl) -> None:
+    def visit_global_decl(self, o: GlobalDecl, /) -> None:
         if not self.visit(o):
             return
         super().visit_global_decl(o)
 
-    def visit_nonlocal_decl(self, o: NonlocalDecl) -> None:
+    def visit_nonlocal_decl(self, o: NonlocalDecl, /) -> None:
         if not self.visit(o):
             return
         super().visit_nonlocal_decl(o)
 
-    def visit_decorator(self, o: Decorator) -> None:
+    def visit_decorator(self, o: Decorator, /) -> None:
         if not self.visit(o):
             return
         super().visit_decorator(o)
 
-    def visit_type_alias(self, o: TypeAlias) -> None:
+    def visit_type_alias(self, o: TypeAlias, /) -> None:
         if not self.visit(o):
             return
         super().visit_type_alias(o)
 
     # Statements
 
-    def visit_block(self, block: Block) -> None:
+    def visit_block(self, block: Block, /) -> None:
         if not self.visit(block):
             return
         super().visit_block(block)
 
-    def visit_expression_stmt(self, o: ExpressionStmt) -> None:
+    def visit_expression_stmt(self, o: ExpressionStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_expression_stmt(o)
 
-    def visit_assignment_stmt(self, o: AssignmentStmt) -> None:
+    def visit_assignment_stmt(self, o: AssignmentStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_assignment_stmt(o)
 
-    def visit_operator_assignment_stmt(self, o: OperatorAssignmentStmt) -> None:
+    def visit_operator_assignment_stmt(self, o: OperatorAssignmentStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_operator_assignment_stmt(o)
 
-    def visit_while_stmt(self, o: WhileStmt) -> None:
+    def visit_while_stmt(self, o: WhileStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_while_stmt(o)
 
-    def visit_for_stmt(self, o: ForStmt) -> None:
+    def visit_for_stmt(self, o: ForStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_for_stmt(o)
 
-    def visit_return_stmt(self, o: ReturnStmt) -> None:
+    def visit_return_stmt(self, o: ReturnStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_return_stmt(o)
 
-    def visit_assert_stmt(self, o: AssertStmt) -> None:
+    def visit_assert_stmt(self, o: AssertStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_assert_stmt(o)
 
-    def visit_del_stmt(self, o: DelStmt) -> None:
+    def visit_del_stmt(self, o: DelStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_del_stmt(o)
 
-    def visit_if_stmt(self, o: IfStmt) -> None:
+    def visit_if_stmt(self, o: IfStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_if_stmt(o)
 
-    def visit_break_stmt(self, o: BreakStmt) -> None:
+    def visit_break_stmt(self, o: BreakStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_break_stmt(o)
 
-    def visit_continue_stmt(self, o: ContinueStmt) -> None:
+    def visit_continue_stmt(self, o: ContinueStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_continue_stmt(o)
 
-    def visit_pass_stmt(self, o: PassStmt) -> None:
+    def visit_pass_stmt(self, o: PassStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_pass_stmt(o)
 
-    def visit_raise_stmt(self, o: RaiseStmt) -> None:
+    def visit_raise_stmt(self, o: RaiseStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_raise_stmt(o)
 
-    def visit_try_stmt(self, o: TryStmt) -> None:
+    def visit_try_stmt(self, o: TryStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_try_stmt(o)
 
-    def visit_with_stmt(self, o: WithStmt) -> None:
+    def visit_with_stmt(self, o: WithStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_with_stmt(o)
 
-    def visit_match_stmt(self, o: MatchStmt) -> None:
+    def visit_match_stmt(self, o: MatchStmt, /) -> None:
         if not self.visit(o):
             return
         super().visit_match_stmt(o)
 
     # Expressions (default no-op implementation)
 
-    def visit_int_expr(self, o: IntExpr) -> None:
+    def visit_int_expr(self, o: IntExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_int_expr(o)
 
-    def visit_str_expr(self, o: StrExpr) -> None:
+    def visit_str_expr(self, o: StrExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_str_expr(o)
 
-    def visit_bytes_expr(self, o: BytesExpr) -> None:
+    def visit_bytes_expr(self, o: BytesExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_bytes_expr(o)
 
-    def visit_float_expr(self, o: FloatExpr) -> None:
+    def visit_float_expr(self, o: FloatExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_float_expr(o)
 
-    def visit_complex_expr(self, o: ComplexExpr) -> None:
+    def visit_complex_expr(self, o: ComplexExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_complex_expr(o)
 
-    def visit_ellipsis(self, o: EllipsisExpr) -> None:
+    def visit_ellipsis(self, o: EllipsisExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_ellipsis(o)
 
-    def visit_star_expr(self, o: StarExpr) -> None:
+    def visit_star_expr(self, o: StarExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_star_expr(o)
 
-    def visit_name_expr(self, o: NameExpr) -> None:
+    def visit_name_expr(self, o: NameExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_name_expr(o)
 
-    def visit_member_expr(self, o: MemberExpr) -> None:
+    def visit_member_expr(self, o: MemberExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_member_expr(o)
 
-    def visit_yield_from_expr(self, o: YieldFromExpr) -> None:
+    def visit_yield_from_expr(self, o: YieldFromExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_yield_from_expr(o)
 
-    def visit_yield_expr(self, o: YieldExpr) -> None:
+    def visit_yield_expr(self, o: YieldExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_yield_expr(o)
 
-    def visit_call_expr(self, o: CallExpr) -> None:
+    def visit_call_expr(self, o: CallExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_call_expr(o)
 
-    def visit_op_expr(self, o: OpExpr) -> None:
+    def visit_op_expr(self, o: OpExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_op_expr(o)
 
-    def visit_comparison_expr(self, o: ComparisonExpr) -> None:
+    def visit_comparison_expr(self, o: ComparisonExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_comparison_expr(o)
 
-    def visit_cast_expr(self, o: CastExpr) -> None:
+    def visit_cast_expr(self, o: CastExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_cast_expr(o)
 
-    def visit_assert_type_expr(self, o: AssertTypeExpr) -> None:
+    def visit_assert_type_expr(self, o: AssertTypeExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_assert_type_expr(o)
 
-    def visit_reveal_expr(self, o: RevealExpr) -> None:
+    def visit_reveal_expr(self, o: RevealExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_reveal_expr(o)
 
-    def visit_super_expr(self, o: SuperExpr) -> None:
+    def visit_super_expr(self, o: SuperExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_super_expr(o)
 
-    def visit_assignment_expr(self, o: AssignmentExpr) -> None:
+    def visit_assignment_expr(self, o: AssignmentExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_assignment_expr(o)
 
-    def visit_unary_expr(self, o: UnaryExpr) -> None:
+    def visit_unary_expr(self, o: UnaryExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_unary_expr(o)
 
-    def visit_list_expr(self, o: ListExpr) -> None:
+    def visit_list_expr(self, o: ListExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_list_expr(o)
 
-    def visit_dict_expr(self, o: DictExpr) -> None:
+    def visit_dict_expr(self, o: DictExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_dict_expr(o)
 
-    def visit_tuple_expr(self, o: TupleExpr) -> None:
+    def visit_tuple_expr(self, o: TupleExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_tuple_expr(o)
 
-    def visit_set_expr(self, o: SetExpr) -> None:
+    def visit_set_expr(self, o: SetExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_set_expr(o)
 
-    def visit_index_expr(self, o: IndexExpr) -> None:
+    def visit_index_expr(self, o: IndexExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_index_expr(o)
 
-    def visit_type_application(self, o: TypeApplication) -> None:
+    def visit_type_application(self, o: TypeApplication, /) -> None:
         if not self.visit(o):
             return
         super().visit_type_application(o)
 
-    def visit_lambda_expr(self, o: LambdaExpr) -> None:
+    def visit_lambda_expr(self, o: LambdaExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_lambda_expr(o)
 
-    def visit_list_comprehension(self, o: ListComprehension) -> None:
+    def visit_list_comprehension(self, o: ListComprehension, /) -> None:
         if not self.visit(o):
             return
         super().visit_list_comprehension(o)
 
-    def visit_set_comprehension(self, o: SetComprehension) -> None:
+    def visit_set_comprehension(self, o: SetComprehension, /) -> None:
         if not self.visit(o):
             return
         super().visit_set_comprehension(o)
 
-    def visit_dictionary_comprehension(self, o: DictionaryComprehension) -> None:
+    def visit_dictionary_comprehension(self, o: DictionaryComprehension, /) -> None:
         if not self.visit(o):
             return
         super().visit_dictionary_comprehension(o)
 
-    def visit_generator_expr(self, o: GeneratorExpr) -> None:
+    def visit_generator_expr(self, o: GeneratorExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_generator_expr(o)
 
-    def visit_slice_expr(self, o: SliceExpr) -> None:
+    def visit_slice_expr(self, o: SliceExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_slice_expr(o)
 
-    def visit_conditional_expr(self, o: ConditionalExpr) -> None:
+    def visit_conditional_expr(self, o: ConditionalExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_conditional_expr(o)
 
-    def visit_type_var_expr(self, o: TypeVarExpr) -> None:
+    def visit_type_var_expr(self, o: TypeVarExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_type_var_expr(o)
 
-    def visit_paramspec_expr(self, o: ParamSpecExpr) -> None:
+    def visit_paramspec_expr(self, o: ParamSpecExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_paramspec_expr(o)
 
-    def visit_type_var_tuple_expr(self, o: TypeVarTupleExpr) -> None:
+    def visit_type_var_tuple_expr(self, o: TypeVarTupleExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_type_var_tuple_expr(o)
 
-    def visit_type_alias_expr(self, o: TypeAliasExpr) -> None:
+    def visit_type_alias_expr(self, o: TypeAliasExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_type_alias_expr(o)
 
-    def visit_namedtuple_expr(self, o: NamedTupleExpr) -> None:
+    def visit_namedtuple_expr(self, o: NamedTupleExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_namedtuple_expr(o)
 
-    def visit_enum_call_expr(self, o: EnumCallExpr) -> None:
+    def visit_enum_call_expr(self, o: EnumCallExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_enum_call_expr(o)
 
-    def visit_typeddict_expr(self, o: TypedDictExpr) -> None:
+    def visit_typeddict_expr(self, o: TypedDictExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_typeddict_expr(o)
 
-    def visit_newtype_expr(self, o: NewTypeExpr) -> None:
+    def visit_newtype_expr(self, o: NewTypeExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_newtype_expr(o)
 
-    def visit_await_expr(self, o: AwaitExpr) -> None:
+    def visit_await_expr(self, o: AwaitExpr, /) -> None:
         if not self.visit(o):
             return
         super().visit_await_expr(o)
 
     # Patterns
 
-    def visit_as_pattern(self, o: AsPattern) -> None:
+    def visit_as_pattern(self, o: AsPattern, /) -> None:
         if not self.visit(o):
             return
         super().visit_as_pattern(o)
 
-    def visit_or_pattern(self, o: OrPattern) -> None:
+    def visit_or_pattern(self, o: OrPattern, /) -> None:
         if not self.visit(o):
             return
         super().visit_or_pattern(o)
 
-    def visit_value_pattern(self, o: ValuePattern) -> None:
+    def visit_value_pattern(self, o: ValuePattern, /) -> None:
         if not self.visit(o):
             return
         super().visit_value_pattern(o)
 
-    def visit_singleton_pattern(self, o: SingletonPattern) -> None:
+    def visit_singleton_pattern(self, o: SingletonPattern, /) -> None:
         if not self.visit(o):
             return
         super().visit_singleton_pattern(o)
 
-    def visit_sequence_pattern(self, o: SequencePattern) -> None:
+    def visit_sequence_pattern(self, o: SequencePattern, /) -> None:
         if not self.visit(o):
             return
         super().visit_sequence_pattern(o)
 
-    def visit_starred_pattern(self, o: StarredPattern) -> None:
+    def visit_starred_pattern(self, o: StarredPattern, /) -> None:
         if not self.visit(o):
             return
         super().visit_starred_pattern(o)
 
-    def visit_mapping_pattern(self, o: MappingPattern) -> None:
+    def visit_mapping_pattern(self, o: MappingPattern, /) -> None:
         if not self.visit(o):
             return
         super().visit_mapping_pattern(o)
 
-    def visit_class_pattern(self, o: ClassPattern) -> None:
+    def visit_class_pattern(self, o: ClassPattern, /) -> None:
         if not self.visit(o):
             return
         super().visit_class_pattern(o)

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -201,25 +201,25 @@ class TypeTranslator(TypeVisitor[Type]):
             self.cache = {}
         self.cache[orig] = new
 
-    def visit_unbound_type(self, t: UnboundType) -> Type:
+    def visit_unbound_type(self, t: UnboundType, /) -> Type:
         return t
 
-    def visit_any(self, t: AnyType) -> Type:
+    def visit_any(self, t: AnyType, /) -> Type:
         return t
 
-    def visit_none_type(self, t: NoneType) -> Type:
+    def visit_none_type(self, t: NoneType, /) -> Type:
         return t
 
-    def visit_uninhabited_type(self, t: UninhabitedType) -> Type:
+    def visit_uninhabited_type(self, t: UninhabitedType, /) -> Type:
         return t
 
-    def visit_erased_type(self, t: ErasedType) -> Type:
+    def visit_erased_type(self, t: ErasedType, /) -> Type:
         return t
 
-    def visit_deleted_type(self, t: DeletedType) -> Type:
+    def visit_deleted_type(self, t: DeletedType, /) -> Type:
         return t
 
-    def visit_instance(self, t: Instance) -> Type:
+    def visit_instance(self, t: Instance, /) -> Type:
         last_known_value: LiteralType | None = None
         if t.last_known_value is not None:
             raw_last_known_value = t.last_known_value.accept(self)
@@ -234,32 +234,32 @@ class TypeTranslator(TypeVisitor[Type]):
             extra_attrs=t.extra_attrs,
         )
 
-    def visit_type_var(self, t: TypeVarType) -> Type:
+    def visit_type_var(self, t: TypeVarType, /) -> Type:
         return t
 
-    def visit_param_spec(self, t: ParamSpecType) -> Type:
+    def visit_param_spec(self, t: ParamSpecType, /) -> Type:
         return t
 
-    def visit_parameters(self, t: Parameters) -> Type:
+    def visit_parameters(self, t: Parameters, /) -> Type:
         return t.copy_modified(arg_types=self.translate_types(t.arg_types))
 
-    def visit_type_var_tuple(self, t: TypeVarTupleType) -> Type:
+    def visit_type_var_tuple(self, t: TypeVarTupleType, /) -> Type:
         return t
 
-    def visit_partial_type(self, t: PartialType) -> Type:
+    def visit_partial_type(self, t: PartialType, /) -> Type:
         return t
 
-    def visit_unpack_type(self, t: UnpackType) -> Type:
+    def visit_unpack_type(self, t: UnpackType, /) -> Type:
         return UnpackType(t.type.accept(self))
 
-    def visit_callable_type(self, t: CallableType) -> Type:
+    def visit_callable_type(self, t: CallableType, /) -> Type:
         return t.copy_modified(
             arg_types=self.translate_types(t.arg_types),
             ret_type=t.ret_type.accept(self),
             variables=self.translate_variables(t.variables),
         )
 
-    def visit_tuple_type(self, t: TupleType) -> Type:
+    def visit_tuple_type(self, t: TupleType, /) -> Type:
         return TupleType(
             self.translate_types(t.items),
             # TODO: This appears to be unsafe.
@@ -268,7 +268,7 @@ class TypeTranslator(TypeVisitor[Type]):
             t.column,
         )
 
-    def visit_typeddict_type(self, t: TypedDictType) -> Type:
+    def visit_typeddict_type(self, t: TypedDictType, /) -> Type:
         # Use cache to avoid O(n**2) or worse expansion of types during translation
         if cached := self.get_cached(t):
             return cached
@@ -285,12 +285,12 @@ class TypeTranslator(TypeVisitor[Type]):
         self.set_cached(t, result)
         return result
 
-    def visit_literal_type(self, t: LiteralType) -> Type:
+    def visit_literal_type(self, t: LiteralType, /) -> Type:
         fallback = t.fallback.accept(self)
         assert isinstance(fallback, Instance)  # type: ignore[misc]
         return LiteralType(value=t.value, fallback=fallback, line=t.line, column=t.column)
 
-    def visit_union_type(self, t: UnionType) -> Type:
+    def visit_union_type(self, t: UnionType, /) -> Type:
         # Use cache to avoid O(n**2) or worse expansion of types during translation
         # (only for large unions, since caching adds overhead)
         use_cache = len(t.items) > 3
@@ -315,7 +315,7 @@ class TypeTranslator(TypeVisitor[Type]):
     ) -> Sequence[TypeVarLikeType]:
         return variables
 
-    def visit_overloaded(self, t: Overloaded) -> Type:
+    def visit_overloaded(self, t: Overloaded, /) -> Type:
         items: list[CallableType] = []
         for item in t.items:
             new = item.accept(self)
@@ -323,11 +323,11 @@ class TypeTranslator(TypeVisitor[Type]):
             items.append(new)
         return Overloaded(items=items)
 
-    def visit_type_type(self, t: TypeType) -> Type:
+    def visit_type_type(self, t: TypeType, /) -> Type:
         return TypeType.make_normalized(t.item.accept(self), line=t.line, column=t.column)
 
     @abstractmethod
-    def visit_type_alias_type(self, t: TypeAliasType) -> Type:
+    def visit_type_alias_type(self, t: TypeAliasType, /) -> Type:
         # This method doesn't have a default implementation for type translators,
         # because type aliases are special: some information is contained in the
         # TypeAlias node, and we normally don't generate new nodes. Every subclass
@@ -359,83 +359,83 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         # to skip targets in some cases (e.g. when collecting type variables).
         self.skip_alias_target = False
 
-    def visit_unbound_type(self, t: UnboundType) -> T:
+    def visit_unbound_type(self, t: UnboundType, /) -> T:
         return self.query_types(t.args)
 
-    def visit_type_list(self, t: TypeList) -> T:
+    def visit_type_list(self, t: TypeList, /) -> T:
         return self.query_types(t.items)
 
-    def visit_callable_argument(self, t: CallableArgument) -> T:
+    def visit_callable_argument(self, t: CallableArgument, /) -> T:
         return t.typ.accept(self)
 
-    def visit_any(self, t: AnyType) -> T:
+    def visit_any(self, t: AnyType, /) -> T:
         return self.strategy([])
 
-    def visit_uninhabited_type(self, t: UninhabitedType) -> T:
+    def visit_uninhabited_type(self, t: UninhabitedType, /) -> T:
         return self.strategy([])
 
-    def visit_none_type(self, t: NoneType) -> T:
+    def visit_none_type(self, t: NoneType, /) -> T:
         return self.strategy([])
 
-    def visit_erased_type(self, t: ErasedType) -> T:
+    def visit_erased_type(self, t: ErasedType, /) -> T:
         return self.strategy([])
 
-    def visit_deleted_type(self, t: DeletedType) -> T:
+    def visit_deleted_type(self, t: DeletedType, /) -> T:
         return self.strategy([])
 
-    def visit_type_var(self, t: TypeVarType) -> T:
+    def visit_type_var(self, t: TypeVarType, /) -> T:
         return self.query_types([t.upper_bound, t.default] + t.values)
 
-    def visit_param_spec(self, t: ParamSpecType) -> T:
+    def visit_param_spec(self, t: ParamSpecType, /) -> T:
         return self.query_types([t.upper_bound, t.default, t.prefix])
 
-    def visit_type_var_tuple(self, t: TypeVarTupleType) -> T:
+    def visit_type_var_tuple(self, t: TypeVarTupleType, /) -> T:
         return self.query_types([t.upper_bound, t.default])
 
-    def visit_unpack_type(self, t: UnpackType) -> T:
+    def visit_unpack_type(self, t: UnpackType, /) -> T:
         return self.query_types([t.type])
 
-    def visit_parameters(self, t: Parameters) -> T:
+    def visit_parameters(self, t: Parameters, /) -> T:
         return self.query_types(t.arg_types)
 
-    def visit_partial_type(self, t: PartialType) -> T:
+    def visit_partial_type(self, t: PartialType, /) -> T:
         return self.strategy([])
 
-    def visit_instance(self, t: Instance) -> T:
+    def visit_instance(self, t: Instance, /) -> T:
         return self.query_types(t.args)
 
-    def visit_callable_type(self, t: CallableType) -> T:
+    def visit_callable_type(self, t: CallableType, /) -> T:
         # FIX generics
         return self.query_types(t.arg_types + [t.ret_type])
 
-    def visit_tuple_type(self, t: TupleType) -> T:
+    def visit_tuple_type(self, t: TupleType, /) -> T:
         return self.query_types(t.items)
 
-    def visit_typeddict_type(self, t: TypedDictType) -> T:
+    def visit_typeddict_type(self, t: TypedDictType, /) -> T:
         return self.query_types(t.items.values())
 
-    def visit_raw_expression_type(self, t: RawExpressionType) -> T:
+    def visit_raw_expression_type(self, t: RawExpressionType, /) -> T:
         return self.strategy([])
 
-    def visit_literal_type(self, t: LiteralType) -> T:
+    def visit_literal_type(self, t: LiteralType, /) -> T:
         return self.strategy([])
 
-    def visit_union_type(self, t: UnionType) -> T:
+    def visit_union_type(self, t: UnionType, /) -> T:
         return self.query_types(t.items)
 
-    def visit_overloaded(self, t: Overloaded) -> T:
+    def visit_overloaded(self, t: Overloaded, /) -> T:
         return self.query_types(t.items)
 
-    def visit_type_type(self, t: TypeType) -> T:
+    def visit_type_type(self, t: TypeType, /) -> T:
         return t.item.accept(self)
 
-    def visit_ellipsis_type(self, t: EllipsisType) -> T:
+    def visit_ellipsis_type(self, t: EllipsisType, /) -> T:
         return self.strategy([])
 
-    def visit_placeholder_type(self, t: PlaceholderType) -> T:
+    def visit_placeholder_type(self, t: PlaceholderType, /) -> T:
         return self.query_types(t.args)
 
-    def visit_type_alias_type(self, t: TypeAliasType) -> T:
+    def visit_type_alias_type(self, t: TypeAliasType, /) -> T:
         # Skip type aliases already visited types to avoid infinite recursion.
         # TODO: Ideally we should fire subvisitors here (or use caching) if we care
         #       about duplicates.
@@ -493,52 +493,52 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         """
         self.seen_aliases = None
 
-    def visit_unbound_type(self, t: UnboundType) -> bool:
+    def visit_unbound_type(self, t: UnboundType, /) -> bool:
         return self.query_types(t.args)
 
-    def visit_type_list(self, t: TypeList) -> bool:
+    def visit_type_list(self, t: TypeList, /) -> bool:
         return self.query_types(t.items)
 
-    def visit_callable_argument(self, t: CallableArgument) -> bool:
+    def visit_callable_argument(self, t: CallableArgument, /) -> bool:
         return t.typ.accept(self)
 
-    def visit_any(self, t: AnyType) -> bool:
+    def visit_any(self, t: AnyType, /) -> bool:
         return self.default
 
-    def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
+    def visit_uninhabited_type(self, t: UninhabitedType, /) -> bool:
         return self.default
 
-    def visit_none_type(self, t: NoneType) -> bool:
+    def visit_none_type(self, t: NoneType, /) -> bool:
         return self.default
 
-    def visit_erased_type(self, t: ErasedType) -> bool:
+    def visit_erased_type(self, t: ErasedType, /) -> bool:
         return self.default
 
-    def visit_deleted_type(self, t: DeletedType) -> bool:
+    def visit_deleted_type(self, t: DeletedType, /) -> bool:
         return self.default
 
-    def visit_type_var(self, t: TypeVarType) -> bool:
+    def visit_type_var(self, t: TypeVarType, /) -> bool:
         return self.query_types([t.upper_bound, t.default] + t.values)
 
-    def visit_param_spec(self, t: ParamSpecType) -> bool:
+    def visit_param_spec(self, t: ParamSpecType, /) -> bool:
         return self.query_types([t.upper_bound, t.default])
 
-    def visit_type_var_tuple(self, t: TypeVarTupleType) -> bool:
+    def visit_type_var_tuple(self, t: TypeVarTupleType, /) -> bool:
         return self.query_types([t.upper_bound, t.default])
 
-    def visit_unpack_type(self, t: UnpackType) -> bool:
+    def visit_unpack_type(self, t: UnpackType, /) -> bool:
         return self.query_types([t.type])
 
-    def visit_parameters(self, t: Parameters) -> bool:
+    def visit_parameters(self, t: Parameters, /) -> bool:
         return self.query_types(t.arg_types)
 
-    def visit_partial_type(self, t: PartialType) -> bool:
+    def visit_partial_type(self, t: PartialType, /) -> bool:
         return self.default
 
-    def visit_instance(self, t: Instance) -> bool:
+    def visit_instance(self, t: Instance, /) -> bool:
         return self.query_types(t.args)
 
-    def visit_callable_type(self, t: CallableType) -> bool:
+    def visit_callable_type(self, t: CallableType, /) -> bool:
         # FIX generics
         # Avoid allocating any objects here as an optimization.
         args = self.query_types(t.arg_types)
@@ -548,34 +548,34 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         else:
             return args and ret
 
-    def visit_tuple_type(self, t: TupleType) -> bool:
+    def visit_tuple_type(self, t: TupleType, /) -> bool:
         return self.query_types(t.items)
 
-    def visit_typeddict_type(self, t: TypedDictType) -> bool:
+    def visit_typeddict_type(self, t: TypedDictType, /) -> bool:
         return self.query_types(list(t.items.values()))
 
-    def visit_raw_expression_type(self, t: RawExpressionType) -> bool:
+    def visit_raw_expression_type(self, t: RawExpressionType, /) -> bool:
         return self.default
 
-    def visit_literal_type(self, t: LiteralType) -> bool:
+    def visit_literal_type(self, t: LiteralType, /) -> bool:
         return self.default
 
-    def visit_union_type(self, t: UnionType) -> bool:
+    def visit_union_type(self, t: UnionType, /) -> bool:
         return self.query_types(t.items)
 
-    def visit_overloaded(self, t: Overloaded) -> bool:
+    def visit_overloaded(self, t: Overloaded, /) -> bool:
         return self.query_types(t.items)  # type: ignore[arg-type]
 
-    def visit_type_type(self, t: TypeType) -> bool:
+    def visit_type_type(self, t: TypeType, /) -> bool:
         return t.item.accept(self)
 
-    def visit_ellipsis_type(self, t: EllipsisType) -> bool:
+    def visit_ellipsis_type(self, t: EllipsisType, /) -> bool:
         return self.default
 
-    def visit_placeholder_type(self, t: PlaceholderType) -> bool:
+    def visit_placeholder_type(self, t: PlaceholderType, /) -> bool:
         return self.query_types(t.args)
 
-    def visit_type_alias_type(self, t: TypeAliasType) -> bool:
+    def visit_type_alias_type(self, t: TypeAliasType, /) -> bool:
         # Skip type aliases already visited types to avoid infinite recursion.
         # TODO: Ideally we should fire subvisitors here (or use caching) if we care
         #       about duplicates.

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -62,87 +62,87 @@ class TypeVisitor(Generic[T]):
     """
 
     @abstractmethod
-    def visit_unbound_type(self, t: UnboundType) -> T:
+    def visit_unbound_type(self, t: UnboundType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_any(self, t: AnyType) -> T:
+    def visit_any(self, t: AnyType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_none_type(self, t: NoneType) -> T:
+    def visit_none_type(self, t: NoneType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_uninhabited_type(self, t: UninhabitedType) -> T:
+    def visit_uninhabited_type(self, t: UninhabitedType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_erased_type(self, t: ErasedType) -> T:
+    def visit_erased_type(self, t: ErasedType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_deleted_type(self, t: DeletedType) -> T:
+    def visit_deleted_type(self, t: DeletedType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_var(self, t: TypeVarType) -> T:
+    def visit_type_var(self, t: TypeVarType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_param_spec(self, t: ParamSpecType) -> T:
+    def visit_param_spec(self, t: ParamSpecType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_parameters(self, t: Parameters) -> T:
+    def visit_parameters(self, t: Parameters, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_var_tuple(self, t: TypeVarTupleType) -> T:
+    def visit_type_var_tuple(self, t: TypeVarTupleType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_instance(self, t: Instance) -> T:
+    def visit_instance(self, t: Instance, /) -> T:
         pass
 
     @abstractmethod
-    def visit_callable_type(self, t: CallableType) -> T:
+    def visit_callable_type(self, t: CallableType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_overloaded(self, t: Overloaded) -> T:
+    def visit_overloaded(self, t: Overloaded, /) -> T:
         pass
 
     @abstractmethod
-    def visit_tuple_type(self, t: TupleType) -> T:
+    def visit_tuple_type(self, t: TupleType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_typeddict_type(self, t: TypedDictType) -> T:
+    def visit_typeddict_type(self, t: TypedDictType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_literal_type(self, t: LiteralType) -> T:
+    def visit_literal_type(self, t: LiteralType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_union_type(self, t: UnionType) -> T:
+    def visit_union_type(self, t: UnionType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_partial_type(self, t: PartialType) -> T:
+    def visit_partial_type(self, t: PartialType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_type(self, t: TypeType) -> T:
+    def visit_type_type(self, t: TypeType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_alias_type(self, t: TypeAliasType) -> T:
+    def visit_type_alias_type(self, t: TypeAliasType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_unpack_type(self, t: UnpackType) -> T:
+    def visit_unpack_type(self, t: UnpackType, /) -> T:
         pass
 
 
@@ -155,23 +155,23 @@ class SyntheticTypeVisitor(TypeVisitor[T]):
     """
 
     @abstractmethod
-    def visit_type_list(self, t: TypeList) -> T:
+    def visit_type_list(self, t: TypeList, /) -> T:
         pass
 
     @abstractmethod
-    def visit_callable_argument(self, t: CallableArgument) -> T:
+    def visit_callable_argument(self, t: CallableArgument, /) -> T:
         pass
 
     @abstractmethod
-    def visit_ellipsis_type(self, t: EllipsisType) -> T:
+    def visit_ellipsis_type(self, t: EllipsisType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_raw_expression_type(self, t: RawExpressionType) -> T:
+    def visit_raw_expression_type(self, t: RawExpressionType, /) -> T:
         pass
 
     @abstractmethod
-    def visit_placeholder_type(self, t: PlaceholderType) -> T:
+    def visit_placeholder_type(self, t: PlaceholderType, /) -> T:
         pass
 
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3258,43 +3258,43 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         self.any_as_dots = False
         self.options = options
 
-    def visit_unbound_type(self, t: UnboundType) -> str:
+    def visit_unbound_type(self, t: UnboundType, /) -> str:
         s = t.name + "?"
         if t.args:
             s += f"[{self.list_str(t.args)}]"
         return s
 
-    def visit_type_list(self, t: TypeList) -> str:
+    def visit_type_list(self, t: TypeList, /) -> str:
         return f"<TypeList {self.list_str(t.items)}>"
 
-    def visit_callable_argument(self, t: CallableArgument) -> str:
+    def visit_callable_argument(self, t: CallableArgument, /) -> str:
         typ = t.typ.accept(self)
         if t.name is None:
             return f"{t.constructor}({typ})"
         else:
             return f"{t.constructor}({typ}, {t.name})"
 
-    def visit_any(self, t: AnyType) -> str:
+    def visit_any(self, t: AnyType, /) -> str:
         if self.any_as_dots and t.type_of_any == TypeOfAny.special_form:
             return "..."
         return "Any"
 
-    def visit_none_type(self, t: NoneType) -> str:
+    def visit_none_type(self, t: NoneType, /) -> str:
         return "None"
 
-    def visit_uninhabited_type(self, t: UninhabitedType) -> str:
+    def visit_uninhabited_type(self, t: UninhabitedType, /) -> str:
         return "Never"
 
-    def visit_erased_type(self, t: ErasedType) -> str:
+    def visit_erased_type(self, t: ErasedType, /) -> str:
         return "<Erased>"
 
-    def visit_deleted_type(self, t: DeletedType) -> str:
+    def visit_deleted_type(self, t: DeletedType, /) -> str:
         if t.source is None:
             return "<Deleted>"
         else:
             return f"<Deleted '{t.source}'>"
 
-    def visit_instance(self, t: Instance) -> str:
+    def visit_instance(self, t: Instance, /) -> str:
         if t.last_known_value and not t.args:
             # Instances with a literal fallback should never be generic. If they are,
             # something went wrong so we fall back to showing the full Instance repr.
@@ -3314,7 +3314,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             s += f"<{self.id_mapper.id(t.type)}>"
         return s
 
-    def visit_type_var(self, t: TypeVarType) -> str:
+    def visit_type_var(self, t: TypeVarType, /) -> str:
         if t.name is None:
             # Anonymous type variable type (only numeric id).
             s = f"`{t.id}"
@@ -3327,7 +3327,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             s += f" = {t.default.accept(self)}"
         return s
 
-    def visit_param_spec(self, t: ParamSpecType) -> str:
+    def visit_param_spec(self, t: ParamSpecType, /) -> str:
         # prefixes are displayed as Concatenate
         s = ""
         if t.prefix.arg_types:
@@ -3344,7 +3344,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             s += f" = {t.default.accept(self)}"
         return s
 
-    def visit_parameters(self, t: Parameters) -> str:
+    def visit_parameters(self, t: Parameters, /) -> str:
         # This is copied from visit_callable -- is there a way to decrease duplication?
         if t.is_ellipsis_args:
             return "..."
@@ -3373,7 +3373,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 
         return f"[{s}]"
 
-    def visit_type_var_tuple(self, t: TypeVarTupleType) -> str:
+    def visit_type_var_tuple(self, t: TypeVarTupleType, /) -> str:
         if t.name is None:
             # Anonymous type variable type (only numeric id).
             s = f"`{t.id}"
@@ -3384,7 +3384,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             s += f" = {t.default.accept(self)}"
         return s
 
-    def visit_callable_type(self, t: CallableType) -> str:
+    def visit_callable_type(self, t: CallableType, /) -> str:
         param_spec = t.param_spec()
         if param_spec is not None:
             num_skip = 2
@@ -3457,13 +3457,13 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 
         return f"def {s}"
 
-    def visit_overloaded(self, t: Overloaded) -> str:
+    def visit_overloaded(self, t: Overloaded, /) -> str:
         a = []
         for i in t.items:
             a.append(i.accept(self))
         return f"Overload({', '.join(a)})"
 
-    def visit_tuple_type(self, t: TupleType) -> str:
+    def visit_tuple_type(self, t: TupleType, /) -> str:
         s = self.list_str(t.items) or "()"
         tuple_name = "tuple" if self.options.use_lowercase_names() else "Tuple"
         if t.partial_fallback and t.partial_fallback.type:
@@ -3472,7 +3472,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
                 return f"{tuple_name}[{s}, fallback={t.partial_fallback.accept(self)}]"
         return f"{tuple_name}[{s}]"
 
-    def visit_typeddict_type(self, t: TypedDictType) -> str:
+    def visit_typeddict_type(self, t: TypedDictType, /) -> str:
         def item_str(name: str, typ: str) -> str:
             modifier = ""
             if name not in t.required_keys:
@@ -3492,36 +3492,36 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
                 prefix = repr(t.fallback.type.fullname) + ", "
         return f"TypedDict({prefix}{s})"
 
-    def visit_raw_expression_type(self, t: RawExpressionType) -> str:
+    def visit_raw_expression_type(self, t: RawExpressionType, /) -> str:
         return repr(t.literal_value)
 
-    def visit_literal_type(self, t: LiteralType) -> str:
+    def visit_literal_type(self, t: LiteralType, /) -> str:
         return f"Literal[{t.value_repr()}]"
 
-    def visit_union_type(self, t: UnionType) -> str:
+    def visit_union_type(self, t: UnionType, /) -> str:
         s = self.list_str(t.items)
         return f"Union[{s}]"
 
-    def visit_partial_type(self, t: PartialType) -> str:
+    def visit_partial_type(self, t: PartialType, /) -> str:
         if t.type is None:
             return "<partial None>"
         else:
             return "<partial {}[{}]>".format(t.type.name, ", ".join(["?"] * len(t.type.type_vars)))
 
-    def visit_ellipsis_type(self, t: EllipsisType) -> str:
+    def visit_ellipsis_type(self, t: EllipsisType, /) -> str:
         return "..."
 
-    def visit_type_type(self, t: TypeType) -> str:
+    def visit_type_type(self, t: TypeType, /) -> str:
         if self.options.use_lowercase_names():
             type_name = "type"
         else:
             type_name = "Type"
         return f"{type_name}[{t.item.accept(self)}]"
 
-    def visit_placeholder_type(self, t: PlaceholderType) -> str:
+    def visit_placeholder_type(self, t: PlaceholderType, /) -> str:
         return f"<placeholder {t.fullname}>"
 
-    def visit_type_alias_type(self, t: TypeAliasType) -> str:
+    def visit_type_alias_type(self, t: TypeAliasType, /) -> str:
         if t.alias is not None:
             unrolled, recursed = t._partial_expansion()
             self.any_as_dots = recursed
@@ -3530,7 +3530,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             return type_str
         return "<alias (unfixed)>"
 
-    def visit_unpack_type(self, t: UnpackType) -> str:
+    def visit_unpack_type(self, t: UnpackType, /) -> str:
         return f"Unpack[{t.type.accept(self)}]"
 
     def list_str(self, a: Iterable[Type]) -> str:
@@ -3546,19 +3546,19 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 class TrivialSyntheticTypeTranslator(TypeTranslator, SyntheticTypeVisitor[Type]):
     """A base class for type translators that need to be run during semantic analysis."""
 
-    def visit_placeholder_type(self, t: PlaceholderType) -> Type:
+    def visit_placeholder_type(self, t: PlaceholderType, /) -> Type:
         return t
 
-    def visit_callable_argument(self, t: CallableArgument) -> Type:
+    def visit_callable_argument(self, t: CallableArgument, /) -> Type:
         return t
 
-    def visit_ellipsis_type(self, t: EllipsisType) -> Type:
+    def visit_ellipsis_type(self, t: EllipsisType, /) -> Type:
         return t
 
-    def visit_raw_expression_type(self, t: RawExpressionType) -> Type:
+    def visit_raw_expression_type(self, t: RawExpressionType, /) -> Type:
         return t
 
-    def visit_type_list(self, t: TypeList) -> Type:
+    def visit_type_list(self, t: TypeList, /) -> Type:
         return t
 
 

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -42,45 +42,45 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
 
     # Atomic types
 
-    def visit_any(self, t: AnyType) -> None:
+    def visit_any(self, t: AnyType, /) -> None:
         pass
 
-    def visit_uninhabited_type(self, t: UninhabitedType) -> None:
+    def visit_uninhabited_type(self, t: UninhabitedType, /) -> None:
         pass
 
-    def visit_none_type(self, t: NoneType) -> None:
+    def visit_none_type(self, t: NoneType, /) -> None:
         pass
 
-    def visit_erased_type(self, t: ErasedType) -> None:
+    def visit_erased_type(self, t: ErasedType, /) -> None:
         pass
 
-    def visit_deleted_type(self, t: DeletedType) -> None:
+    def visit_deleted_type(self, t: DeletedType, /) -> None:
         pass
 
-    def visit_type_var(self, t: TypeVarType) -> None:
+    def visit_type_var(self, t: TypeVarType, /) -> None:
         # Note that type variable values and upper bound aren't treated as
         # components, since they are components of the type variable
         # definition. We want to traverse everything just once.
         t.default.accept(self)
 
-    def visit_param_spec(self, t: ParamSpecType) -> None:
+    def visit_param_spec(self, t: ParamSpecType, /) -> None:
         t.default.accept(self)
 
-    def visit_parameters(self, t: Parameters) -> None:
+    def visit_parameters(self, t: Parameters, /) -> None:
         self.traverse_types(t.arg_types)
 
-    def visit_type_var_tuple(self, t: TypeVarTupleType) -> None:
+    def visit_type_var_tuple(self, t: TypeVarTupleType, /) -> None:
         t.default.accept(self)
 
-    def visit_literal_type(self, t: LiteralType) -> None:
+    def visit_literal_type(self, t: LiteralType, /) -> None:
         t.fallback.accept(self)
 
     # Composite types
 
-    def visit_instance(self, t: Instance) -> None:
+    def visit_instance(self, t: Instance, /) -> None:
         self.traverse_types(t.args)
 
-    def visit_callable_type(self, t: CallableType) -> None:
+    def visit_callable_type(self, t: CallableType, /) -> None:
         # FIX generics
         self.traverse_types(t.arg_types)
         t.ret_type.accept(self)
@@ -92,57 +92,57 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
         if t.type_is is not None:
             t.type_is.accept(self)
 
-    def visit_tuple_type(self, t: TupleType) -> None:
+    def visit_tuple_type(self, t: TupleType, /) -> None:
         self.traverse_types(t.items)
         t.partial_fallback.accept(self)
 
-    def visit_typeddict_type(self, t: TypedDictType) -> None:
+    def visit_typeddict_type(self, t: TypedDictType, /) -> None:
         self.traverse_types(t.items.values())
         t.fallback.accept(self)
 
-    def visit_union_type(self, t: UnionType) -> None:
+    def visit_union_type(self, t: UnionType, /) -> None:
         self.traverse_types(t.items)
 
-    def visit_overloaded(self, t: Overloaded) -> None:
+    def visit_overloaded(self, t: Overloaded, /) -> None:
         self.traverse_types(t.items)
 
-    def visit_type_type(self, t: TypeType) -> None:
+    def visit_type_type(self, t: TypeType, /) -> None:
         t.item.accept(self)
 
     # Special types (not real types)
 
-    def visit_callable_argument(self, t: CallableArgument) -> None:
+    def visit_callable_argument(self, t: CallableArgument, /) -> None:
         t.typ.accept(self)
 
-    def visit_unbound_type(self, t: UnboundType) -> None:
+    def visit_unbound_type(self, t: UnboundType, /) -> None:
         self.traverse_types(t.args)
 
-    def visit_type_list(self, t: TypeList) -> None:
+    def visit_type_list(self, t: TypeList, /) -> None:
         self.traverse_types(t.items)
 
-    def visit_ellipsis_type(self, t: EllipsisType) -> None:
+    def visit_ellipsis_type(self, t: EllipsisType, /) -> None:
         pass
 
-    def visit_placeholder_type(self, t: PlaceholderType) -> None:
+    def visit_placeholder_type(self, t: PlaceholderType, /) -> None:
         self.traverse_types(t.args)
 
-    def visit_partial_type(self, t: PartialType) -> None:
+    def visit_partial_type(self, t: PartialType, /) -> None:
         pass
 
-    def visit_raw_expression_type(self, t: RawExpressionType) -> None:
+    def visit_raw_expression_type(self, t: RawExpressionType, /) -> None:
         pass
 
-    def visit_type_alias_type(self, t: TypeAliasType) -> None:
+    def visit_type_alias_type(self, t: TypeAliasType, /) -> None:
         # TODO: sometimes we want to traverse target as well
         # We need to find a way to indicate explicitly the intent,
         # maybe make this method abstract (like for TypeTranslator)?
         self.traverse_types(t.args)
 
-    def visit_unpack_type(self, t: UnpackType) -> None:
+    def visit_unpack_type(self, t: UnpackType, /) -> None:
         t.type.accept(self)
 
     # Helpers
 
-    def traverse_types(self, types: Iterable[Type]) -> None:
+    def traverse_types(self, types: Iterable[Type], /) -> None:
         for typ in types:
             typ.accept(self)

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -20,179 +20,179 @@ T = TypeVar("T")
 @mypyc_attr(allow_interpreted_subclasses=True)
 class ExpressionVisitor(Generic[T]):
     @abstractmethod
-    def visit_int_expr(self, o: mypy.nodes.IntExpr) -> T:
+    def visit_int_expr(self, o: mypy.nodes.IntExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_str_expr(self, o: mypy.nodes.StrExpr) -> T:
+    def visit_str_expr(self, o: mypy.nodes.StrExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_bytes_expr(self, o: mypy.nodes.BytesExpr) -> T:
+    def visit_bytes_expr(self, o: mypy.nodes.BytesExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_float_expr(self, o: mypy.nodes.FloatExpr) -> T:
+    def visit_float_expr(self, o: mypy.nodes.FloatExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_complex_expr(self, o: mypy.nodes.ComplexExpr) -> T:
+    def visit_complex_expr(self, o: mypy.nodes.ComplexExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_ellipsis(self, o: mypy.nodes.EllipsisExpr) -> T:
+    def visit_ellipsis(self, o: mypy.nodes.EllipsisExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_star_expr(self, o: mypy.nodes.StarExpr) -> T:
+    def visit_star_expr(self, o: mypy.nodes.StarExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_name_expr(self, o: mypy.nodes.NameExpr) -> T:
+    def visit_name_expr(self, o: mypy.nodes.NameExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_member_expr(self, o: mypy.nodes.MemberExpr) -> T:
+    def visit_member_expr(self, o: mypy.nodes.MemberExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_yield_from_expr(self, o: mypy.nodes.YieldFromExpr) -> T:
+    def visit_yield_from_expr(self, o: mypy.nodes.YieldFromExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_yield_expr(self, o: mypy.nodes.YieldExpr) -> T:
+    def visit_yield_expr(self, o: mypy.nodes.YieldExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_call_expr(self, o: mypy.nodes.CallExpr) -> T:
+    def visit_call_expr(self, o: mypy.nodes.CallExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_op_expr(self, o: mypy.nodes.OpExpr) -> T:
+    def visit_op_expr(self, o: mypy.nodes.OpExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_comparison_expr(self, o: mypy.nodes.ComparisonExpr) -> T:
+    def visit_comparison_expr(self, o: mypy.nodes.ComparisonExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_cast_expr(self, o: mypy.nodes.CastExpr) -> T:
+    def visit_cast_expr(self, o: mypy.nodes.CastExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_assert_type_expr(self, o: mypy.nodes.AssertTypeExpr) -> T:
+    def visit_assert_type_expr(self, o: mypy.nodes.AssertTypeExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_reveal_expr(self, o: mypy.nodes.RevealExpr) -> T:
+    def visit_reveal_expr(self, o: mypy.nodes.RevealExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_super_expr(self, o: mypy.nodes.SuperExpr) -> T:
+    def visit_super_expr(self, o: mypy.nodes.SuperExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_unary_expr(self, o: mypy.nodes.UnaryExpr) -> T:
+    def visit_unary_expr(self, o: mypy.nodes.UnaryExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_assignment_expr(self, o: mypy.nodes.AssignmentExpr) -> T:
+    def visit_assignment_expr(self, o: mypy.nodes.AssignmentExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_list_expr(self, o: mypy.nodes.ListExpr) -> T:
+    def visit_list_expr(self, o: mypy.nodes.ListExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_dict_expr(self, o: mypy.nodes.DictExpr) -> T:
+    def visit_dict_expr(self, o: mypy.nodes.DictExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_tuple_expr(self, o: mypy.nodes.TupleExpr) -> T:
+    def visit_tuple_expr(self, o: mypy.nodes.TupleExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_set_expr(self, o: mypy.nodes.SetExpr) -> T:
+    def visit_set_expr(self, o: mypy.nodes.SetExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_index_expr(self, o: mypy.nodes.IndexExpr) -> T:
+    def visit_index_expr(self, o: mypy.nodes.IndexExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_application(self, o: mypy.nodes.TypeApplication) -> T:
+    def visit_type_application(self, o: mypy.nodes.TypeApplication, /) -> T:
         pass
 
     @abstractmethod
-    def visit_lambda_expr(self, o: mypy.nodes.LambdaExpr) -> T:
+    def visit_lambda_expr(self, o: mypy.nodes.LambdaExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_list_comprehension(self, o: mypy.nodes.ListComprehension) -> T:
+    def visit_list_comprehension(self, o: mypy.nodes.ListComprehension, /) -> T:
         pass
 
     @abstractmethod
-    def visit_set_comprehension(self, o: mypy.nodes.SetComprehension) -> T:
+    def visit_set_comprehension(self, o: mypy.nodes.SetComprehension, /) -> T:
         pass
 
     @abstractmethod
-    def visit_dictionary_comprehension(self, o: mypy.nodes.DictionaryComprehension) -> T:
+    def visit_dictionary_comprehension(self, o: mypy.nodes.DictionaryComprehension, /) -> T:
         pass
 
     @abstractmethod
-    def visit_generator_expr(self, o: mypy.nodes.GeneratorExpr) -> T:
+    def visit_generator_expr(self, o: mypy.nodes.GeneratorExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_slice_expr(self, o: mypy.nodes.SliceExpr) -> T:
+    def visit_slice_expr(self, o: mypy.nodes.SliceExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_conditional_expr(self, o: mypy.nodes.ConditionalExpr) -> T:
+    def visit_conditional_expr(self, o: mypy.nodes.ConditionalExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_var_expr(self, o: mypy.nodes.TypeVarExpr) -> T:
+    def visit_type_var_expr(self, o: mypy.nodes.TypeVarExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_paramspec_expr(self, o: mypy.nodes.ParamSpecExpr) -> T:
+    def visit_paramspec_expr(self, o: mypy.nodes.ParamSpecExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_var_tuple_expr(self, o: mypy.nodes.TypeVarTupleExpr) -> T:
+    def visit_type_var_tuple_expr(self, o: mypy.nodes.TypeVarTupleExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_alias_expr(self, o: mypy.nodes.TypeAliasExpr) -> T:
+    def visit_type_alias_expr(self, o: mypy.nodes.TypeAliasExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_namedtuple_expr(self, o: mypy.nodes.NamedTupleExpr) -> T:
+    def visit_namedtuple_expr(self, o: mypy.nodes.NamedTupleExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_enum_call_expr(self, o: mypy.nodes.EnumCallExpr) -> T:
+    def visit_enum_call_expr(self, o: mypy.nodes.EnumCallExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_typeddict_expr(self, o: mypy.nodes.TypedDictExpr) -> T:
+    def visit_typeddict_expr(self, o: mypy.nodes.TypedDictExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_newtype_expr(self, o: mypy.nodes.NewTypeExpr) -> T:
+    def visit_newtype_expr(self, o: mypy.nodes.NewTypeExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit__promote_expr(self, o: mypy.nodes.PromoteExpr) -> T:
+    def visit__promote_expr(self, o: mypy.nodes.PromoteExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_await_expr(self, o: mypy.nodes.AwaitExpr) -> T:
+    def visit_await_expr(self, o: mypy.nodes.AwaitExpr, /) -> T:
         pass
 
     @abstractmethod
-    def visit_temp_node(self, o: mypy.nodes.TempNode) -> T:
+    def visit_temp_node(self, o: mypy.nodes.TempNode, /) -> T:
         pass
 
 
@@ -202,115 +202,115 @@ class StatementVisitor(Generic[T]):
     # Definitions
 
     @abstractmethod
-    def visit_assignment_stmt(self, o: mypy.nodes.AssignmentStmt) -> T:
+    def visit_assignment_stmt(self, o: mypy.nodes.AssignmentStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_for_stmt(self, o: mypy.nodes.ForStmt) -> T:
+    def visit_for_stmt(self, o: mypy.nodes.ForStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_with_stmt(self, o: mypy.nodes.WithStmt) -> T:
+    def visit_with_stmt(self, o: mypy.nodes.WithStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_del_stmt(self, o: mypy.nodes.DelStmt) -> T:
+    def visit_del_stmt(self, o: mypy.nodes.DelStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_func_def(self, o: mypy.nodes.FuncDef) -> T:
+    def visit_func_def(self, o: mypy.nodes.FuncDef, /) -> T:
         pass
 
     @abstractmethod
-    def visit_overloaded_func_def(self, o: mypy.nodes.OverloadedFuncDef) -> T:
+    def visit_overloaded_func_def(self, o: mypy.nodes.OverloadedFuncDef, /) -> T:
         pass
 
     @abstractmethod
-    def visit_class_def(self, o: mypy.nodes.ClassDef) -> T:
+    def visit_class_def(self, o: mypy.nodes.ClassDef, /) -> T:
         pass
 
     @abstractmethod
-    def visit_global_decl(self, o: mypy.nodes.GlobalDecl) -> T:
+    def visit_global_decl(self, o: mypy.nodes.GlobalDecl, /) -> T:
         pass
 
     @abstractmethod
-    def visit_nonlocal_decl(self, o: mypy.nodes.NonlocalDecl) -> T:
+    def visit_nonlocal_decl(self, o: mypy.nodes.NonlocalDecl, /) -> T:
         pass
 
     @abstractmethod
-    def visit_decorator(self, o: mypy.nodes.Decorator) -> T:
+    def visit_decorator(self, o: mypy.nodes.Decorator, /) -> T:
         pass
 
     # Module structure
 
     @abstractmethod
-    def visit_import(self, o: mypy.nodes.Import) -> T:
+    def visit_import(self, o: mypy.nodes.Import, /) -> T:
         pass
 
     @abstractmethod
-    def visit_import_from(self, o: mypy.nodes.ImportFrom) -> T:
+    def visit_import_from(self, o: mypy.nodes.ImportFrom, /) -> T:
         pass
 
     @abstractmethod
-    def visit_import_all(self, o: mypy.nodes.ImportAll) -> T:
+    def visit_import_all(self, o: mypy.nodes.ImportAll, /) -> T:
         pass
 
     # Statements
 
     @abstractmethod
-    def visit_block(self, o: mypy.nodes.Block) -> T:
+    def visit_block(self, o: mypy.nodes.Block, /) -> T:
         pass
 
     @abstractmethod
-    def visit_expression_stmt(self, o: mypy.nodes.ExpressionStmt) -> T:
+    def visit_expression_stmt(self, o: mypy.nodes.ExpressionStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_operator_assignment_stmt(self, o: mypy.nodes.OperatorAssignmentStmt) -> T:
+    def visit_operator_assignment_stmt(self, o: mypy.nodes.OperatorAssignmentStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_while_stmt(self, o: mypy.nodes.WhileStmt) -> T:
+    def visit_while_stmt(self, o: mypy.nodes.WhileStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_return_stmt(self, o: mypy.nodes.ReturnStmt) -> T:
+    def visit_return_stmt(self, o: mypy.nodes.ReturnStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_assert_stmt(self, o: mypy.nodes.AssertStmt) -> T:
+    def visit_assert_stmt(self, o: mypy.nodes.AssertStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_if_stmt(self, o: mypy.nodes.IfStmt) -> T:
+    def visit_if_stmt(self, o: mypy.nodes.IfStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_break_stmt(self, o: mypy.nodes.BreakStmt) -> T:
+    def visit_break_stmt(self, o: mypy.nodes.BreakStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_continue_stmt(self, o: mypy.nodes.ContinueStmt) -> T:
+    def visit_continue_stmt(self, o: mypy.nodes.ContinueStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_pass_stmt(self, o: mypy.nodes.PassStmt) -> T:
+    def visit_pass_stmt(self, o: mypy.nodes.PassStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_raise_stmt(self, o: mypy.nodes.RaiseStmt) -> T:
+    def visit_raise_stmt(self, o: mypy.nodes.RaiseStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_try_stmt(self, o: mypy.nodes.TryStmt) -> T:
+    def visit_try_stmt(self, o: mypy.nodes.TryStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_match_stmt(self, o: mypy.nodes.MatchStmt) -> T:
+    def visit_match_stmt(self, o: mypy.nodes.MatchStmt, /) -> T:
         pass
 
     @abstractmethod
-    def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt) -> T:
+    def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt, /) -> T:
         pass
 
 
@@ -318,35 +318,35 @@ class StatementVisitor(Generic[T]):
 @mypyc_attr(allow_interpreted_subclasses=True)
 class PatternVisitor(Generic[T]):
     @abstractmethod
-    def visit_as_pattern(self, o: mypy.patterns.AsPattern) -> T:
+    def visit_as_pattern(self, o: mypy.patterns.AsPattern, /) -> T:
         pass
 
     @abstractmethod
-    def visit_or_pattern(self, o: mypy.patterns.OrPattern) -> T:
+    def visit_or_pattern(self, o: mypy.patterns.OrPattern, /) -> T:
         pass
 
     @abstractmethod
-    def visit_value_pattern(self, o: mypy.patterns.ValuePattern) -> T:
+    def visit_value_pattern(self, o: mypy.patterns.ValuePattern, /) -> T:
         pass
 
     @abstractmethod
-    def visit_singleton_pattern(self, o: mypy.patterns.SingletonPattern) -> T:
+    def visit_singleton_pattern(self, o: mypy.patterns.SingletonPattern, /) -> T:
         pass
 
     @abstractmethod
-    def visit_sequence_pattern(self, o: mypy.patterns.SequencePattern) -> T:
+    def visit_sequence_pattern(self, o: mypy.patterns.SequencePattern, /) -> T:
         pass
 
     @abstractmethod
-    def visit_starred_pattern(self, o: mypy.patterns.StarredPattern) -> T:
+    def visit_starred_pattern(self, o: mypy.patterns.StarredPattern, /) -> T:
         pass
 
     @abstractmethod
-    def visit_mapping_pattern(self, o: mypy.patterns.MappingPattern) -> T:
+    def visit_mapping_pattern(self, o: mypy.patterns.MappingPattern, /) -> T:
         pass
 
     @abstractmethod
-    def visit_class_pattern(self, o: mypy.patterns.ClassPattern) -> T:
+    def visit_class_pattern(self, o: mypy.patterns.ClassPattern, /) -> T:
         pass
 
 
@@ -365,264 +365,264 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T], Pattern
 
     # Not in superclasses:
 
-    def visit_mypy_file(self, o: mypy.nodes.MypyFile) -> T:
+    def visit_mypy_file(self, o: mypy.nodes.MypyFile, /) -> T:
         pass
 
     # TODO: We have a visit_var method, but no visit_typeinfo or any
     # other non-Statement SymbolNode (accepting those will raise a
     # runtime error). Maybe this should be resolved in some direction.
-    def visit_var(self, o: mypy.nodes.Var) -> T:
+    def visit_var(self, o: mypy.nodes.Var, /) -> T:
         pass
 
     # Module structure
 
-    def visit_import(self, o: mypy.nodes.Import) -> T:
+    def visit_import(self, o: mypy.nodes.Import, /) -> T:
         pass
 
-    def visit_import_from(self, o: mypy.nodes.ImportFrom) -> T:
+    def visit_import_from(self, o: mypy.nodes.ImportFrom, /) -> T:
         pass
 
-    def visit_import_all(self, o: mypy.nodes.ImportAll) -> T:
+    def visit_import_all(self, o: mypy.nodes.ImportAll, /) -> T:
         pass
 
     # Definitions
 
-    def visit_func_def(self, o: mypy.nodes.FuncDef) -> T:
+    def visit_func_def(self, o: mypy.nodes.FuncDef, /) -> T:
         pass
 
-    def visit_overloaded_func_def(self, o: mypy.nodes.OverloadedFuncDef) -> T:
+    def visit_overloaded_func_def(self, o: mypy.nodes.OverloadedFuncDef, /) -> T:
         pass
 
-    def visit_class_def(self, o: mypy.nodes.ClassDef) -> T:
+    def visit_class_def(self, o: mypy.nodes.ClassDef, /) -> T:
         pass
 
-    def visit_global_decl(self, o: mypy.nodes.GlobalDecl) -> T:
+    def visit_global_decl(self, o: mypy.nodes.GlobalDecl, /) -> T:
         pass
 
-    def visit_nonlocal_decl(self, o: mypy.nodes.NonlocalDecl) -> T:
+    def visit_nonlocal_decl(self, o: mypy.nodes.NonlocalDecl, /) -> T:
         pass
 
-    def visit_decorator(self, o: mypy.nodes.Decorator) -> T:
+    def visit_decorator(self, o: mypy.nodes.Decorator, /) -> T:
         pass
 
-    def visit_type_alias(self, o: mypy.nodes.TypeAlias) -> T:
+    def visit_type_alias(self, o: mypy.nodes.TypeAlias, /) -> T:
         pass
 
-    def visit_placeholder_node(self, o: mypy.nodes.PlaceholderNode) -> T:
+    def visit_placeholder_node(self, o: mypy.nodes.PlaceholderNode, /) -> T:
         pass
 
     # Statements
 
-    def visit_block(self, o: mypy.nodes.Block) -> T:
+    def visit_block(self, o: mypy.nodes.Block, /) -> T:
         pass
 
-    def visit_expression_stmt(self, o: mypy.nodes.ExpressionStmt) -> T:
+    def visit_expression_stmt(self, o: mypy.nodes.ExpressionStmt, /) -> T:
         pass
 
-    def visit_assignment_stmt(self, o: mypy.nodes.AssignmentStmt) -> T:
+    def visit_assignment_stmt(self, o: mypy.nodes.AssignmentStmt, /) -> T:
         pass
 
-    def visit_operator_assignment_stmt(self, o: mypy.nodes.OperatorAssignmentStmt) -> T:
+    def visit_operator_assignment_stmt(self, o: mypy.nodes.OperatorAssignmentStmt, /) -> T:
         pass
 
-    def visit_while_stmt(self, o: mypy.nodes.WhileStmt) -> T:
+    def visit_while_stmt(self, o: mypy.nodes.WhileStmt, /) -> T:
         pass
 
-    def visit_for_stmt(self, o: mypy.nodes.ForStmt) -> T:
+    def visit_for_stmt(self, o: mypy.nodes.ForStmt, /) -> T:
         pass
 
-    def visit_return_stmt(self, o: mypy.nodes.ReturnStmt) -> T:
+    def visit_return_stmt(self, o: mypy.nodes.ReturnStmt, /) -> T:
         pass
 
-    def visit_assert_stmt(self, o: mypy.nodes.AssertStmt) -> T:
+    def visit_assert_stmt(self, o: mypy.nodes.AssertStmt, /) -> T:
         pass
 
-    def visit_del_stmt(self, o: mypy.nodes.DelStmt) -> T:
+    def visit_del_stmt(self, o: mypy.nodes.DelStmt, /) -> T:
         pass
 
-    def visit_if_stmt(self, o: mypy.nodes.IfStmt) -> T:
+    def visit_if_stmt(self, o: mypy.nodes.IfStmt, /) -> T:
         pass
 
-    def visit_break_stmt(self, o: mypy.nodes.BreakStmt) -> T:
+    def visit_break_stmt(self, o: mypy.nodes.BreakStmt, /) -> T:
         pass
 
-    def visit_continue_stmt(self, o: mypy.nodes.ContinueStmt) -> T:
+    def visit_continue_stmt(self, o: mypy.nodes.ContinueStmt, /) -> T:
         pass
 
-    def visit_pass_stmt(self, o: mypy.nodes.PassStmt) -> T:
+    def visit_pass_stmt(self, o: mypy.nodes.PassStmt, /) -> T:
         pass
 
-    def visit_raise_stmt(self, o: mypy.nodes.RaiseStmt) -> T:
+    def visit_raise_stmt(self, o: mypy.nodes.RaiseStmt, /) -> T:
         pass
 
-    def visit_try_stmt(self, o: mypy.nodes.TryStmt) -> T:
+    def visit_try_stmt(self, o: mypy.nodes.TryStmt, /) -> T:
         pass
 
-    def visit_with_stmt(self, o: mypy.nodes.WithStmt) -> T:
+    def visit_with_stmt(self, o: mypy.nodes.WithStmt, /) -> T:
         pass
 
-    def visit_match_stmt(self, o: mypy.nodes.MatchStmt) -> T:
+    def visit_match_stmt(self, o: mypy.nodes.MatchStmt, /) -> T:
         pass
 
-    def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt) -> T:
+    def visit_type_alias_stmt(self, o: mypy.nodes.TypeAliasStmt, /) -> T:
         pass
 
     # Expressions (default no-op implementation)
 
-    def visit_int_expr(self, o: mypy.nodes.IntExpr) -> T:
+    def visit_int_expr(self, o: mypy.nodes.IntExpr, /) -> T:
         pass
 
-    def visit_str_expr(self, o: mypy.nodes.StrExpr) -> T:
+    def visit_str_expr(self, o: mypy.nodes.StrExpr, /) -> T:
         pass
 
-    def visit_bytes_expr(self, o: mypy.nodes.BytesExpr) -> T:
+    def visit_bytes_expr(self, o: mypy.nodes.BytesExpr, /) -> T:
         pass
 
-    def visit_float_expr(self, o: mypy.nodes.FloatExpr) -> T:
+    def visit_float_expr(self, o: mypy.nodes.FloatExpr, /) -> T:
         pass
 
-    def visit_complex_expr(self, o: mypy.nodes.ComplexExpr) -> T:
+    def visit_complex_expr(self, o: mypy.nodes.ComplexExpr, /) -> T:
         pass
 
-    def visit_ellipsis(self, o: mypy.nodes.EllipsisExpr) -> T:
+    def visit_ellipsis(self, o: mypy.nodes.EllipsisExpr, /) -> T:
         pass
 
-    def visit_star_expr(self, o: mypy.nodes.StarExpr) -> T:
+    def visit_star_expr(self, o: mypy.nodes.StarExpr, /) -> T:
         pass
 
-    def visit_name_expr(self, o: mypy.nodes.NameExpr) -> T:
+    def visit_name_expr(self, o: mypy.nodes.NameExpr, /) -> T:
         pass
 
-    def visit_member_expr(self, o: mypy.nodes.MemberExpr) -> T:
+    def visit_member_expr(self, o: mypy.nodes.MemberExpr, /) -> T:
         pass
 
-    def visit_yield_from_expr(self, o: mypy.nodes.YieldFromExpr) -> T:
+    def visit_yield_from_expr(self, o: mypy.nodes.YieldFromExpr, /) -> T:
         pass
 
-    def visit_yield_expr(self, o: mypy.nodes.YieldExpr) -> T:
+    def visit_yield_expr(self, o: mypy.nodes.YieldExpr, /) -> T:
         pass
 
-    def visit_call_expr(self, o: mypy.nodes.CallExpr) -> T:
+    def visit_call_expr(self, o: mypy.nodes.CallExpr, /) -> T:
         pass
 
-    def visit_op_expr(self, o: mypy.nodes.OpExpr) -> T:
+    def visit_op_expr(self, o: mypy.nodes.OpExpr, /) -> T:
         pass
 
-    def visit_comparison_expr(self, o: mypy.nodes.ComparisonExpr) -> T:
+    def visit_comparison_expr(self, o: mypy.nodes.ComparisonExpr, /) -> T:
         pass
 
-    def visit_cast_expr(self, o: mypy.nodes.CastExpr) -> T:
+    def visit_cast_expr(self, o: mypy.nodes.CastExpr, /) -> T:
         pass
 
-    def visit_assert_type_expr(self, o: mypy.nodes.AssertTypeExpr) -> T:
+    def visit_assert_type_expr(self, o: mypy.nodes.AssertTypeExpr, /) -> T:
         pass
 
-    def visit_reveal_expr(self, o: mypy.nodes.RevealExpr) -> T:
+    def visit_reveal_expr(self, o: mypy.nodes.RevealExpr, /) -> T:
         pass
 
-    def visit_super_expr(self, o: mypy.nodes.SuperExpr) -> T:
+    def visit_super_expr(self, o: mypy.nodes.SuperExpr, /) -> T:
         pass
 
-    def visit_assignment_expr(self, o: mypy.nodes.AssignmentExpr) -> T:
+    def visit_assignment_expr(self, o: mypy.nodes.AssignmentExpr, /) -> T:
         pass
 
-    def visit_unary_expr(self, o: mypy.nodes.UnaryExpr) -> T:
+    def visit_unary_expr(self, o: mypy.nodes.UnaryExpr, /) -> T:
         pass
 
-    def visit_list_expr(self, o: mypy.nodes.ListExpr) -> T:
+    def visit_list_expr(self, o: mypy.nodes.ListExpr, /) -> T:
         pass
 
-    def visit_dict_expr(self, o: mypy.nodes.DictExpr) -> T:
+    def visit_dict_expr(self, o: mypy.nodes.DictExpr, /) -> T:
         pass
 
-    def visit_tuple_expr(self, o: mypy.nodes.TupleExpr) -> T:
+    def visit_tuple_expr(self, o: mypy.nodes.TupleExpr, /) -> T:
         pass
 
-    def visit_set_expr(self, o: mypy.nodes.SetExpr) -> T:
+    def visit_set_expr(self, o: mypy.nodes.SetExpr, /) -> T:
         pass
 
-    def visit_index_expr(self, o: mypy.nodes.IndexExpr) -> T:
+    def visit_index_expr(self, o: mypy.nodes.IndexExpr, /) -> T:
         pass
 
-    def visit_type_application(self, o: mypy.nodes.TypeApplication) -> T:
+    def visit_type_application(self, o: mypy.nodes.TypeApplication, /) -> T:
         pass
 
-    def visit_lambda_expr(self, o: mypy.nodes.LambdaExpr) -> T:
+    def visit_lambda_expr(self, o: mypy.nodes.LambdaExpr, /) -> T:
         pass
 
-    def visit_list_comprehension(self, o: mypy.nodes.ListComprehension) -> T:
+    def visit_list_comprehension(self, o: mypy.nodes.ListComprehension, /) -> T:
         pass
 
-    def visit_set_comprehension(self, o: mypy.nodes.SetComprehension) -> T:
+    def visit_set_comprehension(self, o: mypy.nodes.SetComprehension, /) -> T:
         pass
 
-    def visit_dictionary_comprehension(self, o: mypy.nodes.DictionaryComprehension) -> T:
+    def visit_dictionary_comprehension(self, o: mypy.nodes.DictionaryComprehension, /) -> T:
         pass
 
-    def visit_generator_expr(self, o: mypy.nodes.GeneratorExpr) -> T:
+    def visit_generator_expr(self, o: mypy.nodes.GeneratorExpr, /) -> T:
         pass
 
-    def visit_slice_expr(self, o: mypy.nodes.SliceExpr) -> T:
+    def visit_slice_expr(self, o: mypy.nodes.SliceExpr, /) -> T:
         pass
 
-    def visit_conditional_expr(self, o: mypy.nodes.ConditionalExpr) -> T:
+    def visit_conditional_expr(self, o: mypy.nodes.ConditionalExpr, /) -> T:
         pass
 
-    def visit_type_var_expr(self, o: mypy.nodes.TypeVarExpr) -> T:
+    def visit_type_var_expr(self, o: mypy.nodes.TypeVarExpr, /) -> T:
         pass
 
-    def visit_paramspec_expr(self, o: mypy.nodes.ParamSpecExpr) -> T:
+    def visit_paramspec_expr(self, o: mypy.nodes.ParamSpecExpr, /) -> T:
         pass
 
-    def visit_type_var_tuple_expr(self, o: mypy.nodes.TypeVarTupleExpr) -> T:
+    def visit_type_var_tuple_expr(self, o: mypy.nodes.TypeVarTupleExpr, /) -> T:
         pass
 
-    def visit_type_alias_expr(self, o: mypy.nodes.TypeAliasExpr) -> T:
+    def visit_type_alias_expr(self, o: mypy.nodes.TypeAliasExpr, /) -> T:
         pass
 
-    def visit_namedtuple_expr(self, o: mypy.nodes.NamedTupleExpr) -> T:
+    def visit_namedtuple_expr(self, o: mypy.nodes.NamedTupleExpr, /) -> T:
         pass
 
-    def visit_enum_call_expr(self, o: mypy.nodes.EnumCallExpr) -> T:
+    def visit_enum_call_expr(self, o: mypy.nodes.EnumCallExpr, /) -> T:
         pass
 
-    def visit_typeddict_expr(self, o: mypy.nodes.TypedDictExpr) -> T:
+    def visit_typeddict_expr(self, o: mypy.nodes.TypedDictExpr, /) -> T:
         pass
 
-    def visit_newtype_expr(self, o: mypy.nodes.NewTypeExpr) -> T:
+    def visit_newtype_expr(self, o: mypy.nodes.NewTypeExpr, /) -> T:
         pass
 
-    def visit__promote_expr(self, o: mypy.nodes.PromoteExpr) -> T:
+    def visit__promote_expr(self, o: mypy.nodes.PromoteExpr, /) -> T:
         pass
 
-    def visit_await_expr(self, o: mypy.nodes.AwaitExpr) -> T:
+    def visit_await_expr(self, o: mypy.nodes.AwaitExpr, /) -> T:
         pass
 
-    def visit_temp_node(self, o: mypy.nodes.TempNode) -> T:
+    def visit_temp_node(self, o: mypy.nodes.TempNode, /) -> T:
         pass
 
     # Patterns
 
-    def visit_as_pattern(self, o: mypy.patterns.AsPattern) -> T:
+    def visit_as_pattern(self, o: mypy.patterns.AsPattern, /) -> T:
         pass
 
-    def visit_or_pattern(self, o: mypy.patterns.OrPattern) -> T:
+    def visit_or_pattern(self, o: mypy.patterns.OrPattern, /) -> T:
         pass
 
-    def visit_value_pattern(self, o: mypy.patterns.ValuePattern) -> T:
+    def visit_value_pattern(self, o: mypy.patterns.ValuePattern, /) -> T:
         pass
 
-    def visit_singleton_pattern(self, o: mypy.patterns.SingletonPattern) -> T:
+    def visit_singleton_pattern(self, o: mypy.patterns.SingletonPattern, /) -> T:
         pass
 
-    def visit_sequence_pattern(self, o: mypy.patterns.SequencePattern) -> T:
+    def visit_sequence_pattern(self, o: mypy.patterns.SequencePattern, /) -> T:
         pass
 
-    def visit_starred_pattern(self, o: mypy.patterns.StarredPattern) -> T:
+    def visit_starred_pattern(self, o: mypy.patterns.StarredPattern, /) -> T:
         pass
 
-    def visit_mapping_pattern(self, o: mypy.patterns.MappingPattern) -> T:
+    def visit_mapping_pattern(self, o: mypy.patterns.MappingPattern, /) -> T:
         pass
 
-    def visit_class_pattern(self, o: mypy.patterns.ClassPattern) -> T:
+    def visit_class_pattern(self, o: mypy.patterns.ClassPattern, /) -> T:
         pass

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -109,31 +109,31 @@ class RTypeVisitor(Generic[T]):
     """Generic visitor over RTypes (uses the visitor design pattern)."""
 
     @abstractmethod
-    def visit_rprimitive(self, typ: RPrimitive) -> T:
+    def visit_rprimitive(self, typ: RPrimitive, /) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rinstance(self, typ: RInstance) -> T:
+    def visit_rinstance(self, typ: RInstance, /) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_runion(self, typ: RUnion) -> T:
+    def visit_runion(self, typ: RUnion, /) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rtuple(self, typ: RTuple) -> T:
+    def visit_rtuple(self, typ: RTuple, /) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rstruct(self, typ: RStruct) -> T:
+    def visit_rstruct(self, typ: RStruct, /) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rarray(self, typ: RArray) -> T:
+    def visit_rarray(self, typ: RArray, /) -> T:
         raise NotImplementedError
 
     @abstractmethod
-    def visit_rvoid(self, typ: RVoid) -> T:
+    def visit_rvoid(self, typ: RVoid, /) -> T:
         raise NotImplementedError
 
 


### PR DESCRIPTION
Extracted from #18356. Make `visit_*` method arguments positional only to ensure better LSP compatibility. Also update some visitors which don't have violations yet but are base classes for other ones, like `TypeTranslator` and `TypeQuery`.