### PR TITLE
Enable colored output for argparse help in Python 3.14

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -33,8 +33,15 @@ class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
         super().__init__(prog=prog, max_help_position=30, **kwargs)
 
 
+parser_kwargs: dict[str, Any] = {}
+if sys.version_info >= (3, 14):
+    parser_kwargs["color"] = True
+
 parser = argparse.ArgumentParser(
-    prog="dmypy", description="Client for mypy daemon mode", fromfile_prefix_chars="@"
+    prog="dmypy",
+    description="Client for mypy daemon mode",
+    fromfile_prefix_chars="@",
+    **parser_kwargs,
 )
 parser.set_defaults(action=None)
 parser.add_argument(

--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -33,16 +33,12 @@ class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
         super().__init__(prog=prog, max_help_position=30, **kwargs)
 
 
-parser_kwargs: dict[str, Any] = {}
-if sys.version_info >= (3, 14):
-    parser_kwargs["color"] = True
-
 parser = argparse.ArgumentParser(
-    prog="dmypy",
-    description="Client for mypy daemon mode",
-    fromfile_prefix_chars="@",
-    **parser_kwargs,
+    prog="dmypy", description="Client for mypy daemon mode", fromfile_prefix_chars="@"
 )
+if sys.version_info >= (3, 14):
+    parser.color = True  # Set as init arg in 3.14
+
 parser.set_defaults(action=None)
 parser.add_argument(
     "--status-file", default=DEFAULT_STATUS_FILE, help="status file to retrieve daemon details"

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -480,10 +480,6 @@ def process_options(
     stdout = stdout or sys.stdout
     stderr = stderr or sys.stderr
 
-    parser_kwargs: dict[str, Any] = {}
-    if sys.version_info >= (3, 14):
-        parser_kwargs["color"] = True
-
     parser = CapturableArgumentParser(
         prog=program,
         usage=header,
@@ -494,8 +490,9 @@ def process_options(
         add_help=False,
         stdout=stdout,
         stderr=stderr,
-        **parser_kwargs,
     )
+    if sys.version_info >= (3, 14):
+        parser.color = True  # Set as init arg in 3.14
 
     strict_flag_names: list[str] = []
     strict_flag_assignments: list[tuple[str, bool]] = []

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -480,6 +480,10 @@ def process_options(
     stdout = stdout or sys.stdout
     stderr = stderr or sys.stderr
 
+    parser_kwargs: dict[str, Any] = {}
+    if sys.version_info >= (3, 14):
+        parser_kwargs["color"] = True
+
     parser = CapturableArgumentParser(
         prog=program,
         usage=header,
@@ -490,6 +494,7 @@ def process_options(
         add_help=False,
         stdout=stdout,
         stderr=stderr,
+        **parser_kwargs,
     )
 
     strict_flag_names: list[str] = []

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -48,7 +48,7 @@ import os.path
 import sys
 import traceback
 from collections.abc import Iterable, Iterator
-from typing import Final
+from typing import Any, Final
 
 import mypy.build
 import mypy.mixedtraverser
@@ -1848,8 +1848,16 @@ manual changes.  This directory is assumed to exist.
 
 
 def parse_options(args: list[str]) -> Options:
+    parser_kwargs: dict[str, Any] = {}
+    if sys.version_info >= (3, 14):
+        parser_kwargs["color"] = True
+
     parser = argparse.ArgumentParser(
-        prog="stubgen", usage=HEADER, description=DESCRIPTION, fromfile_prefix_chars="@"
+        prog="stubgen",
+        usage=HEADER,
+        description=DESCRIPTION,
+        fromfile_prefix_chars="@",
+        **parser_kwargs,
     )
 
     parser.add_argument(

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -48,7 +48,7 @@ import os.path
 import sys
 import traceback
 from collections.abc import Iterable, Iterator
-from typing import Any, Final
+from typing import Final
 
 import mypy.build
 import mypy.mixedtraverser
@@ -1848,17 +1848,11 @@ manual changes.  This directory is assumed to exist.
 
 
 def parse_options(args: list[str]) -> Options:
-    parser_kwargs: dict[str, Any] = {}
-    if sys.version_info >= (3, 14):
-        parser_kwargs["color"] = True
-
     parser = argparse.ArgumentParser(
-        prog="stubgen",
-        usage=HEADER,
-        description=DESCRIPTION,
-        fromfile_prefix_chars="@",
-        **parser_kwargs,
+        prog="stubgen", usage=HEADER, description=DESCRIPTION, fromfile_prefix_chars="@"
     )
+    if sys.version_info >= (3, 14):
+        parser.color = True  # Set as init arg in 3.14
 
     parser.add_argument(
         "--ignore-errors",

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -2081,13 +2081,11 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
 
 
 def parse_options(args: list[str]) -> _Arguments:
-    parser_kwargs: dict[str, Any] = {}
-    if sys.version_info >= (3, 14):
-        parser_kwargs["color"] = True
-
     parser = argparse.ArgumentParser(
-        description="Compares stubs to objects introspected from the runtime.", **parser_kwargs
+        description="Compares stubs to objects introspected from the runtime."
     )
+    if sys.version_info >= (3, 14):
+        parser.color = True  # Set as init arg in 3.14
     parser.add_argument("modules", nargs="*", help="Modules to test")
     parser.add_argument(
         "--concise",

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -2081,8 +2081,12 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
 
 
 def parse_options(args: list[str]) -> _Arguments:
+    parser_kwargs: dict[str, Any] = {}
+    if sys.version_info >= (3, 14):
+        parser_kwargs["color"] = True
+
     parser = argparse.ArgumentParser(
-        description="Compares stubs to objects introspected from the runtime."
+        description="Compares stubs to objects introspected from the runtime.", **parser_kwargs
     )
     parser.add_argument("modules", nargs="*", help="Modules to test")
     parser.add_argument(


### PR DESCRIPTION
Support for colored output was just merged in cpython. Maybe a bit early to add it here already but it doesn't hurt either.

| Current | With color |
| --- | --- |
| <img width="1058" alt="Without color" src="https://github.com/user-attachments/assets/48edae3e-9361-4af0-aff6-7931410bcd2e" /> | <img width="944" alt="With color" src="https://github.com/user-attachments/assets/38e64082-0321-4d36-a5fe-4d59c6eddc31" /> |

The color output can be disable using various environment variables.
https://docs.python.org/3.14/using/cmdline.html#using-on-controlling-color
