### PR TITLE
Another two micro-optimizations

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2517,17 +2517,22 @@ class MessageBuilder:
 
 def quote_type_string(type_string: str) -> str:
     """Quotes a type representation for use in messages."""
-    no_quote_regex = r"^<(tuple|union): \d+ items>$"
     if (
         type_string in ["Module", "overloaded function", "<deleted>"]
         or type_string.startswith("Module ")
-        or re.match(no_quote_regex, type_string) is not None
+        or short_tuple_or_union(type_string)
         or type_string.endswith("?")
     ):
         # Messages are easier to read if these aren't quoted.  We use a
         # regex to match strings with variable contents.
         return type_string
     return f'"{type_string}"'
+
+
+def short_tuple_or_union(typ: str) -> bool:
+    if not (typ.startswith("<tuple ") or typ.startswith("<union ")):
+        return False
+    return typ.endswith(" item>")
 
 
 def format_callable_args(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2520,8 +2520,8 @@ def quote_type_string(type_string: str) -> str:
     if (
         type_string in ["Module", "overloaded function", "<deleted>"]
         or type_string.startswith("Module ")
-        or type_string.startswith(("<tuple ", "<union "))
-        and type_string.endswith(" item>")
+        or type_string.startswith(("<tuple: ", "<union: "))
+        and type_string.endswith(" items>")
         or type_string.endswith("?")
     ):
         # Messages are easier to read if these aren't quoted.  We use a

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2432,13 +2432,13 @@ class MessageBuilder:
         """Format very long tuple type using an ellipsis notation"""
         item_cnt = len(typ.items)
         if item_cnt > MAX_TUPLE_ITEMS:
-            return "tuple[{}, {}, ... <{} more items>]".format(
+            return '"tuple[{}, {}, ... <{} more items>]"'.format(
                 format_type_bare(typ.items[0], self.options),
                 format_type_bare(typ.items[1], self.options),
                 str(item_cnt - 2),
             )
         else:
-            return format_type_bare(typ, self.options)
+            return format_type(typ, self.options)
 
     def generate_incompatible_tuple_error(
         self,
@@ -2520,12 +2520,9 @@ def quote_type_string(type_string: str) -> str:
     if (
         type_string in ["Module", "overloaded function", "<deleted>"]
         or type_string.startswith("Module ")
-        or type_string.startswith(("<tuple: ", "<union: "))
-        and type_string.endswith(" items>")
         or type_string.endswith("?")
     ):
-        # Messages are easier to read if these aren't quoted.  We use a
-        # regex to match strings with variable contents.
+        # These messages are easier to read if these aren't quoted.
         return type_string
     return f'"{type_string}"'
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2520,19 +2520,14 @@ def quote_type_string(type_string: str) -> str:
     if (
         type_string in ["Module", "overloaded function", "<deleted>"]
         or type_string.startswith("Module ")
-        or short_tuple_or_union(type_string)
+        or type_string.startswith(("<tuple ", "<union "))
+        and type_string.endswith(" item>")
         or type_string.endswith("?")
     ):
         # Messages are easier to read if these aren't quoted.  We use a
         # regex to match strings with variable contents.
         return type_string
     return f'"{type_string}"'
-
-
-def short_tuple_or_union(typ: str) -> bool:
-    if not (typ.startswith("<tuple ") or typ.startswith("<union ")):
-        return False
-    return typ.endswith(" item>")
 
 
 def format_callable_args(

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -5,18 +5,7 @@ from __future__ import annotations
 import sys
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Final,
-    NamedTuple,
-    NewType,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, Final, NewType, TypeVar, Union, cast, overload
 from typing_extensions import Self, TypeAlias as _TypeAlias, TypeGuard
 
 import mypy.nodes
@@ -1607,11 +1596,25 @@ class FunctionLike(ProperType):
         return bool(self.items) and self.items[0].is_bound
 
 
-class FormalArgument(NamedTuple):
-    name: str | None
-    pos: int | None
-    typ: Type
-    required: bool
+class FormalArgument:
+    def __init__(self, name: str | None, pos: int | None, typ: Type, required: bool) -> None:
+        self.name = name
+        self.pos = pos
+        self.typ = typ
+        self.required = required
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, FormalArgument):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.pos == other.pos
+            and self.typ == other.typ
+            and self.required == other.required
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.pos, self.typ, self.required))
 
 
 class Parameters(ProperType):

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1612,7 +1612,7 @@ t4: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3
 t5: Tuple[int, int] = (1, 2, "s", 4)  # E: Incompatible types in assignment (expression has type "tuple[int, int, str, int]", variable has type "tuple[int, int]")
 
 # long initializer assignment with mismatched pairs
-t6: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str", 1, 1, 1, 1, 1) # E: Incompatible types in assignment (expression has type tuple[int, int, ... <15 more items>], variable has type tuple[int, int, ... <10 more items>])
+t6: Tuple[int, int, int, int, int, int, int, int, int, int, int, int] = (1, 2, 3, 4, 5, 6, 7, 8, "str", "str", "str", "str", 1, 1, 1, 1, 1) # E: Incompatible types in assignment (expression has type "tuple[int, int, ... <15 more items>]", variable has type "tuple[int, int, ... <10 more items>]")
 
 [builtins fixtures/tuple.pyi]
 


### PR DESCRIPTION
Here are two things:
* Make `FormalArgument` a native class. We create huge amount of these (as callable subtyping is one of the most common subtype checks), and named tuples creation is significantly slower than native classes.
* Do not call `re.match()` in a code path of `format_type()`. This is relatively slow (as it is a `py_call()`) and it is called in almost every error message. This creates problems for code with many third-party dependencies where these errors are ignored anyway.

FWIW in total these give ~0.5% together (I didn't measure individually, but I guess the most benefit for self-check is from the first one).