### PR TITLE
Stop looking for .gitignore at top level of working tree

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -726,7 +726,7 @@ def matches_gitignore(subpath: str, fscache: FileSystemCache, verbose: bool) -> 
 @functools.lru_cache
 def find_gitignores(dir: str) -> list[tuple[str, PathSpec]]:
     parent_dir = os.path.dirname(dir)
-    if parent_dir == dir:
+    if parent_dir == dir or os.path.exists(os.path.join(dir, ".git")):
         parent_gitignores = []
     else:
         parent_gitignores = find_gitignores(parent_dir)

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -957,6 +957,16 @@ bpkg.*
 [out]
 c/cpkg.py:1: error: "int" not callable
 
+[case testCmdlineExcludeGitignoreOnlyWithinTree]
+# cmd: mypy --exclude-gitignore b
+[file .gitignore]
+b
+[file b/.git/config]
+[file b/bpkg.py]
+1()
+[out]
+b/bpkg.py:1: error: "int" not callable
+
 [case testCmdlineCfgExclude]
 # cmd: mypy .
 [file mypy.ini]


### PR DESCRIPTION
I have a checkout where I'm using the new `exclude_gitignore` facility introduced in #18696, and where a parent directory has a `.gitignore` file that happens to match the full path of the checkout.  I just spent quite some time being very confused about why mypy reported success despite the code having obvious typing errors.  Unlike git itself, mypy didn't stop looking for `.gitignore` files at the top level of the working tree; now it does.