### PR TITLE
Stop calling fixed format cache experimental

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1066,11 +1066,7 @@ def define_options(
     incremental_group.add_argument(
         "--fixed-format-cache",
         action="store_true",
-        help=(
-            "Use experimental fast and compact fixed format cache"
-            if compilation_status == "yes"
-            else argparse.SUPPRESS
-        ),
+        help="Use new fast and compact fixed format cache",
     )
     incremental_group.add_argument(
         "--skip-version-check",


### PR DESCRIPTION
It has been around for some time with no issues so far. We can stop calling it experimental so that more people try it before we make it default.
