### PR TITLE
Fix unaligned memory access in librt internal helper function _write_short

### DIFF
--- a/mypyc/lib-rt/librt_internal.c
+++ b/mypyc/lib-rt/librt_internal.c
@@ -3,6 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdint.h>
+#include <string.h>
 #include "CPy.h"
 #define LIBRT_INTERNAL_MODULE
 #include "librt_internal.h"
@@ -39,13 +40,14 @@
 
 #define _READ(result, data, type) \
     do { \
-        *(result) = *(type *)(((ReadBufferObject *)data)->ptr); \
+        memcpy((void *) result, ((ReadBufferObject *)data)->ptr, sizeof(type)); \
         ((ReadBufferObject *)data)->ptr += sizeof(type); \
     } while (0)
 
 #define _WRITE(data, type, v) \
     do { \
-       *(type *)(((WriteBufferObject *)data)->ptr) = v; \
+       type temp = v; \
+       memcpy(((WriteBufferObject *)data)->ptr, (const void *) &temp, sizeof(type)); \
        ((WriteBufferObject *)data)->ptr += sizeof(type); \
     } while (0)
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->
Fixes: #20473

This PR replaces the static upcasting in the helper macros `_READ` and `_WRITE` with a `memcpy` call.

Some of the functions in `librt_internal.c` use these macros to write 16 or 32 bit integer values, while the `data->ptr` is byte-aligned and may point to a memory address that is not divisible by 2 or 4.
This leads to a crash (with SIGBUS) on CPU architectures that have strict memory alignment, or possibly a performance penalty on others.

By replacing the direct assignment with `memcpy`, the compiler will figure out the most optimal method to access the unaligned memory.
I analyzed the resulting machine code generated by gcc 15 on amd64 and sparc64: The `memcpy` call was in fact optimized away, with instructions that avoided the crash on sparc64. On amd64, it made no difference performance-wise (compared to the original code).
