### PR TITLE
[docs] CONTRIBUTING.md: specify bare infinitive instead of imperative

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ Core developers should follow these rules when processing pull requests:
     message is under 80 characters, including the subject line.
   - Capitalize the subject and each paragraph.
   - Make sure that the subject of the commit message has no trailing dot.
-  - Use the imperative mood in the subject line (e.g. "Fix typo in README").
+  - Use the bare infinitive in the subject line (e.g. "Fix typo in README").
   - If the PR fixes an issue, make sure something like "Fixes #xxx." occurs
     in the body of the message (not in the subject).
   - Use Markdown for formatting.


### PR DESCRIPTION
This PR changes the git commit guidelines to say "Use the bare infinitive in the subject line" instead of "Use the imperative mood in the subject line"

Technically, git commit subject lines are in the bare infinitive, not the imperative, because they're merely unconjugated, rather than being a command. (They are identical in form, though, so it's understandable that they were confused here.)

Or, so I think, at least! For more information, you can see https://en.wikipedia.org/wiki/Bare_infinitive , https://en.wikipedia.org/wiki/Imperative_mood , or this blog post I wrote about this subject a while ago: https://wyattscarpenter.github.io/blog/git_commit_messages_are_in_the_bare_infinitive.txt