### PR TITLE
Drop support for --python-version 3.8

### DIFF
--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -10,7 +10,7 @@ PYTHON3_VERSION: Final = (3, 9)
 
 # Earliest Python 3.x version supported via --python-version 3.x. To run
 # mypy, at least version PYTHON3_VERSION is needed.
-PYTHON3_VERSION_MIN: Final = (3, 8)  # Keep in sync with typeshed's python support
+PYTHON3_VERSION_MIN: Final = (3, 9)  # Keep in sync with typeshed's python support
 
 CACHE_DIR: Final = ".mypy_cache"
 

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -995,6 +995,6 @@ def parse_version(version: str) -> tuple[int, int]:
 
 def typeshed_py_version(options: Options) -> tuple[int, int]:
     """Return Python version used for checking whether module supports typeshed."""
-    # Typeshed no longer covers Python 3.x versions before 3.8, so 3.8 is
+    # Typeshed no longer covers Python 3.x versions before 3.9, so 3.9 is
     # the earliest we can support.
-    return max(options.python_version, (3, 8))
+    return max(options.python_version, (3, 9))

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -148,18 +148,6 @@ reverse_builtin_aliases: Final = {
     "builtins.frozenset": "typing.FrozenSet",
 }
 
-_nongen_builtins: Final = {"builtins.tuple": "typing.Tuple", "builtins.enumerate": ""}
-_nongen_builtins.update((name, alias) for alias, name in type_aliases.items())
-# Drop OrderedDict from this for backward compatibility
-del _nongen_builtins["collections.OrderedDict"]
-# HACK: consequence of hackily treating LiteralString as an alias for str
-del _nongen_builtins["builtins.str"]
-
-
-def get_nongen_builtins(python_version: tuple[int, int]) -> dict[str, str]:
-    # After 3.9 with pep585 generic builtins are allowed
-    return _nongen_builtins if python_version < (3, 9) else {}
-
 
 RUNTIME_PROTOCOL_DECOS: Final = (
     "typing.runtime_checkable",

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -184,7 +184,6 @@ from mypy.nodes import (
     YieldExpr,
     YieldFromExpr,
     get_member_expr_fullname,
-    get_nongen_builtins,
     implicit_module_attrs,
     is_final_node,
     type_aliases,
@@ -247,7 +246,6 @@ from mypy.typeanal import (
     find_self_type,
     fix_instance,
     has_any_from_unimported_type,
-    no_subscript_builtin_alias,
     type_constructors,
     validate_instance,
 )
@@ -5996,30 +5994,6 @@ class SemanticAnalyzer(
         expr.analyzed = TypeApplication(base, types)
         expr.analyzed.line = expr.line
         expr.analyzed.column = expr.column
-        # Types list, dict, set are not subscriptable, prohibit this if
-        # subscripted either via type alias...
-        if isinstance(base, RefExpr) and isinstance(base.node, TypeAlias):
-            alias = base.node
-            target = get_proper_type(alias.target)
-            if isinstance(target, Instance):
-                name = target.type.fullname
-                if (
-                    alias.no_args
-                    and name  # this avoids bogus errors for already reported aliases
-                    in get_nongen_builtins(self.options.python_version)
-                    and not self.is_stub_file
-                    and not alias.normalized
-                ):
-                    self.fail(no_subscript_builtin_alias(name, propose_alt=False), expr)
-        # ...or directly.
-        else:
-            n = self.lookup_type_node(base)
-            if (
-                n
-                and n.fullname in get_nongen_builtins(self.options.python_version)
-                and not self.is_stub_file
-            ):
-                self.fail(no_subscript_builtin_alias(n.fullname, propose_alt=False), expr)
 
     def analyze_type_application_args(self, expr: IndexExpr) -> list[Type] | None:
         """Analyze type arguments (index) in a type application.

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -984,15 +984,6 @@ elif sys.version_info[:2] == (3, 10):
 elif sys.version_info[:2] == (3, 9):
     def version() -> int:
         return 9
-elif sys.version_info[:2] == (3, 8):
-    def version() -> int:
-        return 8
-elif sys.version_info[:2] == (3, 7):
-    def version() -> int:
-        return 7
-elif sys.version_info[:2] == (3, 6):
-    def version() -> int:
-        return 6
 else:
     raise Exception("we don't support this version yet!")
 

--- a/mypyc/test/testutil.py
+++ b/mypyc/test/testutil.py
@@ -111,7 +111,7 @@ def build_ir_for_single_file2(
     options.hide_error_codes = True
     options.use_builtins_fixtures = True
     options.strict_optional = True
-    options.python_version = compiler_options.python_version or (3, 8)
+    options.python_version = compiler_options.python_version or (3, 9)
     options.export_types = True
     options.preserve_asts = True
     options.allow_empty_bodies = True

--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -144,15 +144,7 @@ def f4(a: Annotated[T, "metadata"]):
 reveal_type(f4)  # N: Revealed type is "def [T] (a: T`-1) -> Any"
 [builtins fixtures/tuple.pyi]
 
-[case testSliceAnnotated39]
-# flags: --python-version 3.9
-from typing_extensions import Annotated
-a: Annotated[int, 1:2]
-reveal_type(a)  # N: Revealed type is "builtins.int"
-[builtins fixtures/tuple.pyi]
-
-[case testSliceAnnotated38]
-# flags: --python-version 3.8
+[case testSliceAnnotated]
 from typing_extensions import Annotated
 a: Annotated[int, 1:2]
 reveal_type(a)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-columns.test
+++ b/test-data/unit/check-columns.test
@@ -261,10 +261,10 @@ class D(A):
                               # N:5:          def f(self) -> None
 
 [case testColumnMissingTypeParameters]
-# flags: --python-version 3.8 --disallow-any-generics
+# flags: --disallow-any-generics
 from typing import List, Callable
 def f(x: List) -> None: pass # E:10: Missing type parameters for generic type "List"
-def g(x: list) -> None: pass # E:10: Implicit generic "Any". Use "typing.List" and specify generic parameters
+def g(x: list) -> None: pass # E:10: Missing type parameters for generic type "List"
 if int():
     c: Callable # E:8: Missing type parameters for generic type "Callable"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1911,7 +1911,6 @@ SecondClass().SECOND_CONST = 42  # E: Cannot assign to final attribute "SECOND_C
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassFieldsProtocol]
-# flags: --python-version 3.9
 from dataclasses import dataclass
 from typing import Any, Protocol
 

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -341,10 +341,10 @@ a: A
 a.x = ''  # E: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
 
 [case testErrorCodeMissingTypeArg]
-# flags: --python-version 3.8 --disallow-any-generics
+# flags: --disallow-any-generics
 from typing import List, TypeVar
 x: List  # E: Missing type parameters for generic type "List"  [type-arg]
-y: list  # E: Implicit generic "Any". Use "typing.List" and specify generic parameters  [type-arg]
+y: list  # E: Missing type parameters for generic type "List"  [type-arg]
 T = TypeVar('T')
 L = List[List[T]]
 z: L  # E: Missing type parameters for generic type "L"  [type-arg]
@@ -970,22 +970,21 @@ def f(arg: int) -> int:
 def f(arg: str) -> str:
     ...
 
-[case testSliceInDict39]
-# flags: --python-version 3.9 --show-column-numbers
-from typing import Dict
-b: Dict[int, x:y]
-c: Dict[x:y]
+[case testSliceInDictBuiltin]
+# flags: --show-column-numbers
+b: dict[int, x:y]
+c: dict[x:y]
 
 [builtins fixtures/dict.pyi]
 [out]
-main:3:14: error: Invalid type comment or annotation  [valid-type]
-main:3:14: note: did you mean to use ',' instead of ':' ?
-main:4:4: error: "dict" expects 2 type arguments, but 1 given  [type-arg]
-main:4:9: error: Invalid type comment or annotation  [valid-type]
-main:4:9: note: did you mean to use ',' instead of ':' ?
+main:2:14: error: Invalid type comment or annotation  [valid-type]
+main:2:14: note: did you mean to use ',' instead of ':' ?
+main:3:4: error: "dict" expects 2 type arguments, but 1 given  [type-arg]
+main:3:9: error: Invalid type comment or annotation  [valid-type]
+main:3:9: note: did you mean to use ',' instead of ':' ?
 
-[case testSliceInDict38]
-# flags: --python-version 3.8 --show-column-numbers
+[case testSliceInDictTyping]
+# flags: --show-column-numbers
 from typing import Dict
 b: Dict[int, x:y]
 c: Dict[x:y]

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1501,16 +1501,14 @@ GroupsDict = Dict[str, GroupDataDict]  # type: ignore
 
 
 [case testCheckDisallowAnyGenericsStubOnly]
-# flags: --disallow-any-generics --python-version 3.8
+# flags: --disallow-any-generics
 from asyncio import Future
 from queue import Queue
 x: Future[str]
 y: Queue[int]
 
-p: Future  # E: Missing type parameters for generic type "Future" \
-           # N: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/stable/runtime_troubles.html#not-generic-runtime
-q: Queue  # E: Missing type parameters for generic type "Queue" \
-          # N: Subscripting classes that are not generic at runtime may require escaping, see https://mypy.readthedocs.io/en/stable/runtime_troubles.html#not-generic-runtime
+p: Future  # E: Missing type parameters for generic type "Future"
+q: Queue  # E: Missing type parameters for generic type "Queue"
 [file asyncio/__init__.pyi]
 from asyncio.futures import Future as Future
 [file asyncio/futures.pyi]
@@ -1524,28 +1522,28 @@ class Queue(Generic[_T]): ...
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-full.pyi]
 
-[case testDisallowAnyGenericsBuiltinTuplePre39]
-# flags: --disallow-any-generics --python-version 3.8
+[case testDisallowAnyGenericsBuiltinTuple]
+# flags: --disallow-any-generics
 s = tuple([1, 2, 3])
-def f(t: tuple) -> None: pass  # E: Implicit generic "Any". Use "typing.Tuple" and specify generic parameters
+def f(t: tuple) -> None: pass  # E: Missing type parameters for generic type "tuple"
 [builtins fixtures/tuple.pyi]
 
-[case testDisallowAnyGenericsBuiltinListPre39]
-# flags: --disallow-any-generics --python-version 3.8
+[case testDisallowAnyGenericsBuiltinList]
+# flags: --disallow-any-generics
 l = list([1, 2, 3])
-def f(t: list) -> None: pass  # E: Implicit generic "Any". Use "typing.List" and specify generic parameters
+def f(t: list) -> None: pass  # E: Missing type parameters for generic type "List"
 [builtins fixtures/list.pyi]
 
-[case testDisallowAnyGenericsBuiltinSetPre39]
-# flags: --disallow-any-generics --python-version 3.8
+[case testDisallowAnyGenericsBuiltinSet]
+# flags: --disallow-any-generics
 l = set({1, 2, 3})
-def f(s: set) -> None: pass  # E: Implicit generic "Any". Use "typing.Set" and specify generic parameters
+def f(s: set) -> None: pass  # E: Missing type parameters for generic type "Set"
 [builtins fixtures/set.pyi]
 
-[case testDisallowAnyGenericsBuiltinDictPre39]
-# flags: --disallow-any-generics --python-version 3.8
+[case testDisallowAnyGenericsBuiltinDict]
+# flags: --disallow-any-generics
 l = dict([('a', 1)])
-def f(d: dict) -> None: pass  # E: Implicit generic "Any". Use "typing.Dict" and specify generic parameters
+def f(d: dict) -> None: pass  # E: Missing type parameters for generic type "Dict"
 [builtins fixtures/dict.pyi]
 
 [case testCheckDefaultAllowAnyGeneric]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1827,7 +1827,6 @@ def Arg(x, y): pass
 F = Callable[[Arg(int, 'x')], int]  # E: Invalid argument constructor "__main__.Arg"
 
 [case testCallableParsingFromExpr]
-# flags: --python-version 3.9
 from typing import Callable, List
 from mypy_extensions import Arg, VarArg, KwArg
 import mypy_extensions
@@ -1858,13 +1857,6 @@ Q = Callable[[Arg(int, type=int)], int]  # E: Invalid type alias: expression is 
 R = Callable[[Arg(int, 'x', name='y')], int]  # E: Invalid type alias: expression is not a valid type \
                                               # E: Value of type "int" is not indexable \
                                               # E: "Arg" gets multiple values for keyword argument "name"
-
-
-
-
-
-
-
 [builtins fixtures/dict.pyi]
 
 [case testCallableParsing]

--- a/test-data/unit/check-functools.test
+++ b/test-data/unit/check-functools.test
@@ -579,7 +579,6 @@ def bar(f: S) -> S:
 [builtins fixtures/primitives.pyi]
 
 [case testFunctoolsPartialAbstractType]
-# flags: --python-version 3.9
 from abc import ABC, abstractmethod
 from functools import partial
 

--- a/test-data/unit/check-functools.test
+++ b/test-data/unit/check-functools.test
@@ -289,11 +289,10 @@ p1("a", "b")  # TODO: false negative
 [builtins fixtures/dict.pyi]
 
 [case testFunctoolsPartialTypeGuard]
-# flags: --python-version 3.8
 import functools
 from typing_extensions import TypeGuard
 
-def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...  # E: "list" is not subscriptable, use "typing.List" instead
+def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
 
 reveal_type(functools.partial(is_str_list, [1, 2, 3]))  # N: Revealed type is "functools.partial[builtins.bool]"
 reveal_type(functools.partial(is_str_list, [1, 2, 3])())  # N: Revealed type is "builtins.bool"

--- a/test-data/unit/check-generic-alias.test
+++ b/test-data/unit/check-generic-alias.test
@@ -1,48 +1,5 @@
 -- Test cases for generic aliases
 
-[case testGenericBuiltinWarning]
-# flags: --python-version 3.8
-t1: list
-t2: list[int]  # E: "list" is not subscriptable, use "typing.List" instead
-t3: list[str]  # E: "list" is not subscriptable, use "typing.List" instead
-
-t4: tuple
-t5: tuple[int]  # E: "tuple" is not subscriptable, use "typing.Tuple" instead
-t6: tuple[int, str]  # E: "tuple" is not subscriptable, use "typing.Tuple" instead
-t7: tuple[int, ...]  # E: Unexpected "..." \
-                     # E: "tuple" is not subscriptable, use "typing.Tuple" instead
-
-t8: dict = {}
-t9: dict[int, str]  # E: "dict" is not subscriptable, use "typing.Dict" instead
-
-t10: type
-t11: type[int]  # E: "type" expects no type arguments, but 1 given
-[builtins fixtures/dict.pyi]
-
-
-[case testGenericBuiltinSetWarning]
-# flags: --python-version 3.8
-t1: set
-t2: set[int]  # E: "set" is not subscriptable, use "typing.Set" instead
-[builtins fixtures/set.pyi]
-
-
-[case testGenericCollectionsWarning]
-# flags: --python-version 3.8
-import collections
-
-t01: collections.deque
-t02: collections.deque[int]  # E: "deque" is not subscriptable, use "typing.Deque" instead
-t03: collections.defaultdict
-t04: collections.defaultdict[int, str]  # E: "defaultdict" is not subscriptable, use "typing.DefaultDict" instead
-t05: collections.OrderedDict
-t06: collections.OrderedDict[int, str]
-t07: collections.Counter
-t08: collections.Counter[int]  # E: "Counter" is not subscriptable, use "typing.Counter" instead
-t09: collections.ChainMap
-t10: collections.ChainMap[int, str]  # E: "ChainMap" is not subscriptable, use "typing.ChainMap" instead
-
-
 [case testGenericBuiltinFutureAnnotations]
 from __future__ import annotations
 t1: list

--- a/test-data/unit/check-generic-alias.test
+++ b/test-data/unit/check-generic-alias.test
@@ -37,7 +37,6 @@ t10: collections.ChainMap[int, str]
 
 
 [case testGenericAliasBuiltinsReveal]
-# flags: --python-version 3.9
 t1: list
 t2: list[int]
 t3: list[str]
@@ -70,7 +69,6 @@ reveal_type(t11)  # N: Revealed type is "Type[builtins.int]"
 
 
 [case testGenericAliasBuiltinsSetReveal]
-# flags: --python-version 3.9
 t1: set
 t2: set[int]
 t3: set[str]
@@ -82,7 +80,6 @@ reveal_type(t3)  # N: Revealed type is "builtins.set[builtins.str]"
 
 
 [case testGenericAliasCollectionsReveal]
-# flags: --python-version 3.9
 import collections
 
 t1: collections.deque[int]
@@ -100,7 +97,6 @@ reveal_type(t5)  # N: Revealed type is "collections.ChainMap[builtins.int, built
 
 
 [case testGenericAliasCollectionsABCReveal]
-# flags: --python-version 3.9
 import collections.abc
 
 t01: collections.abc.Awaitable[int]
@@ -170,8 +166,6 @@ t09: Tuple[int, ...] = (1, 2, 3)
 
 
 [case testGenericBuiltinTuple]
-# flags: --python-version 3.9
-
 t01: tuple = ()
 t02: tuple[int] = (1, )
 t03: tuple[int, str] = (1, 'a')
@@ -187,8 +181,6 @@ t10: Tuple[int, ...] = t09
 [builtins fixtures/tuple.pyi]
 
 [case testTypeAliasWithBuiltinTuple]
-# flags: --python-version 3.9
-
 A = tuple[int, ...]
 a: A = ()
 b: A = (1, 2, 3)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -515,9 +515,8 @@ Alias[int]("a")  # E: Argument 1 to "Node" has incompatible type "str"; expected
 [out]
 
 [case testTypeApplicationCrash]
-# flags: --python-version 3.8
 import types
-type[int] # this was crashing, see #2302 (comment)  # E: The type "Type[type]" is not generic and not indexable
+type[int]
 [builtins fixtures/tuple.pyi]
 
 
@@ -1130,11 +1129,10 @@ Bad = A[int] # type: ignore
 reveal_type(Bad) # N: Revealed type is "Any"
 [out]
 
-[case testNoSubscriptionOfBuiltinAliases]
-# flags: --python-version 3.8
+[case testSubscriptionOfBuiltinAliases]
 from typing import List, TypeVar
 
-list[int]() # E: "list" is not subscriptable
+list[int]()
 
 ListAlias = List
 def fun() -> ListAlias[int]:
@@ -1143,11 +1141,10 @@ def fun() -> ListAlias[int]:
 reveal_type(fun())  # N: Revealed type is "builtins.list[builtins.int]"
 
 BuiltinAlias = list
-BuiltinAlias[int]() # E: "list" is not subscriptable
+BuiltinAlias[int]()
 
-#check that error is reported only once, and type is still stored
 T = TypeVar('T')
-BadGenList = list[T] # E: "list" is not subscriptable
+BadGenList = list[T]
 
 reveal_type(BadGenList[int]()) # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(BadGenList()) # N: Revealed type is "builtins.list[Any]"

--- a/test-data/unit/check-lowercase.test
+++ b/test-data/unit/check-lowercase.test
@@ -1,64 +1,64 @@
 
 [case testTupleLowercaseSettingOff]
-# flags: --python-version 3.9 --force-uppercase-builtins
+# flags: --force-uppercase-builtins
 x = (3,)
 x = 3 # E: Incompatible types in assignment (expression has type "int", variable has type "Tuple[int]")
 [builtins fixtures/tuple.pyi]
 
 [case testTupleLowercaseSettingOn]
-# flags: --python-version 3.9 --no-force-uppercase-builtins
+# flags: --no-force-uppercase-builtins
 x = (3,)
 x = 3 # E: Incompatible types in assignment (expression has type "int", variable has type "tuple[int]")
 [builtins fixtures/tuple.pyi]
 
 [case testListLowercaseSettingOff]
-# flags: --python-version 3.9 --force-uppercase-builtins
+# flags: --force-uppercase-builtins
 x = [3]
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "List[int]")
 
 [case testListLowercaseSettingOn]
-# flags: --python-version 3.9 --no-force-uppercase-builtins
+# flags: --no-force-uppercase-builtins
 x = [3]
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "list[int]")
 
 [case testDictLowercaseSettingOff]
-# flags: --python-version 3.9 --force-uppercase-builtins
+# flags: --force-uppercase-builtins
 x = {"key": "value"}
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "Dict[str, str]")
 
 [case testDictLowercaseSettingOn]
-# flags: --python-version 3.9 --no-force-uppercase-builtins
+# flags: --no-force-uppercase-builtins
 x = {"key": "value"}
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "dict[str, str]")
 
 [case testSetLowercaseSettingOff]
-# flags: --python-version 3.9 --force-uppercase-builtins
+# flags: --force-uppercase-builtins
 x = {3}
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "Set[int]")
 [builtins fixtures/set.pyi]
 
 [case testSetLowercaseSettingOn]
-# flags: --python-version 3.9 --no-force-uppercase-builtins
+# flags: --no-force-uppercase-builtins
 x = {3}
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "set[int]")
 [builtins fixtures/set.pyi]
 
 [case testTypeLowercaseSettingOff]
-# flags: --python-version 3.9 --no-force-uppercase-builtins
+# flags: --no-force-uppercase-builtins
 x: type[type]
 y: int
 
 y = x  # E: Incompatible types in assignment (expression has type "type[type]", variable has type "int")
 
 [case testLowercaseSettingOnTypeAnnotationHint]
-# flags: --python-version 3.9 --no-force-uppercase-builtins
+# flags: --no-force-uppercase-builtins
 x = []  # E: Need type annotation for "x" (hint: "x: list[<type>] = ...")
 y = {}  # E: Need type annotation for "y" (hint: "y: dict[<type>, <type>] = ...")
 z = set()  # E: Need type annotation for "z" (hint: "z: set[<type>] = ...")
 [builtins fixtures/primitives.pyi]
 
 [case testLowercaseSettingOnRevealTypeType]
-# flags: --python-version 3.9 --no-force-uppercase-builtins
+# flags: --no-force-uppercase-builtins
 def f(t: type[int]) -> None:
     reveal_type(t)  # N: Revealed type is "type[builtins.int]"
 reveal_type(f)  # N: Revealed type is "def (t: type[builtins.int])"

--- a/test-data/unit/check-python39.test
+++ b/test-data/unit/check-python39.test
@@ -19,8 +19,6 @@ reveal_type(f)  # N: Revealed type is "def (builtins.int) -> builtins.str"
 [builtins fixtures/list.pyi]
 
 [case testStarredExpressionsInForLoop]
-# flags: --python-version 3.9
-
 a = b = c = [1, 2, 3]
 for x in *a, *b, *c:
     reveal_type(x)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1002,14 +1002,11 @@ B = List[C[U]]
 y: B[int]
 y_bad: B[str]  # E: Type argument "str" of "B" must be a subtype of "int"
 
-[case testTupleWithDifferentArgsPy38]
-# flags: --python-version 3.8
-NotYet1 = tuple[float]  # E: "tuple" is not subscriptable
-NotYet2 = tuple[float, float]  # E: "tuple" is not subscriptable
-NotYet3 = tuple[float, ...]  # E: Unexpected "..." \
-                             # E: "tuple" is not subscriptable
-NotYet4 = tuple[float, float, ...]  # E: Unexpected "..." \
-                                    # E: "tuple" is not subscriptable
+[case testTupleWithDifferentArgs]
+Alias1 = tuple[float]
+Alias2 = tuple[float, float]
+Alias3 = tuple[float, ...]
+Alias4 = tuple[float, float, ...]  # E: Unexpected "..."
 [builtins fixtures/tuple.pyi]
 
 [case testTupleWithDifferentArgsStub]

--- a/test-data/unit/check-type-object-type-inference.test
+++ b/test-data/unit/check-type-object-type-inference.test
@@ -1,5 +1,4 @@
 [case testInferTupleType]
-# flags: --python-version 3.9
 from typing import TypeVar, Generic, Type
 from abc import abstractmethod
 import types  # Explicitly bring in stubs for 'types'

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -798,7 +798,7 @@ def baz(x: int) -> int:
 [builtins fixtures/exception.pyi]
 
 [case testUnreachableFlagIgnoresSemanticAnalysisUnreachable]
-# flags: --warn-unreachable --python-version 3.8 --platform win32 --always-false FOOBAR
+# flags: --warn-unreachable --python-version 3.9 --platform win32 --always-false FOOBAR
 import sys
 from typing import TYPE_CHECKING
 
@@ -828,7 +828,7 @@ if sys.version_info == (2, 7):
 else:
     reveal_type(x)  # N: Revealed type is "builtins.int"
 
-if sys.version_info == (3, 8):
+if sys.version_info == (3, 9):
     reveal_type(x)  # N: Revealed type is "builtins.int"
 else:
     reveal_type(x)

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -433,11 +433,11 @@ mypy: error: Mypy no longer supports checking Python 2 code. Consider pinning to
 python_version = 3.9
 [out]
 
-[case testPythonVersionAccepted311]
+[case testPythonVersionAccepted313]
 # cmd: mypy -c pass
 [file mypy.ini]
 \[mypy]
-python_version = 3.11
+python_version = 3.13
 [out]
 
 -- This should be a dumping ground for tests of plugins that are sensitive to

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -385,7 +385,7 @@ main.py:1: error: Cannot find implementation or library stub for module named "a
 \[tool.mypy]
 python_version = 3.10
 [out]
-pyproject.toml: [mypy]: python_version: Python 3.1 is not supported (must be 3.8 or higher). You may need to put quotes around your Python version
+pyproject.toml: [mypy]: python_version: Python 3.1 is not supported (must be 3.9 or higher). You may need to put quotes around your Python version
 == Return code: 0
 
 [case testPythonVersionTooOld10]
@@ -397,13 +397,13 @@ python_version = 1.0
 mypy.ini: [mypy]: python_version: Python major version '1' out of range (must be 3)
 == Return code: 0
 
-[case testPythonVersionTooOld37]
+[case testPythonVersionTooOld38]
 # cmd: mypy -c pass
 [file mypy.ini]
 \[mypy]
-python_version = 3.7
+python_version = 3.8
 [out]
-mypy.ini: [mypy]: python_version: Python 3.7 is not supported (must be 3.8 or higher)
+mypy.ini: [mypy]: python_version: Python 3.8 is not supported (must be 3.9 or higher)
 == Return code: 0
 
 [case testPythonVersionTooNew40]
@@ -426,11 +426,11 @@ usage: mypy [-h] [-v] [-V] [more options; see below]
 mypy: error: Mypy no longer supports checking Python 2 code. Consider pinning to mypy<0.980 if you need to check Python 2 code.
 == Return code: 2
 
-[case testPythonVersionAccepted38]
+[case testPythonVersionAccepted39]
 # cmd: mypy -c pass
 [file mypy.ini]
 \[mypy]
-python_version = 3.8
+python_version = 3.9
 [out]
 
 [case testPythonVersionAccepted311]
@@ -469,17 +469,16 @@ int_pow.py:10: note: Revealed type is "builtins.int"
 int_pow.py:11: note: Revealed type is "Any"
 == Return code: 0
 
-[case testDisallowAnyGenericsBuiltinCollectionsPre39]
+[case testDisallowAnyGenericsBuiltinCollections]
 # cmd: mypy m.py
 [file mypy.ini]
 \[mypy]
-python_version = 3.8
 \[mypy-m]
 disallow_any_generics = True
 [file m.py]
 def j(s: frozenset) -> None: pass
 [out]
-m.py:1: error: Implicit generic "Any". Use "typing.FrozenSet" and specify generic parameters
+m.py:1: error: Missing type parameters for generic type "FrozenSet"
 
 [case testDisallowAnyGenericsTypingCollections]
 # cmd: mypy m.py

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -420,7 +420,7 @@ a: int
 a: str
 
 [case testDaemonGetType]
-$ dmypy start --log-file log.txt -- --follow-imports=error --no-error-summary --python-version 3.8
+$ dmypy start --log-file log.txt -- --follow-imports=error --no-error-summary --python-version 3.9
 Daemon started
 $ dmypy inspect foo:1:2:3:4
 Command "inspect" is only valid after a "check" command (that produces no parse errors)

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10233,7 +10233,7 @@ class Base(Protocol):
 main:5: error: Call to abstract method "meth" of "Base" with trivial body via super() is unsafe
 
 [case testPrettyMessageSorting]
-# flags: --python-version 3.8 --pretty
+# flags: --pretty
 import a
 
 [file a.py]
@@ -10248,14 +10248,14 @@ object + 1
 1()
 
 [out]
-b.py:1: error: Unsupported left operand type for + ("Type[object]")
+b.py:1: error: Unsupported left operand type for + ("type[object]")
     object + 1
     ^~~~~~~~~~
 a.py:1: error: Unsupported operand types for + ("int" and "str")
     1 + ''
         ^~
 ==
-b.py:1: error: Unsupported left operand type for + ("Type[object]")
+b.py:1: error: Unsupported left operand type for + ("type[object]")
     object + 1
     ^~~~~~~~~~
 b.py:2: error: "int" not callable

--- a/test-data/unit/parse.test
+++ b/test-data/unit/parse.test
@@ -947,18 +947,17 @@ main:1: error: Invalid syntax
 [out version==3.10.0]
 main:1: error: Invalid syntax. Perhaps you forgot a comma?
 
-[case testSliceInList39]
-# flags: --python-version 3.9
+[case testSliceInList]
 x = [1, 2][1:2]
 [out]
 MypyFile:1(
-  AssignmentStmt:2(
+  AssignmentStmt:1(
     NameExpr(x)
-    IndexExpr:2(
-      ListExpr:2(
+    IndexExpr:1(
+      ListExpr:1(
         IntExpr(1)
         IntExpr(2))
-      SliceExpr:2(
+      SliceExpr:1(
         IntExpr(1)
         IntExpr(2)))))
 


### PR DESCRIPTION
Drop last remaining support for Python 3.8. Support for running with 3.8 was removed in #17492 already. This PR removes the option to use 3.8 with `--python-version` since the type stubs only support 3.9+, see https://github.com/python/mypy/pull/18930.