### PR TITLE
[mypyc] Fixing condition for handling user-defined __del__

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -214,14 +214,12 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
     if not cl.builtin_base:
         fields["tp_new"] = new_name
 
-    # Populate .tp_finalize and generate a finalize method only if __del__ is defined for this class.
-    del_method = next((e.method for e in cl.vtable_entries if e.name == "__del__"), None)
-    # Del method is called from dealloc method. So, dealloc should be generated whenever there is a del method.
-    if generate_full or del_method:
-        fields["tp_dealloc"] = f"(destructor){name_prefix}_dealloc"
     if generate_full:
+        fields["tp_dealloc"] = f"(destructor){name_prefix}_dealloc"
         fields["tp_traverse"] = f"(traverseproc){name_prefix}_traverse"
         fields["tp_clear"] = f"(inquiry){name_prefix}_clear"
+    # Populate .tp_finalize and generate a finalize method only if __del__ is defined for this class.
+    del_method = next((e.method for e in cl.vtable_entries if e.name == "__del__"), None)
     if del_method:
         fields["tp_finalize"] = f"(destructor){finalize_name}"
     if needs_getseters:
@@ -302,6 +300,10 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         emit_line()
         generate_traverse_for_class(cl, traverse_name, emitter)
         emit_line()
+        generate_clear_for_class(cl, clear_name, emitter)
+        emit_line()
+        generate_dealloc_for_class(cl, dealloc_name, clear_name, bool(del_method), emitter)
+        emit_line()
 
         if cl.allow_interpreted_subclasses:
             shadow_vtable_name: str | None = generate_vtables(
@@ -311,11 +313,6 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         else:
             shadow_vtable_name = None
         vtable_name = generate_vtables(cl, vtable_setup_name, vtable_name, emitter, shadow=False)
-        emit_line()
-    if generate_full or del_method:
-        generate_clear_for_class(cl, clear_name, emitter)
-        emit_line()
-        generate_dealloc_for_class(cl, dealloc_name, clear_name, bool(del_method), emitter)
         emit_line()
     if del_method:
         generate_finalize_for_class(del_method, finalize_name, emitter)

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2754,7 +2754,10 @@ def test_function():
     assert(isinstance(d.fitem, ForwardDefinedClass))
     assert(isinstance(d.fitems, ForwardDefinedClass))
 
-[case testDelForDictSubclass]
+[case testDelForDictSubclass-xfail]
+# The crash in issue mypy#19175 is fixed.
+# But, for classes that derive from built-in Python classes, user-defined __del__ method is not
+# being invoked.
 class DictSubclass(dict):
     def __del__(self):
         print("deleting DictSubclass...")
@@ -2785,6 +2788,12 @@ class C(B):
 
 class D(A):
     pass
+
+# Just make sure that this class compiles (see issue mypy#19175). testDelForDictSubclass tests for
+# correct output.
+class NormDict(dict):
+    def __del__(self) -> None:
+        pass
 
 [file driver.py]
 import native

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2754,6 +2754,18 @@ def test_function():
     assert(isinstance(d.fitem, ForwardDefinedClass))
     assert(isinstance(d.fitems, ForwardDefinedClass))
 
+[case testDelForDictSubclass]
+class DictSubclass(dict):
+    def __del__(self):
+        print("deleting DictSubclass...")
+
+[file driver.py]
+import native
+native.DictSubclass()
+
+[out]
+deleting DictSubclass...
+
 [case testDel]
 class A:
     def __del__(self):


### PR DESCRIPTION
Fixes #19175.

Conditions for generating and invoking `del` method were not consistent. This change generates and invokes native code for `dealloc` and `__del__` if either `generate_full` is `True` or class has a user-defined `__del__` method.