### PR TITLE
Fix a bug where runtests.py didn't run non-testcheck .test files individually when asked to

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -114,10 +114,7 @@ def run_cmd(name: str) -> int:
     if name in cmds:
         cmd = cmds[name]
     else:
-        if name.endswith(".test"):
-            cmd = ["pytest", f"mypy/test/testcheck.py::TypeCheckSuite::{name}"]
-        else:
-            cmd = ["pytest", "-n0", "-k", name]
+        cmd = ["pytest", "-n0", "-k", name]
     print(f"run {name}: {cmd}")
     proc = subprocess.run(cmd, stderr=subprocess.STDOUT)
     if proc.returncode:
@@ -161,7 +158,7 @@ def main() -> None:
             "Run the given tests. If given no arguments, run everything except"
             + " pytest-extra and mypyc-extra. Unrecognized arguments will be"
             + " interpreted as individual test names / substring expressions"
-            + " (or, if they end in .test, individual test files)"
+            + " (which can end in .test, to specify individual test files)"
             + " and this script will try to run them."
         )
         if "-h" in args or "--help" in args:


### PR DESCRIPTION
Due to the way I originally wrote this feature, foolishly generalizing too narrowly from the CONTRIBUTING.md example, you actually could only run testcheck files this way. Luckily, the fix is as simple as not specifying some extra stuff! Since the test file name is in whatever string -k checks against.