### PR TITLE
[nit] clarify comment about deprecation warnings about \u

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -234,7 +234,7 @@ def parse(
     try:
         # Disable
         # - deprecation warnings for 'invalid escape sequence' (Python 3.11 and below)
-        # - syntax warnings for 'invalid escape sequence' (3.12+), and 'return in finally' (3.14+)
+        # - syntax warnings for 'invalid escape sequence' (3.12+) and 'return in finally' (3.14+)
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             warnings.filterwarnings("ignore", category=SyntaxWarning)


### PR DESCRIPTION
This is the same as 'invalid escape sequence', just a different type of warning on lower Python versions. Chases https://github.com/python/mypy/pull/20023. More background information is available in https://github.com/python/mypy/pull/19606, although that's probably not very helpful all told.