### PR TITLE
Add and implement primitive list.copy()

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -665,6 +665,7 @@ CPyTagged CPyList_Index(PyObject *list, PyObject *obj);
 PyObject *CPySequence_Multiply(PyObject *seq, CPyTagged t_size);
 PyObject *CPySequence_RMultiply(CPyTagged t_size, PyObject *seq);
 PyObject *CPyList_GetSlice(PyObject *obj, CPyTagged start, CPyTagged end);
+PyObject *CPyList_Copy(PyObject *list);
 int CPySequence_Check(PyObject *obj);
 
 

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -29,6 +29,14 @@ PyObject *CPyList_Build(Py_ssize_t len, ...) {
     return res;
 }
 
+PyObject *CPyList_Copy(PyObject *list) {
+    if(PyList_CheckExact(list)) {
+        return PyList_GetSlice(list, 0, PyList_GET_SIZE(list));
+    }
+    _Py_IDENTIFIER(copy);
+    return _PyObject_CallMethodIdNoArgs(list, &PyID_copy);
+}
+
 PyObject *CPyList_GetItemUnsafe(PyObject *list, CPyTagged index) {
     Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
     PyObject *result = PyList_GET_ITEM(list, n);

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -34,7 +34,7 @@ PyObject *CPyList_Copy(PyObject *list) {
         return PyList_GetSlice(list, 0, PyList_GET_SIZE(list));
     }
     _Py_IDENTIFIER(copy);
-    return _PyObject_CallMethodIdNoArgs(list, &PyID_copy);
+    return _PyObject_CallMethodIdNoArgs(list, &PyId_copy);
 }
 
 PyObject *CPyList_GetItemUnsafe(PyObject *list, CPyTagged index) {

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -262,6 +262,15 @@ method_op(
     error_kind=ERR_MAGIC,
 )
 
+# list.copy()
+method_op(
+    name="copy",
+    arg_types=[list_rprimitive],
+    return_type=list_rprimitive,
+    c_function_name="CPyList_Copy",
+    error_kind=ERR_MAGIC,
+)
+
 # list * int
 binary_op(
     name="*",

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -51,6 +51,33 @@ print(2, a)
 1 [-1, 5]
 2 [340282366920938463463374607431768211461, -170141183460469231731687303715884105736]
 
+[case testListCopy]
+def test_list_copy() -> None:
+    l1 = [1, 2, 3, -4, 5]
+    l2 = l1.copy()
+    assert l1.copy() == l1
+    assert l1.copy() == l2
+    assert l1 == l2
+    assert l1.copy() == l2.copy()
+    l1 = l2.copy()
+    assert l1 == l2
+    assert l1.copy() == l2
+    assert l1 == [1, 2, 3, -4, 5]
+    l2 = [1, 2, -3]
+    l1 = []
+    assert l1.copy() == []
+    assert l2.copy() != l1
+    assert l2 == l2.copy()
+    l1 = l2
+    assert l1.copy().copy() == l2.copy().copy().copy()
+    assert l1.copy() == l2.copy()
+    l1 == [1, 2, -3].copy()
+    assert l1 == l2
+    l2 = [1, 2, 3].copy()
+    assert l2 != l1
+    l1 = [1, 2, 3]
+    assert l1.copy() == l2.copy()
+    
 [case testSieve]
 from typing import List
 

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -51,7 +51,10 @@ print(2, a)
 1 [-1, 5]
 2 [340282366920938463463374607431768211461, -170141183460469231731687303715884105736]
 
+<<<<<<< HEAD
+<<<<<<< HEAD
 [case testListCopy]
+from typing import List
 def test_list_copy() -> None:
     l1 = [1, 2, 3, -4, 5]
     l2 = l1.copy()
@@ -78,9 +81,12 @@ def test_list_copy() -> None:
     l1 = [1, 2, 3]
     assert l1.copy() == l2.copy()
     
+=======
+>>>>>>> e276f33f1 (Add test check_listcopy.test)
+=======
+>>>>>>> d1f946e3d (Remove test)
 [case testSieve]
 from typing import List
-
 def primes(n: int) -> List[int]:
     a = [1] * (n + 1)
     a[0] = 0

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -80,7 +80,7 @@ def test_list_copy() -> None:
     assert l2 != l1
     l1 = [1, 2, 3]
     assert l1.copy() == l2.copy()
-    
+
 =======
 >>>>>>> e276f33f1 (Add test check_listcopy.test)
 =======

--- a/test-data/unit/check-listcopy.test
+++ b/test-data/unit/check-listcopy.test
@@ -1,0 +1,31 @@
+[case testListCopy]
+[builtins fixtures/list.pyi]
+def test_list_copy() -> None:
+    l1 = [1, 2, 3, -4, 5]
+    l2 = l1.copy()
+    assert l1.copy() == l1
+    assert l1.copy() == l2
+    assert l1 == l2
+    assert l1.copy() == l2.copy()
+    l1 = l2.copy()
+    assert l1 == l2
+    assert l1.copy() == l2
+    assert l1 == [1, 2, 3, -4, 5]
+    l2 = [1, 2, -3]
+    l1 = []
+    assert l1.copy() == []
+    assert l2.copy() != l1
+    assert l2 == l2.copy()
+    l1 = l2
+    assert l1.copy().copy() == l2.copy().copy().copy()
+    assert l1.copy() == l2.copy()
+    l1 == [1, 2, -3].copy()
+    assert l1 == l2
+    l2 = [1, 2, 3].copy()
+    assert l2 != l1
+    l1 = [1, 2, 3]
+    assert l1.copy() == l2.copy()
+    l3 = ["string", 2 , 3]
+    assert l3 == l3.copy()
+    l2 = ["string", 2, 3]
+    assert l2 == l3.copy()

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -25,6 +25,7 @@ class list(Sequence[T]):
     def __setitem__(self, x: int, v: T) -> None: pass
     def append(self, x: T) -> None: pass
     def extend(self, x: Iterable[T]) -> None: pass
+    def copy(self) -> list[T] : pass
 
 class tuple(Generic[T]): pass
 class function: pass


### PR DESCRIPTION

I can't directly mention the issue with # because it is from /mypyc repository, refer to this link
[Add primitive for list.copy #1092](https://github.com/mypyc/mypyc/issues/1092)

Is this correct? There is no PyList_Copy() to call?