### PR TITLE
Fix incorrect variable name in `map_actuals_to_formals` docstring

### DIFF
--- a/mypy/argmap.py
+++ b/mypy/argmap.py
@@ -37,7 +37,7 @@ def map_actuals_to_formals(
     callee argument index, indexed by callee index.
 
     The actual_arg_type argument should evaluate to the type of the actual
-    argument type with the given index.
+    argument with the given index.
     """
     nformals = len(formal_kinds)
     formal_to_actual: list[list[int]] = [[] for i in range(nformals)]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

The variables names were updated, but not the docstring in 18b3cbda330a850045223307011aff0169f8b168

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
