### PR TITLE
[mypyc] feat: call native `__len__` when defined

### DIFF
--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2446,14 +2446,8 @@ class LowLevelIRBuilder:
             assert not use_pyssize_t
             class_ir = typ.class_ir
 
-            # Optimize for native extension classes (not built-in base, not Python subclass)
-            # Direct C call for final native methods and exact type
-            if (
-                class_ir.is_ext_class
-                and not class_ir.inherits_python
-                and class_ir.has_method("__len__")
-                and class_ir.is_method_final("__len__")
-            ):
+            # Direct C call for final native __len__ methods
+            if class_ir.has_method("__len__") and class_ir.is_method_final("__len__"):
                 decl = class_ir.method_decl("__len__")
                 length = self.call(decl, [val], [ARG_POS], [None], line)
 

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2453,7 +2453,7 @@ class LowLevelIRBuilder:
             else:
                 # Fallback: generic method call for non-native or ambiguous cases
                 length = self.gen_method_call(val, "__len__", [], int_rprimitive, line)
-            
+
             length = self.coerce(length, int_rprimitive, line)
             ok, fail = BasicBlock(), BasicBlock()
             cond = self.binary_op(length, Integer(0), ">=", line)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2450,24 +2450,10 @@ class LowLevelIRBuilder:
             if class_ir.has_method("__len__") and class_ir.is_method_final("__len__"):
                 decl = class_ir.method_decl("__len__")
                 length = self.call(decl, [val], [ARG_POS], [None], line)
-
-                # Coerce/check result and error handling as before
-                length = self.coerce(length, int_rprimitive, line)
-                ok, fail = BasicBlock(), BasicBlock()
-                cond = self.binary_op(length, Integer(0), ">=", line)
-                self.add_bool_branch(cond, ok, fail)
-                self.activate_block(fail)
-                self.add(
-                    RaiseStandardError(
-                        RaiseStandardError.VALUE_ERROR, "__len__() should return >= 0", line
-                    )
-                )
-                self.add(Unreachable())
-                self.activate_block(ok)
-                return length
-
-            # Fallback: generic method call for non-native or ambiguous cases
-            length = self.gen_method_call(val, "__len__", [], int_rprimitive, line)
+            else:
+                # Fallback: generic method call for non-native or ambiguous cases
+                length = self.gen_method_call(val, "__len__", [], int_rprimitive, line)
+            
             length = self.coerce(length, int_rprimitive, line)
             ok, fail = BasicBlock(), BasicBlock()
             cond = self.binary_op(length, Integer(0), ">=", line)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2441,9 +2441,35 @@ class LowLevelIRBuilder:
             offset = Integer(1, c_pyssize_t_rprimitive, line)
             return self.int_op(short_int_rprimitive, size_value, offset, IntOp.LEFT_SHIFT, line)
 
+        # --- Optimized dispatch for RInstance (native/user-defined classes) ---
         if isinstance(typ, RInstance):
             # TODO: Support use_pyssize_t
             assert not use_pyssize_t
+            class_ir = typ.class_ir
+
+            # Only optimize for native extension classes (not built-in base, not Python subclass)
+            if class_ir.is_ext_class and not class_ir.inherits_python and class_ir.has_method("__len__"):
+                # 1. Direct C call for final native methods and exact type
+                if class_ir.is_method_final("__len__"):
+                    decl = class_ir.method_decl("__len__")
+                    length = self.call(decl, [val], [ARG_POS], [None], line)
+
+                    # Coerce/check result and error handling as before
+                    length = self.coerce(length, int_rprimitive, line)
+                    ok, fail = BasicBlock(), BasicBlock()
+                    cond = self.binary_op(length, Integer(0), ">=", line)
+                    self.add_bool_branch(cond, ok, fail)
+                    self.activate_block(fail)
+                    self.add(
+                        RaiseStandardError(
+                            RaiseStandardError.VALUE_ERROR, "__len__() should return >= 0", line
+                        )
+                    )
+                    self.add(Unreachable())
+                    self.activate_block(ok)
+                    return length
+
+            # 4. Fallback: generic method call for non-native or ambiguous cases
             length = self.gen_method_call(val, "__len__", [], int_rprimitive, line)
             length = self.coerce(length, int_rprimitive, line)
             ok, fail = BasicBlock(), BasicBlock()

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2444,7 +2444,7 @@ class LowLevelIRBuilder:
         if isinstance(typ, RInstance):
             # TODO: Support use_pyssize_t
             assert not use_pyssize_t
-            
+
             if typ.class_ir.has_method("__len__") and typ.class_ir.is_method_final("__len__"):
                 # Direct C call for final native __len__ methods
                 decl = typ.class_ir.method_decl("__len__")
@@ -2452,7 +2452,7 @@ class LowLevelIRBuilder:
             else:
                 # Fallback: generic method call for non-native or ambiguous cases
                 length = self.gen_method_call(val, "__len__", [], int_rprimitive, line)
-            
+
             length = self.coerce(length, int_rprimitive, line)
             ok, fail = BasicBlock(), BasicBlock()
             cond = self.binary_op(length, Integer(0), ">=", line)

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2448,7 +2448,11 @@ class LowLevelIRBuilder:
             class_ir = typ.class_ir
 
             # Only optimize for native extension classes (not built-in base, not Python subclass)
-            if class_ir.is_ext_class and not class_ir.inherits_python and class_ir.has_method("__len__"):
+            if (
+                class_ir.is_ext_class
+                and not class_ir.inherits_python
+                and class_ir.has_method("__len__")
+            ):
                 # 1. Direct C call for final native methods and exact type
                 if class_ir.is_method_final("__len__"):
                     decl = class_ir.method_decl("__len__")

--- a/mypyc/irbuild/ll_builder.py
+++ b/mypyc/irbuild/ll_builder.py
@@ -2444,16 +2444,15 @@ class LowLevelIRBuilder:
         if isinstance(typ, RInstance):
             # TODO: Support use_pyssize_t
             assert not use_pyssize_t
-            class_ir = typ.class_ir
-
-            # Direct C call for final native __len__ methods
-            if class_ir.has_method("__len__") and class_ir.is_method_final("__len__"):
-                decl = class_ir.method_decl("__len__")
+            
+            if typ.class_ir.has_method("__len__") and typ.class_ir.is_method_final("__len__"):
+                # Direct C call for final native __len__ methods
+                decl = typ.class_ir.method_decl("__len__")
                 length = self.call(decl, [val], [ARG_POS], [None], line)
             else:
                 # Fallback: generic method call for non-native or ambiguous cases
                 length = self.gen_method_call(val, "__len__", [], int_rprimitive, line)
-
+            
             length = self.coerce(length, int_rprimitive, line)
             ok, fail = BasicBlock(), BasicBlock()
             cond = self.binary_op(length, Integer(0), ">=", line)

--- a/mypyc/test-data/irbuild-dunders.test
+++ b/mypyc/test-data/irbuild-dunders.test
@@ -1,15 +1,41 @@
 # Test cases for (some) dunder methods
 
 [case testDundersLen]
+from typing import final
+
 class C:
     def __len__(self) -> int:
         return 2
-
+@final
+class D:
+    def __len__(self) -> int:
+        return 2
+class E:
+    @final
+    def __len__(self) -> int:
+        return 2
+class F(C):
+    """def __len__(self) -> int:
+        return 3"""
 def f(c: C) -> int:
     return len(c)
+def g(d: D) -> int:
+    return len(d)
+def h(e: E) -> int:
+    return len(e)
+def i(f: F) -> int:
+    return len(f)
 [out]
 def C.__len__(self):
     self :: __main__.C
+L0:
+    return 4
+def D.__len__(self):
+    self :: __main__.D
+L0:
+    return 4
+def E.__len__(self):
+    self :: __main__.E
 L0:
     return 4
 def f(c):
@@ -18,7 +44,49 @@ def f(c):
     r1 :: bit
     r2 :: bool
 L0:
-    r0 = c.__len__()
+    r0 = C.__len__(c)
+    r1 = int_ge r0, 0
+    if r1 goto L2 else goto L1 :: bool
+L1:
+    r2 = raise ValueError('__len__() should return >= 0')
+    unreachable
+L2:
+    return r0
+def g(d):
+    d :: __main__.D
+    r0 :: int
+    r1 :: bit
+    r2 :: bool
+L0:
+    r0 = D.__len__(d)
+    r1 = int_ge r0, 0
+    if r1 goto L2 else goto L1 :: bool
+L1:
+    r2 = raise ValueError('__len__() should return >= 0')
+    unreachable
+L2:
+    return r0
+def h(e):
+    e :: __main__.E
+    r0 :: int
+    r1 :: bit
+    r2 :: bool
+L0:
+    r0 = E.__len__(e)
+    r1 = int_ge r0, 0
+    if r1 goto L2 else goto L1 :: bool
+L1:
+    r2 = raise ValueError('__len__() should return >= 0')
+    unreachable
+L2:
+    return r0
+def i(f):
+    f :: __main__.F
+    r0 :: int
+    r1 :: bit
+    r2 :: bool
+L0:
+    r0 = C.__len__(f)
     r1 = int_ge r0, 0
     if r1 goto L2 else goto L1 :: bool
 L1:


### PR DESCRIPTION
When a native class defines `__len__`, we don't need to use python's dispatch for a vtable lookup. Instead, we can call the C function directly.