### PR TITLE
Retain `None` as constraints bottom if no bottoms were provided

### DIFF
--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -281,9 +281,10 @@ def solve_one(lowers: Iterable[Type], uppers: Iterable[Type]) -> Type | None:
     # Process each bound separately, and calculate the lower and upper
     # bounds based on constraints. Note that we assume that the constraint
     # targets do not have constraint references.
-    if type_state.infer_unions:
+    if type_state.infer_unions and lowers:
         # This deviates from the general mypy semantics because
         # recursive types are union-heavy in 95% of cases.
+        # Retain `None` when no bottoms were provided to avoid bogus `Never` inference.
         bottom = UnionType.make_union(list(lowers))
     else:
         # The order of lowers is non-deterministic.

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -270,6 +270,7 @@ def solve_one(lowers: Iterable[Type], uppers: Iterable[Type]) -> Type | None:
     uppers = new_uppers
 
     # ...unless this is the only information we have, then we just pass it on.
+    lowers = list(lowers)
     if not uppers and not lowers:
         candidate = UninhabitedType()
         candidate.ambiguous = True
@@ -285,7 +286,7 @@ def solve_one(lowers: Iterable[Type], uppers: Iterable[Type]) -> Type | None:
         # This deviates from the general mypy semantics because
         # recursive types are union-heavy in 95% of cases.
         # Retain `None` when no bottoms were provided to avoid bogus `Never` inference.
-        bottom = UnionType.make_union(list(lowers))
+        bottom = UnionType.make_union(lowers)
     else:
         # The order of lowers is non-deterministic.
         # We attempt to sort lowers because joins are non-associative. For instance:

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -54,7 +54,7 @@ reveal_type(flatten([1, [2, [3]]]))  # N: Revealed type is "builtins.list[builti
 
 class Bad: ...
 x: Nested[int] = [1, [2, [3]]]
-x = [1, [Bad()]]  # E: List item 1 has incompatible type "list[Bad]"; expected "Union[int, Nested[int]]"
+x = [1, [Bad()]]  # E: List item 0 has incompatible type "Bad"; expected "Union[int, Nested[int]]"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testRecursiveAliasGenericInferenceNested]
@@ -605,7 +605,7 @@ class NT(NamedTuple, Generic[T]):
 class A: ...
 class B(A): ...
 
-nti: NT[int] = NT(key=0, value=NT(key=1, value=A()))  # E: Argument "value" to "NT" has incompatible type "NT[A]"; expected "Union[int, NT[int]]"
+nti: NT[int] = NT(key=0, value=NT(key=1, value=A()))  # E: Argument "value" to "NT" has incompatible type "A"; expected "Union[int, NT[int]]"
 reveal_type(nti)  # N: Revealed type is "tuple[builtins.int, Union[builtins.int, ...], fallback=__main__.NT[builtins.int]]"
 
 nta: NT[A]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -4271,3 +4271,21 @@ reveal_type(dicts.TF)  # N: Revealed type is "def (*, user_id: builtins.int =) -
 reveal_type(dicts.TotalFalse)  # N: Revealed type is "def (*, user_id: builtins.int =) -> TypedDict('__main__.Dicts.TF', {'user_id'?: builtins.int})"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
+
+[case testRecursiveNestedTypedDictInference]
+from typing import TypedDict, Sequence
+from typing_extensions import NotRequired
+
+class Component(TypedDict):
+    type: str
+    components: NotRequired[Sequence['Component']]
+
+inputs: Sequence[Component] = [{
+    'type': 'tuple',
+    'components': [
+        {'type': 'uint256'},
+        {'type': 'address'},
+    ]
+}]
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]


### PR DESCRIPTION
Current version replaces `None` (which indicates "no items") with an empty union (=`Uninhabited`). This breaks inference in some cases.

Fixes #19483.