### PR TITLE
Accept value as keyword argument in TypeAliasType

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4061,7 +4061,11 @@ class SemanticAnalyzer(
         type_params: TypeVarLikeList | None
         all_type_params_names: list[str] | None
         if self.check_type_alias_type_call(s.rvalue, name=lvalue.name):
-            rvalue = s.rvalue.args[1]
+            rvalue = (
+                s.rvalue.args[1]
+                if s.rvalue.arg_kinds[1] == ARG_POS
+                else s.rvalue.args[s.rvalue.arg_names.index("value")]
+            )
             pep_695 = True
             type_params, all_type_params_names = self.analyze_type_alias_type_params(s.rvalue)
         else:
@@ -4249,7 +4253,9 @@ class SemanticAnalyzer(
             return False
         if not self.check_typevarlike_name(rvalue, name, rvalue):
             return False
-        if rvalue.arg_kinds.count(ARG_POS) != 2:
+        if rvalue.arg_kinds.count(ARG_POS) != (
+            2 - ("value" in rvalue.arg_names) - ("name" in rvalue.arg_names)
+        ):
             return False
 
         return True

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -1071,6 +1071,14 @@ x: TestType = 42
 y: TestType = 'a'
 z: TestType = object()  # E: Incompatible types in assignment (expression has type "object", variable has type "int | str")
 
+TA = TypeAliasType("TA", value=int)
+a: TA = 1
+b: TA = 's'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
+TA2 = TypeAliasType("TA2", type_params=(), value=int)  # shuffled arguments
+a2: TA2 = 1
+b2: TA2 = 's'  # E: Incompatible types in assignment (expression has type "str", variable has type "int")
+
 reveal_type(TestType)  # N: Revealed type is "typing_extensions.TypeAliasType"
 TestType()  # E: "TypeAliasType" not callable
 


### PR DESCRIPTION
Fixes #20531

The case where value is missing is handled and tested