### PR TITLE
Warn when `@disjoint_base` is used on protocols or TypedDicts

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2259,7 +2259,12 @@ class SemanticAnalyzer(
         if refers_to_fullname(decorator, FINAL_DECORATOR_NAMES):
             info.is_final = True
         elif refers_to_fullname(decorator, DISJOINT_BASE_DECORATOR_NAMES):
-            info.is_disjoint_base = True
+            if info.is_protocol:
+                self.fail("@disjoint_base cannot be used with protocol class", decorator)
+            elif info.typeddict_type is not None:
+                self.fail("@disjoint_base cannot be used with TypedDict", decorator)
+            else:
+                info.is_disjoint_base = True
         elif refers_to_fullname(decorator, TYPE_CHECK_ONLY_NAMES):
             info.is_type_check_only = True
         elif (deprecated := self.get_deprecated(decorator)) is not None:

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4746,3 +4746,13 @@ tmp/a.py:8: note:     Expected:
 tmp/a.py:8: note:         def f(self) -> PNested
 tmp/a.py:8: note:     Got:
 tmp/a.py:8: note:         def f(self) -> CNested
+
+[case testProtocolCannotBeDisjointBase]
+from typing import Protocol
+from typing_extensions import disjoint_base
+
+@disjoint_base  # E: @disjoint_base cannot be used with protocol class
+class A(Protocol):
+    pass
+
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -2515,6 +2515,17 @@ class ForwardDeclared: pass
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testTypedDictCannotBeDisjointBase]
+from typing import TypedDict
+from typing_extensions import disjoint_base
+
+@disjoint_base  # E: @disjoint_base cannot be used with TypedDict
+class A(TypedDict):
+    pass
+
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testTypedDictTypeNarrowingWithFinalKey]
 from typing import Final, Optional, TypedDict
 


### PR DESCRIPTION
Per https://peps.python.org/pep-0800/#disjoint-base-on-special-classes

cc @JelleZijlstra