### PR TITLE
New setting "user_builtins_name": Ignore specific "name-defined" errors

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -817,6 +817,15 @@ section of the command line docs.
    Note: the exact list of flags enabled by :confval:`strict` may
    change over time.
 
+.. confval:: user_builtins_name
+
+   :type: comma-separated list of strings
+
+    Disable name-defined error checking for the given values.
+
+    Note: This setting should be used *only* if new values have beed defined
+    into the ``builtins`` module.
+
 
 Configuring error messages
 **************************

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -193,6 +193,7 @@ ini_config_types: Final[dict[str, _INI_PARSER_CALLABLE]] = {
     "exclude": lambda s: [s.strip()],
     "packages": try_split,
     "modules": try_split,
+    "user_builtins_name": try_split,
 }
 
 # Reuse the ini_config_types and overwrite the diff
@@ -215,6 +216,7 @@ toml_config_types.update(
         "exclude": str_or_array_as_list,
         "packages": try_split,
         "modules": try_split,
+        "user_builtins_name": try_split,
     }
 )
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1283,6 +1283,13 @@ def process_options(
         group=code_group,
     )
     code_group.add_argument(
+        "--user-builtins-name",
+        action="append",
+        metavar="NAME",
+        default=[],
+        help="List of name to ignore; can repeat for more names",
+    )
+    code_group.add_argument(
         "-m",
         "--module",
         action="append",

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -55,6 +55,7 @@ PER_MODULE_OPTIONS: Final = {
     "strict_concatenate",
     "strict_equality",
     "strict_optional",
+    "user_builtins_name",
     "warn_no_return",
     "warn_return_any",
     "warn_unreachable",
@@ -138,6 +139,8 @@ class Options:
         # File names, directory names or subpaths to avoid checking
         self.exclude: list[str] = []
         self.exclude_gitignore: bool = False
+        # User defined builtins names to skip name-defined checking
+        self.user_builtins_name: list[str] = []
 
         # disallow_any options
         self.disallow_any_generics = False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6340,6 +6340,9 @@ class SemanticAnalyzer(
                     return None
                 node = table[name]
                 return node
+        # 6. User Defined Builtins
+        if name in self.options.user_builtins_name:
+            return None
         # Give up.
         if not implicit_name and not suppress_errors:
             self.name_not_defined(name, ctx)

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1507,3 +1507,16 @@ def bad_kwargs(**kwargs: Unpack[TVariadic]):  # E: Unpack item in ** argument mu
     pass
 
 [builtins fixtures/dict.pyi]
+
+[case testUserBuiltinsName]
+# flags: --user-builtins-name foo
+foo()
+egg()
+[out]
+main:3: error: Name "egg" is not defined
+
+[case testUserBuiltinsNameMultiple]
+# flags: --user-builtins-name foo --user-builtins-name egg
+foo()
+egg()
+[out]


### PR DESCRIPTION
Fixes #18932

Adding a new setting "user_builtins_name" that allow to ignore specific "name-defined" errors.

This setting should be used *only* if new values have beed defined into the ``builtins`` module.

Example of user builtins name:
```
builtins.__dict__['prints'] = prints = PrefixedPrint()
```
The function `prints` can be used anywhere in the project without need to write the import. However, in such case mypy raise a error "name-defined", even if the code is valid. This PR allow to not raise this error. The setting can be defined per modules.