### PR TITLE
Tighten metaclass __call__ handling in protocols

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1066,8 +1066,8 @@ class ConstraintBuilderVisitor(TypeVisitor[list[Constraint]]):
                     inst, erase_typevars(temp), ignore_pos_arg_names=True
                 ):
                     continue
-            # This exception matches the one in subtypes.py, see PR #14121 for context.
-            if member == "__call__" and instance.type.is_metaclass():
+            # This exception matches the one in typeops.py, see PR #14121 for context.
+            if member == "__call__" and instance.type.is_metaclass(precise=True):
                 continue
             res.extend(infer_constraints(temp, inst, self.direction))
             if mypy.subtypes.IS_SETTABLE in mypy.subtypes.get_member_flags(member, protocol):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3359,11 +3359,11 @@ class TypeInfo(SymbolNode):
                 return c
         return None
 
-    def is_metaclass(self) -> bool:
+    def is_metaclass(self, *, precise: bool = False) -> bool:
         return (
             self.has_base("builtins.type")
             or self.fullname == "abc.ABCMeta"
-            or self.fallback_to_any
+            or (self.fallback_to_any and not precise)
         )
 
     def has_base(self, fullname: str) -> bool:

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -1257,7 +1257,7 @@ def get_protocol_member(
 
         return type_object_type(left.type, named_type)
 
-    if member == "__call__" and left.type.is_metaclass():
+    if member == "__call__" and left.type.is_metaclass(precise=True):
         # Special case: we want to avoid falling back to metaclass __call__
         # if constructor signature didn't match, this can cause many false negatives.
         return None

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4505,3 +4505,25 @@ def bad() -> Proto:
 class Impl:
     @defer
     def f(self) -> int: ...
+
+[case testInferCallableProtoWithAnySubclass]
+from typing import Any, Generic, Protocol, TypeVar
+
+T = TypeVar("T", covariant=True)
+
+Unknown: Any
+class Mock(Unknown):
+    def __init__(self, **kwargs: Any) -> None: ...
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+class Factory(Protocol[T]):
+    def __call__(self, **kwargs: Any) -> T: ...
+
+
+class Test(Generic[T]):
+    def __init__(self, f: Factory[T]) -> None:
+        ...
+
+t = Test(Mock())
+reveal_type(t)  # N: Revealed type is "__main__.Test[Any]"
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/19184

This fixes an (edge-case) regression introduced in 1.16. Fix is straightforward, only ignore `__call__` if it comes from an _actual_ metaclass.
