### PR TITLE
fix: optimize overloaded signatures check

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8751,8 +8751,9 @@ def is_unsafe_overlapping_overload_signatures(
     # Note: We repeat this check twice in both directions compensate for slight
     # asymmetries in 'is_callable_compatible'.
 
+    other_expanded = expand_callable_variants(other)
     for sig_variant in expand_callable_variants(signature):
-        for other_variant in expand_callable_variants(other):
+        for other_variant in other_expanded:
             # Using only expanded callables may cause false negatives, we can add
             # more variants (e.g. using inference between callables) in the future.
             if is_subset_no_promote(sig_variant.ret_type, other_variant.ret_type):


### PR DESCRIPTION
I've observed numerous calls to `expand_callable_variants` during the investigation of the related issue. However, expanding all the variants for parametrized classes can be time-consuming. Therefore, we should only expand callable variants once. This optimization reduces the processing time from approximately 400 seconds to 7 seconds when using non-compiled mypy in the provided case.

Refs: https://github.com/nipunn1313/mypy-protobuf/issues/707