### PR TITLE
Fix issue #8356: mypy crashes with overloads of functools.singledis

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,6 @@ To contribute to the mypyc project, check out the issue tracker at <https://gith
 
 
 <!-- fix-issue-8629: Document how to import types from stubs -->
+
+
+<!-- fix-issue-8356: mypy crashes with overloads of functools.singledispatch -->


### PR DESCRIPTION
Fixes good-first-issue #8356