### PR TITLE
Use cache for OpExpr

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5994,7 +5994,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             # We cannot use cache inside lambdas, because they skip immediate type
             # context, and use enclosing one, see infer_lambda_type_using_context().
             # TODO: consider using cache for more expression kinds.
-            elif isinstance(node, (CallExpr, ListExpr, TupleExpr)) and not (
+            elif isinstance(node, (CallExpr, ListExpr, TupleExpr, OpExpr)) and not (
                 self.in_lambda_expr or self.chk.current_node_deferred
             ):
                 if (node, type_context) in self.expr_cache:


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/14978

This is irrelevant for self-check (and for most code likely), but it is important for numerical code, where it avoids exponential slowdown in formulas involving arrays etc (see e.g. the original issue).

Unless there will be fallout in `mypy_primer` and/or there are objections, I am going to go ahead and merge it.