### PR TITLE
Updates error examples in Common Issues page for Issue #2393

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -233,7 +233,7 @@ Without the annotation mypy can't always figure out the
 precise type of ``a``.
 
 .. code-block:: python
-    
+
    a = []  # error: Need type annotation for "a" (hint: "a: list[<type>] = ...")
 
 You often need to specify the type when you assign an empty list or


### PR DESCRIPTION
Fixes Issue #2393

Updated generic error statements within the single Common Issues page with actual error responses when running examples.

Tried to incorporate the comments from the PR #3404 as well as the PR #7706. Attempting to take this in smaller chunks and submit multiple PRs.

No test needed as this was a documentation only update.
