### PR TITLE
Don't read errors from cache on silent import (#20508)

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2180,7 +2180,8 @@ class State:
             self.dep_hashes = {
                 k: v for (k, v) in zip(self.meta.dependencies, self.meta.dep_hashes)
             }
-            self.error_lines = self.meta.error_lines
+            # Only copy `error_lines` if the module is not silently imported.
+            self.error_lines = [] if self.ignore_all else self.meta.error_lines
             if temporary:
                 self.load_tree(temporary=True)
             if not manager.use_fine_grained_cache():

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2465,6 +2465,25 @@ def foo(a: int, b: int) -> str:
 [out2]
 tmp/b.py:2: error: Incompatible return value type (got "int", expected "str")
 
+[case testIncrementalWithSilentImportsReverse]
+-- Same commands as previous test, just in reverse order.
+-- expected output is also in reverse order
+# cmd: mypy -m b
+# cmd2: mypy -m a
+# flags: --follow-imports=silent
+[file a.py]
+import b
+
+b.foo(1, 2)
+
+[file b.py]
+def foo(a: int, b: int) -> str:
+    return a + b
+
+[out]
+tmp/b.py:2: error: Incompatible return value type (got "int", expected "str")
+[out2]
+
 [case testForwardNamedTupleToUnionWithOtherNamedTUple]
 from typing import NamedTuple, Union
 


### PR DESCRIPTION
When using `--follow-imports=silent`, we do not care about the errors in imported files, only about errors in the files we're explicitly reading.

Fixes #20508.