### PR TITLE
Fix false negatives in walrus vs inference fallback logic

### DIFF
--- a/test-data/unit/check-python38.test
+++ b/test-data/unit/check-python38.test
@@ -810,3 +810,24 @@ y: List[int]
 if (y := []):
     reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/list.pyi]
+
+[case testAssignToOptionalTupleWalrus]
+from typing import Optional
+
+def condition() -> bool: return False
+
+i: Optional[int] = 0 if condition() else None
+x: Optional[tuple[int, int]] = (i, (i := 1))  # E: Incompatible types in assignment (expression has type "tuple[int | None, int]", variable has type "tuple[int, int] | None")
+[builtins fixtures/tuple.pyi]
+
+[case testReturnTupleOptionalWalrus]
+from typing import Optional
+
+def condition() -> bool: return False
+
+def fn() -> tuple[int, int]:
+    i: Optional[int] = 0 if condition() else None
+    return (i, (i := i + 1))  # E: Incompatible return value type (got "tuple[int | None, int]", expected "tuple[int, int]") \
+                              # E: Unsupported operand types for + ("None" and "int") \
+                              # N: Left operand is of type "int | None"
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/20606

This fixes couple edge cases where walrus interferes with type inference fallback logic. This is not a complete fix, but I think it is OK for now as these are probably rare situations. Most changes in `binder.py` are a pure performance optimization to compensate the fact that `frame_context()` will be more hot now. I also leave a TODO explaining a more proper fix for the assignment case (and other possible cases), return case should be already good (it is simpler since we don't need to apply any of the narrowing).

