### PR TITLE
Fix crash on recursive alias in indirection.py

### DIFF
--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -39,8 +39,9 @@ class TypeIndirectionVisitor(TypeVisitor[None]):
     def _visit(self, typ: types.Type) -> None:
         if isinstance(typ, types.TypeAliasType):
             # Avoid infinite recursion for recursive type aliases.
-            if typ not in self.seen_aliases:
-                self.seen_aliases.add(typ)
+            if typ in self.seen_aliases:
+                return
+            self.seen_aliases.add(typ)
         typ.accept(self)
 
     def _visit_type_tuple(self, typs: tuple[types.Type, ...]) -> None:

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2577,6 +2577,13 @@ C(1)[0]
 [builtins fixtures/list.pyi]
 [out]
 
+[case testSerializeRecursiveAlias]
+from typing import Callable, Union
+
+Node = Union[str, int, Callable[[], "Node"]]
+n: Node
+[out]
+
 [case testSerializeRecursiveAliases1]
 
 from typing import Type, Callable, Union


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/19836

Fix is trivial, I am surprised none of the existing tests caught this in the original PR. After this is merged, I am going to add the test to `master`.