### PR TITLE
Test and fix trailing commas in many multiline string options in `pyproject.toml`

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -55,9 +55,12 @@ def parse_version(v: str | float) -> tuple[int, int]:
 def try_split(v: str | Sequence[str], split_regex: str = "[,]") -> list[str]:
     """Split and trim a str or list of str into a list of str"""
     if isinstance(v, str):
-        return [p.strip() for p in re.split(split_regex, v)]
-
-    return [p.strip() for p in v]
+        items = [p.strip() for p in re.split(split_regex, v)]
+    else:
+        items = [p.strip() for p in v]
+    if items and items[-1] == "":
+        items.pop(-1)
+    return items
 
 
 def validate_codes(codes: list[str]) -> list[str]:

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -56,11 +56,10 @@ def try_split(v: str | Sequence[str], split_regex: str = "[,]") -> list[str]:
     """Split and trim a str or list of str into a list of str"""
     if isinstance(v, str):
         items = [p.strip() for p in re.split(split_regex, v)]
-    else:
-        items = [p.strip() for p in v]
-    if items and items[-1] == "":
-        items.pop(-1)
-    return items
+        if items and items[-1] == "":
+            items.pop(-1)
+        return items
+    return [p.strip() for p in v]
 
 
 def validate_codes(codes: list[str]) -> list[str]:

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -1098,3 +1098,15 @@ reveal_type(1)  # N: Revealed type is "Literal[1]?"
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/custom_errorcode.py
+
+
+[case testPyprojectPluginsTrailingComma]
+# flags: --config-file tmp/pyproject.toml
+[file pyproject.toml]
+# This test checks that trailing commas in string-based `plugins` are allowed.
+\[tool.mypy]
+plugins = """
+  <ROOT>/test-data/unit/plugins/function_sig_hook.py,
+  <ROOT>/test-data/unit/plugins/method_in_decorator.py,
+"""
+[out]

--- a/test-data/unit/cmdline.pyproject.test
+++ b/test-data/unit/cmdline.pyproject.test
@@ -151,10 +151,10 @@ y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", 
 z: int = 'z'
 [out]
 
-# Fails on windows for some reason
 [case testPyprojectPluginsTrailingComma-posix]
 # cmd: mypy .
 [file pyproject.toml]
+# This test fails on windows for some reason, skipping it there.
 \[tool.mypy]
 plugins = """
   <ROOT>/test-data/unit/plugins/function_sig_hook.py,

--- a/test-data/unit/cmdline.pyproject.test
+++ b/test-data/unit/cmdline.pyproject.test
@@ -138,89 +138,77 @@ description = "Factory ⸻ A code generator 🏭"
 # cmd: mypy
 [file pyproject.toml]
 \[tool.mypy]
+# We combine multiple tests in a single one here, because these tests are slow.
 files = """
   a.py,
   b.py,
 """
+always_true = """
+  FLAG_A1,
+  FLAG_B1,
+"""
+always_false = """
+  FLAG_A2,
+  FLAG_B2,
+"""
 [file a.py]
-x: str = 'x'  # ok
+x: str = 'x'  # ok'
+
+# --always-true
+FLAG_A1 = False
+FLAG_B1 = False
+if not FLAG_A1:  # unreachable
+    x: int = 'x'
+if not FLAG_B1:  # unreachable
+    y: int = 'y'
+
+# --always-false
+FLAG_A2 = True
+FLAG_B2 = True
+if FLAG_A2:  # unreachable
+    x: int = 'x'
+if FLAG_B2:  # unreachable
+    y: int = 'y'
 [file b.py]
 y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 [file c.py]
 # This should not trigger any errors, because it is not included:
 z: int = 'z'
 [out]
-
-[case testPyprojectAlwaysTrueTrailingComma]
-# cmd: mypy .
-[file pyproject.toml]
-\[tool.mypy]
-always_true = """
-  FLAG_A,
-  FLAG_B,
-"""
-[file a.py]
-FLAG_A = False
-FLAG_B = False
-if not FLAG_A:  # unreachable
-    x: int = 'x'
-if not FLAG_B:  # unreachable
-    y: int = 'y'
-
-[case testPyprojectAlwaysFalseTrailingComma]
-# cmd: mypy .
-[file pyproject.toml]
-\[tool.mypy]
-always_false = """
-  FLAG_A,
-  FLAG_B,
-"""
-[file a.py]
-FLAG_A = True
-FLAG_B = True
-if FLAG_A:  # unreachable
-    x: int = 'x'
-if FLAG_B:  # unreachable
-    y: int = 'y'
-
-[case testPyprojectEnableErrorCodeTrailingComma]
-# cmd: mypy .
-[file pyproject.toml]
-\[tool.mypy]
-enable_error_code = """
-  redundant-expr,
-  ignore-without-code,
-"""
-[file a.py]
-1 + 'a'  # type: ignore  # E: "type: ignore" comment without error code (consider "type: ignore[operator]" instead)
-
-[case testPyprojectDisableErrorCodeTrailingComma]
-# cmd: mypy .
-[file pyproject.toml]
-\[tool.mypy]
-disable_error_code = """
-  operator,
-  import,
-"""
-[file a.py]
-1 + 'a'
 
 [case testPyprojectModulesTrailingComma]
 # cmd: mypy
 [file pyproject.toml]
 \[tool.mypy]
+# We combine multiple tests in a single one here, because these tests are slow.
 modules = """
   a,
   b,
 """
+disable_error_code = """
+  operator,
+  import,
+"""
+enable_error_code = """
+  redundant-expr,
+  ignore-without-code,
+"""
 [file a.py]
 x: str = 'x'  # ok
+
+# --enable-error-code
+a: int = 'a'  # type: ignore
+
+# --disable-error-code
+'a' + 1
 [file b.py]
-y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+y: int = 'y'
 [file c.py]
 # This should not trigger any errors, because it is not included:
 z: int = 'z'
 [out]
+b.py:1: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+a.py:4: error: "type: ignore" comment without error code (consider "type: ignore[assignment]" instead)
 
 [case testPyprojectPackagesTrailingComma]
 # cmd: mypy

--- a/test-data/unit/cmdline.pyproject.test
+++ b/test-data/unit/cmdline.pyproject.test
@@ -151,17 +151,6 @@ y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", 
 z: int = 'z'
 [out]
 
-[case testPyprojectPluginsTrailingComma-posix]
-# cmd: mypy .
-[file pyproject.toml]
-# This test fails on windows for some reason, skipping it there.
-\[tool.mypy]
-plugins = """
-  <ROOT>/test-data/unit/plugins/function_sig_hook.py,
-  <ROOT>/test-data/unit/plugins/method_in_decorator.py,
-"""
-[out]
-
 [case testPyprojectAlwaysTrueTrailingComma]
 # cmd: mypy .
 [file pyproject.toml]

--- a/test-data/unit/cmdline.pyproject.test
+++ b/test-data/unit/cmdline.pyproject.test
@@ -133,3 +133,118 @@ Neither is this!
 description = "Factory ⸻ A code generator 🏭"
 \[tool.mypy]
 [file x.py]
+
+[case testPyprojectFilesTrailingComma]
+# cmd: mypy
+[file pyproject.toml]
+\[tool.mypy]
+files = """
+  a.py,
+  b.py,
+"""
+[file a.py]
+x: str = 'x'  # ok
+[file b.py]
+y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[file c.py]
+# This should not trigger any errors, because it is not included:
+z: int = 'z'
+[out]
+
+[case testPyprojectPluginsTrailingComma]
+# cmd: mypy .
+[file pyproject.toml]
+\[tool.mypy]
+plugins = """
+  <ROOT>/test-data/unit/plugins/function_sig_hook.py,
+  <ROOT>/test-data/unit/plugins/method_in_decorator.py,
+"""
+[out]
+
+[case testPyprojectAlwaysTrueTrailingComma]
+# cmd: mypy .
+[file pyproject.toml]
+\[tool.mypy]
+always_true = """
+  FLAG_A,
+  FLAG_B,
+"""
+[file a.py]
+FLAG_A = False
+FLAG_B = False
+if not FLAG_A:  # unreachable
+    x: int = 'x'
+if not FLAG_B:  # unreachable
+    y: int = 'y'
+
+[case testPyprojectAlwaysFalseTrailingComma]
+# cmd: mypy .
+[file pyproject.toml]
+\[tool.mypy]
+always_false = """
+  FLAG_A,
+  FLAG_B,
+"""
+[file a.py]
+FLAG_A = True
+FLAG_B = True
+if FLAG_A:  # unreachable
+    x: int = 'x'
+if FLAG_B:  # unreachable
+    y: int = 'y'
+
+[case testPyprojectEnableErrorCodeTrailingComma]
+# cmd: mypy .
+[file pyproject.toml]
+\[tool.mypy]
+enable_error_code = """
+  redundant-expr,
+  ignore-without-code,
+"""
+[file a.py]
+1 + 'a'  # type: ignore  # E: "type: ignore" comment without error code (consider "type: ignore[operator]" instead)
+
+[case testPyprojectDisableErrorCodeTrailingComma]
+# cmd: mypy .
+[file pyproject.toml]
+\[tool.mypy]
+disable_error_code = """
+  operator,
+  import,
+"""
+[file a.py]
+1 + 'a'
+
+[case testPyprojectModulesTrailingComma]
+# cmd: mypy
+[file pyproject.toml]
+\[tool.mypy]
+modules = """
+  a,
+  b,
+"""
+[file a.py]
+x: str = 'x'  # ok
+[file b.py]
+y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[file c.py]
+# This should not trigger any errors, because it is not included:
+z: int = 'z'
+[out]
+
+[case testPyprojectPackagesTrailingComma]
+# cmd: mypy
+[file pyproject.toml]
+\[tool.mypy]
+packages = """
+  a,
+  b,
+"""
+[file a/__init__.py]
+x: str = 'x'  # ok
+[file b/__init__.py]
+y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[file c/__init__.py]
+# This should not trigger any errors, because it is not included:
+z: int = 'z'
+[out]

--- a/test-data/unit/cmdline.pyproject.test
+++ b/test-data/unit/cmdline.pyproject.test
@@ -151,7 +151,8 @@ y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", 
 z: int = 'z'
 [out]
 
-[case testPyprojectPluginsTrailingComma]
+# Fails on windows for some reason
+[case testPyprojectPluginsTrailingComma-posix]
 # cmd: mypy .
 [file pyproject.toml]
 \[tool.mypy]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1342,6 +1342,38 @@ always_true =
   MY_VAR,
 [out]
 
+[case testCmdlineCfgModulesTrailingComma]
+# cmd: mypy
+[file mypy.ini]
+\[mypy]
+modules =
+  a,
+  b,
+[file a.py]
+x: str = 'x'  # ok
+[file b.py]
+y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[file c.py]
+# This should not trigger any errors, because it is not included:
+z: int = 'z'
+[out]
+
+[case testCmdlineCfgPackagesTrailingComma]
+# cmd: mypy
+[file mypy.ini]
+\[mypy]
+packages =
+  a,
+  b,
+[file a/__init__.py]
+x: str = 'x'  # ok
+[file b/__init__.py]
+y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+[file c/__init__.py]
+# This should not trigger any errors, because it is not included:
+z: int = 'z'
+[out]
+
 [case testTypeVarTupleUnpackEnabled]
 # cmd: mypy --enable-incomplete-feature=TypeVarTuple --enable-incomplete-feature=Unpack a.py
 [file a.py]


### PR DESCRIPTION
Refs https://github.com/python/mypy/pull/18621
Closes https://github.com/python/mypy/issues/18623

With a lot more tests.