### PR TITLE
Fix crash when missing format character

### DIFF
--- a/mypy/checkstrformat.py
+++ b/mypy/checkstrformat.py
@@ -145,10 +145,10 @@ class ConversionSpecifier:
         self.key = m_dict.get("key")
 
         # Replace unmatched optional groups with empty matches (for convenience).
-        self.conv_type = m_dict.get("type", "")
-        self.flags = m_dict.get("flags", "")
-        self.width = m_dict.get("width", "")
-        self.precision = m_dict.get("precision", "")
+        self.conv_type = m_dict.get("type") or ""
+        self.flags = m_dict.get("flags") or ""
+        self.width = m_dict.get("width") or ""
+        self.precision = m_dict.get("precision") or ""
 
         # Used only for str.format() calls (it may be custom for types with __format__()).
         self.format_spec = m_dict.get("format_spec")

--- a/test-data/unit/check-formatting.test
+++ b/test-data/unit/check-formatting.test
@@ -60,6 +60,7 @@ a = None # type: Any
 [case testStringInterpolationInvalidPlaceholder]
 '%W' % 1  # E: Unsupported format character "W"
 '%b' % 1  # E: Format character "b" is only supported on bytes patterns
+'%(a)' % {'a': 1}  # E: Unsupported format character ""
 
 [case testStringInterpolationWidth]
 '%2f' % 3.14


### PR DESCRIPTION
Fixes #20523
```
>>> import re
>>> m = re.fullmatch(r"%(?P<type>.)?", "%")
>>> m.groupdict()
{'type': None}
>>> m.groupdict().get("type", "")
>>> m.groupdict().get("type") or ""
''
```