### PR TITLE
Fix crash on deferred supertype and setter override

### DIFF
--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -8443,3 +8443,25 @@ class C:
     def x(self) -> None:
         pass
 [builtins fixtures/property.pyi]
+
+[case testPropertySetterSuperclassDeferred]
+from typing import Callable, TypeVar
+
+class B:
+    def __init__(self) -> None:
+        self.foo = f()
+
+class C(B):
+    @property
+    def foo(self) -> str: ...
+    @foo.setter  # E: Incompatible override of a setter type \
+                 # N:  (base class "B" defined the type as "str", \
+                 # N:  override has type "int")
+    def foo(self, x: int) -> None: ...
+
+T = TypeVar("T")
+def deco(fn: Callable[[], list[T]]) -> Callable[[], T]: ...
+
+@deco
+def f() -> list[str]: ...
+[builtins fixtures/property.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/18648

The fix is straightforward, but unlike for getter I decided to not create any ad-hoc types during `last_pass`.
