### PR TITLE
Avoid spurious non-overlapping eq error with metaclass with `__eq__`

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -1190,6 +1190,10 @@ def custom_special_method(typ: Type, name: str, check_all: bool = False) -> bool
     if isinstance(typ, FunctionLike) and typ.is_type_obj():
         # Look up __method__ on the metaclass for class objects.
         return custom_special_method(typ.fallback, name, check_all)
+    if isinstance(typ, TypeType) and isinstance(typ.item, Instance):
+        if typ.item.type.metaclass_type:
+            # Look up __method__ on the metaclass for class objects.
+            return custom_special_method(typ.item.type.metaclass_type, name, check_all)
     if isinstance(typ, AnyType):
         # Avoid false positives in uncertain cases.
         return True

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -2172,6 +2172,14 @@ class Custom(metaclass=CustomMeta): ...
 Normal == int()  # E: Non-overlapping equality check (left operand type: "type[Normal]", right operand type: "int")
 Normal == Normal
 Custom == int()
+
+n: type[Normal] = Normal
+c: type[Custom] = Custom
+
+n == int()  # E: Non-overlapping equality check (left operand type: "type[Normal]", right operand type: "int")
+n == n
+c == int()
+
 [builtins fixtures/bool.pyi]
 
 [case testCustomContainsCheckStrictEquality]


### PR DESCRIPTION
Currently, doing an `==` on a `type[Foo]` where `Foo` has a metaclass
that defines `__eq__` will spuriously produce a non-overlapping equality
error, because `custom_special_method`, a helper used in the check,
does not consider the `TypeType` case.

Fix that.