### PR TITLE
[stubtest] ignore `__conditional_annotations__`

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1653,6 +1653,7 @@ IGNORED_MODULE_DUNDERS: Final = frozenset(
         "__loader__",
         "__spec__",
         "__annotations__",
+        "__conditional_annotations__",  # 3.14+
         "__annotate__",
         "__path__",  # mypy adds __path__ to packages, but C packages don't have it
         "__getattr__",  # resulting behaviour might be typed explicitly


### PR DESCRIPTION
On Python 3.14, this module attribute seems to exist in certain situations:

```pycon
>>> if True:
...     a: str
...     
>>> __conditional_annotations__
{0}
```

It's a pretty esoteric attribute without any documentation. It seems to have been added in https://github.com/python/cpython/pull/130935

Either way, stubtest was complaining about it in scipy-stubs. So all things considered, I figured it'd be best to just ignore it.