### PR TITLE
Remove support for `builtins.Any`

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -616,7 +616,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         """
         if fullname == "builtins.None":
             return NoneType()
-        elif fullname == "typing.Any" or fullname == "builtins.Any":
+        elif fullname == "typing.Any":
             return AnyType(TypeOfAny.explicit, line=t.line, column=t.column)
         elif fullname in FINAL_TYPE_NAMES:
             if self.prohibit_special_class_field_types:

--- a/test-data/unit/check-ctypes.test
+++ b/test-data/unit/check-ctypes.test
@@ -138,6 +138,7 @@ cua.raw  # E: Array attribute "raw" is only available with element type "c_char"
 
 [case testCtypesAnyArrayAttrs]
 import ctypes
+from typing import Any
 
 aa: ctypes.Array[Any]
 reveal_type(aa.value)  # N: Revealed type is "Any"

--- a/test-data/unit/fixtures/float.pyi
+++ b/test-data/unit/fixtures/float.pyi
@@ -1,7 +1,5 @@
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Any
 T = TypeVar('T')
-
-Any = 0
 
 class object:
     def __init__(self) -> None: pass

--- a/test-data/unit/fixtures/floatdict.pyi
+++ b/test-data/unit/fixtures/floatdict.pyi
@@ -1,10 +1,8 @@
-from typing import TypeVar, Generic, Iterable, Iterator, Mapping, Tuple, overload, Optional, Union
+from typing import TypeVar, Generic, Iterable, Iterator, Mapping, Tuple, overload, Optional, Union, Any
 
 T = TypeVar('T')
 KT = TypeVar('KT')
 VT = TypeVar('VT')
-
-Any = 0
 
 class object:
     def __init__(self) -> None: pass


### PR DESCRIPTION
While doing some cleanup, I noticed a reference to `builtins.Any`. To the best of my knowledge, it was never implemented.