### PR TITLE
[mypyc] Fix generation of function wrappers for decorated functions

### DIFF
--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -365,6 +365,10 @@ def gen_func_ir(
                 func_decl.kind,
                 is_prop_getter=func_decl.is_prop_getter,
                 is_prop_setter=func_decl.is_prop_setter,
+                is_generator=func_decl.is_generator,
+                is_coroutine=func_decl.is_coroutine,
+                implicit=func_decl.implicit,
+                internal=func_decl.internal,
             )
             func_ir = FuncIR(func_decl, args, blocks, fitem.line, traceback_name=fitem.name)
         else:

--- a/mypyc/test-data/run-async.test
+++ b/mypyc/test-data/run-async.test
@@ -1432,16 +1432,16 @@ async def identity_async(val: int) -> int:
 F = TypeVar("F", bound=Callable[..., Any])
 
 def wrap(fn: F) -> F:
+    if is_coroutine(fn):
+        @wraps(fn)
+        async def wrapper_async(*args) -> Any:
+            return await fn(*args) + await fn(*args)
+
+        return cast(F, wrapper_async)
+
     @wraps(fn)
     def wrapper(*args) -> Any:
         return fn(*args) + fn(*args)
-
-    return cast(F, wrapper)
-
-def wrap_async(fn: F) -> F:
-    @wraps(fn)
-    async def wrapper(*args) -> Any:
-        return await fn(*args) + await fn(*args)
 
     return cast(F, wrapper)
 
@@ -1453,11 +1453,11 @@ def wrapped(val: int) -> int:
 def wrapped2(val: int) -> int:
     return val * 2
 
-@wrap_async
+@wrap
 async def wrapped_async(val: int) -> int:
     return val
 
-@wrap_async
+@wrap
 async def wrapped2_async(val: int) -> int:
     return val * 2
 
@@ -1472,7 +1472,7 @@ class T:
     def returns_two(self) -> int:
         return 1
 
-    @wrap_async
+    @wrap
     async def returns_two_async(self) -> int:
         return 1
 
@@ -1569,7 +1569,7 @@ def test_nested() -> None:
     def nested_wrapped() -> int:
         return 2
 
-    @wrap_async
+    @wrap
     async def nested_wrapped_async() -> int:
         return 2
 


### PR DESCRIPTION
For decorated functions, a `FuncDecl` is constructed during compilation from another `FuncDecl` but some attributes are not copied. One of those is `is_coroutine` which is used to determine whether the function will be replaced in the module dictionary by a `CPyFunction` object.

The `CPyFunction` object is needed for introspection functions to work so without it, `inspect.iscoroutinefunction(fn)` returns `False` for decorated async functions. This causes incorrect behavior when the `inspect` function is used in a decorator, for example:
```python
F = TypeVar("F", bound=Callable[..., Any])

def wrap(fn: F) -> F:
    if inspect.iscoroutinefunction(fn):
        @wraps(fn)
        async def wrapper_async(*args) -> Any:
            return await fn(*args) + await fn(*args)

        return cast(F, wrapper_async)

    @wraps(fn)
    def wrapper(*args) -> Any:
        return fn(*args) + fn(*args)

    return cast(F, wrapper)

@wrap
async def wrapped_async(val: int) -> int:
    return val
```

In existing test cases this did not come up because the decorators would unconditionally wrap an async function with another async function. Checking `iscoroutinefunction` of the wrapped function would check the wrapper instead, for which a `CPyFunction` object was generated correctly. But during execution of `wrap`, the actual wrapped function is checked.