### PR TITLE
do not exclude misc/sync-typeshed.pyfrom from tox self-check

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,5 +62,5 @@ passenv =
     MYPY_FORCE_TERMINAL_WIDTH
 commands =
     python runtests.py self
-    python -m mypy --config-file mypy_self_check.ini misc --exclude misc/sync-typeshed.py
+    python -m mypy --config-file mypy_self_check.ini misc
     python -m mypy --config-file mypy_self_check.ini test-data/unit/plugins


### PR DESCRIPTION
it's fine; we can just typecheck it