### PR TITLE
[mypyc] feat: specialize isinstance for tuple of primitive types

### DIFF
--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -606,7 +606,15 @@ def translate_isinstance(builder: IRBuilder, expr: CallExpr, callee: RefExpr) ->
             obj = builder.accept(obj_expr, can_borrow=can_borrow)
             return builder.builder.isinstance_helper(obj, irs, expr.line)
 
-    if isinstance(type_expr, TupleExpr):
+    if isinstance(type_expr, RefExpr):
+        node = type_expr.node
+        if node:
+            desc = isinstance_primitives.get(node.fullname)
+            if desc:
+                obj = builder.accept(obj_expr)
+                return builder.primitive_op(desc, [obj], expr.line)
+
+    elif isinstance(type_expr, TupleExpr):
         node_names: list[str] = []
         for item in type_expr.items:
             if not isinstance(item, RefExpr):
@@ -651,14 +659,6 @@ def translate_isinstance(builder: IRBuilder, expr: CallExpr, callee: RefExpr) ->
         # Return the result
         builder.activate_block(exit_block)
         return retval
-
-    if isinstance(type_expr, RefExpr):
-        node = type_expr.node
-        if node:
-            desc = isinstance_primitives.get(node.fullname)
-            if desc:
-                obj = builder.accept(obj_expr)
-                return builder.primitive_op(desc, [obj], expr.line)
 
     return None
 

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -642,7 +642,9 @@ def translate_isinstance(builder: IRBuilder, expr: CallExpr, callee: RefExpr) ->
             is_last = i == len(descs) - 1
             next_block = fail_block if is_last else BasicBlock()
             builder.add_bool_branch(
-                builder.primitive_op(cast(PrimitiveDescription, desc), [obj], expr.line), pass_block, next_block
+                builder.primitive_op(cast(PrimitiveDescription, desc), [obj], expr.line),
+                pass_block,
+                next_block,
             )
             if not is_last:
                 builder.activate_block(next_block)

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -14,7 +14,7 @@ See comment below for more documentation.
 
 from __future__ import annotations
 
-from typing import Callable, Final, Optional
+from typing import Callable, Final, Optional, cast
 
 from mypy.nodes import (
     ARG_NAMED,
@@ -40,6 +40,7 @@ from mypyc.ir.ops import (
     Call,
     Extend,
     Integer,
+    PrimitiveDescription,
     RaiseStandardError,
     Register,
     Truncate,
@@ -641,7 +642,7 @@ def translate_isinstance(builder: IRBuilder, expr: CallExpr, callee: RefExpr) ->
             is_last = i == len(descs) - 1
             next_block = fail_block if is_last else BasicBlock()
             builder.add_bool_branch(
-                builder.primitive_op(desc, [obj], expr.line), pass_block, next_block  # type: ignore [arg-type]
+                builder.primitive_op(cast(PrimitiveDescription, desc), [obj], expr.line), pass_block, next_block
             )
             if not is_last:
                 builder.activate_block(next_block)

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -633,7 +633,7 @@ def translate_isinstance(builder: IRBuilder, expr: CallExpr, callee: RefExpr) ->
             is_last = i == len(descs) - 1
             next_block = fail_block if is_last else BasicBlock()
             builder.add_bool_branch(
-                builder.primitive_op(desc, [obj], expr.line), pass_block, next_block
+                builder.primitive_op(desc, [obj], expr.line), pass_block, next_block  # type: ignore [arg-type]
             )
             if not is_last:
                 builder.activate_block(next_block)

--- a/mypyc/test-data/irbuild-isinstance.test
+++ b/mypyc/test-data/irbuild-isinstance.test
@@ -189,3 +189,31 @@ def is_tuple(x):
 L0:
     r0 = PyTuple_Check(x)
     return r0
+
+[case testTupleOfPrimitives]
+from typing import Any
+
+def is_instance(x: Any) -> bool:
+    return isinstance(x, (str, int, bytes))
+
+[out]
+def is_instance(x):
+    x :: object
+    r0, r1, r2 :: bit
+    r3 :: bool
+L0:
+    r0 = PyUnicode_Check(x)
+    if r0 goto L3 else goto L1 :: bool
+L1:
+    r1 = PyLong_Check(x)
+    if r1 goto L3 else goto L2 :: bool
+L2:
+    r2 = PyBytes_Check(x)
+    if r2 goto L3 else goto L4 :: bool
+L3:
+    r3 = 1
+    goto L5
+L4:
+    r3 = 0
+L5:
+    return r3

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -1173,3 +1173,26 @@ def test_dummy_context() -> None:
     with c:
         assert c.c == 1
     assert c.c == 0
+
+[case testIsInstanceTuple]
+from typing import Any
+
+def isinstance_empty(x: Any) -> bool:
+    return isinstance(x, ())
+def isinstance_single(x: Any) -> bool:
+    return isinstance(x, (str,))
+def isinstance_multi(x: Any) -> bool:
+    return isinstance(x, (str, int))
+
+def test_isinstance_empty() -> None:
+    assert isinstance_empty("a") is False
+    assert isinstance_empty(1) is False
+    assert isinstance_empty(None) is False
+def test_isinstance_single() -> None:
+    assert isinstance_single("a") is True
+    assert isinstance_single(1) is False
+    assert isinstance_single(None) is False
+def test_isinstance_multi() -> None:
+    assert isinstance_multi("a") is True
+    assert isinstance_multi(1) is True
+    assert isinstance_multi(None) is False


### PR DESCRIPTION
This PR specializes isinstance calls where the type argument is a tuple of primitive types.

We can skip tuple creation and the associated refcounting, and daisy-chain the primitive checks with an early exit option at each step.