### PR TITLE
Defer when class constructor is not ready yet

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -237,6 +237,21 @@ def type_object_type(info: TypeInfo, named_type: Callable[[str], Instance]) -> P
     return result
 
 
+def has_deferred_constructor(info: TypeInfo) -> bool:
+    init_method = info.get("__init__")
+    new_method = info.get("__new__") or init_method
+    return (
+        init_method is not None
+        and _is_deferred_decorator(init_method.node)
+        or new_method is not None
+        and _is_deferred_decorator(new_method.node)
+    )
+
+
+def _is_deferred_decorator(n: SymbolNode | None) -> bool:
+    return isinstance(n, Decorator) and n.type is None
+
+
 def is_valid_constructor(n: SymbolNode | None) -> bool:
     """Does this node represents a valid constructor method?
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -9289,3 +9289,34 @@ from typ import NT
 def f() -> NT:
     return NT(x='')
 [builtins fixtures/tuple.pyi]
+
+[case testDecoratedConstructorDeferral]
+from typing import Any, Callable, TypeVar
+
+Tc = TypeVar('Tc', bound=Callable[..., Any])
+
+def any_decorator_factory() -> Callable[[Tc], Tc]:
+    def inner(func: Tc) -> Tc:
+        return func
+    return inner
+
+
+def function_pre() -> None:
+    reveal_type(GoodClass())  # N: Revealed type is "__main__.GoodClass"
+    reveal_type(BadClass())  # N: Revealed type is "Any"
+
+
+class GoodClass:
+    @any_decorator_factory()
+    def __init__(self):
+        pass
+
+class BadClass:
+    @unknown()  # E: Name "unknown" is not defined
+    def __init__(self):
+        pass
+
+
+def function_post() -> None:
+    reveal_type(GoodClass())  # N: Revealed type is "__main__.GoodClass"
+    reveal_type(BadClass())  # N: Revealed type is "Any"


### PR DESCRIPTION
Fixes #17021. Fixes #14519. 

I'm not super fond of this ad-hoc attempt to recheck the definition, but this looks like the easiest way to preserve `analyze_static_reference` behaviour of never deferring.