### PR TITLE
[mypyc] Speed up generator allocation by using a per-type freelist

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -855,7 +855,6 @@ def emit_reuse_dealloc(cl: ClassIR, emitter: Emitter) -> None:
     """
     prefix = cl.name_prefix(emitter.names)
     emitter.emit_line(f"if ({prefix}_free_instance == NULL) {{")
-    emitter.emit_line(f"{prefix}_free_instance = self;")
 
     # Clear attributes and free referenced objects.
 
@@ -864,6 +863,11 @@ def emit_reuse_dealloc(cl: ClassIR, emitter: Emitter) -> None:
     for base in reversed(cl.base_mro):
         for attr, rtype in base.attributes.items():
             emitter.emit_reuse_clear(f"self->{emitter.attr(attr)}", rtype)
+
+    # TODO: Insert a memory barrier on free-threaded builds? This appears not to be
+    #       needed on x86-64 because of the memory model.
+
+    emitter.emit_line(f"{prefix}_free_instance = self;")
 
     emitter.emit_line("return;")
     emitter.emit_line("}")

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -855,6 +855,7 @@ def emit_reuse_dealloc(cl: ClassIR, emitter: Emitter) -> None:
     """
     prefix = cl.name_prefix(emitter.names)
     emitter.emit_line(f"if ({prefix}_free_instance == NULL) {{")
+    emitter.emit_line(f"{prefix}_free_instance = self;")
 
     # Clear attributes and free referenced objects.
 
@@ -863,11 +864,6 @@ def emit_reuse_dealloc(cl: ClassIR, emitter: Emitter) -> None:
     for base in reversed(cl.base_mro):
         for attr, rtype in base.attributes.items():
             emitter.emit_reuse_clear(f"self->{emitter.attr(attr)}", rtype)
-
-    # TODO: Insert a memory barrier on free-threaded builds? This appears not to be
-    #       needed on x86-64 because of the memory model.
-
-    emitter.emit_line(f"{prefix}_free_instance = self;")
 
     emitter.emit_line("return;")
     emitter.emit_line("}")

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -824,7 +824,7 @@ def emit_reuse_dealloc(cl: ClassIR, emitter: Emitter) -> None:
     emitter.emit_line(f"if ({prefix}_free_instance == NULL) {{")
     emitter.emit_line(f"{prefix}_free_instance = self;")
 
-    # TODO: emit_clear_bitmaps(cl, emitter)
+    emit_clear_bitmaps(cl, emitter)
 
     for base in reversed(cl.base_mro):
         for attr, rtype in base.attributes.items():
@@ -832,6 +832,13 @@ def emit_reuse_dealloc(cl: ClassIR, emitter: Emitter) -> None:
 
     emitter.emit_line("return;")
     emitter.emit_line("}")
+
+
+def emit_clear_bitmaps(cl: ClassIR, emitter: Emitter) -> None:
+    """Emit C code to clear bitmaps that track if attributes have an assigned value."""
+    for i in range(0, len(cl.bitmap_attrs), BITMAP_BITS):
+        field = emitter.bitmap_field(i)
+        emitter.emit_line(f"self->{field} = 0;")
 
 
 def generate_finalize_for_class(

--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -193,7 +193,7 @@ def generate_class_reuse(
     context = c_emitter.context
     name = cl.name_prefix(c_emitter.names) + "_free_instance"
     struct_name = cl.struct_name(c_emitter.names)
-    context.declarations[name] = HeaderDeclaration(f"{struct_name} *{name};", needs_export=True)
+    context.declarations[name] = HeaderDeclaration(f"CPyThreadLocal {struct_name} *{name};", needs_export=True)
 
 
 def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -29,7 +29,7 @@ from mypy.plugin import Plugin, ReportConfigContext
 from mypy.util import hash_digest, json_dumps
 from mypyc.codegen.cstring import c_string_initializer
 from mypyc.codegen.emit import Emitter, EmitterContext, HeaderDeclaration, c_array_initializer
-from mypyc.codegen.emitclass import generate_class, generate_class_type_decl
+from mypyc.codegen.emitclass import generate_class, generate_class_reuse, generate_class_type_decl
 from mypyc.codegen.emitfunc import generate_native_function, native_function_header
 from mypyc.codegen.emitwrapper import (
     generate_legacy_wrapper_function,
@@ -609,6 +609,8 @@ class GroupGenerator:
             self.declare_finals(module_name, module.final_names, declarations)
             for cl in module.classes:
                 generate_class_type_decl(cl, emitter, ext_declarations, declarations)
+                if cl.reuse_freed_instance:
+                    generate_class_reuse(cl, emitter, ext_declarations, declarations)
             self.declare_type_vars(module_name, module.type_var_names, declarations)
             for fn in module.functions:
                 generate_function_declaration(fn, declarations)

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -408,6 +408,7 @@ class ClassIR:
             "_sometimes_initialized_attrs": sorted(self._sometimes_initialized_attrs),
             "init_self_leak": self.init_self_leak,
             "env_user_function": self.env_user_function.id if self.env_user_function else None,
+            "reuse_freed_instance": self.reuse_freed_instance,
         }
 
     @classmethod
@@ -463,6 +464,7 @@ class ClassIR:
         ir.env_user_function = (
             ctx.functions[data["env_user_function"]] if data["env_user_function"] else None
         )
+        ir.reuse_freed_instance = data["reuse_freed_instance"]
 
         return ir
 

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -206,7 +206,8 @@ class ClassIR:
 
         # If True, keep one freed, cleared instance available for immediate reuse to
         # speed up allocations. This helps if many objects are freed quickly, before
-        # other instances of the same class are allocated.
+        # other instances of the same class are allocated. This is effectively a
+        # per-type free "list" of up to length 1.
         self.reuse_freed_instance = False
 
     def __repr__(self) -> str:

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -204,6 +204,11 @@ class ClassIR:
         # If this is a generator environment class, what is the actual method for it
         self.env_user_function: FuncIR | None = None
 
+        # If True, keep one freed, cleared instance available for immediate reuse to
+        # speed up allocations. This helps if many objects are freed quickly, before
+        # other instances of the same class are allocated.
+        self.reuse_freed_instance = False
+
     def __repr__(self) -> str:
         return (
             "ClassIR("

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -156,6 +156,7 @@ def setup_generator_class(builder: IRBuilder) -> ClassIR:
     name = f"{builder.fn_info.namespaced_name()}_gen"
 
     generator_class_ir = ClassIR(name, builder.module_name, is_generated=True, is_final_class=True)
+    generator_class_ir.reuse_freed_instance = True
     if builder.fn_info.can_merge_generator_and_env_classes():
         builder.fn_info.env_class = generator_class_ir
     else:

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -23,6 +23,31 @@
 #define CPy_NOINLINE
 #endif
 
+#ifndef Py_GIL_DISABLED
+
+// Everything is running in the same thread, so no need for thread locals
+#define CPyThreadLocal
+
+#else
+
+// 1. Use C11 standard thread_local storage, if available
+#if defined(__STDC_VERSION__)  && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+#define CPyThreadLocal _Thread_local
+
+// 2. Microsoft Visual Studio fallback
+#elif defined(_MSC_VER)
+#define CPyThreadLocal __declspec(thread)
+
+// 3.  GNU thread local storage for GCC/Clang targets that still need it
+#elif defined(__GNUC__) || defined(__clang__)
+#define CPyThreadLocal __thread
+
+#else
+#error "Cannot define CPyThreadLocal for this compiler/target"
+#endif
+
+#endif // Py_GIL_DISABLED
+
 // INCREF and DECREF that assert the pointer is not NULL.
 // asserts are disabled in release builds so there shouldn't be a perf hit.
 // I'm honestly kind of surprised that this isn't done by default.

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -38,7 +38,7 @@
 #elif defined(_MSC_VER)
 #define CPyThreadLocal __declspec(thread)
 
-// 3.  GNU thread local storage for GCC/Clang targets that still need it
+// 3. GNU thread local storage for GCC/Clang targets that still need it
 #elif defined(__GNUC__) || defined(__clang__)
 #define CPyThreadLocal __thread
 

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -43,7 +43,7 @@
 #define CPyThreadLocal __thread
 
 #else
-#error "Cannot define CPyThreadLocal for this compiler/target"
+#error "Can't define CPyThreadLocal for this compiler/target (consider using a non-free-threaded Python build)"
 #endif
 
 #endif // Py_GIL_DISABLED

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -698,7 +698,7 @@ def test_basic() -> None:
     assert val == 3, val
 
 [case testGeneratorReuse]
-from typing import Iterator
+from typing import Iterator, Any
 
 def gen(x: list[int]) -> Iterator[list[int]]:
     y = [9]
@@ -739,4 +739,30 @@ def test_use_multiple_generator_instances_at_same_time_2() -> None:
         assert b == [0, 1, 2]
     assert a == [0, 1]
     assert list(gen_range(5)) == list(range(5))
+
+def gen_a(x: int) -> Iterator[int]:
+    yield x + 1
+
+def gen_b(x: int) -> Iterator[int]:
+    yield x + 2
+
+def test_generator_identities() -> None:
+    # Sanity check: two distinct live objects can't reuse the same memory location
+    g1 = gen_a(1)
+    g2 = gen_a(1)
+    assert g1 is not g2
+
+    # If two generators have non-overlapping lifetimes, they should reuse a memory location
+    g3 = gen_b(1)
+    id1 = id(g3)
+    g3 = gen_b(1)
+    assert id(g3) == id1
+
+    # More complex case of reuse: allocate other objects in between
+    g4: Any = gen_a(1)
+    id2 = id(g4)
+    g4 = gen_b(1)
+    g4 = [gen_b(n) for n in range(100)]
+    g4 = gen_a(1)
+    assert id(g4) == id2
 

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -681,7 +681,6 @@ def test_basic() -> None:
         assert context.x == 1
     assert context.x == 0
 
-
 [case testYieldSpill]
 from typing import Generator
 from testutil import run_generator
@@ -697,3 +696,47 @@ def test_basic() -> None:
     yields, val = x
     assert yields == ('foo',)
     assert val == 3, val
+
+[case testGeneratorReuse]
+from typing import Iterator
+
+def gen(x: list[int]) -> Iterator[list[int]]:
+    y = [9]
+    for z in x:
+        yield y + [z]
+    yield y
+
+def gen_range(n: int) -> Iterator[int]:
+    for x in range(n):
+        yield x
+
+def test_use_generator_multiple_times_one_at_a_time() -> None:
+    for i in range(100):
+        a = []
+        for x in gen([2, i]):
+            a.append(x)
+        assert a == [[9, 2], [9, i], [9]]
+
+def test_use_multiple_generator_instances_at_same_time() -> None:
+    a = []
+    for x in gen([2]):
+        a.append(x)
+        for y in gen([3, 4]):
+            a.append(y)
+    assert a == [[9, 2], [9, 3], [9, 4], [9], [9], [9, 3], [9, 4], [9]]
+
+def test_use_multiple_generator_instances_at_same_time_2() -> None:
+    a = []
+    for x in gen_range(2):
+        a.append(x)
+        b = []
+        for y in gen_range(3):
+            b.append(y)
+            c = []
+            for z in gen_range(4):
+                c.append(z)
+            assert c == [0, 1, 2, 3]
+        assert b == [0, 1, 2]
+    assert a == [0, 1]
+    assert list(gen_range(5)) == list(range(5))
+

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -766,3 +766,35 @@ def test_generator_identities() -> None:
     g4 = gen_a(1)
     assert id(g4) == id2
 
+[case testGeneratorReuseWithGilDisabled]
+import sys
+import threading
+from typing import Iterator
+
+def gen() -> Iterator[int]:
+    yield 1
+
+def is_gil_disabled() -> bool:
+    return hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
+
+def test_each_thread_gets_separate_instance() -> None:
+    if not is_gil_disabled():
+        # This only makes sense if GIL is disabled
+        return
+
+    g = gen()
+    id1 = id(g)
+
+    id2 = 0
+
+    def run() -> None:
+        nonlocal id2
+        g = gen()
+        id2 = id(g)
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join()
+
+    # Each thread should get a separate reused instance
+    assert id1 != id2

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -798,3 +798,34 @@ def test_each_thread_gets_separate_instance() -> None:
 
     # Each thread should get a separate reused instance
     assert id1 != id2
+
+[case testGeneratorWithUndefinedLocalInEnvironment]
+from typing import Iterator
+
+from testutil import assertRaises
+
+def gen(set: bool) -> Iterator[float]:
+    if set:
+        y = float("-113.0")
+    yield 1.0
+    yield y
+
+def test_bitmap_is_cleared_when_object_is_reused() -> None:
+    # This updates the bitmap of the shared instance.
+    list(gen(True))
+
+    # Ensure bitmap has been cleared.
+    with assertRaises(AttributeError):  # TODO: Should be UnboundLocalError
+      list(gen(False))
+
+def gen2(set: bool) -> Iterator[int]:
+    if set:
+        y = int("5")
+    yield 1
+    yield y
+
+def test_undefined_int_in_environment() -> None:
+    list(gen2(True))
+
+    with assertRaises(AttributeError):  # TODO: Should be UnboundLocalError
+      list(gen2(False))


### PR DESCRIPTION
Add support for per-type free "lists" that can cache up to one instance for quick allocation.

If a free list is empty, fall back to regular object allocation.

The per-type free list can be enabled for a class by setting a flag in ClassIR. Currently there is no way for users to control this, and these must be enabled based on heuristics.

Use this free list for generator objects and coroutines, since they are often short-lived.

Use a thread local variable for the free list so that each thread in a free threaded build has a separate free list. This way we need less synchronization, and the free list hit rate is higher for multithreaded workloads.

This speeds up a microbenchmark that performs non-blocking calls of async functions in a loop by about 20%. The impact will become significantly bigger after some follow-up optimizations that I'm working on.

This trades off memory use for performance, which is often good. This could use a lot of memory if many threads are calling async functions, but generally async functions are run on a single thread, so this case seems unlikely right now. Also, in my experience with large code bases only a small fraction of functions are async functions or generators, so the overall memory use impact shouldn't be too bad.

We can later look into making this profile guided, so that only functions that are called frequently get the free list. Also we could add a compile-time flag to optimize for memory use, and it would turn this off. 