### PR TITLE
Update Final imports in tests

### DIFF
--- a/mypyc/test-data/alwaysdefined.test
+++ b/mypyc/test-data/alwaysdefined.test
@@ -166,8 +166,7 @@ IfConditionalAndNonConditional1: [x]
 IfConditionalAndNonConditional2: []
 
 [case testAlwaysDefinedExpressions]
-from typing import Dict, List, Set, Optional, cast
-from typing_extensions import Final
+from typing import Dict, Final, List, Set, Optional, cast
 
 import other
 
@@ -307,7 +306,7 @@ def f() -> int:
 
 [file other.py]
 # Not compiled
-from typing_extensions import Final
+from typing import Final
 
 Y: Final = 3
 

--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -105,8 +105,7 @@ def f(x: int) -> int:
 # cmd: test.py
 
 [file test.py]
-from typing import List, Any, AsyncIterable
-from typing_extensions import Final
+from typing import Final, List, Any, AsyncIterable
 from mypy_extensions import trait, mypyc_attr
 from functools import singledispatch
 

--- a/mypyc/test-data/exceptions-freq.test
+++ b/mypyc/test-data/exceptions-freq.test
@@ -97,7 +97,7 @@ L2:
 hot blocks: [0, 1]
 
 [case testRareBranch_freq]
-from typing_extensions import Final
+from typing import Final
 
 x: Final = str()
 

--- a/mypyc/test-data/irbuild-constant-fold.test
+++ b/mypyc/test-data/irbuild-constant-fold.test
@@ -187,7 +187,7 @@ L0:
     return 1
 
 [case testIntConstantFoldingFinal]
-from typing_extensions import Final
+from typing import Final
 X: Final = 5
 Y: Final = 2 + 4
 
@@ -203,7 +203,7 @@ L0:
     return 1
 
 [case testIntConstantFoldingClassFinal]
-from typing_extensions import Final
+from typing import Final
 class C:
     X: Final = 5
 
@@ -222,7 +222,7 @@ L0:
     return 1
 
 [case testFloatConstantFolding]
-from typing_extensions import Final
+from typing import Final
 
 N: Final = 1.5
 N2: Final = 1.5 * 2
@@ -391,7 +391,7 @@ L2:
     return 1
 
 [case testStrConstantFolding]
-from typing_extensions import Final
+from typing import Final
 
 S: Final = 'z'
 N: Final = 2
@@ -416,7 +416,7 @@ L0:
     return 1
 
 [case testBytesConstantFolding]
-from typing_extensions import Final
+from typing import Final
 
 N: Final = 2
 
@@ -438,7 +438,7 @@ L0:
     return 1
 
 [case testComplexConstantFolding]
-from typing_extensions import Final
+from typing import Final
 
 N: Final = 1
 FLOAT_N: Final = 1.5

--- a/mypyc/test-data/irbuild-float.test
+++ b/mypyc/test-data/irbuild-float.test
@@ -219,7 +219,7 @@ L0:
     return r0
 
 [case testFloatFinalConstant]
-from typing_extensions import Final
+from typing import Final
 
 X: Final = 123.0
 Y: Final = -1.0

--- a/mypyc/test-data/irbuild-i64.test
+++ b/mypyc/test-data/irbuild-i64.test
@@ -1677,7 +1677,7 @@ L2:
     return 1
 
 [case testI64FinalConstants]
-from typing_extensions import Final
+from typing import Final
 from mypy_extensions import i64
 
 A: Final = -1

--- a/mypyc/test-data/irbuild-int.test
+++ b/mypyc/test-data/irbuild-int.test
@@ -116,7 +116,7 @@ L0:
     return r0
 
 [case testFinalConstantFolding]
-from typing_extensions import Final
+from typing import Final
 
 X: Final = -1
 Y: Final = -(1 + 3*2)

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -628,7 +628,7 @@ L0:
     return r0
 
 [case testOperatorInSetLiteral]
-from typing_extensions import Final
+from typing import Final
 
 CONST: Final = "daylily"
 non_const = 10
@@ -716,7 +716,7 @@ L0:
     return r14
 
 [case testForSetLiteral]
-from typing_extensions import Final
+from typing import Final
 
 CONST: Final = 10
 non_const = 20

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -1339,7 +1339,7 @@ L0:
     return r2
 
 [case testBorrowIntCompareFinal]
-from typing_extensions import Final
+from typing import Final
 
 X: Final = 10
 

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -711,8 +711,7 @@ Traceback (most recent call last):
 AttributeError: attribute 'x' of 'X' undefined
 
 [case testClassMethods]
-from typing import ClassVar, Any
-from typing_extensions import final
+from typing import ClassVar, Any, final
 from mypy_extensions import mypyc_attr
 
 from interp import make_interpreted_subclass

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2543,7 +2543,7 @@ class Derived(Base):
 assert Derived()() == 1
 
 [case testClassWithFinalAttribute]
-from typing_extensions import Final
+from typing import Final
 
 class C:
     A: Final = -1

--- a/mypyc/test-data/run-floats.test
+++ b/mypyc/test-data/run-floats.test
@@ -2,8 +2,7 @@
 
 [case testFloatOps]
 from __future__ import annotations
-from typing import Any, cast
-from typing_extensions import Final
+from typing import Final, Any, cast
 from testutil import assertRaises, float_vals, FLOAT_MAGIC
 import math
 
@@ -348,8 +347,7 @@ def test_tuples() -> None:
     assert t2 == tuple([5.0, 1.5, -7.0, -113.0])
 
 [case testFloatGlueMethodsAndInheritance]
-from typing import Any
-from typing_extensions import Final
+from typing import Final, Any
 
 from mypy_extensions import trait
 

--- a/mypyc/test-data/run-i64.test
+++ b/mypyc/test-data/run-i64.test
@@ -517,11 +517,10 @@ def test_isinstance() -> None:
     assert narrow2("foobar") == 6
 
 [case testI64ErrorValuesAndUndefined]
-from typing import Any, Tuple
+from typing import Any, Final, Tuple
 import sys
 
 from mypy_extensions import mypyc_attr, i64
-from typing_extensions import Final
 
 from testutil import assertRaises
 
@@ -905,8 +904,7 @@ def test_undefined_native_int_tuple_via_any() -> None:
     assert o.t == (-13, 45)
 
 [case testI64DefaultArgValues]
-from typing import Any, Iterator, Tuple
-from typing_extensions import Final
+from typing import Any, Final, Iterator, Tuple
 
 MAGIC: Final = -113
 
@@ -1206,7 +1204,7 @@ def test_magic_default() -> None:
     assert a(MAGIC) == MAGIC
 
 [case testI64UndefinedLocal]
-from typing_extensions import Final
+from typing import Final
 
 from mypy_extensions import i64, i32
 
@@ -1338,8 +1336,7 @@ def test_many_locals() -> None:
     assert a33 == 20
 
 [case testI64GlueMethodsAndInheritance]
-from typing import Any
-from typing_extensions import Final
+from typing import Final, Any
 
 from mypy_extensions import i64, trait
 

--- a/mypyc/test-data/run-math.test
+++ b/mypyc/test-data/run-math.test
@@ -1,8 +1,7 @@
 # Test cases for the math module (compile and run)
 
 [case testMathOps]
-from typing import Any, Callable
-from typing_extensions import Final
+from typing import Any, Callable, Final
 import math
 from math import pi, e, tau, inf, nan
 from testutil import assertRaises, float_vals, assertDomainError, assertMathRangeError

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -155,7 +155,7 @@ def f(c: C) -> int:
     c = cast(C, o)
     return a_global + c.x + c.f() + d.x + d.f() + 1
 [file other.py]
-from typing_extensions import Final
+from typing import Final
 a_global: Final = int('5')
 
 class C:
@@ -735,11 +735,11 @@ def foo() -> int:
     return X
 
 [file other.py]
-from typing_extensions import Final
+from typing import Final
 X: Final = 10
 
 [file other.py.2]
-from typing_extensions import Final
+from typing import Final
 X: Final = 20
 
 [file driver.py]

--- a/mypyc/test-data/run-sets.test
+++ b/mypyc/test-data/run-sets.test
@@ -235,8 +235,7 @@ def test_frozen_sets_from_iterables() -> None:
     assert g4() == frozenset({11, 21, 31})
 
 [case testPrecomputedFrozenSets]
-from typing import Any
-from typing_extensions import Final
+from typing import Final, Any
 
 CONST: Final = "CONST"
 non_const = "non_const"

--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -147,8 +147,7 @@ assert Record.__annotations__ == {
 }, Record.__annotations__
 
 [case testTupleOps]
-from typing import Tuple, List, Any, Optional
-from typing_extensions import Final
+from typing import Tuple, Final, List, Any, Optional
 
 def f() -> Tuple[()]:
     return ()

--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -97,8 +97,7 @@ assert f(Sub(3, 2)) == 3
 
 -- Ref: https://github.com/mypyc/mypyc/issues/924
 [case testNamedTupleClassSyntax]
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
-from typing_extensions import final
+from typing import Dict, List, NamedTuple, Optional, Tuple, Union, final
 
 class FuncIR: pass
 

--- a/mypyc/test-data/run-u8.test
+++ b/mypyc/test-data/run-u8.test
@@ -1,8 +1,7 @@
 [case testU8BasicOps]
-from typing import Any, Tuple
+from typing import Any, Final, Tuple
 
 from mypy_extensions import u8, i16, i32, i64
-from typing_extensions import Final
 
 from testutil import assertRaises
 

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -405,8 +405,7 @@ class B(Enum):
     b = 10
 
 [file b.py]
-from typing import List, Literal, Optional, Union, Sequence, NamedTuple, Tuple, Type, TypedDict
-from typing_extensions import Final
+from typing import Final, List, Literal, Optional, Union, Sequence, NamedTuple, Tuple, Type, TypedDict
 from enum import Enum
 import a
 class A: pass

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -31,7 +31,7 @@ reveal_type(Animal.DOG)  # N: Revealed type is "Literal[__main__.Animal.DOG]?"
 
 [case testEnumCreatedFromFinalValue]
 from enum import Enum
-from typing_extensions import Final
+from typing import Final
 
 x: Final['str'] = 'ANT BEE CAT DOG'
 Animal = Enum('Animal', x)
@@ -975,8 +975,7 @@ else:
 
 [case testEnumReachabilityChecksIndirect]
 from enum import Enum
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 class Foo(Enum):
     A = 1
@@ -1130,8 +1129,7 @@ reveal_type(x3) # N: Revealed type is "Union[__main__.Foo, __main__.Bar]"
 [builtins fixtures/bool.pyi]
 
 [case testEnumReachabilityPEP484ExampleWithFinal]
-from typing import Union
-from typing_extensions import Final
+from typing import Final, Union
 from enum import Enum
 
 class Empty(Enum):
@@ -1176,8 +1174,7 @@ def process(response: Union[str, Reason] = '') -> str:
 
 
 [case testEnumReachabilityPEP484ExampleSingleton]
-from typing import Union
-from typing_extensions import Final
+from typing import Final, Union
 from enum import Enum
 
 class Empty(Enum):
@@ -1200,8 +1197,7 @@ def func(x: Union[int, None, Empty] = _empty) -> int:
 [builtins fixtures/primitives.pyi]
 
 [case testEnumReachabilityPEP484ExampleSingletonWithMethod]
-from typing import Union
-from typing_extensions import Final
+from typing import Final, Union
 from enum import Enum
 
 class Empty(Enum):
@@ -1331,8 +1327,7 @@ reveal_type(x)      # N: Revealed type is "__main__.Foo"
 [case testEnumReachabilityWithChainingDirectConflict]
 # flags: --warn-unreachable
 from enum import Enum
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 class Foo(Enum):
     A = 1
@@ -1367,8 +1362,7 @@ reveal_type(x)      # N: Revealed type is "__main__.Foo"
 [case testEnumReachabilityWithChainingBigDisjoints]
 # flags: --warn-unreachable
 from enum import Enum
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 class Foo(Enum):
     A = 1

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2281,8 +2281,7 @@ def f(x: T) -> T:
 
 [case testStrictEqualityWithALiteral]
 # flags: --strict-equality
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 def returns_a_or_b() -> Literal['a', 'b']:
     ...

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1120,7 +1120,7 @@ class B:
 [out]
 
 [case testFinalInDeferredMethod]
-from typing_extensions import Final
+from typing import Final
 
 class A:
     def __init__(self) -> None:

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1187,8 +1187,7 @@ class Child(Parent):
     def __bar(self) -> None: ...
 
 [case testFinalWithoutBool]
-from typing import Literal
-from typing_extensions import final
+from typing import Literal, final
 
 class A:
     pass
@@ -1208,8 +1207,7 @@ reveal_type(C() and 42)  # N: Revealed type is "Literal[42]?"
 [builtins fixtures/bool.pyi]
 
 [case testFinalWithoutBoolButWithLen]
-from typing import Literal
-from typing_extensions import final
+from typing import Literal, final
 
 # Per Python data model, __len__ is called if __bool__ does not exist.
 # In a @final class, __bool__ would not exist.

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -502,7 +502,7 @@ def better_snakecase(text: str) -> str:
 [builtins fixtures/primitives.pyi]
 
 [case testFormatCallFinal]
-from typing_extensions import Final
+from typing import Final
 
 FMT: Final = '{.x}, {:{:d}}'
 
@@ -511,7 +511,7 @@ FMT.format(1, 2, 'no')  # E: "int" has no attribute "x" \
 [builtins fixtures/primitives.pyi]
 
 [case testFormatCallFinalChar]
-from typing_extensions import Final
+from typing import Final
 
 GOOD: Final = 'c'
 BAD: Final = 'no'

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1892,8 +1892,7 @@ del d[c_key]                  # E: TypedDict "Outer" has no key "c"
 [out]
 
 [case testLiteralIntelligentIndexingUsingFinal]
-from typing import Literal, Tuple, NamedTuple, TypedDict
-from typing_extensions import Final
+from typing import Final, Literal, Tuple, NamedTuple, TypedDict
 
 int_key_good: Final = 0
 int_key_bad: Final = 3
@@ -1959,8 +1958,7 @@ tup2[idx_bad]                   # E: Tuple index out of range
 [out]
 
 [case testLiteralIntelligentIndexingTypedDictUnions]
-from typing import Literal, TypedDict
-from typing_extensions import Final
+from typing import Final, Literal, TypedDict
 
 class A: pass
 class B: pass
@@ -2049,8 +2047,7 @@ reveal_type(x.get(bad_keys, 3))     # N: Revealed type is "builtins.object"
 --
 
 [case testLiteralFinalInferredAsLiteral]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 var1: Final = 1
 var2: Final = "foo"
@@ -2105,8 +2102,7 @@ force4(reveal_type(f.instancevar4))  # N: Revealed type is "None"
 [out]
 
 [case testLiteralFinalDirectInstanceTypesSupersedeInferredLiteral]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 var1: Final[int] = 1
 var2: Final[str] = "foo"
@@ -2161,8 +2157,7 @@ force4(f.instancevar4)
 [out]
 
 [case testLiteralFinalDirectLiteralTypesForceLiteral]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 var1: Final[Literal[1]] = 1
 var2: Final[Literal["foo"]] = "foo"
@@ -2217,7 +2212,7 @@ force4(reveal_type(f.instancevar4))  # N: Revealed type is "None"
 [out]
 
 [case testLiteralFinalErasureInMutableDatastructures1]
-from typing_extensions import Final
+from typing import Final
 
 var1: Final = [0, None]
 var2: Final = (0, None)
@@ -2227,8 +2222,7 @@ reveal_type(var2)  # N: Revealed type is "Tuple[Literal[0]?, None]"
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralFinalErasureInMutableDatastructures2]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 var1: Final = []
 var1.append(0)
@@ -2246,8 +2240,7 @@ reveal_type(var3)  # N: Revealed type is "builtins.list[Literal[0]]"
 [builtins fixtures/list.pyi]
 
 [case testLiteralFinalMismatchCausesError]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 var1: Final[Literal[4]]     = 1      # E: Incompatible types in assignment (expression has type "Literal[1]", variable has type "Literal[4]")
 var2: Final[Literal['bad']] = "foo"  # E: Incompatible types in assignment (expression has type "Literal['foo']", variable has type "Literal['bad']")
@@ -2277,8 +2270,7 @@ Foo().instancevar1 = 10  # E: Cannot assign to final attribute "instancevar1" \
 [out]
 
 [case testLiteralFinalGoesOnlyOneLevelDown]
-from typing import Literal, Tuple
-from typing_extensions import Final
+from typing import Final, Literal, Tuple
 
 a: Final = 1
 b: Final = (1, 2)
@@ -2295,8 +2287,7 @@ force2(b)  # ok
 [out]
 
 [case testLiteralFinalCollectionPropagation]
-from typing import List, Literal
-from typing_extensions import Final
+from typing import Final, List, Literal
 
 a: Final = 1
 implicit = [a]
@@ -2325,8 +2316,7 @@ force2(reveal_type(direct[0]))   # E: Argument 1 to "force2" has incompatible ty
 [out]
 
 [case testLiteralFinalStringTypesPython3]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 a: Final = u"foo"
 b: Final = "foo"
@@ -2349,8 +2339,7 @@ force_bytes(reveal_type(c))    # N: Revealed type is "Literal[b'foo']"
 [out]
 
 [case testLiteralFinalPropagatesThroughGenerics]
-from typing import TypeVar, Generic, Literal
-from typing_extensions import Final
+from typing import TypeVar, Generic, Final, Literal
 
 
 T = TypeVar('T')
@@ -2405,8 +2394,7 @@ over_literal(reveal_type(WrapperClass(var3)))   # N: Revealed type is "__main__.
 [out]
 
 [case testLiteralFinalUsedInLiteralType]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 a: Final[int] = 3
 b: Final = 3
 c: Final[Literal[3]] = 3
@@ -2420,8 +2408,7 @@ d_wrap: Literal[4, d]  # E: Parameter 2 of Literal[...] is invalid
 [out]
 
 [case testLiteralWithFinalPropagation]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 a: Final = 3
 b: Final = a
@@ -2435,8 +2422,7 @@ expect_3(c)  # E: Argument 1 to "expect_3" has incompatible type "int"; expected
 [out]
 
 [case testLiteralWithFinalPropagationIsNotLeaking]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 final_tuple_direct: Final = (2, 3)
 final_tuple_indirect: Final = final_tuple_direct
@@ -2627,8 +2613,7 @@ reveal_type(x)  # N: Revealed type is "Literal[__main__.Test.FOO]"
 [out]
 
 [case testLiteralUsingEnumAttributesInLiteralContexts]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 from enum import Enum
 
 class Test1(Enum):
@@ -2662,8 +2647,7 @@ expects_test2_foo(final2)
 [out]
 
 [case testLiteralUsingEnumAttributeNamesInLiteralContexts]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 from enum import Enum
 
 class Test1(Enum):
@@ -2742,8 +2726,7 @@ z: Literal[~0] = 0  # E: Invalid type: Literal[...] cannot contain arbitrary exp
 [builtins fixtures/ops.pyi]
 
 [case testNegativeIntLiteralWithFinal]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 ONE: Final = 1
 x: Literal[-1] = -ONE
@@ -2851,8 +2834,7 @@ else:
 [case testLiteralAndInstanceSubtyping]
 # https://github.com/python/mypy/issues/7399
 # https://github.com/python/mypy/issues/11232
-from typing import Literal, Tuple, Union
-from typing_extensions import Final
+from typing import Final, Literal, Tuple, Union
 
 x: bool
 

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -672,8 +672,7 @@ if not (abo is None or abo.tag != "B"):
 
 [case testNarrowingEqualityFlipFlop]
 # flags: --warn-unreachable --strict-equality
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 from enum import Enum
 
 class State(Enum):
@@ -738,8 +737,7 @@ def test3(switch: FlipFlopEnum) -> None:
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityRequiresExplicitStrLiteral]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 A_final: Final = "A"
 A_literal: Literal["A"]
@@ -785,8 +783,7 @@ reveal_type(x_union)      # N: Revealed type is "Union[Literal['A'], Literal['B'
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingEqualityRequiresExplicitEnumLiteral]
-from typing import Literal, Union
-from typing_extensions import Final
+from typing import Final, Literal, Union
 from enum import Enum
 
 class Foo(Enum):
@@ -1549,8 +1546,7 @@ if len(x) == len(y) == 3:
 [builtins fixtures/len.pyi]
 
 [case testNarrowingLenFinal]
-from typing import Tuple, Union
-from typing_extensions import Final
+from typing import Final, Tuple, Union
 
 VarTuple = Union[Tuple[int, int], Tuple[int, int, int]]
 

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2528,8 +2528,7 @@ tmp/unittest/suite.pyi:6: error: Name "Iterable" is not defined
 tmp/unittest/suite.pyi:6: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Iterable")
 
 [case testNewAnalyzerNewTypeSpecialCase]
-from typing import Literal, NewType
-from typing_extensions import Final
+from typing import Final, Literal, NewType
 
 X = NewType('X', int)
 
@@ -2777,8 +2776,7 @@ class C:
 reveal_type(C.A)  # N: Revealed type is "def () -> a.A"
 
 [case testNewAnalyzerFinalLiteralInferredAsLiteralWithDeferral]
-from typing import Literal
-from typing_extensions import Final
+from typing import Final, Literal
 
 defer: Yes
 

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -2767,8 +2767,7 @@ p: P = N(lambda a, b, c: 'foo')
 [builtins fixtures/property.pyi]
 
 [case testLiteralsAgainstProtocols]
-from typing import Literal, SupportsInt, SupportsAbs, TypeVar
-from typing_extensions import Final
+from typing import Final, Literal, SupportsInt, SupportsAbs, TypeVar
 
 T = TypeVar('T')
 def abs(x: SupportsAbs[T]) -> T: ...
@@ -3970,7 +3969,7 @@ func(some_module)  # E: Argument 1 to "func" has incompatible type Module; expec
                    # N: Protocol member My.a expected settable variable, got read-only attribute
 
 [file some_module.py]
-from typing_extensions import Final
+from typing import Final
 
 a: Final = 1
 [builtins fixtures/module.pyi]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1906,8 +1906,7 @@ match var:
 [builtins fixtures/tuple.pyi]
 
 [case testMatchNamedAndKeywordsAreTheSame]
-from typing import Generic, TypeVar, Union
-from typing_extensions import Final
+from typing import Generic, Final, TypeVar, Union
 from dataclasses import dataclass
 
 T = TypeVar("T")

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -211,8 +211,7 @@ h(arg=0)  # E: Unexpected keyword argument "arg" for "h"
 i(arg=0)  # E: Unexpected keyword argument "arg"
 
 [case testWalrus]
-from typing import NamedTuple, Optional, List
-from typing_extensions import Final
+from typing import Final, NamedTuple, Optional, List
 
 if a := 2:
     reveal_type(a)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2066,8 +2066,7 @@ v = {bad2: 2}  # E: Missing key "num" for TypedDict "Value" \
 
 [case testOperatorContainsNarrowsTypedDicts_unionWithList]
 from __future__ import annotations
-from typing import assert_type, TypedDict, Union
-from typing_extensions import final
+from typing import assert_type, final, TypedDict, Union
 
 @final
 class D(TypedDict):
@@ -2084,12 +2083,11 @@ else:
     assert_type(d_or_list, list[str])
 
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-typeddict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testOperatorContainsNarrowsTypedDicts_total]
 from __future__ import annotations
-from typing import assert_type, Literal, TypedDict, TypeVar, Union
-from typing_extensions import final
+from typing import assert_type, final, Literal, TypedDict, TypeVar, Union
 
 @final
 class D1(TypedDict):
@@ -2135,13 +2133,12 @@ def f(arg: TD) -> None:
 
 
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-typeddict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testOperatorContainsNarrowsTypedDicts_final]
 # flags: --warn-unreachable
 from __future__ import annotations
-from typing import assert_type, TypedDict, Union
-from typing_extensions import final
+from typing import assert_type, final, TypedDict, Union
 
 @final
 class DFinal(TypedDict):
@@ -2179,12 +2176,11 @@ else:
     assert_type(d_union, DNotFinal)
 
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-typeddict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testOperatorContainsNarrowsTypedDicts_partialThroughTotalFalse]
 from __future__ import annotations
-from typing import assert_type, Literal, TypedDict, Union
-from typing_extensions import final
+from typing import assert_type, final, Literal, TypedDict, Union
 
 @final
 class DTotal(TypedDict):
@@ -2215,12 +2211,12 @@ else:
     assert_type(d, Union[DTotal, DNotTotal])
 
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-typeddict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testOperatorContainsNarrowsTypedDicts_partialThroughNotRequired]
 from __future__ import annotations
-from typing import assert_type, Required, NotRequired, TypedDict, Union
-from typing_extensions import final
+from typing import assert_type, final, TypedDict, Union
+from typing_extensions import Required, NotRequired
 
 @final
 class D1(TypedDict):
@@ -2247,11 +2243,10 @@ else:
     assert_type(d, Union[D1, D2])
 
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-typeddict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testCannotSubclassFinalTypedDict]
-from typing import TypedDict
-from typing_extensions import final
+from typing import TypedDict, final
 
 @final
 class DummyTypedDict(TypedDict):
@@ -2263,11 +2258,10 @@ class SubType(DummyTypedDict): # E: Cannot inherit from final class "DummyTypedD
     pass
 
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-typeddict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testCannotSubclassFinalTypedDictWithForwardDeclarations]
-from typing import TypedDict
-from typing_extensions import final
+from typing import TypedDict, final
 
 @final
 class DummyTypedDict(TypedDict):
@@ -2279,7 +2273,7 @@ class SubType(DummyTypedDict): # E: Cannot inherit from final class "DummyTypedD
 class ForwardDeclared: pass
 
 [builtins fixtures/dict.pyi]
-[typing fixtures/typing-typeddict.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testTypedDictTypeNarrowingWithFinalKey]
 from typing import Final, Optional, TypedDict

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -8889,13 +8889,13 @@ foo: Final = bar
 [file mod2.py]
 from mod3 import qux as bar
 [file mod3.py]
-from typing_extensions import Final
+from typing import Final
 qux: Final = 3
 [file mod3.py.2]
-from typing_extensions import Final
+from typing import Final
 qux: Final = 4
 [file mod3.py.3]
-from typing_extensions import Final
+from typing import Final
 qux: Final[int] = 4
 [builtins fixtures/tuple.pyi]
 [out]

--- a/test-data/unit/semanal-statements.test
+++ b/test-data/unit/semanal-statements.test
@@ -1127,7 +1127,7 @@ MypyFile:1(
         IntExpr(1)))))
 
 [case testConstantFold1]
-from typing_extensions import Final
+from typing import Final
 add: Final = 15 + 47
 add_mul: Final = (2 + 3) * 5
 sub: Final = 7 - 11
@@ -1140,7 +1140,7 @@ lshift0: Final = 5 << 0
 rshift0: Final = 13 >> 0
 [out]
 MypyFile:1(
-  ImportFrom:1(typing_extensions, [Final])
+  ImportFrom:1(typing, [Final])
   AssignmentStmt:2(
     NameExpr(add [__main__.add] = 62)
     OpExpr:2(
@@ -1216,7 +1216,7 @@ MypyFile:1(
     Literal[13]?))
 
 [case testConstantFold2]
-from typing_extensions import Final
+from typing import Final
 neg1: Final = -5
 neg2: Final = --1
 neg3: Final = -0
@@ -1231,7 +1231,7 @@ p3: Final = 0**0
 s: Final = 'x' + 'y'
 [out]
 MypyFile:1(
-  ImportFrom:1(typing_extensions, [Final])
+  ImportFrom:1(typing, [Final])
   AssignmentStmt:2(
     NameExpr(neg1 [__main__.neg1] = -5)
     UnaryExpr:2(


### PR DESCRIPTION
Replace most `typing_extensions.Final` and `typing_extensions.final` imports in tests with `typing.Final` and `typing.final`.