### PR TITLE
[misc] fix spurious newlines generated by gen_blog_post_html.py

### DIFF
--- a/misc/gen_blog_post_html.py
+++ b/misc/gen_blog_post_html.py
@@ -95,7 +95,7 @@ def convert(src: str) -> str:
     h = re.sub(r"`\*\*`", "<tt>**</tt>", h)
 
     # Paragraphs
-    h = re.sub(r"\n([A-Z])", r"\n<p>\1", h)
+    h = re.sub(r"\n\n([A-Z])", r"\n\n<p>\1", h)
 
     # Bullet lists
     h = format_lists(h)


### PR DESCRIPTION
While preparing the 1.15 release blog posts, I noticed that we were inserting `<p>` tags in lots of places where we shouldn't. For example, this single paragraph was transformed into two paragraphs when converted to HTML:

```md
Contributed by Christian Bundy and Marc Mueller
(PR [mypy_mypyc-wheels#76](https://github.com/mypyc/mypy_mypyc-wheels/pull/76),
PR [mypy_mypyc-wheels#89](https://github.com/mypyc/mypy_mypyc-wheels/pull/89)).
```

```html
<p>Contributed by Christian Bundy and Marc Mueller
(PR <a href="https://github.com/mypyc/mypy_mypyc-wheels/pull/76">mypy_mypyc-wheelsPR <a href="https://github.com/python/mypy/pull/76">76</a></a>,
<p>PR <a href="https://github.com/mypyc/mypy_mypyc-wheels/pull/89">mypy_mypyc-wheelsPR <a href="https://github.com/python/mypy/pull/89">89</a></a>).
```

This seems to be due to an overly-hungry regex looking for `\n[A-Z]`. In markdown, a paragraph is typically represented by a double newline; updating the regex to `\n\n[A-Z]` seems to fix the awkward paragraph breaks in the rendered HTML.