### PR TITLE
[match-case] Fix narrowing of class pattern with union-argument.

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7905,6 +7905,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         return False
 
     def get_isinstance_type(self, expr: Expression) -> list[TypeRange] | None:
+        """Get the type(s) resulting from an isinstance check.
+
+        Returns an empty list for isinstance(x, ()).
+        """
         if isinstance(expr, OpExpr) and expr.op == "|":
             left = self.get_isinstance_type(expr.left)
             if left is None and is_literal_none(expr.left):
@@ -7944,11 +7948,6 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 types.append(TypeRange(typ, is_upper_bound=False))
             else:  # we didn't see an actual type, but rather a variable with unknown value
                 return None
-        if not types:
-            # this can happen if someone has empty tuple as 2nd argument to isinstance
-            # strictly speaking, we should return UninhabitedType but for simplicity we will simply
-            # refuse to do any type inference for now
-            return None
         return types
 
     def is_literal_enum(self, n: Expression) -> bool:
@@ -8185,59 +8184,82 @@ def conditional_types(
         UninhabitedType means unreachable.
         None means no new information can be inferred.
     """
-    if proposed_type_ranges:
-        if len(proposed_type_ranges) == 1:
-            target = proposed_type_ranges[0].item
-            target = get_proper_type(target)
-            if isinstance(target, LiteralType) and (
-                target.is_enum_literal() or isinstance(target.value, bool)
-            ):
-                enum_name = target.fallback.type.fullname
-                current_type = try_expanding_sum_type_to_union(current_type, enum_name)
-        proposed_items = [type_range.item for type_range in proposed_type_ranges]
-        proposed_type = make_simplified_union(proposed_items)
-        if isinstance(get_proper_type(current_type), AnyType):
-            return proposed_type, current_type
-        elif isinstance(proposed_type, AnyType):
-            # We don't really know much about the proposed type, so we shouldn't
-            # attempt to narrow anything. Instead, we broaden the expr to Any to
-            # avoid false positives
-            return proposed_type, default
-        elif not any(type_range.is_upper_bound for type_range in proposed_type_ranges) and (
-            # concrete subtypes
-            is_proper_subtype(current_type, proposed_type, ignore_promotions=True)
-            # structural subtypes
-            or (
-                (
-                    isinstance(proposed_type, CallableType)
-                    or (isinstance(proposed_type, Instance) and proposed_type.type.is_protocol)
-                )
-                and is_subtype(current_type, proposed_type, ignore_promotions=True)
-            )
-        ):
-            # Expression is always of one of the types in proposed_type_ranges
-            return default, UninhabitedType()
-        elif not is_overlapping_types(current_type, proposed_type, ignore_promotions=True):
-            # Expression is never of any type in proposed_type_ranges
-            return UninhabitedType(), default
-        else:
-            # we can only restrict when the type is precise, not bounded
-            proposed_precise_type = UnionType.make_union(
-                [
-                    type_range.item
-                    for type_range in proposed_type_ranges
-                    if not type_range.is_upper_bound
-                ]
-            )
-            remaining_type = restrict_subtype_away(
-                current_type,
-                proposed_precise_type,
-                consider_runtime_isinstance=consider_runtime_isinstance,
-            )
-            return proposed_type, remaining_type
-    else:
+    if proposed_type_ranges is None:
         # An isinstance check, but we don't understand the type
         return current_type, default
+
+    if not proposed_type_ranges:
+        # This is the case for `if isinstance(x, ())` which always returns False.
+        return UninhabitedType(), default
+
+    if len(proposed_type_ranges) == 1:
+        # expand e.g. bool -> Literal[True] | Literal[False]
+        target = proposed_type_ranges[0].item
+        target = get_proper_type(target)
+        if isinstance(target, LiteralType) and (
+            target.is_enum_literal() or isinstance(target.value, bool)
+        ):
+            enum_name = target.fallback.type.fullname
+            current_type = try_expanding_sum_type_to_union(current_type, enum_name)
+
+    proper_type = get_proper_type(current_type)
+    # factorize over union types: isinstance(A|B, C) -> yes = A_yes | B_yes
+    if isinstance(proper_type, UnionType):
+        result: list[tuple[Type | None, Type | None]] = [
+            conditional_types(
+                union_item,
+                proposed_type_ranges,
+                default=union_item,
+                consider_runtime_isinstance=consider_runtime_isinstance,
+            )
+            for union_item in get_proper_types(proper_type.items)
+        ]
+        # separate list of tuples into two lists
+        yes_types, no_types = zip(*result)
+        proposed_type = make_simplified_union([t for t in yes_types if t is not None])
+    else:
+        proposed_items = [type_range.item for type_range in proposed_type_ranges]
+        proposed_type = make_simplified_union(proposed_items)
+
+    if isinstance(proper_type, AnyType):
+        return proposed_type, current_type
+    elif isinstance(proposed_type, AnyType):
+        # We don't really know much about the proposed type, so we shouldn't
+        # attempt to narrow anything. Instead, we broaden the expr to Any to
+        # avoid false positives
+        return proposed_type, default
+    elif not any(type_range.is_upper_bound for type_range in proposed_type_ranges) and (
+        # concrete subtypes
+        is_proper_subtype(current_type, proposed_type, ignore_promotions=True)
+        # structural subtypes
+        or (
+            (
+                isinstance(proposed_type, CallableType)
+                or (isinstance(proposed_type, Instance) and proposed_type.type.is_protocol)
+            )
+            and is_subtype(current_type, proposed_type, ignore_promotions=True)
+        )
+    ):
+        # Expression is always of one of the types in proposed_type_ranges
+        return default, UninhabitedType()
+    elif not is_overlapping_types(current_type, proposed_type, ignore_promotions=True):
+        # Expression is never of any type in proposed_type_ranges
+        return UninhabitedType(), default
+    else:
+        # we can only restrict when the type is precise, not bounded
+        proposed_precise_type = UnionType.make_union(
+            [
+                type_range.item
+                for type_range in proposed_type_ranges
+                if not type_range.is_upper_bound
+            ]
+        )
+        remaining_type = restrict_subtype_away(
+            current_type,
+            proposed_precise_type,
+            consider_runtime_isinstance=consider_runtime_isinstance,
+        )
+        return proposed_type, remaining_type
 
 
 def conditional_types_to_typemaps(

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1483,11 +1483,12 @@ def f(x: Union[int, A], a: Type[A]) -> None:
 [builtins fixtures/isinstancelist.pyi]
 
 [case testIsInstanceWithEmtpy2ndArg]
+# flags: --warn-unreachable
 from typing import Union
 
 def f(x: Union[int, str]) -> None:
     if isinstance(x, ()):
-        reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
+        reveal_type(x)  # E: Statement is unreachable
     else:
         reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str]"
 [builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2639,7 +2639,7 @@ def baz(item: Base) -> None:
 
     reveal_type(item)  # N: Revealed type is "Union[__main__.<subclass of "__main__.Base" and "__main__.FooMixin">, __main__.<subclass of "__main__.Base" and "__main__.BarMixin">]"
     if isinstance(item, FooMixin):
-        reveal_type(item)  # N: Revealed type is "__main__.FooMixin"
+        reveal_type(item)  # N: Revealed type is "__main__.<subclass of "__main__.Base" and "__main__.FooMixin">"
         item.foo()
     else:
         reveal_type(item)  # N: Revealed type is "__main__.<subclass of "__main__.Base" and "__main__.BarMixin">"

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1936,6 +1936,22 @@ def union(x: str | bool) -> None:
     reveal_type(x)  # N: Revealed type is "Union[builtins.str, Literal[False]]"
 [builtins fixtures/tuple.pyi]
 
+[case testMatchNarrowDownUnionUsingClassPattern]
+
+class Foo: ...
+class Bar(Foo): ...
+
+def test_1(bar: Bar) -> None:
+    match bar:
+        case Foo() as foo:
+            reveal_type(foo)  # N: Revealed type is "__main__.Bar"
+
+def test_2(bar: Bar | str) -> None:
+    match bar:
+        case Foo() as foo:
+            reveal_type(foo)  # N: Revealed type is "__main__.Bar"
+
+
 [case testMatchAssertFalseToSilenceFalsePositives]
 class C:
     a: int | str


### PR DESCRIPTION
Fixes #19468

Based on earlier PR #19473

- refactored the `conditional_types` function. 
  - return `UninhabitedType(), default` when no ranges are given. This corresponds to `isinstance(x, ())`, with an empty tuple, which always returns `False` at runtime.
  - when the type is a union, factorize the yes type `isinstance(A|B, C) -> yes = A_yes | B_yes` (note: this does **not** apply to the no-type generally, see <https://github.com/python/mypy/pull/19473#discussion_r2234043360>
- modified  #19473 to change the proposed type, rather than directly returning. This is essential to maintain the behavior of the unit test `testIsinstanceWithOverlappingPromotionTypes`
- Allow `TypeChecker.get_isinstance_type` to return empty list (fixes `isinstance(x, ())` behavior).


## Modified tests

- `testIsInstanceWithEmtpy2ndArg` now correctly infers unreachable for `isinstance(x, ())`.
- `testNarrowingUnionMixins` now predicts the same results as [pyright playground](https://pyright-play.net/?strict=true&reportUnreachable=true&code=MQAg2gxghgzgpiALnGiByUBOmD2B3ASwDsBzAVSIJyIFkCAPYmAXQCgIAbWGEAIVjgAuEADox7LjB4AxHDjqMig1iFUgAJnABmILXIAU8DloCUIALQA%2BEGmpDR4ztz5YFxZWo3aQAIyyG4YzMrGzthMRFWTR0-AC99AmQAW2F%2BeGDrWyIhFTUCHSIcRBACGCZEKCIIOATkgBoQfVl5BmIG-kw3IhMTD081TChSuFZc1Uw4ADc4KA4AfUQATwAHGsS4JLMQUDRhACUpmY44dSQVhFKQACIKKiIwObmkoaJHkQAeGABXHycpEBwOiuj2exDeaTgVxAlVOwKeLzezS6V0sDRBCLmH2%2Bv0kPEB13RYMxEKhMIJ8KJIg6yMszCuYxKOlK5Uq1VqGwaSNa3T6-RAE2mswW53Zm1UO32h1mJzOqxKPDhoNemK5inpfNU6ySIj0OH0JgZgXgvP6AqOwtWoq2EpAB0Fx1OSzll0VGKxPz%2BeKBhOVVIEpKIsJ94Nc3JR6o1WpEfkw%2BqAA), https://mypy-play.net/?mypy=latest&python=3.12&gist=734c95f128705cfb0dc4ce24f1ad8eec

## New Tests

- `testMatchNarrowDownUnionUsingClassPattern` (https://mypy-play.net/?mypy=1.17.0&python=3.12&gist=e9ec514f49903022bd32a82ae1774abd)