### PR TITLE
Fix mypyc crash with enum type aliases

### DIFF
--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -73,7 +73,7 @@ def build_ir(
 
     for module in modules:
         # First pass to determine free symbols.
-        pbv = PreBuildVisitor(errors, module, singledispatch_info.decorators_to_remove)
+        pbv = PreBuildVisitor(errors, module, singledispatch_info.decorators_to_remove, types)
         module.accept(pbv)
 
         # Construct and configure builder objects (cyclic runtime dependency).

--- a/mypyc/irbuild/missingtypevisitor.py
+++ b/mypyc/irbuild/missingtypevisitor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from mypy.nodes import Expression, Node
 from mypy.traverser import ExtendedTraverserVisitor
-from mypy.types import Type, AnyType, TypeOfAny
+from mypy.types import AnyType, Type, TypeOfAny
 
 
 class MissingTypesVisitor(ExtendedTraverserVisitor):

--- a/mypyc/irbuild/missingtypevisitor.py
+++ b/mypyc/irbuild/missingtypevisitor.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from mypy.nodes import Expression, Node
+from mypy.traverser import ExtendedTraverserVisitor
+from mypy.types import Type, AnyType, TypeOfAny
+
+
+class MissingTypesVisitor(ExtendedTraverserVisitor):
+    """AST visitor that can be used to add any missing types as a generic AnyType."""
+
+    def __init__(self, types: dict[Expression, Type]) -> None:
+        super().__init__()
+        self.types: dict[Expression, Type] = types
+
+    def visit(self, o: Node) -> bool:
+        if isinstance(o, Expression) and o not in self.types:
+            self.types[o] = AnyType(TypeOfAny.special_form)
+
+        # If returns True, will continue to nested nodes.
+        return True

--- a/mypyc/irbuild/prebuildvisitor.py
+++ b/mypyc/irbuild/prebuildvisitor.py
@@ -8,7 +8,6 @@ from mypy.nodes import (
     FuncDef,
     FuncItem,
     Import,
-    IndexExpr,
     LambdaExpr,
     MemberExpr,
     MypyFile,

--- a/mypyc/irbuild/prebuildvisitor.py
+++ b/mypyc/irbuild/prebuildvisitor.py
@@ -97,7 +97,7 @@ class PreBuildVisitor(ExtendedTraverserVisitor):
     def visit_assignment_stmt(self, stmt: AssignmentStmt) -> None:
         # These are cases where mypy may not have types for certain expressions,
         # but mypyc needs some form type to exist.
-        if isinstance(stmt.rvalue, IndexExpr) and stmt.rvalue.analyzed:
+        if stmt.is_alias_def:
             stmt.rvalue.accept(self.missing_types_visitor)
         return super().visit_assignment_stmt(stmt)
 

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1335,3 +1335,12 @@ def outer():
 if True:
     class OtherInner:  # E: Nested class definitions not supported
         pass
+
+[case testEnumClassAlias]
+from enum import Enum
+from typing import Literal
+
+class SomeEnum(Enum):
+    AVALUE = "a"
+
+ALIAS = Literal[SomeEnum.AVALUE]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1338,9 +1338,10 @@ if True:
 
 [case testEnumClassAlias]
 from enum import Enum
-from typing import Literal
+from typing import Literal, Union
 
 class SomeEnum(Enum):
     AVALUE = "a"
 
 ALIAS = Literal[SomeEnum.AVALUE]
+ALIAS2 = Union[Literal[SomeEnum.AVALUE], None]

--- a/mypyc/test-data/run-python312.test
+++ b/mypyc/test-data/run-python312.test
@@ -1,5 +1,6 @@
 [case testPEP695Basics]
-from typing import Any, TypeAliasType, cast
+from enum import Enum
+from typing import Any, Literal, TypeAliasType, cast
 
 from testutil import assertRaises
 
@@ -188,6 +189,13 @@ type R = int | list[R]
 def test_recursive_type_alias() -> None:
     assert isinstance(R, TypeAliasType)
     assert getattr(R, "__value__") == (int | list[R])
+
+class SomeEnum(Enum):
+    AVALUE = "a"
+
+type EnumLiteralAlias1 = Literal[SomeEnum.AVALUE]
+type EnumLiteralAlias2 = Literal[SomeEnum.AVALUE] | None
+EnumLiteralAlias3 = Literal[SomeEnum.AVALUE] | None
 [typing fixtures/typing-full.pyi]
 
 [case testPEP695GenericTypeAlias]


### PR DESCRIPTION
mypyc was crashing because it couldn't find the type in the type map. This PR adds a generic AnyType to the type map if an expression isn't in the map already.

Tried actually changing mypy to accept these type alias expressions, but ran into problems with nested type aliases where the inner one doesn't have the "analyzed" value and ending up with wrong results.

fixes https://github.com/mypyc/mypyc/issues/1064