### PR TITLE
Do not treat annotated self-assign as special

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3286,7 +3286,7 @@ class SemanticAnalyzer(
 
         Return true if special casing was applied.
         """
-        if not isinstance(s.rvalue, NameExpr) or len(s.lvalues) != 1:
+        if not isinstance(s.rvalue, NameExpr) or len(s.lvalues) != 1 or s.type is not None:
             # Not of form 'X = X'
             return False
         lvalue = s.lvalues[0]

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1173,6 +1173,19 @@ class MyClass:
     a: None
     a: Final[int] = 1  # E: Cannot redefine an existing name as final  # E: Name "a" already defined on line 5
 
+[case testFinalCannotBeRedefinition]
+from typing import Final
+
+# This time travel is suboptimal but good enough for now?
+a = 0  # E: Cannot assign to final name "a"
+b = 0  # E: Cannot assign to final name "b"
+
+a: Final = a  # E: Cannot redefine an existing name as final
+b: Final = 1  # E: Cannot redefine an existing name as final
+
+a = 1  # E: Cannot assign to final name "a"
+b = 1  # E: Cannot assign to final name "b"
+
 [case testFinalOverrideAllowedForPrivate]
 from typing import Final, final
 


### PR DESCRIPTION
Fixes #20144. 

Historically we have special treatment for `X = X` "redefinitions" in global scope. This special case was introduced in #7144, and all test cases there are unannotated. 

I suspect that it was not supposed to include annotated cases at all (cc @JukkaL as the PR author - is my understanding correct?), because it skips a whole bunch of annotation checks - final, classvar, annotation sanity, plugins, etc.:

https://github.com/python/mypy/blob/12d5da449b54ddeb44e4e582defe354cc70b3e94/mypy/semanal.py#L3269-L3280