### PR TITLE
Explicitly check case‐sensitivity of file system for tests

### DIFF
--- a/mypy/test/testfscache.py
+++ b/mypy/test/testfscache.py
@@ -83,7 +83,7 @@ class TestFileSystemCache(unittest.TestCase):
             assert self.isfile_case(os.path.join(other, "other_dir.py"))
             assert not self.isfile_case(os.path.join(other, "Other_Dir.py"))
             assert not self.isfile_case(os.path.join(other, "bar.py"))
-            if sys.platform in ("win32", "darwin"):
+            if os.path.exists(os.path.join(other, "PKG/other_dir.py")):
                 # We only check case for directories under our prefix, and since
                 # this path is not under the prefix, case difference is fine.
                 assert self.isfile_case(os.path.join(other, "PKG/other_dir.py"))

--- a/mypy/test/testfscache.py
+++ b/mypy/test/testfscache.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 import tempfile
 import unittest
 


### PR DESCRIPTION
Both macOS and Windows support using case‐sensitive file systems; this fixes the test suite in those situations.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
