### PR TITLE
Fix intermediate type checking results

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2069,8 +2069,12 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             # in this case external context is almost everything we have.
             if not is_generic_instance(ctx) and not is_literal_type_like(ctx):
                 return callable.copy_modified()
+
+        # GH#19304
+        # needs is_supertype=True since the purpose is to allow sound upcasting
+        # if the context requires it, such as e.g. `x: list[object] = [x for x in (1,2,3)]`
         args = infer_type_arguments(
-            callable.variables, ret_type, erased_ctx, skip_unsatisfied=True
+            callable.variables, ret_type, erased_ctx, is_supertype=True, skip_unsatisfied=True
         )
         # Only substitute non-Uninhabited and non-erased types.
         new_args: list[Type | None] = []

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -478,10 +478,6 @@ class A:
   def __contains__(self, x: 'A') -> str: pass
 [builtins fixtures/bool.pyi]
 
-[case testInWithInvalidArgs]
-a = 1 in ([1] + ['x'])
-[builtins fixtures/list.pyi]
-
 [case testEq]
 a: A
 b: bool

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -308,6 +308,24 @@ main:5: error: Unsupported operand types for ^ ("A" and "A")
 main:6: error: Unsupported operand types for << ("A" and "B")
 main:7: error: Unsupported operand types for >> ("A" and "A")
 
+[case testBinaryOperatorContext]
+from typing import TypeVar, Generic, Iterable, Iterator, Union
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+class Vec(Generic[T]):
+    def __init__(self, iterable: Iterable[T], /) -> None: ...
+    def __iter__(self) -> Iterator[T]: yield from []
+    def __add__(self, value: "Vec[S]", /) -> "Vec[Union[S, T]]": return Vec([])
+
+def fmt(arg: Iterable[Union[int, str]]) -> None: ...
+
+l1: Vec[int] = Vec([1])
+l2: Vec[int] = Vec([1])
+fmt(l1 + l2)
+[builtins fixtures/list.pyi]
+
 [case testBooleanAndOr]
 a: A
 b: bool
@@ -461,7 +479,7 @@ class A:
 [builtins fixtures/bool.pyi]
 
 [case testInWithInvalidArgs]
-a = 1 in ([1] + ['x'])  # E: List item 0 has incompatible type "str"; expected "int"
+a = 1 in ([1] + ['x'])
 [builtins fixtures/list.pyi]
 
 [case testEq]

--- a/test-data/unit/fixtures/list.pyi
+++ b/test-data/unit/fixtures/list.pyi
@@ -1,8 +1,9 @@
 # Builtins stub used in list-related test cases.
 
-from typing import TypeVar, Generic, Iterable, Iterator, Sequence, overload
+from typing import TypeVar, Generic, Iterable, Iterator, Sequence, overload, Union
 
 T = TypeVar('T')
+_S = TypeVar("_S")
 
 class object:
     def __init__(self) -> None: pass
@@ -19,7 +20,7 @@ class list(Sequence[T]):
     def __iter__(self) -> Iterator[T]: pass
     def __len__(self) -> int: pass
     def __contains__(self, item: object) -> bool: pass
-    def __add__(self, x: list[T]) -> list[T]: pass
+    def __add__(self, x: list[_S]) -> list[Union[_S, T]]: pass
     def __mul__(self, x: int) -> list[T]: pass
     def __getitem__(self, x: int) -> T: pass
     def __setitem__(self, x: int, v: T) -> None: pass


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Attempted fix for #19304, still needs debugging.

The major change, following the chain of thought in https://github.com/python/mypy/issues/19304#issuecomment-3009144940, is to add `is_supertype=True` [inside the solver call in `infer_function_type_arguments_using_context`](https://github.com/python/mypy/blob/5e9d657e397cf3e4d43c491525d70144be35d0d8/mypy/checkexpr.py#L2072-L2074)

- added test `check-expressions.test::testBinaryOperatorContext` which does not pass on master.
- updated `__add__` in `list.pyi` stub
- removed now invalidated test `check-expressions.test::testInWithInvalidArgs`

Currently, the following checks fail locally:

| test case                                                | reason                 |
|----------------------------------------------------------|------------------------|
| testSimpleGeneratorExpression                            | msg changed            |
| testGeneratorIncompatibleErrorMessage                    | msg changed            |
| testDictFromList                                         | msg changed            |
| testRecursiveAliasBasicGenericInference                  | new error, msg changed |
| testRecursiveAliasWithRecursiveInstance                  | msg changed            |
| testRecursiveAliasTopUnion                               | new error              |
| testBasicRecursiveGenericNamedTuple                      | msg changed            |
| testAwaitExplicitContext                                 | msg changed            |
| testTupleMeetTupleVariable                               | msg changed            |
| testTupleCompatibleWithSequence                          | different reveal_type  |
| testInferenceWorksWithEmptyCollectionsUnion              | new error              |
| testInferenceWithAbstractClassContext3                   | msg changed            |
| testConditionalExpressionWithEmptyListAndUnionWithAny    | different reveal_type  |
| testConditionalExpressionWithEmptyIteableAndUnionWithAny | different reveal_type  |
| testInferMultipleAnyUnionDifferentVariance               | new error              |

The critical ones that need to be fixed seem to be 

- [ ] `testRecursiveAliasBasicGenericInference`
- [ ] `testTupleCompatibleWithSequence`
- [ ] `testInferenceWorksWithEmptyCollectionsUnion`
- [ ] `testConditionalExpressionWithEmptyListAndUnionWithAny`
- [ ] `testConditionalExpressionWithEmptyIteableAndUnionWithAny`
- [ ] `testInferMultipleAnyUnionDifferentVariance`


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
