### PR TITLE
Docs: added information about deprecated pep 563

### DIFF
--- a/docs/source/runtime_troubles.rst
+++ b/docs/source/runtime_troubles.rst
@@ -11,7 +11,6 @@ three tools at our disposal:
 * Use of string literal types or type comments
 * Use of ``typing.TYPE_CHECKING``
 * Use of ``from __future__ import annotations`` (:pep:`563`)
-  (This directive has been declared deprecated since Python 3.14, and is expected to be removed in a future version of Python)
 
 We provide a description of these before moving onto discussion of specific
 problems you may encounter.

--- a/docs/source/runtime_troubles.rst
+++ b/docs/source/runtime_troubles.rst
@@ -8,10 +8,10 @@ version of Python considers legal code. This section describes these scenarios
 and explains how to get your code running again. Generally speaking, we have
 three tools at our disposal:
 
-* Use of ``from __future__ import annotations`` (:pep:`563`)
-  (this behaviour may eventually be made the default in a future Python version)
 * Use of string literal types or type comments
 * Use of ``typing.TYPE_CHECKING``
+* Use of ``from __future__ import annotations`` (:pep:`563`)
+  (This directive has been declared deprecated since Python 3.14, and is expected to be removed in a future version of Python)
 
 We provide a description of these before moving onto discussion of specific
 problems you may encounter.


### PR DESCRIPTION
Replaced a comment in the documentation that the behavior described in pep 563 might be the default behavior with actual information about what will be declared deprecated in python 3.14