### PR TITLE
[mypyc] Merge generator and environment classes in simple cases

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -246,8 +246,8 @@ def compile_scc_to_ir(
             # Insert refcount handling.
             insert_ref_count_opcodes(fn)
 
-            #if fn in env_user_functions:
-            #    insert_spills(fn, env_user_functions[fn])
+            if fn in env_user_functions:
+                insert_spills(fn, env_user_functions[fn])
 
             # Switch to lower abstraction level IR.
             lower_ir(fn, compiler_options)

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -246,8 +246,8 @@ def compile_scc_to_ir(
             # Insert refcount handling.
             insert_ref_count_opcodes(fn)
 
-            if fn in env_user_functions:
-                insert_spills(fn, env_user_functions[fn])
+            #if fn in env_user_functions:
+            #    insert_spills(fn, env_user_functions[fn])
 
             # Switch to lower abstraction level IR.
             lower_ir(fn, compiler_options)

--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -95,6 +95,11 @@ class FuncInfo:
         assert self._curr_env_reg is not None
         return self._curr_env_reg
 
+    def can_merge_generator_and_env_classes(self) -> bool:
+        # In simple cases we can place the environment into the generator class,
+        # instead of having two separate classes.
+        return self.is_generator and not self.is_nested and not self.contains_nested
+
 
 class ImplicitClass:
     """Contains information regarding implicitly generated classes.

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -47,7 +47,6 @@ def setup_env_class(builder: IRBuilder) -> ClassIR:
     )
     env_class.attributes[SELF_NAME] = RInstance(env_class)
     if builder.fn_info.is_nested:
-        assert False
         # If the function is nested, its environment class must contain an environment
         # attribute pointing to its encapsulating functions' environment class.
         env_class.attributes[ENV_ATTR_NAME] = RInstance(builder.fn_infos[-2].env_class)
@@ -59,7 +58,8 @@ def setup_env_class(builder: IRBuilder) -> ClassIR:
 
 def finalize_env_class(builder: IRBuilder) -> None:
     """Generate, instantiate, and set up the environment of an environment class."""
-    #instantiate_env_class(builder)
+    if not builder.fn_info.can_merge_generator_and_env_classes():
+        instantiate_env_class(builder)
 
     # Iterate through the function arguments and replace local definitions (using registers)
     # that were previously added to the environment with references to the function's
@@ -77,7 +77,6 @@ def instantiate_env_class(builder: IRBuilder) -> Value:
     )
 
     if builder.fn_info.is_nested:
-        assert False
         builder.fn_info.callable_class._curr_env_reg = curr_env_reg
         builder.add(
             SetAttr(
@@ -127,7 +126,6 @@ def load_outer_env(
 
     Returns the register where the environment class was loaded.
     """
-    assert False
     env = builder.add(GetAttr(base, ENV_ATTR_NAME, builder.fn_info.fitem.line))
     assert isinstance(env.type, RInstance), f"{env} must be of type RInstance"
 
@@ -241,7 +239,6 @@ def setup_func_for_recursive_call(builder: IRBuilder, fdef: FuncDef, base: Impli
     prev_env = builder.fn_infos[-2].env_class
     prev_env.attributes[fdef.name] = builder.type_to_rtype(fdef.type)
 
-    assert False
     if isinstance(base, GeneratorClass):
         # If we are dealing with a generator class, then we need to first get the register
         # holding the current environment class, and load the previous environment class from

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -47,6 +47,7 @@ def setup_env_class(builder: IRBuilder) -> ClassIR:
     )
     env_class.attributes[SELF_NAME] = RInstance(env_class)
     if builder.fn_info.is_nested:
+        assert False
         # If the function is nested, its environment class must contain an environment
         # attribute pointing to its encapsulating functions' environment class.
         env_class.attributes[ENV_ATTR_NAME] = RInstance(builder.fn_infos[-2].env_class)
@@ -58,7 +59,7 @@ def setup_env_class(builder: IRBuilder) -> ClassIR:
 
 def finalize_env_class(builder: IRBuilder) -> None:
     """Generate, instantiate, and set up the environment of an environment class."""
-    instantiate_env_class(builder)
+    #instantiate_env_class(builder)
 
     # Iterate through the function arguments and replace local definitions (using registers)
     # that were previously added to the environment with references to the function's
@@ -76,6 +77,7 @@ def instantiate_env_class(builder: IRBuilder) -> Value:
     )
 
     if builder.fn_info.is_nested:
+        assert False
         builder.fn_info.callable_class._curr_env_reg = curr_env_reg
         builder.add(
             SetAttr(
@@ -125,6 +127,7 @@ def load_outer_env(
 
     Returns the register where the environment class was loaded.
     """
+    assert False
     env = builder.add(GetAttr(base, ENV_ATTR_NAME, builder.fn_info.fitem.line))
     assert isinstance(env.type, RInstance), f"{env} must be of type RInstance"
 
@@ -238,6 +241,7 @@ def setup_func_for_recursive_call(builder: IRBuilder, fdef: FuncDef, base: Impli
     prev_env = builder.fn_infos[-2].env_class
     prev_env.attributes[fdef.name] = builder.type_to_rtype(fdef.type)
 
+    assert False
     if isinstance(base, GeneratorClass):
         # If we are dealing with a generator class, then we need to first get the register
         # holding the current environment class, and load the previous environment class from

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -243,7 +243,7 @@ def gen_func_item(
     # are free in their nested functions. Generator functions need an environment class to
     # store a variable denoting the next instruction to be executed when the __next__ function
     # is called, along with all the variables inside the function itself.
-    if contains_nested: # or is_generator:
+    if contains_nested or (is_generator and not builder.fn_info.can_merge_generator_and_env_classes()):
         setup_env_class(builder)
 
     if is_nested or in_non_ext:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -243,7 +243,7 @@ def gen_func_item(
     # are free in their nested functions. Generator functions need an environment class to
     # store a variable denoting the next instruction to be executed when the __next__ function
     # is called, along with all the variables inside the function itself.
-    if contains_nested or is_generator:
+    if contains_nested: # or is_generator:
         setup_env_class(builder)
 
     if is_nested or in_non_ext:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -243,7 +243,9 @@ def gen_func_item(
     # are free in their nested functions. Generator functions need an environment class to
     # store a variable denoting the next instruction to be executed when the __next__ function
     # is called, along with all the variables inside the function itself.
-    if contains_nested or (is_generator and not builder.fn_info.can_merge_generator_and_env_classes()):
+    if contains_nested or (
+        is_generator and not builder.fn_info.can_merge_generator_and_env_classes()
+    ):
         setup_env_class(builder)
 
     if is_nested or in_non_ext:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -64,8 +64,10 @@ def gen_generator_func(
     setup_generator_class(builder)
     load_env_registers(builder)
     gen_arg_defaults(builder)
+    g = instantiate_generator_class(builder)
+    builder.fn_info._curr_env_reg = g
     finalize_env_class(builder)
-    builder.add(Return(instantiate_generator_class(builder)))
+    builder.add(Return(g))
 
     args, _, blocks, ret_type, fn_info = builder.leave()
     func_ir, func_reg = gen_func_ir(args, blocks, fn_info)
@@ -126,18 +128,19 @@ def instantiate_generator_class(builder: IRBuilder) -> Value:
     # generator class gets instantiated from the callable class' '__call__' method, and hence
     # we use the callable class' environment register. Otherwise, we use the original
     # function's environment register.
-    if builder.fn_info.is_nested:
-        curr_env_reg = builder.fn_info.callable_class.curr_env_reg
-    else:
-        curr_env_reg = builder.fn_info.curr_env_reg
+    #if builder.fn_info.is_nested:
+    #    curr_env_reg = builder.fn_info.callable_class.curr_env_reg
+    #else:
+    #    curr_env_reg = builder.fn_info.curr_env_reg
 
     # Set the generator class' environment attribute to point at the environment class
     # defined in the current scope.
-    builder.add(SetAttr(generator_reg, ENV_ATTR_NAME, curr_env_reg, fitem.line))
+    #builder.add(SetAttr(generator_reg, ENV_ATTR_NAME, curr_env_reg, fitem.line))
 
     # Set the generator class' environment class' NEXT_LABEL_ATTR_NAME attribute to 0.
     zero = Integer(0)
-    builder.add(SetAttr(curr_env_reg, NEXT_LABEL_ATTR_NAME, zero, fitem.line))
+    builder.add(SetAttr(generator_reg, NEXT_LABEL_ATTR_NAME, zero, fitem.line))
+    #builder.add(SetAttr(curr_env_reg, NEXT_LABEL_ATTR_NAME, zero, fitem.line))
     return generator_reg
 
 
@@ -145,7 +148,8 @@ def setup_generator_class(builder: IRBuilder) -> ClassIR:
     name = f"{builder.fn_info.namespaced_name()}_gen"
 
     generator_class_ir = ClassIR(name, builder.module_name, is_generated=True)
-    generator_class_ir.attributes[ENV_ATTR_NAME] = RInstance(builder.fn_info.env_class)
+    builder.fn_info.env_class = generator_class_ir
+    #generator_class_ir.attributes[ENV_ATTR_NAME] = RInstance(builder.fn_info.env_class)
     generator_class_ir.mro = [generator_class_ir]
 
     builder.classes.append(generator_class_ir)
@@ -392,7 +396,7 @@ def setup_env_for_generator_class(builder: IRBuilder) -> None:
     cls.send_arg_reg = exc_arg
 
     cls.self_reg = builder.read(self_target, fitem.line)
-    cls.curr_env_reg = load_outer_env(builder, cls.self_reg, builder.symtables[-1])
+    cls.curr_env_reg = cls.self_reg # load_outer_env(builder, cls.self_reg, builder.symtables[-1])
 
     # Define a variable representing the label to go to the next time
     # the '__next__' function of the generator is called, and add it

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -129,6 +129,7 @@ def instantiate_generator_class(builder: IRBuilder) -> Value:
     generator_reg = builder.add(Call(builder.fn_info.generator_class.ir.ctor, [], fitem.line))
 
     if builder.fn_info.can_merge_generator_and_env_classes():
+        # Set the generator instance to the initial state (zero).
         zero = Integer(0)
         builder.add(SetAttr(generator_reg, NEXT_LABEL_ATTR_NAME, zero, fitem.line))
     else:
@@ -145,7 +146,7 @@ def instantiate_generator_class(builder: IRBuilder) -> Value:
         # defined in the current scope.
         builder.add(SetAttr(generator_reg, ENV_ATTR_NAME, curr_env_reg, fitem.line))
 
-        # Set the generator class' environment class' NEXT_LABEL_ATTR_NAME attribute to 0.
+        # Set the generator instance's environment to the initial state (zero).
         zero = Integer(0)
         builder.add(SetAttr(curr_env_reg, NEXT_LABEL_ATTR_NAME, zero, fitem.line))
     return generator_reg

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -64,10 +64,13 @@ def gen_generator_func(
     setup_generator_class(builder)
     load_env_registers(builder)
     gen_arg_defaults(builder)
-    gen = instantiate_generator_class(builder)
     if builder.fn_info.can_merge_generator_and_env_classes():
+        gen = instantiate_generator_class(builder)
         builder.fn_info._curr_env_reg = gen
-    finalize_env_class(builder)
+        finalize_env_class(builder)
+    else:
+        finalize_env_class(builder)
+        gen = instantiate_generator_class(builder)
     builder.add(Return(gen))
 
     args, _, blocks, ret_type, fn_info = builder.leave()

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -64,10 +64,11 @@ def gen_generator_func(
     setup_generator_class(builder)
     load_env_registers(builder)
     gen_arg_defaults(builder)
-    g = instantiate_generator_class(builder)
-    builder.fn_info._curr_env_reg = g
+    gen = instantiate_generator_class(builder)
+    if builder.fn_info.can_merge_generator_and_env_classes():
+        builder.fn_info._curr_env_reg = gen
     finalize_env_class(builder)
-    builder.add(Return(g))
+    builder.add(Return(gen))
 
     args, _, blocks, ret_type, fn_info = builder.leave()
     func_ir, func_reg = gen_func_ir(args, blocks, fn_info)

--- a/mypyc/transform/spill.py
+++ b/mypyc/transform/spill.py
@@ -32,8 +32,11 @@ def insert_spills(ir: FuncIR, env: ClassIR) -> None:
 
 
 def spill_regs(
-    blocks: list[BasicBlock], env: ClassIR, to_spill: set[Value], live: AnalysisResult[Value],
-    self_reg: Register
+    blocks: list[BasicBlock],
+    env: ClassIR,
+    to_spill: set[Value],
+    live: AnalysisResult[Value],
+    self_reg: Register,
 ) -> list[BasicBlock]:
     for op in blocks[0].ops:
         if isinstance(op, GetAttr) and op.attr == "__mypyc_env__":

--- a/mypyc/transform/spill.py
+++ b/mypyc/transform/spill.py
@@ -28,18 +28,20 @@ def insert_spills(ir: FuncIR, env: ClassIR) -> None:
     # TODO: Actually for now, no Registers at all -- we keep the manual spills
     entry_live = {op for op in entry_live if not isinstance(op, Register)}
 
-    ir.blocks = spill_regs(ir.blocks, env, entry_live, live)
+    ir.blocks = spill_regs(ir.blocks, env, entry_live, live, ir.arg_regs[0])
 
 
 def spill_regs(
-    blocks: list[BasicBlock], env: ClassIR, to_spill: set[Value], live: AnalysisResult[Value]
+    blocks: list[BasicBlock], env: ClassIR, to_spill: set[Value], live: AnalysisResult[Value],
+    self_reg: Register
 ) -> list[BasicBlock]:
     for op in blocks[0].ops:
         if isinstance(op, GetAttr) and op.attr == "__mypyc_env__":
             env_reg = op
             break
     else:
-        raise AssertionError("could not find __mypyc_env__")
+        # Environment has been merged into generator object
+        env_reg = self_reg
 
     spill_locs = {}
     for i, val in enumerate(to_spill):

--- a/mypyc/transform/spill.py
+++ b/mypyc/transform/spill.py
@@ -38,6 +38,7 @@ def spill_regs(
     live: AnalysisResult[Value],
     self_reg: Register,
 ) -> list[BasicBlock]:
+    env_reg: Value
     for op in blocks[0].ops:
         if isinstance(op, GetAttr) and op.attr == "__mypyc_env__":
             env_reg = op


### PR DESCRIPTION
Mypyc used to always compile a generator or an async def into two classes: a generator and an environment. Combine these two classes in simple cases where it's clearly okay to do it (when there is no nesting). We could probably extend it to other use cases as well, including some nested functions, but this is a start.

This improves performance by reducing the number of instances that will be allocated. Also access to the environment object is slightly faster, though this is probably relatively minor. This helps calling async defs in particular, since they typically yield only a single value, so the objects are not used much until they are freed. Also generators than only yield a small number of values benefit from this.

The existing test cases provide decent test coverage. I previously added some additional tests in anticipation of this change.

This also reduces the amount of C code generated when compiling async defs and generators.

This speeds up this micro-benchmark on the order of 20%:
```py
import asyncio
from time import time

async def inc(x: int) -> int:
    x = 1
    return x + 1


async def bench(n: int) -> int:
    x = 0
    for i in range(n):
        x = await inc(x)
    return x

asyncio.run(bench(1000))

t0 = time()
asyncio.run(bench(1000 * 1000 * 200))
print(time() - t0)
```
