### PR TITLE
Ignore PEP 649 + 695 implementation details in stubtest

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1482,6 +1482,8 @@ IGNORABLE_CLASS_DUNDERS: Final = frozenset(
         "__vectorcalloffset__",  # undocumented implementation detail of the vectorcall protocol
         "__firstlineno__",
         "__static_attributes__",
+        "__annotate__",
+        "__classdictcell__",
         # isinstance/issubclass hooks that type-checkers don't usually care about
         "__instancecheck__",
         "__subclasshook__",


### PR DESCRIPTION
PEP 649 added `__annotate__` and PEP 695 `__classdictcell__`. At the moment it looks like 649 will be enabled with 3.14 at which point stubtest would complain about these. It probably makes sense to add them to the ignore list now.