### PR TITLE
Include base mypy requirements in docs requirements

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,4 @@
+-r ../mypy-requirements.txt
 sphinx>=8.1.0
 furo>=2022.3.4
 myst-parser>=4.0.0


### PR DESCRIPTION
Attempt to fix #19726

After #19062, the docs build script attempts to import `mypy.main`, so building the docs now requires all of mypy's base requirements to be present as well.