### PR TITLE
Fixes #15127: Added optional error code to flag missing return type and tests

### DIFF
--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -320,9 +320,7 @@ DEPRECATED: Final = ErrorCode(
 )
 
 MISSING_RETURN_ANNOTATION = ErrorCode(
-    "missing-return-annotation", 
-    "Function has no return type annotation",
-    "Optional",
+    "missing-return-annotation", "Function has no return type annotation", "Optional"
 )
 
 

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -319,5 +319,12 @@ DEPRECATED: Final = ErrorCode(
     default_enabled=False,
 )
 
+MISSING_RETURN_ANNOTATION = ErrorCode(
+    "missing-return-annotation", 
+    "Function has no return type annotation",
+    "Optional",
+)
+
+
 # This copy will not include any error codes defined later in the plugins.
 mypy_error_codes = error_codes.copy()

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -57,7 +57,7 @@ from typing_extensions import TypeAlias as _TypeAlias, TypeGuard
 
 from mypy import errorcodes as codes, message_registry
 from mypy.constant_fold import constant_fold_expr
-from mypy.errorcodes import PROPERTY_DECORATOR, ErrorCode, MISSING_RETURN_ANNOTATION
+from mypy.errorcodes import MISSING_RETURN_ANNOTATION, PROPERTY_DECORATOR, ErrorCode
 from mypy.errors import Errors, report_internal_error
 from mypy.exprtotype import TypeTranslationError, expr_to_unanalyzed_type
 from mypy.message_registry import ErrorMessage
@@ -943,7 +943,6 @@ class SemanticAnalyzer(
                         defn,
                         code=MISSING_RETURN_ANNOTATION,
                     )
-        
 
     def function_fullname(self, fullname: str) -> str:
         if self.current_overload_item is None:

--- a/test-data/unit/check-missing-return-annotation.test
+++ b/test-data/unit/check-missing-return-annotation.test
@@ -1,0 +1,8 @@
+[case test_missing_return_annotation_ok]
+# flags: --enable-error-code missing-return-annotation
+def g(x: int) -> int:
+    return x
+
+[case test_missing_return_annotation_off_by_default]
+def h(x: int):
+    return x  # no error expected, since code is opt-in


### PR DESCRIPTION
Added an optional error code in errorcodes.py which flags missing return type annotations in functions that have annotated parameters. The check runs in semanal.py and ignores __init__ and lambdas. There is also a small unit test file which demonstrates behavior.