### PR TITLE
Cache type_object_type()

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -397,6 +397,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         self.is_stub = tree.is_stub
         self.is_typeshed_stub = tree.is_typeshed_file(options)
         self.inferred_attribute_types = None
+        self.allow_constructor_cache = True
 
         # If True, process function definitions. If False, don't. This is used
         # for processing module top levels in fine-grained incremental mode.
@@ -500,12 +501,16 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                         )
 
     def check_second_pass(
-        self, todo: Sequence[DeferredNode | FineGrainedDeferredNode] | None = None
+        self,
+        todo: Sequence[DeferredNode | FineGrainedDeferredNode] | None = None,
+        *,
+        allow_constructor_cache: bool = True,
     ) -> bool:
         """Run second or following pass of type checking.
 
         This goes through deferred nodes, returning True if there were any.
         """
+        self.allow_constructor_cache = allow_constructor_cache
         self.recurse_into_functions = True
         with state.strict_optional_set(self.options.strict_optional), checker_state.set(self):
             if not todo and not self.deferred_nodes:

--- a/mypy/checker_shared.py
+++ b/mypy/checker_shared.py
@@ -137,6 +137,7 @@ class TypeCheckerSharedApi(CheckerPluginInterface):
     module_refs: set[str]
     scope: CheckerScope
     checking_missing_await: bool
+    allow_constructor_cache: bool
 
     @property
     @abstractmethod

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3022,6 +3022,7 @@ class TypeInfo(SymbolNode):
         "dataclass_transform_spec",
         "is_type_check_only",
         "deprecated",
+        "type_object_type",
     )
 
     _fullname: str  # Fully qualified name
@@ -3178,6 +3179,10 @@ class TypeInfo(SymbolNode):
     # The type's deprecation message (in case it is deprecated)
     deprecated: str | None
 
+    # Cached value of class constructor type, i.e. the type of class object when it
+    # appears in runtime context.
+    type_object_type: mypy.types.FunctionLike | None
+
     FLAGS: Final = [
         "is_abstract",
         "is_enum",
@@ -3236,6 +3241,7 @@ class TypeInfo(SymbolNode):
         self.dataclass_transform_spec = None
         self.is_type_check_only = False
         self.deprecated = None
+        self.type_object_type = None
 
     def add_type_vars(self) -> None:
         self.has_type_var_tuple_type = False

--- a/mypy/server/update.py
+++ b/mypy/server/update.py
@@ -1025,10 +1025,10 @@ def reprocess_nodes(
     # We seem to need additional passes in fine-grained incremental mode.
     checker.pass_num = 0
     checker.last_pass = 3
-    more = checker.check_second_pass(nodes)
+    more = checker.check_second_pass(nodes, allow_constructor_cache=False)
     while more:
         more = False
-        if graph[module_id].type_checker().check_second_pass():
+        if graph[module_id].type_checker().check_second_pass(allow_constructor_cache=False):
             more = True
 
     if manager.options.export_types:


### PR DESCRIPTION
This gives almost 4% performance boost (Python 3.12, compiled). Unfortunately, using this in fine-grained mode is tricky, essentially I have three options:
* Use some horrible hacks to invalidate cache when needed
* Add (expensive) class target dependency from `__init__`/`__new__`
* Only allow constructor caching during initial load, but disable it in fine-grained increments

I decided to choose the last option. I think it has the best balance complexity/benefits.