### PR TITLE
Fix false positive for enum members shadowing base properties

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3711,6 +3711,14 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 if is_private(lvalue_node.name):
                     continue
 
+                # Enum members "name"/"value" shadow properties, not overrides.
+                if (
+                    lvalue_node.info.is_enum
+                    and lvalue_node.name in ("name", "value")
+                    and base.fullname in ENUM_BASES
+                ):
+                    continue
+
                 base_type, base_node = self.node_type_from_base(lvalue_node.name, base, lvalue)
                 # TODO: if the r.h.s. is a descriptor, we should check setter override as well.
                 custom_setter = is_custom_settable_property(base_node)

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2982,3 +2982,22 @@ def f(x: SE | None) -> None:
     else:
         reveal_type(x)  # N: Revealed type is "__main__.SE | None"
 [builtins fixtures/primitives.pyi]
+
+[case testEnumMemberNamedValueWithAuto]
+from enum import Enum, auto
+
+class A(Enum):
+    value = auto()
+
+class B(Enum):
+    name = auto()
+
+class C(Enum):
+    name = auto()
+    value = auto()
+
+reveal_type(A.value)  # N: Revealed type is "Literal[__main__.A.value]?"
+reveal_type(B.name)  # N: Revealed type is "Literal[__main__.B.name]?"
+reveal_type(C.name)  # N: Revealed type is "Literal[__main__.C.name]?"
+reveal_type(C.value)  # N: Revealed type is "Literal[__main__.C.value]?"
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
PR Summary:
Defining an enum member called `value` or `name` using `auto()` caused mypy to incorrectly report an incompatible types error, as if overriding the base `Enum.value` property. These are just regular enum members that happen to shadow the property name, not actual overrides. The fix skips the compatibility check for that case.

Fixes #20247