### PR TITLE
Remove duplicate `TYPE_CHECKING` imports

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -6,7 +6,6 @@ import sys
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
 from typing import (
-    TYPE_CHECKING,
     Any,
     ClassVar,
     Final,
@@ -97,18 +96,6 @@ JsonDict: _TypeAlias = dict[str, Any]
 # Literal[...].
 LiteralValue: _TypeAlias = int | str | bool | float
 
-
-# If we only import type_visitor in the middle of the file, mypy
-# breaks, and if we do it at the top, it breaks at runtime because of
-# import cycle issues, so we do it at the top while typechecking and
-# then again in the middle at runtime.
-# We should be able to remove this once we are switched to the new
-# semantic analyzer!
-if TYPE_CHECKING:
-    from mypy.type_visitor import (
-        SyntheticTypeVisitor as SyntheticTypeVisitor,
-        TypeVisitor as TypeVisitor,
-    )
 
 TUPLE_NAMES: Final = ("builtins.tuple", "typing.Tuple")
 TYPE_NAMES: Final = ("builtins.type", "typing.Type")


### PR DESCRIPTION
Summary
--

While reviewing astral-sh/ruff#22560, which expands our `redefined-while-unused` rule to catch re-imports in `TYPE_CHECKING` blocks, we noticed a new diagnostic on this code. When I checked the blame and noticed that the comment was 8 years old, I thought it might be worth trying to remove the import. I'm very happy to close this if I'm missing something, but the tests seem to be passing locally, so I figured I'd open a PR!

Test Plan
--

I set up my environment based on the contributing guide and then ran:

```shell
python runtests.py
```

I also ran:

```shell
tox run -e py310
```

to see if 3.14 was special. However, this is failing for me even on master with what looks like an error from the C compiler, so I figured I'd open the PR anyway and check in CI, assuming that's just a problem with my local environment.