### PR TITLE
Update TypedDict imports in tests

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -5184,11 +5184,12 @@ def test() -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testCrashOnSelfRecursiveTypedDictVar]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 A = TypedDict('A', {'a': 'A'})  # type: ignore
 a: A
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCrashInJoinOfSelfRecursiveNamedTuples]
 
@@ -5205,7 +5206,7 @@ lst = [n, m]
 [builtins fixtures/isinstancelist.pyi]
 
 [case testCorrectJoinOfSelfRecursiveTypedDicts]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 def test() -> None:
     class N(TypedDict):
@@ -5220,6 +5221,7 @@ def test() -> None:
     lst = [n, m]
     reveal_type(lst[0]['x'])  # N: Revealed type is "Any"
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCrashInForwardRefToNamedTupleWithIsinstance]
 from typing import Dict, NamedTuple
@@ -5236,8 +5238,7 @@ def parse_ast(name_dict: NameDict) -> None:
 [typing fixtures/typing-medium.pyi]
 
 [case testCrashInForwardRefToTypedDictWithIsinstance]
-from mypy_extensions import TypedDict
-from typing import Dict
+from typing import Dict, TypedDict
 
 NameDict = Dict[str, 'NameInfo']
 class NameInfo(TypedDict):
@@ -5248,7 +5249,7 @@ def parse_ast(name_dict: NameDict) -> None:
         pass
     reveal_type(name_dict['']['ast'])  # N: Revealed type is "builtins.bool"
 [builtins fixtures/isinstancelist.pyi]
-[typing fixtures/typing-medium.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCorrectIsinstanceInForwardRefToNewType]
 from typing import Dict, NewType
@@ -5313,13 +5314,13 @@ x = NT(N(1))
 
 [case testNewTypeFromForwardTypedDict]
 
-from typing import NewType, Tuple
-from mypy_extensions import TypedDict
+from typing import NewType, Tuple, TypedDict
 
 NT = NewType('NT', 'N') # E: Argument 2 to NewType(...) must be subclassable (got "N")
 class N(TypedDict):
     x: int
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testCorrectAttributeInForwardRefToNamedTuple]
@@ -5335,7 +5336,7 @@ class Process(NamedTuple):
 [out]
 
 [case testCorrectItemTypeInForwardRefToTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 proc: Process
 reveal_type(proc['state'])  # N: Revealed type is "builtins.int"
 
@@ -5344,6 +5345,7 @@ def get_state(proc: 'Process') -> int:
 class Process(TypedDict):
      state: int
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testCorrectDoubleForwardNamedTuple]
@@ -5362,7 +5364,7 @@ reveal_type(x.one.attr)  # N: Revealed type is "builtins.str"
 [out]
 
 [case testCrashOnDoubleForwardTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 x: A
 class A(TypedDict):
@@ -5373,6 +5375,7 @@ class B(TypedDict):
 
 reveal_type(x['one']['attr'])  # N: Revealed type is "builtins.str"
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testCrashOnForwardUnionOfNamedTuples]
@@ -5392,8 +5395,7 @@ def foo(node: Node) -> int:
 [out]
 
 [case testCrashOnForwardUnionOfTypedDicts]
-from mypy_extensions import TypedDict
-from typing import Union
+from typing import TypedDict, Union
 
 NodeType = Union['Foo', 'Bar']
 class Foo(TypedDict):
@@ -5405,6 +5407,7 @@ def foo(node: NodeType) -> int:
     x = node
     return x['x']
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testSupportForwardUnionOfNewTypes]
@@ -5471,8 +5474,7 @@ def f(x: ForwardUnion) -> None:
 [out]
 
 [case testCrashInvalidArgsSyntheticClassSyntax]
-from typing import List, NamedTuple
-from mypy_extensions import TypedDict
+from typing import List, NamedTuple, TypedDict
 class TD(TypedDict):
     x: List[int, str] # E: "list" expects 1 type argument, but 2 given
 class NM(NamedTuple):
@@ -5482,11 +5484,11 @@ class NM(NamedTuple):
 TD({'x': []})
 NM(x=[])
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testCrashInvalidArgsSyntheticClassSyntaxReveals]
-from typing import List, NamedTuple
-from mypy_extensions import TypedDict
+from typing import List, NamedTuple, TypedDict
 class TD(TypedDict):
     x: List[int, str] # E: "list" expects 1 type argument, but 2 given
 class NM(NamedTuple):
@@ -5501,11 +5503,11 @@ reveal_type(x1) # N: Revealed type is "TypedDict('__main__.TD', {'x': builtins.l
 reveal_type(y) # N: Revealed type is "Tuple[builtins.list[Any], fallback=__main__.NM]"
 reveal_type(y1) # N: Revealed type is "Tuple[builtins.list[Any], fallback=__main__.NM]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testCrashInvalidArgsSyntheticFunctionSyntax]
-from typing import List, NewType, NamedTuple
-from mypy_extensions import TypedDict
+from typing import List, NewType, NamedTuple, TypedDict
 TD = TypedDict('TD', {'x': List[int, str]}) # E: "list" expects 1 type argument, but 2 given
 NM = NamedTuple('NM', [('x', List[int, str])]) # E: "list" expects 1 type argument, but 2 given
 NT = NewType('NT', List[int, str]) # E: "list" expects 1 type argument, but 2 given
@@ -5515,11 +5517,11 @@ TD({'x': []})
 NM(x=[])
 NT([])
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testCrashForwardSyntheticClassSyntax]
-from typing import NamedTuple
-from mypy_extensions import TypedDict
+from typing import NamedTuple, TypedDict
 class A1(NamedTuple):
     b: 'B'
     x: int
@@ -5533,11 +5535,11 @@ y: A2
 reveal_type(x.b) # N: Revealed type is "__main__.B"
 reveal_type(y['b']) # N: Revealed type is "__main__.B"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testCrashForwardSyntheticFunctionSyntax]
-from typing import NamedTuple
-from mypy_extensions import TypedDict
+from typing import NamedTuple, TypedDict
 A1 = NamedTuple('A1', [('b', 'B'), ('x', int)])
 A2 = TypedDict('A2', {'b': 'B', 'x': int})
 class B:
@@ -5547,6 +5549,7 @@ y: A2
 reveal_type(x.b) # N: Revealed type is "__main__.B"
 reveal_type(y['b']) # N: Revealed type is "__main__.B"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 -- Special support for six

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -579,8 +579,7 @@ plugins=<ROOT>/test-data/unit/plugins/method_sig_hook.py
 
 [case testMethodSignatureHookNamesFullyQualified]
 # flags: --config-file tmp/mypy.ini
-from mypy_extensions import TypedDict
-from typing import NamedTuple
+from typing import NamedTuple, TypedDict
 
 class FullyQualifiedTestClass:
     @classmethod
@@ -601,6 +600,7 @@ reveal_type(FullyQualifiedTestNamedTuple('')._asdict()) # N: Revealed type is "b
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/fully_qualified_test_hook.py
 [builtins fixtures/classmethod.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testDynamicClassPlugin]
 # flags: --config-file tmp/mypy.ini

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1082,25 +1082,25 @@ main:6: error: A type on this line becomes "Any" due to an unfollowed import
 
 [case testDisallowUnimportedAnyTypedDictSimple]
 # flags: --ignore-missing-imports --disallow-any-unimported
-from mypy_extensions import TypedDict
+from typing import TypedDict
 from x import Unchecked
 
 M = TypedDict('M', {'x': str, 'y': Unchecked})  # E: Type of a TypedDict key becomes "Any" due to an unfollowed import
 
 def f(m: M) -> M: pass  # no error
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testDisallowUnimportedAnyTypedDictGeneric]
 # flags: --ignore-missing-imports --disallow-any-unimported
-
-from mypy_extensions import TypedDict
-from typing import List
+from typing import List, TypedDict
 from x import Unchecked
 
 M = TypedDict('M', {'x': str, 'y': List[Unchecked]})  # E: Type of a TypedDict key becomes "List[Any]" due to an unfollowed import
 
 def f(m: M) -> M: pass  # no error
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testDisallowAnyDecoratedUnannotatedDecorator]
 # flags: --disallow-any-decorated
@@ -1337,13 +1337,14 @@ def k(s: E) -> None: pass
 
 [case testDisallowAnyExprTypedDict]
 # flags: --disallow-any-expr
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 Movie = TypedDict('Movie', {'name': str, 'year': int})
 
 def g(m: Movie) -> Movie:
     return m
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testDisallowIncompleteDefs]
 # flags: --disallow-incomplete-defs
@@ -1483,8 +1484,7 @@ n: N
 
 [case testCheckDisallowAnyGenericsTypedDict]
 # flags: --disallow-any-generics
-from typing import Dict, Any, Optional
-from mypy_extensions import TypedDict
+from typing import Dict, Any, Optional, TypedDict
 
 VarsDict = Dict[str, Any]
 HostsDict = Dict[str, Optional[VarsDict]]
@@ -1497,6 +1497,7 @@ GroupDataDict = TypedDict(
 
 GroupsDict = Dict[str, GroupDataDict]  # type: ignore
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 [case testCheckDisallowAnyGenericsStubOnly]
@@ -1929,22 +1930,22 @@ Bar = NewType('Bar', List[Any])  # E: Explicit "Any" is not allowed  [explicit-a
 
 [case testDisallowAnyExplicitTypedDictSimple]
 # flags: --disallow-any-explicit --show-error-codes
-from mypy_extensions import TypedDict
-from typing import Any
+from typing import Any, TypedDict
 
 M = TypedDict('M', {'x': str, 'y': Any})  # E: Explicit "Any" is not allowed  [explicit-any]
 M(x='x', y=2)  # no error
 def f(m: M) -> None: pass  # no error
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testDisallowAnyExplicitTypedDictGeneric]
 # flags: --disallow-any-explicit --show-error-codes
-from mypy_extensions import TypedDict
-from typing import Any, List
+from typing import Any, List, TypedDict
 
 M = TypedDict('M', {'x': str, 'y': List[Any]})  # E: Explicit "Any" is not allowed  [explicit-any]
 N = TypedDict('N', {'x': str, 'y': List})  # no error
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testDisallowAnyGenericsTupleNoTypeParams]
 # flags: --disallow-any-generics

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -1893,11 +1893,12 @@ main:1: error: Module "ntcrash" has no attribute "nope"
 [case testIncrementalTypedDictInMethod]
 from tdcrash import nope
 [file tdcrash.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class C:
     def f(self) -> None:
         A = TypedDict('A', {'x': int, 'y': int})
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out1]
 main:1: error: Module "tdcrash" has no attribute "nope"
 [out2]
@@ -1906,12 +1907,13 @@ main:1: error: Module "tdcrash" has no attribute "nope"
 [case testIncrementalTypedDictInMethod2]
 from tdcrash import nope
 [file tdcrash.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class C:
     class D:
         def f(self) -> None:
             A = TypedDict('A', {'x': int, 'y': int})
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out1]
 main:1: error: Module "tdcrash" has no attribute "nope"
 [out2]
@@ -1920,13 +1922,14 @@ main:1: error: Module "tdcrash" has no attribute "nope"
 [case testIncrementalTypedDictInMethod3]
 from tdcrash import nope
 [file tdcrash.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class C:
     def a(self):
         class D:
             def f(self) -> None:
                 A = TypedDict('A', {'x': int, 'y': int})
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out1]
 main:1: error: Module "tdcrash" has no attribute "nope"
 [out2]
@@ -1935,8 +1938,7 @@ main:1: error: Module "tdcrash" has no attribute "nope"
 [case testIncrementalNewTypeInMethod]
 from ntcrash import nope
 [file ntcrash.py]
-from mypy_extensions import TypedDict
-from typing import NewType, NamedTuple
+from typing import NewType, NamedTuple, TypedDict
 class C:
     def f(self) -> None:
         X = NewType('X', int)
@@ -1949,6 +1951,7 @@ def f() -> None:
     B = NamedTuple('B', [('x', X)])
 
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out1]
 main:1: error: Module "ntcrash" has no attribute "nope"
 [out2]
@@ -2088,10 +2091,11 @@ reveal_type(b.x)
 y: b.A
 reveal_type(y)
 [file b.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 A = TypedDict('A', {'x': int, 'y': str})
 x: A
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out1]
 main:2: note: Revealed type is "TypedDict('b.A', {'x': builtins.int, 'y': builtins.str})"
 main:4: note: Revealed type is "TypedDict('b.A', {'x': builtins.int, 'y': builtins.str})"
@@ -2532,14 +2536,14 @@ x = NT(N(1))
 [out]
 
 [case testNewTypeFromForwardTypedDictIncremental]
-from typing import NewType, Tuple, Dict
-from mypy_extensions import TypedDict
+from typing import NewType, Tuple, TypedDict, Dict
 
 NT = NewType('NT', N) # type: ignore
 class N(TypedDict):
     x: A
 A = Dict[str, int]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 -- Some crazy self-referential named tuples, types dicts, and aliases
@@ -4146,7 +4150,7 @@ from d import k
 [case testCachedBadProtocolNote]
 import b
 [file a.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 [file b.py]
 from typing import Iterable
@@ -4158,8 +4162,8 @@ from typing import Iterable
 from a import Point
 p: Point
 it: Iterable[int] = p  # change
-[typing fixtures/typing-medium.pyi]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
 [out]
 tmp/b.py:4: error: Incompatible types in assignment (expression has type "Point", variable has type "Iterable[int]")
 tmp/b.py:4: note: Following member(s) of "Point" have conflicts:
@@ -4643,10 +4647,11 @@ from typing import NamedTuple
 from other import B
 A = NamedTuple('A', [('x', B)])
 [file other.pyi]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 from lib import A
 B = TypedDict('B', {'x': A})
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 [out2]
 tmp/a.py:3: note: Revealed type is "Tuple[TypedDict('other.B', {'x': Tuple[..., fallback=lib.A]}), fallback=lib.A]"

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -2087,8 +2087,7 @@ else:
 [out]
 
 [case testNarrowTypeAfterInTypedDict]
-from typing import Optional
-from mypy_extensions import TypedDict
+from typing import Optional, TypedDict
 class TD(TypedDict):
     a: int
     b: str
@@ -2099,8 +2098,8 @@ def f() -> None:
     if x not in td:
         return
     reveal_type(x) # N: Revealed type is "builtins.str"
-[typing fixtures/typing-typeddict.pyi]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testIsinstanceWidensWithAnyArg]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1884,8 +1884,7 @@ tup3: Tup2Class = tup2[:]     # E: Incompatible types in assignment (expression 
 [builtins fixtures/slice.pyi]
 
 [case testLiteralIntelligentIndexingTypedDict]
-from typing_extensions import Literal
-from mypy_extensions import TypedDict
+from typing_extensions import Literal, TypedDict
 
 class Unrelated: pass
 u: Unrelated
@@ -1924,8 +1923,7 @@ del d[c_key]                  # E: TypedDict "Outer" has no key "c"
 
 [case testLiteralIntelligentIndexingUsingFinal]
 from typing import Tuple, NamedTuple
-from typing_extensions import Literal, Final
-from mypy_extensions import TypedDict
+from typing_extensions import Literal, Final, TypedDict
 
 int_key_good: Final = 0
 int_key_bad: Final = 3
@@ -1992,8 +1990,7 @@ tup2[idx_bad]                   # E: Tuple index out of range
 [out]
 
 [case testLiteralIntelligentIndexingTypedDictUnions]
-from typing_extensions import Literal, Final
-from mypy_extensions import TypedDict
+from typing_extensions import Literal, Final, TypedDict
 
 class A: pass
 class B: pass
@@ -2045,8 +2042,7 @@ del test[bad_keys]              # E: Key "a" of TypedDict "Test" cannot be delet
 
 [case testLiteralIntelligentIndexingMultiTypedDict]
 from typing import Union
-from typing_extensions import Literal
-from mypy_extensions import TypedDict
+from typing_extensions import Literal, TypedDict
 
 class A: pass
 class B: pass

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -229,7 +229,7 @@ class C(B):
 [targets b, a, b, a, __main__]
 
 [case testNewAnalyzerTypedDictClass]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 import a
 class T1(TypedDict):
     x: A
@@ -237,7 +237,7 @@ class A: pass
 reveal_type(T1(x=A())) # E
 
 [file a.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 from b import TD1 as TD2, TD3
 class T2(TD3):
     x: int
@@ -246,7 +246,8 @@ reveal_type(T2(x=2)) # E
 [file b.py]
 from a import TypedDict as TD1
 from a import TD2 as TD3
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [out]
 tmp/a.py:5: note: Revealed type is "TypedDict('a.T2', {'x': builtins.int})"
@@ -254,7 +255,7 @@ main:6: note: Revealed type is "TypedDict('__main__.T1', {'x': __main__.A})"
 
 
 [case testNewAnalyzerTypedDictClassInheritance]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class T2(T1):
     y: int
@@ -275,7 +276,8 @@ x: T2
 reveal_type(x) # N: Revealed type is "TypedDict('__main__.T2', {'x': builtins.str, 'y': builtins.int})"
 y: T4
 reveal_type(y) # N: Revealed type is "TypedDict('__main__.T4', {'x': builtins.str, 'y': __main__.A})"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNewAnalyzerRedefinitionAndDeferral1a]
 import a
@@ -1659,8 +1661,7 @@ tmp/a.py:10: error: Type argument "str" of "C" must be a subtype of "int"
 tmp/a.py:11: error: Type argument "str" of "C" must be a subtype of "int"
 
 [case testNewAnalyzerTypeArgBoundCheckDifferentNodes]
-from typing import TypeVar, Generic, NamedTuple, NewType, Union, Any, cast, overload
-from mypy_extensions import TypedDict
+from typing import TypeVar, TypedDict, Generic, NamedTuple, NewType, Union, Any, cast, overload
 
 T = TypeVar('T', bound=int)
 class C(Generic[T]): pass
@@ -1706,7 +1707,8 @@ def g(x: int) -> int: ...
 def g(x: Union[C[str], int]) -> int:  # E: Type argument "str" of "C" must be a subtype of "int"
     y: C[object]  # E: Type argument "object" of "C" must be a subtype of "int"
     return 0
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNewAnalyzerTypeArgBoundCheckWithStrictOptional]
 # flags: --config-file tmp/mypy.ini

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -2913,8 +2913,7 @@ class Wrapper(Generic[T]):
 [builtins fixtures/list.pyi]
 
 [case testOverloadTypedDictDifferentRequiredKeysMeansDictsAreDisjoint]
-from typing import overload
-from mypy_extensions import TypedDict
+from typing import TypedDict, overload
 
 A = TypedDict('A', {'x': int, 'y': int})
 B = TypedDict('B', {'x': int, 'y': str})
@@ -2925,10 +2924,10 @@ def f(x: A) -> int: ...
 def f(x: B) -> str: ...
 def f(x): pass
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testOverloadedTypedDictPartiallyOverlappingRequiredKeys]
-from typing import overload, Union
-from mypy_extensions import TypedDict
+from typing import overload, TypedDict, Union
 
 A = TypedDict('A', {'x': int, 'y': Union[int, str]})
 B = TypedDict('B', {'x': int, 'y': Union[str, float]})
@@ -2945,10 +2944,10 @@ def g(x: A) -> int: ...
 def g(x: B) -> object: ...
 def g(x): pass
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testOverloadedTypedDictFullyNonTotalDictsAreAlwaysPartiallyOverlapping]
-from typing import overload
-from mypy_extensions import TypedDict
+from typing import TypedDict, overload
 
 A = TypedDict('A', {'x': int, 'y': str}, total=False)
 B = TypedDict('B', {'a': bool}, total=False)
@@ -2966,10 +2965,10 @@ def g(x: A) -> int: ...  # E: Overloaded function signatures 1 and 2 overlap wit
 def g(x: C) -> str: ...
 def g(x): pass
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testOverloadedTotalAndNonTotalTypedDictsCanPartiallyOverlap]
-from typing import overload, Union
-from mypy_extensions import TypedDict
+from typing import overload, TypedDict, Union
 
 A = TypedDict('A', {'x': int, 'y': str})
 B = TypedDict('B', {'x': Union[int, str], 'y': str, 'z': int}, total=False)
@@ -2987,10 +2986,10 @@ def f2(x: A) -> str: ...
 def f2(x): pass
 
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testOverloadedTypedDictsWithSomeOptionalKeysArePartiallyOverlapping]
-from typing import overload, Union
-from mypy_extensions import TypedDict
+from typing import overload, TypedDict, Union
 
 class A(TypedDict):
     x: int
@@ -3009,6 +3008,7 @@ def f(x: C) -> str: ...
 def f(x): pass
 
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testOverloadedPartiallyOverlappingInheritedTypes1]
 from typing import overload, List, Union, TypeVar, Generic

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -1054,7 +1054,7 @@ reveal_type(C().a)
 reveal_type(C().b)
 reveal_type(C().c)
 [file ntcrash.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class C:
     def __init__(self) -> None:
         A = TypedDict('A', {'x': int})
@@ -1062,6 +1062,7 @@ class C:
         self.b = A(x=0)  # type: A
         self.c = A
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out1]
 main:2: note: Revealed type is "TypedDict('ntcrash.C.A@4', {'x': builtins.int})"
 main:3: note: Revealed type is "TypedDict('ntcrash.C.A@4', {'x': builtins.int})"
@@ -1075,10 +1076,11 @@ main:4: note: Revealed type is "def (*, x: builtins.int) -> TypedDict('ntcrash.C
 from m import d
 reveal_type(d)
 [file m.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str}, total=False)
 d: D
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out1]
 main:2: note: Revealed type is "TypedDict('m.D', {'x'?: builtins.int, 'y'?: builtins.str})"
 [out2]

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -2182,8 +2182,7 @@ class M(N): pass
 [out]
 
 [case testForwardRefsInWithStatementImplicit]
-from typing import ContextManager, Any
-from mypy_extensions import TypedDict
+from typing import ContextManager, Any, TypedDict
 cm: ContextManager[N]
 
 with cm as g:
@@ -2191,12 +2190,11 @@ with cm as g:
 
 N = TypedDict('N', {'x': int})
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-medium.pyi]
+[typing fixtures/typing-full.pyi]
 [out]
 
 [case testForwardRefsInWithStatement]
-from typing import ContextManager, Any
-from mypy_extensions import TypedDict
+from typing import ContextManager, Any, TypedDict
 cm: ContextManager[Any]
 
 with cm as g:  # type: N
@@ -2204,7 +2202,7 @@ with cm as g:  # type: N
 
 N = TypedDict('N', {'x': int})
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-medium.pyi]
+[typing fixtures/typing-full.pyi]
 [out]
 
 [case testGlobalWithoutInitialization]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1,7 +1,7 @@
 -- Create Instance
 
 [case testCanCreateTypedDictInstanceWithKeywordArguments]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(x=42, y=1337)
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})"
@@ -12,7 +12,7 @@ reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object]"
 [targets __main__]
 
 [case testCanCreateTypedDictInstanceWithDictCall]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337))
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})"
@@ -22,7 +22,7 @@ reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object]"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictInstanceWithDictLiteral]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point({'x': 42, 'y': 1337})
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})"
@@ -32,8 +32,7 @@ reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object]"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictInstanceWithNoArguments]
-from typing import TypeVar, Union
-from mypy_extensions import TypedDict
+from typing import TypedDict, TypeVar, Union
 EmptyDict = TypedDict('EmptyDict', {})
 p = EmptyDict()
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.EmptyDict', {})"
@@ -45,49 +44,55 @@ reveal_type(p.values()) # N: Revealed type is "typing.Iterable[builtins.object]"
 -- Create Instance (Errors)
 
 [case testCannotCreateTypedDictInstanceWithUnknownArgumentPattern]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(42, 1337)  # E: Expected keyword arguments, {...}, or dict(...) in TypedDict constructor
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictInstanceNonLiteralItemName]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 x = 'x'
 p = Point({x: 42, 'y': 1337})  # E: Expected TypedDict key to be string literal
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictInstanceWithExtraItems]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(x=42, y=1337, z=666)  # E: Extra key "z" for TypedDict "Point"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictInstanceWithMissingItems]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(x=42)  # E: Missing key "y" for TypedDict "Point"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictInstanceWithIncompatibleItemType]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(x='meaning_of_life', y=1337)  # E: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictInstanceWithInlineTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {
     'x': TypedDict('E', {  # E: Use dict literal for nested TypedDict
         'y': int
     })
 })
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 -- Define TypedDict (Class syntax)
 
 [case testCanCreateTypedDictWithClass]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Point(TypedDict):
     x: int
@@ -96,9 +101,10 @@ class Point(TypedDict):
 p = Point(x=42, y=1337)
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictWithSubclass]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Point1D(TypedDict):
     x: int
@@ -109,9 +115,10 @@ p: Point2D
 reveal_type(r)  # N: Revealed type is "TypedDict('__main__.Point1D', {'x': builtins.int})"
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point2D', {'x': builtins.int, 'y': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictWithSubclass2]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Point1D(TypedDict):
     x: int
@@ -121,9 +128,10 @@ class Point2D(TypedDict, Point1D): # We also allow to include TypedDict in bases
 p: Point2D
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point2D', {'x': builtins.int, 'y': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictClassEmpty]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class EmptyDict(TypedDict):
     pass
@@ -131,12 +139,12 @@ class EmptyDict(TypedDict):
 p = EmptyDict()
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.EmptyDict', {})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 [case testCanCreateTypedDictWithClassOldVersion]
 # Test that we can use class-syntax to merge function-based TypedDicts
-
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 MovieBase1 = TypedDict(
     'MovieBase1', {'name': str, 'year': int})
@@ -152,13 +160,13 @@ def foo(x):
 
 foo({})  # E: Missing keys ("name", "year") for TypedDict "Movie"
 foo({'name': 'lol', 'year': 2009, 'based_on': 0})  # E: Incompatible types (expression has type "int", TypedDict item "based_on" has type "str")
-
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 -- Define TypedDict (Class syntax errors)
 
 [case testCannotCreateTypedDictWithClassOtherBases]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class A: pass
 
@@ -170,6 +178,7 @@ class Point2D(Point1D, A): # E: All bases of a new TypedDict must be TypedDict t
 p: Point2D
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point2D', {'x': builtins.int, 'y': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictWithDuplicateBases]
 # https://github.com/python/mypy/issues/3673
@@ -187,7 +196,7 @@ class C(TypedDict, TypedDict): # E: Duplicate base class "TypedDict"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictWithClassWithOtherStuff]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Point(TypedDict):
     x: int
@@ -198,6 +207,7 @@ class Point(TypedDict):
 p = Point(x=42, y=1337, z='whatever')
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int, 'z': Any})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictWithClassWithFunctionUsedToCrash]
 # https://github.com/python/mypy/issues/11079
@@ -237,12 +247,13 @@ class Foo(TypedDict):
 [typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictTypeWithUnderscoreItemName]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int, '_fallback': object})
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictWithClassUnderscores]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Point(TypedDict):
     x: int
@@ -251,9 +262,10 @@ class Point(TypedDict):
 p: Point
 reveal_type(p) # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, '_y': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictWithDuplicateKey1]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Bad(TypedDict):
     x: int
@@ -262,6 +274,7 @@ class Bad(TypedDict):
 b: Bad
 reveal_type(b) # N: Revealed type is "TypedDict('__main__.Bad', {'x': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictWithDuplicateKey2]
 from typing import TypedDict
@@ -280,7 +293,7 @@ reveal_type(d2) # N: Revealed type is "TypedDict('__main__.D2', {'x': builtins.s
 [typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictWithClassOverwriting]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Point1(TypedDict):
     x: int
@@ -292,9 +305,10 @@ class Bad(Point1, Point2): # E: Overwriting TypedDict field "x" while merging
 b: Bad
 reveal_type(b) # N: Revealed type is "TypedDict('__main__.Bad', {'x': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictWithClassOverwriting2]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Point1(TypedDict):
     x: int
@@ -304,104 +318,111 @@ class Point2(Point1):
 p2: Point2
 reveal_type(p2) # N: Revealed type is "TypedDict('__main__.Point2', {'x': builtins.float})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- Subtyping
 
 [case testCanConvertTypedDictToItself]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 def identity(p: Point) -> Point:
     return p
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanConvertTypedDictToEquivalentTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 PointA = TypedDict('PointA', {'x': int, 'y': int})
 PointB = TypedDict('PointB', {'x': int, 'y': int})
 def identity(p: PointA) -> PointB:
     return p
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotConvertTypedDictToSimilarTypedDictWithNarrowerItemTypes]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 ObjectPoint = TypedDict('ObjectPoint', {'x': object, 'y': object})
 def convert(op: ObjectPoint) -> Point:
     return op  # E: Incompatible return value type (got "ObjectPoint", expected "Point")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotConvertTypedDictToSimilarTypedDictWithWiderItemTypes]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 ObjectPoint = TypedDict('ObjectPoint', {'x': object, 'y': object})
 def convert(p: Point) -> ObjectPoint:
     return p  # E: Incompatible return value type (got "Point", expected "ObjectPoint")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotConvertTypedDictToSimilarTypedDictWithIncompatibleItemTypes]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 Chameleon = TypedDict('Chameleon', {'x': str, 'y': str})
 def convert(p: Point) -> Chameleon:
     return p  # E: Incompatible return value type (got "Point", expected "Chameleon")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanConvertTypedDictToNarrowerTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 Point1D = TypedDict('Point1D', {'x': int})
 def narrow(p: Point) -> Point1D:
     return p
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotConvertTypedDictToWiderTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 Point3D = TypedDict('Point3D', {'x': int, 'y': int, 'z': int})
 def widen(p: Point) -> Point3D:
     return p  # E: Incompatible return value type (got "Point", expected "Point3D")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanConvertTypedDictToCompatibleMapping]
-from mypy_extensions import TypedDict
-from typing import Mapping
+from typing import Mapping, TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 def as_mapping(p: Point) -> Mapping[str, object]:
     return p
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotConvertTypedDictToIncompatibleMapping]
-from mypy_extensions import TypedDict
-from typing import Mapping
+from typing import Mapping, TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 def as_mapping(p: Point) -> Mapping[str, int]:
     return p  # E: Incompatible return value type (got "Point", expected "Mapping[str, int]")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictAcceptsIntForFloatDuckTypes]
-from mypy_extensions import TypedDict
-from typing import Any, Mapping
+from typing import Any, Mapping, TypedDict
 Point = TypedDict('Point', {'x': float, 'y': float})
 def create_point() -> Point:
     return Point(x=1, y=2)
 reveal_type(Point(x=1, y=2))  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.float, 'y': builtins.float})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictDoesNotAcceptsFloatForInt]
-from mypy_extensions import TypedDict
-from typing import Any, Mapping
+from typing import Any, Mapping, TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 def create_point() -> Point:
     return Point(x=1.2, y=2.5)
 [out]
-main:5: error: Incompatible types (expression has type "float", TypedDict item "x" has type "int")
-main:5: error: Incompatible types (expression has type "float", TypedDict item "y" has type "int")
+main:4: error: Incompatible types (expression has type "float", TypedDict item "x" has type "int")
+main:4: error: Incompatible types (expression has type "float", TypedDict item "y" has type "int")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictAcceptsAnyType]
-from mypy_extensions import TypedDict
-from typing import Any, Mapping
+from typing import Any, Mapping, TypedDict
 Point = TypedDict('Point', {'x': float, 'y': float})
 def create_point(something: Any) -> Point:
     return Point({
@@ -409,17 +430,17 @@ def create_point(something: Any) -> Point:
       'y': something.y
     })
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictValueTypeContext]
-from mypy_extensions import TypedDict
-from typing import List
+from typing import List, TypedDict
 D = TypedDict('D', {'x': List[int]})
 reveal_type(D(x=[]))  # N: Revealed type is "TypedDict('__main__.D', {'x': builtins.list[builtins.int]})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotConvertTypedDictToDictOrMutableMapping]
-from mypy_extensions import TypedDict
-from typing import Dict, MutableMapping
+from typing import Dict, MutableMapping, TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 def as_dict(p: Point) -> Dict[str, int]:
     return p  # E: Incompatible return value type (got "Point", expected "Dict[str, int]")
@@ -429,15 +450,15 @@ def as_mutable_mapping(p: Point) -> MutableMapping[str, object]:
 [typing fixtures/typing-full.pyi]
 
 [case testCanConvertTypedDictToAny]
-from mypy_extensions import TypedDict
-from typing import Any
+from typing import Any, TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 def unprotect(p: Point) -> Any:
     return p
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testAnonymousTypedDictInErrorMessages]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 A = TypedDict('A', {'x': int, 'y': str})
 B = TypedDict('B', {'x': int, 'z': str, 'a': int})
@@ -453,6 +474,7 @@ f(l) # E: Argument 1 to "f" has incompatible type "List[TypedDict({'x': int})]";
 ll = [b, c]
 f(ll) # E: Argument 1 to "f" has incompatible type "List[TypedDict({'x': int, 'z': str})]"; expected "A"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictWithSimpleProtocol]
 from typing_extensions import Protocol, TypedDict
@@ -507,7 +529,7 @@ reveal_type(fun(b))  # N: Revealed type is "builtins.object"
 -- Join
 
 [case testJoinOfTypedDictHasOnlyCommonKeysAndNewFallback]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 Point3D = TypedDict('Point3D', {'x': int, 'y': int, 'z': int})
 p1 = TaggedPoint(type='2d', x=0, y=0)
@@ -520,7 +542,7 @@ reveal_type(joined_points)  # N: Revealed type is "TypedDict({'x': builtins.int,
 [typing fixtures/typing-typeddict.pyi]
 
 [case testJoinOfTypedDictRemovesNonequivalentKeys]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 CellWithInt = TypedDict('CellWithInt', {'value': object, 'meta': int})
 CellWithObject = TypedDict('CellWithObject', {'value': object, 'meta': object})
 c1 = CellWithInt(value=1, meta=42)
@@ -530,9 +552,10 @@ reveal_type(c1)             # N: Revealed type is "TypedDict('__main__.CellWithI
 reveal_type(c2)             # N: Revealed type is "TypedDict('__main__.CellWithObject', {'value': builtins.object, 'meta': builtins.object})"
 reveal_type(joined_cells)   # N: Revealed type is "builtins.list[TypedDict({'value': builtins.object})]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testJoinOfDisjointTypedDictsIsEmptyTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 Cell = TypedDict('Cell', {'value': object})
 d1 = Point(x=0, y=0)
@@ -542,10 +565,10 @@ reveal_type(d1)             # N: Revealed type is "TypedDict('__main__.Point', {
 reveal_type(d2)             # N: Revealed type is "TypedDict('__main__.Cell', {'value': builtins.object})"
 reveal_type(joined_dicts)   # N: Revealed type is "builtins.list[TypedDict({})]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testJoinOfTypedDictWithCompatibleMappingIsMapping]
-from mypy_extensions import TypedDict
-from typing import Mapping
+from typing import Mapping, TypedDict
 Cell = TypedDict('Cell', {'value': int})
 left = Cell(value=42)
 right = {'score': 999}  # type: Mapping[str, int]
@@ -554,10 +577,10 @@ joined2 = [right, left]
 reveal_type(joined1)  # N: Revealed type is "builtins.list[typing.Mapping[builtins.str, builtins.object]]"
 reveal_type(joined2)  # N: Revealed type is "builtins.list[typing.Mapping[builtins.str, builtins.object]]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testJoinOfTypedDictWithCompatibleMappingSupertypeIsSupertype]
-from mypy_extensions import TypedDict
-from typing import Sized
+from typing import Sized, TypedDict
 Cell = TypedDict('Cell', {'value': int})
 left = Cell(value=42)
 right = {'score': 999}  # type: Sized
@@ -569,8 +592,7 @@ reveal_type(joined2)  # N: Revealed type is "builtins.list[typing.Sized]"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testJoinOfTypedDictWithIncompatibleTypeIsObject]
-from mypy_extensions import TypedDict
-from typing import Mapping
+from typing import Mapping, TypedDict
 Cell = TypedDict('Cell', {'value': int})
 left = Cell(value=42)
 right = 42
@@ -579,13 +601,13 @@ joined2 = [right, left]
 reveal_type(joined1)  # N: Revealed type is "builtins.list[builtins.object]"
 reveal_type(joined2)  # N: Revealed type is "builtins.list[builtins.object]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- Meet
 
 [case testMeetOfTypedDictsWithCompatibleCommonKeysHasAllKeysAndNewFallback]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable
+from typing import TypedDict, TypeVar, Callable
 XY = TypedDict('XY', {'x': int, 'y': int})
 YZ = TypedDict('YZ', {'y': int, 'z': int})
 T = TypeVar('T')
@@ -593,10 +615,10 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: XY, y: YZ) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "TypedDict({'x': builtins.int, 'y': builtins.int, 'z': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testMeetOfTypedDictsWithIncompatibleCommonKeysIsUninhabited]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable
+from typing import TypedDict, TypeVar, Callable
 XYa = TypedDict('XYa', {'x': int, 'y': int})
 YbZ = TypedDict('YbZ', {'y': object, 'z': int})
 T = TypeVar('T')
@@ -604,10 +626,10 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: XYa, y: YbZ) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "Never"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testMeetOfTypedDictsWithNoCommonKeysHasAllKeysAndNewFallback]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable
+from typing import TypedDict, TypeVar, Callable
 X = TypedDict('X', {'x': int})
 Z = TypedDict('Z', {'z': int})
 T = TypeVar('T')
@@ -615,11 +637,11 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: X, y: Z) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "TypedDict({'x': builtins.int, 'z': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 # TODO: It would be more accurate for the meet to be TypedDict instead.
 [case testMeetOfTypedDictWithCompatibleMappingIsUninhabitedForNow]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable, Mapping
+from typing import TypedDict, TypeVar, Callable, Mapping
 X = TypedDict('X', {'x': int})
 M = Mapping[str, int]
 T = TypeVar('T')
@@ -627,10 +649,10 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: X, y: M) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "Never"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testMeetOfTypedDictWithIncompatibleMappingIsUninhabited]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable, Mapping
+from typing import TypedDict, TypeVar, Callable, Mapping
 X = TypedDict('X', {'x': int})
 M = Mapping[str, str]
 T = TypeVar('T')
@@ -638,10 +660,10 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: X, y: M) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "Never"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testMeetOfTypedDictWithCompatibleMappingSuperclassIsUninhabitedForNow]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable, Iterable
+from typing import TypedDict, TypeVar, Callable, Iterable
 X = TypedDict('X', {'x': int})
 I = Iterable[str]
 T = TypeVar('T')
@@ -649,10 +671,10 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: X, y: I) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "TypedDict('__main__.X', {'x': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testMeetOfTypedDictsWithNonTotal]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable
+from typing import TypedDict, TypeVar, Callable
 XY = TypedDict('XY', {'x': int, 'y': int}, total=False)
 YZ = TypedDict('YZ', {'y': int, 'z': int}, total=False)
 T = TypeVar('T')
@@ -660,10 +682,10 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: XY, y: YZ) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "TypedDict({'x'?: builtins.int, 'y'?: builtins.int, 'z'?: builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testMeetOfTypedDictsWithNonTotalAndTotal]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable
+from typing import TypedDict, TypeVar, Callable
 XY = TypedDict('XY', {'x': int}, total=False)
 YZ = TypedDict('YZ', {'y': int, 'z': int})
 T = TypeVar('T')
@@ -671,10 +693,10 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: XY, y: YZ) -> None: pass
 reveal_type(f(g))  # N: Revealed type is "TypedDict({'x'?: builtins.int, 'y': builtins.int, 'z': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testMeetOfTypedDictsWithIncompatibleNonTotalAndTotal]
-from mypy_extensions import TypedDict
-from typing import TypeVar, Callable
+from typing import TypedDict, TypeVar, Callable
 XY = TypedDict('XY', {'x': int, 'y': int}, total=False)
 YZ = TypedDict('YZ', {'y': int, 'z': int})
 T = TypeVar('T')
@@ -682,13 +704,13 @@ def f(x: Callable[[T, T], None]) -> T: pass
 def g(x: XY, y: YZ) -> None: pass
 reveal_type(f(g)) # N: Revealed type is "Never"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- Constraint Solver
 
 [case testTypedDictConstraintsAgainstIterable]
-from typing import TypeVar, Iterable
-from mypy_extensions import TypedDict
+from typing import TypedDict, TypeVar, Iterable
 T = TypeVar('T')
 def f(x: Iterable[T]) -> T: pass
 A = TypedDict('A', {'x': int})
@@ -703,25 +725,26 @@ reveal_type(f(a)) # N: Revealed type is "builtins.str"
 -- Special Method: __getitem__
 
 [case testCanGetItemOfTypedDictWithValidStringLiteralKey]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 reveal_type(p['type'])  # N: Revealed type is "builtins.str"
 reveal_type(p['x'])     # N: Revealed type is "builtins.int"
 reveal_type(p['y'])     # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotGetItemOfTypedDictWithInvalidStringLiteralKey]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p: TaggedPoint
 p['typ']  # E: TypedDict "TaggedPoint" has no key "typ" \
           # N: Did you mean "type"?
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotGetItemOfAnonymousTypedDictWithInvalidStringLiteralKey]
-from typing import TypeVar
-from mypy_extensions import TypedDict
+from typing import TypedDict, TypeVar
 A = TypedDict('A', {'x': str, 'y': int, 'z': str})
 B = TypedDict('B', {'x': str, 'z': int})
 C = TypedDict('C', {'x': str, 'y': int, 'z': int})
@@ -732,68 +755,73 @@ ac = join(A(x='', y=1, z=''), C(x='', y=0, z=1))
 ab['y']  # E: "y" is not a valid TypedDict key; expected one of ("x")
 ac['a']  # E: "a" is not a valid TypedDict key; expected one of ("x", "y")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotGetItemOfTypedDictWithNonLiteralKey]
-from mypy_extensions import TypedDict
-from typing import Union
+from typing import TypedDict, Union
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 def get_coordinate(p: TaggedPoint, key: str) -> Union[str, int]:
     return p[key]  # E: TypedDict key must be a string literal; expected one of ("type", "x", "y")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- Special Method: __setitem__
 
 [case testCanSetItemOfTypedDictWithValidStringLiteralKeyAndCompatibleValueType]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 p['type'] = 'two_d'
 p['x'] = 1
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotSetItemOfTypedDictWithIncompatibleValueType]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 p['x'] = 'y'  # E: Value of "x" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotSetItemOfTypedDictWithInvalidStringLiteralKey]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 p['z'] = 1  # E: TypedDict "TaggedPoint" has no key "z"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotSetItemOfTypedDictWithNonLiteralKey]
-from mypy_extensions import TypedDict
-from typing import Union
+from typing import TypedDict, Union
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 def set_coordinate(p: TaggedPoint, key: str, value: int) -> None:
     p[key] = value  # E: TypedDict key must be a string literal; expected one of ("type", "x", "y")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- isinstance
 
 [case testTypedDictWithIsInstanceAndIsSubclass]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int})
 d: object
 if isinstance(d, D):   # E: Cannot use isinstance() with TypedDict type
     reveal_type(d)     # N: Revealed type is "TypedDict('__main__.D', {'x': builtins.int})"
 issubclass(object, D)  # E: Cannot use issubclass() with TypedDict type
 [builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- Scoping
 
 [case testTypedDictInClassNamespace]
 # https://github.com/python/mypy/pull/2553#issuecomment-266474341
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class C:
     def f(self):
         A = TypedDict('A', {'x': int})
@@ -801,20 +829,21 @@ class C:
         A = TypedDict('A', {'y': int})
 C.A  # E: "Type[C]" has no attribute "A"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictInFunction]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 def f() -> None:
     A = TypedDict('A', {'x': int})
 A  # E: Name "A" is not defined
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- Union simplification / proper subtype checks
 
 [case testTypedDictUnionSimplification]
-from typing import TypeVar, Union, Any, cast
-from mypy_extensions import TypedDict
+from typing import TypedDict, TypeVar, Union, Any, cast
 
 T = TypeVar('T')
 S = TypeVar('S')
@@ -842,10 +871,10 @@ reveal_type(u(f, c)) # N: Revealed type is "Union[TypedDict('__main__.C', {'a': 
 reveal_type(u(c, g)) # N: Revealed type is "Union[TypedDict('__main__.G', {'a': Any}), TypedDict('__main__.C', {'a': builtins.int})]"
 reveal_type(u(g, c)) # N: Revealed type is "Union[TypedDict('__main__.C', {'a': builtins.int}), TypedDict('__main__.G', {'a': Any})]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUnionSimplification2]
-from typing import TypeVar, Union, Mapping, Any
-from mypy_extensions import TypedDict
+from typing import TypedDict, TypeVar, Union, Mapping, Any
 
 T = TypeVar('T')
 S = TypeVar('S')
@@ -865,6 +894,7 @@ reveal_type(u(c, m_s_s)) # N: Revealed type is "Union[typing.Mapping[builtins.st
 reveal_type(u(c, m_i_i)) # N: Revealed type is "Union[typing.Mapping[builtins.int, builtins.int], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]"
 reveal_type(u(c, m_s_a)) # N: Revealed type is "Union[typing.Mapping[builtins.str, Any], TypedDict('__main__.C', {'a': builtins.int, 'b': builtins.int})]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUnionUnambiguousCase]
 from typing import Union, Mapping, Any, cast
@@ -901,7 +931,7 @@ c: Union[A, B] = {'@type': 'a-type', 'value': 'Test'}  # E: Type of TypedDict is
 -- Use dict literals
 
 [case testTypedDictDictLiterals]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 Point = TypedDict('Point', {'x': int, 'y': int})
 
@@ -919,9 +949,10 @@ f(dict(x=1, y=3, z=4))  # E: Extra key "z" for TypedDict "Point"
 f(dict(x=1, y=3, z=4, a=5))  # E: Extra keys ("z", "a") for TypedDict "Point"
 
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictExplicitTypes]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 Point = TypedDict('Point', {'x': int, 'y': int})
 
@@ -938,10 +969,10 @@ if int():
 p4: Point = {'x': 1, 'y': 2}
 
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateAnonymousTypedDictInstanceUsingDictLiteralWithExtraItems]
-from mypy_extensions import TypedDict
-from typing import TypeVar
+from typing import TypedDict, TypeVar
 A = TypedDict('A', {'x': int, 'y': int})
 B = TypedDict('B', {'x': int, 'y': str})
 T = TypeVar('T')
@@ -950,10 +981,10 @@ ab = join(A(x=1, y=1), B(x=1, y=''))
 if int():
     ab = {'x': 1, 'z': 1} # E: Expected TypedDict key "x" but found keys ("x", "z")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateAnonymousTypedDictInstanceUsingDictLiteralWithMissingItems]
-from mypy_extensions import TypedDict
-from typing import TypeVar
+from typing import TypedDict, TypeVar
 A = TypedDict('A', {'x': int, 'y': int, 'z': int})
 B = TypedDict('B', {'x': int, 'y': int, 'z': str})
 T = TypeVar('T')
@@ -962,12 +993,13 @@ ab = join(A(x=1, y=1, z=1), B(x=1, y=1, z=''))
 if int():
     ab = {} # E: Expected TypedDict keys ("x", "y") but found no keys
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- Other TypedDict methods
 
 [case testTypedDictGetMethod]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class A: pass
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
@@ -980,8 +1012,7 @@ reveal_type(d.get('y', None)) # N: Revealed type is "Union[builtins.str, None]"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictGetMethodTypeContext]
-from typing import List
-from mypy_extensions import TypedDict
+from typing import List, TypedDict
 class A: pass
 D = TypedDict('D', {'x': List[int], 'y': int})
 d: D
@@ -993,7 +1024,7 @@ reveal_type(d.get('x', a)) # N: Revealed type is "Union[builtins.list[builtins.i
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictGetMethodInvalidArgs]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
 d.get() # E: All overload variants of "get" of "Mapping" require at least one argument \
@@ -1013,14 +1044,15 @@ reveal_type(y) # N: Revealed type is "builtins.object"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictMissingMethod]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
 d.bad(1) # E: "D" has no attribute "bad"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictChainedGetMethodWithDictFallback]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 E = TypedDict('E', {'d': D})
 p = E(d=D(x=0, y=''))
@@ -1029,7 +1061,7 @@ reveal_type(p.get('d', {'x': 1, 'y': ''})) # N: Revealed type is "TypedDict('__m
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictGetDefaultParameterStillTypeChecked]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 TaggedPoint = TypedDict('TaggedPoint', {'type': str, 'x': int, 'y': int})
 p = TaggedPoint(type='2d', x=42, y=1337)
 p.get('x', 1 + 'y')     # E: Unsupported operand types for + ("int" and "str")
@@ -1037,7 +1069,7 @@ p.get('x', 1 + 'y')     # E: Unsupported operand types for + ("int" and "str")
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictChainedGetWithEmptyDictDefault]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 C = TypedDict('C', {'a': int})
 D = TypedDict('D', {'x': C, 'y': str})
 d: D
@@ -1054,23 +1086,25 @@ reveal_type(d.get('x', {})['a']) # N: Revealed type is "builtins.int"
 -- Totality (the "total" keyword argument)
 
 [case testTypedDictWithTotalTrue]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str}, total=True)
 d: D
 reveal_type(d) \
     # N: Revealed type is "TypedDict('__main__.D', {'x': builtins.int, 'y': builtins.str})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictWithInvalidTotalArgument]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 A = TypedDict('A', {'x': int}, total=0) # E: "total" argument must be a True or False literal
 B = TypedDict('B', {'x': int}, total=bool) # E: "total" argument must be a True or False literal
 C = TypedDict('C', {'x': int}, x=False) # E: Unexpected keyword argument "x" for "TypedDict"
 D = TypedDict('D', {'x': int}, False) # E: Unexpected arguments to TypedDict()
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictWithTotalFalse]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str}, total=False)
 def f(d: D) -> None:
     reveal_type(d) # N: Revealed type is "TypedDict('__main__.D', {'x'?: builtins.int, 'y'?: builtins.str})"
@@ -1081,9 +1115,10 @@ f({'x': 1, 'y': ''})
 f({'x': 1, 'z': ''}) # E: Extra key "z" for TypedDict "D"
 f({'x': ''}) # E: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictConstructorWithTotalFalse]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str}, total=False)
 def f(d: D) -> None: pass
 reveal_type(D()) # N: Revealed type is "TypedDict('__main__.D', {'x'?: builtins.int, 'y'?: builtins.str})"
@@ -1093,9 +1128,10 @@ f(D(x=1, y=''))
 f(D(x=1, z='')) # E: Extra key "z" for TypedDict "D"
 f(D(x='')) # E: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictIndexingWithNonRequiredKey]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str}, total=False)
 d: D
 reveal_type(d['x']) # N: Revealed type is "builtins.int"
@@ -1106,7 +1142,7 @@ reveal_type(d.get('y')) # N: Revealed type is "Union[builtins.str, None]"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictSubtypingWithTotalFalse]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 A = TypedDict('A', {'x': int})
 B = TypedDict('B', {'x': int}, total=False)
 C = TypedDict('C', {'x': int, 'y': str}, total=False)
@@ -1123,10 +1159,10 @@ fb(a) # E: Argument 1 to "fb" has incompatible type "A"; expected "B"
 fa(b) # E: Argument 1 to "fa" has incompatible type "B"; expected "A"
 fc(b) # E: Argument 1 to "fc" has incompatible type "B"; expected "C"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictJoinWithTotalFalse]
-from typing import TypeVar
-from mypy_extensions import TypedDict
+from typing import TypedDict, TypeVar
 A = TypedDict('A', {'x': int})
 B = TypedDict('B', {'x': int}, total=False)
 C = TypedDict('C', {'x': int, 'y': str}, total=False)
@@ -1146,18 +1182,20 @@ reveal_type(j(b, c)) \
 reveal_type(j(c, b)) \
     # N: Revealed type is "TypedDict({'x'?: builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictClassWithTotalArgument]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class D(TypedDict, total=False):
     x: int
     y: str
 d: D
 reveal_type(d) # N: Revealed type is "TypedDict('__main__.D', {'x'?: builtins.int, 'y'?: builtins.str})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictClassWithInvalidTotalArgument]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class D(TypedDict, total=1): # E: "total" argument must be a True or False literal
     x: int
 class E(TypedDict, total=bool): # E: "total" argument must be a True or False literal
@@ -1166,9 +1204,10 @@ class F(TypedDict, total=xyz): # E: Name "xyz" is not defined \
                                # E: "total" argument must be a True or False literal
     x: int
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictClassInheritanceWithTotalArgument]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class A(TypedDict):
     x: int
 class B(TypedDict, A, total=False):
@@ -1178,9 +1217,10 @@ class C(TypedDict, B, total=True):
 c: C
 reveal_type(c) # N: Revealed type is "TypedDict('__main__.C', {'x': builtins.int, 'y'?: builtins.int, 'z': builtins.str})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNonTotalTypedDictInErrorMessages]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 A = TypedDict('A', {'x': int, 'y': str}, total=False)
 B = TypedDict('B', {'x': int, 'z': str, 'a': int}, total=False)
@@ -1196,10 +1236,11 @@ f(l) # E: Argument 1 to "f" has incompatible type "List[TypedDict({'x'?: int})]"
 ll = [b, c]
 f(ll) # E: Argument 1 to "f" has incompatible type "List[TypedDict({'x'?: int, 'z'?: str})]"; expected "A"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNonTotalTypedDictCanBeEmpty]
 # flags: --warn-unreachable
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class A(TypedDict):
     ...
@@ -1216,70 +1257,80 @@ if not a:
 if not b:
     reveal_type(b) # N: Revealed type is "TypedDict('__main__.B', {'x'?: builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 -- Create Type (Errors)
 
 [case testCannotCreateTypedDictTypeWithTooFewArguments]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point')  # E: Too few arguments for TypedDict()
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictTypeWithTooManyArguments]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int}, dict)  # E: Unexpected arguments to TypedDict()
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictTypeWithInvalidName]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict(dict, {'x': int, 'y': int})  # E: TypedDict() expects a string literal as the first argument
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictTypeWithInvalidItems]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x'})  # E: TypedDict() expects a dictionary literal as the second argument
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictTypeWithKwargs]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 d = {'x': int, 'y': int}
 Point = TypedDict('Point', {**d})  # E: Invalid TypedDict() field name
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictTypeWithBytes]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict(b'Point', {'x': int, 'y': int})  # E: TypedDict() expects a string literal as the first argument
 # This technically works at runtime but doesn't make sense.
 Point2 = TypedDict('Point2', {b'x': int})  # E: Invalid TypedDict() field name
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 -- NOTE: The following code works at runtime but is not yet supported by mypy.
 --       Keyword arguments may potentially be supported in the future.
 [case testCannotCreateTypedDictTypeWithNonpositionalArgs]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict(typename='Point', fields={'x': int, 'y': int})  # E: Unexpected arguments to TypedDict()
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictTypeWithInvalidItemName]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {int: int, int: int})  # E: Invalid TypedDict() field name
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictTypeWithInvalidItemType]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': 1, 'y': 1})  # E: Invalid type: try using Literal[1] instead?
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCannotCreateTypedDictTypeWithInvalidName2]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 X = TypedDict('Y', {'x': int})  # E: First argument "Y" to TypedDict() does not match variable name "X"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 -- Overloading
 
 [case testTypedDictOverloading]
-from typing import overload, Iterable
-from mypy_extensions import TypedDict
+from typing import overload, Iterable, TypedDict
 
 A = TypedDict('A', {'x': int})
 
@@ -1296,8 +1347,7 @@ reveal_type(f(1))  # N: Revealed type is "builtins.int"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictOverloading2]
-from typing import overload, Iterable
-from mypy_extensions import TypedDict
+from typing import overload, Iterable, TypedDict
 
 A = TypedDict('A', {'x': int})
 
@@ -1312,16 +1362,15 @@ f(a)
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 [out]
-main:13: error: Argument 1 to "f" has incompatible type "A"; expected "Iterable[int]"
-main:13: note: Following member(s) of "A" have conflicts:
-main:13: note:     Expected:
-main:13: note:         def __iter__(self) -> Iterator[int]
-main:13: note:     Got:
-main:13: note:         def __iter__(self) -> Iterator[str]
+main:12: error: Argument 1 to "f" has incompatible type "A"; expected "Iterable[int]"
+main:12: note: Following member(s) of "A" have conflicts:
+main:12: note:     Expected:
+main:12: note:         def __iter__(self) -> Iterator[int]
+main:12: note:     Got:
+main:12: note:         def __iter__(self) -> Iterator[str]
 
 [case testTypedDictOverloading3]
-from typing import overload
-from mypy_extensions import TypedDict
+from typing import TypedDict, overload
 
 A = TypedDict('A', {'x': int})
 
@@ -1340,8 +1389,7 @@ f(a)  # E: No overload variant of "f" matches argument type "A" \
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictOverloading4]
-from typing import overload
-from mypy_extensions import TypedDict
+from typing import TypedDict, overload
 
 A = TypedDict('A', {'x': int})
 B = TypedDict('B', {'x': str})
@@ -1361,8 +1409,7 @@ f(b) # E: Argument 1 to "f" has incompatible type "B"; expected "A"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictOverloading5]
-from typing import overload
-from mypy_extensions import TypedDict
+from typing import TypedDict, overload
 
 A = TypedDict('A', {'x': int})
 B = TypedDict('B', {'y': str})
@@ -1384,8 +1431,7 @@ f(c) # E: Argument 1 to "f" has incompatible type "C"; expected "A"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictOverloading6]
-from typing import overload
-from mypy_extensions import TypedDict
+from typing import TypedDict, overload
 
 A = TypedDict('A', {'x': int})
 B = TypedDict('B', {'y': str})
@@ -1407,8 +1453,7 @@ reveal_type(f(b)) # N: Revealed type is "builtins.str"
 -- Special cases
 
 [case testForwardReferenceInTypedDict]
-from typing import Mapping
-from mypy_extensions import TypedDict
+from typing import TypedDict, Mapping
 X = TypedDict('X', {'b': 'B', 'c': 'C'})
 class B: pass
 class C(B): pass
@@ -1417,10 +1462,10 @@ reveal_type(x) # N: Revealed type is "TypedDict('__main__.X', {'b': __main__.B, 
 m1: Mapping[str, object] = x
 m2: Mapping[str, B] = x # E: Incompatible types in assignment (expression has type "X", variable has type "Mapping[str, B]")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testForwardReferenceInClassTypedDict]
-from typing import Mapping
-from mypy_extensions import TypedDict
+from typing import TypedDict, Mapping
 class X(TypedDict):
     b: 'B'
     c: 'C'
@@ -1431,19 +1476,20 @@ reveal_type(x) # N: Revealed type is "TypedDict('__main__.X', {'b': __main__.B, 
 m1: Mapping[str, object] = x
 m2: Mapping[str, B] = x # E: Incompatible types in assignment (expression has type "X", variable has type "Mapping[str, B]")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testForwardReferenceToTypedDictInTypedDict]
-from typing import Mapping
-from mypy_extensions import TypedDict
+from typing import TypedDict, Mapping
 X = TypedDict('X', {'a': 'A'})
 A = TypedDict('A', {'b': int})
 x: X
 reveal_type(x) # N: Revealed type is "TypedDict('__main__.X', {'a': TypedDict('__main__.A', {'b': builtins.int})})"
 reveal_type(x['a']['b']) # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testSelfRecursiveTypedDictInheriting]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 def test() -> None:
     class MovieBase(TypedDict):
@@ -1456,10 +1502,10 @@ def test() -> None:
     m: Movie
     reveal_type(m['director']['name']) # N: Revealed type is "Any"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testSubclassOfRecursiveTypedDict]
-from typing import List
-from mypy_extensions import TypedDict
+from typing import List, TypedDict
 
 def test() -> None:
     class Command(TypedDict):
@@ -1470,13 +1516,13 @@ def test() -> None:
         pass
 
     hc = HelpCommand(subcommands=[])
-    reveal_type(hc)  # N: Revealed type is "TypedDict('__main__.HelpCommand@8', {'subcommands': builtins.list[Any]})"
+    reveal_type(hc)  # N: Revealed type is "TypedDict('__main__.HelpCommand@7', {'subcommands': builtins.list[Any]})"
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testTypedDictForwardAsUpperBound]
-from typing import TypeVar, Generic
-from mypy_extensions import TypedDict
+from typing import TypedDict, TypeVar, Generic
 T = TypeVar('T', bound='M')
 class G(Generic[T]):
     x: T
@@ -1488,12 +1534,13 @@ z: int = G[M]().x['x']  # type: ignore[used-before-def]
 class M(TypedDict):
     x: int
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testTypedDictWithImportCycleForward]
 import a
 [file a.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 from b import f
 
 N = TypedDict('N', {'a': str})
@@ -1504,6 +1551,7 @@ def f(x: a.N) -> None:
     reveal_type(x)
     reveal_type(x['a'])
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 tmp/b.py:4: note: Revealed type is "TypedDict('a.N', {'a': builtins.str})"
 tmp/b.py:5: note: Revealed type is "builtins.str"
@@ -1524,14 +1572,15 @@ tp(x='no')  # E: Incompatible types (expression has type "str", TypedDict item "
 
 [file b.py]
 from a import C
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 tp = TypedDict('tp', {'x': int})
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 
 [case testTypedDictAsStarStarArg]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 A = TypedDict('A', {'x': int, 'y': str})
 class B: pass
@@ -1551,11 +1600,11 @@ f4(**a) # E: Extra argument "y" from **args for "f4"
 f5(**a) # E: Missing positional arguments "y", "z" in call to "f5"
 f6(**a) # E: Extra argument "y" from **args for "f6"
 f1(1, **a) # E: "f1" gets multiple values for keyword argument "x"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictAsStarStarArgConstraints]
-from typing import TypeVar, Union
-from mypy_extensions import TypedDict
+from typing import TypedDict, TypeVar, Union
 
 T = TypeVar('T')
 S = TypeVar('S')
@@ -1564,10 +1613,11 @@ def f1(x: T, y: S) -> Union[T, S]: ...
 A = TypedDict('A', {'y': int, 'x': str})
 a: A
 reveal_type(f1(**a)) # N: Revealed type is "Union[builtins.str, builtins.int]"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictAsStarStarArgCalleeKwargs]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 A = TypedDict('A', {'x': int, 'y': str})
 B = TypedDict('B', {'x': str, 'y': str})
@@ -1585,9 +1635,10 @@ g(1, **a) # E: "g" gets multiple values for keyword argument "x"
 g(1, **b) # E: "g" gets multiple values for keyword argument "x" \
           # E: Argument "x" to "g" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictAsStarStarTwice]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 A = TypedDict('A', {'x': int, 'y': str})
 B = TypedDict('B', {'z': bytes})
@@ -1609,11 +1660,11 @@ f1(**a, **c) # E: "f1" gets multiple values for keyword argument "x" \
              # E: Argument "x" to "f1" has incompatible type "str"; expected "int"
 f1(**c, **a) # E: "f1" gets multiple values for keyword argument "x" \
              # E: Argument "x" to "f1" has incompatible type "str"; expected "int"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictAsStarStarAndDictAsStarStar]
-from mypy_extensions import TypedDict
-from typing import Any, Dict
+from typing import Any, Dict, TypedDict
 
 TD = TypedDict('TD', {'x': int, 'y': str})
 
@@ -1628,10 +1679,10 @@ f1(**d, **td)
 f2(**td, **d)
 f2(**d, **td)
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictNonMappingMethods]
-from typing import List
-from mypy_extensions import TypedDict
+from typing import List, TypedDict
 
 A = TypedDict('A', {'x': int, 'y': List[int]})
 a: A
@@ -1661,10 +1712,10 @@ a.update({'z': 1, 'x': 1}) # E: Expected TypedDict key "x" but found keys ("z", 
 d = {'x': 1}
 a.update(d) # E: Argument 1 to "update" of "TypedDict" has incompatible type "Dict[str, int]"; expected "TypedDict({'x'?: int, 'y'?: List[int]})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictPopMethod]
-from typing import List
-from mypy_extensions import TypedDict
+from typing import List, TypedDict
 
 A = TypedDict('A', {'x': int, 'y': List[int]}, total=False)
 B = TypedDict('B', {'x': int})
@@ -1683,10 +1734,10 @@ pop = b.pop
 pop('x') # E: Argument 1 has incompatible type "str"; expected "Never"
 pop('invalid') # E: Argument 1 has incompatible type "str"; expected "Never"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictDel]
-from typing import List
-from mypy_extensions import TypedDict
+from typing import List, TypedDict
 
 A = TypedDict('A', {'x': int, 'y': List[int]}, total=False)
 B = TypedDict('B', {'x': int})
@@ -1703,10 +1754,10 @@ alias = b.__delitem__
 alias('x')
 alias(s)
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testPluginUnionsOfTypedDicts]
-from typing import Union
-from mypy_extensions import TypedDict
+from typing import TypedDict, Union
 
 class TDA(TypedDict):
     a: int
@@ -1731,8 +1782,7 @@ reveal_type(td['c'])  # N: Revealed type is "Union[Any, builtins.int]" \
 [typing fixtures/typing-typeddict.pyi]
 
 [case testPluginUnionsOfTypedDictsNonTotal]
-from typing import Union
-from mypy_extensions import TypedDict
+from typing import TypedDict, Union
 
 class TDA(TypedDict, total=False):
     a: int
@@ -1777,8 +1827,7 @@ reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtin
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictOptionalUpdate]
-from typing import Union
-from mypy_extensions import TypedDict
+from typing import TypedDict, Union
 
 class A(TypedDict):
     x: int
@@ -1786,6 +1835,7 @@ class A(TypedDict):
 d: A
 d.update({'x': 1})
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictOverlapWithDict]
 # mypy: strict-equality
@@ -2249,8 +2299,7 @@ if foo[KEY_NAME] is not None:
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictDoubleForwardClass]
-from mypy_extensions import TypedDict
-from typing import Any, List
+from typing import Any, List, TypedDict
 
 class Foo(TypedDict):
     bar: Bar
@@ -2265,8 +2314,7 @@ reveal_type(foo['baz'])  # N: Revealed type is "builtins.list[Any]"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictDoubleForwardFunc]
-from mypy_extensions import TypedDict
-from typing import Any, List
+from typing import Any, List, TypedDict
 
 Foo = TypedDict('Foo', {'bar': 'Bar', 'baz': 'Bar'})
 
@@ -2279,8 +2327,7 @@ reveal_type(foo['baz'])  # N: Revealed type is "builtins.list[Any]"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictDoubleForwardMixed]
-from mypy_extensions import TypedDict
-from typing import Any, List
+from typing import Any, List, TypedDict
 
 Bar = List[Any]
 
@@ -2357,11 +2404,12 @@ d[True] # E: TypedDict key must be a string literal; expected one of ("foo")
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUppercaseKey]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 Foo = TypedDict('Foo', {'camelCaseKey': str})
 value: Foo = {}  # E: Missing key "camelCaseKey" for TypedDict "Foo"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictWithDeferredFieldTypeEval]
 from typing import Generic, TypeVar, TypedDict, NotRequired
@@ -2896,7 +2944,7 @@ d['']  # E: TypedDict "A" has no key ""
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictFlexibleUpdate]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 A = TypedDict("A", {"foo": int, "bar": int})
 B = TypedDict("B", {"foo": int})
@@ -2911,7 +2959,7 @@ a.update(a)
 
 [case testTypedDictStrictUpdate]
 # flags: --extra-checks
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 A = TypedDict("A", {"foo": int, "bar": int})
 B = TypedDict("B", {"foo": int})
@@ -2925,8 +2973,7 @@ a.update(a)  # OK
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictFlexibleUpdateUnion]
-from typing import Union
-from mypy_extensions import TypedDict
+from typing import TypedDict, Union
 
 A = TypedDict("A", {"foo": int, "bar": int})
 B = TypedDict("B", {"foo": int})
@@ -2939,8 +2986,7 @@ a.update(u)
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictFlexibleUpdateUnionExtra]
-from typing import Union
-from mypy_extensions import TypedDict
+from typing import TypedDict, Union
 
 A = TypedDict("A", {"foo": int, "bar": int})
 B = TypedDict("B", {"foo": int, "extra": int})
@@ -2954,8 +3000,7 @@ a.update(u)
 
 [case testTypedDictFlexibleUpdateUnionStrict]
 # flags: --extra-checks
-from typing import Union, NotRequired
-from mypy_extensions import TypedDict
+from typing import TypedDict, Union, NotRequired
 
 A = TypedDict("A", {"foo": int, "bar": int})
 A1 = TypedDict("A1", {"foo": int, "bar": NotRequired[int]})
@@ -3139,7 +3184,7 @@ bar2: Bar = {**bar, "c": {**bar["c"], "b": "wrong"}, "d": 2}  # E: Incompatible 
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUnpackOverrideRequired]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 Details = TypedDict('Details', {'first_name': str, 'last_name': str})
 DetailsSubset = TypedDict('DetailsSubset', {'first_name': str, 'last_name': str}, total=False)
@@ -3270,8 +3315,7 @@ f: Foo = {**foo("no")}  # E: Argument 1 to "foo" has incompatible type "str"; ex
 
 
 [case testTypedDictWith__or__method]
-from typing import Dict
-from mypy_extensions import TypedDict
+from typing import Dict, TypedDict
 
 class Foo(TypedDict):
     key: int
@@ -3311,7 +3355,7 @@ bar | d2  # E: Unsupported operand types for | ("Bar" and "Dict[int, str]")
 [typing fixtures/typing-typeddict-iror.pyi]
 
 [case testTypedDictWith__or__method_error]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Foo(TypedDict):
     key: int
@@ -3334,8 +3378,7 @@ main:10: note:     def [T, T2] __ror__(self, Dict[T, T2], /) -> Dict[Union[Any, 
 [typing fixtures/typing-typeddict-iror.pyi]
 
 [case testTypedDictWith__ror__method]
-from typing import Dict
-from mypy_extensions import TypedDict
+from typing import Dict, TypedDict
 
 class Foo(TypedDict):
     key: int
@@ -3374,8 +3417,7 @@ d2 | bar  # E: Unsupported operand types for | ("Dict[int, str]" and "Bar")
 [typing fixtures/typing-typeddict-iror.pyi]
 
 [case testTypedDictWith__ior__method]
-from typing import Dict
-from mypy_extensions import TypedDict
+from typing import Dict, TypedDict
 
 class Foo(TypedDict):
     key: int
@@ -3471,7 +3513,7 @@ class TotalInTheMiddle(TypedDict, a=1, total=True, b=2, c=3):  # E: Unexpected k
 [typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateClassWithFunctionBasedTypedDictBase]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 
 class Params(TypedDict("Params", {'x': int})):
     pass
@@ -3479,6 +3521,7 @@ class Params(TypedDict("Params", {'x': int})):
 p: Params = {'x': 2}
 reveal_type(p) # N: Revealed type is "TypedDict('__main__.Params', {'x': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testInitTypedDictFromType]
 from typing import TypedDict, Type
@@ -3751,7 +3794,7 @@ x.update({"key": "abc"})  # E: ReadOnly TypedDict key "key" TypedDict is mutated
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictFromMypyExtensionsReadOnlyMutateMethods]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 from typing_extensions import ReadOnly
 
 class TP(TypedDict):

--- a/test-data/unit/deps-types.test
+++ b/test-data/unit/deps-types.test
@@ -818,7 +818,7 @@ class I: pass
 <mod> -> a
 
 [case testAliasDepsTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 from mod import I
 A = I
 class P(TypedDict):
@@ -826,6 +826,7 @@ class P(TypedDict):
 [file mod.py]
 class I: pass
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 <m.A> -> m
 <m.P> -> m.P
@@ -836,7 +837,7 @@ class I: pass
 
 [case testAliasDepsTypedDictFunctional]
 # __dump_all__
-from mypy_extensions import TypedDict
+from typing import TypedDict
 import a
 P = TypedDict('P', {'x': a.A})
 [file a.py]
@@ -845,6 +846,7 @@ A = I
 [file mod.py]
 class I: pass
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 <a.A> -> m
 <a> -> m

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -644,12 +644,13 @@ x = 1
 <pkg> -> m, pkg, pkg.mod
 
 [case testTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337))
 def foo(x: Point) -> int:
     return x['x'] + x['y']
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 <m.Point.__init__> -> m
 <m.Point.__new__> -> m
@@ -657,13 +658,14 @@ def foo(x: Point) -> int:
 <m.p> -> m
 
 [case testTypedDict2]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class A: pass
 Point = TypedDict('Point', {'x': int, 'y': A})
 p = Point(dict(x=42, y=A()))
 def foo(x: Point) -> int:
     return x['x']
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 <m.A.__init__> -> m
 <m.A.__new__> -> m
@@ -674,7 +676,7 @@ def foo(x: Point) -> int:
 <m.p> -> m
 
 [case testTypedDict3]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class A: pass
 class Point(TypedDict):
     x: int
@@ -683,6 +685,7 @@ p = Point(dict(x=42, y=A()))
 def foo(x: Point) -> int:
     return x['x']
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 <m.A.__init__> -> m
 <m.A.__new__> -> m

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -617,57 +617,61 @@ __main__.E
 __main__.F
 
 [case testTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337))
 [file next.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': str})
 p = Point(dict(x=42, y='lurr'))
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 __main__.Point
 __main__.p
 
 [case testTypedDict2]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class Point(TypedDict):
     x: int
     y: int
 p = Point(dict(x=42, y=1337))
 [file next.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class Point(TypedDict):
     x: int
     y: str
 p = Point(dict(x=42, y='lurr'))
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 __main__.Point
 __main__.p
 
 [case testTypedDict3]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337))
 [file next.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int})
 p = Point(dict(x=42))
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 __main__.Point
 __main__.p
 
 [case testTypedDict4]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337))
 [file next.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int}, total=False)
 p = Point(dict(x=42, y=1337))
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 __main__.Point
 __main__.p

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3591,27 +3591,28 @@ c.py:4: note: Revealed type is "Tuple[Union[Tuple[Union[..., None], builtins.int
 c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
 
 [case testTypedDictRefresh]
-[builtins fixtures/dict.pyi]
 import a
 [file a.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337))
 [file a.py.2]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337)) # dummy change
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 ==
 
 [case testTypedDictUpdate]
 import b
 [file a.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(dict(x=42, y=1337))
 [file a.py.2]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': str})
 p = Point(dict(x=42, y='lurr'))
 [file b.py]
@@ -3619,6 +3620,7 @@ from a import Point
 def foo(x: Point) -> int:
     return x['x'] + x['y']
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 ==
 b.py:3: error: Unsupported operand types for + ("int" and "str")
@@ -3626,13 +3628,13 @@ b.py:3: error: Unsupported operand types for + ("int" and "str")
 [case testTypedDictUpdate2]
 import b
 [file a.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class Point(TypedDict):
     x: int
     y: int
 p = Point(dict(x=42, y=1337))
 [file a.py.2]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class Point(TypedDict):
     x: int
     y: str
@@ -3642,6 +3644,7 @@ from a import Point
 def foo(x: Point) -> int:
     return x['x'] + x['y']
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 ==
 b.py:3: error: Unsupported operand types for + ("int" and "str")
@@ -3649,16 +3652,14 @@ b.py:3: error: Unsupported operand types for + ("int" and "str")
 [case testTypedDictUpdate3]
 import b
 [file a.py]
-from mypy_extensions import TypedDict
-from typing import Optional
+from typing import Optional, TypedDict
 class Point(TypedDict):
     x: Optional[Point]
     y: int
     z: int
 p = Point(dict(x=None, y=1337, z=0))
 [file a.py.2]
-from mypy_extensions import TypedDict
-from typing import Optional
+from typing import Optional, TypedDict
 class Point(TypedDict):
     x: Optional[Point]
     y: str
@@ -3670,6 +3671,7 @@ def foo(x: Point) -> int:
     assert x['x'] is not None
     return x['x']['z'] + x['x']['y']
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 ==
 b.py:4: error: Unsupported operand types for + ("int" and "str")
@@ -3677,13 +3679,12 @@ b.py:4: error: Unsupported operand types for + ("int" and "str")
 [case testTypedDictUpdateGeneric]
 import b
 [file a.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class Point(TypedDict):
     x: int
     y: int
 [file a.py.2]
-from mypy_extensions import TypedDict
-from typing import Generic, TypeVar
+from typing import Generic, TypedDict, TypeVar
 
 T = TypeVar("T")
 class Point(TypedDict, Generic[T]):
@@ -3700,6 +3701,7 @@ def foo() -> None:
     p = Point(x=0, y="no")
     i: int = p["y"]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 ==
 ==

--- a/test-data/unit/fixtures/typing-typeddict.pyi
+++ b/test-data/unit/fixtures/typing-typeddict.pyi
@@ -24,6 +24,7 @@ Final = 0
 Literal = 0
 TypedDict = 0
 NoReturn = 0
+NewType = 0
 Required = 0
 NotRequired = 0
 ReadOnly = 0

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -1332,23 +1332,25 @@ MypyFile:1<1>(
 [case testMergeTypedDict_symtable]
 import target
 [file target.py]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class A: pass
 D = TypedDict('D', {'a': A})
 d: D
 [file target.py.next]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class A: pass
 D = TypedDict('D', {'a': A, 'b': int})
 d: D
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [out]
 __main__:
     target: MypyFile<0>
 target:
     A: TypeInfo<1>
     D: TypeInfo<2>
-    TypedDict: FuncDef<3>
+    TypedDict: Var<3>
     d: Var<4>(TypedDict('target.D', {'a': target.A<1>}))
 ==>
 __main__:
@@ -1356,7 +1358,7 @@ __main__:
 target:
     A: TypeInfo<1>
     D: TypeInfo<2>
-    TypedDict: FuncDef<3>
+    TypedDict: Var<3>
     d: Var<4>(TypedDict('target.D', {'a': target.A<1>, 'b': builtins.int<5>}))
 
 [case testNewType_symtable]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1033,7 +1033,7 @@ _program.py:17: note: Revealed type is "builtins.str"
 
 [case testTypedDictGet]
 # Test that TypedDict get plugin works with typeshed stubs
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class A: pass
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
@@ -1054,7 +1054,7 @@ _testTypedDictGet.py:9: note:     def [_T] get(self, str, /, default: object) ->
 _testTypedDictGet.py:11: note: Revealed type is "builtins.object"
 
 [case testTypedDictMappingMethods]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Cell = TypedDict('Cell', {'value': int})
 c = Cell(value=42)
 for x in c:
@@ -1098,8 +1098,7 @@ def foo(mymap) -> Optional[MyNamedTuple]:
 [out]
 
 [case testCanConvertTypedDictToAnySuperclassOfMapping]
-from mypy_extensions import TypedDict
-from typing import Sized, Iterable, Container
+from typing import Sized, TypedDict, Iterable, Container
 
 Point = TypedDict('Point', {'x': int, 'y': int})
 
@@ -1110,12 +1109,12 @@ c: Container[str] = p
 o: object = p
 it2: Iterable[int] = p
 [out]
-_testCanConvertTypedDictToAnySuperclassOfMapping.py:11: error: Incompatible types in assignment (expression has type "Point", variable has type "Iterable[int]")
-_testCanConvertTypedDictToAnySuperclassOfMapping.py:11: note: Following member(s) of "Point" have conflicts:
-_testCanConvertTypedDictToAnySuperclassOfMapping.py:11: note:     Expected:
-_testCanConvertTypedDictToAnySuperclassOfMapping.py:11: note:         def __iter__(self) -> Iterator[int]
-_testCanConvertTypedDictToAnySuperclassOfMapping.py:11: note:     Got:
-_testCanConvertTypedDictToAnySuperclassOfMapping.py:11: note:         def __iter__(self) -> Iterator[str]
+_testCanConvertTypedDictToAnySuperclassOfMapping.py:10: error: Incompatible types in assignment (expression has type "Point", variable has type "Iterable[int]")
+_testCanConvertTypedDictToAnySuperclassOfMapping.py:10: note: Following member(s) of "Point" have conflicts:
+_testCanConvertTypedDictToAnySuperclassOfMapping.py:10: note:     Expected:
+_testCanConvertTypedDictToAnySuperclassOfMapping.py:10: note:         def __iter__(self) -> Iterator[int]
+_testCanConvertTypedDictToAnySuperclassOfMapping.py:10: note:     Got:
+_testCanConvertTypedDictToAnySuperclassOfMapping.py:10: note:         def __iter__(self) -> Iterator[str]
 
 [case testAsyncioGatherPreciseType-xfail]
 # Mysteriously regressed in #11905

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -306,10 +306,7 @@ Total      1      11     90.91%
 
 [file i.py]
 from enum import Enum
-from mypy_extensions import TypedDict
-from typing import NewType, NamedTuple, TypeVar
-
-from typing import TypeVar
+from typing import NewType, NamedTuple, TypedDict, TypeVar
 
 T = TypeVar('T')  # no error
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1411,12 +1411,13 @@ class N:  # E: Name "N" already defined on line 2
 [out]
 
 [case testDuplicateDefTypedDict]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 
 class Point:  # E: Name "Point" already defined on line 2
     pass
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [out]
 

--- a/test-data/unit/semanal-typeddict.test
+++ b/test-data/unit/semanal-typeddict.test
@@ -2,40 +2,43 @@
 
 -- TODO: Implement support for this syntax.
 --[case testCanCreateTypedDictTypeWithDictCall]
---from mypy_extensions import TypedDict
+--from typing import TypedDict
 --Point = TypedDict('Point', dict(x=int, y=int))
 --[builtins fixtures/dict.pyi]
+--[typing fixtures/typing-typeddict.pyi]
 --[out]
 --MypyFile:1(
---  ImportFrom:1(mypy_extensions, [TypedDict])
+--  ImportFrom:1(typing, [TypedDict])
 --  AssignmentStmt:2(
 --    NameExpr(Point* [__main__.Point])
 --    TypedDictExpr:2(Point)))
 
 [case testCanCreateTypedDictTypeWithDictLiteral]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 Point = TypedDict('Point', {'x': int, 'y': int})
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 MypyFile:1(
-  ImportFrom:1(mypy_extensions, [TypedDict])
+  ImportFrom:1(typing, [TypedDict])
   AssignmentStmt:2(
     NameExpr(Point* [__main__.Point])
     TypedDictExpr:2(Point)))
 
 [case testTypedDictWithDocString]
-from mypy_extensions import TypedDict
+from typing import TypedDict
 class A(TypedDict):
     """foo"""
     x: str
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 MypyFile:1(
-  ImportFrom:1(mypy_extensions, [TypedDict])
+  ImportFrom:1(typing, [TypedDict])
   ClassDef:2(
     A
     BaseType(
-      mypy_extensions._TypedDict)
+      typing._TypedDict)
     ExpressionStmt:3(
       StrExpr(foo))
     AssignmentStmt:4(


### PR DESCRIPTION
`mypy_extensions.TypedDict` has been redundant for a while now. With the next mypy_extensions release, it will raise a `DeprecationWarning` when imported.

Replace existing imports in tests with `typing.TypedDict`.