### PR TITLE
Slightly refactor process_error_codes

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -462,7 +462,9 @@ class Options:
 
         valid_error_code_names = set(error_codes.keys())
 
-        invalid_code_names_here = (enabled_code_names | disabled_code_names) - valid_error_code_names
+        invalid_code_names_here = (
+            enabled_code_names | disabled_code_names
+        ) - valid_error_code_names
         if invalid_code_names_here:
             error_callback(f"Invalid error code(s): {', '.join(sorted(invalid_code_names_here))}")
 


### PR DESCRIPTION
process_error_codes was confusing to read due to the lack of distinction it made between error codes (ErrorCode) and error code names (str). This refactor fixes this, and also makes the documentation comment at the topic of the function a real comment.

The current CI ensures this does not introduce errors.