### PR TITLE
Ensure new_cmd is always defined

### DIFF
--- a/mypyc/build_setup.py
+++ b/mypyc/build_setup.py
@@ -40,8 +40,8 @@ NO_EXTRA_FLAGS = "MYPYC_NO_EXTRA_FLAGS" in os.environ
 
 
 def spawn(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    new_cmd = list(cmd)
     if PYODIDE:
-        new_cmd = list(cmd)
         for argument in reversed(new_cmd):
             if not str(argument).endswith(".c"):
                 continue
@@ -50,7 +50,6 @@ def spawn(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
     elif not NO_EXTRA_FLAGS:
         compiler_type: str = self.compiler_type
         extra_options = EXTRA_FLAGS_PER_COMPILER_TYPE_PER_PATH_COMPONENT.get(compiler_type, None)
-        new_cmd = list(cmd)
         if X86_64 and extra_options is not None:
             # filenames are closer to the end of command line
             for argument in reversed(new_cmd):

--- a/mypyc/lib-rt/build_setup.py
+++ b/mypyc/lib-rt/build_setup.py
@@ -40,8 +40,8 @@ NO_EXTRA_FLAGS = "MYPYC_NO_EXTRA_FLAGS" in os.environ
 
 
 def spawn(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    new_cmd = list(cmd)
     if PYODIDE:
-        new_cmd = list(cmd)
         for argument in reversed(new_cmd):
             if not str(argument).endswith(".c"):
                 continue
@@ -50,7 +50,6 @@ def spawn(self, cmd, **kwargs) -> None:  # type: ignore[no-untyped-def]
     elif not NO_EXTRA_FLAGS:
         compiler_type: str = self.compiler_type
         extra_options = EXTRA_FLAGS_PER_COMPILER_TYPE_PER_PATH_COMPONENT.get(compiler_type, None)
-        new_cmd = list(cmd)
         if X86_64 and extra_options is not None:
             # filenames are closer to the end of command line
             for argument in reversed(new_cmd):


### PR DESCRIPTION
Fix build when `MYPYC_NO_EXTRA_FLAGS` env variable is defined.
