### PR TITLE
Improve the support for promotions inside unions.

### DIFF
--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2453,6 +2453,39 @@ while x is not None and b():
 
 [builtins fixtures/primitives.pyi]
 
+[case testNarrowPromotionsInsideUnions1]
+
+from typing import Union
+
+x: Union[str, float, None]
+y: Union[int, str]
+x = y
+reveal_type(x)  # N: Revealed type is "Union[builtins.str, builtins.int]"
+z: Union[complex, str]
+z = x
+reveal_type(z)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowPromotionsInsideUnions2]
+# flags: --warn-unreachable
+
+from typing import Optional
+
+def b() -> bool: ...
+def i() -> int: ...
+x: Optional[float]
+
+while b():
+    x = None
+    while b():
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, None]"
+        if x is None or b():
+            x = i()
+            reveal_type(x)  # N: Revealed type is "builtins.int"
+
+[builtins fixtures/bool.pyi]
+
 [case testNarrowingTypeVarMultiple]
 from typing import TypeVar
 


### PR DESCRIPTION
Fixes #14987

I was puzzled as to why my previous attempts to avoid false `unreachable` warnings for loops failed for issue #14987.  After some debugging, I realised that the underlying problem is that type narrowing does not work with promotions if both the declared type and the constraining type are unions:

```python
x: float | None
y: int | None
x = y
reveal_type(x)
```

The fix seems straightforward (but let's see what the Mypy primer says) and is checked by the test cases  `testNarrowPromotionsInsideUnions1` and `testNarrowPromotionsInsideUnions2`.
