### PR TITLE
[mypyc] Use per-type free "lists" for nested functions

### DIFF
--- a/mypyc/irbuild/callable_class.py
+++ b/mypyc/irbuild/callable_class.py
@@ -56,6 +56,7 @@ def setup_callable_class(builder: IRBuilder) -> None:
     # environment to point at the previously defined environment
     # class.
     callable_class_ir = ClassIR(name, builder.module_name, is_generated=True, is_final_class=True)
+    callable_class_ir.reuse_freed_instance = True
 
     # The functools @wraps decorator attempts to call setattr on
     # nested functions, so we create a dict for these nested

--- a/mypyc/irbuild/env_class.py
+++ b/mypyc/irbuild/env_class.py
@@ -48,6 +48,7 @@ def setup_env_class(builder: IRBuilder) -> ClassIR:
         is_generated=True,
         is_final_class=True,
     )
+    env_class.reuse_freed_instance = True
     env_class.attributes[SELF_NAME] = RInstance(env_class)
     if builder.fn_info.is_nested:
         # If the function is nested, its environment class must contain an environment


### PR DESCRIPTION
Often at most one instance is allocated at any given time, so this improves performance quite significantly in common cases. Uses the freelist feature introduced in #19316.

This speeds up self check by about 0.5% (measured 100 samples). Speeds up this microbenchmark that gets close to the maximal benefit by about 90%:

```
def f(x: int) -> int:
    def inc(y: int) -> int:
        return y + 1
    return inc(x)

def bench(n: int) -> None:
    for x in range(n):
        f(x)

from time import time
bench(1000)
t0 = time()
bench(50 * 1000 * 1000)
print(time() - t0)
```