### PR TITLE
pytest options moved into pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -42,7 +42,6 @@ graft test-data
 graft mypy/test
 include conftest.py
 include runtests.py
-include pytest.ini
 include tox.ini
 
 include LICENSE mypyc/README.md CHANGELOG.md


### PR DESCRIPTION
Fixes this warning:

```
reading manifest template 'MANIFEST.in'
[…]
warning: no files found matching 'pytest.ini'
```

