### PR TITLE
Fix isinstance with explicit (non generic) type alias

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4022,7 +4022,6 @@ class SemanticAnalyzer(
             and not res.args
             and not empty_tuple_index
             and not pep_695
-            and not pep_613
         )
         if isinstance(res, ProperType) and isinstance(res, Instance):
             if not validate_instance(res, self.fail, empty_tuple_index):

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1243,31 +1243,22 @@ A = Union[int, List[A]]
 def func(x: A) -> int: ...
 [builtins fixtures/tuple.pyi]
 
-[case testAliasExplicitNoArgsBasic]
-from typing import Any, List, assert_type
+[case testAliasNonGeneric]
 from typing_extensions import TypeAlias
+class Foo: ...
 
-Implicit = List
-Explicit: TypeAlias = List
+ImplicitFoo = Foo
+ExplicitFoo: TypeAlias = Foo
 
-x1: Implicit[str]
-x2: Explicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
-assert_type(x1, List[str])
-assert_type(x2, List[Any])
-[builtins fixtures/tuple.pyi]
+x1: ImplicitFoo[str]  # E: "Foo" expects no type arguments, but 1 given
+x2: ExplicitFoo[str]  # E: "Foo" expects no type arguments, but 1 given
 
-[case testAliasExplicitNoArgsGenericClass]
-# flags: --python-version 3.9
-from typing import Any, assert_type
-from typing_extensions import TypeAlias
+def is_foo(x: object):
+    if isinstance(x, ImplicitFoo):
+        pass
+    if isinstance(x, ExplicitFoo):
+        pass
 
-Implicit = list
-Explicit: TypeAlias = list
-
-x1: Implicit[str]
-x2: Explicit[str]  # E: Bad number of arguments for type alias, expected 0, given 1
-assert_type(x1, list[str])
-assert_type(x2, list[Any])
 [builtins fixtures/tuple.pyi]
 
 [case testAliasExplicitNoArgsTuple]

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -1563,6 +1563,7 @@ type H[T] = int
 __main__.A
 __main__.C
 __main__.D
+__main__.E
 __main__.G
 __main__.H
 


### PR DESCRIPTION
This is a partial revert of #18173 to unblock the 1.15 release

Fixes #18488