### PR TITLE
[misc] automatically strip periods when generating changelog entries

### DIFF
--- a/misc/generate_changelog.py
+++ b/misc/generate_changelog.py
@@ -145,7 +145,7 @@ def format_changelog_entry(c: CommitInfo) -> str:
         s += f" (#{c.pr_number})"
     s += f" ({c.author})"
     """
-    s = f" * {c.title} ({c.author}"
+    s = f" * {c.title.removesuffix(".")} ({c.author}"
     if c.pr_number:
         s += f", PR [{c.pr_number}](https://github.com/python/mypy/pull/{c.pr_number})"
     s += ")"


### PR DESCRIPTION
Manually removing the periods caused a small amount of busy work in the 1.15 release. It's easy enough to tweak the script, so I went ahead and added a `removesuffix` call.