### PR TITLE
Add an overload for `int`, `str` and `bool`

### DIFF
--- a/mypy/typeshed/stdlib/builtins.pyi
+++ b/mypy/typeshed/stdlib/builtins.pyi
@@ -242,6 +242,8 @@ _LiteralInteger = _PositiveInteger | _NegativeInteger | Literal[0]  # noqa: Y026
 
 class int:
     @overload
+    def __new__(cls, /) -> Literal[0]: ...
+    @overload
     def __new__(cls, x: ConvertibleToInt = ..., /) -> Self: ...
     @overload
     def __new__(cls, x: str | bytes | bytearray, /, base: SupportsIndex) -> Self: ...
@@ -458,6 +460,8 @@ class _TranslateTable(Protocol):
     def __getitem__(self, key: int, /) -> str | int | None: ...
 
 class str(Sequence[str]):
+    @overload
+    def __new__(cls) -> Literal[""]: ...
     @overload
     def __new__(cls, object: object = ...) -> Self: ...
     @overload
@@ -834,6 +838,9 @@ class memoryview(Sequence[_I]):
 
 @final
 class bool(int):
+    @overload
+    def __new__(cls, /) -> Literal[False]: ...
+    @overload
     def __new__(cls, o: object = ..., /) -> Self: ...
     # The following overloads could be represented more elegantly with a TypeVar("_B", bool, int),
     # however mypy has a bug regarding TypeVar constraints (https://github.com/python/mypy/issues/11880).


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Adds overlaods for `__new__` method in `int`, `str` and `bool` classes, when no value is provided as an arguement

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
