### PR TITLE
experiment: handle `__hash__ = None` in somewhat more intuitive fashion

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2030,6 +2030,15 @@ class SemanticAnalyzer(
             self.setup_self_type()
         defn.defs.accept(self)
         self.apply_class_plugin_hooks(defn)
+
+        if "__eq__" in defn.info.names and "__hash__" not in defn.info.names:
+            # If a class defines `__eq__` without `__hash__`, it's no longer hashable.
+            hash_none = Var("__hash__", NoneType())
+            hash_none.info = defn.info
+            hash_none.set_line(defn)
+            hash_none.is_classvar = True
+            self.add_symbol("__hash__", hash_none, defn)
+
         self.leave_class()
 
     def analyze_typeddict_classdef(self, defn: ClassDef) -> bool:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -116,11 +116,7 @@ class Base:
     __hash__: None = None
 
 class Derived(Base):
-    def __hash__(self) -> int:  # E: Signature of "__hash__" incompatible with supertype "Base" \
-                                # N:      Superclass: \
-                                # N:          None \
-                                # N:      Subclass: \
-                                # N:          def __hash__(self) -> int
+    def __hash__(self) -> int:
         pass
 
 # Correct:
@@ -146,6 +142,29 @@ class Base:
 
 class Derived(Base):
     __hash__ = 1  # E: Incompatible types in assignment (expression has type "int", base class "Base" defined the type as "Callable[[], int]")
+
+[case testEqWithoutHash]
+class A:
+    def __eq__(self, other) -> bool: ...
+
+reveal_type(A.__hash__)  # N: Revealed type is "None"
+[builtins fixtures/primitives.pyi]
+
+[case testHashNoneOverride]
+class A:
+    __hash__ = None
+
+class B(A):
+    def __hash__(self) -> int: return 0
+[builtins fixtures/primitives.pyi]
+
+[case testHashNoneBadOverride]
+class A:
+    def __hash__(self) -> int: return 0
+
+class B(A):
+    __hash__ = None  # E: Incompatible types in assignment (expression has type "None", base class "A" defined the type as "Callable[[], int]")
+[builtins fixtures/primitives.pyi]
 
 [case testOverridePartialAttributeWithMethod]
 # This was crashing: https://github.com/python/mypy/issues/11686.

--- a/test-data/unit/fixtures/primitives.pyi
+++ b/test-data/unit/fixtures/primitives.pyi
@@ -10,6 +10,7 @@ class object:
     def __str__(self) -> str: pass
     def __eq__(self, other: object) -> bool: pass
     def __ne__(self, other: object) -> bool: pass
+    def __hash__(self) -> int: ...
 
 class type:
     def __init__(self, x: object) -> None: pass


### PR DESCRIPTION
This is the first step towards checking hashability of dict keys (and `Hashable` compatibility in general). This PR implements the following rules:

* `__hash__ = None` is only allowed on classes who inherited `__hash__` directly from `object` (no redefinitions in MRO)
* `def __hash__` is allowed on subclasses whose parents declare `__hash__ = None` - it is a relatively common solution to derive a hashable subclass, and LSP violation only means `assert SomeCls.__hash__ is None` will not pass for subclasses. This sounds safe enough.
* Classes defining `__eq__` without `__hash__` get their `__hash__` assigned to `None` to match runtime semantics.

Refs #19043.