### PR TITLE
pythoncapi_compat: don't define Py_NULL if it is already defined

### DIFF
--- a/mypyc/lib-rt/pythoncapi_compat.h
+++ b/mypyc/lib-rt/pythoncapi_compat.h
@@ -34,6 +34,7 @@ extern "C" {
 #  define _Py_CAST(type, expr) ((type)(expr))
 #endif
 
+#ifndef _Py_NULL
 // Static inline functions should use _Py_NULL rather than using directly NULL
 // to prevent C++ compiler warnings. On C23 and newer and on C++11 and newer,
 // _Py_NULL is defined as nullptr.
@@ -42,6 +43,7 @@ extern "C" {
 #  define _Py_NULL nullptr
 #else
 #  define _Py_NULL NULL
+#endif
 #endif
 
 // Cast argument to PyObject* type.


### PR DESCRIPTION
Fixes: #18698 

This is a naive fix for the gcc 15 error when compiling for Python 3.12

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
