### PR TITLE
Reset to previous statement when leaving `return` in semanal

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5332,6 +5332,7 @@ class SemanticAnalyzer(
         s.expr.accept(self)
 
     def visit_return_stmt(self, s: ReturnStmt) -> None:
+        old = self.statement
         self.statement = s
         if not self.is_func_scope():
             self.fail('"return" outside function', s)
@@ -5339,6 +5340,7 @@ class SemanticAnalyzer(
             self.fail('"return" not allowed in except* block', s, serious=True)
         if s.expr:
             s.expr.accept(self)
+        self.statement = old
 
     def visit_raise_stmt(self, s: RaiseStmt) -> None:
         self.statement = s

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -9258,3 +9258,18 @@ main:5: note:     def __eq__(self, other: object) -> bool:
 main:5: note:         if not isinstance(other, C):
 main:5: note:             return NotImplemented
 main:5: note:         return <logic to compare two C instances>
+
+[case testLambdaInAttributeCallValue]
+# https://github.com/python/mypy/issues/19632
+import foo
+
+def nop(fn: object) -> foo.Bar:
+    return foo.Bar()
+
+class Bar:
+    foo: foo.Bar = nop(
+        lambda: 0
+    )
+[file foo.py]
+class Bar:
+    ...


### PR DESCRIPTION
Unlike other statements, return can be found in lambdas, and so is not immediately followed by another statement to check or EOF. We need to restore the previous value to continue checking it. 

Fixes #19632