### PR TITLE
[docs] Fix metaclass usage example

### DIFF
--- a/docs/source/metaclasses.rst
+++ b/docs/source/metaclasses.rst
@@ -34,12 +34,14 @@ Mypy supports the lookup of attributes in the metaclass:
 
 .. code-block:: python
 
-    from typing import ClassVar, Self
+    from typing import ClassVar, TypeVar
+
+    S = TypeVar("S")
 
     class M(type):
         count: ClassVar[int] = 0
 
-        def make(cls) -> Self:
+        def make(cls: type[S]) -> S:
             M.count += 1
             return cls()
 
@@ -54,9 +56,6 @@ Mypy supports the lookup of attributes in the metaclass:
 
     b: B = B.make()  # metaclasses are inherited
     print(B.count + " objects were created")  # Error: Unsupported operand types for + ("int" and "str")
-
-.. note::
-    In Python 3.10 and earlier, ``Self`` is available in ``typing_extensions``.
 
 .. _limitations:
 
@@ -88,3 +87,6 @@ so it's better not to combine metaclasses and class hierarchies:
   such as ``class A(metaclass=f()): ...``
 * Mypy does not and cannot understand arbitrary metaclass code.
 * Mypy only recognizes subclasses of :py:class:`type` as potential metaclasses.
+* ``Self`` is not allowed as annotation in metaclasses as per `PEP 673`_.
+
+.. _PEP 673: https://peps.python.org/pep-0673/#valid-locations-for-self


### PR DESCRIPTION
Fixes #18668 

- Fixed the code example to _not_ include `Self`
- Added a note about `Self` & metaclasses in Gotchas section with a link to the relevant PEP


<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
