### PR TITLE
sdist: include `misc/{diff-cache,apply-cache-diff}.py` for `mypy/test/test_diff_cache.py`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -38,6 +38,8 @@ include test-requirements.in
 include test-requirements.txt
 include mypy_self_check.ini
 prune misc
+include misc/diff-cache.py
+include misc/apply-cache-diff.py
 graft test-data
 graft mypy/test
 include conftest.py


### PR DESCRIPTION
In Debian, we build the `mypy` Debian package from the Python package source dists published to https://pypi.org/project/mypy/ ; so to support running the `mypy/test/test_diff_cache.py` tests, include `misc/{diff-cache,apply-cache-diff}.py` in the `MANIFEST.in`