### PR TITLE
Use type context for for loops

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -307,6 +307,9 @@ class PatternChecker(PatternVisitor[PatternType]):
             narrowed_inner_types = []
             inner_rest_types = []
             for inner_type, new_inner_type in zip(inner_types, new_inner_types):
+                # TODO: for loop type context should narrow on "assignment"?
+                assert inner_type is not None
+
                 (narrowed_inner_type, inner_rest_type) = (
                     self.chk.conditional_types_with_intersection(
                         inner_type, [get_type_range(new_inner_type)], o, default=inner_type

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2317,15 +2317,15 @@ class LowLevelIRBuilder:
                 rest_items.append(item)
         exit_block = BasicBlock()
         result = Register(result_type)
-        for i, item in enumerate(fast_items):
+        for i, inst in enumerate(fast_items):
             more_types = i < len(fast_items) - 1 or rest_items
             if more_types:
                 # We are not at the final item so we need one more branch
-                op = self.isinstance_native(obj, item.class_ir, line)
+                op = self.isinstance_native(obj, inst.class_ir, line)
                 true_block, false_block = BasicBlock(), BasicBlock()
                 self.add_bool_branch(op, true_block, false_block)
                 self.activate_block(true_block)
-            coerced = self.coerce(obj, item, line)
+            coerced = self.coerce(obj, inst, line)
             temp = process_item(coerced)
             temp2 = self.coerce(temp, result_type, line)
             self.add(Assign(result, temp2))

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -736,10 +736,8 @@ def not_precomputed() -> None:
 [out]
 def precomputed():
     r0 :: set
-    r1, r2 :: object
-    r3 :: str
-    _ :: object
-    r4 :: bit
+    r1, r2, _ :: object
+    r3 :: bit
 L0:
     r0 = frozenset({'False', 'None', 'True'})
     r1 = PyObject_GetIter(r0)
@@ -747,12 +745,11 @@ L1:
     r2 = PyIter_Next(r1)
     if is_error(r2) goto L4 else goto L2
 L2:
-    r3 = cast(str, r2)
-    _ = r3
+    _ = r2
 L3:
     goto L1
 L4:
-    r4 = CPy_NoErrOccurred()
+    r3 = CPy_NoErrOccurred()
 L5:
     return 1
 def precomputed2():

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1495,3 +1495,12 @@ def g(b: Optional[str]) -> None:
         z: Callable[[], str] = lambda: reveal_type(b)  # N: Revealed type is "builtins.str"
         f2(lambda: reveal_type(b))  # N: Revealed type is "builtins.str"
         lambda: reveal_type(b)  # N: Revealed type is "builtins.str"
+
+[case testInferenceForForLoops]
+from typing import Literal
+
+def func2() -> None:
+    b: Literal["foo", "bar", "baz"]
+    for b in ["foo", "bar"]:
+        # TODO: this should narrow to "foo" | "bar" ideally?
+        reveal_type(b)  # N: Revealed type is "Union[Literal['foo'], Literal['bar'], Literal['baz']]"

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1149,11 +1149,11 @@ for x, (y, z) in [(A(), (B(), C()))]:
     a = x
     b = y
     c = z
-for xx, yy, zz in [(A(), B())]: # E: Need more than 2 values to unpack (3 expected)
+for x2, y2, z2 in [(A(), B())]: # E: Need more than 2 values to unpack (3 expected)
     pass
-for xx, (yy, zz) in [(A(), B())]: # E: "B" object is not iterable
+for x3, (y3, z3) in [(A(), B())]: # E: "B" object is not iterable
     pass
-for xxx, yyy in [(None, None)]:
+for x4, y4 in [(None, None)]:
     pass
 [builtins fixtures/for.pyi]
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes https://github.com/python/mypy/issues/18826. This PR makes for loops use any annotations on the index variable for type context when checking the thing being iterated over.

I'm not confident this should be merged. This breaks this:
```py
from typing import Literal

def func() -> None:
    b: None | str
    for b in ["a", "c"]:
        b + "5"
```

I think it should narrow somehow but I'm not quite sure how to do that.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
