### PR TITLE
Forbid `.pop` of `Readonly` `NotRequired` TypedDict items

### DIFF
--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -316,7 +316,7 @@ def typed_dict_pop_callback(ctx: MethodContext) -> Type:
 
         value_types = []
         for key in keys:
-            if key in ctx.type.required_keys:
+            if key in ctx.type.required_keys or key in ctx.type.readonly_keys:
                 ctx.api.msg.typeddict_key_cannot_be_deleted(ctx.type, key, key_expr)
 
             value_type = ctx.type.items.get(key)

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3760,20 +3760,24 @@ del x["optional_key"]  # E: Key "optional_key" of TypedDict "TP" cannot be delet
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictReadOnlyMutateMethods]
-from typing import ReadOnly, TypedDict
+from typing import ReadOnly, NotRequired, TypedDict
 
 class TP(TypedDict):
     key: ReadOnly[str]
+    optional_key: ReadOnly[NotRequired[str]]
     other: ReadOnly[int]
     mutable: bool
 
 x: TP
 reveal_type(x.pop("key"))  # N: Revealed type is "builtins.str" \
                            # E: Key "key" of TypedDict "TP" cannot be deleted
+reveal_type(x.pop("optional_key"))  # N: Revealed type is "builtins.str" \
+                                    # E: Key "optional_key" of TypedDict "TP" cannot be deleted
 
 
 x.update({"key": "abc", "other": 1, "mutable": True})  # E: ReadOnly TypedDict keys ("key", "other") TypedDict are mutated
 x.setdefault("key", "abc")  # E: ReadOnly TypedDict key "key" TypedDict is mutated
+x.setdefault("optional_key", "foo")  # E: ReadOnly TypedDict key "optional_key" TypedDict is mutated
 x.setdefault("other", 1)  # E: ReadOnly TypedDict key "other" TypedDict is mutated
 x.setdefault("mutable", False)  # ok
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #19130. We already have these checks for `del typed_dict["readonly_notrequired_key"]`, this just aligns `.pop()` logic with that.