### PR TITLE
Fix changed on pop with multiple variables in binder

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -395,7 +395,7 @@ class ConditionalTypeBinder:
                 if current_value is not None or extract_var_from_literal_hash(key) is None:
                     # We definitely learned something new
                     changed = True
-                else:
+                elif not changed:
                     # If there is no current value compare with the declaration. This prevents
                     # reporting false changes in cases like this:
                     #     x: int

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1158,6 +1158,18 @@ class C:
 def defer() -> int: ...
 [builtins fixtures/list.pyi]
 
+[case testNewRedefineCorrectChangedOnPop]
+# flags: --allow-redefinition-new --local-partial-types
+from typing import Optional
+
+def foo() -> None:
+    name: Optional[str] = None
+    name = None
+    for i in [1, 2, 3]:
+        reveal_type(name)  # N: Revealed type is "None | builtins.str"
+        if bool():
+            name = "a"
+
 [case testNewRedefinePartialTypeForUnderscore]
 # flags: --allow-redefinition-new --local-partial-types
 


### PR DESCRIPTION
Fixes an obvious regression introduced in https://github.com/python/mypy/pull/20862 (frame pop changed if at least one variable changed).