### PR TITLE
[mypyc] Report error when registering a nested function

### DIFF
--- a/mypyc/irbuild/main.py
+++ b/mypyc/irbuild/main.py
@@ -71,6 +71,8 @@ def build_ir(
     singledispatch_info = find_singledispatch_register_impls(modules, errors)
 
     result: ModuleIRs = {}
+    if errors.num_errors > 0:
+        return result
 
     # Generate IR for all modules.
     class_irs = []

--- a/mypyc/test-data/commandline.test
+++ b/mypyc/test-data/commandline.test
@@ -101,13 +101,71 @@ assert a.f(10) == 100
 def f(x: int) -> int:
     return x*x
 
-[case testErrorOutput]
+[case testErrorOutput1]
+# cmd: test.py
+
+[file test.py]
+from functools import singledispatch
+from mypy_extensions import trait
+from typing import Any
+
+def decorator(x: Any) -> Any:
+    return x
+
+class NeverMetaclass(type):  # E: Inheriting from most builtin types is unimplemented \
+                             # N: Potential workaround: @mypy_extensions.mypyc_attr(native_class=False) \
+                             # N: https://mypyc.readthedocs.io/en/stable/native_classes.html#defining-non-native-classes
+    pass
+
+class Concrete1:
+    pass
+
+@trait
+class Trait1:
+    pass
+
+class Concrete2:
+    pass
+
+@decorator
+class NonExt(Concrete1):  # E: Non-extension classes may not inherit from extension classes
+    pass
+
+class NopeMultipleInheritanceAndBadOrder3(Trait1, Concrete1, Concrete2):  # E: Non-trait base must appear first in parent list
+    pass
+
+class NopeBadOrder(Trait1, Concrete2):  # E: Non-trait base must appear first in parent list
+    pass
+
+class Foo:
+    pass
+
+@singledispatch
+def a(arg) -> None:
+    pass
+
+@decorator # E: Calling decorator after registering function not supported
+@a.register
+def g(arg: int) -> None:
+    pass
+
+@a.register
+@decorator
+def h(arg: str) -> None:
+    pass
+
+@decorator
+@decorator # E: Calling decorator after registering function not supported
+@a.register
+def i(arg: Foo) -> None:
+    pass
+
+[case testErrorOutput2]
 # cmd: test.py
 
 [file test.py]
 from typing import Final, List, Any, AsyncIterable
 from mypy_extensions import trait, mypyc_attr
-from functools import singledispatch
 
 def busted(b: bool) -> None:
     for i in range(1, 10, 0):  # E: range() step can't be zero
@@ -138,11 +196,6 @@ Foo.lol = 50  # E: Only class variables defined as ClassVar can be assigned to
 def decorator(x: Any) -> Any:
     return x
 
-class NeverMetaclass(type):  # E: Inheriting from most builtin types is unimplemented \
-                             # N: Potential workaround: @mypy_extensions.mypyc_attr(native_class=False) \
-                             # N: https://mypyc.readthedocs.io/en/stable/native_classes.html#defining-non-native-classes
-    pass
-
 class Concrete1:
     pass
 
@@ -161,11 +214,6 @@ class Concrete2:
 class Trait2(Concrete2):
     pass
 
-@decorator
-class NonExt(Concrete1):  # E: Non-extension classes may not inherit from extension classes
-    pass
-
-
 class NopeMultipleInheritance(Concrete1, Concrete2):  # E: Multiple inheritance is not supported (except for traits)
     pass
 
@@ -174,13 +222,6 @@ class NopeMultipleInheritanceAndBadOrder(Concrete1, Trait1, Concrete2):  # E: Mu
 
 class NopeMultipleInheritanceAndBadOrder2(Concrete1, Concrete2, Trait1):  # E: Multiple inheritance is not supported (except for traits)
     pass
-
-class NopeMultipleInheritanceAndBadOrder3(Trait1, Concrete1, Concrete2):  # E: Non-trait base must appear first in parent list # E: Multiple inheritance is not supported (except for traits)
-    pass
-
-class NopeBadOrder(Trait1, Concrete2):  # E: Non-trait base must appear first in parent list
-    pass
-
 
 @decorator
 class NonExt2:
@@ -218,26 +259,6 @@ class AllowInterp2(PureTrait):  # E: Base class "test.PureTrait" does not allow 
 
 async def async_generators() -> AsyncIterable[int]:
     yield 1  # E: async generators are unimplemented
-
-@singledispatch
-def a(arg) -> None:
-    pass
-
-@decorator # E: Calling decorator after registering function not supported
-@a.register
-def g(arg: int) -> None:
-    pass
-
-@a.register
-@decorator
-def h(arg: str) -> None:
-    pass
-
-@decorator
-@decorator # E: Calling decorator after registering function not supported
-@a.register
-def i(arg: Foo) -> None:
-    pass
 
 [case testOnlyWarningOutput]
 # cmd: test.py

--- a/mypyc/test-data/irbuild-singledispatch.test
+++ b/mypyc/test-data/irbuild-singledispatch.test
@@ -274,3 +274,58 @@ L0:
     r1 = f(r0)
     r2 = box(None, 1)
     return r2
+
+[case registerNestedFunctionError]
+from functools import singledispatch
+from typing import Any, overload
+
+def dec(x: Any) -> Any:
+    return x
+
+def f() -> None:
+    @singledispatch  # E: Nested singledispatch functions not supported
+    def singledispatch_in_func(x: Any) -> None:
+        pass
+
+@dec
+def g() -> None:
+    @singledispatch  # E: Nested singledispatch functions not supported
+    def singledispatch_in_decorated(x: Any) -> None:
+        pass
+
+@overload
+def h(x: int) -> None:
+    pass
+@overload
+def h(x: str) -> None:
+    pass
+def h(x: Any) -> None:
+    @singledispatch  # E: Nested singledispatch functions not supported
+    def singledispatch_in_overload(x: Any) -> None:
+        pass
+
+@singledispatch
+def outside(x: Any) -> None:
+    pass
+
+def i() -> None:
+    @outside.register  # E: Registering nested functions not supported
+    def register_in_func(x: int) -> None:
+        pass
+
+@dec
+def j() -> None:
+    @outside.register  # E: Registering nested functions not supported
+    def register_in_decorated(x: int) -> None:
+        pass
+
+@overload
+def k(x: int) -> None:
+    pass
+@overload
+def k(x: str) -> None:
+    pass
+def k(x: Any) -> None:
+    @outside.register  # E: Registering nested functions not supported
+    def register_in_overload(x: int) -> None:
+        pass


### PR DESCRIPTION
Fixes https://github.com/mypyc/mypyc/issues/1118

Added a check for nested `@singledispatch` functions and nested functions registered to `@singledispatch` functions to report an error in mypyc. Currently either of those cases causes mypyc to crash because of the different handling of nested and top-level functions.

Changed to abort the compilation early when these errors are found so that in the transform code we can assume that the singledispatch functions are valid. This means that mypyc might not report as many errors until it quits as before, so I have split the error output test in `commandline.test` into two.