### PR TITLE
Improve cli help somewhat

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -764,7 +764,7 @@ of the above sections.
     :option:`mypy --help` output.
 
     Note: the exact list of flags enabled by running :option:`--strict` may change
-    over time. For the this version of mypy, the list is:
+    over time. For this version of mypy, the list is:
 
     .. include:: strict_list.rst
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -764,7 +764,10 @@ of the above sections.
     :option:`mypy --help` output.
 
     Note: the exact list of flags enabled by running :option:`--strict` may change
-    over time.
+    over time. For the current version of mypy, the list is:
+
+    .. include:: strict_list.rst
+
 
 .. option:: --disable-error-code
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -1093,8 +1093,8 @@ Experimental features
 
       .. code-block:: python
 
-         def test_values() -> {"int": int, "str": str}:
-             return {"int": 42, "str": "test"}
+         def test_values() -> {"foo": int, "bar": str}:
+             return {"foo": 42, "bar": "test"}
 
 .. option:: --find-occurrences CLASS.MEMBER
 

--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -764,7 +764,7 @@ of the above sections.
     :option:`mypy --help` output.
 
     Note: the exact list of flags enabled by running :option:`--strict` may change
-    over time. For the current version of mypy, the list is:
+    over time. For the this version of mypy, the list is:
 
     .. include:: strict_list.rst
 

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -12,7 +12,7 @@ from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment import BuildEnvironment
 
-from mypy.api import run
+from mypy.main import process_options
 
 class MypyHTMLBuilder(StandaloneHTMLBuilder):
     def __init__(self, app: Sphinx, env: BuildEnvironment) -> None:
@@ -34,15 +34,10 @@ class MypyHTMLBuilder(StandaloneHTMLBuilder):
             raise ValueError(complaint+"it was not there.")
         elif c > 1:
             raise ValueError(complaint+"it occurred in multiple locations, so I don't know what to do.")
-        help_text = run(['--help'])[0]
-        strict_regex = r"Strict mode; enables the following flags: (.*?)\r?\n  --"
-        strict_part = re.match(strict_regex, help_text, re.DOTALL)
-        if strict_part is None:
-            print(help_text)
-            raise ValueError(f"Needed to match the regex r'{strict_regex}' in mypy --help, to enhance the docs, but it was not there.")
-        strict_part = strict_part[0]
+        help_text = process_options(['-c', 'pass'])
+        strict_part = help_text[2].split(": ")[1]
         if not strict_part or strict_part.isspace() or len(strict_part) < 20 or len(strict_part) > 2000:
-            raise ValueError(f"List of strict flags in the output is {strict_part}, which doesn't look right")
+           raise ValueError(f"{strict_part=}, which doesn't look right.")
         p.write_bytes(text.replace(lead_in, lead_in+b" The current list is: " + bytes(strict_part, encoding="ascii")))
 
     def _verify_error_codes(self) -> None:

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -26,8 +26,10 @@ class MypyHTMLBuilder(StandaloneHTMLBuilder):
 
     def _add_strict_list(self) -> None:
         p = Path(self.outdir).parent.parent / "source" / "strict_list.rst"
+        strict_flags: list[str] = []
+        process_options(["-c", "pass"], list_to_fill_with_strict_flags=strict_flags)
         strict_part = ", ".join(
-            f":option:`{s} <mypy {s}>`" for s in process_options(["-c", "pass"])[2]
+            f":option:`{s} <mypy {s}>`" for s in strict_flags
         )
         if (
             not strict_part

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -16,6 +16,7 @@ from mypy.main import process_options
 
 class MypyHTMLBuilder(StandaloneHTMLBuilder):
     strict_file: Path
+
     def __init__(self, app: Sphinx, env: BuildEnvironment) -> None:
         super().__init__(app, env)
         self._ref_to_doc = {}

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -11,7 +11,7 @@ from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment import BuildEnvironment
 
-from mypy.main import process_options
+from mypy.main import define_options
 
 
 class MypyHTMLBuilder(StandaloneHTMLBuilder):
@@ -28,8 +28,8 @@ class MypyHTMLBuilder(StandaloneHTMLBuilder):
         self._ref_to_doc.update({_id: docname for _id in doctree.ids})
 
     def _add_strict_list(self) -> None:
-        strict_flags: list[str] = []
-        process_options(["-c", "pass"], list_to_fill_with_strict_flags=strict_flags)
+        strict_flags: list[str]
+        _, strict_flags, _ = define_options()
         strict_part = ", ".join(f":option:`{s} <mypy {s}>`" for s in strict_flags)
         if (
             not strict_part

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -15,12 +15,12 @@ from mypy.main import process_options
 
 
 class MypyHTMLBuilder(StandaloneHTMLBuilder):
-    strict_file: Path
+    strict_file: Sphinx._StrPath
 
     def __init__(self, app: Sphinx, env: BuildEnvironment) -> None:
         super().__init__(app, env)
         self._ref_to_doc = {}
-        self.strict_file = Path(self.outdir) / "strict_list.rst"
+        self.strict_file = Path(self.srcdir) / "strict_list.rst"
         self._add_strict_list()
 
     def write_doc(self, docname: str, doctree: document) -> None:

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -15,7 +15,7 @@ from mypy.main import process_options
 
 
 class MypyHTMLBuilder(StandaloneHTMLBuilder):
-    strict_file: Sphinx._StrPath
+    strict_file: Path
 
     def __init__(self, app: Sphinx, env: BuildEnvironment) -> None:
         super().__init__(app, env)

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -28,9 +28,7 @@ class MypyHTMLBuilder(StandaloneHTMLBuilder):
         p = Path(self.outdir).parent.parent / "source" / "strict_list.rst"
         strict_flags: list[str] = []
         process_options(["-c", "pass"], list_to_fill_with_strict_flags=strict_flags)
-        strict_part = ", ".join(
-            f":option:`{s} <mypy {s}>`" for s in strict_flags
-        )
+        strict_part = ", ".join(f":option:`{s} <mypy {s}>`" for s in strict_flags)
         if (
             not strict_part
             or strict_part.isspace()

--- a/docs/source/html_builder.py
+++ b/docs/source/html_builder.py
@@ -13,6 +13,7 @@ from sphinx.environment import BuildEnvironment
 
 from mypy.main import process_options
 
+
 class MypyHTMLBuilder(StandaloneHTMLBuilder):
     def __init__(self, app: Sphinx, env: BuildEnvironment) -> None:
         super().__init__(app, env)
@@ -25,9 +26,16 @@ class MypyHTMLBuilder(StandaloneHTMLBuilder):
 
     def _add_strict_list(self) -> None:
         p = Path(self.outdir).parent.parent / "source" / "strict_list.rst"
-        strict_part = ", ".join(f":option:`{s} <mypy {s}>`" for s in process_options(['-c', 'pass'])[2])
-        if not strict_part or strict_part.isspace() or len(strict_part) < 20 or len(strict_part) > 2000:
-           raise ValueError(f"{strict_part=}, which doesn't look right (by a simple heuristic).")
+        strict_part = ", ".join(
+            f":option:`{s} <mypy {s}>`" for s in process_options(["-c", "pass"])[2]
+        )
+        if (
+            not strict_part
+            or strict_part.isspace()
+            or len(strict_part) < 20
+            or len(strict_part) > 2000
+        ):
+            raise ValueError(f"{strict_part=}, which doesn't look right (by a simple heuristic).")
         p.write_text(strict_part)
 
     def _verify_error_codes(self) -> None:

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -471,7 +471,7 @@ def process_options(
     fscache: FileSystemCache | None = None,
     program: str = "mypy",
     header: str = HEADER,
-) -> tuple[list[BuildSource], Options]:
+) -> tuple[list[BuildSource], Options, str]:
     """Parse command line arguments.
 
     If a FileSystemCache is passed in, and package_root options are given,
@@ -1521,11 +1521,9 @@ def process_options(
             targets.extend(p_targets)
         for m in special_opts.modules:
             targets.append(BuildSource(None, m, None))
-        return targets, options
     elif special_opts.command:
         options.build_type = BuildType.PROGRAM_TEXT
         targets = [BuildSource(None, None, "\n".join(special_opts.command))]
-        return targets, options
     else:
         try:
             targets = create_source_list(special_opts.files, options, fscache)
@@ -1534,7 +1532,7 @@ def process_options(
         # exceptions of different types.
         except InvalidSourceList as e2:
             fail(str(e2), stderr, options)
-        return targets, options
+    return targets, options, strict_help
 
 
 def process_package_roots(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -471,13 +471,18 @@ def process_options(
     fscache: FileSystemCache | None = None,
     program: str = "mypy",
     header: str = HEADER,
-) -> tuple[list[BuildSource], Options, list[str]]:
+    list_to_fill_with_strict_flags: list[str] | None = None
+) -> tuple[list[BuildSource], Options]:
     """Parse command line arguments.
 
     If a FileSystemCache is passed in, and package_root options are given,
     call fscache.set_package_root() to set the cache's package root.
 
-    Returns a tuple of: a list of source file, an Options collected from flags, and the computed list of strict flags.
+    Returns a tuple of: a list of source files, an Options collected from flags.
+
+    If list_to_fill_with_strict_flags is provided and not none,
+      then that list will be extended with the computed list of flags that --strict enables
+      (as a sort of secret return option).
     """
     stdout = stdout or sys.stdout
     stderr = stderr or sys.stderr
@@ -1534,7 +1539,9 @@ def process_options(
         # exceptions of different types.
         except InvalidSourceList as e2:
             fail(str(e2), stderr, options)
-    return targets, options, strict_flag_names
+    if list_to_fill_with_strict_flags is not None:
+        list_to_fill_with_strict_flags.extend(strict_flag_names)
+    return targets, options
 
 
 def process_package_roots(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -551,7 +551,7 @@ def define_options(
     #     long and will break up into multiple lines if we include that prefix, so for consistency
     #     we omit the prefix on all links.)
 
-    general_group = parser.add_argument_group(title="Optional arguments")
+    general_group = parser.add_argument_group(title="Utility arguments")
     general_group.add_argument(
         "-h", "--help", action="help", help="Show this help message and exit"
     )

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -471,7 +471,7 @@ def process_options(
     fscache: FileSystemCache | None = None,
     program: str = "mypy",
     header: str = HEADER,
-    list_to_fill_with_strict_flags: list[str] | None = None
+    list_to_fill_with_strict_flags: list[str] | None = None,
 ) -> tuple[list[BuildSource], Options]:
     """Parse command line arguments.
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -369,33 +369,45 @@ FOOTER: Final = """Environment variables:
   Define MYPYPATH for additional module search path entries.
   Define MYPY_CACHE_DIR to override configuration cache_dir path."""
 
+
 def is_terminal_punctuation(char: str) -> bool:
     return char in (".", "?", "!")
+
 
 class ArgumentGroup:
     """A wrapper for argparse's ArgumentGroup class that lets us enforce capitalization
     on the added arguments."""
+
     def __init__(self, argument_group: argparse._ArgumentGroup) -> None:
         self.argument_group = argument_group
 
-    def add_argument(self, *name_or_flags, help=None, **kwargs) -> argparse.Action:        
+    def add_argument(self, *name_or_flags, help=None, **kwargs) -> argparse.Action:
         if self.argument_group.title == "Report generation":
             if help and help != argparse.SUPPRESS:
-                raise ValueError(f"CLI documentation style error: help description for the Report generation flag {name_or_flags} was unexpectedly provided. (Currently, '{help}'.)"
+                raise ValueError(
+                    f"CLI documentation style error: help description for the Report generation flag {name_or_flags} was unexpectedly provided. (Currently, '{help}'.)"
                     + " This check is in the code because we assume there's nothing help to say about the report flags."
                     + " If you're improving that situation, feel free to remove this check."
                 )
         else:
             if not help:
-                raise ValueError(f"CLI documentation style error: flag help description for {name_or_flags} must be provided. (Currently, '{help}'.)")
+                raise ValueError(
+                    f"CLI documentation style error: flag help description for {name_or_flags} must be provided. (Currently, '{help}'.)"
+                )
             if help[0] != help[0].upper():
-                raise ValueError(f"CLI documentation style error: flag help description for {name_or_flags} must start with a capital letter (or unicameral symbol). (Currently, '{help}'.)")
-            if help[-1] == '.':
-                raise ValueError(f"CLI documentation style error: flag help description for {name_or_flags} must NOT end with a period. (Currently, '{help}'.)")
+                raise ValueError(
+                    f"CLI documentation style error: flag help description for {name_or_flags} must start with a capital letter (or unicameral symbol). (Currently, '{help}'.)"
+                )
+            if help[-1] == ".":
+                raise ValueError(
+                    f"CLI documentation style error: flag help description for {name_or_flags} must NOT end with a period. (Currently, '{help}'.)"
+                )
         return self.argument_group.add_argument(*name_or_flags, help=help, **kwargs)
-    
+
     def _add_action(self, action) -> None:
         self.argument_group._add_action(action)
+
+
 class CapturableArgumentParser(argparse.ArgumentParser):
     """Override ArgumentParser methods that use sys.stdout/sys.stderr directly.
 
@@ -415,20 +427,28 @@ class CapturableArgumentParser(argparse.ArgumentParser):
     # =====================
     # We just hard fail on these, as CI will ensure the runtime errors never get to users.
     def add_argument_group(
-        self,
-        title: str,
-        description: str | None = None,
-        **kwargs,
+        self, title: str, description: str | None = None, **kwargs
     ) -> ArgumentGroup:
-        if title not in ["positional arguments", "options"]: # These are built-in names, ignore them.
+        if title not in [
+            "positional arguments",
+            "options",
+        ]:  # These are built-in names, ignore them.
             if not title[0].isupper():
-                raise ValueError(f"CLI documentation style error: Title of group {title} must start with a capital letter. (Currently, '{title[0]}'.)")
+                raise ValueError(
+                    f"CLI documentation style error: Title of group {title} must start with a capital letter. (Currently, '{title[0]}'.)"
+                )
             if description and not description[0].isupper():
-                raise ValueError(f"CLI documentation style error: Description of group {title} must start with a capital letter. (Currently, '{description[0]}'.)")
+                raise ValueError(
+                    f"CLI documentation style error: Description of group {title} must start with a capital letter. (Currently, '{description[0]}'.)"
+                )
             if is_terminal_punctuation(title[-1]):
-                raise ValueError(f"CLI documentation style error: Title of group {title} must NOT end with terminal punction. (Currently, '{title[-1]}'.)")
+                raise ValueError(
+                    f"CLI documentation style error: Title of group {title} must NOT end with terminal punction. (Currently, '{title[-1]}'.)"
+                )
             if description and not is_terminal_punctuation(description[-1]):
-                raise ValueError(f"CLI documentation style error: Description of group {title} must end with terminal punction. (Currently, '{description[-1]}'.)")
+                raise ValueError(
+                    f"CLI documentation style error: Description of group {title} must end with terminal punction. (Currently, '{description[-1]}'.)"
+                )
         return ArgumentGroup(super().add_argument_group(title, description, **kwargs))
 
     # =====================
@@ -1148,9 +1168,10 @@ def define_options(
         "--new-type-inference", action="store_true", help=argparse.SUPPRESS
     )
     experimental_group = parser.add_argument_group(
-        title="Experimental options", description="Enable features that work well enough to be useful,"
+        title="Experimental options",
+        description="Enable features that work well enough to be useful,"
         + " but perhaps not as well as you might wish."
-        + " These features may be enabled by default in the future, or perhaps moved to another section."
+        + " These features may be enabled by default in the future, or perhaps moved to another section.",
     )
     experimental_group.add_argument(
         "--enable-incomplete-feature",

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1055,6 +1055,12 @@ def define_options(
         action="store_true",
         help="Include fine-grained dependency information in the cache for the mypy daemon",
     )
+    if server_options:
+        incremental_group.add_argument(
+            "--use-fine-grained-cache",
+            action="store_true",
+            help="Use the cache in fine-grained incremental mode (this flag only available for dmypy)",
+        )
     incremental_group.add_argument(
         "--skip-version-check",
         action="store_true",
@@ -1188,13 +1194,6 @@ def define_options(
         group=other_group,
         inverse="--interactive",
     )
-
-    if server_options:
-        other_group.add_argument(
-            "--use-fine-grained-cache",
-            action="store_true",
-            help="Use the cache in fine-grained incremental mode",
-        )
 
     # hidden options
     parser.add_argument(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -471,11 +471,13 @@ def process_options(
     fscache: FileSystemCache | None = None,
     program: str = "mypy",
     header: str = HEADER,
-) -> tuple[list[BuildSource], Options, str]:
+) -> tuple[list[BuildSource], Options, list[str]]:
     """Parse command line arguments.
 
     If a FileSystemCache is passed in, and package_root options are given,
     call fscache.set_package_root() to set the cache's package root.
+
+    Returns a tuple of: a list of source file, an Options collected from flags, and the computed list of strict flags.
     """
     stdout = stdout or sys.stdout
     stderr = stderr or sys.stderr
@@ -1532,7 +1534,7 @@ def process_options(
         # exceptions of different types.
         except InvalidSourceList as e2:
             fail(str(e2), stderr, options)
-    return targets, options, strict_help
+    return targets, options, strict_flag_names
 
 
 def process_package_roots(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1097,11 +1097,22 @@ def define_options(
     internals_group.add_argument(
         "--new-type-inference", action="store_true", help=argparse.SUPPRESS
     )
-    parser.add_argument(
+    experimental_group = parser.add_argument_group(
+        title="Experimental options", description="Enable features that work well enough to be useful,"
+        + " but perhaps not as well as you might wish."
+        + " These features may be enabled by default in the future, or perhaps moved to another section."
+    )
+    experimental_group.add_argument(
         "--enable-incomplete-feature",
         action="append",
         metavar="{" + ",".join(sorted(INCOMPLETE_FEATURES)) + "}",
         help="Enable support of incomplete/experimental features for early preview",
+    )
+    experimental_group.add_argument(
+        "--find-occurrences",
+        metavar="CLASS.MEMBER",
+        dest="special-opts:find_occurrences",
+        help="Print out all usages of a class member",
     )
     internals_group.add_argument(
         "--custom-typeshed-dir", metavar="DIR", help="Use the custom typeshed in DIR"
@@ -1155,22 +1166,16 @@ def define_options(
         "--skip-c-gen", dest="mypyc_skip_c_generation", action="store_true", help=argparse.SUPPRESS
     )
 
-    other_group = parser.add_argument_group(title="Miscellaneous")
-    other_group.add_argument("--quickstart-file", help=argparse.SUPPRESS)
-    other_group.add_argument("--junit-xml", help="Write junit.xml to the given file")
+    misc_group = parser.add_argument_group(title="Miscellaneous")
+    misc_group.add_argument("--quickstart-file", help=argparse.SUPPRESS)
+    misc_group.add_argument("--junit-xml", help="Write junit.xml to the given file")
     imports_group.add_argument(
         "--junit-format",
         choices=["global", "per_file"],
         default="global",
         help="If --junit-xml is set, specifies format. global: single test with all errors; per_file: one test entry per file with failures",
     )
-    other_group.add_argument(
-        "--find-occurrences",
-        metavar="CLASS.MEMBER",
-        dest="special-opts:find_occurrences",
-        help="Print out all usages of a class member (experimental)",
-    )
-    other_group.add_argument(
+    misc_group.add_argument(
         "--scripts-are-modules",
         action="store_true",
         help="Script x becomes module x instead of __main__",
@@ -1181,7 +1186,7 @@ def define_options(
         default=False,
         strict_flag=False,
         help="Install detected missing library stub packages using pip",
-        group=other_group,
+        group=misc_group,
     )
     add_invertible_flag(
         "--non-interactive",
@@ -1191,7 +1196,7 @@ def define_options(
             "Install stubs without asking for confirmation and hide "
             + "errors, with --install-types"
         ),
-        group=other_group,
+        group=misc_group,
         inverse="--interactive",
     )
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -461,7 +461,14 @@ class CapturableVersionAction(argparse.Action):
         parser._print_message(formatter.format_help(), self.stdout)
         parser.exit()
 
-def define_options(program: str = "mypy", header: str = HEADER, stdout: TextIO = sys.stdout, stderr: TextIO = sys.stderr, server_options: bool = False) -> tuple[CapturableArgumentParser, list[str], list[tuple[str, bool]]]:
+
+def define_options(
+    program: str = "mypy",
+    header: str = HEADER,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+    server_options: bool = False,
+) -> tuple[CapturableArgumentParser, list[str], list[tuple[str, bool]]]:
     """Define the options in the parser (by calling a bunch of methods that express/build our desired command-line flags).
     Returns a tuple of:
       a parser object, that can parse command line arguments to mypy (expected consumer: main's process_options),
@@ -1329,6 +1336,7 @@ def define_options(program: str = "mypy", header: str = HEADER, stdout: TextIO =
     )
     return parser, strict_flag_names, strict_flag_assignments
 
+
 def process_options(
     args: list[str],
     stdout: TextIO | None = None,
@@ -1349,7 +1357,9 @@ def process_options(
     stdout = stdout if stdout is not None else sys.stdout
     stderr = stderr if stderr is not None else sys.stderr
 
-    parser, _, strict_flag_assignments = define_options(header, program, stdout, stderr, server_options)
+    parser, _, strict_flag_assignments = define_options(
+        header, program, stdout, stderr, server_options
+    )
 
     # Parse arguments once into a dummy namespace so we can get the
     # filename for the config file and know if the user requested all strict options.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -615,10 +615,6 @@ def define_options(
     #     Feel free to add subsequent sentences that add additional details.
     # 3.  If you cannot think of a meaningful description for a new group, omit it entirely.
     #     (E.g. see the "miscellaneous" sections).
-    # 4.  The group description should end with a period (unless the last line is a link). If you
-    #     do end the group description with a link, omit the 'http://' prefix. (Some links are too
-    #     long and will break up into multiple lines if we include that prefix, so for consistency
-    #     we omit the prefix on all links.)
 
     general_group = parser.add_argument_group(title="Utility arguments")
     general_group.add_argument(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -573,7 +573,8 @@ def define_options(
         "-O",
         "--output",
         metavar="FORMAT",
-        help="Set a custom output format",
+        # The metavar overrides the default of displaying the choices, so we have to explicitly display them.
+        help=f"Set a custom output format (choices: {set(OUTPUT_CHOICES.keys())})",
         choices=OUTPUT_CHOICES,
     )
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -384,23 +384,27 @@ class ArgumentGroup:
     def add_argument(self, *name_or_flags, help=None, **kwargs) -> argparse.Action:
         if self.argument_group.title == "Report generation":
             if help and help != argparse.SUPPRESS:
-                raise ValueError(
-                    f"CLI documentation style error: help description for the Report generation flag {name_or_flags} was unexpectedly provided. (Currently, '{help}'.)"
-                    + " This check is in the code because we assume there's nothing help to say about the report flags."
-                    + " If you're improving that situation, feel free to remove this check."
+                ValueError(
+                    "Mypy-internal CLI documentation style error: help description for the Report generation flag"
+                     + f" {name_or_flags} was unexpectedly provided. (Currently, '{help}'.)"
+                     + " This check is in the code because we assume there's nothing help to say about the report flags."
+                     + " If you're improving that situation, feel free to remove this check."
                 )
         else:
             if not help:
                 raise ValueError(
-                    f"CLI documentation style error: flag help description for {name_or_flags} must be provided. (Currently, '{help}'.)"
+                    f"Mypy-internal CLI documentation style error: flag help description for {name_or_flags}"
+                     + f" must be provided. (Currently, '{help}'.)"
                 )
             if help[0] != help[0].upper():
                 raise ValueError(
-                    f"CLI documentation style error: flag help description for {name_or_flags} must start with a capital letter (or unicameral symbol). (Currently, '{help}'.)"
+                    f"Mypy-internal CLI documentation style error: flag help description for {name_or_flags}"
+                     + f" must start with a capital letter (or unicameral symbol). (Currently, '{help}'.)"
                 )
             if help[-1] == ".":
                 raise ValueError(
-                    f"CLI documentation style error: flag help description for {name_or_flags} must NOT end with a period. (Currently, '{help}'.)"
+                    f"Mypy-internal CLI documentation style error: flag help description for {name_or_flags}"
+                    + f" must NOT end with a period. (Currently, '{help}'.)"
                 )
         return self.argument_group.add_argument(*name_or_flags, help=help, **kwargs)
 
@@ -435,19 +439,23 @@ class CapturableArgumentParser(argparse.ArgumentParser):
         ]:  # These are built-in names, ignore them.
             if not title[0].isupper():
                 raise ValueError(
-                    f"CLI documentation style error: Title of group {title} must start with a capital letter. (Currently, '{title[0]}'.)"
+                    f"CLI documentation style error: Title of group {title}"
+                    + f" must start with a capital letter. (Currently, '{title[0]}'.)"
                 )
             if description and not description[0].isupper():
                 raise ValueError(
-                    f"CLI documentation style error: Description of group {title} must start with a capital letter. (Currently, '{description[0]}'.)"
+                    f"CLI documentation style error: Description of group {title}"
+                    + f" must start with a capital letter. (Currently, '{description[0]}'.)"
                 )
             if is_terminal_punctuation(title[-1]):
                 raise ValueError(
-                    f"CLI documentation style error: Title of group {title} must NOT end with terminal punction. (Currently, '{title[-1]}'.)"
+                    f"CLI documentation style error: Title of group {title}"
+                    + f" must NOT end with terminal punction. (Currently, '{title[-1]}'.)"
                 )
             if description and not is_terminal_punctuation(description[-1]):
                 raise ValueError(
-                    f"CLI documentation style error: Description of group {title} must end with terminal punction. (Currently, '{description[-1]}'.)"
+                    f"CLI documentation style error: Description of group {title}"
+                    + f" must end with terminal punction. (Currently, '{description[-1]}'.)"
                 )
         return ArgumentGroup(super().add_argument_group(title, description, **kwargs))
 
@@ -538,7 +546,8 @@ def define_options(
     stderr: TextIO = sys.stderr,
     server_options: bool = False,
 ) -> tuple[CapturableArgumentParser, list[str], list[tuple[str, bool]]]:
-    """Define the options in the parser (by calling a bunch of methods that express/build our desired command-line flags).
+    """Define the options in the parser
+    (by calling a bunch of methods that express/build our desired command-line flags).
     Returns a tuple of:
       a parser object, that can parse command line arguments to mypy (expected consumer: main's process_options),
       a list of what flags are strict (expected consumer: docs' html_builder's _add_strict_list),
@@ -638,7 +647,8 @@ def define_options(
         "-O",
         "--output",
         metavar="FORMAT",
-        # The metavar overrides the default of displaying the choices, so we have to explicitly display them.
+        # The metavar overrides the default of displaying the choices,
+        # so we have to explicitly display them.
         help=f"Set a custom output format (choices: {set(OUTPUT_CHOICES.keys())})",
         choices=OUTPUT_CHOICES,
     )
@@ -1167,7 +1177,8 @@ def define_options(
         title="Experimental options",
         description="Enable features that work well enough to be useful,"
         + " but perhaps not as well as you might wish."
-        + " These features may be enabled by default in the future, or perhaps moved to another section.",
+        + " These features may be enabled by default in the future,"
+        + " or perhaps moved to another section.",
     )
     experimental_group.add_argument(
         "--enable-incomplete-feature",
@@ -1240,7 +1251,9 @@ def define_options(
         "--junit-format",
         choices=["global", "per_file"],
         default="global",
-        help="If --junit-xml is set, specifies format. global: single test with all errors; per_file: one test entry per file with failures",
+        help="If --junit-xml is set, specifies format."
+        + " global: single test with all errors;"
+        + " per_file: one test entry per file with failures",
     )
     misc_group.add_argument(
         "--scripts-are-modules",
@@ -1596,7 +1609,8 @@ def process_options(
                 reason = cache.find_module(p)
                 if reason is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
                     fail(
-                        f"Package '{p}' cannot be type checked due to missing py.typed marker. See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
+                        f"Package '{p}' cannot be type checked due to missing py.typed marker."
+                        + " See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
                         stderr,
                         options,
                     )

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1190,13 +1190,6 @@ def define_options(
     )
 
     if server_options:
-        # TODO: This flag is superfluous; remove after a short transition (2018-03-16)
-        other_group.add_argument(
-            "--experimental",
-            action="store_true",
-            dest="fine_grained_incremental",
-            help="Enable fine-grained incremental mode",
-        )
         other_group.add_argument(
             "--use-fine-grained-cache",
             action="store_true",


### PR DESCRIPTION
This PR rearranges a couple of command line flag categorizations to make more sense and not leave any uncategorized — which is debatable, if someone really liked how the current top of `mypy --help` is

```
options:
  --enable-incomplete-feature {InlineTypedDict,PreciseTupleTypes}
                            Enable support of incomplete/experimental features for early preview

Optional arguments:
  -h, --help                Show this help message and exit
  -v, --verbose             More verbose messages
  -V, --version             Show program's version number and exit
  -O FORMAT, --output FORMAT
                            Set a custom output format

Config file:
```

instead of 

```
Utility arguments:
  -h, --help                Show this help message and exit
  -v, --verbose             More verbose messages
  -V, --version             Show program's version number and exit
  -O FORMAT, --output FORMAT
                            Set a custom output format (choices: {'json'})

Config file:
```

This PR also removes the --experimental flag (completing a TODO from 2018-03-16) and programmatically enforces the cli help style guide (from which it removes the advice about links that seemed misguided).

This PR relies on https://github.com/python/mypy/pull/19062 being merged, as I built off of that to save myself time fixing merge conflict later, and so I'm keeping this as a draft PR for now.