### PR TITLE
Update Literal imports in tests

### DIFF
--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -612,8 +612,8 @@ for a in sorted(s):
 9     8   72
 
 [case testDummyTypes]
-from typing import Tuple, List, Dict, NamedTuple
-from typing_extensions import Literal, TypedDict, NewType
+from typing import Tuple, List, Dict, Literal, NamedTuple
+from typing_extensions import TypedDict, NewType
 
 class A:
     pass

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -406,8 +406,8 @@ class B(Enum):
     b = 10
 
 [file b.py]
-from typing import List, Optional, Union, Sequence, NamedTuple, Tuple, Type
-from typing_extensions import Literal, Final, TypedDict
+from typing import List, Literal, Optional, Union, Sequence, NamedTuple, Tuple, Type
+from typing_extensions import Final, TypedDict
 from enum import Enum
 import a
 class A: pass

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -18,7 +18,7 @@ if int():
 
 [case testEnumCreatedFromStringLiteral]
 from enum import Enum
-from typing_extensions import Literal
+from typing import Literal
 
 x: Literal['ANT BEE CAT DOG'] = 'ANT BEE CAT DOG'
 Animal = Enum('Animal', x)
@@ -181,7 +181,7 @@ def infer_truth(truth: Truth) -> None:
 [case testEnumTruthyness]
 # mypy: warn-unreachable
 import enum
-from typing_extensions import Literal
+from typing import Literal
 
 class E(enum.Enum):
     zero = 0
@@ -213,7 +213,7 @@ def main(zero: Literal[E.zero], one: Literal[E.one]) -> None:
 [case testEnumTruthynessCustomDunderBool]
 # mypy: warn-unreachable
 import enum
-from typing_extensions import Literal
+from typing import Literal
 
 class E(enum.Enum):
     zero = 0
@@ -247,7 +247,7 @@ def main(zero: Literal[E.zero], one: Literal[E.one]) -> None:
 [case testEnumTruthynessStrEnum]
 # mypy: warn-unreachable
 import enum
-from typing_extensions import Literal
+from typing import Literal
 
 class E(enum.StrEnum):
     empty = ""
@@ -726,7 +726,7 @@ reveal_type(Test.a)  # N: Revealed type is "Literal[__main__.Test.a]?"
 
 [case testEnumAttributeAccessMatrix]
 from enum import Enum, IntEnum, IntFlag, Flag, EnumMeta, auto
-from typing_extensions import Literal
+from typing import Literal
 
 def is_x(val: Literal['x']) -> None: pass
 
@@ -872,7 +872,7 @@ main:2: note: Revealed type is "Literal['foo']?"
 
 [case testEnumReachabilityChecksBasic]
 from enum import Enum
-from typing_extensions import Literal
+from typing import Literal
 
 class Foo(Enum):
     A = 1
@@ -924,7 +924,7 @@ reveal_type(y) # N: Revealed type is "__main__.Foo"
 
 [case testEnumReachabilityChecksWithOrdering]
 from enum import Enum
-from typing_extensions import Literal
+from typing import Literal
 
 class Foo(Enum):
     _order_ = "A B"
@@ -975,7 +975,8 @@ else:
 
 [case testEnumReachabilityChecksIndirect]
 from enum import Enum
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 
 class Foo(Enum):
     A = 1
@@ -1040,7 +1041,7 @@ else:
 
 [case testEnumReachabilityNoNarrowingForUnionMessiness]
 from enum import Enum
-from typing_extensions import Literal
+from typing import Literal
 
 class Foo(Enum):
     A = 1
@@ -1096,8 +1097,7 @@ reveal_type(x) # N: Revealed type is "Union[__main__.Foo, None]"
 
 [case testEnumReachabilityWithMultipleEnums]
 from enum import Enum
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 class Foo(Enum):
     A = 1
@@ -1331,7 +1331,8 @@ reveal_type(x)      # N: Revealed type is "__main__.Foo"
 [case testEnumReachabilityWithChainingDirectConflict]
 # flags: --warn-unreachable
 from enum import Enum
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 
 class Foo(Enum):
     A = 1
@@ -1366,7 +1367,8 @@ reveal_type(x)      # N: Revealed type is "__main__.Foo"
 [case testEnumReachabilityWithChainingBigDisjoints]
 # flags: --warn-unreachable
 from enum import Enum
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 
 class Foo(Enum):
     A = 1
@@ -1488,8 +1490,7 @@ reveal_type(a._value_)  # N: Revealed type is "Any"
 # as the full type, regardless of the amount of elements
 # the enum contains.
 from enum import Enum
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 class Foo(Enum):
     A = 1
@@ -1507,7 +1508,7 @@ def f(x: Foo):
 
 [case testEnumTypeCompatibleWithLiteralUnion]
 from enum import Enum
-from typing_extensions import Literal
+from typing import Literal
 
 class E(Enum):
     A = 1

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -985,8 +985,7 @@ main:4: error: "A" not callable
 -- assert_type()
 
 [case testAssertType]
-from typing import assert_type, Any
-from typing_extensions import Literal
+from typing import assert_type, Any, Literal
 a: int = 1
 returned = assert_type(a, int)
 reveal_type(returned)  # N: Revealed type is "builtins.int"
@@ -998,8 +997,7 @@ assert_type(42, int)  # E: Expression is of type "Literal[42]", not "int"
 [builtins fixtures/tuple.pyi]
 
 [case testAssertTypeGeneric]
-from typing import assert_type, TypeVar, Generic
-from typing_extensions import Literal
+from typing import assert_type, Literal, TypeVar, Generic
 T = TypeVar("T")
 def f(x: T) -> T: return x
 assert_type(f(1), int)
@@ -2283,7 +2281,8 @@ def f(x: T) -> T:
 
 [case testStrictEqualityWithALiteral]
 # flags: --strict-equality
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 
 def returns_a_or_b() -> Literal['a', 'b']:
     ...

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1187,7 +1187,8 @@ class Child(Parent):
     def __bar(self) -> None: ...
 
 [case testFinalWithoutBool]
-from typing_extensions import final, Literal
+from typing import Literal
+from typing_extensions import final
 
 class A:
     pass
@@ -1207,7 +1208,8 @@ reveal_type(C() and 42)  # N: Revealed type is "Literal[42]?"
 [builtins fixtures/bool.pyi]
 
 [case testFinalWithoutBoolButWithLen]
-from typing_extensions import final, Literal
+from typing import Literal
+from typing_extensions import final
 
 # Per Python data model, __len__ is called if __bool__ does not exist.
 # In a @final class, __bool__ would not exist.

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5080,10 +5080,10 @@ plugins=<ROOT>/test-data/unit/plugins/config_data.py
 import mod
 reveal_type(mod.a)
 [file mod.py]
-from typing_extensions import Literal
+from typing import Literal
 a = 1
 [file mod.py.2]
-from typing_extensions import Literal
+from typing import Literal
 a: Literal[2] = 2
 [builtins fixtures/tuple.pyi]
 [out]

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -2378,7 +2378,7 @@ if isinstance(y, B):
 # flags: --warn-unreachable
 
 from abc import abstractmethod
-from typing_extensions import Literal
+from typing import Literal
 
 class A0:
     def f(self) -> Literal[0]:

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -4,7 +4,7 @@
 --
 
 [case testLiteralInvalidString]
-from typing_extensions import Literal
+from typing import Literal
 def f1(x: 'A[') -> None: pass  # E: Invalid type comment or annotation
 def g1(x: Literal['A[']) -> None: pass
 reveal_type(f1)  # N: Revealed type is "def (x: Any)"
@@ -22,13 +22,13 @@ reveal_type(i2)  # N: Revealed type is "def (x: Literal['A|B'])"
 [out]
 
 [case testLiteralInvalidTypeComment]
-from typing_extensions import Literal
+from typing import Literal
 def f(x):  # E: Syntax error in type comment "(A[) -> None"
     # type: (A[) -> None
     pass
 
 [case testLiteralInvalidTypeComment2]
-from typing_extensions import Literal
+from typing import Literal
 def f(x):  # E: Invalid type comment or annotation
     # type: ("A[") -> None
     pass
@@ -53,8 +53,7 @@ y = 43
 [typing fixtures/typing-medium.pyi]
 
 [case testLiteralInsideOtherTypes]
-from typing import Tuple
-from typing_extensions import Literal
+from typing import Literal, Tuple
 
 x: Tuple[1]                         # E: Invalid type: try using Literal[1] instead?
 def foo(x: Tuple[1]) -> None: ...   # E: Invalid type: try using Literal[1] instead?
@@ -68,8 +67,7 @@ reveal_type(bar)                    # N: Revealed type is "def (x: Tuple[Literal
 [out]
 
 [case testLiteralInsideOtherTypesTypeCommentsPython3]
-from typing import Tuple, Optional
-from typing_extensions import Literal
+from typing import Literal, Tuple, Optional
 
 x = None  # type: Optional[Tuple[1]]  # E: Invalid type: try using Literal[1] instead?
 def foo(x):                           # E: Invalid type: try using Literal[1] instead?
@@ -90,7 +88,7 @@ reveal_type(bar)                    # N: Revealed type is "def (x: Tuple[Literal
 from wrapper import *
 
 [file wrapper.pyi]
-from typing_extensions import Literal
+from typing import Literal
 
 alias_1 = Literal['a+b']
 alias_2 = Literal['1+2']
@@ -153,7 +151,7 @@ reveal_type(expr_com_6)  # N: Revealed type is "Literal['"foo"']"
 [out]
 
 [case testLiteralMixingUnicodeAndBytesPython3]
-from typing_extensions import Literal
+from typing import Literal
 
 a_ann: Literal[u"foo"]
 b_ann: Literal["foo"]
@@ -217,8 +215,7 @@ accepts_bytes(c_alias)
 [out]
 
 [case testLiteralMixingUnicodeAndBytesPython3ForwardStrings]
-from typing import TypeVar, Generic
-from typing_extensions import Literal
+from typing import Literal, TypeVar, Generic
 
 a_unicode_wrapper: u"Literal[u'foo']"
 b_unicode_wrapper: u"Literal['foo']"
@@ -282,8 +279,7 @@ reveal_type(c_bytes_wrapper_alias)    # N: Revealed type is "__main__.Wrap[Liter
 [out]
 
 [case testLiteralUnicodeWeirdCharacters-skip_path_normalization]
-from typing import Any
-from typing_extensions import Literal
+from typing import Any, Literal
 
 a1: Literal["\x00\xAC\x62 \u2227 \u03bb(p)"]
 b1: Literal["\x00¬b ∧ λ(p)"]
@@ -340,7 +336,7 @@ a1 = c3  # E: Incompatible types in assignment (expression has type "Literal['¬
 [out]
 
 [case testLiteralRenamingImportWorks]
-from typing_extensions import Literal as Foo
+from typing import Literal as Foo
 
 x: Foo[3]
 reveal_type(x)   # N: Revealed type is "Literal[3]"
@@ -360,13 +356,13 @@ reveal_type(x)  # N: Revealed type is "Literal[3]"
 reveal_type(y)  # N: Revealed type is "Literal[4]"
 
 [file other_module.py]
-from typing_extensions import Literal as Foo
+from typing import Literal as Foo
 Bar = Foo[4]
 [builtins fixtures/tuple.pyi]
 [out]
 
 [case testLiteralRenamingImportNameConfusion]
-from typing_extensions import Literal as Foo
+from typing import Literal as Foo
 
 x: Foo["Foo"]
 reveal_type(x)  # N: Revealed type is "Literal['Foo']"
@@ -396,7 +392,7 @@ indirect = f()
 --
 
 [case testLiteralBasicIntUsage]
-from typing_extensions import Literal
+from typing import Literal
 
 a1: Literal[4]
 b1: Literal[0x2a]
@@ -435,7 +431,7 @@ reveal_type(f4)  # N: Revealed type is "def (x: Literal[8]) -> Literal[8]"
 [out]
 
 [case testLiteralBasicBoolUsage]
-from typing_extensions import Literal
+from typing import Literal
 
 a1: Literal[True]
 b1: Literal[False]
@@ -460,7 +456,7 @@ reveal_type(f2)  # N: Revealed type is "def (x: Literal[False]) -> Literal[False
 [out]
 
 [case testLiteralBasicStrUsage]
-from typing_extensions import Literal
+from typing import Literal
 
 a: Literal[""]
 b: Literal["  foo bar  "]
@@ -489,7 +485,7 @@ reveal_type(f5)  # N: Revealed type is "def (x: Literal['foo']) -> Literal['foo'
 [out]
 
 [case testLiteralBasicStrUsageSlashes-skip_path_normalization]
-from typing_extensions import Literal
+from typing import Literal
 
 a: Literal[r"foo\nbar"]
 b: Literal["foo\nbar"]
@@ -503,7 +499,7 @@ main:7: note: Revealed type is "Literal['foo\nbar']"
 
 [case testLiteralBasicNoneUsage]
 # Note: Literal[None] and None are equivalent
-from typing_extensions import Literal
+from typing import Literal
 a: Literal[None]
 reveal_type(a)   # N: Revealed type is "None"
 
@@ -518,7 +514,7 @@ reveal_type(f3)  # N: Revealed type is "def (x: None)"
 [out]
 
 [case testLiteralCallingUnionFunction]
-from typing_extensions import Literal
+from typing import Literal
 
 def func(x: Literal['foo', 'bar', '  foo  ']) -> None: ...
 
@@ -544,8 +540,7 @@ func(f)  # E: Argument 1 to "func" has incompatible type "Literal['foo', 'bar', 
 [out]
 
 [case testLiteralDisallowAny]
-from typing import Any
-from typing_extensions import Literal
+from typing import Any, Literal
 from missing_module import BadAlias     # E: Cannot find implementation or library stub for module named "missing_module" \
                                         # N: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 
@@ -558,7 +553,7 @@ reveal_type(b)                          # N: Revealed type is "Any"
 [out]
 
 [case testLiteralDisallowActualTypes]
-from typing_extensions import Literal
+from typing import Literal
 
 a: Literal[int]     # E: Parameter 1 of Literal[...] is invalid
 b: Literal[float]   # E: Parameter 1 of Literal[...] is invalid
@@ -574,7 +569,7 @@ reveal_type(d)      # N: Revealed type is "Any"
 
 [case testLiteralDisallowFloatsAndComplex]
 
-from typing_extensions import Literal
+from typing import Literal
 a1: Literal[3.14]    # E: Parameter 1 of Literal[...] cannot be of type "float"
 b1: 3.14             # E: Invalid type: float literals cannot be used as a type
 c1: Literal[3j]      # E: Parameter 1 of Literal[...] cannot be of type "complex"
@@ -597,7 +592,7 @@ d2: d2t              # E: Variable "__main__.d2t" is not valid as a type \
 [out]
 
 [case testLiteralDisallowComplexExpressions]
-from typing_extensions import Literal
+from typing import Literal
 def dummy() -> int: return 3
 a: Literal[3 + 4]               # E: Invalid type: Literal[...] cannot contain arbitrary expressions
 b: Literal["  foo  ".trim()]    # E: Invalid type: Literal[...] cannot contain arbitrary expressions
@@ -607,7 +602,7 @@ e: Literal[dummy()]             # E: Invalid type: Literal[...] cannot contain a
 [out]
 
 [case testLiteralDisallowCollections]
-from typing_extensions import Literal
+from typing import Literal
 a: Literal[{"a": 1, "b": 2}]    # E: Parameter 1 of Literal[...] is invalid
 b: Literal[{1, 2, 3}]           # E: Invalid type: Literal[...] cannot contain arbitrary expressions
 c: {"a": 1, "b": 2}             # E: Inline TypedDict is experimental, must be enabled with --enable-incomplete-feature=InlineTypedDict \
@@ -618,7 +613,7 @@ d: {1, 2, 3}                    # E: Invalid type comment or annotation
 [typing fixtures/typing-full.pyi]
 
 [case testLiteralDisallowCollections2]
-from typing_extensions import Literal
+from typing import Literal
 a: (1, 2, 3)                    # E: Syntax error in type annotation \
                                 # N: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
 b: Literal[[1, 2, 3]]           # E: Parameter 1 of Literal[...] is invalid
@@ -626,7 +621,7 @@ c: [1, 2, 3]                    # E: Bracketed expression "[...]" is not valid a
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralDisallowCollectionsTypeAlias]
-from typing_extensions import Literal
+from typing import Literal
 at = Literal[{"a": 1, "b": 2}]  # E: Parameter 1 of Literal[...] is invalid
 bt = {"a": 1, "b": 2}
 a: at
@@ -637,7 +632,7 @@ b: bt                           # E: Variable "__main__.bt" is not valid as a ty
 [typing fixtures/typing-typeddict.pyi]
 
 [case testLiteralDisallowCollectionsTypeAlias2]
-from typing_extensions import Literal
+from typing import Literal
 at = Literal[{1, 2, 3}]         # E: Invalid type alias: expression is not a valid type
 bt = {1, 2, 3}
 a: at                           # E: Variable "__main__.at" is not valid as a type \
@@ -645,11 +640,11 @@ a: at                           # E: Variable "__main__.at" is not valid as a ty
 b: bt                           # E: Variable "__main__.bt" is not valid as a type \
                                 # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
 [builtins fixtures/set.pyi]
+[typing fixtures/typing-full.pyi]
 [out]
 
 [case testLiteralDisallowTypeVar]
-from typing import TypeVar, Tuple
-from typing_extensions import Literal
+from typing import Literal, TypeVar, Tuple
 
 T = TypeVar('T')
 
@@ -666,7 +661,7 @@ def foo(b: Literal[T]) -> Tuple[T]: pass   # E: Parameter 1 of Literal[...] is i
 --
 
 [case testLiteralMultipleValues]
-from typing_extensions import Literal
+from typing import Literal
 a: Literal[1, 2, 3]
 b: Literal["a", "b", "c"]
 c: Literal[1, "b", True, None]
@@ -684,7 +679,7 @@ reveal_type(e)   # N: Revealed type is "Union[None, None, None]"
 [out]
 
 [case testLiteralMultipleValuesExplicitTuple]
-from typing_extensions import Literal
+from typing import Literal
 # Unfortunately, it seems like typed_ast is unable to distinguish this from
 # Literal[1, 2, 3]. So we treat the two as being equivalent for now.
 a: Literal[1, 2, 3]
@@ -696,7 +691,7 @@ reveal_type(b)  # N: Revealed type is "Union[Literal[1], Literal[2], Literal[3]]
 
 [case testLiteralNestedUsage]
 
-from typing_extensions import Literal
+from typing import Literal
 a: Literal[Literal[3], 4, Literal["foo"]]
 reveal_type(a)  # N: Revealed type is "Union[Literal[3], Literal[4], Literal['foo']]"
 
@@ -716,7 +711,7 @@ reveal_type(combined)  # N: Revealed type is "Union[Literal['r'], Literal['w'], 
 [out]
 
 [case testLiteralBiasTowardsAssumingForwardReference]
-from typing_extensions import Literal
+from typing import Literal
 
 a: "Foo"
 reveal_type(a)      # N: Revealed type is "__main__.Foo"
@@ -734,7 +729,7 @@ class Foo: pass
 [out]
 
 [case testLiteralBiasTowardsAssumingForwardReferenceForTypeAliases]
-from typing_extensions import Literal
+from typing import Literal
 
 a: "Foo"
 reveal_type(a)      # N: Revealed type is "Literal[5]"
@@ -756,7 +751,7 @@ Foo = Literal[5]
 [out]
 
 [case testLiteralBiasTowardsAssumingForwardReferencesForTypeComments]
-from typing_extensions import Literal
+from typing import Literal
 
 a: Foo
 reveal_type(a)      # N: Revealed type is "__main__.Foo"
@@ -779,7 +774,7 @@ class Foo: pass
 --
 
 [case testLiteralCallingFunction]
-from typing_extensions import Literal
+from typing import Literal
 def foo(x: Literal[3]) -> None: pass
 
 a: Literal[1]
@@ -793,7 +788,7 @@ foo(c)  # E: Argument 1 to "foo" has incompatible type "int"; expected "Literal[
 [out]
 
 [case testLiteralCallingFunctionWithUnionLiteral]
-from typing_extensions import Literal
+from typing import Literal
 def foo(x: Literal[1, 2, 3]) -> None: pass
 
 a: Literal[1]
@@ -809,7 +804,7 @@ foo(d)  # E: Argument 1 to "foo" has incompatible type "int"; expected "Literal[
 [out]
 
 [case testLiteralCallingFunctionWithStandardBase]
-from typing_extensions import Literal
+from typing import Literal
 def foo(x: int) -> None: pass
 
 a: Literal[1]
@@ -823,8 +818,7 @@ foo(c)  # E: Argument 1 to "foo" has incompatible type "Literal[4, 'foo']"; expe
 [out]
 
 [case testLiteralCheckSubtypingStrictOptional]
-from typing import Any, NoReturn
-from typing_extensions import Literal
+from typing import Any, Literal, NoReturn
 
 lit: Literal[1]
 def f_lit(x: Literal[1]) -> None: pass
@@ -848,8 +842,7 @@ f_lit(c) # E: Argument 1 to "f_lit" has incompatible type "None"; expected "Lite
 
 [case testLiteralCheckSubtypingNoStrictOptional]
 # flags: --no-strict-optional
-from typing import Any, NoReturn
-from typing_extensions import Literal
+from typing import Any, Literal, NoReturn
 
 lit: Literal[1]
 def f_lit(x: Literal[1]) -> None: pass
@@ -872,8 +865,7 @@ f_lit(c)
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralCallingOverloadedFunction]
-from typing import overload, Generic, TypeVar, Any
-from typing_extensions import Literal
+from typing import overload, Generic, Literal, TypeVar, Any
 
 T = TypeVar('T')
 class IOLike(Generic[T]): pass
@@ -905,8 +897,7 @@ foo(d)
 [out]
 
 [case testLiteralVariance]
-from typing import Generic, TypeVar
-from typing_extensions import Literal
+from typing import Generic, Literal, TypeVar
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
@@ -937,8 +928,7 @@ c2 = c3
 [out]
 
 [case testLiteralInListAndSequence]
-from typing import List, Sequence
-from typing_extensions import Literal
+from typing import List, Literal, Sequence
 
 def foo(x: List[Literal[1, 2]]) -> None: pass
 def bar(x: Sequence[Literal[1, 2]]) -> None: pass
@@ -956,7 +946,7 @@ bar(b)  # E: Argument 1 to "bar" has incompatible type "List[Literal[1, 2, 3]]";
 [out]
 
 [case testLiteralRenamingDoesNotChangeTypeChecking]
-from typing_extensions import Literal as Foo
+from typing import Literal as Foo
 from other_module import Bar1, Bar2, c
 
 def func(x: Foo[15]) -> None: pass
@@ -968,7 +958,7 @@ func(b)  # E: Argument 1 to "func" has incompatible type "Literal[14]"; expected
 func(c)
 
 [file other_module.py]
-from typing_extensions import Literal
+from typing import Literal
 
 Bar1 = Literal[15]
 Bar2 = Literal[14]
@@ -982,7 +972,7 @@ c: Literal[15]
 --
 
 [case testLiteralInferredInAssignment]
-from typing_extensions import Literal
+from typing import Literal
 
 int1: Literal[1] = 1
 int2 = 1
@@ -1016,7 +1006,7 @@ reveal_type(none3)  # N: Revealed type is "None"
 [out]
 
 [case testLiteralInferredOnlyForActualLiterals]
-from typing_extensions import Literal
+from typing import Literal
 
 w: Literal[1]
 x: Literal["foo"]
@@ -1057,7 +1047,7 @@ combined = h
 [out]
 
 [case testLiteralInferredTypeMustMatchExpected]
-from typing_extensions import Literal
+from typing import Literal
 
 a: Literal[1] = 2           # E: Incompatible types in assignment (expression has type "Literal[2]", variable has type "Literal[1]")
 b: Literal["foo"] = "bar"   # E: Incompatible types in assignment (expression has type "Literal['bar']", variable has type "Literal['foo']")
@@ -1071,7 +1061,7 @@ f: Literal[True, 4] = False         # E: Incompatible types in assignment (expre
 [out]
 
 [case testLiteralInferredInCall]
-from typing_extensions import Literal
+from typing import Literal
 
 def f_int_lit(x: Literal[1]) -> None: pass
 def f_int(x: int) -> None: pass
@@ -1117,7 +1107,7 @@ f_none_lit(n1)
 [out]
 
 [case testLiteralInferredInReturnContext]
-from typing_extensions import Literal
+from typing import Literal
 
 def f1() -> int:
     return 1
@@ -1138,8 +1128,7 @@ def f5(x: Literal[2]) -> Literal[1]:
 [out]
 
 [case testLiteralInferredInListContext]
-from typing import List
-from typing_extensions import Literal
+from typing import List, Literal
 
 a: List[Literal[1]] = [1, 1, 1]
 b = [1, 1, 1]
@@ -1183,8 +1172,7 @@ bad: List[Literal[1, 2]] = [1, 2, 3]  # E: List item 2 has incompatible type "Li
 [case testLiteralInferredInTupleContext]
 # Note: most of the 'are we handling context correctly' tests should have been
 # handled up above, so we keep things comparatively simple for tuples and dicts.
-from typing import Tuple
-from typing_extensions import Literal
+from typing import Literal, Tuple
 
 a: Tuple[Literal[1], Literal[2]] = (1, 2)
 b: Tuple[int, Literal[1, 2], Literal[3], Tuple[Literal["foo"]]] = (1, 2, 3, ("foo",))
@@ -1197,8 +1185,7 @@ reveal_type(d)  # N: Revealed type is "Tuple[builtins.int, builtins.int]"
 [out]
 
 [case testLiteralInferredInDictContext]
-from typing import Dict
-from typing_extensions import Literal
+from typing import Dict, Literal
 
 a = {"x": 1, "y": 2}
 b: Dict[str, Literal[1, 2]] = {"x": 1, "y": 2}
@@ -1210,8 +1197,7 @@ reveal_type(a)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]
 [out]
 
 [case testLiteralInferredInOverloadContextBasic]
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 
 @overload
 def func(x: Literal[1]) -> str: ...
@@ -1239,8 +1225,7 @@ reveal_type(func(c))  # N: Revealed type is "builtins.object"
 [out]
 
 [case testLiteralOverloadProhibitUnsafeOverlaps]
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 
 @overload
 def func1(x: Literal[1]) -> str: ...  # E: Overloaded function signatures 1 and 2 overlap with incompatible return types
@@ -1264,8 +1249,7 @@ def func3(x): pass
 [out]
 
 [case testLiteralInferredInOverloadContextUnionMath]
-from typing import overload, Union
-from typing_extensions import Literal
+from typing import overload, Literal, Union
 
 class A: pass
 class B: pass
@@ -1310,8 +1294,7 @@ reveal_type(func(f))  # E: No overload variant of "func" matches argument type "
 
 [case testLiteralInferredInOverloadContextUnionMathOverloadingReturnsBestType]
 # This test is a transliteration of check-overloading::testUnionMathOverloadingReturnsBestType
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 
 @overload
 def f(x: Literal[1, 2]) -> int: ...
@@ -1333,8 +1316,7 @@ reveal_type(f(z))  # N: Revealed type is "builtins.int" \
 [out]
 
 [case testLiteralInferredInOverloadContextWithTypevars]
-from typing import TypeVar, overload, Union
-from typing_extensions import Literal
+from typing import Literal, TypeVar, overload, Union
 
 T = TypeVar('T')
 
@@ -1385,8 +1367,7 @@ reveal_type(f4(b))      # N: Revealed type is "builtins.str"
 
 [case testLiteralInferredInOverloadContextUnionMathTrickyOverload]
 # This test is a transliteration of check-overloading::testUnionMathTrickyOverload1
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 
 @overload
 def f(x: Literal['a'], y: Literal['a']) -> int: ...
@@ -1408,7 +1389,7 @@ f(x, y)  # E: Argument 1 to "f" has incompatible type "Literal['a', 'b']"; expec
 ---
 
 [case testLiteralFallbackOperatorsWorkCorrectly]
-from typing_extensions import Literal
+from typing import Literal
 
 a: Literal[3]
 b: int
@@ -1440,7 +1421,7 @@ reveal_type(b)          # N: Revealed type is "builtins.int"
 [builtins fixtures/primitives.pyi]
 
 [case testLiteralFallbackInheritedMethodsWorkCorrectly]
-from typing_extensions import Literal
+from typing import Literal
 a: Literal['foo']
 b: str
 
@@ -1452,7 +1433,7 @@ reveal_type(a.strip())          # N: Revealed type is "builtins.str"
 [out]
 
 [case testLiteralFallbackMethodsDoNotCoerceToLiteral]
-from typing_extensions import Literal
+from typing import Literal
 
 a: Literal[3]
 b: int
@@ -1500,10 +1481,9 @@ issubclass(int, indirect.Literal[3])  # E: Cannot use issubclass() with Literal 
 [out]
 
 [case testLiteralErrorsWhenSubclassed]
-
-from typing_extensions import Literal
-from typing_extensions import Literal as Renamed
-import typing_extensions as indirect
+from typing import Literal
+from typing import Literal as Renamed
+import typing as indirect
 
 Alias = Literal[3]
 
@@ -1518,9 +1498,9 @@ class Bad4(Alias): pass                 # E: Invalid base class "Alias"
 # TODO: We don't seem to correctly handle invoking types like
 # 'Final' and 'Protocol' as well. When fixing this, also fix
 # those types?
-from typing_extensions import Literal
-from typing_extensions import Literal as Renamed
-import typing_extensions as indirect
+from typing import Literal
+from typing import Literal as Renamed
+import typing as indirect
 
 Alias = Literal[3]
 
@@ -1542,8 +1522,7 @@ indirect.Literal()
 --
 
 [case testLiteralAndGenericsWithSimpleFunctions]
-from typing import TypeVar
-from typing_extensions import Literal
+from typing import Literal, TypeVar
 
 T = TypeVar('T')
 def foo(x: T) -> T: pass
@@ -1573,8 +1552,7 @@ expects_int(foo(foo(a)))
 [out]
 
 [case testLiteralAndGenericWithUnion]
-from typing import TypeVar, Union
-from typing_extensions import Literal
+from typing import Literal, TypeVar, Union
 
 T = TypeVar('T')
 def identity(x: T) -> T: return x
@@ -1585,8 +1563,7 @@ b: Union[int, Literal['foo']] = identity('bar')  # E: Argument 1 to "identity" h
 [out]
 
 [case testLiteralAndGenericsNoMatch]
-from typing import TypeVar, Union, List
-from typing_extensions import Literal
+from typing import Literal, TypeVar, Union, List
 
 def identity(x: T) -> T:
     return x
@@ -1602,8 +1579,7 @@ z: Bad = identity([42])  # E: List item 0 has incompatible type "Literal[42]"; e
 [out]
 
 [case testLiteralAndGenericsWithSimpleClasses]
-from typing import TypeVar, Generic
-from typing_extensions import Literal
+from typing import Literal, TypeVar, Generic
 
 T = TypeVar('T')
 class Wrapper(Generic[T]):
@@ -1639,8 +1615,7 @@ expects_literal_wrapper(Wrapper(5))  # E: Argument 1 to "Wrapper" has incompatib
 [out]
 
 [case testLiteralAndGenericsRespectsUpperBound]
-from typing import TypeVar
-from typing_extensions import Literal
+from typing import Literal, TypeVar
 
 TLiteral = TypeVar('TLiteral', bound=Literal[3])
 TInt = TypeVar('TInt', bound=int)
@@ -1679,8 +1654,7 @@ reveal_type(func2(c))   # N: Revealed type is "builtins.int"
 [out]
 
 [case testLiteralAndGenericsRespectsValueRestriction]
-from typing import TypeVar
-from typing_extensions import Literal
+from typing import Literal, TypeVar
 
 TLiteral = TypeVar('TLiteral', Literal[3], Literal['foo'])
 TNormal = TypeVar('TNormal', int, str)
@@ -1736,8 +1710,7 @@ reveal_type(func2(s2))      # N: Revealed type is "builtins.str"
 [out]
 
 [case testLiteralAndGenericsWithOverloads]
-from typing import TypeVar, overload, Union
-from typing_extensions import Literal
+from typing import Literal, TypeVar, overload, Union
 
 @overload
 def func1(x: Literal[4]) -> Literal[19]: ...
@@ -1762,8 +1735,7 @@ reveal_type(func1(identity(b)))  # N: Revealed type is "builtins.int"
 --
 
 [case testLiteralMeets]
-from typing import TypeVar, List, Callable, Union, Optional
-from typing_extensions import Literal
+from typing import TypeVar, List, Literal, Callable, Union, Optional
 
 a: Callable[[Literal[1]], int]
 b: Callable[[Literal[2]], str]
@@ -1809,8 +1781,7 @@ reveal_type(unify(f6))  # N: Revealed type is "None"
 [out]
 
 [case testLiteralMeetsWithStrictOptional]
-from typing import TypeVar, Callable, Union
-from typing_extensions import Literal
+from typing import TypeVar, Callable, Literal, Union
 
 a: Callable[[Literal[1]], int]
 b: Callable[[Literal[2]], str]
@@ -1835,8 +1806,7 @@ reveal_type(unify(func))  # N: Revealed type is "Never"
 --
 
 [case testLiteralIntelligentIndexingTuples]
-from typing import Tuple, NamedTuple, Optional, Final
-from typing_extensions import Literal
+from typing import Literal, Tuple, NamedTuple, Optional, Final
 
 class A: pass
 class B: pass
@@ -1884,7 +1854,8 @@ tup3: Tup2Class = tup2[:]     # E: Incompatible types in assignment (expression 
 [builtins fixtures/slice.pyi]
 
 [case testLiteralIntelligentIndexingTypedDict]
-from typing_extensions import Literal, TypedDict
+from typing import Literal
+from typing_extensions import TypedDict
 
 class Unrelated: pass
 u: Unrelated
@@ -1922,8 +1893,8 @@ del d[c_key]                  # E: TypedDict "Outer" has no key "c"
 [out]
 
 [case testLiteralIntelligentIndexingUsingFinal]
-from typing import Tuple, NamedTuple
-from typing_extensions import Literal, Final, TypedDict
+from typing import Literal, Tuple, NamedTuple
+from typing_extensions import Final, TypedDict
 
 int_key_good: Final = 0
 int_key_bad: Final = 3
@@ -1960,8 +1931,7 @@ c[str_key_bad]                       # E: TypedDict "MyDict" has no key "missing
 [out]
 
 [case testLiteralIntelligentIndexingTupleUnions]
-from typing import Tuple, NamedTuple
-from typing_extensions import Literal
+from typing import Literal, Tuple, NamedTuple
 
 class A: pass
 class B: pass
@@ -1990,7 +1960,8 @@ tup2[idx_bad]                   # E: Tuple index out of range
 [out]
 
 [case testLiteralIntelligentIndexingTypedDictUnions]
-from typing_extensions import Literal, Final, TypedDict
+from typing import Literal
+from typing_extensions import Final, TypedDict
 
 class A: pass
 class B: pass
@@ -2041,8 +2012,8 @@ del test[bad_keys]              # E: Key "a" of TypedDict "Test" cannot be delet
 [out]
 
 [case testLiteralIntelligentIndexingMultiTypedDict]
-from typing import Union
-from typing_extensions import Literal, TypedDict
+from typing import Literal, Union
+from typing_extensions import TypedDict
 
 class A: pass
 class B: pass
@@ -2080,7 +2051,8 @@ reveal_type(x.get(bad_keys, 3))     # N: Revealed type is "builtins.object"
 --
 
 [case testLiteralFinalInferredAsLiteral]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 var1: Final = 1
 var2: Final = "foo"
@@ -2135,7 +2107,8 @@ force4(reveal_type(f.instancevar4))  # N: Revealed type is "None"
 [out]
 
 [case testLiteralFinalDirectInstanceTypesSupersedeInferredLiteral]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 var1: Final[int] = 1
 var2: Final[str] = "foo"
@@ -2190,7 +2163,8 @@ force4(f.instancevar4)
 [out]
 
 [case testLiteralFinalDirectLiteralTypesForceLiteral]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 var1: Final[Literal[1]] = 1
 var2: Final[Literal["foo"]] = "foo"
@@ -2255,7 +2229,8 @@ reveal_type(var2)  # N: Revealed type is "Tuple[Literal[0]?, None]"
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralFinalErasureInMutableDatastructures2]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 var1: Final = []
 var1.append(0)
@@ -2273,7 +2248,8 @@ reveal_type(var3)  # N: Revealed type is "builtins.list[Literal[0]]"
 [builtins fixtures/list.pyi]
 
 [case testLiteralFinalMismatchCausesError]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 var1: Final[Literal[4]]     = 1      # E: Incompatible types in assignment (expression has type "Literal[1]", variable has type "Literal[4]")
 var2: Final[Literal['bad']] = "foo"  # E: Incompatible types in assignment (expression has type "Literal['foo']", variable has type "Literal['bad']")
@@ -2303,8 +2279,8 @@ Foo().instancevar1 = 10  # E: Cannot assign to final attribute "instancevar1" \
 [out]
 
 [case testLiteralFinalGoesOnlyOneLevelDown]
-from typing import Tuple
-from typing_extensions import Final, Literal
+from typing import Literal, Tuple
+from typing_extensions import Final
 
 a: Final = 1
 b: Final = (1, 2)
@@ -2321,8 +2297,8 @@ force2(b)  # ok
 [out]
 
 [case testLiteralFinalCollectionPropagation]
-from typing import List
-from typing_extensions import Final, Literal
+from typing import List, Literal
+from typing_extensions import Final
 
 a: Final = 1
 implicit = [a]
@@ -2351,7 +2327,8 @@ force2(reveal_type(direct[0]))   # E: Argument 1 to "force2" has incompatible ty
 [out]
 
 [case testLiteralFinalStringTypesPython3]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 a: Final = u"foo"
 b: Final = "foo"
@@ -2374,8 +2351,8 @@ force_bytes(reveal_type(c))    # N: Revealed type is "Literal[b'foo']"
 [out]
 
 [case testLiteralFinalPropagatesThroughGenerics]
-from typing import TypeVar, Generic
-from typing_extensions import Final, Literal
+from typing import TypeVar, Generic, Literal
+from typing_extensions import Final
 
 
 T = TypeVar('T')
@@ -2430,8 +2407,8 @@ over_literal(reveal_type(WrapperClass(var3)))   # N: Revealed type is "__main__.
 [out]
 
 [case testLiteralFinalUsedInLiteralType]
-
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 a: Final[int] = 3
 b: Final = 3
 c: Final[Literal[3]] = 3
@@ -2445,7 +2422,8 @@ d_wrap: Literal[4, d]  # E: Parameter 2 of Literal[...] is invalid
 [out]
 
 [case testLiteralWithFinalPropagation]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 a: Final = 3
 b: Final = a
@@ -2459,7 +2437,8 @@ expect_3(c)  # E: Argument 1 to "expect_3" has incompatible type "int"; expected
 [out]
 
 [case testLiteralWithFinalPropagationIsNotLeaking]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 final_tuple_direct: Final = (2, 3)
 final_tuple_indirect: Final = final_tuple_direct
@@ -2489,8 +2468,7 @@ expect_2(final_set_2.pop())  # E: Argument 1 to "expect_2" has incompatible type
 --
 
 [case testLiteralWithEnumsBasic]
-
-from typing_extensions import Literal
+from typing import Literal
 from enum import Enum
 
 class Color(Enum):
@@ -2527,7 +2505,7 @@ reveal_type(r.func())     # N: Revealed type is "builtins.int"
 [out]
 
 [case testLiteralWithEnumsDefinedInClass]
-from typing_extensions import Literal
+from typing import Literal
 from enum import Enum
 
 class Wrapper:
@@ -2550,7 +2528,7 @@ reveal_type(r)    # N: Revealed type is "Literal[__main__.Wrapper.Color.RED]"
 [out]
 
 [case testLiteralWithEnumsSimilarDefinitions]
-from typing_extensions import Literal
+from typing import Literal
 import mod_a
 import mod_b
 
@@ -2585,7 +2563,7 @@ class Test(Enum):
 [out]
 
 [case testLiteralWithEnumsDeclaredUsingCallSyntax]
-from typing_extensions import Literal
+from typing import Literal
 from enum import Enum
 
 A = Enum('A', 'FOO BAR')
@@ -2606,7 +2584,7 @@ reveal_type(d)  # N: Revealed type is "Literal[__main__.D.FOO]"
 [out]
 
 [case testLiteralWithEnumsDerivedEnums]
-from typing_extensions import Literal
+from typing import Literal
 from enum import Enum, IntEnum, IntFlag, Flag
 
 def expects_int(x: int) -> None: pass
@@ -2636,7 +2614,7 @@ expects_int(d)  # E: Argument 1 to "expects_int" has incompatible type "Literal[
 [out]
 
 [case testLiteralWithEnumsAliases]
-from typing_extensions import Literal
+from typing import Literal
 from enum import Enum
 
 class Test(Enum):
@@ -2651,7 +2629,8 @@ reveal_type(x)  # N: Revealed type is "Literal[__main__.Test.FOO]"
 [out]
 
 [case testLiteralUsingEnumAttributesInLiteralContexts]
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 from enum import Enum
 
 class Test1(Enum):
@@ -2685,7 +2664,8 @@ expects_test2_foo(final2)
 [out]
 
 [case testLiteralUsingEnumAttributeNamesInLiteralContexts]
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 from enum import Enum
 
 class Test1(Enum):
@@ -2720,8 +2700,7 @@ reveal_type(Test5.FOO.name)  # N: Revealed type is "Literal['FOO']?"
 
 [case testLiteralBinderLastValueErased]
 # mypy: strict-equality
-
-from typing_extensions import Literal
+from typing import Literal
 
 def takes_three(x: Literal[3]) -> None: ...
 x: object
@@ -2745,7 +2724,7 @@ def test() -> None:
 [builtins fixtures/bool.pyi]
 
 [case testUnaryOpLiteral]
-from typing_extensions import Literal
+from typing import Literal
 
 a: Literal[-2] = -2
 b: Literal[-1] = -1
@@ -2765,7 +2744,8 @@ z: Literal[~0] = 0  # E: Invalid type: Literal[...] cannot contain arbitrary exp
 [builtins fixtures/ops.pyi]
 
 [case testNegativeIntLiteralWithFinal]
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 
 ONE: Final = 1
 x: Literal[-1] = -ONE
@@ -2780,7 +2760,7 @@ if bool():
 [builtins fixtures/ops.pyi]
 
 [case testAliasForEnumTypeAsLiteral]
-from typing_extensions import Literal
+from typing import Literal
 from enum import Enum
 
 class Foo(Enum):
@@ -2811,9 +2791,7 @@ assert c.a is False
 
 [case testConditionalBoolLiteralUnionNarrowing]
 # flags: --warn-unreachable
-
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 class Truth:
     def __bool__(self) -> Literal[True]: ...
@@ -2875,8 +2853,8 @@ else:
 [case testLiteralAndInstanceSubtyping]
 # https://github.com/python/mypy/issues/7399
 # https://github.com/python/mypy/issues/11232
-from typing import Tuple, Union
-from typing_extensions import Literal, Final
+from typing import Literal, Tuple, Union
+from typing_extensions import Final
 
 x: bool
 
@@ -2918,7 +2896,7 @@ def incorrect_return2() -> Union[Tuple[Literal[True], int], Tuple[Literal[False]
 [builtins fixtures/bool.pyi]
 
 [case testLiteralSubtypeContext]
-from typing_extensions import Literal
+from typing import Literal
 
 class A:
     foo: Literal['bar', 'spam']
@@ -2929,8 +2907,7 @@ reveal_type(B().foo)  # N: Revealed type is "Literal['spam']"
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralSubtypeContextNested]
-from typing import List
-from typing_extensions import Literal
+from typing import List, Literal
 
 class A:
     foo: List[Literal['bar', 'spam']]
@@ -2941,8 +2918,7 @@ reveal_type(B().foo)  # N: Revealed type is "builtins.list[Union[Literal['bar'],
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralSubtypeContextGeneric]
-from typing_extensions import Literal
-from typing import Generic, List, TypeVar
+from typing import Generic, List, Literal, TypeVar
 
 T = TypeVar("T", bound=str)
 
@@ -2959,8 +2935,7 @@ reveal_type(C().word)  # N: Revealed type is "Literal['word']"
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralTernaryUnionNarrowing]
-from typing_extensions import Literal
-from typing import Optional
+from typing import Literal, Optional
 
 SEP = Literal["a", "b"]
 
@@ -2983,8 +2958,7 @@ class C(Base):
 [builtins fixtures/primitives.pyi]
 
 [case testLiteralInsideAType]
-from typing_extensions import Literal
-from typing import Type, Union
+from typing import Literal, Type, Union
 
 x: Type[Literal[1]]  # E: Type[...] can't contain "Literal[...]"
 y: Type[Union[Literal[1], Literal[2]]]  # E: Type[...] can't contain "Union[Literal[...], Literal[...]]"

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1,7 +1,7 @@
 [case testNarrowingParentWithStrsBasic]
 from dataclasses import dataclass
-from typing import NamedTuple, Tuple, Union
-from typing_extensions import Literal, TypedDict
+from typing import Literal, NamedTuple, Tuple, Union
+from typing_extensions import TypedDict
 
 class Object1:
     key: Literal["A"]
@@ -84,8 +84,8 @@ else:
 [case testNarrowingParentWithEnumsBasic]
 from enum import Enum
 from dataclasses import dataclass
-from typing import NamedTuple, Tuple, Union
-from typing_extensions import Literal, TypedDict
+from typing import Literal, NamedTuple, Tuple, Union
+from typing_extensions import TypedDict
 
 class Key(Enum):
     A = 1
@@ -238,8 +238,7 @@ else:
 [case testNarrowingParentMultipleKeys]
 # flags: --warn-unreachable
 from enum import Enum
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 class Key(Enum):
     A = 1
@@ -271,8 +270,8 @@ else:
 
 [case testNarrowingTypedDictParentMultipleKeys]
 # flags: --warn-unreachable
-from typing import Union
-from typing_extensions import Literal, TypedDict
+from typing import Literal, Union
+from typing_extensions import TypedDict
 
 class TypedDict1(TypedDict):
     key: Literal['A', 'C']
@@ -298,8 +297,8 @@ else:
 
 [case testNarrowingPartialTypedDictParentMultipleKeys]
 # flags: --warn-unreachable
-from typing import Union
-from typing_extensions import Literal, TypedDict
+from typing import Literal, Union
+from typing_extensions import TypedDict
 
 class TypedDict1(TypedDict, total=False):
     key: Literal['A', 'C']
@@ -324,8 +323,8 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingNestedTypedDicts]
-from typing import Union
-from typing_extensions import TypedDict, Literal
+from typing import Literal, Union
+from typing_extensions import TypedDict
 
 class A(TypedDict):
     key: Literal['A']
@@ -353,8 +352,7 @@ if unknown['inner']['key'] == 'C':
 
 [case testNarrowingParentWithMultipleParents]
 from enum import Enum
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 class Key(Enum):
     A = 1
@@ -398,8 +396,8 @@ else:
 
 [case testNarrowingParentWithParentMixtures]
 from enum import Enum
-from typing import Union, NamedTuple
-from typing_extensions import Literal, TypedDict
+from typing import Literal, Union, NamedTuple
+from typing_extensions import TypedDict
 
 class Key(Enum):
     A = 1
@@ -448,8 +446,7 @@ else:
 
 [case testNarrowingParentWithProperties]
 from enum import Enum
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 class Key(Enum):
     A = 1
@@ -476,8 +473,7 @@ else:
 
 [case testNarrowingParentWithAny]
 from enum import Enum
-from typing import Union, Any
-from typing_extensions import Literal
+from typing import Literal, Union, Any
 
 class Key(Enum):
     A = 1
@@ -501,8 +497,7 @@ else:
 [builtins fixtures/tuple.pyi]
 
 [case testNarrowingParentsHierarchy]
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 from enum import Enum
 
 class Key(Enum):
@@ -580,8 +575,8 @@ else:
 
 [case testNarrowingParentsHierarchyTypedDict]
 # flags: --warn-unreachable
-from typing import Union
-from typing_extensions import TypedDict, Literal
+from typing import Literal, Union
+from typing_extensions import TypedDict
 from enum import Enum
 
 class Key(Enum):
@@ -622,8 +617,8 @@ else:
 
 [case testNarrowingParentsHierarchyTypedDictWithStr]
 # flags: --warn-unreachable
-from typing import Union
-from typing_extensions import TypedDict, Literal
+from typing import Literal, Union
+from typing_extensions import TypedDict
 
 class Parent1(TypedDict):
     model: Model1
@@ -657,8 +652,7 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingExprPropagation]
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 class A:
     tag: Literal['A']
@@ -679,7 +673,8 @@ if not (abo is None or abo.tag != "B"):
 
 [case testNarrowingEqualityFlipFlop]
 # flags: --warn-unreachable --strict-equality
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 from enum import Enum
 
 class State(Enum):
@@ -744,7 +739,8 @@ def test3(switch: FlipFlopEnum) -> None:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityRequiresExplicitStrLiteral]
-from typing_extensions import Literal, Final
+from typing import Literal
+from typing_extensions import Final
 
 A_final: Final = "A"
 A_literal: Literal["A"]
@@ -790,8 +786,8 @@ reveal_type(x_union)      # N: Revealed type is "Union[Literal['A'], Literal['B'
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityRequiresExplicitEnumLiteral]
-from typing import Union
-from typing_extensions import Literal, Final
+from typing import Literal, Union
+from typing_extensions import Final
 from enum import Enum
 
 class Foo(Enum):
@@ -832,8 +828,7 @@ def bar(x: Union[SingletonFoo, Foo], y: SingletonFoo) -> None:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityDisabledForCustomEquality]
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 from enum import Enum
 
 class Custom:
@@ -875,8 +870,7 @@ else:
 
 [case testNarrowingEqualityDisabledForCustomEqualityChain]
 # flags: --strict-equality --warn-unreachable
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 class Custom:
     def __eq__(self, other: object) -> bool: return True
@@ -912,8 +906,7 @@ else:
 
 [case testNarrowingUnreachableCases]
 # flags: --strict-equality --warn-unreachable
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 a: Literal[1]
 b: Literal[1, 2]
@@ -960,8 +953,7 @@ else:
 
 [case testNarrowingUnreachableCases2]
 # flags: --strict-equality --warn-unreachable
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 a: Literal[1, 2, 3, 4]
 b: Literal[1, 2, 3, 4]
@@ -999,8 +991,7 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingLiteralTruthiness]
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 str_or_false: Union[Literal[False], str]
 
@@ -1133,8 +1124,7 @@ reveal_type(f(B))  # N: Revealed type is "__main__.B"
 
 
 [case testNarrowingLiteralIdentityCheck]
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 
 str_or_false: Union[Literal[False], str]
 
@@ -1174,8 +1164,7 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingBooleanIdentityCheck]
-from typing import Optional
-from typing_extensions import Literal
+from typing import Literal, Optional
 
 bool_val: bool
 
@@ -1196,8 +1185,7 @@ else:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingBooleanTruthiness]
-from typing import Optional
-from typing_extensions import Literal
+from typing import Literal, Optional
 
 bool_val: bool
 
@@ -1217,8 +1205,7 @@ reveal_type(opt_bool_val)   # N: Revealed type is "Union[builtins.bool, None]"
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingBooleanBoolOp]
-from typing import Optional
-from typing_extensions import Literal
+from typing import Literal, Optional
 
 bool_a: bool
 bool_b: bool
@@ -1245,8 +1232,8 @@ reveal_type(x) # N: Revealed type is "builtins.bool"
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingTypedDictUsingEnumLiteral]
-from typing import Union
-from typing_extensions import TypedDict, Literal
+from typing import Literal, Union
+from typing_extensions import TypedDict
 from enum import Enum
 
 class E(Enum):
@@ -1306,8 +1293,8 @@ def f(t: Type[T], a: A, b: B) -> None:
         reveal_type(b)  # N: Revealed type is "__main__.B"
 
 [case testNarrowingNestedUnionOfTypedDicts]
-from typing import Union
-from typing_extensions import Literal, TypedDict
+from typing import Literal, Union
+from typing_extensions import TypedDict
 
 class A(TypedDict):
     tag: Literal["A"]
@@ -1909,8 +1896,7 @@ reveal_type(x1)  # N: Revealed type is "Any"
 [builtins fixtures/len.pyi]
 
 [case testNarrowingLenExplicitLiteralTypes]
-from typing import Tuple, Union
-from typing_extensions import Literal
+from typing import Literal, Tuple, Union
 
 VarTuple = Union[
     Tuple[int],

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2528,8 +2528,8 @@ tmp/unittest/suite.pyi:6: error: Name "Iterable" is not defined
 tmp/unittest/suite.pyi:6: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Iterable")
 
 [case testNewAnalyzerNewTypeSpecialCase]
-from typing import NewType
-from typing_extensions import Final, Literal
+from typing import Literal, NewType
+from typing_extensions import Final
 
 X = NewType('X', int)
 
@@ -2777,7 +2777,8 @@ class C:
 reveal_type(C.A)  # N: Revealed type is "def () -> a.A"
 
 [case testNewAnalyzerFinalLiteralInferredAsLiteralWithDeferral]
-from typing_extensions import Final, Literal
+from typing import Literal
+from typing_extensions import Final
 
 defer: Yes
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5267,8 +5267,7 @@ tmp/lib.pyi:3: error: Name "overload" is not defined
 main:3: note: Revealed type is "Any"
 
 [case testLiteralSubtypeOverlap]
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 
 class MyInt(int): ...
 

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2767,8 +2767,8 @@ p: P = N(lambda a, b, c: 'foo')
 [builtins fixtures/property.pyi]
 
 [case testLiteralsAgainstProtocols]
-from typing import SupportsInt, SupportsAbs, TypeVar
-from typing_extensions import Literal, Final
+from typing import Literal, SupportsInt, SupportsAbs, TypeVar
+from typing_extensions import Final
 
 T = TypeVar('T')
 def abs(x: SupportsAbs[T]) -> T: ...

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1442,8 +1442,7 @@ def f(value: Literal[1] | Literal[2]) -> int:
 [typing fixtures/typing-medium.pyi]
 
 [case testMatchSequencePatternNegativeNarrowing]
-from typing import Union, Sequence, Tuple
-from typing_extensions import Literal
+from typing import Literal, Union, Sequence, Tuple
 
 m1: Sequence[int | str]
 
@@ -2476,7 +2475,7 @@ def nested_in_dict(d: dict[str, Any]) -> int:
 
 [case testMatchRebindsOuterFunctionName]
 # flags: --warn-unreachable
-from typing_extensions import Literal
+from typing import Literal
 
 def x() -> tuple[Literal["test"]]: ...
 

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -385,8 +385,7 @@ reveal_type(z2)  # E: Name "z2" is not defined  # N: Revealed type is "Any"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testWalrusConditionalTypeBinder]
-from typing import Tuple, Union
-from typing_extensions import Literal
+from typing import Literal, Tuple, Union
 
 class Good:
     @property
@@ -469,8 +468,7 @@ reveal_type(x)  # N: Revealed type is "Literal[0]"
 
 [case testWalrusAssignmentAndConditionScopeForProperty]
 # flags: --warn-unreachable
-
-from typing_extensions import Literal
+from typing import Literal
 
 class PropertyWrapper:
     @property
@@ -497,8 +495,7 @@ reveal_type(y)  # N: Revealed type is "Literal[False]"
 
 [case testWalrusAssignmentAndConditionScopeForFunction]
 # flags: --warn-unreachable
-
-from typing_extensions import Literal
+from typing import Literal
 
 def f() -> str: ...
 

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -936,8 +936,7 @@ if last is not None:
 [builtins fixtures/tuple.pyi]
 
 [case testRecursiveAliasLiteral]
-from typing import Tuple
-from typing_extensions import Literal
+from typing import Literal, Tuple
 
 NotFilter = Tuple[Literal["not"], "NotFilter"]
 n: NotFilter

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -784,8 +784,7 @@ reveal_type(x)  # N: Revealed type is "__main__.SubP[Any]"
 y: SubP[str] = SubP(use_str=True)
 
 [file lib.pyi]
-from typing import TypeVar, Generic, overload, Tuple
-from typing_extensions import Literal
+from typing import Literal, TypeVar, Generic, overload, Tuple
 
 T = TypeVar('T')
 class P(Generic[T]):
@@ -809,8 +808,7 @@ xx = PFallBack(t)  # E: Need type annotation for "xx"
 yy = PFallBackAny(t)  # OK
 
 [file lib.pyi]
-from typing import TypeVar, Generic, overload, Tuple, Any
-from typing_extensions import Literal
+from typing import Literal, TypeVar, Generic, overload, Tuple, Any
 
 class PFallBack(Generic[T]):
     @overload

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -1550,7 +1550,7 @@ class InvalidReturn3:
 [builtins fixtures/bool.pyi]
 
 [case testWithStmtBoolExitReturnOkay]
-from typing_extensions import Literal
+from typing import Literal
 
 class GoodReturn1:
     def __exit__(self, x, y, z) -> bool:

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1050,8 +1050,8 @@ class C(Generic[T]):
 [builtins fixtures/classmethod.pyi]
 
 [case testRecursiveAliasTuple]
-from typing_extensions import Literal, TypeAlias
-from typing import Tuple, Union
+from typing_extensions import TypeAlias
+from typing import Literal, Tuple, Union
 
 Expr: TypeAlias = Union[
     Tuple[Literal[123], int],

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -897,8 +897,8 @@ reveal_type(u(c, m_s_a)) # N: Revealed type is "Union[typing.Mapping[builtins.st
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUnionUnambiguousCase]
-from typing import Union, Mapping, Any, cast
-from typing_extensions import TypedDict, Literal
+from typing import Union, Literal, Mapping, Any, cast
+from typing_extensions import TypedDict
 
 A = TypedDict('A', {'@type': Literal['a-type'], 'a': str})
 B = TypedDict('B', {'@type': Literal['b-type'], 'b': int})
@@ -908,8 +908,8 @@ reveal_type(c) # N: Revealed type is "Union[TypedDict('__main__.A', {'@type': Li
 [builtins fixtures/dict.pyi]
 
 [case testTypedDictUnionAmbiguousCaseBothMatch]
-from typing import Union, Mapping, Any, cast
-from typing_extensions import TypedDict, Literal
+from typing import Union, Literal, Mapping, Any, cast
+from typing_extensions import TypedDict
 
 A = TypedDict('A', {'@type': Literal['a-type'], 'value': str})
 B = TypedDict('B', {'@type': Literal['b-type'], 'value': str})
@@ -918,8 +918,8 @@ c: Union[A, B] = {'@type': 'a-type', 'value': 'Test'}
 [builtins fixtures/dict.pyi]
 
 [case testTypedDictUnionAmbiguousCaseNoMatch]
-from typing import Union, Mapping, Any, cast
-from typing_extensions import TypedDict, Literal
+from typing import Union, Literal, Mapping, Any, cast
+from typing_extensions import TypedDict
 
 A = TypedDict('A', {'@type': Literal['a-type'], 'value': int})
 B = TypedDict('B', {'@type': Literal['b-type'], 'value': int})

--- a/test-data/unit/check-union-error-syntax.test
+++ b/test-data/unit/check-union-error-syntax.test
@@ -30,32 +30,28 @@ x = 3 # E: Incompatible types in assignment (expression has type "int", variable
 
 [case testLiteralOrErrorSyntax]
 # flags: --python-version 3.10 --no-force-union-syntax
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 x : Union[Literal[1], Literal[2], str]
 x = 3 # E: Incompatible types in assignment (expression has type "Literal[3]", variable has type "Literal[1, 2] | str")
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralUnionErrorSyntax]
 # flags: --python-version 3.10 --force-union-syntax
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 x : Union[Literal[1], Literal[2], str]
 x = 3 # E: Incompatible types in assignment (expression has type "Literal[3]", variable has type "Union[str, Literal[1, 2]]")
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralOrNoneErrorSyntax]
 # flags: --python-version 3.10 --no-force-union-syntax
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 x : Union[Literal[1], None]
 x = 3 # E: Incompatible types in assignment (expression has type "Literal[3]", variable has type "Literal[1] | None")
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralOptionalErrorSyntax]
 # flags: --python-version 3.10 --force-union-syntax
-from typing import Union
-from typing_extensions import Literal
+from typing import Literal, Union
 x : Union[Literal[1], None]
 x = 3 # E: Incompatible types in assignment (expression has type "Literal[3]", variable has type "Optional[Literal[1]]")
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -45,9 +45,10 @@ reveal_type(f)  # N: Revealed type is "def (x: Union[__main__.A, __main__.B, __m
 
 [case testUnionOrSyntaxWithLiteral]
 # flags: --python-version 3.10
-from typing_extensions import Literal
+from typing import Literal
 reveal_type(Literal[4] | str)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testUnionOrSyntaxWithBadOperator]
 # flags: --python-version 3.10

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1013,8 +1013,7 @@ def foo(x: T) -> T:
 [case testUnreachableFlagContextManagersNoSuppress]
 # flags: --warn-unreachable
 from contextlib import contextmanager
-from typing import Optional, Iterator, Any
-from typing_extensions import Literal
+from typing import Literal, Optional, Iterator, Any
 class DoesNotSuppress1:
     def __enter__(self) -> int: ...
     def __exit__(self, exctype: object, excvalue: object, traceback: object) -> Optional[bool]: ...
@@ -1078,8 +1077,7 @@ def f_no_suppress_5() -> int:
 [case testUnreachableFlagContextManagersSuppressed]
 # flags: --warn-unreachable
 from contextlib import contextmanager
-from typing import Optional, Iterator, Any
-from typing_extensions import Literal
+from typing import Optional, Iterator, Literal, Any
 
 class DoesNotSuppress:
     def __enter__(self) -> int: ...
@@ -1125,8 +1123,7 @@ def f_mix() -> int:         # E: Missing return statement
 [case testUnreachableFlagContextManagersSuppressedNoStrictOptional]
 # flags: --warn-unreachable --no-strict-optional
 from contextlib import contextmanager
-from typing import Optional, Iterator, Any
-from typing_extensions import Literal
+from typing import Optional, Iterator, Literal, Any
 
 class DoesNotSuppress1:
     def __enter__(self) -> int: ...
@@ -1167,8 +1164,7 @@ def f_suppress() -> int:  # E: Missing return statement
 [case testUnreachableFlagContextAsyncManagersNoSuppress]
 # flags: --warn-unreachable
 from contextlib import asynccontextmanager
-from typing import Optional, AsyncIterator, Any
-from typing_extensions import Literal
+from typing import Optional, AsyncIterator, Literal, Any
 
 class DoesNotSuppress1:
     async def __aenter__(self) -> int: ...
@@ -1233,8 +1229,7 @@ async def f_no_suppress_5() -> int:
 [case testUnreachableFlagContextAsyncManagersSuppressed]
 # flags: --warn-unreachable
 from contextlib import asynccontextmanager
-from typing import Optional, AsyncIterator, Any
-from typing_extensions import Literal
+from typing import Optional, AsyncIterator, Literal, Any
 
 class DoesNotSuppress:
     async def __aenter__(self) -> int: ...
@@ -1280,8 +1275,7 @@ async def f_mix() -> int:         # E: Missing return statement
 [case testUnreachableFlagContextAsyncManagersAbnormal]
 # flags: --warn-unreachable
 from contextlib import asynccontextmanager
-from typing import Optional, AsyncIterator, Any
-from typing_extensions import Literal
+from typing import Optional, AsyncIterator, Literal, Any
 
 class RegularManager:
     def __enter__(self) -> int: ...
@@ -1380,7 +1374,7 @@ def f(t: T) -> None:
 
 [case testUnreachableLiteral]
 # flags: --warn-unreachable
-from typing_extensions import Literal
+from typing import Literal
 
 def nope() -> Literal[False]: ...
 
@@ -1391,7 +1385,7 @@ def f() -> None:
 
 [case testUnreachableLiteralFrom__bool__]
 # flags: --warn-unreachable
-from typing_extensions import Literal
+from typing import Literal
 
 class Truth:
     def __bool__(self) -> Literal[True]: ...

--- a/test-data/unit/deps-expressions.test
+++ b/test-data/unit/deps-expressions.test
@@ -420,7 +420,7 @@ def g() -> None:
 <m.f2> -> m.g
 
 [case testLiteralDepsExpr]
-from typing_extensions import Literal
+from typing import Literal
 
 Alias = Literal[1]
 

--- a/test-data/unit/diff.test
+++ b/test-data/unit/diff.test
@@ -1153,7 +1153,7 @@ __main__.Diff
 __main__.Diff.x
 
 [case testLiteralTriggersVar]
-from typing_extensions import Literal
+from typing import Literal
 
 x: Literal[1] = 1
 y = 1
@@ -1171,7 +1171,7 @@ class C:
         self.same_instance: Literal[1] = 1
 
 [file next.py]
-from typing_extensions import Literal
+from typing import Literal
 
 x = 1
 y: Literal[1] = 1
@@ -1200,7 +1200,7 @@ __main__.y
 __main__.z
 
 [case testLiteralTriggersFunctions]
-from typing_extensions import Literal
+from typing import Literal
 
 def function_1() -> int: pass
 def function_2() -> Literal[1]: pass
@@ -1264,7 +1264,7 @@ class C:
     def staticmethod_same_2(x: Literal[1]) -> None: pass
 
 [file next.py]
-from typing_extensions import Literal
+from typing import Literal
 
 def function_1() -> Literal[1]: pass
 def function_2() -> int: pass
@@ -1354,7 +1354,7 @@ __main__.function_5
 __main__.function_6
 
 [case testLiteralTriggersProperty]
-from typing_extensions import Literal
+from typing import Literal
 
 class C:
     @property
@@ -1367,7 +1367,7 @@ class C:
     def same(self) -> Literal[1]: pass
 
 [file next.py]
-from typing_extensions import Literal
+from typing import Literal
 
 class C:
     @property
@@ -1384,8 +1384,7 @@ __main__.C.p1
 __main__.C.p2
 
 [case testLiteralsTriggersOverload]
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 
 @overload
 def func(x: str) -> str: ...
@@ -1417,8 +1416,7 @@ class C:
         pass
 
 [file next.py]
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 
 @overload
 def func(x: str) -> str: ...
@@ -1454,10 +1452,10 @@ __main__.C.method
 __main__.func
 
 [case testUnionOfLiterals]
-from typing_extensions import Literal
+from typing import Literal
 x: Literal[1, '2']
 [file next.py]
-from typing_extensions import Literal
+from typing import Literal
 x: Literal[1, 2]
 [builtins fixtures/tuple.pyi]
 [out]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8715,10 +8715,10 @@ reveal_type(mod.x)
 [file mod.py]
 x = 1
 [file mod.py.2]
-from typing_extensions import Literal
+from typing import Literal
 x: Literal[1] = 1
 [file mod.py.3]
-from typing_extensions import Literal
+from typing import Literal
 x: Literal[1] = 2
 [builtins fixtures/tuple.pyi]
 [out]
@@ -8735,10 +8735,10 @@ foo(3)
 [file mod.py]
 def foo(x: int) -> None: pass
 [file mod.py.2]
-from typing_extensions import Literal
+from typing import Literal
 def foo(x: Literal[3]) -> None: pass
 [file mod.py.3]
-from typing_extensions import Literal
+from typing import Literal
 def foo(x: Literal[4]) -> None: pass
 [builtins fixtures/tuple.pyi]
 [out]
@@ -8752,10 +8752,10 @@ a: Alias = 1
 [file mod.py]
 Alias = int
 [file mod.py.2]
-from typing_extensions import Literal
+from typing import Literal
 Alias = Literal[1]
 [file mod.py.3]
-from typing_extensions import Literal
+from typing import Literal
 Alias = Literal[2]
 [builtins fixtures/tuple.pyi]
 [out]
@@ -8767,16 +8767,14 @@ main:2: error: Incompatible types in assignment (expression has type "Literal[1]
 from mod import foo
 reveal_type(foo(4))
 [file mod.py]
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 @overload
 def foo(x: int) -> str: ...
 @overload
 def foo(x: Literal['bar']) -> int: ...
 def foo(x): pass
 [file mod.py.2]
-from typing import overload
-from typing_extensions import Literal
+from typing import Literal, overload
 @overload
 def foo(x: Literal[4]) -> Literal['foo']: ...
 @overload
@@ -8792,7 +8790,7 @@ main:2: note: Revealed type is "Literal['foo']"
 
 [case testLiteralFineGrainedChainedDefinitions]
 from mod1 import foo
-from typing_extensions import Literal
+from typing import Literal
 def expect_3(x: Literal[3]) -> None: pass
 expect_3(foo)
 [file mod1.py]
@@ -8801,10 +8799,10 @@ foo = bar
 [file mod2.py]
 from mod3 import qux as bar
 [file mod3.py]
-from typing_extensions import Literal
+from typing import Literal
 qux: Literal[3]
 [file mod3.py.2]
-from typing_extensions import Literal
+from typing import Literal
 qux: Literal[4]
 [builtins fixtures/tuple.pyi]
 [out]
@@ -8813,7 +8811,7 @@ main:4: error: Argument 1 to "expect_3" has incompatible type "Literal[4]"; expe
 
 [case testLiteralFineGrainedChainedAliases]
 from mod1 import Alias1
-from typing_extensions import Literal
+from typing import Literal
 x: Alias1
 def expect_3(x: Literal[3]) -> None: pass
 expect_3(x)
@@ -8824,10 +8822,10 @@ Alias1 = Alias2
 from mod3 import Alias3
 Alias2 = Alias3
 [file mod3.py]
-from typing_extensions import Literal
+from typing import Literal
 Alias3 = Literal[3]
 [file mod3.py.2]
-from typing_extensions import Literal
+from typing import Literal
 Alias3 = Literal[4]
 [builtins fixtures/tuple.pyi]
 [out]
@@ -8836,7 +8834,7 @@ main:5: error: Argument 1 to "expect_3" has incompatible type "Literal[4]"; expe
 
 [case testLiteralFineGrainedChainedFunctionDefinitions]
 from mod1 import func1
-from typing_extensions import Literal
+from typing import Literal
 def expect_3(x: Literal[3]) -> None: pass
 expect_3(func1())
 [file mod1.py]
@@ -8845,10 +8843,10 @@ from mod2 import func2 as func1
 from mod3 import func3
 func2 = func3
 [file mod3.py]
-from typing_extensions import Literal
+from typing import Literal
 def func3() -> Literal[3]: pass
 [file mod3.py.2]
-from typing_extensions import Literal
+from typing import Literal
 def func3() -> Literal[4]: pass
 [builtins fixtures/tuple.pyi]
 [out]
@@ -8867,7 +8865,7 @@ foo = func(bar)
 [file mod2.py]
 bar = 3
 [file mod2.py.2]
-from typing_extensions import Literal
+from typing import Literal
 bar: Literal[3] = 3
 [builtins fixtures/tuple.pyi]
 [out]
@@ -8877,11 +8875,11 @@ main:2: note: Revealed type is "Literal[3]"
 
 [case testLiteralFineGrainedChainedViaFinal]
 from mod1 import foo
-from typing_extensions import Literal
+from typing import Literal
 def expect_3(x: Literal[3]) -> None: pass
 expect_3(foo)
 [file mod1.py]
-from typing_extensions import Final
+from typing import Final
 from mod2 import bar
 foo: Final = bar
 [file mod2.py]
@@ -8909,13 +8907,13 @@ reveal_type(foo)
 from mod2 import bar
 foo = bar()
 [file mod2.py]
-from typing_extensions import Literal
+from typing import Literal
 def bar() -> Literal["foo"]: pass
 [file mod2.py.2]
-from typing_extensions import Literal
+from typing import Literal
 def bar() -> Literal[u"foo"]: pass
 [file mod2.py.3]
-from typing_extensions import Literal
+from typing import Literal
 def bar() -> Literal[b"foo"]: pass
 [builtins fixtures/tuple.pyi]
 [out]

--- a/test-data/unit/fixtures/set.pyi
+++ b/test-data/unit/fixtures/set.pyi
@@ -13,6 +13,7 @@ class tuple(Generic[T]): pass
 class function: pass
 
 class int: pass
+class float: pass
 class str: pass
 class bool: pass
 class ellipsis: pass

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -23,6 +23,7 @@ NamedTuple = 0
 Type = 0
 ClassVar = 0
 Final = 0
+Literal = 0
 NoReturn = 0
 Never = 0
 NewType = 0

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -1514,11 +1514,11 @@ TypeInfo<0>(
 [case testLiteralMerge]
 import target
 [file target.py]
-from typing_extensions import Literal
+from typing import Literal
 def foo(x: Literal[3]) -> Literal['a']: pass
 bar: Literal[4] = 4
 [file target.py.next]
-from typing_extensions import Literal
+from typing import Literal
 def foo(x: Literal['3']) -> Literal['b']: pass
 bar: Literal[5] = 5
 [builtins fixtures/tuple.pyi]
@@ -1528,7 +1528,7 @@ MypyFile:1<0>(
   Import:1(target))
 MypyFile:1<1>(
   tmp/target.py
-  ImportFrom:1(typing_extensions, [Literal])
+  ImportFrom:1(typing, [Literal])
   FuncDef:2<2>(
     foo
     Args(
@@ -1546,7 +1546,7 @@ MypyFile:1<0>(
   Import:1(target))
 MypyFile:1<1>(
   tmp/target.py
-  ImportFrom:1(typing_extensions, [Literal])
+  ImportFrom:1(typing, [Literal])
   FuncDef:2<2>(
     foo
     Args(

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1651,8 +1651,8 @@ f: m.F
 reveal_type(f)
 
 [file m.pyi]
-from typing import Type, Callable
-from typing_extensions import Literal, TypeAlias
+from typing import Type, Callable, Literal
+from typing_extensions import TypeAlias
 
 Foo = Literal[1, 2]
 reveal_type(Foo)

--- a/test-data/unit/semanal-literal.test
+++ b/test-data/unit/semanal-literal.test
@@ -1,9 +1,9 @@
 [case testLiteralSemanalBasicAssignment]
-from typing_extensions import Literal
+from typing import Literal
 foo: Literal[3]
 [out]
 MypyFile:1(
-  ImportFrom:1(typing_extensions, [Literal])
+  ImportFrom:1(typing, [Literal])
   AssignmentStmt:2(
     NameExpr(foo [__main__.foo])
     TempNode:2(
@@ -11,12 +11,12 @@ MypyFile:1(
     Literal[3]))
 
 [case testLiteralSemanalInFunction]
-from typing_extensions import Literal
+from typing import Literal
 def foo(a: Literal[1], b: Literal["  foo  "]) -> Literal[True]: pass
 [builtins fixtures/bool.pyi]
 [out]
 MypyFile:1(
-  ImportFrom:1(typing_extensions, [Literal])
+  ImportFrom:1(typing, [Literal])
   FuncDef:2(
     foo
     Args(


### PR DESCRIPTION
`Literal` was added to Python in 3.8. Replace most `typing_extensions` imports in tests.