### PR TITLE
perf: add `__slots__` to `SubtypeVisitor`

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -390,6 +390,15 @@ def check_type_parameter(
 
 
 class SubtypeVisitor(TypeVisitor[bool]):
+    __slots__ = (
+        "right",
+        "orig_right",
+        "proper_subtype",
+        "subtype_context",
+        "options",
+        "_subtype_kind",
+    )
+
     def __init__(self, right: Type, subtype_context: SubtypeContext, proper_subtype: bool) -> None:
         self.right = get_proper_type(right)
         self.orig_right = right


### PR DESCRIPTION
We construct quite a lot of them. This made a selfcheck benchmark 0.4-0.7% faster when run on my local PC.