### PR TITLE
[mypyc] Fix comparison of tuples with different lengths

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1507,6 +1507,10 @@ class LowLevelIRBuilder:
         assert isinstance(lhs.type, RTuple) and isinstance(rhs.type, RTuple)
         equal = True if op == "==" else False
         result = Register(bool_rprimitive)
+        # tuples of different lengths
+        if len(lhs.type.types) != len(rhs.type.types):
+            self.add(Assign(result, self.false() if equal else self.true(), line))
+            return result
         # empty tuples
         if len(lhs.type.types) == 0 and len(rhs.type.types) == 0:
             self.add(Assign(result, self.true() if equal else self.false(), line))

--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -203,6 +203,12 @@ def f7(x: List[Tuple[int, int]]) -> int:
 def test_unbox_tuple() -> None:
     assert f7([(5, 6)]) == 11
 
+def test_comparison() -> None:
+    assert ('x','y') == ('x','y')
+    assert not(('x','y') != ('x','y'))
+    assert ('x','y') != ('x','y',1)
+    assert not(('x','y') == ('x','y',1))
+
 # Test that order is irrelevant to unions. Really I only care that this builds.
 
 class A:


### PR DESCRIPTION
When comparing tuples, their lengths are now compared and their contents are only compared if their lengths are equal. Otherwise, when they have different lengths, the comparison always evaluates to `False`.