### PR TITLE
[docs] Small improvement to report --help documentation

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1127,13 +1127,13 @@ def define_options(
     internals_group.add_argument("--export-ref-info", action="store_true", help=argparse.SUPPRESS)
 
     report_group = parser.add_argument_group(
-        title="Report generation", description="Generate a report in the specified format."
+        title="Report generation", description="Generate a report in the specified format in the specified directory."
     )
     for report_type in sorted(defaults.REPORTER_NAMES):
         if report_type not in {"memory-xml"}:
             report_group.add_argument(
                 f"--{report_type.replace('_', '-')}-report",
-                metavar="DIR",
+                metavar="OUTPUT_DIR",
                 dest=f"special-opts:{report_type}_report",
             )
 


### PR DESCRIPTION
When I started using the reports functionality, I found the --help documentation a bit confusing at first. This elaborates it a little bit to make it clear that the "DIR" is an output dir (and not, say, a source dir).

I manually tested this to make sure the new help text was right. (It does the obvious thing, indeed.)

Out of curiosity, I also manually tested what happens if you remove the metavar here. It displays long default metavars like SPECIAL-OPTS:HTML_REPORT, which is not helpful — so I didn't do that.