### PR TITLE
Fix `--strict-equality` for iteratively visited code

### DIFF
--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -2446,6 +2446,32 @@ while x is not None and b():
     x = f()
 [builtins fixtures/primitives.pyi]
 
+[case testAvoidFalseNonOverlappingEqualityCheckInLoop1]
+# flags: --allow-redefinition-new --local-partial-types --strict-equality
+
+x = 1
+while True:
+    if x == str():
+        break
+    x = str()
+    if x == int():  # E: Non-overlapping equality check (left operand type: "str", right operand type: "int")
+        break
+[builtins fixtures/primitives.pyi]
+
+[case testAvoidFalseNonOverlappingEqualityCheckInLoop2]
+# flags: --allow-redefinition-new --local-partial-types --strict-equality
+
+class A: ...
+class B: ...
+class C: ...
+
+x = A()
+while True:
+    if x == C():  # E: Non-overlapping equality check (left operand type: "Union[A, B]", right operand type: "C")
+        break
+    x = B()
+[builtins fixtures/primitives.pyi]
+
 [case testNarrowPromotionsInsideUnions1]
 
 from typing import Union


### PR DESCRIPTION
Fixes #19328

The logic is very similar to what we did to report different revealed types that were discovered in multiple iteration steps in one line.  I think this fix is the last one needed before I can implement #19256.