### PR TITLE
Improve security of our GitHub Actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -5,15 +5,16 @@ on:
     branches: [main, master, 'release*']
     tags: ['*']
 
-permissions:
-  contents: write
-
 jobs:
   build-wheels:
     if: github.repository == 'python/mypy'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,8 @@ jobs:
       VERIFY_MYPY_ERROR_CODES: 1
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           path: mypy_to_test
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -102,3 +103,7 @@ jobs:
           name: mypy_primer_diffs
           pattern: mypy_primer_diffs-*
           delete-merged: true
+      - name: Call comments workflow
+        uses: python/mypy/.github/workflows/mypy_primer_comment.yml@master
+        with:
+          workflow_id: ${{ workflow.id }}

--- a/.github/workflows/mypy_primer_comment.yml
+++ b/.github/workflows/mypy_primer_comment.yml
@@ -1,31 +1,32 @@
 name: Comment with mypy_primer diff
 
 on:
-  workflow_run:
-    workflows:
-      - Run mypy_primer
-    types:
-      - completed
+  workflow_call:
+    input:
+      workflow_id:
+        required: true
+        type: integer
 
-permissions:
-  contents: read
-  pull-requests: write
 
 jobs:
   comment:
     name: Comment PR from mypy_primer
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Download diffs
         uses: actions/github-script@v7
+        env:
+          WORKFLOW_ID: ${{ inputs.workflow_id }}
         with:
           script: |
             const fs = require('fs');
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{ github.event.workflow_run.id }},
+               run_id: process.env.WORKFLOW_ID,
             });
             const [matchArtifact] = artifacts.data.artifacts.filter((artifact) =>
               artifact.name == "mypy_primer_diffs");

--- a/.github/workflows/sync_typeshed.yml
+++ b/.github/workflows/sync_typeshed.yml
@@ -5,20 +5,20 @@ on:
   schedule:
     - cron: "0 0 1,15 * *"
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   sync_typeshed:
     name: Sync typeshed
     if: github.repository == 'python/mypy'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
         # TODO: use whatever solution ends up working for
         # https://github.com/python/typeshed/issues/8434
       - uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Debug build
       if: ${{ matrix.debug_build }}
@@ -217,6 +219,8 @@ jobs:
       CC: i686-linux-gnu-gcc
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install 32-bit build dependencies
         run: |
           sudo dpkg --add-architecture i386 && \

--- a/.github/workflows/test_stubgenc.yml
+++ b/.github/workflows/test_stubgenc.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup 🐍 3.9
       uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,5 +29,15 @@ repos:
           -ignore=property "allow_failure" is not defined,
           -ignore=SC2(046|086),
         ]
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.0.0
+    hooks:
+      - id: zizmor
+  # Should be the last one:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+
 ci:
   autoupdate_schedule: quarterly


### PR DESCRIPTION
Recently CPython introduced this new tool: https://github.com/python/cpython/blob/8eebe4e6d02bb4ad3f1ca6c52624186903dce893/.pre-commit-config.yaml#L64-L67

Which finds different security related problems with GitHub Actions.

I added this tool to our `.pre-commit-config.yaml` and followed all its recommendations.

Changes:
- I added `persist-credentials: false` to all `checkout` actions, see `# Whether to configure the token or SSH key with the local git config` in https://github.com/actions/checkout
- I moved all permissions from workflow level to job level
- I changed `.github/workflows/mypy_primer_comment.yml` to be a reusable workflow, see https://woodruffw.github.io/zizmor/audits/#dangerous-triggers