### PR TITLE
Delete Instance.invalid

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4885,9 +4885,6 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         """
         if alias.python_3_12_type_alias:
             return self.type_alias_type_type()
-        if isinstance(alias.target, Instance) and alias.target.invalid:  # type: ignore[misc]
-            # An invalid alias, error already has been reported
-            return AnyType(TypeOfAny.from_error)
         # If this is a generic alias, we set all variables to `Any`.
         # For example:
         #     A = List[Tuple[T, T]]

--- a/mypy/copytype.py
+++ b/mypy/copytype.py
@@ -65,7 +65,6 @@ class TypeShallowCopier(TypeVisitor[ProperType]):
 
     def visit_instance(self, t: Instance) -> ProperType:
         dup = Instance(t.type, t.args, last_known_value=t.last_known_value)
-        dup.invalid = t.invalid
         return self.copy_common(t, dup)
 
     def visit_type_var(self, t: TypeVarType) -> ProperType:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -2097,7 +2097,6 @@ def fix_instance(
             # Already wrong arg count error, don't emit missing type parameters error as well.
             disallow_any = False
         t.args = ()
-        arg_count = 0
 
     args: list[Type] = [*(t.args[:max_tv_count])]
     any_type: AnyType | None = None
@@ -2550,7 +2549,6 @@ def validate_instance(t: Instance, fail: MsgCallback, empty_tuple_index: bool) -
                 t,
                 code=codes.TYPE_ARG,
             )
-            t.invalid = True
         return False
     return True
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1627,9 +1627,6 @@ class Instance(ProperType):
         self.args = tuple(args)
         self.type_ref: str | None = None
 
-        # True if recovered after incorrect number of type arguments error
-        self.invalid = False
-
         # This field keeps track of the underlying Literal[...] value associated with
         # this instance, if one is known.
         #

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1126,7 +1126,7 @@ main:13:1: error: Value of type variable "T" of "SameA" cannot be "str"
 class A: ...
 Bad = A[int] # type: ignore
 
-reveal_type(Bad) # N: Revealed type is "Any"
+reveal_type(Bad) # N: Revealed type is "def () -> __main__.A"
 [out]
 
 [case testSubscriptionOfBuiltinAliases]


### PR DESCRIPTION
`Instance` is like the hottest type ever. Having a whole attribute there to tweak some rare/niche edge case seems really wasteful. I think we should delete it.

(I also delete 1 line of dead code while I am at it.)
