### PR TITLE
Better names of and more compatibility between ad hoc intersections of instances

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5536,11 +5536,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return base_classes_
 
         def _make_fake_typeinfo_and_full_name(
-            base_classes_: list[Instance], curr_module_: MypyFile, options
+            base_classes_: list[Instance], curr_module_: MypyFile, options: Options
         ) -> tuple[TypeInfo, str]:
             names = [format_type_bare(x, options=options, verbosity=2) for x in base_classes_]
             name = f"<subclass of {pretty_seq(names, 'and')}>"
             if (symbol := curr_module_.names.get(name)) is not None:
+                assert isinstance(symbol.node, TypeInfo)
                 return symbol.node, name
             cdef, info_ = self.make_fake_typeinfo(curr_module_.fullname, name, name, base_classes_)
             return info_, name

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5501,13 +5501,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         theoretical subclass of the instances the user may be trying to use
         the generated intersection can serve as a placeholder.
 
-        This function will create a fresh subclass every time you call it,
-        even if you pass in the exact same arguments. So this means calling
-        `self.intersect_intersection([inst_1, inst_2], ctx)` twice will result
-        in instances of two distinct subclasses of inst_1 and inst_2.
-
-        This is by design: we want each ad-hoc intersection to be unique since
-        they're supposed represent some other unknown subclass.
+        This function will create a fresh subclass the first time you call it.
+        So this means calling `self.intersect_intersection([inst_1, inst_2], ctx)`
+        twice will return the same subclass of inst_1 and inst_2.
 
         Returns None if creating the subclass is impossible (e.g. due to
         MRO errors or incompatible signatures). If we do successfully create
@@ -5540,20 +5536,20 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return base_classes_
 
         def _make_fake_typeinfo_and_full_name(
-            base_classes_: list[Instance], curr_module_: MypyFile
+            base_classes_: list[Instance], curr_module_: MypyFile, options
         ) -> tuple[TypeInfo, str]:
-            names_list = pretty_seq([x.type.name for x in base_classes_], "and")
-            short_name = f"<subclass of {names_list}>"
-            full_name_ = gen_unique_name(short_name, curr_module_.names)
+            names = [format_type_bare(x, options=options, verbosity=2) for x in base_classes_]
+            name = f"<subclass of {pretty_seq(names, 'and')}>"
+            if (symbol := curr_module_.names.get(name)) is not None:
+                return symbol.node, name
             cdef, info_ = self.make_fake_typeinfo(
-                curr_module_.fullname, full_name_, short_name, base_classes_
+                curr_module_.fullname, name, name, base_classes_
             )
-            return info_, full_name_
+            return info_, name
 
         base_classes = _get_base_classes(instances)
-        # We use the pretty_names_list for error messages but can't
-        # use it for the real name that goes into the symbol table
-        # because it can have dots in it.
+        # We use the pretty_names_list for error messages but for the real name that goes
+        # into the symbol table because it is not specific enough.
         pretty_names_list = pretty_seq(
             format_type_distinctly(*base_classes, options=self.options, bare=True), "and"
         )
@@ -5567,13 +5563,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return None
 
         try:
-            info, full_name = _make_fake_typeinfo_and_full_name(base_classes, curr_module)
+            info, full_name = _make_fake_typeinfo_and_full_name(base_classes, curr_module, self.options)
             with self.msg.filter_errors() as local_errors:
                 self.check_multiple_inheritance(info)
             if local_errors.has_new_errors():
                 # "class A(B, C)" unsafe, now check "class A(C, B)":
                 base_classes = _get_base_classes(instances[::-1])
-                info, full_name = _make_fake_typeinfo_and_full_name(base_classes, curr_module)
+                info, full_name = _make_fake_typeinfo_and_full_name(base_classes, curr_module, self.options)
                 with self.msg.filter_errors() as local_errors:
                     self.check_multiple_inheritance(info)
             info.is_intersection = True

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5542,9 +5542,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             name = f"<subclass of {pretty_seq(names, 'and')}>"
             if (symbol := curr_module_.names.get(name)) is not None:
                 return symbol.node, name
-            cdef, info_ = self.make_fake_typeinfo(
-                curr_module_.fullname, name, name, base_classes_
-            )
+            cdef, info_ = self.make_fake_typeinfo(curr_module_.fullname, name, name, base_classes_)
             return info_, name
 
         base_classes = _get_base_classes(instances)
@@ -5563,13 +5561,17 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return None
 
         try:
-            info, full_name = _make_fake_typeinfo_and_full_name(base_classes, curr_module, self.options)
+            info, full_name = _make_fake_typeinfo_and_full_name(
+                base_classes, curr_module, self.options
+            )
             with self.msg.filter_errors() as local_errors:
                 self.check_multiple_inheritance(info)
             if local_errors.has_new_errors():
                 # "class A(B, C)" unsafe, now check "class A(C, B)":
                 base_classes = _get_base_classes(instances[::-1])
-                info, full_name = _make_fake_typeinfo_and_full_name(base_classes, curr_module, self.options)
+                info, full_name = _make_fake_typeinfo_and_full_name(
+                    base_classes, curr_module, self.options
+                )
                 with self.msg.filter_errors() as local_errors:
                     self.check_multiple_inheritance(info)
             info.is_intersection = True

--- a/mypy/lookup.py
+++ b/mypy/lookup.py
@@ -22,9 +22,11 @@ def lookup_fully_qualified(
     This function should *not* be used to find a module. Those should be looked
     in the modules dictionary.
     """
-    head = name
+    # 1. Exclude the names of ad hoc instance intersections from step 2.
+    i = name.find("<subclass ")
+    head = name if i == -1 else name[:i]
     rest = []
-    # 1. Find a module tree in modules dictionary.
+    # 2. Find a module tree in modules dictionary.
     while True:
         if "." not in head:
             if raise_on_missing:
@@ -36,12 +38,14 @@ def lookup_fully_qualified(
         if mod is not None:
             break
     names = mod.names
-    # 2. Find the symbol in the module tree.
+    # 3. Find the symbol in the module tree.
     if not rest:
         # Looks like a module, don't use this to avoid confusions.
         if raise_on_missing:
             assert rest, f"Cannot find {name}, got a module symbol"
         return None
+    if i != -1:
+        rest[0] += name[i:]
     while True:
         key = rest.pop()
         if key not in names:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5268,7 +5268,7 @@ reveal_type(Foo().x)
 [builtins fixtures/isinstance.pyi]
 [out]
 [out2]
-tmp/b.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+tmp/b.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 
 [case testIsInstanceAdHocIntersectionIncrementalNoChangeSameName]
 import b
@@ -5291,7 +5291,7 @@ reveal_type(Foo().x)
 [builtins fixtures/isinstance.pyi]
 [out]
 [out2]
-tmp/b.py:2: note: Revealed type is "a.<subclass of "B" and "B">"
+tmp/b.py:2: note: Revealed type is "a.<subclass of "c.B" and "a.B">"
 
 
 [case testIsInstanceAdHocIntersectionIncrementalNoChangeTuple]
@@ -5313,7 +5313,7 @@ reveal_type(Foo().x)
 [builtins fixtures/isinstance.pyi]
 [out]
 [out2]
-tmp/b.py:2: note: Revealed type is "a.<subclass of "tuple" and "B">"
+tmp/b.py:2: note: Revealed type is "a.<subclass of "Tuple[builtins.int, ...]" and "a.B">"
 
 [case testIsInstanceAdHocIntersectionIncrementalIsInstanceChange]
 import c
@@ -5347,9 +5347,9 @@ from b import y
 reveal_type(y)
 [builtins fixtures/isinstance.pyi]
 [out]
-tmp/c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+tmp/c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 [out2]
-tmp/c.py:2: note: Revealed type is "a.<subclass of "A" and "C">"
+tmp/c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.C">"
 
 [case testIsInstanceAdHocIntersectionIncrementalUnderlyingObjChang]
 import c
@@ -5375,9 +5375,9 @@ from b import y
 reveal_type(y)
 [builtins fixtures/isinstance.pyi]
 [out]
-tmp/c.py:2: note: Revealed type is "b.<subclass of "A" and "B">"
+tmp/c.py:2: note: Revealed type is "b.<subclass of "a.A" and "a.B">"
 [out2]
-tmp/c.py:2: note: Revealed type is "b.<subclass of "A" and "C">"
+tmp/c.py:2: note: Revealed type is "b.<subclass of "a.A" and "a.C">"
 
 [case testIsInstanceAdHocIntersectionIncrementalIntersectionToUnreachable]
 import c
@@ -5408,7 +5408,7 @@ from b import z
 reveal_type(z)
 [builtins fixtures/isinstance.pyi]
 [out]
-tmp/c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+tmp/c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 [out2]
 tmp/b.py:2: error: Cannot determine type of "y"
 tmp/c.py:2: note: Revealed type is "Any"
@@ -5445,7 +5445,7 @@ reveal_type(z)
 tmp/b.py:2: error: Cannot determine type of "y"
 tmp/c.py:2: note: Revealed type is "Any"
 [out2]
-tmp/c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+tmp/c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 
 [case testStubFixupIssues]
 import a

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5447,6 +5447,59 @@ tmp/c.py:2: note: Revealed type is "Any"
 [out2]
 tmp/c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 
+[case testIsInstanceAdHocIntersectionIncrementalNestedClass]
+import b
+[file a.py]
+class A:
+    class B: ...
+    class C: ...
+    class D:
+        def __init__(self) -> None:
+            x: A.B
+            assert isinstance(x, A.C)
+            self.x = x
+[file b.py]
+from a import A
+[file b.py.2]
+from a import A
+reveal_type(A.D.x)
+[builtins fixtures/isinstance.pyi]
+[out]
+[out2]
+tmp/b.py:2: note: Revealed type is "a.<subclass of "a.A.B" and "a.A.C">"
+
+[case testIsInstanceAdHocIntersectionIncrementalUnions]
+import c
+[file a.py]
+import b
+class A:
+    p: b.D
+class B:
+    p: b.D
+class C:
+    p: b.D
+    c: str
+x: A
+assert isinstance(x, (B, C))
+y = x
+[file b.py]
+class D:
+    p: int
+[file c.py]
+from a import y
+[file c.py.2]
+from a import y, C
+reveal_type(y)
+reveal_type(y.p.p)
+assert isinstance(y, C)
+reveal_type(y.c)
+[builtins fixtures/isinstance.pyi]
+[out]
+[out2]
+tmp/c.py:2: note: Revealed type is "Union[a.<subclass of "a.A" and "a.B">, a.<subclass of "a.A" and "a.C">]"
+tmp/c.py:3: note: Revealed type is "builtins.int"
+tmp/c.py:5: note: Revealed type is "builtins.str"
+
 [case testStubFixupIssues]
 import a
 [file a.py]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1359,7 +1359,7 @@ class B: pass
 
 x = B()
 if isinstance(x, A):
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "B" and "A">"
+    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.B" and "__main__.A">"
 else:
     reveal_type(x)  # N: Revealed type is "__main__.B"
 reveal_type(x)  # N: Revealed type is "__main__.B"
@@ -2178,7 +2178,7 @@ def foo2(x: Optional[str]) -> None:
     if x is None:
         reveal_type(x)      # N: Revealed type is "None"
     elif isinstance(x, A):
-        reveal_type(x)      # N: Revealed type is "__main__.<subclass of "str" and "A">"
+        reveal_type(x)      # N: Revealed type is "__main__.<subclass of "builtins.str" and "__main__.A">"
     else:
         reveal_type(x)      # N: Revealed type is "builtins.str"
 [builtins fixtures/isinstance.pyi]
@@ -2202,7 +2202,7 @@ def foo2(x: Optional[str]) -> None:
     if x is None:
         reveal_type(x)      # N: Revealed type is "None"
     elif isinstance(x, A):
-        reveal_type(x)      # N: Revealed type is "__main__.<subclass of "str" and "A">"
+        reveal_type(x)      # N: Revealed type is "__main__.<subclass of "builtins.str" and "__main__.A">"
     else:
         reveal_type(x)      # N: Revealed type is "builtins.str"
 [builtins fixtures/isinstance.pyi]
@@ -2313,15 +2313,15 @@ class C:
 
 x: A
 if isinstance(x, B):
-    reveal_type(x)           # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(x)           # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
     if isinstance(x, C):
-        reveal_type(x)       # N: Revealed type is "__main__.<subclass of "A", "B", and "C">"
+        reveal_type(x)       # N: Revealed type is "__main__.<subclass of "__main__.A", "__main__.B", and "__main__.C">"
         reveal_type(x.f1())  # N: Revealed type is "builtins.int"
         reveal_type(x.f2())  # N: Revealed type is "builtins.int"
         reveal_type(x.f3())  # N: Revealed type is "builtins.int"
-        x.bad()              # E: "<subclass of "A", "B", and "C">" has no attribute "bad"
+        x.bad()              # E: "<subclass of "__main__.A", "__main__.B", and "__main__.C">" has no attribute "bad"
     else:
-        reveal_type(x)       # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(x)       # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
 else:
     reveal_type(x)           # N: Revealed type is "__main__.A"
 [builtins fixtures/isinstance.pyi]
@@ -2334,11 +2334,11 @@ class B: pass
 
 x: A
 if isinstance(x, B):
-    reveal_type(x)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(x)      # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
     if isinstance(x, A):
-        reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
     if isinstance(x, B):
-        reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceAdHocIntersectionIncompatibleClasses]
@@ -2359,7 +2359,7 @@ else:
 
 y: C
 if isinstance(y, B):
-    reveal_type(y)        # N: Revealed type is "__main__.<subclass of "C" and "B">"
+    reveal_type(y)        # N: Revealed type is "__main__.<subclass of "__main__.C" and "__main__.B">"
     if isinstance(y, A):  # E: Subclass of "C", "B", and "A" cannot exist: would have incompatible method signatures
         reveal_type(y)    # E: Statement is unreachable
 [builtins fixtures/isinstance.pyi]
@@ -2393,19 +2393,19 @@ class B:
 
     def t1(self) -> None:
         if isinstance(self, A1):
-            reveal_type(self)           # N: Revealed type is "__main__.<subclass of "A1" and "B">"
+            reveal_type(self)           # N: Revealed type is "__main__.<subclass of "__main__.A1" and "__main__.B">"
             x0: Literal[0] = self.f()   # E: Incompatible types in assignment (expression has type "Literal[1]", variable has type "Literal[0]")
             x1: Literal[1] = self.f()
 
     def t2(self) -> None:
         if isinstance(self, (A0, A1)):
-            reveal_type(self)           # N: Revealed type is "__main__.<subclass of "A1" and "B">1"
+            reveal_type(self)           # N: Revealed type is "__main__.<subclass of "__main__.A1" and "__main__.B">"
             x0: Literal[0] = self.f()   # E: Incompatible types in assignment (expression has type "Literal[1]", variable has type "Literal[0]")
             x1: Literal[1] = self.f()
 
     def t3(self) -> None:
         if isinstance(self, (A1, A2)):
-            reveal_type(self)           # N: Revealed type is "Union[__main__.<subclass of "A1" and "B">2, __main__.<subclass of "A2" and "B">]"
+            reveal_type(self)           # N: Revealed type is "Union[__main__.<subclass of "__main__.A1" and "__main__.B">, __main__.<subclass of "__main__.A2" and "__main__.B">]"
             x0: Literal[0] = self.f()   # E: Incompatible types in assignment (expression has type "Literal[1, 2]", variable has type "Literal[0]")
             x1: Literal[1] = self.f()   # E: Incompatible types in assignment (expression has type "Literal[1, 2]", variable has type "Literal[1]")
 
@@ -2432,14 +2432,14 @@ else:
 
 y: A[Parent]
 if isinstance(y, B):
-    reveal_type(y)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(y)      # N: Revealed type is "__main__.<subclass of "__main__.A[__main__.Parent]" and "__main__.B">"
     reveal_type(y.f())  # N: Revealed type is "__main__.Parent"
 else:
     reveal_type(y)      # N: Revealed type is "__main__.A[__main__.Parent]"
 
 z: A[Child]
 if isinstance(z, B):
-    reveal_type(z)      # N: Revealed type is "__main__.<subclass of "A" and "B">1"
+    reveal_type(z)      # N: Revealed type is "__main__.<subclass of "__main__.A[__main__.Child]" and "__main__.B">"
     reveal_type(z.f())  # N: Revealed type is "__main__.Child"
 else:
     reveal_type(z)      # N: Revealed type is "__main__.A[__main__.Child]"
@@ -2460,10 +2460,10 @@ T1 = TypeVar('T1', A, B)
 def f1(x: T1) -> T1:
     if isinstance(x, A):
         reveal_type(x)      # N: Revealed type is "__main__.A" \
-                            # N: Revealed type is "__main__.<subclass of "B" and "A">"
+                            # N: Revealed type is "__main__.<subclass of "__main__.B" and "__main__.A">"
         if isinstance(x, B):
-            reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "B">" \
-                            # N: Revealed type is "__main__.<subclass of "B" and "A">"
+            reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">" \
+                            # N: Revealed type is "__main__.<subclass of "__main__.B" and "__main__.A">"
         else:
             reveal_type(x)  # N: Revealed type is "__main__.A"
     else:
@@ -2502,7 +2502,7 @@ T1 = TypeVar('T1', A, B)
 def f1(x: T1) -> T1:
     if isinstance(x, A):
         # The error message is confusing, but we indeed do run into problems if
-        # 'x' is a subclass of A and B
+        # 'x' is a subclass of __main__.A and __main__.B
         return A()   # E: Incompatible return value type (got "A", expected "B")
     else:
         return B()
@@ -2530,10 +2530,10 @@ def accept_concrete(c: Concrete) -> None: pass
 x: A
 if isinstance(x, B):
     var = x
-    reveal_type(var)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(var)      # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
     accept_a(var)
     accept_b(var)
-    accept_concrete(var)  # E: Argument 1 to "accept_concrete" has incompatible type "<subclass of "A" and "B">"; expected "Concrete"
+    accept_concrete(var)  # E: Argument 1 to "accept_concrete" has incompatible type "<subclass of "__main__.A" and "__main__.B">"; expected "Concrete"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceAdHocIntersectionReinfer]
@@ -2543,14 +2543,14 @@ class B: pass
 
 x: A
 assert isinstance(x, B)
-reveal_type(x)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
+reveal_type(x)      # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
 
 y: A
 assert isinstance(y, B)
-reveal_type(y)      # N: Revealed type is "__main__.<subclass of "A" and "B">1"
+reveal_type(y)      # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
 
 x = y
-reveal_type(x)      # N: Revealed type is "__main__.<subclass of "A" and "B">1"
+reveal_type(x)      # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceAdHocIntersectionWithUnions]
@@ -2563,15 +2563,15 @@ class D: pass
 
 v1: A
 if isinstance(v1, (B, C)):
-    reveal_type(v1)  # N: Revealed type is "Union[__main__.<subclass of "A" and "B">, __main__.<subclass of "A" and "C">]"
+    reveal_type(v1)  # N: Revealed type is "Union[__main__.<subclass of "__main__.A" and "__main__.B">, __main__.<subclass of "__main__.A" and "__main__.C">]"
 
 v2: Union[A, B]
 if isinstance(v2, C):
-    reveal_type(v2)  # N: Revealed type is "Union[__main__.<subclass of "A" and "C">1, __main__.<subclass of "B" and "C">]"
+    reveal_type(v2)  # N: Revealed type is "Union[__main__.<subclass of "__main__.A" and "__main__.C">, __main__.<subclass of "__main__.B" and "__main__.C">]"
 
 v3: Union[A, B]
 if isinstance(v3, (C, D)):
-    reveal_type(v3)  # N: Revealed type is "Union[__main__.<subclass of "A" and "C">2, __main__.<subclass of "A" and "D">, __main__.<subclass of "B" and "C">1, __main__.<subclass of "B" and "D">]"
+    reveal_type(v3)  # N: Revealed type is "Union[__main__.<subclass of "__main__.A" and "__main__.C">, __main__.<subclass of "__main__.A" and "__main__.D">, __main__.<subclass of "__main__.B" and "__main__.C">, __main__.<subclass of "__main__.B" and "__main__.D">]"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceAdHocIntersectionSameNames]
@@ -2581,7 +2581,7 @@ class A: pass
 
 x: A
 if isinstance(x, A2):
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "A">"
+    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "foo.A">"
 
 [file foo.py]
 class A: pass
@@ -2611,7 +2611,7 @@ class Ambiguous:
 # We bias towards assuming these two classes could be overlapping
 foo: Concrete
 if isinstance(foo, Ambiguous):
-    reveal_type(foo)    # N: Revealed type is "__main__.<subclass of "Concrete" and "Ambiguous">"
+    reveal_type(foo)    # N: Revealed type is "__main__.<subclass of "__main__.Concrete" and "__main__.Ambiguous">"
     reveal_type(foo.x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/isinstance.pyi]
 
@@ -2628,11 +2628,11 @@ class C:
 
 x: Type[A]
 if issubclass(x, B):
-    reveal_type(x)        # N: Revealed type is "Type[__main__.<subclass of "A" and "B">]"
+    reveal_type(x)        # N: Revealed type is "Type[__main__.<subclass of "__main__.A" and "__main__.B">]"
     if issubclass(x, C):  # E: Subclass of "A", "B", and "C" cannot exist: would have incompatible method signatures
         reveal_type(x)    # E: Statement is unreachable
     else:
-        reveal_type(x)    # N: Revealed type is "Type[__main__.<subclass of "A" and "B">]"
+        reveal_type(x)    # N: Revealed type is "Type[__main__.<subclass of "__main__.A" and "__main__.B">]"
 else:
     reveal_type(x)        # N: Revealed type is "Type[__main__.A]"
 [builtins fixtures/isinstance.pyi]
@@ -2931,4 +2931,17 @@ if isinstance(var, bool):
 
 # Type of var shouldn't fall back to Any
 reveal_type(var)  # N: Revealed type is "Union[builtins.bool, builtins.str]"
+[builtins fixtures/isinstance.pyi]
+
+[case testReuseIntersectionForRepeatedIsinstanceCalls]
+
+class A: ...
+class B: ...
+
+a: A
+if isinstance(a, B):
+    c = a
+if isinstance(a, B):
+    c = a
+
 [builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2095,11 +2095,11 @@ class Z: ...
 x: X
 
 if isinstance(x, (Y, Z)):
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "X" and "Y">"
+    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.X" and "__main__.Y">"
 if isinstance(x, (Y, NoneType)):
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "X" and "Y">1"
+    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.X" and "__main__.Y">"
 if isinstance(x, (Y, Z, NoneType)):
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "X" and "Y">2"
+    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.X" and "__main__.Y">"
 if isinstance(x, (Z, NoneType)):  # E: Subclass of "X" and "Z" cannot exist: "Z" is final \
                                   # E: Subclass of "X" and "NoneType" cannot exist: "NoneType" is final
     reveal_type(x)  # E: Statement is unreachable

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1754,7 +1754,7 @@ if isinstance(c1i, P1):
 else:
     reveal_type(c1i) # Unreachable
 if isinstance(c1i, P):
-    reveal_type(c1i) # N: Revealed type is "__main__.<subclass of "C1" and "P">"
+    reveal_type(c1i) # N: Revealed type is "__main__.<subclass of "__main__.C1[builtins.int]" and "__main__.P">"
 else:
     reveal_type(c1i) # N: Revealed type is "__main__.C1[builtins.int]"
 
@@ -1766,7 +1766,7 @@ else:
 
 c2: C2
 if isinstance(c2, P):
-    reveal_type(c2) # N: Revealed type is "__main__.<subclass of "C2" and "P">"
+    reveal_type(c2) # N: Revealed type is "__main__.<subclass of "__main__.C2" and "__main__.P">"
 else:
     reveal_type(c2) # N: Revealed type is "__main__.C2"
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -64,7 +64,7 @@ m: A
 
 match m:
     case b.b:
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "A" and "B">1"
+        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "b.B">"
 [file b.py]
 class B: ...
 b: B
@@ -933,9 +933,9 @@ m: B
 
 match m:
     case A():
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">2"
+        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "__main__.B" and "__main__.A">"
     case A(i, j):
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">3"
+        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "__main__.B" and "__main__.A">"
 [builtins fixtures/tuple.pyi]
 
 [case testMatchClassPatternNonexistentKeyword]
@@ -1309,7 +1309,7 @@ m: A
 
 match m:
     case a if isinstance(a, B):
-        reveal_type(a)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(a)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testMatchUnreachablePatternGuard]
@@ -1749,10 +1749,10 @@ class C: pass
 def f(x: A) -> None:
     match x:
         case B() as y:
-            reveal_type(y)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+            reveal_type(y)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
         case C() as y:
-            reveal_type(y)  # N: Revealed type is "__main__.<subclass of "A" and "C">"
-    reveal_type(y)  # N: Revealed type is "Union[__main__.<subclass of "A" and "B">, __main__.<subclass of "A" and "C">]"
+            reveal_type(y)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.C">"
+    reveal_type(y)  # N: Revealed type is "Union[__main__.<subclass of "__main__.A" and "__main__.B">, __main__.<subclass of "__main__.A" and "__main__.C">]"
 
 [case testMatchWithBreakAndContinue]
 def f(x: int | str | None) -> None:

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -452,7 +452,7 @@ def g(x: object) -> None: ...
 def test(x: List[object]) -> None:
     if not(f(x) or isinstance(x, A)):
         return
-    g(reveal_type(x))  # N: Revealed type is "Union[builtins.list[builtins.str], __main__.<subclass of "list" and "A">]"
+    g(reveal_type(x))  # N: Revealed type is "Union[builtins.list[builtins.str], __main__.<subclass of "List[builtins.object]" and "__main__.A">]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeGuardMultipleCondition-xfail]

--- a/test-data/unit/check-typeis.test
+++ b/test-data/unit/check-typeis.test
@@ -384,9 +384,9 @@ def guard(a: object) -> TypeIs[B]:
 
 a = A()
 if guard(a):
-    reveal_type(a)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(a)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
     a = B()  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
-    reveal_type(a)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(a)  # N: Revealed type is "__main__.<subclass of "__main__.A" and "__main__.B">"
     a = A()
     reveal_type(a)  # N: Revealed type is "__main__.A"
 reveal_type(a)  # N: Revealed type is "__main__.A"
@@ -454,7 +454,7 @@ def g(x: object) -> None: ...
 def test(x: List[Any]) -> None:
     if not(f(x) or isinstance(x, A)):
         return
-    g(reveal_type(x))  # N: Revealed type is "Union[builtins.list[builtins.str], __main__.<subclass of "list" and "A">]"
+    g(reveal_type(x))  # N: Revealed type is "Union[builtins.list[builtins.str], __main__.<subclass of "List[Any]" and "__main__.A">]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeIsMultipleCondition]
@@ -473,13 +473,13 @@ def is_bar(item: object) -> TypeIs[Bar]:
 def foobar(x: object):
     if not isinstance(x, Foo) or not isinstance(x, Bar):
         return
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "Foo" and "Bar">"
+    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.Foo" and "__main__.Bar">"
 
 def foobar_typeis(x: object):
     if not is_foo(x) or not is_bar(x):
         return
     # Looks like a typo but this is what our unique name generation produces
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "Foo" and "Bar">1"
+    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "__main__.Foo" and "__main__.Bar">"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeIsAsFunctionArgAsBoolSubtype]

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -432,7 +432,7 @@ def f(x: A) -> None:
         x.y
 [builtins fixtures/isinstancelist.pyi]
 [out]
-<m.<subclass of "A" and "B">.y> -> m.f
+<m.<subclass of "m.A" and "m.B">.y> -> m.f
 <m.A> -> <m.f>, m.A, m.f
 <m.B> -> m.B, m.f
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9591,7 +9591,7 @@ reveal_type(Foo().x)
 [builtins fixtures/isinstance.pyi]
 [out]
 ==
-b.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+b.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 
 [case testIsInstanceAdHocIntersectionFineGrainedIncrementalIsInstanceChange]
 import c
@@ -9625,9 +9625,9 @@ from b import y
 reveal_type(y)
 [builtins fixtures/isinstance.pyi]
 [out]
-c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 ==
-c.py:2: note: Revealed type is "a.<subclass of "A" and "C">"
+c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.C">"
 
 [case testIsInstanceAdHocIntersectionFineGrainedIncrementalUnderlyingObjChang]
 import c
@@ -9653,9 +9653,9 @@ from b import y
 reveal_type(y)
 [builtins fixtures/isinstance.pyi]
 [out]
-c.py:2: note: Revealed type is "b.<subclass of "A" and "B">"
+c.py:2: note: Revealed type is "b.<subclass of "a.A" and "a.B">"
 ==
-c.py:2: note: Revealed type is "b.<subclass of "A" and "C">"
+c.py:2: note: Revealed type is "b.<subclass of "a.A" and "a.C">"
 
 [case testIsInstanceAdHocIntersectionFineGrainedIncrementalIntersectionToUnreachable]
 import c
@@ -9686,7 +9686,7 @@ from b import z
 reveal_type(z)
 [builtins fixtures/isinstance.pyi]
 [out]
-c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 ==
 c.py:2: note: Revealed type is "Any"
 b.py:2: error: Cannot determine type of "y"
@@ -9723,7 +9723,7 @@ reveal_type(z)
 b.py:2: error: Cannot determine type of "y"
 c.py:2: note: Revealed type is "Any"
 ==
-c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+c.py:2: note: Revealed type is "a.<subclass of "a.A" and "a.B">"
 
 [case testStubFixupIssues]
 [file a.py]


### PR DESCRIPTION
While working on #18433, we encountered [this bug.](https://github.com/python/mypy/pull/18433#issuecomment-2583314142).  @ilevkivskyi identified [the underlying problem](https://github.com/python/mypy/pull/18433#issuecomment-2585455830), and we decided to try to reuse previously created ad hoc intersections of instances instead of always creating new ones.

While working on this PR, I realised that reusing intersections requires more complete names.  Currently, module and type variable specifications are not included, which could result in mistakes when using these names as identifiers.

So, I switched to more complete names.  Now, for example, `<subclass of "A" and "A">`  becomes `<subclass of "mod1.A[builtins.int]" and "mod2.A">`.  Hence, I had to adjust many existing test cases where `reveal_type` is used. 

`testReuseIntersectionForRepeatedIsinstanceCalls` confirms that the mentioned bug is fixed. 

`testIsInstanceAdHocIntersectionIncrementalNestedClass` and `testIsInstanceAdHocIntersectionIncrementalUnions` are in a separate commit.  I think they are not really necessary, so we might prefer to remove them.  I added them originally because I had to adjust `lookup_fully_qualified` a little.  The change is very simple, but I could not create a test case where it is not sufficient.