### PR TITLE
Correct "Duplicate argument" error messages

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -90,7 +90,7 @@ from mypy.nodes import (
     WithStmt,
     YieldExpr,
     YieldFromExpr,
-    check_arg_names,
+    check_param_names,
 )
 from mypy.options import Options
 from mypy.patterns import (
@@ -1115,7 +1115,7 @@ class ASTConverter:
             new_args.append(self.make_argument(args.kwarg, None, ARG_STAR2, no_type_check))
             names.append(args.kwarg)
 
-        check_arg_names([arg.variable.name for arg in new_args], names, self.fail_arg)
+        check_param_names([arg.variable.name for arg in new_args], names, self.fail_arg)
 
         return new_args
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -5092,7 +5092,7 @@ def check_arg_kinds(
             is_kw_arg = True
 
 
-def check_arg_names(
+def check_param_names(
     names: Sequence[str | None],
     nodes: list[T],
     fail: Callable[[str, T], None],
@@ -5101,7 +5101,7 @@ def check_arg_names(
     seen_names: set[str | None] = set()
     for name, node in zip(names, nodes):
         if name is not None and name in seen_names:
-            fail(f'Duplicate argument "{name}" in {description}', node)
+            fail(f'Duplicate parameter "{name}" in {description}', node)
             break
         seen_names.add(name)
 

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -47,7 +47,7 @@ from mypy.nodes import (
     TypeVarTupleExpr,
     Var,
     check_arg_kinds,
-    check_arg_names,
+    check_param_names,
 )
 from mypy.options import INLINE_TYPEDDICT, TYPE_FORM, Options
 from mypy.plugin import AnalyzeTypeContext, Plugin, TypeAnalyzerPluginInterface
@@ -1712,7 +1712,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             kinds.append(ARG_STAR2 if second_unpack_last else ARG_STAR)
             names.append(None)
         # Note that arglist below is only used for error context.
-        check_arg_names(names, [arglist] * len(args), self.fail, "Callable")
+        check_param_names(names, [arglist] * len(args), self.fail, "Callable")
         check_arg_kinds(kinds, [arglist] * len(args), self.fail)
         return args, kinds, names
 

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -280,22 +280,22 @@ def f7(x: int):  # E: Function has duplicate type signatures
 def f(x, y, z):
   pass
 
-def g(x, y, x):  # E: Duplicate argument "x" in function definition
+def g(x, y, x):  # E: Duplicate parameter "x" in function definition
   pass
 
-def h(x, y, *x):  # E: Duplicate argument "x" in function definition
+def h(x, y, *x):  # E: Duplicate parameter "x" in function definition
   pass
 
-def i(x, y, *z, **z):  # E: Duplicate argument "z" in function definition
+def i(x, y, *z, **z):  # E: Duplicate parameter "z" in function definition
   pass
 
-def j(x: int, y: int, *, x: int = 3):  # E: Duplicate argument "x" in function definition
+def j(x: int, y: int, *, x: int = 3):  # E: Duplicate parameter "x" in function definition
   pass
 
-def k(*, y, z, y):  # E: Duplicate argument "y" in function definition
+def k(*, y, z, y):  # E: Duplicate parameter "y" in function definition
   pass
 
-lambda x, y, x: ...  # E: Duplicate argument "x" in function definition
+lambda x, y, x: ...  # E: Duplicate parameter "x" in function definition
 
 [case testNoCrashOnImportFromStar]
 from pack import *

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1937,7 +1937,7 @@ def k(f: Callable[[KwArg(), NamedArg(Any, 'x')], int]): pass # E: A **kwargs arg
 from typing import Callable
 from mypy_extensions import Arg, VarArg, KwArg, DefaultArg
 
-def f(f: Callable[[Arg(int, 'x'), int, Arg(int, 'x')], int]): pass # E: Duplicate argument "x" in Callable
+def f(f: Callable[[Arg(int, 'x'), int, Arg(int, 'x')], int]): pass # E: Duplicate parameter "x" in Callable
 
 [builtins fixtures/dict.pyi]
 


### PR DESCRIPTION
Fix: #20936

I also changed:

```python
check_arg_names -> check_param_names
```

Because `param` is correct and consistent but if you're worried that mypy may be broken, I'll revert the above change.