### PR TITLE
Use union for captured vars in or pattern

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -192,7 +192,7 @@ class PatternChecker(PatternVisitor[PatternType]):
         for capture_list in capture_types.values():
             typ = UninhabitedType()
             for _, other in capture_list:
-                typ = join_types(typ, other)
+                typ = make_simplified_union([typ, other])
 
             captures[capture_list[0][0]] = typ
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1204,13 +1204,13 @@ match m:
     case 1 | "foo":
         reveal_type(m)  # N: Revealed type is "Union[Literal[1], Literal['foo']]"
 
-[case testMatchOrPatterCapturesMissing]
+[case testMatchOrPatternCapturesMissing]
 from typing import List
 m: List[int]
 
 match m:
     case [x, y] | list(x):  # E: Alternative patterns bind different names
-        reveal_type(x)  # N: Revealed type is "builtins.object"
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.list[builtins.int]]"
         reveal_type(y)  # N: Revealed type is "builtins.int"
 [builtins fixtures/list.pyi]
 
@@ -1219,7 +1219,7 @@ m: object
 
 match m:
     case list(x) | dict(x):
-        reveal_type(x)  # N: Revealed type is "typing.Iterable[Any]"
+        reveal_type(x)  # N: Revealed type is "Union[builtins.list[Any], builtins.dict[Any, Any]]"
 [builtins fixtures/dict.pyi]
 
 -- Interactions --
@@ -1405,7 +1405,7 @@ m: Union[str, bytes, int]
 
 match m:
     case str(a) | bytes(a):
-        reveal_type(a)  # N: Revealed type is "builtins.object"
+        reveal_type(a)  # N: Revealed type is "Union[builtins.str, builtins.bytes]"
         reveal_type(m)  # N: Revealed type is "Union[builtins.str, builtins.bytes]"
     case b:
         reveal_type(b)  # N: Revealed type is "builtins.int"


### PR DESCRIPTION
Mypy creates a union type for the pattern subject in an or pattern already. Use union for captured variables as well.