### PR TITLE
Optimization: mark some classes as acyclic

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -53,6 +53,7 @@ from librt.internal import (
     write_str as write_str_bare,
     write_tag,
 )
+from mypy_extensions import mypyc_attr
 
 import mypy.semanal_main
 from mypy.cache import (
@@ -194,6 +195,7 @@ initial_gc_freeze_done = False
 Graph: _TypeAlias = dict[str, "State"]
 
 
+@mypyc_attr(acyclic=True)
 class SCC:
     """A simple class that represents a strongly connected component (import cycle)."""
 

--- a/mypy/cache.py
+++ b/mypy/cache.py
@@ -66,7 +66,7 @@ from librt.internal import (
     write_str as write_str_bare,
     write_tag as write_tag,
 )
-from mypy_extensions import u8
+from mypy_extensions import mypyc_attr, u8
 
 # High-level cache layout format
 CACHE_VERSION: Final = 4
@@ -74,6 +74,7 @@ CACHE_VERSION: Final = 4
 SerializedError: _TypeAlias = tuple[str | None, int | str, int, int, int, str, str, str | None]
 
 
+@mypyc_attr(acyclic=True)
 class CacheMeta:
     """Class representing cache metadata for a module."""
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -8,6 +8,8 @@ from collections.abc import Callable
 from re import Pattern
 from typing import Any, Final
 
+from mypy_extensions import mypyc_attr
+
 from mypy import defaults
 from mypy.errorcodes import ErrorCode, error_codes
 from mypy.util import get_class_descriptors, replace_object_state
@@ -92,6 +94,7 @@ INCOMPLETE_FEATURES: Final = frozenset((PRECISE_TUPLE_TYPES, INLINE_TYPEDDICT, T
 COMPLETE_FEATURES: Final = frozenset((TYPE_VAR_TUPLE, UNPACK, NEW_GENERIC_SYNTAX))
 
 
+@mypyc_attr(acyclic=True)
 class Options:
     """Options collected from flags."""
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -25,6 +25,7 @@ from librt.internal import (
     write_int as write_int_bare,
     write_str as write_str_bare,
 )
+from mypy_extensions import mypyc_attr
 
 import mypy.nodes
 from mypy.bogus_type import Bogus
@@ -1273,6 +1274,7 @@ class UnpackType(ProperType):
         return isinstance(other, UnpackType) and self.type == other.type
 
 
+@mypyc_attr(acyclic=True)
 class AnyType(ProperType):
     """The type 'Any'."""
 
@@ -1381,6 +1383,7 @@ class AnyType(ProperType):
         return ret
 
 
+@mypyc_attr(acyclic=True)
 class UninhabitedType(ProperType):
     """This type has no members.
 
@@ -1436,6 +1439,7 @@ class UninhabitedType(ProperType):
         return UninhabitedType()
 
 
+@mypyc_attr(acyclic=True)
 class NoneType(ProperType):
     """The type of 'None'.
 


### PR DESCRIPTION
This will save a bit of memory and make instance construction faster. The impact will be hard to measure, possibly under the noise floor, but it should be a slight improvement, and acts as a real-world test case of the new mypyc feature.