### PR TITLE
Skip existing when retrying upload-pypi.py

### DIFF
--- a/misc/upload-pypi.py
+++ b/misc/upload-pypi.py
@@ -108,7 +108,7 @@ def tmp_twine() -> Iterator[Path]:
 def upload_dist(dist: Path, dry_run: bool = True) -> None:
     with tmp_twine() as twine:
         files = [item for item in dist.iterdir() if item_ok_for_pypi(item.name)]
-        cmd: list[Any] = [twine, "upload"]
+        cmd: list[Any] = [twine, "upload", "--skip-existing"]
         cmd += files
         if dry_run:
             print("[dry run] " + " ".join(map(str, cmd)))


### PR DESCRIPTION
The upload script has been pretty flaky for me. Now rerunning skips the wheels that have already been uploaded, so the upload should always eventually finish after enough retries.

Work on #19174.