### PR TITLE
[mypyc] Add SetElement op for initializing struct values

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -45,12 +45,14 @@ from mypyc.ir.ops import (
     RegisterOp,
     Return,
     SetAttr,
+    SetElement,
     SetMem,
     Truncate,
     TupleGet,
     TupleSet,
     Unborrow,
     Unbox,
+    Undef,
     Unreachable,
     Value,
 )
@@ -272,6 +274,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill[T]]):
     def visit_get_element_ptr(self, op: GetElementPtr) -> GenAndKill[T]:
         return self.visit_register_op(op)
 
+    def visit_set_element(self, op: SetElement) -> GenAndKill[T]:
+        return self.visit_register_op(op)
+
     def visit_load_address(self, op: LoadAddress) -> GenAndKill[T]:
         return self.visit_register_op(op)
 
@@ -444,7 +449,7 @@ class UndefinedVisitor(BaseAnalysisVisitor[Value]):
 def non_trivial_sources(op: Op) -> set[Value]:
     result = set()
     for source in op.sources():
-        if not isinstance(source, (Integer, Float)):
+        if not isinstance(source, (Integer, Float, Undef)):
             result.add(source)
     return result
 

--- a/mypyc/analysis/ircheck.py
+++ b/mypyc/analysis/ircheck.py
@@ -17,6 +17,7 @@ from mypyc.ir.ops import (
     ControlOp,
     DecRef,
     Extend,
+    Float,
     FloatComparisonOp,
     FloatNeg,
     FloatOp,
@@ -42,12 +43,14 @@ from mypyc.ir.ops import (
     Register,
     Return,
     SetAttr,
+    SetElement,
     SetMem,
     Truncate,
     TupleGet,
     TupleSet,
     Unborrow,
     Unbox,
+    Undef,
     Unreachable,
     Value,
 )
@@ -148,7 +151,7 @@ def check_op_sources_valid(fn: FuncIR) -> list[FnError]:
     for block in fn.blocks:
         for op in block.ops:
             for source in op.sources():
-                if isinstance(source, Integer):
+                if isinstance(source, (Integer, Float, Undef)):
                     pass
                 elif isinstance(source, Op):
                     if source not in valid_ops:
@@ -421,6 +424,9 @@ class OpChecker(OpVisitor[None]):
         pass
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> None:
+        pass
+
+    def visit_set_element(self, op: SetElement) -> None:
         pass
 
     def visit_load_address(self, op: LoadAddress) -> None:

--- a/mypyc/analysis/selfleaks.py
+++ b/mypyc/analysis/selfleaks.py
@@ -35,6 +35,7 @@ from mypyc.ir.ops import (
     RegisterOp,
     Return,
     SetAttr,
+    SetElement,
     SetMem,
     Truncate,
     TupleGet,
@@ -179,6 +180,9 @@ class SelfLeakedVisitor(OpVisitor[GenAndKill]):
         return CLEAN
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> GenAndKill:
+        return CLEAN
+
+    def visit_set_element(self, op: SetElement) -> GenAndKill:
         return CLEAN
 
     def visit_load_address(self, op: LoadAddress) -> GenAndKill:

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -816,15 +816,20 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         )
 
     def visit_set_element(self, op: SetElement) -> None:
-        # TODO: do properly
         dest = self.reg(op)
         item = self.reg(op.item)
         field = op.field
         if isinstance(op.src, Undef):
+            # First assignment to an undefined struct is trivial.
             self.emit_line(f"{dest}.{field} = {item};")
         else:
+            # In the general case create a copy of the struct with a single
+            # item modified.
+            #
+            # TODO: Can we do better if only a subset of fields are initialized?
+            # TODO: Make this less verbose in the common case
+            # TODO: Support tuples (or use RStruct for tuples)?
             src = self.reg(op.src)
-            # TODO: Support tuples (or use RStruct for tuples)
             src_type = op.src.type
             assert isinstance(src_type, RStruct), src_type
             init_items = []

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -245,6 +245,7 @@ class CString(Value):
         self.line = line
 
 
+@final
 class Undef(Value):
     """An undefined value.
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -256,8 +256,9 @@ class Undef(Value):
       r1 = set_element r0, "field2", f2
       # r1 now has new struct value with two fields set
 
-    Warning: The generated code can use an arbitrary runtime values for
-    this (likely not explicitly initialized).
+    Warning: Always initialize undefined values before using them,
+    as otherwise the values are garbage. You shouldn't expect that
+    undefined values are zeroed, in particular.
     """
 
     def __init__(self, rtype: RType) -> None:

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -50,12 +50,14 @@ from mypyc.ir.ops import (
     Register,
     Return,
     SetAttr,
+    SetElement,
     SetMem,
     Truncate,
     TupleGet,
     TupleSet,
     Unborrow,
     Unbox,
+    Undef,
     Unreachable,
     Value,
 )
@@ -273,6 +275,9 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
     def visit_get_element_ptr(self, op: GetElementPtr) -> str:
         return self.format("%r = get_element_ptr %r %s :: %t", op, op.src, op.field, op.src_type)
 
+    def visit_set_element(self, op: SetElement) -> str:
+        return self.format("%r = set_element %r, %s, %r", op, op.src, op.field, op.item)
+
     def visit_load_address(self, op: LoadAddress) -> str:
         if isinstance(op.src, Register):
             return self.format("%r = load_address %r", op, op.src)
@@ -330,6 +335,8 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
                         result.append(repr(arg.value))
                     elif isinstance(arg, CString):
                         result.append(f"CString({arg.value!r})")
+                    elif isinstance(arg, Undef):
+                        result.append(f"undef {arg.type.name}")
                     else:
                         result.append(self.names[arg])
                 elif typespec == "d":
@@ -486,7 +493,7 @@ def generate_names_for_ir(args: list[Register], blocks: list[BasicBlock]) -> dic
                     continue
                 if isinstance(value, Register) and value.name:
                     name = value.name
-                elif isinstance(value, (Integer, Float)):
+                elif isinstance(value, (Integer, Float, Undef)):
                     continue
                 else:
                     name = "r%d" % temp_index

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -39,6 +39,7 @@ from mypyc.ir.ops import (
     RaiseStandardError,
     Return,
     SetAttr,
+    SetElement,
     SetMem,
     Truncate,
     TupleGet,
@@ -214,6 +215,9 @@ class IRTransform(OpVisitor[Optional[Value]]):
     def visit_get_element_ptr(self, op: GetElementPtr) -> Value | None:
         return self.add(op)
 
+    def visit_set_element(self, op: SetElement) -> Value | None:
+        return self.add(op)
+
     def visit_load_address(self, op: LoadAddress) -> Value | None:
         return self.add(op)
 
@@ -352,6 +356,9 @@ class PatchVisitor(OpVisitor[None]):
         op.src = self.fix_op(op.src)
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> None:
+        op.src = self.fix_op(op.src)
+
+    def visit_set_element(self, op: SetElement) -> None:
         op.src = self.fix_op(op.src)
 
     def visit_load_address(self, op: LoadAddress) -> None:

--- a/mypyc/transform/refcount.py
+++ b/mypyc/transform/refcount.py
@@ -43,6 +43,7 @@ from mypyc.ir.ops import (
     Op,
     Register,
     RegisterOp,
+    Undef,
     Value,
 )
 
@@ -94,7 +95,7 @@ def is_maybe_undefined(post_must_defined: set[Value], src: Value) -> bool:
 def maybe_append_dec_ref(
     ops: list[Op], dest: Value, defined: AnalysisDict[Value], key: tuple[BasicBlock, int]
 ) -> None:
-    if dest.type.is_refcounted and not isinstance(dest, Integer):
+    if dest.type.is_refcounted and not isinstance(dest, (Integer, Undef)):
         ops.append(DecRef(dest, is_xdec=is_maybe_undefined(defined[key], dest)))
 
 


### PR DESCRIPTION
Also add Undef value type that can currently only used as the
operand for SetElement to signify that we are creating a new
value instead of modifying an existing value.

A new struct value can be created by starting with Undef and
setting each element sequentially. Each operation produces a
new struct value, but the temporaries will be optimized away
in the later passes (currently by the C compiler, but we could
do something more clever here in the future).

This is needed to support packed arrays, which are represented
as structs. I extracted this from my packed array branch, and 
it's currently unused outside tests.