### PR TITLE
Try some aliases speed-up

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -21,6 +21,7 @@ from mypy.nodes import (
     ArgKind,
     TypeInfo,
 )
+from mypy.type_visitor import ALL_STRATEGY, BoolTypeQuery
 from mypy.types import (
     TUPLE_LIKE_INSTANCE_NAMES,
     AnyType,
@@ -41,7 +42,6 @@ from mypy.types import (
     TypeAliasType,
     TypedDictType,
     TypeOfAny,
-    TypeQuery,
     TypeType,
     TypeVarId,
     TypeVarLikeType,
@@ -670,9 +670,9 @@ def is_complete_type(typ: Type) -> bool:
     return typ.accept(CompleteTypeVisitor())
 
 
-class CompleteTypeVisitor(TypeQuery[bool]):
+class CompleteTypeVisitor(BoolTypeQuery):
     def __init__(self) -> None:
-        super().__init__(all)
+        super().__init__(ALL_STRATEGY)
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> bool:
         return False

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -37,16 +37,15 @@ class TypeIndirectionVisitor(TypeVisitor[None]):
         return self.modules
 
     def _visit(self, typ: types.Type) -> None:
-        if isinstance(typ, types.TypeAliasType):
+        if isinstance(typ, types.TypeAliasType) and typ.is_recursive:
             # Avoid infinite recursion for recursive type aliases.
-            if typ not in self.seen_aliases:
-                self.seen_aliases.add(typ)
+            self.seen_aliases.add(typ)
         typ.accept(self)
 
     def _visit_type_tuple(self, typs: tuple[types.Type, ...]) -> None:
         # Micro-optimization: Specialized version of _visit for lists
         for typ in typs:
-            if isinstance(typ, types.TypeAliasType):
+            if isinstance(typ, types.TypeAliasType) and typ.is_recursive:
                 # Avoid infinite recursion for recursive type aliases.
                 if typ in self.seen_aliases:
                     continue
@@ -56,7 +55,7 @@ class TypeIndirectionVisitor(TypeVisitor[None]):
     def _visit_type_list(self, typs: list[types.Type]) -> None:
         # Micro-optimization: Specialized version of _visit for tuples
         for typ in typs:
-            if isinstance(typ, types.TypeAliasType):
+            if isinstance(typ, types.TypeAliasType) and typ.is_recursive:
                 # Avoid infinite recursion for recursive type aliases.
                 if typ in self.seen_aliases:
                     continue

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -83,12 +83,11 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
 
     def visit_type_alias_type(self, t: TypeAliasType) -> None:
         super().visit_type_alias_type(t)
-        if t in self.seen_aliases:
-            # Avoid infinite recursion on recursive type aliases.
-            # Note: it is fine to skip the aliases we have already seen in non-recursive
-            # types, since errors there have already been reported.
-            return
-        self.seen_aliases.add(t)
+        if t.is_recursive:
+            if t in self.seen_aliases:
+                # Avoid infinite recursion on recursive type aliases.
+                return
+            self.seen_aliases.add(t)
         assert t.alias is not None, f"Unfixed type alias {t.type_ref}"
         is_error, is_invalid = self.validate_args(
             t.alias.name, tuple(t.args), t.alias.alias_tvars, t

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -43,6 +43,7 @@ from mypy.nodes import (
     YieldFromExpr,
 )
 from mypy.traverser import TraverserVisitor
+from mypy.type_visitor import ANY_STRATEGY, BoolTypeQuery
 from mypy.typeanal import collect_all_inner_types
 from mypy.types import (
     AnyType,
@@ -52,7 +53,6 @@ from mypy.types import (
     TupleType,
     Type,
     TypeOfAny,
-    TypeQuery,
     TypeVarType,
     get_proper_type,
     get_proper_types,
@@ -453,9 +453,9 @@ def is_imprecise(t: Type) -> bool:
     return t.accept(HasAnyQuery())
 
 
-class HasAnyQuery(TypeQuery[bool]):
+class HasAnyQuery(BoolTypeQuery):
     def __init__(self) -> None:
-        super().__init__(any)
+        super().__init__(ANY_STRATEGY)
 
     def visit_any(self, t: AnyType) -> bool:
         return not is_special_form_any(t)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -201,18 +201,6 @@ class TypesSuite(Suite):
         assert get_proper_type(A) == target
         assert get_proper_type(target) == target
 
-    def test_type_alias_expand_all(self) -> None:
-        A, _ = self.fx.def_alias_1(self.fx.a)
-        assert A.expand_all_if_possible() is None
-        A, _ = self.fx.def_alias_2(self.fx.a)
-        assert A.expand_all_if_possible() is None
-
-        B = self.fx.non_rec_alias(self.fx.a)
-        C = self.fx.non_rec_alias(TupleType([B, B], Instance(self.fx.std_tuplei, [B])))
-        assert C.expand_all_if_possible() == TupleType(
-            [self.fx.a, self.fx.a], Instance(self.fx.std_tuplei, [self.fx.a])
-        )
-
     def test_recursive_nested_in_non_recursive(self) -> None:
         A, _ = self.fx.def_alias_1(self.fx.a)
         T = TypeVarType(

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
-from typing import Any, Callable, Final, Generic, TypeVar, cast
+from typing import Any, Final, Generic, TypeVar, cast
 
 from mypy_extensions import mypyc_attr, trait
 
@@ -353,15 +353,18 @@ class TypeQuery(SyntheticTypeVisitor[T]):
     # TODO: check that we don't have existing violations of this rule.
     """
 
-    def __init__(self, strategy: Callable[[list[T]], T]) -> None:
-        self.strategy = strategy
+    def __init__(self) -> None:
         # Keep track of the type aliases already visited. This is needed to avoid
         # infinite recursion on types like A = Union[int, List[A]].
-        self.seen_aliases: set[TypeAliasType] = set()
+        self.seen_aliases: set[TypeAliasType] | None = None
         # By default, we eagerly expand type aliases, and query also types in the
         # alias target. In most cases this is a desired behavior, but we may want
         # to skip targets in some cases (e.g. when collecting type variables).
         self.skip_alias_target = False
+
+    @abstractmethod
+    def strategy(self, items: list[T]) -> T:
+        raise NotImplementedError
 
     def visit_unbound_type(self, t: UnboundType, /) -> T:
         return self.query_types(t.args)
@@ -440,14 +443,15 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return self.query_types(t.args)
 
     def visit_type_alias_type(self, t: TypeAliasType, /) -> T:
-        # Skip type aliases already visited types to avoid infinite recursion.
-        # TODO: Ideally we should fire subvisitors here (or use caching) if we care
-        #       about duplicates.
-        if t in self.seen_aliases:
-            return self.strategy([])
-        self.seen_aliases.add(t)
         if self.skip_alias_target:
             return self.query_types(t.args)
+        # Skip type aliases already visited types to avoid infinite recursion.
+        if t.is_recursive:
+            if self.seen_aliases is None:
+                self.seen_aliases = set()
+            elif t in self.seen_aliases:
+                return self.strategy([])
+            self.seen_aliases.add(t)
         return get_proper_type(t).accept(self)
 
     def query_types(self, types: Iterable[Type]) -> T:
@@ -580,16 +584,15 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         return self.query_types(t.args)
 
     def visit_type_alias_type(self, t: TypeAliasType, /) -> bool:
-        # Skip type aliases already visited types to avoid infinite recursion.
-        # TODO: Ideally we should fire subvisitors here (or use caching) if we care
-        #       about duplicates.
-        if self.seen_aliases is None:
-            self.seen_aliases = set()
-        elif t in self.seen_aliases:
-            return self.default
-        self.seen_aliases.add(t)
         if self.skip_alias_target:
             return self.query_types(t.args)
+        # Skip type aliases already visited types to avoid infinite recursion.
+        if t.is_recursive:
+            if self.seen_aliases is None:
+                self.seen_aliases = set()
+            elif t in self.seen_aliases:
+                return self.default
+            self.seen_aliases.add(t)
         return get_proper_type(t).accept(self)
 
     def query_types(self, types: list[Type] | tuple[Type, ...]) -> bool:

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -1114,12 +1114,12 @@ def get_all_type_vars(tp: Type) -> list[TypeVarLikeType]:
 
 class TypeVarExtractor(TypeQuery[list[TypeVarLikeType]]):
     def __init__(self, include_all: bool = False) -> None:
-        super().__init__(self._merge)
+        super().__init__()
         self.include_all = include_all
 
-    def _merge(self, iter: Iterable[list[TypeVarLikeType]]) -> list[TypeVarLikeType]:
+    def strategy(self, items: Iterable[list[TypeVarLikeType]]) -> list[TypeVarLikeType]:
         out = []
-        for item in iter:
+        for item in items:
             out.extend(item)
         return out
 

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -189,7 +189,7 @@ class A(NamedTuple('A', [('attr', List[Exp])])): pass
 class B(NamedTuple('B', [('val', object)])): pass
 
 def my_eval(exp: Exp) -> int:
-    reveal_type(exp) # N: Revealed type is "Union[tuple[builtins.list[...], fallback=__main__.A], tuple[builtins.object, fallback=__main__.B]]"
+    reveal_type(exp) # N: Revealed type is "Union[tuple[builtins.list[Union[..., tuple[builtins.object, fallback=__main__.B]]], fallback=__main__.A], tuple[builtins.object, fallback=__main__.B]]"
     if isinstance(exp, A):
         my_eval(exp[0][0])
         return my_eval(exp.attr[0])
@@ -578,7 +578,7 @@ B = NamedTuple('B', [('x', A), ('y', int)])
 A = NamedTuple('A', [('x', str), ('y', 'B')])
 n: A
 def f(m: B) -> None: pass
-reveal_type(n) # N: Revealed type is "tuple[builtins.str, tuple[..., builtins.int, fallback=__main__.B], fallback=__main__.A]"
+reveal_type(n) # N: Revealed type is "tuple[builtins.str, tuple[tuple[builtins.str, ..., fallback=__main__.A], builtins.int, fallback=__main__.B], fallback=__main__.A]"
 reveal_type(f) # N: Revealed type is "def (m: tuple[tuple[builtins.str, ..., fallback=__main__.A], builtins.int, fallback=__main__.B])"
 f(n)  # E: Argument 1 to "f" has incompatible type "A"; expected "B"
 [builtins fixtures/tuple.pyi]
@@ -1013,4 +1013,4 @@ from typing import Callable
 from bogus import Foo  # type: ignore
 
 A = Callable[[Foo, "B"], Foo]  # E: Type alias target becomes "Callable[[Any, B], Any]" due to an unfollowed import
-B = Callable[[Foo, A], Foo]  # E: Type alias target becomes "Callable[[Any, A], Any]" due to an unfollowed import
+B = Callable[[Foo, A], Foo]  # E: Type alias target becomes "Callable[[Any, Callable[[Any, B], Any]], Any]" due to an unfollowed import

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -3528,9 +3528,9 @@ reveal_type(a.n)
 [out]
 ==
 ==
-c.py:4: note: Revealed type is "tuple[Union[tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
+c.py:4: note: Revealed type is "tuple[Union[tuple[Union[tuple[Union[..., None], builtins.int, fallback=a.N], None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 c.py:5: error: Incompatible types in assignment (expression has type "Optional[N]", variable has type "int")
-c.py:7: note: Revealed type is "tuple[Union[tuple[Union[..., None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
+c.py:7: note: Revealed type is "tuple[Union[tuple[Union[tuple[Union[..., None], builtins.int, fallback=a.N], None], builtins.int, fallback=b.M], None], builtins.int, fallback=a.N]"
 
 [case testTupleTypeUpdateNonRecursiveToRecursiveFine]
 import c


### PR DESCRIPTION
This makes self-check almost 2% faster on my desktop (Python 3.12, compiled -O2). Inspired by a slight regression in https://github.com/python/mypy/pull/19798 I decided to re-think how we detect/label the recursive types.

The new algorithm is not 100% equivalent to old one, but should be much faster. The main semantic difference is this:
```python
A = list[B1]
B1 = list[B2]
B2 = list[B1]
```
previously all three aliases where labeled as recursive, now only last two are. Which is kind of correct if you think about it for some time, there is nothing genuinely recursive in `A` by itself. As a result:
* We have somewhat more verbose (but also technically more consistent) `reveal_type()` for _mutually_ recursive aliases (we can probably add some more heuristics if people find it too verbose).
* We can now speed up a bunch of type queries by only using sets for genuinely recursive aliases. This dramatically reduces number of `set_ops` that are known to be slow.
* I also do couple cleanups/speedups in the type queries while I am at it.

If there are no comments/objections, I will merge it later today. Then I will merge https://github.com/python/mypy/pull/19798, and then _maybe_ an equivalent optimization for recursive instances like `class str(Sequence[str]): ...`