### PR TITLE
Use union of current context and left side for right side narrowing of binary ops

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5879,10 +5879,16 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         allow_none_return: bool = False,
         suppress_unreachable_errors: bool = True,
     ) -> Type:
+        ctx_items = []
+        if context is not None:
+            ctx_items.append(context)
         if self.type_context and self.type_context[-1] is not None:
-            ctx = make_simplified_union([context, self.type_context[-1]])
+            ctx_items.append(self.type_context[-1])
+        ctx: Type | None
+        if ctx_items:
+            ctx = make_simplified_union(ctx_items)
         else:
-            ctx = context
+            ctx = None
         with self.chk.binder.frame_context(can_skip=True, fall_through=0):
             if map is None:
                 # We still need to type check node, in case we want to

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5879,16 +5879,20 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         allow_none_return: bool = False,
         suppress_unreachable_errors: bool = True,
     ) -> Type:
+        if self.type_context and self.type_context[-1] is not None:
+            ctx = make_simplified_union([context, self.type_context[-1]])
+        else:
+            ctx = context
         with self.chk.binder.frame_context(can_skip=True, fall_through=0):
             if map is None:
                 # We still need to type check node, in case we want to
                 # process it for isinstance checks later. Since the branch was
                 # determined to be unreachable, any errors should be suppressed.
                 with self.msg.filter_errors(filter_errors=suppress_unreachable_errors):
-                    self.accept(node, type_context=context, allow_none_return=allow_none_return)
+                    self.accept(node, type_context=ctx, allow_none_return=allow_none_return)
                 return UninhabitedType()
             self.chk.push_type_map(map)
-            return self.accept(node, type_context=context, allow_none_return=allow_none_return)
+            return self.accept(node, type_context=ctx, allow_none_return=allow_none_return)
 
     #
     # Helpers

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1510,3 +1510,24 @@ def mymin(
 def check(paths: Iterable[str], key: Callable[[str], int]) -> Union[str, None]:
     return mymin(paths, key=key, default=None)
 [builtins fixtures/tuple.pyi]
+
+[case testBinaryOpInferenceContext]
+from typing import Literal, TypeVar
+
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+def check1(use: bool, val: str) -> "str | Literal[True]":
+    return use or identity(val)
+
+def check2(use: bool, val: str) -> "str | bool":
+    return use or identity(val)
+
+def check3(use: bool, val: str) -> "str | Literal[False]":
+    return use and identity(val)
+
+def check4(use: bool, val: str) -> "str | bool":
+    return use and identity(val)
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #12001. Fixes #6898. Fixes #15368. Improves #17790 and #11508.

When encountering `a {and,or} b`, we used to use `a` as primary context for `b` inference. This results in weird errors when `a` and `b` are completely unrelated, and in many cases return type/assignment type context can do much better. Inferring to union should be harmless in most cases, so use union of `a` and current context instead.