### PR TITLE
Update pathspec to 1.0.0

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -2,6 +2,6 @@
 # and the pins in setup.py
 typing_extensions>=4.6.0
 mypy_extensions>=1.0.0
-pathspec>=0.9.0
+pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'
 librt>=0.6.2; platform_python_implementation != 'PyPy'

--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -16,7 +16,7 @@ from enum import Enum, unique
 from typing import Final, TypeAlias as _TypeAlias
 
 from pathspec import PathSpec
-from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
+from pathspec.patterns.gitignore import GitIgnorePatternError
 
 from mypy import pyinfo
 from mypy.errors import CompileError
@@ -736,8 +736,8 @@ def find_gitignores(dir: str) -> list[tuple[str, PathSpec]]:
         with open(gitignore) as f:
             lines = f.readlines()
         try:
-            return parent_gitignores + [(dir, PathSpec.from_lines("gitwildmatch", lines))]
-        except GitWildMatchPatternError:
+            return parent_gitignores + [(dir, PathSpec.from_lines("gitignore", lines))]
+        except GitIgnorePatternError:
             print(f"error: could not parse {gitignore}", file=sys.stderr)
             return parent_gitignores
     return parent_gitignores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     # the following is from mypy-requirements.txt/setup.py
     "typing_extensions>=4.6.0",
     "mypy_extensions>=1.0.0",
-    "pathspec>=0.9.0",
+    "pathspec>=1.0.0",
     "tomli>=1.1.0; python_version<'3.11'",
     "librt>=0.6.2; platform_python_implementation != 'PyPy'",
     # the following is from build-requirements.txt
@@ -51,7 +51,7 @@ dependencies = [
   # When changing this, also update build-system.requires and mypy-requirements.txt
   "typing_extensions>=4.6.0",
   "mypy_extensions>=1.0.0",
-  "pathspec>=0.9.0",
+  "pathspec>=1.0.0",
   "tomli>=1.1.0; python_version<'3.11'",
   "librt>=0.6.2; platform_python_implementation != 'PyPy'",
 ]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,7 +22,7 @@ identify==2.6.15
     # via pre-commit
 iniconfig==2.1.0
     # via pytest
-librt==0.7.3 ; platform_python_implementation != 'PyPy'
+librt==0.7.3 ; platform_python_implementation != "PyPy"
     # via -r mypy-requirements.txt
 lxml==6.0.2 ; python_version < "3.15"
     # via -r test-requirements.in
@@ -32,7 +32,7 @@ nodeenv==1.9.1
     # via pre-commit
 packaging==25.0
     # via pytest
-pathspec==0.12.1
+pathspec==1.0.0
     # via -r mypy-requirements.txt
 platformdirs==4.5.0
     # via virtualenv


### PR DESCRIPTION
https://github.com/cpburnz/python-pathspec/blob/v1.0.0/CHANGES.rst
https://github.com/cpburnz/python-pathspec/blob/v1.0.0/UPGRADING.rst

Pathspec `v1.0.0` was released a few hours ago. It included a few breaking changes.
- `gitwildmatch` was renamed to `gitignore`
- `GitWildMatchPatternError` is now an (temporary) alias for `GitIgnorePatternError` before it's removed completely