### PR TITLE
[mypyc] Enable assertions in tests and fix failures

### DIFF
--- a/mypyc/build.py
+++ b/mypyc/build.py
@@ -680,10 +680,13 @@ def mypycify(
             cflags.append("-DMYPYC_LOG_TRACE")
         if experimental_features:
             cflags.append("-DMYPYC_EXPERIMENTAL")
+        if opt_level == "0":
+            cflags.append("-UNDEBUG")
     elif compiler.compiler_type == "msvc":
         # msvc doesn't have levels, '/O2' is full and '/Od' is disable
         if opt_level == "0":
             opt_level = "d"
+            cflags.append("/UNDEBUG")
         elif opt_level in ("1", "2", "3"):
             opt_level = "2"
         if debug_level == "0":

--- a/mypyc/lib-rt/CPy.h
+++ b/mypyc/lib-rt/CPy.h
@@ -331,6 +331,11 @@ static inline bool CPyTagged_IsLe(CPyTagged left, CPyTagged right) {
 static inline int64_t CPyLong_AsInt64(PyObject *o) {
     if (likely(PyLong_Check(o))) {
         PyLongObject *lobj = (PyLongObject *)o;
+    #if CPY_3_12_FEATURES
+        if (likely(PyUnstable_Long_IsCompact(lobj))) {
+            return PyUnstable_Long_CompactValue(lobj);
+        }
+    #else
         Py_ssize_t size = Py_SIZE(lobj);
         if (likely(size == 1)) {
             // Fast path
@@ -338,6 +343,7 @@ static inline int64_t CPyLong_AsInt64(PyObject *o) {
         } else if (likely(size == 0)) {
             return 0;
         }
+    #endif
     }
     // Slow path
     return CPyLong_AsInt64_(o);

--- a/mypyc/lib-rt/static_data.c
+++ b/mypyc/lib-rt/static_data.c
@@ -16,6 +16,10 @@ mypyc_interned_str_struct mypyc_interned_str;
 
 int
 intern_strings(void) {
+    if (mypyc_interned_str.values != NULL) {
+        // Already interned.
+        return 0;
+    }
     INTERN_STRING(__init_subclass__, "__init_subclass__");
     INTERN_STRING(__mro_entries__, "__mro_entries__");
     INTERN_STRING(__name__, "__name__");


### PR DESCRIPTION
For some reason assertions are disabled when running mypyc tests. Explicitly undefining `NDEBUG` when compiling enables them again so I have added compiler options to undefine it when requested optimization level is 0.

Found two issues after enabling them:
- When interning strings there is an assertion that makes calling the function multiple times crash. It might be called multiple times when multiple modules are initialized within one compilation unit so I have added an early return when the strings are already interned.
- `Py_SIZE` has an [assertion](https://github.com/python/cpython/blob/2750f3c9b5c5e3787ebf4637125c9d746ad4694b/Include/object.h#L231) to disallow calling it with `PyLong` arguments starting from python 3.12. Compiled code would call it when converting `PyLong` to `int64`. Instead we can use `PyUnstable_Long_CompactValue`. 