### PR TITLE
Fix error code handling in native parser

### DIFF
--- a/mypy/parse.py
+++ b/mypy/parse.py
@@ -55,6 +55,9 @@ def parse(
                 error_code = error.get("code")
                 if error_code is None:
                     error_code = codes.SYNTAX
+                else:
+                    # Fallback to [syntax] for backwards compatibility.
+                    error_code = codes.error_codes.get(error_code) or codes.SYNTAX
                 errors.report(
                     error["line"], error["column"], message, blocker=is_blocker, code=error_code
                 )


### PR DESCRIPTION
Currently few tests cases crash with native parser because of this (and it wasn't caught because we still use `dict[str, Any]` in various places).

cc @JukkaL 
