### PR TITLE
[mypyc] Test cases and compilation error for mypyc-try-finally-await

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -282,6 +282,13 @@ del error_codes[FILE.code]
 # This is a catch-all for remaining uncategorized errors.
 MISC: Final[ErrorCode] = ErrorCode("misc", "Miscellaneous other checks", "General")
 
+# Mypyc-specific error codes
+MYPYC_TRY_FINALLY_AWAIT: Final[ErrorCode] = ErrorCode(
+    "mypyc-try-finally-await",
+    "Async try/finally blocks with await in finally are not supported by mypyc",
+    "General",
+)
+
 OVERLOAD_CANNOT_MATCH: Final[ErrorCode] = ErrorCode(
     "overload-cannot-match",
     "Warn if an @overload signature can never be matched",

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -12,6 +12,9 @@ import importlib.util
 from collections.abc import Sequence
 from typing import Callable
 
+import mypy.nodes
+import mypy.traverser
+from mypy.errorcodes import MYPYC_TRY_FINALLY_AWAIT
 from mypy.nodes import (
     ARG_NAMED,
     ARG_POS,
@@ -673,7 +676,7 @@ def try_finally_resolve_control(
 
 
 def transform_try_finally_stmt(
-    builder: IRBuilder, try_body: GenFunc, finally_body: GenFunc
+    builder: IRBuilder, try_body: GenFunc, finally_body: GenFunc, line: int = -1
 ) -> None:
     """Generalized try/finally handling that takes functions to gen the bodies.
 
@@ -709,6 +712,17 @@ def transform_try_finally_stmt(
     builder.activate_block(out_block)
 
 
+# A simple visitor to detect await expressions
+class AwaitDetector(mypy.traverser.TraverserVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.has_await = False
+
+    def visit_await_expr(self, o: mypy.nodes.AwaitExpr) -> None:
+        self.has_await = True
+        super().visit_await_expr(o)
+
+
 def transform_try_stmt(builder: IRBuilder, t: TryStmt) -> None:
     # Our compilation strategy for try/except/else/finally is to
     # treat try/except/else and try/finally as separate language
@@ -717,6 +731,35 @@ def transform_try_stmt(builder: IRBuilder, t: TryStmt) -> None:
     # body of a try/finally block.
     if t.is_star:
         builder.error("Exception groups and except* cannot be compiled yet", t.line)
+
+    # Check if we're in an async function with a finally block that contains await
+    if t.finally_body and builder.fn_info.is_coroutine:
+        detector = AwaitDetector()
+        t.finally_body.accept(detector)
+
+        if detector.has_await:
+            # Check if this error is suppressed with # type: ignore
+            error_ignored = False
+            if builder.module_name in builder.graph:
+                mypyfile = builder.graph[builder.module_name].tree
+                if mypyfile and t.line in mypyfile.ignored_lines:
+                    ignored_codes = mypyfile.ignored_lines[t.line]
+                    # Empty list means ignore all errors on this line
+                    # Otherwise check for specific error code
+                    if not ignored_codes or "mypyc-try-finally-await" in ignored_codes:
+                        error_ignored = True
+
+            if not error_ignored:
+                builder.error(
+                    "try/(except/)finally blocks in async functions with 'await' in "
+                    "the finally block are not supported by mypyc. Exceptions "
+                    "(re-)raised in the try or except blocks will be silently "
+                    "swallowed if a context switch occurs. Ignore with "
+                    "'# type: ignore[mypyc-try-finally-await, unused-ignore]', if you "
+                    "really know what you're doing.",
+                    t.line
+                )
+
     if t.finally_body:
 
         def transform_try_body() -> None:
@@ -727,7 +770,7 @@ def transform_try_stmt(builder: IRBuilder, t: TryStmt) -> None:
 
         body = t.finally_body
 
-        transform_try_finally_stmt(builder, transform_try_body, lambda: builder.accept(body))
+        transform_try_finally_stmt(builder, transform_try_body, lambda: builder.accept(body), t.line)
     else:
         transform_try_except_stmt(builder, t)
 
@@ -818,6 +861,7 @@ def transform_with(
         builder,
         lambda: transform_try_except(builder, try_body, [(None, None, except_body)], None, line),
         finally_body,
+        line
     )
 
 

--- a/mypyc/test-data/run-async.test
+++ b/mypyc/test-data/run-async.test
@@ -643,3 +643,220 @@ def test_async_def_contains_two_nested_functions() -> None:
 
 [file asyncio/__init__.pyi]
 def run(x: object) -> object: ...
+
+[case testAsyncTryExceptFinallyAwait]
+# Comprehensive test for bug where exceptions are swallowed in async functions
+# when the finally block contains an await statement
+
+import asyncio
+from testutil import assertRaises
+
+class TestError(Exception):
+    pass
+
+# Test 0: Simplest case - just try/finally with raise and await
+async def simple_try_finally_await() -> None:
+    try:  # type: ignore[mypyc-try-finally-await]
+        raise ValueError("simple error")
+    finally:
+        await asyncio.sleep(0)
+
+# Test 1: Raise inside try, catch in except, don't re-raise
+async def async_try_except_no_reraise() -> int:
+    try:  # type: ignore[mypyc-try-finally-await]
+        raise ValueError("test error")
+        return 1  # Never reached
+    except ValueError:
+        return 2  # Should return this
+    finally:
+        await asyncio.sleep(0)
+    return 3  # Should not reach this
+
+# Test 2: Raise inside try, catch in except, re-raise
+async def async_try_except_reraise() -> int:
+    try:  # type: ignore[mypyc-try-finally-await]
+        raise ValueError("test error")
+        return 1  # Never reached
+    except ValueError:
+        raise  # Re-raise the exception
+    finally:
+        await asyncio.sleep(0)
+    return 2  # Should not reach this
+
+# Test 3: Raise inside try, catch in except, raise different error
+async def async_try_except_raise_different() -> int:
+    try:  # type: ignore[mypyc-try-finally-await]
+        raise ValueError("original error")
+        return 1  # Never reached
+    except ValueError:
+        raise RuntimeError("different error")
+    finally:
+        await asyncio.sleep(0)
+    return 2  # Should not reach this
+
+# Test 4: Another try/except block inside finally
+async def async_try_except_inside_finally() -> int:
+    try:  # type: ignore[mypyc-try-finally-await]
+        raise ValueError("outer error")
+        return 1  # Never reached
+    finally:
+        await asyncio.sleep(0)
+        try:
+            raise RuntimeError("inner error")
+        except RuntimeError:
+            pass  # Catch inner error
+    return 2  # What happens after finally with inner exception handled?
+
+# Test 5: Another try/finally block inside finally
+async def async_try_finally_inside_finally() -> int:
+    try:  # type: ignore[mypyc-try-finally-await]
+        raise ValueError("outer error")
+        return 1  # Never reached
+    finally:
+        await asyncio.sleep(0)
+        try:  # type: ignore[mypyc-try-finally-await]
+            raise RuntimeError("inner error")
+        finally:
+            await asyncio.sleep(0)
+    return 2  # Should not reach this
+
+# Control case: No await in finally - should work correctly
+async def async_exception_no_await_in_finally() -> None:
+    """Control case: This works correctly - exception propagates"""
+    try:
+        raise TestError("This exception will propagate!")
+    finally:
+        pass  # No await here
+
+# Test function with no exception to check normal flow
+async def async_no_exception_with_await_in_finally() -> int:
+    try:  # type: ignore[mypyc-try-finally-await]
+        return 1  # Normal return
+    finally:
+        await asyncio.sleep(0)
+    return 2  # Should not reach this
+
+def test_async_try_except_finally_await() -> None:
+    # Test 0: Simplest case - just try/finally with exception
+    # Expected: ValueError propagates
+    with assertRaises(ValueError):
+        asyncio.run(simple_try_finally_await())
+
+    # Test 1: Exception caught, not re-raised
+    # Expected: return 2 (from except block)
+    result = asyncio.run(async_try_except_no_reraise())
+    assert result == 2, f"Expected 2, got {result}"
+
+    # Test 2: Exception caught and re-raised
+    # Expected: ValueError propagates
+    with assertRaises(ValueError):
+        asyncio.run(async_try_except_reraise())
+
+    # Test 3: Exception caught, different exception raised
+    # Expected: RuntimeError propagates
+    with assertRaises(RuntimeError):
+        asyncio.run(async_try_except_raise_different())
+
+    # Test 4: Try/except inside finally
+    # Expected: ValueError propagates (outer exception)
+    with assertRaises(ValueError):
+        asyncio.run(async_try_except_inside_finally())
+
+    # Test 5: Try/finally inside finally
+    # Expected: RuntimeError propagates (inner error)
+    with assertRaises(RuntimeError):
+        asyncio.run(async_try_finally_inside_finally())
+
+    # Control case: No await in finally (should work correctly)
+    with assertRaises(TestError):
+        asyncio.run(async_exception_no_await_in_finally())
+
+    # Test normal flow (no exception)
+    # Expected: return 1
+    result = asyncio.run(async_no_exception_with_await_in_finally())
+    assert result == 1, f"Expected 1, got {result}"
+
+[file asyncio/__init__.pyi]
+async def sleep(t: float) -> None: ...
+def run(x: object) -> object: ...
+
+[case testAsyncContextManagerExceptionHandling]
+# Test async context managers with exceptions
+# Async context managers use try/finally internally but seem to work
+# correctly
+
+import asyncio
+from testutil import assertRaises
+
+# Test 1: Basic async context manager that doesn't suppress exceptions
+class AsyncContextManager:
+    async def __aenter__(self) -> 'AsyncContextManager':
+        return self
+
+    async def __aexit__(self, exc_type: type[BaseException] | None,
+                       exc_val: BaseException | None,
+                       exc_tb: object) -> None:
+        # This await in __aexit__ is like await in finally
+        await asyncio.sleep(0)
+        # Don't suppress the exception (return None/False)
+
+async def func_with_async_context_manager() -> str:
+    async with AsyncContextManager():
+        raise ValueError("Exception inside async with")
+        return "should not reach"  # Never reached
+    return "should not reach either"  # Never reached
+
+async def test_basic_exception() -> str:
+    try:
+        await func_with_async_context_manager()
+        return "func_a returned normally - bug!"
+    except ValueError:
+        return "caught ValueError - correct!"
+    except Exception as e:
+        return f"caught different exception: {type(e).__name__}"
+
+# Test 2: Async context manager that raises a different exception in __aexit__
+class AsyncContextManagerRaisesInExit:
+    async def __aenter__(self) -> 'AsyncContextManagerRaisesInExit':
+        return self
+
+    async def __aexit__(self, exc_type: type[BaseException] | None,
+                       exc_val: BaseException | None,
+                       exc_tb: object) -> None:
+        # This await in __aexit__ is like await in finally
+        await asyncio.sleep(0)
+        # Raise a different exception - this should replace the original exception
+        raise RuntimeError("Exception in __aexit__")
+
+async def func_with_raising_context_manager() -> str:
+    async with AsyncContextManagerRaisesInExit():
+        raise ValueError("Original exception")
+        return "should not reach"  # Never reached
+    return "should not reach either"  # Never reached
+
+async def test_exception_in_aexit() -> str:
+    try:
+        await func_with_raising_context_manager()
+        return "func returned normally - unexpected!"
+    except RuntimeError:
+        return "caught RuntimeError - correct!"
+    except ValueError:
+        return "caught ValueError - original exception not replaced!"
+    except Exception as e:
+        return f"caught different exception: {type(e).__name__}"
+
+def test_async_context_manager_exception_handling() -> None:
+    # Test 1: Basic exception propagation
+    result = asyncio.run(test_basic_exception())
+    # Expected: "caught ValueError - correct!"
+    assert result == "caught ValueError - correct!", f"Expected exception to propagate, got: {result}"
+
+    # Test 2: Exception raised in __aexit__ replaces original exception
+    result = asyncio.run(test_exception_in_aexit())
+    # Expected: "caught RuntimeError - correct!"
+    # (The RuntimeError from __aexit__ should replace the ValueError)
+    assert result == "caught RuntimeError - correct!", f"Expected RuntimeError from __aexit__, got: {result}"
+
+[file asyncio/__init__.pyi]
+async def sleep(t: float) -> None: ...
+def run(x: object) -> object: ...


### PR DESCRIPTION
Any await that causes a context switch inside a finally block swallows any exception (re-)raised in the preceding try or except blocks. As the exception 'never happened', this also changes control flow.

This commit adds several tests (which _intentionally fail_ under mypyc but run fine under cpython) for this bug, and triggers a compiler error if this pattern is detected in the code. `# type: ignore[mypyc-try-finally-await, unused-ignore]` can be used on the try line to bypass the error.

This also newly causes the testAsyncReturn test to fail, as it should.

See mypyc/mypyc#1114

---

I have made several attempts to fix this, but as I am unfamiliar with the code base and this does not seem to be a quick simple fix, I have given up on that for now.

I found it more important to create a compiler error that detects this case so my code stops silently and unexpectedly swallowing exceptions and changing control flow.

---

I've run the full pytest suite, and the only additional failures are one of the test cases I added and testAsyncReturn (as noted above)
