### PR TITLE
Fix `Enum.value` inference for `Enum`s with `@cache`d methods

### DIFF
--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -184,7 +184,7 @@ def enum_value_callback(ctx: mypy.plugin.AttributeContext) -> Type:
             if _implements_new(info):
                 return ctx.default_attr_type
 
-            stnodes = (info.get(name) for name in info.names)
+            stnodes = (info.get(name) for name in info.enum_members)
 
             # Enums _can_ have methods, instance attributes, and `nonmember`s.
             # Omit methods and attributes created by assigning to self.*
@@ -194,12 +194,7 @@ def enum_value_callback(ctx: mypy.plugin.AttributeContext) -> Type:
                 for n in stnodes
                 if n is None or not n.implicit
             )
-            proper_types = [
-                _infer_value_type_with_auto_fallback(ctx, t)
-                for t in node_types
-                if t is None
-                or (not isinstance(t, CallableType) and not is_named_instance(t, "enum.nonmember"))
-            ]
+            proper_types = [_infer_value_type_with_auto_fallback(ctx, t) for t in node_types]
             underlying_type = _first(proper_types)
             if underlying_type is None:
                 return ctx.default_attr_type

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2539,3 +2539,28 @@ def check(thing: Things) -> None:
         return None
     return None  # E: Statement is unreachable
 [builtins fixtures/enum.pyi]
+
+[case testValueFallbackWithCachedMethod]
+from enum import Enum, auto
+from collections.abc import Hashable
+from typing import Callable, Generic, TypeVar
+
+_T = TypeVar("_T")
+
+class _lru_cache_wrapper(Generic[_T]):
+    def __call__(self, *args: Hashable, **kwargs: Hashable) -> _T: ...
+
+def cache(user_function: Callable[..., _T], /) -> _lru_cache_wrapper[_T]: ...
+
+class Color(Enum):
+    RED = auto()
+
+    @cache
+    def lowercase_name(self) -> str:
+        return self.name
+
+reveal_type(Color.RED.value)  # N: Revealed type is "builtins.int"
+
+def frobnicate(color: Color) -> None:
+    reveal_type(color.value)  # N: Revealed type is "builtins.int"
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Before this, adding an annotation like `@functools.cache` to any method on an `Enum` caused the inference for the class's `.value` to fail (i.e., become `Any`).

Fixes #19368

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
