### PR TITLE
Fix #21030

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2113,6 +2113,8 @@ class SemanticAnalyzer(
             and not has_placeholder(defn.info.typeddict_type)
         ):
             # This is a valid TypedDict, and it is fully analyzed.
+            for decorator in defn.decorators:
+                decorator.accept(self)
             return True
         is_typeddict, info = self.typed_dict_analyzer.analyze_typeddict_classdef(defn)
         if is_typeddict:

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -233,6 +233,8 @@ class D(TypedDict):
 d = D()
 reveal_type(d)  # N: Revealed type is "TypedDict('__main__.D', {})"
 [builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testTypedDictDecoratorUndefinedNames]
 from typing import TypedDict
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -233,6 +233,18 @@ class D(TypedDict):
 d = D()
 reveal_type(d)  # N: Revealed type is "TypedDict('__main__.D', {})"
 [builtins fixtures/dict.pyi]
+[case testTypedDictDecoratorUndefinedNames]
+from typing import TypedDict
+
+@abc  # E: Name "abc" is not defined
+@efg.hij  # E: Name "efg" is not defined
+@klm[nop]  # E: Name "klm" is not defined \
+           # E: Name "nop" is not defined
+@qrs.tuv[wxy]  # E: Name "qrs" is not defined \
+               # E: Name "wxy" is not defined
+class A(TypedDict):
+    x: int
+[builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
 [case testTypedDictWithClassmethodAlternativeConstructorDoesNotCrash]


### PR DESCRIPTION
This PR ensures that decorators applied to a TypedDict class definition are correctly analyzed for undefined names.

Previously, the semantic analyzer's special-case handling for TypedDict (analyze_typeddict_classdef) was returning early without visiting the decorators list in the ClassDef. This caused mypy to silently ignore invalid names, attributes, or subscripted expressions used as decorators on these classes.

Fixes #21030 