### PR TITLE
fix: prevent crash on dataclass with PEP695 TypeVarTuple on py3.13

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -410,13 +410,12 @@ class DataclassTransformer:
             for attr in attributes
             if attr.is_in_init
         ]
-        type_vars = [tv for tv in self._cls.type_vars]
         add_method_to_class(
             self._api,
             self._cls,
             "__replace__",
             args=args,
-            return_type=Instance(self._cls.info, type_vars),
+            return_type=fill_typevars(self._cls.info),
         )
 
     def _add_internal_replace_method(self, attributes: list[DataclassAttribute]) -> None:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2682,3 +2682,14 @@ class ClassB(ClassA):
     def value(self) -> int:  # E: Name "value" already defined on line 10
         return 0
 [builtins fixtures/dict.pyi]
+
+[case testDataclassWithTypeVarTuple]
+# flags: --python-version 3.13
+# https://github.com/python/mypy/issues/19559
+from typing import Callable
+from dataclasses import dataclass
+
+@dataclass
+class Test[*Ts, R]:
+    a: Callable[[*Ts], R]
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #19559.

Replaces ad-hoc Instance creation with regular `fill_typevars`.

Huge thanks to @A5rocks for the pointer!