### PR TITLE
docs: reorder incomplete features alphabetically in command_line.rst

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -1175,7 +1175,7 @@ format into the specified directory.
 Enabling incomplete/experimental features
 *****************************************
 
-.. option:: --enable-incomplete-feature {PreciseTupleTypes,InlineTypedDict,TypeForm}
+.. option:: --enable-incomplete-feature {InlineTypedDict,PreciseTupleTypes,TypeForm}
 
     Some features may require several mypy releases to implement, for example
     due to their complexity, potential for backwards incompatibility, or
@@ -1186,6 +1186,14 @@ Enabling incomplete/experimental features
     features.
 
 List of currently incomplete/experimental features:
+
+* ``InlineTypedDict``: this feature enables non-standard syntax for inline
+  :ref:`TypedDicts <typeddict>`, for example:
+
+  .. code-block:: python
+
+     def test_values() -> {"width": int, "description": str}:
+         return {"width": 42, "description": "test"}
 
 * ``PreciseTupleTypes``: this feature will infer more precise tuple types in
   various scenarios. Before variadic types were added to the Python type system
@@ -1221,14 +1229,6 @@ List of currently incomplete/experimental features:
          reveal_type(numbers)
          # Without PreciseTupleTypes: tuple[int, ...]
          # With PreciseTupleTypes: tuple[()] | tuple[int] | tuple[int, int]
-
-* ``InlineTypedDict``: this feature enables non-standard syntax for inline
-  :ref:`TypedDicts <typeddict>`, for example:
-
-  .. code-block:: python
-
-     def test_values() -> {"width": int, "description": str}:
-         return {"width": 42, "description": "test"}
 
 * ``TypeForm``: this feature enables ``TypeForm``, as described in
   `PEP 747 – Annotating Type Forms <https://peps.python.org/pep-0747/>_`.


### PR DESCRIPTION
Fixes #20171

The `--enable-incomplete-feature` flag uses `sorted(INCOMPLETE_FEATURES)` in `mypy/main.py` (line 1117), so `--help` displays features in alphabetical order:

```
{InlineTypedDict,PreciseTupleTypes,TypeForm}
```

However, the documentation in `command_line.rst` listed them in a different order (`PreciseTupleTypes` first, then `InlineTypedDict`), which was inconsistent with both the `--help` output and alphabetical ordering.

This PR reorders both the option metavar and the feature descriptions in the docs to match the alphabetical order shown by `--help`.

No tests needed for this documentation-only change.