### PR TITLE
Inverse interface freshness logic

### DIFF
--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -816,7 +816,7 @@ def foo() -> int: return 10
 [file driver.py]
 import native
 
-[rechecked native, other_a]
+[rechecked other_a]
 
 [case testSeparateCompilationWithUndefinedAttribute]
 from other_a import A

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -205,7 +205,7 @@ def foo() -> int:
         return "foo"
     return inner2()
 
-[rechecked mod1, mod2]
+[rechecked mod2]
 [stale]
 [out2]
 tmp/mod2.py:4: error: Incompatible return value type (got "str", expected "int")
@@ -6982,3 +6982,19 @@ class Sub(Base[Concatenate[int, P]]): ...
 [out]
 [out2]
 tmp/impl.py:7: error: Argument 1 has incompatible type "str"; expected "int"
+
+[case testIncrementalDifferentSourcesFreshnessCorrect]
+# cmd: mypy -m foo bar
+# cmd2: mypy -m foo
+# cmd3: mypy -m foo bar
+[file foo.py]
+foo = 5
+[file foo.py.2]
+foo = None
+[file bar.py]
+from foo import foo
+bar: int = foo
+[out]
+[out2]
+[out3]
+tmp/bar.py:2: error: Incompatible types in assignment (expression has type "None", variable has type "int")


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/9554

This is another case where I am surprised id didn't work like this in the first place. Right now the freshness info originates from the dependency itself (like trust me, I am fresh, whatever it means). IMO this doesn't make much sense, instead a dependent should verify whether all dependencies are the same it last seen them. On the surface the idea is simple, but there are couple tricky parts:
* This requires splitting `write_cache()` in two phases: first write all data files in an SCC (or at least serialize them), the write all meta files. I didn't find any elegant way to do the split, but it is probably fine, as we already have this untyped meta JSON in few places.
* I am adding plugin data (used by mypyc separate compilation currently) as part of interface hash. It is not documented whether it should be this way or not, but I would say it should, and this is essentially how mypyc expects it (group name will appear in `#include <__native_group_name.h>`, so it _is_ a part of the interface). It used to work ~accidentally because we check plugin data in `find_cache_meta()` that is called before setting `interface_hash`, not in `validate_meta()`.

cc @msullivan who wrote some of the relevant code.