### PR TITLE
Improve documentation: explain unannotated functions in common issues

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -33,6 +33,9 @@ Example:
     def foo(a):
         return '(' + a.split() + ')'  # No error!
 
+    This often surprises beginners, because mypy only checks functions that have type annotations by default.
+
+
 This gives no error even though ``a.split()`` is "obviously" a list
 (the author probably meant ``a.strip()``).  The error is reported
 once you add annotations:


### PR DESCRIPTION
This PR improves the "Common issues and solutions" documentation by adding a short explanation and example showing why unannotated functions are not type-checked by mypy.

This helps beginners better understand why obvious errors may not be reported.
