### PR TITLE
Allow passing a callable with type vars in self types

### DIFF
--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -73,13 +73,6 @@ def solve_constraints(
         # Constraints inferred from unions require special handling in polymorphic inference.
         constraints = skip_reverse_union_constraints(constraints)
 
-    # Collect a list of constraints for each type variable.
-    cmap: dict[TypeVarId, list[Constraint]] = {tv: [] for tv in vars + extra_vars}
-    for con in constraints:
-        if con.type_var in vars + extra_vars:
-            cmap[con.type_var].append(con)
-
-    if allow_polymorphic:
         if constraints:
             solutions, free_vars = solve_with_dependent(
                 vars + extra_vars, constraints, vars, originals
@@ -88,6 +81,12 @@ def solve_constraints(
             solutions = {}
             free_vars = []
     else:
+        # Collect a list of constraints for each type variable.
+        cmap: dict[TypeVarId, list[Constraint]] = {tv: [] for tv in vars + extra_vars}
+        for con in constraints:
+            if con.type_var in vars + extra_vars:
+                cmap[con.type_var].append(con)
+
         solutions = {}
         free_vars = []
         for tv, cs in cmap.items():

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -2214,3 +2214,18 @@ class Test2:
 
 reveal_type(Test2().method) # N: Revealed type is "def (foo: builtins.int, *, bar: builtins.str) -> builtins.bytes"
 [builtins fixtures/tuple.pyi]
+
+[case testCallableWithTypeVarInSelfType]
+from typing import Generic, TypeVar, Callable
+
+T = TypeVar("T")
+V = TypeVar("V")
+
+class X(Generic[T]):
+    def f(self: X[Callable[[V], None]]) -> Callable[[V], V]:
+        def inner_f(v: V) -> V:
+            return v
+
+        return inner_f
+
+reveal_type(X[Callable[[T], None]]().f())  # N: Revealed type is "def [V] (V`4) -> V`4"


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes https://github.com/python/mypy/issues/18400

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->

@ilevkivskyi I'd appreciate if you checked the logic in this PR because I enabled polymorphic inference for binding self and had to handle `[T] () -> (T) -> T` into `() -> [T] (T) -> T`... I remember seeing this kind of push down logic before, but I can't remember if there's a common function or if there is an issue with doing that.