### PR TITLE
Optimize bind_self() and deprecation checks

### DIFF
--- a/mypy/checker_shared.py
+++ b/mypy/checker_shared.py
@@ -254,12 +254,6 @@ class TypeCheckerSharedApi(CheckerPluginInterface):
         raise NotImplementedError
 
     @abstractmethod
-    def warn_deprecated_overload_item(
-        self, node: Node | None, context: Context, *, target: Type, selftype: Type | None = None
-    ) -> None:
-        raise NotImplementedError
-
-    @abstractmethod
     def type_is_iterable(self, type: Type) -> bool:
         raise NotImplementedError
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -14,7 +14,6 @@ from mypy.expandtype import (
     freshen_all_functions_type_vars,
 )
 from mypy.maptype import map_instance_to_supertype
-from mypy.meet import is_valid_self_type_best_effort
 from mypy.messages import MessageBuilder
 from mypy.nodes import (
     ARG_POS,
@@ -1049,23 +1048,6 @@ def check_self_arg(
     new_items = []
     if is_classmethod:
         dispatched_arg_type = TypeType.make_normalized(dispatched_arg_type)
-
-    if isinstance(functype, Overloaded):
-        p_dispatched_arg_type = get_proper_type(dispatched_arg_type)
-        filtered_items = []
-        for c in items:
-            if isinstance(p_dispatched_arg_type, Instance):
-                # Filter based on whether declared self type can match actual object type.
-                # For example, if self has type C[int] and method is accessed on a C[str] value,
-                # omit this item. This is best-effort first pass filter obvious mismatches for
-                # performance reasons.
-                keep = is_valid_self_type_best_effort(c, p_dispatched_arg_type)
-            else:
-                keep = True
-            if keep:
-                filtered_items.append(c)
-        if len(filtered_items) != 0:
-            items = filtered_items
 
     for item in items:
         if not item.arg_types or item.arg_kinds[0] not in (ARG_POS, ARG_STAR):

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1064,6 +1064,9 @@ def check_self_arg(
             if isinstance(selfarg, Instance) and isinstance(p_dispatched_arg_type, Instance):
                 if selfarg.type is p_dispatched_arg_type.type and selfarg.args:
                     if not is_overlapping_types(p_dispatched_arg_type, selfarg):
+                        # This special casing is needed since `actual <: erased(template)`
+                        # logic below doesn't always work, and a more correct approach may
+                        # be tricky.
                         continue
             # This matches similar special-casing in bind_self(), see more details there.
             self_callable = name == "__call__" and isinstance(selfarg, CallableType)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -45,7 +45,6 @@ from mypy.typeops import (
     freeze_all_type_vars,
     function_type,
     get_all_type_vars,
-    is_valid_self_type_best_effort,
     make_simplified_union,
     supported_self_type,
     tuple_fallback,
@@ -1049,23 +1048,6 @@ def check_self_arg(
     new_items = []
     if is_classmethod:
         dispatched_arg_type = TypeType.make_normalized(dispatched_arg_type)
-
-    if isinstance(functype, Overloaded):
-        p_dispatched_arg_type = get_proper_type(dispatched_arg_type)
-        filtered_items = []
-        for c in items:
-            if isinstance(p_dispatched_arg_type, Instance):
-                # Filter based on whether declared self type can match actual object type.
-                # For example, if self has type C[int] and method is accessed on a C[str] value,
-                # omit this item. This is best effort first pass filter obvious mismatches for
-                # performance reasons.
-                keep = is_valid_self_type_best_effort(c, p_dispatched_arg_type)
-            else:
-                keep = True
-            if keep:
-                filtered_items.append(c)
-        if len(filtered_items) != 0:
-            items = filtered_items
 
     for item in items:
         if not item.arg_types or item.arg_kinds[0] not in (ARG_POS, ARG_STAR):

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -14,6 +14,7 @@ from mypy.expandtype import (
     freshen_all_functions_type_vars,
 )
 from mypy.maptype import map_instance_to_supertype
+from mypy.meet import is_valid_self_type_best_effort
 from mypy.messages import MessageBuilder
 from mypy.nodes import (
     ARG_POS,
@@ -1048,6 +1049,23 @@ def check_self_arg(
     new_items = []
     if is_classmethod:
         dispatched_arg_type = TypeType.make_normalized(dispatched_arg_type)
+
+    if isinstance(functype, Overloaded):
+        p_dispatched_arg_type = get_proper_type(dispatched_arg_type)
+        filtered_items = []
+        for c in items:
+            if isinstance(p_dispatched_arg_type, Instance):
+                # Filter based on whether declared self type can match actual object type.
+                # For example, if self has type C[int] and method is accessed on a C[str] value,
+                # omit this item. This is best-effort first pass filter obvious mismatches for
+                # performance reasons.
+                keep = is_valid_self_type_best_effort(c, p_dispatched_arg_type)
+            else:
+                keep = True
+            if keep:
+                filtered_items.append(c)
+        if len(filtered_items) != 0:
+            items = filtered_items
 
     for item in items:
         if not item.arg_types or item.arg_kinds[0] not in (ARG_POS, ARG_STAR):

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -165,6 +165,8 @@ class NodeFixer(NodeVisitor[None]):
             func.info = self.current_info
         if func.type is not None:
             func.type.accept(self.type_fixer)
+            if isinstance(func.type, CallableType):
+                func.type.definition = func
 
     def visit_overloaded_func_def(self, o: OverloadedFuncDef) -> None:
         if self.current_info is not None:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -291,6 +291,18 @@ def is_object(t: ProperType) -> bool:
     return isinstance(t, Instance) and t.type.fullname == "builtins.object"
 
 
+def is_none_typevarlike_overlap(t1: ProperType, t2: ProperType) -> bool:
+    return isinstance(t1, NoneType) and isinstance(t2, TypeVarLikeType)
+
+
+def is_none_object_overlap(t1: ProperType, t2: ProperType) -> bool:
+    return (
+        isinstance(t1, NoneType)
+        and isinstance(t2, Instance)
+        and t2.type.fullname == "builtins.object"
+    )
+
+
 def is_overlapping_types(
     left: Type,
     right: Type,
@@ -382,14 +394,6 @@ def is_overlapping_types(
     ):
         return True
 
-    def is_none_object_overlap(t1: Type, t2: Type) -> bool:
-        t1, t2 = get_proper_types((t1, t2))
-        return (
-            isinstance(t1, NoneType)
-            and isinstance(t2, Instance)
-            and t2.type.fullname == "builtins.object"
-        )
-
     if overlap_for_overloads:
         if is_none_object_overlap(left, right) or is_none_object_overlap(right, left):
             return False
@@ -418,10 +422,6 @@ def is_overlapping_types(
     #
     # If both types are singleton variants (and are not TypeVarLikes), we've hit the base case:
     # we skip these checks to avoid infinitely recursing.
-
-    def is_none_typevarlike_overlap(t1: Type, t2: Type) -> bool:
-        t1, t2 = get_proper_types((t1, t2))
-        return isinstance(t1, NoneType) and isinstance(t2, TypeVarLikeType)
 
     if prohibit_none_typevar_overlap:
         if is_none_typevarlike_overlap(left, right) or is_none_typevarlike_overlap(right, left):

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -5,6 +5,7 @@ from typing import Callable
 from mypy import join
 from mypy.erasetype import erase_type
 from mypy.maptype import map_instance_to_supertype
+from mypy.nodes import ARG_OPT, ARG_POS
 from mypy.state import state
 from mypy.subtypes import (
     are_parameters_compatible,
@@ -736,6 +737,39 @@ def is_tuple(typ: Type) -> bool:
     return isinstance(typ, TupleType) or (
         isinstance(typ, Instance) and typ.type.fullname == "builtins.tuple"
     )
+
+
+def is_valid_self_type_best_effort(c: CallableType, self_type: Instance) -> bool:
+    """Quickly check if self_type might match the self in a callable.
+    Avoid performing any complex type operations. This is performance-critical.
+    Default to returning True if we don't know (or it would be too expensive).
+    """
+    if (
+        self_type.args
+        and c.arg_types
+        and isinstance((arg_type := get_proper_type(c.arg_types[0])), Instance)
+        and c.arg_kinds[0] in (ARG_POS, ARG_OPT)
+        and arg_type.args
+        and self_type.type.fullname != "functools._SingleDispatchCallable"
+    ):
+        if self_type.type is not arg_type.type:
+            # We can't map to supertype, since it could trigger expensive checks for
+            # protocol types, so we conservatively assume this is fine.
+            return True
+
+        # Fast path: no explicit annotation on self
+        if all(
+            (
+                type(arg) is TypeVarType
+                and type(arg.upper_bound) is Instance
+                and arg.upper_bound.type.fullname == "builtins.object"
+            )
+            for arg in arg_type.args
+        ):
+            return True
+
+        return is_overlapping_types(self_type, c.arg_types[0])
+    return True
 
 
 class TypeMeetVisitor(TypeVisitor[ProperType]):

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -595,12 +595,14 @@ class OverloadedFuncDef(FuncBase, SymbolNode, Statement):
         """
         if self._is_trivial_self is not None:
             return self._is_trivial_self
-        for item in self.items:
+        for i, item in enumerate(self.items):
+            # Note: bare @property is removed in visit_decorator().
+            trivial = 1 if i > 0 or not self.is_property else 0
             if isinstance(item, FuncDef):
                 if not item.is_trivial_self:
                     self._is_trivial_self = False
                     return False
-            elif item.decorators or not item.func.is_trivial_self:
+            elif len(item.decorators) > trivial or not item.func.is_trivial_self:
                 self._is_trivial_self = False
                 return False
         self._is_trivial_self = True

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -16,7 +16,6 @@ from mypy.copytype import copy_type
 from mypy.expandtype import expand_type, expand_type_by_instance
 from mypy.maptype import map_instance_to_supertype
 from mypy.nodes import (
-    ARG_OPT,
     ARG_POS,
     ARG_STAR,
     ARG_STAR2,
@@ -490,43 +489,6 @@ def bind_self(
         is_bound=True,
     )
     return cast(F, res)
-
-
-def is_valid_self_type_best_effort(c: CallableType, self_type: Instance) -> bool:
-    """Quickly check if self_type might match the self in a callable.
-
-    Avoid performing any complex type operations. This is performance-critical.
-
-    Default to returning True if we don't know (or it would be too expensive).
-    """
-    if (
-        self_type.args
-        and c.arg_types
-        and isinstance((arg_type := get_proper_type(c.arg_types[0])), Instance)
-        and c.arg_kinds[0] in (ARG_POS, ARG_OPT)
-        and arg_type.args
-        and self_type.type.fullname != "functools._SingleDispatchCallable"
-    ):
-        if self_type.type is not arg_type.type:
-            # We can't map to supertype, since it could trigger expensive checks for
-            # protocol types, so we consevatively assume this is fine.
-            return True
-
-        # Fast path: no explicit annotation on self
-        if all(
-            (
-                type(arg) is TypeVarType
-                and type(arg.upper_bound) is Instance
-                and arg.upper_bound.type.fullname == "builtins.object"
-            )
-            for arg in arg_type.args
-        ):
-            return True
-
-        from mypy.meet import is_overlapping_types
-
-        return is_overlapping_types(self_type, c.arg_types[0])
-    return True
 
 
 def erase_to_bound(t: Type) -> Type:

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -421,27 +421,9 @@ def bind_self(
 
     """
     if isinstance(method, Overloaded):
-        items = []
-        original_type = get_proper_type(original_type)
-        for c in method.items:
-            if isinstance(original_type, Instance):
-                # Filter based on whether declared self type can match actual object type.
-                # For example, if self has type C[int] and method is accessed on a C[str] value,
-                # omit this item. This is best effort since bind_self can be called in many
-                # contexts, and doing complete validation might trigger infinite recursion.
-                #
-                # Note that overload item filtering normally happens elsewhere. This is needed
-                # at least during constraint inference.
-                keep = is_valid_self_type_best_effort(c, original_type)
-            else:
-                keep = True
-            if keep:
-                items.append(bind_self(c, original_type, is_classmethod, ignore_instances))
-        if len(items) == 0:
-            # If no item matches, returning all items helps avoid some spurious errors
-            items = [
-                bind_self(c, original_type, is_classmethod, ignore_instances) for c in method.items
-            ]
+        items = [
+            bind_self(c, original_type, is_classmethod, ignore_instances) for c in method.items
+        ]
         return cast(F, Overloaded(items))
     assert isinstance(method, CallableType)
     func: CallableType = method

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -2282,3 +2282,30 @@ class Check:
 reveal_type(Check.foo())  # N: Revealed type is "def () -> __main__.Check"
 reveal_type(Check().foo())  # N: Revealed type is "__main__.Check"
 [builtins fixtures/tuple.pyi]
+
+[case testSelfTypeUpperBoundFiler]
+from typing import Generic, TypeVar, overload, Sequence
+
+class B: ...
+class C(B): ...
+
+TB = TypeVar("TB", bound=B)
+TC = TypeVar("TC", bound=C)
+
+class G(Generic[TB]):
+    @overload
+    def test(self: G[TC]) -> list[TC]: ...
+    @overload
+    def test(self: G[TB]) -> Sequence[TB]: ...
+    def test(self):
+        ...
+
+class D1(B): ...
+class D2(C): ...
+
+gb: G[D1]
+gc: G[D2]
+
+reveal_type(gb.test())  # N: Revealed type is "typing.Sequence[__main__.D1]"
+reveal_type(gc.test())  # N: Revealed type is "builtins.list[__main__.D2]"
+[builtins fixtures/list.pyi]

--- a/test-data/unit/check-serialize.test
+++ b/test-data/unit/check-serialize.test
@@ -158,6 +158,7 @@ def f(__x: int) -> None: pass
 [out2]
 tmp/a.py:3: error: Argument 1 to "f" has incompatible type "str"; expected "int"
 tmp/a.py:4: error: Unexpected keyword argument "__x" for "f"
+tmp/b.py: note: "f" defined here
 
 [case testSerializeArgumentKindsErrors]
 import a


### PR DESCRIPTION
This contains two related optimizations:
* Simplify deprecation check by removing several `bind_self()` calls and instead restoring callable type definitions in `fixup.py`, and using them during overload item matching.
* Consequently, best effort filtering in `bind_self()` should be not needed anymore, since all non-trivial calls to `bind_self()` are now after `check_self_arg()` calls.

There are also few micro-optimizations I noticed when looking at relevant code. In total this gives around 1% on self-check.

Note: this may be not a no-op in some corner cases. If so, I will adjust overload filtering in `check_self_arg()`.