### PR TITLE
[mypyc] Provide instructions for resolving missing test module on Windows

### DIFF
--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -131,10 +131,23 @@ import sys
 from typing import Optional
 from native import ClassIR, FuncIR, Record
 
+HAVE_TEST = False
 if sys.version_info >= (3, 14):
-    from test.support import EqualToForwardRef
-    type_forward_ref = EqualToForwardRef
-else:
+    try:
+        from test.support import EqualToForwardRef
+        type_forward_ref = EqualToForwardRef
+        HAVE_TEST = True
+    except ImportError as e:
+        # catch the case of a pymanager installed Python
+        # without the test module. It is excluded by default
+        # on Windows.
+        msg = 'Missing "test" module.'
+        if sys.platform == "win32":
+            msg += (' Please install a version of Python with the test module'
+                   ' by running pymanager install --force PythonTest\\<version>')
+        raise ImportError(msg) from e
+
+if not HAVE_TEST:
     from typing import ForwardRef
     type_forward_ref = ForwardRef
 

--- a/mypyc/test-data/run-tuples.test
+++ b/mypyc/test-data/run-tuples.test
@@ -143,8 +143,8 @@ if sys.version_info >= (3, 14):
         # on Windows.
         msg = 'Missing "test" module.'
         if sys.platform == "win32":
-            msg += (' Please install a version of Python with the test module'
-                   ' by running pymanager install --force PythonTest\\<version>')
+            msg += (' Please install a version of Python with the test module.'
+                   ' If you are using pymanager, try running pymanager install --force PythonTest\\<version>')
         raise ImportError(msg) from e
 
 if not HAVE_TEST:


### PR DESCRIPTION
This might be overkill - I definitely understand if people think so, but I stumbled over this when testing https://github.com/python/mypy/pull/19578. Python doesn't come with the test module by default on Windows if installed through pymanager. Since `test.support.EqualToForwardRef` is used, I figured a clear error message about how to resolve this would be nice.

Another approach would be to just use the pre-3.14 ForwardRef code and not raise an error here. I'm not totally sure which is better.