### PR TITLE
gh-20542: Fix crash in split_for_callable when passing values to variadic generics

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4963,12 +4963,13 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                     )
                     return [AnyType(TypeOfAny.from_error)] * len(vars)
 
-        if not vars or not any(isinstance(v, TypeVarTupleType) for v in vars):
-            return list(args)
         # TODO: in future we may want to support type application to variadic functions.
-        if not t.is_type_obj():
-            self.chk.fail(f"Invalid type argument: type expected, for {args[0]!r}", ctx)
-            return [AnyType(TypeOfAny.from_error)] * len(vars)
+        if (
+            not vars
+            or not any(isinstance(v, TypeVarTupleType) for v in vars)
+            or not t.is_type_obj()
+        ):
+            return list(args)
         info = t.type_object()
         # We reuse the logic from semanal phase to reduce code duplication.
         fake = Instance(info, args, line=ctx.line, column=ctx.column)

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2756,21 +2756,13 @@ def c(t: X[Concatenate[int, ...]]) -> None:  # E: Cannot use "[int, VarArg(Any),
 [builtins fixtures/tuple.pyi]
 
 [case testTypeVarTupleLiteralValueAsTypeArgument]
-from typing import TypeVarTuple, Generic, Unpack, Callable, TypeVar
+from typing import TypeVarTuple, Unpack, Callable, TypeVar
 
 Ts = TypeVarTuple('Ts')
 T = TypeVar('T')
 
-class C(Generic[Unpack[Ts]]):
-    pass
-
-x = C[1, 2, 3]() # E: Invalid type: try using Literal[1] instead? \
-                 # E: Invalid type: try using Literal[2] instead? \
-                 # E: Invalid type: try using Literal[3] instead?
-
 def func(d: Callable[[Unpack[Ts]], T]) -> T: ...
 
 y = func[1, int] # E: Type application is only supported for generic classes \
-                 # E: Invalid type argument: type expected, for Any \
                  # E: Invalid type: try using Literal[1] instead?
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes gh-20542

Small change, previously passing a literal value (fn[1] in the repro case) to a function using `TypeVarTupleassert` caused a crash in split_for_callable in `checkexpr.py` due to an assert statement. This PR just replaces the assertion with a proper validation check and error message.
