### PR TITLE
Remove unnecessary error message for match class patterns

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -539,12 +539,12 @@ class PatternChecker(PatternVisitor[PatternType]):
         #
         type_info = o.class_ref.node
         if type_info is None:
-            return PatternType(AnyType(TypeOfAny.from_error), AnyType(TypeOfAny.from_error), {})
-        if isinstance(type_info, TypeAlias) and not type_info.no_args:
+            typ: Type = AnyType(TypeOfAny.from_error)
+        elif isinstance(type_info, TypeAlias) and not type_info.no_args:
             self.msg.fail(message_registry.CLASS_PATTERN_GENERIC_TYPE_ALIAS, o)
             return self.early_non_match()
-        if isinstance(type_info, TypeInfo):
-            typ: Type = fill_typevars_with_any(type_info)
+        elif isinstance(type_info, TypeInfo):
+            typ = fill_typevars_with_any(type_info)
         elif isinstance(type_info, TypeAlias):
             typ = type_info.target
         elif (

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -721,13 +721,14 @@ m: object
 match m:
     case xyz(y):  # E: Name "xyz" is not defined
         reveal_type(m)  # N: Revealed type is "Any"
-        reveal_type(y)  # E: Cannot determine type of "y" \
-                        # N: Revealed type is "Any"
+        reveal_type(y)  # N: Revealed type is "Any"
 
 match m:
     case xyz(z=x):  # E: Name "xyz" is not defined
-        reveal_type(x)  # E: Cannot determine type of "x" \
-                        # N: Revealed type is "Any"
+        reveal_type(x)  # N: Revealed type is "Any"
+    case (xyz1() as n) | (xyz2(attr=n)):  # E: Name "xyz1" is not defined \
+                                          # E: Name "xyz2" is not defined
+        reveal_type(n)  # N: Revealed type is "Any"
 
 [case testMatchClassPatternCaptureDataclass]
 from dataclasses import dataclass


### PR DESCRIPTION
Remove `Cannot determine type of ...` error for class patterns if the class to match cannot be resolved. In these cases a `Name ... is not defined` error is already emitted. The captured variable should simply be inferred as `Any`.

Previously, this was especially an issue for class matches to a class from an untyped library together with a MemberExpr. An example from pylint / astroid which shouldn't emit any errors:
```py
from typing import Any
from astroid import nodes

def func(var: Any) -> None:
    match var:
        case nodes.Assign(targets=t):
            reveal_type(t)  # Any
```