### PR TITLE
Fix wrong names listed in "too few arguments" message

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2441,18 +2441,13 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                         self.msg.fail("ParamSpec.kwargs should only be passed once", context)
                         ok = False
         if missing_contiguous_pos_block:
-            if ArgKind.ARG_STAR2 in actual_kinds:
-                # To generate a correct message, expand kwargs manually. If a name was
-                # missing from the call but doesn't belong to continuous positional prefix,
-                # it was already reported as a missing kwarg. All args before first prefix
-                # item are guaranteed to have been passed positionally.
-                names_to_use = [None] * missing_contiguous_pos_block[0] + [
-                    name
-                    for i, name in enumerate(callee.arg_names)
-                    if name is not None and i not in missing_contiguous_pos_block
-                ]
-            else:
-                names_to_use = actual_names
+            # To generate a correct message, expand kwargs manually. If a name was
+            # missing from the call but doesn't belong to continuous positional prefix,
+            # it was already reported as a missing kwarg. All args before first prefix
+            # item are guaranteed to have been passed positionally.
+            passed_or_reported_names = callee.arg_names[missing_contiguous_pos_block[-1] + 1 :]
+            assert None not in passed_or_reported_names
+            names_to_use = [None] * missing_contiguous_pos_block[0] + passed_or_reported_names
             self.msg.too_few_arguments(callee, context, names_to_use)
             if object_type and callable_name and "." in callable_name:
                 self.missing_classvar_callable_note(object_type, callable_name, context)

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -242,7 +242,8 @@ g()  # E: Missing named argument "x" for "g"  [call-arg]
 
 def h(x: int, y: int, z: int) -> None: pass
 h(y=1, z=1)  # E: Missing positional argument "x" in call to "h"  [call-arg]
-h(y=1)  # E: Missing positional arguments "x", "z" in call to "h"  [call-arg]
+h(y=1)  # E: Missing named argument "z" for "h"  [call-arg] \
+        # E: Missing positional argument "x" in call to "h"  [call-arg]
 
 [case testErrorCodeArgType]
 def f(x: int) -> None: pass

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2467,6 +2467,79 @@ f(b=4) # E: Missing positional argument "a" in call to "f"
 def f(a, b, c, d=None) -> None: pass
 f(1, d=3) # E: Missing positional arguments "b", "c" in call to "f"
 
+[case testMissingArgumentsErrorFromTypedDict]
+from typing import Optional,TypedDict
+
+class DA(TypedDict):
+    a: int
+class DB(TypedDict):
+    b: int
+class DC(TypedDict):
+    c: int
+
+class DAB(DA, DB): pass
+class DAC(DA, DC): pass
+class DBC(DB, DC): pass
+class DABC(DA, DB, DC): pass
+
+da: DA
+db: DB
+dc: DC
+dab: DAB
+dac: DAC
+dbc: DBC
+dabc: DABC
+
+def f(a: int, b: int, c: int, d: Optional[int] = None) -> None: pass
+
+f(**da)  # E: Missing named argument "b" for "f" \
+         # E: Missing named argument "c" for "f"
+f(**db)  # E: Missing named argument "c" for "f" \
+         # E: Missing positional argument "a" in call to "f"
+f(**dc)  # E: Missing positional arguments "a", "b" in call to "f"
+f(**dab)  # E: Missing named argument "c" for "f"
+f(**dac)  # E: Missing named argument "b" for "f"
+f(**dbc)  # E: Missing positional argument "a" in call to "f"
+f(**dabc)
+
+def g(a: int, /, b: int, c: int) -> None: pass
+
+g(**da)  # E: Extra argument "a" from **args for "g"
+g(0, **da)  # E: Extra argument "a" from **args for "g"
+g(**db)  # E: Missing named argument "c" for "g" \
+         # E: Too few arguments for "g"
+g(0, **db)  # E: Missing named argument "c" for "g"
+g(**dc)  # E: Too few arguments for "g"
+g(0, **dc)  # E: Missing positional argument "b" in call to "g"
+g(**dab)  # E: Extra argument "a" from **args for "g"
+g(0, **dab)  # E: Extra argument "a" from **args for "g"
+g(**dac)  # E: Extra argument "a" from **args for "g"
+g(0, **dac)  # E: Extra argument "a" from **args for "g"
+g(**dbc)  # E: Too few arguments for "g"
+g(0, **dbc)
+g(**dabc)  # E: Extra argument "a" from **args for "g"
+
+def h(a: int, b: int, /, c: int) -> None: pass
+
+h(**da)  # E: Extra argument "a" from **args for "h"
+h(0, **da)  # E: Extra argument "a" from **args for "h"
+h(0, 1, **da)  # E: Extra argument "a" from **args for "h"
+h(**db)  # E: Extra argument "b" from **args for "h"
+h(0, **db)  # E: Extra argument "b" from **args for "h"
+h(0, 1, **db)  # E: Extra argument "b" from **args for "h"
+h(**dc)  # E: Too few arguments for "h"
+h(0, **dc)  # E: Too few arguments for "h"
+h(0, 1, **dc)
+h(**dab)  # E: Extra argument "b" from **args for "h"
+h(0, **dab)  # E: Extra argument "b" from **args for "h"
+h(**dac)  # E: Extra argument "a" from **args for "h"
+h(0, **dac)  # E: Extra argument "a" from **args for "h"
+h(**dbc)  # E: Extra argument "b" from **args for "h"
+h(0, **dbc)  # E: Extra argument "b" from **args for "h"
+h(**dabc)  # E: Extra argument "b" from **args for "h"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testReturnTypeLineNumberWithDecorator]
 def dec(f): pass
 

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -889,7 +889,7 @@ def h(x: int, y: str) -> None: pass
 
 g(h, 1, y='x')
 g(h, 1, x=1)  # E: "g" gets multiple values for keyword argument "x" \
-              # E: Missing positional argument "y" in call to "g"
+              # E: Missing named argument "y" for "g"
 
 class C[**P, T]:
     def m(self, *args: P.args, **kwargs: P.kwargs) -> T: ...

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -154,7 +154,7 @@ f(0, 0, kw=0)
 f(0, p_or_kw=0, kw=0)
 f(p=0, p_or_kw=0, kw=0)  # E: Unexpected keyword argument "p" for "f"
 f(0, **d)
-f(**d)  # E: Missing positional argument "p_or_kw" in call to "f"
+f(**d)  # E: Too few arguments for "f"
 [builtins fixtures/dict.pyi]
 
 [case testPEP570Signatures1]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1596,7 +1596,7 @@ f1(**a)
 f2(**a) # E: Argument "y" to "f2" has incompatible type "str"; expected "int"
 f3(**a) # E: Argument "x" to "f3" has incompatible type "int"; expected "B"
 f4(**a) # E: Extra argument "y" from **args for "f4"
-f5(**a) # E: Missing positional arguments "y", "z" in call to "f5"
+f5(**a) # E: Missing named argument "z" for "f5"
 f6(**a) # E: Extra argument "y" from **args for "f6"
 f1(1, **a) # E: "f1" gets multiple values for keyword argument "x"
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #12755. When some arguments are passed as keywords, only report everything before them as positional, report per-item missing kwargs for the rest. This logic craves for more tests, let's see if I got the idea right first.