### PR TITLE
Delete old meet hack from checkmember.py

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4600,10 +4600,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         bound_method = analyze_decorator_or_funcbase_access(
             defn=dunder_set,
             itype=attribute_type,
-            info=attribute_type.type,
-            self_type=attribute_type,
             name="__set__",
-            mx=mx,
+            mx=mx.copy_modified(self_type=attribute_type),
         )
         typ = map_instance_to_supertype(attribute_type, dunder_set.info)
         dunder_set_type = expand_type_by_instance(bound_method, typ)


### PR DESCRIPTION
The hack to use `meet_types(original_type, itype)` to select a correct element from a union appeared before we added proper handling of unions in various places related to `checkmember.py`. This is error prone, since `meet_types()` is one of least precise type ops (for good and bad reasons), and results in obscure bugs, see e.g. https://github.com/python/mypy/issues/15600

This hack should not be needed anymore, now we have three-level information available everywhere we needed it:
* `original_type` - as the name says, a type from which everything started. This is used for error messages and for plugin hooks.
* `self_type` - a specific element of the union is the original type is a union. The name is because this is what will be ultimately used by `bind_self()`
* `itype` the actual instance type where we look up the attribute (this will be e.g. a fallback if the `self_type` is not an instance)