### PR TITLE
perf: add `__slots__` to `SubtypeContext`

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -89,6 +89,17 @@ TypeParameterChecker: _TypeAlias = Callable[[Type, Type, int, bool, "SubtypeCont
 
 
 class SubtypeContext:
+    __slots__ = (
+        "ignore_type_params",
+        "ignore_pos_arg_names",
+        "ignore_declared_variance",
+        "always_covariant",
+        "ignore_promotions",
+        "erase_instances",
+        "keep_erased_types",
+        "options",
+    )
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
Follow up to afd5a382dc95532da61e6ebc7002323fbca75548.

```
master                    6.544s (0.0%) | stdev 0.056s 
slotted-subtypecontext    6.512s (-0.5%) | stdev 0.060s 
```