### PR TITLE
[docs] Change the InlineTypedDict example

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -1211,8 +1211,8 @@ List of currently incomplete/experimental features:
 
   .. code-block:: python
 
-     def test_values() -> {"int": int, "str": str}:
-         return {"int": 42, "str": "test"}
+     def test_values() -> {"width": int, "description": str}:
+         return {"width": 42, "description": "test"}
 
 
 Miscellaneous

--- a/docs/source/typed_dict.rst
+++ b/docs/source/typed_dict.rst
@@ -303,8 +303,8 @@ to use inline TypedDict syntax. For example:
 
 .. code-block:: python
 
-    def test_values() -> {"int": int, "str": str}:
-        return {"int": 42, "str": "test"}
+    def test_values() -> {"width": int, "description": str}:
+        return {"width": 42, "description": "test"}
 
     class Response(TypedDict):
         status: int


### PR DESCRIPTION
This way it will be clear that there is no necessary connection between the name of the field and its type.
