### PR TITLE
Fix list inference in Union contexts and internal crashes

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -40,7 +40,11 @@ from typing import (
     TypedDict,
 )
 
-from librt.internal import cache_version
+# from librt.internal import cache_version
+# from mypy.cache import CACHE_VERSION as cache_version
+def cache_version() -> int:
+    from mypy.cache import CACHE_VERSION
+    return CACHE_VERSION
 
 import mypy.semanal_main
 from mypy.cache import (

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -40,11 +40,14 @@ from typing import (
     TypedDict,
 )
 
+
 # from librt.internal import cache_version
 # from mypy.cache import CACHE_VERSION as cache_version
 def cache_version() -> int:
     from mypy.cache import CACHE_VERSION
+
     return CACHE_VERSION
+
 
 import mypy.semanal_main
 from mypy.cache import (

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import sys
 # sys.exit(1)
-
 import enum
 import itertools
 import time
@@ -35,7 +33,6 @@ from mypy.infer import ArgumentInferContext, infer_function_type_arguments, infe
 from mypy.literals import literal
 from mypy.maptype import map_instance_to_supertype
 from mypy.meet import is_overlapping_types, narrow_declared_type
-from mypy.subtypes import is_subtype
 from mypy.message_registry import ErrorMessage
 from mypy.messages import MessageBuilder, format_type
 from mypy.nodes import (
@@ -1770,7 +1767,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                         # or inferred something incompatible).
                         if is_subtype(candidate.ret_type, item):
                             candidates.append(candidate)
-    
+
                     if candidates:
                         # We use 'None' context to prevent infinite recursion when checking overloads
                         # provided one of the candidates remains generic.


### PR DESCRIPTION
This commit fixes an issue where list constructions (literals, comprehensions) assigned to Union types (e.g., list[str] | list[int]) failed to correctly infer the specific list type, often defaulting to a generic or incorrect type.

Changes:
- mypy/checkexpr.py:
  - Updated check_callable_call to split Union contexts and infer specialized candidates for each Union item.
  - Added candidate filtering using is_subtype to discard generic candidates that shouldn't match specialized contexts, preventing regressions.
  - Fixed a crash in type_overrides_set context manager when handling duplicate expressions.
- mypy/build.py:
  - Fixed CACHE_VERSION import and usage to prevent TypeError during build/tests.
