### PR TITLE
Bump version of wasilibs/go-shellcheck to fix lint on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
           # actionlint has a shellcheck integration which extracts shell scripts in `run:` steps from GitHub Actions
           # and checks these with shellcheck. This is arguably its most useful feature,
           # but the integration only works if shellcheck is installed
-          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.0"
+          - "github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1"
   - repo: https://github.com/woodruffw/zizmor-pre-commit
     rev: v1.5.2
     hooks:


### PR DESCRIPTION
Currently, if you try to run our lint step on Windows, shellcheck crashes with a complaint about an empty env var key. However, that has just been fixed in https://github.com/wasilibs/go-shellcheck/issues/10.

Closes https://github.com/python/mypy/issues/19958, which I have already preemptively closed.