### PR TITLE
Allow TypeVarTuple arguments to subclasses of generic TypedDict

### DIFF
--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -182,6 +182,7 @@ class SemanticAnalyzerInterface(SemanticAnalyzerCoreInterface):
         allow_tuple_literal: bool = False,
         allow_unbound_tvars: bool = False,
         allow_typed_dict_special_forms: bool = False,
+        allow_unpack: bool = False,
         allow_placeholder: bool = False,
         report_invalid_types: bool = True,
         prohibit_self_type: str | None = None,

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -253,13 +253,16 @@ class TypedDictAnalyzer:
 
         for arg_expr in args:
             try:
-                type = expr_to_unanalyzed_type(arg_expr, self.options, self.api.is_stub_file)
+                type = expr_to_unanalyzed_type(
+                    arg_expr, self.options, self.api.is_stub_file, allow_unpack=True
+                )
             except TypeTranslationError:
                 self.fail("Invalid TypedDict type argument", ctx)
                 return None
             analyzed = self.api.anal_type(
                 type,
                 allow_typed_dict_special_forms=True,
+                allow_unpack=True,
                 allow_placeholder=not self.api.is_func_scope(),
             )
             if analyzed is None:

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -1159,6 +1159,116 @@ td2 = A({"fn": bad, "val": 42})  # E: Incompatible types (expression has type "C
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testVariadicTypedDictDeriveUnpack]
+from typing import Tuple, Callable, Generic, TypedDict, TypeVar
+from typing_extensions import TypeVarTuple, Unpack
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+class A(TypedDict, Generic[Unpack[Ts]]):
+    fn: Callable[[Unpack[Ts]], None]
+
+class B(A[Unpack[Ts]]):
+    val: bool
+
+class C(A[Unpack[Ts]], Generic[Unpack[Ts], T]):
+    val: T
+
+
+y: B[int, str]
+reveal_type(y)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.str), 'val': builtins.bool})"
+reveal_type(y["fn"])  # N: Revealed type is "def (builtins.int, builtins.str)"
+reveal_type(y["val"])  # N: Revealed type is "builtins.bool"
+
+y2: C[int, str, bool]
+reveal_type(y2)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (builtins.int, builtins.str), 'val': builtins.bool})"
+reveal_type(y2["fn"])  # N: Revealed type is "def (builtins.int, builtins.str)"
+reveal_type(y2["val"])  # N: Revealed type is "builtins.bool"
+
+z: B[Unpack[Tuple[int, ...]]]
+reveal_type(z)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (*builtins.int), 'val': builtins.bool})"
+reveal_type(z["fn"])  # N: Revealed type is "def (*builtins.int)"
+reveal_type(y["val"])  # N: Revealed type is "builtins.bool"
+
+z2: C[Unpack[Tuple[int, ...]]]
+reveal_type(z2)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (*builtins.int), 'val': builtins.int})"
+reveal_type(z2["fn"])  # N: Revealed type is "def (*builtins.int)"
+reveal_type(z2["val"])  # N: Revealed type is "builtins.int"
+
+z3: C[Unpack[Tuple[int, ...]], bool]
+reveal_type(z3)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (*builtins.int), 'val': builtins.bool})"
+reveal_type(z3["fn"])  # N: Revealed type is "def (*builtins.int)"
+reveal_type(z3["val"])  # N: Revealed type is "builtins.bool"
+
+t: B[int, Unpack[Tuple[int, str]]]
+reveal_type(t)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.int, builtins.str), 'val': builtins.bool})"
+
+t2: C[int, Unpack[Tuple[int, str]]]
+reveal_type(t2)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (builtins.int, builtins.int), 'val': builtins.str})"
+
+def test(x: int, y: str) -> None: ...
+td = B({"fn": test, "val": False})
+reveal_type(td)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.str), 'val': builtins.bool})"
+td2 = C({"fn": test, "val": False})
+reveal_type(td2)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (builtins.int, builtins.str), 'val': builtins.bool})"
+
+def bad() -> int: ...
+td3 = B({"fn": bad, "val": False})  # E: Incompatible types (expression has type "Callable[[], int]", TypedDict item "fn" has type "Callable[[], None]")
+td4 = C({"fn": bad, "val": False})  # E: Incompatible types (expression has type "Callable[[], int]", TypedDict item "fn" has type "Callable[[], None]")
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+[case testVariadicTypedDictDeriveStar]
+from typing import Tuple, Callable, Generic, TypedDict, TypeVar
+from typing_extensions import TypeVarTuple
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+class A(TypedDict, Generic[*Ts]):
+    fn: Callable[[*Ts], None]
+
+class B(A[*Ts]):
+    val: bool
+
+class C(A[*Ts], Generic[*Ts, T]):
+    val: T
+
+
+y: B[int, str]
+reveal_type(y)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.str), 'val': builtins.bool})"
+reveal_type(y["fn"])  # N: Revealed type is "def (builtins.int, builtins.str)"
+reveal_type(y["val"])  # N: Revealed type is "builtins.bool"
+
+y2: C[int, str, bool]
+reveal_type(y2)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (builtins.int, builtins.str), 'val': builtins.bool})"
+reveal_type(y2["fn"])  # N: Revealed type is "def (builtins.int, builtins.str)"
+reveal_type(y2["val"])  # N: Revealed type is "builtins.bool"
+
+z: B[*Tuple[int, ...]]
+reveal_type(z)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (*builtins.int), 'val': builtins.bool})"
+reveal_type(z["fn"])  # N: Revealed type is "def (*builtins.int)"
+reveal_type(y["val"])  # N: Revealed type is "builtins.bool"
+
+z2: C[*Tuple[int, ...]]
+reveal_type(z2)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (*builtins.int), 'val': builtins.int})"
+reveal_type(z2["fn"])  # N: Revealed type is "def (*builtins.int)"
+reveal_type(z2["val"])  # N: Revealed type is "builtins.int"
+
+z3: C[*Tuple[int, ...], bool]
+reveal_type(z3)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (*builtins.int), 'val': builtins.bool})"
+reveal_type(z3["fn"])  # N: Revealed type is "def (*builtins.int)"
+reveal_type(z3["val"])  # N: Revealed type is "builtins.bool"
+
+t: B[int, *Tuple[int, str]]
+reveal_type(t)  # N: Revealed type is "TypedDict('__main__.B', {'fn': def (builtins.int, builtins.int, builtins.str), 'val': builtins.bool})"
+
+t2: C[int, *Tuple[int, str]]
+reveal_type(t2)  # N: Revealed type is "TypedDict('__main__.C', {'fn': def (builtins.int, builtins.int), 'val': builtins.str})"
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testFixedUnpackWithRegularInstance]
 from typing import Tuple, Generic, TypeVar
 from typing_extensions import Unpack


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Fixes #16975 
Supersedes #16977 

Allows `TypeVarTuple`s as type argument for subclasses of generic `TypedDict`s.

Since (1) TypedDict became generic and (2) TypeVarTuple was introduced, mypy now supports creating generic typed dictionaries with variadic type arguments. However, things went wrong when deriving a subclass from such a generic typeddict.

Full disclosure: I submitted an earlier PR for this issue, but it's been a while. Earlier I wasn't 100% sure about one minor aspect of the changes I made, but in the mean time the context has changed to the point that that aspect is no longer relevant.

For tests, I started with a copy of an existing one from test-data/unit/check-typevar-tuple.test, and added two subclasses: one which just passes a TypeVarTuple generic type parameter up to the base class, and another which passes a TypeVarTuple and a regular TypeVar argument.

I did this all of this twice: once using the `Unpack[Ts]` syntax and once using the `*Ts`  syntax.