### PR TITLE
Flip fixed-format cache to on by default

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1680,12 +1680,12 @@ def find_cache_meta(
         if manager.plugins_snapshot != manager.old_plugins_snapshot:
             manager.log(f"Metadata abandoned for {id}: plugins differ")
             return None
-    # So that plugins can return data with tuples in it without
-    # things silently always invalidating modules, we round-trip
-    # the config data. This isn't beautiful.
-    plugin_data = json_loads(
-        json_dumps(manager.plugin.report_config_data(ReportConfigContext(id, path, is_check=True)))
-    )
+    plugin_data = manager.plugin.report_config_data(ReportConfigContext(id, path, is_check=True))
+    if not manager.options.fixed_format_cache:
+        # So that plugins can return data with tuples in it without
+        # things silently always invalidating modules, we round-trip
+        # the config data. This isn't beautiful.
+        plugin_data = json_loads(json_dumps(plugin_data))
     if m.plugin_data != plugin_data:
         manager.log(f"Metadata abandoned for {id}: plugin configuration differs")
         return None

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1076,10 +1076,12 @@ def define_options(
         action="store_true",
         help="Include fine-grained dependency information in the cache for the mypy daemon",
     )
-    incremental_group.add_argument(
-        "--fixed-format-cache",
-        action="store_true",
-        help="Use new fast and compact fixed format cache",
+    add_invertible_flag(
+        "--no-fixed-format-cache",
+        dest="fixed_format_cache",
+        default=True,
+        help="Do not use new fixed format cache",
+        group=incremental_group,
     )
     incremental_group.add_argument(
         "--skip-version-check",

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -292,7 +292,7 @@ class Options:
         self.incremental = True
         self.cache_dir = defaults.CACHE_DIR
         self.sqlite_cache = False
-        self.fixed_format_cache = False
+        self.fixed_format_cache = True
         self.debug_cache = False
         self.skip_version_check = False
         self.skip_cache_mtime_checks = False

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -13,4 +13,3 @@ enable_error_code = ignore-without-code,redundant-expr
 enable_incomplete_feature = PreciseTupleTypes
 show_error_code_links = True
 warn_unreachable = True
-fixed_format_cache = True

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -355,7 +355,7 @@ def compile_ir_to_c(
 
 def get_ir_cache_name(id: str, path: str, options: Options) -> str:
     meta_path, _, _ = get_cache_names(id, path, options)
-    # Mypy uses JSON cache even with --fixed-format-cache (for now).
+    # Mypyc uses JSON cache even with --fixed-format-cache (for now).
     return meta_path.replace(".meta.json", ".ir.json").replace(".meta.ff", ".ir.json")
 
 

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -316,7 +316,7 @@ $ {python} -c "print('x=1')" >foo.py
 $ {python} -c "print('x=1')" >bar.py
 $ mypy --local-partial-types --cache-fine-grained --follow-imports=error --no-sqlite-cache --python-version=3.11 -- foo.py bar.py
 Success: no issues found in 2 source files
-$ {python} -c "import shutil; shutil.copy('.mypy_cache/3.11/bar.meta.json', 'asdf.json')"
+$ {python} -c "import shutil; shutil.copy('.mypy_cache/3.11/bar.meta.ff', 'asdf.ff')"
 -- update bar's timestamp but don't change the file
 $ {python} -c "import time;time.sleep(1)"
 $ {python} -c "print('x=1')" >bar.py
@@ -328,7 +328,7 @@ Daemon is up and running
 $ dmypy stop
 Daemon stopped
 -- copy the original bar cache file back so that the mtime mismatches
-$ {python} -c "import shutil; shutil.copy('asdf.json', '.mypy_cache/3.11/bar.meta.json')"
+$ {python} -c "import shutil; shutil.copy('asdf.ff', '.mypy_cache/3.11/bar.meta.ff')"
 -- sleep guarantees timestamp changes
 $ {python} -c "import time;time.sleep(1)"
 $ {python} -c "print('lol')" >foo.py
@@ -341,7 +341,7 @@ Found 1 error in 1 file (checked 2 source files)
 $ {python} -c "import sys; sys.stdout.write(open('log').read())"
 -- make sure the meta file didn't get updated. we use this as an imperfect proxy for
 -- whether the source file got rehashed, which we don't want it to have been.
-$ {python} -c "x = open('.mypy_cache/3.11/bar.meta.json').read(); y = open('asdf.json').read(); assert x == y"
+$ {python} -c "x = open('.mypy_cache/3.11/bar.meta.ff', 'rb').read(); y = open('asdf.ff', 'rb').read(); assert x == y"
 
 [case testDaemonSuggest]
 $ dmypy start --log-file log.txt -- --follow-imports=error --no-error-summary

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -234,8 +234,8 @@ x = 10
 [file p/c.py]
 class C: pass
 
-[delete ../.mypy_cache/3.9/b.meta.json.2]
-[delete ../.mypy_cache/3.9/p/c.meta.json.2]
+[delete ../.mypy_cache/3.9/b.meta.ff.2]
+[delete ../.mypy_cache/3.9/p/c.meta.ff.2]
 
 [out]
 ==


### PR DESCRIPTION
Since this is scheduled for v1.20 it is better do this sooner than later. So that people who are using mypy master can give some early feedback.
