### PR TITLE
[mypyc] Enable partial, unsafe support for free-threading

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -39,6 +39,7 @@ from mypyc.codegen.emitwrapper import (
 )
 from mypyc.codegen.literals import Literals
 from mypyc.common import (
+    IS_FREE_THREADED,
     MODULE_PREFIX,
     PREFIX,
     RUNTIME_C_FILES,
@@ -514,7 +515,9 @@ class GroupGenerator:
         self.use_shared_lib = group_name is not None
         self.compiler_options = compiler_options
         self.multi_file = compiler_options.multi_file
-        self.multi_phase_init = True
+        # Multi-phase init is needed to enable free-threading. In the future we'll
+        # probably want to enable it always, but we'll wait until it's stable.
+        self.multi_phase_init = IS_FREE_THREADED
 
     @property
     def group_suffix(self) -> str:

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -885,6 +885,7 @@ class GroupGenerator:
         emitter.emit_line(
             "{Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},"
         )
+        emitter.emit_line("{Py_mod_gil, Py_MOD_GIL_NOT_USED},")
         emitter.emit_line("{0, NULL},")
         emitter.emit_line("};")
 

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -887,10 +887,14 @@ class GroupGenerator:
         emitter.emit_line(f"static PyModuleDef_Slot {name}[] = {{")
         emitter.emit_line(f"{{Py_mod_exec, {exec_name}}},")
         if sys.version_info >= (3, 12):
+            # Multiple interpreter support requires not using any C global state,
+            # which we don't support yet.
             emitter.emit_line(
                 "{Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},"
             )
         if sys.version_info >= (3, 13):
+            # Declare support for free-threading to enable experimentation,
+            # even if we don't properly support it.
             emitter.emit_line("{Py_mod_gil, Py_MOD_GIL_NOT_USED},")
         emitter.emit_line("{0, NULL},")
         emitter.emit_line("};")

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from collections.abc import Iterable
 from typing import Optional, TypeVar
 
@@ -882,10 +883,12 @@ class GroupGenerator:
 
         emitter.emit_line(f"static PyModuleDef_Slot {name}[] = {{")
         emitter.emit_line(f"{{Py_mod_exec, {exec_name}}},")
-        emitter.emit_line(
-            "{Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},"
-        )
-        emitter.emit_line("{Py_mod_gil, Py_MOD_GIL_NOT_USED},")
+        if sys.version_info >= (3, 12):
+            emitter.emit_line(
+                "{Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},"
+            )
+        if sys.version_info >= (3, 13):
+            emitter.emit_line("{Py_mod_gil, Py_MOD_GIL_NOT_USED},")
         emitter.emit_line("{0, NULL},")
         emitter.emit_line("};")
 

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -88,6 +88,10 @@ RUNTIME_C_FILES: Final = [
 # some details in the PEP are out of date.
 HAVE_IMMORTAL: Final = sys.version_info >= (3, 12)
 
+# Are we running on a free-threaded build (GIL disabled)? This implies that
+# we are on Python 3.13 or later.
+IS_FREE_THREADED: Final = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
 
 JsonDict = dict[str, Any]
 


### PR DESCRIPTION
Enable multi-phase init when using a free-threaded (no-GIL) CPython build so we can enable proper multihreading.

Work on mypyc/mypyc#1104. Work on mypyc/mypyc#1038.

The implementation is still quite incomplete. We are missing synchronization in various places, so race conditions can cause segfaults. Only single-module compilation units are supported for now.

Here's a toy benchmark I used to check that free threading works and can improve performance:
```
import sys
import threading
import time

def fib(n: int) -> int:
    if n <= 1:
        return n
    else:
        return fib(n - 1) + fib(n - 2)

NTHREADS = 6
print(f"Using {NTHREADS} threads")
print(f"{sys._is_gil_enabled()=}")

t0 = time.time()

threads = []
for i in range(NTHREADS):
    t = threading.Thread(target=lambda: fib(36))
    t.start()
    threads.append(t)

for t in threads:
    t.join()

print()
print('elapsed time:', time.time() - t0)
```