### PR TITLE
Fix Typo `attr` -> `attrs` 

### DIFF
--- a/docs/source/additional_features.rst
+++ b/docs/source/additional_features.rst
@@ -135,7 +135,7 @@ Type annotations can be added as follows:
 
 .. code-block:: python
 
-    import attr
+    import attrs
 
     @attrs.define
     class A:


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

In the example, `attrs` is used, even though `attr` is imported.
Picking either one isn't important, but the code gives a runtime error when the other one is used.

Are there doctests, including running Mypy on the docs?

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
