### PR TITLE
[mypyc] Fix crash with NewType and other non-class types in incremental builds

### DIFF
--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -163,6 +163,8 @@ def load_type_map(mapper: Mapper, modules: list[MypyFile], deser_ctx: DeserMaps)
                 isinstance(node.node, TypeInfo)
                 and is_from_module(node.node, module)
                 and not node.node.is_newtype
+                and not node.node.is_named_tuple
+                and node.node.typeddict_type is None
             ):
                 ir = deser_ctx.classes[node.node.fullname]
                 mapper.type_to_ir[node.node] = ir

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -903,12 +903,12 @@ import native
 0
 None
 
-[case testIncrementalCompilationWithNewType]
+[case testIncrementalCompilationWithNonClassTypeDef]
 import other_a
 [file other_a.py]
 from other_b import MyInt
 [file other_a.py.2]
-from other_b import MyInt
+from other_b import MyInt, NT, TD
 i = MyInt(42)
 
 def f(x: MyInt) -> int:
@@ -920,13 +920,33 @@ def g(x: int) -> MyInt:
 print(i)
 print(f(i))
 print(g(13))
+
+def make_nt(x: int) -> NT:
+    return NT(x=MyInt(x))
+
+print(make_nt(4))
+
+def make_td(x: int) -> TD:
+    return {"x": MyInt(x)}
+
+print(make_td(5))
+
 [file other_b.py]
-from typing import NewType
+from typing import NewType, NamedTuple, TypedDict
+from enum import Enum
+
 MyInt = NewType("MyInt", int)
+NT = NamedTuple("NT", [("x", MyInt)])
+TD = TypedDict("TD", {"x": MyInt})
+
 [file driver.py]
 import native
+
+[typing fixtures/typing-full.pyi]
 [out]
 [out2]
 42
 43
 15
+NT(x=4)
+{'x': 5}


### PR DESCRIPTION
Fixes https://github.com/mypyc/mypyc/issues/1138. Also fix similar issue with named tuples and TypedDicts.