### PR TITLE
Generate error in mypyc if using Python 3.14 t-string

### DIFF
--- a/mypyc/irbuild/visitor.py
+++ b/mypyc/irbuild/visitor.py
@@ -313,7 +313,7 @@ class IRBuilderVisitor(IRVisitor):
         return transform_dict_expr(self.builder, expr)
 
     def visit_template_str_expr(self, expr: TemplateStrExpr) -> Value:
-        assert False, "TemplateStrExpr should have been handled already"
+        self.bail("Template strings are not supported by mypyc", expr.line)
 
     def visit_set_expr(self, expr: SetExpr) -> Value:
         return transform_set_expr(self.builder, expr)

--- a/mypyc/test-data/irbuild-python314.test
+++ b/mypyc/test-data/irbuild-python314.test
@@ -1,0 +1,3 @@
+[case testTemplateStringNotSupported_python3_14]
+def f() -> object:
+    return t"value={1}"  # E: Template strings are not supported by mypyc

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os.path
+import sys
 
 from mypy.errors import CompileError
 from mypy.test.config import test_temp_dir
@@ -62,6 +63,9 @@ files = [
     "irbuild-time.test",
     "irbuild-match.test",
 ]
+
+if sys.version_info >= (3, 14):
+    files.append("irbuild-python314.test")
 
 
 class TestGenOps(MypycDataSuite):


### PR DESCRIPTION
These are unsupported by mypyc for now.

Follow-up to #20850.