### PR TITLE
Fix incorrect fast path in is_same_type()

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -271,7 +271,12 @@ def is_same_type(
         and a.last_known_value is b.last_known_value
     ):
         return all(is_same_type(x, y) for x, y in zip(a.args, b.args))
-    elif isinstance(a, TypeVarType) and isinstance(b, TypeVarType) and a.id == b.id:
+    elif (
+        isinstance(a, TypeVarType)
+        and isinstance(b, TypeVarType)
+        and a.id == b.id
+        and a.upper_bound == b.upper_bound
+    ):
         return True
 
     # Note that using ignore_promotions=True (default) makes types like int and int64


### PR DESCRIPTION
Although it is unlikely to ever matter, this is technically not correct since we started narrowing upper bounds a while ago (this is already handled correctly in the subtype/meet/join visitors).
