### PR TITLE
fixed match-case against typing.Callable

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -559,10 +559,12 @@ class PatternChecker(PatternVisitor[PatternType]):
             and type_info.type is not None
             and type_info.fullname == "typing.Callable"
         ):
-            # Consider as `Callable[..., Any]`
+            # Create a `Callable[..., Any]`
             fallback = self.chk.named_type("builtins.function")
             any_type = AnyType(TypeOfAny.unannotated)
-            typ = callable_with_ellipsis(any_type, any_type, fallback)
+            fn_type = callable_with_ellipsis(any_type, ret_type=any_type, fallback=fallback)
+            # if typ is itself callable, use its own type, otherwise Callable[..,, Any]
+            typ = current_type if is_subtype(current_type, fn_type) else fn_type
         else:
             if isinstance(type_info, Var) and type_info.type is not None:
                 name = type_info.type.str_with_options(self.options)

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -50,6 +50,7 @@ from mypy.types import (
     UninhabitedType,
     UnionType,
     UnpackType,
+    callable_with_ellipsis,
     find_unpack_in_list,
     get_proper_type,
     split_with_prefix_and_suffix,
@@ -553,6 +554,15 @@ class PatternChecker(PatternVisitor[PatternType]):
             and isinstance(get_proper_type(type_info.type), AnyType)
         ):
             typ = type_info.type
+        elif (
+            isinstance(type_info, Var)
+            and type_info.type is not None
+            and type_info.fullname == "typing.Callable"
+        ):
+            # Consider as `Callable[..., Any]`
+            fallback = self.chk.named_type("builtins.function")
+            any_type = AnyType(TypeOfAny.unannotated)
+            typ = callable_with_ellipsis(any_type, any_type, fallback)
         else:
             if isinstance(type_info, Var) and type_info.type is not None:
                 name = type_info.type.str_with_options(self.options)

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1078,6 +1078,13 @@ match x:
     case Callable() as fn:
         reveal_type(fn)  # N: Revealed type is "def (*Any, **Any) -> Any"
 
+def int_fun(x: int) -> int: return x+1
+
+match int_fun:
+    case Callable() as fn:
+        reveal_type(fn)  # N: Revealed type is "def (x: builtins.int) -> builtins.int"
+
+
 [case testMatchClassPatternNestedGenerics]
 # From cpython test_patma.py
 x = [[{0: 0}]]

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1069,6 +1069,15 @@ match m:
     case Foo():
         pass
 
+[case testMatchClassPatternCallable]
+from typing import Callable
+
+x: object
+
+match x:
+    case Callable() as fn:
+        reveal_type(fn)  # N: Revealed type is "def (*Any, **Any) -> Any"
+
 [case testMatchClassPatternNestedGenerics]
 # From cpython test_patma.py
 x = [[{0: 0}]]


### PR DESCRIPTION
Fixes #14014


Added an extra elif branch that checks if we are matching against `typing.Callable`, and uses `callable_with_ellipsis` to treat it as a `Callable[..., Any]`.