### PR TITLE
[mypyc] Reduce impact of immortality on reference counting performance

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -12,12 +12,12 @@ from mypyc.common import (
     ATTR_PREFIX,
     BITMAP_BITS,
     FAST_ISINSTANCE_MAX_SUBCLASSES,
+    HAVE_IMMORTAL,
     NATIVE_PREFIX,
     REG_PREFIX,
     STATIC_PREFIX,
     TYPE_PREFIX,
     use_vectorcall,
-    HAVE_IMMORTAL,
 )
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.ir.func_ir import FuncDecl
@@ -545,7 +545,11 @@ class Emitter:
             else:
                 # Inlined
                 if rtype.may_be_immortal:
-                    if HAVE_IMMORTAL and (opt := optional_value_type(rtype)) and not opt.may_be_immortal:
+                    if (
+                        HAVE_IMMORTAL
+                        and (opt := optional_value_type(rtype))
+                        and not opt.may_be_immortal
+                    ):
                         # Optimized decref of optional type avoids reading reference count
                         # if value is None (None is immortal)
                         self.emit_line(f"if ({dest} != Py_None) {{")

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -514,7 +514,18 @@ class Emitter:
         elif not rtype.is_unboxed:
             # Always inline, since this is a simple but very hot op
             if rtype.may_be_immortal or not HAVE_IMMORTAL:
-                self.emit_line("CPy_INCREF(%s);" % dest)
+                if (
+                    HAVE_IMMORTAL
+                    and (opt := optional_value_type(rtype))
+                    and not opt.may_be_immortal
+                ):
+                    # Optimized incref of optional type avoids reading reference count
+                    # if value is None (None is immortal)
+                    self.emit_line(f"if ({dest} != Py_None) {{")
+                    self.emit_line(f"CPy_INCREF_NO_IMM({dest});")
+                    self.emit_line("}")
+                else:
+                    self.emit_line("CPy_INCREF(%s);" % dest)
             else:
                 self.emit_line("CPy_INCREF_NO_IMM(%s);" % dest)
         # Otherwise assume it's an unboxed, pointerless value and do nothing.

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -513,7 +513,7 @@ class Emitter:
                 self.emit_inc_ref(f"{dest}.f{i}", item_type)
         elif not rtype.is_unboxed:
             # Always inline, since this is a simple but very hot op
-            if rtype.may_be_immortal:
+            if rtype.may_be_immortal or not HAVE_IMMORTAL:
                 self.emit_line("CPy_INCREF(%s);" % dest)
             else:
                 self.emit_line("CPy_INCREF_NO_IMM(%s);" % dest)
@@ -544,7 +544,7 @@ class Emitter:
                 self.emit_line(f"CPy_{x}DecRef({dest});")
             else:
                 # Inlined
-                if rtype.may_be_immortal:
+                if rtype.may_be_immortal or not HAVE_IMMORTAL:
                     if (
                         HAVE_IMMORTAL
                         and (opt := optional_value_type(rtype))

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -511,8 +511,11 @@ class Emitter:
             for i, item_type in enumerate(rtype.types):
                 self.emit_inc_ref(f"{dest}.f{i}", item_type)
         elif not rtype.is_unboxed:
-            # Always inline, since this is a simple op
-            self.emit_line("CPy_INCREF(%s);" % dest)
+            # Always inline, since this is a simple but very hot op
+            if rtype.may_be_immortal:
+                self.emit_line("CPy_INCREF(%s);" % dest)
+            else:
+                self.emit_line("CPy_INCREF_NO_IMM(%s);" % dest)
         # Otherwise assume it's an unboxed, pointerless value and do nothing.
 
     def emit_dec_ref(
@@ -540,7 +543,10 @@ class Emitter:
                 self.emit_line(f"CPy_{x}DecRef({dest});")
             else:
                 # Inlined
-                self.emit_line(f"CPy_{x}DECREF({dest});")
+                if rtype.may_be_immortal:
+                    self.emit_line(f"CPy_{x}DECREF({dest});")
+                else:
+                    self.emit_line(f"CPy_{x}DECREF_NO_IMM({dest});")
         # Otherwise assume it's an unboxed, pointerless value and do nothing.
 
     def pretty_name(self, typ: RType) -> str:

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -17,6 +17,7 @@ from mypyc.common import (
     STATIC_PREFIX,
     TYPE_PREFIX,
     use_vectorcall,
+    HAVE_IMMORTAL,
 )
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.ir.func_ir import FuncDecl
@@ -544,7 +545,14 @@ class Emitter:
             else:
                 # Inlined
                 if rtype.may_be_immortal:
-                    self.emit_line(f"CPy_{x}DECREF({dest});")
+                    if HAVE_IMMORTAL and (opt := optional_value_type(rtype)) and not opt.may_be_immortal:
+                        # Optimized decref of optional type avoids reading reference count
+                        # if value is None (None is immortal)
+                        self.emit_line(f"if ({dest} != Py_None) {{")
+                        self.emit_line(f"CPy_{x}DECREF_NO_IMM({dest});")
+                        self.emit_line("}")
+                    else:
+                        self.emit_line(f"CPy_{x}DECREF({dest});")
                 else:
                     self.emit_line(f"CPy_{x}DECREF_NO_IMM({dest});")
         # Otherwise assume it's an unboxed, pointerless value and do nothing.

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -514,18 +514,7 @@ class Emitter:
         elif not rtype.is_unboxed:
             # Always inline, since this is a simple but very hot op
             if rtype.may_be_immortal or not HAVE_IMMORTAL:
-                if (
-                    HAVE_IMMORTAL
-                    and (opt := optional_value_type(rtype))
-                    and not opt.may_be_immortal
-                ):
-                    # Optimized incref of optional type avoids reading reference count
-                    # if value is None (None is immortal)
-                    self.emit_line(f"if ({dest} != Py_None) {{")
-                    self.emit_line(f"CPy_INCREF_NO_IMM({dest});")
-                    self.emit_line("}")
-                else:
-                    self.emit_line("CPy_INCREF(%s);" % dest)
+                self.emit_line("CPy_INCREF(%s);" % dest)
             else:
                 self.emit_line("CPy_INCREF_NO_IMM(%s);" % dest)
         # Otherwise assume it's an unboxed, pointerless value and do nothing.
@@ -556,18 +545,7 @@ class Emitter:
             else:
                 # Inlined
                 if rtype.may_be_immortal or not HAVE_IMMORTAL:
-                    if (
-                        HAVE_IMMORTAL
-                        and (opt := optional_value_type(rtype))
-                        and not opt.may_be_immortal
-                    ):
-                        # Optimized decref of optional type avoids reading reference count
-                        # if value is None (None is immortal)
-                        self.emit_line(f"if ({dest} != Py_None) {{")
-                        self.emit_line(f"CPy_{x}DECREF_NO_IMM({dest});")
-                        self.emit_line("}")
-                    else:
-                        self.emit_line(f"CPy_{x}DECREF({dest});")
+                    self.emit_line(f"CPy_{x}DECREF({dest});")
                 else:
                     self.emit_line(f"CPy_{x}DECREF_NO_IMM({dest});")
         # Otherwise assume it's an unboxed, pointerless value and do nothing.

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -7,13 +7,13 @@ from typing import Final
 from mypyc.analysis.blockfreq import frequently_executed_blocks
 from mypyc.codegen.emit import DEBUG_ERRORS, Emitter, TracebackAndGotoHandler, c_array_initializer
 from mypyc.common import (
+    HAVE_IMMORTAL,
     MODULE_PREFIX,
     NATIVE_PREFIX,
     REG_PREFIX,
     STATIC_PREFIX,
     TYPE_PREFIX,
     TYPE_VAR_PREFIX,
-    HAVE_IMMORTAL,
 )
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD, FuncDecl, FuncIR, all_values
@@ -77,13 +77,13 @@ from mypyc.ir.rtypes import (
     RStruct,
     RTuple,
     RType,
+    is_bool_rprimitive,
     is_int32_rprimitive,
     is_int64_rprimitive,
     is_int_rprimitive,
+    is_none_rprimitive,
     is_pointer_rprimitive,
     is_tagged,
-    is_none_rprimitive,
-    is_bool_rprimitive,
 )
 
 
@@ -581,8 +581,11 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             )
 
     def visit_inc_ref(self, op: IncRef) -> None:
-        if isinstance(op.src, Box) and (is_none_rprimitive(op.src.src.type) or
-                                        is_bool_rprimitive(op.src.src.type)) and HAVE_IMMORTAL:
+        if (
+            isinstance(op.src, Box)
+            and (is_none_rprimitive(op.src.src.type) or is_bool_rprimitive(op.src.src.type))
+            and HAVE_IMMORTAL
+        ):
             # On Python 3.12+, None/True/False are immortal, and we can skip inc ref
             return
 

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -82,7 +82,10 @@ RUNTIME_C_FILES: Final = [
     "pythonsupport.c",
 ]
 
-# Python 3.12 introduced immortal objects, specified via a special reference count value
+# Python 3.12 introduced immortal objects, specified via a special reference count
+# value. The reference counts of immortal objects are normally not modified, but it's
+# not strictly wrong to modify them. See PEP 683 for more information, but note that
+# some details in the PEP are out of date.
 HAVE_IMMORTAL: Final = sys.version_info >= (3, 12)
 
 

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -82,6 +82,9 @@ RUNTIME_C_FILES: Final = [
     "pythonsupport.c",
 ]
 
+# Python 3.12 introduced immortal objects, specified via a special reference count value
+HAVE_IMMORTAL: Final = sys.version_info >= (3, 12)
+
 
 JsonDict = dict[str, Any]
 

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -71,7 +71,7 @@ class RType:
 
     @property
     @abstractmethod
-    def may_be_immortal(sel) -> bool:
+    def may_be_immortal(self) -> bool:
         raise NotImplementedError
 
     def __str__(self) -> str:
@@ -451,8 +451,9 @@ none_rprimitive: Final = RPrimitive(
 # Python list object (or an instance of a subclass of list). These could be
 # immortal, but since this is expected to be very rare, and the immortality checks
 # can be pretty expensive for lists, we treat lists as non-immortal.
-list_rprimitive: Final = RPrimitive("builtins.list", is_unboxed=False, is_refcounted=True,
-                                    may_be_immortal=False)
+list_rprimitive: Final = RPrimitive(
+    "builtins.list", is_unboxed=False, is_refcounted=True, may_be_immortal=False
+)
 
 # Python dict object (or an instance of a subclass of dict).
 dict_rprimitive: Final = RPrimitive("builtins.dict", is_unboxed=False, is_refcounted=True)

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -26,7 +26,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, ClassVar, Final, Generic, TypeVar
 from typing_extensions import TypeGuard
 
-from mypyc.common import IS_32_BIT_PLATFORM, PLATFORM_SIZE, JsonDict, short_name
+from mypyc.common import HAVE_IMMORTAL, IS_32_BIT_PLATFORM, PLATFORM_SIZE, JsonDict, short_name
 from mypyc.namegen import NameGenerator
 
 if TYPE_CHECKING:
@@ -214,7 +214,7 @@ class RPrimitive(RType):
         self._ctype = ctype
         self.size = size
         self.error_overlap = error_overlap
-        self._may_be_immortal = may_be_immortal
+        self._may_be_immortal = may_be_immortal and HAVE_IMMORTAL
         if ctype == "CPyTagged":
             self.c_undefined = "CPY_INT_TAG"
         elif ctype in ("int16_t", "int32_t", "int64_t"):

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -69,6 +69,11 @@ class RType:
     def short_name(self) -> str:
         return short_name(self.name)
 
+    @property
+    @abstractmethod
+    def may_be_immortal(sel) -> bool:
+        raise NotImplementedError
+
     def __str__(self) -> str:
         return short_name(self.name)
 
@@ -151,6 +156,10 @@ class RVoid(RType):
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rvoid(self)
 
+    @property
+    def may_be_immortal(self) -> bool:
+        return False
+
     def serialize(self) -> str:
         return "void"
 
@@ -193,6 +202,7 @@ class RPrimitive(RType):
         ctype: str = "PyObject *",
         size: int = PLATFORM_SIZE,
         error_overlap: bool = False,
+        may_be_immortal: bool = True,
     ) -> None:
         RPrimitive.primitive_map[name] = self
 
@@ -204,6 +214,7 @@ class RPrimitive(RType):
         self._ctype = ctype
         self.size = size
         self.error_overlap = error_overlap
+        self._may_be_immortal = may_be_immortal
         if ctype == "CPyTagged":
             self.c_undefined = "CPY_INT_TAG"
         elif ctype in ("int16_t", "int32_t", "int64_t"):
@@ -229,6 +240,10 @@ class RPrimitive(RType):
 
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rprimitive(self)
+
+    @property
+    def may_be_immortal(self) -> bool:
+        return self._may_be_immortal
 
     def serialize(self) -> str:
         return self.name
@@ -434,13 +449,16 @@ none_rprimitive: Final = RPrimitive(
 )
 
 # Python list object (or an instance of a subclass of list).
-list_rprimitive: Final = RPrimitive("builtins.list", is_unboxed=False, is_refcounted=True)
+list_rprimitive: Final = RPrimitive("builtins.list", is_unboxed=False, is_refcounted=True,
+                                    may_be_immortal=False)
 
 # Python dict object (or an instance of a subclass of dict).
-dict_rprimitive: Final = RPrimitive("builtins.dict", is_unboxed=False, is_refcounted=True)
+dict_rprimitive: Final = RPrimitive("builtins.dict", is_unboxed=False, is_refcounted=True,
+                                    may_be_immortal=False)
 
 # Python set object (or an instance of a subclass of set).
-set_rprimitive: Final = RPrimitive("builtins.set", is_unboxed=False, is_refcounted=True)
+set_rprimitive: Final = RPrimitive("builtins.set", is_unboxed=False, is_refcounted=True,
+                                   may_be_immortal=False)
 
 # Python str object. At the C layer, str is referred to as unicode
 # (PyUnicode).
@@ -642,6 +660,10 @@ class RTuple(RType):
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rtuple(self)
 
+    @property
+    def may_be_immortal(self) -> bool:
+        return False
+
     def __str__(self) -> str:
         return "tuple[%s]" % ", ".join(str(typ) for typ in self.types)
 
@@ -763,6 +785,10 @@ class RStruct(RType):
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rstruct(self)
 
+    @property
+    def may_be_immortal(self) -> bool:
+        return False
+
     def __str__(self) -> str:
         # if not tuple(unnamed structs)
         return "{}{{{}}}".format(
@@ -823,6 +849,10 @@ class RInstance(RType):
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rinstance(self)
 
+    @property
+    def may_be_immortal(self) -> bool:
+        return False
+
     def struct_name(self, names: NameGenerator) -> str:
         return self.class_ir.struct_name(names)
 
@@ -882,6 +912,10 @@ class RUnion(RType):
 
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_runion(self)
+
+    @property
+    def may_be_immortal(self) -> bool:
+        return any(item.may_be_immortal for item in self.items)
 
     def __repr__(self) -> str:
         return "<RUnion %s>" % ", ".join(str(item) for item in self.items)
@@ -952,6 +986,10 @@ class RArray(RType):
 
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rarray(self)
+
+    @property
+    def may_be_immortal(self) -> bool:
+        return False
 
     def __str__(self) -> str:
         return f"{self.item_type}[{self.length}]"

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -448,17 +448,17 @@ none_rprimitive: Final = RPrimitive(
     "builtins.None", is_unboxed=True, is_refcounted=False, ctype="char", size=1
 )
 
-# Python list object (or an instance of a subclass of list).
+# Python list object (or an instance of a subclass of list). These could be
+# immortal, but since this is expected to be very rare, and the immortality checks
+# can be pretty expensive for lists, we treat lists as non-immortal.
 list_rprimitive: Final = RPrimitive("builtins.list", is_unboxed=False, is_refcounted=True,
                                     may_be_immortal=False)
 
 # Python dict object (or an instance of a subclass of dict).
-dict_rprimitive: Final = RPrimitive("builtins.dict", is_unboxed=False, is_refcounted=True,
-                                    may_be_immortal=False)
+dict_rprimitive: Final = RPrimitive("builtins.dict", is_unboxed=False, is_refcounted=True)
 
 # Python set object (or an instance of a subclass of set).
-set_rprimitive: Final = RPrimitive("builtins.set", is_unboxed=False, is_refcounted=True,
-                                   may_be_immortal=False)
+set_rprimitive: Final = RPrimitive("builtins.set", is_unboxed=False, is_refcounted=True)
 
 # Python str object. At the C layer, str is referred to as unicode
 # (PyUnicode).

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -31,6 +31,35 @@
 // Here just for consistency
 #define CPy_XDECREF(p) Py_XDECREF(p)
 
+// The *_NO_IMM operations below are refcount manipulation operations for
+// non-immortal objects (Python 3.12 and later).
+//
+// Py_INCREF and other CPython operations check for immortality. This
+// can be expensive when we know that an object cannot be immortal.
+
+static inline void CPy_INCREF_NO_IMM(PyObject *op)
+{
+    op->ob_refcnt++;
+}
+
+static inline void CPy_DECREF_NO_IMM(PyObject *op)
+{
+    if (--op->ob_refcnt == 0) {
+        _Py_Dealloc(op);
+    }
+}
+
+static inline void CPy_XDECREF_NO_IMM(PyObject *op)
+{
+    if (op != NULL && --op->ob_refcnt == 0) {
+        _Py_Dealloc(op);
+    }
+}
+
+#define CPy_INCREF_NO_IMM(op) CPy_INCREF_NO_IMM((PyObject *)(op))
+#define CPy_DECREF_NO_IMM(op) CPy_DECREF_NO_IMM((PyObject *)(op))
+#define CPy_XDECREF_NO_IMM(op) CPy_XDECREF_NO_IMM((PyObject *)(op))
+
 // Tagged integer -- our representation of Python 'int' objects.
 // Small enough integers are represented as unboxed integers (shifted
 // left by 1); larger integers (larger than 63 bits on a 64-bit

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -31,7 +31,7 @@
 // Here just for consistency
 #define CPy_XDECREF(p) Py_XDECREF(p)
 
-// The *_NO_IMM operations below are refcount manipulation operations for
+// The *_NO_IMM operations below perform refcount manipulation for
 // non-immortal objects (Python 3.12 and later).
 //
 // Py_INCREF and other CPython operations check for immortality. This

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -11,6 +11,7 @@ from mypyc.ir.rtypes import (
     RTuple,
     RUnion,
     bool_rprimitive,
+    dict_rprimitive,
     int_rprimitive,
     list_rprimitive,
     none_rprimitive,
@@ -113,6 +114,19 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
         else:
             self.assert_output("CPy_INCREF(x);\n")
 
+    def test_emit_inc_ref_optional(self) -> None:
+        optional = RUnion([self.instance_a, none_rprimitive])
+        self.emitter.emit_inc_ref("o", optional)
+        if HAVE_IMMORTAL:
+            self.assert_output("if (o != Py_None) {\n    CPy_INCREF_NO_IMM(o);\n}\n")
+        else:
+            self.assert_output("CPy_INCREF(o);\n")
+
+    def test_emit_inc_ref_optional_2(self) -> None:
+        optional = RUnion([dict_rprimitive, none_rprimitive])
+        self.emitter.emit_inc_ref("o", optional)
+        self.assert_output("CPy_INCREF(o);\n")
+
     def test_emit_dec_ref_object(self) -> None:
         self.emitter.emit_dec_ref("x", object_rprimitive)
         self.assert_output("CPy_DECREF(x);\n")
@@ -162,6 +176,11 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
             self.assert_output("if (o != Py_None) {\n    CPy_DECREF_NO_IMM(o);\n}\n")
         else:
             self.assert_output("CPy_DECREF(o);\n")
+
+    def test_emit_dec_ref_optional_2(self) -> None:
+        optional = RUnion([dict_rprimitive, none_rprimitive])
+        self.emitter.emit_dec_ref("o", optional)
+        self.assert_output("CPy_DECREF(o);\n")
 
     def assert_output(self, expected: str) -> None:
         assert "".join(self.emitter.fragments) == expected

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -9,9 +9,11 @@ from mypyc.ir.ops import BasicBlock, Register, Value
 from mypyc.ir.rtypes import (
     RInstance,
     RTuple,
+    RUnion,
     bool_rprimitive,
     int_rprimitive,
     list_rprimitive,
+    none_rprimitive,
     object_rprimitive,
     str_rprimitive,
 )
@@ -152,6 +154,14 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
             self.assert_output("CPy_XDECREF_NO_IMM(x);\n")
         else:
             self.assert_output("CPy_XDECREF(x);\n")
+
+    def test_emit_dec_ref_optional(self) -> None:
+        optional = RUnion([self.instance_a, none_rprimitive])
+        self.emitter.emit_dec_ref("o", optional)
+        if HAVE_IMMORTAL:
+            self.assert_output("if (o != Py_None) {\n    CPy_DECREF_NO_IMM(o);\n}\n")
+        else:
+            self.assert_output("CPy_DECREF(o);\n")
 
     def assert_output(self, expected: str) -> None:
         assert "".join(self.emitter.fragments) == expected

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 import unittest
 
 from mypyc.codegen.emit import Emitter, EmitterContext
+from mypyc.common import HAVE_IMMORTAL
 from mypyc.ir.ops import BasicBlock, Register, Value
-from mypyc.ir.rtypes import RTuple, bool_rprimitive, int_rprimitive, str_rprimitive
+from mypyc.ir.rtypes import (
+    RTuple,
+    bool_rprimitive,
+    int_rprimitive,
+    list_rprimitive,
+    object_rprimitive,
+    str_rprimitive,
+)
 from mypyc.namegen import NameGenerator
 
 
@@ -12,10 +20,10 @@ class TestEmitter(unittest.TestCase):
     def setUp(self) -> None:
         self.n = Register(int_rprimitive, "n")
         self.context = EmitterContext(NameGenerator([["mod"]]))
+        self.emitter = Emitter(self.context, {})
 
     def test_label(self) -> None:
-        emitter = Emitter(self.context, {})
-        assert emitter.label(BasicBlock(4)) == "CPyL4"
+        assert self.emitter.label(BasicBlock(4)) == "CPyL4"
 
     def test_reg(self) -> None:
         names: dict[Value, str] = {self.n: "n"}
@@ -23,17 +31,16 @@ class TestEmitter(unittest.TestCase):
         assert emitter.reg(self.n) == "cpy_r_n"
 
     def test_object_annotation(self) -> None:
-        emitter = Emitter(self.context, {})
-        assert emitter.object_annotation("hello, world", "line;") == " /* 'hello, world' */"
+        assert self.emitter.object_annotation("hello, world", "line;") == " /* 'hello, world' */"
         assert (
-            emitter.object_annotation(list(range(30)), "line;")
+            self.emitter.object_annotation(list(range(30)), "line;")
             == """\
  /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
          23, 24, 25, 26, 27, 28, 29] */"""
         )
 
     def test_emit_line(self) -> None:
-        emitter = Emitter(self.context, {})
+        emitter = self.emitter
         emitter.emit_line("line;")
         emitter.emit_line("a {")
         emitter.emit_line("f();")
@@ -51,13 +58,13 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
         )
 
     def test_emit_undefined_value_for_simple_type(self) -> None:
-        emitter = Emitter(self.context, {})
+        emitter = self.emitter
         assert emitter.c_undefined_value(int_rprimitive) == "CPY_INT_TAG"
         assert emitter.c_undefined_value(str_rprimitive) == "NULL"
         assert emitter.c_undefined_value(bool_rprimitive) == "2"
 
     def test_emit_undefined_value_for_tuple(self) -> None:
-        emitter = Emitter(self.context, {})
+        emitter = self.emitter
         assert (
             emitter.c_undefined_value(RTuple([str_rprimitive, int_rprimitive, bool_rprimitive]))
             == "(tuple_T3OIC) { NULL, CPY_INT_TAG, 2 }"
@@ -67,3 +74,58 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
             emitter.c_undefined_value(RTuple([RTuple([str_rprimitive]), bool_rprimitive]))
             == "(tuple_T2T1OC) { { NULL }, 2 }"
         )
+
+    def test_emit_inc_ref_object(self) -> None:
+        self.emitter.emit_inc_ref("x", object_rprimitive)
+        self.assert_output("CPy_INCREF(x);\n")
+
+    def test_emit_inc_ref_int(self) -> None:
+        self.emitter.emit_inc_ref("x", int_rprimitive)
+        self.assert_output("CPyTagged_INCREF(x);\n")
+
+    def test_emit_inc_ref_rare(self) -> None:
+        self.emitter.emit_inc_ref("x", object_rprimitive, rare=True)
+        self.assert_output("CPy_INCREF(x);\n")
+        self.emitter.emit_inc_ref("x", int_rprimitive, rare=True)
+        self.assert_output("CPyTagged_IncRef(x);\n")
+
+    def test_emit_inc_ref_list(self) -> None:
+        self.emitter.emit_inc_ref("x", list_rprimitive)
+        if HAVE_IMMORTAL:
+            self.assert_output("CPy_INCREF_NO_IMM(x);\n")
+        else:
+            self.assert_output("CPy_INCREF(x);\n")
+
+    def test_emit_dec_ref_object(self) -> None:
+        self.emitter.emit_dec_ref("x", object_rprimitive)
+        self.assert_output("CPy_DECREF(x);\n")
+        self.emitter.emit_dec_ref("x", object_rprimitive, is_xdec=True)
+        self.assert_output("CPy_XDECREF(x);\n")
+
+    def test_emit_dec_ref_int(self) -> None:
+        self.emitter.emit_dec_ref("x", int_rprimitive)
+        self.assert_output("CPyTagged_DECREF(x);\n")
+        self.emitter.emit_dec_ref("x", int_rprimitive, is_xdec=True)
+        self.assert_output("CPyTagged_XDECREF(x);\n")
+
+    def test_emit_dec_ref_rare(self) -> None:
+        self.emitter.emit_dec_ref("x", object_rprimitive, rare=True)
+        self.assert_output("CPy_DecRef(x);\n")
+        self.emitter.emit_dec_ref("x", int_rprimitive, rare=True)
+        self.assert_output("CPyTagged_DecRef(x);\n")
+
+    def test_emit_dec_ref_list(self) -> None:
+        self.emitter.emit_dec_ref("x", list_rprimitive)
+        if HAVE_IMMORTAL:
+            self.assert_output("CPy_DECREF_NO_IMM(x);\n")
+        else:
+            self.assert_output("CPy_DECREF(x);\n")
+        self.emitter.emit_dec_ref("x", list_rprimitive, is_xdec=True)
+        if HAVE_IMMORTAL:
+            self.assert_output("CPy_XDECREF_NO_IMM(x);\n")
+        else:
+            self.assert_output("CPy_XDECREF(x);\n")
+
+    def assert_output(self, expected: str) -> None:
+        assert "".join(self.emitter.fragments) == expected
+        self.emitter.fragments = []

--- a/mypyc/test/test_emit.py
+++ b/mypyc/test/test_emit.py
@@ -11,7 +11,6 @@ from mypyc.ir.rtypes import (
     RTuple,
     RUnion,
     bool_rprimitive,
-    dict_rprimitive,
     int_rprimitive,
     list_rprimitive,
     none_rprimitive,
@@ -117,14 +116,6 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
     def test_emit_inc_ref_optional(self) -> None:
         optional = RUnion([self.instance_a, none_rprimitive])
         self.emitter.emit_inc_ref("o", optional)
-        if HAVE_IMMORTAL:
-            self.assert_output("if (o != Py_None) {\n    CPy_INCREF_NO_IMM(o);\n}\n")
-        else:
-            self.assert_output("CPy_INCREF(o);\n")
-
-    def test_emit_inc_ref_optional_2(self) -> None:
-        optional = RUnion([dict_rprimitive, none_rprimitive])
-        self.emitter.emit_inc_ref("o", optional)
         self.assert_output("CPy_INCREF(o);\n")
 
     def test_emit_dec_ref_object(self) -> None:
@@ -171,14 +162,6 @@ CPyStatics[1]; /* [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
 
     def test_emit_dec_ref_optional(self) -> None:
         optional = RUnion([self.instance_a, none_rprimitive])
-        self.emitter.emit_dec_ref("o", optional)
-        if HAVE_IMMORTAL:
-            self.assert_output("if (o != Py_None) {\n    CPy_DECREF_NO_IMM(o);\n}\n")
-        else:
-            self.assert_output("CPy_DECREF(o);\n")
-
-    def test_emit_dec_ref_optional_2(self) -> None:
-        optional = RUnion([dict_rprimitive, none_rprimitive])
         self.emitter.emit_dec_ref("o", optional)
         self.assert_output("CPy_DECREF(o);\n")
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -820,7 +820,7 @@ else {
         for x in -5, 0, 1, 5, 255, 256:
             b = LoadLiteral(x, object_rprimitive)
             self.assert_emit([b, IncRef(b)], "" if HAVE_IMMORTAL else "CPy_INCREF(cpy_r_r0);")
-        for x in -6, 257:
+        for x in -1123355, -6, 257, 123235345:
             b = LoadLiteral(x, object_rprimitive)
             self.assert_emit([b, IncRef(b)], "CPy_INCREF(cpy_r_r0);")
 

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -5,7 +5,7 @@ import unittest
 from mypy.test.helpers import assert_string_arrays_equal
 from mypyc.codegen.emit import Emitter, EmitterContext
 from mypyc.codegen.emitfunc import FunctionEmitterVisitor, generate_native_function
-from mypyc.common import PLATFORM_SIZE
+from mypyc.common import HAVE_IMMORTAL, PLATFORM_SIZE
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FuncDecl, FuncIR, FuncSignature, RuntimeArg
 from mypyc.ir.ops import (
@@ -28,6 +28,7 @@ from mypyc.ir.ops import (
     Integer,
     IntOp,
     LoadAddress,
+    LoadLiteral,
     LoadMem,
     Op,
     Register,
@@ -53,6 +54,7 @@ from mypyc.ir.rtypes import (
     int64_rprimitive,
     int_rprimitive,
     list_rprimitive,
+    none_rprimitive,
     object_rprimitive,
     pointer_rprimitive,
     short_int_rprimitive,
@@ -114,6 +116,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
         compute_vtable(ir)
         ir.mro = [ir]
         self.r = add_local("r", RInstance(ir))
+        self.none = add_local("none", none_rprimitive)
 
         self.context = EmitterContext(NameGenerator([["mod"]]))
 
@@ -805,9 +808,25 @@ else {
                 Extend(a, int_rprimitive, signed=False), """cpy_r_r0 = (uint32_t)cpy_r_a;"""
             )
 
+    def test_inc_ref_none(self) -> None:
+        b = Box(self.none)
+        self.assert_emit([b, IncRef(b)], "" if HAVE_IMMORTAL else "CPy_INCREF(cpy_r_r0);")
+
+    def test_inc_ref_bool(self) -> None:
+        b = Box(self.b)
+        self.assert_emit([b, IncRef(b)], "" if HAVE_IMMORTAL else "CPy_INCREF(cpy_r_r0);")
+
+    def test_inc_ref_int_literal(self) -> None:
+        for x in -5, 0, 1, 5, 255, 256:
+            b = LoadLiteral(x, object_rprimitive)
+            self.assert_emit([b, IncRef(b)], "" if HAVE_IMMORTAL else "CPy_INCREF(cpy_r_r0);")
+        for x in -6, 257:
+            b = LoadLiteral(x, object_rprimitive)
+            self.assert_emit([b, IncRef(b)], "CPy_INCREF(cpy_r_r0);")
+
     def assert_emit(
         self,
-        op: Op,
+        op: Op | list[Op],
         expected: str,
         next_block: BasicBlock | None = None,
         *,
@@ -816,7 +835,11 @@ else {
         skip_next: bool = False,
     ) -> None:
         block = BasicBlock(0)
-        block.ops.append(op)
+        if isinstance(op, Op):
+            block.ops.append(op)
+        else:
+            block.ops.extend(op)
+            op = op[-1]
         value_names = generate_names_for_ir(self.registers, [block])
         emitter = Emitter(self.context, value_names)
         declarations = Emitter(self.context, value_names)


### PR DESCRIPTION
Fixes mypyc/mypyc#1044.

The addition of object immortality in Python 3.12 (PEP 683) introduced an extra immortality check to incref and decref operations. Objects with a specific reference count are treated as immortal, and their reference counts are never updated.

It turns out that this slowed down the performance of certain workloads a lot (up to 70% increase in runtime, compared to 3.11). This PR reduces the impact of immortality via a few optimizations:

1. Assume instances of native classes and list objects are not immortal (skip immortality checks).
2. Skip incref of certain objects in some contexts when we know that they are immortal (e.g. avoid incref of `None`).

The second change should be clear. We generally depend on CPython implementation details to improve performance, and this seems safe to do here as well.

The first change could turn immortal objects into non-immortal ones. For native classes this is a decision we can arguably make -- native classes don't properly support immortality, and they can't be shared between subinterpreters. As discussed in PEP 683, skipping immortality checks here is acceptable even in cases where somebody tries to make a native instance immortal, but this could have some performance or memory use impact. The performance gains make this a good tradeoff.

Since lists are mutable, they can't be safely shared between subinterpreters, so again not dealing with immortality is acceptable. It could reduce performance in some use cases by deimmortalizing lists, but this potential impact seems marginal compared to faster incref and decref operations on lists, which are some of the more common objects in Python programs.

This speeds up self check by about 1.5% on Python 3.13. This speeds up the richards benchmark by 30-35% (!) on 3.13, and also some other benchmarks see smaller improvements.
