### PR TITLE
[mypyc] Fail run test if default driver does not find test cases

### DIFF
--- a/mypyc/test-data/driver/driver.py
+++ b/mypyc/test-data/driver/driver.py
@@ -11,10 +11,12 @@ import sys
 import native
 
 failures = []
+tests_run = 0
 
 for name in dir(native):
     if name.startswith('test_'):
         test_func = getattr(native, name)
+        tests_run += 1
         try:
             test_func()
         except Exception as e:
@@ -46,3 +48,5 @@ if failures:
     print(f'<< {failures[-1][0]} >>')
     sys.stdout.flush()
     raise failures[-1][1][1]
+
+assert tests_run > 0, 'Default test driver did not find any functions prefixed "test_" to run.'

--- a/mypyc/test-data/fixtures/ir.py
+++ b/mypyc/test-data/fixtures/ir.py
@@ -350,7 +350,12 @@ class GeneratorExit(BaseException): pass
 
 def any(i: Iterable[_T]) -> bool: pass
 def all(i: Iterable[_T]) -> bool: pass
-def sum(i: Iterable[_T]) -> int: pass
+@overload
+def sum(i: Iterable[bool]) -> int: pass
+@overload
+def sum(i: Iterable[_T]) -> _T: pass
+@overload
+def sum(i: Iterable[_T], start: _T) -> _T: pass
 def reversed(object: Sequence[_T]) -> Iterator[_T]: ...
 def id(o: object) -> int: pass
 # This type is obviously wrong but the test stubs don't have Sized anymore

--- a/mypyc/test-data/run-bools.test
+++ b/mypyc/test-data/run-bools.test
@@ -223,7 +223,8 @@ def test_mixed_comparisons_i64() -> None:
             assert gt_mixed_i64(n, x) == (n > int(x))
 
 [case testBoolMixInt]
-y = False
-print((y or 0) and True)
+def test_mix() -> None:
+    y = False
+    print((y or 0) and True)
 [out]
 0

--- a/mypyc/test-data/run-bytes.test
+++ b/mypyc/test-data/run-bytes.test
@@ -277,7 +277,6 @@ class bytes_subclass(bytes):
         return b'spook'
 
 [case testBytesFormatting]
-[typing fixtures/typing-full.pyi]
 from testutil import assertRaises
 
 # https://www.python.org/dev/peps/pep-0461/
@@ -314,6 +313,7 @@ def test_bytes_formatting_2() -> None:
     aa = b'\xe4\xbd\xa0\xe5\xa5\xbd%b' % b'\xe4\xbd\xa0\xe5\xa5\xbd'
     assert aa == b'\xe4\xbd\xa0\xe5\xa5\xbd\xe4\xbd\xa0\xe5\xa5\xbd'
     assert aa.decode() == '你好你好'
+[typing fixtures/typing-full.pyi]
 
 
 class A:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -1278,9 +1278,10 @@ class Bar(Foo):
     def f(self, *args: int, **kwargs: int) -> None:
         print("stuff", args, kwargs)
 
-z: Foo = Bar()
-z.f(1, z=50)
-z.f()
+def test_override() -> None:
+    z: Foo = Bar()
+    z.f(1, z=50)
+    z.f()
 
 [out]
 stuff (1,) {'z': 50}
@@ -1300,18 +1301,19 @@ class Foo:
 def baz_f(self: Any, *args: int, **kwargs: int) -> None:
     print("Baz", args, kwargs)
 
-# Make an "interpreted" subtype of Foo
-type2: Any = type
-Bar = type2('Bar', (Foo,), {})
-Baz = type2('Baz', (Foo,), {'f': baz_f})
+def test_override() -> None:
+    # Make an "interpreted" subtype of Foo
+    type2: Any = type
+    Bar = type2('Bar', (Foo,), {})
+    Baz = type2('Baz', (Foo,), {'f': baz_f})
 
-y: Foo = Bar()
-y.f(1, z=2)
-y.f()
+    y: Foo = Bar()
+    y.f(1, z=2)
+    y.f()
 
-z: Foo = Baz()
-z.f(1, z=2)
-z.f()
+    z: Foo = Baz()
+    z.f(1, z=2)
+    z.f()
 
 [out]
 Foo 1 2
@@ -1330,9 +1332,10 @@ class Bar(Foo):
     def f(self, x: Optional[int]=None) -> None:
         print(x)
 
-z: Foo = Bar()
-z.f(1)
-z.f()
+def test_override() -> None:
+    z: Foo = Bar()
+    z.f(1)
+    z.f()
 
 [out]
 1
@@ -1349,10 +1352,11 @@ class Bar(Foo):
     def f(self, *args: int, **kwargs: int) -> None:
         print("Bar", args, kwargs)
 
-z: Foo = Bar()
-z.f(1, z=2)
-z.f(1, 2, 3)
-# z.f(x=5)  # Not tested because we (knowingly) do the wrong thing and pass it as positional
+def test_override() -> None:
+    z: Foo = Bar()
+    z.f(1, z=2)
+    z.f(1, 2, 3)
+    # z.f(x=5)  # Not tested because we (knowingly) do the wrong thing and pass it as positional
 
 [out]
 Bar (1,) {'z': 2}
@@ -1370,10 +1374,11 @@ class Bar(Foo):
     def f(self, x: int = 10, *args: int, **kwargs: int) -> None:
         print("Bar", x, args, kwargs)
 
-z: Foo = Bar()
-z.f(1, z=2)
-z.f(1, 2, 3)
-z.f()
+def test_override() -> None:
+    z: Foo = Bar()
+    z.f(1, z=2)
+    z.f(1, 2, 3)
+    z.f()
 
 [out]
 Bar 1 () {'z': 2}
@@ -1397,18 +1402,19 @@ class Foo:
 def baz_f(self, a: int=30, y: int=50) -> None:
     print("Baz", a, y)
 
-# Make an "interpreted" subtype of Foo
-type2: Any = type
-Baz = type2('Baz', (Foo,), {'f': baz_f})
+def test_override() -> None:
+    # Make an "interpreted" subtype of Foo
+    type2: Any = type
+    Baz = type2('Baz', (Foo,), {'f': baz_f})
 
-z: Foo = Baz()
-z.f()
-z.f(y=1)
-z.f(1, 2)
-# Not tested because we don't (and probably won't) match cpython here
-# from testutil import assertRaises
-# with assertRaises(TypeError):
-#     z.f(x=7)
+    z: Foo = Baz()
+    z.f()
+    z.f(y=1)
+    z.f(1, 2)
+    # Not tested because we don't (and probably won't) match cpython here
+    # from testutil import assertRaises
+    # with assertRaises(TypeError):
+    #     z.f(x=7)
 
 [out]
 Baz 30 50
@@ -2591,7 +2597,8 @@ class Base:
 class Derived(Base):
     pass
 
-assert Derived()() == 1
+def test_inherited() -> None:
+    assert Derived()() == 1
 
 [case testClassWithFinalAttribute]
 from typing import Final

--- a/mypyc/test-data/run-dunders-special.test
+++ b/mypyc/test-data/run-dunders-special.test
@@ -6,4 +6,5 @@ class UsesNotImplemented:
     def __eq__(self, b: object) -> bool:
         return NotImplemented
 
-assert UsesNotImplemented() != object()
+def test_not_implemented() -> None:
+    assert UsesNotImplemented() != object()

--- a/mypyc/test-data/run-functions.test
+++ b/mypyc/test-data/run-functions.test
@@ -1235,12 +1235,10 @@ from contextlib import contextmanager
 def f() -> Iterator[None]:
     yield
 
-def g() -> None:
+def test_special_case() -> None:
     a = ['']
     with f():
         a.pop()
-
-g()
 
 [case testUnpackKwargsCompiled]
 from typing import TypedDict
@@ -1253,8 +1251,9 @@ class Person(TypedDict):
 def foo(**kwargs: Unpack[Person]) -> None:
     print(kwargs["name"])
 
-# This is not really supported yet, just test that we behave reasonably.
-foo(name='Jennifer', age=38)
+def test_unpack() -> None:
+    # This is not really supported yet, just test that we behave reasonably.
+    foo(name='Jennifer', age=38)
 [typing fixtures/typing-full.pyi]
 [out]
 Jennifer
@@ -1269,8 +1268,9 @@ def foo() -> None:
     print(inner.__dict__)  # type: ignore[attr-defined]
     print(inner.x)  # type: ignore[attr-defined]
 
-if sys.version_info >= (3, 12):  # type: ignore
-    foo()
+def test_nested() -> None:
+    if sys.version_info >= (3, 12):  # type: ignore
+        foo()
 [out]
 [out version>=3.12]
 {}
@@ -1285,7 +1285,8 @@ def bar() -> None:
     functools.update_wrapper(inner, bar)  # type: ignore
     print(inner.__dict__)  # type: ignore
 
-bar()
+def test_update() -> None:
+    bar()
 [typing fixtures/typing-full.pyi]
 [out]
 {'__module__': 'native', '__name__': 'bar', '__qualname__': 'bar', '__doc__': None, '__wrapped__': <built-in function bar>}

--- a/mypyc/test-data/run-generators.test
+++ b/mypyc/test-data/run-generators.test
@@ -617,15 +617,21 @@ else:
 from typing import Iterator
 
 class Foo:
-    flag: bool
+    flag = False
 
 class C:
-    foo: Foo
+    foo = Foo()
 
     def genf(self) -> Iterator[None]:
         self.foo.flag = True
         yield
         self.foo.flag = False
+
+def test_near_yield() -> None:
+    c = C()
+    for x in c.genf():
+        pass
+    assert c.foo.flag == False
 
 [case testGeneratorEarlyReturnWithBorrows]
 from typing import Iterator
@@ -638,6 +644,12 @@ class Foo:
             self.bar.bar += 1
             return
         yield 0
+
+def test_early_return() -> None:
+    foo = Foo()
+    for x in foo.f():
+        pass
+    assert foo.bar.bar == 1
 
 [case testBorrowingInGeneratorInTupleAssignment]
 from typing import Iterator

--- a/mypyc/test-data/run-generics.test
+++ b/mypyc/test-data/run-generics.test
@@ -27,22 +27,23 @@ def fn_typeddict(t: T) -> None:
     print([x for x in t.keys()])
     print({k: v for k, v in t.items()})
 
-fn_mapping({})
-print("=====")
-fn_mapping({"a": 1, "b": 2})
-print("=====")
+def test_mapping() -> None:
+    fn_mapping({})
+    print("=====")
+    fn_mapping({"a": 1, "b": 2})
+    print("=====")
 
-fn_union({"a": 1, "b": 2})
-print("=====")
-fn_union({"a": "1", "b": "2"})
-print("=====")
+    fn_union({"a": 1, "b": 2})
+    print("=====")
+    fn_union({"a": "1", "b": "2"})
+    print("=====")
 
-orig: Union[Dict[str, int], Dict[str, str]] = {"a": 1, "b": 2}
-fn_union(orig)
-print("=====")
+    orig: Union[Dict[str, int], Dict[str, str]] = {"a": 1, "b": 2}
+    fn_union(orig)
+    print("=====")
 
-td: TD = {"foo": 1}
-fn_typeddict(td)
+    td: TD = {"foo": 1}
+    fn_typeddict(td)
 [typing fixtures/typing-full.pyi]
 [out]
 \[]
@@ -96,8 +97,9 @@ def deco(func: Callable[P, int]) -> Callable[P, int]:
 def f(x: int, y: str) -> int:
     return x
 
-assert f(1, 'a') == 1
-assert f(2, y='b') == 2
+def test_usable() -> None:
+    assert f(1, 'a') == 1
+    assert f(2, y='b') == 2
 [out]
 \[1, 'a']
 {}

--- a/mypyc/test-data/run-imports.test
+++ b/mypyc/test-data/run-imports.test
@@ -212,9 +212,10 @@ import shared
 def do_import() -> None:
     import a
 
-assert shared.counter == 0
-do_import()
-assert shared.counter == 1
+def test_lazy() -> None:
+    assert shared.counter == 0
+    do_import()
+    assert shared.counter == 1
 
 [file a.py]
 import shared
@@ -224,9 +225,10 @@ shared.counter += 1
 counter = 0
 
 [case testDelayedImport]
-import a
-print("inbetween")
-import b
+def test_delayed() -> None:
+    import a
+    print("inbetween")
+    import b
 
 [file a.py]
 print("first")
@@ -240,19 +242,21 @@ inbetween
 last
 
 [case testImportErrorLineNumber]
-try:
-    import enum
-    import dataclasses, missing  # type: ignore[import]
-except ImportError as e:
-    line = e.__traceback__.tb_lineno # type: ignore[attr-defined]
-    assert line == 3, f"traceback's line number is {line}, expected 3"
+def test_error() -> None:
+    try:
+        import enum
+        import dataclasses, missing  # type: ignore[import]
+    except ImportError as e:
+        line = e.__traceback__.tb_lineno # type: ignore[attr-defined]
+        assert line == 4, f"traceback's line number is {line}, expected 4"
 
 [case testImportGroupIsolation]
 def func() -> None:
     import second
 
-import first
-func()
+def test_isolation() -> None:
+    import first
+    func()
 
 [file first.py]
 print("first")

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -109,10 +109,11 @@ def gen(b: bool) -> Generator[Any, None, None]:
         y = None
     yield y
 
-assert f(False) == ((1, None), (None, 1))
-assert f(True) == ((None, 1), (1, None))
-assert next(gen(False)) is None
-assert next(gen(True)) == 1
+def test_inferred() -> None:
+    assert f(False) == ((1, None), (None, 1))
+    assert f(True) == ((None, 1), (1, None))
+    assert next(gen(False)) is None
+    assert next(gen(True)) == 1
 
 [case testWith]
 from typing import Any
@@ -829,23 +830,23 @@ assert call_any_nested([[1, 1, 1], [1, 1], []]) == 1
 assert call_any_nested([[1, 1, 1], [0, 1], []]) == 0
 
 [case testSum]
-[typing fixtures/typing-full.pyi]
-from typing import Any, List
+from typing import List
 
+empty: List[int] = []
 def test_sum_of_numbers() -> None:
     assert sum(x for x in [1, 2, 3]) == 6
-    assert sum(x for x in [0.0, 1.2, 2]) == 6.2
+    assert sum(x for x in [0.0, 1.2, 2]) == 3.2
     assert sum(x for x in [1, 1j]) == 1 + 1j
 
 def test_sum_callables() -> None:
-    assert sum((lambda x: x == 0)(x) for x in []) == 0
+    assert sum((lambda x: x == 0)(x) for x in empty) == 0
     assert sum((lambda x: x == 0)(x) for x in [0]) == 1
     assert sum((lambda x: x == 0)(x) for x in [0, 0, 0]) == 3
     assert sum((lambda x: x == 0)(x) for x in [0, 1, 0]) == 2
     assert sum((lambda x: x % 2 == 0)(x) for x in range(2**10)) == 2**9
 
 def test_sum_comparisons() -> None:
-    assert sum(x == 0 for x in []) == 0
+    assert sum(x == 0 for x in empty) == 0
     assert sum(x == 0 for x in [0]) == 1
     assert sum(x == 0 for x in [0, 0, 0]) == 3
     assert sum(x == 0 for x in [0, 1, 0]) == 2
@@ -865,13 +866,14 @@ def test_sum_misc() -> None:
 def test_sum_start_given() -> None:
     a = 1
     assert sum((x == 0 for x in [0, 1]), a) == 2
-    assert sum(((lambda x: x == 0)(x) for x in []), 1) == 1
+    assert sum(((lambda x: x == 0)(x) for x in empty), 1) == 1
     assert sum(((lambda x: x == 0)(x) for x in [0]), 1) == 2
     assert sum(((lambda x: x == 0)(x) for x in [0, 0, 0]), 1) == 4
     assert sum(((lambda x: x == 0)(x) for x in [0, 1, 0]), 1) == 3
     assert sum(((lambda x: x % 2 == 0)(x) for x in range(2**10)), 1) == 2**9 + 1
     assert sum((x for x in [1, 1j]), 2j) == 1 + 3j
     assert sum((c == 'd' for c in 'abcdd'), 1) == 3
+[typing fixtures/typing-full.pyi]
 
 [case testNoneStuff]
 from typing import Optional
@@ -1090,19 +1092,20 @@ def test_complex() -> None:
 from typing import cast
 import sys
 
-A = sys.platform == 'x' and foobar
-B = sys.platform == 'x' and sys.foobar
-C = sys.platform == 'x' and f(a, -b, 'y') > [c + e, g(y=2)]
-C = sys.platform == 'x' and cast(a, b[c])
-C = sys.platform == 'x' and (lambda x: y + x)
-C = sys.platform == 'x' and (x for y in z)
-C = sys.platform == 'x' and [x for y in z]
-C = sys.platform == 'x' and {x: x for y in z}
-C = sys.platform == 'x' and {x for y in z}
+def test_unreachable() -> None:
+    A = sys.platform == 'x' and foobar
+    B = sys.platform == 'x' and sys.foobar
+    C = sys.platform == 'x' and f(a, -b, 'y') > [c + e, g(y=2)]
+    C = sys.platform == 'x' and cast(a, b[c])
+    C = sys.platform == 'x' and (lambda x: y + x)
+    C = sys.platform == 'x' and (x for y in z)
+    C = sys.platform == 'x' and [x for y in z]
+    C = sys.platform == 'x' and {x: x for y in z}
+    C = sys.platform == 'x' and {x for y in z}
 
-assert not A
-assert not B
-assert not C
+    assert not A
+    assert not B
+    assert not C
 
 [case testDoesntSegfaultWhenTopLevelFails]
 # make the initial import fail
@@ -1125,6 +1128,10 @@ class A:
 class B(A):
     def _(arg): pass
     def _(arg): pass
+
+def test_underscore() -> None:
+    A()
+    B()
 
 [case testGlobalRedefinition_toplevel]
 # mypy: allow-redefinition

--- a/mypyc/test-data/run-python38.test
+++ b/mypyc/test-data/run-python38.test
@@ -75,11 +75,12 @@ class Bar(Foo):
     def f(self, *args: int, **kwargs: int) -> None:
         print("stuff", args, kwargs)
 
-z: Foo = Bar()
-z.f(1, z=50)
-z.f()
-z.f(1)
-z.f(z=50)
+def test_pos_only() -> None:
+    z: Foo = Bar()
+    z.f(1, z=50)
+    z.f()
+    z.f(1)
+    z.f(z=50)
 
 [out]
 stuff (1,) {'z': 50}

--- a/mypyc/test-data/run-singledispatch.test
+++ b/mypyc/test-data/run-singledispatch.test
@@ -152,12 +152,14 @@ from functools import singledispatch
 def fun(arg) -> bool:
     return False
 
-try:
-    @fun.register
-    def fun_specialized(arg: None) -> bool:
-        return True
-except TypeError:
-    pass
+def test_argument() -> None:
+    try:
+        @fun.register
+        def fun_specialized(arg: None) -> bool:
+            return True
+        assert False, "expected to raise an exception"
+    except TypeError:
+        pass
 
 [case testRegisteringTheSameFunctionSeveralTimes]
 from functools import singledispatch
@@ -598,9 +600,11 @@ assert f(1) == 'default'
 def _(arg: B) -> str:
     return 'b'
 
-assert f(A()) == 'a'
-assert f(B()) == 'b'
-assert f(1) == 'default'
+# TODO: Move whole testcase to a function when mypyc#1118 is fixed.
+def test_final() -> None:
+    assert f(A()) == 'a'
+    assert f(B()) == 'b'
+    assert f(1) == 'default'
 
 
 [case testDynamicallyRegisteringFunctionFromInterpretedCode]

--- a/mypyc/test-data/run-strings.test
+++ b/mypyc/test-data/run-strings.test
@@ -363,7 +363,6 @@ def test_str_min_max() -> None:
     assert max(x, z) == 'aaa'
 
 [case testStringFormattingCStyle]
-[typing fixtures/typing-full.pyi]
 from typing import Tuple
 
 var = 'mypyc'
@@ -408,6 +407,7 @@ def test_basics() -> None:
     inf_num = float('inf')
     assert '%s, %s' % (nan_num, inf_num) == 'nan, inf'
     assert '%f, %f' % (nan_num, inf_num) == 'nan, inf'
+[typing fixtures/typing-full.pyi]
 
 [case testFStrings]
 import decimal


### PR DESCRIPTION
If a `run-` test doesn't define a custom `driver.py`, the default one looks for functions prefixed `test_` and calls them. If the prefix is missing or misspelled, or there is some other issue that causes the test to have no test cases, the test succeeds without running the cases.

To try to prevent this, the default driver will now fail if it doesn't find any test cases. Existing tests are changed to conform to this requirement in this PR.

For most tests that meant simply moving the statements from top level to a function, but some were revealed to have been broken and weren't actually run, for example because `[typing fixtures/typing-full.pyi]` was at the top of the test instead of at the bottom, which made the test setup code ignore all of the test case.