### PR TITLE
Update options.py: typo `scrict_equality` and phrasing

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -232,7 +232,7 @@ class Options:
         # This makes 1 == '1', 1 in ['1'], and 1 is '1' errors.
         self.strict_equality = False
 
-        # Extend the logic of `scrict_equality` for comparisons with `None`.
+        # Extend the logic of `strict_equality` to comparisons with `None`.
         self.strict_equality_for_none = False
 
         # Disable treating bytearray and memoryview as subtypes of bytes


### PR DESCRIPTION
Fixes a typo `scrict_equality` which meant `strict_equality`. While in there, I also changed a preposition to be more specific.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
