### PR TITLE
Allow `types.NoneType` in match cases

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -46,6 +46,7 @@ from mypy.types import (
     Type,
     TypedDictType,
     TypeOfAny,
+    TypeType,
     TypeVarTupleType,
     TypeVarType,
     UninhabitedType,
@@ -556,6 +557,8 @@ class PatternChecker(PatternVisitor[PatternType]):
             fallback = self.chk.named_type("builtins.function")
             any_type = AnyType(TypeOfAny.unannotated)
             typ = callable_with_ellipsis(any_type, ret_type=any_type, fallback=fallback)
+        elif isinstance(p_typ, TypeType) and isinstance(p_typ.item, NoneType):
+            typ = p_typ.item
         elif not isinstance(p_typ, AnyType):
             self.msg.fail(
                 message_registry.CLASS_PATTERN_TYPE_REQUIRED.format(

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -3178,3 +3178,19 @@ match 5:
         reveal_type(b)  # N: Revealed type is "Any"
     case BlahBlah(c=c):  # E: Name "BlahBlah" is not defined
         reveal_type(c)  # N: Revealed type is "Any"
+
+[case testMatchAllowsNoneTypeAsClass]
+import types
+
+class V:
+    X = types.NoneType
+
+def fun(val: str | None):
+    match val:
+        case V.X():
+            reveal_type(val)  # N: Revealed type is "None"
+
+    match val:
+        case types.NoneType():
+            reveal_type(val)  # N: Revealed type is "None"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes https://github.com/python/mypy/issues/20367

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
