### PR TITLE
Fix crash on type inference against non-normal callables

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1063,11 +1063,11 @@ class ConstraintBuilderVisitor(TypeVisitor[list[Constraint]]):
         # using e.g. callback protocols.
         # TODO: check that callables match? Ideally we should not infer constraints
         # callables that can never be subtypes of one another in given direction.
-        template = template.with_unpacked_kwargs()
+        template = template.with_unpacked_kwargs().with_normalized_var_args()
         extra_tvars = False
         if isinstance(self.actual, CallableType):
             res: list[Constraint] = []
-            cactual = self.actual.with_unpacked_kwargs()
+            cactual = self.actual.with_unpacked_kwargs().with_normalized_var_args()
             param_spec = template.param_spec()
 
             template_ret_type, cactual_ret_type = template.ret_type, cactual.ret_type

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2210,7 +2210,7 @@ class CallableType(FunctionLike):
                     new_unpack = nested_unpacked.args[0]
                 else:
                     if not isinstance(nested_unpacked, TypeVarTupleType):
-                        # We found a non-nomralized tuple type, this means this method
+                        # We found a non-normalized tuple type, this means this method
                         # is called during semantic analysis (e.g. from get_proper_type())
                         # there is no point in normalizing callables at this stage.
                         return self

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2618,3 +2618,13 @@ def deco(func: Callable[[*Ts, int], R]) -> Callable[[*Ts], R]:
 untyped: Any
 reveal_type(deco(untyped))  # N: Revealed type is "def (*Any) -> Any"
 [builtins fixtures/tuple.pyi]
+
+[case testNoCrashOnNonNormalUnpackInCallable]
+from typing import Callable, Unpack, TypeVar
+
+T = TypeVar("T")
+def fn(f: Callable[[*tuple[T]], int]) -> Callable[[*tuple[T]], int]: ...
+
+def test(*args: Unpack[tuple[T]]) -> int: ...
+reveal_type(fn(test))  # N: Revealed type is "def [T] (T`1) -> builtins.int"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/17755

Fix is trivial, so not really waiting for review. Btw I found few other places where we do not normalize callables. TBH I already forgot when we actually _need_ to normalize, but I don't want to just blanket add normalization, as it may be a relatively expensive function. If we will hit another similar crash, I will add more normalization accordingly (similar to what I did with kwargs unpacking).