### PR TITLE
feat: error for Final fields with init=False (#13119)

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -651,6 +651,14 @@ class DataclassTransformer:
             elif not isinstance(stmt.rvalue, TempNode):
                 has_default = True
 
+            if node.is_final and not is_in_init and not has_default:
+                has_post_init = cls.info.get("__post_init__") is not None
+                if not has_post_init:
+                    self._api.fail(
+                        f'Final field with init=False must have a default value',
+                        stmt.rvalue
+                    )
+
             if not has_default and self._spec is _TRANSFORM_SPEC_FOR_DATACLASSES:
                 # Make all non-default dataclass attributes implicit because they are de-facto
                 # set on self in the generated __init__(), not in the class body. On the other

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -655,8 +655,7 @@ class DataclassTransformer:
                 has_post_init = cls.info.get("__post_init__") is not None
                 if not has_post_init:
                     self._api.fail(
-                        f'Final field with init=False must have a default value',
-                        stmt.rvalue
+                        "Final field with init=False must have a default value", stmt.rvalue
                     )
 
             if not has_default and self._spec is _TRANSFORM_SPEC_FOR_DATACLASSES:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2737,3 +2737,59 @@ class ClassB(ClassA):
     def value(self) -> int:
         return 0
 [builtins fixtures/dict.pyi]
+
+[case testErrorFinalFieldNoInitNoArgumentPassed]
+from typing import Final
+from dataclasses import dataclass, field
+@dataclass
+class Foo:
+    a: Final[int] = field(init=False) # E: Final field with init=False must have a default value
+Foo().a
+[builtins fixtures/dataclasses.pyi]
+
+[case testErrorFinalFieldInitNoArgumentPassed]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Foo:
+    a: Final[int] = field() 
+
+Foo().a # E: Missing positional argument "a" in call to "Foo"
+[builtins fixtures/dataclasses.pyi]
+
+[case testFinalFieldGeneratedInitArgumentPassed]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Foo:
+    a: Final[int] = field() 
+
+Foo(1).a 
+[builtins fixtures/dataclasses.pyi]
+
+[case testFinalFieldPostInit]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Foo:
+    a: Final[int] = field(init=False)
+
+    def __post_init__(self):
+        self.a = 1
+
+Foo().a 
+[builtins fixtures/dataclasses.pyi]
+
+[case testFinalFieldInitFalseWithDefault]
+from typing import Final
+from dataclasses import dataclass, field
+
+@dataclass
+class Foo:
+    a: Final[int] = field(init=False, default=1)
+
+Foo().a
+[builtins fixtures/dataclasses.pyi]

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2753,7 +2753,7 @@ from dataclasses import dataclass, field
 
 @dataclass
 class Foo:
-    a: Final[int] = field() 
+    a: Final[int] = field()
 
 Foo().a # E: Missing positional argument "a" in call to "Foo"
 [builtins fixtures/dataclasses.pyi]
@@ -2764,9 +2764,9 @@ from dataclasses import dataclass, field
 
 @dataclass
 class Foo:
-    a: Final[int] = field() 
+    a: Final[int] = field()
 
-Foo(1).a 
+Foo(1).a
 [builtins fixtures/dataclasses.pyi]
 
 [case testFinalFieldPostInit]
@@ -2780,7 +2780,7 @@ class Foo:
     def __post_init__(self):
         self.a = 1
 
-Foo().a 
+Foo().a
 [builtins fixtures/dataclasses.pyi]
 
 [case testFinalFieldInitFalseWithDefault]


### PR DESCRIPTION
This Pull Request adds an error report when a dataclass field is declared as `Final`, has `init=False`, and lacks a default value, as discussed in Issue #13119. This change adds a check to detect this combination while avoiding complex control flow analysis, as requested. It also flags no error if there's a `__post_init__` method, to avoid possible false positives.

Test cases were adapted from PR #14285. I also added a new test case for default values provided on the field declaration.
Thanks to @jakezych for the original test cases.

Fixes #13119