### PR TITLE
Remove prohibit_none_typevar_overlap

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -9322,12 +9322,7 @@ def is_overlapping_types_for_overload(left: Type, right: Type) -> bool:
     #     def foo(x: None) -> None: ..
     #     @overload
     #     def foo(x: T) -> Foo[T]: ...
-    return is_overlapping_types(
-        left,
-        right,
-        ignore_promotions=True,
-        overlap_for_overloads=True,
-    )
+    return is_overlapping_types(left, right, ignore_promotions=True, overlap_for_overloads=True)
 
 
 def is_private(node_name: str) -> bool:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -6399,9 +6399,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                 isinstance(get_proper_type(known_type), AnyType) and self.chk.current_node_deferred
             ):
                 # Note: this call should match the one in narrow_declared_type().
-                if skip_non_overlapping and not is_overlapping_types(
-                    known_type, restriction
-                ):
+                if skip_non_overlapping and not is_overlapping_types(known_type, restriction):
                     return None
                 narrowed = narrow_declared_type(known_type, restriction)
                 if isinstance(get_proper_type(narrowed), UninhabitedType):

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -650,9 +650,7 @@ def is_overlapping_erased_types(
 ) -> bool:
     """The same as 'is_overlapping_erased_types', except the types are erased first."""
     return is_overlapping_types(
-        erase_type(left),
-        erase_type(right),
-        ignore_promotions=ignore_promotions,
+        erase_type(left), erase_type(right), ignore_promotions=ignore_promotions
     )
 
 


### PR DESCRIPTION
Noticed this seems to be useless while investigating a fix for narrowing with TypeVars