### PR TITLE
Fix `--package-root` tests for Windows and Python 3.13+

### DIFF
--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -117,9 +117,9 @@ class FileSystemCache:
             if not stat.S_ISDIR(st.st_mode):
                 return False
         ok = False
-        drive, path = os.path.splitdrive(path)  # Ignore Windows drive name
         if os.path.isabs(path):
             path = os.path.relpath(path)
+        drive, path = os.path.splitdrive(path)  # Ignore Windows drive name
         path = os.path.normpath(path)
         for root in self.package_root:
             if path.startswith(root):

--- a/mypy/fscache.py
+++ b/mypy/fscache.py
@@ -117,9 +117,14 @@ class FileSystemCache:
             if not stat.S_ISDIR(st.st_mode):
                 return False
         ok = False
+
+        # skip if on a different drive
+        current_drive, _ = os.path.splitdrive(os.getcwd())
+        drive, _ = os.path.splitdrive(path)
+        if drive != current_drive:
+            return False
         if os.path.isabs(path):
             path = os.path.relpath(path)
-        drive, path = os.path.splitdrive(path)  # Ignore Windows drive name
         path = os.path.normpath(path)
         for root in self.package_root:
             if path.startswith(root):


### PR DESCRIPTION
This PR should fix the rest of the test failures in https://github.com/python/mypy/pull/19545.

A change to `os.path.relpath` in 3.13 seems to have broken the handling of Windows paths beginning with `\\`. To resolve this issue, we don't split the drive letter off of the path and instead verify the path is on the current drive. If it isn't it will never resolve to the package root because that must be on the same drive as the CWD:
https://github.com/python/mypy/blob/5b03024e829940cf3c3e3d99fc6625f569d02728/mypy/main.py#L1571-L1572

Keeping the drive letter allows relpath to properly generate a relative path and make the tests pass.

I need to investigate if the relpath change is a regression in CPython.