### PR TITLE
feat: implement constant folding for str.format

### DIFF
--- a/mypy/constant_fold.py
+++ b/mypy/constant_fold.py
@@ -81,7 +81,7 @@ def constant_fold_expr(expr: Expression, cur_mod_id: str) -> ConstantValue | Non
     elif (
         isinstance(expr, CallExpr)
         and isinstance(callee := expr.callee, MemberExpr)
-        and isinstance(callee.expr, StrExpr)
+        and isinstance(folded_callee := constant_fold_expr(callee.expr, cur_mod_id), str)
         and callee.name == "join"
         and len(args := expr.args) == 1
         and isinstance(arg := args[0], (ListExpr, TupleExpr))
@@ -92,7 +92,7 @@ def constant_fold_expr(expr: Expression, cur_mod_id: str) -> ConstantValue | Non
             if not isinstance(val, str):
                 return None
             folded_items.append(val)
-        return callee.expr.value.join(folded_items)
+        return folded_callee.join(folded_items)
     return None
 
 

--- a/mypy/constant_fold.py
+++ b/mypy/constant_fold.py
@@ -205,7 +205,3 @@ def constant_fold_unary_op(op: str, value: ConstantValue) -> int | float | None:
     elif op == "+" and isinstance(value, (int, float)):
         return value
     return None
-
-
-def is_f_string_expr(expr: Expression) -> TypeGuard[CallExpr]:
-    

--- a/mypy/constant_fold.py
+++ b/mypy/constant_fold.py
@@ -8,19 +8,19 @@ from __future__ import annotations
 from typing import Final, Union
 
 from mypy.nodes import (
+    CallExpr,
     ComplexExpr,
     Expression,
     FloatExpr,
     IntExpr,
+    ListExpr,
+    MemberExpr,
     NameExpr,
     OpExpr,
     StrExpr,
+    TupleExpr,
     UnaryExpr,
     Var,
-    CallExpr,
-    MemberExpr,
-    ListExpr,
-    TupleExpr,
 )
 
 # All possible result types of constant folding


### PR DESCRIPTION
This PR builds off of #19884 to implement constant folding for str.format, which is only quasi-useful by itself but when combined with 19884 allows us to constant fold f-strings.