### PR TITLE
Fix TypeGuard with call on temporary object 

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6156,9 +6156,6 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
         if isinstance(node, CallExpr) and len(node.args) != 0:
             expr = collapse_walrus(node.args[0])
-            print("[TypeGuard Debug] --- find_isinstance_check_helper ---")
-            print(f"[TypeGuard Debug] {node=}")
-            print(f"[TypeGuard Debug] {node.callee=}")
             if refers_to_fullname(node.callee, "builtins.isinstance"):
                 if len(node.args) != 2:  # the error will be reported elsewhere
                     return {}, {}

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6188,10 +6188,13 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 # For temporaries (e.g., E()(x)), we extract type_is/type_guard from the __call__ method.
                 # For named callables (e.g., is_int(x)), we extract type_is/type_guard directly from the RefExpr.
                 type_is, type_guard = None, None
-                called_type = get_proper_type(self.lookup_type(node.callee))
+                try:
+                    called_type = get_proper_type(self.lookup_type(node.callee))
+                except KeyError:
+                    called_type = None
                 # TODO: there are some more cases in check_call() to handle.
                 # If the callee is an instance, try to extract TypeGuard/TypeIs from its __call__ method.
-                if isinstance(called_type, Instance):
+                if called_type and isinstance(called_type, Instance):
                     call = find_member("__call__", called_type, called_type, is_operator=True)
                     if call is not None:
                         called_type = get_proper_type(call)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6236,7 +6236,6 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                                     consider_runtime_isinstance=False,
                                 ),
                             )
-
         elif isinstance(node, ComparisonExpr):
             return self.comparison_type_narrowing_helper(node)
         elif isinstance(node, AssignmentExpr):

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -742,6 +742,15 @@ class E:
 x = object()
 if E()(x):
     reveal_type(x)  # N: Revealed type is "builtins.int"
+[case testNoCrashOnDunderCallTypeIsTemporaryObject]
+from typing_extensions import TypeIs
+class E:
+    def __init__(self) -> None: ...
+    def __call__(self, o: object) -> TypeIs[int]:
+        return True
+x = object()
+if E()(x):
+    reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeGuardRestrictAwaySingleInvariant]

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -731,7 +731,6 @@ assert a(x=x)
 reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
-
 # https://github.com/python/mypy/issues/19575
 [case testNoCrashOnDunderCallTypeGuardTemporaryObject]
 from typing_extensions import TypeGuard
@@ -742,6 +741,8 @@ class E:
 x = object()
 if E()(x):
     reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]
+
 [case testNoCrashOnDunderCallTypeIsTemporaryObject]
 from typing_extensions import TypeIs
 class E:

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -731,6 +731,19 @@ assert a(x=x)
 reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
+
+# https://github.com/python/mypy/issues/19575
+[case testNoCrashOnDunderCallTypeGuardTemporaryObject]
+from typing_extensions import TypeGuard
+class E:
+    def __init__(self) -> None: ...
+    def __call__(self, o: object) -> TypeGuard[int]:
+        return True
+x = object()
+if E()(x):
+    reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]
+
 [case testTypeGuardRestrictAwaySingleInvariant]
 from typing import List
 from typing_extensions import TypeGuard

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -754,6 +754,19 @@ if E()(x):
     reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
+[case testNoCrashOnDunderCallTypeIsTemporaryObjectGeneric]
+from typing import Generic, TypeVar
+from typing_extensions import TypeIs
+T = TypeVar("T")
+class E(Generic[T]):
+    def __init__(self) -> None: ...
+    def __call__(self, o: object) -> TypeIs[T]:
+        return True
+x = object()
+if E[int]()(x):
+    reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]
+
 [case testTypeGuardRestrictAwaySingleInvariant]
 from typing import List
 from typing_extensions import TypeGuard

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -767,6 +767,17 @@ if E[int]()(x):
     reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
+[case testTypeGuardTemporaryObjectWithKeywordArg]
+from typing_extensions import TypeGuard
+class E:
+    def __init__(self) -> None: ...
+    def __call__(self, o: object) -> TypeGuard[int]:
+        return True
+x = object()
+if E()(o=x):
+    reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]
+
 [case testTypeGuardRestrictAwaySingleInvariant]
 from typing import List
 from typing_extensions import TypeGuard


### PR DESCRIPTION
Fixes #19575 by adding support for TypeGaurd/TypeIs when they are used on methods off of classes which were not saved to a variable.

Solution adapted from copilot answer here and then refined: https://github.com/saulshanabrook/mypy/pull/1

- [x] Add test case for generic classes as well like `X[int](y)`
- [x] See if we can reduce code duplication