### PR TITLE
[docs] document --enable-incomplete-feature TypeForm, minimally but sufficiently

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -1159,7 +1159,7 @@ format into the specified directory.
 Enabling incomplete/experimental features
 *****************************************
 
-.. option:: --enable-incomplete-feature {PreciseTupleTypes,InlineTypedDict}
+.. option:: --enable-incomplete-feature {PreciseTupleTypes,InlineTypedDict,TypeForm}
 
     Some features may require several mypy releases to implement, for example
     due to their complexity, potential for backwards incompatibility, or
@@ -1213,6 +1213,9 @@ List of currently incomplete/experimental features:
 
      def test_values() -> {"int": int, "str": str}:
          return {"int": 42, "str": "test"}
+
+* ``TypeForm``: this feature enables ``TypeForm``, as described in
+  `PEP 747 – Annotating Type Forms <https://peps.python.org/pep-0747/>_`.
 
 
 Miscellaneous


### PR DESCRIPTION
`mypy --help` lists `--enable-incomplete-feature {InlineTypedDict,PreciseTupleTypes,TypeForm}`, so we should probably document `--enable-incomplete-feature TypeForm` now. A link to the PEP mentioned by the [PR](https://github.com/python/mypy/pull/19596)&commit that added this feature should do the trick. (And, congratulations, everyone!)

I manually looked at an RST render of this and the link was right, which is probably all the "testing" we need here.