### PR TITLE
Pin mypy_extensions to <2

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,5 +1,5 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
 # and the pins in setup.py
 typing_extensions>=4.6.0
-mypy_extensions>=1.0.0
+mypy_extensions>=1.0.0,<2
 tomli>=1.1.0; python_version<'3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ requires = [
     # and build-requirements.txt, because those are both needed for
     # self-typechecking :/
     "setuptools >= 75.1.0",
-    # the following is from mypy-requirements.txt/setup.py
+    # the following is from mypy-requirements.txt
     "typing_extensions>=4.6.0",
-    "mypy_extensions>=1.0.0",
+    "mypy_extensions>=1.0.0,<2",
     "tomli>=1.1.0; python_version<'3.11'",
     # the following is from build-requirements.txt
     "types-psutil",
@@ -48,7 +48,7 @@ requires-python = ">=3.9"
 dependencies = [
   # When changing this, also update build-system.requires and mypy-requirements.txt
   "typing_extensions>=4.6.0",
-  "mypy_extensions>=1.0.0",
+  "mypy_extensions>=1.0.0,<2",
   "tomli>=1.1.0; python_version<'3.11'",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
`mypy_extensions.TypedDict` and `mypy_extensions.NoReturn` were recently deprecated and will be removed eventually. Add an upper bound now so we don't break old code using these types in the future, after they are removed from `mypy_extensions`.