### PR TITLE
[mypyc] Improve documentation of native and non-native classes

### DIFF
--- a/mypyc/doc/native_classes.rst
+++ b/mypyc/doc/native_classes.rst
@@ -90,7 +90,7 @@ You need to install ``mypy-extensions`` to use ``@mypyc_attr``:
     pip install --upgrade mypy-extensions
 
 Additionally, mypyc recognizes these base classes as special, and
-undersands how they alter the behavior of classes (including native
+understands how they alter the behavior of classes (including native
 classes) that subclass them:
 
 * ``typing.NamedTuple``


### PR DESCRIPTION
Also discuss `mypyc_attr(native_class=<...>)`.