### PR TITLE
Optimize load_graph to avoid O(n**2) 'not ready' tracking

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3957,12 +3957,12 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
 
     # Prime the ready list with leaf SCCs (that have no dependencies).
     ready = []
-    not_ready = []
+    not_ready = set()
     for scc in sccs:
         if not scc.deps:
             ready.append(scc)
         else:
-            not_ready.append(scc)
+            not_ready.add(scc)
 
     still_working = False
     while ready or not_ready or still_working:


### PR DESCRIPTION
Use a set instead of a list for tracking not ready SCCs, since set provides a O(1) remove operation, instead of O(n) for lists. In a large codebase, up to 37% of CPU was spent in the list.remove call when doing a small incremental run.