### PR TITLE
Documentation : Adding missing reveal_type imports in cheat_sheet_py3.rst

### DIFF
--- a/docs/source/cheat_sheet_py3.rst
+++ b/docs/source/cheat_sheet_py3.rst
@@ -227,7 +227,7 @@ When you're puzzled or when things are complicated
    # To find out what type mypy infers for an expression anywhere in
    # your program, wrap it in reveal_type().  Mypy will print an error
    # message with the type; remove it again before running the code, or
-   # import reveal_type from typing_extensions or typing (on Python 3.11 and newer)
+   # import reveal_type from typing_extensions or typing (on Python 3.11 and newer).
    reveal_type(1)  # Revealed type is "builtins.int"
 
    # If you initialize a variable with an empty container or "None"


### PR DESCRIPTION
Minor documentation fix : Some methods in the cheat_sheet didn't work because of a missing import 

