### PR TITLE
Add librt as runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
   "mypy_extensions>=1.0.0",
   "pathspec>=0.9.0",
   "tomli>=1.1.0; python_version<'3.11'",
+  "librt>=0.1.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
`librt` is needed both at build and runtime. It's already part of mypy-requirements.txt.