### PR TITLE
Do not sort unused error codes in unused error codes warning

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -806,8 +806,8 @@ class Errors:
                 continue
             if codes.UNUSED_IGNORE.code in ignored_codes:
                 continue
-            used_ignored_codes = used_ignored_lines[line]
-            unused_ignored_codes = set(ignored_codes) - set(used_ignored_codes)
+            used_ignored_codes = set(used_ignored_lines[line])
+            unused_ignored_codes = [c for c in ignored_codes if c not in used_ignored_codes]
             # `ignore` is used
             if not ignored_codes and used_ignored_codes:
                 continue
@@ -817,7 +817,7 @@ class Errors:
             # Display detail only when `ignore[...]` specifies more than one error code
             unused_codes_message = ""
             if len(ignored_codes) > 1 and unused_ignored_codes:
-                unused_codes_message = f"[{', '.join(sorted(unused_ignored_codes))}]"
+                unused_codes_message = f"[{', '.join(unused_ignored_codes)}]"
             message = f'Unused "type: ignore{unused_codes_message}" comment'
             for unused in unused_ignored_codes:
                 narrower = set(used_ignored_codes) & codes.sub_code_map[unused]

--- a/test-data/unit/check-ignore.test
+++ b/test-data/unit/check-ignore.test
@@ -282,6 +282,8 @@ class CD(six.with_metaclass(M)):  # E: Multiple metaclass definitions
 5 # type: ignore[steven, import] # E: Unused "type: ignore[steven, import]" comment
 -- Spacing is not preserved
 5 # type: ignore[  steven,      import ] # E: Unused "type: ignore[steven, import]" comment
+-- Make sure it works as intended in more complex situations
+1 + "ok" + "ok".foo # type: ignore[  operator,steven,attr-defined, import] # E: Unused "type: ignore[steven, import]" comment
 
 [case testUnusedIgnoreTryExcept]
 # flags: --warn-unused-ignores


### PR DESCRIPTION
I intuit the previous author of this code sorted the codes for stability, but it actually should be in default order, to match what the user typed in. This will be more intuitive for the user.

In my first commit, I add the failing testUnusedIgnoreCodeOrder test. In my second commit, I fix the code.
