### PR TITLE
Remove --new-type-inference flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1092,10 +1092,6 @@ def process_options(
     internals_group.add_argument(
         "--old-type-inference", action="store_true", help=argparse.SUPPRESS
     )
-    # Deprecated reverse variant of the above.
-    internals_group.add_argument(
-        "--new-type-inference", action="store_true", help=argparse.SUPPRESS
-    )
     internals_group.add_argument(
         "--disable-expression-cache", action="store_true", help=argparse.SUPPRESS
     )
@@ -1486,12 +1482,6 @@ def process_options(
     # Let logical_deps imply cache_fine_grained (otherwise the former is useless).
     if options.logical_deps:
         options.cache_fine_grained = True
-
-    if options.new_type_inference:
-        print(
-            "Warning: --new-type-inference flag is deprecated;"
-            " new type inference algorithm is already enabled by default"
-        )
 
     if options.strict_concatenate and not strict_option_set:
         print("Warning: --strict-concatenate is deprecated; use --extra-checks instead")

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -391,10 +391,8 @@ class Options:
         # skip most errors after this many messages have been reported.
         # -1 means unlimited.
         self.many_errors_threshold = defaults.MANY_ERRORS_THRESHOLD
-        # Disable new experimental type inference algorithm.
+        # Disable new type inference algorithm.
         self.old_type_inference = False
-        # Deprecated reverse version of the above, do not use.
-        self.new_type_inference = False
         # Disable expression cache (for debugging).
         self.disable_expression_cache = False
         # Export line-level, limited, fine-grained dependency information in cache data

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2750,7 +2750,6 @@ reveal_type(func(1))  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testGenericLambdaGenericMethodNoCrash]
-# flags: --new-type-inference
 from typing import TypeVar, Union, Callable, Generic
 
 S = TypeVar("S")
@@ -2789,7 +2788,6 @@ reveal_type(dict2)  # N: Revealed type is "builtins.dict[Any, __main__.B]"
 -- ------------------------------------------------------------------
 
 [case testInferenceAgainstGenericCallable]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 X = TypeVar('X')
@@ -2807,7 +2805,6 @@ reveal_type(bar(id))  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableNoLeak]
-# flags: --new-type-inference
 from typing import TypeVar, Callable
 
 T = TypeVar('T')
@@ -2823,7 +2820,6 @@ reveal_type(f(tpl))  # N: Revealed type is "Any"
 [out]
 
 [case testInferenceAgainstGenericCallableChain]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 X = TypeVar('X')
@@ -2836,7 +2832,6 @@ reveal_type(chain(id, id))  # N: Revealed type is "def (builtins.int) -> builtin
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableGeneric]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -2857,7 +2852,6 @@ reveal_type(same(42))  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableGenericReverse]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -2878,7 +2872,6 @@ reveal_type(same([42]))  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableGenericArg]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -2899,7 +2892,6 @@ reveal_type(single(42))  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableGenericChain]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -2913,7 +2905,6 @@ reveal_type(comb(id, id))  # N: Revealed type is "def [T] (T`1) -> T`1"
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableGenericNonLinear]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -2934,7 +2925,6 @@ reveal_type(mix([id, id, id]))  # N: Revealed type is "def [S] (S`4) -> builtins
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCurry]
-# flags: --new-type-inference
 from typing import Callable, List, TypeVar
 
 S = TypeVar("S")
@@ -2953,7 +2943,6 @@ reveal_type(dec2(test2))  # N: Revealed type is "def [T] (T`3) -> def (T`3) -> T
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableNewVariable]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -2968,7 +2957,6 @@ reveal_type(dec(test))  # N: Revealed type is "def [U] (builtins.list[U`-1]) -> 
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableGenericAlias]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -2986,7 +2974,6 @@ reveal_type(dec(id))  # N: Revealed type is "def [S] (S`1) -> builtins.list[S`1]
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericCallableGenericProtocol]
-# flags: --new-type-inference
 from typing import TypeVar, Protocol, Generic, Optional
 
 T = TypeVar('T')
@@ -3002,7 +2989,6 @@ reveal_type(lift(g))  # N: Revealed type is "def [T] (Union[T`1, None]) -> Union
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericSplitOrder]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -3017,7 +3003,6 @@ reveal_type(dec(id, id))  # N: Revealed type is "def (builtins.int) -> builtins.
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericSplitOrderGeneric]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, Tuple
 
 S = TypeVar('S')
@@ -3048,7 +3033,6 @@ reveal_type(id)  # N: Revealed type is "def (builtins.int) -> builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testInferenceAgainstGenericEllipsisSelfSpecialCase]
-# flags: --new-type-inference
 from typing import Self, Callable, TypeVar
 
 T = TypeVar("T")
@@ -3062,7 +3046,6 @@ c: C
 reveal_type(c.test())  # N: Revealed type is "__main__.C"
 
 [case testInferenceAgainstGenericBoundsAndValues]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 class B: ...
@@ -3090,7 +3073,6 @@ reveal_type(dec2(id2))  # N: Revealed type is "def (Never) -> builtins.list[Neve
                         # E: Argument 1 to "dec2" has incompatible type "Callable[[V], V]"; expected "Callable[[Never], Never]"
 
 [case testInferenceAgainstGenericLambdas]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List
 
 S = TypeVar('S')
@@ -3127,7 +3109,6 @@ dec4_bound(lambda x: x)  # E: Value of type variable "I" of "dec4_bound" cannot 
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecBasicInList]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple
 from typing_extensions import ParamSpec
 
@@ -3146,7 +3127,6 @@ reveal_type(dec(pair))  # N: Revealed type is "def [U, V] (x: U`-1, y: V`-2) -> 
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecBasicDeList]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple
 from typing_extensions import ParamSpec
 
@@ -3163,7 +3143,6 @@ reveal_type(dec(either))  # N: Revealed type is "def [T] (x: builtins.list[T`5],
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecPopOff]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple
 from typing_extensions import ParamSpec, Concatenate
 
@@ -3184,7 +3163,6 @@ reveal_type(dec(dec))  # N: Revealed type is "def () -> def [T, P, S] (def (T`-1
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecPopOn]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple
 from typing_extensions import ParamSpec, Concatenate
 
@@ -3206,7 +3184,6 @@ reveal_type(dec(dec))  # N: Revealed type is "def [T, S] (T`13, f: def () -> def
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecVsParamSpec]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple, Generic
 from typing_extensions import ParamSpec, Concatenate
 
@@ -3227,7 +3204,6 @@ reveal_type(dec(h))  # N: Revealed type is "def [T, Q] (T`-1, *Q.args, **Q.kwarg
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecVsParamSpecConcatenate]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple, Generic
 from typing_extensions import ParamSpec, Concatenate
 
@@ -3245,7 +3221,6 @@ reveal_type(dec(h))  # N: Revealed type is "def [T, Q] (T`-1, *Q.args, **Q.kwarg
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecSecondary]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple, Generic
 from typing_extensions import ParamSpec, Concatenate
 
@@ -3263,7 +3238,6 @@ reveal_type(dec(g))  # N: Revealed type is "def (builtins.int) -> __main__.Foo[[
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericParamSpecSecondOrder]
-# flags: --new-type-inference
 from typing import TypeVar, Callable
 from typing_extensions import ParamSpec, Concatenate
 
@@ -3285,7 +3259,6 @@ reveal_type(transform(dec2))  # N: Revealed type is "def [W, T] (def (builtins.i
 [builtins fixtures/tuple.pyi]
 
 [case testNoAccidentalVariableClashInNestedGeneric]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, Generic, Tuple
 
 T = TypeVar('T')
@@ -3302,7 +3275,6 @@ def apply(a: S, b: T) -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testInferenceAgainstGenericParamSpecSpuriousBoundsNotUsed]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, Generic
 from typing_extensions import ParamSpec, Concatenate
 
@@ -3321,7 +3293,6 @@ reveal_type(test)  # N: Revealed type is "def () -> def [Q] (__main__.Foo[Q`-1])
 [builtins fixtures/tuple.pyi]
 
 [case testInferenceAgainstGenericVariadicBasicInList]
-# flags: --new-type-inference
 from typing import Tuple, TypeVar, List, Callable
 from typing_extensions import Unpack, TypeVarTuple
 
@@ -3341,7 +3312,6 @@ reveal_type(dec(pair))  # N: Revealed type is "def [U, V] (U`-1, V`-2) -> builti
 [builtins fixtures/tuple.pyi]
 
 [case testInferenceAgainstGenericVariadicBasicDeList]
-# flags: --new-type-inference
 from typing import Tuple, TypeVar, List, Callable
 from typing_extensions import Unpack, TypeVarTuple
 
@@ -3359,7 +3329,6 @@ reveal_type(dec(either))  # N: Revealed type is "def [T] (builtins.list[T`5], bu
 [builtins fixtures/tuple.pyi]
 
 [case testInferenceAgainstGenericVariadicPopOff]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple
 from typing_extensions import Unpack, TypeVarTuple
 
@@ -3381,7 +3350,6 @@ reveal_type(dec(dec))  # N: Revealed type is "def () -> def [T, Ts, S] (def (T`-
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericVariadicPopOn]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Tuple
 from typing_extensions import Unpack, TypeVarTuple
 
@@ -3404,7 +3372,6 @@ reveal_type(dec(dec))  # N: Revealed type is "def [T, S] (T`13, def () -> def (T
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericVariadicVsVariadic]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, List, Generic
 from typing_extensions import Unpack, TypeVarTuple
 
@@ -3424,7 +3391,6 @@ reveal_type(dec(g))  # N: Revealed type is "def [Ts] (*Unpack[Ts`4]) -> builtins
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericVariadicVsVariadicConcatenate]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, Generic
 from typing_extensions import Unpack, TypeVarTuple
 
@@ -3443,7 +3409,6 @@ reveal_type(dec(h))  # N: Revealed type is "def [T, Us] (T`-1, *Unpack[Us`-2]) -
 [builtins fixtures/list.pyi]
 
 [case testInferenceAgainstGenericVariadicSecondary]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, Generic
 from typing_extensions import Unpack, TypeVarTuple
 

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -693,7 +693,6 @@ f(lambda: None)
 g(lambda: None)
 
 [case testIsinstanceInInferredLambda]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, Optional
 T = TypeVar('T')
 S = TypeVar('S')

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1405,14 +1405,12 @@ class B: pass
 [builtins fixtures/list.pyi]
 
 [case testUninferableLambda]
-# flags: --new-type-inference
 from typing import TypeVar, Callable
 X = TypeVar('X')
 def f(x: Callable[[X], X]) -> X: pass
 y = f(lambda x: x)  # E: Need type annotation for "y"
 
 [case testUninferableLambdaWithTypeError]
-# flags: --new-type-inference
 from typing import TypeVar, Callable
 X = TypeVar('X')
 def f(x: Callable[[X], X], y: str) -> X: pass

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6637,7 +6637,6 @@ reveal_type(Snafu.snafu('123'))  # N: Revealed type is "builtins.str"
 [builtins fixtures/staticmethod.pyi]
 
 [case testOverloadedWithInternalTypeVars]
-# flags: --new-type-inference
 import m
 
 [file m.pyi]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1121,7 +1121,6 @@ reveal_type(jf(1))  # N: Revealed type is "None"
 [builtins fixtures/paramspec.pyi]
 
 [case testGenericsInInferredParamspecReturn]
-# flags: --new-type-inference
 from typing import Callable, TypeVar, Generic
 from typing_extensions import ParamSpec
 
@@ -1646,7 +1645,6 @@ def f(f: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None: ...
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecDecoratorAppliedToGeneric]
-# flags: --new-type-inference
 from typing import Callable, List, TypeVar
 from typing_extensions import ParamSpec
 
@@ -1684,7 +1682,6 @@ reveal_type(test(*ints))  # N: Revealed type is "__main__.Foo[[*builtins.int]]"
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecArgumentParamInferenceGeneric]
-# flags: --new-type-inference
 from typing import Callable, TypeVar
 from typing_extensions import ParamSpec
 
@@ -1702,7 +1699,6 @@ y: int = call(identity, 2)
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecNestedApplyNoCrash]
-# flags: --new-type-inference
 from typing import Callable, TypeVar
 from typing_extensions import ParamSpec
 

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1201,7 +1201,6 @@ class A:
 [builtins fixtures/bool.pyi]
 
 [case testAttrsFactoryBadReturn]
-# flags: --new-type-inference
 import attr
 def my_factory() -> int:
     return 7

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -886,7 +886,6 @@ reveal_type(z)  # N: Revealed type is "tuple[builtins.int, Unpack[builtins.tuple
 [builtins fixtures/tuple.pyi]
 
 [case testInferenceAgainstGenericVariadicWithBadType]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, Generic
 from typing_extensions import Unpack, TypeVarTuple
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1249,14 +1249,6 @@ note: A user-defined top-level module with name "typing" is not supported
 Failed to find builtin module mypy_extensions, perhaps typeshed is broken?
 == Return code: 2
 
-[case testNewTypeInferenceFlagDeprecated]
-# cmd: mypy --new-type-inference a.py
-[file a.py]
-pass
-[out]
-Warning: --new-type-inference flag is deprecated; new type inference algorithm is already enabled by default
-== Return code: 0
-
 [case testCustomTypeshedDirFilePassedExplicitly]
 # cmd: mypy --custom-typeshed-dir dir m.py dir/stdlib/foo.pyi
 [file m.py]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -797,7 +797,6 @@ _program.py:3: error: Dict entry 1 has incompatible type "str": "str"; expected 
 _program.py:5: error: "dict[str, int]" has no attribute "xyz"
 
 [case testDefaultDict]
-# flags: --new-type-inference
 import typing as t
 from collections import defaultdict
 
@@ -823,11 +822,11 @@ class MyDDict(t.DefaultDict[int,T], t.Generic[T]):
 MyDDict(dict)['0']
 MyDDict(dict)[0]
 [out]
-_program.py:7: error: Argument 1 to "defaultdict" has incompatible type "type[list[_T]]"; expected "Optional[Callable[[], str]]"
-_program.py:10: error: Invalid index type "str" for "defaultdict[int, str]"; expected type "int"
-_program.py:10: error: Incompatible types in assignment (expression has type "int", target has type "str")
-_program.py:20: error: Argument 1 to "tst" has incompatible type "defaultdict[str, list[Never]]"; expected "defaultdict[int, list[Never]]"
-_program.py:24: error: Invalid index type "str" for "MyDDict[dict[Never, Never]]"; expected type "int"
+_program.py:6: error: Argument 1 to "defaultdict" has incompatible type "type[list[_T]]"; expected "Optional[Callable[[], str]]"
+_program.py:9: error: Invalid index type "str" for "defaultdict[int, str]"; expected type "int"
+_program.py:9: error: Incompatible types in assignment (expression has type "int", target has type "str")
+_program.py:19: error: Argument 1 to "tst" has incompatible type "defaultdict[str, list[Never]]"; expected "defaultdict[int, list[Never]]"
+_program.py:23: error: Invalid index type "str" for "MyDDict[dict[Never, Never]]"; expected type "int"
 
 [case testCollectionsAliases]
 import typing as t
@@ -1977,7 +1976,6 @@ _testDataclassReplace.py:11: error: Argument "x" to "replace" of "A" has incompa
 _testDataclassReplace.py:12: error: Unexpected keyword argument "q" for "replace" of "A"
 
 [case testGenericInferenceWithTuple]
-# flags: --new-type-inference
 from typing import TypeVar, Callable, Tuple
 
 T = TypeVar("T")
@@ -1989,7 +1987,6 @@ x: Tuple[str, ...] = f(tuple)
 [out]
 
 [case testGenericInferenceWithDataclass]
-# flags: --new-type-inference
 from typing import Any, Collection, List
 from dataclasses import dataclass, field
 
@@ -2002,7 +1999,6 @@ class A:
 [out]
 
 [case testGenericInferenceWithItertools]
-# flags: --new-type-inference
 from typing import TypeVar, Tuple
 from itertools import groupby
 K = TypeVar("K")


### PR DESCRIPTION
It was on deprecated almost two years ago (it is on by default).
