### PR TITLE
Fix infinite loop on empty Buffer

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -664,7 +664,6 @@ def mypycify(
             )
 
     if install_librt:
-        os.makedirs("librt", exist_ok=True)
         for name in RUNTIME_C_FILES:
             rt_file = os.path.join(build_dir, name)
             with open(os.path.join(include_dir(), name), encoding="utf-8") as f:

--- a/mypyc/lib-rt/librt_internal.c
+++ b/mypyc/lib-rt/librt_internal.c
@@ -70,12 +70,14 @@ Buffer_init_internal(BufferObject *self, PyObject *source) {
             PyErr_SetString(PyExc_TypeError, "source must be a bytes object");
             return -1;
         }
-        self->size = PyBytes_GET_SIZE(source);
-        self->end = self->size;
+        self->end = PyBytes_GET_SIZE(source);
+        // Allocate at least one byte to simplify resizing logic.
+        // The original bytes buffer has last null byte, so this is safe.
+        self->size = self->end + 1;
         // This returns a pointer to internal bytes data, so make our own copy.
         char *buf = PyBytes_AsString(source);
         self->buf = PyMem_Malloc(self->size);
-        memcpy(self->buf, buf, self->size);
+        memcpy(self->buf, buf, self->end);
     } else {
         self->buf = PyMem_Malloc(START_SIZE);
         self->size = START_SIZE;

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2866,6 +2866,15 @@ test_buffer_roundtrip_interpreted()
 test_buffer_int_size_interpreted()
 test_buffer_str_size_interpreted()
 
+[case testBufferEmpty_librt_internal]
+from librt.internal import Buffer, write_int, read_int
+
+def test_empty() -> None:
+    b = Buffer(b"")
+    write_int(b, 42)
+    b1 = Buffer(b.getvalue())
+    assert read_int(b1) == 42
+
 [case testEnumMethodCalls]
 from enum import Enum
 from typing import overload, Optional, Union

--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -285,6 +285,12 @@ class TestRun(MypycDataSuite):
                 )
             )
 
+        if librt:
+            # This hack forces Python to prefer the local "installation".
+            os.makedirs("librt", exist_ok=True)
+            with open(os.path.join("librt", "__init__.py"), "a"):
+                pass
+
         if not run_setup(setup_file, ["build_ext", "--inplace"]):
             if testcase.config.getoption("--mypyc-showc"):
                 show_c(cfiles)


### PR DESCRIPTION
Currently `Buffer(b"")` (as opposite to `Buffer()`) can go into an infinite loop when resizing. Fix this by allocating one more byte, that is conveniently guaranteed by `bytes` ABI.

I also move the `librt/__init__.py` hack to tests, since this is the only place where it is needed. I am still not sure why `*.so` from `site-packages` is preferred over a "local" namespace package with the same `*.so`.