### PR TITLE
[mypyc] Free generator after await encounters StopIteration

### DIFF
--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -940,6 +940,10 @@ def emit_yield_from_or_await(
     # If it wasn't, this reraises the exception.
     builder.activate_block(stop_block)
     builder.assign(result, builder.call_c(check_stop_op, [], line), line)
+    # Clear the spilled iterator/coroutine so that it will be freed.
+    # Otherwise, the freeing of the spilled register would likely be delayed.
+    err = builder.add(LoadErrorValue(object_rprimitive))
+    builder.assign(iter_reg, err, line)
     builder.goto(done_block)
 
     builder.activate_block(main_block)


### PR DESCRIPTION
Previously the awaited coroutine could stay alive until the coroutine that performed the await was freed, delaying object reclamation. The reference counting analysis doesn't understand registers spilled to the environment, so we need to manually clear the value.

Consider code like this:
```
async def foo() -> None:
    await bar()
    await zar()
```
Previously, the `bar()` coroutine was only freed at end of `foo()`. Now we release it before `await zar()`, as expected.