### PR TITLE
Remove non-existing `_DT` from ordered dataclass

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -291,11 +291,7 @@ class DataclassTransformer:
                 self._api, self._cls, "__init__", args=args, return_type=NoneType()
             )
 
-        if (
-            decorator_arguments["eq"]
-            and info.get("__eq__") is None
-            or decorator_arguments["order"]
-        ):
+        if decorator_arguments["eq"] and info.get("__eq__") is None:
             # Type variable for self types in generated methods.
             obj_type = self._api.named_type("builtins.object")
             self_tvar_expr = TypeVarExpr(

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2594,3 +2594,15 @@ class B2(B1):  # E: A NamedTuple cannot be a dataclass
     pass
 
 [builtins fixtures/tuple.pyi]
+
+[case testOrderedDataclassSelfTVARNotExist]
+from dataclasses import dataclass
+
+@dataclass(order=True)
+class A:
+    b: int
+
+a = A(1)
+a._DT  # E: "A" has no attribute "_DT"
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -9,6 +9,7 @@ _Tco = TypeVar('_Tco', covariant=True)
 class object:
     def __init__(self) -> None: pass
     def __new__(cls) -> Self: ...
+    def __eq__(self, other) -> bool: pass
 
 class type:
     def __init__(self, *a: object) -> None: pass


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
Fixes #18811

Remove `_DT` attribute that does not exist in runtime from ordered dataclass.