### PR TITLE
[mypyc] Simplify comparison of tuple elements

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -1534,7 +1534,7 @@ class LowLevelIRBuilder:
             compare = self.binary_op(lhs_item, rhs_item, op, line)
             # Cast to bool if necessary since most types uses comparison returning a object type
             # See generic_ops.py for more information
-            if not is_bool_rprimitive(compare.type):
+            if not (is_bool_rprimitive(compare.type) or is_bit_rprimitive(compare.type)):
                 compare = self.primitive_op(bool_op, [compare], line)
             if i < len(lhs.type.types) - 1:
                 branch = Branch(compare, early_stop, check_blocks[i + 1], Branch.BOOL)

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -453,3 +453,26 @@ L0:
     r0 = CPySequence_Multiply(a, 4)
     b = r0
     return 1
+
+[case testTupleFloatElementComparison]
+def f(x: tuple[float], y: tuple[float]) -> bool:
+    return x == y
+
+[out]
+def f(x, y):
+    x, y :: tuple[float]
+    r0, r1 :: float
+    r2 :: bit
+    r3 :: bool
+L0:
+    r0 = x[0]
+    r1 = y[0]
+    r2 = r0 == r1
+    if not r2 goto L1 else goto L2 :: bool
+L1:
+    r3 = 0
+    goto L3
+L2:
+    r3 = 1
+L3:
+    return r3


### PR DESCRIPTION
Got rid of unnecessary operations when comparing tuple elements returns a bit primitive.

Example code:
```
def f(x: tuple[float], y: tuple[float]) -> bool:
    return x == y
```
IR before:
```
def f(x, y):
    x, y :: tuple[float]
    r0, r1 :: float
    r2 :: bit
    r3 :: object
    r4 :: i32
    r5 :: bit
    r6, r7, r8 :: bool
L0:
    r0 = x[0]
    r1 = y[0]
    r2 = r0 == r1
    r3 = box(bit, r2)
    r4 = PyObject_IsTrue(r3)
    r5 = r4 >= 0 :: signed
    if not r5 goto L5 (error at f:2) else goto L1 :: bool
L1:
    r6 = truncate r4: i32 to builtins.bool
    if not r6 goto L2 else goto L3 :: bool
L2:
    r7 = 0
    goto L4
L3:
    r7 = 1
L4:
    return r7
L5:
    r8 = <error> :: bool
    return r8
```
IR after:
```
def f(x, y):
    x, y :: tuple[float]
    r0, r1 :: float
    r2 :: bit
    r3 :: bool
L0:
    r0 = x[0]
    r1 = y[0]
    r2 = r0 == r1
    if not r2 goto L1 else goto L2 :: bool
L1:
    r3 = 0
    goto L3
L2:
    r3 = 1
L3:
    return r3
```

Tested using the following benchmark:
```
def f(x: tuple[float,float], y: tuple[float,float]) -> bool:
    return x == y

def bench(n: int) -> None:
    for x in range(n):
        lhs = (float(x), float(x * 2))
        rhs = (float(x), float(x * 3))
        f(lhs, rhs)

from time import time
bench(1000)
t0 = time()
bench(50 * 1000 * 1000)
print(time() - t0)
```
Execution time goes from ~315ms to ~150ms on my machine.