### PR TITLE
Add warn-unreachable to strict mode

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -754,9 +754,6 @@ of the above sections.
     strict will catch type errors as long as intentional methods like type ignore
     or casting were not used.)
 
-    Note: the :option:`--warn-unreachable` flag
-    is not automatically enabled by the strict flag.
-
     The strict flag does not take precedence over other strict-related flags.
     Directly specifying a flag of alternate behavior will override the
     behavior of strict, regardless of the order in which they are passed.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -825,7 +825,7 @@ def process_options(
     add_invertible_flag(
         "--warn-unreachable",
         default=False,
-        strict_flag=False,
+        strict_flag=True,
         help="Warn about statements or expressions inferred to be unreachable",
         group=lint_group,
     )


### PR DESCRIPTION
This is useful check for dead code analysis. Iff the rate of false-positives is low enough, then this is a worthwhile addition to strict. (I am currently investigating the current rate of false-positives, eg https://github.com/python/mypy/issues/10806 ; https://github.com/python/mypy/issues/14987 ; mypyc/ir/pprint.py:231: error: Statement is unreachable )

This PR is largely a copy of https://github.com/python/mypy/pull/17944 , which is now closed.

Fixes #11223, #18078

This adds a useful check to the default list of strict arguments.

I personally do not see this as a breaking change, due to the documentation of --strict stating it may include different flags over time. I think this could just be in a minor version. (Either way, this pull request could be used.)


