### PR TITLE
Add comment explaining two-step dependency installation in GitHub 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ runs:
         if [ "${{ inputs.install_project_dependencies }}" == "yes" ]; then
           VENV=$("$VENV_PYTHON" -c 'import sys;print(sys.prefix)')
           echo ::group::Installing project dependencies...
+          # Download dependencies first so they are stored locally before installation.
+          # Installing from local artifacts improves reproducibility in CI environments
+          # and makes debugging dependency resolution easier compared to using
+          # `pip install .` directly.
           "$VENV_PYTHON" -m pip download --dest="$VENV"/deps .
           "$VENV_PYTHON" -m pip install -U --find-links="$VENV"/deps "$VENV"/deps/*
           echo ::endgroup::


### PR DESCRIPTION
This PR adds a short comment explaining why the GitHub Action installs
dependencies using a two-step process (`pip download` followed by
`pip install --find-links`) instead of using `pip install .` directly.

Downloading dependencies first allows installation from local artifacts,
which improves reproducibility in CI environments and can make debugging
dependency resolution issues easier.
Closes #20990
