### PR TITLE
Prevent cache load race condition

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2108,9 +2108,15 @@ class State:
             # We do this **after** reading the file: if avoids the race condition.
             # Discarding is safe, we'll just reprocess everything if someone wrote
             # to that file since we have read from it.
-            actual_mtime = self.manager.getmtime(self.meta.data_file)
+            try:
+                actual_mtime = self.manager.getmtime(self.meta.data_file)
+            except OSError:
+                self.manager.log(f"Cache data abandoned for {self.id}: failed to stat data_file")
+                return False
             if actual_mtime != self.meta.data_mtime:
-                self.manager.log(f"Discarding {self.meta.data_file}: too fresh")
+                self.manager.log(
+                    f"Cache data abandoned for {self.id}: inconsistent data_file mtime"
+                )
                 return False
 
         t0 = time.time()


### PR DESCRIPTION
Fixes #14521. Fixes #19359. Fixes #18473.

We discussed a top-level try/except as a potential solution, but perhaps it's better to just not crash here?

When several concurrent instances of mypy are running, current implementation allows a race condition. If the cache was generated with version X and two processes (A and B) of mypy versions X and Y, resp., run at the same time, the following is possible:

* A reads fresh meta and believes data is also fresh
* B reads stale meta, processes this SCC and writes meta and data
* A reads data and fails to parse it correctly

This can be avoided by running mtime check *after* reading the data file. If it is still fresh, then A is safe to assume that data is usable, otherwise it should fall back to reprocessing the whole SCC as stale.

This change should have very low performance impact: we already perform that mtime check, I just move it to a later phase. This will result in deserializing more data files than necessary when multiple instances are running in parallel, but this is not our normal mode of operation anyway.

I am also considering an alternative - writing a random bytestring to the meta and data file and requiring that they match. This should give the same level of protection and will not fail us on systems where mtime is unreliable, but will introduce more complexity to the serialization/deserialization layer.

The race condition can be reliably reproduced on master by adding `__import__("time").sleep(0.2)` to the beginning `State.load_tree` and then launching two mypy processes as follows:

```bash
cd "$(mktemp -d)"
uv venv .venv && . .venv/bin/activate && uv pip install -e "/your/path/to/local/mypy"
uv venv .old && . .old/bin/activate && uv pip install "mypy == 1.16.1"
echo "import random" >a.py
rm -rf .mypy_cache; .venv/bin/mypy a.py; echo >>a.py; .venv/bin/mypy a.py -v --show-traceback & .old/bin/mypy a.py
```

If `/your/path/to/mypy` has current HEAD checked out with the sleep added.
