### PR TITLE
fix some mis-stacked parentheses in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ of the garbage collector. Additionally, the release includes several micro-optim
 be impactful for large projects.
 
 Contributed by Jukka Lehtosalo (PR [18306](https://github.com/python/mypy/pull/18306),
-PR [18302](https://github.com/python/mypy/pull/18302, PR [18298](https://github.com/python/mypy/pull/18298,
-PR [18299](https://github.com/python/mypy/pull/18299).
+PR [18302](https://github.com/python/mypy/pull/18302), PR [18298](https://github.com/python/mypy/pull/18298),
+PR [18299](https://github.com/python/mypy/pull/18299)).
 
 ### Mypyc Accelerated Mypy Wheels for ARM Linux
 


### PR DESCRIPTION
This managed to slip by at least three humans, sadly. I didn't catch it until I was publishing the final blog post.