### PR TITLE
Fix markdown formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mypy no longer supports running with Python 3.8, which has reached end-of-life.
 When running mypy with Python 3.9+, it is still possible to type check code
 that needs to support Python 3.8 with the `--python-version 3.8` argument.
 Support for this will be dropped in the first half of 2025!
+
 Contributed by Marc Mueller (PR [17492](https://github.com/python/mypy/pull/17492)).
 
 ### Mypyc accelerated mypy wheels for aarch64


### PR DESCRIPTION
Followup to #18364. The `Contributed by` should be placed in a separate paragraph.