### PR TITLE
Correct `check_arg_kinds()`, its relates and error messages

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -5055,41 +5055,41 @@ deserialize_map: Final = {
 }
 
 
-def check_arg_kinds(
+def check_param_kinds(
     arg_kinds: list[ArgKind], nodes: list[T], fail: Callable[[str, T], None]
 ) -> None:
-    is_var_arg = False
-    is_kw_arg = False
+    is_var_param = False
+    is_kw_param = False
     seen_named = False
     seen_opt = False
     for kind, node in zip(arg_kinds, nodes):
         if kind == ARG_POS:
-            if is_var_arg or is_kw_arg or seen_named or seen_opt:
+            if is_var_param or is_kw_param or seen_named or seen_opt:
                 fail(
-                    "Required positional args may not appear after default, named or var args",
+                    "Required positional params may not appear after default, named or var params",
                     node,
                 )
                 break
         elif kind == ARG_OPT:
-            if is_var_arg or is_kw_arg or seen_named:
-                fail("Positional default args may not appear after named or var args", node)
+            if is_var_param or is_kw_param or seen_named:
+                fail("Positional default params may not appear after named or var params", node)
                 break
             seen_opt = True
         elif kind == ARG_STAR:
-            if is_var_arg or is_kw_arg or seen_named:
-                fail("Var args may not appear after named or var args", node)
+            if is_var_param or is_kw_param or seen_named:
+                fail("Var params may not appear after named or var params", node)
                 break
-            is_var_arg = True
+            is_var_param = True
         elif kind == ARG_NAMED or kind == ARG_NAMED_OPT:
             seen_named = True
-            if is_kw_arg:
-                fail("A **kwargs argument must be the last argument", node)
+            if is_kw_param:
+                fail("A **kwargs parameter must be the last parameter", node)
                 break
         elif kind == ARG_STAR2:
-            if is_kw_arg:
-                fail("You may only have one **kwargs argument", node)
+            if is_kw_param:
+                fail("You may only have one **kwargs parameter", node)
                 break
-            is_kw_arg = True
+            is_kw_param = True
 
 
 def check_param_names(

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -46,7 +46,7 @@ from mypy.nodes import (
     TypeVarLikeExpr,
     TypeVarTupleExpr,
     Var,
-    check_arg_kinds,
+    check_param_kinds,
     check_param_names,
 )
 from mypy.options import INLINE_TYPEDDICT, TYPE_FORM, Options
@@ -1713,7 +1713,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             names.append(None)
         # Note that arglist below is only used for error context.
         check_param_names(names, [arglist] * len(args), self.fail, "Callable")
-        check_arg_kinds(kinds, [arglist] * len(args), self.fail)
+        check_param_kinds(kinds, [arglist] * len(args), self.fail)
         return args, kinds, names
 
     def analyze_literal_type(self, t: UnboundType) -> Type:

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1837,7 +1837,7 @@ G = Callable[[Arg(1, 'x')], int] # E: Invalid type: try using Literal[1] instead
 H = Callable[[VarArg(int, 'x')], int] # E: VarArg arguments should not have names
 I = Callable[[VarArg(int)], int] # ok
 J = Callable[[VarArg(), KwArg()], int] # ok
-K = Callable[[VarArg(), int], int] # E: Required positional args may not appear after default, named or var args
+K = Callable[[VarArg(), int], int] # E: Required positional params may not appear after default, named or var params
 L = Callable[[Arg(name='x', type=int)], int] # ok
 # I have commented out the following test because I don't know how to expect the "defined here" note part of the error.
 # M = Callable[[Arg(gnome='x', type=int)], int]   E: Invalid type alias: expression is not a valid type   E: Unexpected keyword argument "gnome" for "Arg"
@@ -1925,12 +1925,12 @@ def h(f: Callable[[Arg(gnome='x', type=int)], int]): pass # E: Unexpected argume
 from typing import Callable, Any
 from mypy_extensions import Arg, VarArg, KwArg, DefaultArg, NamedArg
 
-def f(f: Callable[[VarArg(), int], int]): pass # E: Required positional args may not appear after default, named or var args
-def g(f: Callable[[VarArg(), VarArg()], int]): pass # E: Var args may not appear after named or var args
-def h(f: Callable[[KwArg(), KwArg()], int]): pass # E: You may only have one **kwargs argument
-def i(f: Callable[[DefaultArg(), int], int]): pass # E: Required positional args may not appear after default, named or var args
-def j(f: Callable[[NamedArg(Any, 'x'), DefaultArg(int, 'y')], int]): pass # E: Positional default args may not appear after named or var args
-def k(f: Callable[[KwArg(), NamedArg(Any, 'x')], int]): pass # E: A **kwargs argument must be the last argument
+def f(f: Callable[[VarArg(), int], int]): pass # E: Required positional params may not appear after default, named or var params
+def g(f: Callable[[VarArg(), VarArg()], int]): pass # E: Var params may not appear after named or var params
+def h(f: Callable[[KwArg(), KwArg()], int]): pass # E: You may only have one **kwargs parameter
+def i(f: Callable[[DefaultArg(), int], int]): pass # E: Required positional params may not appear after default, named or var params
+def j(f: Callable[[NamedArg(Any, 'x'), DefaultArg(int, 'y')], int]): pass # E: Positional default params may not appear after named or var params
+def k(f: Callable[[KwArg(), NamedArg(Any, 'x')], int]): pass # E: A **kwargs parameter must be the last parameter
 [builtins fixtures/dict.pyi]
 
 [case testCallableDuplicateNames]


### PR DESCRIPTION
Fix: #20943

I corrected the method name below, its relates and the error messages below: 

```python
check_arg_kinds -> check_param_kinds
```

```python
From 'Required positional args may not appear after default, named or var args'
To   'Required positional params may not appear after default, named or var params'
```

```python
From 'Positional default args may not appear after named or var args'
To   'Positional default params may not appear after named or var params'
```

```python
From 'Var args may not appear after named or var args'
To   'Var params may not appear after named or var params'
```

```python
From 'kwargs argument must be the last argument'
To   'kwargs parameter must be the last parameter'
```

```python
From 'You may only have one **kwargs argument'
To   'You may only have one **kwargs parameter'
```

But if you're worried that mypy may be broken, I'll revert the changes except the error messages above.

