### PR TITLE
fix crash resolving cross-refs to suppressed modules

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2361,7 +2361,15 @@ class State:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"
         # We need to set allow_missing when doing a fine grained cache
         # load because we need to gracefully handle missing modules.
-        fixup_module(self.tree, self.manager.modules, self.options.use_fine_grained_cache)
+        # We also pass missing_modules so that cross-refs pointing to
+        # suppressed modules can be replaced with placeholders instead of
+        # failing lookup.
+        fixup_module(
+            self.tree,
+            self.manager.modules,
+            self.options.use_fine_grained_cache,
+            self.manager.missing_modules,
+        )
 
     # Methods for processing modules from source code.
 

--- a/mypy/lookup.py
+++ b/mypy/lookup.py
@@ -22,6 +22,12 @@ def lookup_fully_qualified(
     This function should *not* be used to find a module. Those should be looked
     in the modules dictionary.
     """
+    # Reject synthetic/placeholder names (they always start with "<").
+    # These can appear in cached data when placeholders (e.g., from suppressed
+    # modules) are serialized and then reloaded. Return None so callers can
+    # substitute a fresh placeholder.
+    if name.startswith("<"):
+        return None
     # 1. Exclude the names of ad hoc instance intersections from step 2.
     i = name.find("<subclass ")
     head = name if i == -1 else name[:i]


### PR DESCRIPTION
When a stub imports from a module without stubs (e.g., protobuf stubs importing from google.protobuf when protobuf stubs aren't installed), the import is suppressed but a cross-ref is cached. On cache reload, resolving the cross-ref fails along the lines of:

    AssertionError: Cannot find module for google

This occurs because the cross-ref points to a module that was suppressed and therefore never loaded into manager.modules.

The fix passes the set of suppressed modules to fixup_module() and checks if a cross-ref points to a suppressed module before attempting lookup. If so, a placeholder node is used instead.

Before this change on my test setup (see #20655) with 128 shards iterating through different dependency combination, 29 crashed with this error.  With the change 0 do so.  The reproduction at https://github.com/Qiskit/qiskit-serverless/pull/1787 also passes for me with this change.

Fixes #16214

Disclaimer: I don't have prior familiarity with the mypy codebase and this change was heavily LLM assisted.