### PR TITLE
Show an error when old and new redefinion are enabled in a file

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -104,6 +104,13 @@ def main(
             options,
         )
 
+    if options.allow_redefinition_new and options.allow_redefinition_old:
+        fail(
+            "--allow-redefinition-old and --allow-redefinition-new should not be used together",
+            stderr,
+            options,
+        )
+
     if options.install_types and (stdout is not sys.stdout or stderr is not sys.stderr):
         # Since --install-types performs user input, we want regular stdout and stderr.
         fail("error: --install-types not supported in this mode of running mypy", stderr, options)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -713,6 +713,17 @@ class SemanticAnalyzer(
             n.end_line = 1
             n.end_column = 0
             self.fail("--local-partial-types must be enabled if using --allow-redefinition-new", n)
+        if self.options.allow_redefinition_new and self.options.allow_redefinition_old:
+            n = TempNode(AnyType(TypeOfAny.special_form))
+            n.line = 1
+            n.column = 0
+            n.end_line = 1
+            n.end_column = 0
+            self.fail(
+                "--allow-redefinition-old and --allow-redefinition-new"
+                " should not be used together",
+                n,
+            )
         self.recurse_into_functions = False
         self.add_implicit_module_attrs(file_node)
         for d in file_node.defs:

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -2737,3 +2737,9 @@ def f() -> None:
 [file mypy.ini]
 \[mypy]
 disallow_redefinition = true
+
+[case testOnlyOneRedefinitionModeAllowed]
+# flags: --allow-redefinition --allow-redefinition-new --local-partial-types
+x = 1
+[out]
+main:1: error: --allow-redefinition-old and --allow-redefinition-new should not be used together


### PR DESCRIPTION
I think we should add this to v1.20, as really not prohibiting this initially was a bug IMO.

Btw @JukkaL all my semantic changes to `--allow-redefinition-new` are now in master. You can try flipping the switch internally.