### PR TITLE
Fix nondeterministic type checking caused by nonassociative of None joins

### DIFF
--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -250,6 +250,8 @@ def solve_iteratively(
 def _join_sorted_key(t: Type) -> int:
     t = get_proper_type(t)
     if isinstance(t, UnionType):
+        return -2
+    if isinstance(t, NoneType):
         return -1
     return 0
 

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3602,4 +3602,17 @@ def draw(
         reveal_type(c1)  # N: Revealed type is "Union[builtins.int, builtins.str]"
         reveal_type(c2)  # N: Revealed type is "Union[builtins.int, builtins.str]"
         reveal_type(c3)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+def takes_int_str_none(x: int | str | None) -> None: ...
+
+def draw_none(
+    colors1: A[str] | B[str] | C[int] | D[None],
+    colors2: A[str] | B[str] | C[int] | D[None],
+    colors3: A[str] | B[str] | C[int] | D[None],
+) -> None:
+    for c1, c2, c3 in zip2(colors1, colors2, colors3):
+        # TODO: can't do reveal type because the union order is not deterministic
+        takes_int_str_none(c1)
+        takes_int_str_none(c2)
+        takes_int_str_none(c3)
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/19121 (xarray case)

The ordering of the union is still nondeterministic. We could solve this by change the solver to use `dict[Type, None` instead of `set[Type]` since dicts are ordered. But doing so could paper over further bad solving from nonassociativity or noncommutativity