### PR TITLE
Use a single pass for core narrowing logic, add comments

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6687,7 +6687,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 continue
 
             expr_type = operand_types[i]
-            expanded_expr_type = try_expanding_sum_type_to_union(coerce_to_literal(expr_type), None)
+            expanded_expr_type = try_expanding_sum_type_to_union(
+                coerce_to_literal(expr_type), None
+            )
             expr_enum_keys = ambiguous_enum_equality_keys(expr_type)
             for j in expr_indices:
                 if i == j:


### PR DESCRIPTION
This PR should not change semantics

We refactor to avoid the separate loops for `type_targets` and `value_targets`, which allows the logic to be more consolidated, helps with future changes and is probably faster