### PR TITLE
[mypyc] Cache built librt in tests

### DIFF
--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -26,8 +26,8 @@ from mypyc.codegen.emitmodule import collect_source_dependencies
 from mypyc.errors import Errors
 from mypyc.options import CompilerOptions
 from mypyc.test.config import test_data_prefix
-from mypyc.test.test_serialization import check_serialization_roundtrip
 from mypyc.test.librt_cache import get_librt_path
+from mypyc.test.test_serialization import check_serialization_roundtrip
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS,
     TESTUTIL_PATH,


### PR DESCRIPTION
Store built `librt` under `build/librt-cache`, so that it can be reused to speed up mypyc tests when there are no changes under `mypyc/lib-rt`. Also invalidate the cache if the build environment changes.

This also ensures that each test run only compiles `librt` at most twice (with and without experimental features), instead of once per test case that requires `librt`.

Use `filelock` to support parallel tests.

Building `librt` can take 6+ seconds, so the savings can be quite significant. We are also planning to add several additional `librt` submodules, which will further slow down the build, and this will result in a larger number of tests that require `librt`. The main benefit is that adding more tests or submodules doesn't significantly slow down tests.