### PR TITLE
Prevent crash when enum/typeddict call is stored as a class attribute

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3464,8 +3464,9 @@ class SemanticAnalyzer(
     def analyze_enum_assign(self, s: AssignmentStmt) -> bool:
         """Check if s defines an Enum."""
         if isinstance(s.rvalue, CallExpr) and isinstance(s.rvalue.analyzed, EnumCallExpr):
-            # Already analyzed enum -- only recheck that it can be stored correctly.
-            return len(s.lvalues) == 1 and isinstance(s.lvalues[0], NameExpr)
+            # This is an analyzed enum definition.
+            # It is valid iff it can be stored correctly, failures were already reported.
+            return self._is_single_name_assignment(s)
         return self.enum_call_analyzer.process_enum_call(s, self.is_func_scope())
 
     def analyze_namedtuple_assign(self, s: AssignmentStmt) -> bool:
@@ -3474,7 +3475,9 @@ class SemanticAnalyzer(
             if s.rvalue.analyzed.info.tuple_type and not has_placeholder(
                 s.rvalue.analyzed.info.tuple_type
             ):
-                return True  # This is a valid and analyzed named tuple definition, nothing to do here.
+                # This is an analyzed named tuple definition.
+                # It is valid iff it can be stored correctly, failures were already reported.
+                return self._is_single_name_assignment(s)
         if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], (NameExpr, MemberExpr)):
             return False
         lvalue = s.lvalues[0]
@@ -3515,8 +3518,9 @@ class SemanticAnalyzer(
             if s.rvalue.analyzed.info.typeddict_type and not has_placeholder(
                 s.rvalue.analyzed.info.typeddict_type
             ):
-                # This is a valid and analyzed typed dict definition, nothing to do here.
-                return True
+                # This is an analyzed typed dict definition.
+                # It is valid iff it can be stored correctly, failures were already reported.
+                return self._is_single_name_assignment(s)
         if len(s.lvalues) != 1 or not isinstance(s.lvalues[0], (NameExpr, MemberExpr)):
             return False
         lvalue = s.lvalues[0]
@@ -3539,6 +3543,9 @@ class SemanticAnalyzer(
                 self.setup_type_vars(defn, tvar_defs)
                 self.setup_alias_type_vars(defn)
             return True
+
+    def _is_single_name_assignment(self, s: AssignmentStmt) -> bool:
+        return len(s.lvalues) == 1 and isinstance(s.lvalues[0], NameExpr)
 
     def analyze_lvalues(self, s: AssignmentStmt) -> None:
         # We cannot use s.type, because analyze_simple_literal_type() will set it.

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3464,8 +3464,8 @@ class SemanticAnalyzer(
     def analyze_enum_assign(self, s: AssignmentStmt) -> bool:
         """Check if s defines an Enum."""
         if isinstance(s.rvalue, CallExpr) and isinstance(s.rvalue.analyzed, EnumCallExpr):
-            # Already analyzed enum -- nothing to do here.
-            return True
+            # Already analyzed enum -- only recheck that it can be stored correctly.
+            return len(s.lvalues) == 1 and isinstance(s.lvalues[0], NameExpr)
         return self.enum_call_analyzer.process_enum_call(s, self.is_func_scope())
 
     def analyze_namedtuple_assign(self, s: AssignmentStmt) -> bool:

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2512,3 +2512,15 @@ def list_vals(e: Type[T]) -> list[T]:
 
 reveal_type(list_vals(Choices))  # N: Revealed type is "builtins.list[__main__.Choices]"
 [builtins fixtures/enum.pyi]
+
+[case testEnumAsClassMemberNoCrash]
+# https://github.com/python/mypy/issues/18736
+from enum import Enum
+
+class Base:
+    def __init__(self, namespace: tuple[str, ...]) -> None:
+        # Not a bug: trigger defer
+        names = [name for name in namespace if fail]  # E: Name "fail" is not defined
+        self.o = Enum("o", names)  # E: Enum type as attribute is not supported \
+                                   # E: Second argument of Enum() must be string, tuple, list or dict literal for mypy to determine Enum members
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1519,3 +1519,14 @@ class C(T):
 c: Union[C, Any]
 reveal_type(c.f())  # N: Revealed type is "Union[builtins.bool, Any]"
 [builtins fixtures/tuple.pyi]
+
+[case testNamedTupleAsClassMemberNoCrash]
+# https://github.com/python/mypy/issues/18736
+from collections import namedtuple
+
+class Base:
+    def __init__(self, namespace: tuple[str, ...]) -> None:
+        # Not a bug: trigger defer
+        names = [name for name in namespace if fail]  # E: Name "fail" is not defined
+        self.n = namedtuple("n", names)  # E: NamedTuple type as an attribute is not supported
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -4138,3 +4138,16 @@ Derived.Params(name="Robert")
 DerivedOverride.Params(name="Robert")
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testEnumAsClassMemberNoCrash]
+# https://github.com/python/mypy/issues/18736
+from typing import TypedDict
+
+class Base:
+    def __init__(self, namespace: dict[str, str]) -> None:
+        # Not a bug: trigger defer
+        names = {n: n for n in namespace if fail}  # E: Name "fail" is not defined
+        self.d = TypedDict("d", names)  # E: TypedDict type as attribute is not supported \
+                                        # E: TypedDict() expects a dictionary literal as the second argument
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]


### PR DESCRIPTION
Fixes #18736. Includes same fix for TypedDict (also crashes on master) and NamedTuple (does not crash as it rejects MemberExpr before setting .analyzed, so just for the sake of consistency)