### PR TITLE
Passing error_formatter in new_messages method of Error Class

### DIFF
--- a/myfile.py
+++ b/myfile.py
@@ -1,0 +1,6 @@
+
+
+def test():
+    return 2
+
+

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -664,7 +664,6 @@ def request(
     try:
         with IPCClient(name, timeout) as client:
             send(client, args)
-
             final = False
             while not final:
                 response = receive(client)

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -635,7 +635,6 @@ class Server:
 
         # Process changes directly reachable from roots.
         messages = fine_grained_manager.update(changed, [], followed=True)
-
         # Follow deps from changed modules (still within graph).
         worklist = changed.copy()
         while worklist:

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -944,7 +944,7 @@ class Errors:
                 return i[1]
         return None
 
-    def new_messages(self, formatter: ErrorFormatter = None) -> list[str]:
+    def new_messages(self, formatter: ErrorFormatter | None = None) -> list[str]:
         """Return a string list of new error messages.
 
         Use a form suitable for displaying to the user.

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -944,7 +944,7 @@ class Errors:
                 return i[1]
         return None
 
-    def new_messages(self) -> list[str]:
+    def new_messages(self, formatter: ErrorFormatter = None) -> list[str]:
         """Return a string list of new error messages.
 
         Use a form suitable for displaying to the user.
@@ -954,7 +954,7 @@ class Errors:
         msgs = []
         for path in self.error_info_map.keys():
             if path not in self.flushed_files:
-                msgs.extend(self.file_messages(path))
+                msgs.extend(self.file_messages(path, formatter=formatter))
         return msgs
 
     def targets(self) -> set[str]:

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -296,7 +296,7 @@ class FineGrainedBuildManager:
                 if not changed_modules:
                     # Preserve state needed for the next update.
                     self.previous_targets_with_errors = self.manager.errors.targets()
-                    messages = self.manager.errors.new_messages()
+                    messages = self.manager.errors.new_messages(formatter=self.manager.error_formatter)
                     break
 
         messages = sort_messages_preserving_file_order(messages, self.previous_messages)
@@ -320,7 +320,7 @@ class FineGrainedBuildManager:
         )
         # Preserve state needed for the next update.
         self.previous_targets_with_errors = self.manager.errors.targets()
-        self.previous_messages = self.manager.errors.new_messages().copy()
+        self.previous_messages = self.manager.errors.new_messages(formatter=self.manager.error_formatter).copy()
         return self.update(changed_modules, [])
 
     def flush_cache(self) -> None:


### PR DESCRIPTION
Fixes: https://github.com/python/mypy/issues/18713

Problem - 
When user runs dmypy for a file once (with flag output=json) , it gave correct validation error (in form of json)
But when user changes something in file and then runs the same command again , it does give error in json format because 
since the daemon is running now , the code flow goes to print out errors without error_formatter set

Solution - 
I passed formatter to new_messages of Errors Class (with default value None), so that when FineGrainedBuildManager is called again , it will have BuildManager associated with it and which will have the error_formatter set (if it was set intially while running daemon).
