### PR TITLE
[mypyc] Add type annotation to setup.py

### DIFF
--- a/mypyc/lib-rt/setup.py
+++ b/mypyc/lib-rt/setup.py
@@ -99,7 +99,7 @@ if "--run-capi-tests" in sys.argv:
     kwargs: dict[str, Any]
     if sys.platform == "darwin":
         kwargs = {"language": "c++"}
-        compile_args = []
+        compile_args: list[str] = []
     else:
         kwargs = {}
         compile_args = ["--std=c++11"]


### PR DESCRIPTION
I was getting mypy errors from setup.py when running `python runtests.py self`.