### PR TITLE
Allow trailing commas for `files` setting in `mypy.ini` and `setup.ini`

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -126,7 +126,7 @@ def split_and_match_files(paths: str) -> list[str]:
     Returns a list of file paths
     """
 
-    return split_and_match_files_list(paths.split(","))
+    return split_and_match_files_list(split_commas(paths))
 
 
 def check_follow_imports(choice: str) -> str:

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1300,6 +1300,22 @@ foo.py:1: error: "int" not callable
 [out]
 foo/m.py:1: error: "int" not callable
 
+[case testCmdlineCfgFilesTrailingComma]
+# cmd: mypy
+[file mypy.ini]
+\[mypy]
+files =
+  a.py,
+  b.py,
+[file a.py]
+x: str = 'x'  # ok
+[file b.py]
+y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[file c.py]
+# This should not trigger any errors, because it is not included:
+z: int = 'z'
+[out]
+
 [case testCmdlineCfgEnableErrorCodeTrailingComma]
 # cmd: mypy .
 [file mypy.ini]


### PR DESCRIPTION
Now 

```ini
files =
  a.py,
  b.py
```

and 

```ini
files =
  a.py,
  b.py,
```

will be the same thing.

Previously, adding a traling comma would add `''` to `paths`, which resulted in a strange error like:

```
  a.py: error: Duplicate module named "a" (also at "a.py") (diff)
  a.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info (diff)
  a.py: note: Common resolutions include: a) using `--exclude` to avoid checking one of them, b) adding `__init__.py` somewhere, c) using `--explicit-package-bases` or adjusting MYPYPATH (diff)
```

Refs https://github.com/python/mypy/pull/14240
Refs https://github.com/python/cpython/pull/129708