### PR TITLE
Update librt dependency to 0.6.0

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -4,4 +4,4 @@ typing_extensions>=4.6.0
 mypy_extensions>=1.0.0
 pathspec>=0.9.0
 tomli>=1.1.0; python_version<'3.11'
-librt>=0.5.0
+librt>=0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     "mypy_extensions>=1.0.0",
     "pathspec>=0.9.0",
     "tomli>=1.1.0; python_version<'3.11'",
-    "librt>=0.5.0",
+    "librt>=0.6.0",
     # the following is from build-requirements.txt
     "types-psutil",
     "types-setuptools",
@@ -54,7 +54,7 @@ dependencies = [
   "mypy_extensions>=1.0.0",
   "pathspec>=0.9.0",
   "tomli>=1.1.0; python_version<'3.11'",
-  "librt>=0.5.0",
+  "librt>=0.6.0",
 ]
 dynamic = ["version"]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,7 +22,7 @@ identify==2.6.15
     # via pre-commit
 iniconfig==2.1.0
     # via pytest
-librt==0.5.0
+librt==0.6.0
     # via -r mypy-requirements.txt
 lxml==6.0.2 ; python_version < "3.15"
     # via -r test-requirements.in


### PR DESCRIPTION
Includes #20221 (which breaks backward compatibility).