### PR TITLE
add `scipy-stubs` as non-typeshed stub package

### DIFF
--- a/mypy/stubinfo.py
+++ b/mypy/stubinfo.py
@@ -291,6 +291,7 @@ non_bundled_packages_flat: dict[str, str] = {
     # for additions here
     "pandas": "pandas-stubs",  # https://github.com/pandas-dev/pandas-stubs
     "lxml": "lxml-stubs",  # https://github.com/lxml/lxml-stubs
+    "scipy": "scipy-stubs",  # https://github.com/scipy/scipy-stubs
 }
 
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

SciPy itself has no `py.typed` and barely any stubs, so I wrote [`scipy-stubs`](https://github.com/scipy/scipy-stubs). Recently, it has been accepted as an official scipy project. 
This stubs-only package is *complete* (no `untyped`) and *valid* (according to mypy, stubtest, pyright, basedmypy and basedpyright), and carefully annotated (by humans). 
And for what it's worth, it's also on the list of `mypy_primer` projects.

I'm open to any feedback, questions, and ideas in general; no need to hold back :)


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
