### PR TITLE
Add object self-type to tuple test fixture

### DIFF
--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -1,13 +1,14 @@
 # Builtins stub used in tuple-related test cases.
 
 import _typeshed
-from typing import Iterable, Iterator, TypeVar, Generic, Sequence, Optional, overload, Tuple, Type
+from typing import Iterable, Iterator, TypeVar, Generic, Sequence, Optional, overload, Tuple, Type, Self
 
 _T = TypeVar("_T")
 _Tco = TypeVar('_Tco', covariant=True)
 
 class object:
     def __init__(self) -> None: pass
+    def __new__(cls) -> Self: ...
 
 class type:
     def __init__(self, *a: object) -> None: pass


### PR DESCRIPTION
This makes it more similar to the real typeshed. It is needed to reproduce tricky failures in tests, e.g. https://github.com/python/mypy/pull/18585. If this causes slower tests, some tests may be switched to `tuple-simple.pyi`.