### PR TITLE
[mypyc] Fix subclass processing in detect_undefined_bitmap

### DIFF
--- a/mypyc/analysis/attrdefined.py
+++ b/mypyc/analysis/attrdefined.py
@@ -421,7 +421,7 @@ def detect_undefined_bitmap(cl: ClassIR, seen: set[ClassIR]) -> None:
         return
     seen.add(cl)
     for base in cl.base_mro[1:]:
-        detect_undefined_bitmap(cl, seen)
+        detect_undefined_bitmap(base, seen)
 
     if len(cl.base_mro) > 1:
         cl.bitmap_attrs.extend(cl.base_mro[1].bitmap_attrs)


### PR DESCRIPTION
Incorrect processing in detect_undefined_bitmap could cause a ValueError exception in emit_undefined_attr_check.
