### PR TITLE
Add flag to allow more flexible variable redefinition

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -66,7 +66,6 @@ jobs:
             --num-shards 5 --shard-index ${{ matrix.shard-index }} \
             --debug \
             --additional-flags="--debug-serialize" \
-            --additional-flags="--local-partial-types" \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]

--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -66,6 +66,7 @@ jobs:
             --num-shards 5 --shard-index ${{ matrix.shard-index }} \
             --debug \
             --additional-flags="--debug-serialize" \
+            --additional-flags="--local-partial-types" \
             --output concise \
             | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -39,6 +39,7 @@ class CurrentType(NamedTuple):
 
 class Frame:
     """A Frame represents a specific point in the execution of a program.
+
     It carries information about the current types of expressions at
     that point, arising either from assignments to those expressions
     or the result of isinstance checks and other type narrowing

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -28,6 +28,7 @@ from mypy.types import (
     get_proper_type,
 )
 from mypy.typevars import fill_typevars_with_any
+from mypy.options import Options
 
 BindableExpression: _TypeAlias = Union[IndexExpr, MemberExpr, NameExpr]
 
@@ -98,7 +99,7 @@ class ConditionalTypeBinder:
     # This maps an expression to a list of bound types for every item in the union type.
     type_assignments: Assigns | None = None
 
-    def __init__(self, bind_all: bool) -> None:
+    def __init__(self, options: Options) -> None:
         # Each frame gets an increasing, distinct id.
         self.next_id = 1
 
@@ -135,7 +136,7 @@ class ConditionalTypeBinder:
         # If True, initial assignment to a simple variable (e.g. "x", but not "x.y")
         # is added to the binder. This allows more precise narrowing and more
         # flexible inference of variable types.
-        self.bind_all = bind_all
+        self.bind_all = options.allow_redefinition_new
 
     def _get_id(self) -> int:
         self.next_id += 1

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -99,8 +99,6 @@ class ConditionalTypeBinder:
     type_assignments: Assigns | None = None
 
     def __init__(self, bind_all: bool) -> None:
-        self.bind_all = bind_all
-
         # Each frame gets an increasing, distinct id.
         self.next_id = 1
 
@@ -133,6 +131,11 @@ class ConditionalTypeBinder:
         self.try_frames: set[int] = set()
         self.break_frames: list[int] = []
         self.continue_frames: list[int] = []
+
+        # If True, initial assignment to a simple variable (e.g. "x", but not "x.y")
+        # is added to the binder. This allows more precise narrowing and more
+        # flexible inference of variable types.
+        self.bind_all = bind_all
 
     def _get_id(self) -> int:
         self.next_id += 1

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -288,7 +288,7 @@ class ConditionalTypeBinder:
                     # still equivalent to such type).
                     if isinstance(type, UnionType):
                         type = collapse_variadic_union(type)
-                    if isinstance(type, ProperType) and isinstance(type, UnionType):
+                    if old_semantics and isinstance(type, ProperType) and isinstance(type, UnionType):
                         # Simplify away any extra Any's that were added to the declared
                         # type when popping a frame.
                         simplified = UnionType.make_union(

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -288,7 +288,11 @@ class ConditionalTypeBinder:
                     # still equivalent to such type).
                     if isinstance(type, UnionType):
                         type = collapse_variadic_union(type)
-                    if old_semantics and isinstance(type, ProperType) and isinstance(type, UnionType):
+                    if (
+                        old_semantics
+                        and isinstance(type, ProperType)
+                        and isinstance(type, UnionType)
+                    ):
                         # Simplify away any extra Any's that were added to the declared
                         # type when popping a frame.
                         simplified = UnionType.make_union(

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -135,7 +135,7 @@ class ConditionalTypeBinder:
 
         # If True, initial assignment to a simple variable (e.g. "x", but not "x.y")
         # is added to the binder. This allows more precise narrowing and more
-        # flexible inference of variable types.
+        # flexible inference of variable types (--allow-redefinition-new).
         self.bind_all = options.allow_redefinition_new
 
     def _get_id(self) -> int:
@@ -233,6 +233,11 @@ class ConditionalTypeBinder:
         for key in keys:
             current_value = self._get(key)
             resulting_values = [f.types.get(key, current_value) for f in frames]
+            # Keys can be narrowed using two different semantics. The new semantics
+            # is enabled for plain variables when bind_all is true, and it allows
+            # variable types to be widened using subsequent assignments. This is
+            # tricky to support for instance attributes (primarily due to deferrals),
+            # so we don't use it for them.
             old_semantics = not self.bind_all or extract_var_from_literal_hash(key) is None
             if old_semantics and any(x is None for x in resulting_values):
                 # We didn't know anything about key before

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -7,7 +7,7 @@ from typing import NamedTuple, Optional, Union
 from typing_extensions import TypeAlias as _TypeAlias
 
 from mypy.erasetype import remove_instance_last_known_values
-from mypy.literals import Key, literal, literal_hash, subkeys, is_member_literal_hash
+from mypy.literals import Key, literal, literal_hash, subkeys, extract_var_from_literal_hash
 from mypy.nodes import Expression, IndexExpr, MemberExpr, NameExpr, RefExpr, TypeInfo, Var
 from mypy.subtypes import is_same_type, is_subtype
 from mypy.typeops import make_simplified_union
@@ -229,7 +229,7 @@ class ConditionalTypeBinder:
         for key in keys:
             current_value = self._get(key)
             resulting_values = [f.types.get(key, current_value) for f in frames]
-            old_semantics = not self.bind_all or is_member_literal_hash(key)
+            old_semantics = not self.bind_all or extract_var_from_literal_hash(key) is None
             if old_semantics and any(x is None for x in resulting_values):
                 # We didn't know anything about key before
                 # (current_value must be None), and we still don't

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -7,8 +7,9 @@ from typing import NamedTuple, Optional, Union
 from typing_extensions import TypeAlias as _TypeAlias
 
 from mypy.erasetype import remove_instance_last_known_values
-from mypy.literals import Key, literal, literal_hash, subkeys, extract_var_from_literal_hash
+from mypy.literals import Key, extract_var_from_literal_hash, literal, literal_hash, subkeys
 from mypy.nodes import Expression, IndexExpr, MemberExpr, NameExpr, RefExpr, TypeInfo, Var
+from mypy.options import Options
 from mypy.subtypes import is_same_type, is_subtype
 from mypy.typeops import make_simplified_union
 from mypy.types import (
@@ -28,7 +29,6 @@ from mypy.types import (
     get_proper_type,
 )
 from mypy.typevars import fill_typevars_with_any
-from mypy.options import Options
 
 BindableExpression: _TypeAlias = Union[IndexExpr, MemberExpr, NameExpr]
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2241,7 +2241,7 @@ class State:
         self.tree.names = SymbolTable()
         if not self.tree.is_stub:
             if not self.options.allow_redefinition_new:
-                # Always perform some low-key variable renaming when assignments can't
+                # Perform some low-key variable renaming when assignments can't
                 # widen inferred types
                 self.tree.accept(LimitedVariableRenameVisitor())
             if options.allow_redefinition:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2240,7 +2240,7 @@ class State:
         # TODO: Do this while constructing the AST?
         self.tree.names = SymbolTable()
         if not self.tree.is_stub:
-            if not self.options.allow_redefinition2:
+            if not self.options.allow_redefinition_new:
                 # Always perform some low-key variable renaming when assignments can't
                 # widen inferred types
                 self.tree.accept(LimitedVariableRenameVisitor())

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2240,8 +2240,10 @@ class State:
         # TODO: Do this while constructing the AST?
         self.tree.names = SymbolTable()
         if not self.tree.is_stub:
-            # Always perform some low-key variable renaming
-            self.tree.accept(LimitedVariableRenameVisitor())
+            if not self.options.allow_redefinition2:
+                # Always perform some low-key variable renaming when assignments can't
+                # widen inferred types
+                self.tree.accept(LimitedVariableRenameVisitor())
             if options.allow_redefinition:
                 # Perform more renaming across the AST to allow variable redefinitions
                 self.tree.accept(VariableRenameVisitor())

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4566,11 +4566,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 rvalue_type = self.expr_checker.accept(
                     rvalue, type_context=lvalue_type, always_allow_any=always_allow_any
                 )
-            if isinstance(lvalue, NameExpr) and inferred is not None and inferred.type is not None:
-                if not inferred.is_final:
-                    new_inferred = remove_instance_last_known_values(rvalue_type)
-                else:
-                    new_inferred = rvalue_type
+            if (
+                isinstance(lvalue, NameExpr)
+                and inferred is not None
+                and inferred.type is not None
+                and not inferred.is_final
+            ):
+                new_inferred = remove_instance_last_known_values(rvalue_type)
                 if not is_same_type(inferred.type, new_inferred):
                     # Should we widen the inferred type or the lvalue? We can only widen
                     # a variable type if the variable was defined in the current function.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4594,7 +4594,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             self.widened_vars.append(inferred.name)
                             self.set_inferred_type(inferred, lvalue, lvalue_type)
                             self.binder.put(lvalue, rvalue_type)
-                            # TODO: hack, maybe integrate into put?
+                            # TODO: A bit hacky, maybe add a binder method that does put and
+                            #       updates declaration?
                             lit = literal_hash(lvalue)
                             if lit is not None:
                                 self.binder.declarations[lit] = lvalue_type

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3351,7 +3351,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             and lvalue.node.is_inferred
                             and lvalue.node.is_index_var
                             and lvalue_type is not None
-                            and not self.options.allow_redefinition_new  # TODO WHAT
                         ):
                             lvalue.node.type = remove_instance_last_known_values(lvalue_type)
                 elif self.options.allow_redefinition_new and lvalue_type is not None:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3328,6 +3328,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             and lvalue.node.is_inferred
                             and lvalue.node.is_index_var
                             and lvalue_type is not None
+                            and not self.options.allow_redefinition2 # TODO WHAT
                         ):
                             lvalue.node.type = remove_instance_last_known_values(lvalue_type)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -596,6 +596,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # Check for potential decreases in the number of partial types so as not to stop the
             # iteration too early:
             partials_old = sum(len(pts.map) for pts in self.partial_types)
+            # Check if assignment widened the inferred type of a variable; in this case we
+            # need to iterate again (we only do one extra iteration, since this could go
+            # on without bound otherwise)
             widened_old = len(self.widened_vars)
 
             # Disable error types that we cannot safely identify in intermediate iteration steps:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5112,8 +5112,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             # try/except block.
                             source = var.name
                             if isinstance(var.node, Var):
-                                var.node.type = DeletedType(source=source)
-                            self.binder.cleanse(var)
+                                new_type = DeletedType(source=source)
+                                var.node.type = new_type
+                                if self.options.allow_redefinition2:
+                                    self.binder.assign_type(var, new_type, new_type)
+                            if not self.options.allow_redefinition2:
+                                self.binder.cleanse(var)
             if s.else_body:
                 self.accept(s.else_body)
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4560,7 +4560,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             always_allow_any = lvalue_type is not None and not isinstance(
                 get_proper_type(lvalue_type), AnyType
             )
-            if inferred is None:
+            if inferred is None or is_typeddict_type_context(lvalue_type):
                 type_context = lvalue_type
             else:
                 type_context = None
@@ -9233,3 +9233,10 @@ def _ambiguous_enum_variants(types: list[Type]) -> set[str]:
         else:
             result.add("<other>")
     return result
+
+
+def is_typeddict_type_context(lvalue_type: Type | None) -> bool:
+    if lvalue_type is None:
+        return False
+    lvalue_proper = get_proper_type(lvalue_type)
+    return isinstance(lvalue_proper, TypedDictType)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4566,6 +4566,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 rvalue_type = self.expr_checker.accept(
                     rvalue, type_context=lvalue_type, always_allow_any=always_allow_any
                 )
+                if not is_valid_inferred_type(rvalue_type, self.options) and inferred is not None:
+                    self.msg.need_annotation_for_var(
+                        inferred, context, self.options.python_version
+                    )
+                    rvalue_type = rvalue_type.accept(SetNothingToAny())
+
             if (
                 isinstance(lvalue, NameExpr)
                 and inferred is not None

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4367,6 +4367,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             init_type = strip_type(init_type)
 
             self.set_inferred_type(name, lvalue, init_type)
+            if self.options.allow_redefinition2:
+                self.binder.assign_type(lvalue, init_type, init_type)
 
     def infer_partial_type(self, name: Var, lvalue: Lvalue, init_type: Type) -> bool:
         init_type = get_proper_type(init_type)
@@ -4535,6 +4537,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         self.widened_vars.append(inferred.name)
                         self.set_inferred_type(inferred, lvalue, lvalue_type)
                         self.binder.put(lvalue, rvalue_type)
+                        # TODO: hack, maybe integrate into put?
+                        self.binder.declarations[literal_hash(lvalue)] = lvalue_type
             if (
                 isinstance(get_proper_type(lvalue_type), UnionType)
                 # Skip literal types, as they have special logic (for better errors).

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1395,7 +1395,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         # TODO: Add these directly using a fast path
                         v = arg.variable
                         if v.type is not None:
-                            n = NameExpr("")
+                            n = NameExpr(v.name)
                             n.node = v
                             self.binder.assign_type(n, v.type, v.type)
 
@@ -5521,11 +5521,13 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # Create a dummy subject expression to handle cases where a match statement's subject
             # is not a literal value. This lets us correctly narrow types and check exhaustivity
             # This is hack!
-            id = s.subject.callee.fullname if isinstance(s.subject.callee, RefExpr) else ""
-            name = "dummy-match-" + id
-            v = Var(name)
-            named_subject = NameExpr(name)
-            named_subject.node = v
+            if s.subject_dummy is None:
+                id = s.subject.callee.fullname if isinstance(s.subject.callee, RefExpr) else ""
+                name = "dummy-match-" + id
+                v = Var(name)
+                s.subject_dummy = NameExpr(name)
+                s.subject_dummy.node = v
+            named_subject = s.subject_dummy
         else:
             named_subject = s.subject
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -618,6 +618,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 partials_old = partials_new
                 widened_old = widened_new
                 iter += 1
+                if iter == 20:
+                    raise RuntimeError(f"Too many iterations when checking a loop")
 
             # If necessary, reset the modified options and make up for the postponed error checks:
             self.options.warn_unreachable = warn_unreachable

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4580,8 +4580,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             ):
                 new_inferred = remove_instance_last_known_values(rvalue_type)
                 if not is_same_type(inferred.type, new_inferred):
-                    # Should we widen the inferred type or the lvalue? We can only widen
-                    # a variable type if the variable was defined in the current function.
+                    # Should we widen the inferred type or the lvalue? Variables defined
+                    # at module level or class bodies can't be widened in functions.
                     different_scopes = (
                         self.scope.top_level_function() is not None and lvalue.kind != LDEF
                     )

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4380,7 +4380,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             # inference (it's not specific enough), but we might be able to give
             # partial type which will be made more specific later. A partial type
             # gets generated in assignment like 'x = []' where item type is not known.
-            if not self.infer_partial_type(name, lvalue, init_type):
+            if name.name != "_" and not self.infer_partial_type(name, lvalue, init_type):
                 self.msg.need_annotation_for_var(name, context, self.options.python_version)
                 self.set_inference_error_fallback_type(name, lvalue, init_type)
         elif (

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -378,7 +378,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         self.plugin = plugin
         self.tscope = Scope()
         self.scope = CheckerScope(tree)
-        self.binder = ConditionalTypeBinder(bind_all=options.allow_redefinition_new)
+        self.binder = ConditionalTypeBinder(options)
         self.globals = tree.names
         self.return_types = []
         self.dynamic_funcs = []
@@ -433,7 +433,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # TODO: verify this is still actually worth it over creating new checkers
         self.partial_reported.clear()
         self.module_refs.clear()
-        self.binder = ConditionalTypeBinder(bind_all=self.options.allow_redefinition_new)
+        self.binder = ConditionalTypeBinder(self.options)
         self._type_maps[1:] = []
         self._type_maps[0].clear()
         self.temp_type_map = None
@@ -1200,7 +1200,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         original_typ = typ
         for item, typ in expanded:
             old_binder = self.binder
-            self.binder = ConditionalTypeBinder(bind_all=self.options.allow_redefinition_new)
+            self.binder = ConditionalTypeBinder(self.options)
             with self.binder.top_frame_context():
                 defn.expanded.append(item)
 
@@ -2584,7 +2584,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.fail(message_registry.CANNOT_INHERIT_FROM_FINAL.format(base.name), defn)
         with self.tscope.class_scope(defn.info), self.enter_partial_types(is_class=True):
             old_binder = self.binder
-            self.binder = ConditionalTypeBinder(bind_all=self.options.allow_redefinition_new)
+            self.binder = ConditionalTypeBinder(self.options)
             with self.binder.top_frame_context():
                 with self.scope.push_class(defn.info):
                     self.accept(defn.defs)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3364,6 +3364,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         ):
                             lvalue.node.type = remove_instance_last_known_values(lvalue_type)
                 elif self.options.allow_redefinition_new and lvalue_type is not None:
+                    # TODO: Can we use put() here?
                     self.binder.assign_type(lvalue, lvalue_type, lvalue_type)
 
             elif index_lvalue:
@@ -5188,6 +5189,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                                 new_type = DeletedType(source=source)
                                 var.node.type = new_type
                                 if self.options.allow_redefinition_new:
+                                    # TODO: Should we use put() here?
                                     self.binder.assign_type(var, new_type, new_type)
                             if not self.options.allow_redefinition_new:
                                 self.binder.cleanse(var)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4548,7 +4548,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     new_inferred = rvalue_type
                 if not is_same_type(inferred.type, new_inferred):
                     lvalue_type = make_simplified_union([inferred.type, new_inferred])
-                    if not is_same_type(lvalue_type, inferred.type):
+                    if not is_same_type(lvalue_type, inferred.type) and not isinstance(inferred.type, PartialType):
                         self.widened_vars.append(inferred.name)
                         self.set_inferred_type(inferred, lvalue, lvalue_type)
                         self.binder.put(lvalue, rvalue_type)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4577,7 +4577,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     # Should we widen the inferred type or the lvalue? We can only widen
                     # a variable type if the variable was defined in the current function.
                     different_scopes = (
-                        self.scope.top_function() is not None and lvalue.kind != LDEF
+                        self.scope.top_level_function() is not None and lvalue.kind != LDEF
                     )
                     if not different_scopes:
                         lvalue_type = make_simplified_union([inferred.type, new_inferred])

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1406,7 +1406,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 if self.options.allow_redefinition_new and not self.is_stub:
                     # Add formal argument types to the binder.
                     for arg in defn.arguments:
-                        # TODO: Add these directly using a fast path
+                        # TODO: Add these directly using a fast path (possibly "put")
                         v = arg.variable
                         if v.type is not None:
                             n = NameExpr(v.name)
@@ -3304,7 +3304,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     # unpleasant, and a generalization of this would
                     # be an improvement!
                     if (
-                        is_literal_none(rvalue)
+                        not self.options.allow_redefinition_new
+                        and is_literal_none(rvalue)
                         and isinstance(lvalue, NameExpr)
                         and lvalue.kind == LDEF
                         and isinstance(lvalue.node, Var)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -618,7 +618,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 widened_new = len(self.widened_vars)
                 if (
                     (partials_new == partials_old)
-                    and not self.binder.last_pop_changed
+                    and (not self.binder.last_pop_changed or iter > 3)
                     and (widened_new == widened_old or iter > 1)
                 ):
                     break

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5786,6 +5786,14 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 _, sequence_type = self.chk.analyze_async_iterable_item_type(sequence)
             else:
                 _, sequence_type = self.chk.analyze_iterable_item_type(sequence)
+                if (
+                    isinstance(sequence_type, UninhabitedType)
+                    and isinstance(index, NameExpr)
+                    and index.name == "_"
+                ):
+                    # To preserve backward compatibility, avoid inferring Never for "_"
+                    sequence_type = AnyType(TypeOfAny.special_form)
+
             self.chk.analyze_index_variables(index, sequence_type, True, e)
             for condition in conditions:
                 self.accept(condition)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5787,7 +5787,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             else:
                 _, sequence_type = self.chk.analyze_iterable_item_type(sequence)
                 if (
-                    isinstance(sequence_type, UninhabitedType)
+                    isinstance(get_proper_type(sequence_type), UninhabitedType)
                     and isinstance(index, NameExpr)
                     and index.name == "_"
                 ):

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1117,8 +1117,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             typ = self.try_infer_partial_value_type_from_call(e, callee.name, var)
             # Var may be deleted from partial_types in try_infer_partial_value_type_from_call
             if typ is not None and var in partial_types:
-                var.type = typ
-                del partial_types[var]
+                self.chk.replace_partial_type(var, typ, partial_types)
         elif isinstance(callee.expr, IndexExpr) and isinstance(callee.expr.base, RefExpr):
             # Call 'x[y].method(...)'; may infer type of 'x' if it's a partial defaultdict.
             if callee.expr.analyzed is not None:
@@ -1140,8 +1139,8 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                     # Store inferred partial type.
                     assert partial_type.type is not None
                     typename = partial_type.type.fullname
-                    var.type = self.chk.named_generic_type(typename, [key_type, value_type])
-                    del partial_types[var]
+                    new_type = self.chk.named_generic_type(typename, [key_type, value_type])
+                    self.chk.replace_partial_type(var, new_type, partial_types)
 
     def get_partial_var(self, ref: RefExpr) -> tuple[Var, dict[Var, Context]] | None:
         var = ref.node

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -163,10 +163,6 @@ def extract_var_from_literal_hash(key: Key) -> Var | None:
     return None
 
 
-def is_member_literal_hash(key: Key) -> bool:
-    return key[0] == "Member"
-
-
 class _Hasher(ExpressionVisitor[Optional[Key]]):
     def visit_int_expr(self, e: IntExpr) -> Key:
         return ("Literal", e.value)

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -163,6 +163,10 @@ def extract_var_from_literal_hash(key: Key) -> Var | None:
     return None
 
 
+def is_member_literal_hash(key: Key) -> bool:
+    return key[0] == "Member"
+
+
 class _Hasher(ExpressionVisitor[Optional[Key]]):
     def visit_int_expr(self, e: IntExpr) -> Key:
         return ("Literal", e.value)

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -94,7 +94,11 @@ def main(
     )
 
     if options.allow_redefinition_new and not options.local_partial_types:
-        fail("error: --local-partial-types must be used if using --allow-redefinition-new", stderr, options)
+        fail(
+            "error: --local-partial-types must be used if using --allow-redefinition-new",
+            stderr,
+            options,
+        )
 
     if options.install_types and (stdout is not sys.stdout or stderr is not sys.stderr):
         # Since --install-types performs user input, we want regular stdout and stderr.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -93,8 +93,8 @@ def main(
         stdout, stderr, options.hide_error_codes, hide_success=bool(options.output)
     )
 
-    if options.allow_redefinition2 and not options.local_partial_types:
-        fail("error: --local-partial-types must be used if using --allow-redefinition2", stderr, options)
+    if options.allow_redefinition_new and not options.local_partial_types:
+        fail("error: --local-partial-types must be used if using --allow-redefinition-new", stderr, options)
 
     if options.install_types and (stdout is not sys.stdout or stderr is not sys.stderr):
         # Since --install-types performs user input, we want regular stdout and stderr.
@@ -859,15 +859,15 @@ def process_options(
         "--allow-redefinition",
         default=False,
         strict_flag=False,
-        help="Allow unconditional variable redefinition with a new type",
+        help="Allow restricted, unconditional variable redefinition with a new type",
         group=strictness_group,
     )
 
     add_invertible_flag(
-        "--allow-redefinition2",
+        "--allow-redefinition-new",
         default=False,
         strict_flag=False,
-        help="Allow variable redefinition with a new type (including conditional)",
+        help="Allow flexible variable redefinition with a new type",
         group=strictness_group,
     )
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -95,7 +95,7 @@ def main(
 
     if options.allow_redefinition_new and not options.local_partial_types:
         fail(
-            "error: --local-partial-types must be used if using --allow-redefinition-new",
+            "error: --local-partial-types must be enabled if using --allow-redefinition-new",
             stderr,
             options,
         )

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -867,7 +867,7 @@ def process_options(
         "--allow-redefinition-new",
         default=False,
         strict_flag=False,
-        help="Allow flexible variable redefinition with a new type",
+        help=argparse.SUPPRESS,  # This is still very experimental
         group=strictness_group,
     )
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1638,11 +1638,12 @@ class WithStmt(Statement):
 
 
 class MatchStmt(Statement):
-    __slots__ = ("subject", "patterns", "guards", "bodies")
+    __slots__ = ("subject", "subject_dummy", "patterns", "guards", "bodies")
 
     __match_args__ = ("subject", "patterns", "guards", "bodies")
 
     subject: Expression
+    subject_dummy: NameExpr | None
     patterns: list[Pattern]
     guards: list[Expression | None]
     bodies: list[Block]
@@ -1657,6 +1658,7 @@ class MatchStmt(Statement):
         super().__init__()
         assert len(patterns) == len(guards) == len(bodies)
         self.subject = subject
+        self.subject_dummy = None
         self.patterns = patterns
         self.guards = guards
         self.bodies = bodies

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1073,7 +1073,8 @@ class Var(SymbolNode):
         return self._fullname
 
     def __repr__(self) -> str:
-        return f"<Var {self.fullname!r} at {hex(id(self))}>"
+        name = self.fullname or self.name
+        return f"<Var {name!r} at {hex(id(self))}>"
 
     def accept(self, visitor: NodeVisitor[T]) -> T:
         return visitor.visit_var(self)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -222,7 +222,7 @@ class Options:
 
         # Allow flexible variable redefinition with an arbitrary type, in different
         # blocks and and at different nesting levels
-        self.allow_redefinition_new = False
+        self.allow_redefinition_new = True
 
         # Prohibit equality, identity, and container checks for non-overlapping types.
         # This makes 1 == '1', 1 in ['1'], and 1 is '1' errors.
@@ -361,7 +361,7 @@ class Options:
         self.dump_deps = False
         self.logical_deps = False
         # If True, partial types can't span a module top level and a function
-        self.local_partial_types = False
+        self.local_partial_types = True
         # Some behaviors are changed when using Bazel (https://bazel.build).
         self.bazel = False
         # If True, export inferred types for all expressions as BuildResult.types

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -222,7 +222,7 @@ class Options:
 
         # Allow flexible variable redefinition with an arbitrary type, in different
         # blocks and and at different nesting levels
-        self.allow_redefinition_new = True
+        self.allow_redefinition_new = False
 
         # Prohibit equality, identity, and container checks for non-overlapping types.
         # This makes 1 == '1', 1 in ['1'], and 1 is '1' errors.
@@ -361,7 +361,7 @@ class Options:
         self.dump_deps = False
         self.logical_deps = False
         # If True, partial types can't span a module top level and a function
-        self.local_partial_types = True
+        self.local_partial_types = False
         # Some behaviors are changed when using Bazel (https://bazel.build).
         self.bazel = False
         # If True, export inferred types for all expressions as BuildResult.types

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -219,8 +219,9 @@ class Options:
         # and the same nesting level as the initialization
         self.allow_redefinition = False
 
-        # TODO
-        self.allow_redefinition2 = False
+        # Allow flexible variable redefinition with an arbitrary type, in different
+        # blocks and and at different nesting levels
+        self.allow_redefinition_new = False
 
         # Prohibit equality, identity, and container checks for non-overlapping types.
         # This makes 1 == '1', 1 in ['1'], and 1 is '1' errors.

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -22,6 +22,7 @@ class BuildType:
 PER_MODULE_OPTIONS: Final = {
     # Please keep this list sorted
     "allow_redefinition",
+    "allow_redefinition_new",
     "allow_untyped_globals",
     "always_false",
     "always_true",

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3764,8 +3764,7 @@ class SemanticAnalyzer(
                     # decide here what to infer: int or Literal[42].
                     safe_literal_inference = self.type.mro[1].get(ref_expr.name) is None
                 if safe_literal_inference and ref_expr.is_inferred_def:
-                    if not self.options.allow_redefinition_new or s.is_final_def:
-                        s.type = self.analyze_simple_literal_type(s.rvalue, s.is_final_def)
+                    s.type = self.analyze_simple_literal_type(s.rvalue, s.is_final_def)
         if s.type:
             # Store type into nodes.
             for lvalue in s.lvalues:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3764,7 +3764,8 @@ class SemanticAnalyzer(
                     # decide here what to infer: int or Literal[42].
                     safe_literal_inference = self.type.mro[1].get(ref_expr.name) is None
                 if safe_literal_inference and ref_expr.is_inferred_def:
-                    s.type = self.analyze_simple_literal_type(s.rvalue, s.is_final_def)
+                    if not self.options.allow_redefinition2 or s.is_final_def:
+                        s.type = self.analyze_simple_literal_type(s.rvalue, s.is_final_def)
         if s.type:
             # Store type into nodes.
             for lvalue in s.lvalues:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4338,6 +4338,8 @@ class SemanticAnalyzer(
                 if self.is_func_scope():
                     if unmangle(name) == "_" and not self.options.allow_redefinition_new:
                         # Special case for assignment to local named '_': always infer 'Any'.
+                        # This isn't needed with --allow-redefinition-new, since arbitrary
+                        # types can be assigned to '_' anyway.
                         typ = AnyType(TypeOfAny.special_form)
                         self.store_declared_types(lvalue, typ)
             if is_final and self.is_final_redefinition(kind, name):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -658,6 +658,13 @@ class SemanticAnalyzer(
 
     def refresh_top_level(self, file_node: MypyFile) -> None:
         """Reanalyze a stale module top-level in fine-grained incremental mode."""
+        if self.options.allow_redefinition_new and not self.options.local_partial_types:
+            n = TempNode(AnyType(TypeOfAny.special_form))
+            n.line = 1
+            n.column = 0
+            n.end_line = 1
+            n.end_column = 0
+            self.fail("--local-partial-types must be enabled if using --allow-redefinition-new", n)
         self.recurse_into_functions = False
         self.add_implicit_module_attrs(file_node)
         for d in file_node.defs:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3764,7 +3764,7 @@ class SemanticAnalyzer(
                     # decide here what to infer: int or Literal[42].
                     safe_literal_inference = self.type.mro[1].get(ref_expr.name) is None
                 if safe_literal_inference and ref_expr.is_inferred_def:
-                    if not self.options.allow_redefinition2 or s.is_final_def:
+                    if not self.options.allow_redefinition_new or s.is_final_def:
                         s.type = self.analyze_simple_literal_type(s.rvalue, s.is_final_def)
         if s.type:
             # Store type into nodes.
@@ -4336,7 +4336,7 @@ class SemanticAnalyzer(
                 else:
                     lvalue.fullname = lvalue.name
                 if self.is_func_scope():
-                    if unmangle(name) == "_" and not self.options.allow_redefinition2:
+                    if unmangle(name) == "_" and not self.options.allow_redefinition_new:
                         # Special case for assignment to local named '_': always infer 'Any'.
                         typ = AnyType(TypeOfAny.special_form)
                         self.store_declared_types(lvalue, typ)

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6855,3 +6855,14 @@ from .lib import NT
 [builtins fixtures/tuple.pyi]
 [out]
 [out2]
+
+[case testNewRedefineAffectsCache]
+# flags: --local-partial-types --allow-redefinition-new
+# flags2: --local-partial-types
+# flags3: --local-partial-types --allow-redefinition-new
+x = 0
+if int():
+    x = ""
+[out]
+[out2]
+main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -2554,7 +2554,7 @@ def f(t: T) -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testRedefine2MatchBasics]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 
 def f1(x: int | str | list[bytes]) -> None:
     match x:

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -2553,7 +2553,7 @@ def f(t: T) -> None:
             reveal_type(k)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.K]"
 [builtins fixtures/tuple.pyi]
 
-[case testRedefine2MatchBasics]
+[case testNewRedefineMatchBasics]
 # flags: --allow-redefinition-new --local-partial-types
 
 def f1(x: int | str | list[bytes]) -> None:

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -2552,3 +2552,16 @@ def f(t: T) -> None:
         case T([K() as k]):
             reveal_type(k)  # N: Revealed type is "Tuple[builtins.int, fallback=__main__.K]"
 [builtins fixtures/tuple.pyi]
+
+[case testRedefine2MatchBasics]
+# flags: --allow-redefinition2 --local-partial-types
+
+def f1(x: int | str | list[bytes]) -> None:
+    match x:
+        case int():
+            reveal_type(x) # N: Revealed type is "builtins.int"
+        case str(y):
+            reveal_type(y) # N: Revealed type is "builtins.str"
+        case [y]:
+            reveal_type(y) # N: Revealed type is "builtins.bytes"
+    reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.bytes]"

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -2565,3 +2565,28 @@ def f1(x: int | str | list[bytes]) -> None:
         case [y]:
             reveal_type(y) # N: Revealed type is "builtins.bytes"
     reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.bytes]"
+
+[case testNewRedefineLoopWithMatch]
+# flags: --allow-redefinition-new --local-partial-types
+
+def f1() -> None:
+    while True:
+        x = object()
+        match x:
+            case str(y):
+                pass
+            case int():
+                pass
+        if int():
+            continue
+
+def f2() -> None:
+    for x in [""]:
+        match str():
+            case "a":
+                y = ""
+            case "b":
+                y = 1
+                return
+    reveal_type(y) # N: Revealed type is "builtins.str"
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1067,3 +1067,22 @@ if int():
 else:
     x = "" # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 reveal_type(x) # N: Revealed type is "builtins.int"
+
+[case testNewRedefineWithoutLocalPartialTypes]
+import a
+import b
+
+[file a.py]
+# mypy: local-partial-types, allow-redefinition-new
+x = 0
+if int():
+    x = ""
+
+[file b.py]
+# mypy: allow-redefinition-new
+x = 0
+if int():
+    x = ""
+
+[out]
+tmp/b.py:1: error: --local-partial-types must be enabled if using --allow-redefinition-new

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -423,6 +423,11 @@ from typing import Final, Literal
 x: Final = "foo"
 reveal_type(x) # N: Revealed type is "Literal['foo']?"
 a: Literal["foo"] = x
+
+class B:
+    x: Final = "bar"
+    a: Literal["bar"] = x
+reveal_type(B.x) # N: Revealed type is "Literal['bar']?"
 [builtins fixtures/tuple.pyi]
 
 [case testNewRedefineAnnotatedVariable]
@@ -1035,8 +1040,10 @@ def f() -> list[str]:
 from typing import Final
 
 x: Final = "foo"
-x = 1 # E: Cannot assign to final name "x"
+x = 1 # E: Cannot assign to final name "x" \
+      # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
 class C:
     y: Final = "foo"
-    y = 1 # E: Cannot assign to final name "y"
+    y = 1 # E: Cannot assign to final name "y" \
+          # E: Incompatible types in assignment (expression has type "int", variable has type "str")

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -66,6 +66,31 @@ class C:
 
 reveal_type(C.x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
+[case testRedefine2NestedFunctionBasics]
+# flags: --allow-redefinition2 --local-partial-types
+def f1() -> None:
+    if int():
+        x = 0
+    else:
+        x = ""
+
+    def nested() -> None:
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def f2() -> None:
+    if int():
+        x = 0
+    else:
+        x = ""
+
+    def nested() -> None:
+        nonlocal x
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+        x = 0
+        reveal_type(x) # N: Revealed type is "builtins.int"
+
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
 [case testRedefine2OptionalTypesSimple]
 # flags: --allow-redefinition2 --local-partial-types
 def f1() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1126,3 +1126,17 @@ def f3() -> None:
 def f4() -> None:
     a, b = 1, [] # E: Need type annotation for "b" (hint: "b: List[<type>] = ...")
 [builtins fixtures/tuple.pyi]
+
+[case testNewRedefineUseInferredTypedDictTypeForContext]
+# flags: --allow-redefinition-new --local-partial-types
+from typing import TypedDict
+
+class TD(TypedDict):
+    x: int
+
+def f() -> None:
+    td = TD(x=1)
+    if int():
+        td = {"x": 5}
+    reveal_type(td) # N: Revealed type is "TypedDict('__main__.TD', {'x': builtins.int})"
+[typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1147,3 +1147,47 @@ def f() -> None:
     gen = (_ for _ in ())
     reveal_type(gen) # N: Revealed type is "typing.Generator[Any, None, None]"
 [builtins fixtures/tuple.pyi]
+
+[case testNewRedefineCannotWidenImportedVariable]
+# flags: --allow-redefinition-new --local-partial-types
+import a
+import b
+reveal_type(a.x) # N: Revealed type is "builtins.str"
+
+[file a.py]
+from b import x
+if int():
+    x = None  # E: Incompatible types in assignment (expression has type "None", variable has type "str")
+
+[file b.py]
+x = "a"
+
+[case testNewRedefineCannotWidenGlobalOrClassVariableWithMemberRef]
+# flags: --allow-redefinition-new --local-partial-types
+from typing import ClassVar
+import a
+
+a.x = None # E: Incompatible types in assignment (expression has type "None", variable has type "str")
+reveal_type(a.x) # N: Revealed type is "builtins.str"
+
+class C:
+    x = ""
+    y: ClassVar[str] = ""
+
+C.x = None # E: Incompatible types in assignment (expression has type "None", variable has type "str")
+reveal_type(C.x) # N: Revealed type is "builtins.str"
+C.y = None # E: Incompatible types in assignment (expression has type "None", variable has type "str")
+reveal_type(C.y) # N: Revealed type is "builtins.str"
+
+[file a.py]
+x = "a"
+
+[case testNewRedefineWidenGlobalInInitModule]
+# flags: --allow-redefinition-new --local-partial-types
+import pkg
+
+[file pkg/__init__.py]
+x = 0
+if int():
+    x = ""
+reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -99,6 +99,15 @@ def f2() -> None:
 
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
+[case testRedefine2AssignmentExpression]
+# flags: --allow-redefinition2 --local-partial-types
+def f() -> None:
+    if x := int():
+        reveal_type(x) # N: Revealed type is "builtins.int"
+    elif x := str():
+        reveal_type(x) # N: Revealed type is "builtins.str"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
 [case testRedefine2OptionalTypesSimple]
 # flags: --allow-redefinition2 --local-partial-types
 def f1() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -369,3 +369,69 @@ def f2() -> None:
         with D() as x:
             reveal_type(x) # N: Revealed type is "builtins.str"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+[case testRedefine2MultipleAssignment]
+# flags: --allow-redefinition2 --local-partial-types
+def f1() -> None:
+    x, y = 1, ""
+    reveal_type(x) # N: Revealed type is "builtins.int"
+    reveal_type(y) # N: Revealed type is "builtins.str"
+    x, y = None, 2
+    reveal_type(x) # N: Revealed type is "None"
+    reveal_type(y) # N: Revealed type is "builtins.int"
+
+def f2() -> None:
+    if int():
+        x, y = 1, ""
+        reveal_type(x) # N: Revealed type is "builtins.int"
+        reveal_type(y) # N: Revealed type is "builtins.str"
+    else:
+        x, y = None, 2
+        reveal_type(x) # N: Revealed type is "None"
+        reveal_type(y) # N: Revealed type is "builtins.int"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
+
+[case testRedefine2ForLoop]
+# flags: --allow-redefinition2 --local-partial-types
+def f1() -> None:
+    for x in [1]:
+        reveal_type(x) # N: Revealed type is "builtins.int"
+    for x in [""]:
+        reveal_type(x) # N: Revealed type is "builtins.str"
+
+def f2() -> None:
+    if int():
+        for x, y in [(1, "x")]:
+            reveal_type(x) # N: Revealed type is "builtins.int"
+            reveal_type(y) # N: Revealed type is "builtins.str"
+    else:
+        for x, y in [(None, 1)]:
+            reveal_type(x) # N: Revealed type is "None"
+            reveal_type(y) # N: Revealed type is "builtins.int"
+
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
+[builtins fixtures/for.pyi]
+
+[case testRedefine2ForStatementIndexNarrowing]
+# flags: --allow-redefinition2 --local-partial-types
+from typing_extensions import TypedDict
+
+class X(TypedDict):
+    hourly: int
+    daily: int
+
+x: X
+for a in ("hourly", "daily"):
+    reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
+    reveal_type(x[a])  # N: Revealed type is "builtins.int"
+    reveal_type(a.upper())  # N: Revealed type is "builtins.str"
+    c = a
+    reveal_type(c)  # N: Revealed type is "builtins.str"
+
+b: str
+for b in ("hourly", "daily"):
+    reveal_type(b)  # N: Revealed type is "builtins.str"
+    reveal_type(b.upper())  # N: Revealed type is "builtins.str"
+[builtins fixtures/for.pyi]

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -118,15 +118,25 @@ def f2() -> None:
 
 reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2DefaultArgument]
+[case testRedefine2ParameterTypes]
 # flags: --allow-redefinition2 --local-partial-types
 from typing import Optional
 
-def f(x: Optional[str] = None) -> None:
+def f1(x: Optional[str] = None) -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.str, None]"
     if x is None:
         x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
+
+def f2(*args: str, **kwargs: int) -> None:
+     reveal_type(args) # N: Revealed type is "builtins.tuple[builtins.str, ...]"
+     reveal_type(kwargs) # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
+
+class C:
+    def m(self) -> None:
+        reveal_type(self) # N: Revealed type is "__main__.C"
+[builtins fixtures/dict.pyi]
+
 
 [case testRedefine2ClassBody]
 # flags: --allow-redefinition2 --local-partial-types
@@ -853,3 +863,28 @@ def f3() -> None:
         for x in [1]:
             x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
+
+[case testRedefine2VariableAnnotatedInLoop]
+# flags: --allow-redefinition2 --local-partial-types --enable-error-code=redundant-expr
+from typing import Optional
+
+def f1() -> None:
+    e: Optional[str] = None
+    for x in ["a"]:
+        if e is None and int():
+            e = x
+            continue
+        elif e is not None and int():
+            break
+        reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"
+    reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"
+
+def f2(e: Optional[str]) -> None:
+    for x in ["a"]:
+        if e is None and int():
+            e = x
+            continue
+        elif e is not None and int():
+            break
+        reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"
+    reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -443,6 +443,31 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
+[case testRedefine2BreakAndContinue]
+# flags: --allow-redefinition2 --local-partial-types
+def b() -> None:
+    while int():
+        x = ""
+        if int():
+            x = 1
+            break
+        reveal_type(x) # N: Revealed type is "builtins.str"
+        x = None
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
+
+def c() -> None:
+    x = 0
+    while int():
+        reveal_type(x) # N: Revealed type is "builtins.int" \
+                       # N: Revealed type is "Union[builtins.int, builtins.str, None]"
+        if int():
+            x = ""
+            continue
+        else:
+            x = None
+        reveal_type(x) # N: Revealed type is "None"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str, None]"
+
 [case testRedefine2Underscore]
 # flags: --allow-redefinition2 --local-partial-types
 def f() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -99,6 +99,19 @@ def f2() -> None:
 
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
+[case testRedefine2LambdaBasics]
+# flags: --allow-redefinition2 --local-partial-types
+def f1() -> None:
+    x = 0
+    if int():
+        x = None
+    f = lambda: reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type(f) # N: Revealed type is "def () -> Union[builtins.int, None]"
+    if x is None:
+        x = ""
+    f = lambda: reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+    reveal_type(f) # N: Revealed type is "def () -> Union[builtins.int, builtins.str]"
+
 [case testRedefine2AssignmentExpression]
 # flags: --allow-redefinition2 --local-partial-types
 def f() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -797,6 +797,16 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.int]"
 [builtins fixtures/for.pyi]
 
+[case testRedefine2ForLoop2]
+# flags: --allow-redefinition2 --local-partial-types
+from typing import Any
+
+def f(a: Any) -> None:
+    for d in a:
+        if isinstance(d["x"], str):
+            return
+[builtins fixtures/isinstance.pyi]
+
 [case testRedefine2ForStatementIndexNarrowing]
 # flags: --allow-redefinition2 --local-partial-types
 from typing_extensions import TypedDict

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1090,18 +1090,18 @@ from typing import Any, Union
 
 def get() -> Union[tuple[Any, Any], tuple[None, None]]: ...
 
-def func() -> None:
+def f() -> None:
     x, _ = get()
     reveal_type(x) # N: Revealed type is "Union[Any, None]"
     if x and int():
-        ...
+        reveal_type(x) # N: Revealed type is "Any"
     reveal_type(x) # N: Revealed type is "Union[Any, None]"
     if x and int():
-        ...
+        reveal_type(x) # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
 [case testNewRedefinePartialTypeForUnderscore]
-# flags: --allow-redefinition-new --local-partial-types --warn-unreachable
+# flags: --allow-redefinition-new --local-partial-types
 
 def t() -> tuple[int]:
     return (42,)

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -594,6 +594,53 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
+[case testRedefine2WhileLoopComplex1]
+# flags: --allow-redefinition2 --local-partial-types
+
+def f1() -> None:
+    while True:
+        try:
+            pass
+        except Exception as e:
+            continue
+[builtins fixtures/exception.pyi]
+
+[case testRedefine2WhileLoopComplex2]
+# flags: --allow-redefinition2 --local-partial-types
+
+class C:
+    def __enter__(self) -> str: ...
+    def __exit__(self, *args) -> str: ...
+
+def f1() -> None:
+    while True:
+        with C() as x:
+            continue
+
+def f2() -> None:
+    while True:
+        from m import y
+        if int():
+            continue
+
+[file m.py]
+y = ""
+[builtins fixtures/tuple.pyi]
+
+[case testRedefine2WhileLoopComplex3]
+# flags: --allow-redefinition2 --local-partial-types --python-version 3.10
+
+def f1() -> None:
+    while True:
+        x = object()
+        match x:
+            case str(y):
+                pass
+            case int():
+                pass
+        if int():
+            continue
+
 [case testRedefine2Return]
 # flags: --allow-redefinition2 --local-partial-types
 def f1() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -917,3 +917,20 @@ def f2(e: Optional[str]) -> None:
             break
         reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"
     reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"
+
+[case testRedefine2LoopAndPartialTypesSpecialCase]
+# flags: --allow-redefinition2 --local-partial-types
+def f() -> list[str]:
+    a = []  # type: ignore
+    o = []
+    for line in ["x"]:
+        if int():
+            continue
+        if int():
+            a = []
+        if int():
+            a.append(line)
+        else:
+            o.append(line)
+    return o
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -422,7 +422,7 @@ def f3() -> None:
     else:
         x = ""
         del x
-    reveal_type(x) # N: Revealed type is "builtins.str"
+    reveal_type(x) # N: Revealed type is "builtins.int"
 
 [case testRedefine2WhileLoopSimple]
 # flags: --allow-redefinition2 --local-partial-types

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1047,3 +1047,23 @@ class C:
     y: Final = "foo"
     y = 1 # E: Cannot assign to final name "y" \
           # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+[case testNewRedefineEnableUsingComment]
+# flags: --local-partial-types
+import a
+import b
+
+[file a.py]
+# mypy: allow-redefinition-new
+if int():
+    x = 0
+else:
+    x = ""
+reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+[file b.py]
+if int():
+    x = 0
+else:
+    x = "" # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+reveal_type(x) # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1061,3 +1061,16 @@ if int():
 
 [out]
 tmp/b.py:1: error: --local-partial-types must be enabled if using --allow-redefinition-new
+
+[case testNewRedefineNestedLoopInfiniteExpansion]
+# flags: --allow-redefinition-new --local-partial-types
+def a(): ...
+
+def f() -> None:
+    while int():
+        x = a()
+
+        while int():
+            x = [x]
+
+    reveal_type(x) # N: Revealed type is "Union[Any, builtins.list[Any], builtins.list[Union[Any, builtins.list[Any]]], builtins.list[Union[Any, builtins.list[Any], builtins.list[Union[Any, builtins.list[Any]]]]], builtins.list[Union[Any, builtins.list[Any], builtins.list[Union[Any, builtins.list[Any]]], builtins.list[Union[Any, builtins.list[Any], builtins.list[Union[Any, builtins.list[Any]]]]]]]]"

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -50,8 +50,16 @@ else:
     reveal_type(x) # N: Revealed type is "builtins.str"
 reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-def f() -> None:
+def f1() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def f2() -> None:
+    global x
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+    x = 0
+    reveal_type(x) # N: Revealed type is "builtins.int"
+
+reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2ClassBody]
 # flags: --allow-redefinition2 --local-partial-types

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -760,7 +760,72 @@ def f1() -> None:
         reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
     reveal_type(e) # N: Revealed type is "<Deleted 'e'>"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def f2() -> None:
+    try:
+        x = 1
+        if int():
+            x = ""
+            return
+    except Exception:
+        # TODO: Too wide
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+    # TODO: Too wide
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def f3() -> None:
+    try:
+        x = 1
+        if int():
+            x = ""
+            return
+    finally:
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]" \
+            # N: Revealed type is "builtins.int"
+    reveal_type(x) # N: Revealed type is "builtins.int"
+
+def f4() -> None:
+    while int():
+        try:
+            x = 1
+            if int():
+                x = ""
+                break
+            if int():
+                while int():
+                    if int():
+                        x = None
+                        break
+        finally:
+            reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str, None]" \
+                # N: Revealed type is "Union[builtins.int, None]"
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 [builtins fixtures/exception.pyi]
+
+[case testRedefine2RaiseStatement]
+# flags: --allow-redefinition2 --local-partial-types
+def f1() -> None:
+    if int():
+        x = ""
+    elif int():
+        x = None
+        raise Exception()
+    else:
+        x = 1
+    reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.int]"
+
+def f2() -> None:
+    try:
+        x = 1
+        if int():
+            x = ""
+            raise Exception()
+        reveal_type(x) # N: Revealed type is "builtins.int"
+    except Exception:
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+[builtins fixtures/exception.pyi]
+
 
 [case testRedefine2MultipleAssignment]
 # flags: --allow-redefinition2 --local-partial-types

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -949,9 +949,9 @@ for a in ("hourly", "daily"):
     c = a
     reveal_type(c)  # N: Revealed type is "builtins.str"
     a = "monthly"
-    reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
+    reveal_type(a)  # N: Revealed type is "builtins.str"
     a = "yearly"
-    reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
+    reveal_type(a)  # N: Revealed type is "builtins.str"
     a = 1
     reveal_type(a)  # N: Revealed type is "builtins.int"
 reveal_type(a) # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -34,11 +34,68 @@ def f2() -> None:
         x = None
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 
-def f3() -> None:
+[case testRedefine2UninitializedCodePath1]
+# flags: --allow-redefinition2 --local-partial-types
+def f1() -> None:
     if int():
         x = 0
+        reveal_type(x) # N: Revealed type is "builtins.int"
         x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
+
+[case testRedefine2UninitializedCodePath2]
+# flags: --allow-redefinition2 --local-partial-types
+from typing import Union
+
+def f1() -> None:
+    if int():
+        x: Union[int, str] = 0
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+        x = ""
+    reveal_type(x) # N: Revealed type is "builtins.str"
+
+[case testRedefine2UninitializedCodePath3]
+# flags: --allow-redefinition2 --local-partial-types
+from typing import Union
+
+def f1() -> None:
+    if int():
+        x = 0
+    elif int():
+        x = ""
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+[case testRedefine2UninitializedCodePath4]
+# flags: --allow-redefinition2 --local-partial-types
+from typing import Union
+
+def f1() -> None:
+    if int():
+        x: Union[int, str] = 0
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+[case testRedefine2UninitializedCodePath5]
+# flags: --allow-redefinition2 --local-partial-types
+from typing import Union
+
+def f1() -> None:
+    x = 0
+    if int():
+        x = ""
+        reveal_type(x) # N: Revealed type is "builtins.str"
+        x = None
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
+
+[case testRedefine2UninitializedCodePath6]
+# flags: --allow-redefinition2 --local-partial-types
+from typing import Union
+
+x: Union[str, None]
+
+def f1() -> None:
+    if x is not None:
+        reveal_type(x) # N: Revealed type is "builtins.str"
+    reveal_type(x) # N: Revealed type is "Union[builtins.str, None]"
 
 [case testRedefine2GlobalVariableSimple]
 # flags: --allow-redefinition2 --local-partial-types
@@ -114,11 +171,25 @@ def f1() -> None:
 
 [case testRedefine2AssignmentExpression]
 # flags: --allow-redefinition2 --local-partial-types
-def f() -> None:
+def f1() -> None:
     if x := int():
         reveal_type(x) # N: Revealed type is "builtins.int"
     elif x := str():
         reveal_type(x) # N: Revealed type is "builtins.str"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def f2() -> None:
+    if x := int():
+        reveal_type(x) # N: Revealed type is "builtins.int"
+    elif x := str():
+        reveal_type(x) # N: Revealed type is "builtins.str"
+    else:
+        pass
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def f3() -> None:
+    if (x := int()) or (x := str()):
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2OperatorAssignment]
@@ -133,7 +204,7 @@ if int():
     reveal_type(c) # N: Revealed type is "__main__.D"
 reveal_type(c) # N: Revealed type is "Union[__main__.C, __main__.D]"
 
-[case testRedefine2ImportFrom]
+[case testRedefine2ImportFrom-xfail]
 # flags: --allow-redefinition2 --local-partial-types
 if int():
     from m import x
@@ -209,15 +280,59 @@ else:
     z = ""
 reveal_type(z) # N: Revealed type is "Union[None, builtins.int, builtins.str]"
 
-[case testRedefine2OptionalTypeForInstanceVariabls]
+[case testRedefine2PartialTypeForInstanceVariable]
 # flags: --allow-redefinition2 --local-partial-types
-class C:
+class C1:
     def __init__(self) -> None:
         self.x = None
         if int():
             self.x = 1
             reveal_type(self.x) # N: Revealed type is "builtins.int"
         reveal_type(self.x) # N: Revealed type is "Union[builtins.int, None]"
+
+reveal_type(C1().x) # N: Revealed type is "Union[builtins.int, None]"
+
+class C2:
+    def __init__(self) -> None:
+        self.x = []
+        for i in [1, 2]:
+            self.x.append(i)
+        reveal_type(self.x) # N: Revealed type is "builtins.list[builtins.int]"
+
+reveal_type(C2().x) # N: Revealed type is "builtins.list[builtins.int]"
+
+class C3:
+    def __init__(self) -> None:
+        self.x = None
+        if int():
+            self.x = 1
+        else:
+            self.x = "" # E: Incompatible types in assignment (expression has type "str", variable has type "Optional[int]")
+        reveal_type(self.x) # N: Revealed type is "Union[builtins.int, None]"
+
+reveal_type(C3().x) # N: Revealed type is "Union[builtins.int, None]"
+
+class C4:
+    def __init__(self) -> None:
+        self.x = []
+        if int():
+            self.x = [""]
+        reveal_type(self.x) # N: Revealed type is "builtins.list[builtins.str]"
+
+reveal_type(C4().x) # N: Revealed type is "builtins.list[builtins.str]"
+[builtins fixtures/list.pyi]
+
+[case testZZZ]
+# flags:  --local-partial-types
+class C:
+    def __init__(self) -> None:
+        self.x = None
+        if int():
+            self.x = 1
+
+        reveal_type(self.x) # N: Revealed type is "Union[builtins.int, None]"
+
+reveal_type(C().x) # N: Revealed type is "Union[builtins.int, None]"
 
 [case testRedefine2PartialGenericTypes]
 # flags: --allow-redefinition2 --local-partial-types
@@ -432,13 +547,13 @@ def f() -> None:
         reveal_type(x) # N: Revealed type is "builtins.str"
         x = 0
         reveal_type(x) # N: Revealed type is "builtins.int"
-    reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.int]"
+    reveal_type(x) # N: Revealed type is "builtins.int"
     while int():
         x = None
         reveal_type(x) # N: Revealed type is "None"
         x = b""
         reveal_type(x) # N: Revealed type is "builtins.bytes"
-    reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.int, None, builtins.bytes]"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.bytes]"
     x = [1]
     reveal_type(x) # N: Revealed type is "builtins.list[builtins.int]"
 
@@ -611,11 +726,14 @@ def f2() -> None:
 
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
     reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
+[builtins fixtures/for.pyi]
 
+[case testRedefine2ForLoop1]
+# flags: --allow-redefinition2 --local-partial-types
 def l() -> list[int]:
     return []
 
-def f3() -> None:
+def f1() -> None:
     x = ""
     for x in l():
         reveal_type(x) # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1,6 +1,6 @@
 -- Test cases for the redefinition of variable with a different type (new version).
 
-[case testRedefine2LocalWithDifferentType]
+[case testNewRedefineLocalWithDifferentType]
 # flags: --allow-redefinition-new --local-partial-types
 def f() -> None:
     x = 0
@@ -8,7 +8,7 @@ def f() -> None:
     x = ''
     reveal_type(x) # N: Revealed type is "builtins.str"
 
-[case testRedefine2ConditionalLocalWithDifferentType]
+[case testNewRedefineConditionalLocalWithDifferentType]
 # flags: --allow-redefinition-new --local-partial-types
 def f() -> None:
     if int():
@@ -18,7 +18,7 @@ def f() -> None:
         x = ''
         reveal_type(x) # N: Revealed type is "builtins.str"
 
-[case testRedefine2MergeConditionalLocal1]
+[case testNewRedefineMergeConditionalLocal1]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
@@ -34,7 +34,7 @@ def f2() -> None:
         x = None
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 
-[case testRedefine2UninitializedCodePath1]
+[case testNewRedefineUninitializedCodePath1]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
@@ -43,7 +43,7 @@ def f1() -> None:
         x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
 
-[case testRedefine2UninitializedCodePath2]
+[case testNewRedefineUninitializedCodePath2]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
@@ -54,7 +54,7 @@ def f1() -> None:
         x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
 
-[case testRedefine2UninitializedCodePath3]
+[case testNewRedefineUninitializedCodePath3]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
@@ -65,7 +65,7 @@ def f1() -> None:
         x = ""
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2UninitializedCodePath4]
+[case testNewRedefineUninitializedCodePath4]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
@@ -74,7 +74,7 @@ def f1() -> None:
         x: Union[int, str] = 0
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2UninitializedCodePath5]
+[case testNewRedefineUninitializedCodePath5]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
@@ -86,7 +86,7 @@ def f1() -> None:
         x = None
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 
-[case testRedefine2UninitializedCodePath6]
+[case testNewRedefineUninitializedCodePath6]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
@@ -97,7 +97,7 @@ def f1() -> None:
         reveal_type(x) # N: Revealed type is "builtins.str"
     reveal_type(x) # N: Revealed type is "Union[builtins.str, None]"
 
-[case testRedefine2GlobalVariableSimple]
+[case testNewRedefineGlobalVariableSimple]
 # flags: --allow-redefinition-new --local-partial-types
 if int():
     x = 0
@@ -118,7 +118,7 @@ def f2() -> None:
 
 reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2ParameterTypes]
+[case testNewRedefineParameterTypes]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Optional
 
@@ -138,7 +138,7 @@ class C:
 [builtins fixtures/dict.pyi]
 
 
-[case testRedefine2ClassBody]
+[case testNewRedefineClassBody]
 # flags: --allow-redefinition-new --local-partial-types
 class C:
     if int():
@@ -151,7 +151,7 @@ class C:
 
 reveal_type(C.x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2NestedFunctionBasics]
+[case testNewRedefineNestedFunctionBasics]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
@@ -176,7 +176,7 @@ def f2() -> None:
 
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2LambdaBasics]
+[case testNewRedefineLambdaBasics]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = 0
@@ -189,7 +189,7 @@ def f1() -> None:
     f = lambda: reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
     reveal_type(f) # N: Revealed type is "def () -> Union[builtins.int, builtins.str]"
 
-[case testRedefine2AssignmentExpression]
+[case testNewRedefineAssignmentExpression]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if x := int():
@@ -212,7 +212,7 @@ def f3() -> None:
         reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2OperatorAssignment]
+[case testNewRedefineOperatorAssignment]
 # flags: --allow-redefinition-new --local-partial-types
 class D: pass
 class C:
@@ -224,7 +224,7 @@ if int():
     reveal_type(c) # N: Revealed type is "__main__.D"
 reveal_type(c) # N: Revealed type is "Union[__main__.C, __main__.D]"
 
-[case testRedefine2ImportFrom-xfail]
+[case testNewRedefineImportFrom-xfail]
 # flags: --allow-redefinition-new --local-partial-types
 if int():
     from m import x
@@ -243,7 +243,7 @@ reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
 x = 1
 y = ""
 
-[case testRedefine2Import]
+[case testNewRedefineImport]
 # flags: --allow-redefinition-new --local-partial-types
 if int():
     import m
@@ -259,7 +259,7 @@ x = 1
 y = ""
 [builtins fixtures/module.pyi]
 
-[case testRedefine2OptionalTypesSimple]
+[case testNewRedefineOptionalTypesSimple]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = None
@@ -300,7 +300,7 @@ else:
     z = ""
 reveal_type(z) # N: Revealed type is "Union[None, builtins.int, builtins.str]"
 
-[case testRedefine2PartialTypeForInstanceVariable]
+[case testNewRedefinePartialTypeForInstanceVariable]
 # flags: --allow-redefinition-new --local-partial-types
 class C1:
     def __init__(self) -> None:
@@ -354,7 +354,7 @@ class C:
 
 reveal_type(C().x) # N: Revealed type is "Union[builtins.int, None]"
 
-[case testRedefine2PartialGenericTypes]
+[case testNewRedefinePartialGenericTypes]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     a = []
@@ -404,7 +404,7 @@ def f6() -> None:
     reveal_type(a) # N: Revealed type is "builtins.list[builtins.str]"
 [builtins fixtures/list.pyi]
 
-[case testRedefine2FinalLiteral]
+[case testNewRedefineFinalLiteral]
 # flags: --allow-redefinition-new --local-partial-types
 from typing_extensions import Final, Literal
 
@@ -413,7 +413,7 @@ reveal_type(x) # N: Revealed type is "Literal['foo']?"
 a: Literal["foo"] = x
 [builtins fixtures/tuple.pyi]
 
-[case testRedefine2AnnotatedVariable]
+[case testNewRedefineAnnotatedVariable]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Optional
 
@@ -447,7 +447,7 @@ class C:
             self.x = ""
         reveal_type(self.x) # N: Revealed type is "builtins.str"
 
-[case testRedefine2AnyType1]
+[case testNewRedefineAnyType1]
 # flags: --allow-redefinition-new --local-partial-types
 def a(): pass
 
@@ -508,7 +508,7 @@ def f7() -> None:
     x = a()
     reveal_type(x) # N: Revealed type is "builtins.int"
 
-[case testRedefine2AnyType2]
+[case testNewRedefineAnyType2]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Any
 
@@ -533,7 +533,7 @@ def f3(x) -> None:
         reveal_type(x) # N: Revealed type is "Any"
     reveal_type(x) # N: Revealed type is "Any"
 
-[case tetRedefine2Del]
+[case tetNewRedefineDel]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = ""
@@ -576,7 +576,7 @@ def f5() -> None:
             continue
         x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
-[case testRedefine2WhileLoopSimple]
+[case testNewRedefineWhileLoopSimple]
 # flags: --allow-redefinition-new --local-partial-types
 def f() -> None:
     while int():
@@ -594,7 +594,7 @@ def f() -> None:
     x = [1]
     reveal_type(x) # N: Revealed type is "builtins.list[builtins.int]"
 
-[case testRedefine2WhileLoopOptional]
+[case testNewRedefineWhileLoopOptional]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = None
@@ -612,7 +612,7 @@ def f2() -> None:
             x = ""
     reveal_type(x) # N: Revealed type is "Union[None, builtins.str]"
 
-[case testRedefine2WhileLoopPartialType]
+[case testNewRedefineWhileLoopPartialType]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = []
@@ -621,7 +621,7 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
-[case testRedefine2WhileLoopComplex1]
+[case testNewRedefineWhileLoopComplex1]
 # flags: --allow-redefinition-new --local-partial-types
 
 def f1() -> None:
@@ -632,7 +632,7 @@ def f1() -> None:
             continue
 [builtins fixtures/exception.pyi]
 
-[case testRedefine2WhileLoopComplex2]
+[case testNewRedefineWhileLoopComplex2]
 # flags: --allow-redefinition-new --local-partial-types
 
 class C:
@@ -654,7 +654,7 @@ def f2() -> None:
 y = ""
 [builtins fixtures/tuple.pyi]
 
-[case testRedefine2LoopWithMatch]
+[case testNewRedefineLoopWithMatch]
 # flags: --allow-redefinition-new --local-partial-types --python-version 3.10
 
 def f1() -> None:
@@ -679,7 +679,7 @@ def f2() -> None:
     reveal_type(y) # N: Revealed type is "builtins.str"
 [builtins fixtures/list.pyi]
 
-[case testRedefine2Return]
+[case testNewRedefineReturn]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
@@ -697,7 +697,7 @@ def f2() -> None:
         return
     reveal_type(x) # N: Revealed type is "builtins.str"
 
-[case testRedefine2BreakAndContinue]
+[case testNewRedefineBreakAndContinue]
 # flags: --allow-redefinition-new --local-partial-types
 def b() -> None:
     while int():
@@ -722,7 +722,7 @@ def c() -> None:
         reveal_type(x) # N: Revealed type is "None"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str, None]"
 
-[case testRedefine2Underscore]
+[case testNewRedefineUnderscore]
 # flags: --allow-redefinition-new --local-partial-types
 def f() -> None:
     if int():
@@ -733,7 +733,7 @@ def f() -> None:
         reveal_type(_) # N: Revealed type is "builtins.str"
     reveal_type(_) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2WithStatement]
+[case testNewRedefineWithStatement]
 # flags: --allow-redefinition-new --local-partial-types
 class C:
     def __enter__(self) -> int: ...
@@ -757,7 +757,7 @@ def f2() -> None:
             reveal_type(x) # N: Revealed type is "builtins.str"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-[case testRedefine2TryStatement]
+[case testNewRedefineTryStatement]
 # flags: --allow-redefinition-new --local-partial-types
 class E(Exception): pass
 
@@ -819,7 +819,7 @@ def f4() -> None:
         reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 [builtins fixtures/exception.pyi]
 
-[case testRedefine2RaiseStatement]
+[case testNewRedefineRaiseStatement]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
@@ -844,7 +844,7 @@ def f2() -> None:
 [builtins fixtures/exception.pyi]
 
 
-[case testRedefine2MultipleAssignment]
+[case testNewRedefineMultipleAssignment]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x, y = 1, ""
@@ -866,7 +866,7 @@ def f2() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
     reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
 
-[case testRedefine2ForLoopBasics]
+[case testNewRedefineForLoopBasics]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     for x in [1]:
@@ -888,7 +888,7 @@ def f2() -> None:
     reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
 [builtins fixtures/for.pyi]
 
-[case testRedefine2ForLoop1]
+[case testNewRedefineForLoop1]
 # flags: --allow-redefinition-new --local-partial-types
 def l() -> list[int]:
     return []
@@ -911,7 +911,7 @@ def f3() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/for.pyi]
 
-[case testRedefine2ForLoop2]
+[case testNewRedefineForLoop2]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Any
 
@@ -921,7 +921,7 @@ def f(a: Any) -> None:
             return
 [builtins fixtures/isinstance.pyi]
 
-[case testRedefine2ForStatementIndexNarrowing]
+[case testNewRedefineForStatementIndexNarrowing]
 # flags: --allow-redefinition-new --local-partial-types
 from typing_extensions import TypedDict
 
@@ -950,7 +950,7 @@ for b in ("hourly", "daily"):
     reveal_type(b.upper())  # N: Revealed type is "builtins.str"
 [builtins fixtures/for.pyi]
 
-[case testRedefine2ForLoopIndexWidening]
+[case testNewRedefineForLoopIndexWidening]
 # flags: --allow-redefinition-new --local-partial-types
 
 def f1() -> None:
@@ -975,7 +975,7 @@ def f3() -> None:
             x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
 
-[case testRedefine2VariableAnnotatedInLoop]
+[case testNewRedefineVariableAnnotatedInLoop]
 # flags: --allow-redefinition-new --local-partial-types --enable-error-code=redundant-expr
 from typing import Optional
 
@@ -1000,7 +1000,7 @@ def f2(e: Optional[str]) -> None:
         reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"
     reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"
 
-[case testRedefine2LoopAndPartialTypesSpecialCase]
+[case testNewRedefineLoopAndPartialTypesSpecialCase]
 # flags: --allow-redefinition-new --local-partial-types
 def f() -> list[str]:
     a = []  # type: ignore

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -376,6 +376,28 @@ def f2() -> None:
             reveal_type(x) # N: Revealed type is "builtins.str"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
+[case testRedefine2TryStatement]
+# flags: --allow-redefinition2 --local-partial-types
+class E(Exception): pass
+
+def g(): ...
+
+def f1() -> None:
+    try:
+        x = 1
+        g()
+        x = ""
+        reveal_type(x) # N: Revealed type is "builtins.str"
+    except RuntimeError as e:
+        reveal_type(e) # N: Revealed type is "builtins.RuntimeError"
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+    except E as e:
+        reveal_type(e) # N: Revealed type is "__main__.E"
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+    reveal_type(e) # N: Revealed type is "<Deleted 'e'>"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+[builtins fixtures/exception.pyi]
+
 [case testRedefine2MultipleAssignment]
 # flags: --allow-redefinition2 --local-partial-types
 def f1() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -671,31 +671,6 @@ def f2() -> None:
 y = ""
 [builtins fixtures/tuple.pyi]
 
-[case testNewRedefineLoopWithMatch]
-# flags: --allow-redefinition-new --local-partial-types --python-version 3.10
-
-def f1() -> None:
-    while True:
-        x = object()
-        match x:
-            case str(y):
-                pass
-            case int():
-                pass
-        if int():
-            continue
-
-def f2() -> None:
-    for x in [""]:
-        match str():
-            case "a":
-                y = ""
-            case "b":
-                y = 1
-                return
-    reveal_type(y) # N: Revealed type is "builtins.str"
-[builtins fixtures/list.pyi]
-
 [case testNewRedefineReturn]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1074,3 +1074,38 @@ def f() -> None:
             x = [x]
 
     reveal_type(x) # N: Revealed type is "Union[Any, builtins.list[Any], builtins.list[Union[Any, builtins.list[Any]]], builtins.list[Union[Any, builtins.list[Any], builtins.list[Union[Any, builtins.list[Any]]]]], builtins.list[Union[Any, builtins.list[Any], builtins.list[Union[Any, builtins.list[Any]]], builtins.list[Union[Any, builtins.list[Any], builtins.list[Union[Any, builtins.list[Any]]]]]]]]"
+
+[case testNewRedefinePartialNoneEmptyList]
+# flags: --allow-redefinition-new --local-partial-types
+def func() -> None:
+    l = None
+
+    if int():
+        l = []
+        l.append(1)
+
+[case testNewRedefineNarrowingSpecialCase]
+# flags: --allow-redefinition-new --local-partial-types --warn-unreachable
+from typing import Any, Union
+
+def get() -> Union[tuple[Any, Any], tuple[None, None]]: ...
+
+def func() -> None:
+    x, _ = get()
+    reveal_type(x) # N: Revealed type is "Union[Any, None]"
+    if x and int():
+        ...
+    reveal_type(x) # N: Revealed type is "Union[Any, None]"
+    if x and int():
+        ...
+[builtins fixtures/tuple.pyi]
+
+[case testNewRedefineAsteriskAssignment]
+# flags: --allow-redefinition-new --local-partial-types --warn-unreachable
+
+def blah() -> tuple[int]:
+    return (42,)
+
+def main() -> None:
+    x, *_ = blah()  # E: Need type annotation for "_" (hint: "_: list[<type>] = ...")
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1140,3 +1140,10 @@ def f() -> None:
         td = {"x": 5}
     reveal_type(td) # N: Revealed type is "TypedDict('__main__.TD', {'x': builtins.int})"
 [typing fixtures/typing-typeddict.pyi]
+
+[case testNewRedefineEmptyGeneratorUsingUnderscore]
+# flags: --allow-redefinition-new --local-partial-types
+def f() -> None:
+    gen = (_ for _ in ())
+    reveal_type(gen) # N: Revealed type is "typing.Generator[Any, None, None]"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1081,8 +1081,10 @@ def func() -> None:
     l = None
 
     if int():
-        l = []
+        l = [] # E: Need type annotation for "l"
         l.append(1)
+    reveal_type(l) # N: Revealed type is "Union[None, builtins.list[Any]]"
+[builtins fixtures/list.pyi]
 
 [case testNewRedefineNarrowingSpecialCase]
 # flags: --allow-redefinition-new --local-partial-types --warn-unreachable

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -805,6 +805,17 @@ def f1() -> None:
     for x in l():
         reveal_type(x) # N: Revealed type is "builtins.int"
     reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.int]"
+
+def f2() -> None:
+    for x in [1, 2]:
+        x = [x]
+    reveal_type(x) # N: Revealed type is "builtins.list[builtins.int]"
+
+def f3() -> None:
+    for x in [1, 2]:
+        if int():
+            x = "x"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/for.pyi]
 
 [case testRedefine2ForLoop2]
@@ -832,6 +843,13 @@ for a in ("hourly", "daily"):
     reveal_type(a.upper())  # N: Revealed type is "builtins.str"
     c = a
     reveal_type(c)  # N: Revealed type is "builtins.str"
+    a = "monthly"
+    reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
+    a = "yearly"
+    reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
+    a = 1
+    reveal_type(a)  # N: Revealed type is "builtins.int"
+reveal_type(a) # N: Revealed type is "builtins.int"
 
 b: str
 for b in ("hourly", "daily"):

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -469,6 +469,24 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
+[case testRedefine2Return]
+# flags: --allow-redefinition2 --local-partial-types
+def f1() -> None:
+    if int():
+        x = 0
+        return
+    else:
+        x = ""
+    reveal_type(x) # N: Revealed type is "builtins.str"
+
+def f2() -> None:
+    if int():
+        x = ""
+    else:
+        x = 0
+        return
+    reveal_type(x) # N: Revealed type is "builtins.str"
+
 [case testRedefine2BreakAndContinue]
 # flags: --allow-redefinition2 --local-partial-types
 def b() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -118,6 +118,16 @@ def f2() -> None:
 
 reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
+[case testRedefine2DefaultArgument]
+# flags: --allow-redefinition2 --local-partial-types
+from typing import Optional
+
+def f(x: Optional[str] = None) -> None:
+    reveal_type(x) # N: Revealed type is "Union[builtins.str, None]"
+    if x is None:
+        x = ""
+    reveal_type(x) # N: Revealed type is "builtins.str"
+
 [case testRedefine2ClassBody]
 # flags: --allow-redefinition2 --local-partial-types
 class C:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -559,6 +559,23 @@ def f3() -> None:
         del x
     reveal_type(x) # N: Revealed type is "builtins.int"
 
+def f4() -> None:
+    while int():
+        if int():
+            x: int = 0
+        else:
+            del x
+    reveal_type(x) # N: Revealed type is "builtins.int"
+
+def f5() -> None:
+    while int():
+        if int():
+            x = 0
+        else:
+            del x
+            continue
+        x = ""
+    reveal_type(x) # N: Revealed type is "builtins.str"
 [case testRedefine2WhileLoopSimple]
 # flags: --allow-redefinition2 --local-partial-types
 def f() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -121,6 +121,18 @@ def f() -> None:
         reveal_type(x) # N: Revealed type is "builtins.str"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
+[case testRedefine2OperatorAssignment]
+# flags: --allow-redefinition2 --local-partial-types
+class D: pass
+class C:
+    def __add__(self, x: C) -> D: ...
+
+c = C()
+if int():
+    c += C()
+    reveal_type(c) # N: Revealed type is "__main__.D"
+reveal_type(c) # N: Revealed type is "Union[__main__.C, __main__.D]"
+
 [case testRedefine2ImportFrom]
 # flags: --allow-redefinition2 --local-partial-types
 if int():

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -398,6 +398,32 @@ def f3(x) -> None:
         reveal_type(x) # N: Revealed type is "Any"
     reveal_type(x) # N: Revealed type is "Any"
 
+[case tetRedefine2Del]
+# flags: --allow-redefinition2 --local-partial-types
+def f1() -> None:
+    x = ""
+    reveal_type(x) # N: Revealed type is "builtins.str"
+    del x
+    reveal_type(x) # N: Revealed type is "<Deleted 'x'>"
+    x = 0
+    reveal_type(x) # N: Revealed type is "builtins.int"
+
+def f2() -> None:
+    if int():
+        x = 0
+        del x
+    else:
+        x = ""
+    reveal_type(x) # N: Revealed type is "builtins.str"
+
+def f3() -> None:
+    if int():
+        x = 0
+    else:
+        x = ""
+        del x
+    reveal_type(x) # N: Revealed type is "builtins.str"
+
 [case testRedefine2WhileLoopSimple]
 # flags: --allow-redefinition2 --local-partial-types
 def f() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -406,7 +406,7 @@ def f6() -> None:
 
 [case testNewRedefineFinalLiteral]
 # flags: --allow-redefinition-new --local-partial-types
-from typing_extensions import Final, Literal
+from typing import Final, Literal
 
 x: Final = "foo"
 reveal_type(x) # N: Revealed type is "Literal['foo']?"
@@ -923,7 +923,7 @@ def f(a: Any) -> None:
 
 [case testNewRedefineForStatementIndexNarrowing]
 # flags: --allow-redefinition-new --local-partial-types
-from typing_extensions import TypedDict
+from typing import TypedDict
 
 class X(TypedDict):
     hourly: int
@@ -949,6 +949,7 @@ for b in ("hourly", "daily"):
     reveal_type(b)  # N: Revealed type is "builtins.str"
     reveal_type(b.upper())  # N: Revealed type is "builtins.str"
 [builtins fixtures/for.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testNewRedefineForLoopIndexWidening]
 # flags: --allow-redefinition-new --local-partial-types
@@ -1016,3 +1017,14 @@ def f() -> list[str]:
             o.append(line)
     return o
 [builtins fixtures/list.pyi]
+
+[case testNewRedefineFinalVariable]
+# flags: --allow-redefinition-new --local-partial-types
+from typing import Final
+
+x: Final = "foo"
+x = 1 # E: Cannot assign to final name "x"
+
+class C:
+    y: Final = "foo"
+    y = 1 # E: Cannot assign to final name "y"

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1100,12 +1100,23 @@ def func() -> None:
         ...
 [builtins fixtures/tuple.pyi]
 
-[case testNewRedefineAsteriskAssignment]
+[case testNewRedefinePartialTypeForUnderscore]
 # flags: --allow-redefinition-new --local-partial-types --warn-unreachable
 
-def blah() -> tuple[int]:
+def t() -> tuple[int]:
     return (42,)
 
-def main() -> None:
-    x, *_ = blah()  # E: Need type annotation for "_" (hint: "_: list[<type>] = ...")
+def f1() -> None:
+    # Underscore is slightly special to preserve backward compatibility
+    x, *_ = t()
+    reveal_type(x) # N: Revealed type is "builtins.int"
+
+def f2() -> None:
+    x, *y = t() # E: Need type annotation for "y" (hint: "y: List[<type>] = ...")
+
+def f3() -> None:
+    x, _ = 1, []
+
+def f4() -> None:
+    a, b = 1, [] # E: Need type annotation for "b" (hint: "b: List[<type>] = ...")
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -637,7 +637,7 @@ def f2() -> None:
 y = ""
 [builtins fixtures/tuple.pyi]
 
-[case testRedefine2WhileLoopComplex3]
+[case testRedefine2LoopWithMatch]
 # flags: --allow-redefinition2 --local-partial-types --python-version 3.10
 
 def f1() -> None:
@@ -650,6 +650,17 @@ def f1() -> None:
                 pass
         if int():
             continue
+
+def f2() -> None:
+    for x in [""]:
+        match str():
+            case "a":
+                y = ""
+            case "b":
+                y = 1
+                return
+    reveal_type(y) # N: Revealed type is "builtins.str"
+[builtins fixtures/list.pyi]
 
 [case testRedefine2Return]
 # flags: --allow-redefinition2 --local-partial-types

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1,7 +1,7 @@
 -- Test cases for the redefinition of variable with a different type (new version).
 
 [case testRedefine2LocalWithDifferentType]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f() -> None:
     x = 0
     reveal_type(x) # N: Revealed type is "builtins.int"
@@ -9,7 +9,7 @@ def f() -> None:
     reveal_type(x) # N: Revealed type is "builtins.str"
 
 [case testRedefine2ConditionalLocalWithDifferentType]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f() -> None:
     if int():
         x = 0
@@ -19,7 +19,7 @@ def f() -> None:
         reveal_type(x) # N: Revealed type is "builtins.str"
 
 [case testRedefine2MergeConditionalLocal1]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
         x = 0
@@ -35,7 +35,7 @@ def f2() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 
 [case testRedefine2UninitializedCodePath1]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
         x = 0
@@ -44,7 +44,7 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "builtins.str"
 
 [case testRedefine2UninitializedCodePath2]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
 def f1() -> None:
@@ -55,7 +55,7 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "builtins.str"
 
 [case testRedefine2UninitializedCodePath3]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
 def f1() -> None:
@@ -66,7 +66,7 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2UninitializedCodePath4]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
 def f1() -> None:
@@ -75,7 +75,7 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2UninitializedCodePath5]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
 def f1() -> None:
@@ -87,7 +87,7 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 
 [case testRedefine2UninitializedCodePath6]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Union
 
 x: Union[str, None]
@@ -98,7 +98,7 @@ def f1() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.str, None]"
 
 [case testRedefine2GlobalVariableSimple]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 if int():
     x = 0
     reveal_type(x) # N: Revealed type is "builtins.int"
@@ -119,7 +119,7 @@ def f2() -> None:
 reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2ParameterTypes]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Optional
 
 def f1(x: Optional[str] = None) -> None:
@@ -139,7 +139,7 @@ class C:
 
 
 [case testRedefine2ClassBody]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 class C:
     if int():
         x = 0
@@ -152,7 +152,7 @@ class C:
 reveal_type(C.x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2NestedFunctionBasics]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
         x = 0
@@ -177,7 +177,7 @@ def f2() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2LambdaBasics]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = 0
     if int():
@@ -190,7 +190,7 @@ def f1() -> None:
     reveal_type(f) # N: Revealed type is "def () -> Union[builtins.int, builtins.str]"
 
 [case testRedefine2AssignmentExpression]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if x := int():
         reveal_type(x) # N: Revealed type is "builtins.int"
@@ -213,7 +213,7 @@ def f3() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2OperatorAssignment]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 class D: pass
 class C:
     def __add__(self, x: C) -> D: ...
@@ -225,7 +225,7 @@ if int():
 reveal_type(c) # N: Revealed type is "Union[__main__.C, __main__.D]"
 
 [case testRedefine2ImportFrom-xfail]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 if int():
     from m import x
 else:
@@ -244,7 +244,7 @@ x = 1
 y = ""
 
 [case testRedefine2Import]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 if int():
     import m
 else:
@@ -260,7 +260,7 @@ y = ""
 [builtins fixtures/module.pyi]
 
 [case testRedefine2OptionalTypesSimple]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = None
     if int():
@@ -301,7 +301,7 @@ else:
 reveal_type(z) # N: Revealed type is "Union[None, builtins.int, builtins.str]"
 
 [case testRedefine2PartialTypeForInstanceVariable]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 class C1:
     def __init__(self) -> None:
         self.x = None
@@ -355,7 +355,7 @@ class C:
 reveal_type(C().x) # N: Revealed type is "Union[builtins.int, None]"
 
 [case testRedefine2PartialGenericTypes]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     a = []
     a.append(1)
@@ -405,7 +405,7 @@ def f6() -> None:
 [builtins fixtures/list.pyi]
 
 [case testRedefine2FinalLiteral]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing_extensions import Final, Literal
 
 x: Final = "foo"
@@ -414,7 +414,7 @@ a: Literal["foo"] = x
 [builtins fixtures/tuple.pyi]
 
 [case testRedefine2AnnotatedVariable]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Optional
 
 def f1() -> None:
@@ -448,7 +448,7 @@ class C:
         reveal_type(self.x) # N: Revealed type is "builtins.str"
 
 [case testRedefine2AnyType1]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def a(): pass
 
 def f1() -> None:
@@ -509,7 +509,7 @@ def f7() -> None:
     reveal_type(x) # N: Revealed type is "builtins.int"
 
 [case testRedefine2AnyType2]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Any
 
 def f1() -> None:
@@ -534,7 +534,7 @@ def f3(x) -> None:
     reveal_type(x) # N: Revealed type is "Any"
 
 [case tetRedefine2Del]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
@@ -577,7 +577,7 @@ def f5() -> None:
         x = ""
     reveal_type(x) # N: Revealed type is "builtins.str"
 [case testRedefine2WhileLoopSimple]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f() -> None:
     while int():
         x = ""
@@ -595,7 +595,7 @@ def f() -> None:
     reveal_type(x) # N: Revealed type is "builtins.list[builtins.int]"
 
 [case testRedefine2WhileLoopOptional]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = None
     while int():
@@ -613,7 +613,7 @@ def f2() -> None:
     reveal_type(x) # N: Revealed type is "Union[None, builtins.str]"
 
 [case testRedefine2WhileLoopPartialType]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x = []
     while int():
@@ -622,7 +622,7 @@ def f1() -> None:
 [builtins fixtures/list.pyi]
 
 [case testRedefine2WhileLoopComplex1]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 
 def f1() -> None:
     while True:
@@ -633,7 +633,7 @@ def f1() -> None:
 [builtins fixtures/exception.pyi]
 
 [case testRedefine2WhileLoopComplex2]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 
 class C:
     def __enter__(self) -> str: ...
@@ -655,7 +655,7 @@ y = ""
 [builtins fixtures/tuple.pyi]
 
 [case testRedefine2LoopWithMatch]
-# flags: --allow-redefinition2 --local-partial-types --python-version 3.10
+# flags: --allow-redefinition-new --local-partial-types --python-version 3.10
 
 def f1() -> None:
     while True:
@@ -680,7 +680,7 @@ def f2() -> None:
 [builtins fixtures/list.pyi]
 
 [case testRedefine2Return]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
         x = 0
@@ -698,7 +698,7 @@ def f2() -> None:
     reveal_type(x) # N: Revealed type is "builtins.str"
 
 [case testRedefine2BreakAndContinue]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def b() -> None:
     while int():
         x = ""
@@ -723,7 +723,7 @@ def c() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str, None]"
 
 [case testRedefine2Underscore]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f() -> None:
     if int():
         _ = 0
@@ -734,7 +734,7 @@ def f() -> None:
     reveal_type(_) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2WithStatement]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 class C:
     def __enter__(self) -> int: ...
     def __exit__(self, x, y, z): ...
@@ -758,7 +758,7 @@ def f2() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 [case testRedefine2TryStatement]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 class E(Exception): pass
 
 def g(): ...
@@ -820,7 +820,7 @@ def f4() -> None:
 [builtins fixtures/exception.pyi]
 
 [case testRedefine2RaiseStatement]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     if int():
         x = ""
@@ -845,7 +845,7 @@ def f2() -> None:
 
 
 [case testRedefine2MultipleAssignment]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     x, y = 1, ""
     reveal_type(x) # N: Revealed type is "builtins.int"
@@ -867,7 +867,7 @@ def f2() -> None:
     reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
 
 [case testRedefine2ForLoopBasics]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
     for x in [1]:
         reveal_type(x) # N: Revealed type is "builtins.int"
@@ -889,7 +889,7 @@ def f2() -> None:
 [builtins fixtures/for.pyi]
 
 [case testRedefine2ForLoop1]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def l() -> list[int]:
     return []
 
@@ -912,7 +912,7 @@ def f3() -> None:
 [builtins fixtures/for.pyi]
 
 [case testRedefine2ForLoop2]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing import Any
 
 def f(a: Any) -> None:
@@ -922,7 +922,7 @@ def f(a: Any) -> None:
 [builtins fixtures/isinstance.pyi]
 
 [case testRedefine2ForStatementIndexNarrowing]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 from typing_extensions import TypedDict
 
 class X(TypedDict):
@@ -951,7 +951,7 @@ for b in ("hourly", "daily"):
 [builtins fixtures/for.pyi]
 
 [case testRedefine2ForLoopIndexWidening]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 
 def f1() -> None:
     for x in [1]:
@@ -976,7 +976,7 @@ def f3() -> None:
     reveal_type(x) # N: Revealed type is "builtins.str"
 
 [case testRedefine2VariableAnnotatedInLoop]
-# flags: --allow-redefinition2 --local-partial-types --enable-error-code=redundant-expr
+# flags: --allow-redefinition-new --local-partial-types --enable-error-code=redundant-expr
 from typing import Optional
 
 def f1() -> None:
@@ -1001,7 +1001,7 @@ def f2(e: Optional[str]) -> None:
     reveal_type(e) # N: Revealed type is "Union[builtins.str, None]"
 
 [case testRedefine2LoopAndPartialTypesSpecialCase]
-# flags: --allow-redefinition2 --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 def f() -> list[str]:
     a = []  # type: ignore
     o = []

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -118,6 +118,18 @@ def f2() -> None:
 
 reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
+[case testNewRedefineGlobalVariableNoneInit]
+# flags: --allow-redefinition-new --local-partial-types
+x = None
+
+def f() -> None:
+    global x
+    reveal_type(x) # N: Revealed type is "None"
+    x = 1 # E: Incompatible types in assignment (expression has type "int", variable has type "None")
+    reveal_type(x) # N: Revealed type is "None"
+
+reveal_type(x) # N: Revealed type is "None"
+
 [case testNewRedefineParameterTypes]
 # flags: --allow-redefinition-new --local-partial-types
 from typing import Optional

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -345,3 +345,27 @@ def f() -> None:
         _ = ""
         reveal_type(_) # N: Revealed type is "builtins.str"
     reveal_type(_) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+[case testRedefine2WithStatement]
+# flags: --allow-redefinition2 --local-partial-types
+class C:
+    def __enter__(self) -> int: ...
+    def __exit__(self, x, y, z): ...
+class D:
+    def __enter__(self) -> str: ...
+    def __exit__(self, x, y, z): ...
+
+def f1() -> None:
+    with C() as x:
+        reveal_type(x) # N: Revealed type is "builtins.int"
+    with D() as x:
+        reveal_type(x) # N: Revealed type is "builtins.str"
+
+def f2() -> None:
+    if int():
+        with C() as x:
+            reveal_type(x) # N: Revealed type is "builtins.int"
+    else:
+        with D() as x:
+            reveal_type(x) # N: Revealed type is "builtins.str"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -121,6 +121,41 @@ def f() -> None:
         reveal_type(x) # N: Revealed type is "builtins.str"
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
+[case testRedefine2ImportFrom]
+# flags: --allow-redefinition2 --local-partial-types
+if int():
+    from m import x
+else:
+    # TODO: This could be useful to allow
+    from m import y as x # E: Incompatible import of "x" (imported name has type "str", local name has type "int")
+reveal_type(x) # N: Revealed type is "builtins.int"
+
+if int():
+    from m import y
+else:
+    y = 1
+reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
+
+[file m.py]
+x = 1
+y = ""
+
+[case testRedefine2Import]
+# flags: --allow-redefinition2 --local-partial-types
+if int():
+    import m
+else:
+    import m2 as m # E: Name "m" already defined (by an import)
+m.x
+m.y # E: Module has no attribute "y"
+
+[file m.py]
+x = 1
+
+[file m2.py]
+y = ""
+[builtins fixtures/module.pyi]
+
 [case testRedefine2OptionalTypesSimple]
 # flags: --allow-redefinition2 --local-partial-types
 def f1() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -371,18 +371,6 @@ class C4:
 reveal_type(C4().x) # N: Revealed type is "builtins.list[builtins.str]"
 [builtins fixtures/list.pyi]
 
-[case testZZZ]
-# flags:  --local-partial-types
-class C:
-    def __init__(self) -> None:
-        self.x = None
-        if int():
-            self.x = 1
-
-        reveal_type(self.x) # N: Revealed type is "Union[builtins.int, None]"
-
-reveal_type(C().x) # N: Revealed type is "Union[builtins.int, None]"
-
 [case testNewRedefinePartialGenericTypes]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:
@@ -794,10 +782,9 @@ def f2() -> None:
             x = ""
             return
     except Exception:
-        # TODO: Too wide
         reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
-    # TODO: Too wide
-    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+        return
+    reveal_type(x) # N: Revealed type is "builtins.int"
 
 def f3() -> None:
     try:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -34,6 +34,23 @@ def f2() -> None:
         x = None
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 
+[case testNewRedefineMergeConditionalLocal2]
+# flags: --allow-redefinition-new --local-partial-types
+def nested_ifs() -> None:
+    if int():
+        if int():
+            x = 0
+        else:
+            x = ''
+        reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+    else:
+        if int():
+            x = None
+        else:
+            x = b""
+        reveal_type(x) # N: Revealed type is "Union[None, builtins.bytes]"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str, None, builtins.bytes]"
+
 [case testNewRedefineUninitializedCodePath1]
 # flags: --allow-redefinition-new --local-partial-types
 def f1() -> None:

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -20,19 +20,25 @@ def f() -> None:
 
 [case testRedefine2MergeConditionalLocal1]
 # flags: --allow-redefinition2 --local-partial-types
-def f() -> None:
+def f1() -> None:
     if int():
         x = 0
     else:
         x = ''
     reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
 
-def g() -> None:
+def f2() -> None:
     if int():
         x = 0
     else:
         x = None
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
+
+def f3() -> None:
+    if int():
+        x = 0
+        x = ""
+    reveal_type(x) # N: Revealed type is "builtins.str"
 
 [case testRedefine2GlobalVariableSimple]
 # flags: --allow-redefinition2 --local-partial-types
@@ -392,7 +398,7 @@ def f2() -> None:
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
     reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
 
-[case testRedefine2ForLoop]
+[case testRedefine2ForLoopBasics]
 # flags: --allow-redefinition2 --local-partial-types
 def f1() -> None:
     for x in [1]:
@@ -412,6 +418,15 @@ def f2() -> None:
 
     reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
     reveal_type(y) # N: Revealed type is "Union[builtins.str, builtins.int]"
+
+def l() -> list[int]:
+    return []
+
+def f3() -> None:
+    x = ""
+    for x in l():
+        reveal_type(x) # N: Revealed type is "builtins.int"
+    reveal_type(x) # N: Revealed type is "Union[builtins.str, builtins.int]"
 [builtins fixtures/for.pyi]
 
 [case testRedefine2ForStatementIndexNarrowing]
@@ -435,3 +450,28 @@ for b in ("hourly", "daily"):
     reveal_type(b)  # N: Revealed type is "builtins.str"
     reveal_type(b.upper())  # N: Revealed type is "builtins.str"
 [builtins fixtures/for.pyi]
+
+[case testRedefine2ForLoopIndexWidening]
+# flags: --allow-redefinition2 --local-partial-types
+
+def f1() -> None:
+    for x in [1]:
+        reveal_type(x) # N: Revealed type is "builtins.int"
+        x = ""
+        reveal_type(x) # N: Revealed type is "builtins.str"
+    reveal_type(x) # N: Revealed type is "builtins.str"
+
+def f2() -> None:
+    for x in [1]:
+        reveal_type(x) # N: Revealed type is "builtins.int"
+        if int():
+            break
+        x = ""
+        reveal_type(x) # N: Revealed type is "builtins.str"
+    reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def f3() -> None:
+    if int():
+        for x in [1]:
+            x = ""
+    reveal_type(x) # N: Revealed type is "builtins.str"


### PR DESCRIPTION
Infer union types for simple variables from multiple assignments, if the variable isn't annotated. The feature is enabled via `--allow-redefinition-new`. `--local-partial-types` must also be enabled.

This is still experimental and has known issues, so it's not documented anywhere. It works well enough that it can be used for non-trivial experimentation, however.

Closes #6233. Closes #6232. Closes #18568. Fixes #18619.

In this example, the type of `x` is inferred as `int | str` when using the new behavior:
```py
def f(i: int, s : str) -> int | str:
    if i > 5:
        x = i
    else:
        x = s  # No longer an error
    reveal_type(x)  # int | str
    return s
```

Here is a summary of how it works:
* Assignment widens the inferred type of a variable and always narrows (when there is no annotation).
* Simple variable lvalues are put into the binder on initial assignment when using the new feature. We need to be able to track whether a variable is defined or not to infer correct types (see #18619).
* Assignment of `None` values are no longer special, and we don't use partial None if the feature is enabled for simple variables.
* Lvalues other than simple variables (e.g. `self.x`) continue to work as in the past. Attribute types can't be widened, since they are externally visible and widening could cause confusion, but this is something we might relax in the future. Globals can be widened, however. This seems necessary for consistency.
* If a loop body widens a variable type, we have to analyze the body again. However, we only do one extra pass, since the inferred type could be expanded without bound (consider `x = 0` outside loop and `x = [x]` within the loop body).
* We first infer the type of an rvalue without using the lvalue type as context, as otherwise the type context would often prevent redefinition. If the rvalue type isn't valid for inference (e.g. list item type can't be inferred), we fall back to the lvalue type context.

There are some other known bugs and limitations:
* Annotated variables can't be freely redefined (but they can still be narrowed, of course). I may want to relax this in the future, but I'm not sure yet.
* If there is a function definition between assignments to a variable, the inferred types may be incorrect.
* There are few tests for `nonlocal` and some other features. We don't have good test coverage for deferrals, mypy daemon, and disabling strict optional.
* Imported names can't be redefined in a consistent way. This needs further analysis.

In self check the feature generates 6 additional errors, which all seem correct -- we infer more precise types, which will generate additional errors due to invariant containers and fixing false negatives.

When type checking the largest internal codebase at Dropbox, this generated about 700 new errors, the vast majority of which seemed legitimate. Mostly they were due to inferring more precise types for variables that used to have `Any` types. I used a recent but not the latest version of the feature to type check the internal codebase.