### PR TITLE
Update docs not to mention 3.8 where possible

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -427,8 +427,8 @@ More specifically, mypy will understand the use of :py:data:`sys.version_info` a
    import sys
 
    # Distinguishing between different versions of Python:
-   if sys.version_info >= (3, 8):
-       # Python 3.8+ specific definitions and imports
+   if sys.version_info >= (3, 13):
+       # Python 3.13+ specific definitions and imports
    else:
        # Other definitions and imports
 

--- a/docs/source/runtime_troubles.rst
+++ b/docs/source/runtime_troubles.rst
@@ -335,16 +335,14 @@ Using new additions to the typing module
 ----------------------------------------
 
 You may find yourself wanting to use features added to the :py:mod:`typing`
-module in earlier versions of Python than the addition, for example, using any
-of ``Literal``, ``Protocol``, ``TypedDict`` with Python 3.6.
+module in earlier versions of Python than the addition.
 
 The easiest way to do this is to install and use the ``typing_extensions``
 package from PyPI for the relevant imports, for example:
 
 .. code-block:: python
 
-   from typing_extensions import Literal
-   x: Literal["open", "close"]
+   from typing_extensions import TypeIs
 
 If you don't want to rely on ``typing_extensions`` being installed on newer
 Pythons, you could alternatively use:
@@ -352,12 +350,10 @@ Pythons, you could alternatively use:
 .. code-block:: python
 
    import sys
-   if sys.version_info >= (3, 8):
-       from typing import Literal
+   if sys.version_info >= (3, 13):
+       from typing import TypeIs
    else:
-       from typing_extensions import Literal
-
-   x: Literal["open", "close"]
+       from typing_extensions import TypeIs
 
 This plays nicely well with following :pep:`508` dependency specification:
-``typing_extensions; python_version<"3.8"``
+``typing_extensions; python_version<"3.13"``


### PR DESCRIPTION
I updated docs to not mention EOL 3.8, where it is possible to use other versions / examples.