### PR TITLE
[mypyc] Fix spilling values with overlapping error values

### DIFF
--- a/mypyc/test-data/run-async.test
+++ b/mypyc/test-data/run-async.test
@@ -455,3 +455,96 @@ def test_stolen() -> None:
 [file asyncio/__init__.pyi]
 def run(x: object) -> object: ...
 async def sleep(t: float) -> None: ...
+
+[case testRunAsyncMiscTypesInEnvironment]
+import asyncio
+
+from mypy_extensions import i64, i32, i16, u8
+
+async def inc_float(x: float) -> float:
+    return x + 1.0
+
+async def inc_i64(x: i64) -> i64:
+    return x + 1
+
+async def inc_i32(x: i32) -> i32:
+    return x + 1
+
+async def inc_i16(x: i16) -> i16:
+    return x + 1
+
+async def inc_u8(x: u8) -> u8:
+    return x + 1
+
+async def inc_tuple(x: tuple[i64, float]) -> tuple[i64, float]:
+    return x[0] + 1, x[1] + 1.5
+
+async def neg_bool(b: bool) -> bool:
+    return not b
+
+async def float_ops(x: float) -> float:
+    n = x
+    n = await inc_float(n)
+    n = float("0.5") + await inc_float(n)
+    return n
+
+def test_float() -> None:
+    assert asyncio.run(float_ops(2.5)) == 5.0
+
+async def i64_ops(x: i64) -> i64:
+    n = x
+    n = await inc_i64(n)
+    n = i64("1") + await inc_i64(n)
+    return n
+
+def test_i64() -> None:
+    assert asyncio.run(i64_ops(2)) == 5
+
+async def i32_ops(x: i32) -> i32:
+    n = x
+    n = await inc_i32(n)
+    n = i32("1") + await inc_i32(n)
+    return n
+
+def test_i32() -> None:
+    assert asyncio.run(i32_ops(3)) == 6
+
+async def i16_ops(x: i16) -> i16:
+    n = x
+    n = await inc_i16(n)
+    n = i16("1") + await inc_i16(n)
+    return n
+
+def test_i16() -> None:
+    assert asyncio.run(i16_ops(4)) == 7
+
+async def u8_ops(x: u8) -> u8:
+    n = x
+    n = await inc_u8(n)
+    n = u8("1") + await inc_u8(n)
+    return n
+
+def test_u8() -> None:
+    assert asyncio.run(u8_ops(5)) == 8
+
+async def tuple_ops(x: tuple[i64, float]) -> tuple[i64, float]:
+    n = x
+    n = await inc_tuple(n)
+    m = ((i64("1"), float("0.5")), await inc_tuple(n))
+    return m[1]
+
+def test_tuple() -> None:
+    assert asyncio.run(tuple_ops((1, 2.5))) == (3, 5.5)
+
+async def bool_ops(x: bool) -> bool:
+    n = x
+    n = await neg_bool(n)
+    m = (bool("1"), await neg_bool(n))
+    return m[0] and m[1]
+
+def test_bool() -> None:
+    assert asyncio.run(bool_ops(True)) is True
+    assert asyncio.run(bool_ops(False)) is False
+
+[file asyncio/__init__.pyi]
+def run(x: object) -> object: ...

--- a/mypyc/transform/spill.py
+++ b/mypyc/transform/spill.py
@@ -45,6 +45,10 @@ def spill_regs(
     for i, val in enumerate(to_spill):
         name = f"{TEMP_ATTR_NAME}2_{i}"
         env.attributes[name] = val.type
+        if val.type.error_overlap:
+            # We can safely treat as always initialized, since the type has no pointers.
+            # This way we also don't need to manage the defined attribute bitfield.
+            env._always_initialized_attrs.add(name)
         spill_locs[val] = name
 
     for block in blocks:


### PR DESCRIPTION
Update spilling transform for async and generator functions to not require a defined attribute bitfield. We now treat temporary spilled values with overlapping error values as always defined. I'm not sure if this would be safe to do for reference counted values, so we only do this in cases where it's clearly fine.