### PR TITLE
small fix in get_default_function_sig

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -322,7 +322,7 @@ class InspectionStubGenerator(BaseStubGenerator):
                 default_value = get_default_value(i, arg)
                 if default_value is not _Missing.VALUE:
                     if arg in annotations:
-                        argtype = annotations[arg]
+                        argtype = get_annotation(arg)
                     else:
                         argtype = self.get_type_annotation(default_value)
                         if argtype == "None":


### PR DESCRIPTION
This small change fixes a  crash in the case when a function arg has both a default value and a non-string type annotation.

Here is an example:
```
def f(i: int = 0): pass
```

Before the change, it crashed as follows:
```
 % stubgen --inspect-mode -o . f.py
Traceback (most recent call last):
  File "/Users/iap/PycharmProjects/py10x/.venv/bin/stubgen", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "mypy/stubgen.py", line 2047, in main
  File "mypy/stubgen.py", line 1848, in generate_stubs
  File "mypy/stubgen.py", line 1806, in generate_stub_for_py_module
  File "/Users/iap/PycharmProjects/py10x/.venv/lib/python3.11/site-packages/mypy/stubgenc.py", line 452, in generate_module
    self.generate_function_stub(name, obj, output=functions)
  File "/Users/iap/PycharmProjects/py10x/.venv/lib/python3.11/site-packages/mypy/stubgenc.py", line 633, in generate_function_stub
    self.process_inferred_sigs(inferred)
  File "/Users/iap/PycharmProjects/py10x/.venv/lib/python3.11/site-packages/mypy/stubgenc.py", line 602, in process_inferred_sigs
    arg.type = self.strip_or_import(arg.type)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/iap/PycharmProjects/py10x/.venv/lib/python3.11/site-packages/mypy/stubgenc.py", line 398, in strip_or_import
    parsed_type = parse_type_comment(type_name, 0, 0, None)[1]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "mypy/fastparse.py", line 303, in parse_type_comment
TypeError: str object expected; got type
```

After the change, it works properly:

```
% stubgen --inspect-mode -o . f.py                      
Processed 1 modules
Generated ./f.pyi

% cat f.pyi 
def f(i: int = ...): ...
```



