### PR TITLE
Traverse module ancestors when traversing reachable graph nodes during dmypy update

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -620,6 +620,9 @@ class Server:
         t1 = time.time()
         manager.log(f"fine-grained increment: find_changed: {t1 - t0:.3f}s")
 
+        # Track all modules encountered so far. New entries for all dependencies
+        # are added below by other module finding methods below. All dependencies
+        # in graph but not in `seen` are considered deleted at the end of this method.
         seen = {source.module for source in sources}
 
         # Find changed modules reachable from roots (or in roots) already in graph.
@@ -736,7 +739,9 @@ class Server:
         Args:
             roots: modules where to start search from
             graph: module graph to use for the search
-            seen: modules we've seen before that won't be visited (mutated here!!)
+            seen: modules we've seen before that won't be visited (mutated here!!).
+                  Needed to accumulate all modules encountered during update and remove
+                  everything that no longer exists.
             changed_paths: which paths have changed (stop search here and return any found)
 
         Return (encountered reachable changed modules,
@@ -776,7 +781,9 @@ class Server:
         """Find suppressed modules that have been added (and not included in seen).
 
         Args:
-            seen: reachable modules we've seen before (mutated here!!)
+            seen: reachable modules we've seen before (mutated here!!).
+                  Needed to accumulate all modules encountered during update and remove
+                  everything that no longer exists.
 
         Return suppressed, added modules.
         """

--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -756,7 +756,8 @@ class Server:
                 changed.append((nxt.module, nxt.path))
             elif nxt.module in graph:
                 state = graph[nxt.module]
-                for dep in state.dependencies:
+                ancestors = state.ancestors or []
+                for dep in state.dependencies + ancestors:
                     if dep not in seen:
                         seen.add(dep)
                         worklist.append(BuildSource(graph[dep].path, graph[dep].id, followed=True))

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -647,3 +647,21 @@ b: str
 from demo.test import a
 [file demo/test.py]
 a: int
+
+[case testDaemonImportAncestors]
+$ dmypy run test.py
+Daemon started
+test.py:2: error: Unsupported operand types for + ("int" and "str")  [operator]
+Found 1 error in 1 file (checked 1 source file)
+== Return code: 1
+$ dmypy run test.py
+test.py:2: error: Unsupported operand types for + ("int" and "str")  [operator]
+Found 1 error in 1 file (checked 1 source file)
+== Return code: 1
+$ dmypy run test.py
+test.py:2: error: Unsupported operand types for + ("int" and "str")  [operator]
+Found 1 error in 1 file (checked 1 source file)
+== Return code: 1
+[file test.py]
+from xml.etree.ElementTree import Element
+1 + 'a'


### PR DESCRIPTION
Fixes #18396. Fixes #17652. Hopefully fixes #15486 (but not enough info to reproduce the original problem).

See discussion in #18396. This PR forces collecting all ancestors of all modules during dep graph traversal in incremental update. 

Ancestors are included in `load_graph`, which means not traversing them during update results in some modules being erroneously treated as deleted:

https://github.com/python/mypy/blob/a4e79ea19506948fd43bf5c14bbf8e2a0ad7158a/mypy/build.py#L3141-L3146