### PR TITLE
[mypyc] fix: inappropriate `None`s in f-strings

### DIFF
--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -719,7 +719,9 @@ def translate_fstring(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Va
             if isinstance(expr, StrExpr):
                 return expr.value
             elif isinstance(expr, RefExpr) and isinstance(expr.node, Var) and expr.node.is_final:
-                return str(expr.node.final_value)
+                final_value = expr.node.final_value
+                if final_value is not None:
+                    return str(final_value)
             return None
 
         for i in range(len(exprs) - 1):


### PR DESCRIPTION
if a variable is Final but the value is not yet known at compile-time, and that variable is used as an input to an f-string, the f-string will incorrectly contain "None"

Fixes [mypyc#1140](https://github.com/mypyc/mypyc/issues/1140)
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
