### PR TITLE
Clarify Read the Docs versioning and retention of older versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,7 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Documentation on Read the Docs is intended to be built from released
+# git tags to support versioned documentation.
 
 version: 2
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -117,3 +117,17 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`search`
+
+Documentation versions
+----------------------
+
+Mypy documentation on Read the Docs is built from released git tags.
+This allows users to browse documentation corresponding to older
+released versions of mypy.
+
+Using git tags for documentation versions avoids relying on long-lived
+maintenance branches and makes it easier to remove stale branches while
+still preserving historical documentation.
+
+Older documentation versions are kept available to support users
+working with pinned or legacy mypy releases.


### PR DESCRIPTION
### What this PR does
Clarifies that mypy documentation on Read the Docs is intended to be
versioned using released git tags, and that older documentation versions
are kept available.

### Why
Read the Docs supports documentation versioning for community projects.
Using git tags avoids relying on long-lived maintenance branches while
still allowing users to access documentation for older mypy releases.

### Scope
Documentation-only change. No impact on mypy runtime or type checking.

Fixes #19922
