### PR TITLE
Update dmypy/client.py:  Enable ANSI color codes for windows cmd

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -562,6 +562,10 @@ def check_output(
 
     Call sys.exit() unless the status code is zero.
     """
+    if os.name == "nt":
+        # Enable ANSI color codes for Windows cmd using this strange workaround
+        # ( see https://github.com/python/cpython/issues/74261 )
+        os.system("")
     if "error" in response:
         fail(response["error"])
     try:


### PR DESCRIPTION
I still use windows cmd, and the color codes emitted by dmypy do not work on there. instead printing a bunch of codes like ←[37m    ←[39;49;00ms. However, for whatever reason you can fix this simply by calling os.system("") once. (The main mypy program works fine, presumably because it makes an os system call somewhere before it prints.)

I did not write a test of this, as that seems difficult and unnecessary. Instead, I manually tested it, and it worked great.