### PR TITLE
Fix #19507 Prevent final reassignment in match case

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5577,6 +5577,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 previous_type, _, _ = self.check_lvalue(expr)
                 if previous_type is not None:
                     already_exists = True
+                    if isinstance(expr.node, Var) and expr.node.is_final:
+                        self.msg.cant_assign_to_final(expr.name, False, expr)
                     if self.check_subtype(
                         typ,
                         previous_type,

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -2839,3 +2839,13 @@ match value_type:
     case _:
         assert_never(value_type)
 [builtins fixtures/tuple.pyi]
+
+[case testAssignmentToFinalInMatchCaseNotAllowed]
+from typing import Final
+
+FOO: Final[int] = 10
+
+val: int = 8
+match val:
+    case FOO:  # E: Cannot assign to final name "FOO"
+        pass


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Fixes #19507

This PR adds a check to prevent reassignment of final variables in a match statement.

Currently, the following passes without an error:
```Python
from typing import Final
FOO: Final = 8

a = 10

match a:
    case FOO:
        pass
print(FOO)  # FOO is reassigned, prints 10
```

MyPy already checks that the type of FOO isn't changed if used like this. I added a check in the same place that makes sure it's not `Final` either.

Since this tests the match syntax, I put the test where I did. If it's not the appropriate place for it I will move it as instructed :)
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
