### PR TITLE
docs: Put specific ignore comment for missing types

### DIFF
--- a/docs/source/running_mypy.rst
+++ b/docs/source/running_mypy.rst
@@ -309,7 +309,7 @@ All this will do is make mypy stop reporting an error on the line containing the
 import: the imported module will continue to be of type ``Any``, and mypy may
 not catch errors in its use.
 
-1.  To suppress a *single* missing import error, add a ``# type: ignore`` at the end of the
+1.  To suppress a *single* missing import error, add a ``# type: ignore[import-not-found]`` at the end of the
     line containing the import.
 
 2.  To suppress *all* missing import errors from a single library, add


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

The docs for "Missing library stubs or py.typed marker" give you an option to ignore the error, but its not complete. Copying it verbatim into your code results in this error:
```
error: "type: ignore" comment without error code (consider "type: ignore[import-not-found]" instead)  [ignore-without-code]
```
The error is helpful, but just having it work right away will be better :)

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
