### PR TITLE
Remove last unreachable block from mypyc code

### DIFF
--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -220,19 +220,7 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
             return self.format("%r = %s(%s)", op, op.function_name, args_str)
 
     def visit_primitive_op(self, op: PrimitiveOp) -> str:
-        args = []
-        arg_index = 0
-        type_arg_index = 0
-        for arg_type in zip(op.desc.arg_types):
-            if arg_type:
-                args.append(self.format("%r", op.args[arg_index]))
-                arg_index += 1
-            else:
-                assert op.type_args
-                args.append(self.format("%r", op.type_args[type_arg_index]))
-                type_arg_index += 1
-
-        args_str = ", ".join(args)
+        args_str = ", ".join(self.format("%r", arg) for arg in op.args)
         if op.is_void:
             return self.format("%s %s", op.desc.name, args_str)
         else:


### PR DESCRIPTION
Supplements #19050. The old version did certainly contain unreachable code, as otherwise that branch would have crashed, there is no `type_args` attribute. This block was introduced in #17027 - probably as a future-proof expansion to generic primitive operations, but it makes no sense now, this logic can be added back should it become necessary. cc @JukkaL as the original author