### PR TITLE
Fix missing error when redeclaring type variable in nested generic class

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -354,6 +354,10 @@ TYPE_VAR_GENERIC_CONSTRAINT_TYPE: Final = ErrorMessage(
     "TypeVar constraint type cannot be parametrized by type variables", codes.MISC
 )
 
+TYPE_VAR_REDECLARED_IN_NESTED_CLASS: Final = ErrorMessage(
+    'Type variable "{}" is bound by an outer class', codes.VALID_TYPE
+)
+
 TYPE_ALIAS_WITH_YIELD_EXPRESSION: Final = ErrorMessage(
     "Yield expression cannot be used within a type alias", codes.SYNTAX
 )

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2387,6 +2387,14 @@ class SemanticAnalyzer(
             tvar_expr.default = tvar_expr.default.accept(
                 TypeVarDefaultTranslator(self, tvar_expr.name, context)
             )
+            # PEP-695 type variables that are redeclared in an inner scope are warned
+            # about elsewhere.
+            if not tvar_expr.is_new_style and not self.tvar_scope.allow_binding(
+                tvar_expr.fullname
+            ):
+                self.fail(
+                    message_registry.TYPE_VAR_REDECLARED_IN_NESTED_CLASS.format(name), context
+                )
             tvar_def = self.tvar_scope.bind_new(name, tvar_expr)
             if last_tvar_name_with_default is not None and not tvar_def.has_default():
                 self.msg.tvar_without_default_type(

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1869,11 +1869,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         defs = []
         for name, tvar in typevars:
             if not self.tvar_scope.allow_binding(tvar.fullname):
-                self.fail(
-                    f'Type variable "{name}" is bound by an outer class',
-                    defn,
-                    code=codes.VALID_TYPE,
-                )
+                self.fail(message_registry.TYPE_VAR_REDECLARED_IN_NESTED_CLASS.format(name), defn)
             binding = self.tvar_scope.bind_new(name, tvar)
             defs.append(binding)
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1015,6 +1015,12 @@ class A(Generic[T]):
           # E: Free type variable expected in Generic[...]
 [out]
 
+[case testRedeclaredTypeVarWithinNestedGenericClass]
+from typing import Generic, Iterable, TypeVar
+T = TypeVar('T')
+class A(Generic[T]):
+    class B(Iterable[T]): pass  # E: Type variable "T" is bound by an outer class
+
 [case testIncludingGenericTwiceInBaseClassList]
 from typing import Generic, TypeVar
 T = TypeVar('T')


### PR DESCRIPTION
Closes #10479

Fixes a case where mypy doesn't warn about an inner generic class using a type variable by the same name as an outer generic class if the inner generic class doesn't declare the type variable using `Generic`, `Protocol`, or PEP-695 syntax.