### PR TITLE
Reverse op for subclass

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4049,18 +4049,19 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
 
             variants_raw = [(op_name, left_op, left_type, right_expr)]
         elif (
-            # Note: use covers_at_runtime instead of is_subtype.
-            #    fixes https://github.com/python/mypy/issues/19006
+            # Note: use `covers_at_runtime` instead of `is_subtype` (#19006)
             covers_at_runtime(right_type, left_type)
             and (
+                # Checking (A implies B) using the logically equivalent (not A or B), where
+                #    A: left and right are both `Instance` objects
+                #    B: right's __rop__ method is different from left's __op__ method
                 not (isinstance(left_type, Instance) and isinstance(right_type, Instance))
                 or (
-                    (
+                    lookup_definer(left_type, op_name) != lookup_definer(right_type, rev_op_name)
+                    and (
                         left_type.type.alt_promote is None
                         or left_type.type.alt_promote.type is not right_type.type
                     )
-                    and lookup_definer(left_type, op_name)
-                    != lookup_definer(right_type, rev_op_name)
                 )
             )
         ):

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -681,6 +681,29 @@ class B:
 s: str
 s = A() + B() # E: Unsupported operand types for + ("A" and "B")
 
+[case testReverseBinaryOperator4]
+
+from typing import assert_type, Never
+
+class Size(tuple[int, ...]):
+    def __add__(self, other: tuple[int, ...], /) -> "Size": return Size()
+    def __radd__(self, other: tuple[int, ...], /) -> "Size": return Size()
+
+size: Size = Size([3, 4])
+tup0: tuple[()] = ()
+tup1: tuple[int] = (1,)
+tup2: tuple[int, int] = (1, 2)
+tupN: tuple[int, ...] = (1, 2, 3)
+tupX: tuple[Never, ...] = ()
+
+assert_type(tup0 + size, Size)
+assert_type(tup1 + size, Size)
+assert_type(tup2 + size, Size)
+assert_type(tupN + size, Size)
+assert_type(tupX + size, Size)
+
+[builtins fixtures/tuple.pyi]
+
 [case testBinaryOperatorWithAnyRightOperand]
 from typing import Any, cast
 class A: pass

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -681,8 +681,8 @@ class B:
 s: str
 s = A() + B() # E: Unsupported operand types for + ("A" and "B")
 
-[case testReverseBinaryOperator4]
 
+[case testReverseBinaryOperator4]
 from typing import assert_type, Never
 
 class Size(tuple[int, ...]):


### PR DESCRIPTION
Fixes #19006

- Added unit test `TypeCheckSuite::check-expressions.test::testReverseBinaryOperator4`

This patch drops the `is_subtype(right_type, left_type)` check in favor of the weaker `covers_at_runtime(right_type, left_type)`. 

------

## Open Issues

- [ ] Some tests were still failing because `isinstance(left_type, Instance)` fails when `left_type` is `tuple[()]`. As a workaround, I changed the unconditional check

    ```python
    and isinstance(left_type, Instance)
    and isinstance(right_type, Instance)
    and not (
        left_type.type.alt_promote is not None
        and left_type.type.alt_promote.type is right_type.type
    )
    and lookup_definer(left_type, op_name) != lookup_definer(right_type, rev_op_name)
    ```

    into the conditional check

    ```python
    # Checking (A implies B) using the logically equivalent (not A or B), where
    #    A: left and right are both `Instance` objects
    #    B: right's __rop__ method is different from left's __op__ method
    not (isinstance(left_type, Instance) and isinstance(right_type, Instance))
    or (
        lookup_definer(left_type, op_name) != lookup_definer(right_type, rev_op_name)
        and (
            left_type.type.alt_promote is None
            or left_type.type.alt_promote.type is not right_type.type
        )
    )
    ```
    
    But I am not sure this is the correct thing to do.

- [ ] I get different results when running tests versus checking a file manually:

    ```
    $ pytest mypy/test/testcheck.py::TypeCheckSuite::check-expressions.test
    
    Expected:
    Actual:
    main:15: error: Expression is of type "Tuple[int, ...]", not "Size" (diff)
    main:16: error: Expression is of type "Tuple[int, ...]", not "Size" (diff)
    ```
    
    versus

    ```
    $ mypy example.py
    example.py:4: error: Signature of "__add__" incompatible with supertype "tuple"  [override]
    example.py:4: note:      Superclass:
    example.py:4: note:          @overload
    example.py:4: note:          def __add__(self, tuple[int, ...], /) -> tuple[int, ...]
    example.py:4: note:          @overload
    example.py:4: note:          def [_T] __add__(self, tuple[_T, ...], /) -> tuple[int | _T, ...]
    example.py:4: note:      Subclass:
    example.py:4: note:          def __add__(self, tuple[int, ...], /) -> Size
    example.py:14: error: Expression is of type "tuple[int, ...]", not "Size"  [assert-type]
    example.py:15: error: Expression is of type "tuple[int, ...]", not "Size"  [assert-type]
    example.py:16: error: Expression is of type "tuple[int, ...]", not "Size"  [assert-type]
    example.py:18: error: Expression is of type "tuple[int, ...]", not "Size"  [assert-type]
    Found 5 errors in 1 file (checked 1 source file)
    ```


