### PR TITLE
Use Generator TypeVar defaults

### DIFF
--- a/mypyc/irbuild/match.py
+++ b/mypyc/irbuild/match.py
@@ -331,7 +331,7 @@ class MatchVisitor(TraverserVisitor):
                 self.builder.goto(self.code_block)
 
     @contextmanager
-    def enter_subpattern(self, subject: Value) -> Generator[None, None, None]:
+    def enter_subpattern(self, subject: Value) -> Generator[None]:
         old_subject = self.subject
         self.subject = subject
         yield


### PR DESCRIPTION
`collections.abc.Generator` doesn't check the number of TypeVars (in contrast to `typing.Generator`). So it's possible to use `Generator[None]` even for Python 3.9.