### PR TITLE
[stubgen] Fix UnpackType for 3.11+

### DIFF
--- a/mypy/stubutil.py
+++ b/mypy/stubutil.py
@@ -19,7 +19,16 @@ from mypy.modulefinder import ModuleNotFoundReason
 from mypy.moduleinspect import InspectError, ModuleInspect
 from mypy.nodes import PARAM_SPEC_KIND, TYPE_VAR_TUPLE_KIND, ClassDef, FuncDef, TypeAliasStmt
 from mypy.stubdoc import ArgSig, FunctionSig
-from mypy.types import AnyType, NoneType, Type, TypeList, TypeStrVisitor, UnboundType, UnionType
+from mypy.types import (
+    AnyType,
+    NoneType,
+    Type,
+    TypeList,
+    TypeStrVisitor,
+    UnboundType,
+    UnionType,
+    UnpackType,
+)
 
 # Modules that may fail when imported, or that may have side effects (fully qualified).
 NOT_IMPORTABLE_MODULES = ()
@@ -291,6 +300,11 @@ class AnnotationPrinter(TypeStrVisitor):
 
     def visit_union_type(self, t: UnionType) -> str:
         return " | ".join([item.accept(self) for item in t.items])
+
+    def visit_unpack_type(self, t: UnpackType) -> str:
+        if self.options.python_version >= (3, 11):
+            return f"*{t.type.accept(self)}"
+        return super().visit_unpack_type(t)
 
     def args_str(self, args: Iterable[Type]) -> str:
         """Convert an array of arguments to strings and join the results with commas.

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -1225,6 +1225,7 @@ from typing import Generic
 from typing_extensions import TypeVarTuple, Unpack
 Ts = TypeVarTuple('Ts')
 class D(Generic[Unpack[Ts]]): ...
+def callback(func: Callable[[Unpack[Ts]], None], *args: Unpack[Ts]) -> None: ...
 [out]
 from typing import Generic
 from typing_extensions import TypeVarTuple, Unpack
@@ -1232,12 +1233,15 @@ from typing_extensions import TypeVarTuple, Unpack
 Ts = TypeVarTuple('Ts')
 
 class D(Generic[Unpack[Ts]]): ...
+
+def callback(func: Callable[[Unpack[Ts]], None], *args: Unpack[Ts]) -> None: ...
 
 [case testGenericClassTypeVarTuple_semanal]
 from typing import Generic
 from typing_extensions import TypeVarTuple, Unpack
 Ts = TypeVarTuple('Ts')
 class D(Generic[Unpack[Ts]]): ...
+def callback(func: Callable[[Unpack[Ts]], None], *args: Unpack[Ts]) -> None: ...
 [out]
 from typing import Generic
 from typing_extensions import TypeVarTuple, Unpack
@@ -1246,29 +1250,37 @@ Ts = TypeVarTuple('Ts')
 
 class D(Generic[Unpack[Ts]]): ...
 
+def callback(func: Callable[[Unpack[Ts]], None], *args: Unpack[Ts]) -> None: ...
+
 [case testGenericClassTypeVarTuplePy311]
 # flags: --python-version=3.11
 from typing import Generic, TypeVarTuple
 Ts = TypeVarTuple('Ts')
 class D(Generic[*Ts]): ...
+def callback(func: Callable[[*Ts], None], *args: *Ts) -> None: ...
 [out]
 from typing import Generic, TypeVarTuple
 
 Ts = TypeVarTuple('Ts')
 
 class D(Generic[*Ts]): ...
+
+def callback(func: Callable[[*Ts], None], *args: *Ts) -> None: ...
 
 [case testGenericClassTypeVarTuplePy311_semanal]
 # flags: --python-version=3.11
 from typing import Generic, TypeVarTuple
 Ts = TypeVarTuple('Ts')
 class D(Generic[*Ts]): ...
+def callback(func: Callable[[*Ts], None], *args: *Ts) -> None: ...
 [out]
 from typing import Generic, TypeVarTuple
 
 Ts = TypeVarTuple('Ts')
 
 class D(Generic[*Ts]): ...
+
+def callback(func: Callable[[*Ts], None], *args: *Ts) -> None: ...
 
 [case testObjectBaseClass]
 class A(object): ...


### PR DESCRIPTION
Don't replace `*Ts` with `Unpack[Ts]` on Python 3.11+.
This is broken currently since `Unpack` isn't added as import in the stub file.