### PR TITLE
Report that `NamedTuple` and `dataclass` are incompatile instead of crashing.

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -966,7 +966,7 @@ def dataclass_tag_callback(ctx: ClassDefContext) -> None:
 def dataclass_class_maker_callback(ctx: ClassDefContext) -> bool:
     """Hooks into the class typechecking process to add support for dataclasses."""
     if any(i.is_named_tuple for i in ctx.cls.info.mro):
-        ctx.api.fail("A NamedTuple cannot be a dataclass.", ctx=ctx.cls.info)
+        ctx.api.fail("A NamedTuple cannot be a dataclass", ctx=ctx.cls.info)
         return True
     transformer = DataclassTransformer(
         ctx.cls, ctx.reason, _get_transform_spec(ctx.reason), ctx.api

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -965,6 +965,9 @@ def dataclass_tag_callback(ctx: ClassDefContext) -> None:
 
 def dataclass_class_maker_callback(ctx: ClassDefContext) -> bool:
     """Hooks into the class typechecking process to add support for dataclasses."""
+    if any(i.is_named_tuple for i in ctx.cls.info.mro):
+        ctx.api.fail(f"A NamedTuple cannot be a dataclass.", ctx=ctx.cls.info)
+        return True
     transformer = DataclassTransformer(
         ctx.cls, ctx.reason, _get_transform_spec(ctx.reason), ctx.api
     )

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -966,7 +966,7 @@ def dataclass_tag_callback(ctx: ClassDefContext) -> None:
 def dataclass_class_maker_callback(ctx: ClassDefContext) -> bool:
     """Hooks into the class typechecking process to add support for dataclasses."""
     if any(i.is_named_tuple for i in ctx.cls.info.mro):
-        ctx.api.fail(f"A NamedTuple cannot be a dataclass.", ctx=ctx.cls.info)
+        ctx.api.fail("A NamedTuple cannot be a dataclass.", ctx=ctx.cls.info)
         return True
     transformer = DataclassTransformer(
         ctx.cls, ctx.reason, _get_transform_spec(ctx.reason), ctx.api

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2589,7 +2589,7 @@ class A(NamedTuple):  # E: A NamedTuple cannot be a dataclass
 class B1(NamedTuple):
     i: int
 @dataclass
-class B2(B1):  # E: A NamedTuple cannot be a dataclass.
+class B2(B1):  # E: A NamedTuple cannot be a dataclass
     pass
 
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2583,7 +2583,7 @@ from dataclasses import dataclass
 from typing import NamedTuple
 
 @dataclass
-class A(NamedTuple):  # E: A NamedTuple cannot be a dataclass.
+class A(NamedTuple):  # E: A NamedTuple cannot be a dataclass
     i: int
 
 class B1(NamedTuple):

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2576,3 +2576,20 @@ reveal_type(m.b)  # N: Revealed type is "builtins.int"
 m.a = 1  # E: Cannot assign to final attribute "a"
 m.b = 2  # E: Cannot assign to final attribute "b"
 [builtins fixtures/tuple.pyi]
+
+[case testNoCrashForDataclassNamedTupleCombination]
+# flags: --python-version 3.13
+from dataclasses import dataclass
+from typing import NamedTuple
+
+@dataclass
+class A(NamedTuple):  # E: A NamedTuple cannot be a dataclass.
+    i: int
+
+class B1(NamedTuple):
+    i: int
+@dataclass
+class B2(B1):  # E: A NamedTuple cannot be a dataclass.
+    pass
+
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #18527

The fix is pretty simple.  I could not find a situation where combining `NamedTuple` and `dataclass` makes sense, so emitting an error and just not applying the dataclass transformations seems sensible.
