### PR TITLE
Document undesirable generator expression behavior in test and fix one case

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2918,7 +2918,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
 
         for typ in plausible_targets:
             assert self.msg is self.chk.msg
-            with self.msg.filter_errors() as w:
+            with self.msg.filter_errors(filter_revealed_type=True) as w:
                 with self.chk.local_type_map as m:
                     ret_type, infer_type = self.check_call(
                         callee=typ,

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1456,6 +1456,27 @@ if int():
     b = (x for x in a)  # E: Generator has incompatible item type "Callable[[], str]"; expected "Callable[[], int]"
 [builtins fixtures/list.pyi]
 
+[case testGeneratorNoSpuriousError]
+from typing import Iterable, overload
+
+@overload
+def take_iterable(iterable: Iterable[bool], /) -> None: ...
+@overload
+def take_iterable(iterable: Iterable[int], /) -> None: ...
+def take_iterable(iterable): pass
+
+take_iterable(1 for _ in [])
+take_iterable(reveal_type(1 for _ in [])) # N: Revealed type is "typing.Generator[builtins.int, None, None]"
+
+# NOTE: Type is revealed for every overload tried
+# TODO: Overload shouldn't fail if expression contains an error that shouldn't affect the inferred type.
+take_iterable(reveal_type(1 if (-"") else 1 for _ in [])) # N: Revealed type is "typing.Generator[builtins.int, None, None]" \
+                                                          # N: Revealed type is "typing.Generator[builtins.bool, None, None]" \
+                                                          # E: Generator has incompatible item type "int"; expected "bool" \
+                                                          # E: Unsupported operand type for unary - ("str")
+
+[builtins fixtures/for.pyi]
+
 -- Conditional expressions
 -- -----------------------
 


### PR DESCRIPTION
Adds a test case to explicitly demonstrate behavior which I believe has the same root cause as https://github.com/python/mypy/issues/18026

The short explanation is that if _any_ get produced while inferring the type of a generator expression which is being passed to an overloaded function, the overload will be considered failed, even if the error has no effect on the inferred type of the generator expression.

One experiment to try that might address this could be to only fail the overload if the inferred type contains `AnyType(TypeOfAny.from_error)`.

For now, only fix the specific case where the "error" is a `reveal_type` note.

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
