### PR TITLE
Remove --show-speed-regression in primer

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -67,7 +67,6 @@ jobs:
             --debug \
             --additional-flags="--debug-serialize" \
             --output concise \
-            --show-speed-regression \
             | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]
       - if: ${{ matrix.shard-index == 0 }}


### PR DESCRIPTION
It's too noisy. We added it to benchmark a specific PR