### PR TITLE
Avoid false `unreachable`, `redundant-expr`, and `redundant-casts` warnings in loops more robustly and efficiently, and avoid multiple `revealed type` notes for the same line.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -636,7 +636,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 iter += 1
                 if iter == 20:
                     raise RuntimeError("Too many iterations when checking a loop")
-asdf
+
             # Report those unreachable and redundant expression errors identified in all
             # iteration steps:
             for error_info in uselessness_errors:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -636,7 +636,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 iter += 1
                 if iter == 20:
                     raise RuntimeError("Too many iterations when checking a loop")
-
+asdf
             # Report those unreachable and redundant expression errors identified in all
             # iteration steps:
             for error_info in uselessness_errors:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -600,7 +600,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
             # on without bound otherwise)
             widened_old = len(self.widened_vars)
 
-            # one set of `unreachable` and `redundant-expr`errors per iteration step:
+            # one set of `unreachable`, `redundant-expr`, and `redundant-casts` errors
+            # per iteration step:
             uselessness_errors = []
             # one set of unreachable line numbers per iteration step:
             unreachable_lines = []
@@ -640,8 +641,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 if iter == 20:
                     raise RuntimeError("Too many iterations when checking a loop")
 
-            # Report only those `unreachable` and `redundant-expr` errors that could not
-            # be ruled out in any iteration step:
+            # Report only those `unreachable`, `redundant-expr`, and `redundant-casts`
+            # errors that could not be ruled out in any iteration step:
             persistent_uselessness_errors = set()
             for candidate in set(itertools.chain(*uselessness_errors)):
                 if all(

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -222,8 +222,8 @@ class ErrorWatcher:
 
 class LoopErrorWatcher(ErrorWatcher):
     """Error watcher that filters and separately collects `unreachable` errors,
-    `redundant-expr` errors, and revealed types when analysing loops iteratively
-    to help avoid making too-hasty reports."""
+    `redundant-expr` and `redundant-casts` errors, and revealed types when analysing
+    loops iteratively to help avoid making too-hasty reports."""
 
     # Meaning of the tuple items: ErrorCode, message, line, column, end_line, end_column:
     uselessness_errors: set[tuple[ErrorCode, str, int, int, int, int]]
@@ -254,7 +254,7 @@ class LoopErrorWatcher(ErrorWatcher):
 
     def on_error(self, file: str, info: ErrorInfo) -> bool:
 
-        if info.code in (codes.UNREACHABLE, codes.REDUNDANT_EXPR):
+        if info.code in (codes.UNREACHABLE, codes.REDUNDANT_EXPR, codes.REDUNDANT_CAST):
             self.uselessness_errors.add(
                 (info.code, info.message, info.line, info.column, info.end_line, info.end_column)
             )

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -259,6 +259,7 @@ class LoopErrorWatcher(ErrorWatcher):
             return True
         return super().on_error(file, info)
 
+
 class Errors:
     """Container for compile errors.
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -343,7 +343,7 @@ for var2 in [g, h, i, j, k, l]:
     reveal_type(var2)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 
 for var3 in [m, n, o, p, q, r]:
-    reveal_type(var3)  # N: Revealed type is "Union[builtins.int, Any]"
+    reveal_type(var3)  # N: Revealed type is "Union[Any, builtins.int]"
 
 T = TypeVar("T", bound=Type[Foo])
 
@@ -1247,7 +1247,7 @@ class X(TypedDict):
 
 x: X
 for a in ("hourly", "daily"):
-    reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
+    reveal_type(a)  # N: Revealed type is "Union[Literal['daily']?, Literal['hourly']?]"
     reveal_type(x[a])  # N: Revealed type is "builtins.int"
     reveal_type(a.upper())  # N: Revealed type is "builtins.str"
     c = a

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2382,6 +2382,28 @@ while True:
 
 [builtins fixtures/bool.pyi]
 
+[case testAvoidFalseRedundantCastInLoops]
+# flags: --warn-redundant-casts
+
+from typing import Callable, cast, Union
+
+ProcessorReturnValue = Union[str, int]
+Processor = Callable[[str], ProcessorReturnValue]
+
+def main_cast(p: Processor) -> None:
+    ed: ProcessorReturnValue
+    ed = cast(str, ...)
+    while True:
+        ed = p(cast(str, ed))
+
+def main_no_cast(p: Processor) -> None:
+    ed: ProcessorReturnValue
+    ed = cast(str, ...)
+    while True:
+        ed = p(ed)  # E: Argument 1 has incompatible type "Union[str, int]"; expected "str"
+
+[builtins fixtures/bool.pyi]
+
 [case testAvoidFalseUnreachableInLoop1]
 # flags: --warn-unreachable --python-version 3.11
 

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2369,6 +2369,19 @@ class A:
 
 [builtins fixtures/primitives.pyi]
 
+[case testPersistentUnreachableLinesNestedInInpersistentUnreachableLines]
+# flags: --warn-unreachable --python-version 3.11
+
+x = None
+y = None
+while True:
+    if x is not None:
+        if y is not None:
+            reveal_type(y)  # E: Statement is unreachable
+    x = 1
+
+[builtins fixtures/bool.pyi]
+
 [case testAvoidFalseUnreachableInLoop1]
 # flags: --warn-unreachable --python-version 3.11
 

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2346,8 +2346,7 @@ def f() -> bool: ...
 
 y = None
 while f():
-    reveal_type(y)  # N: Revealed type is "None" \
-                    # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type(y)  # N: Revealed type is "Union[builtins.int, None]"
     y = 1
 reveal_type(y)  # N: Revealed type is "Union[builtins.int, None]"
 
@@ -2370,7 +2369,7 @@ class A:
 
 [builtins fixtures/primitives.pyi]
 
-[case testAvoidFalseUnreachableInLoop]
+[case testAvoidFalseUnreachableInLoop1]
 # flags: --warn-unreachable --python-version 3.11
 
 def f() -> int | None: ...
@@ -2382,6 +2381,29 @@ while x is not None or b():
     x = f()
 
 [builtins fixtures/bool.pyi]
+
+[case testAvoidFalseUnreachableInLoop2]
+# flags: --warn-unreachable --python-version 3.11
+
+y = None
+while y is None:
+    if y is None:
+        y = []
+    y.append(1)
+
+[builtins fixtures/list.pyi]
+
+[case testAvoidFalseUnreachableInLoop3]
+# flags: --warn-unreachable --python-version 3.11
+
+xs: list[int | None]
+y = None
+for x in xs:
+    if x is not None:
+        if y is None:
+            y = {}  # E: Need type annotation for "y" (hint: "y: Dict[<type>, <type>] = ...")
+
+[builtins fixtures/list.pyi]
 
 [case testAvoidFalseRedundantExprInLoop]
 # flags: --enable-error-code redundant-expr --python-version 3.11

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -628,7 +628,7 @@ def f1() -> None:
 def f2() -> None:
     x = None
     while int():
-        reveal_type(x) # N: Revealed type is "Union[None, builtins.str]"
+        reveal_type(x) # N: Revealed type is "Union[builtins.str, None]"
         if int():
             x = ""
     reveal_type(x) # N: Revealed type is "Union[None, builtins.str]"
@@ -808,8 +808,7 @@ def f4() -> None:
                         x = None
                         break
         finally:
-            reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str, None]" \
-                # N: Revealed type is "Union[builtins.int, None]"
+            reveal_type(x) # N: Revealed type is "Union[builtins.int, builtins.str, None]"
         reveal_type(x) # N: Revealed type is "Union[builtins.int, None]"
 [builtins fixtures/exception.pyi]
 
@@ -925,7 +924,7 @@ class X(TypedDict):
 
 x: X
 for a in ("hourly", "daily"):
-    reveal_type(a)  # N: Revealed type is "Union[Literal['hourly']?, Literal['daily']?]"
+    reveal_type(a)  # N: Revealed type is "Union[Literal['daily']?, Literal['hourly']?]"
     reveal_type(x[a])  # N: Revealed type is "builtins.int"
     reveal_type(a.upper())  # N: Revealed type is "builtins.str"
     c = a

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -628,8 +628,7 @@ def f1() -> None:
 def f2() -> None:
     x = None
     while int():
-        reveal_type(x) # N: Revealed type is "None" \
-                       # N: Revealed type is "Union[None, builtins.str]"
+        reveal_type(x) # N: Revealed type is "Union[None, builtins.str]"
         if int():
             x = ""
     reveal_type(x) # N: Revealed type is "Union[None, builtins.str]"
@@ -709,8 +708,7 @@ def b() -> None:
 def c() -> None:
     x = 0
     while int():
-        reveal_type(x) # N: Revealed type is "builtins.int" \
-                       # N: Revealed type is "Union[builtins.int, builtins.str, None]"
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str, None]"
         if int():
             x = ""
             continue

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -989,7 +989,7 @@ from typing_extensions import Unpack
 
 def pipeline(*xs: Unpack[Tuple[int, Unpack[Tuple[float, ...]], bool]]) -> None:
     for x in xs:
-        reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.float]"
+        reveal_type(x)  # N: Revealed type is "Union[builtins.float, builtins.int]"
 [builtins fixtures/tuple.pyi]
 
 [case testFixedUnpackItemInInstanceArguments]


### PR DESCRIPTION
Fixes #18606 
Closes #18511
Improves #18991
Fixes #19170

This change is an improvement over 9685171.  Besides fixing the regressions reported in #18606 and #19170 and removing the duplicates reported in #18511, it should significantly reduce the performance regression reported in #18991.  At least running `Measure-command {python runtests.py self}` on my computer (with removed cache) is 10 % faster.
