### PR TITLE
Micro-optimization: Make ArgKind a regular class instead of enum

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -34,6 +34,7 @@ from mypy.message_registry import ErrorMessage
 from mypy.messages import MessageBuilder, format_type
 from mypy.nodes import (
     ARG_NAMED,
+    ARG_NAMED_OPT,
     ARG_POS,
     ARG_STAR,
     ARG_STAR2,
@@ -1000,7 +1001,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         return CallableType(
             list(callee.items.values()),
             [
-                ArgKind.ARG_NAMED if name in callee.required_keys else ArgKind.ARG_NAMED_OPT
+                ARG_NAMED if name in callee.required_keys else ARG_NAMED_OPT
                 for name in callee.items
             ],
             list(callee.items.keys()),
@@ -1074,7 +1075,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                 # TypedDict. This is a bit arbitrary, but in most cases will work better than
                 # trying to infer a union or a join.
                 [args[0] for args in kwargs.values()],
-                [ArgKind.ARG_NAMED] * len(kwargs),
+                [ARG_NAMED] * len(kwargs),
                 context,
                 list(kwargs.keys()),
                 None,

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1041,7 +1041,7 @@ class SemanticAnalyzer(
         self.pop_type_args(defn.type_args)
 
     def remove_unpack_kwargs(self, defn: FuncDef, typ: CallableType) -> CallableType:
-        if not typ.arg_kinds or typ.arg_kinds[-1] is not ArgKind.ARG_STAR2:
+        if not typ.arg_kinds or typ.arg_kinds[-1] is not ARG_STAR2:
             return typ
         last_type = typ.arg_types[-1]
         if not isinstance(last_type, UnpackType):

--- a/mypyc/codegen/emitwrapper.py
+++ b/mypyc/codegen/emitwrapper.py
@@ -14,7 +14,16 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from mypy.nodes import ARG_NAMED, ARG_NAMED_OPT, ARG_OPT, ARG_POS, ARG_STAR, ARG_STAR2, ArgKind
+from mypy.nodes import (
+    ALL_ARG_KINDS,
+    ARG_NAMED,
+    ARG_NAMED_OPT,
+    ARG_OPT,
+    ARG_POS,
+    ARG_STAR,
+    ARG_STAR2,
+    ArgKind,
+)
 from mypy.operators import op_methods_to_symbols, reverse_op_method_names, reverse_op_methods
 from mypyc.codegen.emit import AssignHandler, Emitter, ErrorHandler, GotoHandler, ReturnHandler
 from mypyc.common import (
@@ -88,7 +97,7 @@ def generate_traceback_code(
 
 def make_arg_groups(args: list[RuntimeArg]) -> dict[ArgKind, list[RuntimeArg]]:
     """Group arguments by kind."""
-    return {k: [arg for arg in args if arg.kind == k] for k in ArgKind}
+    return {k: [arg for arg in args if arg.kind == k] for k in ALL_ARG_KINDS}
 
 
 def reorder_arg_groups(groups: dict[ArgKind, list[RuntimeArg]]) -> list[RuntimeArg]:

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -17,6 +17,8 @@ from collections.abc import Sequence
 from typing import NamedTuple
 
 from mypy.nodes import (
+    ARG_OPT,
+    ARG_POS,
     ArgKind,
     ClassDef,
     Decorator,
@@ -907,7 +909,7 @@ def generate_dispatch_glue_native_function(
     decl = builder.mapper.func_to_decl[fitem]
     arg_info = get_args(builder, decl.sig.args, line)
     args = [callable_class] + arg_info.args
-    arg_kinds = [ArgKind.ARG_POS] + arg_info.arg_kinds
+    arg_kinds = [ARG_POS] + arg_info.arg_kinds
     arg_names = arg_info.arg_names
     arg_names.insert(0, "self")
     ret_val = builder.builder.call(callable_class_decl, args, arg_kinds, arg_names, line)
@@ -935,7 +937,7 @@ def add_register_method_to_callable_class(builder: IRBuilder, fn_info: FuncInfo)
     line = -1
     with builder.enter_method(fn_info.callable_class.ir, "register", object_rprimitive):
         cls_arg = builder.add_argument("cls", object_rprimitive)
-        func_arg = builder.add_argument("func", object_rprimitive, ArgKind.ARG_OPT)
+        func_arg = builder.add_argument("func", object_rprimitive, ARG_OPT)
         ret_val = builder.call_c(register_function, [builder.self(), cls_arg, func_arg], line)
         builder.add(Return(ret_val, line))
 


### PR DESCRIPTION
Mypyc doesn't generate very efficient code for enums, so switch to a regular class. We can later revert the change if/when we can improve enum support in mypyc.

Operations related to ArgKind were pretty prominent in the op trace log (#19457).

By itself this improves performance by ~1.7%, based on `perf_compare.py`, which is significant:
```
master                    4.168s (0.0%) | stdev 0.037s
HEAD                      4.098s (-1.7%) | stdev 0.028s
```

This is a part of a set of micro-optimizations that improve self check performance by ~5.5%.