### PR TITLE
Use more compact cache representation for int and str

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1674,7 +1674,7 @@ class Instance(ProperType):
     def serialize(self) -> JsonDict | str:
         assert self.type is not None
         type_ref = self.type.fullname
-        if not self.args and not self.last_known_value:
+        if not self.args and not self.last_known_value and not self.extra_attrs:
             return type_ref
         data: JsonDict = {
             ".class": "Instance",
@@ -1745,7 +1745,6 @@ class Instance(ProperType):
             ),
             extra_attrs=self.extra_attrs,
         )
-        # We intentionally don't copy the extra_attrs here, so they will be erased.
         new.can_be_true = self.can_be_true
         new.can_be_false = self.can_be_false
         return new

--- a/mypyc/primitives/misc_ops.py
+++ b/mypyc/primitives/misc_ops.py
@@ -430,7 +430,7 @@ function_op(
     arg_types=[object_rprimitive, uint8_rprimitive],
     return_type=none_rprimitive,
     c_function_name="write_tag_internal",
-    error_kind=ERR_MAGIC_OVERLAPPING,
+    error_kind=ERR_MAGIC,
 )
 
 function_op(

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2741,7 +2741,9 @@ def test_buffer_roundtrip() -> None:
     write_tag(b, TAG_B)
     write_int(b, 2)
     write_int(b, 2 ** 85)
+    write_int(b, 255)
     write_int(b, -1)
+    write_int(b, -255)
 
     b = Buffer(b.getvalue())
     assert read_str(b) == "foo"
@@ -2756,7 +2758,9 @@ def test_buffer_roundtrip() -> None:
     assert read_tag(b) == TAG_B
     assert read_int(b) == 2
     assert read_int(b) == 2 ** 85
+    assert read_int(b) == 255
     assert read_int(b) == -1
+    assert read_int(b) == -255
 
 [file driver.py]
 from native import *
@@ -2782,7 +2786,9 @@ def test_buffer_roundtrip_interpreted() -> None:
     write_tag(b, 255)
     write_int(b, 2)
     write_int(b, 2 ** 85)
+    write_int(b, 255)
     write_int(b, -1)
+    write_int(b, -255)
 
     b = Buffer(b.getvalue())
     assert read_str(b) == "foo"
@@ -2797,7 +2803,9 @@ def test_buffer_roundtrip_interpreted() -> None:
     assert read_tag(b) == 255
     assert read_int(b) == 2
     assert read_int(b) == 2 ** 85
+    assert read_int(b) == 255
     assert read_int(b) == -1
+    assert read_int(b) == -255
 
 test_buffer_basic_interpreted()
 test_buffer_roundtrip_interpreted()

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2744,6 +2744,8 @@ def test_buffer_roundtrip() -> None:
     write_int(b, 255)
     write_int(b, -1)
     write_int(b, -255)
+    write_int(b, 1234512344)
+    write_int(b, 1234512345)
 
     b = Buffer(b.getvalue())
     assert read_str(b) == "foo"
@@ -2761,12 +2763,38 @@ def test_buffer_roundtrip() -> None:
     assert read_int(b) == 255
     assert read_int(b) == -1
     assert read_int(b) == -255
+    assert read_int(b) == 1234512344
+    assert read_int(b) == 1234512345
+
+def test_buffer_int_size() -> None:
+    for i in (-10, -9, 0, 116, 117):
+        b = Buffer()
+        write_int(b, i)
+        assert len(b.getvalue()) == 1
+        b = Buffer(b.getvalue())
+        assert read_int(b) == i
+    for i in (-12345, -12344, -11, 118, 12344, 12345):
+        b = Buffer()
+        write_int(b, i)
+        assert len(b.getvalue()) <= 9  # sizeof(size_t) + 1
+        b = Buffer(b.getvalue())
+        assert read_int(b) == i
+
+def test_buffer_str_size() -> None:
+    for s in ("", "a", "a" * 127):
+        b = Buffer()
+        write_str(b, s)
+        assert len(b.getvalue()) == len(s) + 1
+        b = Buffer(b.getvalue())
+        assert read_str(b) == s
 
 [file driver.py]
 from native import *
 
 test_buffer_basic()
 test_buffer_roundtrip()
+test_buffer_int_size()
+test_buffer_str_size()
 
 def test_buffer_basic_interpreted() -> None:
     b = Buffer(b"foo")
@@ -2789,6 +2817,8 @@ def test_buffer_roundtrip_interpreted() -> None:
     write_int(b, 255)
     write_int(b, -1)
     write_int(b, -255)
+    write_int(b, 1234512344)
+    write_int(b, 1234512345)
 
     b = Buffer(b.getvalue())
     assert read_str(b) == "foo"
@@ -2806,9 +2836,35 @@ def test_buffer_roundtrip_interpreted() -> None:
     assert read_int(b) == 255
     assert read_int(b) == -1
     assert read_int(b) == -255
+    assert read_int(b) == 1234512344
+    assert read_int(b) == 1234512345
+
+def test_buffer_int_size_interpreted() -> None:
+    for i in (-10, -9, 0, 116, 117):
+        b = Buffer()
+        write_int(b, i)
+        assert len(b.getvalue()) == 1
+        b = Buffer(b.getvalue())
+        assert read_int(b) == i
+    for i in (-12345, -12344, -11, 118, 12344, 12345):
+        b = Buffer()
+        write_int(b, i)
+        assert len(b.getvalue()) <= 9  # sizeof(size_t) + 1
+        b = Buffer(b.getvalue())
+        assert read_int(b) == i
+
+def test_buffer_str_size_interpreted() -> None:
+    for s in ("", "a", "a" * 127):
+        b = Buffer()
+        write_str(b, s)
+        assert len(b.getvalue()) == len(s) + 1
+        b = Buffer(b.getvalue())
+        assert read_str(b) == s
 
 test_buffer_basic_interpreted()
 test_buffer_roundtrip_interpreted()
+test_buffer_int_size_interpreted()
+test_buffer_str_size_interpreted()
 
 [case testEnumMethodCalls]
 from enum import Enum


### PR DESCRIPTION
After looking more at some real data I found that:
* More than 99.9% of all `int`s are between -10 and 117. Values are a bit arbitrary TBH, the idea is that we should include small negative values (for `TypeVarId`s) and still be able to fit them in 1 byte.
* More than 99.9% of strings are shorter that 128 bytes (again the idea is to fit the length into a single byte)

Note there are very few integers that would fit in two bytes currently. This is because we only store line for type alias nodes, and type aliases are usually defined at the top of a module. We can add special case for two bytes later when needed.

We could probably save another byte for long strings and medium integers, but I don't want to have anything fancy that would only affect less than 0.1% cases.

Finally you may notice I add a small correctness change I noticed accidentally when working on this, it is not really related, but it is so minor that it doesn't deserve a separate PR.