### PR TITLE
fixed Incorrect type of enum in 'if' clause #20234

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -241,7 +241,6 @@ from mypy.typetraverser import TypeTraverserVisitor
 from mypy.typevars import fill_typevars, fill_typevars_with_any, has_no_typevars
 from mypy.util import is_dunder, is_sunder
 from mypy.visitor import NodeVisitor
-from mypy.types import LiteralType
 
 T = TypeVar("T")
 
@@ -6581,18 +6580,18 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
                 if left_index in narrowable_operand_index_to_hash:
                     # We only try and narrow away 'None' for now
-                        if is_overlapping_none(item_type):
-                            collection_item_type = get_proper_type(builtin_item_type(iterable_type))
-                            if (
-                                collection_item_type is not None
-                                and not is_overlapping_none(collection_item_type)
-                                and not (
-                                    isinstance(collection_item_type, Instance)
-                                    and collection_item_type.type.fullname == "builtins.object"
-                                )
-                                and is_overlapping_erased_types(item_type, collection_item_type)
-                            ):
-                                if_map[operands[left_index]] = remove_optional(item_type)
+                    if is_overlapping_none(item_type):
+                        collection_item_type = get_proper_type(builtin_item_type(iterable_type))
+                        if (
+                            collection_item_type is not None
+                            and not is_overlapping_none(collection_item_type)
+                            and not (
+                                isinstance(collection_item_type, Instance)
+                                and collection_item_type.type.fullname == "builtins.object"
+                            )
+                            and is_overlapping_erased_types(item_type, collection_item_type)
+                        ):
+                            if_map[operands[left_index]] = remove_optional(item_type)
                 if_map[operands[left_index]] = remove_optional(item_type)
                 literal_types = []
                 if isinstance(get_proper_type(iterable_type), TupleType):
@@ -6603,7 +6602,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
                             if item_type.type.is_enum:
                                 # Enum values in tuples are represented as Instance types, not LiteralType
-                                if hasattr(item_type, 'last_known_value') and item_type.last_known_value:
+                                if (
+                                    hasattr(item_type, "last_known_value")
+                                    and item_type.last_known_value
+                                ):
                                     # Use the existing literal representation
                                     literal_types.append(item_type.last_known_value)
                                 else:


### PR DESCRIPTION
# Fixes #20234 --- Correct Enum Literal Narrowing for `in` Operator with Tuples

## Problem

When using the `in` operator with tuples containing enum members, mypy
failed to narrow the left-hand side to the correct enum literal type.

### **Before this fix:**

``` python
if pizza in (Pizza.MARGHERITA,):
    reveal_type(pizza)
    # Revealed: Pizza
    # Expected: Literal[Pizza.MARGHERITA]
```

Mypy treated the tuple contents as regular `Instance` types and did not
extract the literal enum values, so narrowing never happened.

------------------------------------------------------------------------

## Solution

Enhanced `comparison_type_narrowing_helper` to detect tuples containing
enum literals and correctly narrow the type based on the enum values
inside the tuple.

### Key Points:

-   Enum values inside tuples appear as **Instance** types, not
    `LiteralType`.
-   Their literal identity is available via `last_known_value`.
-   The fix extracts these literal values, builds a `Union` of enum
    literals, and applies narrowing on the true branch of the `in`
    expression.

------------------------------------------------------------------------

##  Implementation Details

**File:** `mypy/checker.py`\
**Function:** `comparison_type_narrowing_helper`

Added enum-specific logic immediately after the existing `None`-removal
narrowing for the `in` operator:

-   Extract literal enum values from the tuple's items\
-   Construct a `Union[Literal[Enum.X], Literal[Enum.Y], ...]`\
-   Use that union as the narrowed type for the LHS\
-   Supports both `in` and `not in`

------------------------------------------------------------------------

##  Tests & Behavior

###  Correctly handled:

-   **Single enum in tuple**
    `python     if op in (Op.A,):         reveal_type(op)   # Literal[Op.A]`
-   **Multiple enums**
    `python     if op in (Op.A, Op.B):         reveal_type(op)   # Literal[Op.A] | Literal[Op.B]`
-   **Works with `not in`**
-   **Preserves existing None-removal behavior**

------------------------------------------------------------------------

##  Example

``` python
from enum import Enum

class Op(Enum):
    A = "a"
    B = "b"

def process(op: Op) -> None:
    if op in (Op.A,):
        reveal_type(op)  # Literal[Op.A]
        return

    if op is Op.B:
        reveal_type(op)  # Literal[Op.B]
        return
```