### PR TITLE
Optimization: avoid path operations that need syscalls

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -813,6 +813,7 @@ class BuildManager:
             and not has_reporters
         )
         self.fscache = fscache
+        self.cwd = os.getcwd()
         self.find_module_cache = FindModuleCache(
             self.search_paths, self.fscache, self.options, source_set=self.source_set
         )
@@ -2440,7 +2441,11 @@ class State:
         self.id = id
         self.path = path
         if path:
-            self.abspath = os.path.abspath(path)
+            # Avoid calling os.abspath, since it makes a getcwd() syscall, which is slow
+            if os.path.isabs(path):
+                self.abspath = path
+            else:
+                self.abspath = os.path.normpath(os.path.join(manager.cwd, path))
         self.xpath = path or "<string>"
         self.source = source
         self.options = options
@@ -3164,12 +3169,14 @@ class State:
             # We only need this for the daemon, regular incremental does this unconditionally.
             if self.meta and self.options.fine_grained_incremental:
                 self.verify_dependencies(suppressed_only=True)
-            self.manager.errors.generate_unused_ignore_errors(self.xpath)
+            is_typeshed = self.tree is not None and self.tree.is_typeshed_file(self.options)
+            self.manager.errors.generate_unused_ignore_errors(self.xpath, is_typeshed)
 
     def generate_ignore_without_code_notes(self) -> None:
         if self.manager.errors.is_error_code_enabled(codes.IGNORE_WITHOUT_CODE):
+            is_typeshed = self.tree is not None and self.tree.is_typeshed_file(self.options)
             self.manager.errors.generate_ignore_without_code_errors(
-                self.xpath, self.options.warn_unused_ignores
+                self.xpath, self.options.warn_unused_ignores, is_typeshed
             )
 
 
@@ -3809,7 +3816,7 @@ def load_graph(
                         st.suppress_dependency(dep)
                 else:
                     if newst.path:
-                        newst_path = os.path.abspath(newst.path)
+                        newst_path = newst.abspath
 
                         if newst_path in seen_files:
                             manager.errors.report(

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -16,7 +16,7 @@ from mypy.nodes import Context
 from mypy.options import Options
 from mypy.scope import Scope
 from mypy.types import Type
-from mypy.util import DEFAULT_SOURCE_OFFSET, is_typeshed_file
+from mypy.util import DEFAULT_SOURCE_OFFSET
 from mypy.version import __version__ as mypy_version
 
 T = TypeVar("T")
@@ -869,11 +869,8 @@ class Errors:
             if not has_blocker and path in self.has_blockers:
                 self.has_blockers.remove(path)
 
-    def generate_unused_ignore_errors(self, file: str) -> None:
-        if (
-            is_typeshed_file(self.options.abs_custom_typeshed_dir if self.options else None, file)
-            or file in self.ignored_files
-        ):
+    def generate_unused_ignore_errors(self, file: str, is_typeshed: bool = False) -> None:
+        if is_typeshed or file in self.ignored_files:
             return
         ignored_lines = self.ignored_lines[file]
         used_ignored_lines = self.used_ignored_lines[file]
@@ -921,12 +918,9 @@ class Errors:
             self._add_error_info(file, info)
 
     def generate_ignore_without_code_errors(
-        self, file: str, is_warning_unused_ignores: bool
+        self, file: str, is_warning_unused_ignores: bool, is_typeshed: bool = False
     ) -> None:
-        if (
-            is_typeshed_file(self.options.abs_custom_typeshed_dir if self.options else None, file)
-            or file in self.ignored_files
-        ):
+        if is_typeshed or file in self.ignored_files:
             return
 
         used_ignored_lines = self.used_ignored_lines[file]

--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -53,7 +53,6 @@ from mypy.semanal_infer import infer_decorator_signature_if_simple
 from mypy.semanal_shared import find_dataclass_transform_spec
 from mypy.semanal_typeargs import TypeArgumentAnalyzer
 from mypy.server.aststrip import SavedAttributes
-from mypy.util import is_typeshed_file
 
 if TYPE_CHECKING:
     from mypy.build import Graph, State
@@ -450,10 +449,11 @@ def check_type_arguments_in_targets(
     This mirrors the logic in check_type_arguments() except that we process only
     some targets. This is used in fine grained incremental mode.
     """
+    assert state.tree
     analyzer = TypeArgumentAnalyzer(
         errors,
         state.options,
-        is_typeshed_file(state.options.abs_custom_typeshed_dir, state.path or ""),
+        state.tree.is_typeshed_file(state.options),
         state.manager.semantic_analyzer.named_type,
     )
     with state.wrap_context():


### PR DESCRIPTION
Notably `os.path.abspath` makes a getcwd syscall, and it can be pretty slow. Now we avoid the syscall is several places.

These appeared to be at least minor bottlenecks based on some CPU profiles I looked at.

Based on microbenchmarks, `os.path.join` + `os.path.normpath` can be over 10x faster than `abspath`.