### PR TITLE
Write some tests that enforce that disabled_error_codes and enabled_error_codes do not affect program behavior

### DIFF
--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1,3 +1,43 @@
+[case testDisabledErrorCodesIsNotARealFlagContrast]
+-- This is the real flag, that contrasts with the fake one in the other test.
+-- see also: cmdline.test for the one that does a usage error and prints to stderr
+# flags: --disable-error-code=name-defined
+A
+
+[case testDisabledErrorCodesIsNotARealFlagConfig]
+-- disabled-error-codes is not a real flag, just an implementation field, and this test serves to ensure it doesn't affect program behavior.
+# flags: --config tmp/n.ini
+A  # E: Name "A" is not defined
+[file n.ini]
+\[mypy]
+disabled_error_codes=name-defined
+
+[case testDisabledErrorCodesIsNotARealFlagInline]
+-- disabled-error-codes is not a real flag, just an implementation field, and this test serves to ensure it doesn't affect program behavior.
+#mypy: disabled_error_codes=name-defined
+A # E: Name "A" is not defined
+
+
+[case testEnabledErrorCodesIsNotARealFlagContrast]
+-- This is the real flag, that contrasts with the fake one in the other test.
+-- see also: cmdline.test for the one that does a usage error and prints to stderr
+# flags: --enable-error-code=unused-ignore
+#type: ignore # E: Unused "type: ignore" comment
+
+[case testEnabledErrorCodesIsNotARealFlagConfig]
+-- enabled-error-codes is not a real flag, just an implementation field, and this test serves to ensure it doesn't affect program behavior.
+# flags: --config tmp/n.ini
+#type: ignore
+[file n.ini]
+\[mypy]
+disabled_error_codes=unused-ignore
+
+[case testEnabledErrorCodesIsNotARealFlagInline]
+-- enabled-error-codes is not a real flag, just an implementation field, and this test serves to ensure it doesn't affect program behavior.
+#mypy: enabled_error_codes=unused-ignore
+#type: ignore
+
+
 [case testUnannotatedFunction]
 # flags: --disallow-untyped-defs
 def f(x): pass

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1388,6 +1388,41 @@ Warning: TypeVarTuple is already enabled by default
 Warning: Unpack is already enabled by default
 == Return code: 0
 
+[case testDisabledErrorCodesIsNotARealFlagCmdContrast]
+# cmd: mypy --disable-error-code=name-defined a.py
+-- This is the real flag, that contrasts with the fake one in the other test.
+[file a.py]
+A
+
+[case testDisabledErrorCodesIsNotARealFlagCmd]
+# cmd: mypy --disabled-error-codes=name-defined a.py
+-- disabled-error-codes is not a real flag, just an implementation field, and this test serves to ensure it doesn't affect program behavior.
+-- see also: check-flags.test for the ones that can be check without the full cmdline.test treatment.
+[file a.py]
+A
+[out]
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: unrecognized arguments: --disabled-error-codes=name-defined
+== Return code: 2
+
+[case testEnabledErrorCodesIsNotARealFlagCmdContrast]
+# cmd: mypy --enable-error-code=unused-ignore a.py
+-- This is the real flag, that contrasts with the fake one in the other test.
+[file a.py]
+#type: ignore # E: Unused "type: ignore" comment
+
+[case testEnabledErrorCodesIsNotARealFlagCmd]
+# cmd: mypy --enabled-error-codes=unused-ignore a.py
+-- enabled-error-codes is not a real flag, just an implementation field, and this test serves to ensure it doesn't affect program behavior.
+-- see also: check-flags.test for the ones that can be check without the full cmdline.test treatment.
+[file a.py]
+#type: ignore
+[out]
+usage: mypy [-h] [-v] [-V] [more options; see below]
+            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
+mypy: error: unrecognized arguments: --enabled-error-codes=unused-ignore
+== Return code: 2
 [case testImportlibImportCannotBeResolved]
 # cmd: mypy a.py
 # This test is here because it needs use_builtins_fixtures off.


### PR DESCRIPTION
While disabled_error_codes and enabled_error_codes are internal fields in the options class, they cannot be set externally, unlike their peers. These tests ensure this intended behavior is maintained. Closes https://github.com/python/mypy/issues/12394, which failed to understand this.

Some of these tests have to be in cmdline.test because they error so badly that they break check-flags.test (they exit with 2 and print to stderr instead, which apparently check-flags.test can't handle; cf https://github.com/python/mypy/issues/19554).