### PR TITLE
clear out CFLAGS from the environement

### DIFF
--- a/mypyc/test/test_run.py
+++ b/mypyc/test/test_run.py
@@ -14,6 +14,8 @@ import time
 from collections.abc import Iterator
 from typing import Any
 
+import pytest
+
 from mypy import build
 from mypy.errors import CompileError
 from mypy.options import Options
@@ -162,13 +164,15 @@ class TestRun(MypycDataSuite):
     strict_dunder_typing = False
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
-        # setup.py wants to be run from the root directory of the package, which we accommodate
-        # by chdiring into tmp/
-        with (
-            use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase),
-            chdir_manager("tmp"),
-        ):
-            self.run_case_inner(testcase)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.delenv("CFLAGS", raising=False)
+            # setup.py wants to be run from the root directory of the package, which we accommodate
+            # by chdiring into tmp/
+            with (
+                use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase),
+                chdir_manager("tmp"),
+            ):
+                self.run_case_inner(testcase)
 
     def run_case_inner(self, testcase: DataDrivenTestCase) -> None:
         if not os.path.isdir(WORKDIR):  # (one test puts something in build...)


### PR DESCRIPTION
While packaging from Debian we set

`CFLAGS=-g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/package/package=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection`

This causes the following test failures:

```
FAILED mypyc/test/test_run.py::TestRun::run-i64.test::testI64GlueMethodsAndInheritance - data: /build/package/package/mypyc/test-data/run-i64.test:1338:
FAILED mypyc/test/test_run.py::TestRun::run-bools.test::testBoolOps - data: /build/package/package/mypyc/test-data/run-bools.test:17:
FAILED mypyc/test/test_run.py::TestRun::run-i64.test::testI64ErrorValuesAndUndefined - data: /build/package/package/mypyc/test-data/run-i64.test:519:
FAILED mypyc/test/test_run.py::TestRun::run-i64.test::testI64BasicOps - data: /build/package/package/mypyc/test-data/run-i64.test:1:
FAILED mypyc/test/test_run.py::TestRun::run-i64.test::testI64DefaultArgValues - data: /build/package/package/mypyc/test-data/run-i64.test:906:
```
All with the same underlying error:
> python3.13: /usr/include/python3.13/object.h:352: Py_SIZE: Assertion `ob->ob_type != &PyLong_Type' failed.


<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Therefor this PR clears `CFLAGS` environement variable while running the mypyc data driven test cases.