### PR TITLE
Traverse ParamSpec prefix where we should

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -6435,7 +6435,7 @@ class HasAnyType(types.BoolTypeQuery):
 
     def visit_param_spec(self, t: ParamSpecType) -> bool:
         default = [t.default] if t.has_default() else []
-        return self.query_types([t.upper_bound, *default])
+        return self.query_types([t.upper_bound, *default, t.prefix])
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> bool:
         default = [t.default] if t.has_default() else []

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -222,6 +222,7 @@ class TypeVarEraser(TypeTranslator):
         return t
 
     def visit_param_spec(self, t: ParamSpecType) -> Type:
+        # TODO: we should probably preserve prefix here.
         if self.erase_id is None or self.erase_id(t.id):
             return self.replacement
         return t

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -347,6 +347,7 @@ class TypeFixer(TypeVisitor[None]):
     def visit_param_spec(self, p: ParamSpecType) -> None:
         p.upper_bound.accept(self)
         p.default.accept(self)
+        p.prefix.accept(self)
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> None:
         t.tuple_fallback.accept(self)

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -93,6 +93,7 @@ class TypeIndirectionVisitor(TypeVisitor[None]):
     def visit_param_spec(self, t: types.ParamSpecType) -> None:
         self._visit(t.upper_bound)
         self._visit(t.default)
+        self._visit(t.prefix)
 
     def visit_type_var_tuple(self, t: types.TypeVarTupleType) -> None:
         self._visit(t.upper_bound)

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -435,6 +435,7 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
             typ.flavor,
             snapshot_type(typ.upper_bound),
             snapshot_type(typ.default),
+            snapshot_type(typ.prefix),
         )
 
     def visit_type_var_tuple(self, typ: TypeVarTupleType) -> SnapshotItem:

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -489,6 +489,7 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
     def visit_param_spec(self, typ: ParamSpecType) -> None:
         typ.upper_bound.accept(self)
         typ.default.accept(self)
+        typ.prefix.accept(self)
 
     def visit_type_var_tuple(self, typ: TypeVarTupleType) -> None:
         typ.upper_bound.accept(self)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -1037,10 +1037,8 @@ class TypeTriggersVisitor(TypeVisitor[list[str]]):
         triggers = []
         if typ.fullname:
             triggers.append(make_trigger(typ.fullname))
-        if typ.upper_bound:
-            triggers.extend(self.get_type_triggers(typ.upper_bound))
-        if typ.default:
-            triggers.extend(self.get_type_triggers(typ.default))
+        triggers.extend(self.get_type_triggers(typ.upper_bound))
+        triggers.extend(self.get_type_triggers(typ.default))
         for val in typ.values:
             triggers.extend(self.get_type_triggers(val))
         return triggers
@@ -1049,22 +1047,17 @@ class TypeTriggersVisitor(TypeVisitor[list[str]]):
         triggers = []
         if typ.fullname:
             triggers.append(make_trigger(typ.fullname))
-        if typ.upper_bound:
-            triggers.extend(self.get_type_triggers(typ.upper_bound))
-        if typ.default:
-            triggers.extend(self.get_type_triggers(typ.default))
         triggers.extend(self.get_type_triggers(typ.upper_bound))
+        triggers.extend(self.get_type_triggers(typ.default))
+        triggers.extend(self.get_type_triggers(typ.prefix))
         return triggers
 
     def visit_type_var_tuple(self, typ: TypeVarTupleType) -> list[str]:
         triggers = []
         if typ.fullname:
             triggers.append(make_trigger(typ.fullname))
-        if typ.upper_bound:
-            triggers.extend(self.get_type_triggers(typ.upper_bound))
-        if typ.default:
-            triggers.extend(self.get_type_triggers(typ.default))
         triggers.extend(self.get_type_triggers(typ.upper_bound))
+        triggers.extend(self.get_type_triggers(typ.default))
         return triggers
 
     def visit_unpack_type(self, typ: UnpackType) -> list[str]:

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -525,7 +525,7 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         return self.query_types([t.upper_bound, t.default] + t.values)
 
     def visit_param_spec(self, t: ParamSpecType, /) -> bool:
-        return self.query_types([t.upper_bound, t.default])
+        return self.query_types([t.upper_bound, t.default, t.prefix])
 
     def visit_type_var_tuple(self, t: TypeVarTupleType, /) -> bool:
         return self.query_types([t.upper_bound, t.default])

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -2615,7 +2615,7 @@ class FindTypeVarVisitor(SyntheticTypeVisitor[None]):
         self.process_types([t.upper_bound, t.default] + t.values)
 
     def visit_param_spec(self, t: ParamSpecType) -> None:
-        self.process_types([t.upper_bound, t.default])
+        self.process_types([t.upper_bound, t.default, t.prefix])
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> None:
         self.process_types([t.upper_bound, t.default])

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -64,6 +64,7 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
         t.default.accept(self)
 
     def visit_param_spec(self, t: ParamSpecType, /) -> None:
+        # TODO: do we need to traverse prefix here?
         t.default.accept(self)
 
     def visit_parameters(self, t: Parameters, /) -> None:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6897,3 +6897,70 @@ import does_not_exist
 [builtins fixtures/ops.pyi]
 [out]
 [out2]
+
+[case testIncrementalNoCrashOnParamSpecPrefixUpdateMethod]
+import impl
+[file impl.py]
+from typing_extensions import ParamSpec
+from lib import Sub
+
+P = ParamSpec("P")
+class Impl(Sub[P]):
+    def test(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        self.meth(1, *args, **kwargs)
+
+[file impl.py.2]
+from typing_extensions import ParamSpec
+from lib import Sub
+
+P = ParamSpec("P")
+class Impl(Sub[P]):
+    def test(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        self.meth("no", *args, **kwargs)
+
+[file lib.py]
+from typing import Generic
+from typing_extensions import ParamSpec, Concatenate
+
+P = ParamSpec("P")
+class Base(Generic[P]):
+    def meth(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+class Sub(Base[Concatenate[int, P]]): ...
+[builtins fixtures/paramspec.pyi]
+[out]
+[out2]
+tmp/impl.py:7: error: Argument 1 to "meth" of "Base" has incompatible type "str"; expected "int"
+
+[case testIncrementalNoCrashOnParamSpecPrefixUpdateMethodAlias]
+import impl
+[file impl.py]
+from typing_extensions import ParamSpec
+from lib import Sub
+
+P = ParamSpec("P")
+class Impl(Sub[P]):
+    def test(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        self.alias(1, *args, **kwargs)
+
+[file impl.py.2]
+from typing_extensions import ParamSpec
+from lib import Sub
+
+P = ParamSpec("P")
+class Impl(Sub[P]):
+    def test(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        self.alias("no", *args, **kwargs)
+
+[file lib.py]
+from typing import Generic
+from typing_extensions import ParamSpec, Concatenate
+
+P = ParamSpec("P")
+class Base(Generic[P]):
+    def meth(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+    alias = meth
+class Sub(Base[Concatenate[int, P]]): ...
+[builtins fixtures/paramspec.pyi]
+[out]
+[out2]
+tmp/impl.py:7: error: Argument 1 has incompatible type "str"; expected "int"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -11485,3 +11485,36 @@ class A:
 [out]
 ==
 main:3: error: Too few arguments
+
+[case testFineGrainedParamSpecPrefixUpdateMethod]
+import impl
+[file impl.py]
+from typing_extensions import ParamSpec
+from lib import Sub
+
+P = ParamSpec("P")
+class Impl(Sub[P]):
+    def test(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        self.meth(1, *args, **kwargs)
+
+[file lib.py]
+from typing import Generic
+from typing_extensions import ParamSpec, Concatenate
+
+P = ParamSpec("P")
+class Base(Generic[P]):
+    def meth(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+class Sub(Base[Concatenate[int, P]]): ...
+
+[file lib.py.2]
+from typing import Generic
+from typing_extensions import ParamSpec, Concatenate
+
+P = ParamSpec("P")
+class Base(Generic[P]):
+    def meth(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+class Sub(Base[Concatenate[str, P]]): ...
+[builtins fixtures/paramspec.pyi]
+[out]
+==
+impl.py:7: error: Argument 1 to "meth" of "Base" has incompatible type "int"; expected "str"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/18087

I started from fixing an incremental crash from `fixup.py`, but then noticed we don't traverse `ParamSpec` prefix in multiple places where we should, so I fixed most of those as well.
