### PR TITLE
Fix crash on settable property alias

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -130,6 +130,7 @@ from mypy.nodes import (
     WhileStmt,
     WithStmt,
     YieldExpr,
+    get_func_def,
     is_final_node,
 )
 from mypy.operators import flip_ops, int_op_to_method, neg_ops
@@ -2507,8 +2508,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
                 override_ids = override.type_var_ids()
                 type_name = None
-                if isinstance(override.definition, FuncDef):
-                    type_name = override.definition.info.name
+                definition = get_func_def(override)
+                if isinstance(definition, FuncDef):
+                    type_name = definition.info.name
 
                 def erase_override(t: Type) -> Type:
                     return erase_typevars(t, ids_to_erase=override_ids)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4501,7 +4501,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                     if isinstance(p_type, Overloaded):
                         # TODO: in theory we can have a property with a deleter only.
                         var.is_settable_property = True
-                        assert isinstance(definition, Decorator)
+                        assert isinstance(definition, Decorator), definition
                         var.setter_type = definition.var.setter_type
 
     def set_inference_error_fallback_type(self, var: Var, lvalue: Lvalue, type: Type) -> None:

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -984,7 +984,7 @@ def expand_and_bind_callable(
             # A broken overload, error should be already reported.
             return AnyType(TypeOfAny.from_error)
         expanded = expanded.items[0]
-    assert isinstance(expanded, CallableType)
+    assert isinstance(expanded, CallableType), expanded
     if var.is_settable_property and mx.is_lvalue and var.setter_type is not None:
         if expanded.variables:
             type_ctx = mx.rvalue or TempNode(AnyType(TypeOfAny.special_form), context=mx.context)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -976,7 +976,14 @@ def expand_and_bind_callable(
     freeze_all_type_vars(expanded)
     if not var.is_property:
         return expanded
-    # TODO: a decorated property can result in Overloaded here.
+    if isinstance(expanded, Overloaded):
+        # Legacy way to store settable properties is with overloads. Also in case it is
+        # an actual overloaded property, selecting first item that passed check_self_arg()
+        # is a good approximation, long-term we should use check_call() inference below.
+        if not expanded.items:
+            # A broken overload, error should be already reported.
+            return AnyType(TypeOfAny.from_error)
+        expanded = expanded.items[0]
     assert isinstance(expanded, CallableType)
     if var.is_settable_property and mx.is_lvalue and var.setter_type is not None:
         if expanded.variables:

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -181,8 +181,7 @@ class NodeFixer(NodeVisitor[None]):
         if isinstance(o.type, Overloaded):
             # For error messages we link the original definition for each item.
             for typ, item in zip(o.type.items, o.items):
-                if isinstance(item, Decorator):
-                    typ.definition = item.func
+                typ.definition = item
 
     def visit_decorator(self, d: Decorator) -> None:
         if self.current_info is not None:
@@ -193,8 +192,9 @@ class NodeFixer(NodeVisitor[None]):
             d.var.accept(self)
         for node in d.decorators:
             node.accept(self)
-        if isinstance(d.var.type, ProperType) and isinstance(d.var.type, CallableType):
-            d.var.type.definition = d.func
+        typ = d.var.type
+        if isinstance(typ, ProperType) and isinstance(typ, CallableType):
+            typ.definition = d.func
 
     def visit_class_def(self, c: ClassDef) -> None:
         for v in c.type_vars:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -44,6 +44,7 @@ from mypy.nodes import (
     CallExpr,
     ClassDef,
     Context,
+    Decorator,
     Expression,
     FuncDef,
     IndexExpr,
@@ -2938,10 +2939,13 @@ def format_type_distinctly(*types: Type, options: Options, bare: bool = False) -
 
 def pretty_class_or_static_decorator(tp: CallableType) -> str | None:
     """Return @classmethod or @staticmethod, if any, for the given callable type."""
-    if tp.definition is not None and isinstance(tp.definition, SYMBOL_FUNCBASE_TYPES):
-        if tp.definition.is_class:
+    definition = tp.definition
+    if isinstance(definition, Decorator):
+        definition = definition.func
+    if definition is not None and isinstance(definition, SYMBOL_FUNCBASE_TYPES):
+        if definition.is_class:
             return "@classmethod"
-        if tp.definition.is_static:
+        if definition.is_static:
             return "@staticmethod"
     return None
 
@@ -2991,12 +2995,15 @@ def pretty_callable(tp: CallableType, options: Options, skip_self: bool = False)
             slash = True
 
     # If we got a "special arg" (i.e: self, cls, etc...), prepend it to the arg list
+    definition = tp.definition
+    if isinstance(definition, Decorator):
+        definition = definition.func
     if (
-        isinstance(tp.definition, FuncDef)
-        and hasattr(tp.definition, "arguments")
+        isinstance(definition, FuncDef)
+        and hasattr(definition, "arguments")
         and not tp.from_concatenate
     ):
-        definition_arg_names = [arg.variable.name for arg in tp.definition.arguments]
+        definition_arg_names = [arg.variable.name for arg in definition.arguments]
         if (
             len(definition_arg_names) > len(tp.arg_names)
             and definition_arg_names[0]
@@ -3005,7 +3012,7 @@ def pretty_callable(tp: CallableType, options: Options, skip_self: bool = False)
             if s:
                 s = ", " + s
             s = definition_arg_names[0] + s
-        s = f"{tp.definition.name}({s})"
+        s = f"{definition.name}({s})"
     elif tp.name:
         first_arg = get_first_arg(tp)
         if first_arg:
@@ -3051,9 +3058,12 @@ def pretty_callable(tp: CallableType, options: Options, skip_self: bool = False)
 
 
 def get_first_arg(tp: CallableType) -> str | None:
-    if not isinstance(tp.definition, FuncDef) or not tp.definition.info or tp.definition.is_static:
+    definition = tp.definition
+    if isinstance(definition, Decorator):
+        definition = definition.func
+    if not isinstance(definition, FuncDef) or not definition.info or definition.is_static:
         return None
-    return tp.definition.original_first_arg
+    return definition.original_first_arg
 
 
 def variance_string(variance: int) -> str:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -44,7 +44,6 @@ from mypy.nodes import (
     CallExpr,
     ClassDef,
     Context,
-    Decorator,
     Expression,
     FuncDef,
     IndexExpr,
@@ -56,6 +55,7 @@ from mypy.nodes import (
     SymbolTable,
     TypeInfo,
     Var,
+    get_func_def,
     reverse_builtin_aliases,
 )
 from mypy.operators import op_methods, op_methods_to_symbols
@@ -2939,9 +2939,7 @@ def format_type_distinctly(*types: Type, options: Options, bare: bool = False) -
 
 def pretty_class_or_static_decorator(tp: CallableType) -> str | None:
     """Return @classmethod or @staticmethod, if any, for the given callable type."""
-    definition = tp.definition
-    if isinstance(definition, Decorator):
-        definition = definition.func
+    definition = get_func_def(tp)
     if definition is not None and isinstance(definition, SYMBOL_FUNCBASE_TYPES):
         if definition.is_class:
             return "@classmethod"
@@ -2995,9 +2993,7 @@ def pretty_callable(tp: CallableType, options: Options, skip_self: bool = False)
             slash = True
 
     # If we got a "special arg" (i.e: self, cls, etc...), prepend it to the arg list
-    definition = tp.definition
-    if isinstance(definition, Decorator):
-        definition = definition.func
+    definition = get_func_def(tp)
     if (
         isinstance(definition, FuncDef)
         and hasattr(definition, "arguments")
@@ -3058,9 +3054,7 @@ def pretty_callable(tp: CallableType, options: Options, skip_self: bool = False)
 
 
 def get_first_arg(tp: CallableType) -> str | None:
-    definition = tp.definition
-    if isinstance(definition, Decorator):
-        definition = definition.func
+    definition = get_func_def(tp)
     if not isinstance(definition, FuncDef) or not definition.info or definition.is_static:
         return None
     return definition.original_first_arg

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -4380,6 +4380,13 @@ def is_final_node(node: SymbolNode | None) -> bool:
     return isinstance(node, (Var, FuncDef, OverloadedFuncDef, Decorator)) and node.is_final
 
 
+def get_func_def(typ: mypy.types.CallableType) -> SymbolNode | None:
+    definition = typ.definition
+    if isinstance(definition, Decorator):
+        definition = definition.func
+    return definition
+
+
 def local_definitions(
     names: SymbolTable, name_prefix: str, info: TypeInfo | None = None
 ) -> Iterator[Definition]:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1243,6 +1243,7 @@ class SemanticAnalyzer(
             bare_setter_type = self.analyze_property_with_multi_part_definition(defn)
             typ = function_type(first_item.func, self.named_type("builtins.function"))
             assert isinstance(typ, CallableType)
+            typ.definition = first_item
             types = [typ]
         else:
             # This is a normal overload. Find the item signatures, the
@@ -1374,6 +1375,7 @@ class SemanticAnalyzer(
             if isinstance(item, Decorator):
                 callable = function_type(item.func, self.named_type("builtins.function"))
                 assert isinstance(callable, CallableType)
+                callable.definition = item
                 if not any(refers_to_fullname(dec, OVERLOAD_NAMES) for dec in item.decorators):
                     if i == len(defn.items) - 1 and not self.is_stub_file:
                         # Last item outside a stub is impl

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1887,6 +1887,9 @@ class CallableType(FunctionLike):
         self.fallback = fallback
         assert not name or "<bound method" not in name
         self.name = name
+        # The rules for what exactly is considered a definition:
+        #   * If it is a non-decorated function, FuncDef is the definition
+        #   * If it is a decorated function, enclosing Decorator is the definition
         self.definition = definition
         self.variables = variables
         self.is_ellipsis_args = is_ellipsis_args

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -9211,3 +9211,33 @@ class CGT(BG[T]): ...
 
 reveal_type(CGI)  # N: Revealed type is "def () -> __main__.CGI"
 reveal_type(CGT)  # N: Revealed type is "def [T] () -> __main__.CGT[T`1]"
+
+[case testSettablePropertyAlias]
+from typing import Any, TypeVar
+
+class A:
+    @property
+    def prop(self: Any) -> str: ...
+    @prop.setter
+    def prop(self, val: str) -> None: ...
+
+T = TypeVar("T")
+class AT:
+    @property
+    def prop(self: T) -> T: ...
+    @prop.setter
+    def prop(self: T, val: list[T]) -> None: ...
+
+class B:
+    prop: str
+    prop_t: str
+
+class C(B):
+    prop = A.prop
+    prop_t = AT.prop  # E: Incompatible types in assignment (expression has type "C", base class "B" defined the type as "str")
+
+reveal_type(C().prop)  # N: Revealed type is "builtins.str"
+C().prop = "no"  # E: Invalid self argument "C" to attribute function "prop" with type "Callable[[A, str], None]"
+reveal_type(C().prop_t)  # N: Revealed type is "__main__.C"
+C().prop_t = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "list[C]")
+[builtins fixtures/property.pyi]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -9241,3 +9241,20 @@ C().prop = "no"  # E: Invalid self argument "C" to attribute function "prop" wit
 reveal_type(C().prop_t)  # N: Revealed type is "__main__.C"
 C().prop_t = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "list[C]")
 [builtins fixtures/property.pyi]
+
+[case testClassEqDecoratedAbstractNote]
+from abc import abstractmethod
+
+class C:
+    @abstractmethod
+    def __eq__(self, other: C) -> bool: ...
+[builtins fixtures/plugin_attrs.pyi]
+[out]
+main:5: error: Argument 1 of "__eq__" is incompatible with supertype "builtins.object"; supertype defines the argument type as "object"
+main:5: note: This violates the Liskov substitution principle
+main:5: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+main:5: note: It is recommended for "__eq__" to work with arbitrary objects, for example:
+main:5: note:     def __eq__(self, other: object) -> bool:
+main:5: note:         if not isinstance(other, C):
+main:5: note:             return NotImplemented
+main:5: note:         return <logic to compare two C instances>

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2055,7 +2055,7 @@ from dataclasses import dataclass, replace, InitVar
 from typing import ClassVar
 
 @dataclass
-class A:
+class A:  # N: "replace" of "A" defined here
     x: int
     q: InitVar[int]
     q2: InitVar[int] = 0

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -7312,9 +7312,7 @@ class C:
 ==
 mod.py:9: error: Incompatible types in assignment (expression has type "int", variable has type "str")
 
-[case testOverloadedMethodSupertype-only_when_cache]
--- Different cache/no-cache tests because
--- CallableType.def_extras.first_arg differs ("self"/None)
+[case testOverloadedMethodSupertype]
 from typing import overload, Any
 import b
 class Child(b.Parent):
@@ -7354,49 +7352,6 @@ main:4: note:          @overload
 main:4: note:          def f(self, arg: int) -> int
 main:4: note:          @overload
 main:4: note:          def f(self, arg: str) -> str
-
-[case testOverloadedMethodSupertype2-only_when_nocache]
--- Different cache/no-cache tests because
--- CallableType.def_extras.first_arg differs ("self"/None)
-from typing import overload, Any
-import b
-class Child(b.Parent):
-    @overload                           # Fail
-    def f(self, arg: int) -> int: ...
-    @overload
-    def f(self, arg: str) -> str: ...
-    def f(self, arg: Any) -> Any: ...
-[file b.py]
-from typing import overload, Any
-class C: pass
-class Parent:
-    @overload
-    def f(self, arg: int) -> int: ...
-    @overload
-    def f(self, arg: str) -> str: ...
-    def f(self, arg: Any) -> Any: ...
-[file b.py.2]
-from typing import overload, Any
-class C: pass
-class Parent:
-    @overload
-    def f(self, arg: int) -> int: ...
-    @overload
-    def f(self, arg: str) -> C: ...
-    def f(self, arg: Any) -> Any: ...
-[out]
-==
-main:4: error: Signature of "f" incompatible with supertype "b.Parent"
-main:4: note:      Superclass:
-main:4: note:          @overload
-main:4: note:          def f(self, arg: int) -> int
-main:4: note:          @overload
-main:4: note:          def f(self, arg: str) -> C
-main:4: note:      Subclass:
-main:4: note:          @overload
-main:4: note:          def f(arg: int) -> int
-main:4: note:          @overload
-main:4: note:          def f(arg: str) -> str
 
 [case testOverloadedInitSupertype]
 import a
@@ -8486,9 +8441,7 @@ class D:
 ==
 a.py:3: error: Cannot override final attribute "meth" (previously declared in base class "C")
 
-[case testFinalBodyReprocessedAndStillFinalOverloaded-only_when_cache]
--- Different cache/no-cache tests because
--- CallableType.def_extras.first_arg differs ("self"/None)
+[case testFinalBodyReprocessedAndStillFinalOverloaded]
 import a
 [file a.py]
 from c import C
@@ -8530,53 +8483,6 @@ a.py:3: note:          @overload
 a.py:3: note:          def meth(self, x: int) -> int
 a.py:3: note:          @overload
 a.py:3: note:          def meth(self, x: str) -> str
-a.py:3: note:      Subclass:
-a.py:3: note:          def meth(self) -> None
-
-[case testFinalBodyReprocessedAndStillFinalOverloaded2-only_when_nocache]
--- Different cache/no-cache tests because
--- CallableType.def_extras.first_arg differs ("self"/None)
-import a
-[file a.py]
-from c import C
-class A:
-    def meth(self) -> None: ...
-
-[file a.py.3]
-from c import C
-class A(C):
-    def meth(self) -> None: ...
-
-[file c.py]
-from typing import final, overload, Union
-from d import D
-
-class C:
-    @overload
-    def meth(self, x: int) -> int: ...
-    @overload
-    def meth(self, x: str) -> str: ...
-    @final
-    def meth(self, x: Union[int, str]) -> Union[int, str]:
-        D(int())
-        return x
-[file d.py]
-class D:
-    def __init__(self, x: int) -> None: ...
-[file d.py.2]
-from typing import Optional
-class D:
-    def __init__(self, x: Optional[int]) -> None: ...
-[out]
-==
-==
-a.py:3: error: Cannot override final attribute "meth" (previously declared in base class "C")
-a.py:3: error: Signature of "meth" incompatible with supertype "c.C"
-a.py:3: note:      Superclass:
-a.py:3: note:          @overload
-a.py:3: note:          def meth(x: int) -> int
-a.py:3: note:          @overload
-a.py:3: note:          def meth(x: str) -> str
 a.py:3: note:      Subclass:
 a.py:3: note:          def meth(self) -> None
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1970,6 +1970,7 @@ a2 = replace()
 a2 = replace(a, x='spam')
 a2 = replace(a, x=42, q=42)
 [out]
+_testDataclassReplace.py:4: note: "replace" of "A" defined here
 _testDataclassReplace.py:9: note: Revealed type is "_testDataclassReplace.A"
 _testDataclassReplace.py:10: error: Too few arguments for "replace"
 _testDataclassReplace.py:11: error: Argument "x" to "replace" of "A" has incompatible type "str"; expected "int"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/19572

Surprisingly, when working on this I found another inconsistency in how `.definiton` is set. So after all I decided to do some cleanup, now `.definiton` should always point do the `Decortor` if the definition is a decorated function (no matter whether it is a trivial decorator like `@abstractmethod` or `@overload` or a "real" one).