### PR TITLE
Consider non-empty enums assignable to Self

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -779,7 +779,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             if self.api.type.has_base("builtins.type"):
                 self.fail("Self type cannot be used in a metaclass", t)
             if self.api.type.self_type is not None:
-                if self.api.type.is_final:
+                if self.api.type.is_final or self.api.type.is_enum and self.api.type.enum_members:
                     return fill_typevars(self.api.type)
                 return self.api.type.self_type.copy_modified(line=t.line, column=t.column)
             # TODO: verify this is unreachable and replace with an assert?

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -2351,10 +2351,30 @@ reveal_type(gc.test())  # N: Revealed type is "builtins.list[__main__.D2]"
 from enum import Enum
 from typing import Self
 
+# This enum has members and so is implicitly final.
+# Foo and Self are interchangeable within the class.
 class Foo(Enum):
     A = 1
 
     @classmethod
-    def foo(self) -> Self:
+    def foo(cls) -> Self:
         return Foo.A
+
+    @classmethod
+    def foo2(cls) -> Self:
+        return cls.bar()
+
+    @classmethod
+    def bar(cls) -> Foo:
+        ...
+
+# This enum is empty and should not be assignable to Self
+class Bar(Enum):
+    @classmethod
+    def foo(cls) -> Self:
+        return cls.bar()  # E: Incompatible return value type (got "Bar", expected "Self")
+
+    @classmethod
+    def bar(cls) -> Bar:
+        ...
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -2346,3 +2346,15 @@ gc: G[D2]
 reveal_type(gb.test())  # N: Revealed type is "typing.Sequence[__main__.D1]"
 reveal_type(gc.test())  # N: Revealed type is "builtins.list[__main__.D2]"
 [builtins fixtures/list.pyi]
+
+[case testEnumImplicitlyFinalForSelfType]
+from enum import Enum
+from typing import Self
+
+class Foo(Enum):
+    A = 1
+
+    @classmethod
+    def foo(self) -> Self:
+        return Foo.A
+[builtins fixtures/classmethod.pyi]


### PR DESCRIPTION
Fixes #18345. See the linked ticket for reasoning - enums with members are implicitly final and should be treated exactly as if they were decorated with `@final`.