### PR TITLE
Omit constraints referencing `dict` if a conflicting `TypedDict` constraint exists

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -274,7 +274,9 @@ def infer_constraints_for_callable(
         # As a perf optimization filter imprecise constraints only when we can have them.
         constraints = filter_imprecise_kinds(constraints)
 
-    return _omit_dict_constraints_if_typeddict_found(constraints)
+    if any(isinstance(c.target, TypedDictType) for c in constraints):
+        constraints = _omit_dict_constraints_if_typeddict_found(constraints)
+    return constraints
 
 
 def _omit_dict_constraints_if_typeddict_found(constraints: list[Constraint]) -> list[Constraint]:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -4149,3 +4149,27 @@ class Foo:
         else:
             self.qux = {}  # E: Need type annotation for "qux" (hint: "qux: dict[<type>, <type>] = ...")
 [builtins fixtures/dict.pyi]
+
+[case testInferLiteralTypedDict]
+from typing import Generic, TypeVar, TypedDict
+
+T = TypeVar("T")
+
+class D(TypedDict):
+    x: int
+
+class A(Generic[T]): ...
+
+
+def f(a: A[T], t: T) -> T: ...
+def g(a: T, t: A[T]) -> T: ...
+
+def check(obj: A[D]) -> None:
+    reveal_type(f(obj, {"x": 1}))  # N: Revealed type is "TypedDict('__main__.D', {'x': builtins.int})"
+    reveal_type(f(obj, {"x": ''}))  # N: Revealed type is "TypedDict('__main__.D', {'x': builtins.int})" \
+                                    # E: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
+    reveal_type(g({"x": 1}, obj))  # N: Revealed type is "TypedDict('__main__.D', {'x': builtins.int})"
+    reveal_type(g({"x": ''}, obj))  # N: Revealed type is "TypedDict('__main__.D', {'x': builtins.int})" \
+                                    # E: Incompatible types (expression has type "str", TypedDict item "x" has type "int")
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]


### PR DESCRIPTION
Fixes #19201, let's see what primer says.