### PR TITLE
[docs] Fix a common and harmless grammatical error, 'allows to'

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -372,7 +372,7 @@ definitions or calls.
 
 .. option:: --untyped-calls-exclude
 
-    This flag allows to selectively disable :option:`--disallow-untyped-calls`
+    This flag allows one to selectively disable :option:`--disallow-untyped-calls`
     for functions and methods defined in specific packages, modules, or classes.
     Note that each exclude entry acts as a prefix. For example (assuming there
     are no type annotations for ``third_party_lib`` available):
@@ -562,7 +562,7 @@ potentially problematic or redundant in some way.
 
 .. option:: --deprecated-calls-exclude
 
-    This flag allows to selectively disable :ref:`deprecated<code-deprecated>` warnings
+    This flag allows one to selectively disable :ref:`deprecated<code-deprecated>` warnings
     for functions and methods defined in specific packages, modules, or classes.
     Note that each exclude entry acts as a prefix. For example (assuming ``foo.A.func`` is deprecated):
 

--- a/docs/source/error_code_list.rst
+++ b/docs/source/error_code_list.rst
@@ -1032,8 +1032,8 @@ Warn about top level await expressions [top-level-await]
 This error code is separate from the general ``[syntax]`` errors, because in
 some environments (e.g. IPython) a top level ``await`` is allowed. In such
 environments a user may want to use ``--disable-error-code=top-level-await``,
-that allows to still have errors for other improper uses of ``await``, for
-example:
+which allows one to still have errors for other improper uses of ``await``,
+for example:
 
 .. code-block:: python
 

--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -252,16 +252,16 @@ command.
 Statically inspect expressions
 ******************************
 
-The daemon allows to get declared or inferred type of an expression (or other
+The daemon allows one to get the declared or inferred type of an expression (or other
 information about an expression, such as known attributes or definition location)
-using ``dmypy inspect LOCATION`` command. The location of the expression should be
+using the ``dmypy inspect LOCATION`` command. The location of the expression should be
 specified in the format ``path/to/file.py:line:column[:end_line:end_column]``.
 Both line and column are 1-based. Both start and end position are inclusive.
 These rules match how mypy prints the error location in error messages.
 
 If a span is given (i.e. all 4 numbers), then only an exactly matching expression
 is inspected. If only a position is given (i.e. 2 numbers, line and column), mypy
-will inspect all *expressions*, that include this position, starting from the
+will inspect all expressions that include this position, starting from the
 innermost one.
 
 Consider this Python code snippet:

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -504,7 +504,7 @@ class ExtendedTraverserVisitor(TraverserVisitor):
     In addition to the base traverser it:
         * has visit_ methods for leaf nodes
         * has common method that is called for all nodes
-        * allows to skip recursing into a node
+        * allows skipping recursing into a node
 
     Note that this traverser still doesn't visit some internal
     mypy constructs like _promote expression and Var.


### PR DESCRIPTION
This is a grammatical error (at least in American English, which I think this project is written in) because in the relevant sense the verb "allows" is transitive and needs to apply to a noun, not a verb.

More info, if desired:

https://english.stackexchange.com/questions/60271/grammatical-complements-for-allow

https://english.stackexchange.com/questions/85069/is-the-construction-it-allows-to-proper-english

(I don't know of any weighty publications who have taken this question on, so it's just a bunch of speakers, such as myself, opining.)
