### PR TITLE
Cleanup backwards compat layer for use_vectorcall and use_method_vectorcall

### DIFF
--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -17,7 +17,6 @@ from mypyc.common import (
     REG_PREFIX,
     STATIC_PREFIX,
     TYPE_PREFIX,
-    use_vectorcall,
 )
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
 from mypyc.ir.func_ir import FuncDecl
@@ -397,9 +396,6 @@ class Emitter:
             self.emit_line(f"{bitmap} |= {mask};")
         if value:
             self.emit_line("}")
-
-    def use_vectorcall(self) -> bool:
-        return use_vectorcall(self.capi_version)
 
     def emit_undefined_attr_check(
         self,

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -45,7 +45,6 @@ from mypyc.common import (
     TYPE_VAR_PREFIX,
     shared_lib_name,
     short_id_from_name,
-    use_vectorcall,
 )
 from mypyc.errors import Errors
 from mypyc.ir.func_ir import FuncIR
@@ -1106,7 +1105,7 @@ def is_fastcall_supported(fn: FuncIR, capi_version: tuple[int, int]) -> bool:
     if fn.class_name is not None:
         if fn.name == "__call__":
             # We can use vectorcalls (PEP 590) when supported
-            return use_vectorcall(capi_version)
+            return True
         # TODO: Support fastcall for __init__.
         return fn.name != "__init__"
     return True

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -24,7 +24,6 @@ from mypyc.common import (
     NATIVE_PREFIX,
     PREFIX,
     bitmap_name,
-    use_vectorcall,
 )
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FUNC_STATICMETHOD, FuncIR, RuntimeArg
@@ -173,7 +172,7 @@ def generate_wrapper_function(
         arg_ptrs += [f"&obj_{groups[ARG_STAR2][0].name}" if groups[ARG_STAR2] else "NULL"]
     arg_ptrs += [f"&obj_{arg.name}" for arg in reordered_args]
 
-    if fn.name == "__call__" and use_vectorcall(emitter.capi_version):
+    if fn.name == "__call__":
         nargs = "PyVectorcall_NARGS(nargs)"
     else:
         nargs = "nargs"

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -106,16 +106,6 @@ def short_name(name: str) -> str:
     return name
 
 
-def use_vectorcall(capi_version: tuple[int, int]) -> bool:
-    # We can use vectorcalls to make calls on Python 3.8+ (PEP 590).
-    return capi_version >= (3, 8)
-
-
-def use_method_vectorcall(capi_version: tuple[int, int]) -> bool:
-    # We can use a dedicated vectorcall API to call methods on Python 3.9+.
-    return capi_version >= (3, 9)
-
-
 def get_id_from_name(name: str, fullname: str, line: int) -> str:
     """Create a unique id for a function.
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -21,8 +21,6 @@ from mypyc.common import (
     MIN_LITERAL_SHORT_INT,
     MIN_SHORT_INT,
     PLATFORM_SIZE,
-    use_method_vectorcall,
-    use_vectorcall,
 )
 from mypyc.errors import Errors
 from mypyc.ir.class_ir import ClassIR, all_concrete_classes
@@ -892,11 +890,9 @@ class LowLevelIRBuilder:
 
         Use py_call_op or py_call_with_kwargs_op for Python function call.
         """
-        if use_vectorcall(self.options.capi_version):
-            # More recent Python versions support faster vectorcalls.
-            result = self._py_vector_call(function, arg_values, line, arg_kinds, arg_names)
-            if result is not None:
-                return result
+        result = self._py_vector_call(function, arg_values, line, arg_kinds, arg_names)
+        if result is not None:
+            return result
 
         # If all arguments are positional, we can use py_call_op.
         if arg_kinds is None or all(kind == ARG_POS for kind in arg_kinds):
@@ -971,13 +967,11 @@ class LowLevelIRBuilder:
         arg_names: Sequence[str | None] | None,
     ) -> Value:
         """Call a Python method (non-native and slow)."""
-        if use_method_vectorcall(self.options.capi_version):
-            # More recent Python versions support faster vectorcalls.
-            result = self._py_vector_method_call(
-                obj, method_name, arg_values, line, arg_kinds, arg_names
-            )
-            if result is not None:
-                return result
+        result = self._py_vector_method_call(
+            obj, method_name, arg_values, line, arg_kinds, arg_names
+        )
+        if result is not None:
+            return result
 
         if arg_kinds is None or all(kind == ARG_POS for kind in arg_kinds):
             # Use legacy method call API


### PR DESCRIPTION
Followup to #18341 and #18546

We only support Python 3.9+, so `PyObject_Vectorcall` and `PyObject_VectorcallMethod` are always available. Remove backwards compatibility layer.