### PR TITLE
Don't consider indirect dependencies when calculating SCCs

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3488,7 +3488,7 @@ def process_stale_scc(graph: Graph, scc: list[str], manager: BuildManager) -> No
 
 
 def sorted_components(
-    graph: Graph, vertices: AbstractSet[str] | None = None, pri_max: int = PRI_ALL
+    graph: Graph, vertices: AbstractSet[str] | None = None, pri_max: int = PRI_INDIRECT
 ) -> list[AbstractSet[str]]:
     """Return the graph's SCCs, topologically sorted by dependencies.
 


### PR DESCRIPTION
SCC construction should only consider import dependencies, since indirect dependencies are not available during non-incremental runs. I think otherwise SCCs can be different in non-incremental vs incremtal runs.

Attempt to fix an issue with excessively large SCCs computed (sometimes) after #19798 when doing incremental runs. I haven't been able to create a self-contained test case that reproduces the issue, but this appears to fix this issue with an internal codebase.