### PR TITLE
Special case TypedDict.get

### DIFF
--- a/mypy/plugins/default.py
+++ b/mypy/plugins/default.py
@@ -5,7 +5,7 @@ from typing import Callable, Final
 
 import mypy.errorcodes as codes
 from mypy import message_registry
-from mypy.nodes import DictExpr, IntExpr, StrExpr, UnaryExpr
+from mypy.nodes import IntExpr, StrExpr, UnaryExpr
 from mypy.plugin import (
     AttributeContext,
     ClassDefContext,
@@ -75,6 +75,7 @@ from mypy.types import (
     TypedDictType,
     TypeOfAny,
     TypeVarType,
+    UninhabitedType,
     UnionType,
     get_proper_type,
     get_proper_types,
@@ -120,9 +121,9 @@ class DefaultPlugin(Plugin):
     def get_method_signature_hook(
         self, fullname: str
     ) -> Callable[[MethodSigContext], FunctionLike] | None:
-        if fullname == "typing.Mapping.get":
-            return typed_dict_get_signature_callback
-        elif fullname in TD_SETDEFAULT_NAMES:
+        # NOTE: signatures for `__setitem__`, `__delitem__` and `get` are
+        #  defined in checkmember.py/analyze_typeddict_access
+        if fullname in TD_SETDEFAULT_NAMES:
             return typed_dict_setdefault_signature_callback
         elif fullname in TD_POP_NAMES:
             return typed_dict_pop_signature_callback
@@ -212,46 +213,6 @@ class DefaultPlugin(Plugin):
         return None
 
 
-def typed_dict_get_signature_callback(ctx: MethodSigContext) -> CallableType:
-    """Try to infer a better signature type for TypedDict.get.
-
-    This is used to get better type context for the second argument that
-    depends on a TypedDict value type.
-    """
-    signature = ctx.default_signature
-    if (
-        isinstance(ctx.type, TypedDictType)
-        and len(ctx.args) == 2
-        and len(ctx.args[0]) == 1
-        and isinstance(ctx.args[0][0], StrExpr)
-        and len(signature.arg_types) == 2
-        and len(signature.variables) == 1
-        and len(ctx.args[1]) == 1
-    ):
-        key = ctx.args[0][0].value
-        value_type = get_proper_type(ctx.type.items.get(key))
-        ret_type = signature.ret_type
-        if value_type:
-            default_arg = ctx.args[1][0]
-            if (
-                isinstance(value_type, TypedDictType)
-                and isinstance(default_arg, DictExpr)
-                and len(default_arg.items) == 0
-            ):
-                # Caller has empty dict {} as default for typed dict.
-                value_type = value_type.copy_modified(required_keys=set())
-            # Tweak the signature to include the value type as context. It's
-            # only needed for type inference since there's a union with a type
-            # variable that accepts everything.
-            tv = signature.variables[0]
-            assert isinstance(tv, TypeVarType)
-            return signature.copy_modified(
-                arg_types=[signature.arg_types[0], make_simplified_union([value_type, tv])],
-                ret_type=ret_type,
-            )
-    return signature
-
-
 def typed_dict_get_callback(ctx: MethodContext) -> Type:
     """Infer a precise return type for TypedDict.get with literal first argument."""
     if (
@@ -263,30 +224,41 @@ def typed_dict_get_callback(ctx: MethodContext) -> Type:
         if keys is None:
             return ctx.default_return_type
 
+        default_type: Type
+        if len(ctx.arg_types) <= 1 or not ctx.arg_types[1]:
+            default_type = NoneType()
+        elif len(ctx.arg_types[1]) == 1 and len(ctx.args[1]) == 1:
+            default_type = ctx.arg_types[1][0]
+        else:
+            return ctx.default_return_type
+
         output_types: list[Type] = []
         for key in keys:
-            value_type = get_proper_type(ctx.type.items.get(key))
+            value_type: Type | None = ctx.type.items.get(key)
             if value_type is None:
                 return ctx.default_return_type
 
-            if len(ctx.arg_types) == 1:
+            if key in ctx.type.required_keys:
                 output_types.append(value_type)
-            elif len(ctx.arg_types) == 2 and len(ctx.arg_types[1]) == 1 and len(ctx.args[1]) == 1:
-                default_arg = ctx.args[1][0]
+            else:
+                # HACK to deal with get(key, {})
+                proper_default = get_proper_type(default_type)
                 if (
-                    isinstance(default_arg, DictExpr)
-                    and len(default_arg.items) == 0
-                    and isinstance(value_type, TypedDictType)
+                    isinstance(vt := get_proper_type(value_type), TypedDictType)
+                    and isinstance(proper_default, Instance)
+                    and proper_default.type.fullname == "builtins.dict"
+                    and len(proper_default.args) == 2
+                    and isinstance(get_proper_type(proper_default.args[0]), UninhabitedType)
+                    and isinstance(get_proper_type(proper_default.args[1]), UninhabitedType)
                 ):
-                    # Special case '{}' as the default for a typed dict type.
-                    output_types.append(value_type.copy_modified(required_keys=set()))
+                    output_types.append(vt.copy_modified(required_keys=set()))
                 else:
                     output_types.append(value_type)
-                    output_types.append(ctx.arg_types[1][0])
+                    output_types.append(default_type)
 
-        if len(ctx.arg_types) == 1:
-            output_types.append(NoneType())
-
+        # for nicer reveal_type, put default at the end, if it is present
+        if default_type in output_types:
+            output_types = [t for t in output_types if t != default_type] + [default_type]
         return make_simplified_union(output_types)
     return ctx.default_return_type
 

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1884,7 +1884,7 @@ reveal_type(d[a_key])         # N: Revealed type is "builtins.int"
 reveal_type(d[b_key])         # N: Revealed type is "builtins.str"
 d[c_key]                      # E: TypedDict "Outer" has no key "c"
 
-reveal_type(d.get(a_key, u))  # N: Revealed type is "Union[builtins.int, __main__.Unrelated]"
+reveal_type(d.get(a_key, u))  # N: Revealed type is "builtins.int"
 reveal_type(d.get(b_key, u))  # N: Revealed type is "Union[builtins.str, __main__.Unrelated]"
 reveal_type(d.get(c_key, u))  # N: Revealed type is "builtins.object"
 
@@ -1928,7 +1928,7 @@ u: Unrelated
 reveal_type(a[int_key_good])         # N: Revealed type is "builtins.int"
 reveal_type(b[int_key_good])         # N: Revealed type is "builtins.int"
 reveal_type(c[str_key_good])         # N: Revealed type is "builtins.int"
-reveal_type(c.get(str_key_good, u))  # N: Revealed type is "Union[builtins.int, __main__.Unrelated]"
+reveal_type(c.get(str_key_good, u))  # N: Revealed type is "builtins.int"
 reveal_type(c.get(str_key_bad, u))   # N: Revealed type is "builtins.object"
 
 a[int_key_bad]                       # E: Tuple index out of range
@@ -1993,8 +1993,8 @@ optional_keys: Literal["d", "e"]
 bad_keys: Literal["a", "bad"]
 
 reveal_type(test[good_keys])                      # N: Revealed type is "Union[__main__.A, __main__.B]"
-reveal_type(test.get(good_keys))                  # N: Revealed type is "Union[__main__.A, __main__.B, None]"
-reveal_type(test.get(good_keys, 3))               # N: Revealed type is "Union[__main__.A, Literal[3]?, __main__.B]"
+reveal_type(test.get(good_keys))                  # N: Revealed type is "Union[__main__.A, __main__.B]"
+reveal_type(test.get(good_keys, 3))               # N: Revealed type is "Union[__main__.A, __main__.B]"
 reveal_type(test.pop(optional_keys))              # N: Revealed type is "Union[__main__.D, __main__.E]"
 reveal_type(test.pop(optional_keys, 3))           # N: Revealed type is "Union[__main__.D, __main__.E, Literal[3]?]"
 reveal_type(test.setdefault(good_keys, AAndB()))  # N: Revealed type is "Union[__main__.A, __main__.B]"
@@ -2037,15 +2037,18 @@ class D2(TypedDict):
     d: D
 
 x: Union[D1, D2]
-bad_keys: Literal['a', 'b', 'c', 'd']
 good_keys: Literal['b', 'c']
+mixed_keys: Literal['a', 'b', 'c', 'd']
+bad_keys: Literal['e', 'f']
 
-x[bad_keys]         # E: TypedDict "D1" has no key "d" \
+x[mixed_keys]         # E: TypedDict "D1" has no key "d" \
                     # E: TypedDict "D2" has no key "a"
 
 reveal_type(x[good_keys])           # N: Revealed type is "Union[__main__.B, __main__.C]"
-reveal_type(x.get(good_keys))       # N: Revealed type is "Union[__main__.B, __main__.C, None]"
-reveal_type(x.get(good_keys, 3))    # N: Revealed type is "Union[__main__.B, Literal[3]?, __main__.C]"
+reveal_type(x.get(good_keys))       # N: Revealed type is "Union[__main__.B, __main__.C]"
+reveal_type(x.get(good_keys, 3))    # N: Revealed type is "Union[__main__.B, __main__.C]"
+reveal_type(x.get(mixed_keys))      # N: Revealed type is "builtins.object"
+reveal_type(x.get(mixed_keys, 3))   # N: Revealed type is "builtins.object"
 reveal_type(x.get(bad_keys))        # N: Revealed type is "builtins.object"
 reveal_type(x.get(bad_keys, 3))     # N: Revealed type is "builtins.object"
 

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -690,10 +690,11 @@ class TD(TypedDict, total=False):
     y: TD
 
 td: TD
+reveal_type(td.get("y"))  # N: Revealed type is "Union[TypedDict('__main__.TD', {'x'?: builtins.int, 'y'?: ...}), None]"
 td["y"] = {"x": 0, "y": {}}
 td["y"] = {"x": 0, "y": {"x": 0, "y": 42}}  # E: Incompatible types (expression has type "int", TypedDict item "y" has type "TD")
 
-reveal_type(td.get("y"))  # N: Revealed type is "Union[TypedDict('__main__.TD', {'x'?: builtins.int, 'y'?: TypedDict('__main__.TD', {'x'?: builtins.int, 'y'?: ...})}), None]"
+reveal_type(td.get("y"))  # N: Revealed type is "Union[TypedDict('__main__.TD', {'x'?: builtins.int, 'y'?: ...}), None]"
 s: str = td.get("y")  # E: Incompatible types in assignment (expression has type "Optional[TD]", variable has type "str")
 
 td.update({"x": 0, "y": {"x": 1, "y": {}}})

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -997,10 +997,32 @@ if int():
 
 -- Other TypedDict methods
 
+
+[case testTypedDictGetMethodOverloads]
+from typing import TypedDict
+from typing_extensions import Required, NotRequired
+
+class D(TypedDict):
+    a: int
+    b: NotRequired[str]
+
+def test(d: D) -> None:
+    reveal_type(d.get)  # N: Revealed type is \
+        "Overload(\
+        def (Literal['a'], builtins.object =) -> builtins.int, \
+        def (Literal['b']) -> Union[builtins.str, None], \
+        def (Literal['b'], builtins.str) -> builtins.str, \
+        def [T] (Literal['b'], T`-1) -> Union[builtins.str, T`-1], \
+        def (builtins.str, builtins.object =) -> builtins.object)"
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
 [case testTypedDictGetMethod]
 from typing import TypedDict
 class A: pass
-D = TypedDict('D', {'x': int, 'y': str})
+D = TypedDict('D', {'x': int, 'y': str}, total=False)
 d: D
 reveal_type(d.get('x')) # N: Revealed type is "Union[builtins.int, None]"
 reveal_type(d.get('y')) # N: Revealed type is "Union[builtins.str, None]"
@@ -1010,13 +1032,27 @@ reveal_type(d.get('y', None)) # N: Revealed type is "Union[builtins.str, None]"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictGetMethod2]
+from typing import TypedDict
+class A: pass
+D = TypedDict('D', {'x': int, 'y': str}, total=True)
+d: D
+reveal_type(d.get('x')) # N: Revealed type is "builtins.int"
+reveal_type(d.get('y')) # N: Revealed type is "builtins.str"
+reveal_type(d.get('x', A())) # N: Revealed type is "builtins.int"
+reveal_type(d.get('x', 1)) # N: Revealed type is "builtins.int"
+reveal_type(d.get('y', None)) # N: Revealed type is "builtins.str"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
 [case testTypedDictGetMethodTypeContext]
 from typing import List, TypedDict
 class A: pass
-D = TypedDict('D', {'x': List[int], 'y': int})
+D = TypedDict('D', {'x': List[int], 'y': int}, total=False)
 d: D
 reveal_type(d.get('x', [])) # N: Revealed type is "builtins.list[builtins.int]"
-d.get('x', ['x']) # E: List item 0 has incompatible type "str"; expected "int"
+reveal_type(d.get('x', ['x']))  # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.str]]"
 a = ['']
 reveal_type(d.get('x', a)) # N: Revealed type is "Union[builtins.list[builtins.int], builtins.list[builtins.str]]"
 [builtins fixtures/dict.pyi]
@@ -1026,14 +1062,16 @@ reveal_type(d.get('x', a)) # N: Revealed type is "Union[builtins.list[builtins.i
 from typing import TypedDict
 D = TypedDict('D', {'x': int, 'y': str})
 d: D
-d.get() # E: All overload variants of "get" of "Mapping" require at least one argument \
+d.get() # E: All overload variants of "get" require at least one argument \
         # N: Possible overload variants: \
-        # N:     def get(self, k: str) -> object \
-        # N:     def [V] get(self, k: str, default: object) -> object
-d.get('x', 1, 2) # E: No overload variant of "get" of "Mapping" matches argument types "str", "int", "int" \
+        # N:     def get(Literal['x'], object = ..., /) -> int \
+        # N:     def get(Literal['y'], object = ..., /) -> str \
+        # N:     def get(str, object = ..., /) -> object
+d.get('x', 1, 2) # E: No overload variant of "get" matches argument types "str", "int", "int" \
                  # N: Possible overload variants: \
-                 # N:     def get(self, k: str) -> object \
-                 # N:     def [V] get(self, k: str, default: Union[int, V]) -> object
+                 # N:     def get(Literal['x'], object = ..., /) -> int \
+                 # N:     def get(Literal['y'], object = ..., /) -> str \
+                 # N:     def get(str, object = ..., /) -> object
 x = d.get('z')
 reveal_type(x) # N: Revealed type is "builtins.object"
 s = ''
@@ -1069,15 +1107,109 @@ p.get('x', 1 + 'y')     # E: Unsupported operand types for + ("int" and "str")
 
 [case testTypedDictChainedGetWithEmptyDictDefault]
 from typing import TypedDict
-C = TypedDict('C', {'a': int})
-D = TypedDict('D', {'x': C, 'y': str})
+C = TypedDict('C', {'a': int}, total=True)
+D = TypedDict('D', {'x': C, 'y': str}, total=False)
 d: D
-reveal_type(d.get('x', {})) \
-    # N: Revealed type is "TypedDict('__main__.C', {'a'?: builtins.int})"
-reveal_type(d.get('x', None)) \
-    # N: Revealed type is "Union[TypedDict('__main__.C', {'a': builtins.int}), None]"
+reveal_type(d.get('x', {})) # N: Revealed type is "TypedDict('__main__.C', {'a'?: builtins.int})"
+reveal_type(d.get('x', None)) # N: Revealed type is "Union[TypedDict('__main__.C', {'a': builtins.int}), None]"
 reveal_type(d.get('x', {}).get('a')) # N: Revealed type is "Union[builtins.int, None]"
 reveal_type(d.get('x', {})['a']) # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
+[case testTypedDictChainedGetWithEmptyDictDefault2]
+from typing import TypedDict
+C = TypedDict('C', {'a': int}, total=False)
+D = TypedDict('D', {'x': C, 'y': str}, total=True)
+d: D
+reveal_type(d.get('x', {}))  # N: Revealed type is "TypedDict('__main__.C', {'a'?: builtins.int})"
+reveal_type(d.get('x', None))  # N: Revealed type is "TypedDict('__main__.C', {'a'?: builtins.int})"
+reveal_type(d.get('x', {}).get('a')) # N: Revealed type is "Union[builtins.int, None]"
+reveal_type(d.get('x', {})['a']) # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
+[case testTypedDictChainedGetWithEmptyDictDefault3]
+from typing import TypedDict
+C = TypedDict('C', {'a': int}, total=True)
+D = TypedDict('D', {'x': C, 'y': str}, total=True)
+d: D
+reveal_type(d.get('x', {}))  # N: Revealed type is "TypedDict('__main__.C', {'a': builtins.int})"
+reveal_type(d.get('x', None))  # N: Revealed type is "TypedDict('__main__.C', {'a': builtins.int})"
+reveal_type(d.get('x', {}).get('a')) # N: Revealed type is "builtins.int"
+reveal_type(d.get('x', {})['a']) # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
+[case testTypedDictChainedGetWithEmptyDictDefault4]
+from typing import TypedDict
+C = TypedDict('C', {'a': int}, total=False)
+D = TypedDict('D', {'x': C, 'y': str}, total=False)
+d: D
+reveal_type(d.get('x', {}))  # N: Revealed type is "TypedDict('__main__.C', {'a'?: builtins.int})"
+reveal_type(d.get('x', None))  # N: Revealed type is "Union[TypedDict('__main__.C', {'a'?: builtins.int}), None]"
+reveal_type(d.get('x', {}).get('a')) # N: Revealed type is "Union[builtins.int, None]"
+reveal_type(d.get('x', {})['a']) # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
+
+[case testTypedDictGetMethodChained]
+# check that chaining with get like ``.get(key, {}).get(subkey, {})`` works.
+from typing import TypedDict, Mapping
+from typing_extensions import Required, NotRequired, Never
+
+class Total(TypedDict, total=True):  # no keys optional
+    key_one: int
+    key_two: str
+
+class Maybe(TypedDict, total=False):  # all keys are optional
+    key_one: int
+    key_two: str
+
+class Mixed(TypedDict):  # some keys optional
+    key_one: Required[int]
+    key_two: NotRequired[str]
+
+class Config(TypedDict):
+    required_total: Required[Total]
+    optional_total: NotRequired[Total]
+    required_mixed: Required[Mixed]
+    optional_mixed: NotRequired[Mixed]
+    required_maybe: Required[Maybe]
+    optional_maybe: NotRequired[Maybe]
+
+def test_chaining(d: Config) -> None:
+    reveal_type( d.get("required_total", {}) ) # N: Revealed type is "TypedDict('__main__.Total', {'key_one': builtins.int, 'key_two': builtins.str})"
+    reveal_type( d.get("optional_total", {}) ) # N: Revealed type is "TypedDict('__main__.Total', {'key_one'?: builtins.int, 'key_two'?: builtins.str})"
+    reveal_type( d.get("required_maybe", {}) ) # N: Revealed type is "TypedDict('__main__.Maybe', {'key_one'?: builtins.int, 'key_two'?: builtins.str})"
+    reveal_type( d.get("optional_maybe", {}) ) # N: Revealed type is "TypedDict('__main__.Maybe', {'key_one'?: builtins.int, 'key_two'?: builtins.str})"
+    reveal_type( d.get("required_mixed", {}) ) # N: Revealed type is "TypedDict('__main__.Mixed', {'key_one': builtins.int, 'key_two'?: builtins.str})"
+    reveal_type( d.get("optional_mixed", {}) ) # N: Revealed type is "TypedDict('__main__.Mixed', {'key_one'?: builtins.int, 'key_two'?: builtins.str})"
+
+    reveal_type( d.get("required_total", {}).get("key_one")  )  # N: Revealed type is "builtins.int"
+    reveal_type( d.get("required_total", {}).get("key_two")  )  # N: Revealed type is "builtins.str"
+    reveal_type( d.get("required_total", {}).get("bad_key")  )  # N: Revealed type is "builtins.object"
+    reveal_type( d.get("optional_total", {}).get("key_one")  )  # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type( d.get("optional_total", {}).get("key_two")  )  # N: Revealed type is "Union[builtins.str, None]"
+    reveal_type( d.get("optional_total", {}).get("bad_key")  )  # N: Revealed type is "builtins.object"
+
+    reveal_type( d.get("required_maybe", {}).get("key_one")  )  # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type( d.get("required_maybe", {}).get("key_two")  )  # N: Revealed type is "Union[builtins.str, None]"
+    reveal_type( d.get("required_maybe", {}).get("bad_key")  )  # N: Revealed type is "builtins.object"
+    reveal_type( d.get("optional_maybe", {}).get("key_one")  )  # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type( d.get("optional_maybe", {}).get("key_two")  )  # N: Revealed type is "Union[builtins.str, None]"
+    reveal_type( d.get("optional_maybe", {}).get("bad_key")  )  # N: Revealed type is "builtins.object"
+
+    reveal_type( d.get("required_mixed", {}).get("key_one")  )  # N: Revealed type is "builtins.int"
+    reveal_type( d.get("required_mixed", {}).get("key_two")  )  # N: Revealed type is "Union[builtins.str, None]"
+    reveal_type( d.get("required_mixed", {}).get("bad_key")  )  # N: Revealed type is "builtins.object"
+    reveal_type( d.get("optional_mixed", {}).get("key_one")  )  # N: Revealed type is "Union[builtins.int, None]"
+    reveal_type( d.get("optional_mixed", {}).get("key_two")  )  # N: Revealed type is "Union[builtins.str, None]"
+    reveal_type( d.get("optional_mixed", {}).get("bad_key")  )  # N: Revealed type is "builtins.object"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
@@ -1769,8 +1901,8 @@ class TDB(TypedDict):
 
 td: Union[TDA, TDB]
 
-reveal_type(td.get('a'))  # N: Revealed type is "Union[builtins.int, None]"
-reveal_type(td.get('b'))  # N: Revealed type is "Union[builtins.str, None, builtins.int]"
+reveal_type(td.get('a'))  # N: Revealed type is "builtins.int"
+reveal_type(td.get('b'))  # N: Revealed type is "Union[builtins.str, builtins.int]"
 reveal_type(td.get('c'))  # N: Revealed type is "builtins.object"
 
 reveal_type(td['a'])  # N: Revealed type is "builtins.int"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1034,24 +1034,47 @@ _program.py:17: note: Revealed type is "builtins.str"
 # Test that TypedDict get plugin works with typeshed stubs
 from typing import TypedDict
 class A: pass
-D = TypedDict('D', {'x': int, 'y': str})
-d: D
-reveal_type(d.get('x'))
-reveal_type(d.get('y'))
-reveal_type(d.get('z'))
-d.get()
-s = ''
-reveal_type(d.get(s))
+D_total = TypedDict('D_total', {'x': int, 'y': str}, total=True)
+D_not_total = TypedDict('D_not_total', {'x': int, 'y': str}, total=False)
+
+def test_total(d: D_total) -> None:
+    reveal_type(d.get('x'))
+    reveal_type(d.get('y'))
+    reveal_type(d.get('z'))
+    d.get()
+    s = ''
+    reveal_type(d.get(s))
+
+def test_not_total(d: D_not_total) -> None:
+    reveal_type(d.get('x'))
+    reveal_type(d.get('y'))
+    reveal_type(d.get('z'))
+    d.get()
+    s = ''
+    reveal_type(d.get(s))
 [out]
-_testTypedDictGet.py:6: note: Revealed type is "Union[builtins.int, None]"
-_testTypedDictGet.py:7: note: Revealed type is "Union[builtins.str, None]"
-_testTypedDictGet.py:8: note: Revealed type is "builtins.object"
-_testTypedDictGet.py:9: error: All overload variants of "get" of "Mapping" require at least one argument
-_testTypedDictGet.py:9: note: Possible overload variants:
-_testTypedDictGet.py:9: note:     def get(self, str, /) -> object
-_testTypedDictGet.py:9: note:     def get(self, str, /, default: object) -> object
-_testTypedDictGet.py:9: note:     def [_T] get(self, str, /, default: _T) -> object
-_testTypedDictGet.py:11: note: Revealed type is "builtins.object"
+_testTypedDictGet.py:8: note: Revealed type is "builtins.int"
+_testTypedDictGet.py:9: note: Revealed type is "builtins.str"
+_testTypedDictGet.py:10: note: Revealed type is "builtins.object"
+_testTypedDictGet.py:11: error: All overload variants of "get" require at least one argument
+_testTypedDictGet.py:11: note: Possible overload variants:
+_testTypedDictGet.py:11: note:     def get(Literal['x'], object = ..., /) -> int
+_testTypedDictGet.py:11: note:     def get(Literal['y'], object = ..., /) -> str
+_testTypedDictGet.py:11: note:     def get(str, object = ..., /) -> object
+_testTypedDictGet.py:13: note: Revealed type is "builtins.object"
+_testTypedDictGet.py:16: note: Revealed type is "Union[builtins.int, None]"
+_testTypedDictGet.py:17: note: Revealed type is "Union[builtins.str, None]"
+_testTypedDictGet.py:18: note: Revealed type is "builtins.object"
+_testTypedDictGet.py:19: error: All overload variants of "get" require at least one argument
+_testTypedDictGet.py:19: note: Possible overload variants:
+_testTypedDictGet.py:19: note:     def get(Literal['x'], /) -> Optional[int]
+_testTypedDictGet.py:19: note:     def get(Literal['x'], int, /) -> int
+_testTypedDictGet.py:19: note:     def [T] get(Literal['x'], T, /) -> Union[int, T]
+_testTypedDictGet.py:19: note:     def get(Literal['y'], /) -> Optional[str]
+_testTypedDictGet.py:19: note:     def get(Literal['y'], str, /) -> str
+_testTypedDictGet.py:19: note:     def [T] get(Literal['y'], T, /) -> Union[str, T]
+_testTypedDictGet.py:19: note:     def get(str, object = ..., /) -> object
+_testTypedDictGet.py:21: note: Revealed type is "builtins.object"
 
 [case testTypedDictMappingMethods]
 from typing import TypedDict


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Makes `TypedDict.get` smarter by producing a list of overloads corresponding to the key-value pairs.

```python
from typing import TypedDict, Required

class Demo(TypedDict, total=False):
    x: Required[int]
    y: str

def test(d: Demo) -> None:
    reveal_type(d.get)
```

On 1.17.1:

```
note: Revealed type is "Overload(
    def (builtins.str) -> builtins.object,
    def [_T] (builtins.str, default: builtins.object) -> builtins.object,
)"
```

With this PR:

```
note: Revealed type is "Overload(
    def (Literal['x'], builtins.object =) -> builtins.int,
    def (Literal['y']) -> builtins.str | None,
    def (Literal['y'], builtins.str) -> builtins.str,
    def [T] (Literal['y'], T`-1 =) -> builtins.str | T`-1,
    def (builtins.str, builtins.object =) -> builtins.object
)"
```

I think in principle we should be able to combine the last two `y` overloads like pyright does it, but this likely needs some changes in generic callable inference.

Moreover, we now get the non-optional type when doing `TypedDict.get(required_key)`:

```python
from typing import TypedDict, Required

class Demo(TypedDict, total=False):
    x: Required[int]
    y: str

def test(d: Demo) -> None:
    reveal_type(d.get("x"))  # master: int | None, PR: int
    reveal_type(d.get("y"))  # master: str | None, PR: str | None
```

We get slightly different behavior with `List`/`Set`/`Dict` expressions:

```python
from typing import TypedDict

class C(TypedDict):
    a: int

class Demo(TypedDict, total=False):
    x: list[int]
    y: C

def test(d: Demo):
    reveal_type(d.get("x", ["x"]))
    reveal_type(d.get("y", {}))   
```

master: https://mypy-play.net/?mypy=master&python=3.12&gist=b3cac3b9355a53f8a5a1ad3fcdd8bbba

```
main.py:11: note: Revealed type is "builtins.list[builtins.int] | builtins.list[builtins.str]"
main.py:12: note: Revealed type is "TypedDict('__main__.C', {'a'?: builtins.int})"
```

1.17.1:  https://mypy-play.net/?mypy=latest&python=3.12&gist=dfb9f9df42e01a143f8f14d644347cc6

```
main.py:11: note: Revealed type is "builtins.list[builtins.int]"
main.py:11: error: List item 0 has incompatible type "str"; expected "int"  [list-item]
main.py:12: note: Revealed type is "TypedDict('__main__.C', {'a'?: builtins.int})"
```

This PR:

```
note: Revealed type is "builtins.list[builtins.int] | builtins.list[builtins.str]"
note: Revealed type is "TypedDict('tmp.C', {'a': builtins.int}) | builtins.dict[Never, Never]"
```

Since in the example above, `C` is total, so an empty dict is not compatible with `C`. Therefore, the behavior on both master and 1.17.1 is incorrect in this example.