### PR TITLE
Fix redefinition tests with native parser

### DIFF
--- a/mypy/nativeparse.py
+++ b/mypy/nativeparse.py
@@ -596,6 +596,7 @@ def read_parameters(state: State, data: ReadBuffer) -> tuple[list[Argument], boo
 
         var = Var(arg_name, ann)
         var.is_inferred = False
+        var.is_argument = True
         arg = Argument(var, ann, default, arg_kind, pos_only)
         read_loc(data, arg)
         set_line_column_range(var, arg)


### PR DESCRIPTION
This starts getting out of sync, so I will probably fix couple dozen more native parser tests soon, and enable it in CI (while skipping the remaining with something like `_no_native_parse` suffix).

cc @JukkaL 
