### PR TITLE
Avoid false `unreachable` and `redundant-expr` warnings in loops.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -595,11 +595,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
             # Disable error types that we cannot safely identify in intermediate iteration steps:
             warn_unreachable = self.options.warn_unreachable
-            if warn_unreachable:
-                self.options.warn_unreachable = False
             warn_redundant = codes.REDUNDANT_EXPR in self.options.enabled_error_codes
-            if warn_redundant:
-                self.options.enabled_error_codes.remove(codes.REDUNDANT_EXPR)
+            self.options.warn_unreachable = False
+            self.options.enabled_error_codes.discard(codes.REDUNDANT_EXPR)
 
             while True:
                 with self.binder.frame_context(can_skip=True, break_frame=2, continue_frame=1):
@@ -610,10 +608,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 partials_old = partials_new
 
             # If necessary, reset the modified options and make up for the postponed error checks:
+            self.options.warn_unreachable = warn_unreachable
+            if warn_redundant:
+                self.options.enabled_error_codes.add(codes.REDUNDANT_EXPR)
             if warn_unreachable or warn_redundant:
-                self.options.warn_unreachable = warn_unreachable
-                if warn_redundant:
-                    self.options.enabled_error_codes.add(codes.REDUNDANT_EXPR)
                 with self.binder.frame_context(can_skip=True, break_frame=2, continue_frame=1):
                     self.accept(body)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -612,7 +612,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # If necessary, reset the modified options and make up for the postponed error checks:
             if warn_unreachable or warn_redundant:
                 self.options.warn_unreachable = warn_unreachable
-                self.options.enabled_error_codes.add(codes.REDUNDANT_EXPR)
+                if warn_redundant:
+                    self.options.enabled_error_codes.add(codes.REDUNDANT_EXPR)
                 with self.binder.frame_context(can_skip=True, break_frame=2, continue_frame=1):
                     self.accept(body)
 

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2390,3 +2390,29 @@ class A:
                 z.append(1)
 
 [builtins fixtures/primitives.pyi]
+
+[case testAvoidFalseUnreachableInLoop]
+# flags: --warn-unreachable --python-version 3.11
+
+def f() -> int | None: ...
+def b() -> bool: ...
+
+x: int | None
+x = 1
+while x is not None or b():
+    x = f()
+
+[builtins fixtures/bool.pyi]
+
+[case testAvoidFalseRedundantExprInLoop]
+# flags: --enable-error-code redundant-expr --python-version 3.11
+
+def f() -> int | None: ...
+def b() -> bool: ...
+
+x: int | None
+x = 1
+while x is not None and b():
+    x = f()
+
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Fixes #18348
Fixes #13973
Fixes #11612
Fixes #8721
Fixes #8865
Fixes #7204

I manually checked all the listed issues.  Some of them were already partly fixed by #18180.
