### PR TITLE
[stubtest] Fix false positives for type[TypeVar] defaults

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -851,6 +851,10 @@ def _verify_arg_default_value(
             stub_type = stub_arg.variable.type or stub_arg.type_annotation
             if isinstance(stub_type, mypy.types.TypeVarType):
                 stub_type = stub_type.upper_bound
+            # Also handle type[TypeVar] -> type[bound]
+            elif isinstance(stub_type, mypy.types.TypeType):
+                if isinstance(stub_type.item, mypy.types.TypeVarType):
+                    stub_type = mypy.types.TypeType(stub_type.item.upper_bound)
             if (
                 runtime_type is not None
                 and stub_type is not None
@@ -2095,6 +2099,7 @@ def get_mypy_type_of_runtime_value(
         )
 
     skip_type_object_type = False
+    type_typevar_context = False
     if type_context:
         # Don't attempt to process the type object when context is generic
         # This is related to issue #3737
@@ -2103,16 +2108,23 @@ def get_mypy_type_of_runtime_value(
         if isinstance(type_context, mypy.types.CallableType):
             if isinstance(type_context.ret_type, mypy.types.TypeVarType):
                 skip_type_object_type = True
-        # Type[x] where x is generic
+        # Type[TypeVar] context, see https://github.com/python/mypy/issues/13316
         if isinstance(type_context, mypy.types.TypeType):
             if isinstance(type_context.item, mypy.types.TypeVarType):
-                skip_type_object_type = True
+                type_typevar_context = True
 
     if isinstance(runtime, type) and not skip_type_object_type:
         # Try and look up a stub for the runtime object itself
         # The logic here is similar to ExpressionChecker.analyze_ref_expr
         type_info = get_mypy_node_for_name(runtime.__module__, runtime.__name__)
         if isinstance(type_info, nodes.TypeInfo):
+            # For Type[TypeVar] contexts, return Type[Instance] directly
+            if type_typevar_context:
+                any_type = mypy.types.AnyType(mypy.types.TypeOfAny.special_form)
+                instance = mypy.types.Instance(
+                    type_info, [any_type] * len(type_info.defn.type_vars)
+                )
+                return mypy.types.TypeType(instance)
             result = mypy.typeops.type_object_type(type_info)
             if mypy.checkexpr.is_type_type_context(type_context):
                 # This is the type in a type[] expression, so substitute type
@@ -2131,7 +2143,24 @@ def get_mypy_type_of_runtime_value(
 
     if isinstance(runtime, tuple):
         # Special case tuples so we construct a valid mypy.types.TupleType
-        optional_items = [get_mypy_type_of_runtime_value(v) for v in runtime]
+        # Propagate type context to elements, see https://github.com/python/mypy/issues/19852
+        element_contexts: list[mypy.types.Type | None] = []
+        if type_context is not None:
+            proper_ctx = mypy.types.get_proper_type(type_context)
+            if isinstance(proper_ctx, mypy.types.TupleType):
+                element_contexts = list(proper_ctx.items)
+            elif isinstance(proper_ctx, mypy.types.Instance):
+                # Handle homogeneous tuple[T, ...]
+                if proper_ctx.type.fullname == "builtins.tuple" and proper_ctx.args:
+                    element_contexts = [proper_ctx.args[0]] * len(runtime)
+        # Pad with None for elements without context
+        while len(element_contexts) < len(runtime):
+            element_contexts.append(None)
+        element_contexts = element_contexts[: len(runtime)]
+        optional_items = [
+            get_mypy_type_of_runtime_value(v, type_context=ctx)
+            for v, ctx in zip(runtime, element_contexts)
+        ]
         items = [(i if i is not None else anytype()) for i in optional_items]
         fallback = mypy.types.Instance(type_info, [anytype()])
         return mypy.types.TupleType(items, fallback)

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -852,9 +852,13 @@ def _verify_arg_default_value(
             if isinstance(stub_type, mypy.types.TypeVarType):
                 stub_type = stub_type.upper_bound
             # Also handle type[TypeVar] -> type[bound]
-            elif isinstance(stub_type, mypy.types.TypeType):
-                if isinstance(stub_type.item, mypy.types.TypeVarType):
-                    stub_type = mypy.types.TypeType(stub_type.item.upper_bound)
+            else:
+                proper_stub_type = mypy.types.get_proper_type(stub_type)
+                if isinstance(proper_stub_type, mypy.types.TypeType):
+                    if isinstance(proper_stub_type.item, mypy.types.TypeVarType):
+                        stub_type = mypy.types.TypeType.make_normalized(
+                            proper_stub_type.item.upper_bound
+                        )
             if (
                 runtime_type is not None
                 and stub_type is not None

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -617,6 +617,53 @@ class StubtestUnit(unittest.TestCase):
             error="f12",
         )
 
+        # type[TypeVar] with ABC class default
+        yield Case(
+            stub="""
+            from abc import ABC
+            from typing import TypeVar
+            class Handler(ABC): ...
+            class DefaultHandler(Handler): ...
+            _H = TypeVar("_H", bound=Handler)
+            def get_handler(cls: type[_H] = ...) -> _H: ...
+            """,
+            runtime="""
+            from abc import ABC
+            class Handler(ABC): pass
+            class DefaultHandler(Handler): pass
+            def get_handler(cls=DefaultHandler): return cls()
+            """,
+            error=None,
+        )
+
+        # type[TypeVar] rejects invalid default
+        yield Case(
+            stub="""
+            from abc import ABC
+            from typing import TypeVar
+            class Animal(ABC): ...
+            _A = TypeVar("_A", bound=Animal)
+            def create(cls: type[_A] = ...) -> _A: ...
+            """,
+            runtime="""
+            from abc import ABC
+            class Animal(ABC): pass
+            def create(cls=str): return cls()
+            """,
+            error="create",
+        )
+
+        # tuple[type[list[_T]], ...] with type context propagation
+        yield Case(
+            stub="""
+            from typing import TypeVar
+            _T = TypeVar("_T")
+            def process(types: tuple[type[list[_T]], ...] = ...) -> None: ...
+            """,
+            runtime="def process(types=(list,)): pass",
+            error=None,
+        )
+
     @collect_cases
     def test_static_class_method(self) -> Iterator[Case]:
         yield Case(

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1345,6 +1345,22 @@ class StubtestUnit(unittest.TestCase):
             runtime="X_FINAL_OK = 1",
             error=None,
         )
+        # type[T] class variable with non-type metaclass
+        yield Case(
+            stub="""
+            from abc import ABCMeta
+            class W(metaclass=ABCMeta): ...
+            class V:
+                foo: type[W]
+            """,
+            runtime="""
+            from abc import ABCMeta
+            class W(metaclass=ABCMeta): pass
+            class V:
+                foo = W
+            """,
+            error=None,
+        )
 
     @collect_cases
     def test_type_alias(self) -> Iterator[Case]:


### PR DESCRIPTION
### PR Summary
While working on `django-stubs` I find out that stubtest was reporting false positives when checking default values for parameters typed as `type[TypeVar]`. Classes with custom metaclasses (like ABC, Enum, or Django models) would fail because stubtest fell back to comparing metaclass types instead of the class itself. This PR also fixes a related issue where type context wasn't propagated to tuple elements, causing `tuple[type[list[_T]], ...]` to fail with a `(list,)` default.

Example 1:
```python
# stub
from abc import ABC
from typing import TypeVar
class Handler(ABC): ...
_H = TypeVar("_H", bound=Handler)
def get_handler(cls: type[_H] = ...) -> _H: ...

# runtime
from abc import ABC
class Handler(ABC): pass
def get_handler(cls=Handler): return cls()
```
Output before fix:
>  error: get_handler is inconsistent, runtime argument "cls" has a default value of type "ABCMeta", which is incompatible with stub argument type "type[Handler]"

Example 2:
```python
# stub
from typing import TypeVar
_T = TypeVar("_T")
def process(types: tuple[type[list[_T]], ...] = ...) -> None: ...

# runtime
def process(types=(list,)): pass
```
Output before fix:
> error: process is inconsistent, runtime argument "types" has a default value of type "tuple[type[list[Any]]]", which is incompatible with stub argument type "tuple[type[list[_T]], ...]"

Fixes #13316
Fixes #19852