### PR TITLE
[mypyc] Improve access to generated C on test failures and document this

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv/
 test-data/packages/.pip_lock
 dmypy.json
 .dmypy.json
+/.mypyc_test_output
 
 # Packages
 *.egg

--- a/mypy/test/config.py
+++ b/mypy/test/config.py
@@ -18,6 +18,9 @@ package_path = os.path.join(PREFIX, "test-data", "packages")
 # It is also hard-coded in numerous places, so don't change it.
 test_temp_dir = "tmp"
 
+# Mypyc tests may write intermediate files (e.g. generated C) here on failure
+mypyc_output_dir = os.path.join(PREFIX, ".mypyc_test_output")
+
 # The PEP 561 tests do a bunch of pip installs which, even though they operate
 # on distinct temporary virtual environments, run into race conditions on shared
 # file-system state. To make this work reliably in parallel mode, we'll use a

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -20,7 +20,7 @@ from typing_extensions import TypeAlias as _TypeAlias
 import pytest
 
 from mypy import defaults
-from mypy.test.config import PREFIX, test_data_prefix, test_temp_dir
+from mypy.test.config import PREFIX, mypyc_output_dir, test_data_prefix, test_temp_dir
 
 root_dir = os.path.normpath(PREFIX)
 
@@ -584,6 +584,13 @@ def fix_cobertura_filename(line: str) -> str:
 # pytest setup
 #
 ##
+
+
+def pytest_sessionstart(session: Any) -> None:
+    # Clean up directory where mypyc tests write intermediate files on failure
+    # to avoid any confusion between test runs
+    if os.path.isdir(mypyc_output_dir):
+        shutil.rmtree(mypyc_output_dir)
 
 
 # This function name is special to pytest.  See

--- a/mypyc/doc/dev-intro.md
+++ b/mypyc/doc/dev-intro.md
@@ -296,6 +296,22 @@ Compiled native functions have the prefix `CPyDef_`, while wrapper
 functions used for calling functions from interpreted Python code have
 the `CPyPy_` prefix.
 
+When running a test, the first test failure will copy generated C code
+into the `.mypyc_test_output` directory. You will see something like
+this in the test output:
+
+```
+...
+---------------------------- Captured stderr call -----------------------------
+
+Generated files: /Users/me/src/mypy/.mypyc_test_output (for first failure only)
+
+...
+```
+
+You can also run pytest with `--mypyc-showc` to display C code on every
+test failure.
+
 ## Other Important Limitations
 
 All of these limitations will likely be fixed in the future:


### PR DESCRIPTION
Now the generated C files for the first mypyc run test failure in a pytest session will be copied to the `.mypyc_test_output` directory, and this will be indicated in the test output. This is a convenience feature to help in the common scenario where all test failures have the same root cause, so any single output is sufficient for debugging.

Document this and `--mypyc-showc`, which allows showing generated C for every test failure. The latter is too verbose to be enabled by default.