### PR TITLE
Add `install_types` to `OPTIONS_AFFECTING_CACHE`

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -78,6 +78,7 @@ OPTIONS_AFFECTING_CACHE: Final = (
         "fixed_format_cache",
         "untyped_calls_exclude",
         "enable_incomplete_feature",
+        "install_types",
     }
 ) - {"debug_cache"}
 


### PR DESCRIPTION
Noticed in #21068

Invalidate the cache when `--install-types` changes so that previous runs without `--install-types` don't prevent stub packages from being installed.

**Before** (note: no install attempt in second invocation)
```shell
$ echo 'import pygments' > file.py

$ python3 -m mypy  ./file.py
file.py:1: error: Library stubs not installed for "pygments.lexers"  [import-untyped]
file.py:1: note: Hint: "python3 -m pip install types-Pygments"
file.py:1: note: (or run "mypy --install-types" to install all missing stub packages)
file.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
file.py:1: error: Library stubs not installed for "pygments"  [import-untyped]
Found 2 errors in 1 file (checked 1 source file)

$ python3 -m mypy --install-types --non-interactive ./file.py                  
file.py:1: error: Library stubs not installed for "pygments.lexers"  [import-untyped]
file.py:1: note: Hint: "python3 -m pip install types-Pygments"
file.py:1: note: (or run "mypy --install-types" to install all missing stub packages)
file.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
file.py:1: error: Library stubs not installed for "pygments"  [import-untyped]
Found 2 errors in 1 file (checked 1 source file)
```

**After** (note: install in second invocation)
```shell
$ echo 'import pygments' > file.py

$ python3 -m mypy  ./file.py
file.py:1: error: Library stubs not installed for "pygments.lexers"  [import-untyped]
file.py:1: note: Hint: "python3 -m pip install types-Pygments"
file.py:1: note: (or run "mypy --install-types" to install all missing stub packages)
file.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
file.py:1: error: Library stubs not installed for "pygments"  [import-untyped]
Found 2 errors in 1 file (checked 1 source file)

$ python3 -m mypy --install-types --non-interactive ./file.py                  
Installing missing stub packages:
[...]/.temp_venv/bin/python3 -m pip install types-Pygments

Collecting types-Pygments
  Using cached types_pygments-2.19.0.20251121-py3-none-any.whl.metadata (2.0 kB)
Requirement already satisfied: types-docutils in ./.temp_venv/lib/python3.13/site-packages (from types-Pygments) (0.22.3.20260322)
Using cached types_pygments-2.19.0.20251121-py3-none-any.whl (25 kB)
Installing collected packages: types-Pygments
Successfully installed types-Pygments-2.19.0.20251121

[notice] A new release of pip is available: 25.3 -> 26.0.1
[notice] To update, run: pip install --upgrade pip

Success: no issues found in 1 source file
```