### PR TITLE
[mypyc] Use smaller default buffer for BytesWriter

### DIFF
--- a/mypyc/lib-rt/librt_strings.h
+++ b/mypyc/lib-rt/librt_strings.h
@@ -31,7 +31,7 @@ import_librt_strings(void)
 static void *LibRTStrings_API[LIBRT_STRINGS_API_LEN];
 
 // Length of the default buffer embedded directly in a BytesWriter object
-#define WRITER_EMBEDDED_BUF_LEN 512
+#define WRITER_EMBEDDED_BUF_LEN 256
 
 typedef struct {
     PyObject_HEAD


### PR DESCRIPTION
This seems to make allocations and/or frees a lot faster, at least in this microbenchmark (on 3.14 it's over 2x faster with the smaller buffer):
```
def bench(b: bytes, n: int) -> None:
    for x in range(n):
        w = BytesWriter()
        w.write(b)
        w.getvalue()

n = 30 * 1000 * 1000
b = b"foo"

bench(b, n)
```