### PR TITLE
docs: move "Configuring and running mypy" section to before "Type system reference"

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,20 @@ Contents
    cheat_sheet_py3
    existing_code
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuring and running mypy
+
+   running_mypy
+   command_line
+   config_file
+   inline_config
+   mypy_daemon
+   installed_packages
+   extending_mypy
+   stubgen
+   stubtest
+
 .. _overview-type-system-reference:
 
 .. toctree::
@@ -77,20 +91,6 @@ Contents
    typed_dict
    final_attrs
    metaclasses
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Configuring and running mypy
-
-   running_mypy
-   command_line
-   config_file
-   inline_config
-   mypy_daemon
-   installed_packages
-   extending_mypy
-   stubgen
-   stubtest
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
I always struggle to find the docs pages for mypy's configuration options and command-line flags. I think it would be helpful to move these pages further up in the docs so that they're visible in the sidebar without scrolling. It also feels like better flow to have "Configuring and running mypy" come right after "First steps" instead of having the more abstract "Type system reference" section fall in between.