### PR TITLE
Fix markup in CHANGELOG for mypy@1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ Mypy is up to 40% faster in some use cases. This improvement comes largely from 
 of the garbage collector. Additionally, the release includes several micro-optimizations that may
 be impactful for large projects.
 
-Contributed by Jukka Lehtosalo (PR [18306](https://github.com/python/mypy/pull/18306),
-PR [18302](https://github.com/python/mypy/pull/18302, PR [18298](https://github.com/python/mypy/pull/18298,
-PR [18299](https://github.com/python/mypy/pull/18299).
+Contributed by Jukka Lehtosalo
+- PR [18306](https://github.com/python/mypy/pull/18306)
+- PR [18302](https://github.com/python/mypy/pull/18302)
+- PR [18298](https://github.com/python/mypy/pull/18298)
+- PR [18299](https://github.com/python/mypy/pull/18299)
 
 ### Mypyc Accelerated Mypy Wheels for ARM Linux
 


### PR DESCRIPTION
Before:
<img width="951" alt="Снимок экрана 2025-02-05 в 11 10 16" src="https://github.com/user-attachments/assets/e79c8ddc-1c84-46cc-b157-329e49d72c70" />
