### PR TITLE
Move `is_defined_in_stub` to shared checker API to break import cycle

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7889,6 +7889,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
     def get_expression_type(self, node: Expression, type_context: Type | None = None) -> Type:
         return self.expr_checker.accept(node, type_context=type_context)
 
+    def is_defined_in_stub(self, typ: Instance, /) -> bool:
+        return self.modules[typ.type.module_name].is_stub
+
     def check_deprecated(self, node: Node | None, context: Context) -> None:
         """Warn if deprecated and not directly imported with a `from` statement."""
         if isinstance(node, Decorator):

--- a/mypy/checker_shared.py
+++ b/mypy/checker_shared.py
@@ -277,6 +277,10 @@ class TypeCheckerSharedApi(CheckerPluginInterface):
     def get_precise_awaitable_type(self, typ: Type, local_errors: ErrorWatcher) -> Type | None:
         raise NotImplementedError
 
+    @abstractmethod
+    def is_defined_in_stub(self, typ: Instance, /) -> bool:
+        raise NotImplementedError
+
 
 class CheckerScope:
     # We keep two stacks combined, to maintain the relative order

--- a/mypy/plugins/enums.py
+++ b/mypy/plugins/enums.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable, Sequence
 from typing import TypeVar, cast
 
 import mypy.plugin  # To avoid circular imports.
-from mypy.checker import TypeChecker
+from mypy.checker_shared import TypeCheckerSharedApi
 from mypy.nodes import TypeInfo, Var
 from mypy.subtypes import is_equivalent
 from mypy.typeops import fixup_partial_type, make_simplified_union
@@ -122,8 +122,8 @@ def _infer_value_type_with_auto_fallback(
 
 
 def _is_defined_in_stub(ctx: mypy.plugin.AttributeContext) -> bool:
-    assert isinstance(ctx.api, TypeChecker)
-    return isinstance(ctx.type, Instance) and ctx.api.modules[ctx.type.type.module_name].is_stub
+    assert isinstance(ctx.api, TypeCheckerSharedApi)
+    return isinstance(ctx.type, Instance) and ctx.api.is_defined_in_stub(ctx.type)
 
 
 def _implements_new(info: TypeInfo) -> bool:


### PR DESCRIPTION
Follow-up after #19352 as requested by @JukkaL