### PR TITLE
Fix unwrapping assignment expressions in match subject

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5552,10 +5552,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         return
 
     def visit_match_stmt(self, s: MatchStmt) -> None:
-        named_subject = self._make_named_statement_for_match(s)
         # In sync with similar actions elsewhere, narrow the target if
         # we are matching an AssignmentExpr
         unwrapped_subject = collapse_walrus(s.subject)
+        named_subject = self._make_named_statement_for_match(s, unwrapped_subject)
         with self.binder.frame_context(can_skip=False, fall_through=0):
             subject_type = get_proper_type(self.expr_checker.accept(s.subject))
 
@@ -5646,9 +5646,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
             with self.binder.frame_context(can_skip=False, fall_through=2):
                 pass
 
-    def _make_named_statement_for_match(self, s: MatchStmt) -> Expression:
+    def _make_named_statement_for_match(self, s: MatchStmt, subject: Expression) -> Expression:
         """Construct a fake NameExpr for inference if a match clause is complex."""
-        subject = s.subject
         if self.binder.can_put_directly(subject):
             # Already named - we should infer type of it as given
             return subject

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -1393,6 +1393,16 @@ match m:
         reveal_type(a)
 [builtins fixtures/isinstancelist.pyi]
 
+[case testMatchSubjectAssignExprWithGuard]
+from typing import Optional
+def func() -> Optional[str]: ...
+
+match m := func():
+    case _ if not m:
+        reveal_type(m)  # N: Revealed type is "Union[Literal[''], None]"
+    case _:
+        reveal_type(m)  # N: Revealed type is "builtins.str"
+
 -- Exhaustiveness --
 
 [case testMatchUnionNegativeNarrowing]


### PR DESCRIPTION
The `else_map` from guard clauses can only be applied properly if the subject expression itself can be put on the binder. Unwrap assignment expressions so we don't need to fall back to a dummy name and loose the guard clause inference.