### PR TITLE
Fix missing error context for unpacking assignment involving star expression

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3864,7 +3864,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 if rvalue_needed > 0:
                     rvalues = (
                         rvalues[0:iterable_start]
-                        + [TempNode(iterable_type) for i in range(rvalue_needed)]
+                        + [TempNode(iterable_type, context=rval) for _ in range(rvalue_needed)]
                         + rvalues[iterable_end + 1 :]
                     )
 

--- a/test-data/unit/check-lists.test
+++ b/test-data/unit/check-lists.test
@@ -94,3 +94,12 @@ def foo(x: object) -> None:
         [reveal_type(x) for x in [1, 2, 3]]  # N: Revealed type is "builtins.int"
 
 [builtins fixtures/isinstancelist.pyi]
+
+[case testUnpackAssignmentWithStarExpr]
+a: A
+b: list[B]
+if int():
+    (a,) = [*b]  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+
+class A: pass
+class B: pass

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -618,6 +618,15 @@ u, v, w = r, s = 1, 1 # E: Need more than 2 values to unpack (3 expected)
 d, e = f, g, h = 1, 1 # E: Need more than 2 values to unpack (3 expected)
 [builtins fixtures/tuple.pyi]
 
+[case testUnpackAssignmentWithStarExpr]
+a: A
+b: list[B]
+if int():
+    (a,) = (*b,)  # E: Incompatible types in assignment (expression has type "B", variable has type "A")
+
+class A: pass
+class B: pass
+
 
 -- Assignment to starred expressions
 -- ---------------------------------


### PR DESCRIPTION
Fixes #19257

Given:
```python
a: int
b: list[str]
(a,) = (*b,)
(a,) = [*b]
```
Before:
```text
TESTFILES/SCRATCH.py: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
Found 1 error in 1 file (checked 1 source file)
```
After:
```text
main.py:3: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
    (a,) = (*b,)
            ^
main.py:4: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
    (a,) = [*b]
            ^
Found 2 errors in 1 file (checked 1 source file)
```
