### PR TITLE
[wip] Better handling of generics when narrowing

### DIFF
--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -285,3 +285,17 @@ class LastKnownValueEraser(TypeTranslator):
                     merged.append(orig_item)
             return UnionType.make_union(merged)
         return new
+
+
+def shallow_erase_type_for_equality(typ: Type) -> ProperType:
+    """Erase type variables from Instance's inside a type."""
+    p_typ = get_proper_type(typ)
+    if isinstance(p_typ, Instance):
+        if not p_typ.args:
+            return p_typ
+        args = erased_vars(p_typ.type.defn.type_vars, TypeOfAny.special_form)
+        return Instance(p_typ.type, args, p_typ.line)
+    if isinstance(p_typ, UnionType):
+        items = [shallow_erase_type_for_equality(item) for item in p_typ.items]
+        return UnionType.make_union(items)
+    return p_typ

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from mypy import join
-from mypy.erasetype import erase_type
 from mypy.maptype import map_instance_to_supertype
 from mypy.state import state
 from mypy.subtypes import (
@@ -655,18 +654,6 @@ def is_overlapping_types(
 
     assert type(left) != type(right), f"{type(left)} vs {type(right)}"
     return False
-
-
-def is_overlapping_erased_types(
-    left: Type, right: Type, *, ignore_promotions: bool = False
-) -> bool:
-    """The same as 'is_overlapping_erased_types', except the types are erased first."""
-    return is_overlapping_types(
-        erase_type(left),
-        erase_type(right),
-        ignore_promotions=ignore_promotions,
-        prohibit_none_typevar_overlap=True,
-    )
 
 
 def are_typed_dicts_overlapping(

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1065,6 +1065,92 @@ def f(x: Custom, y: CustomSub):
         reveal_type(y)  # N: Revealed type is "__main__.CustomSub"
 [builtins fixtures/tuple.pyi]
 
+[case testNarrowingCustomEqualityGeneric]
+# flags: --strict-equality --warn-unreachable
+from __future__ import annotations
+from typing import Union
+
+class Custom:
+    def __eq__(self, other: object) -> bool:
+        raise
+
+class Default: ...
+
+def f1(x: list[Custom] | Default, y: list[int]):
+    if x == y:  # E: Non-overlapping equality check (left operand type: "list[Custom] | Default", right operand type: "list[int]")
+        reveal_type(x)  # N: Revealed type is "builtins.list[__main__.Custom]"
+        reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int]"
+    else:
+        reveal_type(x)  # N: Revealed type is "builtins.list[__main__.Custom] | __main__.Default"
+        reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int]"
+
+f1([], [])
+
+def f2(x: list[Custom] | Default, y: list[int] | list[Default]):
+    if x == y:  # E: Non-overlapping equality check (left operand type: "list[Custom] | Default", right operand type: "list[int] | list[Default]")
+        reveal_type(x)  # N: Revealed type is "builtins.list[__main__.Custom]"
+        reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int] | builtins.list[__main__.Default]"
+    else:
+        reveal_type(x)  # N: Revealed type is "builtins.list[__main__.Custom] | __main__.Default"
+        reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int] | builtins.list[__main__.Default]"
+
+listcustom_or_default = Union[list[Custom], Default]
+listint_or_default = Union[list[int], list[Default]]
+
+def f2_with_alias(x: listcustom_or_default, y: listint_or_default):
+    if x == y:  # E: Non-overlapping equality check (left operand type: "list[Custom] | Default", right operand type: "list[int] | list[Default]")
+        reveal_type(x)  # N: Revealed type is "builtins.list[__main__.Custom]"
+        reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int] | builtins.list[__main__.Default]"
+    else:
+        reveal_type(x)  # N: Revealed type is "builtins.list[__main__.Custom] | __main__.Default"
+        reveal_type(y)  # N: Revealed type is "builtins.list[builtins.int] | builtins.list[__main__.Default]"
+
+def f3(x: Custom | dict[str, str], y: dict[int, int]):
+    if x == y:
+        reveal_type(x)  # N: Revealed type is "__main__.Custom | builtins.dict[builtins.str, builtins.str]"
+        reveal_type(y)  # N: Revealed type is "builtins.dict[builtins.int, builtins.int]"
+    else:
+        reveal_type(x)  # N: Revealed type is "__main__.Custom | builtins.dict[builtins.str, builtins.str]"
+        reveal_type(y)  # N: Revealed type is "builtins.dict[builtins.int, builtins.int]"
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingRecursiveCallable]
+# flags: --strict-equality --warn-unreachable
+from __future__ import annotations
+from typing import Callable
+
+class A: ...
+class B: ...
+
+T = Callable[[A], "S"]
+S = Callable[[B], "T"]
+
+def f(x: S, y: T):
+    if x == y:  # E: Unsupported left operand type for == ("Callable[[B], T]")
+        reveal_type(x)  # N: Revealed type is "def (__main__.B) -> def (__main__.A) -> ..."
+        reveal_type(y)  # N: Revealed type is "def (__main__.A) -> def (__main__.B) -> ..."
+    else:
+        reveal_type(x)  # N: Revealed type is "def (__main__.B) -> def (__main__.A) -> ..."
+        reveal_type(y)  # N: Revealed type is "def (__main__.A) -> def (__main__.B) -> ..."
+[builtins fixtures/tuple.pyi]
+
+[case testNarrowingRecursiveUnion]
+# flags: --strict-equality --warn-unreachable
+from __future__ import annotations
+from typing import Union
+
+class A: ...
+class B: ...
+
+T = Union[A, "S"]
+S = Union[B, "T"]  # E: Invalid recursive alias: a union item of itself
+
+def f(x: S, y: T):
+    if x == y:
+        reveal_type(x)  # N: Revealed type is "Any"
+        reveal_type(y)  # N: Revealed type is "__main__.A | Any"
+[builtins fixtures/tuple.pyi]
+
 [case testNarrowingUnreachableCases]
 # flags: --strict-equality --warn-unreachable
 from typing import Literal, Union

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1540,7 +1540,9 @@ class B: pass
 
 def f1(possibles: Tuple[int, Tuple[A]], x: Optional[Tuple[B]]):
     if x in possibles:
-        reveal_type(x)  # N: Revealed type is "tuple[__main__.B]"
+        # TODO: this branch is actually unreachable
+        # This is an easy fix: https://github.com/python/mypy/pull/20660
+        reveal_type(x)  # N: Revealed type is "tuple[__main__.B] | None"
     else:
         reveal_type(x) # N: Revealed type is "tuple[__main__.B] | None"
 


### PR DESCRIPTION
Notably we preserve behaviour on the `testNarrowingCollections` test I added