### PR TITLE
Cache common instances

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -432,10 +432,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
             self, self.msg, self.plugin, per_line_checking_time_ns
         )
 
-        self._object_type: Instance | None = None
-        self._int_type: Instance | None = None
         self._str_type: Instance | None = None
         self._function_type: Instance | None = None
+        self._int_type: Instance | None = None
+        self._bool_type: Instance | None = None
+        self._object_type: Instance | None = None
 
         self.pattern_checker = PatternChecker(self, self.msg, self.plugin, options)
         self._unique_id = 0
@@ -7387,6 +7388,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
             if self._int_type is None:
                 self._int_type = self._named_type(name)
             return self._int_type
+        if name == "builtins.bool":
+            if self._bool_type is None:
+                self._bool_type = self._named_type(name)
+            return self._bool_type
         if name == "builtins.object":
             if self._object_type is None:
                 self._object_type = self._named_type(name)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -433,7 +433,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         )
 
         self._object_type: Instance | None = None
-        self._type_type: Instance | None = None
+        self._int_type: Instance | None = None
         self._str_type: Instance | None = None
         self._function_type: Instance | None = None
 
@@ -7375,22 +7375,22 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
         For example, named_type('builtins.object') produces the 'object' type.
         """
-        if name == "builtins.function":
-            if self._function_type is None:
-                self._function_type = self._named_type(name)
-            return self._function_type
-        if name == "builtins.object":
-            if self._object_type is None:
-                self._object_type = self._named_type(name)
-            return self._object_type
-        if name == "builtins.type":
-            if self._type_type is None:
-                self._type_type = self._named_type(name)
-            return self._type_type
         if name == "builtins.str":
             if self._str_type is None:
                 self._str_type = self._named_type(name)
             return self._str_type
+        if name == "builtins.function":
+            if self._function_type is None:
+                self._function_type = self._named_type(name)
+            return self._function_type
+        if name == "builtins.int":
+            if self._int_type is None:
+                self._int_type = self._named_type(name)
+            return self._int_type
+        if name == "builtins.object":
+            if self._object_type is None:
+                self._object_type = self._named_type(name)
+            return self._object_type
         return self._named_type(name)
 
     def _named_type(self, name: str) -> Instance:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -431,6 +431,12 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         self._expr_checker = mypy.checkexpr.ExpressionChecker(
             self, self.msg, self.plugin, per_line_checking_time_ns
         )
+
+        self._object_type: Instance | None = None
+        self._type_type: Instance | None = None
+        self._str_type: Instance | None = None
+        self._function_type: Instance | None = None
+
         self.pattern_checker = PatternChecker(self, self.msg, self.plugin, options)
         self._unique_id = 0
 
@@ -7369,6 +7375,25 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
         For example, named_type('builtins.object') produces the 'object' type.
         """
+        if name == "builtins.function":
+            if self._function_type is None:
+                self._function_type = self._named_type(name)
+            return self._function_type
+        if name == "builtins.object":
+            if self._object_type is None:
+                self._object_type = self._named_type(name)
+            return self._object_type
+        if name == "builtins.type":
+            if self._type_type is None:
+                self._type_type = self._named_type(name)
+            return self._type_type
+        if name == "builtins.str":
+            if self._str_type is None:
+                self._str_type = self._named_type(name)
+            return self._str_type
+        return self._named_type(name)
+
+    def _named_type(self, name: str) -> Instance:
         # Assume that the name refers to a type.
         sym = self.lookup_qualified(name)
         node = sym.node

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -497,9 +497,9 @@ class SemanticAnalyzer(
         # Used to track edge case when return is still inside except* if it enters a loop
         self.return_stmt_inside_except_star_block: bool = False
 
-        self._object_type: Instance | None = None
         self._str_type: Instance | None = None
         self._function_type: Instance | None = None
+        self._object_type: Instance | None = None
 
     # mypyc doesn't properly handle implementing an abstractproperty
     # with a regular attribute so we make them properties

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -497,6 +497,10 @@ class SemanticAnalyzer(
         # Used to track edge case when return is still inside except* if it enters a loop
         self.return_stmt_inside_except_star_block: bool = False
 
+        self._object_type: Instance | None = None
+        self._str_type: Instance | None = None
+        self._function_type: Instance | None = None
+
     # mypyc doesn't properly handle implementing an abstractproperty
     # with a regular attribute so we make them properties
     @property
@@ -1241,7 +1245,7 @@ class SemanticAnalyzer(
             # This is a property.
             first_item.func.is_overload = True
             bare_setter_type = self.analyze_property_with_multi_part_definition(defn)
-            typ = function_type(first_item.func, self.named_type("builtins.function"))
+            typ = function_type(first_item.func, self.function_type())
             assert isinstance(typ, CallableType)
             typ.definition = first_item
             types = [typ]
@@ -1373,7 +1377,7 @@ class SemanticAnalyzer(
                     item.accept(self)
             # TODO: support decorated overloaded functions properly
             if isinstance(item, Decorator):
-                callable = function_type(item.func, self.named_type("builtins.function"))
+                callable = function_type(item.func, self.function_type())
                 assert isinstance(callable, CallableType)
                 callable.definition = item
                 if not any(refers_to_fullname(dec, OVERLOAD_NAMES) for dec in item.decorators):
@@ -1536,9 +1540,7 @@ class SemanticAnalyzer(
                         if first_node.name == "setter":
                             # The first item represents the entire property.
                             first_item.var.is_settable_property = True
-                            setter_func_type = function_type(
-                                item.func, self.named_type("builtins.function")
-                            )
+                            setter_func_type = function_type(item.func, self.function_type())
                             assert isinstance(setter_func_type, CallableType)
                             bare_setter_type = setter_func_type
                             defn.setter_index = i + 1
@@ -6630,10 +6632,19 @@ class SemanticAnalyzer(
             return result
 
     def object_type(self) -> Instance:
-        return self.named_type("builtins.object")
+        if self._object_type is None:
+            self._object_type = self.named_type("builtins.object")
+        return self._object_type
 
     def str_type(self) -> Instance:
-        return self.named_type("builtins.str")
+        if self._str_type is None:
+            self._str_type = self.named_type("builtins.str")
+        return self._str_type
+
+    def function_type(self) -> Instance:
+        if self._function_type is None:
+            self._function_type = self.named_type("builtins.function")
+        return self._function_type
 
     def named_type(self, fullname: str, args: list[Type] | None = None) -> Instance:
         sym = self.lookup_fully_qualified(fullname)


### PR DESCRIPTION
These few types account for a significant proportion of all types created:
* `str` is just everywhere
* `object` and `function` are used as fallbacks in many places
* `int` and `bool` are coming from various literals

This gives around 1.5% performance improvement on my desktop. This is a bit ugly, but also looks like an easy win. Note that during semantic analysis I am caching types more conservatively, just in case some plugins modify them in place (`named_type()` is a part of semantic analyzer plugin interface).