### PR TITLE
prevent false unreachable warnings for @final instances that occur when strict optional checking is disabled

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -791,7 +791,7 @@ def false_only(t: Type) -> ProperType:
         elif isinstance(t, Instance):
             if (t.type.is_final or t.type.is_enum) and state.strict_optional:
                 return UninhabitedType(line=t.line)
-        elif isinstance(t, LiteralType) and t.is_enum_literal():
+        elif isinstance(t, LiteralType) and t.is_enum_literal() and state.strict_optional:
             return UninhabitedType(line=t.line)
 
         new_t = copy_type(t)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1976,6 +1976,19 @@ if not x:
     x = C()
 [builtins fixtures/dict.pyi]
 
+[case testNoWrongUnreachableWarningWithNoStrictOptionalAndEnumLiteral]
+# flags: --no-strict-optional --warn-unreachable
+from enum import Enum
+from typing import Literal, Optional
+
+class E(Enum):
+    a = 1
+
+x: Optional[Literal[E.a]]
+if not x:
+    x = E.a
+[builtins fixtures/dict.pyi]
+
 [case testInferFromEmptyListWhenUsingInWithStrictEquality]
 # flags: --strict-equality
 def f() -> None:


### PR DESCRIPTION
Fixes #19849

See #11717 for some background information on `--no-strict-optional`.