### PR TITLE
Make sure new redefinition semantics only apply to inferred vars

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -314,11 +314,13 @@ class ConditionalTypeBinder:
             current_value = self._get(key)
             resulting_values = [f.types.get(key, current_value) for f in frames]
             # Keys can be narrowed using two different semantics. The new semantics
-            # is enabled for plain variables when bind_all is true, and it allows
+            # is enabled for inferred variables when bind_all is true, and it allows
             # variable types to be widened using subsequent assignments. This is
-            # tricky to support for instance attributes (primarily due to deferrals),
-            # so we don't use it for them.
-            old_semantics = not self.bind_all or extract_var_from_literal_hash(key) is None
+            # not allowed for instance attributes and annotated variables.
+            var = extract_var_from_literal_hash(key)
+            old_semantics = (
+                not self.bind_all or var is None or not var.is_inferred and not var.is_argument
+            )
             if old_semantics and any(x is None for x in resulting_values):
                 # We didn't know anything about key before
                 # (current_value must be None), and we still don't

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3432,6 +3432,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi):
                     self.options.allow_redefinition_new
                     and lvalue_type is not None
                     and not isinstance(lvalue_type, PartialType)
+                    # Note that `inferred is not None` is not a reliable check here, because
+                    # simple assignments like x = "a" are inferred during semantic analysis.
+                    and isinstance(lvalue, NameExpr)
+                    and isinstance(lvalue.node, Var)
+                    and lvalue.node.is_inferred
                 ):
                     # TODO: Can we use put() here?
                     self.binder.assign_type(lvalue, lvalue_type, lvalue_type)

--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -69,7 +69,7 @@ def f1() -> None:
         x: Union[int, str] = 0
         reveal_type(x) # N: Revealed type is "builtins.int | builtins.str"
         x = ""
-    reveal_type(x) # N: Revealed type is "builtins.str"
+    reveal_type(x) # N: Revealed type is "builtins.int | builtins.str"
 
 [case testNewRedefineUninitializedCodePath3]
 # flags: --allow-redefinition-new --local-partial-types
@@ -1270,6 +1270,40 @@ x = 0
 if int():
     x = ""
 reveal_type(x) # N: Revealed type is "builtins.int | builtins.str"
+
+[case testNewRedefineNarrowingOnFirstAssignment]
+# flags: --allow-redefinition-new --local-partial-types
+from typing import Any
+
+li: list[int]
+
+def test() -> None:
+    x: list[Any] = li
+    reveal_type(x)  # N: Revealed type is "builtins.list[Any]"
+
+    if bool():
+        y: list[Any] = li
+    else:
+        y = li
+    reveal_type(y)  # N: Revealed type is "builtins.list[Any]"
+[builtins fixtures/primitives.pyi]
+
+[case testNewRedefineAnyNoSpecialCasing]
+# flags: --allow-redefinition-new --local-partial-types
+from typing import Any
+
+def test() -> None:
+    a: Any
+    x = 1
+    if bool():
+        x = a
+    reveal_type(x)  # N: Revealed type is "builtins.int | Any"
+
+    if bool():
+        y = a
+    else:
+        y = 1
+    reveal_type(y)  # N: Revealed type is "Any | builtins.int"
 
 [case testNewRedefineSequentialRedefinitionToEmpty]
 # flags: --allow-redefinition-new --local-partial-types


### PR DESCRIPTION
All aspects of `--allow-redefinition-new` should only apply to _inferred_ variables, all variables with explicit annotations should follow all aspects of old semantics, including special-casing for `Any` etc.
