### PR TITLE
Optimize: skip logging and stats collection calls if they are no-ops

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3990,9 +3990,8 @@ def find_stale_sccs(
             else:
                 assert stale_indirect is not None
                 fresh_msg = f"stale due to stale indirect dep(s): first {stale_indirect}"
-
-        if manager.logging_enabled:
             scc_str = " ".join(ascc.mod_ids)
+
         if fresh:
             if manager.tracing_enabled:
                 manager.trace(f"Found {fresh_msg} SCC ({scc_str})")


### PR DESCRIPTION
We had lots of logging that was fairly expensive even if disabled, since
just calling the functions or constructing the log messages adds overhead,
and calling `time.time()` to collect timings has a cost. Now put some of the 
most expensive logging/stats calls behind fast bool flag checks.

Based on CPU profiles, this should improve performance of mostly cached
incremental runs if they are big enough by at least 2%, but potentially by
even more (hard to predict).