### PR TITLE
Update capi_version for mypyc tests to 3.9

### DIFF
--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -750,7 +750,7 @@ L0:
     r1 = b'1234'
     return r1
 
-[case testPyMethodCall1]
+[case testPyMethodCall1_64bit]
 from typing import Any
 def f(x: Any) -> int:
     y: int = x.pop()
@@ -759,20 +759,30 @@ def f(x: Any) -> int:
 def f(x):
     x :: object
     r0 :: str
-    r1 :: object
-    r2, y :: int
-    r3 :: str
-    r4 :: object
-    r5 :: int
+    r1 :: object[1]
+    r2 :: object_ptr
+    r3 :: object
+    r4, y :: int
+    r5 :: str
+    r6 :: object[1]
+    r7 :: object_ptr
+    r8 :: object
+    r9 :: int
 L0:
     r0 = 'pop'
-    r1 = CPyObject_CallMethodObjArgs(x, r0, 0)
-    r2 = unbox(int, r1)
-    y = r2
-    r3 = 'pop'
-    r4 = CPyObject_CallMethodObjArgs(x, r3, 0)
-    r5 = unbox(int, r4)
-    return r5
+    r1 = [x]
+    r2 = load_address r1
+    r3 = PyObject_VectorcallMethod(r0, r2, 9223372036854775809, 0)
+    keep_alive x
+    r4 = unbox(int, r3)
+    y = r4
+    r5 = 'pop'
+    r6 = [x]
+    r7 = load_address r6
+    r8 = PyObject_VectorcallMethod(r5, r7, 9223372036854775809, 0)
+    keep_alive x
+    r9 = unbox(int, r8)
+    return r9
 
 [case testObjectType]
 def g(y: object) -> None:
@@ -1167,7 +1177,7 @@ L0:
     r2 = unbox(float, r1)
     return r2
 
-[case testCallableTypesWithKeywordArgs]
+[case testCallableTypesWithKeywordArgs_64bit]
 from typing import List
 
 def call_python_function_with_keyword_arg(x: str) -> int:
@@ -1200,34 +1210,32 @@ def call_python_method_with_keyword_args(xs, first, second):
     xs :: list
     first, second :: int
     r0 :: str
-    r1, r2, r3 :: object
-    r4 :: object[2]
-    r5 :: object_ptr
-    r6, r7 :: object
-    r8 :: str
-    r9, r10, r11 :: object
-    r12 :: object[2]
-    r13 :: object_ptr
-    r14, r15 :: object
+    r1, r2 :: object
+    r3 :: object[3]
+    r4 :: object_ptr
+    r5, r6 :: object
+    r7 :: str
+    r8, r9 :: object
+    r10 :: object[3]
+    r11 :: object_ptr
+    r12, r13 :: object
 L0:
     r0 = 'insert'
-    r1 = CPyObject_GetAttr(xs, r0)
-    r2 = object 0
-    r3 = box(int, first)
-    r4 = [r2, r3]
-    r5 = load_address r4
-    r6 = ('x',)
-    r7 = PyObject_Vectorcall(r1, r5, 1, r6)
-    keep_alive r2, r3
-    r8 = 'insert'
-    r9 = CPyObject_GetAttr(xs, r8)
-    r10 = box(int, second)
-    r11 = object 1
-    r12 = [r10, r11]
-    r13 = load_address r12
-    r14 = ('x', 'i')
-    r15 = PyObject_Vectorcall(r9, r13, 0, r14)
-    keep_alive r10, r11
+    r1 = object 0
+    r2 = box(int, first)
+    r3 = [xs, r1, r2]
+    r4 = load_address r3
+    r5 = ('x',)
+    r6 = PyObject_VectorcallMethod(r0, r4, 9223372036854775810, r5)
+    keep_alive xs, r1, r2
+    r7 = 'insert'
+    r8 = box(int, second)
+    r9 = object 1
+    r10 = [xs, r8, r9]
+    r11 = load_address r10
+    r12 = ('x', 'i')
+    r13 = PyObject_VectorcallMethod(r7, r11, 9223372036854775809, r12)
+    keep_alive xs, r8, r9
     return xs
 
 [case testObjectAsBoolean]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -606,7 +606,7 @@ L0:
     r3 = CPyTagged_Add(r0, r2)
     return r3
 
-[case testCallClassMethodViaCls]
+[case testCallClassMethodViaCls_64bit]
 class C:
     @classmethod
     def f(cls, x: int) -> int:
@@ -647,14 +647,20 @@ def D.f(cls, x):
     cls :: object
     x :: int
     r0 :: str
-    r1, r2 :: object
-    r3 :: int
+    r1 :: object
+    r2 :: object[2]
+    r3 :: object_ptr
+    r4 :: object
+    r5 :: int
 L0:
     r0 = 'g'
     r1 = box(int, x)
-    r2 = CPyObject_CallMethodObjArgs(cls, r0, r1, 0)
-    r3 = unbox(int, r2)
-    return r3
+    r2 = [cls, r1]
+    r3 = load_address r2
+    r4 = PyObject_VectorcallMethod(r0, r3, 9223372036854775810, 0)
+    keep_alive cls, r1
+    r5 = unbox(int, r4)
+    return r5
 def D.g(cls, x):
     cls :: object
     x :: int
@@ -904,7 +910,7 @@ L0:
     r1 = unbox(bool, r0)
     return r1
 
-[case testEqDefinedLater]
+[case testEqDefinedLater_64bit]
 def f(a: 'Base', b: 'Base') -> bool:
     return a == b
 
@@ -951,13 +957,18 @@ L0:
 def fOpt2(a, b):
     a, b :: __main__.Derived
     r0 :: str
-    r1 :: object
-    r2 :: bool
+    r1 :: object[2]
+    r2 :: object_ptr
+    r3 :: object
+    r4 :: bool
 L0:
     r0 = '__ne__'
-    r1 = CPyObject_CallMethodObjArgs(a, r0, b, 0)
-    r2 = unbox(bool, r1)
-    return r2
+    r1 = [a, b]
+    r2 = load_address r1
+    r3 = PyObject_VectorcallMethod(r0, r2, 9223372036854775810, 0)
+    keep_alive a, b
+    r4 = unbox(bool, r3)
+    return r4
 def Derived.__eq__(self, other):
     self :: __main__.Derived
     other, r0 :: object

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -189,7 +189,7 @@ L0:
     s4 = r13
     return 1
 
-[case testFStrings]
+[case testFStrings_64bit]
 def f(var: str, num: int) -> None:
     s1 = f"Hi! I'm {var}. I am {num} years old."
     s2 = f'Hello {var:>{num}}'
@@ -200,11 +200,13 @@ def f(var, num):
     var :: str
     num :: int
     r0, r1, r2, r3, r4, s1, r5, r6, r7, r8, r9, r10, r11 :: str
-    r12 :: object
-    r13 :: str
-    r14 :: list
-    r15 :: ptr
-    r16, s2, r17, s3, r18, s4 :: str
+    r12 :: object[3]
+    r13 :: object_ptr
+    r14 :: object
+    r15 :: str
+    r16 :: list
+    r17 :: ptr
+    r18, s2, r19, s3, r20, s4 :: str
 L0:
     r0 = "Hi! I'm "
     r1 = '. I am '
@@ -219,19 +221,22 @@ L0:
     r9 = CPyTagged_Str(num)
     r10 = CPyStr_Build(2, r8, r9)
     r11 = 'format'
-    r12 = CPyObject_CallMethodObjArgs(r7, r11, var, r10, 0)
-    r13 = cast(str, r12)
-    r14 = PyList_New(2)
-    r15 = list_items r14
-    buf_init_item r15, 0, r6
-    buf_init_item r15, 1, r13
-    keep_alive r14
-    r16 = PyUnicode_Join(r5, r14)
-    s2 = r16
-    r17 = ''
-    s3 = r17
-    r18 = 'abc'
-    s4 = r18
+    r12 = [r7, var, r10]
+    r13 = load_address r12
+    r14 = PyObject_VectorcallMethod(r11, r13, 9223372036854775811, 0)
+    keep_alive r7, var, r10
+    r15 = cast(str, r14)
+    r16 = PyList_New(2)
+    r17 = list_items r16
+    buf_init_item r17, 0, r6
+    buf_init_item r17, 1, r15
+    keep_alive r16
+    r18 = PyUnicode_Join(r5, r16)
+    s2 = r18
+    r19 = ''
+    s3 = r19
+    r20 = 'abc'
+    s4 = r20
     return 1
 
 [case testStringFormattingCStyle]
@@ -289,7 +294,7 @@ L0:
     r5 = CPy_Decode(b, r3, r4)
     return 1
 
-[case testEncode]
+[case testEncode_64bit]
 def f(s: str) -> None:
     s.encode()
     s.encode('utf-8')
@@ -321,22 +326,19 @@ def f(s):
     r14, errors, r15 :: str
     r16 :: bytes
     r17, r18 :: str
-    r19 :: object
-    r20 :: object[2]
-    r21 :: object_ptr
-    r22, r23 :: object
-    r24 :: str
-    r25 :: object
-    r26 :: object[1]
-    r27 :: object_ptr
-    r28, r29 :: object
-    r30 :: str
-    r31 :: object
-    r32 :: object[2]
-    r33 :: object_ptr
-    r34, r35 :: object
-    r36 :: str
-    r37 :: bytes
+    r19 :: object[3]
+    r20 :: object_ptr
+    r21, r22 :: object
+    r23 :: str
+    r24 :: object[2]
+    r25 :: object_ptr
+    r26, r27 :: object
+    r28 :: str
+    r29 :: object[3]
+    r30 :: object_ptr
+    r31, r32 :: object
+    r33 :: str
+    r34 :: bytes
 L0:
     r0 = PyUnicode_AsUTF8String(s)
     r1 = PyUnicode_AsUTF8String(s)
@@ -359,28 +361,25 @@ L0:
     r16 = CPy_Encode(s, r15, errors)
     r17 = 'utf8'
     r18 = 'encode'
-    r19 = CPyObject_GetAttr(s, r18)
-    r20 = [r17, errors]
-    r21 = load_address r20
-    r22 = ('errors',)
-    r23 = PyObject_Vectorcall(r19, r21, 1, r22)
-    keep_alive r17, errors
-    r24 = 'encode'
-    r25 = CPyObject_GetAttr(s, r24)
-    r26 = [errors]
-    r27 = load_address r26
-    r28 = ('errors',)
-    r29 = PyObject_Vectorcall(r25, r27, 0, r28)
-    keep_alive errors
-    r30 = 'encode'
-    r31 = CPyObject_GetAttr(s, r30)
-    r32 = [encoding, errors]
-    r33 = load_address r32
-    r34 = ('encoding', 'errors')
-    r35 = PyObject_Vectorcall(r31, r33, 0, r34)
-    keep_alive encoding, errors
-    r36 = 'latin2'
-    r37 = CPy_Encode(s, r36, 0)
+    r19 = [s, r17, errors]
+    r20 = load_address r19
+    r21 = ('errors',)
+    r22 = PyObject_VectorcallMethod(r18, r20, 9223372036854775810, r21)
+    keep_alive s, r17, errors
+    r23 = 'encode'
+    r24 = [s, errors]
+    r25 = load_address r24
+    r26 = ('errors',)
+    r27 = PyObject_VectorcallMethod(r23, r25, 9223372036854775809, r26)
+    keep_alive s, errors
+    r28 = 'encode'
+    r29 = [s, encoding, errors]
+    r30 = load_address r29
+    r31 = ('encoding', 'errors')
+    r32 = PyObject_VectorcallMethod(r28, r30, 9223372036854775809, r31)
+    keep_alive s, encoding, errors
+    r33 = 'latin2'
+    r34 = CPy_Encode(s, r33, 0)
     return 1
 
 [case testOrd]

--- a/mypyc/test-data/irbuild-vectorcall.test
+++ b/mypyc/test-data/irbuild-vectorcall.test
@@ -60,39 +60,7 @@ L0:
     keep_alive r5, r6, r7
     return 1
 
-[case testVectorcallMethod]
-from typing import Any
-
-def f(o: Any) -> None:
-    # On Python 3.8 vectorcalls are only faster with keyword args
-    o.m('x')
-    o.m('x', a='y')
-[out]
-def f(o):
-    o :: object
-    r0, r1 :: str
-    r2 :: object
-    r3, r4, r5 :: str
-    r6 :: object
-    r7 :: object[2]
-    r8 :: object_ptr
-    r9, r10 :: object
-L0:
-    r0 = 'x'
-    r1 = 'm'
-    r2 = CPyObject_CallMethodObjArgs(o, r1, r0, 0)
-    r3 = 'x'
-    r4 = 'y'
-    r5 = 'm'
-    r6 = CPyObject_GetAttr(o, r5)
-    r7 = [r3, r4]
-    r8 = load_address r7
-    r9 = ('a',)
-    r10 = PyObject_Vectorcall(r6, r8, 1, r9)
-    keep_alive r3, r4
-    return 1
-
-[case testVectorcallMethod_python3_9_64bit]
+[case testVectorcallMethod_64bit]
 from typing import Any
 
 def f(o: Any) -> None:
@@ -128,7 +96,7 @@ L0:
     keep_alive o, r5, r6, r7
     return 1
 
-[case testVectorcallMethod_python3_9_32bit]
+[case testVectorcallMethod_32bit]
 from typing import Any
 
 def f(o: Any) -> None:

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -896,7 +896,7 @@ L0:
     dec_ref r3
     return r4
 
-[case testVectorcallMethod_python3_9_64bit]
+[case testVectorcallMethod_64bit]
 from typing import Any
 
 def call(o: Any, x: int) -> int:

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -103,7 +103,7 @@ def build_ir_for_single_file2(
 
     # By default generate IR compatible with the earliest supported Python C API.
     # If a test needs more recent API features, this should be overridden.
-    compiler_options = compiler_options or CompilerOptions(capi_version=(3, 8))
+    compiler_options = compiler_options or CompilerOptions(capi_version=(3, 9))
     options = Options()
     options.show_traceback = True
     options.hide_error_codes = True
@@ -273,8 +273,8 @@ def infer_ir_build_options_from_test_name(name: str) -> CompilerOptions | None:
         return None
     if "_32bit" in name and not IS_32_BIT_PLATFORM:
         return None
-    options = CompilerOptions(strip_asserts="StripAssert" in name, capi_version=(3, 8))
-    # A suffix like _python3_8 is used to set the target C API version.
+    options = CompilerOptions(strip_asserts="StripAssert" in name, capi_version=(3, 9))
+    # A suffix like _python3_9 is used to set the target C API version.
     m = re.search(r"_python([3-9]+)_([0-9]+)(_|\b)", name)
     if m:
         options.capi_version = (int(m.group(1)), int(m.group(2)))


### PR DESCRIPTION
Followup to #18341

This PR updates the `capi_version` used for mypyc tests to `3.9` (mypy / mypyc requires `>=3.9`). For Python 3.9+ mypyc uses `PyObject_VectorcallMethod` instead of `CPyObject_CallMethodObjArgs` and select `PyObject_Vectorcall` where ever possible.

Will remove the now unnecessary `use_method_vectorcall` check in a followup.


https://github.com/python/mypy/blob/42e005c999d8341c0da6d7b93b10d05f2db2099c/mypyc/common.py#L114-L116