### PR TITLE
Emit a friendlier warning on invalid exclude regex, instead of a stacktrace

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -688,14 +688,17 @@ def matches_exclude(
             if re.search(exclude, subpath_str):
                 if verbose:
                     print(
-                        f"TRACE: Excluding {subpath_str} (matches pattern {exclude})", file=sys.stderr
+                        f"TRACE: Excluding {subpath_str} (matches pattern {exclude})",
+                        file=sys.stderr,
                     )
                 return True
         except re.error as e:
             print(f"error: The exclude {exclude} is an invalid regular expression, because:", e)
-            if '\\' in exclude:
+            if "\\" in exclude:
                 print("(Hint: use / as a path separator, even if you're on Windows!)")
-            print("For more information on Python's flavor of regex, see: https://docs.python.org/3/library/re.html")
+            print(
+                "For more information on Python's flavor of regex, see: https://docs.python.org/3/library/re.html"
+            )
             sys.exit(2)
     return False
 

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -693,11 +693,16 @@ def matches_exclude(
                     )
                 return True
         except re.error as e:
-            print(f"error: The exclude {exclude} is an invalid regular expression, because:", e)
-            if "\\" in exclude:
-                print("(Hint: use / as a path separator, even if you're on Windows!)")
             print(
-                "For more information on Python's flavor of regex, see: https://docs.python.org/3/library/re.html"
+                f"error: The exclude {exclude} is an invalid regular expression, because: {e}"
+                + (
+                    "\n(Hint: use / as a path separator, even if you're on Windows!)"
+                    if "\\" in exclude
+                    else ""
+                )
+                + "\nFor more information on Python's flavor of regex, see:"
+                + " https://docs.python.org/3/library/re.html",
+                file=sys.stderr,
             )
             sys.exit(2)
     return False
@@ -796,7 +801,8 @@ def default_lib_path(
             print(
                 "error: --custom-typeshed-dir does not point to a valid typeshed ({})".format(
                     custom_typeshed_dir
-                )
+                ),
+                file=sys.stderr,
             )
             sys.exit(2)
     else:

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -684,12 +684,19 @@ def matches_exclude(
     if fscache.isdir(subpath):
         subpath_str += "/"
     for exclude in excludes:
-        if re.search(exclude, subpath_str):
-            if verbose:
-                print(
-                    f"TRACE: Excluding {subpath_str} (matches pattern {exclude})", file=sys.stderr
-                )
-            return True
+        try:
+            if re.search(exclude, subpath_str):
+                if verbose:
+                    print(
+                        f"TRACE: Excluding {subpath_str} (matches pattern {exclude})", file=sys.stderr
+                    )
+                return True
+        except re.error as e:
+            print(f"error: The exclude {exclude} is an invalid regular expression, because:", e)
+            if '\\' in exclude:
+                print("(Hint: use / as a path separator, even if you're on Windows!)")
+            print("For more information on Python's flavor of regex, see: https://docs.python.org/3/library/re.html")
+            sys.exit(2)
     return False
 
 


### PR DESCRIPTION
If an invalid exclude is used, the error message

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\wyatt\files\gits\wyattscarpenter\!!! contributory forks\mypy\mypy\__main__.py", line 37, in <module>
    console_entry()
  File "C:\Users\wyatt\files\gits\wyattscarpenter\!!! contributory forks\mypy\mypy\__main__.py", line 15, in console_entry
    main()
  File "C:\Users\wyatt\files\gits\wyattscarpenter\!!! contributory forks\mypy\mypy\main.py", line 89, in main
    sources, options = process_options(args, stdout=stdout, stderr=stderr, fscache=fscache)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\files\gits\wyattscarpenter\!!! contributory forks\mypy\mypy\main.py", line 1531, in process_options
    targets = create_source_list(special_opts.files, options, fscache)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\files\gits\wyattscarpenter\!!! contributory forks\mypy\mypy\find_sources.py", line 48, in create_source_list
    sub_sources = finder.find_sources_in_dir(path)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\files\gits\wyattscarpenter\!!! contributory forks\mypy\mypy\find_sources.py", line 121, in find_sources_in_dir
    if matches_exclude(subpath, self.exclude, self.fscache, self.verbosity >= 2):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\files\gits\wyattscarpenter\!!! contributory forks\mypy\mypy\modulefinder.py", line 687, in matches_exclude
    if re.search(exclude, subpath_str):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\AppData\Local\Programs\Python\Python312\Lib\re\__init__.py", line 177, in search
    return _compile(pattern, flags).search(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\AppData\Local\Programs\Python\Python312\Lib\re\__init__.py", line 307, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\AppData\Local\Programs\Python\Python312\Lib\re\_compiler.py", line 750, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\AppData\Local\Programs\Python\Python312\Lib\re\_parser.py", line 979, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\AppData\Local\Programs\Python\Python312\Lib\re\_parser.py", line 460, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\AppData\Local\Programs\Python\Python312\Lib\re\_parser.py", line 544, in _parse
    code = _escape(source, this, state)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wyatt\AppData\Local\Programs\Python\Python312\Lib\re\_parser.py", line 443, in _escape
    raise source.error("bad escape %s" % escape, len(escape))
re.error: bad escape \p at position 2
```

now looks like this:

```
error: The exclude ..\publish is an invalid regular expression, because: bad escape \p at position 2
(Hint: use / as a path separator, even if you're on Windows!)
For more information on Python's flavor of regex, see: https://docs.python.org/3/library/re.html
```