### PR TITLE
Don't expand PEP 695 aliases when checking node fullnames

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -7678,7 +7678,7 @@ def refers_to_fullname(node: Expression, fullnames: str | tuple[str, ...]) -> bo
         return False
     if node.fullname in fullnames:
         return True
-    if isinstance(node.node, TypeAlias):
+    if isinstance(node.node, TypeAlias) and not node.node.python_3_12_type_alias:
         return is_named_instance(node.node.target, fullnames)
     return False
 

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2095,3 +2095,19 @@ from dataclasses import dataclass
 class Test[*Ts, R]:
     a: Callable[[*Ts], R]
 [builtins fixtures/dict.pyi]
+
+[case testPEP695AliasDoesNotReferToFullname]
+# https://github.com/python/mypy/issues/19698
+from typing import TypeAliasType
+type D = dict
+type T = type
+type TA = TypeAliasType
+
+D()          # E: "TypeAliasType" not callable
+X = TA("Y")  # E: "TypeAliasType" not callable
+
+x: object
+if T(x) is str:     # E: "TypeAliasType" not callable
+    reveal_type(x)  # N: Revealed type is "builtins.object"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
Fixes #19698