### PR TITLE
Do not show protocol compatibility note against unpacked sequence or mapping

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2684,9 +2684,12 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                 context=context,
                 outer_context=outer_context,
             )
-            self.msg.incompatible_argument_note(
-                original_caller_type, callee_type, context, parent_error=error
-            )
+            if not caller_kind.is_star():
+                # For *args and **kwargs this note would be incorrect - we're comparing
+                # iterable/mapping type with union of relevant arg types.
+                self.msg.incompatible_argument_note(
+                    original_caller_type, callee_type, context, parent_error=error
+                )
             if not self.msg.prefer_simple_messages():
                 self.chk.check_possible_missing_await(
                     caller_type, callee_type, context, error.code

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3705,6 +3705,8 @@ class P(Protocol):
 
 def foo(x: P, y: P) -> None: ...
 
-foo(*[0, ''])  # E: Argument 1 to "foo" has incompatible type "*list[object]"; expected "P"
-foo(**{'x': 0, 'y': ''})  # E: Argument 1 to "foo" has incompatible type "**dict[str, object]"; expected "P"
+args: list[object]
+foo(*args)  # E: Argument 1 to "foo" has incompatible type "*list[object]"; expected "P"
+kwargs: dict[str, object]
+foo(**kwargs)  # E: Argument 1 to "foo" has incompatible type "**dict[str, object]"; expected "P"
 [builtins fixtures/dict.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -3694,3 +3694,17 @@ def defer() -> int: ...
 [out]
 main: note: In function "a":
 main:6: error: Unsupported operand types for + ("int" and "str")
+
+[case testNoExtraNoteForUnpacking]
+from typing import Protocol
+
+class P(Protocol):
+    arg: int
+    # Something that list and dict also have
+    def __contains__(self, item: object) -> bool: ...
+
+def foo(x: P, y: P) -> None: ...
+
+foo(*[0, ''])  # E: Argument 1 to "foo" has incompatible type "*list[object]"; expected "P"
+foo(**{'x': 0, 'y': ''})  # E: Argument 1 to "foo" has incompatible type "**dict[str, object]"; expected "P"
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
This was discovered in #19294 where an unrelated change produced a weird notice that should not be shown. Current behavior of the added testcase: 

```
main.py:10: error: Argument 1 to "foo" has incompatible type "*list[object]"; expected "P"  [arg-type]
main.py:10: note: "list" is missing following "P" protocol member:
main.py:10: note:     arg
main.py:11: error: Argument 1 to "foo" has incompatible type "**dict[str, object]"; expected "P"  [arg-type]
main.py:11: note: "dict" is missing following "P" protocol member:
main.py:11: note:     arg
```

https://mypy-play.net/?mypy=master&python=3.12&flags=strict&gist=d0228ba7d2802db8ac4457f374ccc148