### PR TITLE
Update lxml test requirement to 5.3.0

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -5,8 +5,7 @@
 -r build-requirements.txt
 attrs>=18.0
 filelock>=3.3.0
-# lxml 4.9.3 switched to manylinux_2_28, the wheel builder still uses manylinux2014
-lxml>=4.9.1,<4.9.3; (python_version<'3.11' or sys_platform!='win32') and python_version<'3.12'
+lxml>=5.3.0; python_version<'3.14'
 psutil>=4.0
 pytest>=8.1.0
 pytest-xdist>=1.34.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,7 +22,7 @@ identify==2.6.6
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-lxml==4.9.2 ; (python_version < "3.11" or sys_platform != "win32") and python_version < "3.12"
+lxml==5.3.0 ; python_version < "3.14"
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via -r mypy-requirements.txt


### PR DESCRIPTION
`lxml` has wheels for both `manylinux_2_17` and `manylinux_2_28` so we won't run into issue installing it.
Furthermore there are also wheels for `win32` and `win_amd64`.

Basically all platforms are fully supported now. The upper bound can be updated too, once wheels for `3.14` are available.

https://pypi.org/project/lxml/5.3.0/#files