### PR TITLE
[nit] command_line.rst: the standard format for multiple choice has no space

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -1159,7 +1159,7 @@ format into the specified directory.
 Enabling incomplete/experimental features
 *****************************************
 
-.. option:: --enable-incomplete-feature {PreciseTupleTypes, InlineTypedDict}
+.. option:: --enable-incomplete-feature {PreciseTupleTypes,InlineTypedDict}
 
     Some features may require several mypy releases to implement, for example
     due to their complexity, potential for backwards incompatibility, or


### PR DESCRIPTION
Removing this spaces causes this documentation to match the other documentation on the page, and also in `--help`

There are no tests for this change. I manually verified that the link to the option currently is https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-enable-incomplete-feature, so changing the arguments text does not necessitate adding a new anchor in to preserve old inbound links to this section.