### PR TITLE
[mypyc] Raise NameError on undefined names

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1141,12 +1141,20 @@ class IRBuilder:
         )
 
     def shortcircuit_expr(self, expr: OpExpr) -> Value:
+        def handle_right():
+            if expr.right_unreachable:
+                self.builder.add(
+                    RaiseStandardError(
+                        RaiseStandardError.RUNTIME_ERROR,
+                        "mypyc internal error: should be unreachable",
+                        expr.right.line,
+                    )
+                )
+                return self.builder.none()
+            return self.accept(expr.right)
+
         return self.builder.shortcircuit_helper(
-            expr.op,
-            self.node_type(expr),
-            lambda: self.accept(expr.left),
-            lambda: self.accept(expr.right),
-            expr.line,
+            expr.op, self.node_type(expr), lambda: self.accept(expr.left), handle_right, expr.line
         )
 
     # Basic helpers

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -117,9 +117,7 @@ def transform_name_expr(builder: IRBuilder, expr: NameExpr) -> Value:
     if expr.node is None:
         builder.add(
             RaiseStandardError(
-                RaiseStandardError.RUNTIME_ERROR,
-                "mypyc internal error: should be unreachable",
-                expr.line,
+                RaiseStandardError.NAME_ERROR, f'name "{expr.name}" is not defined', expr.line
             )
         )
         return builder.none()

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -3556,3 +3556,18 @@ L3:
     s = arg
     r3 = CPyObject_Size(s)
     return r3
+
+[case testUndefinedFunction]
+def f():
+    non_existent_function()
+
+[out]
+def f():
+    r0 :: bool
+    r1, r2, r3 :: object
+L0:
+    r0 = raise NameError('name "non_existent_function" is not defined')
+    r1 = box(None, 1)
+    r2 = PyObject_Vectorcall(r1, 0, 0, 0)
+    r3 = box(None, 1)
+    return r3

--- a/mypyc/test-data/irbuild-unreachable.test
+++ b/mypyc/test-data/irbuild-unreachable.test
@@ -17,11 +17,7 @@ def f():
     r8, r9, r10 :: bit
     r11, r12 :: bool
     r13 :: object
-    r14 :: str
-    r15 :: object
-    r16 :: tuple[int, int]
-    r17, r18 :: object
-    r19, y :: bool
+    r14, y :: bool
 L0:
     r0 = sys :: module
     r1 = 'platform'
@@ -46,13 +42,8 @@ L4:
 L5:
     r12 = raise RuntimeError('mypyc internal error: should be unreachable')
     r13 = box(None, 1)
-    r14 = 'version_info'
-    r15 = CPyObject_GetAttr(r13, r14)
-    r16 = (6, 10)
-    r17 = box(tuple[int, int], r16)
-    r18 = PyObject_RichCompare(r15, r17, 4)
-    r19 = unbox(bool, r18)
-    r11 = r19
+    r14 = unbox(bool, r13)
+    r11 = r14
 L6:
     y = r11
     return 1


### PR DESCRIPTION
Fixes https://github.com/mypyc/mypyc/issues/879

Changed the type of exception that is raised on undefined names from `RuntimeError` to `NameError`.

Moved the runtime error that refers to unexpected execution of unreachable code to `shortcircuit_expr` to keep existing behavior and generate the exception in blocks that are unreachable due to short-circuiting.

In the future this could probably be optimized to not generate any code at all and just constant-fold the boolean expression.