### PR TITLE
Fix crash on multiple unpacks in a bare type application

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6071,9 +6071,8 @@ class SemanticAnalyzer(
                 return None
             types.append(analyzed)
 
-        analyzer = self.type_analyzer()
-        types = analyzer.check_unpacks_in_list(types)
-
+        if allow_unpack:
+            types = self.type_analyzer().check_unpacks_in_list(types)
         if has_param_spec and num_args == 1 and types:
             first_arg = get_proper_type(types[0])
             single_any = len(types) == 1 and isinstance(first_arg, AnyType)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6071,6 +6071,9 @@ class SemanticAnalyzer(
                 return None
             types.append(analyzed)
 
+        analyzer = self.type_analyzer()
+        types = analyzer.check_unpacks_in_list(types)
+
         if has_param_spec and num_args == 1 and types:
             first_arg = get_proper_type(types[0])
             single_any = len(types) == 1 and isinstance(first_arg, AnyType)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -2006,7 +2006,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
         if num_unpacks > 1:
             assert final_unpack is not None
-            self.fail("More than one Unpack in a type is not allowed", final_unpack)
+            self.fail("More than one Unpack in a type is not allowed", final_unpack.type)
         return new_items
 
     def tuple_type(self, items: list[Type], line: int, column: int) -> TupleType:

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2035,7 +2035,10 @@ class Z: ...  # E: Name "Z" already defined on line 2
 class A[*Ts]: ...
 
 A[*tuple[int, ...], *tuple[int, ...]]  # E: More than one Unpack in a type is not allowed
+a: A[*tuple[int, ...], *tuple[int, ...]]  # E: More than one Unpack in a type is not allowed
+def foo(a: A[*tuple[int, ...], *tuple[int, ...]]): ...  # E: More than one Unpack in a type is not allowed
 
+tuple[*tuple[int, ...], *tuple[int, ...]]  # E: More than one Unpack in a type is not allowed
 b: tuple[*tuple[int, ...], *tuple[int, ...]]  # E: More than one Unpack in a type is not allowed
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2029,3 +2029,13 @@ def foo() -> None:
 class Z: ...  # E: Name "Z" already defined on line 2
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testPEP695MultipleUnpacksInBareApplicationNoCrash]
+# https://github.com/python/mypy/issues/18856
+class A[*Ts]: ...
+
+A[*tuple[int, ...], *tuple[int, ...]]  # E: More than one Unpack in a type is not allowed
+
+b: tuple[*tuple[int, ...], *tuple[int, ...]]  # E: More than one Unpack in a type is not allowed
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
Fixes #18856. This should be done by `TypeAnalyzer.anal_array` but is not - semanal only invokes its own wrapper around `anal_type`