### PR TITLE
Fix crash on invalid unpack in base class

### DIFF
--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -303,7 +303,9 @@ def calculate_tuple_fallback(typ: TupleType) -> None:
             ):
                 items.append(unpacked_type.args[0])
             else:
-                raise NotImplementedError
+                # This is called before semanal_typeargs.py fixes broken unpacks,
+                # where the error should also be generated.
+                items.append(AnyType(TypeOfAny.from_error))
         else:
             items.append(item)
     fallback.args = (make_simplified_union(items),)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -634,7 +634,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             )
         elif fullname == "typing.Union":
             items = self.anal_array(t.args)
-            return UnionType.make_union(items)
+            return UnionType.make_union(items, line=t.line, column=t.column)
         elif fullname == "typing.Optional":
             if len(t.args) != 1:
                 self.fail(

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2121,3 +2121,13 @@ class A: ...
 
 x1: Alias1[A]  # ok
 x2: Alias2[A]  # ok
+
+[case testUndefinedUnpackInPEP696Base]
+# Typo below is intentional.
+class MyTuple[*Ts](tuple[*TS]):  # E: Name "TS" is not defined
+    ...
+
+x: MyTuple[int, str]
+reveal_type(x[0])  # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2692,3 +2692,27 @@ tuple(a)
 (x,) = a
 (_,) = a
 [builtins fixtures/tuple.pyi]
+
+[case testNoCrashOnUndefinedUnpackInBase]
+from typing import TypeVarTuple, Generic, Unpack
+
+Ts = TypeVarTuple("Ts")
+
+class MyTuple(tuple[Unpack[TsWithTypo]], Generic[Unpack[Ts]]):  # E: Name "TsWithTypo" is not defined
+    ...
+
+x: MyTuple[int, str]
+reveal_type(x[0])  # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]
+
+[case testNoCrashOnInvalidUnpackInBase]
+from typing import TypeVarTuple, Generic, Unpack, Union
+
+Ts = TypeVarTuple("Ts")
+
+class MyTuple(tuple[Unpack[Union[int, str]]], Generic[Unpack[Ts]]):  # E: "Union[int, str]" cannot be unpacked (must be tuple or TypeVarTuple)
+    ...
+
+x: MyTuple[int, str]
+reveal_type(x[0])  # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/19960

Fix is trivial, we can't use the "assertion" before type checking phase. I also fix missing line/column for union types. I am surprised this didn't cause problems before.

cc @JukkaL 
