### PR TITLE
Update the overlapping check for tuples to account for NamedTuples

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -50,6 +50,7 @@ from mypy.types import (
     find_unpack_in_list,
     get_proper_type,
     get_proper_types,
+    is_named_instance,
     split_with_prefix_and_suffix,
 )
 
@@ -645,7 +646,18 @@ def are_tuples_overlapping(
 
     if len(left.items) != len(right.items):
         return False
-    return all(is_overlapping(l, r) for l, r in zip(left.items, right.items))
+    if not all(is_overlapping(l, r) for l, r in zip(left.items, right.items)):
+        return False
+
+    # Check that the tuples aren't from e.g. different NamedTuples.
+    if is_named_instance(right.partial_fallback, "builtins.tuple") or is_named_instance(
+        left.partial_fallback, "builtins.tuple"
+    ):
+        return True
+    else:
+        return is_subtype(left.partial_fallback, right.partial_fallback) or is_subtype(
+            right.partial_fallback, left.partial_fallback
+        )
 
 
 def expand_tuple_if_possible(tup: TupleType, target: int) -> TupleType:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -655,9 +655,7 @@ def are_tuples_overlapping(
     ):
         return True
     else:
-        return is_subtype(left.partial_fallback, right.partial_fallback) or is_subtype(
-            right.partial_fallback, left.partial_fallback
-        )
+        return is_overlapping(left.partial_fallback, right.partial_fallback)
 
 
 def expand_tuple_if_possible(tup: TupleType, target: int) -> TupleType:

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1478,15 +1478,31 @@ def main(n: NT[T]) -> None:
 [case testNamedTupleOverlappingCheck]
 from typing import overload, NamedTuple, Union
 
-class A(NamedTuple): ...
+class AKey(NamedTuple):
+    k: str
 
-class B(NamedTuple): ...
+class A(NamedTuple):
+    key: AKey
+
+
+class BKey(NamedTuple):
+    k: str
+
+class B(NamedTuple):
+    key: BKey
 
 @overload
 def f(arg: A) -> A: ...
 @overload
 def f(arg: B) -> B: ...
 def f(arg: Union[A, B]) -> Union[A, B]: ...
+
+def g(x: Union[A, B, str]) -> Union[A, B, str]:
+    if isinstance(x, str):
+        return x
+    else:
+        reveal_type(x)  # N: Revealed type is "Union[Tuple[Tuple[builtins.str, fallback=__main__.AKey], fallback=__main__.A], Tuple[Tuple[builtins.str, fallback=__main__.BKey], fallback=__main__.B]]"
+        return x._replace()
 
 # no errors should be raised above.
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1474,3 +1474,19 @@ def main(n: NT[T]) -> None:
 
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-namedtuple.pyi]
+
+[case testNamedTupleOverlappingCheck]
+from typing import overload, NamedTuple, Union
+
+class A(NamedTuple): ...
+
+class B(NamedTuple): ...
+
+@overload
+def f(arg: A) -> A: ...
+@overload
+def f(arg: B) -> B: ...
+def f(arg: Union[A, B]) -> Union[A, B]: ...
+
+# no errors should be raised above.
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes https://github.com/python/mypy/issues/18562.

Fixes https://github.com/python/mypy/issues/6623.

Fixes https://github.com/python/mypy/issues/18520. (Only incidentally and I'm not exactly sure why.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->

I was investigating what input mypy thought satisfied both overloads and I found that mypy is missing a check on the fallback type.