### PR TITLE
Use union types instead of join in binder

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -21,6 +21,7 @@ from mypy.types import (
     Type,
     TypeOfAny,
     TypeType,
+    TypeVarType,
     UnionType,
     UnpackType,
     find_unpack_in_list,
@@ -247,8 +248,10 @@ class ConditionalTypeBinder:
                     type = possible_types[0]
                 else:
                     type = make_simplified_union(possible_types)
-                    # Legacy guard for corner case, e.g. when the original type is TypeVarType.
-                    if declaration_type is not None and not is_subtype(type, declaration_type):
+                    # Legacy guard for corner case when the original type is TypeVarType.
+                    if isinstance(declaration_type, TypeVarType) and not is_subtype(
+                        type, declaration_type
+                    ):
                         type = declaration_type
                     # Try simplifying resulting type for unions involving variadic tuples.
                     # Technically, everything is still valid without this step, but if we do

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -370,6 +370,13 @@ class ConditionalTypeBinder:
             else:
                 # In all other cases we don't narrow to Any to minimize false negatives.
                 self.put(expr, declared_type)
+        elif isinstance(p_declared, AnyType):
+            # Mirroring the first case above, we don't narrow to a precise type if the variable
+            # has an explicit `Any` type annotation.
+            if isinstance(expr, RefExpr) and isinstance(expr.node, Var) and expr.node.is_inferred:
+                self.put(expr, type)
+            else:
+                self.put(expr, declared_type)
         else:
             self.put(expr, type)
 

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -247,6 +247,9 @@ class ConditionalTypeBinder:
                     type = possible_types[0]
                 else:
                     type = make_simplified_union(possible_types)
+                    # Legacy guard for corner case, e.g. when the original type is TypeVarType.
+                    if declaration_type is not None and not is_subtype(type, declaration_type):
+                        type = declaration_type
                     # Try simplifying resulting type for unions involving variadic tuples.
                     # Technically, everything is still valid without this step, but if we do
                     # not do this, this may create long unions after exiting an if check like:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3282,7 +3282,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if rvalue_type and infer_lvalue_type and not isinstance(lvalue_type, PartialType):
                     # Don't use type binder for definitions of special forms, like named tuples.
                     if not (isinstance(lvalue, NameExpr) and lvalue.is_special_form):
-                        self.binder.assign_type(lvalue, rvalue_type, lvalue_type, False)
+                        self.binder.assign_type(lvalue, rvalue_type, lvalue_type)
                         if (
                             isinstance(lvalue, NameExpr)
                             and isinstance(lvalue.node, Var)
@@ -4021,7 +4021,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if isinstance(expr, StarExpr):
                 expr = expr.expr
 
-            # TODO: See todo in binder.py, ConditionalTypeBinder.assign_type
+            # TODO: See comment in binder.py, ConditionalTypeBinder.assign_type
             # It's unclear why the 'declared_type' param is sometimes 'None'
             clean_items: list[tuple[Type, Type]] = []
             for type, declared_type in items:
@@ -4033,7 +4033,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 expr,
                 make_simplified_union(list(types)),
                 make_simplified_union(list(declared_types)),
-                False,
             )
         for union, lv in zip(union_types, self.flatten_lvalues(lvalues)):
             # Properly store the inferred types.
@@ -5231,7 +5230,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             for elt in flatten(s.expr):
                 if isinstance(elt, NameExpr):
                     self.binder.assign_type(
-                        elt, DeletedType(source=elt.name), get_declaration(elt), False
+                        elt, DeletedType(source=elt.name), get_declaration(elt)
                     )
 
     def visit_decorator(self, e: Decorator) -> None:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1106,7 +1106,9 @@ class ASTConverter:
         if argument_elide_name(arg.arg):
             pos_only = True
 
-        argument = Argument(Var(arg.arg, arg_type), arg_type, self.visit(default), kind, pos_only)
+        var = Var(arg.arg, arg_type)
+        var.is_inferred = False
+        argument = Argument(var, arg_type, self.visit(default), kind, pos_only)
         argument.set_line(
             arg.lineno,
             arg.col_offset,

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -183,55 +183,6 @@ class InstanceJoiner:
         return best
 
 
-def join_simple(declaration: Type | None, s: Type, t: Type) -> ProperType:
-    """Return a simple least upper bound given the declared type.
-
-    This function should be only used by binder, and should not recurse.
-    For all other uses, use `join_types()`.
-    """
-    declaration = get_proper_type(declaration)
-    s = get_proper_type(s)
-    t = get_proper_type(t)
-
-    if (s.can_be_true, s.can_be_false) != (t.can_be_true, t.can_be_false):
-        # if types are restricted in different ways, use the more general versions
-        s = mypy.typeops.true_or_false(s)
-        t = mypy.typeops.true_or_false(t)
-
-    if isinstance(s, AnyType):
-        return s
-
-    if isinstance(s, ErasedType):
-        return t
-
-    if is_proper_subtype(s, t, ignore_promotions=True):
-        return t
-
-    if is_proper_subtype(t, s, ignore_promotions=True):
-        return s
-
-    if isinstance(declaration, UnionType):
-        return mypy.typeops.make_simplified_union([s, t])
-
-    if isinstance(s, NoneType) and not isinstance(t, NoneType):
-        s, t = t, s
-
-    if isinstance(s, UninhabitedType) and not isinstance(t, UninhabitedType):
-        s, t = t, s
-
-    # Meets/joins require callable type normalization.
-    s, t = normalize_callables(s, t)
-
-    if isinstance(s, UnionType) and not isinstance(t, UnionType):
-        s, t = t, s
-
-    value = t.accept(TypeJoinVisitor(s))
-    if declaration is None or is_subtype(value, declaration):
-        return value
-
-    return declaration
-
-
 def trivial_join(s: Type, t: Type) -> Type:
     """Return one of types (expanded) if it is a supertype of other, otherwise top type."""
     if is_subtype(s, t):

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -7,7 +7,7 @@ from unittest import TestCase, skipUnless
 
 from mypy.erasetype import erase_type, remove_instance_last_known_values
 from mypy.indirection import TypeIndirectionVisitor
-from mypy.join import join_simple, join_types
+from mypy.join import join_types
 from mypy.meet import meet_types, narrow_declared_type
 from mypy.nodes import (
     ARG_NAMED,
@@ -817,12 +817,12 @@ class JoinSuite(Suite):
             self.assert_join(t, self.fx.anyt, self.fx.anyt)
 
     def test_mixed_truth_restricted_type_simple(self) -> None:
-        # join_simple against differently restricted truthiness types drops restrictions.
+        # make_simplified_union against differently restricted truthiness types drops restrictions.
         true_a = true_only(self.fx.a)
         false_o = false_only(self.fx.o)
-        j = join_simple(self.fx.o, true_a, false_o)
-        assert j.can_be_true
-        assert j.can_be_false
+        u = make_simplified_union([true_a, false_o])
+        assert u.can_be_true
+        assert u.can_be_false
 
     def test_mixed_truth_restricted_type(self) -> None:
         # join_types against differently restricted truthiness types drops restrictions.

--- a/mypyc/test-data/irbuild-any.test
+++ b/mypyc/test-data/irbuild-any.test
@@ -37,7 +37,6 @@ def f(a: Any, n: int, c: C) -> None:
     c.n = a
     a = n
     n = a
-    a.a = n
 [out]
 def f(a, n, c):
     a :: object
@@ -49,10 +48,6 @@ def f(a, n, c):
     r3 :: bool
     r4 :: object
     r5 :: int
-    r6 :: object
-    r7 :: str
-    r8 :: i32
-    r9 :: bit
 L0:
     r0 = box(int, n)
     c.a = r0; r1 = is_error
@@ -62,10 +57,6 @@ L0:
     a = r4
     r5 = unbox(int, a)
     n = r5
-    r6 = box(int, n)
-    r7 = 'a'
-    r8 = PyObject_SetAttr(a, r7, r6)
-    r9 = r8 >= 0 :: signed
     return 1
 
 [case testCoerceAnyInOps]

--- a/mypyc/test-data/irbuild-any.test
+++ b/mypyc/test-data/irbuild-any.test
@@ -49,8 +49,8 @@ def f(a, n, c):
     r3 :: bool
     r4 :: object
     r5 :: int
-    r6 :: str
-    r7 :: object
+    r6 :: object
+    r7 :: str
     r8 :: i32
     r9 :: bit
 L0:
@@ -62,9 +62,9 @@ L0:
     a = r4
     r5 = unbox(int, a)
     n = r5
-    r6 = 'a'
-    r7 = box(int, n)
-    r8 = PyObject_SetAttr(a, r6, r7)
+    r6 = box(int, n)
+    r7 = 'a'
+    r8 = PyObject_SetAttr(a, r7, r6)
     r9 = r8 >= 0 :: signed
     return 1
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3709,7 +3709,7 @@ def new(uc: Type[U]) -> U:
     if 1:
         u = uc(0)
         u.foo()
-        u = uc('')  # Error
+        uc('')  # Error
         u.foo(0)  # Error
         return uc()
 u = new(User)

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -320,8 +320,10 @@ d = None # All ok
 d = t
 d = g
 d = A
-t = d
-f = d
+
+d1: Any
+t = d1
+f = d1
 [builtins fixtures/tuple.pyi]
 
 

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -252,7 +252,7 @@ if int():
 if int():
     a = d.foo(a, a)
 d.x = a
-d.x.y.z  # E: "A" has no attribute "y"
+d.x.y.z
 
 class A: pass
 [out]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1915,11 +1915,23 @@ if isinstance(x, str, 1): # E: Too many arguments for "isinstance"
     reveal_type(x) # N: Revealed type is "builtins.int"
 [builtins fixtures/isinstancelist.pyi]
 
-[case testIsinstanceNarrowAny]
+[case testIsinstanceNarrowAnyExplicit]
 from typing import Any
 
 def narrow_any_to_str_then_reassign_to_int() -> None:
     v: Any = 1
+
+    if isinstance(v, str):
+        reveal_type(v)  # N: Revealed type is "builtins.str"
+        v = 2
+        reveal_type(v)  # N: Revealed type is "Any"
+[builtins fixtures/isinstance.pyi]
+
+[case testIsinstanceNarrowAnyImplicit]
+def foo(): ...
+
+def narrow_any_to_str_then_reassign_to_int() -> None:
+    v = foo()
 
     if isinstance(v, str):
         reveal_type(v)  # N: Revealed type is "builtins.str"

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -115,8 +115,8 @@ if int():
     x = B()
     x.z
     x = foo()
-    x.z          # E: "A" has no attribute "z"
-    x.y
+    reveal_type(x)  # N: Revealed type is "Any"
+reveal_type(x)  # N: Revealed type is "__main__.A"
 
 [case testSingleMultiAssignment]
 x = 'a'

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1919,13 +1919,12 @@ if isinstance(x, str, 1): # E: Too many arguments for "isinstance"
 from typing import Any
 
 def narrow_any_to_str_then_reassign_to_int() -> None:
-    v = 1 # type: Any
+    v: Any = 1
 
     if isinstance(v, str):
         reveal_type(v)  # N: Revealed type is "builtins.str"
         v = 2
-        reveal_type(v)  # N: Revealed type is "Any"
-
+        reveal_type(v)  # N: Revealed type is "builtins.int"
 [builtins fixtures/isinstance.pyi]
 
 [case testNarrowTypeAfterInList]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2431,5 +2431,6 @@ def foo(x: T) -> T:
         pass
     else:
         raise
+    reveal_type(x)  # N: Revealed type is "T`-1"
     return x
 [builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2416,3 +2416,20 @@ while x is not None and b():
     x = f()
 
 [builtins fixtures/primitives.pyi]
+
+[case testNarrowingTypeVarMultiple]
+from typing import TypeVar
+
+class A: ...
+class B: ...
+
+T = TypeVar("T")
+def foo(x: T) -> T:
+    if isinstance(x, A):
+        pass
+    elif isinstance(x, B):
+        pass
+    else:
+        raise
+    return x
+[builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -723,9 +723,10 @@ def f():
 def g(x: Optional[int]) -> int:
     if x is None:
         reveal_type(x)  # N: Revealed type is "None"
+        # As a special case for Unions containing None, during
         x = f()
-        reveal_type(x)  # N: Revealed type is "Any"
-    reveal_type(x)  # N: Revealed type is "Union[Any, builtins.int]"
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, Any]"
+    reveal_type(x)  # N: Revealed type is "Union[builtins.int, Any]"
     return x
 [builtins fixtures/bool.pyi]
 
@@ -739,9 +740,10 @@ def g(x: Optional[int]) -> int:
         reveal_type(x)  # N: Revealed type is "None"
         x = 1
         reveal_type(x)  # N: Revealed type is "builtins.int"
+        # Same as above, even after we've assigned to x
         x = f()
-        reveal_type(x)  # N: Revealed type is "Any"
-    reveal_type(x)  # N: Revealed type is "Union[Any, builtins.int]"
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, Any]"
+    reveal_type(x)  # N: Revealed type is "Union[builtins.int, Any]"
     return x
 [builtins fixtures/bool.pyi]
 
@@ -754,11 +756,9 @@ def g(x: Optional[int]) -> int:
     if x is not None:
         return x
     reveal_type(x)  # N: Revealed type is "None"
-    if bool():
-        x = f()
-        reveal_type(x)  # N: Revealed type is "Any"
-        return x
-    return x  # E: Incompatible return value type (got "None", expected "int")
+    x = f()
+    reveal_type(x)  # N: Revealed type is "Union[builtins.int, Any]"
+    return x
 [builtins fixtures/bool.pyi]
 
 [case testStrictOptionalCovarianceCrossModule]

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -723,12 +723,10 @@ def f():
 def g(x: Optional[int]) -> int:
     if x is None:
         reveal_type(x)  # N: Revealed type is "None"
-        # As a special case for Unions containing None, during
         x = f()
-        reveal_type(x)  # N: Revealed type is "Union[builtins.int, Any]"
-    reveal_type(x)  # N: Revealed type is "Union[builtins.int, Any]"
+        reveal_type(x)  # N: Revealed type is "Any"
+    reveal_type(x)  # N: Revealed type is "Union[Any, builtins.int]"
     return x
-
 [builtins fixtures/bool.pyi]
 
 [case testOptionalAssignAny2]
@@ -741,12 +739,10 @@ def g(x: Optional[int]) -> int:
         reveal_type(x)  # N: Revealed type is "None"
         x = 1
         reveal_type(x)  # N: Revealed type is "builtins.int"
-        # Since we've assigned to x, the special case None behavior shouldn't happen
         x = f()
-        reveal_type(x)  # N: Revealed type is "Union[builtins.int, None]"
-    reveal_type(x)  # N: Revealed type is "Union[builtins.int, None]"
-    return x  # E: Incompatible return value type (got "Optional[int]", expected "int")
-
+        reveal_type(x)  # N: Revealed type is "Any"
+    reveal_type(x)  # N: Revealed type is "Union[Any, builtins.int]"
+    return x
 [builtins fixtures/bool.pyi]
 
 [case testOptionalAssignAny3]
@@ -758,11 +754,11 @@ def g(x: Optional[int]) -> int:
     if x is not None:
         return x
     reveal_type(x)  # N: Revealed type is "None"
-    if 1:
+    if bool():
         x = f()
-        reveal_type(x)  # N: Revealed type is "Union[builtins.int, Any]"
+        reveal_type(x)  # N: Revealed type is "Any"
         return x
-
+    return x  # E: Incompatible return value type (got "None", expected "int")
 [builtins fixtures/bool.pyi]
 
 [case testStrictOptionalCovarianceCrossModule]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -343,8 +343,9 @@ class C(Generic[P]):
         a = kwargs
         args = kwargs  # E: Incompatible types in assignment (expression has type "P.kwargs", variable has type "P.args")
         kwargs = args  # E: Incompatible types in assignment (expression has type "P.args", variable has type "P.kwargs")
-        args = a
-        kwargs = a
+        a1: Any
+        args = a1
+        kwargs = a1
 [builtins fixtures/dict.pyi]
 
 [case testParamSpecSubtypeChecking2]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1487,11 +1487,13 @@ match m5:
     case _:
         reveal_type(m5)  # N: Revealed type is "Tuple[Literal[2], Union[Literal['a'], Literal['b']]]"
 
-match m5:
+m6: Tuple[Literal[1, 2], Literal["a", "b"]]
+
+match m6:
     case (1, "a"):
-        reveal_type(m5)  # N: Revealed type is "Tuple[Literal[1], Literal['a']]"
+        reveal_type(m6)  # N: Revealed type is "Tuple[Literal[1], Literal['a']]"
     case _:
-        reveal_type(m5)  # N: Revealed type is "Tuple[Union[Literal[1], Literal[2]], Union[Literal['a'], Literal['b']]]"
+        reveal_type(m6)  # N: Revealed type is "Tuple[Union[Literal[1], Literal[2]], Union[Literal['a'], Literal['b']]]"
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -193,7 +193,8 @@ def f() -> None:
     _, _ = 1, ''
     if 1:
         _, _ = '', 1
-        reveal_type(_) # N: Revealed type is "Any"
+        # This is unintentional but probably fine. No one is going to read _ value.
+        reveal_type(_) # N: Revealed type is "builtins.int"
 
 [case testRedefineWithBreakAndContinue]
 # flags: --allow-redefinition

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -321,7 +321,7 @@ def f() -> None:
     x = 1
     if int():
         x = ''
-    reveal_type(x) # N: Revealed type is "builtins.object"
+    reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.int]"
     x = ''
     reveal_type(x) # N: Revealed type is "builtins.str"
     if int():

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -786,3 +786,20 @@ def func2(val: Union[int, str]):
     else:
         reveal_type(val)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/tuple.pyi]
+
+[case testTypeGuardRestrictAwaySingleInvariant]
+from typing import List
+from typing_extensions import TypeGuard
+
+class B: ...
+class C(B): ...
+
+def is_c_list(x: list[B]) -> TypeGuard[list[C]]: ...
+
+def test() -> None:
+    x: List[B]
+    if not is_c_list(x):
+        reveal_type(x)  # N: Revealed type is "builtins.list[__main__.B]"
+        return
+    reveal_type(x)  # N: Revealed type is "builtins.list[__main__.C]"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -528,7 +528,7 @@ x: Union[int, str]
 a: Any
 if bool():
     x = a
-    reveal_type(x)  # N: Revealed type is "Any"
+    reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/bool.pyi]
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -528,8 +528,7 @@ x: Union[int, str]
 a: Any
 if bool():
     x = a
-    # TODO: Maybe we should infer Any as the type instead.
-    reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+    reveal_type(x)  # N: Revealed type is "Any"
 reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/bool.pyi]
 

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -631,11 +631,12 @@ class Child(Parent):
     def bar(self) -> int:
         if 1:
             self = super(Child, self).something()
-            reveal_type(self)       # N: Revealed type is "__main__.Child"
+            reveal_type(self)       # N: Revealed type is "Any"
+            # TODO: we should probably make this unreachable similar to above.
             if self is None:
-                reveal_type(self)
-                return None
-            reveal_type(self)       # N: Revealed type is "__main__.Child"
+                reveal_type(self)   # N: Revealed type is "Never"
+                return None         # E: Incompatible return value type (got "None", expected "int")
+            reveal_type(self)       # N: Revealed type is "Any"
             return 3
 [builtins fixtures/isinstance.pyi]
 

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -631,12 +631,11 @@ class Child(Parent):
     def bar(self) -> int:
         if 1:
             self = super(Child, self).something()
-            reveal_type(self)       # N: Revealed type is "Any"
-            # TODO: we should probably make this unreachable similar to above.
+            reveal_type(self)       # N: Revealed type is "__main__.Child"
             if self is None:
-                reveal_type(self)   # N: Revealed type is "Never"
-                return None         # E: Incompatible return value type (got "None", expected "int")
-            reveal_type(self)       # N: Revealed type is "Any"
+                reveal_type(self)
+                return None
+            reveal_type(self)       # N: Revealed type is "__main__.Child"
             return 3
 [builtins fixtures/isinstance.pyi]
 

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -255,7 +255,7 @@ NameExpr(6) : A
 NameExpr(6) : A
 MemberExpr(7) : A
 MemberExpr(7) : A
-MemberExpr(7) : A
+MemberExpr(7) : Any
 NameExpr(7) : A
 NameExpr(7) : A
 

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -238,7 +238,7 @@ NameExpr(4) : Any
 NameExpr(5) : A
 NameExpr(5) : Any
 NameExpr(6) : A
-NameExpr(6) : A
+NameExpr(6) : Any
 
 [case testMemberAssignment]
 from typing import Any

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -238,7 +238,7 @@ NameExpr(4) : Any
 NameExpr(5) : A
 NameExpr(5) : Any
 NameExpr(6) : A
-NameExpr(6) : Any
+NameExpr(6) : A
 
 [case testMemberAssignment]
 from typing import Any


### PR DESCRIPTION
This would be more consistent with what we already do for ternary expressions. Note the change in match test results from match logic not handling well the situation when initial type is a union. A possible workaround would be to force "collapsing" union of tuples back into a tuple with union, but it is not easy and was planning to do some cleanup in the match handling as well (in particular it uses joins instead of unions in a way that will be inconsistent with new binder behavior). I want to put the switch from join to union for match statement in a separate PR.

Note I also simplify a bunch of special-casing around `Any` in the binder that existed mostly because `join(Any, X) == Any`.
Fixes https://github.com/python/mypy/issues/3724