### PR TITLE
Work in Progress CallableType usingpretty_callable_or_overload

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -405,39 +405,37 @@ class MessageBuilder:
                     return codes.OPERATOR
         elif member == "__neg__":
             display_type = (
-            self.pretty_callable_or_overload(original_type)
-            if isinstance(original_type, CallableType)
-            else format_type(original_type, self.options)
-)
-            self.fail(
-            f"Unsupported operand type for unary - ({display_type})",
-            context,
-            code=codes.OPERATOR,
-)
-            return codes.OPERATOR
-        elif member == "__pos__":
-
-            display_type=(
                 self.pretty_callable_or_overload(original_type)
                 if isinstance(original_type, CallableType)
                 else format_type(original_type, self.options)
             )
             self.fail(
-                 f"Unsupported operand type for unary + ({display_type})",
+                f"Unsupported operand type for unary - ({display_type})",
+                context,
+                code=codes.OPERATOR,
+            )
+            return codes.OPERATOR
+        elif member == "__pos__":
+
+            display_type = (
+                self.pretty_callable_or_overload(original_type)
+                if isinstance(original_type, CallableType)
+                else format_type(original_type, self.options)
+            )
+            self.fail(
+                f"Unsupported operand type for unary + ({display_type})",
                 context,
                 code=codes.OPERATOR,
             )
             return codes.OPERATOR
         elif member == "__invert__":
-            display_type=(
+            display_type = (
                 self.pretty_callable_or_overload(original_type)
                 if isinstance(original_type, CallableType)
                 else format_type(original_type, self.options)
             )
             self.fail(
-                f"Unsupported operand type for ~ ({display_type})",
-                context,
-                code=codes.OPERATOR,
+                f"Unsupported operand type for ~ ({display_type})", context, code=codes.OPERATOR
             )
             return codes.OPERATOR
         elif member == "__getitem__":

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -404,22 +404,38 @@ class MessageBuilder:
                     self.unsupported_left_operand(op, original_type, context)
                     return codes.OPERATOR
         elif member == "__neg__":
+            display_type = (
+            self.pretty_callable_or_overload(original_type)
+            if isinstance(original_type, CallableType)
+            else format_type(original_type, self.options)
+)
             self.fail(
-                f"Unsupported operand type for unary - ({format_type(original_type, self.options)})",
-                context,
-                code=codes.OPERATOR,
-            )
+            f"Unsupported operand type for unary - ({display_type})",
+            context,
+            code=codes.OPERATOR,
+)
             return codes.OPERATOR
         elif member == "__pos__":
+
+            display_type=(
+                self.pretty_callable_or_overload(original_type)
+                if isinstance(original_type, CallableType)
+                else format_type(original_type, self.options)
+            )
             self.fail(
-                f"Unsupported operand type for unary + ({format_type(original_type, self.options)})",
+                 f"Unsupported operand type for unary + ({display_type})",
                 context,
                 code=codes.OPERATOR,
             )
             return codes.OPERATOR
         elif member == "__invert__":
+            display_type=(
+                self.pretty_callable_or_overload(original_type)
+                if isinstance(original_type, CallableType)
+                else format_type(original_type, self.options)
+            )
             self.fail(
-                f"Unsupported operand type for ~ ({format_type(original_type, self.options)})",
+                f"Unsupported operand type for ~ ({display_type})",
                 context,
                 code=codes.OPERATOR,
             )


### PR DESCRIPTION
**Objective**
Refactor the generation of error messages involving CallableType by using pretty_callable_or_overload(...) to improve clarity and consistency, as discussed in [issue #5490](https://github.com/python/mypy/issues/5490).

**Changes Made**
Refactored the __pos__, __invert__, __call__, and other related blocks.

Replaced calls to format_type(...) with conditional logic that uses pretty_callable_or_overload(...) when applicable.

Added a test case in operators.test to verify the new message formatting.

**Tests**
Ran with pytest, and all tests passed successfully.