### PR TITLE
[mypyc] Only generate an export table if using separate compilation

### DIFF
--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -652,7 +652,8 @@ class GroupGenerator:
                 decls.emit_lines(*declaration.decl)
 
         if self.group_name:
-            self.generate_export_table(ext_declarations, emitter)
+            if self.compiler_options.separate:
+                self.generate_export_table(ext_declarations, emitter)
 
             self.generate_shared_lib_init(emitter)
 
@@ -809,20 +810,21 @@ class GroupGenerator:
             "",
         )
 
-        emitter.emit_lines(
-            'capsule = PyCapsule_New(&exports, "{}.exports", NULL);'.format(
-                shared_lib_name(self.group_name)
-            ),
-            "if (!capsule) {",
-            "goto fail;",
-            "}",
-            'res = PyObject_SetAttrString(module, "exports", capsule);',
-            "Py_DECREF(capsule);",
-            "if (res < 0) {",
-            "goto fail;",
-            "}",
-            "",
-        )
+        if self.compiler_options.separate:
+            emitter.emit_lines(
+                'capsule = PyCapsule_New(&exports, "{}.exports", NULL);'.format(
+                    shared_lib_name(self.group_name)
+                ),
+                "if (!capsule) {",
+                "goto fail;",
+                "}",
+                'res = PyObject_SetAttrString(module, "exports", capsule);',
+                "Py_DECREF(capsule);",
+                "if (res < 0) {",
+                "goto fail;",
+                "}",
+                "",
+            )
 
         for mod in self.modules:
             name = exported_name(mod)


### PR DESCRIPTION
When not using separate compilation, the export table is not used. Also, there's actually no simple and safe way to use it without separate compilation, since we'd have to first ensure that the structure of the export table is compatible, as otherwise the order of fields or the types of the fields could be incompatible and cause segfaults and other fun stuff.