### PR TITLE
[mypyc] Make type objects immortal if using free threading

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2328,7 +2328,7 @@ class LowLevelIRBuilder:
     def set_immortal_if_free_threaded(self, v: Value, line: int) -> None:
         """Make an object immortal on free-threaded builds (to avoid contention)."""
         if IS_FREE_THREADED and sys.version_info >= (3, 14):
-            self.call_c(set_immortal_op, [v], line)
+            self.primitive_op(set_immortal_op, [v], line)
 
     # Internal helpers
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -6,6 +6,7 @@ See the docstring of class LowLevelIRBuilder for more information.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Sequence
 from typing import Callable, Final, Optional
 
@@ -16,6 +17,7 @@ from mypy.types import AnyType, TypeOfAny
 from mypyc.common import (
     BITMAP_BITS,
     FAST_ISINSTANCE_MAX_SUBCLASSES,
+    IS_FREE_THREADED,
     MAX_LITERAL_SHORT_INT,
     MAX_SHORT_INT,
     MIN_LITERAL_SHORT_INT,
@@ -164,6 +166,7 @@ from mypyc.primitives.misc_ops import (
     fast_isinstance_op,
     none_object_op,
     not_implemented_op,
+    set_immortal_op,
     var_object_size,
 )
 from mypyc.primitives.registry import (
@@ -2321,6 +2324,11 @@ class LowLevelIRBuilder:
 
     def int_to_float(self, n: Value, line: int) -> Value:
         return self.primitive_op(int_to_float_op, [n], line)
+
+    def set_immortal_if_free_threaded(self, v: Value, line: int) -> None:
+        """Make an object immortal on free-threaded builds (to avoid contention)."""
+        if IS_FREE_THREADED and sys.version_info >= (3, 14):
+            self.call_c(set_immortal_op, [v], line)
 
     # Internal helpers
 

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -931,6 +931,10 @@ PyObject *CPy_GetANext(PyObject *aiter);
 void CPy_SetTypeAliasTypeComputeFunction(PyObject *alias, PyObject *compute_value);
 void CPyTrace_LogEvent(const char *location, const char *line, const char *op, const char *details);
 
+#if CPY_3_14_FEATURES
+void CPy_SetImmortal(PyObject *obj);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -1058,7 +1058,7 @@ void CPyTrace_LogEvent(const char *location, const char *line, const char *op, c
 
 #endif
 
-#ifdef CPY_3_12_FEATURES
+#if CPY_3_12_FEATURES
 
 // Copied from Python 3.12.3, since this struct is internal to CPython. It defines
 // the structure of typing.TypeAliasType objects. We need it since compute_value is
@@ -1085,6 +1085,16 @@ void CPy_SetTypeAliasTypeComputeFunction(PyObject *alias, PyObject *compute_valu
         Py_DECREF(obj->compute_value);
     }
     obj->compute_value = compute_value;
+}
+
+#endif
+
+#if CPY_3_14_FEATURES
+
+#include "internal/pycore_object.h"
+
+void CPy_SetImmortal(PyObject *obj) {
+    _Py_SetImmortal(obj);
 }
 
 #endif

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -139,8 +139,9 @@ static inline CPyTagged CPyTagged_ShortFromSsize_t(Py_ssize_t x) {
     return x << 1;
 }
 
-// Are we targeting Python 3.12 or newer?
+// Are we targeting Python 3.X or newer?
 #define CPY_3_12_FEATURES (PY_VERSION_HEX >= 0x030c0000)
+#define CPY_3_14_FEATURES (PY_VERSION_HEX >= 0x030e0000)
 
 #if CPY_3_12_FEATURES
 

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -311,3 +311,18 @@ log_trace_event = custom_primitive_op(
     return_type=void_rtype,
     error_kind=ERR_NEVER,
 )
+
+# Mark object as immortal -- it won't be freed via reference counting, as
+# the reference count won't be updated any longer. Immortal objects support
+# fast concurrent read-only access from multiple threads when using free
+# threading, since this eliminates contention from concurrent reference count
+# updates.
+#
+# Needs at least Python 3.14.
+set_immortal_op = custom_primitive_op(
+    name="set_immmortal",
+    c_function_name="CPy_SetImmortal",
+    arg_types=[object_rprimitive],
+    return_type=void_rtype,
+    error_kind=ERR_NEVER,
+)


### PR DESCRIPTION
If they are not immortal, concurrent construction of objects by multiple
threads can cause serious contention due to reference count updates.

Making them immortal is similar to how both user-defined normal Python 
classes and built-in types in free-threaded builds are immortal.

Fix the issue for both native and non-native classes. Dataclasses still have
contention, and they may be harder to fix (this may require a fix in CPython).

This speeds up a few micro-benchmarks that construct instances of classes
in multiple threads by a big factor (5x+).