### PR TITLE
[mypyc] Fixing __init__ for classes with @attr.s(slots=True).

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -377,9 +377,10 @@ class DataClassBuilder(ExtClassBuilder):
         dec = self.builder.accept(
             next(d for d in self.cdef.decorators if is_dataclass_decorator(d))
         )
+        dataclass_type_val = self.builder.load_str(dataclass_type(self.cdef) or "unknown")
         self.builder.call_c(
             dataclass_sleight_of_hand,
-            [dec, self.type_obj, self.non_ext.dict, self.non_ext.anns],
+            [dec, self.type_obj, self.non_ext.dict, self.non_ext.anns, dataclass_type_val],
             self.cdef.line,
         )
 

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -73,6 +73,8 @@ def is_dataclass(cdef: ClassDef) -> bool:
     return any(is_dataclass_decorator(d) for d in cdef.decorators)
 
 
+# The string values returned by this function are inspected in
+# mypyc/lib-rt/misc_ops.c:CPyDataclass_SleightOfHand(...).
 def dataclass_type(cdef: ClassDef) -> str | None:
     for d in cdef.decorators:
         typ = dataclass_decorator_type(d)

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -860,7 +860,8 @@ PyObject *CPyType_FromTemplateWrapper(PyObject *template_,
                                       PyObject *orig_bases,
                                       PyObject *modname);
 int CPyDataclass_SleightOfHand(PyObject *dataclass_dec, PyObject *tp,
-                               PyObject *dict, PyObject *annotations);
+                               PyObject *dict, PyObject *annotations,
+                               PyObject *dataclass_type);
 PyObject *CPyPickle_SetState(PyObject *obj, PyObject *state);
 PyObject *CPyPickle_GetState(PyObject *obj);
 CPyTagged CPyTagged_Id(PyObject *o);

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -381,6 +381,15 @@ CPyDataclass_SleightOfHand(PyObject *dataclass_dec, PyObject *tp,
     if (!res) {
         goto fail;
     }
+    // These attributes are added or modified by @attr.s(slots=True).
+    const char * const keys[] = {"__attrs_attrs__", "__attrs_own_setattr__", "__init__", ""};
+    for (const char * const *key_iter = keys; **key_iter != '\0'; key_iter++) {
+        PyObject *value = PyObject_GetAttrString(res, *key_iter);
+        if (value) {
+            PyObject_SetAttrString(tp, *key_iter, value);
+            Py_DECREF(value);
+        }
+    }
     Py_DECREF(res);
 
     /* Copy back the original contents of the dict */

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -399,6 +399,7 @@ CPyDataclass_SleightOfHand(PyObject *dataclass_dec, PyObject *tp,
         goto fail;
     }
 
+    Py_DECREF(res);
     Py_DECREF(orig_dict);
     return 1;
 

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -224,7 +224,13 @@ pytype_from_template_op = custom_op(
 # Create a dataclass from an extension class. See
 # CPyDataclass_SleightOfHand for more docs.
 dataclass_sleight_of_hand = custom_op(
-    arg_types=[object_rprimitive, object_rprimitive, dict_rprimitive, dict_rprimitive],
+    arg_types=[
+        object_rprimitive,
+        object_rprimitive,
+        dict_rprimitive,
+        dict_rprimitive,
+        str_rprimitive,
+    ],
     return_type=bit_rprimitive,
     c_function_name="CPyDataclass_SleightOfHand",
     error_kind=ERR_FALSE,

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2705,3 +2705,17 @@ print(native.ColorCode.OKGREEN.value)
 
 [out]
 okgreen
+
+[case testAttrWithSlots]
+import attr
+
+@attr.s(slots=True)
+class A:
+    ints: list[int] = attr.ib()
+
+[file driver.py]
+import native
+print(native.A(ints=[1, -17]).ints)
+
+[out]
+\[1, -17]


### PR DESCRIPTION
Fixes mypyc/mypyc#1079.

`@attr.s` generates a `__init__` function which was getting lost in `CPyDataclass_SleightOfHand`. This change copies the generated `__init__` function and a couple of others ones to maintain consistency with CPython.