### PR TITLE
Fix (#20975) subtyping and join for constrained TypeVars

### DIFF
--- a/mypy/join.py
+++ b/mypy/join.py
@@ -295,8 +295,9 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
 
     def visit_erased_type(self, t: ErasedType) -> ProperType:
         return self.s
-
     def visit_type_var(self, t: TypeVarType) -> ProperType:
+        if is_subtype(self.s, t):
+            return t
         if isinstance(self.s, TypeVarType):
             if self.s.id == t.id:
                 if self.s.upper_bound == t.upper_bound:
@@ -308,7 +309,6 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             return get_proper_type(join_types(self.s.upper_bound, t.upper_bound))
         else:
             return self.default(self.s)
-
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
         if self.s == t:
             return t

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -295,6 +295,7 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
 
     def visit_erased_type(self, t: ErasedType) -> ProperType:
         return self.s
+
     def visit_type_var(self, t: TypeVarType) -> ProperType:
         if is_subtype(self.s, t):
             return t
@@ -309,6 +310,7 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             return get_proper_type(join_types(self.s.upper_bound, t.upper_bound))
         else:
             return self.default(self.s)
+
     def visit_param_spec(self, t: ParamSpecType) -> ProperType:
         if self.s == t:
             return t

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -311,7 +311,7 @@ def _is_subtype(
         # TODO: should we consider all types proper subtypes of UnboundType and/or
         # ErasedType as we do for non-proper subtyping.
         return True
-        
+
     if isinstance(right, TypeVarType) and right.values:
         if isinstance(left, TypeVarType) and left.id == right.id:
             return True

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -324,10 +324,8 @@ def _is_subtype(
             return all(
                 is_subtype(orig_left, v, subtype_context=subtype_context) for v in right.values
             )
-        # Normally, when 'left' is not itself a union, the only way
-        # 'left' can be a subtype of the union 'right' is if it is a
-        # subtype of one of the items making up the union.
- if isinstance(right, UnionType) and not isinstance(left, UnionType):
+
+    if isinstance(right, UnionType) and not isinstance(left, UnionType):
         # Normally, when 'left' is not itself a union, the only way
         # 'left' can be a subtype of the union 'right' is if it is a
         # subtype of one of the items making up the union.

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -311,8 +311,23 @@ def _is_subtype(
         # TODO: should we consider all types proper subtypes of UnboundType and/or
         # ErasedType as we do for non-proper subtyping.
         return True
-
-    if isinstance(right, UnionType) and not isinstance(left, UnionType):
+        
+    if isinstance(right, TypeVarType) and right.values:
+        if isinstance(left, TypeVarType) and left.id == right.id:
+            return True
+        if proper_subtype:
+            return all(
+                is_proper_subtype(orig_left, v, subtype_context=subtype_context)
+                for v in right.values
+            )
+        else:
+            return all(
+                is_subtype(orig_left, v, subtype_context=subtype_context) for v in right.values
+            )
+        # Normally, when 'left' is not itself a union, the only way
+        # 'left' can be a subtype of the union 'right' is if it is a
+        # subtype of one of the items making up the union.
+ if isinstance(right, UnionType) and not isinstance(left, UnionType):
         # Normally, when 'left' is not itself a union, the only way
         # 'left' can be a subtype of the union 'right' is if it is a
         # subtype of one of the items making up the union.


### PR DESCRIPTION
This fixes #20975 by refining subtyping and join logic for constrained `TypeVars`.

Previously, compatible types were flagged as incompatible because it failed to recognize a concrete type as a valid `subtype` even when it matched every constraint.

Changes:- 
**Subtyping**: Updated `subtypes.py` to recognize concrete types as valid subtypes when they satisfy all TypeVar constraints.
**Join Logic**: Modified `join.py` to ensure the TypeVar is preserved during join operations.

This resolves incorrect `arg-type` errors where compatible types were being flagged as incompatible in generic contexts.

Closes #20975