### PR TITLE
Infer constraints eagerly if actual is Any

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -416,7 +416,7 @@ def _infer_constraints(
                 infer_constraints_if_possible(t_item, actual, direction)
                 for t_item in template.items
             ],
-            eager=False,
+            eager=isinstance(actual, AnyType),
         )
         if result:
             return result

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -4071,3 +4071,13 @@ def check_or_nested(maybe: bool) -> None:
         reveal_type(foo)  # N: Revealed type is "builtins.list[builtins.int]"
         reveal_type(bar)  # N: Revealed type is "builtins.list[builtins.int]"
         reveal_type(baz)  # N: Revealed type is "builtins.list[builtins.int]"
+
+[case testInferOptionalAgainstAny]
+from typing import Any, Optional, TypeVar
+
+a: Any
+oa: Optional[Any]
+T = TypeVar("T")
+def f(x: Optional[T]) -> T: ...
+reveal_type(f(a))  # N: Revealed type is "Any"
+reveal_type(f(oa))  # N: Revealed type is "Any"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/8829

This case is more common in 1.16 due to some changes in binder, so it would be good to fix it. My fix may be a bit naive, but if `mypy_primer` looks good, I think it should be OK.
