### PR TITLE
[mypyc] Allow specifying annotate test case outputs using comments

### DIFF
--- a/mypyc/test-data/annotate-basic.test
+++ b/mypyc/test-data/annotate-basic.test
@@ -1,26 +1,20 @@
 [case testAnnotateNonNativeAttribute]
 def f(x):
-    return x.foo
+    return x.foo  # A: Get non-native attribute "foo".
 
 class C:
     foo: int
 
 def g(x: C) -> int:
     return x.foo
-[out]
-2: Get non-native attribute "foo".
 
 [case testAnnotateGenericAdd]
 def f(x):
-    return x + 1
+    return x + 1  # A: Generic "+" operation.
 
 def g(x: int) -> int:
     return x + 1
-[out]
-2: Generic "+" operation.
 
 [case testAnnotateTwoOperationsOnLine]
 def f(x):
-    return x.foo + 1
-[out]
-2: Get non-native attribute "foo". Generic "+" operation.
+    return x.foo + 1  # A: Get non-native attribute "foo". Generic "+" operation.


### PR DESCRIPTION
This makes it more convenient to write source code annotation tests.