### PR TITLE
Fix conditional_types remainder for structural types

### DIFF
--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -866,6 +866,20 @@ class Foo:
         return 2
 [builtins fixtures/list.pyi]
 
+[case testRedundantExpressionsUnionWithAny]
+# flags: --enable-error-code redundant-expr
+from typing import Any, Awaitable, Union
+ok_list: list[Union[Any, Awaitable]]
+for y in ok_list:
+    z = 1 if isinstance(y, Awaitable) else 2
+
+bad_list: list[Awaitable]
+for y in bad_list:
+    z = 1 if isinstance(y, Awaitable) else 2  # E: If condition is always true  [redundant-expr]
+[builtins fixtures/isinstancelist.pyi]
+[typing fixtures/typing-full.pyi]
+
+
 [case testNamedTupleNameMismatch]
 from typing import NamedTuple
 


### PR DESCRIPTION
Fixes #20445

Fixes a regression in `conditional_type` when given a union of `Any | Protocol`