### PR TITLE
Allow redefinitions in except/else/finally

### DIFF
--- a/test-data/unit/check-python311.test
+++ b/test-data/unit/check-python311.test
@@ -259,3 +259,47 @@ def foo():
                 continue  # E: "continue" not allowed in except* block
             return  # E: "return" not allowed in except* block
 [builtins fixtures/exception.pyi]
+
+[case testRedefineLocalWithinExceptStarTryClauses]
+# flags: --allow-redefinition
+def fn_str(_: str) -> int: ...
+def fn_int(_: int) -> None: ...
+def fn_exc(_: Exception) -> str: ...
+
+def in_block() -> None:
+    try:
+        a = ""
+        a = fn_str(a)  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+        fn_int(a)  # E: Argument 1 to "fn_int" has incompatible type "str"; expected "int"
+    except* Exception:
+        b = ""
+        b = fn_str(b)
+        fn_int(b)
+    else:
+        c = ""
+        c = fn_str(c)
+        fn_int(c)
+    finally:
+        d = ""
+        d = fn_str(d)
+        fn_int(d)
+    reveal_type(a)  # N: Revealed type is "builtins.str"
+    reveal_type(b)  # N: Revealed type is "builtins.int"
+    reveal_type(c)  # N: Revealed type is "builtins.int"
+    reveal_type(d)  # N: Revealed type is "builtins.int"
+
+def across_blocks() -> None:
+    try:
+        a = ""
+    except* Exception:
+        a = fn_str(a)  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+    else:
+        a = fn_str(a)  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+    reveal_type(a)  # N: Revealed type is "builtins.str"
+
+def exc_name() -> None:
+    try:
+        pass
+    except* RuntimeError as e:
+        e = fn_exc(e)
+[builtins fixtures/exception.pyi]

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -88,6 +88,7 @@ def h(a: Iterable[int]) -> None:
 
 [case testCannotRedefineLocalWithinTry]
 # flags: --allow-redefinition
+def g(): pass
 def f() -> None:
     try:
         x = 0
@@ -102,7 +103,52 @@ def f() -> None:
     y
     y = ''
 
-def g(): pass
+[case testRedefineLocalWithinTryClauses]
+# flags: --allow-redefinition
+def fn_str(_: str) -> int: ...
+def fn_int(_: int) -> None: ...
+
+def in_block() -> None:
+    try:
+        a = ""
+        a = fn_str(a)  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+        fn_int(a)  # E: Argument 1 to "fn_int" has incompatible type "str"; expected "int"
+    except:
+        b = ""
+        b = fn_str(b)
+        fn_int(b)
+    else:
+        c = ""
+        c = fn_str(c)
+        fn_int(c)
+    finally:
+        d = ""
+        d = fn_str(d)
+        fn_int(d)
+    reveal_type(a)  # N: Revealed type is "builtins.str"
+    reveal_type(b)  # N: Revealed type is "builtins.int"
+    reveal_type(c)  # N: Revealed type is "builtins.int"
+    reveal_type(d)  # N: Revealed type is "builtins.int"
+
+def across_blocks() -> None:
+    try:
+        a = ""
+    except:
+        pass
+    else:
+        a = fn_str(a)  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+    reveal_type(a)  # N: Revealed type is "builtins.str"
+
+[case testRedefineLocalExceptVar]
+# flags: --allow-redefinition
+def fn_exc(_: Exception) -> str: ...
+
+def exc_name() -> None:
+    try:
+        pass
+    except RuntimeError as e:
+        e = fn_exc(e)
+[builtins fixtures/exception.pyi]
 
 [case testRedefineLocalWithinWith]
 # flags: --allow-redefinition
@@ -274,7 +320,6 @@ def f() -> None:
            # E: Incompatible types in assignment (expression has type "int", variable has type "TypeVar")
     reveal_type(x) # N: Revealed type is "typing.TypeVar"
     y = 1
-    # NOTE: '"int" not callable' is due to test stubs
     y = TypeVar('y')  # E: Cannot redefine "y" as a type variable \
                       # E: Incompatible types in assignment (expression has type "TypeVar", variable has type "int")
     def h(a: y) -> y: return a # E: Variable "y" is not valid as a type \

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -150,6 +150,21 @@ def exc_name() -> None:
         e = fn_exc(e)
 [builtins fixtures/exception.pyi]
 
+[case testRedefineNestedInTry]
+# flags: --allow-redefinition
+
+def fn_int(_: int) -> None: ...
+
+try:
+    try:
+        ...
+    finally:
+        a = ""
+        a = 5  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+        fn_int(a)  # E: Argument 1 to "fn_int" has incompatible type "str"; expected "int"
+except:
+    pass
+
 [case testRedefineLocalWithinWith]
 # flags: --allow-redefinition
 def f() -> None:


### PR DESCRIPTION
Fixes #18514.

Only `try` clause should be treated as fallible, this should not prevent `--allow-redefinition` from working in other try clauses (except, else, finally).