### PR TITLE
Fix crash on circular star import in incremental mode

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3224,6 +3224,12 @@ class SemanticAnalyzer(
                     self.add_imported_symbol(
                         name, node, context=i, module_public=True, module_hidden=False
                     )
+                    # This is a (minimalist) copy of the logic in visit_import_from(), we need
+                    # to clean-up any remaining placeholders by replacing them with Var(Any).
+                    if isinstance(node.node, PlaceholderNode) and self.final_iteration:
+                        self.add_unknown_imported_symbol(
+                            name, i, target_name=None, module_public=True, module_hidden=False
+                        )
 
         else:
             # Don't add any dummy symbols for 'from x import *' if 'x' is unknown.

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -7683,3 +7683,20 @@ main:4: error: Too many arguments for "C"
 [out2]
 main:2: error: Module "m1" has no attribute "D"
 main:4: error: Too many arguments for "C"
+
+[case testCyclicUndefinedImportWithStarIncremental]
+import m
+[file m.py]
+import a
+[file m.py.2]
+import a
+reveal_type(a.no_such_export)
+[file a.py]
+from b import no_such_export
+[file b.py]
+from a import *
+[out]
+tmp/b.py:1: error: Cannot resolve name "no_such_export" (possible cyclic definition)
+[out2]
+tmp/b.py:1: error: Cannot resolve name "no_such_export" (possible cyclic definition)
+tmp/m.py:2: note: Revealed type is "Any"

--- a/test-data/unit/check-modules.test
+++ b/test-data/unit/check-modules.test
@@ -3184,7 +3184,7 @@ from b import no_such_export
 [file b.py]
 from a import no_such_export  # E: Module "a" has no attribute "no_such_export"
 
-[case testCyclicUndefinedImportWithStar1_no_parallel]
+[case testCyclicUndefinedImportWithStar1]
 import a
 [file a.py]
 from b import no_such_export
@@ -3192,9 +3192,8 @@ from b import no_such_export
 from a import *
 [out]
 tmp/b.py:1: error: Cannot resolve name "no_such_export" (possible cyclic definition)
-tmp/a.py:1: error: Module "b" has no attribute "no_such_export"
 
-[case testCyclicUndefinedImportWithStar2_no_parallel]
+[case testCyclicUndefinedImportWithStar2]
 import a
 [file a.py]
 from b import no_such_export
@@ -3204,8 +3203,6 @@ from c import *
 from a import *
 [out]
 tmp/c.py:1: error: Cannot resolve name "no_such_export" (possible cyclic definition)
-tmp/b.py:1: error: Cannot resolve name "no_such_export" (possible cyclic definition)
-tmp/a.py:1: error: Module "b" has no attribute "no_such_export"
 
 [case testCyclicUndefinedImportWithStar3]
 import test1


### PR DESCRIPTION
This allows to re-enable two more tests in parallel mode.

The fix is kind of simple, replace any remaining placeholders with a `Var` on final iteration (similar to what we do for regular `from ... import x`). This has one unfortunate consequence: now each error is only reported once (which is good), _but_ it will be always reported in a module with a star import (because of how SCCs are ordered). I don't see any simple way to fix this, but IMO an error in a somewhat confusing place is better than a crash.