### PR TITLE
Keep trivial instances and aliases during expansion

### DIFF
--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -210,8 +210,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
 
     def visit_instance(self, t: Instance) -> Type:
         if len(t.args) == 0:
-            # TODO: Why do we need to create a copy here?
-            return t.copy_modified()
+            return t
 
         args = self.expand_type_tuple_with_unpack(t.args)
 
@@ -525,6 +524,8 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:
         # Target of the type alias cannot contain type variables (not bound by the type
         # alias itself), so we just expand the arguments.
+        if len(t.args) == 0:
+            return t
         args = self.expand_type_list_with_unpack(t.args)
         # TODO: normalize if target is Tuple, and args are [*tuple[X, ...]]?
         return t.copy_modified(args=args)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1046,12 +1046,12 @@ class SemanticAnalyzer(
         last_type = typ.arg_types[-1]
         if not isinstance(last_type, UnpackType):
             return typ
-        last_type = get_proper_type(last_type.type)
-        if not isinstance(last_type, TypedDictType):
+        p_last_type = get_proper_type(last_type.type)
+        if not isinstance(p_last_type, TypedDictType):
             self.fail("Unpack item in ** argument must be a TypedDict", last_type)
             new_arg_types = typ.arg_types[:-1] + [AnyType(TypeOfAny.from_error)]
             return typ.copy_modified(arg_types=new_arg_types)
-        overlap = set(typ.arg_names) & set(last_type.items)
+        overlap = set(typ.arg_names) & set(p_last_type.items)
         # It is OK for TypedDict to have a key named 'kwargs'.
         overlap.discard(typ.arg_names[-1])
         if overlap:
@@ -1060,7 +1060,7 @@ class SemanticAnalyzer(
             new_arg_types = typ.arg_types[:-1] + [AnyType(TypeOfAny.from_error)]
             return typ.copy_modified(arg_types=new_arg_types)
         # OK, everything looks right now, mark the callable type as using unpack.
-        new_arg_types = typ.arg_types[:-1] + [last_type]
+        new_arg_types = typ.arg_types[:-1] + [p_last_type]
         return typ.copy_modified(arg_types=new_arg_types, unpack_kwargs=True)
 
     def prepare_method_signature(self, func: FuncDef, info: TypeInfo, has_self_type: bool) -> None:


### PR DESCRIPTION
This weirdly looking change consistently shows 1% performance improvement on my machine (Python 3.12, compiled). The key here is to _not_ create new objects for trivial instances and aliases (i.e. those with no `.args`). The problem however is that some callers modify expanded type aliases _in place_ (for better error locations). I updated couple places discovered by tests, but there may be more.

I think we should go ahead, and then fix bugs exposed by this using following strategy:
* Always use original aliases (not theirs expansions) as error locations (see change in `semanal.py`).
* If above is not possible (see unpacked tuple change), then call `t.copy_modified()` followed by `t.set_line()` manually.