### PR TITLE
Clarify --warn-unreachable behavior for pass statements

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -535,7 +535,7 @@ potentially problematic or redundant in some way.
             else:
                 # Error: 'Statement is unreachable' error
                 print(x + "bad")
-                
+
     Note that unreachable ``pass`` statements are intentionally not
     reported by this option. This allows ``pass`` to be used as a
     placeholder during development without triggering an error.


### PR DESCRIPTION
This PR clarifies the documentation for the `--warn-unreachable` option by explaining that unreachable `pass` statements are intentionally not reported, and adds a small example for clarity.

Fixes #20462