### PR TITLE
Local forward refs should precede global forward refs

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6382,6 +6382,8 @@ class SemanticAnalyzer(
             if node.name not in self.globals:
                 return True
             global_node = self.globals[node.name]
+            if not self.is_textually_before_class(global_node.node):
+                return True
             return not self.is_type_like(global_node.node)
         return False
 
@@ -6408,6 +6410,13 @@ class SemanticAnalyzer(
             return line_diff > len(node.original_decorators)
         else:
             return line_diff > 0
+
+    def is_textually_before_class(self, node: SymbolNode | None) -> bool:
+        """Similar to above, but check if a node is defined before current class."""
+        assert self.type is not None
+        if node is None:
+            return False
+        return node.line < self.type.defn.line
 
     def is_overloaded_item(self, node: SymbolNode, statement: Statement) -> bool:
         """Check whether the function belongs to the overloaded variants"""

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2004,15 +2004,18 @@ reveal_type(x.related_resources)  # N: Revealed type is "__main__.ResourceRule"
 
 [case testPEP695TypeAliasRecursiveOuterClass]
 class A:
-    type X = X
+    type X = X  # E: Cannot resolve name "X" (possible cyclic definition)
 class X: ...
+
+class AA:
+    XX = XX  # OK, we allow this as a special case.
+class XX: ...
 
 class Y: ...
 class B:
     type Y = Y
 
-x: A.X
-reveal_type(x)  # N: Revealed type is "__main__.X"
+reveal_type(AA.XX)  # N: Revealed type is "def () -> __main__.XX"
 y: B.Y
 reveal_type(y)  # N: Revealed type is "__main__.Y"
 [builtins fixtures/tuple.pyi]
@@ -2042,3 +2045,17 @@ tuple[*tuple[int, ...], *tuple[int, ...]]  # E: More than one Unpack in a type i
 b: tuple[*tuple[int, ...], *tuple[int, ...]]  # E: More than one Unpack in a type is not allowed
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testForwardNestedPrecedesForwardGlobal]
+from typing import NewType
+
+class W[T]: pass
+
+class R:
+    class M(W[Action.V], type):
+        FOO = R.Action.V(0)
+    class Action(metaclass=M):
+        V = NewType('V', int)
+
+class Action:
+    pass


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/18988

This should be a minimal change to restore backwards compatibility for an edge case with forward references.
