### PR TITLE
Allow lowered opts to be deleted in lowering trasnform

### DIFF
--- a/mypyc/lower/registry.py
+++ b/mypyc/lower/registry.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
-from typing import Callable, Final
+from typing import Callable, Final, Optional, TypeVar
 
 from mypyc.ir.ops import Value
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder
 
 LowerFunc = Callable[[LowLevelIRBuilder, list[Value], int], Value]
+LowerFuncOpt = Callable[[LowLevelIRBuilder, list[Value], int], Optional[Value]]
+
+lowering_registry: Final[dict[str, LowerFuncOpt]] = {}
+
+LF = TypeVar("LF", LowerFunc, LowerFuncOpt)
 
 
-lowering_registry: Final[dict[str, LowerFunc]] = {}
-
-
-def lower_primitive_op(name: str) -> Callable[[LowerFunc], LowerFunc]:
+def lower_primitive_op(name: str) -> Callable[[LF], LF]:
     """Register a handler that generates low-level IR for a primitive op."""
 
-    def wrapper(f: LowerFunc) -> LowerFunc:
+    def wrapper(f: LF) -> LF:
         assert name not in lowering_registry
         lowering_registry[name] = f
         return f

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -119,6 +119,9 @@ class IRTransform(OpVisitor[Optional[Value]]):
         self.add(op)
 
     def visit_assign(self, op: Assign) -> Value | None:
+        if op.src in self.op_map and self.op_map[op.src] is None:
+            # Special case: allow removing register initialization assignments
+            return None
         return self.add(op)
 
     def visit_assign_multi(self, op: AssignMulti) -> Value | None:

--- a/mypyc/transform/lower.py
+++ b/mypyc/transform/lower.py
@@ -9,6 +9,8 @@ Lowering of various primitive ops is implemented in the mypyc.lower
 package.
 """
 
+from __future__ import annotations
+
 from mypyc.ir.func_ir import FuncIR
 from mypyc.ir.ops import PrimitiveOp, Value
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder
@@ -25,7 +27,7 @@ def lower_ir(ir: FuncIR, options: CompilerOptions) -> None:
 
 
 class LoweringVisitor(IRTransform):
-    def visit_primitive_op(self, op: PrimitiveOp) -> Value:
+    def visit_primitive_op(self, op: PrimitiveOp) -> Value | None:
         # The lowering implementation functions of various primitive ops are stored
         # in a registry, which is populated using function decorators. The name
         # of op (such as "int_eq") is used as the key.


### PR DESCRIPTION
This only works for simple initialization ops and ops where the return value is ignored. This can be used for dummy init ops that are used to give hints to data flow analysis about lifetimes of values, when initialization is done via a pointer argument (e.g. `init_my_struct(&reg)` in C).