### PR TITLE
Make stubtest ignore `__slotnames__`

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1541,6 +1541,7 @@ IGNORABLE_CLASS_DUNDERS: Final = frozenset(
         "__getinitargs__",
         "__reduce_ex__",
         "__reduce__",
+        "__slotnames__",  # Cached names of slots added by `copyreg` module.
         # ctypes weirdness
         "__ctype_be__",
         "__ctype_le__",


### PR DESCRIPTION
This is a cached list of names of slots added by the `copyreg` module.

See https://github.com/typeddjango/django-stubs/pull/2584 for a case of these cropping up in `django-stubs`.