### PR TITLE
[mypyc] Make generated generator helper method internal

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -831,7 +831,7 @@ def generate_finalize_for_class(
 def generate_methods_table(cl: ClassIR, name: str, emitter: Emitter) -> None:
     emitter.emit_line(f"static PyMethodDef {name}[] = {{")
     for fn in cl.methods.values():
-        if fn.decl.is_prop_setter or fn.decl.is_prop_getter:
+        if fn.decl.is_prop_setter or fn.decl.is_prop_getter or fn.internal:
             continue
         emitter.emit_line(f'{{"{fn.name}",')
         emitter.emit_line(f" (PyCFunction){PREFIX}{fn.cname(emitter.names)},")

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -455,7 +455,7 @@ def generate_function_declaration(fn: FuncIR, emitter: Emitter) -> None:
     emitter.context.declarations[emitter.native_function_name(fn.decl)] = HeaderDeclaration(
         f"{native_function_header(fn.decl, emitter)};", needs_export=True
     )
-    if fn.name != TOP_LEVEL_NAME:
+    if fn.name != TOP_LEVEL_NAME and not fn.internal:
         if is_fastcall_supported(fn, emitter.capi_version):
             emitter.context.declarations[PREFIX + fn.cname(emitter.names)] = HeaderDeclaration(
                 f"{wrapper_function_header(fn, emitter.names)};"
@@ -571,7 +571,7 @@ class GroupGenerator:
             for fn in module.functions:
                 emitter.emit_line()
                 generate_native_function(fn, emitter, self.source_paths[module_name], module_name)
-                if fn.name != TOP_LEVEL_NAME:
+                if fn.name != TOP_LEVEL_NAME and not fn.internal:
                     emitter.emit_line()
                     if is_fastcall_supported(fn, emitter.capi_version):
                         generate_wrapper_function(

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -61,6 +61,7 @@ def wrapper_function_header(fn: FuncIR, names: NameGenerator) -> str:
 
     See comment above for a summary of the arguments.
     """
+    assert not fn.internal
     return (
         "PyObject *{prefix}{name}("
         "PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames)"

--- a/mypyc/ir/func_ir.py
+++ b/mypyc/ir/func_ir.py
@@ -140,6 +140,7 @@ class FuncDecl:
         is_prop_setter: bool = False,
         is_prop_getter: bool = False,
         implicit: bool = False,
+        internal: bool = False,
     ) -> None:
         self.name = name
         self.class_name = class_name
@@ -159,6 +160,9 @@ class FuncDecl:
         # If True, not present in the mypy AST and must be synthesized during irbuild
         # Currently only supported for property getters/setters
         self.implicit = implicit
+
+        # If True, only direct C level calls are supported (no wrapper function)
+        self.internal = internal
 
         # This is optional because this will be set to the line number when the corresponding
         # FuncIR is created
@@ -204,6 +208,7 @@ class FuncDecl:
             "is_prop_setter": self.is_prop_setter,
             "is_prop_getter": self.is_prop_getter,
             "implicit": self.implicit,
+            "internal": self.internal,
         }
 
     # TODO: move this to FuncIR?
@@ -226,6 +231,7 @@ class FuncDecl:
             data["is_prop_setter"],
             data["is_prop_getter"],
             data["implicit"],
+            data["internal"],
         )
 
 
@@ -286,6 +292,10 @@ class FuncIR:
     @property
     def id(self) -> str:
         return self.decl.id
+
+    @property
+    def internal(self) -> bool:
+        return self.decl.internal
 
     def cname(self, names: NameGenerator) -> str:
         return self.decl.cname(names)

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -249,7 +249,11 @@ def add_helper_to_generator_class(
         sig.ret_type,
     )
     helper_fn_decl = FuncDecl(
-        "__mypyc_generator_helper__", fn_info.generator_class.ir.name, builder.module_name, sig
+        "__mypyc_generator_helper__",
+        fn_info.generator_class.ir.name,
+        builder.module_name,
+        sig,
+        internal=True,
     )
     helper_fn_ir = FuncIR(
         helper_fn_decl, arg_regs, blocks, fn_info.fitem.line, traceback_name=fn_info.fitem.name


### PR DESCRIPTION
Add a flag to FuncIR to allow functions to be marked as internal.  Don't generate wrapper functions/methods that allow calls from Python for internal methods, since these are internal implementation details.

This has these benefits:
 * Internal functions are private and don't pollute public namespaces.
 * Signatures of generated functions can use arbitrary C types (e.g. arbitrary pointer types), even those that can't be passed to/from Python.
 * We generate less C code (fewer wrapper functions).