### PR TITLE
Fix some compiler warnings about unused vars

### DIFF
--- a/mypyc/lib-rt/getargsfast.c
+++ b/mypyc/lib-rt/getargsfast.c
@@ -119,7 +119,7 @@ static int
 parser_init(CPyArg_Parser *parser)
 {
     const char * const *keywords;
-    const char *format, *msg;
+    const char *format;
     int i, len, min, max, nkw;
     PyObject *kwtuple;
 

--- a/mypyc/lib-rt/librt_strings.c
+++ b/mypyc/lib-rt/librt_strings.c
@@ -37,7 +37,6 @@ static bool
 _grow_buffer(BytesWriterObject *data, Py_ssize_t n) {
     Py_ssize_t target = data->len + n;
     Py_ssize_t size = data->capacity;
-    Py_ssize_t old_size = size;
     do {
         size *= 2;
     } while (target >= size);


### PR DESCRIPTION
We can't really set `-Werror` in `librt` yet, but this makes the `librt` build almost fully clean.