### PR TITLE
[mypyc] Refactor IR building for generator functions

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1219,10 +1219,9 @@ class IRBuilder:
             self_type: If not None, override default type of the implicit 'self'
                 argument (by default, derive type from class_ir)
         """
-        self.enter(fn_info)
+        self.enter(fn_info, ret_type=ret_type)
         self.function_name_stack.append(name)
         self.class_ir_stack.append(class_ir)
-        self.ret_types[-1] = ret_type
         if self_type is None:
             self_type = RInstance(class_ir)
         self.add_argument(SELF_NAME, self_type)

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1169,7 +1169,7 @@ class IRBuilder:
                     return None
             return res
 
-    def enter(self, fn_info: FuncInfo | str = "") -> None:
+    def enter(self, fn_info: FuncInfo | str = "", *, ret_type: RType = none_rprimitive) -> None:
         if isinstance(fn_info, str):
             fn_info = FuncInfo(name=fn_info)
         self.builder = LowLevelIRBuilder(self.errors, self.options)
@@ -1179,7 +1179,7 @@ class IRBuilder:
         self.runtime_args.append([])
         self.fn_info = fn_info
         self.fn_infos.append(self.fn_info)
-        self.ret_types.append(none_rprimitive)
+        self.ret_types.append(ret_type)
         if fn_info.is_generator:
             self.nonlocal_control.append(GeneratorNonlocalControl())
         else:

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -192,12 +192,14 @@ def add_args_to_env(
 
 
 def add_vars_to_env(builder: IRBuilder) -> None:
-    # Add all variables and functions that are declared/defined within this
-    # function and are referenced in functions nested within this one to this
-    # function's environment class so the nested functions can reference
-    # them even if they are declared after the nested function's definition.
-    # Note that this is done before visiting the body of this function.
+    """Add relevant local variables and nested functions to the environment class.
 
+    Add all variables and functions that are declared/defined within current
+    function and are referenced in functions nested within this one to this
+    function's environment class so the nested functions can reference
+    them even if they are declared after the nested function's definition.
+    Note that this is done before visiting the body of the function.
+    """
     env_for_func: FuncInfo | ImplicitClass = builder.fn_info
     if builder.fn_info.is_generator:
         env_for_func = builder.fn_info.generator_class

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -191,6 +191,39 @@ def add_args_to_env(
                 builder.add_var_to_env_class(arg.variable, rtype, base, reassign=reassign)
 
 
+def add_vars_to_env(builder: IRBuilder) -> None:
+    # Add all variables and functions that are declared/defined within this
+    # function and are referenced in functions nested within this one to this
+    # function's environment class so the nested functions can reference
+    # them even if they are declared after the nested function's definition.
+    # Note that this is done before visiting the body of this function.
+
+    env_for_func: FuncInfo | ImplicitClass = builder.fn_info
+    if builder.fn_info.is_generator:
+        env_for_func = builder.fn_info.generator_class
+    elif builder.fn_info.is_nested or builder.fn_info.in_non_ext:
+        env_for_func = builder.fn_info.callable_class
+
+    if builder.fn_info.fitem in builder.free_variables:
+        # Sort the variables to keep things deterministic
+        for var in sorted(builder.free_variables[builder.fn_info.fitem], key=lambda x: x.name):
+            if isinstance(var, Var):
+                rtype = builder.type_to_rtype(var.type)
+                builder.add_var_to_env_class(var, rtype, env_for_func, reassign=False)
+
+    if builder.fn_info.fitem in builder.encapsulating_funcs:
+        for nested_fn in builder.encapsulating_funcs[builder.fn_info.fitem]:
+            if isinstance(nested_fn, FuncDef):
+                # The return type is 'object' instead of an RInstance of the
+                # callable class because differently defined functions with
+                # the same name and signature across conditional blocks
+                # will generate different callable classes, so the callable
+                # class that gets instantiated must be generic.
+                builder.add_var_to_env_class(
+                    nested_fn, object_rprimitive, env_for_func, reassign=False
+                )
+
+
 def setup_func_for_recursive_call(builder: IRBuilder, fdef: FuncDef, base: ImplicitClass) -> None:
     """Enable calling a nested function (with a callable class) recursively.
 

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -76,11 +76,7 @@ from mypyc.irbuild.env_class import (
     load_env_registers,
     setup_env_class,
 )
-from mypyc.irbuild.generator import (
-    add_methods_to_generator_class,
-    gen_generator_func,
-    gen_generator_func_body,
-)
+from mypyc.irbuild.generator import gen_generator_func, gen_generator_func_body
 from mypyc.irbuild.targets import AssignmentTarget
 from mypyc.irbuild.util import is_constant
 from mypyc.primitives.dict_ops import dict_get_method_with_none, dict_new_op, dict_set_item_op
@@ -266,15 +262,7 @@ def gen_func_item(
         )
 
         # Re-enter the FuncItem and visit the body of the function this time.
-        gen_generator_func_body(builder, fn_info, sig)
-
-        # Hang on to the local symbol table for a while, since we use it
-        # to calculate argument defaults below.
-        symtable = builder.symtables[-1]
-
-        args, _, blocks, ret_type, fn_info = builder.leave()
-
-        add_methods_to_generator_class(builder, fn_info, sig, args, blocks, fitem.is_coroutine)
+        symtable = gen_generator_func_body(builder, fn_info, sig)
 
         # Evaluate argument defaults in the surrounding scope, since we
         # calculate them *once* when the function definition is evaluated.

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -69,17 +69,17 @@ from mypyc.irbuild.callable_class import (
     instantiate_callable_class,
     setup_callable_class,
 )
-from mypyc.irbuild.context import FuncInfo, ImplicitClass
+from mypyc.irbuild.context import FuncInfo
 from mypyc.irbuild.env_class import (
+    add_vars_to_env,
     finalize_env_class,
     load_env_registers,
     setup_env_class,
-    add_vars_to_env,
 )
 from mypyc.irbuild.generator import (
     add_methods_to_generator_class,
-    gen_generator_func,
     gen_generator_body_func,
+    gen_generator_func,
 )
 from mypyc.irbuild.targets import AssignmentTarget
 from mypyc.irbuild.util import is_constant
@@ -260,7 +260,10 @@ def gen_func_item(
         # First generate a function that just constructs and returns a generator object.
         func_ir, func_reg = gen_generator_func(
             builder,
-            lambda args, blocks, fn_info: gen_func_ir(builder, args, blocks, sig, fn_info, cdef, is_singledispatch))
+            lambda args, blocks, fn_info: gen_func_ir(
+                builder, args, blocks, sig, fn_info, cdef, is_singledispatch
+            ),
+        )
 
         # Re-enter the FuncItem and visit the body of the function this time.
         gen_generator_body_func(builder, fn_info, sig)

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -262,15 +262,9 @@ def gen_func_item(
 
     if is_generator:
         # Do a first-pass and generate a function that just returns a generator object.
-        gen_generator_func(builder)
-        args, _, blocks, ret_type, fn_info = builder.leave()
-        func_ir, func_reg = gen_func_ir(
-            builder, args, blocks, sig, fn_info, cdef, is_singledispatch
-        )
-
-        # Re-enter the FuncItem and visit the body of the function this time.
-        builder.enter(fn_info)
-        setup_env_for_generator_class(builder)
+        func_ir, func_reg = gen_generator_func(
+            builder,
+            lambda args, blocks, fn_info: gen_func_ir(builder, args, blocks, sig, fn_info, cdef, is_singledispatch))
 
         load_outer_envs(builder, builder.fn_info.generator_class)
         top_level = builder.top_level_fn_info()

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -248,7 +248,7 @@ def gen_func_item(
         add_nested_funcs_to_env=add_nested_funcs_to_env,
     )
     is_generator = fn_info.is_generator
-    builder.enter(fn_info, ret_type=sig.ret_type if not is_generator else object_rprimitive)
+    builder.enter(fn_info, ret_type=sig.ret_type)
 
     # Functions that contain nested functions need an environment class to store variables that
     # are free in their nested functions. Generator functions need an environment class to
@@ -281,19 +281,23 @@ def gen_func_item(
             setup_func_for_recursive_call(builder, fitem, builder.fn_info.generator_class)
         create_switch_for_generator_class(builder)
         add_raise_exception_blocks_to_generator_class(builder, fitem.line)
+
+        add_vars_to_env(builder)
+
+        builder.accept(fitem.body)
+        builder.maybe_add_implicit_return()
+
+        populate_switch_for_generator_class(builder)
     else:
         load_env_registers(builder)
         gen_arg_defaults(builder)
         if contains_nested:
             finalize_env_class(builder)
 
-    add_vars_to_env(builder)
+        add_vars_to_env(builder)
 
-    builder.accept(fitem.body)
-    builder.maybe_add_implicit_return()
-
-    if is_generator:
-        populate_switch_for_generator_class(builder)
+        builder.accept(fitem.body)
+        builder.maybe_add_implicit_return()
 
     # Hang on to the local symbol table for a while, since we use it
     # to calculate argument defaults below.

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -249,7 +249,7 @@ def gen_func_item(
         )
     )
     is_generator = builder.fn_info.is_generator
-    
+
     # Functions that contain nested functions need an environment class to store variables that
     # are free in their nested functions. Generator functions need an environment class to
     # store a variable denoting the next instruction to be executed when the __next__ function
@@ -286,9 +286,8 @@ def gen_func_item(
     else:
         load_env_registers(builder)
         gen_arg_defaults(builder)
-
-    if contains_nested and not is_generator:
-        finalize_env_class(builder)
+        if contains_nested:
+            finalize_env_class(builder)
 
     builder.ret_types[-1] = sig.ret_type
 

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -291,36 +291,7 @@ def gen_func_item(
 
     builder.ret_types[-1] = sig.ret_type
 
-    # Add all variables and functions that are declared/defined within this
-    # function and are referenced in functions nested within this one to this
-    # function's environment class so the nested functions can reference
-    # them even if they are declared after the nested function's definition.
-    # Note that this is done before visiting the body of this function.
-
-    env_for_func: FuncInfo | ImplicitClass = builder.fn_info
-    if is_generator:
-        env_for_func = builder.fn_info.generator_class
-    elif is_nested or in_non_ext:
-        env_for_func = builder.fn_info.callable_class
-
-    if builder.fn_info.fitem in builder.free_variables:
-        # Sort the variables to keep things deterministic
-        for var in sorted(builder.free_variables[builder.fn_info.fitem], key=lambda x: x.name):
-            if isinstance(var, Var):
-                rtype = builder.type_to_rtype(var.type)
-                builder.add_var_to_env_class(var, rtype, env_for_func, reassign=False)
-
-    if builder.fn_info.fitem in builder.encapsulating_funcs:
-        for nested_fn in builder.encapsulating_funcs[builder.fn_info.fitem]:
-            if isinstance(nested_fn, FuncDef):
-                # The return type is 'object' instead of an RInstance of the
-                # callable class because differently defined functions with
-                # the same name and signature across conditional blocks
-                # will generate different callable classes, so the callable
-                # class that gets instantiated must be generic.
-                builder.add_var_to_env_class(
-                    nested_fn, object_rprimitive, env_for_func, reassign=False
-                )
+    add_vars_to_env(builder)
 
     builder.accept(fitem.body)
     builder.maybe_add_implicit_return()
@@ -353,6 +324,39 @@ def gen_func_item(
         return gen_dispatch_func_ir(builder, fitem, fn_info.name, name, sig)
 
     return func_ir, func_reg
+
+
+def add_vars_to_env(builder: IRBuilder) -> None:
+    # Add all variables and functions that are declared/defined within this
+    # function and are referenced in functions nested within this one to this
+    # function's environment class so the nested functions can reference
+    # them even if they are declared after the nested function's definition.
+    # Note that this is done before visiting the body of this function.
+
+    env_for_func: FuncInfo | ImplicitClass = builder.fn_info
+    if builder.fn_info.is_generator:
+        env_for_func = builder.fn_info.generator_class
+    elif builder.fn_info.is_nested or builder.fn_info.in_non_ext:
+        env_for_func = builder.fn_info.callable_class
+
+    if builder.fn_info.fitem in builder.free_variables:
+        # Sort the variables to keep things deterministic
+        for var in sorted(builder.free_variables[builder.fn_info.fitem], key=lambda x: x.name):
+            if isinstance(var, Var):
+                rtype = builder.type_to_rtype(var.type)
+                builder.add_var_to_env_class(var, rtype, env_for_func, reassign=False)
+
+    if builder.fn_info.fitem in builder.encapsulating_funcs:
+        for nested_fn in builder.encapsulating_funcs[builder.fn_info.fitem]:
+            if isinstance(nested_fn, FuncDef):
+                # The return type is 'object' instead of an RInstance of the
+                # callable class because differently defined functions with
+                # the same name and signature across conditional blocks
+                # will generate different callable classes, so the callable
+                # class that gets instantiated must be generic.
+                builder.add_var_to_env_class(
+                    nested_fn, object_rprimitive, env_for_func, reassign=False
+                )
 
 
 def has_nested_func_self_reference(builder: IRBuilder, fitem: FuncItem) -> bool:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -72,7 +72,7 @@ def gen_generator_func(
     return func_ir, func_reg
 
 
-def gen_generator_body_func(builder: IRBuilder, fn_info: FuncInfo, sig: FuncSignature) -> None:
+def gen_generator_func_body(builder: IRBuilder, fn_info: FuncInfo, sig: FuncSignature) -> None:
     """Generate IR for the body of the generator function.
 
     This will be used by the generated "__next__".

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Callable
 
-from mypy.nodes import ARG_OPT, Var
+from mypy.nodes import ARG_OPT, Var, FuncDef
 from mypyc.common import ENV_ATTR_NAME, NEXT_LABEL_ATTR_NAME, SELF_NAME
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FuncDecl, FuncIR, FuncSignature, RuntimeArg
@@ -37,9 +37,12 @@ from mypyc.irbuild.builder import IRBuilder, gen_arg_defaults
 from mypyc.irbuild.context import FuncInfo, GeneratorClass
 from mypyc.irbuild.env_class import (
     add_args_to_env,
+    add_vars_to_env,
     finalize_env_class,
     load_env_registers,
     load_outer_env,
+    load_outer_envs,
+    setup_func_for_recursive_call,
 )
 from mypyc.irbuild.nonlocalcontrol import ExceptNonlocalControl
 from mypyc.primitives.exc_ops import (
@@ -55,6 +58,7 @@ def gen_generator_func(
     builder: IRBuilder,
     gen_func_ir: Callable[[list[Register], list[BasicBlock], FuncInfo], tuple[FuncIR, Value | None]],
 ) -> tuple[FuncIR, Value | None]:
+    """Generate IR for generator function that returns generator object."""
     setup_generator_class(builder)
     load_env_registers(builder)
     gen_arg_defaults(builder)
@@ -63,8 +67,36 @@ def gen_generator_func(
 
     args, _, blocks, ret_type, fn_info = builder.leave()
     func_ir, func_reg = gen_func_ir(args, blocks, fn_info)
-
     return func_ir, func_reg
+
+
+def gen_generator_body_func(builder: IRBuilder, fn_info: FuncInfo, sig: FuncSignature) -> None:
+    """Generate IR for the body of the generator function.
+
+    This will be used by the generated "__next__".
+    """
+    builder.enter(fn_info, ret_type=sig.ret_type)
+    setup_env_for_generator_class(builder)
+
+    load_outer_envs(builder, builder.fn_info.generator_class)
+    top_level = builder.top_level_fn_info()
+    fitem = fn_info.fitem
+    if (
+        builder.fn_info.is_nested
+        and isinstance(fitem, FuncDef)
+        and top_level
+        and top_level.add_nested_funcs_to_env
+    ):
+        setup_func_for_recursive_call(builder, fitem, builder.fn_info.generator_class)
+    create_switch_for_generator_class(builder)
+    add_raise_exception_blocks_to_generator_class(builder, fitem.line)
+
+    add_vars_to_env(builder)
+
+    builder.accept(fitem.body)
+    builder.maybe_add_implicit_return()
+
+    populate_switch_for_generator_class(builder)
 
 
 def instantiate_generator_class(builder: IRBuilder) -> Value:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -75,9 +75,12 @@ def gen_generator_func(
 def gen_generator_func_body(
     builder: IRBuilder, fn_info: FuncInfo, sig: FuncSignature
 ) -> dict[SymbolNode, SymbolTarget]:
-    """Generate IR for the body of the generator function.
+    """Generate IR based on the body of a generator function.
 
-    This will be used by the generated "__next__".
+    Add "__next__", "__iter__" and other generator methods to the generator
+    class that implements the function (each function gets a separate class).
+
+    Return the symbol table for the body.
     """
     builder.enter(fn_info, ret_type=sig.ret_type)
     setup_env_for_generator_class(builder)
@@ -102,13 +105,14 @@ def gen_generator_func_body(
 
     populate_switch_for_generator_class(builder)
 
-    # Hang on to the local symbol table for a while, since we use it
-    # to calculate argument defaults below.
+    # Hang on to the local symbol table, since the caller will use it
+    # to calculate argument defaults.
     symtable = builder.symtables[-1]
 
     args, _, blocks, ret_type, fn_info = builder.leave()
 
     add_methods_to_generator_class(builder, fn_info, sig, args, blocks, fitem.is_coroutine)
+
     return symtable
 
 

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Callable
 
-from mypy.nodes import ARG_OPT, Var, FuncDef
+from mypy.nodes import ARG_OPT, FuncDef, Var
 from mypyc.common import ENV_ATTR_NAME, NEXT_LABEL_ATTR_NAME, SELF_NAME
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FuncDecl, FuncIR, FuncSignature, RuntimeArg
@@ -56,7 +56,9 @@ from mypyc.primitives.exc_ops import (
 
 def gen_generator_func(
     builder: IRBuilder,
-    gen_func_ir: Callable[[list[Register], list[BasicBlock], FuncInfo], tuple[FuncIR, Value | None]],
+    gen_func_ir: Callable[
+        [list[Register], list[BasicBlock], FuncInfo], tuple[FuncIR, Value | None]
+    ],
 ) -> tuple[FuncIR, Value | None]:
     """Generate IR for generator function that returns generator object."""
     setup_generator_class(builder)

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -64,10 +64,6 @@ def gen_generator_func(
     args, _, blocks, ret_type, fn_info = builder.leave()
     func_ir, func_reg = gen_func_ir(args, blocks, fn_info)
 
-    # Re-enter the FuncItem and visit the body of the function this time.
-    builder.enter(fn_info)
-    setup_env_for_generator_class(builder)
-
     return func_ir, func_reg
 
 


### PR DESCRIPTION
The code was pretty hard to follow, since there were many conditional code paths in a very long function that handles both normal functions, nested functions and generators.

Move much of the generator-specific code to a helper function. This required moving some functionality to helper functions to avoid code duplication. Also pass a function as an argument to avoid a dependency cycle.

This is quite a big refactoring, and it's easier to follow by looking at the individual commits in this PR.