### PR TITLE
Somewhat better support for isinstance on old-style unions

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -582,7 +582,10 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                     and not node.node.no_args
                     and not (
                         isinstance(union_target := get_proper_type(node.node.target), UnionType)
-                        and union_target.uses_pep604_syntax
+                        and (
+                            union_target.uses_pep604_syntax
+                            or self.chk.options.python_version >= (3, 10)
+                        )
                     )
                 ):
                     self.msg.type_arguments_not_allowed(e)

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -1345,3 +1345,30 @@ x: Union[C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11]
 y: Union[C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, None]
 x = y  # E: Incompatible types in assignment (expression has type "Union[C1, C2, C3, C4, C5, <6 more items>, None]", variable has type "Union[C1, C2, C3, C4, C5, <6 more items>]") \
        # N: Item in the first union not in the second: "None"
+
+[case testTypeAliasWithOldUnionIsInstance]
+# flags: --python-version 3.10
+from typing import Union
+SimpleAlias = Union[int, str]
+
+def foo(x: Union[int, str, tuple]):
+    # TODO: fix the typeshed stub for isinstance
+    if isinstance(x, SimpleAlias):  # E: Argument 2 to "isinstance" has incompatible type "<typing special form>"; expected "type"
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str, builtins.tuple[Any, ...]]"
+    else:
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str, builtins.tuple[Any, ...]]"
+[builtins fixtures/tuple.pyi]
+
+
+[case testTypeAliasWithOldUnionIsInstancePython39]
+# flags: --python-version 3.9
+from typing import Union
+SimpleAlias = Union[int, str]
+
+def foo(x: Union[int, str, tuple]):
+    if isinstance(x, SimpleAlias):  # E: Parameterized generics cannot be used with class or instance checks \
+                                    # E: Argument 2 to "isinstance" has incompatible type "<typing special form>"; expected "type"
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str, builtins.tuple[Any, ...]]"
+    else:
+        reveal_type(x)  # N: Revealed type is "Union[builtins.int, builtins.str, builtins.tuple[Any, ...]]"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Partially fixes #17680 , remainder of the issue should probably be fixed in the isinstance stub