### PR TITLE
Remove incorrect platform restriction for `zlib.ZLIBNG_VERSION`

### DIFF
--- a/mypy/typeshed/stdlib/zlib.pyi
+++ b/mypy/typeshed/stdlib/zlib.pyi
@@ -26,8 +26,8 @@ Z_RLE: Final = 3
 Z_SYNC_FLUSH: Final = 2
 Z_TREES: Final = 6
 
-if sys.version_info >= (3, 14) and sys.platform == "win32":
-    # Available when zlib was built with zlib-ng, usually only on Windows
+if sys.version_info >= (3, 14):
+    # Available when zlib was built with zlib-ng
     ZLIBNG_VERSION: Final[str]
 
 class error(Exception): ...


### PR DESCRIPTION
IIRC we compile Windows releases with zlib-ng, but there is nothing stopping you from doing so on other platforms. The constant is also not [documented](https://docs.python.org/3/library/zlib.html#zlib.ZLIBNG_VERSION) as "Availability: Windows only".