### PR TITLE
Try using pinned version in a better way

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
     # To speed-up process until ast_serialize is on PyPI.
     - name: Install pinned ast-serialize
       if: ${{ matrix.dev_ast_serialize }}
-      run: pip install ast-serialize @ git+https://github.com/mypyc/ast_serialize.git@da5a16cf268dbec63ed6b2e6b715470576e2d1a6
+      run: pip install ast-serialize@git+https://github.com/mypyc/ast_serialize.git@da5a16cf268dbec63ed6b2e6b715470576e2d1a6
 
     - name: Setup tox environment
       run: |


### PR DESCRIPTION
It looks like newer version of pip can install directly from a `maturin`-based repo.
