### PR TITLE
Fix crash on typevar with forward ref used in other module

### DIFF
--- a/mypy/plugins/proper_plugin.py
+++ b/mypy/plugins/proper_plugin.py
@@ -108,6 +108,7 @@ def is_special_target(right: ProperType) -> bool:
             "mypy.types.RequiredType",
             "mypy.types.ReadOnlyType",
             "mypy.types.TypeGuardedType",
+            "mypy.types.PlaceholderType",
         ):
             # Special case: these are not valid targets for a type alias and thus safe.
             # TODO: introduce a SyntheticType base to simplify this?

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4941,7 +4941,7 @@ class SemanticAnalyzer(
             )
             if analyzed is None:
                 # Type variables are special: we need to place them in the symbol table
-                # soon, even if upper bound is not ready yet. Otherwise avoiding
+                # soon, even if upper bound is not ready yet. Otherwise, avoiding
                 # a "deadlock" in this common pattern would be tricky:
                 #     T = TypeVar('T', bound=Custom[Any])
                 #     class Custom(Generic[T]):

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -176,12 +176,12 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
                         code=codes.VALID_TYPE,
                     )
                     continue
+                if self.in_type_alias_expr and isinstance(arg, TypeVarType):
+                    # Type aliases are allowed to use unconstrained type variables
+                    # error will be checked at substitution point.
+                    continue
                 if tvar.values:
                     if isinstance(arg, TypeVarType):
-                        if self.in_type_alias_expr:
-                            # Type aliases are allowed to use unconstrained type variables
-                            # error will be checked at substitution point.
-                            continue
                         arg_values = arg.values
                         if not arg_values:
                             is_error = True
@@ -205,10 +205,6 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
                     and upper_bound.type.fullname == "builtins.object"
                 )
                 if not object_upper_bound and not is_subtype(arg, upper_bound):
-                    if self.in_type_alias_expr and isinstance(arg, TypeVarType):
-                        # Type aliases are allowed to use unconstrained type variables
-                        # error will be checked at substitution point.
-                        continue
                     is_error = True
                     self.fail(
                         message_registry.INVALID_TYPEVAR_ARG_BOUND.format(

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1351,3 +1351,93 @@ reveal_type(D(x="asdf"))  # E: No overload variant of "dict" matches argument ty
                           # N:     def __init__(self, arg: Iterable[tuple[str, int]], **kwargs: int) -> dict[str, int] \
                           # N: Revealed type is "Any"
 [builtins fixtures/dict.pyi]
+
+[case testTypeAliasesInCyclicImport1]
+import p.aliases
+
+[file p/__init__.py]
+[file p/aliases.py]
+from typing_extensions import TypeAlias
+from .defs import C, Alias1
+
+Alias2: TypeAlias = Alias1[C]
+
+[file p/defs.py]
+from typing import TypeVar
+from typing_extensions import TypeAlias
+import p.aliases
+
+C = TypeVar("C", bound="SomeClass")
+Alias1: TypeAlias = C
+
+class SomeClass:
+    pass
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testTypeAliasesInCyclicImport2]
+import p.aliases
+
+[file p/__init__.py]
+[file p/aliases.py]
+from typing_extensions import TypeAlias
+from .defs import C, Alias1
+
+Alias2: TypeAlias = Alias1[C]
+
+[file p/defs.py]
+from typing import TypeVar, Union
+from typing_extensions import TypeAlias
+import p.aliases
+
+C = TypeVar("C", bound="SomeClass")
+Alias1: TypeAlias = Union[C, int]
+
+class SomeClass:
+    pass
+[builtins fixtures/tuple.pyi]
+
+[case testTypeAliasesInCyclicImport3]
+import p.aliases
+
+[file p/__init__.py]
+[file p/aliases.py]
+from typing_extensions import TypeAlias
+from .defs import C, Alias1
+
+Alias2: TypeAlias = Alias1[C]
+
+[file p/defs.py]
+from typing import TypeVar
+from typing_extensions import TypeAlias
+import p.aliases
+
+C = TypeVar("C", bound="list[SomeClass]")
+Alias1: TypeAlias = C
+
+class SomeClass:
+    pass
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testTypeAliasesInCyclicImport4]
+import p.aliases
+
+[file p/__init__.py]
+[file p/aliases.py]
+from typing_extensions import TypeAlias
+from .defs import C, Alias1
+
+Alias2: TypeAlias = Alias1[C]
+
+[file p/defs.py]
+from typing import TypeVar, Union
+from typing_extensions import TypeAlias
+import p.aliases
+
+C = TypeVar("C", bound="list[SomeClass]")
+Alias1: TypeAlias = Union[C, int]
+
+class SomeClass:
+    pass
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/20326

Type variables with forward references in upper bound are known to be problematic. Existing mechanisms to work with them implicitly assumed that they are used in the same module where they are defined, which is not necessarily the case for "old-style" type variables that can be imported.

Note that the simplification I made in `semanal_typeargs.py` would be probably sufficient to fix this, but that would be papering over the real issue, so I am making a bit more principled fix.
