### PR TITLE
[stubtest] transparent `@type_check_only` types

### DIFF
--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -312,6 +312,29 @@ class StubtestUnit(unittest.TestCase):
         )
 
     @collect_cases
+    def test_transparent_type_check_only_subclasses(self) -> Iterator[Case]:
+        # See https://github.com/python/mypy/issues/20223
+        yield Case(
+            stub="""
+            from typing import type_check_only
+
+            class UFunc: ...
+
+            @type_check_only
+            class _BinaryUFunc(UFunc): ...
+
+            equal: _BinaryUFunc
+            """,
+            runtime="""
+            class UFunc:
+                pass
+
+            equal = UFunc()
+            """,
+            error=None,
+        )
+
+    @collect_cases
     def test_coroutines(self) -> Iterator[Case]:
         yield Case(stub="def bar() -> int: ...", runtime="async def bar(): return 5", error="bar")
         # Don't error for this one -- we get false positives otherwise


### PR DESCRIPTION
This closes #20223 by mapping a `@type_check_only` type (of an instance) to its first non-`@type_check_only` superclass.

A use case is for annotating specific `numpy.ufunc` instances through `@type_check_only` specialized `ufunc` subtypes, as explained in #20223.