### PR TITLE
Do not store deferred NamedTuple fields as redefinitions

### DIFF
--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -34,6 +34,7 @@ from mypy.nodes import (
     NamedTupleExpr,
     NameExpr,
     PassStmt,
+    PlaceholderNode,
     RefExpr,
     Statement,
     StrExpr,
@@ -697,10 +698,14 @@ class NamedTupleAnalyzer:
                 if isinstance(sym.node, (FuncBase, Decorator)) and not sym.plugin_generated:
                     # Keep user-defined methods as is.
                     continue
-                # Keep existing (user-provided) definitions under mangled names, so they
-                # get semantically analyzed.
-                r_key = get_unique_redefinition_name(key, named_tuple_info.names)
-                named_tuple_info.names[r_key] = sym
+                # Do not retain placeholders - we'll get back here if they cease to
+                # be placeholders later. If we keep placeholders alive, they may never
+                # be reached again, making it to cacheable symtable.
+                if not isinstance(sym.node, PlaceholderNode):
+                    # Keep existing (user-provided) definitions under mangled names, so they
+                    # get semantically analyzed.
+                    r_key = get_unique_redefinition_name(key, named_tuple_info.names)
+                    named_tuple_info.names[r_key] = sym
             named_tuple_info.names[key] = value
 
     # Helpers

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1530,3 +1530,28 @@ class Base:
         names = [name for name in namespace if fail]  # E: Name "fail" is not defined
         self.n = namedtuple("n", names)  # E: NamedTuple type as an attribute is not supported
 [builtins fixtures/tuple.pyi]
+
+[case testNamedTupleDefaultValueDefer]
+# flags: --debug-serialize
+from typing import NamedTuple
+
+class NT(NamedTuple):
+    foo: int = UNDEFINED  # E: Name "UNDEFINED" is not defined
+[builtins fixtures/tuple.pyi]
+
+[case testNamedTupleDefaultValueDefer2]
+# flags: --debug-serialize
+from typing import NamedTuple
+
+class NT(NamedTuple):
+    foo: int = DEFERRED_INT
+
+class NT2(NamedTuple):
+    foo: int = DEFERRED_STR  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+from foo import DEFERRED_INT, DEFERRED_STR
+
+[file foo.py]
+DEFERRED_INT = 1
+DEFERRED_STR = "a"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #17059.

When we encounter a field with a Placeholder as a default, do not record it in the new symtable as redefinition - it becomes orphan immediately and remains there, crashing suring serialization.

The test cases are both crashing on current master. Ideally we hould emit name-defined in all cases, but it is another unrelated issue (#17610, and likely some others; this is not specific to named tuples - plain classes also allow referencing variables that are not defined yet).