### PR TITLE
Try fixing test times after GC hack

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3364,7 +3364,8 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
                 # TODO: see if it's possible to determine if we need to process only a
                 # _subset_ of the past SCCs instead of having to process them all.
                 if (
-                    platform.python_implementation() == "CPython"
+                    not manager.options.test_env
+                    and platform.python_implementation() == "CPython"
                     and manager.gc_freeze_cycles < MAX_GC_FREEZE_CYCLES
                 ):
                     # When deserializing cache we create huge amount of new objects, so even
@@ -3379,7 +3380,8 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
                 for prev_scc in fresh_scc_queue:
                     process_fresh_modules(graph, prev_scc, manager)
                 if (
-                    platform.python_implementation() == "CPython"
+                    not manager.options.test_env
+                    and platform.python_implementation() == "CPython"
                     and manager.gc_freeze_cycles < MAX_GC_FREEZE_CYCLES
                 ):
                     manager.gc_freeze_cycles += 1

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -133,6 +133,7 @@ class TypeCheckSuite(DataSuite):
         options = parse_options(original_program_text, testcase, incremental_step)
         options.use_builtins_fixtures = True
         options.show_traceback = True
+        options.test_env = True
 
         # Enable some options automatically based on test file name.
         if "columns" in testcase.file:

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -133,7 +133,6 @@ class TypeCheckSuite(DataSuite):
         options = parse_options(original_program_text, testcase, incremental_step)
         options.use_builtins_fixtures = True
         options.show_traceback = True
-        options.test_env = True
 
         # Enable some options automatically based on test file name.
         if "columns" in testcase.file:


### PR DESCRIPTION
I am not sure what happens, but for some reason after GC `freeze()`/`unfreeze()` hack https://github.com/python/mypy/pull/19681 was merged, compiled tests are running twice slower (on GH runner, but I also see much smaller but visible slow-down locally). I have two theories:
* The constant overhead we add outweighs the savings when running thousands of tiny builds.
* The 8% of extra memory we use goes over the limit in the runner because we were already very close to it.

In any case, I propose to try disabling this hack in most tests and see if it helps.
cc @JukkaL 

