### PR TITLE
Run enum.Enum analysis on non-assigned calls

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -221,7 +221,7 @@ from mypy.reachability import (
     infer_reachability_of_match_statement,
 )
 from mypy.scope import Scope
-from mypy.semanal_enum import EnumCallAnalyzer
+from mypy.semanal_enum import ENUM_BASES, EnumCallAnalyzer
 from mypy.semanal_namedtuple import NamedTupleAnalyzer
 from mypy.semanal_newtype import NewTypeAnalyzer
 from mypy.semanal_shared import (
@@ -5986,6 +5986,13 @@ class SemanticAnalyzer(
             expr.analyzed.line = expr.line
             expr.analyzed.column = expr.column
             expr.analyzed.accept(self)
+        elif refers_to_fullname(expr.callee, ENUM_BASES):
+            assert isinstance(expr.callee, RefExpr)
+            for a in expr.args:
+                a.accept(self)
+
+            # ensure we get analytics about enum.Enum, even if we don't assign it
+            self.enum_call_analyzer.parse_enum_call_args(expr, expr.callee.fullname.split(".")[-1])
         else:
             # Normal call expression.
             calculate_type_forms = TYPE_FORM in self.options.enable_incomplete_feature

--- a/mypy/semanal_enum.py
+++ b/mypy/semanal_enum.py
@@ -35,9 +35,7 @@ from mypy.types import LiteralType, get_proper_type
 
 # Note: 'enum.EnumMeta' is deliberately excluded from this list. Classes that directly use
 # enum.EnumMeta do not necessarily automatically have the 'name' and 'value' attributes.
-ENUM_BASES: Final = frozenset(
-    ("enum.Enum", "enum.IntEnum", "enum.Flag", "enum.IntFlag", "enum.StrEnum")
-)
+ENUM_BASES: Final = ("enum.Enum", "enum.IntEnum", "enum.Flag", "enum.IntFlag", "enum.StrEnum")
 ENUM_SPECIAL_PROPS: Final = frozenset(
     (
         "name",

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2681,3 +2681,9 @@ reveal_type(Wrapper.Nested.FOO)  # N: Revealed type is "Literal[__main__.Wrapper
 reveal_type(Wrapper.Nested.FOO.value)  # N: Revealed type is "builtins.ellipsis"
 reveal_type(Wrapper.Nested.FOO._value_)  # N: Revealed type is "builtins.ellipsis"
 [builtins fixtures/enum.pyi]
+
+[case testCatchesEnumCallWithoutAssignment]
+import enum
+
+enum.Enum()  # E: Too few arguments for Enum()
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes https://github.com/python/mypy/issues/20266

`semanal_enum.py` generally feels kinda strange, like `process_enum_call` feels redundant? The only thing it adds over simply making `semanal` do `check_enum_call` is... check that we aren't assigning to a property or a tuple. I feel like we could separate that and make it somewhat nicer.

I did the minimal thing though, so I did not refactor things.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
