### PR TITLE
fix: Allow instantiation of type[None] in analyze_type_type_callee

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1935,7 +1935,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                 ret_type=NoneType(),
                 fallback=self.named_type("builtins.function"),
                 name=None,
-                from_type_type=True
+                from_type_type=True,
             )
 
         self.msg.unsupported_type_type(item, context)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1926,6 +1926,17 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             return self.analyze_type_type_callee(tuple_fallback(item), context)
         if isinstance(item, TypedDictType):
             return self.typeddict_callable_from_context(item)
+        if isinstance(item, NoneType):
+            # NoneType() returns None, so treat it as a callable that returns None
+            return CallableType(
+                arg_types=[],
+                arg_kinds=[],
+                arg_names=[],
+                ret_type=NoneType(),
+                fallback=self.named_type("builtins.function"),
+                name=None,
+                from_type_type=True
+            )
 
         self.msg.unsupported_type_type(item, context)
         return AnyType(TypeOfAny.from_error)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3868,6 +3868,9 @@ def f(a: Type[Tuple[int, int]]):
 
 [case testTypeUsingTypeCNoneType]
 from typing_extensions import assert_type
+
+[builtins fixtures/tuple.pyi]
+
 NoneType = type(None)
 assert_type(type(None)(), None)
 assert_type(NoneType(), None)
@@ -3876,7 +3879,7 @@ def f(n: type[None]):
     assert_type(n(), None)
 def g(n: type[NoneType]):  # type: ignore[valid-type]
     assert_type(n(), None)
-
+    
 f(NoneType)
 g(NoneType)
 [out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3867,13 +3867,16 @@ def f(a: Type[Tuple[int, int]]):
 [builtins fixtures/tuple.pyi]
 
 [case testTypeUsingTypeCNoneType]
+from typing_extensions import assert_type
 NoneType = type(None)
-type(None)()
-NoneType()
+assert_type(type(None)(), None)
+assert_type(NoneType(), None)
+
 def f(n: type[None]):
-    n()
-def g(n: type[NoneType]):
-    n()
+    assert_type(n(), None)
+def g(n: type[NoneType]):  # type: ignore[valid-type]
+    assert_type(n(), None)
+    
 f(NoneType)
 g(NoneType)
 [out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3866,6 +3866,18 @@ def f(a: Type[Tuple[int, int]]):
     a()  # E: Cannot instantiate type "type[tuple[int, int]]"
 [builtins fixtures/tuple.pyi]
 
+[case testTypeUsingTypeCNoneType]
+NoneType = type(None)
+type(None)()
+NoneType()
+def f(n: type[None]):
+    n()
+def g(n: type[NoneType]):
+    n()
+f(NoneType)
+g(NoneType)
+[out]
+
 [case testTypeUsingTypeCNamedTuple]
 from typing import Type, NamedTuple
 N = NamedTuple('N', [('x', int), ('y', int)])

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3879,7 +3879,7 @@ def f(n: type[None]):
     assert_type(n(), None)
 def g(n: type[NoneType]):  # type: ignore[valid-type]
     assert_type(n(), None)
-    
+
 f(NoneType)
 g(NoneType)
 [out]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3876,7 +3876,7 @@ def f(n: type[None]):
     assert_type(n(), None)
 def g(n: type[NoneType]):  # type: ignore[valid-type]
     assert_type(n(), None)
-    
+
 f(NoneType)
 g(NoneType)
 [out]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->

Fixes #19660

Allow instantiation of NoneType in type checker

This change fixes the error "Cannot instantiate type 'Type[None]'"
when calling NoneType() or type(None)().

By treating NoneType as a callable that returns None, mypy can now correctly
handle such calls without raising spurious errors.

Also, I added test case testTypeUsingTypeCNoneType covering:
- direct calls to type(None)() and NoneType()
- functions accepting type[None] and type[NoneType] parameters and invoking them

This ensures proper handling of NoneType instantiation and prevents spurious errors.