### PR TITLE
[mypyc] ircheck: Check for incompatible signs in int ops

### DIFF
--- a/mypyc/analysis/ircheck.py
+++ b/mypyc/analysis/ircheck.py
@@ -243,7 +243,7 @@ class OpChecker(OpVisitor[None]):
 
     def expect_primitive_type(self, op: Op, v: Value) -> None:
         if not isinstance(v.type, RPrimitive):
-            self.fail(op, f"RPrimitive expected, got {v.type.__name__}")
+            self.fail(op, f"RPrimitive expected, got {type(v.type).__name__}")
 
     def visit_goto(self, op: Goto) -> None:
         self.check_control_op_targets(op)


### PR DESCRIPTION
This is still a bit lenient, and only the most problematic issues are reported.