### PR TITLE
Omit errors for class pattern matches against object

### DIFF
--- a/mypy/checker_shared.py
+++ b/mypy/checker_shared.py
@@ -273,6 +273,10 @@ class TypeCheckerSharedApi(CheckerPluginInterface):
         raise NotImplementedError
 
     @abstractmethod
+    def add_any_attribute_to_type(self, typ: Type, name: str) -> Type:
+        raise NotImplementedError
+
+    @abstractmethod
     def is_defined_in_stub(self, typ: Instance, /) -> bool:
         raise NotImplementedError
 

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -671,12 +671,13 @@ class PatternChecker(PatternVisitor[PatternType]):
                 has_local_errors = local_errors.has_new_errors()
             if has_local_errors or key_type is None:
                 key_type = AnyType(TypeOfAny.from_error)
-                self.msg.fail(
-                    message_registry.CLASS_PATTERN_UNKNOWN_KEYWORD.format(
-                        typ.str_with_options(self.options), keyword
-                    ),
-                    pattern,
-                )
+                if not (type_info and type_info.fullname == "builtins.object"):
+                    self.msg.fail(
+                        message_registry.CLASS_PATTERN_UNKNOWN_KEYWORD.format(
+                            typ.str_with_options(self.options), keyword
+                        ),
+                        pattern,
+                    )
 
             inner_type, inner_rest_type, inner_captures = self.accept(pattern, key_type)
             if is_uninhabited(inner_type):

--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -678,6 +678,8 @@ class PatternChecker(PatternVisitor[PatternType]):
                         ),
                         pattern,
                     )
+                elif keyword is not None:
+                    new_type = self.chk.add_any_attribute_to_type(new_type, keyword)
 
             inner_type, inner_rest_type, inner_captures = self.accept(pattern, key_type)
             if is_uninhabited(inner_type):

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1002,14 +1002,22 @@ match m:
 [builtins fixtures/tuple.pyi]
 
 [case testMatchClassPatternNonexistentKeyword]
+from typing import Any
 class A: ...
 
 m: object
+n: Any
 
 match m:
     case A(a=j):  # E: Class "__main__.A" has no attribute "a"
         reveal_type(m)  # N: Revealed type is "__main__.A"
         reveal_type(j)  # N: Revealed type is "Any"
+
+match n:
+    # Matching against object should not emit an error for non-existing keys
+    case object(a=k):
+        reveal_type(n)  # N: Revealed type is "builtins.object"
+        reveal_type(k)  # N: Revealed type is "Any"
 
 [case testMatchClassPatternDuplicateKeyword]
 class A:

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1017,6 +1017,7 @@ match n:
     # Matching against object should not emit an error for non-existing keys
     case object(a=k):
         reveal_type(n)  # N: Revealed type is "builtins.object"
+        reveal_type(n.a)  # N: Revealed type is "Any"
         reveal_type(k)  # N: Revealed type is "Any"
 
 [case testMatchClassPatternDuplicateKeyword]


### PR DESCRIPTION
Since the class pattern matches any subclass, it can also be used to check whether the matched object has a specific attribute. Mypy should not emit an error for it.
```py
match m:
    case object(foo=_):
        m.foo
```

Using `object` for it is recommended in [PEP 635](https://peps.python.org/pep-0635/#history-and-context) and more prominently in the precursor [PEP 622](https://peps.python.org/pep-0622/#class-patterns).