### PR TITLE
Support non-trivial meets and joins of callables

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2322,6 +2322,7 @@ class State:
                 manager.plugin,
                 self.per_line_checking_time_ns,
             )
+            type_state.object_type = self._type_checker.named_type("builtins.object")
         return self._type_checker
 
     def type_map(self) -> dict[Expression, Type]:

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -733,10 +733,10 @@ def combine_parameters_with(
         if s_kind.is_star():
             continue
 
-        candidates = [t.argument_by_position(s_a.pos)]
+        raw_candidates = [t.argument_by_position(s_a.pos)]
         if s_a.name is not None and s_a.name not in spent_names:
-            candidates.append(t.argument_by_name(s_a.name))
-        candidates = [c for c in candidates if c is not None]
+            raw_candidates.append(t.argument_by_name(s_a.name))
+        candidates = [c for c in raw_candidates if c is not None]
         if not candidates:
             if s_a.required:
                 return None
@@ -782,10 +782,14 @@ def join_similar_callables(t: CallableType, s: CallableType) -> CallableType | N
     # TODO in combine_similar_callables also applies here (names and kinds; user metaclasses)
     # The fallback type can be either 'function', 'type', or some user-provided metaclass.
     # The result should always use 'function' as a fallback if either operands are using it.
+    fallback: ProperType
     if t.fallback.type.fullname == "builtins.function":
         fallback = t.fallback
-    else:
+    elif s.fallback.type.fullname == "builtins.function":
         fallback = s.fallback
+    else:
+        fallback = join_types(s.fallback, t.fallback)
+    assert isinstance(fallback, Instance)
     return t.copy_modified(
         arg_types=joined_params.arg_types,
         arg_names=joined_params.arg_names,
@@ -842,10 +846,14 @@ def combine_similar_callables(t: CallableType, s: CallableType) -> CallableType:
     # TODO what should happen if one fallback is 'type' and the other is a user-provided metaclass?
     # The fallback type can be either 'function', 'type', or some user-provided metaclass.
     # The result should always use 'function' as a fallback if either operands are using it.
+    fallback: ProperType
     if t.fallback.type.fullname == "builtins.function":
         fallback = t.fallback
-    else:
+    elif s.fallback.type.fullname == "builtins.function":
         fallback = s.fallback
+    else:
+        fallback = join_types(s.fallback, t.fallback)
+    assert isinstance(fallback, Instance)
     return t.copy_modified(
         arg_types=joined_params.arg_types,
         arg_names=joined_params.arg_names,

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1126,10 +1126,14 @@ def meet_similar_callables(t: CallableType, s: CallableType) -> CallableType | N
     # TODO in combine_similar_callables also applies here (names and kinds)
     # The fallback type can be either 'function' or 'type'. The result should have 'function' as
     # fallback only if both operands have it as 'function'.
-    if t.fallback.type.fullname != "builtins.function":
+    fallback: ProperType
+    if t.fallback.type.fullname == "builtins.function":
+        fallback = s.fallback
+    elif s.fallback.type.fullname == "builtins.function":
         fallback = t.fallback
     else:
-        fallback = s.fallback
+        fallback = meet_types(s.fallback, t.fallback)
+    assert isinstance(fallback, Instance)
     return t.copy_modified(
         arg_types=joined_params.arg_types,
         arg_names=joined_params.arg_names,

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -15,6 +15,7 @@ from mypy.subtypes import is_subtype
 from mypy.typeops import get_all_type_vars
 from mypy.types import (
     AnyType,
+    CallableType,
     Instance,
     NoneType,
     ParamSpecType,
@@ -576,6 +577,8 @@ def pre_validate_solutions(
 
 def is_callable_protocol(t: Type) -> bool:
     proper_t = get_proper_type(t)
+    if isinstance(proper_t, CallableType) and proper_t.is_ellipsis_args:
+        return True
     if isinstance(proper_t, Instance) and proper_t.type.is_protocol:
         return "__call__" in proper_t.type.protocol_members
     return False

--- a/mypy/typestate.py
+++ b/mypy/typestate.py
@@ -97,10 +97,7 @@ class TypeState:
     # This is temporary and will be removed soon when new algorithm is more polished.
     infer_polymorphic: bool
 
-    # N.B: We do all of the accesses to these properties through
-    # TypeState, instead of making these classmethods and accessing
-    # via the cls parameter, since mypyc can optimize accesses to
-    # Final attributes of a directly referenced type.
+    object_type: Instance | None
 
     def __init__(self) -> None:
         self._subtype_caches = {}
@@ -114,6 +111,7 @@ class TypeState:
         self.inferring = []
         self.infer_unions = False
         self.infer_polymorphic = False
+        self.object_type = None
 
     def is_assumed_subtype(self, left: Type, right: Type) -> bool:
         for l, r in reversed(self._assuming):
@@ -140,6 +138,7 @@ class TypeState:
         """Completely reset all known subtype caches."""
         self._subtype_caches.clear()
         self._negative_subtype_caches.clear()
+        self.object_type = None
 
     def reset_subtype_caches_for(self, info: TypeInfo) -> None:
         """Reset subtype caches (if any) for a given supertype TypeInfo."""

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3712,3 +3712,27 @@ reveal_type(join(base, bad2))  # E: Value of type variable "C" of "join" cannot 
 reveal_type(join(base, bad3))  # E: Value of type variable "C" of "join" cannot be "function" \
                                # N: Revealed type is "builtins.function"
 [builtins fixtures/tuple.pyi]
+
+[case testCallableJoin5]
+from typing import Callable, TypeVar
+
+C = TypeVar("C", bound=Callable[..., None])
+
+def join(t: C, val: C) -> C:
+    pass
+
+def less1(code, lang, style=None): ...
+def more1(code, lang, suffix="", style=None): ...
+reveal_type(join(less1, more1))  # N: Revealed type is "def (code: Any, lang: Any, Any =) -> Any"
+reveal_type(join(more1, less1))  # N: Revealed type is "def (code: Any, lang: Any, Any =) -> Any"
+
+def less2(code, lang, style: int = 0): ...
+def more2(code, lang, suffix: str = "", style: int = 0): ...
+reveal_type(join(less2, more2))  # N: Revealed type is "def (code: Any, lang: Any, *, style: builtins.int =) -> Any"
+reveal_type(join(more2, less2))  # N: Revealed type is "def (code: Any, lang: Any, *, style: builtins.int =) -> Any"
+
+def less3(code, lang, style: int = 0): ...
+def more3(code, lang, suffix: int = 0, style: str = ""): ...
+reveal_type(join(less3, more3))  # N: Revealed type is "def (code: Any, lang: Any, builtins.int =) -> Any"
+reveal_type(join(more3, less3))  # N: Revealed type is "def (code: Any, lang: Any, builtins.int =) -> Any"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3542,3 +3542,173 @@ def f(x: Callable[[Arg(int, 'x')], None]) -> None: pass
 y: Callable[[Union[int, str]], None]
 f(y)  # E: Argument 1 to "f" has incompatible type "Callable[[Union[int, str]], None]"; expected "Callable[[Arg(int, 'x')], None]"
 [builtins fixtures/tuple.pyi]
+
+[case testCallableJoin1]
+from typing import Callable, TypeVar
+
+C = TypeVar("C", bound=Callable[..., None])
+
+def join(t: C, val: C) -> C:
+    pass
+
+def base(x: str) -> None: ...
+
+def ok1(y: str) -> None: ...
+def ok2(x: str, /) -> None: ...
+def ok3(x: str, *args: int) -> None: ...
+def ok4(x: str, **kwargs: int) -> None: ...
+def ok5(x: str, /, **kwargs: int) -> None: ...
+def ok6(*, x: str) -> None: ...
+
+def bad1(x: int) -> None: ...
+def bad2(x: int, /) -> None: ...
+def bad3(x: str, y: int) -> None: ...
+def bad4(x: str, *, y: int) -> None: ...
+def bad5(*, y: str) -> None: ...
+
+reveal_type(join(base, base))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok1))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok2))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok3))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok4))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok5))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok6))  # N: Revealed type is "def (*, x: builtins.str)"
+
+reveal_type(join(base, bad1))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad2))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad3))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad4))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad5))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+[builtins fixtures/tuple.pyi]
+
+[case testCallableJoin2]
+from typing import Callable, TypeVar
+
+C = TypeVar("C", bound=Callable[..., None])
+
+def join(t: C, val: C) -> C:
+    pass
+
+def base(x: str, /) -> None: ...
+
+def ok1(y: str) -> None: ...
+def ok2(x: str) -> None: ...
+def ok3(x: str, *args: int) -> None: ...
+def ok4(x: str, **kwargs: int) -> None: ...
+def ok5(x: str, /, **kwargs: int) -> None: ...
+
+def bad1(x: int) -> None: ...
+def bad2(x: int, /) -> None: ...
+def bad3(x: str, y: int) -> None: ...
+def bad4(x: str, *, y: int) -> None: ...
+def bad5(*, x: str) -> None: ...
+def bad6(*, y: str) -> None: ...
+
+reveal_type(join(base, base))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok1))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok2))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok3))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok4))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok5))  # N: Revealed type is "def (builtins.str)"
+
+reveal_type(join(base, bad1))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad2))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad3))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad4))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad5))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad6))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+[builtins fixtures/tuple.pyi]
+
+[case testCallableJoin3]
+from typing import Callable, TypeVar
+
+C = TypeVar("C", bound=Callable[..., None])
+
+def join(t: C, val: C) -> C:
+    pass
+
+def base(x: str, *args: int) -> None: ...
+
+def ok1(y: str) -> None: ...
+def ok2(x: str) -> None: ...
+def ok3(x: str, y: int) -> None: ...
+def ok4(x: str, **kwargs: int) -> None: ...
+def ok5(x: str, /, **kwargs: int) -> None: ...
+def ok6(x: str, *args: str) -> None: ...
+def ok7(*, x: str) -> None: ...
+
+def bad1(x: int) -> None: ...
+def bad2(x: int, /) -> None: ...
+def bad3(x: str, *, y: int) -> None: ...
+def bad4(*, y: str) -> None: ...
+
+reveal_type(join(base, base))  # N: Revealed type is "def (x: builtins.str, *builtins.int)"
+reveal_type(join(base, ok1))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok2))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok3))  # N: Revealed type is "def (x: builtins.str, builtins.int)"
+reveal_type(join(base, ok4))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok5))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok6))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok7))  # N: Revealed type is "def (*, x: builtins.str)"
+
+reveal_type(join(base, bad1))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad2))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad3))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad4))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+[builtins fixtures/tuple.pyi]
+
+[case testCallableJoin4]
+from typing import Callable, TypeVar
+
+C = TypeVar("C", bound=Callable[..., None])
+
+def join(t: C, val: C) -> C:
+    pass
+
+def base(x: str, **kwargs: int) -> None: ...
+
+def ok1(y: str) -> None: ...
+def ok2(x: str) -> None: ...
+def ok3(x: str, y: int) -> None: ...
+def ok4(x: str, *, y: int) -> None: ...
+def ok5(x: str, *args: int) -> None: ...
+def ok6(x: str, /, *args: int) -> None: ...
+def ok7(x: str, **kwargs: str) -> None: ...
+def ok8(*, x: str) -> None: ...
+
+def bad1(x: int) -> None: ...
+def bad2(x: int, /) -> None: ...
+def bad3(*, y: str) -> None: ...
+
+reveal_type(join(base, base))  # N: Revealed type is "def (x: builtins.str, **builtins.int)"
+reveal_type(join(base, ok1))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok2))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok3))  # N: Revealed type is "def (x: builtins.str, *, y: builtins.int)"
+reveal_type(join(base, ok4))  # N: Revealed type is "def (x: builtins.str, *, y: builtins.int)"
+reveal_type(join(base, ok5))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok6))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(base, ok7))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(base, ok8))  # N: Revealed type is "def (*, x: builtins.str)"
+
+reveal_type(join(base, bad1))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad2))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+reveal_type(join(base, bad3))  # E: Value of type variable "C" of "join" cannot be "function" \
+                               # N: Revealed type is "builtins.function"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1109,8 +1109,10 @@ def f(*, x: int) -> int: ...
 def g(*, y: int) -> int: ...
 def h(*, x: int) -> int: ...
 
-list_1 = [f, g]  # E: List item 0 has incompatible type "Callable[[NamedArg(int, 'x')], int]"; expected "Callable[[NamedArg(int, 'y')], int]"
+list_1 = [f, g]
 list_2 = [f, h]
+reveal_type(list_1)  # N: Revealed type is "builtins.list[builtins.function]"
+reveal_type(list_2)  # N: Revealed type is "builtins.list[def (*, x: builtins.int) -> builtins.int]"
 [builtins fixtures/list.pyi]
 
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1424,9 +1424,13 @@ def wrong_name_constructor(b: bool) -> SomeClass:
     return SomeClass("a")
 
 func(SomeClass, constructor)
-reveal_type(func(SomeClass, wrong_constructor))  # N: Revealed type is "def (a: Never) -> __main__.SomeClass"
+reveal_type(func(SomeClass, wrong_constructor))  # N: Revealed type is "def (*builtins.object, **builtins.object) -> __main__.SomeClass" \
+                                                 # E: Argument 1 to "func" has incompatible type "Type[SomeClass]"; expected "Callable[[VarArg(object), KwArg(object)], SomeClass]" \
+                                                 # E: Argument 2 to "func" has incompatible type "Callable[[bool], SomeClass]"; expected "Callable[[VarArg(object), KwArg(object)], SomeClass]"
 reveal_type(func_regular(SomeClass, wrong_constructor))  # N: Revealed type is "def (Never) -> __main__.SomeClass"
-reveal_type(func(SomeClass, wrong_name_constructor))  # N: Revealed type is "def (Never) -> __main__.SomeClass"
+reveal_type(func(SomeClass, wrong_name_constructor))  # N: Revealed type is "def (*builtins.object, **builtins.object) -> __main__.SomeClass" \
+                                                      # E: Argument 1 to "func" has incompatible type "Type[SomeClass]"; expected "Callable[[VarArg(object), KwArg(object)], SomeClass]" \
+                                                      # E: Argument 2 to "func" has incompatible type "Callable[[bool], SomeClass]"; expected "Callable[[VarArg(object), KwArg(object)], SomeClass]"
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecInTypeAliasBasic]
@@ -2559,4 +2563,48 @@ class ServerErrorMiddleware(App):
 def fn(f: MiddlewareFactory[P]) -> Capture[P]: ...
 
 reveal_type(fn(ServerErrorMiddleware))  # N: Revealed type is "__main__.Capture[[handler: Union[builtins.str, None] =, debug: builtins.bool =]]"
+[builtins fixtures/paramspec.pyi]
+
+[case testParamSpecJoin2]
+from typing import Callable, ParamSpec
+
+P = ParamSpec("P")
+
+def join(t: Callable[P, None], val: Callable[P, None]) -> Callable[P, None]:
+    pass
+
+def f1(x: str) -> None: ...
+def f2(y: str) -> None: ...
+def f3(x: int) -> None: ...
+def f4(x: int, /) -> None: ...
+def f5(x: str, /) -> None: ...
+def f6(x: str, y: int) -> None: ...
+def f7(x: str, *, y: int) -> None: ...
+def f8(*, x: str) -> None: ...
+def f9(*, y: str) -> None: ...
+def f10(x: str, *args: int) -> None: ...
+def f11(x: str, **kwargs: int) -> None: ...
+def f12(x: str, /, **kwargs: int) -> None: ...
+
+reveal_type(join(f1, f2))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(f1, f3))  # N: Revealed type is "def (*builtins.object, **builtins.object)" \
+                             # E: Argument 1 to "join" has incompatible type "Callable[[str], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]" \
+                             # E: Argument 2 to "join" has incompatible type "Callable[[int], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]"
+reveal_type(join(f1, f4))  # N: Revealed type is "def (*builtins.object, **builtins.object)" \
+                             # E: Argument 1 to "join" has incompatible type "Callable[[str], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]" \
+                             # E: Argument 2 to "join" has incompatible type "Callable[[int], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]"
+reveal_type(join(f1, f5))  # N: Revealed type is "def (builtins.str)"
+reveal_type(join(f1, f6))  # N: Revealed type is "def (*builtins.object, **builtins.object)" \
+                             # E: Argument 1 to "join" has incompatible type "Callable[[str], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]" \
+                             # E: Argument 2 to "join" has incompatible type "Callable[[str, int], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]"
+reveal_type(join(f1, f7))  # N: Revealed type is "def (*builtins.object, **builtins.object)" \
+                             # E: Argument 1 to "join" has incompatible type "Callable[[str], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]" \
+                             # E: Argument 2 to "join" has incompatible type "Callable[[str, NamedArg(int, 'y')], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]"
+reveal_type(join(f1, f8))  # N: Revealed type is "def (*, x: builtins.str)"
+reveal_type(join(f1, f9))  # N: Revealed type is "def (*builtins.object, **builtins.object)" \
+                             # E: Argument 1 to "join" has incompatible type "Callable[[str], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]" \
+                             # E: Argument 2 to "join" has incompatible type "Callable[[NamedArg(str, 'y')], None]"; expected "Callable[[VarArg(object), KwArg(object)], None]"
+reveal_type(join(f1, f10))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(f1, f11))  # N: Revealed type is "def (x: builtins.str)"
+reveal_type(join(f1, f12))  # N: Revealed type is "def (builtins.str)"
 [builtins fixtures/paramspec.pyi]


### PR DESCRIPTION
Fixes #17766 and probably several other tickets - will be updated. 

This PR changes how mypy solves mutliple ParamSpecs in a signature and callable-valued TypeVars.

Three primary steps:

1. Actually support joins and meets of callables with varying argument kinds and counts. Tricky, and I'm not yet certain that I found all cases - tests are welcome, especially failing ones.
2. Pass object type to join. This is necessary to avoid producing false `def (*Any, **Any)` callables where constraints can't be satisfied. I'm not particlarly fond of this, but threading object type through all meet and join helpers looks even worse.
3. When solving constraints, do not fall back to upper bound with ellipsis (`Callable[..., something]`) as that produces **a lot** of false negatives.

This is really just an exploration attempt for now, because I was bitten by such false positives twice this week. Let's see the primer diff.