### PR TITLE
Short term fix for bytes narrowing

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8630,7 +8630,6 @@ def reduce_and_conditional_type_maps(ms: list[TypeMap], *, use_meet: bool) -> Ty
 
 
 BUILTINS_CUSTOM_EQ_CHECKS: Final = {
-    "builtins.bytes",
     "builtins.bytearray",
     "builtins.memoryview",
     "builtins.list",

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -3389,3 +3389,80 @@ def foo(x: str | array) -> str:
         return result
     raise
 [builtins fixtures/tuple.pyi]
+
+[case testNarrowingOptionalBytes]
+from __future__ import annotations
+def f(x: bytes | None):
+    if x == b"asdf":
+        reveal_type(x)  # N: Revealed type is "builtins.bytes"
+    else:
+        reveal_type(x)  # N: Revealed type is "builtins.bytes | None"
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingBytesLikeWithPromotion]
+# flags: --strict-equality --warn-unreachable --strict-bytes
+from __future__ import annotations
+
+def check_test(x: bytes) -> None: ...
+check_test(bytearray(b"asdf"))  # E: Argument 1 to "check_test" has incompatible type "bytearray"; expected "bytes"
+
+def main(
+    v_bytes: bytes,
+    v_bytearray: bytearray,
+    v_memoryview: memoryview,
+    v_all: bytes | bytearray | memoryview,
+) -> None:
+    if v_bytes == v_bytearray:
+        reveal_type(v_bytes)  # N: Revealed type is "builtins.bytes"
+        reveal_type(v_bytearray)  # N: Revealed type is "builtins.bytearray"
+    if v_bytes == v_memoryview:
+        reveal_type(v_bytes)  # N: Revealed type is "builtins.bytes"
+        reveal_type(v_memoryview)  # N: Revealed type is "builtins.memoryview"
+    if v_bytearray == v_memoryview:
+        reveal_type(v_bytearray)  # N: Revealed type is "builtins.bytearray"
+        reveal_type(v_memoryview)  # N: Revealed type is "builtins.memoryview"
+
+    if v_all == v_bytes:
+        reveal_type(v_all)  # N: Revealed type is "builtins.bytes"
+        reveal_type(v_bytes)  # N: Revealed type is "builtins.bytes"
+    if v_all == v_bytearray:
+        reveal_type(v_all)  # N: Revealed type is "builtins.bytes | builtins.bytearray | builtins.memoryview"
+        reveal_type(v_bytearray)  # N: Revealed type is "builtins.bytearray"
+    if v_all == v_memoryview:
+        reveal_type(v_all)  # N: Revealed type is "builtins.bytes | builtins.bytearray | builtins.memoryview"
+        reveal_type(v_memoryview)  # N: Revealed type is "builtins.memoryview"
+[builtins fixtures/primitives.pyi]
+
+[case testNarrowingBytesLikeNoPromotion]
+# flags: --strict-equality --warn-unreachable --no-strict-bytes
+from __future__ import annotations
+
+def check_test(x: bytes) -> None: ...
+check_test(bytearray(b"asdf"))
+
+def main(
+    v_bytes: bytes,
+    v_bytearray: bytearray,
+    v_memoryview: memoryview,
+    v_all: bytes | bytearray | memoryview,
+) -> None:
+    if v_bytes == v_bytearray:
+        reveal_type(v_bytes)  # N: Revealed type is "builtins.bytes"
+        reveal_type(v_bytearray)  # N: Revealed type is "builtins.bytearray"
+    if v_bytes == v_memoryview:
+        reveal_type(v_bytes)  # N: Revealed type is "builtins.bytes"
+        reveal_type(v_memoryview)  # N: Revealed type is "builtins.memoryview"
+    if v_bytearray == v_memoryview:
+        reveal_type(v_bytearray)  # N: Revealed type is "builtins.bytearray"
+        reveal_type(v_memoryview)  # N: Revealed type is "builtins.memoryview"
+
+    if v_all == v_bytes:
+        reveal_type(v_all)  # N: Revealed type is "builtins.bytes"
+        reveal_type(v_bytes)  # N: Revealed type is "builtins.bytes"
+    if v_all == v_bytearray:
+        reveal_type(v_all)  # N: Revealed type is "builtins.bytes | builtins.bytearray | builtins.memoryview"
+        reveal_type(v_bytearray)  # N: Revealed type is "builtins.bytearray"
+    if v_all == v_memoryview:
+        reveal_type(v_all)  # N: Revealed type is "builtins.bytes | builtins.bytearray | builtins.memoryview"
+        reveal_type(v_memoryview)  # N: Revealed type is "builtins.memoryview"
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Fixes #20701 / see discussion there

Background:
- In https://github.com/python/mypy/pull/20492 I added code to treat bytes, bytearray and memoryview as having custom `__eq__`, since they can compare equal to values that are of other types. I did this based on primer hits on draft versions of that PR
- In https://github.com/python/mypy/pull/20643 I rewrote the handling of custom equality when narrowing. That fixed many issues, but regressed the equivalent of `testNarrowingOptionalBytes` because we're now more principled about custom `__eq__`. Perhaps interestingly the primer on that PR is small and not controversial, so I didn't feel the need to prioritise unsound things

However, we only need one of the operands to have custom equality to model these things as reachable, so I think we can probably just remove `builtins.bytes` from here.

This behaviour still isn't ideal. For instance, narrowing here shouldn't depend on whether we promote or not (we shouldn't narrow `v_all` to bytes)

The real fix is adding more dedicated special casing so that we have an in-between option between "narrow assuming we can only compare equal to values of the same type" and "assume `__eq__` means we can't conclude anything about the positive case"

Other relevant PRs:
- https://github.com/python/mypy/pull/20673 attempts to remove the other custom eq logic for list, dict, set I added in #20492 . It should be close to mergeable
- https://github.com/python/mypy/pull/20660 improves reachability and unfortunately to land it I have to do a rethink for how int, float, complex narrowing works. I actually think the current version has pretty good semantics and the primer is valid (but scary). But I want to think about it more