### PR TITLE
Add line number to function cache

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -989,6 +989,8 @@ class FuncDef(FuncItem, SymbolNode, Statement):
             ),
             "deprecated": self.deprecated,
             "original_first_arg": self.original_first_arg,
+            "line": self.line,
+            "column": self.column,
         }
 
     @classmethod
@@ -1018,6 +1020,8 @@ class FuncDef(FuncItem, SymbolNode, Statement):
             else None
         )
         ret.deprecated = data["deprecated"]
+        ret.line = data["line"]
+        ret.column = data["column"]
         # Leave these uninitialized so that future uses will trigger an error
         del ret.arguments
         del ret.max_pos
@@ -1040,6 +1044,8 @@ class FuncDef(FuncItem, SymbolNode, Statement):
             self.dataclass_transform_spec.write(data)
         write_str_opt(data, self.deprecated)
         write_str_opt(data, self.original_first_arg)
+        write_int(data, self.line)
+        write_int(data, self.column)
 
     @classmethod
     def read(cls, data: Buffer) -> FuncDef:
@@ -1058,6 +1064,8 @@ class FuncDef(FuncItem, SymbolNode, Statement):
             ret.dataclass_transform_spec = DataclassTransformSpec.read(data)
         ret.deprecated = read_str_opt(data)
         ret.original_first_arg = read_str_opt(data)
+        ret.line = read_int(data)
+        ret.column = read_int(data)
         # Leave these uninitialized so that future uses will trigger an error
         del ret.arguments
         del ret.max_pos

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -210,6 +210,7 @@ def foo() -> int:
 [out2]
 tmp/mod2.py:4: error: Incompatible return value type (got "str", expected "int")
 
+-- Function line numbers can affect error messages, so should be part of public interface.
 [case testIncrementalInternalScramble]
 import mod1
 
@@ -236,8 +237,8 @@ def bar() -> int:
 
 def baz() -> int:
     return 42
-[rechecked mod2]
-[stale]
+[rechecked mod1, mod2]
+[stale mod2]
 
 [case testIncrementalMethodInterfaceChange]
 import mod1
@@ -6897,3 +6898,20 @@ import does_not_exist
 [builtins fixtures/ops.pyi]
 [out]
 [out2]
+
+[case testCachedUnexpectedKeywordArgument]
+import a
+[file a.py]
+import b
+b.lol(uhhhh=12) # tweak
+[file a.py.2]
+import b
+b.lol(uhhhh=12)
+[file b.py]
+def lol() -> None: pass
+[out]
+tmp/a.py:2: error: Unexpected keyword argument "uhhhh" for "lol"
+tmp/b.py:1: note: "lol" defined here
+[out2]
+tmp/a.py:2: error: Unexpected keyword argument "uhhhh" for "lol"
+tmp/b.py:1: note: "lol" defined here

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -5178,6 +5178,20 @@ def g(y: T) -> T:
 a.py:2: error: Unexpected keyword argument "x"
 c.py:4: note: Called function defined here
 
+[case testFineGrainedUnexpectedKeywordArgument]
+import a
+[file a.py]
+import b
+[file a.py.2]
+import b
+b.lol(uhhhh=12)
+[file b.py]
+def lol() -> None: pass
+[out]
+==
+a.py:2: error: Unexpected keyword argument "uhhhh" for "lol"
+b.py:1: note: "lol" defined here
+
 [case testGenericFineCallableInBound]
 import a
 [file a.py]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/4772

TBH I am a bit torn here. After some thinking this is definitely needed for cache correctness, OTOH it only affects some rare error messages at a cost of potentially triggering pointless re-checking. I am leaning toward actually doing this, we should start from correctness, and optimize later. Any objections, or other ideas?