### PR TITLE
Skip more method bodies in third-party libraries

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -2234,7 +2234,7 @@ class FindAttributeAssign(TraverserVisitor):
         pass
 
     def visit_member_expr(self, e: MemberExpr) -> None:
-        if self.lvalue:
+        if self.lvalue and isinstance(e.expr, NameExpr):
             self.found = True
 
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -818,6 +818,7 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         "original_def",
         "is_trivial_body",
         "is_trivial_self",
+        "has_self_attr_def",
         "is_mypy_only",
         # Present only when a function is decorated with @typing.dataclass_transform or similar
         "dataclass_transform_spec",
@@ -856,6 +857,8 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         # the majority). In cases where self is not annotated and there are no Self
         # in the signature we can simply drop the first argument.
         self.is_trivial_self = False
+        # Keep track of functions where self attributes are defined.
+        self.has_self_attr_def = False
         # This is needed because for positional-only arguments the name is set to None,
         # but we sometimes still want to show it in error messages.
         if arguments:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4570,6 +4570,9 @@ class SemanticAnalyzer(
                     lval.node = v
                     # TODO: should we also set lval.kind = MDEF?
                     self.type.names[lval.name] = SymbolTableNode(MDEF, v, implicit=True)
+                    for func in self.scope.functions:
+                        if isinstance(func, FuncDef):
+                            func.has_self_attr_def = True
         self.check_lvalue_validity(lval.node, lval)
 
     def is_self_member_ref(self, memberexpr: MemberExpr) -> bool:


### PR DESCRIPTION
A while ago we started stripping function bodies when checking third-party libraries. This PR pushes this idea further:
* Tighten the check in `fastparse.py` to only consider `foo.bar` as possible self attribute definition.
* Do not type-check bodies where we didn't find any `self` attribute _definitions_ during semantic analysis.
* Skip method override checks in third-party libraries.

In total this makes e.g. `mypy -c 'import torch'` ~10% faster. Surprisingly, this also has some visible impact on self-check.