### PR TITLE
Optimization: make State final and avoid construction via cls()

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -39,6 +39,7 @@ from typing import (
     TypeAlias as _TypeAlias,
     TypedDict,
     cast,
+    final,
 )
 
 from librt.base64 import b64encode
@@ -2172,6 +2173,7 @@ class ModuleNotFound(Exception):
         self.reason = reason
 
 
+@final
 class State:
     """The state for a module.
 
@@ -2258,9 +2260,8 @@ class State:
     # Mapping from line number to type ignore codes on this line (for imports only).
     imports_ignored: dict[int, list[str]]
 
-    @classmethod
+    @staticmethod
     def new_state(
-        cls,
         id: str | None,
         path: str | None,
         source: str | None,
@@ -2350,7 +2351,7 @@ class State:
             error_lines = []
             imports_ignored = {}
 
-        state = cls(
+        state = State(
             manager=manager,
             order=State.order_counter,
             id=id,


### PR DESCRIPTION
Construction via cls() was pretty slow, possibly due to the large number of keyword arguments, as this used a generic calling convention because of mypyc limitations. This might improve performance of mostly cached, huge incremental builds by 1-2% perhaps, if the CPU profiles I looked at are to be trusted.