### PR TITLE
Enable --pretty by default

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -937,6 +937,7 @@ in error messages.
 
     Use visually nicer output in error messages: use soft word wrap,
     show source code snippets, and show error location markers.
+    This is enabled by default. Use ``--no-pretty`` to disable.
 
 .. option:: --no-color-output
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -904,7 +904,7 @@ These options may only be set in the global section (``[mypy]``).
 .. confval:: pretty
 
     :type: boolean
-    :default: False
+    :default: True
 
     Use visually nicer output in error messages: use soft word wrap,
     show source code snippets, and show error location markers.

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -365,7 +365,7 @@ class Options:
         self.hide_error_codes = False
         self.show_error_code_links = False
         # Use soft word wrap and show trimmed source snippets with error location markers.
-        self.pretty = False
+        self.pretty = True
         self.dump_graph = False
         self.dump_deps = False
         self.logical_deps = False


### PR DESCRIPTION
## Summary

This PR enables the `--pretty` option by default, making mypy show visually nicer error messages with source code snippets and error location markers.

## Changes

- Changed default value of `self.pretty` from `False` to `True` in `mypy/options.py`
- Updated documentation in `docs/source/command_line.rst` to reflect the new default
- Updated documentation in `docs/source/config_file.rst` to show `default: True`

## Behavior

**Before (default):**
```
foo.py:13: error: List item 0 has incompatible type "str"; expected "int"  [list-item]
```

**After (new default):**
```
foo.py:13: error: List item 0 has incompatible type "str"; expected "int"  [list-item]
    aa = ["x"]
          ^~~
```

Users can still use `--no-pretty` to get the previous concise output format.

Closes #19108