### PR TITLE
Prevent a crash when InitVar is redefined with a method in a subclass

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2188,7 +2188,14 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         else:
             override_class_or_static = defn.func.is_class or defn.func.is_static
         typ, _ = self.node_type_from_base(defn.name, defn.info, defn)
-        assert typ is not None
+        if typ is None:
+            # This may only happen if we're checking `x-redefinition` member
+            # and `x` itself is for some reason gone. Normally the node should
+            # be reachable from the containing class by its name.
+            # The redefinition is never removed, use this as a sanity check to verify
+            # the reasoning above.
+            assert f"{defn.name}-redefinition" in defn.info.names
+            return False
 
         original_node = base_attr.node
         # `original_type` can be partial if (e.g.) it is originally an

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2666,3 +2666,19 @@ class PersonBad(TypedDict):
 class JobBad:
     person: PersonBad = field(default_factory=PersonBad)  # E: Argument "default_factory" to "field" has incompatible type "type[PersonBad]"; expected "Callable[[], PersonBad]"
 [builtins fixtures/dict.pyi]
+
+[case testDataclassInitVarRedefinitionNoCrash]
+# https://github.com/python/mypy/issues/19443
+from dataclasses import InitVar, dataclass
+
+class ClassA:
+    def value(self) -> int:
+        return 0
+
+@dataclass
+class ClassB(ClassA):
+    value: InitVar[int]
+
+    def value(self) -> int:  # E: Name "value" already defined on line 9
+        return 0
+[builtins fixtures/dict.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2679,6 +2679,6 @@ class ClassA:
 class ClassB(ClassA):
     value: InitVar[int]
 
-    def value(self) -> int:  # E: Name "value" already defined on line 9
+    def value(self) -> int:  # E: Name "value" already defined on line 10
         return 0
 [builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #19443. This case is too niche (and should be trivially avoidable), so just not crashing should be good enough. The value is indeed redefined, and trying to massage the plugin to move the `X-redefinition` back to `X` in names is not worth the effort IMO.