### PR TITLE
Prevent crash on generic NamedTuple with unresolved typevar bound

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8485,6 +8485,11 @@ class InvalidInferredTypes(BoolTypeQuery):
         # multi-step type inference.
         return t.id.is_meta_var()
 
+    def visit_tuple_type(self, t: TupleType, /) -> bool:
+        # Exclude fallback to avoid bogus "need type annotation" errors
+        # TODO: Maybe erase plain tuples used as fallback in TupleType constructor?
+        return self.query_types(t.items)
+
 
 class SetNothingToAny(TypeTranslator):
     """Replace all ambiguous Uninhabited types with Any (to avoid spurious extra errors)."""

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -364,9 +364,6 @@ class HasPlaceholders(BoolTypeQuery):
     def __init__(self) -> None:
         super().__init__(ANY_STRATEGY)
 
-    def visit_tuple_type(self, t: TupleType, /) -> bool:
-        return super().visit_tuple_type(t) or t.partial_fallback.accept(self)
-
     def visit_placeholder_type(self, t: PlaceholderType) -> bool:
         return True
 

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -364,6 +364,9 @@ class HasPlaceholders(BoolTypeQuery):
     def __init__(self) -> None:
         super().__init__(ANY_STRATEGY)
 
+    def visit_tuple_type(self, t: TupleType, /) -> bool:
+        return super().visit_tuple_type(t) or t.partial_fallback.accept(self)
+
     def visit_placeholder_type(self, t: PlaceholderType) -> bool:
         return True
 

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -410,7 +410,7 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return self.query_types(t.arg_types + [t.ret_type])
 
     def visit_tuple_type(self, t: TupleType, /) -> T:
-        return self.query_types(t.items)
+        return self.query_types([t.partial_fallback] + t.items)
 
     def visit_typeddict_type(self, t: TypedDictType, /) -> T:
         return self.query_types(t.items.values())
@@ -550,7 +550,7 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
             return args and ret
 
     def visit_tuple_type(self, t: TupleType, /) -> bool:
-        return self.query_types(t.items)
+        return self.query_types([t.partial_fallback] + t.items)
 
     def visit_typeddict_type(self, t: TypedDictType, /) -> bool:
         return self.query_types(list(t.items.values()))

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6829,3 +6829,22 @@ reveal_type(a.f)
 tmp/b.py:4: note: Revealed type is "builtins.int"
 tmp/b.py:5: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 tmp/b.py:6: note: Revealed type is "builtins.int"
+
+[case testSerializeDeferredGenericNamedTuple]
+import pkg
+[file pkg/__init__.py]
+from .lib import NT
+[file pkg/lib.py]
+from typing import Generic, NamedTuple, TypeVar
+from pkg import does_not_exist  # type: ignore
+from pkg.missing import also_missing  # type: ignore
+
+T = TypeVar("T", bound=does_not_exist)
+class NT(NamedTuple, Generic[T]):
+    values: also_missing[T]
+[file pkg/__init__.py.2]
+# touch
+from .lib import NT
+[builtins fixtures/tuple.pyi]
+[out]
+[out2]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3886,3 +3886,10 @@ def a4(x: List[str], y: List[Never]) -> None:
     reveal_type(z2)  # N: Revealed type is "builtins.list[builtins.object]"
     z1[1].append("asdf")  # E: "object" has no attribute "append"
 [builtins fixtures/dict.pyi]
+
+[case testTupleJoinFallbackInference]
+foo = [
+    (1, ("a", "b")),
+    (2, []),
+]
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3892,4 +3892,5 @@ foo = [
     (1, ("a", "b")),
     (2, []),
 ]
+reveal_type(foo)  # N: Revealed type is "builtins.list[Tuple[builtins.int, typing.Sequence[builtins.str]]]"
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #18582. Fixes #17396. Supersedes #18351.

cc @hauntsaninja - see my comments on your original PR, maybe this change should be lifted to BoolTypeQuery and TypeQuery instead? (opening a separate PR to see CI results)