### PR TITLE
Update duck_type_compatibility.rst: mention strict-bytes & mypy 2.0

### DIFF
--- a/docs/source/duck_type_compatibility.rst
+++ b/docs/source/duck_type_compatibility.rst
@@ -9,6 +9,8 @@ supported for a small set of built-in types:
 * ``int`` is duck type compatible with ``float`` and ``complex``.
 * ``float`` is duck type compatible with ``complex``.
 * ``bytearray`` and ``memoryview`` are duck type compatible with ``bytes``.
+  (this will be disabled by default in **mypy 2.0**, and currently can be
+  disabled with :option:`--strict-bytes <mypy --strict-bytes>`.)
 
 For example, mypy considers an ``int`` object to be valid whenever a
 ``float`` object is expected.  Thus code like this is nice and clean


### PR DESCRIPTION
Seems like a good idea to mention this, while we're on the subject.