### PR TITLE
[mypyc] Fix incref/decref on free-threaded builds

### DIFF
--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -31,6 +31,8 @@
 // Here just for consistency
 #define CPy_XDECREF(p) Py_XDECREF(p)
 
+#ifndef Py_GIL_DISABLED
+
 // The *_NO_IMM operations below perform refcount manipulation for
 // non-immortal objects (Python 3.12 and later).
 //
@@ -59,6 +61,14 @@ static inline void CPy_XDECREF_NO_IMM(PyObject *op)
 #define CPy_INCREF_NO_IMM(op) CPy_INCREF_NO_IMM((PyObject *)(op))
 #define CPy_DECREF_NO_IMM(op) CPy_DECREF_NO_IMM((PyObject *)(op))
 #define CPy_XDECREF_NO_IMM(op) CPy_XDECREF_NO_IMM((PyObject *)(op))
+
+#else
+
+#define CPy_INCREF_NO_IMM(op) CPy_INCREF(op)
+#define CPy_DECREF_NO_IMM(op) CPy_DECREF(op)
+#define CPy_XDECREF_NO_IMM(op) CPy_XDECREF(op)
+
+#endif
 
 // Tagged integer -- our representation of Python 'int' objects.
 // Small enough integers are represented as unboxed integers (shifted


### PR DESCRIPTION
Fix C compile errors on free-threaded builds. We can't (easily) access the reference count value directly, so always use the C API functions when on a free-threaded build.

Work on mypyc/mypyc#1038.