### PR TITLE
Update Fix help message url for "None and Optional handling" section

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -785,7 +785,7 @@ def process_options(
         title="None and Optional handling",
         description="Adjust how values of type 'None' are handled. For more context on "
         "how mypy handles values of type 'None', see: "
-        "https://mypy.readthedocs.io/en/stable/kinds_of_types.html#no-strict-optional",
+        "https://mypy.readthedocs.io/en/stable/kinds_of_types.html#optional-types-and-the-none-type",
     )
     add_invertible_flag(
         "--implicit-optional",


### PR DESCRIPTION
Fixes #19251 

Correct url in help message"None and Optional handling" group
Checklist:

- [x] Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- [ ] ~~Add tests for all changed behaviour.~~
- [x] If you can't add a test, please explain why and how you verified your changes work.
```
$ mypy -h
....
None and Optional handling:
  Adjust how values of type 'None' are handled. For more context on how mypy handles values of type 'None', see:
  https://mypy.readthedocs.io/en/stable/kinds_of_types.html#optional-types-and-the-none-type
...
```
- [ ] - Make sure CI passes.
- [x] - Please do not force push to the PR once it has been reviewed.

