### PR TITLE
Refactor/unify access to static attributes

### DIFF
--- a/mypy/checker_shared.py
+++ b/mypy/checker_shared.py
@@ -21,7 +21,7 @@ from mypy.nodes import (
     MypyFile,
     Node,
     RefExpr,
-    TypeAlias,
+    SymbolNode,
     TypeInfo,
     Var,
 )
@@ -62,10 +62,6 @@ class ExpressionCheckerSharedApi:
 
     @abstractmethod
     def analyze_ref_expr(self, e: RefExpr, lvalue: bool = False) -> Type:
-        raise NotImplementedError
-
-    @abstractmethod
-    def module_type(self, node: MypyFile) -> Instance:
         raise NotImplementedError
 
     @abstractmethod
@@ -113,23 +109,25 @@ class ExpressionCheckerSharedApi:
         raise NotImplementedError
 
     @abstractmethod
-    def alias_type_in_runtime_context(
-        self, alias: TypeAlias, *, ctx: Context, alias_definition: bool = False
-    ) -> Type:
-        raise NotImplementedError
-
-    @abstractmethod
     def visit_typeddict_index_expr(
         self, td_type: TypedDictType, index: Expression, setitem: bool = False
     ) -> tuple[Type, set[str]]:
         raise NotImplementedError
 
     @abstractmethod
-    def typeddict_callable(self, info: TypeInfo) -> CallableType:
+    def infer_literal_expr_type(self, value: LiteralValue, fallback_name: str) -> Type:
         raise NotImplementedError
 
     @abstractmethod
-    def infer_literal_expr_type(self, value: LiteralValue, fallback_name: str) -> Type:
+    def analyze_static_reference(
+        self,
+        node: SymbolNode,
+        ctx: Context,
+        is_lvalue: bool,
+        *,
+        include_modules: bool = True,
+        suppress_errors: bool = False,
+    ) -> Type:
         raise NotImplementedError
 
 

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -188,7 +188,6 @@ INVALID_PARAM_SPEC_LOCATION_NOTE: Final = (
 
 # TypeVar
 INCOMPATIBLE_TYPEVAR_VALUE: Final = 'Value of type variable "{}" of {} cannot be {}'
-CANNOT_USE_TYPEVAR_AS_EXPRESSION: Final = 'Type variable "{}.{}" cannot be used as an expression'
 INVALID_TYPEVAR_AS_TYPEARG: Final = 'Type variable "{}" not valid as type argument value for "{}"'
 INVALID_TYPEVAR_ARG_BOUND: Final = 'Type argument {} of "{}" must be a subtype of {}'
 INVALID_TYPEVAR_ARG_VALUE: Final = 'Invalid type argument value for "{}"'

--- a/mypyc/test-data/fixtures/typing-full.pyi
+++ b/mypyc/test-data/fixtures/typing-full.pyi
@@ -12,12 +12,14 @@ class GenericMeta(type): pass
 
 class _SpecialForm:
     def __getitem__(self, index): ...
+class TypeVar:
+    def __init__(self, name, *args, bound=None): ...
+    def __or__(self, other): ...
 
 cast = 0
 overload = 0
 Any = object()
 Optional = 0
-TypeVar = 0
 Generic = 0
 Protocol = 0
 Tuple = 0

--- a/mypyc/test-data/run-functions.test
+++ b/mypyc/test-data/run-functions.test
@@ -1286,6 +1286,7 @@ def bar() -> None:
     print(inner.__dict__)  # type: ignore
 
 bar()
+[typing fixtures/typing-full.pyi]
 [out]
 {'__module__': 'native', '__name__': 'bar', '__qualname__': 'bar', '__doc__': None, '__wrapped__': <built-in function bar>}
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7902,8 +7902,7 @@ class Foo:
     from mod import meth2  # E: Unsupported class scoped import
     from mod import T
 
-reveal_type(Foo.T)  # E: Type variable "Foo.T" cannot be used as an expression \
-                    # N: Revealed type is "Any"
+reveal_type(Foo.T)  # N: Revealed type is "typing.TypeVar"
 
 [file mod.pyi]
 from typing import Any, TypeVar, overload
@@ -7915,6 +7914,8 @@ def meth1(self: Any, y: str) -> str: ...
 
 T = TypeVar("T")
 def meth2(self: Any, y: T) -> T: ...
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testNewAndInitNoReturn]
 from typing import NoReturn

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2647,3 +2647,22 @@ User("", 0)  # E: Too many positional arguments for "User"
 User("", id=0)
 User("", name="")  # E: "User" gets multiple values for keyword argument "name"
 [builtins fixtures/tuple.pyi]
+
+[case testDataclassDefaultFactoryTypedDict]
+from dataclasses import dataclass, field
+from mypy_extensions import TypedDict
+
+class Person(TypedDict, total=False):
+    name: str
+
+@dataclass
+class Job:
+    person: Person = field(default_factory=Person)
+
+class PersonBad(TypedDict):
+    name: str
+
+@dataclass
+class JobBad:
+    person: PersonBad = field(default_factory=PersonBad)  # E: Argument "default_factory" to "field" has incompatible type "type[PersonBad]"; expected "Callable[[], PersonBad]"
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -1582,8 +1582,8 @@ def f() -> types.ModuleType:
     return types
 reveal_type(f())  # N: Revealed type is "types.ModuleType"
 reveal_type(types)  # N: Revealed type is "types.ModuleType"
-
 [builtins fixtures/module.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testClassImportAccessedInMethod]
 class C:
@@ -1997,6 +1997,7 @@ from typing import TypeVar
 T = TypeVar('T')
 def whatever(x: T) -> T: pass
 [builtins fixtures/module.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testModuleAliasToQualifiedImport2]
 import mod
@@ -2012,8 +2013,8 @@ from typing import TypeVar
 T = TypeVar('T')
 def whatever(x: T) -> T: pass
 [file othermod.py]
-
 [builtins fixtures/module.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testModuleLevelGetattr]
 import has_getattr

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -2805,6 +2805,7 @@ def get() -> int: ...
 import typing
 t = typing.typevar('t') # E: Module has no attribute "typevar"
 [builtins fixtures/module.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testNewAnalyzerImportFromTopLevelFunction]
 import a.b  # This works at runtime

--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -351,6 +351,7 @@ def f() -> None:
     n = 1
     import typing as n  # E: Incompatible import of "n" (imported name has type Module, local name has type "int")
 [builtins fixtures/module.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testRedefineLocalWithTypeAnnotation]
 # flags: --allow-redefinition
@@ -547,6 +548,7 @@ try:
 except Exception as typing:
     pass
 [builtins fixtures/exception.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testRedefiningUnderscoreFunctionIsntAnError]
 def _(arg):

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -4258,3 +4258,17 @@ e1: E = {"x": 0, "y": "a"}
 e2: E = {"x": "no", "y": "a"}
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testTypedDictAliasAsInstanceAttribute]
+from typing import TypedDict
+
+class Dicts:
+    class TF(TypedDict, total=False):
+        user_id: int
+    TotalFalse = TF
+
+dicts = Dicts()
+reveal_type(dicts.TF)  # N: Revealed type is "def (*, user_id: builtins.int =) -> TypedDict('__main__.Dicts.TF', {'user_id'?: builtins.int})"
+reveal_type(dicts.TotalFalse)  # N: Revealed type is "def (*, user_id: builtins.int =) -> TypedDict('__main__.Dicts.TF', {'user_id'?: builtins.int})"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -592,11 +592,10 @@ class C:
     def f(self, x: T) -> T:
         L = List[S]
         y: L[C.T] = [x]
-        C.T  # E: Type variable "C.T" cannot be used as an expression
-        A = C.T  # E: Type variable "C.T" cannot be used as an expression
+        reveal_type(C.T)  # N: Revealed type is "typing.TypeVar"
         return y[0]
-
 [builtins fixtures/list.pyi]
+[typing fixtures/typing-full.pyi]
 
 [case testTypeVarWithAnyTypeBound]
 # flags: --follow-imports=skip

--- a/test-data/unit/fixtures/exception.pyi
+++ b/test-data/unit/fixtures/exception.pyi
@@ -12,6 +12,7 @@ class list: pass
 class dict: pass
 class function: pass
 class int: pass
+class float: pass
 class str: pass
 class bool: pass
 class ellipsis: pass


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/3832
Fixes https://github.com/python/mypy/issues/5723
Fixes https://github.com/python/mypy/issues/17174
Improves https://github.com/python/mypy/issues/7217

This is a sixth "major" PR toward https://github.com/python/mypy/issues/7724. Previously access to "static" attributes (like type aliases, class objects) was duplicated in four places:
* In `analyze_ref_expr()`
* In `determine_type_of_member()` (for modules as subtypes of protocols)
* In instance attribute access logic
* In class attribute logic

Most of these were somewhat incomplete and/or inconsistent, this PR unifies all four (there is still tiny duplication because I decided to limit the number of deferrals, i.e. preserve the existing logic in this respect). Some notable things that are not pure refactoring:
* Previously we disabled access to type variables as class attributes. This was inconsistent with plain references and instance attributes that just return `Instance("typing.TypeVar")`.
* Instance access plugins were only applied on `TypeInfo`s and `TypeAlias`es, now they are applied always.
* Previously arguments kinds were sometimes not correct for TypedDict class objects with non-required keys.
* I tweaked `TypeOfAny` in couple places to be more logical.
