### PR TITLE
[mypyc] Improve str.startswith and str.endswith with tuple argument

### DIFF
--- a/mypyc/lib-rt/str_ops.c
+++ b/mypyc/lib-rt/str_ops.c
@@ -173,7 +173,7 @@ int CPyStr_Startswith(PyObject *self, PyObject *subobj) {
                              "tuple for startswith must only contain str, "
                              "not %.100s",
                              Py_TYPE(substring)->tp_name);
-                return -1;
+                return 2;
             }
             int result = PyUnicode_Tailmatch(self, substring, start, end, -1);
             if (result) {
@@ -197,7 +197,7 @@ int CPyStr_Endswith(PyObject *self, PyObject *subobj) {
                              "tuple for endswith must only contain str, "
                              "not %.100s",
                              Py_TYPE(substring)->tp_name);
-                return -1;
+                return 2;
             }
             int result = PyUnicode_Tailmatch(self, substring, start, end, 1);
             if (result) {

--- a/mypyc/primitives/str_ops.py
+++ b/mypyc/primitives/str_ops.py
@@ -111,14 +111,13 @@ method_op(
     error_kind=ERR_NEVER,
 )
 
-# str.startswith(tuple) (return -1/0/1)
+# str.startswith(tuple)
 method_op(
     name="startswith",
     arg_types=[str_rprimitive, tuple_rprimitive],
-    return_type=c_int_rprimitive,
+    return_type=bool_rprimitive,
     c_function_name="CPyStr_Startswith",
-    truncated_type=bool_rprimitive,
-    error_kind=ERR_NEG_INT,
+    error_kind=ERR_MAGIC,
 )
 
 # str.endswith(str)
@@ -131,14 +130,13 @@ method_op(
     error_kind=ERR_NEVER,
 )
 
-# str.endswith(tuple) (return -1/0/1)
+# str.endswith(tuple)
 method_op(
     name="endswith",
     arg_types=[str_rprimitive, tuple_rprimitive],
-    return_type=c_int_rprimitive,
+    return_type=bool_rprimitive,
     c_function_name="CPyStr_Endswith",
-    truncated_type=bool_rprimitive,
-    error_kind=ERR_NEG_INT,
+    error_kind=ERR_MAGIC,
 )
 
 # str.removeprefix(str)

--- a/mypyc/test-data/irbuild-str.test
+++ b/mypyc/test-data/irbuild-str.test
@@ -153,55 +153,39 @@ def do_tuple_literal_args(s1: str) -> None:
 def do_startswith(s1, s2):
     s1 :: str
     s2 :: tuple
-    r0 :: i32
-    r1 :: bit
-    r2 :: bool
+    r0 :: bool
 L0:
     r0 = CPyStr_Startswith(s1, s2)
-    r1 = r0 >= 0 :: signed
-    r2 = truncate r0: i32 to builtins.bool
-    return r2
+    return r0
 def do_endswith(s1, s2):
     s1 :: str
     s2 :: tuple
-    r0 :: i32
-    r1 :: bit
-    r2 :: bool
+    r0 :: bool
 L0:
     r0 = CPyStr_Endswith(s1, s2)
-    r1 = r0 >= 0 :: signed
-    r2 = truncate r0: i32 to builtins.bool
-    return r2
+    return r0
 def do_tuple_literal_args(s1):
     s1, r0, r1 :: str
     r2 :: tuple[str, str]
     r3 :: object
-    r4 :: i32
-    r5 :: bit
-    r6, x :: bool
-    r7, r8 :: str
-    r9 :: tuple[str, str]
-    r10 :: object
-    r11 :: i32
-    r12 :: bit
-    r13, y :: bool
+    r4, x :: bool
+    r5, r6 :: str
+    r7 :: tuple[str, str]
+    r8 :: object
+    r9, y :: bool
 L0:
     r0 = 'a'
     r1 = 'b'
     r2 = (r0, r1)
     r3 = box(tuple[str, str], r2)
     r4 = CPyStr_Startswith(s1, r3)
-    r5 = r4 >= 0 :: signed
-    r6 = truncate r4: i32 to builtins.bool
-    x = r6
-    r7 = 'a'
-    r8 = 'b'
-    r9 = (r7, r8)
-    r10 = box(tuple[str, str], r9)
-    r11 = CPyStr_Endswith(s1, r10)
-    r12 = r11 >= 0 :: signed
-    r13 = truncate r11: i32 to builtins.bool
-    y = r13
+    x = r4
+    r5 = 'a'
+    r6 = 'b'
+    r7 = (r5, r6)
+    r8 = box(tuple[str, str], r7)
+    r9 = CPyStr_Endswith(s1, r8)
+    y = r9
     return 1
 
 [case testStrToBool]


### PR DESCRIPTION
Followup to #18678

Missed that we can also use `bool_rprimitive` as return type with a value of `2` for errors.