### PR TITLE
Avoid setattr/getattr with fixed format cache

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -4999,7 +4999,7 @@ def write_flags(data: WriteBuffer, flags: list[bool]) -> None:
 
 def read_flags(data: ReadBuffer, num_flags: int) -> list[bool]:
     packed = read_int(data)
-    return [packed & 1 << i != 0 for i in range(num_flags)]
+    return [(packed & (1 << i)) != 0 for i in range(num_flags)]
 
 
 def get_member_expr_fullname(expr: MemberExpr) -> str | None:


### PR DESCRIPTION
This is a small optimization, and something that bothered me for a while. I write bit packing in Python because we have mypyc and we should use it (it should write relatively efficient code for this). Implementation is really basic, I only allow at most 26 flags, which will hopefully be enough for few years. Btw `Var` has _21 flags_, I am quite sure some of those can be cleaned up.