### PR TITLE
Fix decorated methods with self-types in protocols

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -956,7 +956,7 @@ def expand_and_bind_callable(
 ) -> Type:
     if not mx.preserve_type_var_ids:
         functype = freshen_all_functions_type_vars(functype)
-    typ = get_proper_type(expand_self_type(var, functype, mx.original_type))
+    typ = get_proper_type(expand_self_type(var, functype, mx.self_type))
     assert isinstance(typ, FunctionLike)
     if is_trivial_self:
         typ = bind_self_fast(typ, mx.self_type)

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1110,7 +1110,10 @@ class ConstraintBuilderVisitor(TypeVisitor[list[Constraint]]):
                     # like U -> U, should be Callable[..., Any], but if U is a self-type, we can
                     # allow it to leak, to be later bound to self. A bunch of existing code
                     # depends on this old behaviour.
-                    and not any(tv.id.is_self() for tv in cactual.variables)
+                    and not (
+                        any(tv.id.is_self() for tv in cactual.variables)
+                        and template.is_ellipsis_args
+                    )
                 ):
                     # If the actual callable is generic, infer constraints in the opposite
                     # direction, and indicate to the solver there are extra type variables

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4646,3 +4646,17 @@ reveal_type(t.bar)  # N: Revealed type is "def () -> builtins.int"
 tt: Type[P] = C
 reveal_type(tt.foo)  # N: Revealed type is "def (builtins.object) -> builtins.int"
 reveal_type(tt.bar)  # N: Revealed type is "def (builtins.object) -> builtins.int"
+
+[case testProtocolDecoratedSelfBound]
+from abc import abstractmethod
+from typing import Protocol, Self
+
+class Proto(Protocol):
+    @abstractmethod
+    def foo(self, x: Self) -> None: ...
+
+class Impl:
+    def foo(self, x: Self) -> None:
+        pass
+
+x: Proto = Impl()


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/19482

The regression is caused by overlap of three problems (directly or indirectly):
* Using `mx.original_type` instead of `mx.self_type` for expanding (not otherwise bound) self-types.
* Having a weird special case `...` vs self-types in constraint inference.
* Not refreshing type variable ids during protocol subtype checks (hack needed for technical reasons).

I fix the first one, and limit the blast radius of the second one.