### PR TITLE
Fix regression on redefinition in deferred loop

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4409,6 +4409,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
             and isinstance(lvalue.node, Var)
             and lvalue.node.is_inferred
             and lvalue.node.type is not None
+            and not isinstance(lvalue.node.type, PartialType)
             # Indexes in for loops require special handling, we need to reset them to
             # a literal value on each loop, but binder doesn't work well with literals.
             and not lvalue.node.is_index_var

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1141,6 +1141,23 @@ def f() -> None:
         reveal_type(x) # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
+[case testNewRedefinitionPartialTypeInLoopDeferred]
+# flags: --allow-redefinition-new --local-partial-types
+
+def f(self) -> None:
+    x = []
+    for i in [1, 2, 3]:
+        C().x
+        x.append(1)
+    reveal_type(x)  # N: Revealed type is "builtins.list[builtins.int]"
+
+class C:
+    def __init__(self) -> None:
+        self.x = defer()
+
+def defer() -> int: ...
+[builtins fixtures/list.pyi]
+
 [case testNewRedefinePartialTypeForUnderscore]
 # flags: --allow-redefinition-new --local-partial-types
 


### PR DESCRIPTION
Trivial fix for a regression introduced in https://github.com/python/mypy/pull/20865, a partial type is usually the same as no type at all.