### PR TITLE
Update kinds_of_types.rst: keep old anchor for #no-strict-optional

### DIFF
--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -294,6 +294,7 @@ isn't supported by the runtime with some limitations, if you use
    def f(x: int | str) -> None:   # OK on Python 3.7 and later
        ...
 
+.. _no-strict-optional:
 .. _strict_optional:
 
 Optional types and the None type


### PR DESCRIPTION
Addresses https://github.com/python/mypy/pull/19252#issuecomment-2953310853
> support this old anchor, for people on older mypy versions

This way, when people get the old documentation link, it will continue to go to the right place.

I have looked at the documentation that gets generated locally to see if everything still works. It does. In our vast panoply of documentation, we now have two very similar refs, `no-strict-optional` and `no_strict_optional` (used in https://mypy.readthedocs.io/en/stable/common_issues.html#no-errors-reported-for-obviously-wrong-code to link to https://mypy.readthedocs.io/en/stable/command_line.html#no-strict-optional) but the software handles them fine, without getting confused.