### PR TITLE
Replace deprecated `_PyLong_new` with `PyLongWriter` API

### DIFF
--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -124,23 +124,12 @@ static inline CPyTagged CPyTagged_ShortFromSsize_t(Py_ssize_t x) {
 // Number of digits, assuming int is non-negative
 #define CPY_LONG_SIZE_UNSIGNED(o) CPY_LONG_SIZE(o)
 
-static inline void CPyLong_SetUnsignedSize(PyLongObject *o, Py_ssize_t n) {
-    if (n == 0)
-        o->long_value.lv_tag = CPY_SIGN_ZERO;
-    else
-        o->long_value.lv_tag = n << CPY_NON_SIZE_BITS;
-}
-
 #else
 
 #define CPY_LONG_DIGIT(o, n) ((o)->ob_digit[n])
 #define CPY_LONG_IS_NEGATIVE(o) (((o)->ob_base.ob_size < 0)
 #define CPY_LONG_SIZE_SIGNED(o) ((o)->ob_base.ob_size)
 #define CPY_LONG_SIZE_UNSIGNED(o) ((o)->ob_base.ob_size)
-
-static inline void CPyLong_SetUnsignedSize(PyLongObject *o, Py_ssize_t n) {
-    o->ob_base.ob_size = n;
-}
 
 #endif
 


### PR DESCRIPTION
`_PyLong_New` will be deprecated in `3.14.0a5`. Replace it with the `PyLongWriter` API available in `pythoncapi_compat.h` for older versions.

https://docs.python.org/dev/c-api/long.html#pylongwriter-api