### PR TITLE
Lessen dmypy suggest path limitations for Windows machines

### DIFF
--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -550,6 +550,10 @@ class SuggestionEngine:
         # TODO: Also return OverloadedFuncDef -- currently these are ignored.
         node: SymbolNode | None = None
         if ":" in key:
+            # A colon might be part of a drive name on Windows (like `C:/foo/bar`)
+            # and is also used as a delimiter between file path and lineno.
+            # If a colon is there for any of those reasons, it must be a file+line
+            # reference.
             platform_key_count = 2 if sys.platform == "win32" else 1
             if key.count(":") > platform_key_count:
                 raise SuggestionFailure(


### PR DESCRIPTION
In this pull request, we allow dmypy suggest absolute paths to contain the drive letter colon for Windows machines. Fixes #19335.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This is done by changing how `find_node` works slightly, allowing there to be at most two colon (`:`) characters in the passed key for windows machines instead of just one like on all other platforms, and then using `rsplit` and a split limit of 1 instead of just `split` like prior.

I was looking at the existing tests for dmypy suggest and noticed nothing is testing absolute paths for any platform, so I am unsure what I need to do to add tests; This sounds like maybe it could require changes to the test framework system, and I'd like feedback from others before trying to do that.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
