### PR TITLE
Re-widen custom properties after narrowing

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4605,7 +4605,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 lvalue, is_lvalue=False
             )
 
-        # Special case: if the rvalue_type is a subtype of both '__get__' type, and
+        # Special case: if the rvalue_type is a subtype of '__get__' type, and
         # '__get__' type is narrower than '__set__', then we invoke the binder to narrow type
         # by this assignment. Technically, this is not safe, but in practice this is
         # what a user expects.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4580,7 +4580,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         self,
         lvalue: MemberExpr,
         instance_type: Type,
-        attribute_type: Type,
+        set_lvalue_type: Type,
         rvalue: Expression,
         context: Context,
     ) -> tuple[Type, Type, bool]:
@@ -4597,23 +4597,21 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         if (isinstance(instance_type, FunctionLike) and instance_type.is_type_obj()) or isinstance(
             instance_type, TypeType
         ):
-            rvalue_type, _ = self.check_simple_assignment(attribute_type, rvalue, context)
-            return rvalue_type, attribute_type, True
+            rvalue_type, _ = self.check_simple_assignment(set_lvalue_type, rvalue, context)
+            return rvalue_type, set_lvalue_type, True
 
         with self.msg.filter_errors(filter_deprecated=True):
             get_lvalue_type = self.expr_checker.analyze_ordinary_member_access(
                 lvalue, is_lvalue=False
             )
 
-        # Special case: if the rvalue_type is a subtype of both '__get__' and '__set__' types,
-        # and '__get__' type is narrower than '__set__', then we invoke the binder to narrow type
+        # Special case: if the rvalue_type is a subtype of both '__get__' type, and
+        # '__get__' type is narrower than '__set__', then we invoke the binder to narrow type
         # by this assignment. Technically, this is not safe, but in practice this is
         # what a user expects.
-        rvalue_type, _ = self.check_simple_assignment(attribute_type, rvalue, context)
-        infer = is_subtype(rvalue_type, get_lvalue_type) and is_subtype(
-            get_lvalue_type, attribute_type
-        )
-        return rvalue_type if infer else attribute_type, attribute_type, infer
+        rvalue_type, _ = self.check_simple_assignment(set_lvalue_type, rvalue, context)
+        rvalue_type = rvalue_type if is_subtype(rvalue_type, get_lvalue_type) else get_lvalue_type
+        return rvalue_type, set_lvalue_type, is_subtype(get_lvalue_type, set_lvalue_type)
 
     def check_indexed_assignment(
         self, lvalue: IndexExpr, rvalue: Expression, context: Context

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2593,3 +2593,22 @@ def baz(item: Base) -> None:
         reveal_type(item)  # N: Revealed type is "__main__.<subclass of "__main__.Base" and "__main__.BarMixin">"
         item.bar()
 [builtins fixtures/isinstance.pyi]
+
+[case testCustomSetterNarrowingReWidened]
+class B: ...
+class C(B): ...
+class C1(B): ...
+class D(C): ...
+
+class Test:
+    @property
+    def foo(self) -> C: ...
+    @foo.setter
+    def foo(self, val: B) -> None: ...
+
+t: Test
+t.foo = D()
+reveal_type(t.foo)  # N: Revealed type is "__main__.D"
+t.foo = C1()
+reveal_type(t.foo)  # N: Revealed type is "__main__.C"
+[builtins fixtures/property.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/10399

This is another smaller cleanup for https://github.com/python/mypy/issues/7724. The current logic as documented  is IMO correct, for attributes (either properties or custom descriptors) with setter type different from getter type, we narrow the attribute type in an assignment if:
* The attribute is "normalizing", i.e. getter type is a subtype of setter type (e.g. `Sequence[Employee]` is normalized to `tuple[Employee, ...]`)
* The given r.h.s. type in the assignment is a subtype of getter type (and thus transitively the setter as well), e.g. `tuple[Manager, ...]` vs `tuple[Employee, ...]` in the example above.

The problem was that this logic was implemented too literally, as a result assignments that didn't satisfy these two rules were simply ignored (thus making previous narrowing incorrectly "sticky"). In fact, we also need to re-widen previously narrowed types whenever second condition is not satisfied.

(I also decided to rename one variable name to make it more obvious.)