### PR TITLE
Fix false negative with walrus operator in tuples

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5087,8 +5087,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
 
         if isinstance(expr, DictExpr):
             # Check both keys and values
-            for k, v in zip(expr.items, expr.values):
-                if self.contains_assignment_expr(k) or self.contains_assignment_expr(v):
+            # DictExpr.items is list[tuple[Expression | None, Expression]]
+            for key_expr, value_expr in expr.items:
+                if key_expr is not None and self.contains_assignment_expr(key_expr):
+                    return True
+                if self.contains_assignment_expr(value_expr):
                     return True
             return False
 
@@ -5117,9 +5120,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         if isinstance(expr, IndexExpr):
             if self.contains_assignment_expr(expr.base):
                 return True
-            if expr.index is not None:
-                return self.contains_assignment_expr(expr.index)
-            return False
+            return self.contains_assignment_expr(expr.index)
 
         # Member access
         if isinstance(expr, MemberExpr):


### PR DESCRIPTION
# Fix false negative with walrus operator in tuples

## Summary

Fixes #20606.

This PR fixes a regression introduced in mypy 1.18+ where type errors involving assignment expressions (walrus operators) inside tuples were silently ignored. In short: errors that should have been reported were not, resulting in false negatives.

---

## Problem Description

Since commit `a856e55` (#19767), mypy fails to detect certain type errors when assignment expressions appear inside tuples.

The issue originates in `infer_context_dependent()` inside `checker.py`. This method uses an optimization where type inference is attempted twice:

1. First pass: using the provided type context (this correctly finds errors)
2. Second pass: if errors are found, retry inference with an empty context (this is where things go wrong)

When walrus expressions are involved, the empty-context fallback can incorrectly infer types, effectively masking real errors.

### Example

```python
def condition() -> bool:
    return False

def fn() -> tuple[int, int]:
    i: int | None = 0 if condition() else None
    return (i, (i := i + 1))  # NO ERROR REPORTED!
```

**Expected**

* Incompatible return type
* Unsupported operand type (`None + int`)

**Actual**

* No errors reported (false negative)

### Why this happens

In the expression `(i := i + 1)`, when inferred without the tuple context, mypy infers `i` as `int` instead of `int | None`. That makes the expression appear valid, even though it isn’t.

---

## Root Cause

The empty-context fallback in `infer_context_dependent()` is unsafe for expressions that contain assignment expressions.

While the first inference pass correctly detects errors, the second pass can override those results with an incorrect but “valid-looking” inference.

---

## Solution

This PR introduces a conservative fix:

* Add a new helper method `contains_assignment_expr()` that recursively checks whether an expression contains a walrus operator.
* If an expression contains an assignment expression, skip the empty-context fallback in `infer_context_dependent()`.

This preserves correctness without affecting the existing optimization for regular expressions.

---

## Changes

* Modified `infer_context_dependent()` to skip empty-context inference when assignment expressions are present
* Added a comprehensive `contains_assignment_expr()` helper that handles all expression types
* Updated `visit_return_stmt()` to include `AssignmentExpr` in the set of expression types checked in return values

---

## Testing

### Test Cases

```python
def fn() -> tuple[int, int]:
    i: int | None = 0 if condition() else None
    return (i, (i := i + 1))  # Should error (now does!)

def fn2() -> tuple[int, int]:
    i: int | None = None
    return (i, (i := i + 1))  # Should error (now does!)

def fn3() -> tuple[int, int]:
    i: int | None = 0 if condition() else None
    return (i, (j := i + 1))  # Should error (already did, still does)
```

**Before the fix**

* Only `fn3()` produced errors
* Total errors: 2

**After the fix**

* All three functions produce errors
* Total errors: 6

---

## Additional Notes

* The fix is intentionally conservative and only affects expressions containing walrus operators
* Regular expressions continue to benefit from the empty-context optimization
* Related (but separate) runtime issue: mypyc/mypyc#1179
* Regression introduced in mypy 1.18 (bisects to commit `a856e55`)

---

## Files Changed

* `mypy/checker.py`

  * Modified `infer_context_dependent()`
  * Updated `visit_return_stmt()`
  * Added `contains_assignment_expr()` helper
