### PR TITLE
Use cache for DictExpr as well

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -6043,7 +6043,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             # We cannot use cache inside lambdas, because they skip immediate type
             # context, and use enclosing one, see infer_lambda_type_using_context().
             # TODO: consider using cache for more expression kinds.
-            elif isinstance(node, (CallExpr, ListExpr, TupleExpr, OpExpr)) and not (
+            elif isinstance(node, (CallExpr, ListExpr, TupleExpr, DictExpr, OpExpr)) and not (
                 self.in_lambda_expr or self.chk.current_node_deferred
             ):
                 if (node, type_context) in self.expr_cache:


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/14271
Fixes https://github.com/python/mypy/issues/14636

TBH examples in those issues are already sufficiently fast (probably because of combined effect of fast dict literals, and the fact that there are some lists and/or function calls in that examples, so some caching already kicks in). But this PR will probably make them even faster.

This has ~0 effect on self-check.
