### PR TITLE
Remove --force-uppercase-builtins flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Support for this will be dropped in the first half of 2026!
 
 Contributed by Marc Mueller (PR [20156](https://github.com/python/mypy/pull/20156)).
 
+### Removed Flag: `--force-uppercase-builtins`
+
+Removed the deprecated `--force-uppercase-builtins` flag. It has been a no-op since mypy 1.17.0.
+
+Contributed by Marc Mueller (PR [20410](https://github.com/python/mypy/pull/20410))
+
 ### Removed Flag: `--force-union-syntax`
 
 Mypy only supports Python 3.10+. Removed the `--force-union-syntax` flag as it's no longer necessary.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -815,11 +815,6 @@ def define_options(
         help="Disable strict Optional checks (inverse: --strict-optional)",
     )
 
-    # This flag is deprecated, Mypy only supports Python 3.9+
-    add_invertible_flag(
-        "--force-uppercase-builtins", default=False, help=argparse.SUPPRESS, group=none_group
-    )
-
     lint_group = parser.add_argument_group(
         title="Configuring warnings",
         description="Detect code that is sound but redundant or problematic.",
@@ -1536,9 +1531,6 @@ def process_options(
 
     if options.strict_concatenate and not strict_option_set:
         print("Warning: --strict-concatenate is deprecated; use --extra-checks instead")
-
-    if options.force_uppercase_builtins:
-        print("Warning: --force-uppercase-builtins is deprecated; mypy only supports Python 3.9+")
 
     # Set target.
     if special_opts.modules + special_opts.packages:

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -4,7 +4,6 @@ import pprint
 import re
 import sys
 import sysconfig
-import warnings
 from collections.abc import Callable
 from re import Pattern
 from typing import Any, Final
@@ -410,8 +409,6 @@ class Options:
 
         self.disable_bytearray_promotion = False
         self.disable_memoryview_promotion = False
-        # Deprecated, Mypy only supports Python 3.9+
-        self.force_uppercase_builtins = False
 
         # Sets custom output format
         self.output: str | None = None
@@ -421,14 +418,6 @@ class Options:
         # Skip writing C output files, but perform all other steps of a build (allows
         # preserving manual tweaks to generated C file)
         self.mypyc_skip_c_generation = False
-
-    def use_lowercase_names(self) -> bool:
-        warnings.warn(
-            "options.use_lowercase_names() is deprecated and will be removed in a future version",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return True
 
     def use_star_unpack(self) -> bool:
         return self.python_version >= (3, 11)


### PR DESCRIPTION
The flag has been a no-op since mypy 1.17.0.