### PR TITLE
Use empty context as fallback for return statements

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4884,7 +4884,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 alt_typ = get_proper_type(
                     self.expr_checker.accept(expr, None, allow_none_return=allow_none_func_call)
                 )
-        if not msg.has_new_errors() and is_proper_subtype(alt_typ, typ):
+        if not msg.has_new_errors() and is_subtype(alt_typ, type_ctx):
             self.store_types(type_map)
             return alt_typ
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4865,7 +4865,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         self, expr: Expression, type_ctx: Type, allow_none_func_call: bool
     ) -> ProperType:
         """Infer type of an expression with fallback to empty type context."""
-        with self.msg.filter_errors(filter_errors=True, save_filtered_errors=True) as msg:
+        with self.msg.filter_errors(
+            filter_errors=True, filter_deprecated=True, save_filtered_errors=True
+        ) as msg:
             with self.local_type_map as type_map:
                 typ = get_proper_type(
                     self.expr_checker.accept(
@@ -4879,7 +4881,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         # If there are errors with the original type context, try re-inferring in empty context.
         original_messages = msg.filtered_errors()
         original_type_map = type_map
-        with self.msg.filter_errors(filter_errors=True, save_filtered_errors=True) as msg:
+        with self.msg.filter_errors(
+            filter_errors=True, filter_deprecated=True, save_filtered_errors=True
+        ) as msg:
             with self.local_type_map as type_map:
                 alt_typ = get_proper_type(
                     self.expr_checker.accept(expr, None, allow_none_return=allow_none_func_call)

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -206,7 +206,8 @@ class ErrorWatcher:
         """
         if info.code == codes.DEPRECATED:
             # Deprecated is not a type error, so it is handled on opt-in basis here.
-            return self._filter_deprecated
+            if not self._filter_deprecated:
+                return False
 
         self._has_new_errors = True
         if isinstance(self._filter, bool):

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1540,3 +1540,17 @@ def f(x: dict[str, Union[str, None, int]]) -> None:
 def g(x: Optional[dict[str, Any]], s: Optional[str]) -> None:
     f(x or {'x': s})
 [builtins fixtures/dict.pyi]
+
+[case testReturnFallbackInference]
+from typing import TypeVar, Union
+
+T = TypeVar("T")
+def foo(x: list[T]) -> tuple[T, ...]: ...
+
+def bar(x: list[int]) -> tuple[Union[str, int], ...]:
+    return foo(x)
+
+def bar2(x: list[int]) -> tuple[Union[str, int], ...]:
+    y = foo(x)
+    return y
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1541,7 +1541,7 @@ def g(x: Optional[dict[str, Any]], s: Optional[str]) -> None:
     f(x or {'x': s})
 [builtins fixtures/dict.pyi]
 
-[case testReturnFallbackInference]
+[case testReturnFallbackInferenceTuple]
 from typing import TypeVar, Union
 
 T = TypeVar("T")
@@ -1554,3 +1554,31 @@ def bar2(x: list[int]) -> tuple[Union[str, int], ...]:
     y = foo(x)
     return y
 [builtins fixtures/tuple.pyi]
+
+[case testReturnFallbackInferenceUnion]
+from typing import Generic, TypeVar, Union
+
+T = TypeVar("T")
+
+class Cls(Generic[T]):
+    pass
+
+def inner(c: Cls[T]) -> Union[T, int]:
+    return 1
+
+def outer(c: Cls[T]) -> Union[T, int]:
+    return inner(c)
+
+[case testReturnFallbackInferenceAsync]
+from typing import Generic, TypeVar, Optional
+
+T = TypeVar("T")
+
+class Cls(Generic[T]):
+    pass
+
+async def inner(c: Cls[T]) -> Optional[T]:
+    return None
+
+async def outer(c: Cls[T]) -> Optional[T]:
+    return await inner(c)

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2188,3 +2188,19 @@ reveal_type([*map(str, x)])
 [out]
 _testUnpackIteratorBuiltins.py:4: note: Revealed type is "builtins.list[builtins.int]"
 _testUnpackIteratorBuiltins.py:5: note: Revealed type is "builtins.list[builtins.str]"
+
+[case testReturnFallbackInferenceDict]
+# Requires full dict stubs.
+from typing import Dict, Mapping, TypeVar, Union
+
+K = TypeVar("K")
+V = TypeVar("V")
+K2 = TypeVar("K2")
+V2 = TypeVar("V2")
+
+def func(one: Dict[K, V], two: Mapping[K2, V2]) -> Dict[Union[K, K2], Union[V, V2]]:
+    ...
+
+def caller(arg1: Mapping[K, V], arg2: Mapping[K2, V2]) -> Dict[Union[K, K2], Union[V, V2]]:
+    _arg1 = arg1 if isinstance(arg1, dict) else dict(arg1)
+    return func(_arg1, arg2)


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16924
Fixes https://github.com/python/mypy/issues/15886

Mypy uses external type context first, this can cause bad type inference in return statements (see example in test case added), usually we recommend a workaround to users like replacing:
```python
    return foo(x)
```
with
```python
    y = foo(x)
    return y
```
But this is a bit ugly, and more importantly we can essentially automatically try this workaround. This is what this PR adds. I checked performance impact, and don't see any (but for some reason noise level on my desktop is much higher now).