### PR TITLE
Update project metadata for PEP 639

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
         echo debug build; python -c 'import sysconfig; print(bool(sysconfig.get_config_var("Py_DEBUG")))'
         echo os.cpu_count; python -c 'import os; print(os.cpu_count())'
         echo os.sched_getaffinity; python -c 'import os; print(len(getattr(os, "sched_getaffinity", lambda *args: [])(0)))'
-        pip install setuptools==75.1.0 tox==4.21.2
+        pip install tox==4.21.2
 
     - name: Compiled with mypyc
       if: ${{ matrix.test_mypyc }}
@@ -230,7 +230,7 @@ jobs:
           default: 3.11.1
           command: python -c "import platform; print(f'{platform.architecture()=} {platform.machine()=}');"
       - name: Install tox
-        run: pip install setuptools==75.1.0 tox==4.21.2
+        run: pip install tox==4.21.2
       - name: Setup tox environment
         run: tox run -e py --notest
       - name: Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     # NOTE: this needs to be kept in sync with mypy-requirements.txt
     # and build-requirements.txt, because those are both needed for
     # self-typechecking :/
-    "setuptools >= 75.1.0",
+    "setuptools >= 77.0.3",
     # the following is from mypy-requirements.txt/setup.py
     "typing_extensions>=4.6.0",
     "mypy_extensions>=1.0.0",
@@ -30,12 +30,12 @@ features such as type inference, gradual typing, generics and union
 types.
 """, content-type = "text/x-rst"}
 authors = [{name = "Jukka Lehtosalo", email = "jukka.lehtosalo@iki.fi"}]
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE", "mypy/typeshed/LICENSE"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -10,6 +10,6 @@ psutil>=4.0
 pytest>=8.1.0
 pytest-xdist>=1.34.0
 pytest-cov>=2.10.0
-setuptools>=75.1.0
+setuptools>=77.0.3
 tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.9
 pre_commit>=3.5.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -63,5 +63,5 @@ virtualenv==20.29.1
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.8.0
+setuptools==77.0.3
     # via -r test-requirements.in


### PR DESCRIPTION
Setuptools `v77` was released today which adds full support for PEP 639.
https://setuptools.pypa.io/en/latest/history.html#v77-0-0
https://peps.python.org/pep-0639/

The relevant project metadata changes
```diff
 ...
-License: MIT
+License-Expression: MIT
 ...
-Classifier: License :: OSI Approved :: MIT License
 ...
 License-File: LICENSE
+License-File: mypy/typeshed/LICENSE
 ...
```