### PR TITLE
[mypyc] feat: reorder gens for speed in `ForZip.gen_condition`

### DIFF
--- a/mypyc/irbuild/for_helpers.py
+++ b/mypyc/irbuild/for_helpers.py
@@ -1292,7 +1292,9 @@ class ForZip(ForGenerator):
 
         # this is a failsafe for ForHelper classes which might have been added after this commit but not added to this function's code
         leftovers = [
-            g_and_block for g_and_block in zip(gens, cond_blocks) if g_and_block not in ordered + for_iterable
+            g_and_block
+            for g_and_block in zip(gens, cond_blocks)
+            if g_and_block not in ordered + for_iterable
         ]
 
         gens_and_blocks = ordered + leftovers + for_iterable


### PR DESCRIPTION
Not all generators have an equally fast gen_condition, some are quite fast while others quite the opposite

This PR orders them in what I see to be a reasonably fastest -> slowest order