### PR TITLE
use is_same_type when determining if a cast is redundant

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4688,7 +4688,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         if (
             options.warn_redundant_casts
             and not isinstance(get_proper_type(target_type), AnyType)
-            and source_type == target_type
+            and is_same_type(source_type, target_type)
         ):
             self.msg.redundant_cast(target_type, expr)
         if options.disallow_any_unimported and has_any_from_unimported_type(target_type):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4687,7 +4687,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         options = self.chk.options
         if (
             options.warn_redundant_casts
-            and not isinstance(get_proper_type(target_type), AnyType)
+            and not is_same_type(target_type, AnyType(TypeOfAny.special_form))
             and is_same_type(source_type, target_type)
         ):
             self.msg.redundant_cast(target_type, expr)

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -42,6 +42,21 @@ a: Any
 b = cast(Any, a)
 [builtins fixtures/list.pyi]
 
+[case testCastToObjectNotRedunant]
+# flags: --warn-redundant-casts
+from typing import cast
+
+a = 1
+b = cast(object, 1)
+
+[case testCastFromLiteralRedundant]
+# flags: --warn-redundant-casts
+from typing import cast
+
+cast(int, 1)
+[out]
+main:4: error: Redundant cast to "int"
+
 -- Unused 'type: ignore' comments
 -- ------------------------------
 

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -57,6 +57,17 @@ cast(int, 1)
 [out]
 main:4: error: Redundant cast to "int"
 
+[case testCastFromUnionOfAnyOk]
+# flags: --warn-redundant-casts
+from typing import Any, cast, Union
+
+x = Any
+y = Any
+z = Any
+
+def f(q: Union[x, y, z]) -> None:
+    cast(Union[x, y], q)
+
 -- Unused 'type: ignore' comments
 -- ------------------------------
 


### PR DESCRIPTION
while working on #18540 (which my original prototype based the code on `warn-redundant-casts`) I noticed the suggestion [here](https://github.com/python/mypy/issues/18540#issuecomment-2615574503) would probably make sense to apply to redundant-cast as well!

I also made sure to include the example from the [original implementation](https://github.com/python/mypy/pull/1705#issue-159944226) just to make sure I wasn't regressing that as well since it seemed related.
