### PR TITLE
Fix `TypeGuard`/`TypeIs` being forgotten when semanal defers

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1109,8 +1109,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 variables = t.variables
             else:
                 variables, _ = self.bind_function_type_variables(t, t)
-            type_guard = self.anal_type_guard(t.ret_type)
-            type_is = self.anal_type_is(t.ret_type)
+            type_guard = self.anal_type_guard(t.ret_type) if t.type_guard is None else t.type_guard
+            type_is = self.anal_type_is(t.ret_type) if t.type_is is None else t.type_is
 
             arg_kinds = t.arg_kinds
             arg_types = []

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -813,3 +813,20 @@ raw_target: object
 if isinstance(raw_target, type) and is_xlike(raw_target):
     reveal_type(raw_target)  # N: Revealed type is "type[__main__.X]"
 [builtins fixtures/tuple.pyi]
+
+[case testTypeGuardWithDefer]
+from typing import Union
+from typing_extensions import TypeGuard
+
+class A: ...
+class B: ...
+
+def is_a(x: object) -> TypeGuard[A]:
+    return defer_not_defined()  # E: Name "defer_not_defined" is not defined
+
+def main(x: Union[A, B]) -> None:
+    if is_a(x):
+        reveal_type(x)  # N: Revealed type is "__main__.A"
+    else:
+        reveal_type(x)  # N: Revealed type is "Union[__main__.A, __main__.B]"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typeis.test
+++ b/test-data/unit/check-typeis.test
@@ -933,3 +933,20 @@ def main(f: Callable[[], int | Awaitable[int]]) -> None:
     else:
         reveal_type(f)  # N: Revealed type is "def () -> Union[builtins.int, typing.Awaitable[builtins.int]]"
 [builtins fixtures/tuple.pyi]
+
+[case testTypeIsWithDefer]
+from typing import Union
+from typing_extensions import TypeIs
+
+class A: ...
+class B: ...
+
+def is_a(x: object) -> TypeIs[A]:
+    return defer_not_defined()  # E: Name "defer_not_defined" is not defined
+
+def main(x: Union[A, B]) -> None:
+    if is_a(x):
+        reveal_type(x)  # N: Revealed type is "__main__.A"
+    else:
+        reveal_type(x)  # N: Revealed type is "__main__.B"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #19318

Don't re-analyze `type_is`/`type_guard` if the callable's type was successfully analyzed on a previous semanal pass. After the first successful pass, the return type will have been replaced by `builtins.bool`, so subsequent analysis can't detect `Type{Guard,Is}`.
