### PR TITLE
Bind self to the class being defined when checking multiple inheritance

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2232,8 +2232,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 is_class_method = sym.node.is_class
 
             mapped_typ = cast(FunctionLike, map_type_from_supertype(typ, sub_info, super_info))
-            active_self_type = self.scope.active_self_type()
-            if isinstance(mapped_typ, Overloaded) and active_self_type:
+            active_self_type = fill_typevars(sub_info)
+            if isinstance(mapped_typ, Overloaded):
                 # If we have an overload, filter to overloads that match the self type.
                 # This avoids false positives for concrete subclasses of generic classes,
                 # see testSelfTypeOverrideCompatibility for an example.

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -2214,3 +2214,22 @@ class Test2:
 
 reveal_type(Test2().method) # N: Revealed type is "def (foo: builtins.int, *, bar: builtins.str) -> builtins.bytes"
 [builtins fixtures/tuple.pyi]
+
+[case testSelfInMultipleInheritance]
+from typing_extensions import Self
+
+class A:
+    foo: int
+    def method(self: Self, other: Self) -> None:
+        self.foo
+        other.foo
+
+class B:
+    bar: str
+    def method(self: Self, other: Self) -> None:
+        self.bar
+        other.bar
+
+class C(A, B):  # OK: both methods take Self
+    pass
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION

Fixes #18458. 

When checking base class compatibility, the class being defined is not yet in scope. However, it should be equivalent to the class passed to `bind_and_map_method` with free typevars, as that's exactly what we are currently defining.