### PR TITLE
Bump version to 1.20.0

### DIFF
--- a/mypy/version.py
+++ b/mypy/version.py
@@ -8,7 +8,7 @@ from mypy import git
 # - Release versions have the form "1.2.3".
 # - Dev versions have the form "1.2.3+dev" (PLUS sign to conform to PEP 440).
 # - Before 1.0 we had the form "0.NNN".
-__version__ = "1.19.0+dev"
+__version__ = "1.20.0+dev"
 base_version = __version__
 
 mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
Release branch for 1.19 is now cut off, so bump the version on master.
