### PR TITLE
lib-rt tests: discover lib-rt source more flexibly

### DIFF
--- a/mypyc/test/test_external.py
+++ b/mypyc/test/test_external.py
@@ -12,7 +12,8 @@ from typing import Any
 
 from mypyc.build import get_cflags, include_dir
 
-base_dir = os.path.join(os.path.dirname(__file__), "..", "..")
+from .config import PREFIX
+
 EXCLUDED_LIB_RT_COMPILE_FILES = ["static_data.c"]
 
 
@@ -88,7 +89,7 @@ class TestExternal(unittest.TestCase):
                     "--run-capi-tests",
                 ],
                 env=env,
-                cwd=os.path.join(base_dir, "mypyc", "lib-rt"),
+                cwd=os.path.join(PREFIX, "mypyc", "lib-rt"),
             )
             # Run C unit tests.
             env = os.environ.copy()


### PR DESCRIPTION
When running the tests as part of Debian packaging, the current working directory will not be the root of the unpacked mypy sdist/archive, therefore searching parent directories will fail.

Use the `PREFIX` variable from `mypyc.test.config`, which will reflect the value of the `MYPY_TEST_PREFIX` enviornment variable.