### PR TITLE
[mypyc] Derive .c file name from full module name if using multi_file

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -582,7 +582,7 @@ class GroupGenerator:
                             fn, emitter, self.source_paths[module_name], module_name
                         )
             if multi_file:
-                name = f"__native_{emitter.names.private_name(module_name)}.c"
+                name = f"__native_{exported_name(module_name)}.c"
                 file_contents.append((name, "".join(emitter.fragments)))
 
         # The external header file contains type declarations while


### PR DESCRIPTION
Don't shorten the module name prefixes, so that the names of output files are more predictable. This can help if integrating with build systems, and it arguably also makes it easier to inspect the output manually.

Now the file name could be `__native_pkg___mod.c` instead of `__native_mod.c` for the module `pkg.mod`.