### PR TITLE
Add regression test for typing_extensions.Literal and mypy_extensions.TypedDict

### DIFF
--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -52,6 +52,16 @@ y: Literal[43]
 y = 43
 [typing fixtures/typing-medium.pyi]
 
+[case testLiteralFromTypingExtensionsWorks]
+from typing_extensions import Literal
+
+x: Literal[42]
+x = 43  # E: Incompatible types in assignment (expression has type "Literal[43]", variable has type "Literal[42]")
+
+y: Literal[43]
+y = 43
+[builtins fixtures/tuple.pyi]
+
 [case testLiteralInsideOtherTypes]
 from typing import Literal, Tuple
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3791,7 +3791,7 @@ x.update({"key": "abc"})  # E: ReadOnly TypedDict key "key" TypedDict is mutated
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictFromMypyExtensionsReadOnlyMutateMethods]
-from typing import TypedDict
+from mypy_extensions import TypedDict
 from typing_extensions import ReadOnly
 
 class TP(TypedDict):
@@ -4120,7 +4120,7 @@ Func = TypedDict('Func', {
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictNestedInClassAndInherited]
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class Base:
     class Params(TypedDict):


### PR DESCRIPTION
#18640 removed almost all instances of `typing_extensions.Literal` in the tests. Re-add a simple regression test. Similarly at least one test case should import `mypy_extensions.TypedDict`.