### PR TITLE
Treat functions that return None as returning None

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -666,7 +666,6 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             and self.always_returns_none(e.callee)
         ):
             self.chk.msg.does_not_return_value(callee_type, e)
-            return AnyType(TypeOfAny.from_error)
         return ret_type
 
     def check_str_format_call(self, e: CallExpr) -> None:

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1075,7 +1075,8 @@ class A:
 a: A
 o: object
 if int():
-    a = f()         # E: "f" does not return a value (it only ever returns None)
+    a = f()         # E: "f" does not return a value (it only ever returns None) \
+                    # E: Incompatible types in assignment (expression has type "None", variable has type "A")
 if int():
     o = a()         # E: Function does not return a value (it only ever returns None)
 if int():
@@ -1083,7 +1084,8 @@ if int():
 if int():
     o = A.g(a, a)   # E: "g" of "A" does not return a value (it only ever returns None)
 A().g(f())      # E: "f" does not return a value (it only ever returns None)
-x: A = f()      # E: "f" does not return a value (it only ever returns None)
+x: A = f()      # E: "f" does not return a value (it only ever returns None) \
+                # E: Incompatible types in assignment (expression has type "None", variable has type "A")
 f()
 A().g(a)
 [builtins fixtures/tuple.pyi]
@@ -1100,7 +1102,8 @@ while f(): # E: "f" does not return a value (it only ever returns None)
     pass
 def g() -> object:
     return f() # E: "f" does not return a value (it only ever returns None)
-raise f() # E: "f" does not return a value (it only ever returns None)
+raise f() # E: Exception must be derived from BaseException \
+          # E: "f" does not return a value (it only ever returns None)
 [builtins fixtures/exception.pyi]
 
 [case testNoneReturnTypeWithExpressions]
@@ -1112,12 +1115,16 @@ class A:
 
 a: A
 [f()]       # E: "f" does not return a value (it only ever returns None)
-f() + a     # E: "f" does not return a value (it only ever returns None)
-a + f()     # E: "f" does not return a value (it only ever returns None)
+f() + a     # E: "f" does not return a value (it only ever returns None) \
+            # E: Unsupported left operand type for + ("None")
+a + f()     # E: "f" does not return a value (it only ever returns None) \
+            # E: Unsupported operand types for + ("A" and "None")
 f() == a    # E: "f" does not return a value (it only ever returns None)
-a != f()    # E: "f" does not return a value (it only ever returns None)
+a != f()    # E: Unsupported left operand type for != ("A") \
+            # E: "f" does not return a value (it only ever returns None)
 cast(A, f())
-f().foo     # E: "f" does not return a value (it only ever returns None)
+f().foo     # E: "f" does not return a value (it only ever returns None) \
+            # E: "None" has no attribute "foo"
 [builtins fixtures/list.pyi]
 
 [case testNoneReturnTypeWithExpressions2]
@@ -1130,11 +1137,16 @@ class A:
 
 a: A
 b: bool
-f() in a   # E: "f" does not return a value (it only ever returns None)  # E: Unsupported right operand type for in ("A")
-a < f()    # E: "f" does not return a value (it only ever returns None)
-f() <= a   # E: "f" does not return a value (it only ever returns None)
-a in f()   # E: "f" does not return a value (it only ever returns None)
--f()       # E: "f" does not return a value (it only ever returns None)
+f() in a   # E: "f" does not return a value (it only ever returns None) \
+           # E: Unsupported right operand type for in ("A")
+a < f()    # E: Unsupported left operand type for < ("A") \
+           # E: "f" does not return a value (it only ever returns None)
+f() <= a   # E: "f" does not return a value (it only ever returns None) \
+           # E: Unsupported left operand type for <= ("None")
+a in f()   # E: Unsupported right operand type for in ("None") \
+           # E: "f" does not return a value (it only ever returns None)
+-f()       # E: Unsupported operand type for unary - ("None") \
+           # E: "f" does not return a value (it only ever returns None)
 not f()    # E: "f" does not return a value (it only ever returns None)
 f() and b  # E: "f" does not return a value (it only ever returns None)
 b or f()   # E: "f" does not return a value (it only ever returns None)

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1180,7 +1180,8 @@ for e, f in [[]]:  # E: Need type annotation for "e" \
 [case testForStatementInferenceWithVoid]
 def f() -> None: pass
 
-for x in f(): # E: "f" does not return a value (it only ever returns None)
+for x in f(): # E: "f" does not return a value (it only ever returns None) \
+              # E: "None" has no attribute "__iter__" (not iterable)
     pass
 [builtins fixtures/for.pyi]
 
@@ -2176,6 +2177,7 @@ arr.append(arr.append(1))
 [builtins fixtures/list.pyi]
 [out]
 main:3: error: "append" of "list" does not return a value (it only ever returns None)
+main:3: error: Argument 1 to "append" of "list" has incompatible type "None"; expected "int"
 
 -- Multipass
 -- ---------

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -365,7 +365,8 @@ def g(x: Optional[int]) -> int:
   pass
 
 x = f()  # E: "f" does not return a value (it only ever returns None)
-f() + 1  # E: "f" does not return a value (it only ever returns None)
+f() + 1  # E: "f" does not return a value (it only ever returns None) \
+         # E: Unsupported left operand type for + ("None")
 g(f())  # E: "f" does not return a value (it only ever returns None)
 
 [case testEmptyReturn]

--- a/test-data/unit/check-varargs.test
+++ b/test-data/unit/check-varargs.test
@@ -52,8 +52,10 @@ c: C
 
 f(c)       # E: Argument 1 to "f" has incompatible type "C"; expected "A"
 f(a, b, c) # E: Argument 3 to "f" has incompatible type "C"; expected "A"
-f(g())     # E: "g" does not return a value (it only ever returns None)
-f(a, g())  # E: "g" does not return a value (it only ever returns None)
+f(g())     # E: "g" does not return a value (it only ever returns None) \
+           # E: Argument 1 to "f" has incompatible type "None"; expected "A"
+f(a, g())  # E: "g" does not return a value (it only ever returns None) \
+           # E: Argument 2 to "f" has incompatible type "None"; expected "A"
 f()
 f(a)
 f(b)


### PR DESCRIPTION
Fixes #20346

I assume the behaviour here came from the bad old days before strict optional :-)