### PR TITLE
Show name of type variable in "Cannot infer type argument" message

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2341,7 +2341,9 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         for i, inferred_type in enumerate(inferred_args):
             if not inferred_type or has_erased_component(inferred_type):
                 # Could not infer a non-trivial type for a type variable.
-                self.msg.could_not_infer_type_arguments(callee_type, i + 1, context)
+                self.msg.could_not_infer_type_arguments(
+                    callee_type, callee_type.variables[i], context
+                )
                 inferred_args = [AnyType(TypeOfAny.from_error)] * len(inferred_args)
         # Apply the inferred types to the function type. In this case the
         # return type must be CallableType, since we give the right number of type

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2338,12 +2338,10 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         # Report error if some of the variables could not be solved. In that
         # case assume that all variables have type Any to avoid extra
         # bogus error messages.
-        for i, inferred_type in enumerate(inferred_args):
+        for inferred_type, tv in zip(inferred_args, callee_type.variables):
             if not inferred_type or has_erased_component(inferred_type):
                 # Could not infer a non-trivial type for a type variable.
-                self.msg.could_not_infer_type_arguments(
-                    callee_type, callee_type.variables[i], context
-                )
+                self.msg.could_not_infer_type_arguments(callee_type, tv, context)
                 inferred_args = [AnyType(TypeOfAny.from_error)] * len(inferred_args)
         # Apply the inferred types to the function type. In this case the
         # return type must be CallableType, since we give the right number of type

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1375,7 +1375,7 @@ class MessageBuilder:
         callee_name = callable_name(callee_type)
         if callee_name is not None:
             self.fail(
-                f"Cannot infer type argument to type parameter {format_type(tv, self.options)} of {callee_name}",
+                f"Cannot infer value of type parameter {format_type(tv, self.options)} of {callee_name}",
                 context,
             )
             if callee_name == "<dict>":

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1370,11 +1370,14 @@ class MessageBuilder:
             self.fail(f"Type application has too few types ({s})", context)
 
     def could_not_infer_type_arguments(
-        self, callee_type: CallableType, n: int, context: Context
+        self, callee_type: CallableType, tv: TypeVarLikeType, context: Context
     ) -> None:
         callee_name = callable_name(callee_type)
-        if callee_name is not None and n > 0:
-            self.fail(f"Cannot infer type argument {n} of {callee_name}", context)
+        if callee_name is not None:
+            self.fail(
+                f"Cannot infer type argument to type parameter {format_type(tv, self.options)} of {callee_name}",
+                context,
+            )
             if callee_name == "<dict>":
                 # Invariance in key type causes more of these errors than we would want.
                 self.note(

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -705,7 +705,7 @@ class A(Generic[T]):
     return self.z  # E: Incompatible return value type (got "list[T]", expected "T")
 
 reveal_type(A)  # N: Revealed type is "def [T] (x: T`1, y: T`1, z: builtins.list[T`1]) -> __main__.A[T`1]"
-A(1, 2, ["a", "b"])  # E: Cannot infer type argument 1 of "A"
+A(1, 2, ["a", "b"])  # E: Cannot infer type argument to type parameter "T" of "A"
 a = A(1, 2, [1, 2])
 reveal_type(a)  # N: Revealed type is "__main__.A[builtins.int]"
 reveal_type(a.x)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -705,7 +705,7 @@ class A(Generic[T]):
     return self.z  # E: Incompatible return value type (got "list[T]", expected "T")
 
 reveal_type(A)  # N: Revealed type is "def [T] (x: T`1, y: T`1, z: builtins.list[T`1]) -> __main__.A[T`1]"
-A(1, 2, ["a", "b"])  # E: Cannot infer type argument to type parameter "T" of "A"
+A(1, 2, ["a", "b"])  # E: Cannot infer value of type parameter "T" of "A"
 a = A(1, 2, [1, 2])
 reveal_type(a)  # N: Revealed type is "__main__.A[builtins.int]"
 reveal_type(a.x)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1878,7 +1878,7 @@ a = {'a': 1}
 b = {'z': 26, **a}
 c = {**b}
 d = {**a, **b, 'c': 3}
-e = {1: 'a', **a}  # E: Cannot infer type argument 1 of <dict> \
+e = {1: 'a', **a}  # E: Cannot infer type argument to type parameter "KT" of <dict> \
                    # N: Try assigning the literal to a variable annotated as dict[<key>, <val>]
 f = {**b}  # type: Dict[int, int]  # E: Unpacked dict entry 0 has incompatible type "dict[str, int]"; expected "SupportsKeysAndGetItem[int, int]"
 g = {**Thing()}
@@ -1893,7 +1893,7 @@ i = {**Thing()}  # type: Dict[int, int]  # E: Unpacked dict entry 0 has incompat
                  # N:         def keys(self) -> Iterable[int] \
                  # N:     Got: \
                  # N:         def keys(self) -> Iterable[str]
-j = {1: 'a', **Thing()}  # E: Cannot infer type argument 1 of <dict> \
+j = {1: 'a', **Thing()}  # E: Cannot infer type argument to type parameter "KT" of <dict> \
                          # N: Try assigning the literal to a variable annotated as dict[<key>, <val>]
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-medium.pyi]

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1878,7 +1878,7 @@ a = {'a': 1}
 b = {'z': 26, **a}
 c = {**b}
 d = {**a, **b, 'c': 3}
-e = {1: 'a', **a}  # E: Cannot infer type argument to type parameter "KT" of <dict> \
+e = {1: 'a', **a}  # E: Cannot infer value of type parameter "KT" of <dict> \
                    # N: Try assigning the literal to a variable annotated as dict[<key>, <val>]
 f = {**b}  # type: Dict[int, int]  # E: Unpacked dict entry 0 has incompatible type "dict[str, int]"; expected "SupportsKeysAndGetItem[int, int]"
 g = {**Thing()}
@@ -1893,7 +1893,7 @@ i = {**Thing()}  # type: Dict[int, int]  # E: Unpacked dict entry 0 has incompat
                  # N:         def keys(self) -> Iterable[int] \
                  # N:     Got: \
                  # N:         def keys(self) -> Iterable[str]
-j = {1: 'a', **Thing()}  # E: Cannot infer type argument to type parameter "KT" of <dict> \
+j = {1: 'a', **Thing()}  # E: Cannot infer value of type parameter "KT" of <dict> \
                          # N: Try assigning the literal to a variable annotated as dict[<key>, <val>]
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-medium.pyi]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -584,7 +584,7 @@ def func2(x: SameNode[T]) -> SameNode[T]:
     return x
 reveal_type(func2) # N: Revealed type is "def [T] (x: __main__.Node[T`-1, T`-1]) -> __main__.Node[T`-1, T`-1]"
 
-func2(Node(1, 'x')) # E: Cannot infer type argument 1 of "func2"
+func2(Node(1, 'x')) # E: Cannot infer type argument to type parameter "T" of "func2"
 y = func2(Node('x', 'x'))
 reveal_type(y) # N: Revealed type is "__main__.Node[builtins.str, builtins.str]"
 
@@ -888,7 +888,7 @@ def fun2(v: Vec[T], scale: T) -> Vec[T]:
 
 reveal_type(fun1([(1, 1)])) # N: Revealed type is "builtins.int"
 fun1(1) # E: Argument 1 to "fun1" has incompatible type "int"; expected "list[tuple[bool, bool]]"
-fun1([(1, 'x')]) # E: Cannot infer type argument 1 of "fun1"
+fun1([(1, 'x')]) # E: Cannot infer type argument to type parameter "T" of "fun1"
 
 reveal_type(fun2([(1, 1)], 1)) # N: Revealed type is "builtins.list[tuple[builtins.int, builtins.int]]"
 fun2([('x', 'x')], 'x') # E: Value of type variable "T" of "fun2" cannot be "str"
@@ -909,7 +909,7 @@ def f(x: Node[T, T]) -> TupledNode[T]:
     return Node(x.x, (x.x, x.x))
 
 f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "Node[Never, Never]"
-f(Node(1, 'x')) # E: Cannot infer type argument 1 of "f"
+f(Node(1, 'x')) # E: Cannot infer type argument to type parameter "T" of "f"
 reveal_type(Node('x', 'x')) # N: Revealed type is "a.Node[builtins.str, builtins.str]"
 
 [file a.py]

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -584,7 +584,7 @@ def func2(x: SameNode[T]) -> SameNode[T]:
     return x
 reveal_type(func2) # N: Revealed type is "def [T] (x: __main__.Node[T`-1, T`-1]) -> __main__.Node[T`-1, T`-1]"
 
-func2(Node(1, 'x')) # E: Cannot infer type argument to type parameter "T" of "func2"
+func2(Node(1, 'x')) # E: Cannot infer value of type parameter "T" of "func2"
 y = func2(Node('x', 'x'))
 reveal_type(y) # N: Revealed type is "__main__.Node[builtins.str, builtins.str]"
 
@@ -888,7 +888,7 @@ def fun2(v: Vec[T], scale: T) -> Vec[T]:
 
 reveal_type(fun1([(1, 1)])) # N: Revealed type is "builtins.int"
 fun1(1) # E: Argument 1 to "fun1" has incompatible type "int"; expected "list[tuple[bool, bool]]"
-fun1([(1, 'x')]) # E: Cannot infer type argument to type parameter "T" of "fun1"
+fun1([(1, 'x')]) # E: Cannot infer value of type parameter "T" of "fun1"
 
 reveal_type(fun2([(1, 1)], 1)) # N: Revealed type is "builtins.list[tuple[builtins.int, builtins.int]]"
 fun2([('x', 'x')], 'x') # E: Value of type variable "T" of "fun2" cannot be "str"
@@ -909,7 +909,7 @@ def f(x: Node[T, T]) -> TupledNode[T]:
     return Node(x.x, (x.x, x.x))
 
 f(1) # E: Argument 1 to "f" has incompatible type "int"; expected "Node[Never, Never]"
-f(Node(1, 'x')) # E: Cannot infer type argument to type parameter "T" of "f"
+f(Node(1, 'x')) # E: Cannot infer value of type parameter "T" of "f"
 reveal_type(Node('x', 'x')) # N: Revealed type is "a.Node[builtins.str, builtins.str]"
 
 [file a.py]

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1009,7 +1009,7 @@ class D(C): ...
 
 def f(x: List[T], y: List[T]) -> List[T]: ...
 
-f([C()], [D()]) # E: Cannot infer type argument to type parameter "T" of "f"
+f([C()], [D()]) # E: Cannot infer value of type parameter "T" of "f"
 [builtins fixtures/list.pyi]
 
 [case testInferTypeVariableFromTwoGenericTypes3]

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1009,7 +1009,7 @@ class D(C): ...
 
 def f(x: List[T], y: List[T]) -> List[T]: ...
 
-f([C()], [D()]) # E: Cannot infer type argument 1 of "f"
+f([C()], [D()]) # E: Cannot infer type argument to type parameter "T" of "f"
 [builtins fixtures/list.pyi]
 
 [case testInferTypeVariableFromTwoGenericTypes3]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -693,8 +693,8 @@ class A(Generic[T]): pass
 class B: pass
 
 
-f(ao, ab) # E: Cannot infer type argument 1 of "f"
-f(ab, ao) # E: Cannot infer type argument 1 of "f"
+f(ao, ab) # E: Cannot infer type argument to type parameter "T" of "f"
+f(ab, ao) # E: Cannot infer type argument to type parameter "T" of "f"
 f(ao, ao)
 f(ab, ab)
 
@@ -3774,8 +3774,8 @@ reveal_type(f(x, []))  # N: Revealed type is "builtins.str"
 reveal_type(f(["yes"], []))  # N: Revealed type is "builtins.str"
 
 empty: List[NoReturn]
-f(x, empty)  # E: Cannot infer type argument 1 of "f"
-f(["no"], empty)  # E: Cannot infer type argument 1 of "f"
+f(x, empty)  # E: Cannot infer type argument to type parameter "T" of "f"
+f(["no"], empty)  # E: Cannot infer type argument to type parameter "T" of "f"
 [builtins fixtures/list.pyi]
 
 [case testInferenceWorksWithEmptyCollectionsUnion]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -693,8 +693,8 @@ class A(Generic[T]): pass
 class B: pass
 
 
-f(ao, ab) # E: Cannot infer type argument to type parameter "T" of "f"
-f(ab, ao) # E: Cannot infer type argument to type parameter "T" of "f"
+f(ao, ab) # E: Cannot infer value of type parameter "T" of "f"
+f(ab, ao) # E: Cannot infer value of type parameter "T" of "f"
 f(ao, ao)
 f(ab, ab)
 
@@ -3774,8 +3774,8 @@ reveal_type(f(x, []))  # N: Revealed type is "builtins.str"
 reveal_type(f(["yes"], []))  # N: Revealed type is "builtins.str"
 
 empty: List[NoReturn]
-f(x, empty)  # E: Cannot infer type argument to type parameter "T" of "f"
-f(["no"], empty)  # E: Cannot infer type argument to type parameter "T" of "f"
+f(x, empty)  # E: Cannot infer value of type parameter "T" of "f"
+f(["no"], empty)  # E: Cannot infer value of type parameter "T" of "f"
 [builtins fixtures/list.pyi]
 
 [case testInferenceWorksWithEmptyCollectionsUnion]
@@ -4163,5 +4163,5 @@ def foo(
 
 def bar(y: float) -> float: ...
 
-foo(1, None, bar)  # E: Cannot infer type argument to type parameter "T2" of "foo"
+foo(1, None, bar)  # E: Cannot infer value of type parameter "T2" of "foo"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -4149,3 +4149,19 @@ class Foo:
         else:
             self.qux = {}  # E: Need type annotation for "qux" (hint: "qux: dict[<type>, <type>] = ...")
 [builtins fixtures/dict.pyi]
+
+[case testConstraintSolvingFailureShowsCorrectArgument]
+from typing import Callable, TypeVar
+
+T1 = TypeVar('T1')
+T2 = TypeVar('T2')
+def foo(
+    a: T1,
+    b: T2,
+    c: Callable[[T2], T2],
+) -> tuple[T1, T2]: ...
+
+def bar(y: float) -> float: ...
+
+foo(1, None, bar)  # E: Cannot infer type argument to type parameter "T2" of "foo"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2989,9 +2989,9 @@ def g(a: T, t: A[T]) -> T: ...
 
 def check(obj: A[Literal[1]]) -> None:
     reveal_type(f(obj, 1))  # N: Revealed type is "Literal[1]"
-    reveal_type(f(obj, ''))  # E: Cannot infer type argument to type parameter "T" of "f" \
+    reveal_type(f(obj, ''))  # E: Cannot infer value of type parameter "T" of "f" \
                              # N: Revealed type is "Any"
     reveal_type(g(1, obj))  # N: Revealed type is "Literal[1]"
-    reveal_type(g('', obj))  # E: Cannot infer type argument to type parameter "T" of "g" \
+    reveal_type(g('', obj))  # E: Cannot infer value of type parameter "T" of "g" \
                              # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -2989,9 +2989,9 @@ def g(a: T, t: A[T]) -> T: ...
 
 def check(obj: A[Literal[1]]) -> None:
     reveal_type(f(obj, 1))  # N: Revealed type is "Literal[1]"
-    reveal_type(f(obj, ''))  # E: Cannot infer type argument 1 of "f" \
+    reveal_type(f(obj, ''))  # E: Cannot infer type argument to type parameter "T" of "f" \
                              # N: Revealed type is "Any"
     reveal_type(g(1, obj))  # N: Revealed type is "Literal[1]"
-    reveal_type(g('', obj))  # E: Cannot infer type argument 1 of "g" \
+    reveal_type(g('', obj))  # E: Cannot infer type argument to type parameter "T" of "g" \
                              # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -3370,10 +3370,10 @@ def wrapper() -> None:
     obj2: Union[W1[A], W2[B]]
 
     reveal_type(foo(obj2))  # N: Revealed type is "Union[__main__.A, __main__.B]"
-    bar(obj2)  # E: Cannot infer type argument 1 of "bar"
+    bar(obj2)  # E: Cannot infer type argument to type parameter "T" of "bar"
 
     b1_overload: A = foo(obj2)  # E: Incompatible types in assignment (expression has type "Union[A, B]", variable has type "A")
-    b1_union: A    = bar(obj2)  # E: Cannot infer type argument 1 of "bar"
+    b1_union: A    = bar(obj2)  # E: Cannot infer type argument to type parameter "T" of "bar"
 
 [case testOverloadingInferUnionReturnWithObjectTypevarReturn]
 from typing import overload, Union, TypeVar, Generic
@@ -3496,7 +3496,7 @@ def t_is_same_bound(arg1: T1, arg2: S) -> Tuple[T1, S]:
     # The arguments in the tuple are swapped
     x3: Union[List[S], List[Tuple[S, T1]]]
     y3: S
-    Dummy[T1]().foo(x3, y3)  # E: Cannot infer type argument 1 of "foo" of "Dummy" \
+    Dummy[T1]().foo(x3, y3)  # E: Cannot infer type argument to type parameter "S" of "foo" of "Dummy" \
                              # E: Argument 1 to "foo" of "Dummy" has incompatible type "Union[list[S], list[tuple[S, T1]]]"; expected "list[tuple[T1, Any]]"
 
     x4: Union[List[int], List[Tuple[C, int]]]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -3370,10 +3370,10 @@ def wrapper() -> None:
     obj2: Union[W1[A], W2[B]]
 
     reveal_type(foo(obj2))  # N: Revealed type is "Union[__main__.A, __main__.B]"
-    bar(obj2)  # E: Cannot infer type argument to type parameter "T" of "bar"
+    bar(obj2)  # E: Cannot infer value of type parameter "T" of "bar"
 
     b1_overload: A = foo(obj2)  # E: Incompatible types in assignment (expression has type "Union[A, B]", variable has type "A")
-    b1_union: A    = bar(obj2)  # E: Cannot infer type argument to type parameter "T" of "bar"
+    b1_union: A    = bar(obj2)  # E: Cannot infer value of type parameter "T" of "bar"
 
 [case testOverloadingInferUnionReturnWithObjectTypevarReturn]
 from typing import overload, Union, TypeVar, Generic
@@ -3496,7 +3496,7 @@ def t_is_same_bound(arg1: T1, arg2: S) -> Tuple[T1, S]:
     # The arguments in the tuple are swapped
     x3: Union[List[S], List[Tuple[S, T1]]]
     y3: S
-    Dummy[T1]().foo(x3, y3)  # E: Cannot infer type argument to type parameter "S" of "foo" of "Dummy" \
+    Dummy[T1]().foo(x3, y3)  # E: Cannot infer value of type parameter "S" of "foo" of "Dummy" \
                              # E: Argument 1 to "foo" of "Dummy" has incompatible type "Union[list[S], list[tuple[S, T1]]]"; expected "list[tuple[T1, Any]]"
 
     x4: Union[List[int], List[Tuple[C, int]]]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -2135,7 +2135,7 @@ def d(f: Callable[P, None], fn: Callable[Concatenate[Callable[P, None], P], None
 
 reveal_type(d(a, f1))  # N: Revealed type is "def (i: builtins.int)"
 reveal_type(d(a, f2))  # N: Revealed type is "def (i: builtins.int)"
-reveal_type(d(b, f1))  # E: Cannot infer type argument to type parameter "P" of "d" \
+reveal_type(d(b, f1))  # E: Cannot infer value of type parameter "P" of "d" \
                        # N: Revealed type is "def (*Any, **Any)"
 reveal_type(d(b, f2))  # N: Revealed type is "def (builtins.int)"
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -2135,7 +2135,7 @@ def d(f: Callable[P, None], fn: Callable[Concatenate[Callable[P, None], P], None
 
 reveal_type(d(a, f1))  # N: Revealed type is "def (i: builtins.int)"
 reveal_type(d(a, f2))  # N: Revealed type is "def (i: builtins.int)"
-reveal_type(d(b, f1))  # E: Cannot infer type argument 1 of "d" \
+reveal_type(d(b, f1))  # E: Cannot infer type argument to type parameter "P" of "d" \
                        # N: Revealed type is "def (*Any, **Any)"
 reveal_type(d(b, f2))  # N: Revealed type is "def (builtins.int)"
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -470,8 +470,8 @@ reveal_type(a)  # N: Revealed type is "__main__.A[builtins.int]"
 reveal_type(a.x)  # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(a.y)  # N: Revealed type is "builtins.int"
 
-A(['str'], 7)  # E: Cannot infer type argument to type parameter "T" of "A"
-A([1], '2')  # E: Cannot infer type argument to type parameter "T" of "A"
+A(['str'], 7)  # E: Cannot infer value of type parameter "T" of "A"
+A([1], '2')  # E: Cannot infer value of type parameter "T" of "A"
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -470,8 +470,8 @@ reveal_type(a)  # N: Revealed type is "__main__.A[builtins.int]"
 reveal_type(a.x)  # N: Revealed type is "builtins.list[builtins.int]"
 reveal_type(a.y)  # N: Revealed type is "builtins.int"
 
-A(['str'], 7)  # E: Cannot infer type argument 1 of "A"
-A([1], '2')  # E: Cannot infer type argument 1 of "A"
+A(['str'], 7)  # E: Cannot infer type argument to type parameter "T" of "A"
+A([1], '2')  # E: Cannot infer type argument to type parameter "T" of "A"
 
 [builtins fixtures/list.pyi]
 

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4217,10 +4217,10 @@ def g2(a: Input[bytes], b: Output[bytes]) -> None:
     f(a, b)
 
 def g3(a: Input[str], b: Output[bytes]) -> None:
-    f(a, b)  # E: Cannot infer type argument to type parameter "AnyStr" of "f"
+    f(a, b)  # E: Cannot infer value of type parameter "AnyStr" of "f"
 
 def g4(a: Input[bytes], b: Output[str]) -> None:
-    f(a, b)  # E: Cannot infer type argument to type parameter "AnyStr" of "f"
+    f(a, b)  # E: Cannot infer value of type parameter "AnyStr" of "f"
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4217,10 +4217,10 @@ def g2(a: Input[bytes], b: Output[bytes]) -> None:
     f(a, b)
 
 def g3(a: Input[str], b: Output[bytes]) -> None:
-    f(a, b)  # E: Cannot infer type argument 1 of "f"
+    f(a, b)  # E: Cannot infer type argument to type parameter "AnyStr" of "f"
 
 def g4(a: Input[bytes], b: Output[str]) -> None:
-    f(a, b)  # E: Cannot infer type argument 1 of "f"
+    f(a, b)  # E: Cannot infer type argument to type parameter "AnyStr" of "f"
 
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2372,9 +2372,9 @@ def pointwise_multiply(x: Array[Unpack[Ts]], y: Array[Unpack[Ts]]) -> Array[Unpa
 
 def a1(x: Array[int], y: Array[str], z: Array[int, str]) -> None:
     reveal_type(pointwise_multiply(x, x))  # N: Revealed type is "__main__.Array[builtins.int]"
-    reveal_type(pointwise_multiply(x, y))  # E: Cannot infer type argument 1 of "pointwise_multiply" \
+    reveal_type(pointwise_multiply(x, y))  # E: Cannot infer type argument to type parameter "Ts" of "pointwise_multiply" \
                                            # N: Revealed type is "__main__.Array[Unpack[builtins.tuple[Any, ...]]]"
-    reveal_type(pointwise_multiply(x, z))  # E: Cannot infer type argument 1 of "pointwise_multiply" \
+    reveal_type(pointwise_multiply(x, z))  # E: Cannot infer type argument to type parameter "Ts" of "pointwise_multiply" \
                                            # N: Revealed type is "__main__.Array[Unpack[builtins.tuple[Any, ...]]]"
 
 def func(x: Array[Unpack[Ts]], *args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
@@ -2382,9 +2382,9 @@ def func(x: Array[Unpack[Ts]], *args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
 
 def a2(x: Array[int, str]) -> None:
     reveal_type(func(x, 2, "Hello"))  # N: Revealed type is "tuple[builtins.int, builtins.str]"
-    reveal_type(func(x, 2))           # E: Cannot infer type argument 1 of "func" \
+    reveal_type(func(x, 2))           # E: Cannot infer type argument to type parameter "Ts" of "func" \
                                       # N: Revealed type is "builtins.tuple[Any, ...]"
-    reveal_type(func(x, 2, "Hello", True))   # E: Cannot infer type argument 1 of "func" \
+    reveal_type(func(x, 2, "Hello", True))   # E: Cannot infer type argument to type parameter "Ts" of "func" \
                                              # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/tuple.pyi]
 

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2372,9 +2372,9 @@ def pointwise_multiply(x: Array[Unpack[Ts]], y: Array[Unpack[Ts]]) -> Array[Unpa
 
 def a1(x: Array[int], y: Array[str], z: Array[int, str]) -> None:
     reveal_type(pointwise_multiply(x, x))  # N: Revealed type is "__main__.Array[builtins.int]"
-    reveal_type(pointwise_multiply(x, y))  # E: Cannot infer type argument to type parameter "Ts" of "pointwise_multiply" \
+    reveal_type(pointwise_multiply(x, y))  # E: Cannot infer value of type parameter "Ts" of "pointwise_multiply" \
                                            # N: Revealed type is "__main__.Array[Unpack[builtins.tuple[Any, ...]]]"
-    reveal_type(pointwise_multiply(x, z))  # E: Cannot infer type argument to type parameter "Ts" of "pointwise_multiply" \
+    reveal_type(pointwise_multiply(x, z))  # E: Cannot infer value of type parameter "Ts" of "pointwise_multiply" \
                                            # N: Revealed type is "__main__.Array[Unpack[builtins.tuple[Any, ...]]]"
 
 def func(x: Array[Unpack[Ts]], *args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
@@ -2382,9 +2382,9 @@ def func(x: Array[Unpack[Ts]], *args: Unpack[Ts]) -> Tuple[Unpack[Ts]]:
 
 def a2(x: Array[int, str]) -> None:
     reveal_type(func(x, 2, "Hello"))  # N: Revealed type is "tuple[builtins.int, builtins.str]"
-    reveal_type(func(x, 2))           # E: Cannot infer type argument to type parameter "Ts" of "func" \
+    reveal_type(func(x, 2))           # E: Cannot infer value of type parameter "Ts" of "func" \
                                       # N: Revealed type is "builtins.tuple[Any, ...]"
-    reveal_type(func(x, 2, "Hello", True))   # E: Cannot infer type argument to type parameter "Ts" of "func" \
+    reveal_type(func(x, 2, "Hello", True))   # E: Cannot infer value of type parameter "Ts" of "func" \
                                              # N: Revealed type is "builtins.tuple[Any, ...]"
 [builtins fixtures/tuple.pyi]
 


### PR DESCRIPTION
Fixes #19289

The type argument index currently shown can be wrong if other type arguments were substituted during an earlier pass.

Given:
```python
def foo[T1, T2](
    a: T1,
    b: T2,
    c: Callable[[T2], T2],
) -> tuple[T1, T2]: ...

def bar(y: float) -> float: ...

reveal_type(foo(1, None, bar))  # Expect T1=int, T2=<failed>
```
Before:
```
main.py:9: error: Cannot infer type argument 1 of "foo"  [misc]
main.py:9: note: Revealed type is "tuple[builtins.int, Any]"
```
After:
```
main.py:9: error: Cannot infer type argument to type parameter "T2" of "foo"  [misc]
main.py:9: note: Revealed type is "tuple[builtins.int, Any]"
```