### PR TITLE
Consider property access from class objects in checkmember.py

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -38,6 +38,7 @@ from mypy.nodes import (
     is_final_node,
 )
 from mypy.plugin import AttributeContext
+from mypy.semanal import refers_to_fullname
 from mypy.typeops import (
     bind_self,
     class_callable,
@@ -50,6 +51,7 @@ from mypy.typeops import (
     type_object_type_from_function,
 )
 from mypy.types import (
+    PROPERTY_DECORATOR_NAMES,
     AnyType,
     CallableType,
     DeletedType,
@@ -1109,6 +1111,19 @@ def analyze_class_attribute_access(
             #     C.x -> Any
             #     C[int].x -> int
             t = erase_typevars(expand_type_by_instance(t, isuper), {tv.id for tv in def_vars})
+
+        if is_decorated:
+            property_deco_name = next(
+                (
+                    name
+                    for d in cast(Decorator, node.node).original_decorators
+                    for name in PROPERTY_DECORATOR_NAMES
+                    if refers_to_fullname(d, name)
+                ),
+                None,
+            )
+            if property_deco_name is not None:
+                return mx.named_type(property_deco_name)
 
         is_classmethod = (is_decorated and cast(Decorator, node.node).func.is_class) or (
             isinstance(node.node, FuncBase) and node.node.is_class

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -256,6 +256,7 @@ from mypy.types import (
     NEVER_NAMES,
     OVERLOAD_NAMES,
     OVERRIDE_DECORATOR_NAMES,
+    PROPERTY_DECORATOR_NAMES,
     PROTOCOL_NAMES,
     REVEAL_TYPE_NAMES,
     TPDICT_NAMES,
@@ -1645,16 +1646,7 @@ class SemanticAnalyzer(
                 removed.append(i)
                 dec.func.is_explicit_override = True
                 self.check_decorated_function_is_method("override", dec)
-            elif refers_to_fullname(
-                d,
-                (
-                    "builtins.property",
-                    "abc.abstractproperty",
-                    "functools.cached_property",
-                    "enum.property",
-                    "types.DynamicClassAttribute",
-                ),
-            ):
+            elif refers_to_fullname(d, PROPERTY_DECORATOR_NAMES):
                 removed.append(i)
                 dec.func.is_property = True
                 dec.var.is_property = True

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -172,6 +172,15 @@ DATACLASS_TRANSFORM_NAMES: Final = (
 # Supported @override decorator names.
 OVERRIDE_DECORATOR_NAMES: Final = ("typing.override", "typing_extensions.override")
 
+# Supported property decorators
+PROPERTY_DECORATOR_NAMES: Final = (
+    "builtins.property",
+    "abc.abstractproperty",
+    "functools.cached_property",
+    "enum.property",
+    "types.DynamicClassAttribute",
+)
+
 # A placeholder used for Bogus[...] parameters
 _dummy: Final[Any] = object()
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -1665,6 +1665,36 @@ a.f = a.f # E: Property "f" defined in "A" is read-only
 a.f.x # E: "int" has no attribute "x"
 [builtins fixtures/property.pyi]
 
+[case testPropertyAccessOnClass]
+class Foo:
+    @property
+    def bar(self) -> bool:
+        return True
+
+reveal_type(Foo.bar)  # N: Revealed type is "builtins.property"
+reveal_type(Foo.bar(Foo()))  # E: "property" not callable \
+                             # N: Revealed type is "Any"
+[builtins fixtures/property.pyi]
+
+[case testPropertyAccessOnClass2]
+import functools
+from functools import cached_property
+
+class Foo:
+    @cached_property
+    def foo(self) -> bool:
+        return True
+
+    @functools.cached_property
+    def bar(self) -> bool:
+        return True
+
+reveal_type(Foo.foo)  # N: Revealed type is "functools.cached_property[Any]"
+reveal_type(Foo.bar)  # N: Revealed type is "functools.cached_property[Any]"
+Foo.foo(Foo())  # E: "cached_property[Any]" not callable
+Foo.bar(Foo())  # E: "cached_property[Any]" not callable
+[builtins fixtures/property.pyi]
+
 -- Descriptors
 -- -----------
 

--- a/test-data/unit/fixtures/property.pyi
+++ b/test-data/unit/fixtures/property.pyi
@@ -10,7 +10,7 @@ class type:
 
 class function: pass
 
-property = object()  # Dummy definition
+class property: pass  # Dummy definition
 class classmethod: pass
 
 class list: pass


### PR DESCRIPTION
Fixes 16090.

This version ignores any generic parameters (e.g. functools.cached_property is generic in the return type) - IMO that should be sufficient to avoid running all related checks here.