### PR TITLE
Allow enum members to have type objects as values

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3301,8 +3301,8 @@ class TypeInfo(SymbolNode):
                         continue  # unannotated value not a member
 
                     typ = mypy.types.get_proper_type(sym.node.type)
-                    if isinstance(
-                        typ, mypy.types.FunctionLike
+                    if (
+                        isinstance(typ, mypy.types.FunctionLike) and not typ.is_type_obj()
                     ) or (  # explicit `@member` is required
                         isinstance(typ, mypy.types.Instance)
                         and typ.type.fullname == "enum.nonmember"

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -2638,3 +2638,24 @@ def f2() -> None:
                 return
     reveal_type(y) # N: Revealed type is "builtins.str"
 [builtins fixtures/list.pyi]
+
+[case testEnumTypeObjectMember]
+import enum
+from typing import NoReturn
+
+def assert_never(x: NoReturn) -> None: ...
+
+class ValueType(enum.Enum):
+    INT = int
+    STR = str
+
+value_type: ValueType = ValueType.INT
+
+match value_type:
+    case ValueType.INT:
+        pass
+    case ValueType.STR:
+        pass
+    case _:
+        assert_never(value_type)
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Type objects as enum values are supported at runtime.

Fixes #19151.