### PR TITLE
Fix --warn-unreachable fall-through from ALWAYS_TRUE ifs

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4871,6 +4871,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if s.else_body:
                     self.accept(s.else_body)
 
+        # If this if-statement had a block that is considered always true for
+        # semantic reachability in semanal_pass1 and it has no else block;
+        # then we undo any unreachablilty properties for frames after the
+        # if-statement. These can be caused by early returns or raises and
+        # are only applicable on certain platforms or versions.
+        if s.has_pass1_always_true_block and (not s.else_body.body):
+            self.binder.frames[-1].unreachable = False
+
     def visit_while_stmt(self, s: WhileStmt) -> None:
         """Type check a while statement."""
         if_stmt = IfStmt([s.expr], [s.body], None)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1523,19 +1523,21 @@ class PassStmt(Statement):
 
 
 class IfStmt(Statement):
-    __slots__ = ("expr", "body", "else_body")
+    __slots__ = ("expr", "body", "else_body", "has_pass1_always_true_block")
 
-    __match_args__ = ("expr", "body", "else_body")
+    __match_args__ = ("expr", "body", "else_body", "has_pass1_always_true_block")
 
     expr: list[Expression]
     body: list[Block]
     else_body: Block | None
+    pass1_always_true_block: bool
 
-    def __init__(self, expr: list[Expression], body: list[Block], else_body: Block | None) -> None:
+    def __init__(self, expr: list[Expression], body: list[Block], else_body: Block | None, has_pass1_always_true_block=False) -> None:
         super().__init__()
         self.expr = expr
         self.body = body
         self.else_body = else_body
+        self.has_pass1_always_true_block = has_pass1_always_true_block
 
     def accept(self, visitor: StatementVisitor[T]) -> T:
         return visitor.visit_if_stmt(self)

--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -57,6 +57,7 @@ def infer_reachability_of_if_statement(s: IfStmt, options: Options) -> None:
             # The condition is considered always false, so we skip the if/elif body.
             mark_block_unreachable(s.body[i])
         elif result in (ALWAYS_TRUE, MYPY_TRUE):
+            s.has_pass1_always_true_block = True
             # This condition is considered always true, so all of the remaining
             # elif/else bodies should not be checked.
             if result == MYPY_TRUE:

--- a/mypy/semanal_pass1.py
+++ b/mypy/semanal_pass1.py
@@ -53,6 +53,10 @@ class SemanticAnalyzerPreAnalysis(TraverserVisitor):
 
     The block containing 'import xyz' is unreachable in Python 3 mode. The import
     shouldn't be processed in Python 3 mode, even if the module happens to exist.
+
+    Note: Blocks marked unreachable here will not be reported by the
+    `--warn-unreachable` option. They are considered intentionally unreachable,
+    such as platform and version checks.
     """
 
     def visit_file(self, file: MypyFile, fnam: str, mod_id: str, options: Options) -> None:

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -349,6 +349,17 @@ def foo() -> None:
 [builtins fixtures/ops.pyi]
 [out]
 
+[case testSysVersionInfoInFunctionEarlyReturn]
+# flags: --warn-unreachable
+import sys
+
+def foo(self) -> int:
+    if sys.version_info >= (3, 5):
+        return 1
+    return 0
+[builtins fixtures/ops.pyi]
+[out]
+
 [case testSysPlatformInMethod]
 import sys
 class C:
@@ -358,6 +369,29 @@ class C:
         else:
             x = 0
         reveal_type(x)  # N: Revealed type is "builtins.str"
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testSysPlatformInFunctionEarlyReturn]
+# flags: --warn-unreachable
+import sys
+
+def foo(self) -> int:
+    if sys.platform != 'fictional':
+        return 1
+    return 0
+[builtins fixtures/ops.pyi]
+[out]
+
+[case testSysPlatformInFunctionEarlyReturnWithActualUnreachableCode]
+# flags: --warn-unreachable
+import sys
+
+def foo() -> int:
+    if sys.platform != 'fictional':
+        return 1
+    return 0
+    return 0 + 1  # E: Statement is unreachable
 [builtins fixtures/ops.pyi]
 [out]
 


### PR DESCRIPTION
This is a quick swing at trying to fix https://github.com/python/mypy/issues/10773

Lots of details in my comment on the original issue and the commit message. This was a quick first approach that I came up with, it's not perfect. Since this doesn't tackle handling early `return`s in the `semanal_pass1.py`, conditional imports etc caused before the short-circuiting return are not considered.

/cc @A5rocks 