### PR TITLE
gh-20495: Update checkpattern.py

### DIFF
--- a/mypy/checkpattern.py
+++ b/mypy/checkpattern.py
@@ -546,7 +546,7 @@ class PatternChecker(PatternVisitor[PatternType]):
         typ = self.chk.expr_checker.accept(o.class_ref)
         p_typ = get_proper_type(typ)
         if isinstance(type_info, TypeAlias) and not type_info.no_args:
-            self.msg.fail(message_registry.CLASS_PATTERN_GENERIC_TYPE_ALIAS, o)
+            self.msg.fail(message_registry.NOT_CALLABLE.format('"TypeAliasType"'), o)
             return self.early_non_match()
         elif isinstance(p_typ, FunctionLike) and p_typ.is_type_obj():
             typ = fill_typevars_with_any(p_typ.type_object())


### PR DESCRIPTION
gh-20495

`CLASS_PATTERN_GENERIC_TYPE_ALIAS` in `mypy/mypy/message_registry.py` below is no longer used so you can decide to remove it or not:

```python
CLASS_PATTERN_GENERIC_TYPE_ALIAS: Final = (
    "Class pattern class must not be a type alias with type parameters"
)
```