### PR TITLE
Stop `--update-data` from inserting spurious blank lines when dealing with report comments

### DIFF
--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -445,7 +445,7 @@ class TestItem:
 
 
 def parse_test_data(raw_data: str, name: str) -> list[TestItem]:
-    """Parse a list of lines that represent a sequence of test items."""
+    """Parse a multi-line text that represents a sequence of test items in a single test case."""
 
     lines = ["", "[case " + name + "]"] + raw_data.split("\n")
     ret: list[TestItem] = []

--- a/mypy/test/meta/test_update_data.py
+++ b/mypy/test/meta/test_update_data.py
@@ -49,10 +49,26 @@ class UpdateDataSuite(Suite):
             s: str = 'foo'  # W: foo \
                             # N: bar
 
+            [case testIndentationOfMultiline]
+            s: str = 42;  i: int = 'foo' # E: Incompatible types in assignment (expression has type "int", variable has type "str")\
+                # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+            s2: str = 42;  i2: int = 'foo' # E: Incompatible types in assignment (expression has type "int", variable has type "str")\
+                # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+
             [case testOutCorrect]
             s: str = 42
             [out]
             main:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+            [case testOutWithMuchTraillingWhitespace]
+            s: str = 42
+            [out]
+            main:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+
+
+
+
 
             [case testOutWrong]
             s: str = 42
@@ -105,10 +121,26 @@ class UpdateDataSuite(Suite):
         [case testExtraneousMultilineNonError]
         s: str = 'foo'
 
+        [case testIndentationOfMultiline]
+        s: str = 42;  i: int = 'foo' # E: Incompatible types in assignment (expression has type "int", variable has type "str") \
+                                     # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+        s2: str = 42;  i2: int = 'foo' # E: Incompatible types in assignment (expression has type "int", variable has type "str") \
+                                       # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
         [case testOutCorrect]
         s: str = 42
         [out]
         main:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+        [case testOutWithMuchTraillingWhitespace]
+        s: str = 42
+        [out]
+        main:1: error: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+
+
+
+
 
         [case testOutWrong]
         s: str = 42

--- a/mypy/test/meta/test_update_data.py
+++ b/mypy/test/meta/test_update_data.py
@@ -21,7 +21,7 @@ class UpdateDataSuite(Suite):
         # Note: We test multiple testcases rather than 'test case per test case'
         #       so we could also exercise rewriting multiple testcases at once.
         result = _run_pytest_update_data(
-            """
+            r"""
             [case testCorrect]
             s: str = 42  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
@@ -79,7 +79,7 @@ class UpdateDataSuite(Suite):
 
         # Assert
         expected = dedent_docstring(
-            """
+            r"""
         [case testCorrect]
         s: str = 42  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
@@ -93,7 +93,7 @@ class UpdateDataSuite(Suite):
         s: str = 42  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
 
         [case testMissingMultiline]
-        s: str = 42;  i: int = 'foo'  # E: Incompatible types in assignment (expression has type "int", variable has type "str") \\
+        s: str = 42;  i: int = 'foo'  # E: Incompatible types in assignment (expression has type "int", variable has type "str") \
                                       # E: Incompatible types in assignment (expression has type "str", variable has type "int")
 
         [case testExtraneous]

--- a/mypy/test/update_data.py
+++ b/mypy/test/update_data.py
@@ -63,17 +63,19 @@ def _iter_fixes(
 
         fix_lines = []
         for lineno, source_line in enumerate(source_lines, start=1):
-            reports = reports_by_line.get((file_path, lineno))
+            reports_on_this_line = reports_by_line.get((file_path, lineno))
             comment_match = re.search(r"(?P<indent>\s+)(?P<comment># [EWN]: .+)$", source_line)
             if comment_match:
                 source_line = source_line[: comment_match.start("indent")]  # strip old comment
-            if reports:
+            if reports_on_this_line:
                 indent = comment_match.group("indent") if comment_match else "  "
-                # multiline comments are on the first line and then on subsequent lines empty lines
-                # with a continuation backslash
-                for j, (severity, msg) in enumerate(reports):
-                    out_l = source_line if j == 0 else " " * len(source_line)
-                    is_last = j == len(reports) - 1
+                # Multiple info reports for the same line are represented in these
+                # comments with the first on the relevant line, then the subsequent
+                # ones on subsequent empty (indented) lines
+                # using continuation backslashes
+                for i, (severity, msg) in enumerate(reports_on_this_line):
+                    out_l = source_line if i == 0 else " " * len(source_line)
+                    is_last = (i == len(reports_on_this_line) - 1)
                     severity_char = severity[0].upper()
                     continuation = "" if is_last else " \\"
                     fix_lines.append(f"{out_l}{indent}# {severity_char}: {msg}{continuation}")


### PR DESCRIPTION
Fixes #19940. However, this PR is extremely WIP, because I haven't figured out the fix yet. These are just failing tests...