### PR TITLE
[mypyc] Add back test for next with list iterator

### DIFF
--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -486,6 +486,17 @@ def test_from_gen() -> None:
     f = list("str:" + x for x in source_str)
     assert f == ["str:a", "str:b", "str:c", "str:d"]
 
+[case testNext]
+from typing import List
+
+def get_next(x: List[int]) -> int | None:
+    return next((i for i in x), None)
+
+def test_next() -> None:
+    assert get_next([]) is None
+    assert get_next([1]) == 1
+    assert get_next([3,2,1]) == 3
+
 [case testListGetItemWithBorrow]
 from typing import List
 

--- a/mypyc/test-data/run-lists.test
+++ b/mypyc/test-data/run-lists.test
@@ -489,11 +489,11 @@ def test_from_gen() -> None:
 [case testNext]
 from typing import List
 
-def get_next(x: List[int]) -> int | None:
-    return next((i for i in x), None)
+def get_next(x: List[int]) -> int:
+    return next((i for i in x), -1)
 
 def test_next() -> None:
-    assert get_next([]) is None
+    assert get_next([]) == -1
     assert get_next([1]) == 1
     assert get_next([3,2,1]) == 3
 


### PR DESCRIPTION
Adding back a test for `next` with a list iterator as argument. Previously this test only checked if compilation succeeded so I have removed it in #19416, now it calls the test function and checks the result.
