### PR TITLE
Remove this old skipped test disallowing calling a _ function

### DIFF
--- a/test-data/unit/check-redefine.test
+++ b/test-data/unit/check-redefine.test
@@ -564,18 +564,6 @@ def _(arg: str):
 def _(arg: int) -> int:
     return 'a' # E: Incompatible return value type (got "str", expected "int")
 
-[case testCallingUnderscoreFunctionIsNotAllowed-skip]
-# Skipped because of https://github.com/python/mypy/issues/11774
-def _(arg: str) -> None:
-    pass
-
-def _(arg: int) -> int:
-    return arg
-
-_('a') # E: Calling function named "_" is not allowed
-
-y = _(5) # E: Calling function named "_" is not allowed
-
 [case testFunctionStillTypeCheckedWhenAliasedAsUnderscoreDuringImport]
 from a import f as _
 


### PR DESCRIPTION
If additional constraints on this are eventually added, then the error would surely be different anyway, so just let the future feature maker deal with that with a clean slate.