### PR TITLE
Make untyped_calls_exclude invalidate cache

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -74,6 +74,7 @@ OPTIONS_AFFECTING_CACHE: Final = (
         "disable_memoryview_promotion",
         "strict_bytes",
         "fixed_format_cache",
+        "untyped_calls_exclude",
     }
 ) - {"debug_cache"}
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6865,6 +6865,24 @@ if int():
 [out2]
 main:6: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 
+[case testUntypedCallsExcludeAffectsCache]
+# flags: --disallow-untyped-calls --untyped-calls-exclude=mod.Super
+# flags2: --disallow-untyped-calls --untyped-calls-exclude=mod
+# flags3: --disallow-untyped-calls --untyped-calls-exclude=mod.Super
+import mod
+[file mod.py]
+class Super:
+    def draw(self):
+        ...
+class Class(Super):
+    ...
+Class().draw()
+[out]
+tmp/mod.py:6: error: Call to untyped function "draw" in typed context
+[out2]
+[out3]
+tmp/mod.py:6: error: Call to untyped function "draw" in typed context
+
 [case testMethodMakeBoundIncremental]
 from a import A
 a = A()


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/16652

This is minor and straightforward, so I am going to just merge it (assuming everything passes).
