### PR TITLE
[stubtest] Improve checking of positional-only parameters in dunder methods

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -929,7 +929,7 @@ class ASTConverter:
 
         lineno = n.lineno
         args = self.transform_args(n.args, lineno, no_type_check=no_type_check)
-        if special_function_elide_names(n.name):
+        if self.options.pos_only_special_methods and special_function_elide_names(n.name):
             for arg in args:
                 arg.pos_only = True
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -398,6 +398,9 @@ class Options:
         # Export line-level, limited, fine-grained dependency information in cache data
         # (undocumented feature).
         self.export_ref_info = False
+        # Treat special methods as being implicitly positional-only.
+        # Set to False when running stubtest.
+        self.pos_only_special_methods = True
 
         self.disable_bytearray_promotion = False
         self.disable_memoryview_promotion = False

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -943,7 +943,6 @@ def _verify_signature(
             and not stub_arg.pos_only
             and not stub_arg.variable.name.startswith("__")
             and stub_arg.variable.name.strip("_") != "self"
-            and not is_dunder(function_name, exclude_special=True)  # noisy for dunder methods
         ):
             yield (
                 f'stub argument "{stub_arg.variable.name}" should be positional-only '
@@ -2010,6 +2009,7 @@ def test_stubs(args: _Arguments, use_builtins_fixtures: bool = False) -> int:
     options.use_builtins_fixtures = use_builtins_fixtures
     options.show_traceback = args.show_traceback
     options.pdb = args.pdb
+    options.pos_only_special_methods = False
 
     if options.config_file:
 


### PR DESCRIPTION
Currently, stubtest ignores positional-only parameter discrepancies in dunder methods. The sources mentions this as being noisy. I haven't looked into the history, but I am guessing that much of the noise was due to mypy treating all special methods as being positional-only, which meant that stubtest would complain about any dunder method that accepted keyword arguments at runtime (meaning, most dunder methods implemented in Python).

I think a simple way to improve things would be to disable the positional-only-special-method heuristic when running stubtest. That way stubtest can see the actual stub signatures and can properly verify them against the runtime signatures.