### PR TITLE
Fix forward references in type parameters of overparameterized PEP 695 type aliases

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5597,7 +5597,8 @@ class SemanticAnalyzer(
             else:
                 incomplete_target = has_placeholder(res)
 
-            if self.found_incomplete_ref(tag) or incomplete_target:
+            incomplete_tv = any(has_placeholder(tv) for tv in alias_tvars)
+            if self.found_incomplete_ref(tag) or incomplete_target or incomplete_tv:
                 # Since we have got here, we know this must be a type alias (incomplete refs
                 # may appear in nested positions), therefore use becomes_typeinfo=True.
                 self.mark_incomplete(s.name.name, s.value, becomes_typeinfo=True)

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2111,3 +2111,12 @@ if T(x) is str:     # E: "TypeAliasType" not callable
     reveal_type(x)  # N: Revealed type is "builtins.object"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
+
+[case testPEP695TypeAliasForwardReferenceInUnusedTypeVar]
+# https://discuss.python.org/t/103305
+type Alias1[T: "A"] = int
+type Alias2[T: ("A", int)] = int
+class A: ...
+
+x1: Alias1[A]  # ok
+x2: Alias2[A]  # ok


### PR DESCRIPTION
Make semanal defer for placeholders in the type variable upper bounds / constraints, even when they don't appear in the target.

https://discuss.python.org/t/mypy-raises-exception-for-certain-type-alias-definitions-with-parameters-bounded-by-a-not-yet-defined-type/103305
