### PR TITLE
extended error messages for unnarrowed unions

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -540,6 +540,13 @@ class MessageBuilder:
                     context,
                     code=codes.UNION_ATTR,
                 )
+
+                self.note(
+                    "Use \"if <variableName> is not None\" to ensure you have no 'None' values",
+                    context,
+                    code=codes.UNION_ATTR,
+                )
+
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):
                 bound = get_proper_type(original_type.upper_bound)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3646,7 +3646,7 @@ def process(cls: Type[Union[BasicUser, ProUser]]):
     obj = cls()
     cls.bar(obj)
     cls.mro()  # Defined in class type
-    cls.error  # E: Item "type" of "Union[Type[BasicUser], Type[ProUser]]" has no attribute "error"
+    cls.error  # E: Item "type" of "Union[Type[BasicUser], Type[ProUser]]" has no attribute "error", try using "if <variableName> is not \'None' to avoid this error
 [builtins fixtures/classmethod.pyi]
 [out]
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -357,7 +357,7 @@ class A:
 class B:
     y: str
 a: Union[A, B]
-a.x  # E: Item "B" of "Union[A, B]" has no attribute "x"  [union-attr]
+a.x  # E: Item "B" of "Union[A, B]" has no attribute "x", use "if <variableName> not \'None' to avoid this issue  [union-attr]
 
 [case testErrorCodeFunctionHasNoAnnotation]
 # flags: --disallow-untyped-defs

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -818,7 +818,7 @@ if not isinstance(s, str):
 
 z = None # type: TNode # Same as TNode[Any]
 z.x
-z.foo() # E: Item "Node[int]" of "Union[Any, Node[int]]" has no attribute "foo"
+z.foo() # E: Item "Node[int]" of "Union[Any, Node[int]]" has no attribute "foo," use "if <variableName> not \'None' to prevent this issue
 
 [builtins fixtures/isinstance.pyi]
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2864,7 +2864,7 @@ class C:
     a = None  # E: Need type annotation for "a" (hint: "a: Optional[<type>] = ...")
 
     def f(self, x) -> None:
-        C.a.y  # E: Item "None" of "Optional[Any]" has no attribute "y"
+        C.a.y  # E: Item "None" of "Optional[Any]" has no attribute "y," use if <variable_name> is not None to prevent this issue
 
 [case testLocalPartialTypesAccessPartialNoneAttribute2]
 # flags: --local-partial-types

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -578,7 +578,7 @@ v = A() # type: Union[A, B, C]
 
 if isinstance(v, (B, C)):
     v.method2(123)
-    v.method3('xyz') # E: Item "B" of "Union[B, C]" has no attribute "method3"
+    v.method3('xyz') # E: Item "B" of "Union[B, C]" has no attribute "method3," use if <variable_name> is not None to prevent this issue
 [builtins fixtures/isinstance.pyi]
 
 [case testIsinstanceNeverWidens]
@@ -1007,7 +1007,7 @@ def bar() -> None:
           if isinstance(x, int):
              x + 1
           else:
-             x.a     # E: Item "str" of "Union[str, A]" has no attribute "a"
+             x.a     # E: Item "str" of "Union[str, A]" has no attribute "a," use if <variable_name> is not None to prevent this issue
           x = 'a'
 [builtins fixtures/isinstancelist.pyi]
 
@@ -2138,7 +2138,7 @@ reveal_type(x)  # N: Revealed type is "Any"
 from typing import Union
 from foo import A  # type: ignore
 def f(x: Union[A, str]) -> None:
-    x.method_only_in_a()  # E: Item "str" of "Union[Any, str]" has no attribute "method_only_in_a"
+    x.method_only_in_a()  # E: Item "str" of "Union[Any, str]" has no attribute "method_only_in_a," use if <variable_name> is not None to prevent this issue
     if isinstance(x, A):
         x.method_only_in_a()
 [builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -417,7 +417,7 @@ else:
     reveal_type(ok_mixture)             # N: Revealed type is "Tuple[Literal[__main__.Key.C], fallback=__main__.KeyedNamedTuple]"
 
 impossible_mixture: Union[KeyedObject, KeyedTypedDict]
-if impossible_mixture.key is Key.A:     # E: Item "KeyedTypedDict" of "Union[KeyedObject, KeyedTypedDict]" has no attribute "key"
+if impossible_mixture.key is Key.A:     # E: Item "KeyedTypedDict" of "Union[KeyedObject, KeyedTypedDict]" has no attribute "key," use if <variable_name> is not None to prevent this issue
     reveal_type(impossible_mixture)     # N: Revealed type is "Union[__main__.KeyedObject, TypedDict('__main__.KeyedTypedDict', {'key': Literal[__main__.Key.B]})]"
 else:
     reveal_type(impossible_mixture)     # N: Revealed type is "Union[__main__.KeyedObject, TypedDict('__main__.KeyedTypedDict', {'key': Literal[__main__.Key.B]})]"

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -567,7 +567,7 @@ if int():
 if int():
     x = f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 
-x.x = 1 # E: Item "None" of "Optional[Node[int]]" has no attribute "x"
+x.x = 1 # E: Item "None" of "Optional[Node[int]]" has no attribute "x," use if <variable_name> is not None to prevent this issue
 if x is not None:
     x.x = 1 # OK here
 
@@ -620,7 +620,7 @@ A = None  # type: Any
 class C(A):
     pass
 x = None  # type: Optional[C]
-x.foo()  # E: Item "None" of "Optional[C]" has no attribute "foo"
+x.foo()  # E: Item "None" of "Optional[C]" has no attribute "foo," use if <variable_name> is not None to prevent this issue
 
 [case testIsinstanceAndOptionalAndAnyBase]
 from typing import Any, Optional

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -5166,7 +5166,7 @@ def foo() -> None: ...
 def foo(iterable: Iterable[_T]) -> None: ...
 def foo(iterable = None) -> None: pass
 
-foo(bar('lol').foo())  # E: Item "int" of "Union[A, int]" has no attribute "foo" \
+foo(bar('lol').foo())  # E: Item "int" of "Union[A, int]" has no attribute "foo," use if <variable_name> is not None to prevent this issue \
                        # E: Argument 1 to "bar" has incompatible type "str"; expected "int"
 
 

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -64,9 +64,9 @@ z: str
 
 if int():
     y = w.y
-v.y           # E: Item "C" of "Union[C, D]" has no attribute "y" \
+v.y           # E: Item "C" of "Union[C, D]" has no attribute "y," use if <variable_name> is not None to prevent this issue \
               # E: Item "D" of "Union[C, D]" has no attribute "y"
-u.y           # E: Item "C" of "Union[A, C, D]" has no attribute "y" \
+u.y           # E: Item "C" of "Union[A, C, D]" has no attribute "y," use if <variable_name> is not None to prevent this issue \
               # E: Item "D" of "Union[A, C, D]" has no attribute "y"
 if int():
     z = w.y       # E: Incompatible types in assignment (expression has type "int", variable has type "str")


### PR DESCRIPTION
 Fixes #17036

This is a simple option for fixing issue 17036, which has been open for over a year now. This is similar to other users (specifically [dexterkennedy](https://github.com/dexterkennedy)) attempts at solving the problem, but none of them have been successfully merged into master. At the very least hopefully this can restart the discussion and somebody can help finish fixing this issue. We may also need to add more tests for the issue, as some contributors have also failed to get the notes to print when proper. 

