### PR TITLE
[mypyc] Add debug op (and builder helper) for printing str or Value

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -420,6 +420,9 @@ class IRBuilder:
     def new_tuple(self, items: list[Value], line: int) -> Value:
         return self.builder.new_tuple(items, line)
 
+    def debug_print(self, toprint: str | Value) -> None:
+        return self.builder.debug_print(toprint)
+
     # Helpers for IR building
 
     def add_to_non_ext_dict(

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -162,11 +162,11 @@ from mypyc.primitives.list_ops import list_build_op, list_extend_op, list_items,
 from mypyc.primitives.misc_ops import (
     bool_op,
     buf_init_item,
+    debug_print_op,
     fast_isinstance_op,
     none_object_op,
     not_implemented_op,
     var_object_size,
-    debug_print_op,
 )
 from mypyc.primitives.registry import (
     ERR_NEG_INT,

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -166,6 +166,7 @@ from mypyc.primitives.misc_ops import (
     none_object_op,
     not_implemented_op,
     var_object_size,
+    debug_print_op,
 )
 from mypyc.primitives.registry import (
     ERR_NEG_INT,
@@ -299,6 +300,11 @@ class LowLevelIRBuilder:
         if self.keep_alives:
             self.add(KeepAlive(self.keep_alives.copy()))
             self.keep_alives = []
+
+    def debug_print(self, toprint: str | Value) -> None:
+        if isinstance(toprint, str):
+            toprint = self.load_str(toprint)
+        self.primitive_op(debug_print_op, [toprint], -1)
 
     # Type conversions
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -866,6 +866,7 @@ PyObject *CPyPickle_SetState(PyObject *obj, PyObject *state);
 PyObject *CPyPickle_GetState(PyObject *obj);
 CPyTagged CPyTagged_Id(PyObject *o);
 void CPyDebug_Print(const char *msg);
+void CPyDebug_PrintObject(PyObject *obj);
 void CPy_Init(void);
 int CPyArg_ParseTupleAndKeywords(PyObject *, PyObject *,
                                  const char *, const char *, const char * const *, ...);

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -535,6 +535,22 @@ void CPyDebug_Print(const char *msg) {
     fflush(stdout);
 }
 
+void CPyDebug_PrintObject(PyObject *obj) {
+    // Printing can cause errors. We don't want this to affect any existing
+    // state so we'll save any existing error and restore it at the end.
+    PyObject *exc_type, *exc_value, *exc_traceback;
+    PyErr_Fetch(&exc_type, &exc_value, &exc_traceback);
+
+    if (PyObject_Print(obj, stderr, 0) == -1) {
+        PyErr_Print();
+    } else {
+        fprintf(stderr, "\n");
+    }
+    fflush(stderr);
+
+    PyErr_Restore(exc_type, exc_value, exc_traceback);
+}
+
 int CPySequence_CheckUnpackCount(PyObject *sequence, Py_ssize_t expected) {
     Py_ssize_t actual = Py_SIZE(sequence);
     if (unlikely(actual != expected)) {

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -283,3 +283,11 @@ set_type_alias_compute_function_op = custom_primitive_op(
     return_type=void_rtype,
     error_kind=ERR_NEVER,
 )
+
+debug_print_op = custom_primitive_op(
+    name="debug_print",
+    c_function_name="CPyDebug_PrintObject",
+    arg_types=[object_rprimitive],
+    return_type=void_rtype,
+    error_kind=ERR_NEVER,
+)

--- a/mypyc/test/test_misc.py
+++ b/mypyc/test/test_misc.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import unittest
+
+from mypyc.ir.ops import BasicBlock
+from mypyc.ir.pprint import format_blocks, generate_names_for_ir
+from mypyc.irbuild.ll_builder import LowLevelIRBuilder
+from mypyc.options import CompilerOptions
+
+class TestMisc(unittest.TestCase):
+    def test_debug_op(self) -> None:
+        block = BasicBlock()
+        builder = LowLevelIRBuilder(errors=None, options=CompilerOptions())
+        builder.activate_block(block)
+        builder.debug_print("foo")
+
+        names = generate_names_for_ir([], [block])
+        code = format_blocks([block], names, {})
+        assert code[:-1] == [
+            "L0:",
+            "    r0 = 'foo'",
+            '    CPyDebug_PrintObject(r0)',
+        ]

--- a/mypyc/test/test_misc.py
+++ b/mypyc/test/test_misc.py
@@ -7,6 +7,7 @@ from mypyc.ir.pprint import format_blocks, generate_names_for_ir
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder
 from mypyc.options import CompilerOptions
 
+
 class TestMisc(unittest.TestCase):
     def test_debug_op(self) -> None:
         block = BasicBlock()
@@ -16,8 +17,4 @@ class TestMisc(unittest.TestCase):
 
         names = generate_names_for_ir([], [block])
         code = format_blocks([block], names, {})
-        assert code[:-1] == [
-            "L0:",
-            "    r0 = 'foo'",
-            '    CPyDebug_PrintObject(r0)',
-        ]
+        assert code[:-1] == ["L0:", "    r0 = 'foo'", "    CPyDebug_PrintObject(r0)"]


### PR DESCRIPTION
It generates C code to print to stdout, but tries to preserve the error state and not affect the code it's added to.

Added test for it, but also tested this by adding
`builder.debug_print(typ)` in `add_non_ext_class_attr_ann` and it prints the class name.
It's also useful to use it like `builder.debug_print("MARKER")` and then to search in the generated C code for MARKER. For more complex debugging tasks, this is useful in finding your way around the generated C code and quickly looking at the interesting part.

I saw that there's already a misc op `CPyDebug_Print`. I haven't seen it used though. I think we can remove that one if this is proving useful.