### PR TITLE
Admit that Final variables are never redefined

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1557,6 +1557,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         Note that this doesn't do a full CFG analysis but uses a line number based
         heuristic that isn't correct in some (rare) cases.
         """
+        if v.is_final:
+            # Final vars are definitely never reassigned.
+            return False
+
         outers = self.tscope.outer_functions()
         if not outers:
             # Top-level function -- outer context is top level, and we can't reason about

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1258,9 +1258,6 @@ def _init() -> Union[int, None]:
     return 0
 
 FOO: Final = _init()
-# For some reason the following isn't narrowed at all
-# (always stays int | None):
-# FOO: Final[Union[int, None]] = 0
 
 class Example:
 

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1250,3 +1250,30 @@ def check_final_init() -> None:
     new_instance = FinalInit()
     new_instance.__init__()
 [builtins fixtures/tuple.pyi]
+
+[case testNarrowingOfFinalPersistsInFunctions]
+from typing import Final, Union
+
+def _init() -> Union[int, None]:
+    return 0
+
+FOO: Final = _init()
+# For some reason the following isn't narrowed at all
+# (always stays int | None):
+# FOO: Final[Union[int, None]] = 0
+
+class Example:
+
+    if FOO is not None:
+        reveal_type(FOO)  # N: Revealed type is "builtins.int"
+
+        def fn(self) -> int:
+            return FOO
+
+if FOO is not None:
+    reveal_type(FOO)  # N: Revealed type is "builtins.int"
+
+    def func() -> int:
+        return FOO
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1275,5 +1275,3 @@ if FOO is not None:
 
     def func() -> int:
         return FOO
-
-[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #19080. There is no point applying our heuristics if the variable is declared Final - it is not reassigned anywhere.