### PR TITLE
Fix and simplify error de-duplication

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -25,7 +25,7 @@ from mypy.checkpattern import PatternChecker
 from mypy.constraints import SUPERTYPE_OF
 from mypy.erasetype import erase_type, erase_typevars, remove_instance_last_known_values
 from mypy.errorcodes import TYPE_VAR, UNUSED_AWAITABLE, UNUSED_COROUTINE, ErrorCode
-from mypy.errors import Errors, ErrorWatcher, LoopErrorWatcher, report_internal_error
+from mypy.errors import ErrorInfo, Errors, ErrorWatcher, LoopErrorWatcher, report_internal_error
 from mypy.expandtype import expand_type
 from mypy.literals import Key, extract_var_from_literal_hash, literal, literal_hash
 from mypy.maptype import map_instance_to_supertype
@@ -7207,7 +7207,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         if extra_info:
             msg = msg.with_additional_msg(" (" + ", ".join(extra_info) + ")")
 
-        self.fail(msg, context)
+        error = self.fail(msg, context)
         for note in notes:
             self.msg.note(note, context, code=msg.code)
         if note_msg:
@@ -7218,7 +7218,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
             and supertype.type.is_protocol
             and isinstance(subtype, (CallableType, Instance, TupleType, TypedDictType))
         ):
-            self.msg.report_protocol_problems(subtype, supertype, context, code=msg.code)
+            self.msg.report_protocol_problems(subtype, supertype, context, parent_error=error)
         if isinstance(supertype, CallableType) and isinstance(subtype, Instance):
             call = find_member("__call__", subtype, subtype, is_operator=True)
             if call:
@@ -7547,12 +7547,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
     def fail(
         self, msg: str | ErrorMessage, context: Context, *, code: ErrorCode | None = None
-    ) -> None:
+    ) -> ErrorInfo:
         """Produce an error message."""
         if isinstance(msg, ErrorMessage):
-            self.msg.fail(msg.value, context, code=msg.code)
-            return
-        self.msg.fail(msg, context, code=code)
+            return self.msg.fail(msg.value, context, code=msg.code)
+        return self.msg.fail(msg, context, code=code)
 
     def note(
         self,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2647,7 +2647,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         elif self.has_abstract_type_part(caller_type, callee_type):
             self.msg.concrete_only_call(callee_type, context)
         elif not is_subtype(caller_type, callee_type, options=self.chk.options):
-            code = self.msg.incompatible_argument(
+            error = self.msg.incompatible_argument(
                 n,
                 m,
                 callee,
@@ -2658,10 +2658,12 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                 outer_context=outer_context,
             )
             self.msg.incompatible_argument_note(
-                original_caller_type, callee_type, context, code=code
+                original_caller_type, callee_type, context, parent_error=error
             )
             if not self.msg.prefer_simple_messages():
-                self.chk.check_possible_missing_await(caller_type, callee_type, context, code)
+                self.chk.check_possible_missing_await(
+                    caller_type, callee_type, context, error.code
+                )
 
     def check_overload_call(
         self,

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -124,6 +124,7 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, TypeVar
 from mypy_extensions import mypyc_attr, trait
 
 from mypy.errorcodes import ErrorCode
+from mypy.errors import ErrorInfo
 from mypy.lookup import lookup_fully_qualified
 from mypy.message_registry import ErrorMessage
 from mypy.nodes import (
@@ -240,7 +241,7 @@ class CheckerPluginInterface:
     @abstractmethod
     def fail(
         self, msg: str | ErrorMessage, ctx: Context, /, *, code: ErrorCode | None = None
-    ) -> None:
+    ) -> ErrorInfo | None:
         """Emit an error message at given location."""
         raise NotImplementedError
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -9,6 +9,7 @@ from typing import Callable, Final, Protocol, TypeVar
 
 from mypy import errorcodes as codes, message_registry, nodes
 from mypy.errorcodes import ErrorCode
+from mypy.errors import ErrorInfo
 from mypy.expandtype import expand_type
 from mypy.message_registry import (
     INVALID_PARAM_SPEC_LOCATION,
@@ -1990,7 +1991,9 @@ TypeVarLikeList = list[tuple[str, TypeVarLikeExpr]]
 
 
 class MsgCallback(Protocol):
-    def __call__(self, __msg: str, __ctx: Context, *, code: ErrorCode | None = None) -> None: ...
+    def __call__(
+        self, __msg: str, __ctx: Context, *, code: ErrorCode | None = None
+    ) -> ErrorInfo | None: ...
 
 
 def get_omitted_any(

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -8738,7 +8738,7 @@ class NoopPowerResource:
 [builtins fixtures/property.pyi]
 
 [case testOverrideErrorReportingNoDuplicates]
-from typing import Callable, Protocol, Generic, TypeVar
+from typing import Callable, TypeVar
 
 def nested() -> None:
     class B:

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -8736,3 +8736,25 @@ class NoopPowerResource:
     def hardware_type(self) -> None:  # E: Invalid property setter signature
         self.hardware_type = None  # Note: intentionally recursive
 [builtins fixtures/property.pyi]
+
+[case testOverrideErrorReportingNoDuplicates]
+from typing import Callable, Protocol, Generic, TypeVar
+
+def nested() -> None:
+    class B:
+        def meth(self, x: str) -> int: ...
+    class C(B):
+        def meth(self) -> str:  # E: Signature of "meth" incompatible with supertype "B" \
+                # N:      Superclass: \
+                # N:          def meth(self, x: str) -> int \
+                # N:      Subclass: \
+                # N:          def meth(self) -> str
+            pass
+    x = defer()
+
+T = TypeVar("T")
+def deco(fn: Callable[[], T]) -> Callable[[], list[T]]: ...
+
+@deco
+def defer() -> int: ...
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3655,3 +3655,42 @@ reveal_type(C().x6)  # N: Revealed type is "def (x: builtins.int) -> builtins.st
 reveal_type(C().x7)  # E: Invalid self argument "C" to attribute function "x7" with type "Callable[[int], str]" \
                      # N: Revealed type is "def () -> builtins.str"
 [builtins fixtures/classmethod.pyi]
+
+[case testFunctionRedefinitionDeferred]
+from typing import Callable, TypeVar
+
+def outer() -> None:
+    if bool():
+        def inner() -> str: ...
+    else:
+        def inner() -> int: ...  # E: All conditional function variants must have identical signatures \
+                                 # N: Original: \
+                                 # N:     def inner() -> str \
+                                 # N: Redefinition: \
+                                 # N:     def inner() -> int
+    x = defer()
+
+T = TypeVar("T")
+def deco(fn: Callable[[], T]) -> Callable[[], list[T]]: ...
+
+@deco
+def defer() -> int: ...
+[builtins fixtures/list.pyi]
+
+[case testCheckFunctionErrorContextDuplicateDeferred]
+# flags: --show-error-context
+from typing import Callable, TypeVar
+
+def a() -> None:
+    def b() -> None:
+        1 + ""
+        x = defer()
+
+T = TypeVar("T")
+def deco(fn: Callable[[], T]) -> Callable[[], list[T]]: ...
+
+@deco
+def defer() -> int: ...
+[out]
+main: note: In function "a":
+main:6: error: Unsupported operand types for + ("int" and "str")

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2366,7 +2366,6 @@ class A:
                 if z:
                     z[0] + "v"  # E: Unsupported operand types for + ("int" and "str")
                 z.append(1)
-
 [builtins fixtures/primitives.pyi]
 
 [case testPersistentUnreachableLinesNestedInInpersistentUnreachableLines]
@@ -2379,7 +2378,6 @@ while True:
         if y is not None:
             reveal_type(y)  # E: Statement is unreachable
     x = 1
-
 [builtins fixtures/bool.pyi]
 
 [case testAvoidFalseRedundantCastInLoops]
@@ -2401,7 +2399,6 @@ def main_no_cast(p: Processor) -> None:
     ed = cast(str, ...)
     while True:
         ed = p(ed)  # E: Argument 1 has incompatible type "Union[str, int]"; expected "str"
-
 [builtins fixtures/bool.pyi]
 
 [case testAvoidFalseUnreachableInLoop1]
@@ -2414,7 +2411,6 @@ x: int | None
 x = 1
 while x is not None or b():
     x = f()
-
 [builtins fixtures/bool.pyi]
 
 [case testAvoidFalseUnreachableInLoop2]
@@ -2425,7 +2421,6 @@ while y is None:
     if y is None:
         y = []
     y.append(1)
-
 [builtins fixtures/list.pyi]
 
 [case testAvoidFalseUnreachableInLoop3]
@@ -2436,8 +2431,7 @@ y = None
 for x in xs:
     if x is not None:
         if y is None:
-            y = {}  # E: Need type annotation for "y" (hint: "y: Dict[<type>, <type>] = ...")
-
+            y = {}  # E: Need type annotation for "y" (hint: "y: dict[<type>, <type>] = ...")
 [builtins fixtures/list.pyi]
 
 [case testAvoidFalseRedundantExprInLoop]
@@ -2450,7 +2444,6 @@ x: int | None
 x = 1
 while x is not None and b():
     x = f()
-
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingTypeVarMultiple]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4553,7 +4553,7 @@ reveal_type(t)  # N: Revealed type is "__main__.Test[Any]"
 [builtins fixtures/dict.pyi]
 
 [case testProtocolErrorReportingNoDuplicates]
-from typing import Callable, Protocol, Generic, TypeVar
+from typing import Callable, Protocol, TypeVar
 
 class P(Protocol):
     def meth(self) -> int: ...

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4551,3 +4551,28 @@ class Test(Generic[T]):
 t = Test(Mock())
 reveal_type(t)  # N: Revealed type is "__main__.Test[Any]"
 [builtins fixtures/dict.pyi]
+
+[case testProtocolErrorReportingNoDuplicates]
+from typing import Callable, Protocol, Generic, TypeVar
+
+class P(Protocol):
+    def meth(self) -> int: ...
+
+class C:
+    def meth(self) -> str: ...
+
+def foo() -> None:
+    c: P = C()  # E: Incompatible types in assignment (expression has type "C", variable has type "P") \
+                # N: Following member(s) of "C" have conflicts: \
+                # N:     Expected: \
+                # N:         def meth(self) -> int \
+                # N:     Got: \
+                # N:         def meth(self) -> str
+    x = defer()
+
+T = TypeVar("T")
+def deco(fn: Callable[[], T]) -> Callable[[], list[T]]: ...
+
+@deco
+def defer() -> int: ...
+[builtins fixtures/list.pyi]

--- a/test-data/unit/fine-grained-dataclass-transform.test
+++ b/test-data/unit/fine-grained-dataclass-transform.test
@@ -88,7 +88,6 @@ class A(Dataclass):
 main:7: error: Unexpected keyword argument "x" for "B"
 builtins.pyi:14: note: "B" defined here
 main:7: error: Unexpected keyword argument "y" for "B"
-builtins.pyi:14: note: "B" defined here
 ==
 
 [case frozenInheritanceViaDefault]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/19240
Fixes https://github.com/python/mypy/issues/13517
Fixes https://github.com/python/mypy/issues/17791

Existing de-duplication logic is both complicated and fragile. By specifying a `parent_error` for a note explicitly, we can do everything in a more robust and simple way. In addition, this new argument makes error code matching simpler.