### PR TITLE
Clean-up and move operator access to checkmember.py

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -615,6 +615,11 @@ class TypeVarLikeType(ProperType):
         t = get_proper_type(self.default)
         return not (isinstance(t, AnyType) and t.type_of_any == TypeOfAny.from_omitted_generics)
 
+    def values_or_bound(self) -> ProperType:
+        if isinstance(self, TypeVarType) and self.values:
+            return UnionType(self.values)
+        return get_proper_type(self.upper_bound)
+
 
 class TypeVarType(TypeVarLikeType):
     """Type that refers to a type variable."""

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3358,16 +3358,13 @@ foo: Foo = {'key': 1}
 foo | 1
 
 class SubDict(dict): ...
-foo | SubDict()
+reveal_type(foo | SubDict())
 [out]
 main:7: error: No overload variant of "__or__" of "TypedDict" matches argument type "int"
 main:7: note: Possible overload variants:
 main:7: note:     def __or__(self, TypedDict({'key'?: int}), /) -> Foo
 main:7: note:     def __or__(self, dict[str, Any], /) -> dict[str, object]
-main:10: error: No overload variant of "__ror__" of "dict" matches argument type "Foo"
-main:10: note: Possible overload variants:
-main:10: note:     def __ror__(self, dict[Any, Any], /) -> dict[Any, Any]
-main:10: note:     def [T, T2] __ror__(self, dict[T, T2], /) -> dict[Union[Any, T], Union[Any, T2]]
+main:10: note: Revealed type is "builtins.dict[builtins.str, builtins.object]"
 [builtins fixtures/dict-full.pyi]
 [typing fixtures/typing-typeddict-iror.pyi]
 
@@ -3389,8 +3386,10 @@ d2: Dict[int, str]
 
 reveal_type(d1 | foo)  # N: Revealed type is "builtins.dict[builtins.str, builtins.object]"
 d2 | foo  # E: Unsupported operand types for | ("dict[int, str]" and "Foo")
-1 | foo  # E: Unsupported left operand type for | ("int")
-
+1 | foo  # E: No overload variant of "__ror__" of "TypedDict" matches argument type "int" \
+         # N: Possible overload variants: \
+         # N:     def __ror__(self, TypedDict({'key'?: int}), /) -> Foo \
+         # N:     def __ror__(self, dict[str, Any], /) -> dict[str, object]
 
 class Bar(TypedDict):
     key: int


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5136
Fixes https://github.com/python/mypy/issues/5491

This is a fifth "major" PR toward https://github.com/python/mypy/issues/7724. Although it would be impractical to move all the operator special-casing to `checkmember.py`, this does two things:
* Removes known inconsistencies in operator handling
* Adds a much more complete `has_operator()` helper that can be a starting point for future performance optimizations
