### PR TITLE
Do not cache fast container types inside lambdas

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5082,7 +5082,10 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             self.resolved_type[e] = NoneType()
             return None
         ct = self.chk.named_generic_type(container_fullname, [vt])
-        self.resolved_type[e] = ct
+        if not self.in_lambda_expr:
+            # We cannot cache results in lambdas - their bodies can be accepted in
+            # error-suppressing watchers too early
+            self.resolved_type[e] = ct
         return ct
 
     def _first_or_join_fast_item(self, items: list[Type]) -> Type | None:
@@ -5317,7 +5320,10 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             self.resolved_type[e] = NoneType()
             return None
         dt = self.chk.named_generic_type("builtins.dict", [kt, vt])
-        self.resolved_type[e] = dt
+        if not self.in_lambda_expr:
+            # We cannot cache results in lambdas - their bodies can be accepted in
+            # error-suppressing watchers too early
+            self.resolved_type[e] = dt
         return dt
 
     def check_typeddict_literal_in_context(

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -709,6 +709,20 @@ f(
     A(), r=B())
 [builtins fixtures/isinstance.pyi]
 
+[case testLambdaWithFastContainerType]
+from collections.abc import Callable
+from typing import Never, TypeVar
+
+T = TypeVar("T")
+
+def f(a: Callable[[], T]) -> None: ...
+
+def foo(x: str) -> Never: ...
+
+f(lambda: [foo(0)])  # E: Argument 1 to "foo" has incompatible type "int"; expected "str"
+f(lambda: {"x": foo(0)})  # E: Argument 1 to "foo" has incompatible type "int"; expected "str"
+[builtins fixtures/tuple.pyi]
+
 
 -- Overloads + generic functions
 -- -----------------------------


### PR DESCRIPTION
Fixes #20163. `fast_container_type` uses another layer of expression cache, it also has to be bypassed from within lambdas.