### PR TITLE
Handle more cases in `any_constraints`

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -541,13 +541,14 @@ def any_constraints(options: list[list[Constraint] | None], *, eager: bool) -> l
         # TODO: More generally, if a given (variable, direction) pair appears in
         # every option, combine the bounds with meet/join always, not just for Any.
         trivial_options = select_trivial(valid_options)
-        if trivial_options and len(trivial_options) < len(valid_options):
+        if 0 < len(trivial_options) < len(valid_options):
             merged_options = []
             for option in valid_options:
                 if option in trivial_options:
                     continue
                 merged_options.append([merge_with_any(c) for c in option])
             return any_constraints(list(merged_options), eager=eager)
+        return sum(valid_options, [])
 
     # If normal logic didn't work, try excluding trivially unsatisfiable constraint (due to
     # upper bounds) from each option, and comparing them again.

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -411,18 +411,15 @@ def _infer_constraints(
         # When the template is a union, we are okay with leaving some
         # type variables indeterminate. This helps with some special
         # cases, though this isn't very principled.
-        result = any_constraints(
+        if has_recursive_types(template) and not has_recursive_types(actual):
+            return handle_recursive_union(template, actual, direction)
+        return any_constraints(
             [
                 infer_constraints_if_possible(t_item, actual, direction)
                 for t_item in template.items
             ],
             eager=isinstance(actual, AnyType),
         )
-        if result:
-            return result
-        elif has_recursive_types(template) and not has_recursive_types(actual):
-            return handle_recursive_union(template, actual, direction)
-        return []
 
     # Remaining cases are handled by ConstraintBuilderVisitor.
     return template.accept(ConstraintBuilderVisitor(actual, direction, skip_neg_op))

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1530,3 +1530,15 @@ def check3(use: bool, val: str) -> "str | Literal[False]":
 def check4(use: bool, val: str) -> "str | bool":
     return use and identity(val)
 [builtins fixtures/tuple.pyi]
+
+[case testDictOrLiteralInContext]
+from typing import Union, Optional, Any
+
+P = dict[str, Union[Optional[str], dict[str, Optional[str]]]]
+
+def f(x: P) -> None:
+    pass
+
+def g(x: Union[dict[str, Any], None], s: Union[str, None]) -> None:
+    f(x or {'x': s})
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #19492. When all options have the same structure, we can meaningfully OR such constraints as meets/joins of upper/lower bounds for all variables separately. Fortunately, that's exactly what solver will do later, so we can just add all constraints together.