### PR TITLE
Fix argparse for Python 3.14

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -29,8 +29,8 @@ from mypy.version import __version__
 
 
 class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
-    def __init__(self, prog: str) -> None:
-        super().__init__(prog=prog, max_help_position=30)
+    def __init__(self, prog: str, **kwargs: Any) -> None:
+        super().__init__(prog=prog, max_help_position=30, **kwargs)
 
 
 parser = argparse.ArgumentParser(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -249,8 +249,8 @@ def show_messages(
 
 # Make the help output a little less jarring.
 class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
-    def __init__(self, prog: str) -> None:
-        super().__init__(prog=prog, max_help_position=28)
+    def __init__(self, prog: str, **kwargs: Any) -> None:
+        super().__init__(prog=prog, max_help_position=28, **kwargs)
 
     def _fill_text(self, text: str, width: int, indent: str) -> str:
         if "\n" in text:


### PR DESCRIPTION
https://github.com/python/cpython/pull/132323 added an optional `color` argument to ArgumentParser. As a side effect the help formatters are now called with two new keyword arguments `prefix_chars` and `color`. Add `**kwargs` to the custom `AugmentedHelpFormatter` and pass it through to the super class.