### PR TITLE
Fix nondeterministic type checking by making join between TypeType and TypeVar commute

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -635,6 +635,8 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
         typ = get_proper_type(typ)
         if isinstance(typ, Instance):
             return object_from_instance(typ)
+        elif isinstance(typ, TypeType):
+            return self.default(typ.item)
         elif isinstance(typ, UnboundType):
             return AnyType(TypeOfAny.special_form)
         elif isinstance(typ, TupleType):

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -1064,6 +1064,10 @@ class JoinSuite(Suite):
             self.tuple(UnpackType(Instance(self.fx.std_tuplei, [self.fx.a])), self.fx.a),
         )
 
+    def test_join_type_type_type_var(self) -> None:
+        self.assert_join(self.fx.type_a, self.fx.t, self.fx.o)
+        self.assert_join(self.fx.t, self.fx.type_a, self.fx.o)
+
     # There are additional test cases in check-inference.test.
 
     # TODO: Function types + varargs and default args.


### PR DESCRIPTION
Fixes #18125

Unhandled cases in `default` seem fairly dangerous