### PR TITLE
Update main.py: remove superfluous `--experimental` flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1204,13 +1204,6 @@ def define_options(
     )
 
     if server_options:
-        # TODO: This flag is superfluous; remove after a short transition (2018-03-16)
-        other_group.add_argument(
-            "--experimental",
-            action="store_true",
-            dest="fine_grained_incremental",
-            help="Enable fine-grained incremental mode",
-        )
         other_group.add_argument(
             "--use-fine-grained-cache",
             action="store_true",


### PR DESCRIPTION
This commit removes the --experimental flag, completing a TODO from 2018-03-16.

It seems like this flag is unused and undocumented and the task of removing it "after a short transition" simply slipped under everyone's radar.