### PR TITLE
fix: prevent `ClassVar` override with instance property

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2280,6 +2280,17 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             if inner is not None:
                 typ = inner
                 typ = get_property_type(typ)
+
+                if (
+                    isinstance(original_node, Var)
+                    and original_node.is_classvar
+                    and defn.name == original_node.name
+                    and isinstance(defn, Decorator)
+                ):
+                    self.fail(
+                        message_registry.CANNOT_OVERRIDE_CLASS_VAR.format(base.name), defn.func
+                    )
+
                 if (
                     isinstance(original_node, Var)
                     and not original_node.is_final

--- a/test-data/unit/check-classvar.test
+++ b/test-data/unit/check-classvar.test
@@ -269,6 +269,19 @@ class A(metaclass=ABCMeta):
 class B(A):
     x = 0  # type: ClassVar[int]
 
+[case testOverrideWithPropertyDecorator]
+from typing import ClassVar
+
+class A:
+    x: ClassVar[int]
+class B(A):
+    @property
+    def x(self) -> int: ...
+[builtins fixtures/property.pyi]
+[out]
+main:7: error: Cannot override class variable (previously declared on base class "A") with instance variable
+main:7: error: Cannot override writeable attribute with read-only property
+
 [case testAcrossModules]
 import m
 reveal_type(m.A().x)


### PR DESCRIPTION
Fixes #18790

