### PR TITLE
Removes some of the Anys from mypy/config_parser.py

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -600,7 +600,7 @@ def parse_section(
     return results, report_dirs
 
 
-def convert_to_boolean(value: Any | None) -> bool:
+def convert_to_boolean(value: object) -> bool:
     """Return a boolean value translating from other types if necessary."""
     if isinstance(value, bool):
         return value

--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -31,7 +31,7 @@ _INI_PARSER_CALLABLE: TypeAlias = Callable[[Any], _CONFIG_VALUE_TYPES]
 class VersionTypeError(argparse.ArgumentTypeError):
     """Provide a fallback value if the Python version is unsupported."""
 
-    def __init__(self, *args: Any, fallback: tuple[int, int]) -> None:
+    def __init__(self, *args: object, fallback: tuple[int, int]) -> None:
         self.fallback = fallback
         super().__init__(*args)
 


### PR DESCRIPTION
This pull request removes some of the Anys from mypy/config_parser.py, beginning to address mypy/config_parser.py with the easiest wins first.