### PR TITLE
Two more micro-optimizations

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3048,7 +3048,9 @@ class SemanticAnalyzer(
                 message = (
                     f'Module "{import_id}" does not explicitly export attribute "{source_id}"'
                 )
-            else:
+            elif not (
+                self.options.ignore_errors or self.cur_mod_node.path in self.errors.ignored_files
+            ):
                 alternatives = set(module.names.keys()).difference({source_id})
                 matches = best_matches(source_id, alternatives, n=3)
                 if matches:


### PR DESCRIPTION
This has two things (totalling 1.5% locally, but see caveat below):
* Do not use `@contextmanger` (that is relatively slow) for `local_type_map`, since it appears in multiple hot paths.
* Do not show name suggestions for import errors in third party packages (since those errors are ignored anyway). It calls `difflib` that can be extremely slow with large modules.

Btw the second will probably not affect self-check, although it did affect _my_ self-check, since apparently `pytest` depends on `numpy`. Well, they don't specify it as a package dependency, but https://github.com/pytest-dev/pytest/blob/main/src/_pytest/python_api.py#L17-L18
```python
if TYPE_CHECKING:
    from numpy import ndarray
```
(and I have numpy installed in all my environments, LOL)