### PR TITLE
[mypyc] Handle non extention classes with attribute annotations for forward defined classes

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -645,7 +645,16 @@ def add_non_ext_class_attr_ann(
     if get_type_info is not None:
         type_info = get_type_info(stmt)
         if type_info:
-            typ = load_type(builder, type_info, stmt.line)
+            # NOTE: Using string type information is similar to using
+            # `from __future__ import annotations` in standard python.
+            # NOTE: For string types we need to use the fullname since it
+            # includes the module. If string type doesn't have the module,
+            # @dataclass will try to get the current module and fail since the
+            # current module is not in sys.modules.
+            if builder.current_module == type_info.module_name and stmt.line < type_info.line:
+                typ = builder.load_str(type_info.fullname)
+            else:
+                typ = load_type(builder, type_info, stmt.line)
 
     if typ is None:
         # FIXME: if get_type_info is not provided, don't fall back to stmt.type?

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2719,3 +2719,32 @@ print(native.A(ints=[1, -17]).ints)
 
 [out]
 \[1, -17]
+
+[case testDataclassClassReference]
+from __future__ import annotations
+from dataclasses import dataclass
+
+class BackwardDefinedClass:
+    pass
+
+@dataclass
+class Data:
+    bitem: BackwardDefinedClass
+    bitems: 'BackwardDefinedClass'
+    fitem: ForwardDefinedClass
+    fitems: 'ForwardDefinedClass'
+
+class ForwardDefinedClass:
+    pass
+
+def test_function():
+    d = Data(
+        bitem=BackwardDefinedClass(),
+        bitems=BackwardDefinedClass(),
+        fitem=ForwardDefinedClass(),
+        fitems=ForwardDefinedClass(),
+    )
+    assert(isinstance(d.bitem, BackwardDefinedClass))
+    assert(isinstance(d.bitems, BackwardDefinedClass))
+    assert(isinstance(d.fitem, ForwardDefinedClass))
+    assert(isinstance(d.fitems, ForwardDefinedClass))


### PR DESCRIPTION
This PR makes `add_non_ext_class_attr_ann` behave the same way standard python handles modules with `from __future__ import annotations` by using string types. With this we can reference types declared further in the file. But since this will change in future versions of python, let's only do this for forward references, for types that are defined further down in the same module.
This also works with string type annotations.

Fixes https://github.com/mypyc/mypyc/issues/992