### PR TITLE
Support running stubtest in non-UTF8 terminals

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -2107,11 +2107,12 @@ def safe_print(text: str) -> None:
     # If `sys.stdout` encoding is not the same as out (usually UTF8) string,
     # if may cause painful crashes. I don't want to reconfigure `sys.stdout`
     # to do `errors = "replace"` as that sounds scary.
-    print(
-        text.encode(sys.stdout.encoding, errors="replace").decode(
-            sys.stdout.encoding, errors="replace"
-        )
-    )
+    out_encoding = sys.stdout.encoding
+    if out_encoding is not None:
+        # Can be None if stdout is replaced (including our own tests). This should be
+        # safe to omit if the actual stream doesn't care about encoding.
+        text = text.encode(out_encoding, errors="replace").decode(out_encoding, errors="replace")
+    print(text)
 
 
 def parse_options(args: list[str]) -> _Arguments:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -2062,7 +2062,7 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
             if args.generate_allowlist:
                 generated_allowlist.add(error.object_desc)
                 continue
-            print(error.get_description(concise=args.concise))
+            safe_print(error.get_description(concise=args.concise))
             error_count += 1
 
     # Print unused allowlist entries
@@ -2100,6 +2100,18 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
             )
 
     return exit_code
+
+
+def safe_print(text: str) -> None:
+    """Print a text replacing chars not representable in stdout encoding."""
+    # If `sys.stdout` encoding is not the same as out (usually UTF8) string,
+    # if may cause painful crashes. I don't want to reconfigure `sys.stdout`
+    # to do `errors = "replace"` as that sounds scary.
+    print(
+        text.encode(sys.stdout.encoding, errors="replace").decode(
+            sys.stdout.encoding, errors="replace"
+        )
+    )
 
 
 def parse_options(args: list[str]) -> _Arguments:


### PR DESCRIPTION
Fixes #19071. I looked through the `open()` calls in the codebase, and only `reports.py` raises some concerns. Stubtest crashes due to this `print` call with incompatible encoding.

I tested this on Linux with `LC_CTYPE=ru_RU.CP1251` (random non-utf8 locale I found in `/usr/share/i18n/SUPPORTED`) and confirmed that `stubtest` crashes without the patch and passes with it.

Using a simple MRE (empty stub file and `A = "╙"` in a file, this symbol is `$'\u2559'`), I got this:

```
error: package.A is not present in stub
Stub: in file /tmp/tmp.Cs4RioNSuR/demo/stub/package/__init__.pyi
MISSING
Runtime:                                                                                                                                                                                                          
'?'
                                                                                                                                                                                                                  
Found 1 error (checked 1 module)
```

Without the patch I get a crash - same as in the linked issue.

@Avasam could you check this patch on windows, please? My nerves really aren't strong enough to configure whole virtualbox for a tiny encoding problem...