### PR TITLE
Update crash issue template to use syntax highlighting in code blocks

### DIFF
--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -25,6 +25,11 @@ labels: "crash"
 appreciated.  We also very much appreciate it if you try to narrow the
 source down to a small stand-alone example.)
 
+```python
+# Ideally, a small sample program that demonstrates the problem.
+# Or even better, a reproducible playground link https://mypy-play.net/ (use the "Gist" button)
+```
+
 **Your Environment**
 
 <!-- Include as many relevant details about the environment you experienced the bug in -->

--- a/.github/ISSUE_TEMPLATE/crash.md
+++ b/.github/ISSUE_TEMPLATE/crash.md
@@ -15,7 +15,7 @@ labels: "crash"
 
 **Traceback**
 
-```
+```python-traceback
 (Insert traceback and other messages from mypy here -- use `--show-traceback`.)
 ```
 


### PR DESCRIPTION
People often forget or don't know how to add syntax highlighting to markdown code blocks (especially for tracebacks!). Let's help them out by pre-filling the template with code blocks that have the right language hints.