### PR TITLE
Fix indirect dependencies for protocols

### DIFF
--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -123,6 +123,13 @@ class TypeIndirectionVisitor(TypeVisitor[None]):
                 self._visit(t.type.typeddict_type)
             if t.type.tuple_type:
                 self._visit(t.type.tuple_type)
+            if t.type.is_protocol:
+                # For protocols, member types constitute the semantic meaning of the type.
+                # TODO: this doesn't cover some edge cases, like setter types and exotic nodes.
+                for m in t.type.protocol_members:
+                    node = t.type.names.get(m)
+                    if node and node.type:
+                        self._visit(node.type)
 
     def visit_callable_type(self, t: types.CallableType) -> None:
         self._visit_type_list(t.arg_types)

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4693,3 +4693,55 @@ class Impl:
         pass
 
 x: Proto = Impl()
+
+[case testIndirectDependencyOnProtocolIncremental]
+import a
+[file a.py]
+from b import P
+
+class CNested:
+    def f(self) -> int: ...
+class C:
+    def f(self) -> CNested: ...
+
+x: P = C()
+
+[file b.py]
+from typing import Protocol
+from c import PNested
+
+class P(Protocol):
+    def f(self) -> PNested: ...
+
+[file c.py]
+from typing import Protocol
+
+class PNested(Protocol):
+    def f(self) -> str: ...
+
+[file c.py.2]
+from typing import Protocol
+
+class PNested(Protocol):
+    def f(self) -> int: ...
+
+[file c.py.3]
+from typing import Protocol
+
+class PNested(Protocol):
+    def f(self) -> str: ...
+[out]
+tmp/a.py:8: error: Incompatible types in assignment (expression has type "C", variable has type "P")
+tmp/a.py:8: note: Following member(s) of "C" have conflicts:
+tmp/a.py:8: note:     Expected:
+tmp/a.py:8: note:         def f(self) -> PNested
+tmp/a.py:8: note:     Got:
+tmp/a.py:8: note:         def f(self) -> CNested
+[out2]
+[out3]
+tmp/a.py:8: error: Incompatible types in assignment (expression has type "C", variable has type "P")
+tmp/a.py:8: note: Following member(s) of "C" have conflicts:
+tmp/a.py:8: note:     Expected:
+tmp/a.py:8: note:         def f(self) -> PNested
+tmp/a.py:8: note:     Got:
+tmp/a.py:8: note:         def f(self) -> CNested


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/15762

This is straightforward, for protocols, member types constitute semantic meaning of a type (for performance reasons we can actually skip bases for protocols, but some edge cases are not covered for members yet, I left a TODO).