### PR TITLE
[mypyc] Speed up native-to-native calls using await

### DIFF
--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -167,6 +167,8 @@ class GeneratorClass(ImplicitClass):
         # Holds the arg passed to send
         self.send_arg_reg: Value | None = None
 
+        self.stop_iter_value_reg: Value | None = None
+
         # The switch block is used to decide which instruction to go using the value held in the
         # next-label register.
         self.switch_block = BasicBlock()

--- a/mypyc/irbuild/context.py
+++ b/mypyc/irbuild/context.py
@@ -167,6 +167,9 @@ class GeneratorClass(ImplicitClass):
         # Holds the arg passed to send
         self.send_arg_reg: Value | None = None
 
+        # Holds the PyObject ** pointer through which return value can be passed
+        # instead of raising StopIteration(ret_value) (only if not NULL). This
+        # is used for faster native-to-native calls.
         self.stop_iter_value_reg: Value | None = None
 
         # The switch block is used to decide which instruction to go using the value held in the

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -32,7 +32,12 @@ from mypyc.ir.ops import (
     Unreachable,
     Value,
 )
-from mypyc.ir.rtypes import RInstance, int32_rprimitive, object_rprimitive, object_pointer_rprimitive
+from mypyc.ir.rtypes import (
+    RInstance,
+    int32_rprimitive,
+    object_pointer_rprimitive,
+    object_rprimitive,
+)
 from mypyc.irbuild.builder import IRBuilder, calculate_arg_defaults, gen_arg_defaults
 from mypyc.irbuild.context import FuncInfo, GeneratorClass
 from mypyc.irbuild.env_class import (
@@ -256,7 +261,14 @@ def add_next_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl: 
         result = builder.add(
             Call(
                 fn_decl,
-                [builder.self(), none_reg, none_reg, none_reg, none_reg, Integer(0, object_pointer_rprimitive)],
+                [
+                    builder.self(),
+                    none_reg,
+                    none_reg,
+                    none_reg,
+                    none_reg,
+                    Integer(0, object_pointer_rprimitive),
+                ],
                 fn_info.fitem.line,
             )
         )
@@ -272,7 +284,14 @@ def add_send_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl: 
         result = builder.add(
             Call(
                 fn_decl,
-                [builder.self(), none_reg, none_reg, none_reg, builder.read(arg), Integer(0, object_pointer_rprimitive)],
+                [
+                    builder.self(),
+                    none_reg,
+                    none_reg,
+                    none_reg,
+                    builder.read(arg),
+                    Integer(0, object_pointer_rprimitive),
+                ],
                 fn_info.fitem.line,
             )
         )
@@ -297,7 +316,14 @@ def add_throw_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl:
         result = builder.add(
             Call(
                 fn_decl,
-                [builder.self(), builder.read(typ), builder.read(val), builder.read(tb), none_reg, Integer(0, object_pointer_rprimitive)],
+                [
+                    builder.self(),
+                    builder.read(typ),
+                    builder.read(val),
+                    builder.read(tb),
+                    none_reg,
+                    Integer(0, object_pointer_rprimitive),
+                ],
                 fn_info.fitem.line,
             )
         )
@@ -379,7 +405,9 @@ def setup_env_for_generator_class(builder: IRBuilder) -> None:
 
     # Parameter that can used to pass a pointer which can used instead of
     # raising StopIteration(value). If the value is NULL, this won't be used.
-    stop_iter_value_arg = builder.add_local(Var("stop_iter_ptr"), object_pointer_rprimitive, is_arg=True)
+    stop_iter_value_arg = builder.add_local(
+        Var("stop_iter_ptr"), object_pointer_rprimitive, is_arg=True
+    )
 
     cls.exc_regs = (exc_type, exc_val, exc_tb)
     cls.send_arg_reg = exc_arg

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -32,7 +32,7 @@ from mypyc.ir.ops import (
     Unreachable,
     Value,
 )
-from mypyc.ir.rtypes import RInstance, int32_rprimitive, object_rprimitive
+from mypyc.ir.rtypes import RInstance, int32_rprimitive, object_rprimitive, object_pointer_rprimitive
 from mypyc.irbuild.builder import IRBuilder, calculate_arg_defaults, gen_arg_defaults
 from mypyc.irbuild.context import FuncInfo, GeneratorClass
 from mypyc.irbuild.env_class import (
@@ -256,7 +256,7 @@ def add_next_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl: 
         result = builder.add(
             Call(
                 fn_decl,
-                [builder.self(), none_reg, none_reg, none_reg, none_reg],
+                [builder.self(), none_reg, none_reg, none_reg, none_reg, Integer(0, object_pointer_rprimitive)],
                 fn_info.fitem.line,
             )
         )
@@ -272,7 +272,7 @@ def add_send_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl: 
         result = builder.add(
             Call(
                 fn_decl,
-                [builder.self(), none_reg, none_reg, none_reg, builder.read(arg)],
+                [builder.self(), none_reg, none_reg, none_reg, builder.read(arg), Integer(0, object_pointer_rprimitive)],
                 fn_info.fitem.line,
             )
         )
@@ -297,7 +297,7 @@ def add_throw_to_generator_class(builder: IRBuilder, fn_info: FuncInfo, fn_decl:
         result = builder.add(
             Call(
                 fn_decl,
-                [builder.self(), builder.read(typ), builder.read(val), builder.read(tb), none_reg],
+                [builder.self(), builder.read(typ), builder.read(val), builder.read(tb), none_reg, Integer(0, object_pointer_rprimitive)],
                 fn_info.fitem.line,
             )
         )
@@ -376,6 +376,8 @@ def setup_env_for_generator_class(builder: IRBuilder) -> None:
     exc_tb = builder.add_local(Var("traceback"), object_rprimitive, is_arg=True)
     # TODO: Use the right type here instead of object?
     exc_arg = builder.add_local(Var("arg"), object_rprimitive, is_arg=True)
+    stop_iter_value_arg = builder.add_local(Var("stop_iter_value"), object_pointer_rprimitive, is_arg=True)
+    # TODO: do something with stop_iter_value_arg
 
     cls.exc_regs = (exc_type, exc_val, exc_tb)
     cls.send_arg_reg = exc_arg

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -376,8 +376,10 @@ def setup_env_for_generator_class(builder: IRBuilder) -> None:
     exc_tb = builder.add_local(Var("traceback"), object_rprimitive, is_arg=True)
     # TODO: Use the right type here instead of object?
     exc_arg = builder.add_local(Var("arg"), object_rprimitive, is_arg=True)
+
+    # Parameter that can used to pass a pointer which can used instead of
+    # raising StopIteration(value). If the value is NULL, this won't be used.
     stop_iter_value_arg = builder.add_local(Var("stop_iter_ptr"), object_pointer_rprimitive, is_arg=True)
-    # TODO: do something with stop_iter_value_arg
 
     cls.exc_regs = (exc_type, exc_val, exc_tb)
     cls.send_arg_reg = exc_arg

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -376,11 +376,12 @@ def setup_env_for_generator_class(builder: IRBuilder) -> None:
     exc_tb = builder.add_local(Var("traceback"), object_rprimitive, is_arg=True)
     # TODO: Use the right type here instead of object?
     exc_arg = builder.add_local(Var("arg"), object_rprimitive, is_arg=True)
-    stop_iter_value_arg = builder.add_local(Var("stop_iter_value"), object_pointer_rprimitive, is_arg=True)
+    stop_iter_value_arg = builder.add_local(Var("stop_iter_ptr"), object_pointer_rprimitive, is_arg=True)
     # TODO: do something with stop_iter_value_arg
 
     cls.exc_regs = (exc_type, exc_val, exc_tb)
     cls.send_arg_reg = exc_arg
+    cls.stop_iter_value_reg = stop_iter_value_arg
 
     cls.self_reg = builder.read(self_target, fitem.line)
     if builder.fn_info.can_merge_generator_and_env_classes():

--- a/mypyc/irbuild/nonlocalcontrol.py
+++ b/mypyc/irbuild/nonlocalcontrol.py
@@ -14,7 +14,6 @@ from mypyc.ir.ops import (
     Branch,
     Goto,
     Integer,
-    LoadErrorValue,
     Register,
     Return,
     SetMem,
@@ -130,6 +129,7 @@ class GeneratorNonlocalControl(BaseNonlocalControl):
         # native function.
         builder.add(SetMem(object_rprimitive, stop_iter_reg, value))
         builder.add(Return(Integer(0, object_rprimitive)))
+
 
 class CleanupNonlocalControl(NonlocalControl):
     """Abstract nonlocal control that runs some cleanup code."""

--- a/mypyc/irbuild/nonlocalcontrol.py
+++ b/mypyc/irbuild/nonlocalcontrol.py
@@ -113,6 +113,7 @@ class GeneratorNonlocalControl(BaseNonlocalControl):
 
         true, false = BasicBlock(), BasicBlock()
         stop_iter_reg = builder.fn_info.generator_class.stop_iter_value_reg
+        assert stop_iter_reg is not None
 
         builder.add(Branch(stop_iter_reg, true, false, Branch.IS_ERROR))
 
@@ -124,9 +125,9 @@ class GeneratorNonlocalControl(BaseNonlocalControl):
         builder.builder.pop_error_handler()
 
         builder.activate_block(false)
-        # Store return value via caller-provided pointer instead of raising
-        # an exception. This fast path can only be used when the caller is a
-        # native function.
+        # The fast path is to store return value via caller-provided pointer
+        # instead of raising an exception. This can only be used when the
+        # caller is a native function.
         builder.add(SetMem(object_rprimitive, stop_iter_reg, value))
         builder.add(Return(Integer(0, object_rprimitive)))
 

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -221,6 +221,7 @@ def create_generator_class_if_needed(
                 RuntimeArg("value", object_rprimitive),
                 RuntimeArg("traceback", object_rprimitive),
                 RuntimeArg("arg", object_rprimitive),
+                # If not NULL, store value via this instead of raising StopIteration
                 RuntimeArg("stop_iter_ptr", object_pointer_rprimitive),
             ),
             object_rprimitive,

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -69,6 +69,7 @@ from mypyc.irbuild.util import (
 )
 from mypyc.options import CompilerOptions
 from mypyc.sametype import is_same_type
+from mypyc.ir.rtypes import object_rprimitive, object_pointer_rprimitive
 
 
 def build_type_map(
@@ -220,6 +221,7 @@ def create_generator_class_if_needed(
                 RuntimeArg("value", object_rprimitive),
                 RuntimeArg("traceback", object_rprimitive),
                 RuntimeArg("arg", object_rprimitive),
+                RuntimeArg("stop_iter_ptr", object_pointer_rprimitive),
             ),
             object_rprimitive,
         )

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -56,6 +56,7 @@ from mypyc.ir.rtypes import (
     RType,
     dict_rprimitive,
     none_rprimitive,
+    object_pointer_rprimitive,
     object_rprimitive,
     tuple_rprimitive,
 )
@@ -69,7 +70,6 @@ from mypyc.irbuild.util import (
 )
 from mypyc.options import CompilerOptions
 from mypyc.sametype import is_same_type
-from mypyc.ir.rtypes import object_rprimitive, object_pointer_rprimitive
 
 
 def build_type_map(

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -221,7 +221,7 @@ def create_generator_class_if_needed(
                 RuntimeArg("value", object_rprimitive),
                 RuntimeArg("traceback", object_rprimitive),
                 RuntimeArg("arg", object_rprimitive),
-                # If not NULL, store value via this instead of raising StopIteration
+                # If non-NULL, used to store return value instead of raising StopIteration(retv)
                 RuntimeArg("stop_iter_ptr", object_pointer_rprimitive),
             ),
             object_rprimitive,

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -960,7 +960,7 @@ def emit_yield_from_or_await(
         # Second fast path optimization: call helper directly (see also comment above).
         obj = builder.read(iter_reg)
         nn = builder.none_object()
-        m = MethodCall(obj, helper_method, [nn, nn, nn, nn], line)
+        m = MethodCall(obj, helper_method, [nn, nn, nn, nn, Integer(0, object_pointer_rprimitive)], line)
         # Generators have custom error handling, so disable normal error handling.
         m.error_kind = ERR_NEVER
         _y_init = builder.add(m)

--- a/mypyc/lower/misc_ops.py
+++ b/mypyc/lower/misc_ops.py
@@ -14,4 +14,5 @@ def var_object_size(builder: LowLevelIRBuilder, args: list[Value], line: int) ->
 
 @lower_primitive_op("propagate_if_error")
 def propagate_if_error_op(builder: LowLevelIRBuilder, args: list[Value], line: int) -> Value:
+    # Return False on NULL. The primitive uses ERR_FALSE, so this is an error.
     return builder.add(ComparisonOp(args[0], Integer(0, object_rprimitive), ComparisonOp.NEQ))

--- a/mypyc/lower/misc_ops.py
+++ b/mypyc/lower/misc_ops.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from mypyc.ir.ops import GetElementPtr, LoadMem, Value
-from mypyc.ir.rtypes import PyVarObject, c_pyssize_t_rprimitive
+from mypyc.ir.ops import ComparisonOp, GetElementPtr, Integer, LoadMem, Value
+from mypyc.ir.rtypes import PyVarObject, c_pyssize_t_rprimitive, object_rprimitive
 from mypyc.irbuild.ll_builder import LowLevelIRBuilder
 from mypyc.lower.registry import lower_primitive_op
 
@@ -10,3 +10,8 @@ from mypyc.lower.registry import lower_primitive_op
 def var_object_size(builder: LowLevelIRBuilder, args: list[Value], line: int) -> Value:
     elem_address = builder.add(GetElementPtr(args[0], PyVarObject, "ob_size"))
     return builder.add(LoadMem(c_pyssize_t_rprimitive, elem_address))
+
+
+@lower_primitive_op("propagate_if_error")
+def propagate_if_error_op(builder: LowLevelIRBuilder, args: list[Value], line: int) -> Value:
+    return builder.add(ComparisonOp(args[0], Integer(0, object_rprimitive), ComparisonOp.NEQ))

--- a/mypyc/primitives/exc_ops.py
+++ b/mypyc/primitives/exc_ops.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from mypyc.ir.ops import ERR_ALWAYS, ERR_FALSE, ERR_NEVER
 from mypyc.ir.rtypes import bit_rprimitive, exc_rtuple, object_rprimitive, void_rtype
-from mypyc.primitives.registry import custom_op
+from mypyc.primitives.registry import custom_op, custom_primitive_op
 
 # If the argument is a class, raise an instance of the class. Otherwise, assume
 # that the argument is an exception object, and raise it.
@@ -59,6 +59,16 @@ keep_propagating_op = custom_op(
     arg_types=[],
     return_type=bit_rprimitive,
     c_function_name="CPy_KeepPropagating",
+    error_kind=ERR_FALSE,
+)
+
+# If argument is NULL, propagate currently raised exception (in this case
+# an exception must have been raised). If this can be used, it's faster
+# than using PyErr_Occurred().
+propagate_if_error_op = custom_primitive_op(
+    "propagate_if_error",
+    arg_types=[object_rprimitive],
+    return_type=bit_rprimitive,
     error_kind=ERR_FALSE,
 )
 


### PR DESCRIPTION
When calling a native async function using `await`, e.g. `await foo()`, avoid raising `StopIteration` to pass the return value, since this is expensive. Instead, pass an extra `PyObject **` argument to the generator helper method and use that to return the return value. This is mostly helpful when there are many calls using await that don't block (e.g. there is a fast path that is usually taken that doesn't block). When awaiting from non-compiled code, the slow path is still taken.

This builds on top of #19376.

This PR makes this microbenchmark about 3x faster, which is about the ideal scenario for this optimization:
```
import asyncio
from time import time

async def inc(x: int) -> int:
    return x + 1


async def bench(n: int) -> int:
    x = 0
    for i in range(n):
        x = await inc(x)
    return x

asyncio.run(bench(1000))

t0 = time()
asyncio.run(bench(1000 * 1000 * 200))
print(time() - t0)
```
