### PR TITLE
Apply union expansion when checking ops to typevars

### DIFF
--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -706,6 +706,32 @@ if int():
 class C:
     def __lt__(self, o: object, x: str = "") -> int: ...
 
+[case testReversibleOpOnTypeVarBound]
+from typing import TypeVar, Union
+
+class A:
+    def __lt__(self, a: A) -> bool: ...
+    def __gt__(self, a: A) -> bool: ...
+
+class B(A):
+    def __lt__(self, b: B) -> bool: ...  # type: ignore[override]
+    def __gt__(self, b: B) -> bool: ...  # type: ignore[override]
+
+_T = TypeVar("_T", bound=Union[A, B])
+
+def check(x: _T, y: _T) -> bool:
+    return x < y
+
+[case testReversibleOpOnTypeVarBoundPromotion]
+from typing import TypeVar, Union
+
+_T = TypeVar("_T", bound=Union[int, float])
+
+def check(x: _T, y: _T) -> bool:
+    return x < y
+[builtins fixtures/ops.pyi]
+
+
 [case testErrorContextAndBinaryOperators]
 import typing
 class A:

--- a/test-data/unit/fixtures/ops.pyi
+++ b/test-data/unit/fixtures/ops.pyi
@@ -61,6 +61,12 @@ class float:
     def __rdiv__(self, x: 'float') -> 'float': pass
     def __truediv__(self, x: 'float') -> 'float': pass
     def __rtruediv__(self, x: 'float') -> 'float': pass
+    def __eq__(self, x: object) -> bool: pass
+    def __ne__(self, x: object) -> bool: pass
+    def __lt__(self, x: 'float') -> bool: pass
+    def __le__(self, x: 'float') -> bool: pass
+    def __gt__(self, x: 'float') -> bool: pass
+    def __ge__(self, x: 'float') -> bool: pass
 
 class complex:
     def __add__(self, x: complex) -> complex: pass


### PR DESCRIPTION
Fixes #19454. This might not be the most disciplined approach, but it should match the general expectations.