### PR TITLE
Don't create .mypy_cache directory when --no-incremental is used

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1551,6 +1551,10 @@ def exclude_from_backups(target_dir: str) -> None:
 
 def create_metastore(options: Options, parallel_worker: bool = False) -> MetadataStore:
     """Create the appropriate metadata store."""
+    if not options.incremental:
+        # When incremental mode is disabled, use a no-op store to avoid
+        # creating a .mypy_cache directory.
+        return FilesystemMetadataStore(os.devnull)
     if options.sqlite_cache:
         # We use this flag in both coordinator and workers to seep up commits,
         # see mypy.metastore.connect_db() for details.


### PR DESCRIPTION
## Summary

When running mypy with `--no-incremental`, the `.mypy_cache` directory is still created, even though the help text implies it won't be:

```
$ rm -rf .mypy_cache
$ mypy t.py --no-incremental
Success: no issues found in 1 source file
$ ls -d .mypy_cache
.mypy_cache  # Unexpected!
```

## Root cause

The metadata store (which manages the cache directory) is initialized unconditionally in `BuildManager.__init__()`. While the `cache_enabled` flag prevents cache *reads*, the store still creates the cache directory on init (for SQLite stores) or on first write (for filesystem stores).

## Fix

When `options.incremental` is False, `create_metastore()` now returns a no-op `FilesystemMetadataStore` backed by `os.devnull`. Both store implementations already handle `os.devnull` as a no-op — this is the same behavior users get with `--cache-dir /dev/null`, which was the documented workaround.

**After:**
```
$ rm -rf .mypy_cache
$ mypy t.py --no-incremental
Success: no issues found in 1 source file
$ ls -d .mypy_cache
ls: cannot access '.mypy_cache': No such file or directory  # Correct!
```

## Test plan

- Manual verification: `--no-incremental` no longer creates `.mypy_cache`
- Normal mode still creates cache as expected
- All 147 incremental-related tests pass
- `python -m pytest mypy/test/testcheck.py -k "testNoIncremental or testIncremental" -o "addopts="` — all pass

Fixes #19489