### PR TITLE
Check superclass compatibility of untyped methods if `--check-untyped-defs` is set

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5285,7 +5285,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         # For overloaded functions/properties we already checked override for overload as a whole.
         if allow_empty or skip_first_item:
             return
-        if e.func.info and not e.func.is_dynamic() and not e.is_overload:
+        if e.func.info and not e.is_overload:
             found_method_base_classes = self.check_method_override(e)
             if (
                 e.func.is_explicit_override

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -750,6 +750,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 defn.is_explicit_override
                 and not found_method_base_classes
                 and found_method_base_classes is not None
+                # If the class has Any fallback, we can't be certain that a method
+                # is really missing - it might come from unfollowed import.
+                and not defn.info.fallback_to_any
             ):
                 self.msg.no_overridable_method(defn.name, defn)
             self.check_explicit_override_decorator(defn, found_method_base_classes, defn.impl)
@@ -5291,6 +5294,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 e.func.is_explicit_override
                 and not found_method_base_classes
                 and found_method_base_classes is not None
+                # If the class has Any fallback, we can't be certain that a method
+                # is really missing - it might come from unfollowed import.
+                and not e.func.info.fallback_to_any
             ):
                 self.msg.no_overridable_method(e.func.name, e.func)
             self.check_explicit_override_decorator(e.func, found_method_base_classes)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -6651,7 +6651,51 @@ from typing import TypeVar, Tuple, Callable
 T = TypeVar('T')
 def deco(f: Callable[..., T]) -> Callable[..., Tuple[T, int]]: ...
 [builtins fixtures/tuple.pyi]
-[out]
+
+[case testOverrideWithUntypedNotChecked]
+class Parent:
+    def foo(self, x):
+        ...
+    def bar(self, x):
+        ...
+    def baz(self, x: int) -> str:
+        return ""
+
+class Child(Parent):
+    def foo(self, y):  # OK: names not checked
+        ...
+    def bar(self, x, y):
+        ...
+    def baz(self, x, y):
+        return ""
+[builtins fixtures/tuple.pyi]
+
+[case testOverrideWithUntypedCheckedWithCheckUntypedDefs]
+# flags: --check-untyped-defs
+class Parent:
+    def foo(self, x):
+        ...
+    def bar(self, x):
+        ...
+    def baz(self, x: int) -> str:
+        return ""
+
+class Child(Parent):
+    def foo(self, y):  # OK: names not checked
+        ...
+    def bar(self, x, y) -> None:  # E: Signature of "bar" incompatible with supertype "Parent" \
+                                  # N:      Superclass: \
+                                  # N:          def bar(self, x: Any) -> Any \
+                                  # N:      Subclass: \
+                                  # N:          def bar(self, x: Any, y: Any) -> None
+        ...
+    def baz(self, x, y):  # E: Signature of "baz" incompatible with supertype "Parent" \
+                          # N:      Superclass: \
+                          # N:          def baz(self, x: int) -> str \
+                          # N:      Subclass: \
+                          # N:          def baz(self, x: Any, y: Any) -> Any
+        return ""
+[builtins fixtures/tuple.pyi]
 
 [case testOptionalDescriptorsBinder]
 from typing import Type, TypeVar, Optional

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3294,6 +3294,28 @@ class Parent: pass
 class Child(Parent):
     @override
     def foo(self, y): pass  # E: Method "foo" is marked as an override, but no base method was found with this name
+
+[typing fixtures/typing-override.pyi]
+
+[case testOverrideOnUnknownBaseClass]
+# flags: --python-version 3.12
+from typing import overload, override
+
+from unknown import UnknownParent  # type: ignore[import-not-found]
+
+class UnknownChild(UnknownParent):
+    @override
+    def foo(self, y): pass  # OK
+    @override
+    def bar(self, y: str) -> None: pass  # OK
+
+    @override
+    @overload
+    def baz(self, y: str) -> None: ...
+    @override
+    @overload
+    def baz(self, y: int) -> None: ...
+    def baz(self, y: str | int) -> None: ...
 [typing fixtures/typing-override.pyi]
 
 [case testCallableProperty]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3285,6 +3285,17 @@ class C(B):
     def __f(self, y: int) -> str: pass  # OK
 [typing fixtures/typing-override.pyi]
 
+[case testOverrideUntypedDef]
+# flags: --python-version 3.12
+from typing import override
+
+class Parent: pass
+
+class Child(Parent):
+    @override
+    def foo(self, y): pass  # E: Method "foo" is marked as an override, but no base method was found with this name
+[typing fixtures/typing-override.pyi]
+
 [case testCallableProperty]
 from typing import Callable
 


### PR DESCRIPTION
This PR enables superclass compatibility checks for untyped methods when `--check-untyped-defs` is set. IMO this behavior is correct as `--check-untyped-defs` is essentially "treat everything as if there were `: Any` annotations on all arguments", hence checking arg count and names is sound.

This PR, however, allows `@override` on classes that have Any fallback as those are often coming from unfollowed imports. This PR started as an attempt to reject `@override` on untyped defs not found in superclass, but I think it's better to just run all compatibility checks if the flag is enabled.