### PR TITLE
Avoid erasing type objects when checking runtime cover

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2106,7 +2106,8 @@ def covers_at_runtime(item: Type, supertype: Type) -> bool:
     supertype = get_proper_type(supertype)
 
     # Since runtime type checks will ignore type arguments, erase the types.
-    supertype = erase_type(supertype)
+    if isinstance(supertype, Instance):
+        supertype = erase_type(supertype)
     if is_proper_subtype(
         erase_type(item), supertype, ignore_promotions=True, erase_instances=True
     ):

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2117,7 +2117,7 @@ def covers_at_runtime(item: Type, supertype: Type) -> bool:
     supertype = get_proper_type(supertype)
 
     # Since runtime type checks will ignore type arguments, erase the types.
-    if not isinstance(supertype, CallableType):
+    if not (isinstance(supertype, CallableType) and supertype.is_type_obj()):
         supertype = erase_type(supertype)
     if is_proper_subtype(
         erase_type(item), supertype, ignore_promotions=True, erase_instances=True

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2106,7 +2106,7 @@ def covers_at_runtime(item: Type, supertype: Type) -> bool:
     supertype = get_proper_type(supertype)
 
     # Since runtime type checks will ignore type arguments, erase the types.
-    if isinstance(supertype, Instance):
+    if not isinstance(supertype, CallableType):
         supertype = erase_type(supertype)
     if is_proper_subtype(
         erase_type(item), supertype, ignore_promotions=True, erase_instances=True

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -2602,6 +2602,7 @@ def f(t: T) -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testMatchTypeObjectTypeVar]
+# flags: --warn-unreachable
 from typing import TypeVar
 import b
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -2601,6 +2601,27 @@ def f(t: T) -> None:
             reveal_type(k)  # N: Revealed type is "tuple[builtins.int, fallback=__main__.K]"
 [builtins fixtures/tuple.pyi]
 
+[case testMatchTypeObjectTypeVar]
+from typing import TypeVar
+import b
+
+T_Choice = TypeVar("T_Choice", bound=b.One | b.Two)
+
+def switch(choice: type[T_Choice]) -> None:
+    match choice:
+        case b.One:
+            reveal_type(choice)  # N: Revealed type is "def () -> b.One"
+        case b.Two:
+            reveal_type(choice)  # N: Revealed type is "def () -> b.Two"
+        case _:
+            reveal_type(choice)  # N: Revealed type is "type[T_Choice`-1]"
+
+[file b.py]
+class One: ...
+class Two: ...
+
+[builtins fixtures/tuple.pyi]
+
 [case testNewRedefineMatchBasics]
 # flags: --allow-redefinition-new --local-partial-types
 


### PR DESCRIPTION
In particular, avoid erasing CallableType that represent type objects

Helps with #19159