### PR TITLE
Refactor State creation logic

### DIFF
--- a/mypy/test/testgraph.py
+++ b/mypy/test/testgraph.py
@@ -60,10 +60,10 @@ class GraphSuite(Suite):
     def test_sorted_components(self) -> None:
         manager = self._make_manager()
         graph = {
-            "a": State("a", None, "import b, c", manager),
-            "d": State("d", None, "pass", manager),
-            "b": State("b", None, "import c", manager),
-            "c": State("c", None, "import b, d", manager),
+            "a": State.new_state("a", None, "import b, c", manager),
+            "d": State.new_state("d", None, "pass", manager),
+            "b": State.new_state("b", None, "import c", manager),
+            "c": State.new_state("c", None, "import b, d", manager),
         }
         res = [scc.mod_ids for scc in sorted_components(graph)]
         assert_equal(res, [{"d"}, {"c", "b"}, {"a"}])
@@ -71,10 +71,10 @@ class GraphSuite(Suite):
     def test_order_ascc(self) -> None:
         manager = self._make_manager()
         graph = {
-            "a": State("a", None, "import b, c", manager),
-            "d": State("d", None, "def f(): import a", manager),
-            "b": State("b", None, "import c", manager),
-            "c": State("c", None, "import b, d", manager),
+            "a": State.new_state("a", None, "import b, c", manager),
+            "d": State.new_state("d", None, "def f(): import a", manager),
+            "b": State.new_state("b", None, "import c", manager),
+            "c": State.new_state("c", None, "import b, d", manager),
         }
         res = [scc.mod_ids for scc in sorted_components(graph)]
         assert_equal(res, [frozenset({"a", "d", "c", "b"})])


### PR DESCRIPTION
Ref https://github.com/python/mypy/issues/933

This should be a pure refactoring unless i messed something up. This is needed to prepare to make `State` serializeable, so that we can send graph over the network to build workers (which is required for parallel parsing). Also not having tons of custom logic in `__init__()` is a better style anyway.

Note I make the new state factory a classmethod to minimize the diff. If there is a preference, I can make it a regular function.