### PR TITLE
Fix "ignored exception in `hasattr`" in dmypy

### DIFF
--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -351,6 +351,9 @@ class NodeReplaceVisitor(TraverserVisitor):
                 # in external types (e.g. named tuples), so we need to update it manually.
                 skip_slots = ("special_alias",)
                 replace_object_state(new.special_alias, node.special_alias)
+            if isinstance(node, OverloadedFuncDef) and isinstance(new, OverloadedFuncDef):
+                # Non-settable property that can raise AssertionError's during patching
+                skip_slots = ("setter",)
             replace_object_state(new, node, skip_slots=skip_slots)
             return cast(SN, new)
         return node

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -345,16 +345,11 @@ class NodeReplaceVisitor(TraverserVisitor):
     def fixup(self, node: SN) -> SN:
         if node in self.replacements:
             new = self.replacements[node]
-            skip_slots: tuple[str, ...] = ()
             if isinstance(node, TypeInfo) and isinstance(new, TypeInfo):
                 # Special case: special_alias is not exposed in symbol tables, but may appear
                 # in external types (e.g. named tuples), so we need to update it manually.
-                skip_slots = ("special_alias",)
                 replace_object_state(new.special_alias, node.special_alias)
-            if isinstance(node, OverloadedFuncDef) and isinstance(new, OverloadedFuncDef):
-                # Non-settable property that can raise AssertionError's during patching
-                skip_slots = ("setter",)
-            replace_object_state(new, node, skip_slots=skip_slots)
+            replace_object_state(new, node, skip_slots=_get_ignored_slots(new))
             return cast(SN, new)
         return node
 
@@ -559,9 +554,16 @@ def replace_nodes_in_symbol_table(
             if node.node in replacements:
                 new = replacements[node.node]
                 old = node.node
-                # Needed for TypeInfo, see comment in fixup() above.
-                replace_object_state(new, old, skip_slots=("special_alias",))
+                replace_object_state(new, old, skip_slots=_get_ignored_slots(new))
                 node.node = new
             if isinstance(node.node, (Var, TypeAlias)):
                 # Handle them here just in case these aren't exposed through the AST.
                 node.node.accept(NodeReplaceVisitor(replacements))
+
+
+def _get_ignored_slots(node: SymbolNode) -> tuple[str, ...]:
+    if isinstance(node, OverloadedFuncDef):
+        return ("setter",)
+    if isinstance(node, TypeInfo):
+        return ("special_alias",)
+    return ()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,14 @@ addopts = "-nauto --strict-markers --strict-config"
 # treat xpasses as test failures so they get converted to regular tests as soon as possible
 xfail_strict = true
 
+# Force warnings as errors
+filterwarnings = [
+  "error",
+  # Some testcases may contain code that emits SyntaxWarnings, and they are not yet
+  # handled consistently in 3.14 (PEP 765)
+  "default::SyntaxWarning",
+]
+
 [tool.coverage.run]
 branch = true
 source = ["mypy"]


### PR DESCRIPTION
Fixes #19425. That property has no setter so it should safe to exclude. It can raise in inconsistent state that arises when it is not copied last?