### PR TITLE
refactor(mypy): improve type inference for Union type comparisons

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -388,19 +388,19 @@ def _infer_constraints(
         if isinstance(template_proper, UnionType) and len(template_proper.items) == 2:
             type_var_items = []
             non_type_var_items = []
-            
+
             for t_item in template_proper.items:
                 t_item_proper = get_proper_type(t_item)
                 if isinstance(t_item_proper, TypeVarType):
                     type_var_items.append(t_item_proper)
                 else:
                     non_type_var_items.append(t_item_proper)
-            
+
             if len(type_var_items) == 1 and len(non_type_var_items) == 1:
                 # This is Union[T, X] vs Union[Y, Z] case
                 type_var = type_var_items[0]
                 non_type_var = non_type_var_items[0]
-                
+
                 # Check if any actual items are NOT subtypes of the non-type-var part
                 compatible_items = []
                 actual_proper = get_proper_type(actual)
@@ -408,7 +408,7 @@ def _infer_constraints(
                     for actual_item in actual_proper.items:
                         if not mypy.subtypes.is_subtype(actual_item, non_type_var):
                             compatible_items.append(actual_item)
-                
+
                 # If we have compatible items, create constraint for the type variable
                 if compatible_items:
                     if len(compatible_items) == 1:
@@ -416,7 +416,7 @@ def _infer_constraints(
                     else:
                         union_type = UnionType.make_union(compatible_items)
                         return [Constraint(type_var, SUBTYPE_OF, union_type)]
-        
+
         res = []
         for a_item in actual.items:
             # `orig_template` has to be preserved intact in case it's recursive.

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -403,9 +403,8 @@ def _infer_constraints(
 
                 # Check if any actual items are NOT subtypes of the non-type-var part
                 compatible_items = []
-                actual_proper = get_proper_type(actual)
-                if isinstance(actual_proper, UnionType):
-                    for actual_item in actual_proper.items:
+                if isinstance(actual, UnionType):
+                    for actual_item in actual.items:
                         if not mypy.subtypes.is_subtype(actual_item, non_type_var):
                             compatible_items.append(actual_item)
 

--- a/test-data/unit/check-typevar-union.test
+++ b/test-data/unit/check-typevar-union.test
@@ -88,7 +88,7 @@ T = TypeVar('T')
 class CreateProject:
     jsonFilePath: pathlib.Path
 
-@dataclass  
+@dataclass
 class LoadProject:
     jsonFilePath: pathlib.Path
 
@@ -122,7 +122,7 @@ T = TypeVar('T')
 class CreateProject:
     jsonFilePath: pathlib.Path
 
-@dataclass  
+@dataclass
 class LoadProject:
     jsonFilePath: pathlib.Path
 

--- a/test-data/unit/check-typevar-union.test
+++ b/test-data/unit/check-typevar-union.test
@@ -1,0 +1,145 @@
+[case testUnionTypeVarInferenceBasic]
+from typing import TypeVar, Union
+
+class A: pass
+class B: pass
+class C: pass
+
+T = TypeVar('T')
+
+def foo(x: Union[T, A]) -> T: ...
+
+obj: Union[B, C]
+reveal_type(foo(obj))  # N: Revealed type is "__main__.B | __main__.C"
+
+[builtins fixtures/tuple.pyi]
+
+[case testUnionTypeVarInferenceSingle]
+from typing import TypeVar, Union
+
+class A: pass
+class B: pass
+
+T = TypeVar('T')
+
+def foo(x: Union[T, A]) -> T: ...
+
+obj: B
+reveal_type(foo(obj))  # N: Revealed type is "__main__.B"
+
+[builtins fixtures/tuple.pyi]
+
+[case testUnionTypeVarInferenceThreeWay]
+from typing import TypeVar, Union
+
+class A: pass
+class B: pass
+class C: pass
+class D: pass
+
+T = TypeVar('T')
+
+def foo(x: Union[T, A]) -> T: ...
+
+obj: Union[B, C, D]
+reveal_type(foo(obj))  # N: Revealed type is "__main__.B | __main__.C | __main__.D"
+
+[builtins fixtures/tuple.pyi]
+
+[case testUnionTypeVarInferenceOverlapping]
+from typing import TypeVar, Union
+
+class A: pass
+class B: pass
+
+T = TypeVar('T')
+
+def foo(x: Union[T, A]) -> T: ...
+
+obj: Union[A, B]
+reveal_type(foo(obj))  # N: Revealed type is "__main__.A | __main__.B"
+
+[builtins fixtures/tuple.pyi]
+
+[case testUnionTypeVarInferenceJustA]
+from typing import TypeVar, Union
+
+class A: pass
+
+T = TypeVar('T')
+
+def foo(x: Union[T, A]) -> T: ...
+
+obj: A
+reveal_type(foo(obj))  # N: Revealed type is "__main__.A"
+
+[builtins fixtures/tuple.pyi]
+
+[case testUnionTypeVarInferenceComplex]
+from typing import TypeVar, Union
+from dataclasses import dataclass
+import pathlib
+
+class Cancelled: pass
+
+T = TypeVar('T')
+
+@dataclass
+class CreateProject:
+    jsonFilePath: pathlib.Path
+
+@dataclass  
+class LoadProject:
+    jsonFilePath: pathlib.Path
+
+@dataclass
+class MigrateProject:
+    oldJsonFilePath: pathlib.Path
+    newProjectFolderPath: pathlib.Path
+
+Project = Union[CreateProject, LoadProject, MigrateProject]
+
+def getProject() -> Union[Project, Cancelled]: ...
+
+def value(maybeCancelled: Union[T, Cancelled]) -> T: ...
+
+def main() -> None:
+    maybeCancelled = getProject()
+    project: Project = reveal_type(value(maybeCancelled))  # N: Revealed type is "__main__.CreateProject | __main__.LoadProject | __main__.MigrateProject"
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-medium.pyi]
+
+[case testUnionTypeVarInferenceComplex]
+from typing import TypeVar, Union
+import pathlib
+
+class Cancelled: pass
+
+T = TypeVar('T')
+
+@dataclass
+class CreateProject:
+    jsonFilePath: pathlib.Path
+
+@dataclass  
+class LoadProject:
+    jsonFilePath: pathlib.Path
+
+@dataclass
+class MigrateProject:
+    oldJsonFilePath: pathlib.Path
+    newProjectFolderPath: pathlib.Path
+
+Project = Union[CreateProject, LoadProject, MigrateProject]
+
+def getProject() -> Union[Project, Cancelled]: ...
+
+def value(maybeCancelled: Union[T, Cancelled]) -> T: ...
+
+def main() -> None:
+    maybeCancelled = getProject()
+    project: Project = reveal_type(value(maybeCancelled))  # N: Revealed type is "__main__.CreateProject | __main__.LoadProject | __main__.MigrateProject"
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-medium.pyi]


### PR DESCRIPTION
- Add special handling for Union[T, X] vs Union[Y, Z] case
- Implement more precise subtype checking for Union types
- Enhance type variable inference in Union type comparisons

Fix #19640 
