### PR TITLE
Fix IndexError when unpacking empty tuple in type alias

### DIFF
--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -224,6 +224,10 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             return t.copy_modified(args=args)
 
         if t.type.fullname == "builtins.tuple":
+            if not args:
+                # After expansion, args is empty (e.g. Unpack[tuple[()]] expanded
+                # to nothing). Return the empty fixed-length tuple tuple[()].
+                return TupleType([], fallback=t.copy_modified(args=[]))
             # Normalize Tuple[*Tuple[X, ...], ...] -> Tuple[X, ...]
             arg = args[0]
             if isinstance(arg, UnpackType):
@@ -519,7 +523,15 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             if isinstance(item, UnpackType) and isinstance(item.type, TypeVarTupleType):
                 items.extend(self.expand_unpack(item))
             else:
-                items.append(item.accept(self))
+                expanded = item.accept(self)
+                if isinstance(expanded, UnpackType) and isinstance(
+                    expanded.type, TupleType
+                ):
+                    # Inline Unpack[tuple[X, Y]] -> X, Y
+                    # This also handles Unpack[tuple[()]] -> nothing
+                    items.extend(expanded.type.items)
+                    continue
+                items.append(expanded)
         return items
 
     def expand_type_tuple_with_unpack(self, typs: tuple[Type, ...]) -> list[Type]:
@@ -530,7 +542,15 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             if isinstance(item, UnpackType) and isinstance(item.type, TypeVarTupleType):
                 items.extend(self.expand_unpack(item))
             else:
-                items.append(item.accept(self))
+                expanded = item.accept(self)
+                if isinstance(expanded, UnpackType) and isinstance(
+                    expanded.type, TupleType
+                ):
+                    # Inline Unpack[tuple[X, Y]] -> X, Y
+                    # This also handles Unpack[tuple[()]] -> nothing
+                    items.extend(expanded.type.items)
+                    continue
+                items.append(expanded)
         return items
 
     def visit_tuple_type(self, t: TupleType) -> Type:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -524,9 +524,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
                 items.extend(self.expand_unpack(item))
             else:
                 expanded = item.accept(self)
-                if isinstance(expanded, UnpackType) and isinstance(
-                    expanded.type, TupleType
-                ):
+                if isinstance(expanded, UnpackType) and isinstance(expanded.type, TupleType):
                     # Inline Unpack[tuple[X, Y]] -> X, Y
                     # This also handles Unpack[tuple[()]] -> nothing
                     items.extend(expanded.type.items)
@@ -543,9 +541,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
                 items.extend(self.expand_unpack(item))
             else:
                 expanded = item.accept(self)
-                if isinstance(expanded, UnpackType) and isinstance(
-                    expanded.type, TupleType
-                ):
+                if isinstance(expanded, UnpackType) and isinstance(expanded.type, TupleType):
                     # Inline Unpack[tuple[X, Y]] -> X, Y
                     # This also handles Unpack[tuple[()]] -> nothing
                     items.extend(expanded.type.items)

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2237,3 +2237,20 @@ class D[*Ts](Generic[Unpack[Us]]):  # E: Generic[...] base class is redundant \
                                     # E: Can only use one type var tuple in a class def
     pass
 [builtins fixtures/tuple.pyi]
+
+[case testUnpackEmptyTupleInTypeAliasNoCrash]
+# https://github.com/python/mypy/issues/20913
+from typing import Unpack
+
+class C[*Ts]:
+    pass
+
+type T[T, *Ts] = C[*Ts]
+
+x: T[bool, Unpack[tuple[()]]]
+reveal_type(x)  # N: Revealed type is "__main__.C[()]"
+
+y: T[bool]
+reveal_type(y)  # N: Revealed type is "__main__.C[()]"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
Fixes #20913

mypy crashes with `IndexError` when using `Unpack[tuple[()]]` (or just omitting the TypeVarTuple args entirely) in a PEP 695 type alias:

```python
class C[*Ts]:
    pass

type T[T, *Ts] = C[*Ts]

x: T[bool, Unpack[tuple[()]]]  # IndexError
y: T[bool]                      # also crashes
```

The crash is in `visit_instance()` — when expanding `builtins.tuple` args that reduce to nothing, `args[0]` is accessed on an empty list.

The fix handles this in two places:

1. `visit_instance`: when `builtins.tuple` ends up with empty args after expansion, return `TupleType([], ...)` (the empty fixed-length tuple) instead of crashing
2. `expand_type_list_with_unpack` / `expand_type_tuple_with_unpack`: inline `Unpack[TupleType]` results into their items, so `Unpack[tuple[()]]` correctly expands to nothing

Both `T[bool]` and `T[bool, Unpack[tuple[()]]]` now correctly resolve to `C[()]`.
