### PR TITLE
Admit that **kwargs mapping subtypes may have no direct type parameters

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -249,10 +249,8 @@ class ArgTypeExpander:
                     formal_name = (set(actual_type.items.keys()) - self.kwargs_used).pop()
                 self.kwargs_used.add(formal_name)
                 return actual_type.items[formal_name]
-            elif (
-                isinstance(actual_type, Instance)
-                and len(actual_type.args) > 1
-                and is_subtype(actual_type, self.context.mapping_type)
+            elif isinstance(actual_type, Instance) and is_subtype(
+                actual_type, self.context.mapping_type
             ):
                 # Only `Mapping` type can be unpacked with `**`.
                 # Other types will produce an error somewhere else.

--- a/test-data/unit/check-kwargs.test
+++ b/test-data/unit/check-kwargs.test
@@ -345,7 +345,7 @@ from typing import Mapping
 class MappingSubclass(Mapping[str, str]): pass
 def f(**kwargs: 'A') -> None: pass
 d: MappingSubclass
-f(**d)
+f(**d)  # E: Argument 1 to "f" has incompatible type "**MappingSubclass"; expected "A"
 class A: pass
 [builtins fixtures/dict.pyi]
 


### PR DESCRIPTION
Fixes #13675. I don't know why this check was ever needed (since #11151), but it doesn't seem correct.