### PR TITLE
Avoid widening to Any for checks like `type(x) is type(y: Any)`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6827,6 +6827,13 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 expr = operands[j]
 
                 current_type_range = self.get_isinstance_type(expr)
+                if current_type_range is not None:
+                    target_type = make_simplified_union([tr.item for tr in current_type_range])
+                    if isinstance(target_type, AnyType):
+                        # Avoid widening to Any for checks like `type(x) is type(y: Any)`.
+                        # We patch this here because it is desirable to widen to any for cases like
+                        # isinstance(x, (y: Any))
+                        continue
                 if_map, else_map = conditional_types_to_typemaps(
                     expr_in_type_expr,
                     *self.conditional_types_with_intersection(

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -3040,6 +3040,28 @@ z: Any
 if int == type(z) == int:
     reveal_type(z) # N: Revealed type is "builtins.int"
 
+[case testTypeEqualsCheckWidening]
+# flags: --strict-equality --warn-unreachable
+from typing import Any
+
+def f(x: str, y: Any, z: object):
+    if type(x) is type(y):
+        reveal_type(x) # N: Revealed type is "builtins.str"
+        reveal_type(y) # N: Revealed type is "builtins.str"
+
+    if type(x) == type(y):
+        reveal_type(x) # N: Revealed type is "builtins.str"
+        reveal_type(y) # N: Revealed type is "builtins.str"
+
+    if type(x) is type(z):
+        reveal_type(x) # N: Revealed type is "builtins.str"
+        reveal_type(z) # N: Revealed type is "builtins.str"
+
+    if type(x) == type(z):
+        reveal_type(x) # N: Revealed type is "builtins.str"
+        reveal_type(z) # N: Revealed type is "builtins.str"
+[builtins fixtures/primitives.pyi]
+
 [case testTypeEqualsCheckUsingIs]
 # flags: --strict-equality --warn-unreachable
 from typing import Any
@@ -3075,20 +3097,6 @@ def main(x: Union[B, C]):
     else:
         reveal_type(x)  # N: Revealed type is "__main__.B | __main__.C"
 [builtins fixtures/isinstance.pyi]
-
-[case testTypeEqualsCheckUsingImplicitTypes-xfail]
-from typing import Any
-
-x: str
-y: Any
-z: object
-if type(y) is type(x):
-    reveal_type(x) # N: Revealed type is "builtins.str"
-    reveal_type(y) # N: Revealed type is "builtins.str"
-
-if type(x) is type(z):
-    reveal_type(x) # N: Revealed type is "builtins.str"
-    reveal_type(z) # N: Revealed type is "builtins.str"
 
 [case testTypeEqualsCheckUsingDifferentSpecializedTypes]
 # flags: --warn-unreachable


### PR DESCRIPTION
This is a little arguable, but I think it's better here to just use whatever type we have for x.
Note the current behaviour is pretty confusing, it's weird to both narrow y to str but widen x to Any