### PR TITLE
[mypyc] feat: enhance ForSequence with start, stop, step for IndexExpr case

### DIFF
--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -450,9 +450,9 @@ def make_for_loop_generator(
             def constant_fold_or_none(expr: Expression | None) -> Any:
                 return None if expr is None else constant_fold_expr(builder, expr)
 
-            start = constant_fold_or_none(expr.index.start)
-            stop = constant_fold_or_none(expr.index.stop)
-            step = constant_fold_or_none(expr.index.step)
+            start = constant_fold_or_none(expr.index.begin_index)
+            stop = constant_fold_or_none(expr.index.end_index)
+            step = constant_fold_or_none(expr.index.stride)
 
             if all(s is None or isinstance(s, int) for s in (start, stop, step)):
                 for_list.init(


### PR DESCRIPTION
This will create optimized code paths for:
- `for x in seq[1:]`
- `for x in seq[1:2]`
- `for x in seq[1:-1]`
- `for x in seq[:]`  # TODO: exempt this, its invalid
- `for x in seq[:2]`
- `for x in seq[:-1]`
- `for x in seq[1::-1]`
- `for x in seq[1:2:-1]`
- `for x in seq[1:-1:-1]`
- `for x in seq[:2:-1]`
- `for x in seq[:-1:-1]`

There is no reason to actually create a sliced sequence from the original sequence when we can just grab the appropriate items from the original sequence. We are already grabbing the same number of items from the sliced sequence anyway.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

(Explain how this PR changes mypy.)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
