### PR TITLE
Micro-optimize chained plugin

### DIFF
--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -846,12 +846,22 @@ class ChainedPlugin(Plugin):
         return deps
 
     def get_type_analyze_hook(self, fullname: str) -> Callable[[AnalyzeTypeContext], Type] | None:
-        return self._find_hook(lambda plugin: plugin.get_type_analyze_hook(fullname))
+        # Micro-optimization: Inline iteration over plugins
+        for plugin in self._plugins:
+            hook = plugin.get_type_analyze_hook(fullname)
+            if hook is not None:
+                return hook
+        return None
 
     def get_function_signature_hook(
         self, fullname: str
     ) -> Callable[[FunctionSigContext], FunctionLike] | None:
-        return self._find_hook(lambda plugin: plugin.get_function_signature_hook(fullname))
+        # Micro-optimization: Inline iteration over plugins
+        for plugin in self._plugins:
+            hook = plugin.get_function_signature_hook(fullname)
+            if hook is not None:
+                return hook
+        return None
 
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
         return self._find_hook(lambda plugin: plugin.get_function_hook(fullname))
@@ -859,13 +869,28 @@ class ChainedPlugin(Plugin):
     def get_method_signature_hook(
         self, fullname: str
     ) -> Callable[[MethodSigContext], FunctionLike] | None:
-        return self._find_hook(lambda plugin: plugin.get_method_signature_hook(fullname))
+        # Micro-optimization: Inline iteration over plugins
+        for plugin in self._plugins:
+            hook = plugin.get_method_signature_hook(fullname)
+            if hook is not None:
+                return hook
+        return None
 
     def get_method_hook(self, fullname: str) -> Callable[[MethodContext], Type] | None:
-        return self._find_hook(lambda plugin: plugin.get_method_hook(fullname))
+        # Micro-optimization: Inline iteration over plugins
+        for plugin in self._plugins:
+            hook = plugin.get_method_hook(fullname)
+            if hook is not None:
+                return hook
+        return None
 
     def get_attribute_hook(self, fullname: str) -> Callable[[AttributeContext], Type] | None:
-        return self._find_hook(lambda plugin: plugin.get_attribute_hook(fullname))
+        # Micro-optimization: Inline iteration over plugins
+        for plugin in self._plugins:
+            hook = plugin.get_attribute_hook(fullname)
+            if hook is not None:
+                return hook
+        return None
 
     def get_class_attribute_hook(self, fullname: str) -> Callable[[AttributeContext], Type] | None:
         return self._find_hook(lambda plugin: plugin.get_class_attribute_hook(fullname))
@@ -897,6 +922,6 @@ class ChainedPlugin(Plugin):
     def _find_hook(self, lookup: Callable[[Plugin], T]) -> T | None:
         for plugin in self._plugins:
             hook = lookup(plugin)
-            if hook:
+            if hook is not None:
                 return hook
         return None


### PR DESCRIPTION
Avoid using lambdas in the most expensive hooks, since they are slower than direct method calls. Also use `if hook is None` checks instead of `if hook`, since the prior is more efficient when compiled.

I used trace logging to look for generic/unoptimized function calls, and it was clear that ChainedPlugin was doing many unoptimized calls that were easy to avoid.

This duplicates some code, but I think it's fine since this code is updated very rarely but the code paths are very hot.

This is a part of a set of micro-optimizations that improve self check performance by ~5.5%.