### PR TITLE
[mypyc] Fix error value check for GetAttr that allows nullable values

### DIFF
--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -361,8 +361,8 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             return f"({cast}{obj})->{self.emitter.attr(op.attr)}"
 
     def visit_get_attr(self, op: GetAttr) -> None:
-        if op.allow_null:
-            self.get_attr_with_allow_null(op)
+        if op.allow_error_value:
+            self.get_attr_with_allow_error_value(op)
             return
         dest = self.reg(op)
         obj = self.reg(op.obj)
@@ -432,8 +432,11 @@ class FunctionEmitterVisitor(OpVisitor[None]):
             elif not always_defined:
                 self.emitter.emit_line("}")
 
-    def get_attr_with_allow_null(self, op: GetAttr) -> None:
-        """Handle GetAttr with allow_null=True which allows NULL without raising AttributeError."""
+    def get_attr_with_allow_error_value(self, op: GetAttr) -> None:
+        """Handle GetAttr with allow_error_value=True.
+
+        This allows NULL or other error value without raising AttributeError.
+        """
         dest = self.reg(op)
         obj = self.reg(op.obj)
         rtype = op.class_type

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -811,7 +811,13 @@ class GetAttr(RegisterOp):
     error_kind = ERR_MAGIC
 
     def __init__(
-        self, obj: Value, attr: str, line: int, *, borrow: bool = False, allow_error_value: bool = False
+        self,
+        obj: Value,
+        attr: str,
+        line: int,
+        *,
+        borrow: bool = False,
+        allow_error_value: bool = False,
     ) -> None:
         super().__init__(line)
         self.obj = obj

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -811,17 +811,17 @@ class GetAttr(RegisterOp):
     error_kind = ERR_MAGIC
 
     def __init__(
-        self, obj: Value, attr: str, line: int, *, borrow: bool = False, allow_null: bool = False
+        self, obj: Value, attr: str, line: int, *, borrow: bool = False, allow_error_value: bool = False
     ) -> None:
         super().__init__(line)
         self.obj = obj
         self.attr = attr
-        self.allow_null = allow_null
+        self.allow_error_value = allow_error_value
         assert isinstance(obj.type, RInstance), "Attribute access not supported: %s" % obj.type
         self.class_type = obj.type
         attr_type = obj.type.attr_type(attr)
         self.type = attr_type
-        if allow_null:
+        if allow_error_value:
             self.error_kind = ERR_NEVER
         elif attr_type.error_overlap:
             self.error_kind = ERR_MAGIC_OVERLAPPING

--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -709,13 +709,9 @@ class IRBuilder:
         assert False, "Unsupported lvalue: %r" % target
 
     def read_nullable_attr(self, obj: Value, attr: str, line: int = -1) -> Value:
-        """Read an attribute that might be NULL without raising AttributeError.
-
-        This is used for reading spill targets in try/finally blocks where NULL
-        indicates the non-return path was taken.
-        """
+        """Read an attribute that might have an error value without raising AttributeError."""
         assert isinstance(obj.type, RInstance) and obj.type.class_ir.is_ext_class
-        return self.add(GetAttr(obj, attr, line, allow_null=True))
+        return self.add(GetAttr(obj, attr, line, allow_error_value=True))
 
     def assign(self, target: Register | AssignmentTarget, rvalue_reg: Value, line: int) -> None:
         if isinstance(target, Register):

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -111,6 +111,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             "y": int_rprimitive,
             "i1": int64_rprimitive,
             "i2": int32_rprimitive,
+            "t": RTuple([object_rprimitive, object_rprimitive]),
         }
         ir.bitmap_attrs = ["i1", "i2"]
         compute_vtable(ir)
@@ -414,6 +415,17 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
             """cpy_r_r0 = ((mod___AObject *)cpy_r_r)->_i1;
                if (unlikely(cpy_r_r0 == -113) && !(((mod___AObject *)cpy_r_r)->bitmap & 1)) {
                    PyErr_SetString(PyExc_AttributeError, "attribute 'i1' of 'A' undefined");
+               }
+            """,
+        )
+
+    def test_get_attr_nullable_with_tuple(self) -> None:
+        self.assert_emit(
+            GetAttr(self.r, "t", 1, allow_null=True),
+            """cpy_r_r0 = ((mod___AObject *)cpy_r_r)->_t;
+               if (cpy_r_r0.f0 != NULL) {
+                   CPy_INCREF(cpy_r_r0.f0);
+                   CPy_INCREF(cpy_r_r0.f1);
                }
             """,
         )

--- a/mypyc/test/test_emitfunc.py
+++ b/mypyc/test/test_emitfunc.py
@@ -421,7 +421,7 @@ class TestFunctionEmitterVisitor(unittest.TestCase):
 
     def test_get_attr_nullable_with_tuple(self) -> None:
         self.assert_emit(
-            GetAttr(self.r, "t", 1, allow_null=True),
+            GetAttr(self.r, "t", 1, allow_error_value=True),
             """cpy_r_r0 = ((mod___AObject *)cpy_r_r)->_t;
                if (cpy_r_r0.f0 != NULL) {
                    CPy_INCREF(cpy_r_r0.f0);


### PR DESCRIPTION
Also rename `allow_null` to `allow_error_value` to make it clear that this works with non-pointer types such as tuples.