### PR TITLE
[docs] move --use-fine-grained-cache to Incremental group

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1063,6 +1063,12 @@ def define_options(
         action="store_true",
         help="Include fine-grained dependency information in the cache for the mypy daemon",
     )
+    if server_options:
+        incremental_group.add_argument(
+            "--use-fine-grained-cache",
+            action="store_true",
+            help="Use the cache in fine-grained incremental mode (this flag only available for dmypy)",
+        )
     incremental_group.add_argument(
         "--fixed-format-cache",
         action="store_true",
@@ -1202,13 +1208,6 @@ def define_options(
         group=misc_group,
         inverse="--interactive",
     )
-
-    if server_options:
-        misc_group.add_argument(
-            "--use-fine-grained-cache",
-            action="store_true",
-            help="Use the cache in fine-grained incremental mode",
-        )
 
     # hidden options
     parser.add_argument(


### PR DESCRIPTION
This commit moves `--use-fine-grained-cache` out of misc into incremental, a cli documentation group that seems more suitable. It also notes that the flag can only be used in dmypy.

----

@ilevkivskyi, you seem like something of a "code owner" for this feature, so feel free to close this PR if you thought the old location was better — you would know! 🙂