### PR TITLE
Add codespell to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,13 @@ repos:
       - id: check-github-workflows
       - id: check-github-actions
       - id: check-readthedocs
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=HAX,ccompiler,ot,statics,whet,zar
+        exclude: ^(mypy/test/|mypy/typeshed/|mypyc/test-data/|test-data/).+$
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -557,7 +557,7 @@ class ASTConverter:
         ast3.Is: "is",
         ast3.IsNot: "is not",
         ast3.In: "in",
-        ast3.NotIn: "not in",
+        ast3.NotIn: "not in",  # codespell:ignore notin
     }
 
     def from_comp_operator(self, op: ast3.cmpop) -> str:
@@ -2169,7 +2169,7 @@ class FindAttributeAssign(TraverserVisitor):
 
 
 class FindYield(TraverserVisitor):
-    """Check if an AST contains yields or yield froms."""
+    """Check if an AST contains yields or yield froms."""  # codespell:ignore froms
 
     def __init__(self) -> None:
         self.found = False

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -176,15 +176,15 @@ class Node(Context):
     __slots__ = ()
 
     def __str__(self) -> str:
-        ans = self.accept(mypy.strconv.StrConv(options=Options()))
-        if ans is None:
+        a = self.accept(mypy.strconv.StrConv(options=Options()))
+        if a is None:
             return repr(self)
-        return ans
+        return a
 
     def str_with_options(self, options: Options) -> str:
-        ans = self.accept(mypy.strconv.StrConv(options=options))
-        assert ans
-        return ans
+        a = self.accept(mypy.strconv.StrConv(options=options))
+        assert a
+        return a
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
         raise RuntimeError("Not implemented", type(self))

--- a/mypy/stubinfo.py
+++ b/mypy/stubinfo.py
@@ -97,7 +97,7 @@ non_bundled_packages_flat: dict[str, str] = {
     "commctrl": "types-pywin32",
     "commonmark": "types-commonmark",
     "consolemenu": "types-console-menu",
-    "corus": "types-corus",
+    "corus": "types-corus",  # codespell:ignore corus
     "cronlog": "types-python-crontab",
     "crontab": "types-python-crontab",
     "crontabs": "types-python-crontab",


### PR DESCRIPTION
Replaces #18387

Use codespell in pre-commit to detect spelling mistakes, see #18642. Ignore test and typeshed folders.