### PR TITLE
[mypyc] Call generator helper method directly in await expression

### DIFF
--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -261,7 +261,7 @@ def gen_func_item(
         )
 
         # Re-enter the FuncItem and visit the body of the function this time.
-        gen_generator_func_body(builder, fn_info, sig, func_reg)
+        gen_generator_func_body(builder, fn_info, func_reg)
     else:
         func_ir, func_reg = gen_func_body(builder, sig, cdef, is_singledispatch)
 

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -241,23 +241,7 @@ def add_helper_to_generator_class(
     fn_info: FuncInfo,
 ) -> FuncDecl:
     """Generates a helper method for a generator class, called by '__next__' and 'throw'."""
-    sig = FuncSignature(
-        (
-            RuntimeArg(SELF_NAME, object_rprimitive),
-            RuntimeArg("type", object_rprimitive),
-            RuntimeArg("value", object_rprimitive),
-            RuntimeArg("traceback", object_rprimitive),
-            RuntimeArg("arg", object_rprimitive),
-        ),
-        sig.ret_type,
-    )
-    helper_fn_decl = FuncDecl(
-        "__mypyc_generator_helper__",
-        fn_info.generator_class.ir.name,
-        builder.module_name,
-        sig,
-        internal=True,
-    )
+    helper_fn_decl = fn_info.generator_class.ir.method_decls["__mypyc_generator_helper__"]
     helper_fn_ir = FuncIR(
         helper_fn_decl, arg_regs, blocks, fn_info.fitem.line, traceback_name=fn_info.fitem.name
     )

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -152,6 +152,7 @@ def instantiate_generator_class(builder: IRBuilder) -> Value:
 
 def setup_generator_class(builder: IRBuilder) -> ClassIR:
     mapper = builder.mapper
+    assert isinstance(builder.fn_info.fitem, FuncDef)
     generator_class_ir = mapper.fdef_to_generator[builder.fn_info.fitem]
     if builder.fn_info.can_merge_generator_and_env_classes():
         builder.fn_info.env_class = generator_class_ir

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -155,8 +155,10 @@ def instantiate_generator_class(builder: IRBuilder) -> Value:
 def setup_generator_class(builder: IRBuilder) -> ClassIR:
     name = f"{builder.fn_info.namespaced_name()}_gen"
 
-    generator_class_ir = ClassIR(name, builder.module_name, is_generated=True, is_final_class=True)
-    generator_class_ir.reuse_freed_instance = True
+    m = builder.mapper
+    generator_class_ir = m.fdef_to_generator[builder.fn_info.fitem]
+    generator_class_ir.name = name
+    generator_class_ir.ctor.name = name
     if builder.fn_info.can_merge_generator_and_env_classes():
         builder.fn_info.env_class = generator_class_ir
     else:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -153,12 +153,12 @@ def instantiate_generator_class(builder: IRBuilder) -> Value:
 
 
 def setup_generator_class(builder: IRBuilder) -> ClassIR:
-    name = f"{builder.fn_info.namespaced_name()}_gen"
+    #name = f"{builder.fn_info.namespaced_name()}_gen"
 
     m = builder.mapper
     generator_class_ir = m.fdef_to_generator[builder.fn_info.fitem]
-    generator_class_ir.name = name
-    generator_class_ir.ctor.name = name
+    #generator_class_ir.name = name
+    #generator_class_ir.ctor.name = name
     if builder.fn_info.can_merge_generator_and_env_classes():
         builder.fn_info.env_class = generator_class_ir
     else:

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 from typing import Callable
 
 from mypy.nodes import ARG_OPT, FuncDef, Var
-from mypyc.common import ENV_ATTR_NAME, NEXT_LABEL_ATTR_NAME, SELF_NAME
+from mypyc.common import ENV_ATTR_NAME, NEXT_LABEL_ATTR_NAME
 from mypyc.ir.class_ir import ClassIR
-from mypyc.ir.func_ir import FuncDecl, FuncIR, FuncSignature, RuntimeArg
+from mypyc.ir.func_ir import FuncDecl, FuncIR
 from mypyc.ir.ops import (
     NO_TRACEBACK_LINE_NO,
     BasicBlock,
@@ -78,9 +78,7 @@ def gen_generator_func(
     return func_ir, func_reg
 
 
-def gen_generator_func_body(
-    builder: IRBuilder, fn_info: FuncInfo, func_reg: Value | None
-) -> None:
+def gen_generator_func_body(builder: IRBuilder, fn_info: FuncInfo, func_reg: Value | None) -> None:
     """Generate IR based on the body of a generator function.
 
     Add "__next__", "__iter__" and other generator methods to the generator
@@ -229,10 +227,7 @@ def add_methods_to_generator_class(
 
 
 def add_helper_to_generator_class(
-    builder: IRBuilder,
-    arg_regs: list[Register],
-    blocks: list[BasicBlock],
-    fn_info: FuncInfo,
+    builder: IRBuilder, arg_regs: list[Register], blocks: list[BasicBlock], fn_info: FuncInfo
 ) -> FuncDecl:
     """Generates a helper method for a generator class, called by '__next__' and 'throw'."""
     helper_fn_decl = fn_info.generator_class.ir.method_decls["__mypyc_generator_helper__"]
@@ -252,9 +247,7 @@ def add_iter_to_generator_class(builder: IRBuilder, fn_info: FuncInfo) -> None:
         builder.add(Return(builder.self()))
 
 
-def add_next_to_generator_class(
-    builder: IRBuilder, fn_info: FuncInfo, fn_decl: FuncDecl
-) -> None:
+def add_next_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl: FuncDecl) -> None:
     """Generates the '__next__' method for a generator class."""
     with builder.enter_method(fn_info.generator_class.ir, "__next__", object_rprimitive, fn_info):
         none_reg = builder.none_object()
@@ -269,9 +262,7 @@ def add_next_to_generator_class(
         builder.add(Return(result))
 
 
-def add_send_to_generator_class(
-    builder: IRBuilder, fn_info: FuncInfo, fn_decl: FuncDecl
-) -> None:
+def add_send_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl: FuncDecl) -> None:
     """Generates the 'send' method for a generator class."""
     with builder.enter_method(fn_info.generator_class.ir, "send", object_rprimitive, fn_info):
         arg = builder.add_argument("arg", object_rprimitive)
@@ -287,9 +278,7 @@ def add_send_to_generator_class(
         builder.add(Return(result))
 
 
-def add_throw_to_generator_class(
-    builder: IRBuilder, fn_info: FuncInfo, fn_decl: FuncDecl
-) -> None:
+def add_throw_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl: FuncDecl) -> None:
     """Generates the 'throw' method for a generator class."""
     with builder.enter_method(fn_info.generator_class.ir, "throw", object_rprimitive, fn_info):
         typ = builder.add_argument("type", object_rprimitive)

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from typing import Any, Callable, TypeVar, cast
 
 from mypy.build import Graph
-from mypy.nodes import ClassDef, Expression, MypyFile
+from mypy.nodes import ClassDef, Expression, MypyFile, FuncDef
 from mypy.state import state
 from mypy.types import Type
 from mypyc.analysis.attrdefined import analyze_always_defined_attrs
@@ -37,7 +37,7 @@ from mypyc.ir.rtypes import none_rprimitive
 from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.prebuildvisitor import PreBuildVisitor
-from mypyc.irbuild.prepare import build_type_map, find_singledispatch_register_impls
+from mypyc.irbuild.prepare import build_type_map, find_singledispatch_register_impls, create_generator_class_if_needed
 from mypyc.irbuild.visitor import IRBuilderVisitor
 from mypyc.irbuild.vtable import compute_vtable
 from mypyc.options import CompilerOptions
@@ -75,6 +75,13 @@ def build_ir(
         # First pass to determine free symbols.
         pbv = PreBuildVisitor(errors, module, singledispatch_info.decorators_to_remove, types)
         module.accept(pbv)
+
+        # Declare generator classes for nested async functions and generators.
+        for fdef in pbv.nested_funcs:
+            if isinstance(fdef, FuncDef):
+                # Make generator class name sufficiently unique.
+                suffix = f"___{fdef.line}"
+                create_generator_class_if_needed(module.fullname, None, fdef, mapper, name_suffix=suffix)
 
         # Construct and configure builder objects (cyclic runtime dependency).
         visitor = IRBuilderVisitor()

--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from typing import Any, Callable, TypeVar, cast
 
 from mypy.build import Graph
-from mypy.nodes import ClassDef, Expression, MypyFile, FuncDef
+from mypy.nodes import ClassDef, Expression, FuncDef, MypyFile
 from mypy.state import state
 from mypy.types import Type
 from mypyc.analysis.attrdefined import analyze_always_defined_attrs
@@ -37,7 +37,11 @@ from mypyc.ir.rtypes import none_rprimitive
 from mypyc.irbuild.builder import IRBuilder
 from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.prebuildvisitor import PreBuildVisitor
-from mypyc.irbuild.prepare import build_type_map, find_singledispatch_register_impls, create_generator_class_if_needed
+from mypyc.irbuild.prepare import (
+    build_type_map,
+    create_generator_class_if_needed,
+    find_singledispatch_register_impls,
+)
 from mypyc.irbuild.visitor import IRBuilderVisitor
 from mypyc.irbuild.vtable import compute_vtable
 from mypyc.options import CompilerOptions
@@ -81,7 +85,9 @@ def build_ir(
             if isinstance(fdef, FuncDef):
                 # Make generator class name sufficiently unique.
                 suffix = f"___{fdef.line}"
-                create_generator_class_if_needed(module.fullname, None, fdef, mapper, name_suffix=suffix)
+                create_generator_class_if_needed(
+                    module.fullname, None, fdef, mapper, name_suffix=suffix
+                )
 
         # Construct and configure builder objects (cyclic runtime dependency).
         visitor = IRBuilderVisitor()

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -64,6 +64,7 @@ class Mapper:
         self.type_to_ir: dict[TypeInfo, ClassIR] = {}
         self.func_to_decl: dict[SymbolNode, FuncDecl] = {}
         self.symbol_fullnames: set[str] = set()
+        self.fdef_to_generator: dict[FuncDef, ClassIR] = {}
 
     def type_to_rtype(self, typ: Type | None) -> RType:
         if typ is None:
@@ -171,7 +172,10 @@ class Mapper:
                 for typ, kind in zip(fdef.type.arg_types, fdef.type.arg_kinds)
             ]
             arg_pos_onlys = [name is None for name in fdef.type.arg_names]
-            ret = self.type_to_rtype(fdef.type.ret_type)
+            if fdef.is_coroutine or fdef.is_generator:
+                ret = RInstance(self.fdef_to_generator[fdef])
+            else:
+                ret = self.type_to_rtype(fdef.type.ret_type)
         else:
             # Handle unannotated functions
             arg_types = [object_rprimitive for _ in fdef.arguments]

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -64,6 +64,7 @@ class Mapper:
         self.type_to_ir: dict[TypeInfo, ClassIR] = {}
         self.func_to_decl: dict[SymbolNode, FuncDecl] = {}
         self.symbol_fullnames: set[str] = set()
+        # The corresponding generator class that implements a generator/async function
         self.fdef_to_generator: dict[FuncDef, ClassIR] = {}
 
     def type_to_rtype(self, typ: Type | None) -> RType:
@@ -174,6 +175,9 @@ class Mapper:
             arg_pos_onlys = [name is None for name in fdef.type.arg_names]
             # TODO: We could probably support decorators sometimes (static and class method?)
             if (fdef.is_coroutine or fdef.is_generator) and not fdef.is_decorated:
+                # Give a more precise type for generators, so that we can optimize
+                # code that uses them. They return a generator object, which has a
+                # specific class. Without this, the type would have to be 'object'.
                 ret = RInstance(self.fdef_to_generator[fdef])
             else:
                 ret = self.type_to_rtype(fdef.type.ret_type)

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -172,7 +172,8 @@ class Mapper:
                 for typ, kind in zip(fdef.type.arg_types, fdef.type.arg_kinds)
             ]
             arg_pos_onlys = [name is None for name in fdef.type.arg_names]
-            if fdef.is_coroutine or fdef.is_generator:
+            # TODO: We could probably support decorators sometimes (static and class method?)
+            if (fdef.is_coroutine or fdef.is_generator) and not fdef.is_decorated:
                 ret = RInstance(self.fdef_to_generator[fdef])
             else:
                 ret = self.type_to_rtype(fdef.type.ret_type)

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -178,7 +178,7 @@ class Mapper:
                 # Give a more precise type for generators, so that we can optimize
                 # code that uses them. They return a generator object, which has a
                 # specific class. Without this, the type would have to be 'object'.
-                ret = RInstance(self.fdef_to_generator[fdef])
+                ret: RType = RInstance(self.fdef_to_generator[fdef])
             else:
                 ret = self.type_to_rtype(fdef.type.ret_type)
         else:

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -38,7 +38,7 @@ from mypy.nodes import (
 from mypy.semanal import refers_to_fullname
 from mypy.traverser import TraverserVisitor
 from mypy.types import Instance, Type, get_proper_type
-from mypyc.common import PROPSET_PREFIX, get_id_from_name, SELF_NAME
+from mypyc.common import PROPSET_PREFIX, SELF_NAME, get_id_from_name
 from mypyc.crash import catch_errors
 from mypyc.errors import Errors
 from mypyc.ir.class_ir import ClassIR
@@ -51,7 +51,14 @@ from mypyc.ir.func_ir import (
     RuntimeArg,
 )
 from mypyc.ir.ops import DeserMaps
-from mypyc.ir.rtypes import RInstance, RType, dict_rprimitive, none_rprimitive, tuple_rprimitive
+from mypyc.ir.rtypes import (
+    RInstance,
+    RType,
+    dict_rprimitive,
+    none_rprimitive,
+    object_rprimitive,
+    tuple_rprimitive,
+)
 from mypyc.irbuild.mapper import Mapper
 from mypyc.irbuild.util import (
     get_func_def,
@@ -62,7 +69,6 @@ from mypyc.irbuild.util import (
 )
 from mypyc.options import CompilerOptions
 from mypyc.sametype import is_same_type
-from mypyc.ir.rtypes import object_rprimitive
 
 
 def build_type_map(
@@ -220,11 +226,7 @@ def create_generator_class_if_needed(
 
         # The implementation of most generator functionality is behind this magic method.
         helper_fn_decl = FuncDecl(
-            "__mypyc_generator_helper__",
-            name,
-            module_name,
-            helper_sig,
-            internal=True,
+            "__mypyc_generator_helper__", name, module_name, helper_sig, internal=True
         )
         cir.method_decls[helper_fn_decl.name] = helper_fn_decl
 

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -182,7 +182,7 @@ def prepare_func_def(
 ) -> FuncDecl:
     if fdef.is_coroutine or fdef.is_generator:
         name = "_".join(x for x in [fdef.name, class_name] if x) + "_gen"
-        cir = ClassIR(name, module_name, is_generated=True)
+        cir = ClassIR(name, module_name, is_generated=True, is_final_class=True)
         cir.reuse_freed_instance = True
         mapper.fdef_to_generator[fdef] = cir
 

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -180,7 +180,8 @@ def prepare_func_def(
     options: CompilerOptions,
 ) -> FuncDecl:
     if fdef.is_coroutine or fdef.is_generator:
-        cir = ClassIR(fdef.name, module_name, is_generated=True)
+        name = "_".join(x for x in [fdef.name, class_name] if x) + "_gen"
+        cir = ClassIR(name, module_name, is_generated=True)
         cir.reuse_freed_instance = True
         mapper.fdef_to_generator[fdef] = cir
 

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -194,7 +194,7 @@ def prepare_func_def(
                 RuntimeArg("traceback", object_rprimitive),
                 RuntimeArg("arg", object_rprimitive),
             ),
-            RInstance(cir),
+            object_rprimitive,
         )
 
         helper_fn_decl = FuncDecl(

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -179,6 +179,11 @@ def prepare_func_def(
     mapper: Mapper,
     options: CompilerOptions,
 ) -> FuncDecl:
+    if fdef.is_coroutine or fdef.is_generator:
+        cir = ClassIR(fdef.name, module_name, is_generated=True)
+        cir.reuse_freed_instance = True
+        mapper.fdef_to_generator[fdef] = cir
+
     kind = (
         FUNC_STATICMETHOD
         if fdef.is_static

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -196,6 +196,11 @@ def prepare_func_def(
 def create_generator_class_if_needed(
     module_name: str, class_name: str | None, fdef: FuncDef, mapper: Mapper, name_suffix: str = ""
 ) -> None:
+    """If function is a generator/async function, declare a generator class.
+
+    Each generator and async function gets a dedicated class that implements the
+    generator protocol with generated methods.
+    """
     if fdef.is_coroutine or fdef.is_generator:
         name = "_".join(x for x in [fdef.name, class_name] if x) + "_gen" + name_suffix
         cir = ClassIR(name, module_name, is_generated=True, is_final_class=True)
@@ -213,6 +218,7 @@ def create_generator_class_if_needed(
             object_rprimitive,
         )
 
+        # The implementation of most generator functionality is behind this magic method.
         helper_fn_decl = FuncDecl(
             "__mypyc_generator_helper__",
             name,

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -933,9 +933,7 @@ def emit_yield_from_or_await(
 
     if isinstance(val, Call) and isinstance(val.type, RInstance) and val.type.class_ir.is_generated:
         # XXX is_generator not is_generated !!!!!!! FIXME FIXME
-        r = Register(val.type)
-        builder.assign(r, val, line)
-        iter_val = r
+        iter_val = val
     else:
         get_op = coro_op if is_await else iter_op
         if isinstance(get_op, PrimitiveDescription):

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -946,8 +946,11 @@ def emit_yield_from_or_await(
 
     stop_block, main_block, done_block = BasicBlock(), BasicBlock(), BasicBlock()
 
-    if isinstance(iter_reg.type, RInstance) and iter_reg.type.class_ir.has_method("__next__"):
-        m = MethodCall(builder.read(iter_reg), "__next__", [], line)
+    helper_method = "__mypyc_generator_helper__"
+    if isinstance(iter_reg.type, RInstance) and iter_reg.type.class_ir.has_method(helper_method):
+        obj = builder.read(iter_reg)
+        nn = builder.none_object()
+        m = MethodCall(obj, helper_method, [nn, nn, nn, nn], line)
         m.error_kind = ERR_NEVER
         _y_init = builder.add(m)
     else:

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -955,6 +955,7 @@ def emit_yield_from_or_await(
         obj = builder.read(iter_reg)
         nn = builder.none_object()
         m = MethodCall(obj, helper_method, [nn, nn, nn, nn], line)
+        # Generators have custom error handling, so disable normal error handling.
         m.error_kind = ERR_NEVER
         _y_init = builder.add(m)
     else:

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -932,8 +932,9 @@ def emit_yield_from_or_await(
     to_yield_reg = Register(object_rprimitive)
     received_reg = Register(object_rprimitive)
 
-    if isinstance(val, (Call, MethodCall)) and isinstance(val.type, RInstance) and val.type.class_ir.is_generated:
-        # XXX is_generator not is_generated !!!!!!! FIXME FIXME
+    helper_method = "__mypyc_generator_helper__"
+    if isinstance(val, (Call, MethodCall)) and isinstance(val.type, RInstance) and val.type.class_ir.has_method(helper_method):
+        # This is a generated generator class, and we can use a fast path.
         iter_val = val
     else:
         get_op = coro_op if is_await else iter_op
@@ -946,7 +947,6 @@ def emit_yield_from_or_await(
 
     stop_block, main_block, done_block = BasicBlock(), BasicBlock(), BasicBlock()
 
-    helper_method = "__mypyc_generator_helper__"
     if isinstance(iter_reg.type, RInstance) and iter_reg.type.class_ir.has_method(helper_method):
         obj = builder.read(iter_reg)
         nn = builder.none_object()

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -933,7 +933,9 @@ def emit_yield_from_or_await(
 
     if isinstance(val, Call) and isinstance(val.type, RInstance) and val.type.class_ir.is_generated:
         # XXX is_generator not is_generated !!!!!!! FIXME FIXME
-        iter_val = val
+        r = Register(val.type)
+        builder.assign(r, val, line)
+        iter_val = r
     else:
         get_op = coro_op if is_await else iter_op
         if isinstance(get_op, PrimitiveDescription):

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -933,7 +933,11 @@ def emit_yield_from_or_await(
     received_reg = Register(object_rprimitive)
 
     helper_method = "__mypyc_generator_helper__"
-    if isinstance(val, (Call, MethodCall)) and isinstance(val.type, RInstance) and val.type.class_ir.has_method(helper_method):
+    if (
+        isinstance(val, (Call, MethodCall))
+        and isinstance(val.type, RInstance)
+        and val.type.class_ir.has_method(helper_method)
+    ):
         # This is a generated generator class, and we can use a fast path.
         iter_val = val
     else:

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -955,7 +955,7 @@ def emit_yield_from_or_await(
     builder.assign(result, builder.call_c(check_stop_op, [], line), line)
     # Clear the spilled iterator/coroutine so that it will be freed.
     # Otherwise, the freeing of the spilled register would likely be delayed.
-    err = builder.add(LoadErrorValue(object_rprimitive))
+    err = builder.add(LoadErrorValue(iter_reg.type))
     builder.assign(iter_reg, err, line)
     builder.goto(done_block)
 

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -939,7 +939,7 @@ def emit_yield_from_or_await(
         and val.type.class_ir.has_method(helper_method)
     ):
         # This is a generated generator class, and we can use a fast path.
-        iter_val = val
+        iter_val: Value = val
     else:
         get_op = coro_op if is_await else iter_op
         if isinstance(get_op, PrimitiveDescription):

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -932,7 +932,7 @@ def emit_yield_from_or_await(
     to_yield_reg = Register(object_rprimitive)
     received_reg = Register(object_rprimitive)
 
-    if isinstance(val, Call) and isinstance(val.type, RInstance) and val.type.class_ir.is_generated:
+    if isinstance(val, (Call, MethodCall)) and isinstance(val.type, RInstance) and val.type.class_ir.is_generated:
         # XXX is_generator not is_generated !!!!!!! FIXME FIXME
         iter_val = val
     else:

--- a/mypyc/test-data/run-async.test
+++ b/mypyc/test-data/run-async.test
@@ -107,6 +107,29 @@ def test_indirect_call() -> None:
     with assertRaises(MyError):
         asyncio.run(indirect_call_3(ident(-113.0, True)))
 
+class C:
+    def __init__(self, n: int) -> None:
+        self.n = n
+
+    async def add(self, x: int, err: bool = False) -> int:
+        await asyncio.sleep(0)
+        if err:
+            raise MyError()
+        return x + self.n
+
+async def method_call(x: int) -> int:
+    c = C(5)
+    return await c.add(x)
+
+async def method_call_exception() -> int:
+    c = C(5)
+    return await c.add(3, err=True)
+
+def test_async_method_call() -> None:
+    assert asyncio.run(method_call(3)) == 8
+    with assertRaises(MyError):
+        asyncio.run(method_call_exception())
+
 [file asyncio/__init__.pyi]
 async def sleep(t: float) -> None: ...
 # eh, we could use the real type but it doesn't seem important

--- a/mypyc/test-data/run-async.test
+++ b/mypyc/test-data/run-async.test
@@ -563,8 +563,10 @@ def test_bool() -> None:
 def run(x: object) -> object: ...
 
 [case testRunAsyncNestedFunctions]
+from __future__ import annotations
+
 import asyncio
-from typing import cast, Iterator
+from typing import cast, Iterator, overload, Awaitable, Any, TypeVar
 
 from testutil import assertRaises
 
@@ -641,6 +643,37 @@ def test_async_def_contains_two_nested_functions() -> None:
         (5 + 3 + 1), (7 + 4 + 10 + 1)
     )
 
+async def async_def_contains_overloaded_async_def(n: int) -> int:
+    @overload
+    async def f(x: int) -> int: ...
+
+    @overload
+    async def f(x: str) -> str: ...
+
+    async def f(x: int | str) -> Any:
+        return x
+
+    return (await f(n)) + 1
+
+
+def test_async_def_contains_overloaded_async_def() -> None:
+    assert asyncio.run(async_def_contains_overloaded_async_def(5)) == 6
+
+T = TypeVar("T")
+
+def deco(f: T) -> T:
+    return f
+
+async def async_def_contains_decorated_async_def(n: int) -> int:
+    @deco
+    async def f(x: int) -> int:
+        return x + 2
+
+    return (await f(n)) + 1
+
+
+def test_async_def_contains_decorated_async_def() -> None:
+    assert asyncio.run(async_def_contains_decorated_async_def(7)) == 10
 [file asyncio/__init__.pyi]
 def run(x: object) -> object: ...
 

--- a/mypyc/test-data/run-async.test
+++ b/mypyc/test-data/run-async.test
@@ -2,6 +2,7 @@
 
 [case testRunAsyncBasics]
 import asyncio
+from typing import Callable, Awaitable
 
 from testutil import assertRaises
 
@@ -71,6 +72,40 @@ def test_exception() -> None:
         asyncio.run(exc4())
     assert asyncio.run(exc5()) == 3
     assert asyncio.run(exc6()) == 3
+
+async def indirect_call(x: int, c: Callable[[int], Awaitable[int]]) -> int:
+    return await c(x)
+
+async def indirect_call_2(a: Awaitable[None]) -> None:
+    await a
+
+async def indirect_call_3(a: Awaitable[float]) -> float:
+    return (await a) + 1.0
+
+async def inc(x: int) -> int:
+    await asyncio.sleep(0)
+    return x + 1
+
+async def ident(x: float, err: bool = False) -> float:
+    await asyncio.sleep(0.0)
+    if err:
+        raise MyError()
+    return x + float("0.0")
+
+def test_indirect_call() -> None:
+    assert asyncio.run(indirect_call(3, inc)) == 4
+
+    with assertRaises(MyError):
+        asyncio.run(indirect_call_2(exc1()))
+
+    assert asyncio.run(indirect_call_3(ident(2.0))) == 3.0
+    assert asyncio.run(indirect_call_3(ident(-113.0))) == -112.0
+    assert asyncio.run(indirect_call_3(ident(-114.0))) == -113.0
+
+    with assertRaises(MyError):
+        asyncio.run(indirect_call_3(ident(1.0, True)))
+    with assertRaises(MyError):
+        asyncio.run(indirect_call_3(ident(-113.0, True)))
 
 [file asyncio/__init__.pyi]
 async def sleep(t: float) -> None: ...

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -190,7 +190,9 @@ exit! a exception!
 ((1,), 'exception!')
 
 [case testYieldNested]
-from typing import Callable, Generator
+from typing import Callable, Generator, Iterator, TypeVar, overload
+
+from testutil import run_generator
 
 def normal(a: int, b: float) -> Callable:
     def generator(x: int, y: str) -> Generator:
@@ -235,15 +237,43 @@ def outer() -> Generator:
             yield i
     return recursive(10)
 
-[file driver.py]
-from native import normal, generator, triple, another_triple, outer
-from testutil import run_generator
+def test_return_nested_generator() -> None:
+    assert run_generator(normal(1, 2.0)(3, '4.00')) == ((1, 2.0, 3, '4.00'), None)
+    assert run_generator(generator(1)) == ((1, 2, 3), None)
+    assert run_generator(triple()()) == ((1, 2, 3), None)
+    assert run_generator(another_triple()()) == ((1,), None)
+    assert run_generator(outer()) == ((0, 1, 2, 3, 4), None)
 
-assert run_generator(normal(1, 2.0)(3, '4.00')) == ((1, 2.0, 3, '4.00'), None)
-assert run_generator(generator(1)) == ((1, 2, 3), None)
-assert run_generator(triple()()) == ((1, 2, 3), None)
-assert run_generator(another_triple()()) == ((1,), None)
-assert run_generator(outer()) == ((0, 1, 2, 3, 4), None)
+def call_nested(x: int) -> list[int]:
+    def generator() -> Iterator[int]:
+        n = int() + 2
+        yield x
+        yield n * x
+
+    a = []
+    for x in generator():
+        a.append(x)
+    return a
+
+T = TypeVar("T")
+
+def deco(f: T) -> T:
+    return f
+
+def call_nested_decorated(x: int) -> list[int]:
+    @deco
+    def generator() -> Iterator[int]:
+        n = int() + 3
+        yield x
+        yield n * x
+
+    a = []
+    for x in generator():
+        a.append(x)
+    return a
+
+def test_call_nested_generator_in_function() -> None:
+    assert call_nested_decorated(5) == [5, 15]
 
 [case testYieldThrow]
 from typing import Generator, Iterable, Any, Union


### PR DESCRIPTION
Previously calls like `await foo()` were compiled to code that included code like this (in Python-like pseudocode):
```
a = foo()
...
b = iter(a)
...
c = next(b)
```
In the above code, `iter(a)` just returns `a` if `foo` is a native async function, so we now optimize the `iter` call away. Also `next(b)` calls `b.__next__()`, which calls the generated generator helper method `__mypyc_generator_helper__`. Now we call the helper method directly, which saves some unnecessary calls. 

More importantly, in a follow-up PR I can easily change the way `__mypyc_generator_helper__` is called, since we now call it directly. This makes it possible to avoid raising a `StopIteration` exception in many await  expressions. The goal of this PR is to prepare for the latter optimization. This PR doesn't help performance significantly by itself.

In order to call the helper method directly, I had to generate the declaration of this method and the generated generator class before the main irbuild pass, since otherwise a call site could be processed before we have processed the called generator.

I also improved test coverage of related functionality. We don't have an IR test for async calls, since the IR is very verbose. I manually inspected the generated IR to verify that the new code path works both when calling a top-level function and when calling a method. I'll later add a mypyc benchmark to ensure that we will notice if the performance of async calls is degraded.