### PR TITLE
add --strict-bytes to --strict

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -898,7 +898,7 @@ def process_options(
     add_invertible_flag(
         "--strict-bytes",
         default=False,
-        strict_flag=False,
+        strict_flag=True,
         help="Disable treating bytearray and memoryview as subtypes of bytes",
         group=strictness_group,
     )

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -1,7 +1,6 @@
 [mypy]
 
 strict = True
-strict_bytes = True
 local_partial_types = True
 disallow_any_unimported = True
 show_traceback = True

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2408,6 +2408,21 @@ f(bytearray(b"asdf"))
 f(memoryview(b"asdf"))
 [builtins fixtures/primitives.pyi]
 
+[case testStrictBytesDisabledByDefault]
+# TODO: probably change this default in Mypy v2.0, with https://github.com/python/mypy/pull/18371
+# (this would also obsolete the testStrictBytesEnabledByStrict test, below)
+def f(x: bytes) -> None: ...
+f(bytearray(b"asdf"))
+f(memoryview(b"asdf"))
+[builtins fixtures/primitives.pyi]
+
+[case testStrictBytesEnabledByStrict]
+# flags: --strict
+def f(x: bytes) -> None: ...
+f(bytearray(b"asdf"))  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
+f(memoryview(b"asdf"))  # E: Argument 1 to "f" has incompatible type "memoryview"; expected "bytes"
+[builtins fixtures/primitives.pyi]
+
 [case testNoCrashFollowImportsForStubs]
 # flags: --config-file tmp/mypy.ini
 {**{"x": "y"}}

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2417,7 +2417,9 @@ f(memoryview(b"asdf"))
 [builtins fixtures/primitives.pyi]
 
 [case testStrictBytesEnabledByStrict]
-# flags: --strict
+# flags: --strict --disable-error-code type-arg
+# The type-arg thing is just work around the primitives.pyi isinstance Tuple not having type parameters,
+#   which isn't important for this.
 def f(x: bytes) -> None: ...
 f(bytearray(b"asdf"))  # E: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
 f(memoryview(b"asdf"))  # E: Argument 1 to "f" has incompatible type "memoryview"; expected "bytes"


### PR DESCRIPTION
This is a check that ensures static correctness, so it is useful to have in --strict. Unlike making this the default behavior eventually in 2.0, which we are also planning to do, it can be added to --strict immediately due to --strict having looser backwards-compatibility requirements (or so I interpret --strict's [documentation](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict)). This PR also includes tests, for --strict and also for no flags.