### PR TITLE
stubgen: add import for types in __exit__ method signature

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -633,6 +633,11 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
             new_args = infer_method_arg_types(
                 ctx.name, ctx.class_info.self_var, [arg.name for arg in args]
             )
+
+            if ctx.name == "__exit__":
+                self.import_tracker.add_import("types")
+                self.import_tracker.require_name("types")
+
             if new_args is not None:
                 args = new_args
 

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -3777,6 +3777,8 @@ class MatchNames:
     def __exit__(self, type, value, traceback): ...
 
 [out]
+import types
+
 class MismatchNames:
     def __exit__(self, tp: type[BaseException] | None, val: BaseException | None, tb: types.TracebackType | None) -> None: ...
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #17037

add import for types in __exit__ method signature

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
