### PR TITLE
Fix handling of docstrings with tokenization errors (Fixes #18388)

### DIFF
--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -429,6 +429,59 @@ class StubgenUtilSuite(unittest.TestCase):
             == []
         )
 
+    def test_infer_sig_from_docstring_unterminated_string_literal(self) -> None:
+        docstring = """
+        func(*args, **kwargs)
+        Overloaded function.
+
+        1. func(x: int) -> None
+
+        This is a valid docstring with an "unterminated string literal.
+
+        2. func(x: int, y: int) -> str
+
+        This is an overloaded method.
+        """
+        sigs = infer_sig_from_docstring(docstring, name="func")
+        assert_equal(
+            sigs[0], FunctionSig(name="func", args=[ArgSig(name="x", type="int")], ret_type="None")
+        )
+        assert_equal(
+            sigs[1],
+            FunctionSig(
+                name="func",
+                args=[ArgSig(name="x", type="int"), ArgSig(name="y", type="int")],
+                ret_type="str",
+            ),
+        )
+
+    def test_infer_sig_from_docstring_latex(self) -> None:
+        docstring = """
+        func(*args, **kwargs)
+        Overloaded function.
+
+        1. func(x: int) -> None
+
+        .. math::
+            \\mathbf{f}\\left(x\\right) = \\pi \\cdot x
+
+        2. func(x: int, y: int) -> str
+
+        This is an overloaded method.
+        """
+        sigs = infer_sig_from_docstring(docstring, name="func")
+        assert_equal(
+            sigs[0], FunctionSig(name="func", args=[ArgSig(name="x", type="int")], ret_type="None")
+        )
+        assert_equal(
+            sigs[1],
+            FunctionSig(
+                name="func",
+                args=[ArgSig(name="x", type="int"), ArgSig(name="y", type="int")],
+                ret_type="str",
+            ),
+        )
+
     def test_remove_misplaced_type_comments_1(self) -> None:
         good = """
         \u1234


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This changes fixes #18388.

When parsing docstrings, stubgen will bail on a docstring when the first tokenization error is encountered. This behavior is brittle, because docstrings need not be entirely valid python and can contain characters that cause early failure. Consider the following example:

```python
def thing():
  """
  thing(*args, **kwargs)
  Overloaded function.

  1. thing(x: int) -> None

  .. math::
    \mathbf{x} = 3 \cdot \mathbf{y}

  2. thing(x: int, y: int) -> str

  This signature will never get parsed due to TokenError.
  """
```

The presence of the LaTeX code will cause `TokenError` to occur, and the second overload will never get parsed. 

This change causes mypy to resume parsing after an error is occurred, such that later overloads can still be discovered. The new behavior is somewhat more robust to failures of this kind. I also added two tests with example docstrings that previously failed.