### PR TITLE
[mypyc] lib-rt base64: support pyodide for Python 3.12

### DIFF
--- a/mypyc/lib-rt/base64/config.h
+++ b/mypyc/lib-rt/base64/config.h
@@ -8,17 +8,15 @@
   #define HAVE_AVX 1
   #define HAVE_AVX2 1
   #define HAVE_AVX512 0
+#elif (defined(__APPLE__) && defined(__aarch64__))
+  #define HAVE_NEON64 1
+#elif (defined(__wasm__) && defined(__wasm_simd128__))
+  #include "emscripten/version.h"
+  #if __EMSCRIPTEN_major__ == 3
+    #define HAVE_NEON32 1
+  #elif __EMSCRIPTEN_major__ > 3
+    #define HAVE_NEON64 1
+  #endif
 #endif
-
-#define BASE64_WITH_NEON32 0
-#define HAVE_NEON32 BASE64_WITH_NEON32
-
-#if (defined(__APPLE__) && defined(__aarch64__)) || (defined(__wasm__) && defined(__wasm_simd128__))
-#define BASE64_WITH_NEON64 1
-#else
-#define BASE64_WITH_NEON64 0
-#endif
-
-#define HAVE_NEON64 BASE64_WITH_NEON64
 
 #endif // BASE64_CONFIG_H


### PR DESCRIPTION
Fixes the issue reported at https://github.com/mypyc/librt/pull/14#issuecomment-3592044739

For Python 3.12, [the pyodide_2024_0 ABI requires emscripten 3.1.58](https://pyodide.org/en/stable/development/abi.html#pyodide-2024-0), which uses an older version of SIMDe that doesn't include all the NEON 64-bit intrinsics we need.

So we use the 32-bit NEON intrinsics implementation of base64 for Pyodide on Python 3.12, and use the 64-bit NEON intrinsics implementations of base64 for Pyodide on Python 3.13.

[Pyodide for Python 3.13, the pyodide_2025_0 ABI, uses emscripten 4.0.9](https://pyodide.org/en/stable/development/abi.html#pyodide-2025-0-under-development)

Emscripten versdion 3.1.63 appears to be the first version with the updated SIMDe versions:

https://github.com/emscripten-core/emscripten/commit/6223c43516e41d78154f24dd319fc37da3ba1a46