### PR TITLE
Add missing branch for `is_subtype(TypeType, Overload)`

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1091,7 +1091,12 @@ class SubtypeVisitor(TypeVisitor[bool]):
         right = self.right
         if isinstance(right, TypeType):
             return self._is_subtype(left.item, right.item)
-        if isinstance(right, CallableType):
+        if isinstance(right, (Overloaded, CallableType)):
+            if isinstance(right, Overloaded) and right.is_type_obj():
+                # Same as in other direction: if it's a constructor callable, all
+                # items should belong to the same class' constructor, so it's enough
+                # to check one of them.
+                right = right.items[0]
             if self.proper_subtype and not right.is_type_obj():
                 # We can't accept `Type[X]` as a *proper* subtype of Callable[P, X]
                 # since this will break transitivity of subtyping.

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -1091,12 +1091,12 @@ class SubtypeVisitor(TypeVisitor[bool]):
         right = self.right
         if isinstance(right, TypeType):
             return self._is_subtype(left.item, right.item)
-        if isinstance(right, (Overloaded, CallableType)):
-            if isinstance(right, Overloaded) and right.is_type_obj():
-                # Same as in other direction: if it's a constructor callable, all
-                # items should belong to the same class' constructor, so it's enough
-                # to check one of them.
-                right = right.items[0]
+        if isinstance(right, Overloaded) and right.is_type_obj():
+            # Same as in other direction: if it's a constructor callable, all
+            # items should belong to the same class' constructor, so it's enough
+            # to check one of them.
+            return self._is_subtype(left, right.items[0])
+        if isinstance(right, CallableType):
             if self.proper_subtype and not right.is_type_obj():
                 # We can't accept `Type[X]` as a *proper* subtype of Callable[P, X]
                 # since this will break transitivity of subtyping.

--- a/test-data/unit/check-assert-type-fail.test
+++ b/test-data/unit/check-assert-type-fail.test
@@ -31,3 +31,19 @@ def f(si: arr.array[int]):
 from typing import assert_type, Callable
 def myfunc(arg: int) -> None: pass
 assert_type(myfunc, Callable[[int], None])  # E: Expression is of type "Callable[[Arg(int, 'arg')], None]", not "Callable[[int], None]"
+
+[case testAssertTypeOverload]
+from typing import assert_type, overload
+
+class Foo:
+    @overload
+    def __new__(cls, x: int) -> Foo: ...
+    @overload
+    def __new__(cls, x: str) -> Foo: ...
+    def __new__(cls, x: "int | str") -> Foo:
+        return cls(0)
+
+assert_type(Foo, type[Foo])
+A = Foo
+assert_type(A, type[Foo])
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #18974. This simply adds a missed branch - we do support `is_subtype(Overload, TypeType)` but not another type order.