### PR TITLE
Fix crash when calling type[Any] from dict.get()

### DIFF
--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -674,6 +674,15 @@ class TypeOpsSuite(Suite):
             variables=tv,
         )
 
+    def test_is_type_obj_with_any_return(self) -> None:
+        # https://github.com/python/mypy/issues/20585
+        c = CallableType([], [], [], self.fx.anyt, self.fx.type_type)
+        assert not c.is_type_obj()
+
+    def test_is_type_obj_with_instance_return(self) -> None:
+        c = CallableType([], [], [], self.fx.a, self.fx.type_type)
+        assert c.is_type_obj()
+
 
 class JoinSuite(Suite):
     def setUp(self) -> None:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2331,7 +2331,7 @@ class CallableType(FunctionLike):
 
     def is_type_obj(self) -> bool:
         return self.fallback.type.is_metaclass() and not isinstance(
-            get_proper_type(self.ret_type), UninhabitedType
+            get_proper_type(self.ret_type), (UninhabitedType, AnyType)
         )
 
     def type_object(self) -> mypy.nodes.TypeInfo:


### PR DESCRIPTION
Fixes #20585

When a callable has `type[Any]` as its return type (e.g., from `dict.get(key, type[Any])`), calling it would crash with `AssertionError: isinstance(ret, Instance)`.

The issue was in `is_type_obj()` which returned `True` for `type[Any]` because `type` is a metaclass and `AnyType` isn't `UninhabitedType`. However, `type_object()` then failed because it expects an `Instance`, not `AnyType`.

The fix excludes `AnyType` from `is_type_obj()` since we can't determine a concrete type object when the return type is `Any`.

---

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=4217675