### PR TITLE
Disallow `ClassVar` in type aliases

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -675,6 +675,10 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                     t,
                     code=codes.VALID_TYPE,
                 )
+            if self.defining_alias:
+                self.fail(
+                    "ClassVar[...] can't be used inside a type alias", t, code=codes.VALID_TYPE
+                )
             if len(t.args) == 0:
                 return AnyType(TypeOfAny.from_omitted_generics, line=t.line, column=t.column)
             if len(t.args) != 1:

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1311,3 +1311,10 @@ class Bar(Generic[T]):
 x: Bar[int]
 reveal_type(x.var.bar)  # N: Revealed type is "__main__.Bar[builtins.int]"
 [builtins fixtures/tuple.pyi]
+
+[case testExplicitTypeAliasClassVarProhibited]
+from typing import ClassVar
+from typing_extensions import TypeAlias
+
+Foo: TypeAlias = ClassVar[int]  # E: ClassVar[...] can't be used inside a type alias
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Reject the [following case](https://github.com/python/typing/blob/9e4ac4732438ecc1231a83ee0e6e0a8990046687/conformance/tests/classes_classvar.py#L78) from the conformance tests:
```python
bad12: TypeAlias = ClassVar[str]  # E: ClassVar not allowed here
```
