### PR TITLE
Wrap callable in union syntax

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -4013,7 +4013,11 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         """
         res = []
         for t in a:
-            res.append(t.accept(self))
+            s = t.accept(self)
+            if use_or_syntax and isinstance(get_proper_type(t), CallableType):
+                res.append(f"({s})")
+            else:
+                res.append(s)
         sep = ", " if not use_or_syntax else " | "
         return sep.join(res)
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -7147,7 +7147,7 @@ def test() -> None:
         x = Other
     else:
         return
-    reveal_type(x)  # N: Revealed type is "def () -> __main__.One | def () -> __main__.Other"
+    reveal_type(x)  # N: Revealed type is "(def () -> __main__.One) | (def () -> __main__.Other)"
     reveal_type(x.x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/isinstancelist.pyi]
 

--- a/test-data/unit/check-classvar.test
+++ b/test-data/unit/check-classvar.test
@@ -344,7 +344,7 @@ class C:
     def f(self) -> int: ...
     g: ClassVar[Union[Callable[[C], int], int]] = f
 
-reveal_type(C().g)  # N: Revealed type is "def () -> builtins.int | builtins.int"
+reveal_type(C().g)  # N: Revealed type is "(def () -> builtins.int) | builtins.int"
 
 [case testGenericSubclassAccessNoLeak]
 from typing import ClassVar, Generic, TypeVar

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2293,7 +2293,7 @@ def f() -> None:
 def g(x: int) -> None:
     pass
 h = f if bool() else g
-reveal_type(h) # N: Revealed type is "def () | def (x: builtins.int)"
+reveal_type(h) # N: Revealed type is "(def ()) | (def (x: builtins.int))"
 h(7) # E: Too many arguments for "f"
 
 T = TypeVar("T")

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -1467,17 +1467,17 @@ class Wrapper:
 
 def f(cond: bool) -> Any:
     f = Wrapper if cond else lambda x: x
-    reveal_type(f)  # N: Revealed type is "def (x: Any) -> __main__.Wrapper | def (x: Any) -> Any"
+    reveal_type(f)  # N: Revealed type is "(def (x: Any) -> __main__.Wrapper) | (def (x: Any) -> Any)"
     return f(3)
 
 def g(cond: bool) -> Any:
     f = lambda x: x if cond else Wrapper
-    reveal_type(f)  # N: Revealed type is "def (x: Any) -> Any | def (x: Any) -> __main__.Wrapper"
+    reveal_type(f)  # N: Revealed type is "def (x: Any) -> Any | (def (x: Any) -> __main__.Wrapper)"
     return f(3)
 
 def h(cond: bool) -> Any:
     f = (lambda x: x) if cond else Wrapper
-    reveal_type(f)  # N: Revealed type is "def (x: Any) -> Any | def (x: Any) -> __main__.Wrapper"
+    reveal_type(f)  # N: Revealed type is "(def (x: Any) -> Any) | (def (x: Any) -> __main__.Wrapper)"
     return f(3)
 
 -- Boolean operators

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -1951,7 +1951,7 @@ reveal_type(t1.__iter__) # N: Revealed type is "def () -> typing.Iterator[__main
 t2: NTInt
 reveal_type(t2.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.int]"
 nt: Union[NTInt, NTStr]
-reveal_type(nt.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.int] | def () -> typing.Iterator[builtins.str]"
+reveal_type(nt.__iter__) # N: Revealed type is "(def () -> typing.Iterator[builtins.int]) | (def () -> typing.Iterator[builtins.str])"
 for nx in nt:
     reveal_type(nx) # N: Revealed type is "builtins.int | builtins.str"
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1509,9 +1509,9 @@ def foo(x: int) -> str: ...
 def foo2(__x: int) -> Callable[[int], str]: ...
 
 x: C[[int, str]]
-reveal_type(x)  # N: Revealed type is "def (builtins.int, builtins.str) -> builtins.int | ..."
+reveal_type(x)  # N: Revealed type is "def (builtins.int, builtins.str) -> builtins.int | (...)"
 y: C[int, str]
-reveal_type(y)  # N: Revealed type is "def (builtins.int, builtins.str) -> builtins.int | ..."
+reveal_type(y)  # N: Revealed type is "def (builtins.int, builtins.str) -> builtins.int | (...)"
 [builtins fixtures/paramspec.pyi]
 
 [case testParamSpecAliasInRuntimeContext]

--- a/test-data/unit/check-recursive-types.test
+++ b/test-data/unit/check-recursive-types.test
@@ -95,7 +95,7 @@ A = Union[B, int]
 B = Callable[[C], int]
 C = Type[A]
 x: A
-reveal_type(x)  # N: Revealed type is "def (type[def (...) -> builtins.int] | type[builtins.int]) -> builtins.int | builtins.int"
+reveal_type(x)  # N: Revealed type is "(def (type[def (...) -> builtins.int] | type[builtins.int]) -> builtins.int) | builtins.int"
 
 [case testRecursiveAliasesProhibited-skip]
 from typing import Type, Callable, Union

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -1135,7 +1135,7 @@ class C:
     def same(self: T) -> T: ...
 
 x: Union[A, C]
-reveal_type(x.same)  # N: Revealed type is "builtins.int | def () -> __main__.C"
+reveal_type(x.same)  # N: Revealed type is "builtins.int | (def () -> __main__.C)"
 
 [case testSelfTypeOnUnionClassMethod]
 from typing import TypeVar, Union, Type
@@ -1150,7 +1150,7 @@ class C:
     def same(cls: Type[T]) -> T: ...
 
 x: Union[A, C]
-reveal_type(x.same)  # N: Revealed type is "builtins.int | def () -> __main__.C"
+reveal_type(x.same)  # N: Revealed type is "builtins.int | (def () -> __main__.C)"
 [builtins fixtures/classmethod.pyi]
 
 [case SelfTypeOverloadedClassMethod]
@@ -1201,7 +1201,7 @@ class B(A): ...
 class C(A): ...
 
 t: Type[Union[B, C]]
-reveal_type(t.meth)  # N: Revealed type is "def () -> __main__.B | def () -> __main__.C"
+reveal_type(t.meth)  # N: Revealed type is "(def () -> __main__.B) | (def () -> __main__.C)"
 x = t.meth()
 reveal_type(x)  # N: Revealed type is "__main__.B | __main__.C"
 [builtins fixtures/classmethod.pyi]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -386,8 +386,8 @@ reveal_type(u(type, type)) # N: Revealed type is "def (x: builtins.object) -> bu
 # One type, other non-type
 reveal_type(u(t_s, 1)) # N: Revealed type is "builtins.int | type[builtins.str]"
 reveal_type(u(1, t_s)) # N: Revealed type is "type[builtins.str] | builtins.int"
-reveal_type(u(type, 1)) # N: Revealed type is "builtins.int | def (x: builtins.object) -> builtins.type"
-reveal_type(u(1, type)) # N: Revealed type is "def (x: builtins.object) -> builtins.type | builtins.int"
+reveal_type(u(type, 1)) # N: Revealed type is "builtins.int | (def (x: builtins.object) -> builtins.type)"
+reveal_type(u(1, type)) # N: Revealed type is "(def (x: builtins.object) -> builtins.type) | builtins.int"
 reveal_type(u(t_a, 1)) # N: Revealed type is "builtins.int | type[Any]"
 reveal_type(u(1, t_a)) # N: Revealed type is "type[Any] | builtins.int"
 reveal_type(u(t_o, 1)) # N: Revealed type is "builtins.int | type[builtins.object]"
@@ -468,11 +468,11 @@ i_C: Callable[[int], C]
 
 reveal_type(u(D_C, D_C)) # N: Revealed type is "def (__main__.D) -> __main__.C"
 
-reveal_type(u(A_C, D_C)) # N: Revealed type is "def (__main__.D) -> __main__.C | def (Any) -> __main__.C"
-reveal_type(u(D_C, A_C)) # N: Revealed type is "def (Any) -> __main__.C | def (__main__.D) -> __main__.C"
+reveal_type(u(A_C, D_C)) # N: Revealed type is "(def (__main__.D) -> __main__.C) | (def (Any) -> __main__.C)"
+reveal_type(u(D_C, A_C)) # N: Revealed type is "(def (Any) -> __main__.C) | (def (__main__.D) -> __main__.C)"
 
-reveal_type(u(D_A, D_C)) # N: Revealed type is "def (__main__.D) -> __main__.C | def (__main__.D) -> Any"
-reveal_type(u(D_C, D_A)) # N: Revealed type is "def (__main__.D) -> Any | def (__main__.D) -> __main__.C"
+reveal_type(u(D_A, D_C)) # N: Revealed type is "(def (__main__.D) -> __main__.C) | (def (__main__.D) -> Any)"
+reveal_type(u(D_C, D_A)) # N: Revealed type is "(def (__main__.D) -> Any) | (def (__main__.D) -> __main__.C)"
 
 reveal_type(u(D_C, C_C)) # N: Revealed type is "def (__main__.D) -> __main__.C"
 reveal_type(u(C_C, D_C)) # N: Revealed type is "def (__main__.D) -> __main__.C"
@@ -480,7 +480,7 @@ reveal_type(u(C_C, D_C)) # N: Revealed type is "def (__main__.D) -> __main__.C"
 reveal_type(u(D_C, D_D)) # N: Revealed type is "def (__main__.D) -> __main__.C"
 reveal_type(u(D_D, D_C)) # N: Revealed type is "def (__main__.D) -> __main__.C"
 
-reveal_type(u(D_C, i_C)) # N: Revealed type is "def (builtins.int) -> __main__.C | def (__main__.D) -> __main__.C"
+reveal_type(u(D_C, i_C)) # N: Revealed type is "(def (builtins.int) -> __main__.C) | (def (__main__.D) -> __main__.C)"
 
 [case testUnionOperatorMethodSpecialCase]
 from typing import Union
@@ -821,7 +821,7 @@ class NTStr(NamedTuple):
 t1: NTInt
 reveal_type(t1.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.int]"
 nt: Union[NTInt, NTStr]
-reveal_type(nt.__iter__) # N: Revealed type is "def () -> typing.Iterator[builtins.int] | def () -> typing.Iterator[builtins.str]"
+reveal_type(nt.__iter__) # N: Revealed type is "(def () -> typing.Iterator[builtins.int]) | (def () -> typing.Iterator[builtins.str])"
 for nx in nt:
     reveal_type(nx) # N: Revealed type is "builtins.int | builtins.str"
 

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10383,7 +10383,7 @@ reveal_type(x)
 [builtins fixtures/tuple.pyi]
 [out]
 ==
-a.py:3: note: Revealed type is "def (x: builtins.int) -> builtins.int | def (*x: builtins.int) -> builtins.int"
+a.py:3: note: Revealed type is "(def (x: builtins.int) -> builtins.int) | (def (*x: builtins.int) -> builtins.int)"
 
 [case testErrorInReAddedModule]
 # flags: --disallow-untyped-defs --follow-imports=error


### PR DESCRIPTION
Followup to https://github.com/python/mypy/pull/20332#issuecomment-3591897907

Wrap the callable with `( )` if it's within a union to reduce ambiguity. This matches the pyright behavior.

```py
def f1() -> int | None: return 1
def f2() -> int: return 1

reveal_type(f1)                     # def () -> builtins.int | None
reveal_type(f2 if int() else None)  # (def () -> builtins.int)) | None
```