### PR TITLE
stubgen: Fix valid type detection to allow pipe unions

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -21,7 +21,7 @@ import mypy.util
 Sig: _TypeAlias = tuple[str, str]
 
 
-_TYPE_RE: Final = re.compile(r"^[a-zA-Z_][\w\[\], .\"\']*(\.[a-zA-Z_][\w\[\], ]*)*$")
+_TYPE_RE: Final = re.compile(r"^[a-zA-Z_][\w\[\], .\"\'|]*(\.[a-zA-Z_][\w\[\], ]*)*$")
 _ARG_NAME_RE: Final = re.compile(r"\**[A-Za-z_][A-Za-z0-9_]*$")
 
 

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -1405,6 +1405,9 @@ class IsValidTypeSuite(unittest.TestCase):
         assert is_valid_type("Literal[True]")
         assert is_valid_type("Literal[Color.RED]")
         assert is_valid_type("Literal[None]")
+        assert is_valid_type("str | int")
+        assert is_valid_type("dict[str, int] | int")
+        assert is_valid_type("tuple[str, ...]")
         assert is_valid_type(
             'Literal[26, 0x1A, "hello world", b"hello world", u"hello world", True, Color.RED, None]'
         )


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

`stubgen` has a regex which it uses to reject invalid types that are extracted from docstrings.  It needed to be updated to support union shorthand: `str | int`.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
