### PR TITLE
Update TypedDict imports in tests (2)

### DIFF
--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -218,8 +218,7 @@ L0:
     return r2
 
 [case testDictIterationMethods]
-from typing import Dict, Union
-from typing_extensions import TypedDict
+from typing import Dict, TypedDict, Union
 
 class Person(TypedDict):
     name: str
@@ -239,6 +238,7 @@ def typeddict(d: Person) -> None:
     for k, v in d.items():
         if k == "name":
             name = v
+[typing fixtures/typing-full.pyi]
 [out]
 def print_dict_methods(d1, d2):
     d1, d2 :: dict

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -78,7 +78,7 @@ assert hasattr(c, 'x')
 
 [case testTypedDictWithFields]
 import collections
-from typing_extensions import TypedDict
+from typing import TypedDict
 class C(TypedDict):
     x: collections.deque
 [file driver.py]
@@ -86,6 +86,7 @@ from native import C
 from collections import deque
 
 print(C.__annotations__["x"] is deque)
+[typing fixtures/typing-full.pyi]
 [out]
 True
 

--- a/mypyc/test-data/run-dicts.test
+++ b/mypyc/test-data/run-dicts.test
@@ -95,8 +95,7 @@ assert get_content_set(od) == ({1, 3}, {2, 4}, {(1, 2), (3, 4)})
 [typing fixtures/typing-full.pyi]
 
 [case testDictIterationMethodsRun]
-from typing import Dict, Union
-from typing_extensions import TypedDict
+from typing import Dict, TypedDict, Union
 
 class ExtensionDict(TypedDict):
     python: str
@@ -188,6 +187,7 @@ except TypeError as e:
     assert str(e) == "a tuple of length 2 expected"
 else:
     assert False
+[typing fixtures/typing-full.pyi]
 [out]
 1
 3

--- a/mypyc/test-data/run-functions.test
+++ b/mypyc/test-data/run-functions.test
@@ -1243,7 +1243,8 @@ def g() -> None:
 g()
 
 [case testUnpackKwargsCompiled]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -1254,6 +1255,7 @@ def foo(**kwargs: Unpack[Person]) -> None:
 
 # This is not really supported yet, just test that we behave reasonably.
 foo(name='Jennifer', age=38)
+[typing fixtures/typing-full.pyi]
 [out]
 Jennifer
 

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -612,8 +612,8 @@ for a in sorted(s):
 9     8   72
 
 [case testDummyTypes]
-from typing import Tuple, List, Dict, Literal, NamedTuple
-from typing_extensions import TypedDict, NewType
+from typing import Tuple, List, Dict, Literal, NamedTuple, TypedDict
+from typing_extensions import NewType
 
 class A:
     pass
@@ -664,6 +664,7 @@ except Exception as e:
     print(type(e).__name__)
 # ... but not that it is a valid literal value
 take_literal(10)
+[typing fixtures/typing-full.pyi]
 [out]
 Lol(a=1, b=[])
 10
@@ -675,7 +676,7 @@ TypeError
 10
 
 [case testClassBasedTypedDict]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class TD(TypedDict):
     a: int
@@ -707,6 +708,7 @@ def test_non_total_typed_dict() -> None:
     d4 = TD4(a=1, b=2, c=3, d=4)
     assert d3['c'] == 3
     assert d4['d'] == 4
+[typing fixtures/typing-full.pyi]
 
 [case testClassBasedNamedTuple]
 from typing import NamedTuple

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -396,8 +396,7 @@ y = x # E: Incompatible types in assignment (expression has type "Dict[str, int]
 import b
 
 [file a.py]
-from typing import NamedTuple
-from typing_extensions import TypedDict
+from typing import NamedTuple, TypedDict
 from enum import Enum
 class A: pass
 N = NamedTuple('N', [('x', int)])
@@ -406,8 +405,8 @@ class B(Enum):
     b = 10
 
 [file b.py]
-from typing import List, Literal, Optional, Union, Sequence, NamedTuple, Tuple, Type
-from typing_extensions import Final, TypedDict
+from typing import List, Literal, Optional, Union, Sequence, NamedTuple, Tuple, Type, TypedDict
+from typing_extensions import Final
 from enum import Enum
 import a
 class A: pass
@@ -464,8 +463,8 @@ def typeddict() -> Sequence[D]:
 
 a = (a.A(), A())
 a.x  # E: "Tuple[a.A, b.A]" has no attribute "x"
-
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testReturnAnyFromFunctionDeclaredToReturnObject]
 # flags: --warn-return-any

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1408,7 +1408,7 @@ class C:
 
 [case testDataclassFieldWithTypedDictUnpacking]
 from dataclasses import dataclass, field
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class FieldKwargs(TypedDict):
     repr: bool
@@ -1421,6 +1421,7 @@ class Foo:
 
 reveal_type(Foo(bar=1.5))  # N: Revealed type is "__main__.Foo"
 [builtins fixtures/dataclasses.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testDataclassWithSlotsArg]
 # flags: --python-version 3.10

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -449,7 +449,7 @@ y: Dict[int, int] = {1: ''}  # E: Dict entry 0 has incompatible type "int": "str
 [builtins fixtures/dict.pyi]
 
 [case testErrorCodeTypedDict]
-from typing_extensions import TypedDict
+from typing import TypedDict
 class D(TypedDict):
     x: int
 class E(TypedDict):
@@ -472,7 +472,7 @@ a['y']  # E: TypedDict "D" has no key "y"  [typeddict-item]
 [typing fixtures/typing-typeddict.pyi]
 
 [case testErrorCodeTypedDictNoteIgnore]
-from typing_extensions import TypedDict
+from typing import TypedDict
 class A(TypedDict):
     one_commonpart: int
     two_commonparts: int
@@ -484,7 +484,7 @@ not_exist = a['not_exist'] # type: ignore[typeddict-item]
 [typing fixtures/typing-typeddict.pyi]
 
 [case testErrorCodeTypedDictSubCodeIgnore]
-from typing_extensions import TypedDict
+from typing import TypedDict
 class D(TypedDict):
     x: int
 d: D = {'x': 1, 'y': 2}  # type: ignore[typeddict-item]
@@ -831,10 +831,11 @@ Foo = NamedTuple("Bar", [])  # E: First argument to namedtuple() should be "Foo"
 [builtins fixtures/tuple.pyi]
 
 [case testTypedDictNameMismatch]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 Foo = TypedDict("Bar", {})  # E: First argument "Bar" to TypedDict() does not match variable name "Foo"  [name-match]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTruthyBool]
 # flags: --enable-error-code truthy-bool --no-local-partial-types
@@ -993,7 +994,7 @@ reveal_type(t)  # N: Revealed type is "__main__.TensorType"
 [builtins fixtures/tuple.pyi]
 
 [case testNoteAboutChangedTypedDictErrorCode]
-from typing_extensions import TypedDict
+from typing import TypedDict
 class D(TypedDict):
     x: int
 

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -542,7 +542,7 @@ x: Any
 [builtins fixtures/primitives.pyi]
 
 [case testFormatCallAccessorsIndices]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class User(TypedDict):
     id: int
@@ -554,6 +554,7 @@ u: User
 def f() -> str: ...
 '{[f()]}'.format(u)  # E: Invalid index expression in format field accessor "[f()]"
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testFormatCallFlags]
 from typing import Union

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3399,8 +3399,7 @@ class Bar(Foo):
 [builtins fixtures/property.pyi]
 
 [case testNoCrashOnUnpackOverride]
-from typing import Unpack
-from typing_extensions import TypedDict
+from typing import TypedDict, Unpack
 
 class Params(TypedDict):
     x: int
@@ -3419,9 +3418,9 @@ class C(B):
                                                       # N:          def meth(*, x: int, y: str) -> None \
                                                       # N:      Subclass: \
                                                       # N:          def meth(*, x: int, y: int) -> None
-
         ...
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testOverrideErrorLocationNamed]
 class B:

--- a/test-data/unit/check-functools.test
+++ b/test-data/unit/check-functools.test
@@ -433,7 +433,8 @@ def foo(cls3: Type[B[T]]):
 [builtins fixtures/tuple.pyi]
 
 [case testFunctoolsPartialTypedDictUnpack]
-from typing_extensions import TypedDict, Unpack
+from typing import TypedDict
+from typing_extensions import Unpack
 from functools import partial
 
 class D1(TypedDict, total=False):
@@ -509,8 +510,8 @@ def main6(a2good: A2Good, a2bad: A2Bad, **d1: Unpack[D1]) -> None:
     partial(fn4, **d1)(a2="asdf")
     partial(fn4, **d1)(**a2good)
     partial(fn4, **d1)(**a2bad)  # E: Argument "a2" to "fn4" has incompatible type "int"; expected "str"
-
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 
 [case testFunctoolsPartialNestedGeneric]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5740,8 +5740,8 @@ import b
 b.xyz
 
 [file b.py]
-from typing import NamedTuple, NewType
-from typing_extensions import TypedDict, TypeAlias
+from typing import NamedTuple, NewType, TypedDict
+from typing_extensions import TypeAlias
 from enum import Enum
 from dataclasses import dataclass
 
@@ -5777,6 +5777,7 @@ class C:
         n: N = N(NT1(c=1))
 
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out2]
 tmp/a.py:2: error: "object" has no attribute "xyz"
 
@@ -6079,7 +6080,8 @@ tmp/b.py:3: error: Incompatible types in assignment (expression has type "int", 
 [case testUnpackKwargsSerialize]
 import m
 [file lib.py]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -6095,6 +6097,7 @@ foo(name='Jennifer', age=38)
 from lib import foo
 foo(name='Jennifer', age="38")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 [out2]
 tmp/m.py:2: error: Argument "age" to "foo" has incompatible type "str"; expected "int"
@@ -6276,7 +6279,7 @@ import f
 # modify
 
 [file f.py]
-from typing_extensions import TypedDict
+from typing import TypedDict
 import c
 class D(TypedDict):
     x: c.C
@@ -6297,6 +6300,7 @@ class C: ...
 class C: ...
 [file pb1.py.2]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 [out2]
 [out3]
@@ -6464,8 +6468,7 @@ y: int = x
 [case testGenericTypedDictWithError]
 import b
 [file a.py]
-from typing import Generic, TypeVar
-from typing_extensions import TypedDict
+from typing import Generic, TypeVar, TypedDict
 
 TValue = TypeVar("TValue")
 class Dict(TypedDict, Generic[TValue]):
@@ -6487,6 +6490,7 @@ def f(d: Dict[TValue]) -> TValue:
 def g(d: Dict[TValue]) -> TValue:
     return d["y"]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 tmp/b.py:6: error: TypedDict "a.Dict[TValue]" has no key "x"
 [out2]
@@ -6588,9 +6592,10 @@ import counts
 import counts
 # touch
 [file counts.py]
-from typing_extensions import TypedDict
+from typing import TypedDict
 Counts = TypedDict("Counts", {k: int for k in "abc"})  # type: ignore
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNoIncrementalCrashOnInvalidTypedDictFunc]
 import m
@@ -6600,10 +6605,11 @@ import counts
 import counts
 # touch
 [file counts.py]
-from typing_extensions import TypedDict
+from typing import TypedDict
 def test() -> None:
     Counts = TypedDict("Counts", {k: int for k in "abc"})  # type: ignore
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNoIncrementalCrashOnTypedDictMethod]
 import a
@@ -6615,13 +6621,14 @@ from b import C
 x: C
 reveal_type(x.h)
 [file b.py]
-from typing_extensions import TypedDict
+from typing import TypedDict
 class C:
     def __init__(self) -> None:
         self.h: Hidden
         class Hidden(TypedDict):
             x: int
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 [out2]
 tmp/a.py:3: note: Revealed type is "TypedDict('b.C.Hidden@5', {'x': builtins.int})"

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1239,7 +1239,7 @@ class B: pass
 [out]
 
 [case testForStatementIndexNarrowing]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class X(TypedDict):
     hourly: int
@@ -1266,6 +1266,7 @@ for b in ("hourly", "daily"):
     reveal_type(b)  # N: Revealed type is "builtins.str"
     reveal_type(b.upper())  # N: Revealed type is "builtins.str"
 [builtins fixtures/for.pyi]
+[typing fixtures/typing-full.pyi]
 
 
 -- Regression tests

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1854,8 +1854,7 @@ tup3: Tup2Class = tup2[:]     # E: Incompatible types in assignment (expression 
 [builtins fixtures/slice.pyi]
 
 [case testLiteralIntelligentIndexingTypedDict]
-from typing import Literal
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict
 
 class Unrelated: pass
 u: Unrelated
@@ -1893,8 +1892,8 @@ del d[c_key]                  # E: TypedDict "Outer" has no key "c"
 [out]
 
 [case testLiteralIntelligentIndexingUsingFinal]
-from typing import Literal, Tuple, NamedTuple
-from typing_extensions import Final, TypedDict
+from typing import Literal, Tuple, NamedTuple, TypedDict
+from typing_extensions import Final
 
 int_key_good: Final = 0
 int_key_bad: Final = 3
@@ -1960,8 +1959,8 @@ tup2[idx_bad]                   # E: Tuple index out of range
 [out]
 
 [case testLiteralIntelligentIndexingTypedDictUnions]
-from typing import Literal
-from typing_extensions import Final, TypedDict
+from typing import Literal, TypedDict
+from typing_extensions import Final
 
 class A: pass
 class B: pass
@@ -2012,8 +2011,7 @@ del test[bad_keys]              # E: Key "a" of TypedDict "Test" cannot be delet
 [out]
 
 [case testLiteralIntelligentIndexingMultiTypedDict]
-from typing import Literal, Union
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict, Union
 
 class A: pass
 class B: pass

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -2883,7 +2883,7 @@ CustomDict(foo="abc", bar="def")
 [file foo/__init__.py]
 [file foo/bar/__init__.py]
 [file foo/bar/custom_dict.py]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 CustomDict = TypedDict(
     "CustomDict",

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1,7 +1,6 @@
 [case testNarrowingParentWithStrsBasic]
 from dataclasses import dataclass
-from typing import Literal, NamedTuple, Tuple, Union
-from typing_extensions import TypedDict
+from typing import Literal, NamedTuple, Tuple, TypedDict, Union
 
 class Object1:
     key: Literal["A"]
@@ -80,12 +79,12 @@ if x5["key"] == "A":
 else:
     reveal_type(x5)         # N: Revealed type is "TypedDict('__main__.TypedDict2', {'key': Literal['B'], 'foo': builtins.str})"
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingParentWithEnumsBasic]
 from enum import Enum
 from dataclasses import dataclass
-from typing import Literal, NamedTuple, Tuple, Union
-from typing_extensions import TypedDict
+from typing import Literal, NamedTuple, Tuple, TypedDict, Union
 
 class Key(Enum):
     A = 1
@@ -168,12 +167,12 @@ if x5["key"] is Key.A:
     reveal_type(x5)         # N: Revealed type is "TypedDict('__main__.TypedDict1', {'key': Literal[__main__.Key.A], 'foo': builtins.int})"
 else:
     reveal_type(x5)         # N: Revealed type is "TypedDict('__main__.TypedDict2', {'key': Literal[__main__.Key.B], 'foo': builtins.str})"
-[builtins fixtures/narrowing.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingParentWithIsInstanceBasic]
 from dataclasses import dataclass
-from typing import NamedTuple, Tuple, Union
-from typing_extensions import TypedDict
+from typing import NamedTuple, Tuple, TypedDict, Union
 
 class Object1:
     key: int
@@ -233,7 +232,8 @@ if isinstance(x5["key"], int):
     reveal_type(x5)         # N: Revealed type is "TypedDict('__main__.TypedDict1', {'key': builtins.int})"
 else:
     reveal_type(x5)         # N: Revealed type is "TypedDict('__main__.TypedDict2', {'key': builtins.str})"
-[builtins fixtures/narrowing.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingParentMultipleKeys]
 # flags: --warn-unreachable
@@ -270,8 +270,7 @@ else:
 
 [case testNarrowingTypedDictParentMultipleKeys]
 # flags: --warn-unreachable
-from typing import Literal, Union
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict, Union
 
 class TypedDict1(TypedDict):
     key: Literal['A', 'C']
@@ -294,11 +293,11 @@ if x['key'] == 'D':
 else:
     reveal_type(x)  # N: Revealed type is "Union[TypedDict('__main__.TypedDict1', {'key': Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key': Union[Literal['B'], Literal['C']]})]"
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingPartialTypedDictParentMultipleKeys]
 # flags: --warn-unreachable
-from typing import Literal, Union
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict, Union
 
 class TypedDict1(TypedDict, total=False):
     key: Literal['A', 'C']
@@ -321,10 +320,10 @@ if x['key'] == 'D':
 else:
     reveal_type(x)  # N: Revealed type is "Union[TypedDict('__main__.TypedDict1', {'key'?: Union[Literal['A'], Literal['C']]}), TypedDict('__main__.TypedDict2', {'key'?: Union[Literal['B'], Literal['C']]})]"
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingNestedTypedDicts]
-from typing import Literal, Union
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict, Union
 
 class A(TypedDict):
     key: Literal['A']
@@ -349,6 +348,7 @@ if unknown['inner']['key'] == 'C':
     reveal_type(unknown)            # N: Revealed type is "TypedDict('__main__.Y', {'inner': Union[TypedDict('__main__.B', {'key': Literal['B']}), TypedDict('__main__.C', {'key': Literal['C']})]})"
     reveal_type(unknown['inner'])   # N: Revealed type is "TypedDict('__main__.C', {'key': Literal['C']})"
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingParentWithMultipleParents]
 from enum import Enum
@@ -396,8 +396,7 @@ else:
 
 [case testNarrowingParentWithParentMixtures]
 from enum import Enum
-from typing import Literal, Union, NamedTuple
-from typing_extensions import TypedDict
+from typing import Literal, Union, NamedTuple, TypedDict
 
 class Key(Enum):
     A = 1
@@ -575,8 +574,7 @@ else:
 
 [case testNarrowingParentsHierarchyTypedDict]
 # flags: --warn-unreachable
-from typing import Literal, Union
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict, Union
 from enum import Enum
 
 class Key(Enum):
@@ -613,12 +611,12 @@ if y["model"]["key"] is Key.C:
 else:
     reveal_type(y)              # N: Revealed type is "Union[TypedDict('__main__.Parent1', {'model': TypedDict('__main__.Model1', {'key': Literal[__main__.Key.A]}), 'foo': builtins.int}), TypedDict('__main__.Parent2', {'model': TypedDict('__main__.Model2', {'key': Literal[__main__.Key.B]}), 'bar': builtins.str})]"
     reveal_type(y["model"])     # N: Revealed type is "Union[TypedDict('__main__.Model1', {'key': Literal[__main__.Key.A]}), TypedDict('__main__.Model2', {'key': Literal[__main__.Key.B]})]"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingParentsHierarchyTypedDictWithStr]
 # flags: --warn-unreachable
-from typing import Literal, Union
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict, Union
 
 class Parent1(TypedDict):
     model: Model1
@@ -650,6 +648,7 @@ else:
     reveal_type(y)              # N: Revealed type is "Union[TypedDict('__main__.Parent1', {'model': TypedDict('__main__.Model1', {'key': Literal['A']}), 'foo': builtins.int}), TypedDict('__main__.Parent2', {'model': TypedDict('__main__.Model2', {'key': Literal['B']}), 'bar': builtins.str})]"
     reveal_type(y["model"])     # N: Revealed type is "Union[TypedDict('__main__.Model1', {'key': Literal['A']}), TypedDict('__main__.Model2', {'key': Literal['B']})]"
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingExprPropagation]
 from typing import Literal, Union
@@ -1232,8 +1231,7 @@ reveal_type(x) # N: Revealed type is "builtins.bool"
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingTypedDictUsingEnumLiteral]
-from typing import Literal, Union
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict, Union
 from enum import Enum
 
 class E(Enum):
@@ -1253,6 +1251,7 @@ def f(d: Union[Foo, Bar]) -> None:
     d['x']
     reveal_type(d)  # N: Revealed type is "TypedDict('__main__.Foo', {'tag': Literal[__main__.E.FOO], 'x': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingUsingMetaclass]
 from typing import Type
@@ -1293,8 +1292,7 @@ def f(t: Type[T], a: A, b: B) -> None:
         reveal_type(b)  # N: Revealed type is "__main__.B"
 
 [case testNarrowingNestedUnionOfTypedDicts]
-from typing import Literal, Union
-from typing_extensions import TypedDict
+from typing import Literal, TypedDict, Union
 
 class A(TypedDict):
     tag: Literal["A"]
@@ -1318,9 +1316,8 @@ elif abc["tag"] == "C":
     reveal_type(abc) # N: Revealed type is "TypedDict('__main__.C', {'tag': Literal['C'], 'c': builtins.int})"
 else:
     reveal_type(abc) # N: Revealed type is "TypedDict('__main__.B', {'tag': Literal['B'], 'b': builtins.int})"
-
 [builtins fixtures/primitives.pyi]
-
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNarrowingRuntimeCover]
 from typing import Dict, List, Union

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3233,15 +3233,15 @@ class User:
         self.name = name  # E: Cannot assign to a method
 
 [case testNewAnalyzerMemberNameMatchesTypedDict]
-from typing import Union, Any
-from typing_extensions import TypedDict
+from typing import TypedDict, Union, Any
 
 class T(TypedDict):
     b: b.T
 
 class b:
     T: Union[Any]
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testNewAnalyzerMemberNameMatchesNamedTuple]
 from typing import Union, Any, NamedTuple

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -2691,8 +2691,7 @@ reveal_type(f(**{'a': 4, 'b': 4, 'c': 4}))   # N: Revealed type is "builtins.tup
 [builtins fixtures/dict.pyi]
 
 [case testOverloadKwargsSelectionWithTypedDict]
-from typing import overload, Tuple
-from typing_extensions import TypedDict
+from typing import overload, Tuple, TypedDict
 @overload
 def f(*, x: int) -> Tuple[int]: ...
 @overload
@@ -2713,6 +2712,7 @@ reveal_type(f(**a))  # N: Revealed type is "Tuple[builtins.int]"
 reveal_type(f(**b))  # N: Revealed type is "Tuple[builtins.int, builtins.int]"
 reveal_type(f(**c))  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testOverloadVarargsAndKwargsSelection]
 from typing import overload, Any, Tuple, Dict

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -675,7 +675,8 @@ main:16: note:     def foo(cls, float, /) -> Any
 main:16: note:     def foo(cls, a: str) -> Any
 
 [case testUnpackWithDuplicateNamePositionalOnly]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -683,6 +684,7 @@ class Person(TypedDict):
 def foo(name: str, /, **kwargs: Unpack[Person]) -> None:  # Allowed
     ...
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testPossiblyUndefinedWithAssignmentExpr]
 # flags: --enable-error-code possibly-undefined

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -879,13 +879,13 @@ def list_thing(transforming: InList[T]) -> T:
 reveal_type(list_thing([5]))  # N: Revealed type is "builtins.list[builtins.int]"
 
 [case testRecursiveTypedDictWithList]
-from typing import List
-from typing_extensions import TypedDict
+from typing import List, TypedDict
 
 Example = TypedDict("Example", {"rec": List["Example"]})
 e: Example
 reveal_type(e)  # N: Revealed type is "TypedDict('__main__.Example', {'rec': builtins.list[...]})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testRecursiveNamedTupleWithList]
 from typing import List, NamedTuple

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -477,7 +477,7 @@ f(ll) # E: Argument 1 to "f" has incompatible type "List[TypedDict({'x': int, 'z
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictWithSimpleProtocol]
-from typing_extensions import Protocol, TypedDict
+from typing import Protocol, TypedDict
 
 class StrObjectMap(Protocol):
     def __getitem__(self, key: str) -> object: ...
@@ -505,8 +505,7 @@ main:17: note:     Got:
 main:17: note:         def __getitem__(self, str, /) -> object
 
 [case testTypedDictWithSimpleProtocolInference]
-from typing_extensions import Protocol, TypedDict
-from typing import TypeVar
+from typing import Protocol, TypedDict, TypeVar
 
 T_co = TypeVar('T_co', covariant=True)
 T = TypeVar('T')
@@ -897,8 +896,7 @@ reveal_type(u(c, m_s_a)) # N: Revealed type is "Union[typing.Mapping[builtins.st
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUnionUnambiguousCase]
-from typing import Union, Literal, Mapping, Any, cast
-from typing_extensions import TypedDict
+from typing import Union, Literal, Mapping, TypedDict, Any, cast
 
 A = TypedDict('A', {'@type': Literal['a-type'], 'a': str})
 B = TypedDict('B', {'@type': Literal['b-type'], 'b': int})
@@ -906,20 +904,20 @@ B = TypedDict('B', {'@type': Literal['b-type'], 'b': int})
 c: Union[A, B] = {'@type': 'a-type', 'a': 'Test'}
 reveal_type(c) # N: Revealed type is "Union[TypedDict('__main__.A', {'@type': Literal['a-type'], 'a': builtins.str}), TypedDict('__main__.B', {'@type': Literal['b-type'], 'b': builtins.int})]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUnionAmbiguousCaseBothMatch]
-from typing import Union, Literal, Mapping, Any, cast
-from typing_extensions import TypedDict
+from typing import Union, Literal, Mapping, TypedDict, Any, cast
 
 A = TypedDict('A', {'@type': Literal['a-type'], 'value': str})
 B = TypedDict('B', {'@type': Literal['b-type'], 'value': str})
 
 c: Union[A, B] = {'@type': 'a-type', 'value': 'Test'}
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUnionAmbiguousCaseNoMatch]
-from typing import Union, Literal, Mapping, Any, cast
-from typing_extensions import TypedDict
+from typing import Union, Literal, Mapping, TypedDict, Any, cast
 
 A = TypedDict('A', {'@type': Literal['a-type'], 'value': int})
 B = TypedDict('B', {'@type': Literal['b-type'], 'value': int})
@@ -927,6 +925,7 @@ B = TypedDict('B', {'@type': Literal['b-type'], 'value': int})
 c: Union[A, B] = {'@type': 'a-type', 'value': 'Test'}  # E: Type of TypedDict is ambiguous, none of ("A", "B") matches cleanly \
                                                        # E: Incompatible types in assignment (expression has type "Dict[str, str]", variable has type "Union[A, B]")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 -- Use dict literals
 
@@ -1813,6 +1812,7 @@ class Point(TypedDict):
 p = Point(x=42, y=1337)
 reveal_type(p)  # N: Revealed type is "TypedDict('__main__.Point', {'x': builtins.int, 'y': builtins.int})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testCanCreateTypedDictWithTypingProper]
 from typing import TypedDict
@@ -2932,7 +2932,7 @@ foo({"foo": {"e": "foo"}})  # E: Type of TypedDict is ambiguous, none of ("A", "
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictMissingEmptyKey]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class A(TypedDict):
     my_attr_1: str
@@ -3564,8 +3564,8 @@ class A(Generic[T]):
 [builtins fixtures/tuple.pyi]
 
 [case testNameUndefinedErrorDoesNotLoseUnpackedKWArgsInformation]
-from typing import overload
-from typing_extensions import TypedDict, Unpack
+from typing import TypedDict, overload
+from typing_extensions import Unpack
 
 class TD(TypedDict, total=False):
     x: int
@@ -3600,10 +3600,11 @@ class B(A):
 reveal_type(B.f)  # N: Revealed type is "def (self: __main__.B, **kwargs: Unpack[TypedDict('__main__.TD', {'x'?: builtins.int, 'y'?: builtins.str})])"
 B().f(x=1.0)  # E: Argument "x" to "f" of "B" has incompatible type "float"; expected "int"
 [builtins fixtures/primitives.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictUnpackWithParamSpecInference]
-from typing import TypeVar, ParamSpec, Callable
-from typing_extensions import TypedDict, Unpack
+from typing import TypedDict, TypeVar, ParamSpec, Callable
+from typing_extensions import Unpack
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -3624,11 +3625,12 @@ class Test:
     def h(self, **params: Unpack[Params]) -> None:
         run(test2, other="yes", **params)
         run(test2, other=0, **params)  # E: Argument "other" to "run" has incompatible type "int"; expected "str"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testTypedDictUnpackSingleWithSubtypingNoCrash]
-from typing import Callable
-from typing_extensions import TypedDict, Unpack
+from typing import Callable, TypedDict
+from typing_extensions import Unpack
 
 class Kwargs(TypedDict):
     name: str
@@ -3642,7 +3644,8 @@ class C:
 # TODO: it is an old question whether we should allow this, for now simply don't crash.
 class D(C):
     d = f
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictInlineNoOldStyleAlias]
 # flags: --enable-incomplete-feature=InlineTypedDict
@@ -3806,7 +3809,8 @@ x.update({"key": "abc"})  # E: ReadOnly TypedDict key "key" TypedDict is mutated
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictReadOnlyMutate__ior__Statements]
-from typing_extensions import ReadOnly, TypedDict
+from typing import TypedDict
+from typing_extensions import ReadOnly
 
 class TP(TypedDict):
     key: ReadOnly[str]
@@ -3821,7 +3825,8 @@ x |= {"key": "a", "other": 1, "mutable": True}  # E: ReadOnly TypedDict keys ("k
 [typing fixtures/typing-typeddict-iror.pyi]
 
 [case testTypedDictReadOnlyMutate__or__Statements]
-from typing_extensions import ReadOnly, TypedDict
+from typing import TypedDict
+from typing_extensions import ReadOnly
 
 class TP(TypedDict):
     key: ReadOnly[str]
@@ -4013,7 +4018,8 @@ reveal_type(f(g))  # N: Revealed type is "TypedDict({'x'=: builtins.int, 'y': bu
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictReadOnlyUnpack]
-from typing_extensions import TypedDict, Unpack, ReadOnly
+from typing import TypedDict
+from typing_extensions import Unpack, ReadOnly
 
 class TD(TypedDict):
     x: ReadOnly[int]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -1130,8 +1130,8 @@ nt2 = A(fn=bad, val=42)  # E: Argument "fn" to "A" has incompatible type "Callab
 [builtins fixtures/tuple.pyi]
 
 [case testVariadicTypedDict]
-from typing import Tuple, Callable, Generic, TypeVar
-from typing_extensions import TypeVarTuple, Unpack, TypedDict
+from typing import Tuple, Callable, Generic, TypedDict, TypeVar
+from typing_extensions import TypeVarTuple, Unpack
 
 T = TypeVar("T")
 Ts = TypeVarTuple("Ts")
@@ -1156,7 +1156,8 @@ reveal_type(td)  # N: Revealed type is "TypedDict('__main__.A', {'fn': def (buil
 
 def bad() -> int: ...
 td2 = A({"fn": bad, "val": 42})  # E: Incompatible types (expression has type "Callable[[], int]", TypedDict item "fn" has type "Callable[[], None]")
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testFixedUnpackWithRegularInstance]
 from typing import Tuple, Generic, TypeVar
@@ -2167,8 +2168,8 @@ reveal_type([f, h])  # N: Revealed type is "builtins.list[def (builtins.int, *Un
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarTupleBothUnpacksSimple]
-from typing import Tuple
-from typing_extensions import Unpack, TypeVarTuple, TypedDict
+from typing import Tuple, TypedDict
+from typing_extensions import Unpack, TypeVarTuple
 
 class Keywords(TypedDict):
     a: str
@@ -2202,11 +2203,12 @@ def bad2(
      **kwargs: Unpack[Ints],  # E: Unpack item in ** argument must be a TypedDict
 ) -> None: ...
 reveal_type(bad2)  # N: Revealed type is "def (one: builtins.int, *args: Any, other: builtins.str =, **kwargs: Any)"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypeVarTupleBothUnpacksCallable]
-from typing import Callable, Tuple
-from typing_extensions import Unpack, TypedDict
+from typing import Callable, Tuple, TypedDict
+from typing_extensions import Unpack
 
 class Keywords(TypedDict):
     a: str
@@ -2229,11 +2231,12 @@ reveal_type(bad2)  # N: Revealed type is "def (*Any, **Unpack[TypedDict('__main_
 bad3: Callable[[Unpack[Keywords], Unpack[Ints]], None]  # E: "Keywords" cannot be unpacked (must be tuple or TypeVarTuple) \
                                                         # E: More than one Unpack in a type is not allowed
 reveal_type(bad3)  # N: Revealed type is "def (*Any)"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypeVarTupleBothUnpacksApplication]
-from typing import Callable, TypeVar, Optional
-from typing_extensions import Unpack, TypeVarTuple, TypedDict
+from typing import Callable, TypedDict, TypeVar, Optional
+from typing_extensions import Unpack, TypeVarTuple
 
 class Keywords(TypedDict):
     a: str
@@ -2262,7 +2265,8 @@ def test2(
         func(*args)  # E: Missing named argument "a" \
                      # E: Missing named argument "b"
     return func(*args, **kwargs)
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackTupleSpecialCaseNoCrash]
 from typing import Tuple, TypeVar

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -633,8 +633,7 @@ def f(x: S) -> None:
     h(x)
 
 [case testTypeVarWithTypedDictBoundInIndexExpression]
-from typing import TypeVar
-from typing_extensions import TypedDict
+from typing import TypedDict, TypeVar
 
 class Data(TypedDict):
     x: int
@@ -645,11 +644,11 @@ T = TypeVar("T", bound=Data)
 
 def f(data: T) -> None:
     reveal_type(data["x"]) # N: Revealed type is "builtins.int"
-[builtins fixtures/tuple.pyi]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypeVarWithUnionTypedDictBoundInIndexExpression]
-from typing import TypeVar, Union, Dict
-from typing_extensions import TypedDict
+from typing import TypedDict, TypeVar, Union, Dict
 
 class Data(TypedDict):
     x: int
@@ -661,10 +660,10 @@ T = TypeVar("T", bound=Union[Data, Dict[str, str]])
 def f(data: T) -> None:
     reveal_type(data["x"]) # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testTypeVarWithTypedDictValueInIndexExpression]
-from typing import TypeVar, Union, Dict
-from typing_extensions import TypedDict
+from typing import TypedDict, TypeVar, Union, Dict
 
 class Data(TypedDict):
     x: int
@@ -676,10 +675,10 @@ T = TypeVar("T", Data, Dict[str, str])
 def f(data: T) -> None:
     _: Union[str, int] = data["x"]
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testSelfTypeVarIndexExpr]
-from typing import TypeVar, Union, Type
-from typing_extensions import TypedDict
+from typing import TypedDict, TypeVar, Union, Type
 
 T = TypeVar("T", bound="Indexable")
 
@@ -697,6 +696,7 @@ class Indexable:
     def m(self: T) -> T:
         return self["foo"]
 [builtins fixtures/classmethod.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testTypeVarWithValueDeferral]
 from typing import TypeVar, Callable

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -745,7 +745,8 @@ bar(*bad2)  # E: Expected iterable as variadic argument
 -- Keyword arguments unpacking
 
 [case testUnpackKwargsReveal]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -754,9 +755,11 @@ def foo(arg: bool, **kwargs: Unpack[Person]) -> None: ...
 
 reveal_type(foo)  # N: Revealed type is "def (arg: builtins.bool, **kwargs: Unpack[TypedDict('__main__.Person', {'name': builtins.str, 'age': builtins.int})])"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackOutsideOfKwargs]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 class Person(TypedDict):
     name: str
     age: int
@@ -768,6 +771,7 @@ def bar(x: int, *args: Unpack[Person]) -> None:  # E: "Person" cannot be unpacke
 def baz(**kwargs: Unpack[Person]) -> None:  # OK
     ...
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackWithoutTypedDict]
 from typing_extensions import Unpack
@@ -777,7 +781,8 @@ def foo(**kwargs: Unpack[dict]) -> None:  # E: Unpack item in ** argument must b
 [builtins fixtures/dict.pyi]
 
 [case testUnpackWithDuplicateKeywords]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -785,10 +790,11 @@ class Person(TypedDict):
 def foo(name: str, **kwargs: Unpack[Person]) -> None:  # E: Overlap between argument names and ** TypedDict items: "name"
     ...
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackWithDuplicateKeywordKwargs]
-from typing_extensions import Unpack, TypedDict
-from typing import Dict, List
+from typing_extensions import Unpack
+from typing import Dict, List, TypedDict
 
 class Spec(TypedDict):
     args: List[int]
@@ -797,9 +803,11 @@ def foo(**kwargs: Unpack[Spec]) -> None:  # Allowed
     ...
 foo(args=[1], kwargs={"2": 3})  # E: Dict entry 0 has incompatible type "str": "int"; expected "int": "int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsNonIdentifier]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 Weird = TypedDict("Weird", {"@": int})
 
@@ -808,9 +816,11 @@ def foo(**kwargs: Unpack[Weird]) -> None:
 foo(**{"@": 42})
 foo(**{"no": "way"})  # E: Argument 1 to "foo" has incompatible type "**Dict[str, str]"; expected "int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsEmpty]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 Empty = TypedDict("Empty", {})
 
@@ -819,9 +829,11 @@ def foo(**kwargs: Unpack[Empty]) -> None:  # N: "foo" defined here
 foo()
 foo(x=1)  # E: Unexpected keyword argument "x" for "foo"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackTypedDictTotality]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Circle(TypedDict, total=True):
     radius: int
@@ -841,9 +853,11 @@ def bar(**kwargs: Unpack[Square]):
     ...
 bar(side=12)
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackUnexpectedKeyword]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict, total=False):
     name: str
@@ -854,9 +868,11 @@ def foo(**kwargs: Unpack[Person]) -> None:  # N: "foo" defined here
 foo(name='John', age=42, department='Sales')  # E: Unexpected keyword argument "department" for "foo"
 foo(name='Jennifer', age=38)
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKeywordTypes]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -867,9 +883,11 @@ def foo(**kwargs: Unpack[Person]):
 foo(name='John', age='42')  # E: Argument "age" to "foo" has incompatible type "str"; expected "int"
 foo(name='Jennifer', age=38)
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKeywordTypesTypedDict]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -884,9 +902,11 @@ def foo(**kwargs: Unpack[Person]) -> None:
 lp = LegacyPerson(name="test", age="42")
 foo(**lp)  # E: Argument "age" to "foo" has incompatible type "str"; expected "int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testFunctionBodyWithUnpackedKwargs]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -898,9 +918,11 @@ def foo(**kwargs: Unpack[Person]) -> int:
     department: str = kwargs['department']  # E: TypedDict "Person" has no key "department"
     return kwargs['age']
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsOverrides]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -915,9 +937,11 @@ class SubBad(Base):
     # N: This violates the Liskov substitution principle \
     # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsOverridesTypedDict]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -940,10 +964,11 @@ class SubBad(Base):
     # N:      Subclass: \
     # N:          def foo(self, *, baz: int) -> None
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsGeneric]
-from typing import Generic, TypeVar
-from typing_extensions import Unpack, TypedDict
+from typing import Generic, TypedDict, TypeVar
+from typing_extensions import Unpack
 
 T = TypeVar("T")
 class Person(TypedDict, Generic[T]):
@@ -953,10 +978,11 @@ class Person(TypedDict, Generic[T]):
 def foo(**kwargs: Unpack[Person[T]]) -> T: ...
 reveal_type(foo(name="test", value=42))  # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsInference]
-from typing import Generic, TypeVar, Protocol
-from typing_extensions import Unpack, TypedDict
+from typing import Generic, TypedDict, TypeVar, Protocol
+from typing_extensions import Unpack
 
 T_contra = TypeVar("T_contra", contravariant=True)
 class CBPerson(Protocol[T_contra]):
@@ -972,10 +998,11 @@ def test(cb: CBPerson[T]) -> T: ...
 def foo(*, name: str, value: int) -> None: ...
 reveal_type(test(foo))  # N: Revealed type is "builtins.int"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsOverload]
-from typing import Any, overload
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict, Any, overload
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -994,9 +1021,11 @@ def foo(**kwargs: Any) -> Any:
 
 reveal_type(foo(sort="test", taste=999))  # N: Revealed type is "builtins.str"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsJoin]
-from typing_extensions import Unpack, TypedDict
+from typing import TypedDict
+from typing_extensions import Unpack
 
 class Person(TypedDict):
     name: str
@@ -1008,10 +1037,11 @@ def bar(**kwargs: Unpack[Person]) -> None: ...
 reveal_type([foo, bar])  # N: Revealed type is "builtins.list[def (*, name: builtins.str, age: builtins.int)]"
 reveal_type([bar, foo])  # N: Revealed type is "builtins.list[def (*, name: builtins.str, age: builtins.int)]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackKwargsParamSpec]
-from typing import Callable, Any, TypeVar, List
-from typing_extensions import ParamSpec, Unpack, TypedDict
+from typing import Callable, Any, TypedDict, TypeVar, List
+from typing_extensions import ParamSpec, Unpack
 
 class Person(TypedDict):
     name: str
@@ -1027,10 +1057,11 @@ def g(**kwargs: Unpack[Person]) -> int: ...
 
 reveal_type(g)  # N: Revealed type is "def (*, name: builtins.str, age: builtins.int) -> builtins.list[builtins.int]"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackGenericTypedDictImplicitAnyEnabled]
-from typing import Generic, TypeVar
-from typing_extensions import Unpack, TypedDict
+from typing import Generic, TypedDict, TypeVar
+from typing_extensions import Unpack
 
 T = TypeVar("T")
 class TD(TypedDict, Generic[T]):
@@ -1041,11 +1072,12 @@ def foo(**kwds: Unpack[TD]) -> None: ...  # Same as `TD[Any]`
 foo(key="yes", value=42)
 foo(key="yes", value="ok")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackGenericTypedDictImplicitAnyDisabled]
 # flags: --disallow-any-generics
-from typing import Generic, TypeVar
-from typing_extensions import Unpack, TypedDict
+from typing import Generic, TypedDict, TypeVar
+from typing_extensions import Unpack
 
 T = TypeVar("T")
 class TD(TypedDict, Generic[T]):
@@ -1056,6 +1088,7 @@ def foo(**kwds: Unpack[TD]) -> None: ...  # E: Missing type parameters for gener
 foo(key="yes", value=42)
 foo(key="yes", value="ok")
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 
 [case testUnpackNoCrashOnEmpty]
 from typing_extensions import Unpack
@@ -1067,8 +1100,8 @@ class D:
 [builtins fixtures/dict.pyi]
 
 [case testUnpackInCallableType]
-from typing import Callable
-from typing_extensions import Unpack, TypedDict
+from typing import Callable, TypedDict
+from typing_extensions import Unpack
 
 class TD(TypedDict):
     key: str
@@ -1080,3 +1113,4 @@ foo(key="yes", value="ok")
 
 bad: Callable[[*TD], None]  # E: "TD" cannot be unpacked (must be tuple or TypeVarTuple)
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/fine-grained-follow-imports.test
+++ b/test-data/unit/fine-grained-follow-imports.test
@@ -831,8 +831,7 @@ class A: ...
 import trio
 
 [file trio/__init__.py.2]
-from typing import TypeVar
-from typing_extensions import TypedDict
+from typing import TypedDict, TypeVar
 import trio
 from . import abc as abc
 
@@ -844,5 +843,6 @@ class C(TypedDict):
 import trio
 class A: ...
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 ==

--- a/test-data/unit/fine-grained-suggest.test
+++ b/test-data/unit/fine-grained-suggest.test
@@ -159,13 +159,14 @@ def foo():
 [case testSuggestInferTypedDict]
 # suggest: foo.foo
 [file foo.py]
-from typing_extensions import TypedDict
+from typing import TypedDict
 TD = TypedDict('TD', {'x': int})
 def foo():
     return bar()
 
 def bar() -> TD: ...
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 () -> foo.TD
 ==

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3710,17 +3710,20 @@ b.py:4: error: Incompatible types in assignment (expression has type "str", vari
 [case testTypedDictUpdateReadOnly]
 import b
 [file a.py]
-from typing_extensions import TypedDict, ReadOnly
+from typing import TypedDict
+from typing_extensions import ReadOnly
 Point = TypedDict('Point', {'x': int, 'y': int})
 p = Point(x=1, y=2)
 [file a.py.2]
-from typing_extensions import TypedDict, ReadOnly
+from typing import TypedDict
+from typing_extensions import ReadOnly
 class Point(TypedDict):
     x: int
     y: ReadOnly[int]
 p = Point(x=1, y=2)
 [file a.py.3]
-from typing_extensions import TypedDict, ReadOnly
+from typing import TypedDict
+from typing_extensions import ReadOnly
 Point = TypedDict('Point', {'x': ReadOnly[int], 'y': int})
 p = Point(x=1, y=2)
 [file b.py]
@@ -3729,6 +3732,7 @@ def foo(x: Point) -> None:
     x['x'] = 1
     x['y'] = 2
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 ==
 b.py:4: error: ReadOnly TypedDict key "y" TypedDict is mutated
@@ -10060,14 +10064,14 @@ main:4: error: "C" expects no type arguments, but 2 given
 [case testUnpackKwargsUpdateFine]
 import m
 [file shared.py]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class Person(TypedDict):
     name: str
     age: int
 
 [file shared.py.2]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class Person(TypedDict):
     name: str
@@ -10084,6 +10088,7 @@ from lib import foo
 foo(name='Jennifer', age=38)
 
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 ==
 m.py:2: error: Argument "age" to "foo" has incompatible type "int"; expected "str"
@@ -10389,7 +10394,7 @@ import n
 import m
 x: m.TD
 [file m.py]
-from typing_extensions import TypedDict
+from typing import TypedDict
 from f import A
 
 class TD(TypedDict):
@@ -10402,6 +10407,7 @@ A = int
 [file f.py.2]
 A = str
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
 [out]
 m.py:5: error: Invalid statement in TypedDict definition; expected "field_name: field_type"
 ==

--- a/test-data/unit/fixtures/for.pyi
+++ b/test-data/unit/fixtures/for.pyi
@@ -15,6 +15,7 @@ class function: pass
 class ellipsis: pass
 class bool: pass
 class int: pass # for convenience
+class float: pass  # for convenience
 class str:  # for convenience
     def upper(self) -> str: ...
 


### PR DESCRIPTION
Followup to #18528

Replace most `typing_extensions.TypedDict` imports in tests with `typing.TypedDict`.