### PR TITLE
Fix incremental issue with namespace packages (option 2)

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -404,9 +404,6 @@ class SemanticAnalyzer(
     cur_mod_id = ""  # Current module id (or None) (phase 2)
     _is_stub_file = False  # Are we analyzing a stub file?
     _is_typeshed_stub_file = False  # Are we analyzing a typeshed stub file?
-    imports: set[str]  # Imported modules (during phase 2 analysis)
-    # Note: some imports (and therefore dependencies) might
-    # not be found in phase 1, for example due to * imports.
     errors: Errors  # Keeps track of generated errors
     plugin: Plugin  # Mypy plugin for special casing of library features
     statement: Statement | None = None  # Statement/definition being analyzed
@@ -445,7 +442,6 @@ class SemanticAnalyzer(
         self.saved_locals: dict[
             FuncItem | GeneratorExpr | DictionaryComprehension, SymbolTable
         ] = {}
-        self.imports = set()
         self._type = None
         self.type_stack = []
         # Are the namespaces of classes being processed complete?
@@ -3114,9 +3110,6 @@ class SemanticAnalyzer(
                 # if '__all__' exists, all nodes not included have had module_public set to
                 # False, and we can skip checking '_' because it's been explicitly included.
                 if node.module_public and (not name.startswith("_") or "__all__" in m.names):
-                    if isinstance(node.node, MypyFile):
-                        # Star import of submodule from a package, add it as a dependency.
-                        self.imports.add(node.node.fullname)
                     # `from x import *` always reexports symbols
                     self.add_imported_symbol(
                         name, node, context=i, module_public=True, module_hidden=False

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -405,11 +405,6 @@ def semantic_analyze_target(
         )
         if isinstance(node, Decorator):
             infer_decorator_signature_if_simple(node, analyzer)
-    for dep in analyzer.imports:
-        state.add_dependency(dep)
-        priority = mypy.build.PRI_LOW
-        if priority <= state.priorities.get(dep, priority):
-            state.priorities[dep] = priority
 
     # Clear out some stale data to avoid memory leaks and astmerge
     # validity check confusion


### PR DESCRIPTION
Fixes #12664

See #18907 which is another possible fix

I'm not sure why this logic is actually needed given that we should record the dependency from import analysis in fastparse... maybe just because it adjusts priority?

Relevant history:
- https://github.com/python/mypy/pull/6582
- https://github.com/python/mypy/pull/6179

I can't write a good test for this because it requires something in site_packages, but here's a minimal repro:
```
set -eux
rm -rf repro
mkdir repro
cd repro

SITEPACK=env/site-packages
mkdir -p $SITEPACK

mkdir $SITEPACK/ruamel
mkdir $SITEPACK/ruamel/yaml

printf 'from ruamel.yaml.main import *' > $SITEPACK/ruamel/yaml/__init__.py
printf 'import ruamel.yaml' > $SITEPACK/ruamel/yaml/main.py
printf '' > $SITEPACK/ruamel/yaml/py.typed

printf 'import ruamel.yaml' > a.py
printf 'import a' > main.py

rm -rf .mypy_cache
PYTHONPATH=$SITEPACK mypy main.py
PYTHONPATH=$SITEPACK mypy main.py
```