### PR TITLE
Fix constructor type for subclasses of Any

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -125,7 +125,8 @@ def tuple_fallback(typ: TupleType) -> Instance:
     )
 
 
-def get_self_type(func: CallableType, default_self: Instance | TupleType) -> Type | None:
+def get_self_type(func: CallableType, def_info: TypeInfo) -> Type | None:
+    default_self = fill_typevars(def_info)
     if isinstance(get_proper_type(func.ret_type), UninhabitedType):
         return func.ret_type
     elif func.arg_types and func.arg_types[0] != default_self and func.arg_kinds[0] == ARG_POS:
@@ -227,9 +228,8 @@ def type_object_type_from_function(
     # self-types only in the defining class, similar to __new__ (but not exactly the same,
     # see comment in class_callable below). This is mostly useful for annotating library
     # classes such as subprocess.Popen.
-    default_self = fill_typevars(info)
     if not is_new and not info.is_newtype:
-        orig_self_types = [get_self_type(it, default_self) for it in signature.items]
+        orig_self_types = [get_self_type(it, def_info) for it in signature.items]
     else:
         orig_self_types = [None] * len(signature.items)
 
@@ -245,7 +245,7 @@ def type_object_type_from_function(
     # We need to map B's __init__ to the type (List[T]) -> None.
     signature = bind_self(
         signature,
-        original_type=default_self,
+        original_type=fill_typevars(info),
         is_classmethod=is_new,
         # Explicit instance self annotations have special handling in class_callable(),
         # we don't need to bind any type variables in them if they are generic.

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -8781,8 +8781,19 @@ C().bar = "fine"
 [builtins fixtures/property.pyi]
 
 [case testCorrectConstructorTypeWithAnyFallback]
+from typing import Generic, TypeVar
+
 class B(Unknown):  # type: ignore
     def __init__(self) -> None: ...
 class C(B): ...
 
 reveal_type(C)  # N: Revealed type is "def () -> __main__.C"
+
+T = TypeVar("T")
+class BG(Generic[T], Unknown):  # type: ignore
+    def __init__(self) -> None: ...
+class CGI(BG[int]): ...
+class CGT(BG[T]): ...
+
+reveal_type(CGI)  # N: Revealed type is "def () -> __main__.CGI"
+reveal_type(CGT)  # N: Revealed type is "def [T] () -> __main__.CGT[T`1]"

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -8779,3 +8779,10 @@ class C:
 C().foo = "no"  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 C().bar = "fine"
 [builtins fixtures/property.pyi]
+
+[case testCorrectConstructorTypeWithAnyFallback]
+class B(Unknown):  # type: ignore
+    def __init__(self) -> None: ...
+class C(B): ...
+
+reveal_type(C)  # N: Revealed type is "def () -> __main__.C"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/9815
Fixes https://github.com/python/mypy/issues/10848
Fixes https://github.com/python/mypy/issues/17781

Also discovered this while working on `checkmember` stuff. Previously, return type of the type object was the class where `__init__()` was defined (if there was an `Any` somewhere in MRO). And since we use return type for attribute access on type objects, it went completely sideways. Fix is simple (we accidentally used `info` instead of `def_info` in one place).