### PR TITLE
[docs] Update common_issues.rst: update information about reveal type & locals

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -510,7 +510,7 @@ to see the types of all local variables at once. Example:
    if you don't import them, then they don't exist at runtime! Therefore,
    you'll have to remove any ``reveal_type`` and ``reveal_locals`` calls from your program
    or else Python will give you an error at runtime about those names being undefined.
-   Alternatively, you can import ``reveal_type`` from ``typing_extensions``
+   Alternatively, you can import :py:data:`~typing.reveal_type` from ``typing_extensions``
    (or, in more recent versions of python, from ``typing``)
    so its name will be defined at runtime.
    There is no analogous fix for ``reveal_locals``.

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -505,11 +505,15 @@ to see the types of all local variables at once. Example:
    #     b: builtins.str
 .. note::
 
-   ``reveal_type`` and ``reveal_locals`` are only understood by mypy and
-   don't exist in Python. If you try to run your program, you'll have to
-   remove any ``reveal_type`` and ``reveal_locals`` calls before you can
-   run your code. Both are always available and you don't need to import
-   them.
+   ``reveal_type`` and ``reveal_locals`` are understood by mypy during typechecking,
+   and don't have to be imported as functions. However,
+   if you don't import them, then they don't exist at runtime! Therefore,
+   in that case, if you try to run your program, you'll have to
+   remove any ``reveal_type`` and ``reveal_locals`` calls
+   or else Python will give you an error at runtime about those names being undefined.
+  Alternatively, you can import ``reveal_type`` from ``typing_extensions`` (or, in more recent versions of python, from ``typing``) so its name will be defined at runtime.
+   There is no analogous fix for ``reveal_locals``. It simply must be removed from the code before the code is run.
+   (Although, technically, if you really didn't want to remove those calls, you could use ``if not TYPE_CHECKING: reveal_locals = lambda: pass`` or similar to define the function to something else at runtime.)
 
 .. _silencing-linters:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -507,11 +507,11 @@ to see the types of all local variables at once. Example:
 
     ``reveal_type`` and ``reveal_locals`` are handled specially by mypy during
     type checking, and don't have to be defined or imported.
-    
+
     However, if you want to run your code,
     you'll have to remove any ``reveal_type`` and ``reveal_locals``
     calls from your program or else Python will give you an error at runtime.
-    
+
     Alternatively, you can import ``reveal_type`` from ``typing_extensions``
     or ``typing`` (on Python 3.11 and newer)
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -508,12 +508,14 @@ to see the types of all local variables at once. Example:
    ``reveal_type`` and ``reveal_locals`` are understood by mypy during typechecking,
    and don't have to be imported as functions. However,
    if you don't import them, then they don't exist at runtime! Therefore,
-   in that case, if you try to run your program, you'll have to
-   remove any ``reveal_type`` and ``reveal_locals`` calls
+   you'll have to remove any ``reveal_type`` and ``reveal_locals`` calls from your program
    or else Python will give you an error at runtime about those names being undefined.
-   Alternatively, you can import ``reveal_type`` from ``typing_extensions`` (or, in more recent versions of python, from ``typing``) so its name will be defined at runtime.
+   Alternatively, you can import ``reveal_type`` from :py:data:`typing_extensions`
+   (or, in more recent versions of python, from :py:data:`typing`) so its name will be defined at runtime.
    There is no analogous fix for ``reveal_locals``. It simply must be removed from the code before the code is run.
-   (Although, technically, if you really didn't want to remove those calls, you could use ``if not TYPE_CHECKING: reveal_locals = lambda: None`` or similar to define the function to something else at runtime.)
+   (Although, technically, if you really didn't want to remove those calls, you could use
+   ``if not typing.TYPE_CHECKING: reveal_locals = lambda: None``
+   or similar to define the function to something else at runtime.)
 
 .. _silencing-linters:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -511,9 +511,9 @@ to see the types of all local variables at once. Example:
    in that case, if you try to run your program, you'll have to
    remove any ``reveal_type`` and ``reveal_locals`` calls
    or else Python will give you an error at runtime about those names being undefined.
-  Alternatively, you can import ``reveal_type`` from ``typing_extensions`` (or, in more recent versions of python, from ``typing``) so its name will be defined at runtime.
+   Alternatively, you can import ``reveal_type`` from ``typing_extensions`` (or, in more recent versions of python, from ``typing``) so its name will be defined at runtime.
    There is no analogous fix for ``reveal_locals``. It simply must be removed from the code before the code is run.
-   (Although, technically, if you really didn't want to remove those calls, you could use ``if not TYPE_CHECKING: reveal_locals = lambda: pass`` or similar to define the function to something else at runtime.)
+   (Although, technically, if you really didn't want to remove those calls, you could use ``if not TYPE_CHECKING: reveal_locals = lambda: None`` or similar to define the function to something else at runtime.)
 
 .. _silencing-linters:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -505,18 +505,15 @@ to see the types of all local variables at once. Example:
    #     b: builtins.str
 .. note::
 
-    ``reveal_type`` and ``reveal_locals`` are understood by mypy during
-    typechecking, and don't have to be imported as functions. However, if you
-    don't import them, then they don't exist at runtime! Therefore, you'll have
-    to remove any ``reveal_type`` and ``reveal_locals`` calls from your program
-    or else Python will give you an error at runtime about those names being
-    undefined. Alternatively, you can import ``reveal_type`` from ``typing``
-    (or, in versions of python older than 3.11, from ``typing_extensions``) so
-    its name will be defined at runtime. There is no analogous fix for
-    ``reveal_locals``. It simply must be removed from the code before the code
-    is run. (Although, technically, if you really didn't want to remove those
-    calls, you could use ``if not typing.TYPE_CHECKING: reveal_locals = lambda:
-    None`` or similar to define the function to something else at runtime.)
+    ``reveal_type`` and ``reveal_locals`` are handled specially by mypy during
+    type checking, and don't have to be defined or imported.
+    
+    However, if you want to run your code,
+    you'll have to remove any ``reveal_type`` and ``reveal_locals``
+    calls from your program or else Python will give you an error at runtime.
+    
+    Alternatively, you can import ``reveal_type`` from ``typing_extensions``
+    or ``typing`` (on Python 3.11 and newer)
 
 .. _silencing-linters:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -510,7 +510,7 @@ to see the types of all local variables at once. Example:
    if you don't import them, then they don't exist at runtime! Therefore,
    you'll have to remove any ``reveal_type`` and ``reveal_locals`` calls from your program
    or else Python will give you an error at runtime about those names being undefined.
-   Alternatively, you can import :py:data:`~typing.reveal_type` from ``typing_extensions``
+   Alternatively, you can import ``reveal_type`` from ``typing_extensions``
    (or, in more recent versions of python, from ``typing``)
    so its name will be defined at runtime.
    There is no analogous fix for ``reveal_locals``.

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -510,9 +510,11 @@ to see the types of all local variables at once. Example:
    if you don't import them, then they don't exist at runtime! Therefore,
    you'll have to remove any ``reveal_type`` and ``reveal_locals`` calls from your program
    or else Python will give you an error at runtime about those names being undefined.
-   Alternatively, you can import ``reveal_type`` from :py:data:`typing_extensions`
-   (or, in more recent versions of python, from :py:data:`typing`) so its name will be defined at runtime.
-   There is no analogous fix for ``reveal_locals``. It simply must be removed from the code before the code is run.
+   Alternatively, you can import ``reveal_type`` from ``typing_extensions``
+   (or, in more recent versions of python, from ``typing``)
+   so its name will be defined at runtime.
+   There is no analogous fix for ``reveal_locals``.
+   It simply must be removed from the code before the code is run.
    (Although, technically, if you really didn't want to remove those calls, you could use
    ``if not typing.TYPE_CHECKING: reveal_locals = lambda: None``
    or similar to define the function to something else at runtime.)

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -504,20 +504,19 @@ to see the types of all local variables at once. Example:
    #     a: builtins.int
    #     b: builtins.str
 .. note::
-
-   ``reveal_type`` and ``reveal_locals`` are understood by mypy during typechecking,
-   and don't have to be imported as functions. However,
+   ``reveal_type`` and ``reveal_locals`` are understood by mypy during
+   typechecking, and don't have to be imported as functions. However,
    if you don't import them, then they don't exist at runtime! Therefore,
-   you'll have to remove any ``reveal_type`` and ``reveal_locals`` calls from your program
-   or else Python will give you an error at runtime about those names being undefined.
-   Alternatively, you can import ``reveal_type`` from ``typing_extensions``
-   (or, in more recent versions of python, from ``typing``)
-   so its name will be defined at runtime.
-   There is no analogous fix for ``reveal_locals``.
-   It simply must be removed from the code before the code is run.
-   (Although, technically, if you really didn't want to remove those calls, you could use
-   ``if not typing.TYPE_CHECKING: reveal_locals = lambda: None``
-   or similar to define the function to something else at runtime.)
+   you'll have to remove any ``reveal_type`` and ``reveal_locals`` calls
+   from your program or else Python will give you an error at runtime about
+   those names being undefined. Alternatively, you can import ``reveal_type``
+   from ``typing_extensions`` (or, in more recent versions of python, from
+   ``typing``) so its name will be defined at runtime. There is no analogous
+   fix for ``reveal_locals``. It simply must be removed from the code before
+   the code is run. (Although, technically, if you really didn't want to
+   remove those calls, you could use ``if not typing.TYPE_CHECKING:
+   reveal_locals = lambda: None`` or similar to define the function to
+   something else at runtime.)
 
 .. _silencing-linters:
 

--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -504,19 +504,19 @@ to see the types of all local variables at once. Example:
    #     a: builtins.int
    #     b: builtins.str
 .. note::
-   ``reveal_type`` and ``reveal_locals`` are understood by mypy during
-   typechecking, and don't have to be imported as functions. However,
-   if you don't import them, then they don't exist at runtime! Therefore,
-   you'll have to remove any ``reveal_type`` and ``reveal_locals`` calls
-   from your program or else Python will give you an error at runtime about
-   those names being undefined. Alternatively, you can import ``reveal_type``
-   from ``typing_extensions`` (or, in more recent versions of python, from
-   ``typing``) so its name will be defined at runtime. There is no analogous
-   fix for ``reveal_locals``. It simply must be removed from the code before
-   the code is run. (Although, technically, if you really didn't want to
-   remove those calls, you could use ``if not typing.TYPE_CHECKING:
-   reveal_locals = lambda: None`` or similar to define the function to
-   something else at runtime.)
+
+    ``reveal_type`` and ``reveal_locals`` are understood by mypy during
+    typechecking, and don't have to be imported as functions. However, if you
+    don't import them, then they don't exist at runtime! Therefore, you'll have
+    to remove any ``reveal_type`` and ``reveal_locals`` calls from your program
+    or else Python will give you an error at runtime about those names being
+    undefined. Alternatively, you can import ``reveal_type`` from ``typing``
+    (or, in versions of python older than 3.11, from ``typing_extensions``) so
+    its name will be defined at runtime. There is no analogous fix for
+    ``reveal_locals``. It simply must be removed from the code before the code
+    is run. (Although, technically, if you really didn't want to remove those
+    calls, you could use ``if not typing.TYPE_CHECKING: reveal_locals = lambda:
+    None`` or similar to define the function to something else at runtime.)
 
 .. _silencing-linters:
 


### PR DESCRIPTION
Previously it was impossible to have these in at run time (more or less), but now you can just import one of them.

Tangential open question I'm curious about: Is there any interest in getting reveal_locals into typing? I've never used it myself, so I have no strong opinions one way or the other, but I'm surprised reveal_type made it in and reveal_locals didn't! I tried to find the history of this decision but gave up.