### PR TITLE
feat: validate mypyc attrs

### DIFF
--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -142,7 +142,7 @@ def get_mypyc_attrs(
             or (key == "allow_interpreted_subclasses" and value is True and attrs.get("native_class") is False)
         ):
             errors.error("'allow_interpreted_subclasses' cannot be True if 'native_class' is False"
-        
+
         if key in MYPYC_ATTRS:
             key = cast(MypycAttr, key)
             attrs[key] = value


### PR DESCRIPTION
This PR ensures that the values set for mypyc attrs `native_class` and `allow_interpreted_subclasses` are compatible with each other

A user should not be able to pass both `native_class=False` and `allow_interpreted_subclasses=True` at the same time