### PR TITLE
[mypyc] Use native integers for some sequence indexing operations

### DIFF
--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -652,7 +652,7 @@ PyObject *CPyList_GetItemShortBorrow(PyObject *list, CPyTagged index);
 PyObject *CPyList_GetItemInt64(PyObject *list, int64_t index);
 PyObject *CPyList_GetItemInt64Borrow(PyObject *list, int64_t index);
 bool CPyList_SetItem(PyObject *list, CPyTagged index, PyObject *value);
-bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value);
+void CPyList_SetItemUnsafe(PyObject *list, Py_ssize_t index, PyObject *value);
 bool CPyList_SetItemInt64(PyObject *list, int64_t index, PyObject *value);
 PyObject *CPyList_PopLast(PyObject *obj);
 PyObject *CPyList_Pop(PyObject *obj, CPyTagged index);
@@ -703,14 +703,13 @@ tuple_T4CIOO CPyDict_NextItem(PyObject *dict_or_iter, CPyTagged offset);
 int CPyMapping_Check(PyObject *obj);
 
 // Check that dictionary didn't change size during iteration.
-static inline char CPyDict_CheckSize(PyObject *dict, CPyTagged size) {
+static inline char CPyDict_CheckSize(PyObject *dict, Py_ssize_t size) {
     if (!PyDict_CheckExact(dict)) {
         // Dict subclasses will be checked by Python runtime.
         return 1;
     }
-    Py_ssize_t py_size = CPyTagged_AsSsize_t(size);
     Py_ssize_t dict_size = PyDict_Size(dict);
-    if (py_size != dict_size) {
+    if (size != dict_size) {
         PyErr_SetString(PyExc_RuntimeError, "dictionary changed size during iteration");
         return 0;
     }
@@ -783,7 +782,8 @@ bool CPySet_Remove(PyObject *set, PyObject *key);
 
 PyObject *CPySequenceTuple_GetItem(PyObject *tuple, CPyTagged index);
 PyObject *CPySequenceTuple_GetSlice(PyObject *obj, CPyTagged start, CPyTagged end);
-bool CPySequenceTuple_SetItemUnsafe(PyObject *tuple, CPyTagged index, PyObject *value);
+PyObject *CPySequenceTuple_GetItemUnsafe(PyObject *tuple, Py_ssize_t index);
+void CPySequenceTuple_SetItemUnsafe(PyObject *tuple, Py_ssize_t index, PyObject *value);
 
 
 // Exception operations

--- a/mypyc/lib-rt/list_ops.c
+++ b/mypyc/lib-rt/list_ops.c
@@ -231,15 +231,8 @@ bool CPyList_SetItemInt64(PyObject *list, int64_t index, PyObject *value) {
 }
 
 // This function should only be used to fill in brand new lists.
-bool CPyList_SetItemUnsafe(PyObject *list, CPyTagged index, PyObject *value) {
-    if (CPyTagged_CheckShort(index)) {
-        Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
-        PyList_SET_ITEM(list, n, value);
-        return true;
-    } else {
-        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
-        return false;
-    }
+void CPyList_SetItemUnsafe(PyObject *list, Py_ssize_t index, PyObject *value) {
+    PyList_SET_ITEM(list, index, value);
 }
 
 PyObject *CPyList_PopLast(PyObject *obj)

--- a/mypyc/lib-rt/tuple_ops.c
+++ b/mypyc/lib-rt/tuple_ops.c
@@ -46,16 +46,17 @@ PyObject *CPySequenceTuple_GetSlice(PyObject *obj, CPyTagged start, CPyTagged en
     return CPyObject_GetSlice(obj, start, end);
 }
 
+// No error checking
+PyObject *CPySequenceTuple_GetItemUnsafe(PyObject *tuple, Py_ssize_t index)
+{
+    PyObject *result = PyTuple_GET_ITEM(tuple, index);
+    Py_INCREF(result);
+    return result;
+}
+
 // PyTuple_SET_ITEM does no error checking,
 // and should only be used to fill in brand new tuples.
-bool CPySequenceTuple_SetItemUnsafe(PyObject *tuple, CPyTagged index, PyObject *value)
+void CPySequenceTuple_SetItemUnsafe(PyObject *tuple, Py_ssize_t index, PyObject *value)
 {
-    if (CPyTagged_CheckShort(index)) {
-        Py_ssize_t n = CPyTagged_ShortAsSsize_t(index);
-        PyTuple_SET_ITEM(tuple, n, value);
-        return true;
-    } else {
-        PyErr_SetString(PyExc_OverflowError, CPYTHON_LARGE_INT_ERRMSG);
-        return false;
-    }
+    PyTuple_SET_ITEM(tuple, index, value);
 }

--- a/mypyc/primitives/dict_ops.py
+++ b/mypyc/primitives/dict_ops.py
@@ -289,7 +289,7 @@ dict_next_item_op = custom_op(
 
 # check that len(dict) == const during iteration
 dict_check_size_op = custom_op(
-    arg_types=[dict_rprimitive, int_rprimitive],
+    arg_types=[dict_rprimitive, c_pyssize_t_rprimitive],
     return_type=bit_rprimitive,
     c_function_name="CPyDict_CheckSize",
     error_kind=ERR_FALSE,

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -13,6 +13,7 @@ from mypyc.ir.rtypes import (
     object_rprimitive,
     pointer_rprimitive,
     short_int_rprimitive,
+    void_rtype,
 )
 from mypyc.primitives.registry import (
     ERR_NEG_INT,
@@ -154,7 +155,7 @@ method_op(
 # that is in-bounds for the list.
 list_get_item_unsafe_op = custom_primitive_op(
     name="list_get_item_unsafe",
-    arg_types=[list_rprimitive, short_int_rprimitive],
+    arg_types=[list_rprimitive, c_pyssize_t_rprimitive],
     return_type=object_rprimitive,
     error_kind=ERR_NEVER,
 )
@@ -183,10 +184,10 @@ method_op(
 # PyList_SET_ITEM does no error checking,
 # and should only be used to fill in brand new lists.
 new_list_set_item_op = custom_op(
-    arg_types=[list_rprimitive, int_rprimitive, object_rprimitive],
-    return_type=bit_rprimitive,
+    arg_types=[list_rprimitive, c_pyssize_t_rprimitive, object_rprimitive],
+    return_type=void_rtype,
     c_function_name="CPyList_SetItemUnsafe",
-    error_kind=ERR_FALSE,
+    error_kind=ERR_NEVER,
     steals=[False, False, True],
 )
 

--- a/mypyc/primitives/tuple_ops.py
+++ b/mypyc/primitives/tuple_ops.py
@@ -6,14 +6,14 @@ objects, i.e. tuple_rprimitive (RPrimitive), not RTuple.
 
 from __future__ import annotations
 
-from mypyc.ir.ops import ERR_FALSE, ERR_MAGIC
+from mypyc.ir.ops import ERR_MAGIC, ERR_NEVER
 from mypyc.ir.rtypes import (
-    bit_rprimitive,
     c_pyssize_t_rprimitive,
     int_rprimitive,
     list_rprimitive,
     object_rprimitive,
     tuple_rprimitive,
+    void_rtype,
 )
 from mypyc.primitives.registry import binary_op, custom_op, function_op, load_address_op, method_op
 
@@ -27,6 +27,15 @@ tuple_get_item_op = method_op(
     return_type=object_rprimitive,
     c_function_name="CPySequenceTuple_GetItem",
     error_kind=ERR_MAGIC,
+)
+
+# This is unsafe because it assumes that the index is a non-negative integer
+# that is in-bounds for the tuple.
+tuple_get_item_unsafe_op = custom_op(
+    arg_types=[tuple_rprimitive, c_pyssize_t_rprimitive],
+    return_type=object_rprimitive,
+    c_function_name="CPySequenceTuple_GetItemUnsafe",
+    error_kind=ERR_NEVER,
 )
 
 # Construct a boxed tuple from items: (item1, item2, ...)
@@ -48,10 +57,10 @@ new_tuple_with_length_op = custom_op(
 # PyTuple_SET_ITEM does no error checking,
 # and should only be used to fill in brand new tuples.
 new_tuple_set_item_op = custom_op(
-    arg_types=[tuple_rprimitive, int_rprimitive, object_rprimitive],
-    return_type=bit_rprimitive,
+    arg_types=[tuple_rprimitive, c_pyssize_t_rprimitive, object_rprimitive],
+    return_type=void_rtype,
     c_function_name="CPySequenceTuple_SetItemUnsafe",
-    error_kind=ERR_FALSE,
+    error_kind=ERR_NEVER,
     steals=[False, False, True],
 )
 

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -1895,18 +1895,16 @@ def f():
     r0, r1 :: list
     r2, r3, r4 :: object
     r5 :: ptr
-    r6 :: short_int
-    r7 :: native_int
-    r8 :: short_int
-    r9 :: bit
-    r10 :: object
-    r11, x :: int
-    r12, r13 :: bit
-    r14 :: int
-    r15 :: object
-    r16 :: i32
-    r17 :: bit
-    r18 :: short_int
+    r6, r7 :: native_int
+    r8 :: bit
+    r9 :: object
+    r10, x :: int
+    r11, r12 :: bit
+    r13 :: int
+    r14 :: object
+    r15 :: i32
+    r16 :: bit
+    r17 :: native_int
 L0:
     r0 = PyList_New(0)
     r1 = PyList_New(3)
@@ -1921,30 +1919,29 @@ L0:
     r6 = 0
 L1:
     r7 = var_object_size r1
-    r8 = r7 << 1
-    r9 = int_lt r6, r8
-    if r9 goto L2 else goto L8 :: bool
+    r8 = r6 < r7 :: signed
+    if r8 goto L2 else goto L8 :: bool
 L2:
-    r10 = list_get_item_unsafe r1, r6
-    r11 = unbox(int, r10)
-    x = r11
-    r12 = int_ne x, 4
-    if r12 goto L4 else goto L3 :: bool
+    r9 = list_get_item_unsafe r1, r6
+    r10 = unbox(int, r9)
+    x = r10
+    r11 = int_ne x, 4
+    if r11 goto L4 else goto L3 :: bool
 L3:
     goto L7
 L4:
-    r13 = int_ne x, 6
-    if r13 goto L6 else goto L5 :: bool
+    r12 = int_ne x, 6
+    if r12 goto L6 else goto L5 :: bool
 L5:
     goto L7
 L6:
-    r14 = CPyTagged_Multiply(x, x)
-    r15 = box(int, r14)
-    r16 = PyList_Append(r0, r15)
-    r17 = r16 >= 0 :: signed
+    r13 = CPyTagged_Multiply(x, x)
+    r14 = box(int, r13)
+    r15 = PyList_Append(r0, r14)
+    r16 = r15 >= 0 :: signed
 L7:
-    r18 = r6 + 2
-    r6 = r18
+    r17 = r6 + 1
+    r6 = r17
     goto L1
 L8:
     return r0
@@ -1959,18 +1956,16 @@ def f():
     r1 :: list
     r2, r3, r4 :: object
     r5 :: ptr
-    r6 :: short_int
-    r7 :: native_int
-    r8 :: short_int
-    r9 :: bit
-    r10 :: object
-    r11, x :: int
-    r12, r13 :: bit
-    r14 :: int
-    r15, r16 :: object
-    r17 :: i32
-    r18 :: bit
-    r19 :: short_int
+    r6, r7 :: native_int
+    r8 :: bit
+    r9 :: object
+    r10, x :: int
+    r11, r12 :: bit
+    r13 :: int
+    r14, r15 :: object
+    r16 :: i32
+    r17 :: bit
+    r18 :: native_int
 L0:
     r0 = PyDict_New()
     r1 = PyList_New(3)
@@ -1985,31 +1980,30 @@ L0:
     r6 = 0
 L1:
     r7 = var_object_size r1
-    r8 = r7 << 1
-    r9 = int_lt r6, r8
-    if r9 goto L2 else goto L8 :: bool
+    r8 = r6 < r7 :: signed
+    if r8 goto L2 else goto L8 :: bool
 L2:
-    r10 = list_get_item_unsafe r1, r6
-    r11 = unbox(int, r10)
-    x = r11
-    r12 = int_ne x, 4
-    if r12 goto L4 else goto L3 :: bool
+    r9 = list_get_item_unsafe r1, r6
+    r10 = unbox(int, r9)
+    x = r10
+    r11 = int_ne x, 4
+    if r11 goto L4 else goto L3 :: bool
 L3:
     goto L7
 L4:
-    r13 = int_ne x, 6
-    if r13 goto L6 else goto L5 :: bool
+    r12 = int_ne x, 6
+    if r12 goto L6 else goto L5 :: bool
 L5:
     goto L7
 L6:
-    r14 = CPyTagged_Multiply(x, x)
-    r15 = box(int, x)
-    r16 = box(int, r14)
-    r17 = CPyDict_SetItem(r0, r15, r16)
-    r18 = r17 >= 0 :: signed
+    r13 = CPyTagged_Multiply(x, x)
+    r14 = box(int, x)
+    r15 = box(int, r13)
+    r16 = CPyDict_SetItem(r0, r14, r15)
+    r17 = r16 >= 0 :: signed
 L7:
-    r19 = r6 + 2
-    r6 = r19
+    r18 = r6 + 1
+    r6 = r18
     goto L1
 L8:
     return r0
@@ -2023,74 +2017,66 @@ def f(l: List[Tuple[int, int, int]]) -> List[int]:
 [out]
 def f(l):
     l :: list
-    r0 :: short_int
-    r1 :: native_int
-    r2 :: short_int
-    r3 :: bit
-    r4 :: object
-    r5 :: tuple[int, int, int]
-    r6, x, r7, y, r8, z :: int
-    r9 :: short_int
-    r10 :: native_int
-    r11 :: list
-    r12 :: short_int
-    r13 :: native_int
-    r14 :: short_int
-    r15 :: bit
-    r16 :: object
-    r17 :: tuple[int, int, int]
-    r18, x_2, r19, y_2, r20, z_2, r21, r22 :: int
-    r23 :: object
-    r24 :: bit
-    r25 :: short_int
+    r0, r1 :: native_int
+    r2 :: bit
+    r3 :: object
+    r4 :: tuple[int, int, int]
+    r5, x, r6, y, r7, z :: int
+    r8, r9 :: native_int
+    r10 :: list
+    r11, r12 :: native_int
+    r13 :: bit
+    r14 :: object
+    r15 :: tuple[int, int, int]
+    r16, x_2, r17, y_2, r18, z_2, r19, r20 :: int
+    r21 :: object
+    r22 :: native_int
 L0:
     r0 = 0
 L1:
     r1 = var_object_size l
-    r2 = r1 << 1
-    r3 = int_lt r0, r2
-    if r3 goto L2 else goto L4 :: bool
+    r2 = r0 < r1 :: signed
+    if r2 goto L2 else goto L4 :: bool
 L2:
-    r4 = list_get_item_unsafe l, r0
-    r5 = unbox(tuple[int, int, int], r4)
-    r6 = r5[0]
-    x = r6
-    r7 = r5[1]
-    y = r7
-    r8 = r5[2]
-    z = r8
+    r3 = list_get_item_unsafe l, r0
+    r4 = unbox(tuple[int, int, int], r3)
+    r5 = r4[0]
+    x = r5
+    r6 = r4[1]
+    y = r6
+    r7 = r4[2]
+    z = r7
 L3:
-    r9 = r0 + 2
-    r0 = r9
+    r8 = r0 + 1
+    r0 = r8
     goto L1
 L4:
-    r10 = var_object_size l
-    r11 = PyList_New(r10)
-    r12 = 0
+    r9 = var_object_size l
+    r10 = PyList_New(r9)
+    r11 = 0
 L5:
-    r13 = var_object_size l
-    r14 = r13 << 1
-    r15 = int_lt r12, r14
-    if r15 goto L6 else goto L8 :: bool
+    r12 = var_object_size l
+    r13 = r11 < r12 :: signed
+    if r13 goto L6 else goto L8 :: bool
 L6:
-    r16 = list_get_item_unsafe l, r12
-    r17 = unbox(tuple[int, int, int], r16)
-    r18 = r17[0]
-    x_2 = r18
-    r19 = r17[1]
-    y_2 = r19
-    r20 = r17[2]
-    z_2 = r20
-    r21 = CPyTagged_Add(x_2, y_2)
-    r22 = CPyTagged_Add(r21, z_2)
-    r23 = box(int, r22)
-    r24 = CPyList_SetItemUnsafe(r11, r12, r23)
+    r14 = list_get_item_unsafe l, r11
+    r15 = unbox(tuple[int, int, int], r14)
+    r16 = r15[0]
+    x_2 = r16
+    r17 = r15[1]
+    y_2 = r17
+    r18 = r15[2]
+    z_2 = r18
+    r19 = CPyTagged_Add(x_2, y_2)
+    r20 = CPyTagged_Add(r19, z_2)
+    r21 = box(int, r20)
+    CPyList_SetItemUnsafe(r10, r11, r21)
 L7:
-    r25 = r12 + 2
-    r12 = r25
+    r22 = r11 + 1
+    r11 = r22
     goto L5
 L8:
-    return r11
+    return r10
 
 [case testProperty]
 class PropertyHolder:

--- a/mypyc/test-data/irbuild-dict.test
+++ b/mypyc/test-data/irbuild-dict.test
@@ -152,41 +152,39 @@ def increment(d):
     d :: dict
     r0 :: short_int
     r1 :: native_int
-    r2 :: short_int
-    r3 :: object
-    r4 :: tuple[bool, short_int, object]
-    r5 :: short_int
-    r6 :: bool
-    r7 :: object
-    r8, k :: str
-    r9, r10, r11 :: object
-    r12 :: i32
-    r13, r14, r15 :: bit
+    r2 :: object
+    r3 :: tuple[bool, short_int, object]
+    r4 :: short_int
+    r5 :: bool
+    r6 :: object
+    r7, k :: str
+    r8, r9, r10 :: object
+    r11 :: i32
+    r12, r13, r14 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d)
-    r2 = r1 << 1
-    r3 = CPyDict_GetKeysIter(d)
+    r2 = CPyDict_GetKeysIter(d)
 L1:
-    r4 = CPyDict_NextKey(r3, r0)
-    r5 = r4[1]
-    r0 = r5
-    r6 = r4[0]
-    if r6 goto L2 else goto L4 :: bool
+    r3 = CPyDict_NextKey(r2, r0)
+    r4 = r3[1]
+    r0 = r4
+    r5 = r3[0]
+    if r5 goto L2 else goto L4 :: bool
 L2:
-    r7 = r4[2]
-    r8 = cast(str, r7)
-    k = r8
-    r9 = CPyDict_GetItem(d, k)
-    r10 = object 1
-    r11 = PyNumber_InPlaceAdd(r9, r10)
-    r12 = CPyDict_SetItem(d, k, r11)
-    r13 = r12 >= 0 :: signed
+    r6 = r3[2]
+    r7 = cast(str, r6)
+    k = r7
+    r8 = CPyDict_GetItem(d, k)
+    r9 = object 1
+    r10 = PyNumber_InPlaceAdd(r8, r9)
+    r11 = CPyDict_SetItem(d, k, r10)
+    r12 = r11 >= 0 :: signed
 L3:
-    r14 = CPyDict_CheckSize(d, r2)
+    r13 = CPyDict_CheckSize(d, r1)
     goto L1
 L4:
-    r15 = CPy_NoErrOccurred()
+    r14 = CPy_NoErrOccurred()
 L5:
     return d
 
@@ -244,192 +242,184 @@ def print_dict_methods(d1, d2):
     d1, d2 :: dict
     r0 :: short_int
     r1 :: native_int
-    r2 :: short_int
-    r3 :: object
-    r4 :: tuple[bool, short_int, object]
-    r5 :: short_int
-    r6 :: bool
-    r7 :: object
-    r8, v :: int
-    r9 :: object
-    r10 :: i32
-    r11 :: bit
-    r12 :: bool
-    r13, r14 :: bit
-    r15 :: short_int
-    r16 :: native_int
-    r17 :: short_int
-    r18 :: object
-    r19 :: tuple[bool, short_int, object, object]
-    r20 :: short_int
-    r21 :: bool
-    r22, r23 :: object
-    r24, r25, k :: int
-    r26, r27, r28, r29, r30 :: object
-    r31 :: i32
-    r32, r33, r34 :: bit
+    r2 :: object
+    r3 :: tuple[bool, short_int, object]
+    r4 :: short_int
+    r5 :: bool
+    r6 :: object
+    r7, v :: int
+    r8 :: object
+    r9 :: i32
+    r10 :: bit
+    r11 :: bool
+    r12, r13 :: bit
+    r14 :: short_int
+    r15 :: native_int
+    r16 :: object
+    r17 :: tuple[bool, short_int, object, object]
+    r18 :: short_int
+    r19 :: bool
+    r20, r21 :: object
+    r22, r23, k :: int
+    r24, r25, r26, r27, r28 :: object
+    r29 :: i32
+    r30, r31, r32 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d1)
-    r2 = r1 << 1
-    r3 = CPyDict_GetValuesIter(d1)
+    r2 = CPyDict_GetValuesIter(d1)
 L1:
-    r4 = CPyDict_NextValue(r3, r0)
-    r5 = r4[1]
-    r0 = r5
-    r6 = r4[0]
-    if r6 goto L2 else goto L6 :: bool
+    r3 = CPyDict_NextValue(r2, r0)
+    r4 = r3[1]
+    r0 = r4
+    r5 = r3[0]
+    if r5 goto L2 else goto L6 :: bool
 L2:
-    r7 = r4[2]
-    r8 = unbox(int, r7)
-    v = r8
-    r9 = box(int, v)
-    r10 = PyDict_Contains(d2, r9)
-    r11 = r10 >= 0 :: signed
-    r12 = truncate r10: i32 to builtins.bool
-    if r12 goto L3 else goto L4 :: bool
+    r6 = r3[2]
+    r7 = unbox(int, r6)
+    v = r7
+    r8 = box(int, v)
+    r9 = PyDict_Contains(d2, r8)
+    r10 = r9 >= 0 :: signed
+    r11 = truncate r9: i32 to builtins.bool
+    if r11 goto L3 else goto L4 :: bool
 L3:
     return 1
 L4:
 L5:
-    r13 = CPyDict_CheckSize(d1, r2)
+    r12 = CPyDict_CheckSize(d1, r1)
     goto L1
 L6:
-    r14 = CPy_NoErrOccurred()
+    r13 = CPy_NoErrOccurred()
 L7:
-    r15 = 0
-    r16 = PyDict_Size(d2)
-    r17 = r16 << 1
-    r18 = CPyDict_GetItemsIter(d2)
+    r14 = 0
+    r15 = PyDict_Size(d2)
+    r16 = CPyDict_GetItemsIter(d2)
 L8:
-    r19 = CPyDict_NextItem(r18, r15)
-    r20 = r19[1]
-    r15 = r20
-    r21 = r19[0]
-    if r21 goto L9 else goto L11 :: bool
+    r17 = CPyDict_NextItem(r16, r14)
+    r18 = r17[1]
+    r14 = r18
+    r19 = r17[0]
+    if r19 goto L9 else goto L11 :: bool
 L9:
-    r22 = r19[2]
-    r23 = r19[3]
-    r24 = unbox(int, r22)
-    r25 = unbox(int, r23)
-    k = r24
-    v = r25
-    r26 = box(int, k)
-    r27 = CPyDict_GetItem(d2, r26)
-    r28 = box(int, v)
-    r29 = PyNumber_InPlaceAdd(r27, r28)
-    r30 = box(int, k)
-    r31 = CPyDict_SetItem(d2, r30, r29)
-    r32 = r31 >= 0 :: signed
+    r20 = r17[2]
+    r21 = r17[3]
+    r22 = unbox(int, r20)
+    r23 = unbox(int, r21)
+    k = r22
+    v = r23
+    r24 = box(int, k)
+    r25 = CPyDict_GetItem(d2, r24)
+    r26 = box(int, v)
+    r27 = PyNumber_InPlaceAdd(r25, r26)
+    r28 = box(int, k)
+    r29 = CPyDict_SetItem(d2, r28, r27)
+    r30 = r29 >= 0 :: signed
 L10:
-    r33 = CPyDict_CheckSize(d2, r17)
+    r31 = CPyDict_CheckSize(d2, r15)
     goto L8
 L11:
-    r34 = CPy_NoErrOccurred()
+    r32 = CPy_NoErrOccurred()
 L12:
     return 1
 def union_of_dicts(d):
     d, r0, new :: dict
     r1 :: short_int
     r2 :: native_int
-    r3 :: short_int
-    r4 :: object
-    r5 :: tuple[bool, short_int, object, object]
-    r6 :: short_int
-    r7 :: bool
-    r8, r9 :: object
-    r10 :: str
-    r11 :: union[int, str]
+    r3 :: object
+    r4 :: tuple[bool, short_int, object, object]
+    r5 :: short_int
+    r6 :: bool
+    r7, r8 :: object
+    r9 :: str
+    r10 :: union[int, str]
     k :: str
     v :: union[int, str]
-    r12 :: object
-    r13 :: object[1]
-    r14 :: object_ptr
-    r15 :: object
-    r16 :: int
-    r17 :: object
-    r18 :: i32
-    r19, r20, r21 :: bit
+    r11 :: object
+    r12 :: object[1]
+    r13 :: object_ptr
+    r14 :: object
+    r15 :: int
+    r16 :: object
+    r17 :: i32
+    r18, r19, r20 :: bit
 L0:
     r0 = PyDict_New()
     new = r0
     r1 = 0
     r2 = PyDict_Size(d)
-    r3 = r2 << 1
-    r4 = CPyDict_GetItemsIter(d)
+    r3 = CPyDict_GetItemsIter(d)
 L1:
-    r5 = CPyDict_NextItem(r4, r1)
-    r6 = r5[1]
-    r1 = r6
-    r7 = r5[0]
-    if r7 goto L2 else goto L4 :: bool
+    r4 = CPyDict_NextItem(r3, r1)
+    r5 = r4[1]
+    r1 = r5
+    r6 = r4[0]
+    if r6 goto L2 else goto L4 :: bool
 L2:
-    r8 = r5[2]
-    r9 = r5[3]
-    r10 = cast(str, r8)
-    r11 = cast(union[int, str], r9)
-    k = r10
-    v = r11
-    r12 = load_address PyLong_Type
-    r13 = [v]
-    r14 = load_address r13
-    r15 = PyObject_Vectorcall(r12, r14, 1, 0)
+    r7 = r4[2]
+    r8 = r4[3]
+    r9 = cast(str, r7)
+    r10 = cast(union[int, str], r8)
+    k = r9
+    v = r10
+    r11 = load_address PyLong_Type
+    r12 = [v]
+    r13 = load_address r12
+    r14 = PyObject_Vectorcall(r11, r13, 1, 0)
     keep_alive v
-    r16 = unbox(int, r15)
-    r17 = box(int, r16)
-    r18 = CPyDict_SetItem(new, k, r17)
-    r19 = r18 >= 0 :: signed
+    r15 = unbox(int, r14)
+    r16 = box(int, r15)
+    r17 = CPyDict_SetItem(new, k, r16)
+    r18 = r17 >= 0 :: signed
 L3:
-    r20 = CPyDict_CheckSize(d, r3)
+    r19 = CPyDict_CheckSize(d, r2)
     goto L1
 L4:
-    r21 = CPy_NoErrOccurred()
+    r20 = CPy_NoErrOccurred()
 L5:
     return 1
 def typeddict(d):
     d :: dict
     r0 :: short_int
     r1 :: native_int
-    r2 :: short_int
-    r3 :: object
-    r4 :: tuple[bool, short_int, object, object]
-    r5 :: short_int
-    r6 :: bool
-    r7, r8 :: object
-    r9, k :: str
+    r2 :: object
+    r3 :: tuple[bool, short_int, object, object]
+    r4 :: short_int
+    r5 :: bool
+    r6, r7 :: object
+    r8, k :: str
     v :: object
-    r10 :: str
-    r11 :: bool
+    r9 :: str
+    r10 :: bool
     name :: object
-    r12, r13 :: bit
+    r11, r12 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d)
-    r2 = r1 << 1
-    r3 = CPyDict_GetItemsIter(d)
+    r2 = CPyDict_GetItemsIter(d)
 L1:
-    r4 = CPyDict_NextItem(r3, r0)
-    r5 = r4[1]
-    r0 = r5
-    r6 = r4[0]
-    if r6 goto L2 else goto L6 :: bool
+    r3 = CPyDict_NextItem(r2, r0)
+    r4 = r3[1]
+    r0 = r4
+    r5 = r3[0]
+    if r5 goto L2 else goto L6 :: bool
 L2:
-    r7 = r4[2]
-    r8 = r4[3]
-    r9 = cast(str, r7)
-    k = r9
-    v = r8
-    r10 = 'name'
-    r11 = CPyStr_Equal(k, r10)
-    if r11 goto L3 else goto L4 :: bool
+    r6 = r3[2]
+    r7 = r3[3]
+    r8 = cast(str, r6)
+    k = r8
+    v = r7
+    r9 = 'name'
+    r10 = CPyStr_Equal(k, r9)
+    if r10 goto L3 else goto L4 :: bool
 L3:
     name = v
 L4:
 L5:
-    r12 = CPyDict_CheckSize(d, r2)
+    r11 = CPyDict_CheckSize(d, r1)
     goto L1
 L6:
-    r13 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L7:
     return 1
 

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -226,153 +226,145 @@ def fn_mapping(m):
     r0 :: list
     r1 :: short_int
     r2 :: native_int
-    r3 :: short_int
-    r4 :: object
-    r5 :: tuple[bool, short_int, object]
-    r6 :: short_int
-    r7 :: bool
-    r8 :: object
-    r9, x :: str
-    r10 :: i32
-    r11, r12, r13 :: bit
-    r14 :: list
-    r15 :: short_int
-    r16 :: native_int
-    r17 :: short_int
-    r18 :: object
-    r19 :: tuple[bool, short_int, object]
-    r20 :: short_int
-    r21 :: bool
+    r3 :: object
+    r4 :: tuple[bool, short_int, object]
+    r5 :: short_int
+    r6 :: bool
+    r7 :: object
+    r8, x :: str
+    r9 :: i32
+    r10, r11, r12 :: bit
+    r13 :: list
+    r14 :: short_int
+    r15 :: native_int
+    r16 :: object
+    r17 :: tuple[bool, short_int, object]
+    r18 :: short_int
+    r19 :: bool
+    r20 :: object
+    r21, x_2 :: int
     r22 :: object
-    r23, x_2 :: int
-    r24 :: object
-    r25 :: i32
-    r26, r27, r28 :: bit
-    r29 :: set
-    r30 :: short_int
-    r31 :: native_int
+    r23 :: i32
+    r24, r25, r26 :: bit
+    r27 :: set
+    r28 :: short_int
+    r29 :: native_int
+    r30 :: object
+    r31 :: tuple[bool, short_int, object]
     r32 :: short_int
-    r33 :: object
-    r34 :: tuple[bool, short_int, object]
-    r35 :: short_int
-    r36 :: bool
-    r37 :: object
-    r38, x_3 :: str
-    r39 :: i32
-    r40, r41, r42 :: bit
-    r43 :: dict
-    r44 :: short_int
-    r45 :: native_int
-    r46 :: short_int
-    r47 :: object
-    r48 :: tuple[bool, short_int, object, object]
-    r49 :: short_int
-    r50 :: bool
-    r51, r52 :: object
-    r53 :: str
-    r54 :: int
+    r33 :: bool
+    r34 :: object
+    r35, x_3 :: str
+    r36 :: i32
+    r37, r38, r39 :: bit
+    r40 :: dict
+    r41 :: short_int
+    r42 :: native_int
+    r43 :: object
+    r44 :: tuple[bool, short_int, object, object]
+    r45 :: short_int
+    r46 :: bool
+    r47, r48 :: object
+    r49 :: str
+    r50 :: int
     k :: str
     v :: int
-    r55 :: object
-    r56 :: i32
-    r57, r58, r59 :: bit
+    r51 :: object
+    r52 :: i32
+    r53, r54, r55 :: bit
 L0:
     r0 = PyList_New(0)
     r1 = 0
     r2 = PyDict_Size(m)
-    r3 = r2 << 1
-    r4 = CPyDict_GetKeysIter(m)
+    r3 = CPyDict_GetKeysIter(m)
 L1:
-    r5 = CPyDict_NextKey(r4, r1)
-    r6 = r5[1]
-    r1 = r6
-    r7 = r5[0]
-    if r7 goto L2 else goto L4 :: bool
+    r4 = CPyDict_NextKey(r3, r1)
+    r5 = r4[1]
+    r1 = r5
+    r6 = r4[0]
+    if r6 goto L2 else goto L4 :: bool
 L2:
-    r8 = r5[2]
-    r9 = cast(str, r8)
-    x = r9
-    r10 = PyList_Append(r0, x)
-    r11 = r10 >= 0 :: signed
+    r7 = r4[2]
+    r8 = cast(str, r7)
+    x = r8
+    r9 = PyList_Append(r0, x)
+    r10 = r9 >= 0 :: signed
 L3:
-    r12 = CPyDict_CheckSize(m, r3)
+    r11 = CPyDict_CheckSize(m, r2)
     goto L1
 L4:
-    r13 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L5:
-    r14 = PyList_New(0)
-    r15 = 0
-    r16 = PyDict_Size(m)
-    r17 = r16 << 1
-    r18 = CPyDict_GetValuesIter(m)
+    r13 = PyList_New(0)
+    r14 = 0
+    r15 = PyDict_Size(m)
+    r16 = CPyDict_GetValuesIter(m)
 L6:
-    r19 = CPyDict_NextValue(r18, r15)
-    r20 = r19[1]
-    r15 = r20
-    r21 = r19[0]
-    if r21 goto L7 else goto L9 :: bool
+    r17 = CPyDict_NextValue(r16, r14)
+    r18 = r17[1]
+    r14 = r18
+    r19 = r17[0]
+    if r19 goto L7 else goto L9 :: bool
 L7:
-    r22 = r19[2]
-    r23 = unbox(int, r22)
-    x_2 = r23
-    r24 = box(int, x_2)
-    r25 = PyList_Append(r14, r24)
-    r26 = r25 >= 0 :: signed
+    r20 = r17[2]
+    r21 = unbox(int, r20)
+    x_2 = r21
+    r22 = box(int, x_2)
+    r23 = PyList_Append(r13, r22)
+    r24 = r23 >= 0 :: signed
 L8:
-    r27 = CPyDict_CheckSize(m, r17)
+    r25 = CPyDict_CheckSize(m, r15)
     goto L6
 L9:
-    r28 = CPy_NoErrOccurred()
+    r26 = CPy_NoErrOccurred()
 L10:
-    r29 = PySet_New(0)
-    r30 = 0
-    r31 = PyDict_Size(m)
-    r32 = r31 << 1
-    r33 = CPyDict_GetKeysIter(m)
+    r27 = PySet_New(0)
+    r28 = 0
+    r29 = PyDict_Size(m)
+    r30 = CPyDict_GetKeysIter(m)
 L11:
-    r34 = CPyDict_NextKey(r33, r30)
-    r35 = r34[1]
-    r30 = r35
-    r36 = r34[0]
-    if r36 goto L12 else goto L14 :: bool
+    r31 = CPyDict_NextKey(r30, r28)
+    r32 = r31[1]
+    r28 = r32
+    r33 = r31[0]
+    if r33 goto L12 else goto L14 :: bool
 L12:
-    r37 = r34[2]
-    r38 = cast(str, r37)
-    x_3 = r38
-    r39 = PySet_Add(r29, x_3)
-    r40 = r39 >= 0 :: signed
+    r34 = r31[2]
+    r35 = cast(str, r34)
+    x_3 = r35
+    r36 = PySet_Add(r27, x_3)
+    r37 = r36 >= 0 :: signed
 L13:
-    r41 = CPyDict_CheckSize(m, r32)
+    r38 = CPyDict_CheckSize(m, r29)
     goto L11
 L14:
-    r42 = CPy_NoErrOccurred()
+    r39 = CPy_NoErrOccurred()
 L15:
-    r43 = PyDict_New()
-    r44 = 0
-    r45 = PyDict_Size(m)
-    r46 = r45 << 1
-    r47 = CPyDict_GetItemsIter(m)
+    r40 = PyDict_New()
+    r41 = 0
+    r42 = PyDict_Size(m)
+    r43 = CPyDict_GetItemsIter(m)
 L16:
-    r48 = CPyDict_NextItem(r47, r44)
-    r49 = r48[1]
-    r44 = r49
-    r50 = r48[0]
-    if r50 goto L17 else goto L19 :: bool
+    r44 = CPyDict_NextItem(r43, r41)
+    r45 = r44[1]
+    r41 = r45
+    r46 = r44[0]
+    if r46 goto L17 else goto L19 :: bool
 L17:
-    r51 = r48[2]
-    r52 = r48[3]
-    r53 = cast(str, r51)
-    r54 = unbox(int, r52)
-    k = r53
-    v = r54
-    r55 = box(int, v)
-    r56 = CPyDict_SetItem(r43, k, r55)
-    r57 = r56 >= 0 :: signed
+    r47 = r44[2]
+    r48 = r44[3]
+    r49 = cast(str, r47)
+    r50 = unbox(int, r48)
+    k = r49
+    v = r50
+    r51 = box(int, v)
+    r52 = CPyDict_SetItem(r40, k, r51)
+    r53 = r52 >= 0 :: signed
 L18:
-    r58 = CPyDict_CheckSize(m, r46)
+    r54 = CPyDict_CheckSize(m, r42)
     goto L16
 L19:
-    r59 = CPy_NoErrOccurred()
+    r55 = CPy_NoErrOccurred()
 L20:
     return 1
 def fn_union(m):
@@ -380,149 +372,141 @@ def fn_union(m):
     r0 :: list
     r1 :: short_int
     r2 :: native_int
-    r3 :: short_int
-    r4 :: object
-    r5 :: tuple[bool, short_int, object]
-    r6 :: short_int
-    r7 :: bool
-    r8 :: object
-    r9, x :: str
-    r10 :: i32
-    r11, r12, r13 :: bit
-    r14 :: list
-    r15 :: short_int
-    r16 :: native_int
-    r17 :: short_int
-    r18 :: object
-    r19 :: tuple[bool, short_int, object]
-    r20 :: short_int
-    r21 :: bool
-    r22 :: object
-    r23, x_2 :: union[int, str]
-    r24 :: i32
-    r25, r26, r27 :: bit
-    r28 :: set
-    r29 :: short_int
-    r30 :: native_int
+    r3 :: object
+    r4 :: tuple[bool, short_int, object]
+    r5 :: short_int
+    r6 :: bool
+    r7 :: object
+    r8, x :: str
+    r9 :: i32
+    r10, r11, r12 :: bit
+    r13 :: list
+    r14 :: short_int
+    r15 :: native_int
+    r16 :: object
+    r17 :: tuple[bool, short_int, object]
+    r18 :: short_int
+    r19 :: bool
+    r20 :: object
+    r21, x_2 :: union[int, str]
+    r22 :: i32
+    r23, r24, r25 :: bit
+    r26 :: set
+    r27 :: short_int
+    r28 :: native_int
+    r29 :: object
+    r30 :: tuple[bool, short_int, object]
     r31 :: short_int
-    r32 :: object
-    r33 :: tuple[bool, short_int, object]
-    r34 :: short_int
-    r35 :: bool
-    r36 :: object
-    r37, x_3 :: str
-    r38 :: i32
-    r39, r40, r41 :: bit
-    r42 :: dict
-    r43 :: short_int
-    r44 :: native_int
-    r45 :: short_int
-    r46 :: object
-    r47 :: tuple[bool, short_int, object, object]
-    r48 :: short_int
-    r49 :: bool
-    r50, r51 :: object
-    r52 :: str
-    r53 :: union[int, str]
+    r32 :: bool
+    r33 :: object
+    r34, x_3 :: str
+    r35 :: i32
+    r36, r37, r38 :: bit
+    r39 :: dict
+    r40 :: short_int
+    r41 :: native_int
+    r42 :: object
+    r43 :: tuple[bool, short_int, object, object]
+    r44 :: short_int
+    r45 :: bool
+    r46, r47 :: object
+    r48 :: str
+    r49 :: union[int, str]
     k :: str
     v :: union[int, str]
-    r54 :: i32
-    r55, r56, r57 :: bit
+    r50 :: i32
+    r51, r52, r53 :: bit
 L0:
     r0 = PyList_New(0)
     r1 = 0
     r2 = PyDict_Size(m)
-    r3 = r2 << 1
-    r4 = CPyDict_GetKeysIter(m)
+    r3 = CPyDict_GetKeysIter(m)
 L1:
-    r5 = CPyDict_NextKey(r4, r1)
-    r6 = r5[1]
-    r1 = r6
-    r7 = r5[0]
-    if r7 goto L2 else goto L4 :: bool
+    r4 = CPyDict_NextKey(r3, r1)
+    r5 = r4[1]
+    r1 = r5
+    r6 = r4[0]
+    if r6 goto L2 else goto L4 :: bool
 L2:
-    r8 = r5[2]
-    r9 = cast(str, r8)
-    x = r9
-    r10 = PyList_Append(r0, x)
-    r11 = r10 >= 0 :: signed
+    r7 = r4[2]
+    r8 = cast(str, r7)
+    x = r8
+    r9 = PyList_Append(r0, x)
+    r10 = r9 >= 0 :: signed
 L3:
-    r12 = CPyDict_CheckSize(m, r3)
+    r11 = CPyDict_CheckSize(m, r2)
     goto L1
 L4:
-    r13 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L5:
-    r14 = PyList_New(0)
-    r15 = 0
-    r16 = PyDict_Size(m)
-    r17 = r16 << 1
-    r18 = CPyDict_GetValuesIter(m)
+    r13 = PyList_New(0)
+    r14 = 0
+    r15 = PyDict_Size(m)
+    r16 = CPyDict_GetValuesIter(m)
 L6:
-    r19 = CPyDict_NextValue(r18, r15)
-    r20 = r19[1]
-    r15 = r20
-    r21 = r19[0]
-    if r21 goto L7 else goto L9 :: bool
+    r17 = CPyDict_NextValue(r16, r14)
+    r18 = r17[1]
+    r14 = r18
+    r19 = r17[0]
+    if r19 goto L7 else goto L9 :: bool
 L7:
-    r22 = r19[2]
-    r23 = cast(union[int, str], r22)
-    x_2 = r23
-    r24 = PyList_Append(r14, x_2)
-    r25 = r24 >= 0 :: signed
+    r20 = r17[2]
+    r21 = cast(union[int, str], r20)
+    x_2 = r21
+    r22 = PyList_Append(r13, x_2)
+    r23 = r22 >= 0 :: signed
 L8:
-    r26 = CPyDict_CheckSize(m, r17)
+    r24 = CPyDict_CheckSize(m, r15)
     goto L6
 L9:
-    r27 = CPy_NoErrOccurred()
+    r25 = CPy_NoErrOccurred()
 L10:
-    r28 = PySet_New(0)
-    r29 = 0
-    r30 = PyDict_Size(m)
-    r31 = r30 << 1
-    r32 = CPyDict_GetKeysIter(m)
+    r26 = PySet_New(0)
+    r27 = 0
+    r28 = PyDict_Size(m)
+    r29 = CPyDict_GetKeysIter(m)
 L11:
-    r33 = CPyDict_NextKey(r32, r29)
-    r34 = r33[1]
-    r29 = r34
-    r35 = r33[0]
-    if r35 goto L12 else goto L14 :: bool
+    r30 = CPyDict_NextKey(r29, r27)
+    r31 = r30[1]
+    r27 = r31
+    r32 = r30[0]
+    if r32 goto L12 else goto L14 :: bool
 L12:
-    r36 = r33[2]
-    r37 = cast(str, r36)
-    x_3 = r37
-    r38 = PySet_Add(r28, x_3)
-    r39 = r38 >= 0 :: signed
+    r33 = r30[2]
+    r34 = cast(str, r33)
+    x_3 = r34
+    r35 = PySet_Add(r26, x_3)
+    r36 = r35 >= 0 :: signed
 L13:
-    r40 = CPyDict_CheckSize(m, r31)
+    r37 = CPyDict_CheckSize(m, r28)
     goto L11
 L14:
-    r41 = CPy_NoErrOccurred()
+    r38 = CPy_NoErrOccurred()
 L15:
-    r42 = PyDict_New()
-    r43 = 0
-    r44 = PyDict_Size(m)
-    r45 = r44 << 1
-    r46 = CPyDict_GetItemsIter(m)
+    r39 = PyDict_New()
+    r40 = 0
+    r41 = PyDict_Size(m)
+    r42 = CPyDict_GetItemsIter(m)
 L16:
-    r47 = CPyDict_NextItem(r46, r43)
-    r48 = r47[1]
-    r43 = r48
-    r49 = r47[0]
-    if r49 goto L17 else goto L19 :: bool
+    r43 = CPyDict_NextItem(r42, r40)
+    r44 = r43[1]
+    r40 = r44
+    r45 = r43[0]
+    if r45 goto L17 else goto L19 :: bool
 L17:
-    r50 = r47[2]
-    r51 = r47[3]
-    r52 = cast(str, r50)
-    r53 = cast(union[int, str], r51)
-    k = r52
-    v = r53
-    r54 = CPyDict_SetItem(r42, k, v)
-    r55 = r54 >= 0 :: signed
+    r46 = r43[2]
+    r47 = r43[3]
+    r48 = cast(str, r46)
+    r49 = cast(union[int, str], r47)
+    k = r48
+    v = r49
+    r50 = CPyDict_SetItem(r39, k, v)
+    r51 = r50 >= 0 :: signed
 L18:
-    r56 = CPyDict_CheckSize(m, r45)
+    r52 = CPyDict_CheckSize(m, r41)
     goto L16
 L19:
-    r57 = CPy_NoErrOccurred()
+    r53 = CPy_NoErrOccurred()
 L20:
     return 1
 def fn_typeddict(t):
@@ -530,144 +514,136 @@ def fn_typeddict(t):
     r0 :: list
     r1 :: short_int
     r2 :: native_int
-    r3 :: short_int
-    r4 :: object
-    r5 :: tuple[bool, short_int, object]
-    r6 :: short_int
-    r7 :: bool
-    r8 :: object
-    r9, x :: str
-    r10 :: i32
-    r11, r12, r13 :: bit
-    r14 :: list
-    r15 :: short_int
-    r16 :: native_int
-    r17 :: short_int
-    r18 :: object
-    r19 :: tuple[bool, short_int, object]
-    r20 :: short_int
-    r21 :: bool
-    r22, x_2 :: object
-    r23 :: i32
-    r24, r25, r26 :: bit
-    r27 :: set
-    r28 :: short_int
-    r29 :: native_int
+    r3 :: object
+    r4 :: tuple[bool, short_int, object]
+    r5 :: short_int
+    r6 :: bool
+    r7 :: object
+    r8, x :: str
+    r9 :: i32
+    r10, r11, r12 :: bit
+    r13 :: list
+    r14 :: short_int
+    r15 :: native_int
+    r16 :: object
+    r17 :: tuple[bool, short_int, object]
+    r18 :: short_int
+    r19 :: bool
+    r20, x_2 :: object
+    r21 :: i32
+    r22, r23, r24 :: bit
+    r25 :: set
+    r26 :: short_int
+    r27 :: native_int
+    r28 :: object
+    r29 :: tuple[bool, short_int, object]
     r30 :: short_int
-    r31 :: object
-    r32 :: tuple[bool, short_int, object]
-    r33 :: short_int
-    r34 :: bool
-    r35 :: object
-    r36, x_3 :: str
-    r37 :: i32
-    r38, r39, r40 :: bit
-    r41 :: dict
-    r42 :: short_int
-    r43 :: native_int
-    r44 :: short_int
-    r45 :: object
-    r46 :: tuple[bool, short_int, object, object]
-    r47 :: short_int
-    r48 :: bool
-    r49, r50 :: object
-    r51, k :: str
+    r31 :: bool
+    r32 :: object
+    r33, x_3 :: str
+    r34 :: i32
+    r35, r36, r37 :: bit
+    r38 :: dict
+    r39 :: short_int
+    r40 :: native_int
+    r41 :: object
+    r42 :: tuple[bool, short_int, object, object]
+    r43 :: short_int
+    r44 :: bool
+    r45, r46 :: object
+    r47, k :: str
     v :: object
-    r52 :: i32
-    r53, r54, r55 :: bit
+    r48 :: i32
+    r49, r50, r51 :: bit
 L0:
     r0 = PyList_New(0)
     r1 = 0
     r2 = PyDict_Size(t)
-    r3 = r2 << 1
-    r4 = CPyDict_GetKeysIter(t)
+    r3 = CPyDict_GetKeysIter(t)
 L1:
-    r5 = CPyDict_NextKey(r4, r1)
-    r6 = r5[1]
-    r1 = r6
-    r7 = r5[0]
-    if r7 goto L2 else goto L4 :: bool
+    r4 = CPyDict_NextKey(r3, r1)
+    r5 = r4[1]
+    r1 = r5
+    r6 = r4[0]
+    if r6 goto L2 else goto L4 :: bool
 L2:
-    r8 = r5[2]
-    r9 = cast(str, r8)
-    x = r9
-    r10 = PyList_Append(r0, x)
-    r11 = r10 >= 0 :: signed
+    r7 = r4[2]
+    r8 = cast(str, r7)
+    x = r8
+    r9 = PyList_Append(r0, x)
+    r10 = r9 >= 0 :: signed
 L3:
-    r12 = CPyDict_CheckSize(t, r3)
+    r11 = CPyDict_CheckSize(t, r2)
     goto L1
 L4:
-    r13 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L5:
-    r14 = PyList_New(0)
-    r15 = 0
-    r16 = PyDict_Size(t)
-    r17 = r16 << 1
-    r18 = CPyDict_GetValuesIter(t)
+    r13 = PyList_New(0)
+    r14 = 0
+    r15 = PyDict_Size(t)
+    r16 = CPyDict_GetValuesIter(t)
 L6:
-    r19 = CPyDict_NextValue(r18, r15)
-    r20 = r19[1]
-    r15 = r20
-    r21 = r19[0]
-    if r21 goto L7 else goto L9 :: bool
+    r17 = CPyDict_NextValue(r16, r14)
+    r18 = r17[1]
+    r14 = r18
+    r19 = r17[0]
+    if r19 goto L7 else goto L9 :: bool
 L7:
-    r22 = r19[2]
-    x_2 = r22
-    r23 = PyList_Append(r14, x_2)
-    r24 = r23 >= 0 :: signed
+    r20 = r17[2]
+    x_2 = r20
+    r21 = PyList_Append(r13, x_2)
+    r22 = r21 >= 0 :: signed
 L8:
-    r25 = CPyDict_CheckSize(t, r17)
+    r23 = CPyDict_CheckSize(t, r15)
     goto L6
 L9:
-    r26 = CPy_NoErrOccurred()
+    r24 = CPy_NoErrOccurred()
 L10:
-    r27 = PySet_New(0)
-    r28 = 0
-    r29 = PyDict_Size(t)
-    r30 = r29 << 1
-    r31 = CPyDict_GetKeysIter(t)
+    r25 = PySet_New(0)
+    r26 = 0
+    r27 = PyDict_Size(t)
+    r28 = CPyDict_GetKeysIter(t)
 L11:
-    r32 = CPyDict_NextKey(r31, r28)
-    r33 = r32[1]
-    r28 = r33
-    r34 = r32[0]
-    if r34 goto L12 else goto L14 :: bool
+    r29 = CPyDict_NextKey(r28, r26)
+    r30 = r29[1]
+    r26 = r30
+    r31 = r29[0]
+    if r31 goto L12 else goto L14 :: bool
 L12:
-    r35 = r32[2]
-    r36 = cast(str, r35)
-    x_3 = r36
-    r37 = PySet_Add(r27, x_3)
-    r38 = r37 >= 0 :: signed
+    r32 = r29[2]
+    r33 = cast(str, r32)
+    x_3 = r33
+    r34 = PySet_Add(r25, x_3)
+    r35 = r34 >= 0 :: signed
 L13:
-    r39 = CPyDict_CheckSize(t, r30)
+    r36 = CPyDict_CheckSize(t, r27)
     goto L11
 L14:
-    r40 = CPy_NoErrOccurred()
+    r37 = CPy_NoErrOccurred()
 L15:
-    r41 = PyDict_New()
-    r42 = 0
-    r43 = PyDict_Size(t)
-    r44 = r43 << 1
-    r45 = CPyDict_GetItemsIter(t)
+    r38 = PyDict_New()
+    r39 = 0
+    r40 = PyDict_Size(t)
+    r41 = CPyDict_GetItemsIter(t)
 L16:
-    r46 = CPyDict_NextItem(r45, r42)
-    r47 = r46[1]
-    r42 = r47
-    r48 = r46[0]
-    if r48 goto L17 else goto L19 :: bool
+    r42 = CPyDict_NextItem(r41, r39)
+    r43 = r42[1]
+    r39 = r43
+    r44 = r42[0]
+    if r44 goto L17 else goto L19 :: bool
 L17:
-    r49 = r46[2]
-    r50 = r46[3]
-    r51 = cast(str, r49)
-    k = r51
-    v = r50
-    r52 = CPyDict_SetItem(r41, k, v)
-    r53 = r52 >= 0 :: signed
+    r45 = r42[2]
+    r46 = r42[3]
+    r47 = cast(str, r45)
+    k = r47
+    v = r46
+    r48 = CPyDict_SetItem(r38, k, v)
+    r49 = r48 >= 0 :: signed
 L18:
-    r54 = CPyDict_CheckSize(t, r44)
+    r50 = CPyDict_CheckSize(t, r40)
     goto L16
 L19:
-    r55 = CPy_NoErrOccurred()
+    r51 = CPy_NoErrOccurred()
 L20:
     return 1
 
@@ -713,38 +689,34 @@ def inner_deco_obj.__call__(__mypyc_self__, args, kwargs):
     r0 :: __main__.deco_env
     r1 :: native_int
     r2 :: list
-    r3 :: short_int
-    r4 :: native_int
-    r5 :: short_int
-    r6 :: bit
-    r7, x :: object
-    r8 :: bit
-    r9 :: short_int
+    r3, r4 :: native_int
+    r5 :: bit
+    r6, x :: object
+    r7 :: native_int
     can_listcomp :: list
-    r10 :: dict
-    r11 :: short_int
-    r12 :: native_int
+    r8 :: dict
+    r9 :: short_int
+    r10 :: native_int
+    r11 :: object
+    r12 :: tuple[bool, short_int, object, object]
     r13 :: short_int
-    r14 :: object
-    r15 :: tuple[bool, short_int, object, object]
-    r16 :: short_int
-    r17 :: bool
-    r18, r19 :: object
-    r20, k :: str
+    r14 :: bool
+    r15, r16 :: object
+    r17, k :: str
     v :: object
-    r21 :: i32
-    r22, r23, r24 :: bit
+    r18 :: i32
+    r19, r20, r21 :: bit
     can_dictcomp :: dict
-    r25, can_iter, r26, can_use_keys, r27, can_use_values :: list
-    r28 :: object
-    r29 :: list
-    r30 :: object
-    r31 :: dict
-    r32 :: i32
-    r33 :: bit
-    r34 :: tuple
-    r35 :: object
-    r36 :: int
+    r22, can_iter, r23, can_use_keys, r24, can_use_values :: list
+    r25 :: object
+    r26 :: list
+    r27 :: object
+    r28 :: dict
+    r29 :: i32
+    r30 :: bit
+    r31 :: tuple
+    r32 :: object
+    r33 :: int
 L0:
     r0 = __mypyc_self__.__mypyc_env__
     r1 = var_object_size args
@@ -752,61 +724,59 @@ L0:
     r3 = 0
 L1:
     r4 = var_object_size args
-    r5 = r4 << 1
-    r6 = int_lt r3, r5
-    if r6 goto L2 else goto L4 :: bool
+    r5 = r3 < r4 :: signed
+    if r5 goto L2 else goto L4 :: bool
 L2:
-    r7 = CPySequenceTuple_GetItem(args, r3)
-    x = r7
-    r8 = CPyList_SetItemUnsafe(r2, r3, x)
+    r6 = CPySequenceTuple_GetItemUnsafe(args, r3)
+    x = r6
+    CPyList_SetItemUnsafe(r2, r3, x)
 L3:
-    r9 = r3 + 2
-    r3 = r9
+    r7 = r3 + 1
+    r3 = r7
     goto L1
 L4:
     can_listcomp = r2
-    r10 = PyDict_New()
-    r11 = 0
-    r12 = PyDict_Size(kwargs)
-    r13 = r12 << 1
-    r14 = CPyDict_GetItemsIter(kwargs)
+    r8 = PyDict_New()
+    r9 = 0
+    r10 = PyDict_Size(kwargs)
+    r11 = CPyDict_GetItemsIter(kwargs)
 L5:
-    r15 = CPyDict_NextItem(r14, r11)
-    r16 = r15[1]
-    r11 = r16
-    r17 = r15[0]
-    if r17 goto L6 else goto L8 :: bool
+    r12 = CPyDict_NextItem(r11, r9)
+    r13 = r12[1]
+    r9 = r13
+    r14 = r12[0]
+    if r14 goto L6 else goto L8 :: bool
 L6:
-    r18 = r15[2]
-    r19 = r15[3]
-    r20 = cast(str, r18)
-    k = r20
-    v = r19
-    r21 = CPyDict_SetItem(r10, k, v)
-    r22 = r21 >= 0 :: signed
+    r15 = r12[2]
+    r16 = r12[3]
+    r17 = cast(str, r15)
+    k = r17
+    v = r16
+    r18 = CPyDict_SetItem(r8, k, v)
+    r19 = r18 >= 0 :: signed
 L7:
-    r23 = CPyDict_CheckSize(kwargs, r13)
+    r20 = CPyDict_CheckSize(kwargs, r10)
     goto L5
 L8:
-    r24 = CPy_NoErrOccurred()
+    r21 = CPy_NoErrOccurred()
 L9:
-    can_dictcomp = r10
-    r25 = PySequence_List(kwargs)
-    can_iter = r25
-    r26 = CPyDict_Keys(kwargs)
-    can_use_keys = r26
-    r27 = CPyDict_Values(kwargs)
-    can_use_values = r27
-    r28 = r0.func
-    r29 = PyList_New(0)
-    r30 = CPyList_Extend(r29, args)
-    r31 = PyDict_New()
-    r32 = CPyDict_UpdateInDisplay(r31, kwargs)
-    r33 = r32 >= 0 :: signed
-    r34 = PyList_AsTuple(r29)
-    r35 = PyObject_Call(r28, r34, r31)
-    r36 = unbox(int, r35)
-    return r36
+    can_dictcomp = r8
+    r22 = PySequence_List(kwargs)
+    can_iter = r22
+    r23 = CPyDict_Keys(kwargs)
+    can_use_keys = r23
+    r24 = CPyDict_Values(kwargs)
+    can_use_values = r24
+    r25 = r0.func
+    r26 = PyList_New(0)
+    r27 = CPyList_Extend(r26, args)
+    r28 = PyDict_New()
+    r29 = CPyDict_UpdateInDisplay(r28, kwargs)
+    r30 = r29 >= 0 :: signed
+    r31 = PyList_AsTuple(r26)
+    r32 = PyObject_Call(r25, r31, r28)
+    r33 = unbox(int, r32)
+    return r33
 def deco(func):
     func :: object
     r0 :: __main__.deco_env
@@ -825,3 +795,4 @@ def f(x):
     x :: int
 L0:
     return x
+

--- a/mypyc/test-data/irbuild-generics.test
+++ b/mypyc/test-data/irbuild-generics.test
@@ -795,4 +795,3 @@ def f(x):
     x :: int
 L0:
     return x
-

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -371,27 +371,21 @@ def f(source):
     source :: list
     r0 :: native_int
     r1 :: list
-    r2 :: short_int
-    r3 :: native_int
-    r4 :: short_int
-    r5 :: bit
-    r6 :: object
-    r7, x, r8 :: int
-    r9 :: object
-    r10 :: bit
-    r11 :: short_int
+    r2, r3 :: native_int
+    r4 :: bit
+    r5 :: object
+    r6, x, r7 :: int
+    r8 :: object
+    r9 :: native_int
     a :: list
-    r12 :: native_int
-    r13 :: list
-    r14 :: short_int
-    r15 :: native_int
-    r16 :: short_int
-    r17 :: bit
+    r10 :: native_int
+    r11 :: list
+    r12, r13 :: native_int
+    r14 :: bit
+    r15 :: object
+    r16, x_2, r17 :: int
     r18 :: object
-    r19, x_2, r20 :: int
-    r21 :: object
-    r22 :: bit
-    r23 :: short_int
+    r19 :: native_int
     b :: list
 L0:
     r0 = var_object_size source
@@ -399,43 +393,41 @@ L0:
     r2 = 0
 L1:
     r3 = var_object_size source
-    r4 = r3 << 1
-    r5 = int_lt r2, r4
-    if r5 goto L2 else goto L4 :: bool
+    r4 = r2 < r3 :: signed
+    if r4 goto L2 else goto L4 :: bool
 L2:
-    r6 = list_get_item_unsafe source, r2
-    r7 = unbox(int, r6)
-    x = r7
-    r8 = CPyTagged_Add(x, 2)
-    r9 = box(int, r8)
-    r10 = CPyList_SetItemUnsafe(r1, r2, r9)
+    r5 = list_get_item_unsafe source, r2
+    r6 = unbox(int, r5)
+    x = r6
+    r7 = CPyTagged_Add(x, 2)
+    r8 = box(int, r7)
+    CPyList_SetItemUnsafe(r1, r2, r8)
 L3:
-    r11 = r2 + 2
-    r2 = r11
+    r9 = r2 + 1
+    r2 = r9
     goto L1
 L4:
     a = r1
-    r12 = var_object_size source
-    r13 = PyList_New(r12)
-    r14 = 0
+    r10 = var_object_size source
+    r11 = PyList_New(r10)
+    r12 = 0
 L5:
-    r15 = var_object_size source
-    r16 = r15 << 1
-    r17 = int_lt r14, r16
-    if r17 goto L6 else goto L8 :: bool
+    r13 = var_object_size source
+    r14 = r12 < r13 :: signed
+    if r14 goto L6 else goto L8 :: bool
 L6:
-    r18 = list_get_item_unsafe source, r14
-    r19 = unbox(int, r18)
-    x_2 = r19
-    r20 = CPyTagged_Add(x_2, 2)
-    r21 = box(int, r20)
-    r22 = CPyList_SetItemUnsafe(r13, r14, r21)
+    r15 = list_get_item_unsafe source, r12
+    r16 = unbox(int, r15)
+    x_2 = r16
+    r17 = CPyTagged_Add(x_2, 2)
+    r18 = box(int, r17)
+    CPyList_SetItemUnsafe(r11, r12, r18)
 L7:
-    r23 = r14 + 2
-    r14 = r23
+    r19 = r12 + 1
+    r12 = r19
     goto L5
 L8:
-    b = r13
+    b = r11
     return 1
 
 [case testGeneratorNext]
@@ -446,40 +438,37 @@ def test(x: List[int]) -> None:
 [out]
 def test(x):
     x :: list
-    r0 :: short_int
-    r1 :: native_int
-    r2 :: short_int
-    r3 :: bit
-    r4 :: object
-    r5, i :: int
-    r6 :: object
-    r7 :: union[int, None]
-    r8 :: short_int
-    r9 :: object
+    r0, r1 :: native_int
+    r2 :: bit
+    r3 :: object
+    r4, i :: int
+    r5 :: object
+    r6 :: union[int, None]
+    r7 :: native_int
+    r8 :: object
     res :: union[int, None]
 L0:
     r0 = 0
 L1:
     r1 = var_object_size x
-    r2 = r1 << 1
-    r3 = int_lt r0, r2
-    if r3 goto L2 else goto L4 :: bool
+    r2 = r0 < r1 :: signed
+    if r2 goto L2 else goto L4 :: bool
 L2:
-    r4 = list_get_item_unsafe x, r0
-    r5 = unbox(int, r4)
-    i = r5
-    r6 = box(int, i)
-    r7 = r6
+    r3 = list_get_item_unsafe x, r0
+    r4 = unbox(int, r3)
+    i = r4
+    r5 = box(int, i)
+    r6 = r5
     goto L5
 L3:
-    r8 = r0 + 2
-    r0 = r8
+    r7 = r0 + 1
+    r0 = r7
     goto L1
 L4:
-    r9 = box(None, 1)
-    r7 = r9
+    r8 = box(None, 1)
+    r6 = r8
 L5:
-    res = r7
+    res = r6
     return 1
 
 [case testSimplifyListUnion]
@@ -517,53 +506,47 @@ L2:
     return r4
 def loop(a):
     a :: list
-    r0 :: short_int
-    r1 :: native_int
-    r2 :: short_int
-    r3 :: bit
-    r4 :: object
-    r5, x :: union[str, bytes]
-    r6 :: short_int
+    r0, r1 :: native_int
+    r2 :: bit
+    r3 :: object
+    r4, x :: union[str, bytes]
+    r5 :: native_int
 L0:
     r0 = 0
 L1:
     r1 = var_object_size a
-    r2 = r1 << 1
-    r3 = int_lt r0, r2
-    if r3 goto L2 else goto L4 :: bool
+    r2 = r0 < r1 :: signed
+    if r2 goto L2 else goto L4 :: bool
 L2:
-    r4 = list_get_item_unsafe a, r0
-    r5 = cast(union[str, bytes], r4)
-    x = r5
+    r3 = list_get_item_unsafe a, r0
+    r4 = cast(union[str, bytes], r3)
+    x = r4
 L3:
-    r6 = r0 + 2
-    r0 = r6
+    r5 = r0 + 1
+    r0 = r5
     goto L1
 L4:
     return 1
 def nested_union(a):
     a :: list
-    r0 :: short_int
-    r1 :: native_int
-    r2 :: short_int
-    r3 :: bit
-    r4 :: object
-    r5, x :: union[str, None]
-    r6 :: short_int
+    r0, r1 :: native_int
+    r2 :: bit
+    r3 :: object
+    r4, x :: union[str, None]
+    r5 :: native_int
 L0:
     r0 = 0
 L1:
     r1 = var_object_size a
-    r2 = r1 << 1
-    r3 = int_lt r0, r2
-    if r3 goto L2 else goto L4 :: bool
+    r2 = r0 < r1 :: signed
+    if r2 goto L2 else goto L4 :: bool
 L2:
-    r4 = list_get_item_unsafe a, r0
-    r5 = cast(union[str, None], r4)
-    x = r5
+    r3 = list_get_item_unsafe a, r0
+    r4 = cast(union[str, None], r3)
+    x = r4
 L3:
-    r6 = r0 + 2
-    r0 = r6
+    r5 = r0 + 1
+    r0 = r5
     goto L1
 L4:
     return 1

--- a/mypyc/test-data/irbuild-set.test
+++ b/mypyc/test-data/irbuild-set.test
@@ -85,16 +85,14 @@ def test1():
     r4 :: ptr
     tmp_list :: list
     r5 :: set
-    r6 :: short_int
-    r7 :: native_int
-    r8 :: short_int
-    r9 :: bit
-    r10 :: object
-    r11, x, r12 :: int
-    r13 :: object
-    r14 :: i32
-    r15 :: bit
-    r16 :: short_int
+    r6, r7 :: native_int
+    r8 :: bit
+    r9 :: object
+    r10, x, r11 :: int
+    r12 :: object
+    r13 :: i32
+    r14 :: bit
+    r15 :: native_int
     a :: set
 L0:
     r0 = PyList_New(3)
@@ -111,20 +109,19 @@ L0:
     r6 = 0
 L1:
     r7 = var_object_size tmp_list
-    r8 = r7 << 1
-    r9 = int_lt r6, r8
-    if r9 goto L2 else goto L4 :: bool
+    r8 = r6 < r7 :: signed
+    if r8 goto L2 else goto L4 :: bool
 L2:
-    r10 = list_get_item_unsafe tmp_list, r6
-    r11 = unbox(int, r10)
-    x = r11
-    r12 = f(x)
-    r13 = box(int, r12)
-    r14 = PySet_Add(r5, r13)
-    r15 = r14 >= 0 :: signed
+    r9 = list_get_item_unsafe tmp_list, r6
+    r10 = unbox(int, r9)
+    x = r10
+    r11 = f(x)
+    r12 = box(int, r11)
+    r13 = PySet_Add(r5, r12)
+    r14 = r13 >= 0 :: signed
 L3:
-    r16 = r6 + 2
-    r6 = r16
+    r15 = r6 + 1
+    r6 = r15
     goto L1
 L4:
     a = r5
@@ -168,16 +165,15 @@ def test3():
     r7 :: set
     r8 :: short_int
     r9 :: native_int
-    r10 :: short_int
-    r11 :: object
-    r12 :: tuple[bool, short_int, object]
-    r13 :: short_int
-    r14 :: bool
-    r15 :: object
-    r16, x, r17 :: int
-    r18 :: object
-    r19 :: i32
-    r20, r21, r22 :: bit
+    r10 :: object
+    r11 :: tuple[bool, short_int, object]
+    r12 :: short_int
+    r13 :: bool
+    r14 :: object
+    r15, x, r16 :: int
+    r17 :: object
+    r18 :: i32
+    r19, r20, r21 :: bit
     c :: set
 L0:
     r0 = '1'
@@ -191,27 +187,26 @@ L0:
     r7 = PySet_New(0)
     r8 = 0
     r9 = PyDict_Size(tmp_dict)
-    r10 = r9 << 1
-    r11 = CPyDict_GetKeysIter(tmp_dict)
+    r10 = CPyDict_GetKeysIter(tmp_dict)
 L1:
-    r12 = CPyDict_NextKey(r11, r8)
-    r13 = r12[1]
-    r8 = r13
-    r14 = r12[0]
-    if r14 goto L2 else goto L4 :: bool
+    r11 = CPyDict_NextKey(r10, r8)
+    r12 = r11[1]
+    r8 = r12
+    r13 = r11[0]
+    if r13 goto L2 else goto L4 :: bool
 L2:
-    r15 = r12[2]
-    r16 = unbox(int, r15)
-    x = r16
-    r17 = f(x)
-    r18 = box(int, r17)
-    r19 = PySet_Add(r7, r18)
-    r20 = r19 >= 0 :: signed
+    r14 = r11[2]
+    r15 = unbox(int, r14)
+    x = r15
+    r16 = f(x)
+    r17 = box(int, r16)
+    r18 = PySet_Add(r7, r17)
+    r19 = r18 >= 0 :: signed
 L3:
-    r21 = CPyDict_CheckSize(tmp_dict, r10)
+    r20 = CPyDict_CheckSize(tmp_dict, r9)
     goto L1
 L4:
-    r22 = CPy_NoErrOccurred()
+    r21 = CPy_NoErrOccurred()
 L5:
     c = r7
     return 1
@@ -313,28 +308,26 @@ def test():
     tmp_list :: list
     r7 :: set
     r8, r9 :: list
-    r10 :: short_int
-    r11 :: native_int
-    r12 :: short_int
-    r13 :: bit
-    r14 :: object
-    r15, z :: int
-    r16 :: bit
-    r17 :: int
-    r18 :: object
-    r19 :: i32
-    r20 :: bit
-    r21 :: short_int
-    r22, r23, r24 :: object
-    r25, y, r26 :: int
-    r27 :: object
-    r28 :: i32
-    r29, r30 :: bit
-    r31, r32, r33 :: object
-    r34, x, r35 :: int
-    r36 :: object
-    r37 :: i32
-    r38, r39 :: bit
+    r10, r11 :: native_int
+    r12 :: bit
+    r13 :: object
+    r14, z :: int
+    r15 :: bit
+    r16 :: int
+    r17 :: object
+    r18 :: i32
+    r19 :: bit
+    r20 :: native_int
+    r21, r22, r23 :: object
+    r24, y, r25 :: int
+    r26 :: object
+    r27 :: i32
+    r28, r29 :: bit
+    r30, r31, r32 :: object
+    r33, x, r34 :: int
+    r35 :: object
+    r36 :: i32
+    r37, r38 :: bit
     a :: set
 L0:
     r0 = PyList_New(5)
@@ -357,60 +350,59 @@ L0:
     r10 = 0
 L1:
     r11 = var_object_size tmp_list
-    r12 = r11 << 1
-    r13 = int_lt r10, r12
-    if r13 goto L2 else goto L6 :: bool
+    r12 = r10 < r11 :: signed
+    if r12 goto L2 else goto L6 :: bool
 L2:
-    r14 = list_get_item_unsafe tmp_list, r10
-    r15 = unbox(int, r14)
-    z = r15
-    r16 = int_lt z, 8
-    if r16 goto L4 else goto L3 :: bool
+    r13 = list_get_item_unsafe tmp_list, r10
+    r14 = unbox(int, r13)
+    z = r14
+    r15 = int_lt z, 8
+    if r15 goto L4 else goto L3 :: bool
 L3:
     goto L5
 L4:
-    r17 = f1(z)
-    r18 = box(int, r17)
-    r19 = PyList_Append(r9, r18)
-    r20 = r19 >= 0 :: signed
+    r16 = f1(z)
+    r17 = box(int, r16)
+    r18 = PyList_Append(r9, r17)
+    r19 = r18 >= 0 :: signed
 L5:
-    r21 = r10 + 2
-    r10 = r21
+    r20 = r10 + 1
+    r10 = r20
     goto L1
 L6:
-    r22 = PyObject_GetIter(r9)
-    r23 = PyObject_GetIter(r22)
+    r21 = PyObject_GetIter(r9)
+    r22 = PyObject_GetIter(r21)
 L7:
-    r24 = PyIter_Next(r23)
-    if is_error(r24) goto L10 else goto L8
+    r23 = PyIter_Next(r22)
+    if is_error(r23) goto L10 else goto L8
 L8:
-    r25 = unbox(int, r24)
-    y = r25
-    r26 = f2(y)
-    r27 = box(int, r26)
-    r28 = PyList_Append(r8, r27)
-    r29 = r28 >= 0 :: signed
+    r24 = unbox(int, r23)
+    y = r24
+    r25 = f2(y)
+    r26 = box(int, r25)
+    r27 = PyList_Append(r8, r26)
+    r28 = r27 >= 0 :: signed
 L9:
     goto L7
 L10:
-    r30 = CPy_NoErrOccurred()
+    r29 = CPy_NoErrOccurred()
 L11:
-    r31 = PyObject_GetIter(r8)
-    r32 = PyObject_GetIter(r31)
+    r30 = PyObject_GetIter(r8)
+    r31 = PyObject_GetIter(r30)
 L12:
-    r33 = PyIter_Next(r32)
-    if is_error(r33) goto L15 else goto L13
+    r32 = PyIter_Next(r31)
+    if is_error(r32) goto L15 else goto L13
 L13:
-    r34 = unbox(int, r33)
-    x = r34
-    r35 = f3(x)
-    r36 = box(int, r35)
-    r37 = PySet_Add(r7, r36)
-    r38 = r37 >= 0 :: signed
+    r33 = unbox(int, r32)
+    x = r33
+    r34 = f3(x)
+    r35 = box(int, r34)
+    r36 = PySet_Add(r7, r35)
+    r37 = r36 >= 0 :: signed
 L14:
     goto L12
 L15:
-    r39 = CPy_NoErrOccurred()
+    r38 = CPy_NoErrOccurred()
 L16:
     a = r7
     return 1

--- a/mypyc/test-data/irbuild-statements.test
+++ b/mypyc/test-data/irbuild-statements.test
@@ -230,30 +230,27 @@ def f(ls: List[int]) -> int:
 def f(ls):
     ls :: list
     y :: int
-    r0 :: short_int
-    r1 :: native_int
-    r2 :: short_int
-    r3 :: bit
-    r4 :: object
-    r5, x, r6 :: int
-    r7 :: short_int
+    r0, r1 :: native_int
+    r2 :: bit
+    r3 :: object
+    r4, x, r5 :: int
+    r6 :: native_int
 L0:
     y = 0
     r0 = 0
 L1:
     r1 = var_object_size ls
-    r2 = r1 << 1
-    r3 = int_lt r0, r2
-    if r3 goto L2 else goto L4 :: bool
+    r2 = r0 < r1 :: signed
+    if r2 goto L2 else goto L4 :: bool
 L2:
-    r4 = list_get_item_unsafe ls, r0
-    r5 = unbox(int, r4)
-    x = r5
-    r6 = CPyTagged_Add(y, x)
-    y = r6
+    r3 = list_get_item_unsafe ls, r0
+    r4 = unbox(int, r3)
+    x = r4
+    r5 = CPyTagged_Add(y, x)
+    y = r5
 L3:
-    r7 = r0 + 2
-    r0 = r7
+    r6 = r0 + 1
+    r0 = r6
     goto L1
 L4:
     return y
@@ -269,39 +266,37 @@ def f(d):
     d :: dict
     r0 :: short_int
     r1 :: native_int
-    r2 :: short_int
-    r3 :: object
-    r4 :: tuple[bool, short_int, object]
-    r5 :: short_int
-    r6 :: bool
-    r7 :: object
-    r8, key :: int
-    r9, r10 :: object
-    r11 :: int
-    r12, r13 :: bit
+    r2 :: object
+    r3 :: tuple[bool, short_int, object]
+    r4 :: short_int
+    r5 :: bool
+    r6 :: object
+    r7, key :: int
+    r8, r9 :: object
+    r10 :: int
+    r11, r12 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d)
-    r2 = r1 << 1
-    r3 = CPyDict_GetKeysIter(d)
+    r2 = CPyDict_GetKeysIter(d)
 L1:
-    r4 = CPyDict_NextKey(r3, r0)
-    r5 = r4[1]
-    r0 = r5
-    r6 = r4[0]
-    if r6 goto L2 else goto L4 :: bool
+    r3 = CPyDict_NextKey(r2, r0)
+    r4 = r3[1]
+    r0 = r4
+    r5 = r3[0]
+    if r5 goto L2 else goto L4 :: bool
 L2:
-    r7 = r4[2]
-    r8 = unbox(int, r7)
-    key = r8
-    r9 = box(int, key)
-    r10 = CPyDict_GetItem(d, r9)
-    r11 = unbox(int, r10)
+    r6 = r3[2]
+    r7 = unbox(int, r6)
+    key = r7
+    r8 = box(int, key)
+    r9 = CPyDict_GetItem(d, r8)
+    r10 = unbox(int, r9)
 L3:
-    r12 = CPyDict_CheckSize(d, r2)
+    r11 = CPyDict_CheckSize(d, r1)
     goto L1
 L4:
-    r13 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L5:
     return 1
 
@@ -321,54 +316,52 @@ def sum_over_even_values(d):
     s :: int
     r0 :: short_int
     r1 :: native_int
-    r2 :: short_int
-    r3 :: object
-    r4 :: tuple[bool, short_int, object]
-    r5 :: short_int
-    r6 :: bool
-    r7 :: object
-    r8, key :: int
-    r9, r10 :: object
-    r11, r12 :: int
-    r13 :: bit
-    r14, r15 :: object
-    r16, r17 :: int
-    r18, r19 :: bit
+    r2 :: object
+    r3 :: tuple[bool, short_int, object]
+    r4 :: short_int
+    r5 :: bool
+    r6 :: object
+    r7, key :: int
+    r8, r9 :: object
+    r10, r11 :: int
+    r12 :: bit
+    r13, r14 :: object
+    r15, r16 :: int
+    r17, r18 :: bit
 L0:
     s = 0
     r0 = 0
     r1 = PyDict_Size(d)
-    r2 = r1 << 1
-    r3 = CPyDict_GetKeysIter(d)
+    r2 = CPyDict_GetKeysIter(d)
 L1:
-    r4 = CPyDict_NextKey(r3, r0)
-    r5 = r4[1]
-    r0 = r5
-    r6 = r4[0]
-    if r6 goto L2 else goto L6 :: bool
+    r3 = CPyDict_NextKey(r2, r0)
+    r4 = r3[1]
+    r0 = r4
+    r5 = r3[0]
+    if r5 goto L2 else goto L6 :: bool
 L2:
-    r7 = r4[2]
-    r8 = unbox(int, r7)
-    key = r8
-    r9 = box(int, key)
-    r10 = CPyDict_GetItem(d, r9)
-    r11 = unbox(int, r10)
-    r12 = CPyTagged_Remainder(r11, 4)
-    r13 = r12 != 0
-    if r13 goto L3 else goto L4 :: bool
+    r6 = r3[2]
+    r7 = unbox(int, r6)
+    key = r7
+    r8 = box(int, key)
+    r9 = CPyDict_GetItem(d, r8)
+    r10 = unbox(int, r9)
+    r11 = CPyTagged_Remainder(r10, 4)
+    r12 = r11 != 0
+    if r12 goto L3 else goto L4 :: bool
 L3:
     goto L5
 L4:
-    r14 = box(int, key)
-    r15 = CPyDict_GetItem(d, r14)
-    r16 = unbox(int, r15)
-    r17 = CPyTagged_Add(s, r16)
-    s = r17
+    r13 = box(int, key)
+    r14 = CPyDict_GetItem(d, r13)
+    r15 = unbox(int, r14)
+    r16 = CPyTagged_Add(s, r15)
+    s = r16
 L5:
-    r18 = CPyDict_CheckSize(d, r2)
+    r17 = CPyDict_CheckSize(d, r1)
     goto L1
 L6:
-    r19 = CPy_NoErrOccurred()
+    r18 = CPy_NoErrOccurred()
 L7:
     return s
 
@@ -597,16 +590,16 @@ L0:
     r0 = CPySequence_CheckUnpackCount(l, 2)
     r1 = r0 >= 0 :: signed
     r2 = list_get_item_unsafe l, 0
-    r3 = list_get_item_unsafe l, 2
+    r3 = list_get_item_unsafe l, 1
     x = r2
     r4 = unbox(int, r3)
     y = r4
     r5 = CPySequence_CheckUnpackCount(t, 2)
     r6 = r5 >= 0 :: signed
-    r7 = CPySequenceTuple_GetItem(t, 0)
-    r8 = CPySequenceTuple_GetItem(t, 2)
-    r9 = unbox(int, r8)
+    r7 = CPySequenceTuple_GetItemUnsafe(t, 0)
+    r8 = CPySequenceTuple_GetItemUnsafe(t, 1)
     x = r7
+    r9 = unbox(int, r8)
     y = r9
     return 1
 
@@ -872,33 +865,32 @@ def g(x: Iterable[int]) -> None:
 [out]
 def f(a):
     a :: list
-    r0, r1 :: short_int
-    r2 :: native_int
-    r3 :: short_int
-    r4 :: bit
+    r0 :: short_int
+    r1, r2 :: native_int
+    r3 :: bit
     i :: int
-    r5 :: object
-    r6, x, r7 :: int
-    r8, r9 :: short_int
+    r4 :: object
+    r5, x, r6 :: int
+    r7 :: short_int
+    r8 :: native_int
 L0:
     r0 = 0
     r1 = 0
 L1:
     r2 = var_object_size a
-    r3 = r2 << 1
-    r4 = int_lt r1, r3
-    if r4 goto L2 else goto L4 :: bool
+    r3 = r1 < r2 :: signed
+    if r3 goto L2 else goto L4 :: bool
 L2:
     i = r0
-    r5 = list_get_item_unsafe a, r1
-    r6 = unbox(int, r5)
-    x = r6
-    r7 = CPyTagged_Add(i, x)
+    r4 = list_get_item_unsafe a, r1
+    r5 = unbox(int, r4)
+    x = r5
+    r6 = CPyTagged_Add(i, x)
 L3:
-    r8 = r0 + 2
-    r0 = r8
-    r9 = r1 + 2
-    r1 = r9
+    r7 = r0 + 2
+    r0 = r7
+    r8 = r1 + 1
+    r1 = r8
     goto L1
 L4:
 L5:
@@ -944,66 +936,65 @@ def g(a: Iterable[bool], b: List[int]) -> None:
 def f(a, b):
     a :: list
     b :: object
-    r0 :: short_int
+    r0 :: native_int
     r1 :: object
     r2 :: native_int
-    r3 :: short_int
-    r4 :: bit
-    r5, r6 :: object
-    r7, x :: int
-    r8, y :: bool
-    r9 :: i32
-    r10 :: bit
-    r11 :: bool
-    r12 :: short_int
-    r13 :: bit
+    r3 :: bit
+    r4, r5 :: object
+    r6, x :: int
+    r7, y :: bool
+    r8 :: i32
+    r9 :: bit
+    r10 :: bool
+    r11 :: native_int
+    r12 :: bit
 L0:
     r0 = 0
     r1 = PyObject_GetIter(b)
 L1:
     r2 = var_object_size a
-    r3 = r2 << 1
-    r4 = int_lt r0, r3
-    if r4 goto L2 else goto L7 :: bool
+    r3 = r0 < r2 :: signed
+    if r3 goto L2 else goto L7 :: bool
 L2:
-    r5 = PyIter_Next(r1)
-    if is_error(r5) goto L7 else goto L3
+    r4 = PyIter_Next(r1)
+    if is_error(r4) goto L7 else goto L3
 L3:
-    r6 = list_get_item_unsafe a, r0
-    r7 = unbox(int, r6)
-    x = r7
-    r8 = unbox(bool, r5)
-    y = r8
-    r9 = PyObject_IsTrue(b)
-    r10 = r9 >= 0 :: signed
-    r11 = truncate r9: i32 to builtins.bool
-    if r11 goto L4 else goto L5 :: bool
+    r5 = list_get_item_unsafe a, r0
+    r6 = unbox(int, r5)
+    x = r6
+    r7 = unbox(bool, r4)
+    y = r7
+    r8 = PyObject_IsTrue(b)
+    r9 = r8 >= 0 :: signed
+    r10 = truncate r8: i32 to builtins.bool
+    if r10 goto L4 else goto L5 :: bool
 L4:
     x = 2
 L5:
 L6:
-    r12 = r0 + 2
-    r0 = r12
+    r11 = r0 + 1
+    r0 = r11
     goto L1
 L7:
-    r13 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L8:
     return 1
 def g(a, b):
     a :: object
     b :: list
     r0 :: object
-    r1, r2 :: short_int
+    r1 :: native_int
+    r2 :: short_int
     z :: int
     r3 :: object
     r4 :: native_int
-    r5 :: short_int
-    r6, r7 :: bit
-    r8, x :: bool
-    r9 :: object
-    r10, y :: int
-    r11, r12 :: short_int
-    r13 :: bit
+    r5, r6 :: bit
+    r7, x :: bool
+    r8 :: object
+    r9, y :: int
+    r10 :: native_int
+    r11 :: short_int
+    r12 :: bit
 L0:
     r0 = PyObject_GetIter(a)
     r1 = 0
@@ -1014,28 +1005,27 @@ L1:
     if is_error(r3) goto L6 else goto L2
 L2:
     r4 = var_object_size b
-    r5 = r4 << 1
-    r6 = int_lt r1, r5
-    if r6 goto L3 else goto L6 :: bool
+    r5 = r1 < r4 :: signed
+    if r5 goto L3 else goto L6 :: bool
 L3:
-    r7 = int_lt r2, 10
-    if r7 goto L4 else goto L6 :: bool
+    r6 = int_lt r2, 10
+    if r6 goto L4 else goto L6 :: bool
 L4:
-    r8 = unbox(bool, r3)
-    x = r8
-    r9 = list_get_item_unsafe b, r1
-    r10 = unbox(int, r9)
-    y = r10
+    r7 = unbox(bool, r3)
+    x = r7
+    r8 = list_get_item_unsafe b, r1
+    r9 = unbox(int, r8)
+    y = r9
     x = 0
 L5:
-    r11 = r1 + 2
-    r1 = r11
-    r12 = r2 + 2
-    r2 = r12
-    z = r12
+    r10 = r1 + 1
+    r1 = r10
+    r11 = r2 + 2
+    r2 = r11
+    z = r11
     goto L1
 L6:
-    r13 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L7:
     return 1
 

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -272,7 +272,7 @@ L4:
     a = r6
     return 1
 
-[case testTupleBuiltFromStr]
+[case testTupleBuiltFromStr_64bit]
 def f2(val: str) -> str:
     return val + "f2"
 

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -127,27 +127,24 @@ def f(xs: Tuple[str, ...]) -> None:
 [out]
 def f(xs):
     xs :: tuple
-    r0 :: short_int
-    r1 :: native_int
-    r2 :: short_int
-    r3 :: bit
-    r4 :: object
-    r5, x :: str
-    r6 :: short_int
+    r0, r1 :: native_int
+    r2 :: bit
+    r3 :: object
+    r4, x :: str
+    r5 :: native_int
 L0:
     r0 = 0
 L1:
     r1 = var_object_size xs
-    r2 = r1 << 1
-    r3 = int_lt r0, r2
-    if r3 goto L2 else goto L4 :: bool
+    r2 = r0 < r1 :: signed
+    if r2 goto L2 else goto L4 :: bool
 L2:
-    r4 = CPySequenceTuple_GetItem(xs, r0)
-    r5 = cast(str, r4)
-    x = r5
+    r3 = CPySequenceTuple_GetItemUnsafe(xs, r0)
+    r4 = cast(str, r3)
+    x = r4
 L3:
-    r6 = r0 + 2
-    r0 = r6
+    r5 = r0 + 1
+    r0 = r5
     goto L1
 L4:
     return 1
@@ -234,16 +231,13 @@ def test():
     source :: list
     r5 :: native_int
     r6 :: tuple
-    r7 :: short_int
-    r8 :: native_int
-    r9 :: short_int
-    r10 :: bit
-    r11 :: object
-    r12, x :: int
-    r13 :: bool
-    r14 :: object
-    r15 :: bit
-    r16 :: short_int
+    r7, r8 :: native_int
+    r9 :: bit
+    r10 :: object
+    r11, x :: int
+    r12 :: bool
+    r13 :: object
+    r14 :: native_int
     a :: tuple
 L0:
     r0 = PyList_New(3)
@@ -261,19 +255,18 @@ L0:
     r7 = 0
 L1:
     r8 = var_object_size source
-    r9 = r8 << 1
-    r10 = int_lt r7, r9
-    if r10 goto L2 else goto L4 :: bool
+    r9 = r7 < r8 :: signed
+    if r9 goto L2 else goto L4 :: bool
 L2:
-    r11 = list_get_item_unsafe source, r7
-    r12 = unbox(int, r11)
-    x = r12
-    r13 = f(x)
-    r14 = box(bool, r13)
-    r15 = CPySequenceTuple_SetItemUnsafe(r6, r7, r14)
+    r10 = list_get_item_unsafe source, r7
+    r11 = unbox(int, r10)
+    x = r11
+    r12 = f(x)
+    r13 = box(bool, r12)
+    CPySequenceTuple_SetItemUnsafe(r6, r7, r13)
 L3:
-    r16 = r7 + 2
-    r7 = r16
+    r14 = r7 + 1
+    r7 = r14
     goto L1
 L4:
     a = r6
@@ -298,14 +291,11 @@ def test():
     r1 :: native_int
     r2 :: bit
     r3 :: tuple
-    r4 :: short_int
-    r5 :: native_int
-    r6 :: bit
-    r7 :: short_int
-    r8 :: bit
-    r9, x, r10 :: str
-    r11 :: bit
-    r12 :: short_int
+    r4, r5 :: native_int
+    r6, r7, r8, r9 :: bit
+    r10, r11, r12 :: int
+    r13, x, r14 :: str
+    r15 :: native_int
     a :: tuple
 L0:
     r0 = 'abc'
@@ -317,19 +307,31 @@ L0:
 L1:
     r5 = CPyStr_Size_size_t(source)
     r6 = r5 >= 0 :: signed
-    r7 = r5 << 1
-    r8 = int_lt r4, r7
-    if r8 goto L2 else goto L4 :: bool
+    r7 = r4 < r5 :: signed
+    if r7 goto L2 else goto L8 :: bool
 L2:
-    r9 = CPyStr_GetItem(source, r4)
-    x = r9
-    r10 = f2(x)
-    r11 = CPySequenceTuple_SetItemUnsafe(r3, r4, r10)
+    r8 = r4 <= 4611686018427387903 :: signed
+    if r8 goto L3 else goto L4 :: bool
 L3:
-    r12 = r4 + 2
-    r4 = r12
-    goto L1
+    r9 = r4 >= -4611686018427387904 :: signed
+    if r9 goto L5 else goto L4 :: bool
 L4:
+    r10 = CPyTagged_FromInt64(r4)
+    r11 = r10
+    goto L6
+L5:
+    r12 = r4 << 1
+    r11 = r12
+L6:
+    r13 = CPyStr_GetItem(source, r11)
+    x = r13
+    r14 = f2(x)
+    CPySequenceTuple_SetItemUnsafe(r3, r4, r14)
+L7:
+    r15 = r4 + 1
+    r4 = r15
+    goto L1
+L8:
     a = r3
     return 1
 
@@ -351,15 +353,12 @@ def test(source):
     source :: tuple
     r0 :: native_int
     r1 :: tuple
-    r2 :: short_int
-    r3 :: native_int
-    r4 :: short_int
-    r5 :: bit
-    r6 :: object
-    r7, x, r8 :: bool
-    r9 :: object
-    r10 :: bit
-    r11 :: short_int
+    r2, r3 :: native_int
+    r4 :: bit
+    r5 :: object
+    r6, x, r7 :: bool
+    r8 :: object
+    r9 :: native_int
     a :: tuple
 L0:
     r0 = var_object_size source
@@ -367,19 +366,18 @@ L0:
     r2 = 0
 L1:
     r3 = var_object_size source
-    r4 = r3 << 1
-    r5 = int_lt r2, r4
-    if r5 goto L2 else goto L4 :: bool
+    r4 = r2 < r3 :: signed
+    if r4 goto L2 else goto L4 :: bool
 L2:
-    r6 = CPySequenceTuple_GetItem(source, r2)
-    r7 = unbox(bool, r6)
-    x = r7
-    r8 = f(x)
-    r9 = box(bool, r8)
-    r10 = CPySequenceTuple_SetItemUnsafe(r1, r2, r9)
+    r5 = CPySequenceTuple_GetItemUnsafe(source, r2)
+    r6 = unbox(bool, r5)
+    x = r6
+    r7 = f(x)
+    r8 = box(bool, r7)
+    CPySequenceTuple_SetItemUnsafe(r1, r2, r8)
 L3:
-    r11 = r2 + 2
-    r2 = r11
+    r9 = r2 + 1
+    r2 = r9
     goto L1
 L4:
     a = r1

--- a/mypyc/test-data/lowering-int.test
+++ b/mypyc/test-data/lowering-int.test
@@ -381,4 +381,3 @@ L5:
 L6:
     r11 = <error> :: None
     return r11
-

--- a/mypyc/test-data/lowering-int.test
+++ b/mypyc/test-data/lowering-int.test
@@ -341,47 +341,44 @@ def f(l: list[int]) -> None:
 [out]
 def f(l):
     l :: list
-    r0 :: short_int
+    r0 :: native_int
     r1 :: ptr
     r2 :: native_int
-    r3 :: short_int
-    r4 :: bit
-    r5 :: native_int
-    r6, r7 :: ptr
-    r8 :: native_int
-    r9 :: ptr
-    r10 :: object
-    r11, x :: int
-    r12 :: short_int
-    r13 :: None
+    r3 :: bit
+    r4, r5 :: ptr
+    r6 :: native_int
+    r7 :: ptr
+    r8 :: object
+    r9, x :: int
+    r10 :: native_int
+    r11 :: None
 L0:
     r0 = 0
 L1:
     r1 = get_element_ptr l ob_size :: PyVarObject
     r2 = load_mem r1 :: native_int*
-    r3 = r2 << 1
-    r4 = r0 < r3 :: signed
-    if r4 goto L2 else goto L5 :: bool
+    r3 = r0 < r2 :: signed
+    if r3 goto L2 else goto L5 :: bool
 L2:
-    r5 = r0 >> 1
-    r6 = get_element_ptr l ob_item :: PyListObject
-    r7 = load_mem r6 :: ptr*
-    r8 = r5 * 8
-    r9 = r7 + r8
-    r10 = load_mem r9 :: builtins.object*
-    inc_ref r10
-    r11 = unbox(int, r10)
-    dec_ref r10
-    if is_error(r11) goto L6 (error at f:4) else goto L3
+    r4 = get_element_ptr l ob_item :: PyListObject
+    r5 = load_mem r4 :: ptr*
+    r6 = r0 * 8
+    r7 = r5 + r6
+    r8 = load_mem r7 :: builtins.object*
+    inc_ref r8
+    r9 = unbox(int, r8)
+    dec_ref r8
+    if is_error(r9) goto L6 (error at f:4) else goto L3
 L3:
-    x = r11
+    x = r9
     dec_ref x :: int
 L4:
-    r12 = r0 + 2
-    r0 = r12
+    r10 = r0 + 1
+    r0 = r10
     goto L1
 L5:
     return 1
 L6:
-    r13 = <error> :: None
-    return r13
+    r11 = <error> :: None
+    return r11
+

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -730,49 +730,47 @@ def f(d):
     d :: dict
     r0 :: short_int
     r1 :: native_int
-    r2 :: short_int
-    r3 :: object
-    r4 :: tuple[bool, short_int, object]
-    r5 :: short_int
-    r6 :: bool
-    r7 :: object
-    r8, key :: int
-    r9, r10 :: object
-    r11 :: int
-    r12, r13 :: bit
+    r2 :: object
+    r3 :: tuple[bool, short_int, object]
+    r4 :: short_int
+    r5 :: bool
+    r6 :: object
+    r7, key :: int
+    r8, r9 :: object
+    r10 :: int
+    r11, r12 :: bit
 L0:
     r0 = 0
     r1 = PyDict_Size(d)
-    r2 = r1 << 1
-    r3 = CPyDict_GetKeysIter(d)
+    r2 = CPyDict_GetKeysIter(d)
 L1:
-    r4 = CPyDict_NextKey(r3, r0)
-    r5 = r4[1]
-    r0 = r5
-    r6 = r4[0]
-    if r6 goto L2 else goto L6 :: bool
+    r3 = CPyDict_NextKey(r2, r0)
+    r4 = r3[1]
+    r0 = r4
+    r5 = r3[0]
+    if r5 goto L2 else goto L6 :: bool
 L2:
-    r7 = r4[2]
-    dec_ref r4
-    r8 = unbox(int, r7)
-    dec_ref r7
-    key = r8
-    r9 = box(int, key)
-    r10 = CPyDict_GetItem(d, r9)
+    r6 = r3[2]
+    dec_ref r3
+    r7 = unbox(int, r6)
+    dec_ref r6
+    key = r7
+    r8 = box(int, key)
+    r9 = CPyDict_GetItem(d, r8)
+    dec_ref r8
+    r10 = unbox(int, r9)
     dec_ref r9
-    r11 = unbox(int, r10)
-    dec_ref r10
-    dec_ref r11 :: int
+    dec_ref r10 :: int
 L3:
-    r12 = CPyDict_CheckSize(d, r2)
+    r11 = CPyDict_CheckSize(d, r1)
     goto L1
 L4:
-    r13 = CPy_NoErrOccurred()
+    r12 = CPy_NoErrOccurred()
 L5:
     return 1
 L6:
+    dec_ref r2
     dec_ref r3
-    dec_ref r4
     goto L4
 
 [case testBorrowRefs]


### PR DESCRIPTION
For example, when iterating over a list, now we use a native integer
for the index (which is not exposed to the user). Previously we used
tagged integers, but in these use cases they provide no real benefit.

This simplifies the IR and should slightly improve performance, as fewer
tagged int to native int conversions are needed.

Multiple ops have to be migrated in one go, as these interact with
each other, and by only changing a subset of them would actually
generate more verbose IR, as a bunch of extra coercions would be
needed.

List of impacted statements:
 * For loop over sequence
 * Assignment like `x, y = a` for tuple/list rvalue
 * Dict iteration
 * List comprehension

For example, consider this example:
```
def foo(a: list[int]) -> None:
    for x in a:
        pass
```

Old generated IR was like this:
```
def foo(a):
    a :: list
    r0 :: short_int
    r1 :: ptr
    r2 :: native_int
    r3 :: short_int
    r4 :: bit
    r5 :: native_int
    r6, r7 :: ptr
    r8 :: native_int
    r9 :: ptr
    r10 :: object
    r11 :: int
    r12 :: short_int
    r13 :: None
L0:
    r0 = 0
L1:
    r1 = get_element_ptr a ob_size :: PyVarObject
    r2 = load_mem r1 :: native_int*
    r3 = r2 << 1
    r4 = r0 < r3 :: signed
    if r4 goto L2 else goto L5 :: bool
L2:
    r5 = r0 >> 1
    r6 = get_element_ptr a ob_item :: PyListObject
    r7 = load_mem r6 :: ptr*
    r8 = r5 * 8
    r9 = r7 + r8
    r10 = load_mem r9 :: builtins.object*
    inc_ref r10
    r11 = unbox(int, r10)
    dec_ref r10
    if is_error(r11) goto L6 (error at foo:2) else goto L3
L3:
    dec_ref r11 :: int
L4:
    r12 = r0 + 2
    r0 = r12
    goto L1
L5:
    return 1
L6:
    r13 = <error> :: None
    return r13
```

Now the generated IR is simpler:
```
def foo(a):
    a :: list
    r0 :: native_int
    r1 :: ptr
    r2 :: native_int
    r3 :: bit
    r4, r5 :: ptr
    r6 :: native_int
    r7 :: ptr
    r8 :: object
    r9 :: int
    r10 :: native_int
    r11 :: None
L0:
    r0 = 0
L1:
    r1 = get_element_ptr a ob_size :: PyVarObject
    r2 = load_mem r1 :: native_int*
    r3 = r0 < r2 :: signed
    if r3 goto L2 else goto L5 :: bool
L2:
    r4 = get_element_ptr a ob_item :: PyListObject
    r5 = load_mem r4 :: ptr*
    r6 = r0 * 8
    r7 = r5 + r6
    r8 = load_mem r7 :: builtins.object*
    inc_ref r8
    r9 = unbox(int, r8)
    dec_ref r8
    if is_error(r9) goto L6 (error at foo:2) else goto L3
L3:
    dec_ref r9 :: int
L4:
    r10 = r0 + 1
    r0 = r10
    goto L1
L5:
    return 1
L6:
    r11 = <error> :: None
    return r11
```