### PR TITLE
[docs] Include a real listing of the flags strict enables in the online documentation

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -764,7 +764,10 @@ of the above sections.
     :option:`mypy --help` output.
 
     Note: the exact list of flags enabled by running :option:`--strict` may change
-    over time.
+    over time. For the current version of mypy, the list is:
+
+    .. include:: strict_list.rst
+
 
 .. option:: --disable-error-code
 

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -12,7 +12,7 @@ from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment import BuildEnvironment
 
-from mypy.api import run
+from mypy.main import process_options
 
 class MypyHTMLBuilder(StandaloneHTMLBuilder):
     def __init__(self, app: Sphinx, env: BuildEnvironment) -> None:
@@ -34,15 +34,10 @@ class MypyHTMLBuilder(StandaloneHTMLBuilder):
             raise ValueError(complaint+"it was not there.")
         elif c > 1:
             raise ValueError(complaint+"it occurred in multiple locations, so I don't know what to do.")
-        help_text = run(['--help'])[0]
-        strict_regex = r"Strict mode; enables the following flags: (.*?)\r?\n  --"
-        strict_part = re.match(strict_regex, help_text, re.DOTALL)
-        if strict_part is None:
-            print(help_text)
-            raise ValueError(f"Needed to match the regex r'{strict_regex}' in mypy --help, to enhance the docs, but it was not there.")
-        strict_part = strict_part[0]
+        help_text = process_options(['-c', 'pass'])
+        strict_part = help_text[2].split(": ")[1]
         if not strict_part or strict_part.isspace() or len(strict_part) < 20 or len(strict_part) > 2000:
-            raise ValueError(f"List of strict flags in the output is {strict_part}, which doesn't look right")
+           raise ValueError(f"{strict_part=}, which doesn't look right.")
         p.write_bytes(text.replace(lead_in, lead_in+b" The current list is: " + bytes(strict_part, encoding="ascii")))
 
     def _verify_error_codes(self) -> None:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -471,7 +471,7 @@ def process_options(
     fscache: FileSystemCache | None = None,
     program: str = "mypy",
     header: str = HEADER,
-) -> tuple[list[BuildSource], Options]:
+) -> tuple[list[BuildSource], Options, str]:
     """Parse command line arguments.
 
     If a FileSystemCache is passed in, and package_root options are given,
@@ -1502,11 +1502,9 @@ def process_options(
             targets.extend(p_targets)
         for m in special_opts.modules:
             targets.append(BuildSource(None, m, None))
-        return targets, options
     elif special_opts.command:
         options.build_type = BuildType.PROGRAM_TEXT
         targets = [BuildSource(None, None, "\n".join(special_opts.command))]
-        return targets, options
     else:
         try:
             targets = create_source_list(special_opts.files, options, fscache)
@@ -1515,7 +1513,7 @@ def process_options(
         # exceptions of different types.
         except InvalidSourceList as e2:
             fail(str(e2), stderr, options)
-        return targets, options
+    return targets, options, strict_help
 
 
 def process_package_roots(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -471,11 +471,13 @@ def process_options(
     fscache: FileSystemCache | None = None,
     program: str = "mypy",
     header: str = HEADER,
-) -> tuple[list[BuildSource], Options, str]:
+) -> tuple[list[BuildSource], Options, list[str]]:
     """Parse command line arguments.
 
     If a FileSystemCache is passed in, and package_root options are given,
     call fscache.set_package_root() to set the cache's package root.
+
+    Returns a tuple of: a list of source file, an Options collected from flags, and the computed list of strict flags.
     """
     stdout = stdout or sys.stdout
     stderr = stderr or sys.stderr
@@ -1513,7 +1515,7 @@ def process_options(
         # exceptions of different types.
         except InvalidSourceList as e2:
             fail(str(e2), stderr, options)
-    return targets, options, strict_help
+    return targets, options, strict_flag_names
 
 
 def process_package_roots(


### PR DESCRIPTION
Fixes #19061

Currently, https://mypy.readthedocs.io/en/stable/command_line.html just says

> You can see the list of flags enabled by strict mode in the full [mypy --help](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-h) output.

Which makes cross-referencing the documentation difficult. Instead, there should be the same list there as appears when running `mypy --help`: eg

> --warn-unused-configs, --disallow-any-generics,
                            --disallow-subclassing-any, --disallow-untyped-
                            calls, --disallow-untyped-defs, --disallow-
                            incomplete-defs, --check-untyped-defs, --disallow-
                            untyped-decorators, --warn-redundant-casts,
                            --warn-unused-ignores, --warn-return-any, --no-
                            implicit-reexport, --strict-equality, --extra-
                            checks

Ideally this section would be automatically generated from the code.

This pull request accomplishes this.