### PR TITLE
[mypyc] Use non-tagged integer for generator label

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1300,12 +1300,19 @@ class IRBuilder:
         return self.type_to_rtype(mypy_type)
 
     def add_var_to_env_class(
-        self, var: SymbolNode, rtype: RType, base: FuncInfo | ImplicitClass, reassign: bool = False
+        self,
+        var: SymbolNode,
+        rtype: RType,
+        base: FuncInfo | ImplicitClass,
+        reassign: bool = False,
+        always_defined: bool = False,
     ) -> AssignmentTarget:
         # First, define the variable name as an attribute of the environment class, and then
         # construct a target for that attribute.
         name = remangle_redefinition_name(var.name)
         self.fn_info.env_class.attributes[name] = rtype
+        if always_defined:
+            self.fn_info.env_class.attrs_with_defaults.add(name)
         attr_target = AssignmentTargetAttr(base.curr_env_reg, name)
 
         if reassign:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -32,7 +32,7 @@ from mypyc.ir.ops import (
     Unreachable,
     Value,
 )
-from mypyc.ir.rtypes import RInstance, int_rprimitive, object_rprimitive
+from mypyc.ir.rtypes import RInstance, int32_rprimitive, object_rprimitive
 from mypyc.irbuild.builder import IRBuilder, calculate_arg_defaults, gen_arg_defaults
 from mypyc.irbuild.context import FuncInfo, GeneratorClass
 from mypyc.irbuild.env_class import (
@@ -415,7 +415,7 @@ def setup_env_for_generator_class(builder: IRBuilder) -> None:
     # the '__next__' function of the generator is called, and add it
     # as an attribute to the environment class.
     cls.next_label_target = builder.add_var_to_env_class(
-        Var(NEXT_LABEL_ATTR_NAME), int_rprimitive, cls, reassign=False
+        Var(NEXT_LABEL_ATTR_NAME), int32_rprimitive, cls, reassign=False, always_defined=True
     )
 
     # Add arguments from the original generator function to the


### PR DESCRIPTION
Also consider it as always defined to generate simpler code.

This appears to speed up a simple benchmark by 3%, but it could be noise. This reduces the volume of generated code -- the line count of a small compiled program with a few async functions was reduced by 5%.