### PR TITLE
Assert that Parameters are not passed to tuples

### DIFF
--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1824,3 +1824,10 @@ class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "tuple[A, A]", variable has type "tuple_aa_subclass")
 [builtins fixtures/tuple.pyi]
+
+[case testTuplePassedParameters]
+from typing_extensions import Concatenate
+
+def c(t: tuple[Concatenate[int, ...]]) -> None:  # E: Cannot use "[int, VarArg(Any), KwArg(Any)]" for tuple, only for ParamSpec
+    reveal_type(t)  # N: Revealed type is "tuple[Any]"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2481,9 +2481,11 @@ reveal_type(a)  # N: Revealed type is "__main__.A[[builtins.int, builtins.str], 
 b: B[int, str, [int, str]]
 reveal_type(b)  # N: Revealed type is "__main__.B[builtins.int, builtins.str, [builtins.int, builtins.str]]"
 
-x: A[int, str, [int, str]]  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "int"
+x: A[int, str, [int, str]]  # E: Cannot use "[int, str]" for TypeVarTuple, only for ParamSpec \
+                            # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "int"
 reveal_type(x)  # N: Revealed type is "__main__.A[Any, Unpack[builtins.tuple[Any, ...]]]"
-y: B[[int, str], int, str]  # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "str"
+y: B[[int, str], int, str]  # E: Cannot use "[int, str]" for TypeVarTuple, only for ParamSpec \
+                            # E: Can only replace ParamSpec with a parameter types list or another ParamSpec, got "str"
 reveal_type(y)  # N: Revealed type is "__main__.B[Unpack[builtins.tuple[Any, ...]], Any]"
 
 R = TypeVar("R")
@@ -2738,4 +2740,17 @@ def foo() -> str:
 
 # this is a false positive, but it no longer crashes
 call(run, foo, some_kwarg="a")  # E: Argument 1 to "call" has incompatible type "def [Ts`-1, T] run(func: def (*Unpack[Ts]) -> T, *args: Unpack[Ts], some_kwarg: str = ...) -> T"; expected "Callable[[Callable[[], str], str], str]"
+[builtins fixtures/tuple.pyi]
+
+[case testTypeVarTuplePassedParameters]
+from typing import TypeVarTuple, Generic, Unpack
+from typing_extensions import Concatenate
+
+Ts = TypeVarTuple("Ts")
+
+class X(Generic[Unpack[Ts]]):
+    ...
+
+def c(t: X[Concatenate[int, ...]]) -> None:  # E: Cannot use "[int, VarArg(Any), KwArg(Any)]" for TypeVarTuple, only for ParamSpec
+    reveal_type(t)  # N: Revealed type is "__main__.X[Unpack[builtins.tuple[Any, ...]]]"
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes https://github.com/python/mypy/issues/20452. I also noticed `TypeVarTuple`s have the same issue, so I fixed that too.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
