### PR TITLE
Remove old TypedDict + NamedTuple code from mypyc

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import typing_extensions
 from abc import abstractmethod
 from typing import Callable, Final
 
@@ -542,29 +541,10 @@ def populate_non_ext_bases(builder: IRBuilder, cdef: ClassDef) -> Value:
             # HAX: Mypy internally represents TypedDict classes differently from what
             #      should happen at runtime. Replace with something that works.
             module = "typing"
-            if builder.options.capi_version < (3, 9):
-                name = "TypedDict"
-                if builder.options.capi_version < (3, 8):
-                    # TypedDict was added to typing in Python 3.8.
-                    module = "typing_extensions"
-                    # TypedDict is not a real type on typing_extensions 4.7.0+
-                    name = "_TypedDict"
-                    if isinstance(typing_extensions.TypedDict, type):
-                        raise RuntimeError(
-                            "It looks like you may have an old version "
-                            "of typing_extensions installed. "
-                            "typing_extensions>=4.7.0 is required on Python 3.7."
-                        )
-            else:
-                # In Python 3.9 TypedDict is not a real type.
-                name = "_TypedDict"
+            name = "_TypedDict"
             base = builder.get_module_attr(module, name, cdef.line)
         elif is_named_tuple and cls.fullname == "builtins.tuple":
-            if builder.options.capi_version < (3, 9):
-                name = "NamedTuple"
-            else:
-                # This was changed in Python 3.9.
-                name = "_NamedTuple"
+            name = "_NamedTuple"
             base = builder.get_module_attr("typing", name, cdef.line)
         else:
             cls_module = cls.fullname.rsplit(".", 1)[0]


### PR DESCRIPTION
Mypyc requires Python 3.9+. This PR removes the old TypedDict and NamedTuple code for versions prior to 3.9.