### PR TITLE
Remove unnecessary mypyc files from wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,8 +26,10 @@ prune docs/source/_build
 # assorted mypyc requirements
 graft mypyc/external
 graft mypyc/lib-rt
+graft mypyc/test
 graft mypyc/test-data
 graft mypyc/doc
+prune mypyc/doc/build
 
 # files necessary for testing sdist
 include mypy-requirements.txt
@@ -37,6 +39,7 @@ include test-requirements.txt
 include mypy_self_check.ini
 prune misc
 graft test-data
+graft mypy/test
 include conftest.py
 include runtests.py
 include pytest.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ mypyc = "mypyc.__main__:main"
 
 [tool.setuptools.packages.find]
 include = ["mypy*", "mypyc*", "*__mypyc*"]
+exclude = ["mypyc.test-data*"]
 namespaces = false
 
 [tool.setuptools.package-data]
@@ -88,6 +89,15 @@ mypy = [
   "xml/*.xsd",
   "xml/*.xslt",
   "xml/*.css",
+]
+[tool.setuptools.exclude-package-data]
+mypyc = [
+  "README.md",
+  "doc/**",
+  "external/**",
+  "lib-rt/test_capi.cc",
+  "lib-rt/setup.py",
+  "test-data/**",
 ]
 
 [tool.black]


### PR DESCRIPTION
Remove mypyc docs and some testing files from wheels. They aren't included for mypy itself as well. The sdist content will stay the same, so it's possible for distributors to continue to run the tests.

Files which will no longer be included
```
mypyc/README.md
mypyc/doc/**
mypyc/external/googletest/**
mypyc/lib-rt/setup.py
mypyc/lib-rt/test_capi.cc
mypyc/test-data/**
```