### PR TITLE
Fix C compiler flags in the profile self check script

### DIFF
--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -42,6 +42,8 @@ def build_mypy(target_dir: str, multi_file: bool, *, cflags: str | None = None) 
     env["PYTHONHASHSEED"] = "1"
     if multi_file:
         env["MYPYC_MULTI_FILE"] = "1"
+    if cflags is not None:
+        env["CFLAGS"] = cflags
     cmd = [sys.executable, "setup.py", "--use-mypyc", "build_ext", "--inplace"]
     subprocess.run(cmd, env=env, check=True, cwd=target_dir)
 


### PR DESCRIPTION
This was mistakenly omitted in the original PR.