### PR TITLE
[mypyc] Make some generated classes implicitly final

### DIFF
--- a/mypyc/irbuild/callable_class.py
+++ b/mypyc/irbuild/callable_class.py
@@ -55,7 +55,7 @@ def setup_callable_class(builder: IRBuilder) -> None:
     # Define the actual callable class ClassIR, and set its
     # environment to point at the previously defined environment
     # class.
-    callable_class_ir = ClassIR(name, builder.module_name, is_generated=True)
+    callable_class_ir = ClassIR(name, builder.module_name, is_generated=True, is_final_class=True)
 
     # The functools @wraps decorator attempts to call setattr on
     # nested functions, so we create a dict for these nested

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -43,7 +43,10 @@ def setup_env_class(builder: IRBuilder) -> ClassIR:
     containing a nested function.
     """
     env_class = ClassIR(
-        f"{builder.fn_info.namespaced_name()}_env", builder.module_name, is_generated=True
+        f"{builder.fn_info.namespaced_name()}_env",
+        builder.module_name,
+        is_generated=True,
+        is_final_class=True,
     )
     env_class.attributes[SELF_NAME] = RInstance(env_class)
     if builder.fn_info.is_nested:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -155,7 +155,7 @@ def instantiate_generator_class(builder: IRBuilder) -> Value:
 def setup_generator_class(builder: IRBuilder) -> ClassIR:
     name = f"{builder.fn_info.namespaced_name()}_gen"
 
-    generator_class_ir = ClassIR(name, builder.module_name, is_generated=True)
+    generator_class_ir = ClassIR(name, builder.module_name, is_generated=True, is_final_class=True)
     if builder.fn_info.can_merge_generator_and_env_classes():
         builder.fn_info.env_class = generator_class_ir
     else:


### PR DESCRIPTION
Classes used for generators, async functions and nested functions are now final. This may slightly improve performance when using separate compilation.