### PR TITLE
Fix swapping TypeVars with defaults.

### DIFF
--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -246,10 +246,14 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             if (tvar_id := repl.id) in self.recursive_tvar_guard:
                 return self.recursive_tvar_guard[tvar_id] or repl
             self.recursive_tvar_guard[tvar_id] = None
-            repl = repl.accept(self)
-            if isinstance(repl, TypeVarType):
-                repl.default = repl.default.accept(self)
-            self.recursive_tvar_guard[tvar_id] = repl
+            expanded = repl.accept(self)
+
+            if isinstance(expanded, TypeVarType):
+                expanded.default = expanded.default.accept(self)
+            else:
+                repl = expanded
+
+            self.recursive_tvar_guard[tvar_id] = expanded
         return repl
 
     def visit_param_spec(self, t: ParamSpecType) -> Type:

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -416,6 +416,24 @@ def func_c4(
     reveal_type(m)  # N: Revealed type is "__main__.ClassC4[builtins.int, builtins.float]"
 [builtins fixtures/tuple.pyi]
 
+[case testTypeVarDefaultsSwap]
+from typing import TypeVar, Generic
+
+T = TypeVar("T")
+X = TypeVar("X", default=object)
+Y = TypeVar("Y", default=object)
+
+
+class Foo(Generic[T, Y]):
+    def test(self) -> None:
+        reveal_type( Foo[Y, T]() )  # N: Revealed type is "__main__.Foo[Y`2 = builtins.object, T`1]"
+
+
+class Bar(Generic[X, Y]):
+    def test(self) -> None:
+        reveal_type( Bar[Y, X]() )  # N: Revealed type is "__main__.Bar[Y`2 = builtins.object, Y`2 = builtins.object]"
+
+
 [case testTypeVarDefaultsClassRecursive1]
 # flags: --disallow-any-generics
 from typing import Generic, TypeVar, List


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

- Fixes #19444
- added `testTypeVarDefaultsSwap`

My idea is that we should only return the result of `repl = repl.accept(self)` if that result is no longer a `TypeVarType`, because if we are simply permuting the type variables, then this will be incorrect.
         