### PR TITLE
Include `ambiguous` into `UninhabitedType` identity

### DIFF
--- a/mypy/test/testsolve.py
+++ b/mypy/test/testsolve.py
@@ -64,12 +64,14 @@ class SolveSuite(Suite):
         )
 
     def test_no_constraints_for_var(self) -> None:
-        self.assert_solve([self.fx.t], [], [self.fx.uninhabited])
-        self.assert_solve([self.fx.t, self.fx.s], [], [self.fx.uninhabited, self.fx.uninhabited])
+        self.assert_solve([self.fx.t], [], [self.fx.a_uninhabited])
+        self.assert_solve(
+            [self.fx.t, self.fx.s], [], [self.fx.a_uninhabited, self.fx.a_uninhabited]
+        )
         self.assert_solve(
             [self.fx.t, self.fx.s],
             [self.supc(self.fx.s, self.fx.a)],
-            [self.fx.uninhabited, self.fx.a],
+            [self.fx.a_uninhabited, self.fx.a],
         )
 
     def test_simple_constraints_with_dynamic_type(self) -> None:
@@ -116,7 +118,7 @@ class SolveSuite(Suite):
         self.assert_solve(
             [self.fx.t, self.fx.u],
             [],
-            [self.fx.uninhabited, self.fx.uninhabited],
+            [self.fx.a_uninhabited, self.fx.a_uninhabited],
             allow_polymorphic=True,
         )
 
@@ -152,7 +154,7 @@ class SolveSuite(Suite):
         self.assert_solve(
             [self.fx.ub, self.fx.uc],
             [self.subc(self.fx.ub, self.fx.uc)],
-            [self.fx.uninhabited, self.fx.uninhabited],
+            [self.fx.a_uninhabited, self.fx.a_uninhabited],
             [],
             allow_polymorphic=True,
         )

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -78,6 +78,8 @@ class TypeFixture:
         self.anyt = AnyType(TypeOfAny.special_form)
         self.nonet = NoneType()
         self.uninhabited = UninhabitedType()
+        self.a_uninhabited = UninhabitedType()
+        self.a_uninhabited.ambiguous = True
 
         # Abstract class TypeInfos
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1236,10 +1236,10 @@ class UninhabitedType(ProperType):
         return visitor.visit_uninhabited_type(self)
 
     def __hash__(self) -> int:
-        return hash(UninhabitedType)
+        return hash((UninhabitedType, self.ambiguous))
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, UninhabitedType)
+        return isinstance(other, UninhabitedType) and other.ambiguous == self.ambiguous
 
     def serialize(self) -> JsonDict:
         return {".class": "UninhabitedType"}

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -753,6 +753,20 @@ s, s = Nums() # E: Incompatible types in assignment (expression has type "int", 
 [builtins fixtures/for.pyi]
 [out]
 
+[case testUninhabitedCacheChecksAmbiguous]
+# https://github.com/python/mypy/issues/19641
+from typing import Mapping, Never, TypeVar
+
+M = TypeVar("M", bound=Mapping[str,object])
+
+def get(arg: M, /) -> M:
+    return arg
+
+get({})
+
+def upcast(d: dict[Never, Never]) -> Mapping[str, object]:
+    return d  # E: Incompatible return value type (got "dict[Never, Never]", expected "Mapping[str, object]")
+[builtins fixtures/dict.pyi]
 
 -- Variance
 -- --------

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3776,7 +3776,7 @@ f(x, empty)  # E: Cannot infer value of type parameter "T" of "f"
 f(["no"], empty)  # E: Cannot infer value of type parameter "T" of "f"
 [builtins fixtures/list.pyi]
 
-[case testInferenceWorksWithEmptyCollectionsUnion]
+[case testInferenceWorksWithEmptyCollectionsUnion-xfail]
 from typing import Any, Dict, NoReturn, NoReturn, Union
 
 def foo() -> Union[Dict[str, Any], Dict[int, Any]]:

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3776,15 +3776,23 @@ f(x, empty)  # E: Cannot infer value of type parameter "T" of "f"
 f(["no"], empty)  # E: Cannot infer value of type parameter "T" of "f"
 [builtins fixtures/list.pyi]
 
-[case testInferenceWorksWithEmptyCollectionsUnion-xfail]
+[case testInferenceWorksWithEmptyCollectionsUnion]
 from typing import Any, Dict, NoReturn, NoReturn, Union
 
 def foo() -> Union[Dict[str, Any], Dict[int, Any]]:
     return {}
+[builtins fixtures/dict.pyi]
+
+[case testExistingEmptyCollectionDoesNotUpcast]
+from typing import Any, Dict, NoReturn, NoReturn, Union
 
 empty: Dict[NoReturn, NoReturn]
+
+def foo() -> Dict[str, Any]:
+    return empty  # E: Incompatible return value type (got "dict[Never, Never]", expected "dict[str, Any]")
+
 def bar() -> Union[Dict[str, Any], Dict[int, Any]]:
-    return empty
+    return empty  # E: Incompatible return value type (got "dict[Never, Never]", expected "Union[dict[str, Any], dict[int, Any]]")
 [builtins fixtures/dict.pyi]
 
 [case testUpperBoundInferenceFallbackNotOverused]


### PR DESCRIPTION
Fixes #19641, but also reveals a test that was only passing by coincidence. This inference has never worked correctly:

```python
from typing import Mapping, Never

d: dict[Never, Never]
def run() -> Mapping[str, int]:
    return d
```

As discussed, I updated the test to expect failure in that case. We should only special-case inline collection literals for that, everything else (including locals) can cause undesired false negatives.

Cc @ilevkivskyi as the original author (#16122)