### PR TITLE
Improve narrowing with numeric types

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6687,7 +6687,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 target = TypeRange(target_type, is_upper_bound=False)
 
                 if_map, else_map = conditional_types_to_typemaps(
-                    operands[i], *conditional_types(expr_type, [target])
+                    operands[i],
+                    *conditional_types(expr_type, [target], consider_promotion_overlap=True),
                 )
                 if is_target_for_value_narrowing(get_proper_type(target_type)):
                     all_if_maps.append(if_map)
@@ -6724,7 +6725,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                     target = TypeRange(target_type, is_upper_bound=False)
                     if is_target_for_value_narrowing(get_proper_type(target_type)):
                         if_map, else_map = conditional_types_to_typemaps(
-                            operands[i], *conditional_types(expr_type, [target])
+                            operands[i],
+                            *conditional_types(
+                                expr_type, [target], consider_promotion_overlap=True
+                            ),
                         )
                         all_else_maps.append(else_map)
                 continue
@@ -6754,7 +6758,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                     target = TypeRange(target_type, is_upper_bound=False)
 
                     if_map, else_map = conditional_types_to_typemaps(
-                        operands[i], *conditional_types(expr_type, [target], default=expr_type)
+                        operands[i],
+                        *conditional_types(
+                            expr_type, [target], default=expr_type, consider_promotion_overlap=True
+                        ),
                     )
                     or_if_maps.append(if_map)
                     if is_target_for_value_narrowing(get_proper_type(target_type)):
@@ -8256,6 +8263,7 @@ def conditional_types(
     default: None = None,
     *,
     consider_runtime_isinstance: bool = True,
+    consider_promotion_overlap: bool = False,
 ) -> tuple[Type | None, Type | None]: ...
 
 
@@ -8266,6 +8274,7 @@ def conditional_types(
     default: Type,
     *,
     consider_runtime_isinstance: bool = True,
+    consider_promotion_overlap: bool = False,
 ) -> tuple[Type, Type]: ...
 
 
@@ -8275,6 +8284,7 @@ def conditional_types(
     default: Type | None = None,
     *,
     consider_runtime_isinstance: bool = True,
+    consider_promotion_overlap: bool = False,
 ) -> tuple[Type | None, Type | None]:
     """Takes in the current type and a proposed type of an expression.
 
@@ -8319,6 +8329,7 @@ def conditional_types(
                 proposed_type_ranges,
                 default=union_item,
                 consider_runtime_isinstance=consider_runtime_isinstance,
+                consider_promotion_overlap=consider_promotion_overlap,
             )
             yes_items.append(yes_type)
             no_items.append(no_type)
@@ -8354,9 +8365,17 @@ def conditional_types(
                 consider_runtime_isinstance=consider_runtime_isinstance,
             )
             return default, remainder
-    if not is_overlapping_types(current_type, proposed_type, ignore_promotions=True):
+    if not is_overlapping_types(
+        current_type, proposed_type, ignore_promotions=not consider_promotion_overlap
+    ):
         # Expression is never of any type in proposed_type_ranges
         return UninhabitedType(), default
+    if consider_promotion_overlap and not is_overlapping_types(
+        current_type, proposed_type, ignore_promotions=True
+    ):
+        # We set consider_promotion_overlap when comparing equality. This is one of the places
+        # at runtime where subtyping with promotion does happen to match runtime semantics
+        return default, default
     # we can only restrict when the type is precise, not bounded
     proposed_precise_type = UnionType.make_union(
         [type_range.item for type_range in proposed_type_ranges if not type_range.is_upper_bound]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -3567,7 +3567,6 @@ def convert_type(target_type: Type[TargetType]) -> TargetType:
 from __future__ import annotations
 from typing import Literal
 
-# TODO: the behaviour on some of these test cases is incorrect
 def f1(number: float, i: int):
     if number == i:
         reveal_type(number)  # N: Revealed type is "builtins.float"
@@ -3575,22 +3574,30 @@ def f1(number: float, i: int):
 
 def f2(number: float, five: Literal[5]):
     if number == five:
-        reveal_type(number)  # E: Statement is unreachable
-        reveal_type(five)
+        reveal_type(number)  # N: Revealed type is "builtins.float"
+        reveal_type(five)  # N: Revealed type is "Literal[5]"
 
 def f3(number: float | int, five: Literal[5]):
     if number == five:
-        reveal_type(number)  # N: Revealed type is "Literal[5]"
+        reveal_type(number)  # N: Revealed type is "builtins.float | Literal[5]"
+        reveal_type(five)  # N: Revealed type is "Literal[5]"
+
+def f8(number: float | Literal[5], five: Literal[5]):
+    if number == five:
+        reveal_type(number)  # N: Revealed type is "builtins.float | Literal[5]"
+        reveal_type(five)  # N: Revealed type is "Literal[5]"
+    else:
+        reveal_type(number)  # N: Revealed type is "builtins.float"
         reveal_type(five)  # N: Revealed type is "Literal[5]"
 
 def f4(number: float | None, i: int):
     if number == i:
-        reveal_type(number)  # N: Revealed type is "builtins.float | None"
+        reveal_type(number)  # N: Revealed type is "builtins.float"
         reveal_type(i)  # N: Revealed type is "builtins.int"
 
 def f5(number: float | int, i: int):
     if number == i:
-        reveal_type(number)  # N: Revealed type is "builtins.int"
+        reveal_type(number)  # N: Revealed type is "builtins.float | builtins.int"
         reveal_type(i)  # N: Revealed type is "builtins.int"
 
 def f6(number: float | complex, i: int):
@@ -3604,7 +3611,7 @@ class Custom:
 def f7(number: float, x: Custom | int):
     if number == x:
         reveal_type(number)  # N: Revealed type is "builtins.float"
-        reveal_type(x)  # N: Revealed type is "__main__.Custom"
+        reveal_type(x)  # N: Revealed type is "__main__.Custom | builtins.int"
 [builtins fixtures/primitives.pyi]
 
 [case testNarrowingAnyNegativeIntersection-xfail]
@@ -3694,7 +3701,7 @@ def main(
         reveal_type(v_memoryview)  # N: Revealed type is "builtins.memoryview"
 
     if v_all == v_bytes:
-        reveal_type(v_all)  # N: Revealed type is "builtins.bytes"
+        reveal_type(v_all)  # N: Revealed type is "builtins.bytes | builtins.bytearray | builtins.memoryview"
         reveal_type(v_bytes)  # N: Revealed type is "builtins.bytes"
     if v_all == v_bytearray:
         reveal_type(v_all)  # N: Revealed type is "builtins.bytes | builtins.bytearray | builtins.memoryview"


### PR DESCRIPTION
I added tests for this change in #20709 so it's easier to see the diff. Like a few others, this was factored out of #20660 to make that one easier to land.
The change in bytes narrowing is also desirable (but unfortunately only applies with --no-strict-bytes). We can figure out something else for that case, as discussed in #20704