### PR TITLE
Filter SyntaxWarnings during AST parsing

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -232,9 +232,12 @@ def parse(
         assert options.python_version[0] >= 3
         feature_version = options.python_version[1]
     try:
-        # Disable deprecation warnings about \u
+        # Disable
+        # - deprecation warnings about \u
+        # - syntax warnings for 'invalid escape sequence' (3.12+)  and 'return in finally' (3.14+)
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
+            warnings.filterwarnings("ignore", category=SyntaxWarning)
             ast = ast3_parse(source, fnam, "exec", feature_version=feature_version)
 
         tree = ASTConverter(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,9 +227,6 @@ xfail_strict = true
 # Force warnings as errors
 filterwarnings = [
   "error",
-  # Some testcases may contain code that emits SyntaxWarnings, and they are not yet
-  # handled consistently in 3.14 (PEP 765)
-  "default::SyntaxWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
Especially with [PEP 765](https://peps.python.org/pep-0765/) in 3.14, Python has been getting more liberal in emitting SyntaxWarnings during AST parsing and compilation. Generally, they aren't really helpful for mypy itself. There are discussions on the Python issue tracker currently to add a flag which would disable these. Until that's implemented, filter the warnings manually.

_This also get's rid of the warnings emitted on test code. If at some point `return in finally` will be made an error, those tests could be adjust / removed. Until then, we can continue to test these as is without issues._

```py
def func() -> None:
    try:
        x = 1/0
    finally:
        return None  # return in finally

"Hello \P world"  # invalid escape sequence
"" is 1            # "is" with 'int' literal
```
