### PR TITLE
Update shellcheck version in actionlint pre-commit to 0.11.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
           # actionlint has a shellcheck integration which extracts shell scripts in `run:` steps from GitHub Actions
           # and checks these with shellcheck. This is arguably its most useful feature,
           # but the integration only works if shellcheck is installed
-          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.10.0"
+          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.0"
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.5.2
     hooks:


### PR DESCRIPTION
I was getting bizarre wasm failures from runtests running pre-commit
running actionlint running shellcheck (shellcheck is written in
haskell but we depend on go-shellcheck which is a packaged up version
of it using wasm?).
(https://github.com/python/mypy/issues/19958#issuecomment-3383449423)

If I update it, I don't get bizarre wasm failures and it still doesn't
complain about anything.