### PR TITLE
Consistently store settable property type

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1246,10 +1246,11 @@ class SemanticAnalyzer(
         with self.overload_item_set(0):
             first_item.accept(self)
 
+        bare_setter_type = None
         if isinstance(first_item, Decorator) and first_item.func.is_property:
             # This is a property.
             first_item.func.is_overload = True
-            self.analyze_property_with_multi_part_definition(defn)
+            bare_setter_type = self.analyze_property_with_multi_part_definition(defn)
             typ = function_type(first_item.func, self.named_type("builtins.function"))
             assert isinstance(typ, CallableType)
             types = [typ]
@@ -1283,6 +1284,11 @@ class SemanticAnalyzer(
             #   * Put decorator everywhere, use "bare" types in overloads.
             defn.type = Overloaded(types)
             defn.type.line = defn.line
+            # In addition, we can set the getter/setter type for valid properties as some
+            # code paths may either use the above type, or var.type etc. of the first item.
+            if isinstance(first_item, Decorator) and bare_setter_type:
+                first_item.var.type = types[0]
+                first_item.var.setter_type = bare_setter_type
 
         if not defn.items:
             # It was not a real overload after all, but function redefinition. We've
@@ -1502,19 +1508,25 @@ class SemanticAnalyzer(
             defn.is_class = class_status[0]
             defn.is_static = static_status[0]
 
-    def analyze_property_with_multi_part_definition(self, defn: OverloadedFuncDef) -> None:
+    def analyze_property_with_multi_part_definition(
+        self, defn: OverloadedFuncDef
+    ) -> CallableType | None:
         """Analyze a property defined using multiple methods (e.g., using @x.setter).
 
         Assume that the first method (@property) has already been analyzed.
+        Return bare setter type (without any other decorators applied), this may be used
+        by the caller for performance optimizations.
         """
         defn.is_property = True
         items = defn.items
         first_item = defn.items[0]
         assert isinstance(first_item, Decorator)
         deleted_items = []
+        bare_setter_type = None
         for i, item in enumerate(items[1:]):
             if isinstance(item, Decorator):
-                if len(item.decorators) >= 1:
+                item.func.accept(self)
+                if item.decorators:
                     first_node = item.decorators[0]
                     if isinstance(first_node, MemberExpr):
                         if first_node.name == "setter":
@@ -1522,6 +1534,11 @@ class SemanticAnalyzer(
                             first_item.var.is_settable_property = True
                             # Get abstractness from the original definition.
                             item.func.abstract_status = first_item.func.abstract_status
+                            setter_func_type = function_type(
+                                item.func, self.named_type("builtins.function")
+                            )
+                            assert isinstance(setter_func_type, CallableType)
+                            bare_setter_type = setter_func_type
                         if first_node.name == "deleter":
                             item.func.abstract_status = first_item.func.abstract_status
                         for other_node in item.decorators[1:]:
@@ -1530,7 +1547,6 @@ class SemanticAnalyzer(
                         self.fail(
                             f"Only supported top decorator is @{first_item.func.name}.setter", item
                         )
-                item.func.accept(self)
             else:
                 self.fail(f'Unexpected definition for property "{first_item.func.name}"', item)
                 deleted_items.append(i + 1)
@@ -1544,6 +1560,7 @@ class SemanticAnalyzer(
                         item.func.deprecated = (
                             f"function {item.fullname} is deprecated: {deprecated}"
                         )
+        return bare_setter_type
 
     def add_function_to_symbol_table(self, func: FuncDef | OverloadedFuncDef) -> None:
         if self.is_class_scope():

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -8508,6 +8508,33 @@ class C(B):
     @deco
     def bar(self, x: int, y: int) -> None: ...
 
+    @property
+    def baz(self) -> int: ...
+    @baz.setter
+    @deco_untyped
+    def baz(self, x: int) -> None: ...
+
+c: C
+c.baz = "yes"  # OK, because of untyped decorator
+
 T = TypeVar("T")
 def deco(fn: Callable[[T, int, int], None]) -> Callable[[T, int], None]: ...
+def deco_untyped(fn): ...
+[builtins fixtures/property.pyi]
+
+[case testPropertyDeleterBodyChecked]
+class C:
+    @property
+    def foo(self) -> int: ...
+    @foo.deleter
+    def foo(self) -> None:
+        1()  # E: "int" not callable
+
+    @property
+    def bar(self) -> int: ...
+    @bar.setter
+    def bar(self, x: str) -> None: ...
+    @bar.deleter
+    def bar(self) -> None:
+        1()  # E: "int" not callable
 [builtins fixtures/property.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -8464,3 +8464,50 @@ def deco(fn: Callable[[], list[T]]) -> Callable[[], T]: ...
 @deco
 def f() -> list[str]: ...
 [builtins fixtures/property.pyi]
+
+[case testPropertySetterSuperclassDeferred2]
+import a
+[file a.py]
+import b
+class D(b.C):
+    @property
+    def foo(self) -> str: ...
+    @foo.setter  # E: Incompatible override of a setter type \
+                 # N:  (base class "C" defined the type as "str", \
+                 # N:  override has type "int")
+    def foo(self, x: int) -> None: ...
+[file b.py]
+from a import D
+class C:
+    @property
+    def foo(self) -> str: ...
+    @foo.setter
+    def foo(self, x: str) -> None: ...
+[builtins fixtures/property.pyi]
+
+[case testPropertySetterDecorated]
+from typing import Callable, TypeVar
+
+class B:
+    def __init__(self) -> None:
+        self.foo: str
+        self.bar: int
+
+class C(B):
+    @property
+    def foo(self) -> str: ...
+    @foo.setter  # E: Incompatible override of a setter type \
+                 # N:  (base class "B" defined the type as "str", \
+                 # N:  override has type "int")
+    @deco
+    def foo(self, x: int, y: int) -> None: ...
+
+    @property
+    def bar(self) -> int: ...
+    @bar.setter
+    @deco
+    def bar(self, x: int, y: int) -> None: ...
+
+T = TypeVar("T")
+def deco(fn: Callable[[T, int, int], None]) -> Callable[[T, int], None]: ...
+[builtins fixtures/property.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/18764

There are two things important to understand this PR:
* First, mypy has a performance optimization - we store decorator/overload type during semantic analysis in certain "trivial" situations (to avoid deferrals). Otherwise, we infer the type of decorated function or an overload variant during type checking.
* Second, for settable properties we store getter type in two places, as a `Var.type` of getter (as a decorator), and also in overall `OverloadedFuncDef.type`. The latter is ugly, but unfortunately it is hard to get rid of, since some code in multiple plugins rely on this.

It turns out there are _three_ inconsistencies in how these two things interact (first one causes the actual crash):
* For trivial settable properties (i.e. without extra decorators) when we store the type in `semanal.py` we only store it the second way (i.e. as `OverloadedFuncDef.type`).
* For non-trivial settable properties (where getter and/or setter are themselves decorated), we only set the inferred type the first way (as `Var.type`).
* When inferring setter type (unlike getter, that is handled correctly) we actually ignore any extra decorators (this is probably quire niche, but still inconsistent).

Essentially I simply remove these inconsistencies.