### PR TITLE
Update docs.yml: add mypy/main.py

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,9 @@ on:
     # so it's important to do the docs build on all PRs touching mypy/errorcodes.py
     # in case somebody's adding a new error code without any docs
     - 'mypy/errorcodes.py'
+    # Part of the documentation is automatically generated from the options
+    # definitions in mypy/main.py
+    - 'mypy/main.py'
     - 'mypyc/doc/**'
     - '**/*.rst'
     - '**/*.md'


### PR DESCRIPTION
Part of the documentation is automatically generated from the options definitions in mypy/main.py, so we need to run the docs CI when that file is modified.

This follows up on https://github.com/python/mypy/pull/19727, which itself follows up on https://github.com/python/mypy/pull/19062