### PR TITLE
Suggest narrowing for None in union attribute errors

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -47,6 +47,7 @@ from mypy.nodes import (
     Expression,
     FuncDef,
     IndexExpr,
+    MemberExpr,
     MypyFile,
     NameExpr,
     ReturnStmt,
@@ -56,6 +57,7 @@ from mypy.nodes import (
     TypeInfo,
     Var,
     get_func_def,
+    get_member_expr_fullname,
     reverse_builtin_aliases,
 )
 from mypy.operators import op_methods, op_methods_to_symbols
@@ -512,6 +514,25 @@ class MessageBuilder:
                     context,
                     code=codes.UNION_ATTR,
                 )
+                if typ_format == '"None"':
+                    var_name: str | None = None
+                    if isinstance(context, MemberExpr) and isinstance(
+                        context.expr, NameExpr
+                    ):
+                        var_name = context.expr.name
+                    elif isinstance(context, MemberExpr) and isinstance(
+                        context.expr, MemberExpr
+                    ):
+                        var_name = get_member_expr_fullname(context.expr)
+                    elif isinstance(context, NameExpr):
+                        var_name = context.name
+                    if var_name is not None:
+                        self.note(
+                            'You can use "if {} is not None" to guard'
+                            " against a None value".format(var_name),
+                            context,
+                            code=codes.UNION_ATTR,
+                        )
                 return codes.UNION_ATTR
             elif isinstance(original_type, TypeVarType):
                 bound = get_proper_type(original_type.upper_bound)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -516,13 +516,9 @@ class MessageBuilder:
                 )
                 if typ_format == '"None"':
                     var_name: str | None = None
-                    if isinstance(context, MemberExpr) and isinstance(
-                        context.expr, NameExpr
-                    ):
+                    if isinstance(context, MemberExpr) and isinstance(context.expr, NameExpr):
                         var_name = context.expr.name
-                    elif isinstance(context, MemberExpr) and isinstance(
-                        context.expr, MemberExpr
-                    ):
+                    elif isinstance(context, MemberExpr) and isinstance(context.expr, MemberExpr):
                         var_name = get_member_expr_fullname(context.expr)
                     elif isinstance(context, NameExpr):
                         var_name = context.name

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3001,7 +3001,8 @@ class C:
     a = None  # E: Need type annotation for "a" (hint: "a: <type> | None = ...")
 
     def f(self, x) -> None:
-        C.a.y  # E: Item "None" of "Any | None" has no attribute "y"
+        C.a.y  # E: Item "None" of "Any | None" has no attribute "y" \
+               # N: You can use "if C.a is not None" to guard against a None value
 
 [case testLocalPartialTypesAccessPartialNoneAttribute2]
 # flags: --local-partial-types
@@ -3009,7 +3010,8 @@ class C:
     a = None  # E: Need type annotation for "a" (hint: "a: <type> | None = ...")
 
     def f(self, x) -> None:
-        self.a.y  # E: Item "None" of "Any | None" has no attribute "y"
+        self.a.y  # E: Item "None" of "Any | None" has no attribute "y" \
+                  # N: You can use "if self.a is not None" to guard against a None value
 
 -- Special case for assignment to '_'
 -- ----------------------------------

--- a/test-data/unit/check-optional.test
+++ b/test-data/unit/check-optional.test
@@ -580,7 +580,8 @@ if int():
 if int():
     x = f('x') # E: Argument 1 to "f" has incompatible type "str"; expected "int"
 
-x.x = 1 # E: Item "None" of "Node[int] | None" has no attribute "x"
+x.x = 1 # E: Item "None" of "Node[int] | None" has no attribute "x" \
+        # N: You can use "if x is not None" to guard against a None value
 if x is not None:
     x.x = 1 # OK here
 
@@ -633,7 +634,8 @@ A = None  # type: Any
 class C(A):
     pass
 x = None  # type: Optional[C]
-x.foo()  # E: Item "None" of "C | None" has no attribute "foo"
+x.foo()  # E: Item "None" of "C | None" has no attribute "foo" \
+         # N: You can use "if x is not None" to guard against a None value
 
 [case testIsinstanceAndOptionalAndAnyBase]
 from typing import Any, Optional

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -921,12 +921,15 @@ a: Any
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
 
-for y in x: pass # E: Item "None" of "list[tuple[str, str]] | None" has no attribute "__iter__" (not iterable)
+for y in x: pass
 if x:
     for s, t in x:
-        reveal_type(s) # N: Revealed type is "builtins.str"
+        reveal_type(s)
 [builtins fixtures/dict.pyi]
 [out]
+main:7: error: Item "None" of "list[tuple[str, str]] | None" has no attribute "__iter__" (not iterable)
+main:7: note: You can use "if x is not None" to guard against a None value
+main:10: note: Revealed type is "builtins.str"
 
 [case testUnpackUnionNoCrashOnPartialNone2]
 from typing import Dict, Tuple, List, Any
@@ -936,12 +939,23 @@ x = None
 d: Dict[str, Tuple[List[Tuple[str, str]], str]]
 x, _ = d.get(a, (None, None))
 
-for y in x: pass # E: Item "None" of "list[tuple[str, str]] | None" has no attribute "__iter__" (not iterable)
+for y in x: pass
 if x:
     for s, t in x:
-        reveal_type(s) # N: Revealed type is "builtins.str"
+        reveal_type(s)
 [builtins fixtures/dict.pyi]
 [out]
+main:8: error: Item "None" of "list[tuple[str, str]] | None" has no attribute "__iter__" (not iterable)
+main:8: note: You can use "if x is not None" to guard against a None value
+main:11: note: Revealed type is "builtins.str"
+
+[case testUnionAttributeNoneNarrowingHint]
+from typing import Optional
+
+def f(s: Optional[str]) -> bool:
+    return s.startswith('x')  # E: Item "None" of "str | None" has no attribute "startswith" \
+                              # N: You can use "if s is not None" to guard against a None value
+[builtins fixtures/ops.pyi]
 
 [case testUnpackUnionNoCrashOnPartialNoneBinder]
 from typing import Dict, Tuple, List, Any


### PR DESCRIPTION
## Summary

When accessing an attribute on a union type that includes `None`, mypy now emits a note suggesting the user narrow the type with an `if x is not None` guard:

```
error: Item "None" of "str | None" has no attribute "startswith"
note: You can use "if s is not None" to guard against a None value
```

This is especially helpful for beginners who may not know about type narrowing. The note is only shown when:
- The offending union item is `None` (not for arbitrary `Union[A, B]`)
- The variable name can be extracted from the AST context (simple names like `x`, or member access like `self.a`)
- For complex expressions like `items[0].attr`, the note is skipped to avoid unhelpful suggestions

Fixes #17036