### PR TITLE
Fix union edge case in function argument redefinition

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4725,7 +4725,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
         # and use it results in a narrower type. This helps with various practical
         # examples, see e.g. testOptionalTypeNarrowedByGenericCall.
         union_fallback = (
-            inferred is None
+            preferred_context is not None
             and isinstance(get_proper_type(lvalue_type), UnionType)
             and binder_version == self.binder.version
         )
@@ -4744,7 +4744,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                 not alt_local_errors.has_new_errors()
                 and is_valid_inferred_type(alt_rvalue_type, self.options)
                 and (
-                    # For redefinition fallback we are fine getting not a subtype.
+                    # For redefinition fallbacks we are fine getting not a subtype.
                     redefinition_fallback
                     or argument_redefinition_fallback
                     # Skip Any type, since it is special cased in binder.

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -1321,6 +1321,30 @@ def process(items: list[Optional[str]]) -> None:
         reveal_type(items)  # N: Revealed type is "builtins.list[builtins.str | None]"
     process(items)  # OK
 
+[case testNewRedefineUnionArgumentFallbackUnion]
+# flags: --allow-redefinition-new --local-partial-types
+from typing import Union, Optional, TypeVar, Sequence
+
+T = TypeVar("T")
+def gen(x: T) -> Union[str, T]: ...
+
+def test(x: Optional[str]) -> None:
+    if x is None:
+        x = gen("foo")
+    reveal_type(x)  # N: Revealed type is "builtins.str"
+
+[case testNewRedefineUnionArgumentFallbackAsync]
+# flags: --allow-redefinition-new --local-partial-types
+from typing import Optional, TypeVar
+
+T = TypeVar("T")
+async def gen(x: T) -> T: ...
+
+async def test(x: Optional[str]) -> None:
+    if x is None:
+        x = await gen("foo")
+    reveal_type(x)  # N: Revealed type is "builtins.str"
+
 [case testNewRedefineFunctionArgumentsEmptyContext]
 # flags: --allow-redefinition-new --local-partial-types
 def process1(items: list[str]) -> None:


### PR DESCRIPTION
Logic is simple: inference for function arguments should match inference for regular annotated variables exactly, including falling back to empty context in _union context_ (even if there are no errors) provided this results in a narrower type.
