### PR TITLE
Recover from corrupted fixed-format cache meta file

### DIFF
--- a/mypy/cache.py
+++ b/mypy/cache.py
@@ -224,7 +224,7 @@ class CacheMeta:
                 ignore_all=read_bool(data),
                 plugin_data=read_json_value(data),
             )
-        except ValueError:
+        except (ValueError, AssertionError):
             return None
 
 


### PR DESCRIPTION
Various read functions may raise AssertionError in addition to ValueError.