### PR TITLE
Fix example to use correct method of Stack

### DIFF
--- a/docs/source/generics.rst
+++ b/docs/source/generics.rst
@@ -93,7 +93,7 @@ Using ``Stack`` is similar to built-in container types:
    stack.push('x')
 
    stack2: Stack[str] = Stack()
-   stack2.append('x')
+   stack2.push('x')
 
 Construction of instances of generic types is type checked (Python 3.12 syntax):
 


### PR DESCRIPTION
This PR updates the `generics.rst` documentation to correct a method call in the `Stack` usage example. Previously, the example incorrectly used `.append('x')` on a `Stack[str]` instance, which is not a valid method for the `Stack` class.

