### PR TITLE
Use self-descriptive cache with type tags

### DIFF
--- a/mypyc/lib-rt/librt_internal.c
+++ b/mypyc/lib-rt/librt_internal.c
@@ -204,6 +204,10 @@ read_bool_internal(PyObject *data) {
     _CHECK_BUFFER(data, CPY_BOOL_ERROR)
     _CHECK_READ(data, 1, CPY_BOOL_ERROR)
     char res = _READ(data, char)
+    if (unlikely((res != 0) & (res != 1))) {
+        PyErr_SetString(PyExc_ValueError, "invalid bool value");
+        return CPY_BOOL_ERROR;
+    }
     return res;
 }
 


### PR DESCRIPTION
This should make our cache format more future proof w.r.t lazy deserialization and other features:
* This makes cache ~5% larger (data + meta)
* This makes interpreted performance ~5% worse (just the serialization steps, *not* overall time)
* No visible performance impact when compiled (probably because all extra indirections like `read_str()` -> `read_str_bare()` etc are C calls).

Note that I now serialize various little arbitrary JSON blobs (like plugin data etc) using fixed format, since with the tags we can do this.