### PR TITLE
Micro-optimization: Avoid temporary set creation in is_proper_subtype

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -213,8 +213,8 @@ def is_proper_subtype(
             keep_erased_types=keep_erased_types,
         )
     else:
-        assert not any(
-            {ignore_promotions, erase_instances, keep_erased_types}
+        assert (
+            not ignore_promotions and not erase_instances and not keep_erased_types
         ), "Don't pass both context and individual flags"
     if type_state.is_assumed_proper_subtype(left, right):
         return True


### PR DESCRIPTION
This was suggested by @sterliakov in https://github.com/python/mypy/pull/19384#issuecomment-3044364827

This is a part of a set of micro-optimizations that improve self check performance by ~5.5%.
