### PR TITLE
Add the capacity to run individual tests and test files to runtests.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,14 @@ python runtests.py self
 # or equivalently:
 python -m mypy --config-file mypy_self_check.ini -p mypy
 
-# Run a single test from the test suite
-pytest -n0 -k 'test_name'
+# Run a single test from the test suite (uses pytest substring expression matching)
+python runtests.py test_name
+# or equivalently:
+pytest -n0 -k test_name
 
 # Run all test cases in the "test-data/unit/check-dataclasses.test" file
+python runtests.py check-dataclasses.test
+# or equivalently:
 pytest mypy/test/testcheck.py::TypeCheckSuite::check-dataclasses.test
 
 # Run the formatters and linters

--- a/runtests.py
+++ b/runtests.py
@@ -160,8 +160,9 @@ def main() -> None:
         print(
             "Run the given tests. If given no arguments, run everything except"
             + " pytest-extra and mypyc-extra. Unrecognized arguments will be"
-            + " interpreted as individual test names (or, if they end in .test,"
-            + " individual test files) and this script will try to run them."
+            + " interpreted as individual test names / substring expressions"
+            + " (or, if they end in .test, individual test files)"
+            + " and this script will try to run them."
         )
         if "-h" in args or "--help" in args:
             exit(1)

--- a/runtests.py
+++ b/runtests.py
@@ -111,7 +111,13 @@ assert all(cmd in cmds for cmd in FAST_FAIL)
 
 def run_cmd(name: str) -> int:
     status = 0
-    cmd = cmds[name]
+    if name in cmds:
+        cmd = cmds[name]
+    else:
+        if name.endswith(".test"):
+            cmd = ["pytest", f"mypy/test/testcheck.py::TypeCheckSuite::{name}"]
+        else:
+            cmd = ["pytest", "-n0", "-k", name]
     print(f"run {name}: {cmd}")
     proc = subprocess.run(cmd, stderr=subprocess.STDOUT)
     if proc.returncode:
@@ -144,13 +150,21 @@ def main() -> None:
     prog, *args = argv
 
     if not set(args).issubset(cmds):
-        print("usage:", prog, " ".join(f"[{k}]" for k in cmds))
+        print(
+            "usage:",
+            prog,
+            " ".join(f"[{k}]" for k in cmds),
+            "[names of individual tests and files...]",
+        )
         print()
         print(
             "Run the given tests. If given no arguments, run everything except"
-            + " pytest-extra and mypyc-extra."
+            + " pytest-extra and mypyc-extra. Unrecognized arguments will be"
+            + " interpreted as individual test names (or, if they end in .test,"
+            + " individual test files) and this script will try to run them."
         )
-        exit(1)
+        if "-h" in args or "--help" in args:
+            exit(1)
 
     if not args:
         args = DEFAULT_COMMANDS.copy()


### PR DESCRIPTION
I have added the capacity to run individual tests and files by specifying them to runtests.py, removing the burden of remembering the correct arguments to pytest. I have updated the contributor documentation accordingly.
