### PR TITLE
Improve documentation of test format

### DIFF
--- a/test-data/unit/README.md
+++ b/test-data/unit/README.md
@@ -42,6 +42,10 @@ with text "abc..."
 - repeating ` # E: ` several times in one line indicates multiple expected errors in one line
 - `W: ...` and `N: ...` work exactly like `E: ...`, but report a warning and a note respectively
 - lines that don't contain the above should cause no type check errors
+- lines that begin with `--` are test-file-format comments, and will not appear in the tested python
+  source code
+- some test files are run in a special way by the test runner; this is typically documented in
+  test-file-format comments at the top of the test file
 - optional `[builtins fixtures/...]` tells the type checker to use
 `builtins` stubs from the indicated file (see Fixtures section below)
 - optional `[out]` is an alternative to the `# E: ` notation: it indicates that


### PR DESCRIPTION
There are some advanced edge cases that were indirectly described here or not described at all; this fixes that.

For example, the previous documentation implied that `# E: ...# E: ...` would work, but it wouldn't.

This PR also adds some examples of usage.

This PR conflicts slightly with https://github.com/python/mypy/pull/19546 as it documents the current behavior, not the improved behavior that relies less on spaces.