### PR TITLE
trace log both current and prior plugin hash values

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -848,6 +848,8 @@ class BuildManager:
         self.plugin = plugin
         self.plugins_snapshot = plugins_snapshot
         self.old_plugins_snapshot = read_plugins_snapshot(self)
+        if self.verbosity() >= 2:
+            self.trace(f"Plugins snapshot (fresh) {json.dumps(self.plugins_snapshot)}")
         self.quickstart_state = read_quickstart_file(options, self.stdout)
         # Fine grained targets (module top levels and top level functions) processed by
         # the semantic analyzer, used only for testing. Currently used only by the new
@@ -1355,7 +1357,7 @@ def read_plugins_snapshot(manager: BuildManager) -> dict[str, str] | None:
     snapshot = _load_json_file(
         PLUGIN_SNAPSHOT_FILE,
         manager,
-        log_success="Plugins snapshot ",
+        log_success="Plugins snapshot (cached) ",
         log_error="Could not load plugins snapshot: ",
     )
     if snapshot is None:


### PR DESCRIPTION
I was debugging an issue where cache entries were being invalidated due to a plugin hash not matching.  It would have helped a little to have both hashes listed so I could see which plugin didn't match and have the hash to go hunt down the problem file on my workstation.

In this repo, first run (no cache):

```
 $ mypy --config-file mypy_self_check.ini -vv mypy 2> l
Success: no issues found in 190 source files
(.venv) ecsb@fw16 ~/src/o/c-mypy (cbs/hash-debug) $ grep Plugin l
TRACE: Plugins snapshot (fresh) {"mypy.plugins.proper_plugin": "none:4449d775ee477b70f3e3ad7268db2128dae4324d"}
```

Second run:
```
$ mypy --config-file mypy_self_check.ini -vv mypy 2> l2
Success: no issues found in 190 source files
$ grep Plugin l2
TRACE: Plugins snapshot (cached) {"mypy.plugins.proper_plugin":"none:4449d775ee477b70f3e3ad7268db2128dae4324d"}
TRACE: Plugins snapshot (fresh) {"mypy.plugins.proper_plugin": "none:4449d775ee477b70f3e3ad7268db2128dae4324d"}
```