### PR TITLE
Clear more data in TypeChecker.reset() instead of asserting

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -437,12 +437,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         self._type_maps[0].clear()
         self.temp_type_map = None
         self.expr_checker.reset()
-
-        assert self.inferred_attribute_types is None
-        assert self.partial_types == []
-        assert self.deferred_nodes == []
-        assert len(self.scope.stack) == 1
-        assert self.partial_types == []
+        self.deferred_nodes = []
+        self.partial_types = []
+        self.inferred_attribute_types = None
+        self.scope = CheckerScope(self.tree)
 
     def check_first_pass(self) -> None:
         """Type check the entire file, but defer functions with unresolved references.


### PR DESCRIPTION
Running mypy daemon on internal Dropbox codebase can cause an Assertion Error:

```
version: 1.16.0+dev.ca609acabdc94ee973a53d62b8dcb7e55c789aec
Daemon crashed!
Traceback (most recent call last):
  File "mypy/dmypy_server.py", line 237, in serve
  File "mypy/dmypy_server.py", line 286, in run_command
  File "mypy/dmypy_server.py", line 364, in cmd_check
  File "mypy/dmypy_server.py", line 428, in check
  File "mypy/dmypy_server.py", line 517, in initialize_fine_grained
  File "mypy/server/update.py", line 265, in update
  File "mypy/server/update.py", line 367, in update_one
  File "mypy/server/update.py", line 432, in update_module
  File "mypy/server/update.py", line 672, in update_module_isolated
  File "mypy/build.py", line 2410, in finish_passes
  File "mypy/build.py", line 2417, in free_state
  File "mypy/checker.py", line 443, in reset
AssertionError
```

Let's convert these asserts in reset() to actual cleanup. I see no reason not to clean them up.
It also seems safe for this particular crash, since in File "mypy/build.py", line 2417, in free_state
right after this line there's `self._type_checker = None`. So even if we wer not to call reset() everything would still be correct.