### PR TITLE
Make librt.base64 non-experimental

### DIFF
--- a/mypyc/lib-rt/base64/librt_base64.c
+++ b/mypyc/lib-rt/base64/librt_base64.c
@@ -5,8 +5,6 @@
 #include "libbase64.h"
 #include "pythoncapi_compat.h"
 
-#ifdef MYPYC_EXPERIMENTAL
-
 static PyObject *
 b64decode_handle_invalid_input(
     PyObject *out_bytes, char *outbuf, size_t max_out, const char *src, size_t srclen, bool freesrc);
@@ -327,19 +325,13 @@ urlsafe_b64decode(PyObject *self, PyObject *const *args, size_t nargs) {
     return b64decode_internal(args[0], true);
 }
 
-#endif
-
 static PyMethodDef librt_base64_module_methods[] = {
-#ifdef MYPYC_EXPERIMENTAL
     {"b64encode", (PyCFunction)b64encode, METH_FASTCALL, PyDoc_STR("Encode bytes object using Base64.")},
     {"b64decode", (PyCFunction)b64decode, METH_FASTCALL, PyDoc_STR("Decode a Base64 encoded bytes object or ASCII string.")},
     {"urlsafe_b64encode", (PyCFunction)urlsafe_b64encode, METH_FASTCALL, PyDoc_STR("Encode bytes object using URL and file system safe Base64 alphabet.")},
     {"urlsafe_b64decode", (PyCFunction)urlsafe_b64decode, METH_FASTCALL, PyDoc_STR("Decode bytes or ASCII string using URL and file system safe Base64 alphabet.")},
-#endif
     {NULL, NULL, 0, NULL}
 };
-
-#ifdef MYPYC_EXPERIMENTAL
 
 static int
 base64_abi_version(void) {
@@ -351,12 +343,9 @@ base64_api_version(void) {
     return LIBRT_BASE64_API_VERSION;
 }
 
-#endif
-
 static int
 librt_base64_module_exec(PyObject *m)
 {
-#ifdef MYPYC_EXPERIMENTAL
     // Export mypy internal C API, be careful with the order!
     static void *base64_api[LIBRT_BASE64_API_LEN] = {
         (void *)base64_abi_version,
@@ -368,7 +357,6 @@ librt_base64_module_exec(PyObject *m)
     if (PyModule_Add(m, "_C_API", c_api_object) < 0) {
         return -1;
     }
-#endif
     return 0;
 }
 

--- a/mypyc/lib-rt/base64/librt_base64.h
+++ b/mypyc/lib-rt/base64/librt_base64.h
@@ -1,17 +1,6 @@
 #ifndef LIBRT_BASE64_H
 #define LIBRT_BASE64_H
 
-#ifndef MYPYC_EXPERIMENTAL
-
-static int
-import_librt_base64(void)
-{
-    // All librt.base64 features are experimental for now, so don't set up the API here
-    return 0;
-}
-
-#else  // MYPYC_EXPERIMENTAL
-
 #include <Python.h>
 
 #define LIBRT_BASE64_ABI_VERSION 1
@@ -57,7 +46,5 @@ import_librt_base64(void)
     }
     return 0;
 }
-
-#endif  // MYPYC_EXPERIMENTAL
 
 #endif  // LIBRT_BASE64_H

--- a/mypyc/test-data/run-base64.test
+++ b/mypyc/test-data/run-base64.test
@@ -1,4 +1,4 @@
-[case testAllBase64Features_librt_experimental]
+[case testAllBase64Features_librt]
 from typing import Any, cast
 import base64
 import binascii
@@ -204,14 +204,7 @@ def test_urlsafe_b64decode_errors() -> None:
         with assertRaises(ValueError):
             b64decode(b)
 
-[case testBase64FeaturesNotAvailableInNonExperimentalBuild_librt_base64]
-# This also ensures librt.base64 can be built without experimental features
-import librt.base64
-
-def test_b64encode_not_available() -> None:
-    assert not hasattr(librt.base64, "b64encode")
-
-[case testBase64UsedAtTopLevelOnly_librt_experimental]
+[case testBase64UsedAtTopLevelOnly_librt]
 from librt.base64 import b64encode
 
 # The only reference to b64encode is at module top level


### PR DESCRIPTION
It is highly unlikely ABI will change here, and `base64` part of `librt` is already well tested.

cc @JukkaL as we discussed.
