### PR TITLE
Always try to report missing protocol members

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2137,10 +2137,6 @@ class MessageBuilder:
         }
         if supertype.type.fullname in exclusions.get(type(subtype), []):
             return
-        if any(isinstance(tp, UninhabitedType) for tp in get_proper_types(supertype.args)):
-            # We don't want to add notes for failed inference (e.g. Iterable[Never]).
-            # This will be only confusing a user even more.
-            return
 
         class_obj = False
         is_module = False
@@ -2195,6 +2191,11 @@ class MessageBuilder:
                 self.note(", ".join(missing), context, offset=OFFSET, parent_error=parent_error)
         elif len(missing) > MAX_ITEMS or len(missing) == len(supertype.type.protocol_members):
             # This is an obviously wrong type: too many missing members
+            return
+
+        if any(isinstance(tp, UninhabitedType) for tp in get_proper_types(supertype.args)):
+            # We don't want to add type conflict notes for failed inference (e.g. Iterable[Never]).
+            # This will be only confusing a user even more.
             return
 
         # Report member type conflicts


### PR DESCRIPTION
Reporting missing members can't confuse user even more -- it can only help to see what's missing. Also, sometimes implementing missing member helps `mypy` to correctly infer the type it couldn't infer before

I'm not sure if a separate test is needed for that, but here's a silly example:

```python
from typing import Protocol, reveal_type

class CMD[T](Protocol):
    def command(self) -> T:
        ...
    def arguments(self) -> list[T]:
        ...

class CMDImpl:
    def command(self) -> str:
        return ""
    # def arguments(self) -> list[str]:
    #     return []

class CMDRunner[T]:
    def __init__(self, cmd: CMD[T]) -> None:
        self.cmd = cmd


r = CMDRunner(CMDImpl())
reveal_type(r)
```

```console
$ mypy t.py

t.py:20: error: Need type annotation for "r"  [var-annotated]
t.py:20: error: Argument 1 to "CMDRunner" has incompatible type "CMDImpl"; expected "CMD[Never]"  [arg-type]
t.py:21: note: Revealed type is "t.CMDRunner[Any]"
Found 2 errors in 1 file (checked 1 source file)
```

whereas after uncommenting missing protocol member implementation:
```console
$ mypy t.py

t.py:21: note: Revealed type is "t.CMDRunner[builtins.str]"
Success: no issues found in 1 source file
```

and the note about this missing member would've had pointed to the cause:
```console
t.py:20: error: Need type annotation for "r"  [var-annotated]
t.py:20: error: Argument 1 to "CMDRunner" has incompatible type "CMDImpl"; expected "CMD[Never]"  [arg-type]
t.py:20: note: "CMDImpl" is missing following "CMD" protocol member:
t.py:20: note:     arguments
t.py:21: note: Revealed type is "t.CMDRunner[Any]"
Found 2 errors in 1 file (checked 1 source file)
```