### PR TITLE
[mypyc] feat: support negative index in TupleGet op

### DIFF
--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1053,7 +1053,9 @@ class TupleGet(RegisterOp):
         self.index = index
         if index < 0:
             self.index += src_len
-        assert self.index <= src_len - 1, f"Index out of range.\nsource type: {src.type}\nindex: {index}"
+        assert (
+            self.index <= src_len - 1
+        ), f"Index out of range.\nsource type: {src.type}\nindex: {index}"
         self.type = src.type.types[index]
         self.is_borrowed = borrow
 

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1047,7 +1047,7 @@ class TupleGet(RegisterOp):
         super().__init__(line)
         assert isinstance(
             src.type, RTuple
-        ), "TupleGet only operates on tuples, not {type(src.type).__name__}"
+        ), f"TupleGet only operates on tuples, not {type(src.type).__name__}"
         src_len = len(src.type.types)
         self.src = src
         self.index = index

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -1045,10 +1045,15 @@ class TupleGet(RegisterOp):
 
     def __init__(self, src: Value, index: int, line: int = -1, *, borrow: bool = False) -> None:
         super().__init__(line)
+        assert isinstance(
+            src.type, RTuple
+        ), "TupleGet only operates on tuples, not {type(src.type).__name__}"
+        src_len = len(src.type.types)
         self.src = src
         self.index = index
-        assert isinstance(src.type, RTuple), "TupleGet only operates on tuples"
-        assert index >= 0
+        if index < 0:
+            self.index += src_len
+        assert self.index <= src_len - 1, f"Index out of range.\nsource type: {src.type}\nindex: {index}"
         self.type = src.type.types[index]
         self.is_borrowed = borrow
 


### PR DESCRIPTION
This PR modifies `TupleGet.__init__` to automatically convert negative indexes to positive indexes instead of crashing at the assert

This won't change functionality on its own, since none of the existing calling locations can pass a negative value, but will allow us to pass negative values in https://github.com/python/mypy/pull/19972 so I think we should consider this PR a prerequisite to that one