### PR TITLE
Add classifier for Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development",
   "Typing :: Typed",
 ]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -433,11 +433,11 @@ mypy: error: Mypy no longer supports checking Python 2 code. Consider pinning to
 python_version = 3.9
 [out]
 
-[case testPythonVersionAccepted313]
+[case testPythonVersionAccepted314]
 # cmd: mypy -c pass
 [file mypy.ini]
 \[mypy]
-python_version = 3.13
+python_version = 3.14
 [out]
 
 -- This should be a dumping ground for tests of plugins that are sensitive to


### PR DESCRIPTION
Similar to https://github.com/python/mypy/pull/17891 add the classifier for 3.14. The tests all pass and the next release is unlikely to happen before 3.14.0b3. Note though, not all features might be supported just yet.