### PR TITLE
[mypyc] Mark dict.setdefault as optimized

### DIFF
--- a/mypyc/doc/dict_operations.rst
+++ b/mypyc/doc/dict_operations.rst
@@ -50,6 +50,8 @@ Methods
 * ``d.items()``
 * ``d.copy()``
 * ``d.clear()``
+* ``d.setdefault(key)``
+* ``d.setdefault(key, value)``
 * ``d1.update(d2: dict)``
 * ``d.update(x: Iterable)``
 


### PR DESCRIPTION
Support for `dict.setdefault` was added in https://github.com/python/mypy/commit/f463a3921fcd5cb360c12a84650880a2a92e0566 a few years ago.