### PR TITLE
[mypyc] Add GetElement op and other minor ir tweaks

### DIFF
--- a/mypyc/analysis/dataflow.py
+++ b/mypyc/analysis/dataflow.py
@@ -24,6 +24,7 @@ from mypyc.ir.ops import (
     FloatNeg,
     FloatOp,
     GetAttr,
+    GetElement,
     GetElementPtr,
     Goto,
     IncRef,
@@ -269,6 +270,9 @@ class BaseAnalysisVisitor(OpVisitor[GenAndKill[T]]):
         return self.visit_register_op(op)
 
     def visit_load_mem(self, op: LoadMem) -> GenAndKill[T]:
+        return self.visit_register_op(op)
+
+    def visit_get_element(self, op: GetElement) -> GenAndKill[T]:
         return self.visit_register_op(op)
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> GenAndKill[T]:

--- a/mypyc/analysis/ircheck.py
+++ b/mypyc/analysis/ircheck.py
@@ -22,6 +22,7 @@ from mypyc.ir.ops import (
     FloatNeg,
     FloatOp,
     GetAttr,
+    GetElement,
     GetElementPtr,
     Goto,
     IncRef,
@@ -447,6 +448,9 @@ class OpChecker(OpVisitor[None]):
         pass
 
     def visit_set_mem(self, op: SetMem) -> None:
+        pass
+
+    def visit_get_element(self, op: GetElement) -> None:
         pass
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> None:

--- a/mypyc/analysis/selfleaks.py
+++ b/mypyc/analysis/selfleaks.py
@@ -16,6 +16,7 @@ from mypyc.ir.ops import (
     FloatNeg,
     FloatOp,
     GetAttr,
+    GetElement,
     GetElementPtr,
     Goto,
     InitStatic,
@@ -177,6 +178,9 @@ class SelfLeakedVisitor(OpVisitor[GenAndKill]):
         return CLEAN
 
     def visit_load_mem(self, op: LoadMem) -> GenAndKill:
+        return CLEAN
+
+    def visit_get_element(self, op: GetElement) -> GenAndKill:
         return CLEAN
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> GenAndKill:

--- a/mypyc/codegen/emitfunc.py
+++ b/mypyc/codegen/emitfunc.py
@@ -42,6 +42,7 @@ from mypyc.ir.ops import (
     FloatNeg,
     FloatOp,
     GetAttr,
+    GetElement,
     GetElementPtr,
     Goto,
     IncRef,
@@ -794,6 +795,12 @@ class FunctionEmitterVisitor(OpVisitor[None]):
         # for some casts), so don't emit it.
         if dest != src:
             self.emit_line(f"*({dest_type} *){dest} = {src};")
+
+    def visit_get_element(self, op: GetElement) -> None:
+        dest = self.reg(op)
+        src = self.reg(op.src)
+        dest_type = self.ctype(op.type)
+        self.emit_line(f"{dest} = ({dest_type}){src}.{op.field};")
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> None:
         dest = self.reg(op)

--- a/mypyc/ir/ops.py
+++ b/mypyc/ir/ops.py
@@ -337,6 +337,8 @@ class Assign(BaseAssign):
         (self.src,) = new
 
     def stolen(self) -> list[Value]:
+        if not self.dest.type.is_refcounted:
+            return []
         return [self.src]
 
     def accept(self, visitor: OpVisitor[T]) -> T:
@@ -1680,8 +1682,35 @@ class SetMem(Op):
 
 
 @final
+class GetElement(RegisterOp):
+    """Get the value of a struct element from a struct value."""
+
+    error_kind = ERR_NEVER
+    is_borrowed = True
+
+    def __init__(self, src: Value, field: str, line: int = -1) -> None:
+        super().__init__(line)
+        assert isinstance(src.type, RStruct)
+        self.type = src.type.field_type(field)
+        self.src = src
+        self.src_type = src.type
+        self.field = field
+
+    def sources(self) -> list[Value]:
+        return [self.src]
+
+    def set_sources(self, new: list[Value]) -> None:
+        (self.src,) = new
+
+    def accept(self, visitor: OpVisitor[T]) -> T:
+        return visitor.visit_get_element(self)
+
+
+@final
 class GetElementPtr(RegisterOp):
-    """Get the address of a struct element.
+    """Get the address of a struct element from a pointer to a struct.
+
+    If you have a struct value, use GetElement instead.
 
     Note that you may need to use KeepAlive to avoid the struct
     being freed, if it's reference counted, such as PyObject *.
@@ -1691,6 +1720,7 @@ class GetElementPtr(RegisterOp):
 
     def __init__(self, src: Value, src_type: RType, field: str, line: int = -1) -> None:
         super().__init__(line)
+        assert not isinstance(src.type, RStruct)
         self.type = pointer_rprimitive
         self.src = src
         self.src_type = src_type
@@ -2006,6 +2036,10 @@ class OpVisitor(Generic[T]):
 
     @abstractmethod
     def visit_set_mem(self, op: SetMem) -> T:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visit_get_element(self, op: GetElement) -> T:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypyc/ir/pprint.py
+++ b/mypyc/ir/pprint.py
@@ -29,6 +29,7 @@ from mypyc.ir.ops import (
     FloatNeg,
     FloatOp,
     GetAttr,
+    GetElement,
     GetElementPtr,
     Goto,
     IncRef,
@@ -279,6 +280,9 @@ class IRPrettyPrintVisitor(OpVisitor[str]):
 
     def visit_set_mem(self, op: SetMem) -> str:
         return self.format("set_mem %r, %r :: %t*", op.dest, op.src, op.dest_type)
+
+    def visit_get_element(self, op: GetElement) -> str:
+        return self.format("%r = %r.%s", op, op.src, op.field)
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> str:
         return self.format("%r = get_element_ptr %r %s :: %t", op, op.src, op.field, op.src_type)

--- a/mypyc/ir/rtypes.py
+++ b/mypyc/ir/rtypes.py
@@ -865,12 +865,20 @@ class RStruct(RType):
         self.name = name
         self.names = names
         self.types = types
+        self.is_refcounted = any(t.is_refcounted for t in self.types)
+
         # generate dummy names
         if len(self.names) < len(self.types):
             for i in range(len(self.types) - len(self.names)):
                 self.names.append("_item" + str(i))
         self.offsets, self.size = compute_aligned_offsets_and_size(types)
         self._ctype = name
+
+    def field_type(self, name: str) -> RType:
+        for n, t in zip(self.names, self.types):
+            if n == name:
+                return t
+        assert False, f"{self.name} has no field '{name}'"
 
     def accept(self, visitor: RTypeVisitor[T]) -> T:
         return visitor.visit_rstruct(self)

--- a/mypyc/transform/ir_transform.py
+++ b/mypyc/transform/ir_transform.py
@@ -20,6 +20,7 @@ from mypyc.ir.ops import (
     FloatNeg,
     FloatOp,
     GetAttr,
+    GetElement,
     GetElementPtr,
     Goto,
     IncRef,
@@ -212,6 +213,9 @@ class IRTransform(OpVisitor[Value | None]):
     def visit_set_mem(self, op: SetMem) -> Value | None:
         return self.add(op)
 
+    def visit_get_element(self, op: GetElement) -> Value | None:
+        return self.add(op)
+
     def visit_get_element_ptr(self, op: GetElementPtr) -> Value | None:
         return self.add(op)
 
@@ -353,6 +357,9 @@ class PatchVisitor(OpVisitor[None]):
 
     def visit_set_mem(self, op: SetMem) -> None:
         op.dest = self.fix_op(op.dest)
+        op.src = self.fix_op(op.src)
+
+    def visit_get_element(self, op: GetElement) -> None:
         op.src = self.fix_op(op.src)
 
     def visit_get_element_ptr(self, op: GetElementPtr) -> None:


### PR DESCRIPTION
The `GetElement` op gets a struct field from a struct value, unlike `GetElementPtr` which takes a pointer to a struct.

These changes were extracted from mypyc vec type support branch, and aren't very useful by themselves. I'm splitting the branch into multiple PRs to simplify reviewing.