### PR TITLE
Fix list index while checking for Enum class.

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -682,7 +682,8 @@ def add_non_ext_class_attr(
         # are final.
         if (
             cdef.info.bases
-            and cdef.info.bases[0].type.is_enum
+            # Enum class must be the last parent class.
+            and cdef.info.bases[-1].type.is_enum
             # Skip these since Enum will remove it
             and lvalue.name not in EXCLUDED_ENUM_ATTRIBUTES
         ):

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2692,3 +2692,16 @@ print(native.C(22).v)
 
 [out]
 22.1
+
+[case testLastParentEnum]
+from enum import Enum
+
+class ColorCode(str, Enum):
+    OKGREEN = "okgreen"
+
+[file driver.py]
+import native
+print(native.ColorCode.OKGREEN.value)
+
+[out]
+okgreen


### PR DESCRIPTION
Fixes mypyc/mypyc#1080

Python requires that Enum must be the last class in the parent class list. This change fixes the index in `ClassDef.bases` list where we check for `Enum`.