### PR TITLE
investigate and change a couple of -skips to -xfails

### DIFF
--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -514,7 +514,7 @@ class E: pass
 [builtins fixtures/tuple.pyi]
 [out]
 
-[case testSubtypingWithTypeImplementingGenericABCViaInheritance2-skip]
+[case testSubtypingWithTypeImplementingGenericABCViaInheritance2-xfail]
 from typing import TypeVar, Generic
 T = TypeVar('T')
 class I(Generic[T]): pass

--- a/test-data/unit/merge.test
+++ b/test-data/unit/merge.test
@@ -1392,7 +1392,7 @@ target:
     D: TypeInfo<5>
     NewType: Var<4>
 
-[case testCallable_symtable-skip]
+[case testCallable_symtable-xfail]
 # The TypeInfo is currently not being merged correctly
 import target
 [file target.py]

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -345,7 +345,7 @@ CallExpr(5) : T`1
 MemberExpr(5) : def () -> T`1
 NameExpr(5) : A[T`1]
 
-[case testGenericFunctionCallWithTypeApp-skip]
+[case testGenericFunctionCallWithTypeApp-xfail]
 ## CallExpr|TypeApplication|NameExpr
 from typing import Any, TypeVar, Tuple
 T = TypeVar('T')


### PR DESCRIPTION
There are surely more that should be dealt with. This addresses part of https://github.com/python/mypy/issues/20881

I think these, and probably several more of the tests marked -skip in our corpus, are just mistakenly -skip when they should be -xfail. There are two benefits, both admittedly marginal, to making them xfail instead of skip: 1. It is semantically correct (at least according to my interpretation of https://docs.pytest.org/en/stable/how-to/skipping.html) 2. If they get fixed they will be reported as an unexpected xpass, instead of silently continuing to skip.