### PR TITLE
Rename optional arguments group to utility arguments.

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -85,8 +85,9 @@ for full details, see :ref:`running-mypy`.
 
     This flag will add everything that matches ``.gitignore`` file(s) to :option:`--exclude`.
 
+.. _optional-arguments:
 
-Optional arguments
+Utility arguments
 ******************
 
 .. option:: -h, --help

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -549,7 +549,7 @@ def define_options(
     #     long and will break up into multiple lines if we include that prefix, so for consistency
     #     we omit the prefix on all links.)
 
-    general_group = parser.add_argument_group(title="Optional arguments")
+    general_group = parser.add_argument_group(title="Utility arguments")
     general_group.add_argument(
         "-h", "--help", action="help", help="Show this help message and exit"
     )


### PR DESCRIPTION
The rationale behind this is that all of our arguments are optional, so that name isn't very good. But these are options that deal with the program as a utility (eg, version number) so that's a more fitting name.

The old anchor is recreated to aid incoming old links.

I have manually verified that the --help looks right.