### PR TITLE
Adjust HTML reports in tests to support newer libxml

### DIFF
--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -444,6 +444,8 @@ def check_test_output_files(
             if testcase.suite.native_sep and os.path.sep == "\\":
                 normalized_output = [fix_cobertura_filename(line) for line in normalized_output]
             normalized_output = normalize_error_messages(normalized_output)
+        if os.path.basename(testcase.file) == "reports.test":
+            normalized_output = normalize_report_meta(normalized_output)
         assert_string_arrays_equal(
             expected_content.splitlines(),
             normalized_output,
@@ -465,6 +467,13 @@ def normalize_file_output(content: list[str], current_abs_path: str) -> list[str
     result = [re.sub(r"\b" + re.escape(base_version) + r"\b", "$VERSION", x) for x in result]
     result = [timestamp_regex.sub("$TIMESTAMP", x) for x in result]
     return result
+
+
+def normalize_report_meta(content: list[str]) -> list[str]:
+    # libxml 2.15 and newer emits the "modern" version of this <meta> element.
+    # Normalize the old style to look the same.
+    html_meta = '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'
+    return ['<meta charset="UTF-8">' if x == html_meta else x for x in content]
 
 
 def find_test_files(pattern: str, exclude: list[str] | None = None) -> list[str]:

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -118,7 +118,7 @@ class A(object):
 [outfile report/html/n.py.html]
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="../mypy-html.css">
 </head>
 <body>
@@ -172,7 +172,7 @@ T = TypeVar('T')
 [outfile report/html/n.py.html]
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="../mypy-html.css">
 </head>
 <body>
@@ -214,7 +214,7 @@ def bar(x):
 [outfile report/html/n.py.html]
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="../mypy-html.css">
 </head>
 <body>
@@ -255,7 +255,7 @@ old_stdout = sys.stdout
 [outfile report/html/n.py.html]
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="../mypy-html.css">
 </head>
 <body>
@@ -487,7 +487,7 @@ DisplayToSource = Callable[[int], int]
 [outfile report/html/n.py.html]
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="../mypy-html.css">
 </head>
 <body>
@@ -529,7 +529,7 @@ namespace_packages = True
 [outfile report/html/folder/subfolder/something.py.html]
 <html>
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta charset="UTF-8">
 <link rel="stylesheet" type="text/css" href="../../../mypy-html.css">
 </head>
 <body>


### PR DESCRIPTION
Fixes #20070.

I tested this manually in debian:sid container with `libxml2-16` installed via `apt` and `lxml==6.0.2` built against it (`--no-binary`). HTML reports testcases fail on master as reported and pass on my branch.