### PR TITLE
Fix literal context for ternary expressions (for real)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4469,7 +4469,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if (
                 isinstance(get_proper_type(lvalue_type), UnionType)
                 # Skip literal types, as they have special logic (for better errors).
-                and not isinstance(get_proper_type(rvalue_type), LiteralType)
+                and not is_literal_type_like(rvalue_type)
                 and not self.simple_rvalue(rvalue)
             ):
                 # Try re-inferring r.h.s. in empty context, and use that if it

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2980,7 +2980,7 @@ class C(Base):
             sep = "a" if int() else "b"
             reveal_type(sep)  # N: Revealed type is "Union[Literal['a'], Literal['b']]"
         return super().feed_data(sep)
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/primitives.pyi]
 
 [case testLiteralInsideAType]
 from typing_extensions import Literal

--- a/test-data/unit/fixtures/primitives.pyi
+++ b/test-data/unit/fixtures/primitives.pyi
@@ -19,6 +19,7 @@ class int:
     def __init__(self, x: object = ..., base: int = ...) -> None: pass
     def __add__(self, i: int) -> int: pass
     def __rmul__(self, x: int) -> int: pass
+    def __bool__(self) -> bool: pass
 class float:
     def __float__(self) -> float: pass
     def __add__(self, x: float) -> float: pass


### PR DESCRIPTION
I am not waiting for review as the fix is obvious. The only annoying thing is that we had an exact test as in the repro but it passed accidentally because we use builtins fixtures.