### PR TITLE
Clarified strict documentation

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -754,6 +754,9 @@ of the above sections.
     strict will catch type errors as long as intentional methods like type ignore
     or casting were not used.)
 
+    Note: the --warn-unreachable flag documented in :option:`--warn-unreadhable`
+    is not automatically enabled by the strict flag.
+
     If both strict and strict-included flags are set, strict does not take precedence
     nor override corresponding flags. You can see the list of flags enabled by strict
     mode in the full :option:`mypy --help` output.

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -749,12 +749,18 @@ of the above sections.
 
 .. option:: --strict
 
-    This flag mode enables all optional error checking flags.  You can see the
-    list of flags enabled by strict mode in the full :option:`mypy --help` output.
+    This flag mode enables a defined subset of optional error-checking flags. 
+    This subset primarily includes checks for inadvertent type unsoundness (i.e 
+    strict will catch type errors as long as intentional methods like type ignore
+    or casting were not used.)
 
-    Note: the exact list of flags enabled by running :option:`--strict` may change
+    If both strict and strict-included flags are set, strict does not take precedence
+    nor override corresponding flags. You can see the list of flags enabled by strict 
+    mode in the full :option:`mypy --help` output.
+
+    Note: the exact list of flags enabled by running :option:`--strict` may change 
     over time.
-
+   
 .. option:: --disable-error-code
 
     This flag allows disabling one or multiple error codes globally.

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -754,7 +754,7 @@ of the above sections.
     strict will catch type errors as long as intentional methods like type ignore
     or casting were not used.)
 
-    Note: the --warn-unreachable flag documented in :option:`--warn-unreadhable`
+    Note: the --warn-unreachable flag documented in :option:`--warn-unreachable`
     is not automatically enabled by the strict flag.
 
     If both strict and strict-included flags are set, strict does not take precedence

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -754,7 +754,7 @@ of the above sections.
     strict will catch type errors as long as intentional methods like type ignore
     or casting were not used.)
 
-    Note: the --warn-unreachable flag documented in :option:`--warn-unreachable`
+    Note: the :option:`--warn-unreachable` flag
     is not automatically enabled by the strict flag.
 
     If both strict and strict-included flags are set, strict does not take precedence

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -757,9 +757,11 @@ of the above sections.
     Note: the :option:`--warn-unreachable` flag
     is not automatically enabled by the strict flag.
 
-    If both strict and strict-included flags are set, strict does not take precedence
-    nor override corresponding flags. You can see the list of flags enabled by strict
-    mode in the full :option:`mypy --help` output.
+    The strict flag does not take precedence over other strict-related flags. 
+    Directly specifying a flag of alternate behavior will override the 
+    behavior of strict, regardless of the order in which they are passed.
+    You can see the list of flags enabled by strict mode in the full
+    :option:`mypy --help` output.
 
     Note: the exact list of flags enabled by running :option:`--strict` may change
     over time.

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -757,8 +757,8 @@ of the above sections.
     Note: the :option:`--warn-unreachable` flag
     is not automatically enabled by the strict flag.
 
-    The strict flag does not take precedence over other strict-related flags. 
-    Directly specifying a flag of alternate behavior will override the 
+    The strict flag does not take precedence over other strict-related flags.
+    Directly specifying a flag of alternate behavior will override the
     behavior of strict, regardless of the order in which they are passed.
     You can see the list of flags enabled by strict mode in the full
     :option:`mypy --help` output.

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -749,18 +749,18 @@ of the above sections.
 
 .. option:: --strict
 
-    This flag mode enables a defined subset of optional error-checking flags. 
-    This subset primarily includes checks for inadvertent type unsoundness (i.e 
+    This flag mode enables a defined subset of optional error-checking flags.
+    This subset primarily includes checks for inadvertent type unsoundness (i.e
     strict will catch type errors as long as intentional methods like type ignore
     or casting were not used.)
 
     If both strict and strict-included flags are set, strict does not take precedence
-    nor override corresponding flags. You can see the list of flags enabled by strict 
+    nor override corresponding flags. You can see the list of flags enabled by strict
     mode in the full :option:`mypy --help` output.
 
-    Note: the exact list of flags enabled by running :option:`--strict` may change 
+    Note: the exact list of flags enabled by running :option:`--strict` may change
     over time.
-   
+
 .. option:: --disable-error-code
 
     This flag allows disabling one or multiple error codes globally.


### PR DESCRIPTION
Fixes #18760

This documentation change basically clarifies strict's behavior as described in the issue, adding precedence of the strict flag with respect to other error-checking flags