### PR TITLE
(docs) Update common_issues.rst: document how the type ignore must come first

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -148,6 +148,14 @@ error:
 The second line is now fine, since the ignore comment causes the name
 ``frobnicate`` to get an implicit ``Any`` type.
 
+The type ignore comment must be at the start of the comments on a line.
+This type ignore will not take effect:
+
+.. code-block:: python
+
+    import frobnicate  #example other comment # type: ignore
+    frobnicate.start()
+
 .. note::
 
     You can use the form ``# type: ignore[<code>]`` to only ignore


### PR DESCRIPTION
https://github.com/python/mypy/issues/19366 won't be fixed/changed any time soon, but this constraint should be noted to the end user.