### PR TITLE
Enable ruff SIM101 duplicate isinstance check

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1534,8 +1534,15 @@ def is_probably_private(name: str) -> bool:
 
 def is_probably_a_function(runtime: Any) -> bool:
     return (
-        isinstance(runtime, (types.FunctionType, types.BuiltinFunctionType))
-        or isinstance(runtime, (types.MethodType, types.BuiltinMethodType))
+        isinstance(
+            runtime,
+            (
+                types.FunctionType,
+                types.BuiltinFunctionType,
+                types.MethodType,
+                types.BuiltinMethodType,
+            ),
+        )
         or (inspect.ismethoddescriptor(runtime) and callable(runtime))
         or (isinstance(runtime, types.MethodWrapperType) and callable(runtime))
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ select = [
   "PGH004",  # blanket noqa comments
   "UP",      # pyupgrade
   "C4",      # flake8-comprehensions
+  "SIM101",  # merge duplicate isinstance calls
   "SIM201", "SIM202", "SIM222", "SIM223",  # flake8-simplify
   "FURB188", # use str.remove(pre|suf)fix
   "ISC001",  # implicitly concatenated string


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Enforce no unnecessary duplicate isinstance calls (that could be merged into a tuple call).

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
