### PR TITLE
[mypyc] Fix seg fault due to heap type objects with static tp_doc

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -375,7 +375,7 @@ def generate_class(cl: ClassIR, module: str, emitter: Emitter) -> None:
         flags.append("Py_TPFLAGS_MANAGED_DICT")
     fields["tp_flags"] = " | ".join(flags)
 
-    fields["tp_doc"] = native_class_doc_initializer(cl)
+    fields["tp_doc"] = f"PyDoc_STR({native_class_doc_initializer(cl)})"
 
     emitter.emit_line(f"static PyTypeObject {emitter.type_struct_name(cl)}_template_ = {{")
     emitter.emit_line("PyVarObject_HEAD_INIT(NULL, 0)")
@@ -925,7 +925,7 @@ def generate_methods_table(cl: ClassIR, name: str, emitter: Emitter) -> None:
             flags.append("METH_CLASS")
 
         doc = native_function_doc_initializer(fn)
-        emitter.emit_line(" {}, {}}},".format(" | ".join(flags), doc))
+        emitter.emit_line(" {}, PyDoc_STR({})}},".format(" | ".join(flags), doc))
 
     # Provide a default __getstate__ and __setstate__
     if not cl.has_method("__setstate__") and not cl.has_method("__getstate__"):

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -983,7 +983,7 @@ class GroupGenerator:
             emitter.emit_line(
                 (
                     '{{"{name}", (PyCFunction){prefix}{cname}, {flag} | METH_KEYWORDS, '
-                    "{doc} /* docstring */}},"
+                    "PyDoc_STR({doc}) /* docstring */}},"
                 ).format(
                     name=name, cname=fn.cname(emitter.names), prefix=PREFIX, flag=flag, doc=doc
                 )

--- a/mypyc/test-data/run-signatures.test
+++ b/mypyc/test-data/run-signatures.test
@@ -184,6 +184,22 @@ for cls in [Empty, HasInit, InheritedInit]:
     assert getattr(cls, "__doc__") == ""
 assert getattr(HasInitBad, "__doc__") is None
 
+[case testSignaturesConstructorsNonExt]
+from mypy_extensions import mypyc_attr
+
+@mypyc_attr(native_class=False)
+class NonExt:
+    def __init__(self, x) -> None: pass
+
+[file driver.py]
+import inspect
+from testutil import assertRaises
+from native import *
+
+# TODO: support constructor signatures for non-extension classes
+with assertRaises(ValueError, "no signature found for builtin"):
+    inspect.signature(NonExt)
+
 [case testSignaturesHistoricalPositionalOnly]
 import inspect
 


### PR DESCRIPTION
See https://github.com/python/mypy/pull/19634#issuecomment-3172291620

Is there a good way to test that this that this doesn't seg fault when we exit with an uncaught exception?

Also took the opportunity to add `PyDoc_STR` to the static docstrings. AFAIK this isn't strictly necessary, but it's better style and in theory makes it possible to compile without docstrings if someone wanted to do that.