### PR TITLE
Suggest typing.Literal for exit-return error messages

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1992,7 +1992,7 @@ class MessageBuilder:
             code=codes.EXIT_RETURN,
         )
         self.note(
-            'Use "typing_extensions.Literal[False]" as the return type or change it to "None"',
+            'Use "typing.Literal[False]" as the return type or change it to "None"',
             context,
             code=codes.EXIT_RETURN,
         )

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -729,7 +729,7 @@ main:2: error: Syntax error in type comment "int"  [syntax]
 [case testErrorCode__exit__Return]
 class InvalidReturn:
     def __exit__(self, x, y, z) -> bool:  # E: "bool" is invalid as return type for "__exit__" that always returns False  [exit-return] \
-# N: Use "typing_extensions.Literal[False]" as the return type or change it to "None" \
+# N: Use "typing.Literal[False]" as the return type or change it to "None" \
 # N: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
         return False
 [builtins fixtures/bool.pyi]

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1527,13 +1527,13 @@ from typing import Optional
 
 class InvalidReturn1:
     def __exit__(self, x, y, z) -> bool:  # E: "bool" is invalid as return type for "__exit__" that always returns False \
-# N: Use "typing_extensions.Literal[False]" as the return type or change it to "None" \
+# N: Use "typing.Literal[False]" as the return type or change it to "None" \
 # N: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
         return False
 
 class InvalidReturn2:
     def __exit__(self, x, y, z) -> Optional[bool]:  # E: "bool" is invalid as return type for "__exit__" that always returns False \
-# N: Use "typing_extensions.Literal[False]" as the return type or change it to "None" \
+# N: Use "typing.Literal[False]" as the return type or change it to "None" \
 # N: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
         if int():
             return False
@@ -1542,7 +1542,7 @@ class InvalidReturn2:
 
 class InvalidReturn3:
     def __exit__(self, x, y, z) -> bool:  # E: "bool" is invalid as return type for "__exit__" that always returns False \
-# N: Use "typing_extensions.Literal[False]" as the return type or change it to "None" \
+# N: Use "typing.Literal[False]" as the return type or change it to "None" \
 # N: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
         def nested() -> bool:
             return True


### PR DESCRIPTION
`typing.Literal` was added to the stdlib in Python 3.8.