### PR TITLE
Fix "not callable" issue for `@dataclass(frozen=True)` with `Final` attr

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -755,10 +755,8 @@ def is_instance_var(var: Var) -> bool:
         var.name in var.info.names
         and var.info.names[var.name].node is var
         and not var.is_classvar
-        # variables without annotations are treated as classvar,
-        # but not when they are annotated as `a: Final = 1`,
-        # since it will be inferenced as `Literal[1]`
-        and not (var.is_inferred and not var.is_final)
+        # variables without annotations are treated as classvar
+        and not var.is_inferred
     )
 
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -755,8 +755,10 @@ def is_instance_var(var: Var) -> bool:
         var.name in var.info.names
         and var.info.names[var.name].node is var
         and not var.is_classvar
-        # variables without annotations are treated as classvar
-        and not var.is_inferred
+        # variables without annotations are treated as classvar,
+        # but not when they are annotated as `a: Final = 1`,
+        # since it will be inferenced as `Literal[1]`
+        and not (var.is_inferred and not var.is_final)
     )
 
 

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -768,6 +768,8 @@ class DataclassTransformer:
             if sym_node is not None:
                 var = sym_node.node
                 if isinstance(var, Var):
+                    if var.is_final:
+                        continue  # do not turn `Final` attrs to `@property`
                     var.is_property = True
             else:
                 var = attr.to_var(info)

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2564,7 +2564,15 @@ class My:
     a: Final = 1
     b: Final[int] = 2
 
+reveal_type(My.a)  # N: Revealed type is "Literal[1]?"
+reveal_type(My.b)  # N: Revealed type is "builtins.int"
+My.a = 1  # E: Cannot assign to final attribute "a"
+My.b = 2  # E: Cannot assign to final attribute "b"
+
 m = My()
 reveal_type(m.a)  # N: Revealed type is "Literal[1]?"
 reveal_type(m.b)  # N: Revealed type is "builtins.int"
+
+m.a = 1  # E: Cannot assign to final attribute "a"
+m.b = 2  # E: Cannot assign to final attribute "b"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2553,3 +2553,18 @@ class X(metaclass=DCMeta):
 class Y(X):
     a: int  # E: Covariant override of a mutable attribute (base class "X" defined the type as "Optional[int]", expression has type "int")
 [builtins fixtures/tuple.pyi]
+
+
+[case testFrozenWithFinal]
+from dataclasses import dataclass
+from typing import Final
+
+@dataclass(frozen=True)
+class My:
+    a: Final = 1
+    b: Final[int] = 2
+
+m = My()
+reveal_type(m.a)  # N: Revealed type is "Literal[1]?"
+reveal_type(m.b)  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Closes #18567 

We should allow inferenced `a: Final = 1`