### PR TITLE
Fix `meet_types` for literal and instance

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -94,6 +94,36 @@ def meet_types(s: Type, t: Type) -> ProperType:
                 return s
             return t
 
+        # special casing for dealing with last known values
+        if is_proper_subtype(s, t, ignore_promotions=True) and is_proper_subtype(
+            t, s, ignore_promotions=True
+        ):
+            lkv: LiteralType | None
+            if s.last_known_value is None and t.last_known_value is None:
+                # Both types have no last known value, so we return the original type.
+                lkv = None
+            elif s.last_known_value is None and t.last_known_value is not None:
+                lkv = t.last_known_value
+            elif s.last_known_value is not None and t.last_known_value is None:
+                lkv = s.last_known_value
+            elif s.last_known_value is not None and t.last_known_value is not None:
+                lkv_meet = meet_types(s.last_known_value, t.last_known_value)
+                if isinstance(lkv_meet, UninhabitedType):
+                    lkv = None
+                elif isinstance(lkv_meet, LiteralType):
+                    lkv = lkv_meet
+                else:
+                    msg = (
+                        f"Unexpected meet result for last known values: "
+                        f"{s.last_known_value=} and {t.last_known_value=} "
+                        f"resulted in {lkv_meet=}"
+                    )
+                    raise ValueError(msg)
+            else:
+                assert False
+            assert lkv is None or isinstance(lkv, LiteralType)
+            return t.copy_modified(last_known_value=lkv)
+
     if not isinstance(s, UnboundType) and not isinstance(t, UnboundType):
         if is_proper_subtype(s, t, ignore_promotions=True):
             return s
@@ -1088,8 +1118,12 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
     def visit_literal_type(self, t: LiteralType) -> ProperType:
         if isinstance(self.s, LiteralType) and self.s == t:
             return t
-        elif isinstance(self.s, Instance) and is_subtype(t.fallback, self.s):
-            return t
+        elif isinstance(self.s, Instance):
+            if is_subtype(t.fallback, self.s):
+                return t
+            if self.s.last_known_value is not None:
+                return meet_types(self.s.last_known_value, t)
+            return self.default(self.s)
         else:
             return self.default(self.s)
 

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -629,8 +629,17 @@ class SubtypeVisitor(TypeVisitor[bool]):
                         return True
                     if isinstance(item, Instance):
                         return is_named_instance(item, "builtins.object")
-        if isinstance(right, LiteralType) and left.last_known_value is not None:
-            return self._is_subtype(left.last_known_value, right)
+        # if isinstance(right, LiteralType) and left.last_known_value is not None:
+        # return self._is_subtype(left.last_known_value, right)
+        if isinstance(right, LiteralType):
+            if self.proper_subtype:
+                # Instance types like Literal["sum"]? is *assignable* to Literal["sum"],
+                # but is not a proper subtype of it. (Literal["sum"]? is a gradual type,
+                # that is a proper subtype of str, and is assignable to Literal["sum"],
+                # but not a proper subtype of it.)
+                return False
+            if left.last_known_value is not None:
+                return self._is_subtype(left.last_known_value, right)
         if isinstance(right, FunctionLike):
             # Special case: Instance can be a subtype of Callable / Overloaded.
             call = find_member("__call__", left, left, is_operator=True)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -4076,7 +4076,7 @@ def check_and(maybe: bool) -> None:
     bar = None
     if maybe and (foo := [1])[(bar := 0)]:
         reveal_type(foo)  # N: Revealed type is "builtins.list[builtins.int]"
-        reveal_type(bar)  # N: Revealed type is "builtins.int"
+        reveal_type(bar)  # N: Revealed type is "Literal[0]?"
     else:
         reveal_type(foo)  # N: Revealed type is "Union[builtins.list[builtins.int], None]"
         reveal_type(bar)  # N: Revealed type is "Union[builtins.int, None]"
@@ -4102,7 +4102,7 @@ def check_or(maybe: bool) -> None:
         reveal_type(bar)  # N: Revealed type is "Union[builtins.int, None]"
     else:
         reveal_type(foo)  # N: Revealed type is "builtins.list[builtins.int]"
-        reveal_type(bar)  # N: Revealed type is "builtins.int"
+        reveal_type(bar)  # N: Revealed type is "Literal[0]?"
 
 def check_or_nested(maybe: bool) -> None:
     foo = None

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1354,7 +1354,7 @@ m: str
 
 match m:
     case a if a := "test":
-        reveal_type(a)  # N: Revealed type is "builtins.str"
+        reveal_type(a)  # N: Revealed type is "Literal['test']?"
 
 [case testMatchNarrowingPatternGuard]
 m: object
@@ -2686,7 +2686,7 @@ match m[k]:
 
 match 0:
     case 0 as i:
-        reveal_type(i)  # N: Revealed type is "Literal[0]?"
+        reveal_type(i)  # N: Revealed type is "Literal[0]"
     case int(i):
         i  # E: Statement is unreachable
     case other:

--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -214,10 +214,10 @@ i(arg=0)  # E: Unexpected keyword argument "arg"
 from typing import Final, NamedTuple, Optional, List
 
 if a := 2:
-    reveal_type(a)  # N: Revealed type is "builtins.int"
+    reveal_type(a)  # N: Revealed type is "Literal[2]?"
 
 while b := "x":
-    reveal_type(b)  # N: Revealed type is "builtins.str"
+    reveal_type(b)  # N: Revealed type is "Literal['x']?"
 
 l = [y2 := 1, y2 + 2, y2 + 3]
 reveal_type(y2)  # N: Revealed type is "builtins.int"
@@ -242,10 +242,10 @@ reveal_type(new_v)  # N: Revealed type is "builtins.int"
 
 def f(x: int = (c := 4)) -> int:
     if a := 2:
-        reveal_type(a)  # N: Revealed type is "builtins.int"
+        reveal_type(a)  # N: Revealed type is "Literal[2]?"
 
     while b := "x":
-        reveal_type(b)  # N: Revealed type is "builtins.str"
+        reveal_type(b)  # N: Revealed type is "Literal['x']?"
 
     x = (y := 1) + (z := 2)
     reveal_type(x)  # N: Revealed type is "builtins.int"
@@ -284,7 +284,7 @@ def f(x: int = (c := 4)) -> int:
     f(x=(y7 := 3))
     reveal_type(y7)  # N: Revealed type is "builtins.int"
 
-    reveal_type((lambda: (y8 := 3) and y8)())  # N: Revealed type is "builtins.int"
+    reveal_type((lambda: (y8 := 3) and y8)())  # N: Revealed type is "Literal[3]?"
     y8  # E: Name "y8" is not defined
 
     y7 = 1.0  # E: Incompatible types in assignment (expression has type "float", variable has type "int")
@@ -325,16 +325,16 @@ def check_binder(x: Optional[int], y: Optional[int], z: Optional[int], a: Option
         reveal_type(y)  # N: Revealed type is "Union[builtins.int, None]"
 
     if x and (y := 1):
-        reveal_type(y)  # N: Revealed type is "builtins.int"
+        reveal_type(y)  # N: Revealed type is "Literal[1]?"
 
     if (a := 1) and x:
-        reveal_type(a)  # N: Revealed type is "builtins.int"
+        reveal_type(a)  # N: Revealed type is "Literal[1]?"
 
     if (b := 1) or x:
         reveal_type(b)  # N: Revealed type is "builtins.int"
 
     if z := 1:
-        reveal_type(z)  # N: Revealed type is "builtins.int"
+        reveal_type(z)  # N: Revealed type is "Literal[1]?"
 
 def check_partial() -> None:
     x = None


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #19560

- `is_proper_subtype(Literal?, Literal)` now always returns `False`; `is_subtype` retains original behavior.
- updated `meet_types` with special casing to carry over `last_known_value` correctly.
  - [ ]: TODO: need to merge with the `extra_attrs` code. (note: the `extra_attrs` only seems semi-correct, should it use a symmetric combination of the attrs as well?)

Currently, one unit test still fails, as an "unreachable" with match-case is not raises


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
