### PR TITLE
Deprecated --force-uppercase-builtins flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 
+### Deprecated Flag: \--force-uppercase-builtins
+
+Mypy only supports Python 3.9+. The \--force-uppercase-builtins flag is now deprecated and a no-op. It will be removed in a future version.
+
 ## Mypy 1.16
 
 We’ve just uploaded mypy 1.16 to the Python Package Index ([PyPI](https://pypi.org/project/mypy/)).

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -801,6 +801,7 @@ def process_options(
         help="Disable strict Optional checks (inverse: --strict-optional)",
     )
 
+    # This flag is deprecated, Mypy only supports Python 3.9+
     add_invertible_flag(
         "--force-uppercase-builtins", default=False, help=argparse.SUPPRESS, group=none_group
     )
@@ -1493,6 +1494,9 @@ def process_options(
 
     if options.strict_concatenate and not strict_option_set:
         print("Warning: --strict-concatenate is deprecated; use --extra-checks instead")
+
+    if options.force_uppercase_builtins:
+        print("Warning: --force-uppercase-builtins is deprecated; Mypy only supports Python 3.9+.")
 
     # Set target.
     if special_opts.modules + special_opts.packages:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1823,13 +1823,10 @@ class MessageBuilder:
                     recommended_type = f"Optional[{type_dec}]"
             elif node.type.type.fullname in reverse_builtin_aliases:
                 # partial types other than partial None
-                alias = reverse_builtin_aliases[node.type.type.fullname]
-                alias = alias.split(".")[-1]
-                if alias == "Dict":
+                name = node.type.type.fullname.partition(".")[2]
+                if name == "dict":
                     type_dec = f"{type_dec}, {type_dec}"
-                if self.options.use_lowercase_names():
-                    alias = alias.lower()
-                recommended_type = f"{alias}[{type_dec}]"
+                recommended_type = f"{name}[{type_dec}]"
         if recommended_type is not None:
             hint = f' (hint: "{node.name}: {recommended_type} = ...")'
 
@@ -2419,8 +2416,7 @@ class MessageBuilder:
         """Format very long tuple type using an ellipsis notation"""
         item_cnt = len(typ.items)
         if item_cnt > MAX_TUPLE_ITEMS:
-            return "{}[{}, {}, ... <{} more items>]".format(
-                "tuple" if self.options.use_lowercase_names() else "Tuple",
+            return "tuple[{}, {}, ... <{} more items>]".format(
                 format_type_bare(typ.items[0], self.options),
                 format_type_bare(typ.items[1], self.options),
                 str(item_cnt - 2),
@@ -2595,10 +2591,7 @@ def format_type_inner(
         if itype.type.fullname == "typing._SpecialForm":
             # This is not a real type but used for some typing-related constructs.
             return "<typing special form>"
-        if itype.type.fullname in reverse_builtin_aliases and not options.use_lowercase_names():
-            alias = reverse_builtin_aliases[itype.type.fullname]
-            base_str = alias.split(".")[-1]
-        elif verbosity >= 2 or (fullnames and itype.type.fullname in fullnames):
+        if verbosity >= 2 or (fullnames and itype.type.fullname in fullnames):
             base_str = itype.type.fullname
         else:
             base_str = itype.type.name
@@ -2609,7 +2602,7 @@ def format_type_inner(
             return base_str
         elif itype.type.fullname == "builtins.tuple":
             item_type_str = format(itype.args[0])
-            return f"{'tuple' if options.use_lowercase_names() else 'Tuple'}[{item_type_str}, ...]"
+            return f"tuple[{item_type_str}, ...]"
         else:
             # There are type arguments. Convert the arguments to strings.
             return f"{base_str}[{format_list(itype.args)}]"
@@ -2645,11 +2638,7 @@ def format_type_inner(
         if typ.partial_fallback.type.fullname != "builtins.tuple":
             return format(typ.partial_fallback)
         type_items = format_list(typ.items) or "()"
-        if options.use_lowercase_names():
-            s = f"tuple[{type_items}]"
-        else:
-            s = f"Tuple[{type_items}]"
-        return s
+        return f"tuple[{type_items}]"
     elif isinstance(typ, TypedDictType):
         # If the TypedDictType is named, return the name
         if not typ.is_anonymous():
@@ -2721,8 +2710,7 @@ def format_type_inner(
     elif isinstance(typ, UninhabitedType):
         return "Never"
     elif isinstance(typ, TypeType):
-        type_name = "type" if options.use_lowercase_names() else "Type"
-        return f"{type_name}[{format(typ.item)}]"
+        return f"type[{format(typ.item)}]"
     elif isinstance(typ, FunctionLike):
         func = typ
         if func.is_type_obj():

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -4,6 +4,7 @@ import pprint
 import re
 import sys
 import sysconfig
+import warnings
 from collections.abc import Mapping
 from re import Pattern
 from typing import Any, Callable, Final
@@ -400,6 +401,7 @@ class Options:
 
         self.disable_bytearray_promotion = False
         self.disable_memoryview_promotion = False
+        # Deprecated, Mypy only supports Python 3.9+
         self.force_uppercase_builtins = False
         self.force_union_syntax = False
 
@@ -413,6 +415,11 @@ class Options:
         self.mypyc_skip_c_generation = False
 
     def use_lowercase_names(self) -> bool:
+        warnings.warn(
+            "options.use_lowercase_names is deprecated and will be removed in a future version",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self.python_version >= (3, 9):
             return not self.force_uppercase_builtins
         return False

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3455,12 +3455,11 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
 
     def visit_tuple_type(self, t: TupleType, /) -> str:
         s = self.list_str(t.items) or "()"
-        tuple_name = "tuple" if self.options.use_lowercase_names() else "Tuple"
         if t.partial_fallback and t.partial_fallback.type:
             fallback_name = t.partial_fallback.type.fullname
             if fallback_name != "builtins.tuple":
-                return f"{tuple_name}[{s}, fallback={t.partial_fallback.accept(self)}]"
-        return f"{tuple_name}[{s}]"
+                return f"tuple[{s}, fallback={t.partial_fallback.accept(self)}]"
+        return f"tuple[{s}]"
 
     def visit_typeddict_type(self, t: TypedDictType, /) -> str:
         def item_str(name: str, typ: str) -> str:
@@ -3502,11 +3501,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         return "..."
 
     def visit_type_type(self, t: TypeType, /) -> str:
-        if self.options.use_lowercase_names():
-            type_name = "type"
-        else:
-            type_name = "Type"
-        return f"{type_name}[{t.item.accept(self)}]"
+        return f"type[{t.item.accept(self)}]"
 
     def visit_placeholder_type(self, t: PlaceholderType, /) -> str:
         return f"<placeholder {t.fullname}>"

--- a/test-data/unit/check-lowercase.test
+++ b/test-data/unit/check-lowercase.test
@@ -1,64 +1,34 @@
-
-[case testTupleLowercaseSettingOff]
-# flags: --force-uppercase-builtins
-x = (3,)
-x = 3 # E: Incompatible types in assignment (expression has type "int", variable has type "Tuple[int]")
-[builtins fixtures/tuple.pyi]
-
-[case testTupleLowercaseSettingOn]
-# flags: --no-force-uppercase-builtins
+[case testTupleLowercase]
 x = (3,)
 x = 3 # E: Incompatible types in assignment (expression has type "int", variable has type "tuple[int]")
 [builtins fixtures/tuple.pyi]
 
-[case testListLowercaseSettingOff]
-# flags: --force-uppercase-builtins
-x = [3]
-x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "List[int]")
-
-[case testListLowercaseSettingOn]
-# flags: --no-force-uppercase-builtins
+[case testListLowercase]
 x = [3]
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "list[int]")
 
-[case testDictLowercaseSettingOff]
-# flags: --force-uppercase-builtins
-x = {"key": "value"}
-x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "Dict[str, str]")
-
-[case testDictLowercaseSettingOn]
-# flags: --no-force-uppercase-builtins
+[case testDictLowercase]
 x = {"key": "value"}
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "dict[str, str]")
 
-[case testSetLowercaseSettingOff]
-# flags: --force-uppercase-builtins
-x = {3}
-x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "Set[int]")
-[builtins fixtures/set.pyi]
-
-[case testSetLowercaseSettingOn]
-# flags: --no-force-uppercase-builtins
+[case testSetLowercase]
 x = {3}
 x = 3  # E: Incompatible types in assignment (expression has type "int", variable has type "set[int]")
 [builtins fixtures/set.pyi]
 
-[case testTypeLowercaseSettingOff]
-# flags: --no-force-uppercase-builtins
+[case testTypeLowercase]
 x: type[type]
 y: int
 
 y = x  # E: Incompatible types in assignment (expression has type "type[type]", variable has type "int")
 
-[case testLowercaseSettingOnTypeAnnotationHint]
-# flags: --no-force-uppercase-builtins
+[case testLowercaseTypeAnnotationHint]
 x = []  # E: Need type annotation for "x" (hint: "x: list[<type>] = ...")
 y = {}  # E: Need type annotation for "y" (hint: "y: dict[<type>, <type>] = ...")
 z = set()  # E: Need type annotation for "z" (hint: "z: set[<type>] = ...")
 [builtins fixtures/primitives.pyi]
 
-[case testLowercaseSettingOnRevealTypeType]
-# flags: --no-force-uppercase-builtins
+[case testLowercaseRevealTypeType]
 def f(t: type[int]) -> None:
     reveal_type(t)  # N: Revealed type is "type[builtins.int]"
 reveal_type(f)  # N: Revealed type is "def (t: type[builtins.int])"


### PR DESCRIPTION
Use lowercase builtins for error messages, Mypy only supports 3.9+. This PR deprecates the `--force-uppercase-builtins` flag and makes it a no-op.