### PR TITLE
Handle union types when binding self

### DIFF
--- a/test-data/unit/check-classvar.test
+++ b/test-data/unit/check-classvar.test
@@ -334,3 +334,12 @@ class C:
 c:C
 c.foo()  # E: Too few arguments \
          # N: "foo" is considered instance variable, to make it class variable use ClassVar[...]
+
+[case testClassVarUnionBoundOnInstance]
+from typing import Union, Callable, ClassVar
+
+class C:
+    def f(self) -> int: ...
+    g: ClassVar[Union[Callable[[C], int], int]] = f
+
+reveal_type(C().g)  # N: Revealed type is "Union[def () -> builtins.int, builtins.int]"


### PR DESCRIPTION
Currently we only bind self if the type is callable, but we actually should do this for all callable items in a union.

This use case is probably quite niche (since adding an annotation makes a variable an instance variable, and we rarely infer unions). I found it when looking at `checkmember`-related issues it was easy to handle it. I also use this opportunity to refactor and add comments to `analyze_var()`.