### PR TITLE
[mypyc] Report error on reserved method name

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -64,6 +64,7 @@ from mypyc.irbuild.function import (
     handle_non_ext_method,
     load_type,
 )
+from mypyc.irbuild.prepare import GENERATOR_HELPER_NAME
 from mypyc.irbuild.util import dataclass_type, get_func_def, is_constant, is_dataclass_decorator
 from mypyc.primitives.dict_ops import dict_new_op, dict_set_item_op
 from mypyc.primitives.generic_ops import (
@@ -135,6 +136,14 @@ def transform_class_def(builder: IRBuilder, cdef: ClassDef) -> None:
         cls_builder = NonExtClassBuilder(builder, cdef)
 
     for stmt in cdef.defs.body:
+        if (
+            isinstance(stmt, (FuncDef, Decorator, OverloadedFuncDef))
+            and stmt.name == GENERATOR_HELPER_NAME
+        ):
+            builder.error(
+                f'Method name "{stmt.name}" is reserved for mypyc internal use', stmt.line
+            )
+
         if isinstance(stmt, OverloadedFuncDef) and stmt.is_property:
             if isinstance(cls_builder, NonExtClassBuilder):
                 # properties with both getters and setters in non_extension

--- a/mypyc/irbuild/generator.py
+++ b/mypyc/irbuild/generator.py
@@ -45,6 +45,7 @@ from mypyc.irbuild.env_class import (
     setup_func_for_recursive_call,
 )
 from mypyc.irbuild.nonlocalcontrol import ExceptNonlocalControl
+from mypyc.irbuild.prepare import GENERATOR_HELPER_NAME
 from mypyc.primitives.exc_ops import (
     error_catch_op,
     exc_matches_op,
@@ -231,11 +232,11 @@ def add_helper_to_generator_class(
     builder: IRBuilder, arg_regs: list[Register], blocks: list[BasicBlock], fn_info: FuncInfo
 ) -> FuncDecl:
     """Generates a helper method for a generator class, called by '__next__' and 'throw'."""
-    helper_fn_decl = fn_info.generator_class.ir.method_decls["__mypyc_generator_helper__"]
+    helper_fn_decl = fn_info.generator_class.ir.method_decls[GENERATOR_HELPER_NAME]
     helper_fn_ir = FuncIR(
         helper_fn_decl, arg_regs, blocks, fn_info.fitem.line, traceback_name=fn_info.fitem.name
     )
-    fn_info.generator_class.ir.methods["__mypyc_generator_helper__"] = helper_fn_ir
+    fn_info.generator_class.ir.methods[GENERATOR_HELPER_NAME] = helper_fn_ir
     builder.functions.append(helper_fn_ir)
     fn_info.env_class.env_user_function = helper_fn_ir
 

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -70,6 +70,8 @@ from mypyc.irbuild.util import (
 from mypyc.options import CompilerOptions
 from mypyc.sametype import is_same_type
 
+GENERATOR_HELPER_NAME = "__mypyc_generator_helper__"
+
 
 def build_type_map(
     mapper: Mapper,
@@ -226,7 +228,7 @@ def create_generator_class_if_needed(
 
         # The implementation of most generator functionality is behind this magic method.
         helper_fn_decl = FuncDecl(
-            "__mypyc_generator_helper__", name, module_name, helper_sig, internal=True
+            GENERATOR_HELPER_NAME, name, module_name, helper_sig, internal=True
         )
         cir.method_decls[helper_fn_decl.name] = helper_fn_decl
 

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -90,6 +90,7 @@ from mypyc.irbuild.nonlocalcontrol import (
     FinallyNonlocalControl,
     TryFinallyNonlocalControl,
 )
+from mypyc.irbuild.prepare import GENERATOR_HELPER_NAME
 from mypyc.irbuild.targets import (
     AssignmentTarget,
     AssignmentTargetAttr,
@@ -932,7 +933,7 @@ def emit_yield_from_or_await(
     to_yield_reg = Register(object_rprimitive)
     received_reg = Register(object_rprimitive)
 
-    helper_method = "__mypyc_generator_helper__"
+    helper_method = GENERATOR_HELPER_NAME
     if (
         isinstance(val, (Call, MethodCall))
         and isinstance(val.type, RInstance)

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1383,3 +1383,28 @@ class M(type):  # E: Inheriting from most builtin types is unimplemented \
 @mypyc_attr(native_class=True)
 class A(metaclass=M):  # E: Class is marked as native_class=True but it can't be a native class. Classes with a metaclass other than ABCMeta, TypingMeta or GenericMeta can't be native classes.
     pass
+
+[case testReservedName]
+from typing import Any, overload
+
+def decorator(cls):
+    return cls
+
+class TestMethod:
+    def __mypyc_generator_helper__(self) -> None:  # E: Method name "__mypyc_generator_helper__" is reserved for mypyc internal use
+        pass
+
+class TestDecorator:
+    @decorator  # E: Method name "__mypyc_generator_helper__" is reserved for mypyc internal use
+    def __mypyc_generator_helper__(self) -> None:
+        pass
+
+class TestOverload:
+    @overload # E: Method name "__mypyc_generator_helper__" is reserved for mypyc internal use
+    def __mypyc_generator_helper__(self, x: int) -> int: ...
+
+    @overload
+    def __mypyc_generator_helper__(self, x: str) -> str: ...
+
+    def __mypyc_generator_helper__(self, x: Any) -> Any:
+        return x


### PR DESCRIPTION
Changed mypyc to report an error if a method of a compiled class is called `__mypyc_generator_helper__`. The name should be reserved because it might clash with an auto-generated method.