### PR TITLE
Fix crash on star import of redefinition

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3201,6 +3201,10 @@ class SemanticAnalyzer(
                 # namespace is incomplete.
                 self.mark_incomplete("*", i)
             for name, node in m.names.items():
+                if node.no_serialize:
+                    # This is either internal or generated symbol, skip it to avoid problems
+                    # like accidental name conflicts or invalid cross-references.
+                    continue
                 fullname = i_id + "." + name
                 self.set_future_import_flags(fullname)
                 # if '__all__' exists, all nodes not included have had module_public set to

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -7596,3 +7596,33 @@ X = 0
 tmp/a.py:6: error: "object" has no attribute "dtypes"
 [out2]
 tmp/a.py:2: error: "object" has no attribute "dtypes"
+
+[case testStarImportCycleRedefinition]
+import m
+
+[file m.py]
+import a
+
+[file m.py.2]
+import a
+reveal_type(a.C)
+
+[file a/__init__.py]
+from a.b import *
+from a.c import *
+x = 1
+
+[file a/b.py]
+from other import C
+from a.c import y
+class C: ...  # type: ignore
+
+[file a/c.py]
+from other import C
+from a import x
+y = 1
+
+[file other.py]
+class C: ...
+[out2]
+tmp/m.py:2: note: Revealed type is "def () -> other.C"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/20327

Fix is trivial, do not grab various internal/temporary symbols with star imports. This may create an invalid cross-reference (and is generally dangerous). Likely, this worked previously because we processed all fresh modules in queue, not just the dependencies of current SCC.