### PR TITLE
Prohibit assignment to __class__ (Fixes #7724)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8880,6 +8880,9 @@ class VarAssignVisitor(TraverserVisitor):
         self.lvalue = True
         for lv in s.lvalues:
             lv.accept(self)
+            if isinstance(lv, MemberExpr):
+                if lv.name == '__class__':
+                    self.fail("Assignment to '__class__' is unsafe and not allowed", lv)
         self.lvalue = False
 
     def visit_name_expr(self, e: NameExpr) -> None:

--- a/test-data/unit/check-assign-to-class.test
+++ b/test-data/unit/check-assign-to-class.test
@@ -20,3 +20,5 @@ class E:
     x = 1
     def baz(self):
         self.x = 2  # OK
+
+# Trigger GitHub Actions for testing

--- a/test-data/unit/check-assign-to-class.test
+++ b/test-data/unit/check-assign-to-class.test
@@ -1,0 +1,22 @@
+[case test_assign_to_dunder_class]
+class A:
+    def foo(self):
+        self.__class__ = B  # E: Assignment to '__class__' is unsafe and not allowed
+
+class B:
+    pass
+
+[case test_assign_to_other_dunder_attributes]
+class C:
+    def bar(self):
+        self.__name__ = "NewName"  # OK
+        self.__doc__ = "Test doc"  # OK
+
+class D:
+    pass
+
+[case test_assign_to_regular_attribute]
+class E:
+    x = 1
+    def baz(self):
+        self.x = 2  # OK


### PR DESCRIPTION
Adds a type check that disallows assignments to __class__, which can lead to unsafe runtime behavior.

Includes tests for __class__ assignments and verifies that other dunder and regular attributes remain assignable.

Fixes #7724