### PR TITLE
[mypyc] Cleanup old version guard

### DIFF
--- a/mypyc/lib-rt/function_wrapper.c
+++ b/mypyc/lib-rt/function_wrapper.c
@@ -156,10 +156,7 @@ static PyType_Spec CPyFunction_spec = {
     .name = "Function compiled with mypyc",
     .basicsize = sizeof(CPyFunction),
     .itemsize = 0,
-    .flags =
-#if PY_VERSION_HEX >= 0x030A0000
-             Py_TPFLAGS_IMMUTABLETYPE |
-#endif
+    .flags = Py_TPFLAGS_IMMUTABLETYPE |
 #if PY_VERSION_HEX >= 0x030C0000
              Py_TPFLAGS_MANAGED_DICT |
 #endif


### PR DESCRIPTION
Support for Python 3.9 has been removed. The check will always be true.