### PR TITLE
Revert "Enable colored output for argparse help in Python 3.14 (#19021)"

### DIFF
--- a/mypy/dmypy/client.py
+++ b/mypy/dmypy/client.py
@@ -36,9 +36,6 @@ class AugmentedHelpFormatter(argparse.RawDescriptionHelpFormatter):
 parser = argparse.ArgumentParser(
     prog="dmypy", description="Client for mypy daemon mode", fromfile_prefix_chars="@"
 )
-if sys.version_info >= (3, 14):
-    parser.color = True  # Set as init arg in 3.14
-
 parser.set_defaults(action=None)
 parser.add_argument(
     "--status-file", default=DEFAULT_STATUS_FILE, help="status file to retrieve daemon details"

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -485,8 +485,6 @@ def define_options(
         stdout=stdout,
         stderr=stderr,
     )
-    if sys.version_info >= (3, 14):
-        parser.color = True  # Set as init arg in 3.14
 
     strict_flag_names: list[str] = []
     strict_flag_assignments: list[tuple[str, bool]] = []

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -1899,8 +1899,6 @@ def parse_options(args: list[str]) -> Options:
     parser = argparse.ArgumentParser(
         prog="stubgen", usage=HEADER, description=DESCRIPTION, fromfile_prefix_chars="@"
     )
-    if sys.version_info >= (3, 14):
-        parser.color = True  # Set as init arg in 3.14
 
     parser.add_argument(
         "--ignore-errors",

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -2348,8 +2348,6 @@ def parse_options(args: list[str]) -> _Arguments:
     parser = argparse.ArgumentParser(
         description="Compares stubs to objects introspected from the runtime."
     )
-    if sys.version_info >= (3, 14):
-        parser.color = True  # Set as init arg in 3.14
     parser.add_argument("modules", nargs="*", help="Modules to test")
     parser.add_argument(
         "--concise",


### PR DESCRIPTION
Reverts #19021

After the PR was merged, `color` was changed to `true` for Python 3.14. Setting it manually is no longer necessary. https://github.com/python/cpython/pull/136809
https://docs.python.org/3.14/library/argparse.html#color