### PR TITLE
[mypyc] Fix calling base class async method using super()

### DIFF
--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -504,12 +504,12 @@ def translate_super_method_call(builder: IRBuilder, expr: CallExpr, callee: Supe
         if decl.kind == FUNC_CLASSMETHOD:
             vself = builder.primitive_op(type_op, [vself], expr.line)
         elif builder.fn_info.is_generator:
-            # For generator classes, the self target is the 6th value
+            # For generator classes, the self target is the 7th value
             # in the symbol table (which is an ordered dict). This is sort
             # of ugly, but we can't search by name since the 'self' parameter
             # could be named anything, and it doesn't get added to the
             # environment indexes.
-            self_targ = list(builder.symtables[-1].values())[6]
+            self_targ = list(builder.symtables[-1].values())[7]
             vself = builder.read(self_targ, builder.fn_info.fitem.line)
         arg_values.insert(0, vself)
         arg_kinds.insert(0, ARG_POS)

--- a/mypyc/test-data/run-async.test
+++ b/mypyc/test-data/run-async.test
@@ -1382,5 +1382,20 @@ async def trait_foo(o: TraitBase, x: int) -> int:
 def test_override_trait() -> None:
     assert asyncio.run(trait_foo(DerivedFromTrait(), 7)) == 10
 
+class Base5:
+    def __init__(self) -> None:
+        self._name = "test"
+
+    async def foo(self, x: int) -> int:
+        assert self._name == "test"
+        return x + 11
+
+class Derived5(Base5):
+    async def foo(self, x: int) -> int:
+        return await super().foo(x) + 22
+
+def test_call_using_super() -> None:
+    assert asyncio.run(Derived5().foo(5)) == 38
+
 [file asyncio/__init__.pyi]
 def run(x: object) -> object: ...


### PR DESCRIPTION
Fixes mypyc/mypyc#1154.

The next label integer value was incorrectly passed as the `self` argument.