### PR TITLE
Update math error messages for 3.14

### DIFF
--- a/mypyc/lib-rt/float_ops.c
+++ b/mypyc/lib-rt/float_ops.c
@@ -16,6 +16,24 @@ static double CPy_MathRangeError(void) {
     return CPY_FLOAT_ERROR;
 }
 
+static double CPy_MathExpectedNonNegativeInputError(double x) {
+    char *buf = PyOS_double_to_string(x, 'r', 0, Py_DTSF_ADD_DOT_0, NULL);
+    if (buf) {
+        PyErr_Format(PyExc_ValueError, "expected a nonnegative input, got %s", buf);
+        PyMem_Free(buf);
+    }
+    return CPY_FLOAT_ERROR;
+}
+
+static double CPy_MathExpectedPositiveInputError(double x) {
+    char *buf = PyOS_double_to_string(x, 'r', 0, Py_DTSF_ADD_DOT_0, NULL);
+    if (buf) {
+        PyErr_Format(PyExc_ValueError, "expected a positive input, got %s", buf);
+        PyMem_Free(buf);
+    }
+    return CPY_FLOAT_ERROR;
+}
+
 double CPyFloat_FromTagged(CPyTagged x) {
     if (CPyTagged_CheckShort(x)) {
         return CPyTagged_ShortAsSsize_t(x);
@@ -52,7 +70,11 @@ double CPyFloat_Tan(double x) {
 
 double CPyFloat_Sqrt(double x) {
     if (x < 0.0) {
+#if CPY_3_14_FEATURES
+        return CPy_MathExpectedNonNegativeInputError(x);
+#else
         return CPy_DomainError();
+#endif
     }
     return sqrt(x);
 }
@@ -67,7 +89,11 @@ double CPyFloat_Exp(double x) {
 
 double CPyFloat_Log(double x) {
     if (x <= 0.0) {
+#if CPY_3_14_FEATURES
+        return CPy_MathExpectedPositiveInputError(x);
+#else
         return CPy_DomainError();
+#endif
     }
     return log(x);
 }

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -147,4 +147,7 @@ static inline void CPyLong_SetUnsignedSize(PyLongObject *o, Py_ssize_t n) {
 // Are we targeting Python 3.13 or newer?
 #define CPY_3_13_FEATURES (PY_VERSION_HEX >= 0x030d0000)
 
+// Are we targeting Python 3.14 or newer?
+#define CPY_3_14_FEATURES (PY_VERSION_HEX >= 0x030e0000)
+
 #endif


### PR DESCRIPTION
The error messages for some math functions got changed in https://github.com/python/cpython/pull/124299. Adjust mypyc to emit the same ones.

Fixes `mypyc/test/test_run.py::TestRun::run-math.test::testMathOps`