### PR TITLE
Document show_error_codes config option and CLI flag

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -924,6 +924,15 @@ in error messages.
     ``file:line:column:end_line:end_column``. This option implies
     ``--show-column-numbers``.
 
+.. option:: --show-error-codes
+
+    This flag will show the error code ``[<code>]`` after each error message. This is the
+    default behavior::
+
+        prog.py:1: error: "str" has no attribute "trim"  [attr-defined]
+
+    See :ref:`error-codes` for more information.
+
 .. option:: --hide-error-codes
 
     This flag will hide the error code ``[<code>]`` from error messages. By default, the error

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -894,6 +894,15 @@ These options may only be set in the global section (``[mypy]``).
 
     Shows documentation link to corresponding error code.
 
+.. confval:: show_error_codes
+
+    :type: boolean
+    :default: True
+
+    Shows error codes in error messages. See :ref:`error-codes` for more information.
+
+    This is the default behavior. To hide error codes, use :confval:`hide_error_codes` instead.
+
 .. confval:: hide_error_codes
 
     :type: boolean


### PR DESCRIPTION
## Summary
Fixes #17083

Both the config file and command line documentation were missing documentation for `show_error_codes`, which is the default behavior (error codes are shown by default).

## Changes
- Added `show_error_codes` documentation in `config_file.rst` (as the default True option)
- Added `--show-error-codes` documentation in `command_line.rst` (as the default behavior)

This makes it clear that:
- Error codes are shown by default
- Users can use either `show_error_codes = True` or `hide_error_codes = False` in the config file
- Users can use either `--show-error-codes` or `--no-hide-error-codes` on the command line

## Test plan
- [x] Updated documentation files
- [x] Verified cross-references work correctly
- [x] Checked that the new entries follow the existing documentation style