### PR TITLE
Fix false positive unreachable with Any in equality comparison

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7072,6 +7072,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         non_optional_types = []
         for i in chain_indices:
             typ = operand_types[i]
+            if isinstance(get_proper_type(typ), AnyType):
+                continue
             if not is_overlapping_none(typ):
                 non_optional_types.append(typ)
 

--- a/mypy/types_utils.py
+++ b/mypy/types_utils.py
@@ -123,7 +123,7 @@ def is_generic_instance(tp: Type) -> bool:
 
 def is_overlapping_none(t: Type) -> bool:
     t = get_proper_type(t)
-    return isinstance(t, (NoneType, AnyType)) or (
+    return isinstance(t, NoneType) or (
         isinstance(t, UnionType) and any(isinstance(get_proper_type(e), NoneType) for e in t.items)
     )
 


### PR DESCRIPTION
Fixes #20532

When comparing a value of type `Any` with an optional type using `==`, `!=`, or `is`/`is not`, mypy was incorrectly narrowing the optional type by removing `None`. This caused false positive "unreachable" warnings with `--warn-unreachable`.

For example:
```python
from typing import Any

def main(contents: Any, commit: str | None) -> None:
    if (
        contents.get("commit") == commit
        and (commit is not None or print("can_be_reached"))
    ):
        pass
```

Previously reported: Right operand of "or" is never evaluated  [unreachable]

The issue was in refine_away_none_in_comparison(): when building the list of "non-optional types" to use for narrowing, Any was included because is_overlapping_none(Any) returns False. However, Any could itself be None, so it shouldn't be used as evidence that the other operand can't be None.

The fix skips Any types when collecting non-optional types for narrowing.