### PR TITLE
nit: Fix wrong example code in comment

### DIFF
--- a/mypy/reachability.py
+++ b/mypy/reachability.py
@@ -221,7 +221,7 @@ def consider_sys_platform(expr: Expression, platform: str) -> int:
     Return ALWAYS_TRUE, ALWAYS_FALSE, or TRUTH_VALUE_UNKNOWN.
     """
     # Cases supported:
-    # - sys.platform == 'posix'
+    # - sys.platform == 'linux'
     # - sys.platform != 'win32'
     # - sys.platform.startswith('win')
     if isinstance(expr, ComparisonExpr):


### PR DESCRIPTION
"posix" is not a valid value for sys.platform

Found when researching about https://github.com/python/typing/issues/1732.
I hope it's okay to send a trivial PR. If you don't want to bother with this, feel free to close this. 
