### PR TITLE
Enable ruff FURB188: str.remove(pre|suf)fix

### DIFF
--- a/misc/upload-pypi.py
+++ b/misc/upload-pypi.py
@@ -34,10 +34,8 @@ def item_ok_for_pypi(name: str) -> bool:
     if not is_whl_or_tar(name):
         return False
 
-    if name.endswith(".tar.gz"):
-        name = name[:-7]
-    if name.endswith(".whl"):
-        name = name[:-4]
+    name = name.removesuffix(".tar.gz")
+    name = name.removesuffix(".whl")
 
     if name.endswith("wasm32"):
         return False
@@ -123,8 +121,7 @@ def upload_to_pypi(version: str, dry_run: bool = True) -> None:
     assert re.match(r"v?[1-9]\.[0-9]+\.[0-9](\+\S+)?$", version)
     if "dev" in version:
         assert dry_run, "Must use --dry-run with dev versions of mypy"
-    if version.startswith("v"):
-        version = version[1:]
+    version = version.removeprefix("v")
 
     target_dir = tempfile.mkdtemp()
     dist = Path(target_dir) / "dist"

--- a/mypy/find_sources.py
+++ b/mypy/find_sources.py
@@ -176,8 +176,7 @@ class SourceFinder:
             return "", dir
 
         parent, name = os.path.split(dir)
-        if name.endswith("-stubs"):
-            name = name[:-6]  # PEP-561 stub-only directory
+        name = name.removesuffix("-stubs")  # PEP-561 stub-only directory
 
         # recurse if there's an __init__.py
         init_file = self.get_init_file(dir)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -639,7 +639,7 @@ def _verify_arg_name(
         return
 
     def strip_prefix(s: str, prefix: str) -> str:
-        return s[len(prefix) :] if s.startswith(prefix) else s
+        return s.removeprefix(prefix)
 
     if strip_prefix(stub_arg.variable.name, "__") == runtime_arg.name:
         return

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -413,8 +413,7 @@ def check_test_output_files(
     testcase: DataDrivenTestCase, step: int, strip_prefix: str = ""
 ) -> None:
     for path, expected_content in testcase.output_files:
-        if path.startswith(strip_prefix):
-            path = path[len(strip_prefix) :]
+        path = path.removeprefix(strip_prefix)
         if not os.path.exists(path):
             raise AssertionError(
                 "Expected file {} was not produced by test case{}".format(

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1345,8 +1345,7 @@ class LowLevelIRBuilder:
             return self.translate_instance_contains(rreg, lreg, op, line)
         if is_fixed_width_rtype(ltype):
             if op in FIXED_WIDTH_INT_BINARY_OPS:
-                if op.endswith("="):
-                    op = op[:-1]
+                op = op.removesuffix("=")
                 if op != "//":
                     op_id = int_op_to_id[op]
                 else:
@@ -1372,8 +1371,7 @@ class LowLevelIRBuilder:
                     return self.comparison_op(lreg, self.coerce(rreg, ltype, line), op_id, line)
         elif is_fixed_width_rtype(rtype):
             if op in FIXED_WIDTH_INT_BINARY_OPS:
-                if op.endswith("="):
-                    op = op[:-1]
+                op = op.removesuffix("=")
                 if op != "//":
                     op_id = int_op_to_id[op]
                 else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ select = [
   "UP",      # pyupgrade
   "C4",      # flake8-comprehensions
   "SIM201", "SIM202", "SIM222", "SIM223",  # flake8-simplify
+  "FURB188", # use str.remove(pre|suf)fix
   "ISC001",  # implicitly concatenated string
   "RET501", "RET502",  # better return None handling
 ]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Enable ruff rule FURB188 to str remove(pref|suf)fix - more readable and efficient.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
