### PR TITLE
Refactor: replace make_simplified_union with UnionType.make_union (#8624)

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -11,7 +11,6 @@ from mypy.literals import Key, extract_var_from_literal_hash, literal, literal_h
 from mypy.nodes import Expression, IndexExpr, MemberExpr, NameExpr, RefExpr, TypeInfo, Var
 from mypy.options import Options
 from mypy.subtypes import is_same_type, is_subtype
-from mypy.typeops import make_simplified_union
 from mypy.types import (
     AnyType,
     Instance,

--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -277,7 +277,7 @@ class ConditionalTypeBinder:
                     # interfere with our (hacky) TypeGuard support.
                     type = possible_types[0]
                 else:
-                    type = make_simplified_union(possible_types)
+                    type = UnionType.make_union(possible_types)
                     # Legacy guard for corner case when the original type is TypeVarType.
                     if isinstance(declaration_type, TypeVarType) and not is_subtype(
                         type, declaration_type

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -161,7 +161,6 @@ from mypy.typeops import (
     function_type,
     is_literal_type_like,
     is_singleton_type,
-    make_simplified_union,
     true_only,
     try_expanding_sum_type_to_union,
     try_getting_int_literals_from_type,
@@ -4012,9 +4011,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
             types, declared_types = zip(*clean_items)
             self.binder.assign_type(
-                expr,
-                UnionType.make_union(list(types)),
-                UnionType.make_union(list(declared_types)),
+                expr, UnionType.make_union(list(types)), UnionType.make_union(list(declared_types))
             )
         for union, lv in zip(union_types, self.flatten_lvalues(lvalues)):
             # Properly store the inferred types.

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -258,7 +258,7 @@ def _analyze_member_access(
     elif isinstance(typ, TypeVarLikeType):
         if isinstance(typ, TypeVarType) and typ.values:
             return _analyze_member_access(
-                name, make_simplified_union(typ.values), mx, override_info
+                name, UnionType.make_union(typ.values), mx, override_info
             )
         return _analyze_member_access(name, typ.upper_bound, mx, override_info)
     elif isinstance(typ, DeletedType):
@@ -486,7 +486,7 @@ def analyze_union_member_access(name: str, typ: UnionType, mx: MemberContext) ->
             # Self types should be bound to every individual item of a union.
             item_mx = mx.copy_modified(self_type=subtype)
             results.append(_analyze_member_access(name, subtype, item_mx))
-    return make_simplified_union(results)
+    return UnionType.make_union(results)
 
 
 def analyze_none_member_access(name: str, typ: NoneType, mx: MemberContext) -> Type:
@@ -668,7 +668,7 @@ def analyze_descriptor_access(descriptor_type: Type, mx: MemberContext) -> Type:
 
     if isinstance(descriptor_type, UnionType):
         # Map the access over union types
-        return make_simplified_union(
+        return UnionType.make_union(
             [analyze_descriptor_access(typ, mx) for typ in descriptor_type.items]
         )
     elif not isinstance(descriptor_type, Instance):

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -45,7 +45,6 @@ from mypy.typeops import (
     function_type,
     get_all_type_vars,
     get_type_vars,
-    make_simplified_union,
     supported_self_type,
     tuple_fallback,
     type_object_type,

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -29,12 +29,7 @@ from mypy.patterns import (
 )
 from mypy.plugin import Plugin
 from mypy.subtypes import is_subtype
-from mypy.typeops import (
-    coerce_to_literal,
-    make_simplified_union,
-    try_getting_str_literals_from_type,
-    tuple_fallback,
-)
+from mypy.typeops import coerce_to_literal, try_getting_str_literals_from_type, tuple_fallback
 from mypy.types import (
     AnyType,
     Instance,

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -196,7 +196,7 @@ class PatternChecker(PatternVisitor[PatternType]):
 
             captures[capture_list[0][0]] = typ
 
-        union_type = make_simplified_union(types)
+        union_type = UnionType.make_union(types)
         return PatternType(union_type, current_type, captures)
 
     def visit_value_pattern(self, o: ValuePattern) -> PatternType:
@@ -359,7 +359,7 @@ class PatternChecker(PatternVisitor[PatternType]):
             items = [self.get_sequence_type(item, context) for item in t.items]
             not_none_items = [item for item in items if item is not None]
             if not_none_items:
-                return make_simplified_union(not_none_items)
+                return UnionType.make_union(not_none_items)
             else:
                 return None
 
@@ -409,13 +409,13 @@ class PatternChecker(PatternVisitor[PatternType]):
                     new_middle.append(unpacked.args[0])
                 else:
                     new_middle.append(m)
-            return list(prefix) + [make_simplified_union(new_middle)] + list(suffix)
+            return list(prefix) + [UnionType.make_union(new_middle)] + list(suffix)
         else:
             if star_pos is None:
                 return types
             new_types = types[:star_pos]
             star_length = len(types) - num_patterns
-            new_types.append(make_simplified_union(types[star_pos : star_pos + star_length]))
+            new_types.append(UnionType.make_union(types[star_pos : star_pos + star_length]))
             new_types += types[star_pos + star_length :]
             return new_types
 
@@ -764,7 +764,7 @@ class PatternChecker(PatternVisitor[PatternType]):
                 for item in proper_type.items
                 if self.can_match_sequence(get_proper_type(item))
             ]
-            return make_simplified_union(types)
+            return UnionType.make_union(types)
         sequence = self.chk.named_generic_type("typing.Sequence", [inner_type])
         if is_subtype(outer_type, self.chk.named_type("typing.Sequence")):
             if isinstance(proper_type, TupleType):

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -29,11 +29,7 @@ from mypy.patterns import (
 )
 from mypy.plugin import Plugin
 from mypy.subtypes import is_subtype
-from mypy.typeops import (
-    coerce_to_literal,
-    try_getting_str_literals_from_type,
-    tuple_fallback,
-)
+from mypy.typeops import coerce_to_literal, try_getting_str_literals_from_type, tuple_fallback
 from mypy.types import (
     AnyType,
     Instance,

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -131,7 +131,7 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
         erased_items = [erase_type(item) for item in t.items]
         from mypy.typeops import make_simplified_union
 
-        return make_simplified_union(erased_items)
+        return UnionType.make_union(erased_items)
 
     def visit_type_type(self, t: TypeType) -> ProperType:
         return TypeType.make_normalized(t.item.accept(self), line=t.line)
@@ -271,7 +271,7 @@ class LastKnownValueEraser(TypeTranslator):
                         else:
                             from mypy.typeops import make_simplified_union
 
-                            merged.append(make_simplified_union(types))
+                            merged.append(UnionType.make_union(types))
                             del instances_by_name[item.type.fullname]
                 else:
                     merged.append(orig_item)

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -129,7 +129,6 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
 
     def visit_union_type(self, t: UnionType) -> ProperType:
         erased_items = [erase_type(item) for item in t.items]
-        from mypy.typeops import make_simplified_union
 
         return UnionType.make_union(erased_items)
 
@@ -269,7 +268,6 @@ class LastKnownValueEraser(TypeTranslator):
                         if len(types) == 1:
                             merged.append(item)
                         else:
-                            from mypy.typeops import make_simplified_union
 
                             merged.append(UnionType.make_union(types))
                             del instances_by_name[item.type.fullname]

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -15,7 +15,7 @@ from mypy.subtypes import (
     is_same_type,
     is_subtype,
 )
-from mypy.typeops import is_recursive_pair, make_simplified_union, tuple_fallback
+from mypy.typeops import is_recursive_pair, tuple_fallback
 from mypy.types import (
     MYPYC_NATIVE_INT_NAMES,
     TUPLE_LIKE_INSTANCE_NAMES,

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -127,7 +127,7 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
     if declared == narrowed:
         return original_declared
     if isinstance(declared, UnionType):
-        return make_simplified_union(
+        return UnionType.make_union(
             [
                 narrow_declared_type(x, narrowed)
                 for x in declared.relevant_items()
@@ -146,7 +146,7 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
         # Quick check before reaching `is_overlapping_types`. If it's enum/literal overlap,
         # avoid full expansion and make it faster.
         assert isinstance(narrowed, UnionType)
-        return make_simplified_union(
+        return UnionType.make_union(
             [narrow_declared_type(declared, x) for x in narrowed.relevant_items()]
         )
     elif not is_overlapping_types(declared, narrowed, prohibit_none_typevar_overlap=True):
@@ -155,7 +155,7 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
         else:
             return NoneType()
     elif isinstance(narrowed, UnionType):
-        return make_simplified_union(
+        return UnionType.make_union(
             [narrow_declared_type(declared, x) for x in narrowed.relevant_items()]
         )
     elif isinstance(narrowed, AnyType):
@@ -745,7 +745,7 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
                     meets.append(meet_types(x, y))
         else:
             meets = [meet_types(x, self.s) for x in t.items]
-        return make_simplified_union(meets)
+        return UnionType.make_union(meets)
 
     def visit_none_type(self, t: NoneType) -> ProperType:
         if state.strict_optional:

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -56,11 +56,7 @@ from mypy.plugins.common import (
 )
 from mypy.server.trigger import make_wildcard_trigger
 from mypy.state import state
-from mypy.typeops import (
-    get_type_vars,
-    map_type_from_supertype,
-    type_object_type,
-)
+from mypy.typeops import get_type_vars, map_type_from_supertype, type_object_type
 from mypy.types import (
     AnyType,
     CallableType,

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -782,7 +782,7 @@ def _parse_converter(
             types.append(item.arg_types[0])
         # Make a union of all the valid types.
         if types:
-            converter_info.init_type = make_simplified_union(types)
+            converter_info.init_type = UnionType.make_union(types)
 
     if is_attr_converters_optional and converter_info.init_type:
         # If the converter was attr.converter.optional(type) then add None to

--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -56,12 +56,7 @@ from mypy.plugins.common import (
 )
 from mypy.server.trigger import make_wildcard_trigger
 from mypy.state import state
-from mypy.typeops import (
-    get_type_vars,
-    make_simplified_union,
-    map_type_from_supertype,
-    type_object_type,
-)
+from mypy.typeops import get_type_vars, map_type_from_supertype, type_object_type
 from mypy.types import (
     AnyType,
     CallableType,

--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -72,7 +72,7 @@ def _autoconvertible_to_cdata(tp: Type, api: mypy.plugin.CheckerPluginInterface)
                     allowed_types.append(api.named_generic_type("builtins.int", []))
                     allowed_types.append(NoneType())
 
-    return make_simplified_union(allowed_types)
+    return UnionType.make_union(allowed_types)
 
 
 def _autounboxed_cdata(tp: Type) -> ProperType:
@@ -85,7 +85,7 @@ def _autounboxed_cdata(tp: Type) -> ProperType:
     tp = get_proper_type(tp)
 
     if isinstance(tp, UnionType):
-        return make_simplified_union([_autounboxed_cdata(t) for t in tp.items])
+        return UnionType.make_union([_autounboxed_cdata(t) for t in tp.items])
     elif isinstance(tp, Instance):
         for base in tp.type.bases:
             if base.type.fullname == "_ctypes._SimpleCData":
@@ -218,7 +218,7 @@ def array_value_callback(ctx: mypy.plugin.AttributeContext) -> Type:
                     ),
                     ctx.context,
                 )
-        return make_simplified_union(types)
+        return UnionType.make_union(types)
     return ctx.default_attr_type
 
 
@@ -241,5 +241,5 @@ def array_raw_callback(ctx: mypy.plugin.AttributeContext) -> Type:
                     ' with element type "c_char", not {}'.format(format_type(et, ctx.api.options)),
                     ctx.context,
                 )
-        return make_simplified_union(types)
+        return UnionType.make_union(types)
     return ctx.default_attr_type

--- a/mypy/plugins/ctypes.py
+++ b/mypy/plugins/ctypes.py
@@ -8,7 +8,6 @@ from mypy import nodes
 from mypy.maptype import map_instance_to_supertype
 from mypy.messages import format_type
 from mypy.subtypes import is_subtype
-from mypy.typeops import make_simplified_union
 from mypy.types import (
     AnyType,
     CallableType,

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -222,7 +222,7 @@ def typed_dict_get_signature_callback(ctx: MethodSigContext) -> CallableType:
             tv = signature.variables[0]
             assert isinstance(tv, TypeVarType)
             return signature.copy_modified(
-                arg_types=[signature.arg_types[0], make_simplified_union([value_type, tv])],
+                arg_types=[signature.arg_types[0], UnionType.make_union([value_type, tv])],
                 ret_type=ret_type,
             )
     return signature
@@ -263,7 +263,7 @@ def typed_dict_get_callback(ctx: MethodContext) -> Type:
         if len(ctx.arg_types) == 1:
             output_types.append(NoneType())
 
-        return make_simplified_union(output_types)
+        return UnionType.make_union(output_types)
     return ctx.default_return_type
 
 
@@ -292,7 +292,7 @@ def typed_dict_pop_signature_callback(ctx: MethodSigContext) -> CallableType:
             # variable that accepts everything.
             tv = signature.variables[0]
             assert isinstance(tv, TypeVarType)
-            typ = make_simplified_union([value_type, tv])
+            typ = UnionType.make_union([value_type, tv])
             return signature.copy_modified(arg_types=[str_type, typ], ret_type=typ)
     return signature.copy_modified(arg_types=[str_type, signature.arg_types[1]])
 
@@ -327,9 +327,9 @@ def typed_dict_pop_callback(ctx: MethodContext) -> Type:
                 return AnyType(TypeOfAny.from_error)
 
         if len(ctx.args[1]) == 0:
-            return make_simplified_union(value_types)
+            return UnionType.make_union(value_types)
         elif len(ctx.arg_types) == 2 and len(ctx.arg_types[1]) == 1 and len(ctx.args[1]) == 1:
-            return make_simplified_union([*value_types, ctx.arg_types[1][0]])
+            return UnionType.make_union([*value_types, ctx.arg_types[1][0]])
     return ctx.default_return_type
 
 
@@ -401,7 +401,7 @@ def typed_dict_setdefault_callback(ctx: MethodContext) -> Type:
 
             value_types.append(value_type)
 
-        return make_simplified_union(value_types)
+        return UnionType.make_union(value_types)
     return ctx.default_return_type
 
 
@@ -479,7 +479,7 @@ def typed_dict_update_signature_callback(ctx: MethodSigContext) -> CallableType:
                     item = item.copy_modified(item_names=list(td.items))
                 items.append(item)
             if items:
-                arg_type = make_simplified_union(items)
+                arg_type = UnionType.make_union(items)
         return signature.copy_modified(arg_types=[arg_type])
     return signature
 

--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -17,7 +17,7 @@ from mypy.plugin import (
 )
 from mypy.plugins.common import try_getting_str_literals
 from mypy.subtypes import is_subtype
-from mypy.typeops import is_literal_type_like, make_simplified_union
+from mypy.typeops import is_literal_type_like
 from mypy.types import (
     TPDICT_FB_NAMES,
     AnyType,

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -27,6 +27,7 @@ from mypy.types import (
     LiteralType,
     ProperType,
     Type,
+    UnionType,
     get_proper_type,
     is_named_instance,
 )
@@ -235,7 +236,7 @@ def enum_value_callback(ctx: mypy.plugin.AttributeContext) -> Type:
                 for proper_type in proper_types
             )
             if all_equivalent_types:
-                return make_simplified_union(cast(Sequence[Type], proper_types))
+                return UnionType.make_union(cast(Sequence[Type], proper_types))
         return ctx.default_attr_type
 
     assert isinstance(ctx.type, Instance)

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -20,7 +20,7 @@ import mypy.plugin  # To avoid circular imports.
 from mypy.nodes import TypeInfo
 from mypy.semanal_enum import ENUM_BASES
 from mypy.subtypes import is_equivalent
-from mypy.typeops import fixup_partial_type, make_simplified_union
+from mypy.typeops import fixup_partial_type
 from mypy.types import (
     CallableType,
     Instance,

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -28,7 +28,6 @@ from mypy.nodes import (
 from mypy.plugin import SemanticAnalyzerPluginInterface
 from mypy.tvar_scope import TypeVarLikeScope
 from mypy.type_visitor import ANY_STRATEGY, BoolTypeQuery
-from mypy.typeops import make_simplified_union
 from mypy.types import (
     TPDICT_FB_NAMES,
     AnyType,
@@ -45,9 +44,9 @@ from mypy.types import (
     TypeVarId,
     TypeVarLikeType,
     TypeVarTupleType,
+    UnionType,
     UnpackType,
     get_proper_type,
-    UnionType,
 )
 
 # Subclasses can override these Var attributes with incompatible types. This can also be

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -47,6 +47,7 @@ from mypy.types import (
     TypeVarTupleType,
     UnpackType,
     get_proper_type,
+    UnionType,
 )
 
 # Subclasses can override these Var attributes with incompatible types. This can also be
@@ -305,7 +306,7 @@ def calculate_tuple_fallback(typ: TupleType) -> None:
                 raise NotImplementedError
         else:
             items.append(item)
-    fallback.args = (make_simplified_union(items),)
+    fallback.args = (UnionType.make_union(items),)
 
 
 class _NamedTypeCallback(Protocol):

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -60,7 +60,7 @@ from mypy.plugin import FunctionContext, MethodContext, Plugin
 from mypy.server.update import FineGrainedBuildManager
 from mypy.state import state
 from mypy.traverser import TraverserVisitor
-from mypy.typeops import bind_self, make_simplified_union
+from mypy.typeops import bind_self
 from mypy.types import (
     AnyType,
     CallableType,

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -924,7 +924,7 @@ def generate_type_combinations(types: list[Type]) -> list[Type]:
     and unioning the types. We try both.
     """
     joined_type = join_type_list(types)
-    union_type = make_simplified_union(types)
+    union_type = UnionType.make_union(types)
     if joined_type == union_type:
         return [joined_type]
     else:
@@ -1018,7 +1018,7 @@ def refine_union(t: UnionType, s: ProperType) -> Type:
     # Turn strict optional on when simplifying the union since we
     # don't want to drop Nones.
     with state.strict_optional_set(True):
-        return make_simplified_union(new_items)
+        return UnionType.make_union(new_items)
 
 
 def refine_callable(t: CallableType, s: CallableType) -> CallableType:

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -846,14 +846,14 @@ def erase_def_to_union_or_bound(tdef: TypeVarLikeType) -> Type:
     if isinstance(tdef, ParamSpecType):
         return AnyType(TypeOfAny.from_error)
     if isinstance(tdef, TypeVarType) and tdef.values:
-        return make_simplified_union(tdef.values)
+        return UnionType.make_union(tdef.values)
     else:
         return tdef.upper_bound
 
 
 def erase_to_union_or_bound(typ: TypeVarType) -> ProperType:
     if typ.values:
-        return make_simplified_union(typ.values)
+        return UnionType.make_union(typ.values)
     else:
         return get_proper_type(typ.upper_bound)
 


### PR DESCRIPTION
This PR replaces calls to `make_simplified_union` with the more modern `UnionType.make_union` across several files, as part of the cleanup and modernization discussed in issue #8624.

This change does not modify behavior but standardizes the way union types are created in the type system, improving code consistency.

### Affected files:
- binder.py
- checker.py
- checkexpr.py
- checkmember.py
- checkpattern.py
- erasetype.py
- meet.py
- mypy/plugins/attrs.py
- mypy/plugins/ctypes.py
- mypy/plugins/default.py
- mypy/plugins/enums.py
- semanal_shared.py
- suggestions.py
- typeops.py
