### PR TITLE
Do not use outer context for `or` expr inference if the LHS has Any

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -6004,6 +6004,10 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
     def _combined_context(self, ty: Type | None) -> Type | None:
         ctx_items = []
         if ty is not None:
+            if has_any_type(ty):
+                # HACK: Any should be contagious, `dict[str, Any] or <x>` should still
+                # infer Any in x.
+                return ty
             ctx_items.append(ty)
         if self.type_context and self.type_context[-1] is not None:
             ctx_items.append(self.type_context[-1])

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1530,3 +1530,13 @@ def check3(use: bool, val: str) -> "str | Literal[False]":
 def check4(use: bool, val: str) -> "str | bool":
     return use and identity(val)
 [builtins fixtures/tuple.pyi]
+
+[case testDictAnyOrLiteralInContext]
+from typing import Union, Optional, Any
+
+def f(x: dict[str, Union[str, None, int]]) -> None:
+    pass
+
+def g(x: Optional[dict[str, Any]], s: Optional[str]) -> None:
+    f(x or {'x': s})
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes #19492.

In #19695 I tried to add another set of heuristics to `any_constraints`, but can't get that working: trying to join/meet all similar constraints together breaks inference in other cases, and only doing that for Any would be somewhat non-trivial. This PR reverts behaviour introduced in #19492 when LHS of the expression contains `Any`. Outer context is still included in all other cases, and this seems to strike a good balance.