### PR TITLE
stubgen: Fix mis-parsing of double colon ("::")

### DIFF
--- a/mypy/stubdoc.py
+++ b/mypy/stubdoc.py
@@ -235,6 +235,19 @@ class DocStringParser:
 
         elif (
             token.type == tokenize.OP
+            and token.string == ":"
+            and self.state[-1] == STATE_ARGUMENT_TYPE
+            and self.accumulator == ""
+        ):
+            # We thought we were after the colon of an "arg_name: arg_type"
+            # stanza, so we were expecting an "arg_type" now. However, we ended
+            # up with "arg_name::" (with two colons). That's a C++ type name,
+            # not an argument name followed by a Python type. This function
+            # signature is malformed / invalid.
+            self.reset()
+
+        elif (
+            token.type == tokenize.OP
             and token.string == "="
             and self.state[-1] in (STATE_ARGUMENT_LIST, STATE_ARGUMENT_TYPE)
         ):

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -371,6 +371,8 @@ class StubgenUtilSuite(unittest.TestCase):
             [FunctionSig(name="func", args=[ArgSig(name="x", type=None)], ret_type="Any")],
         )
 
+        assert_equal(infer_sig_from_docstring("\nfunc(invalid::type)", "func"), [])
+
         assert_equal(
             infer_sig_from_docstring('\nfunc(x: str="")', "func"),
             [


### PR DESCRIPTION
When parsing the docstrings of a function to find its set of overloads, C++ code samples that mention the function name were at risk of matching the C++ scoping operator "::" as a type annotation, leading to malformed output. For example "MyFunc(foo: int) -> bool" is a valid signature, but the sample code "MyFunc(Eigen::Lower)" was being mis-parsed. Fix this by patching stubgen to reset in case it sees a double colon where a single colon "name: type" stanza was expected.
