### PR TITLE
Use checkmember.py to check multiple inheritance

### DIFF
--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -990,7 +990,6 @@ class Mixin:
 class C(Mixin, A):
     pass
 [builtins fixtures/property.pyi]
-[out]
 
 [case testMixinSubtypedProperty]
 class X:
@@ -1006,7 +1005,6 @@ class Mixin:
 class C(Mixin, A):
     pass
 [builtins fixtures/property.pyi]
-[out]
 
 [case testMixinTypedPropertyReversed]
 class A:
@@ -1015,10 +1013,9 @@ class A:
         return "no"
 class Mixin:
     foo = "foo"
-class C(A, Mixin): # E: Definition of "foo" in base class "A" is incompatible with definition in base class "Mixin"
+class C(A, Mixin): # E: Cannot override writeable attribute "foo" in base "Mixin" with read-only property in base "A"
     pass
 [builtins fixtures/property.pyi]
-[out]
 
 -- Special cases
 -- -------------

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1836,6 +1836,7 @@ class B:
 class AB(A, B):
     pass
 [builtins fixtures/plugin_attrs.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testAttrsForwardReferenceInTypeVarBound]
 from typing import TypeVar, Generic


### PR DESCRIPTION
This is the third "major" PR towards https://github.com/python/mypy/issues/7724

This one is mostly straightforward. I tried to preserve the existing logic about mutable overrides (to minimize fallout), as currently we e.g. don't use the covariant mutable override error code here. In future we can separately "synchronize" mutable override logic across variable override, method override, and multiple inheritance code paths (as currently all three are subtly different).