### PR TITLE
docs: clarify that invariant-by-default applies to legacy TypeVar syntax

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -307,8 +307,10 @@ Most mutable generic collections are invariant. When using the legacy
 ``TypeVar`` syntax, mypy considers all user-defined generic classes invariant
 by default (see :ref:`variance-of-generics` for motivation). When using the
 :pep:`695` syntax (``class MyClass[T]: ...``), variance is inferred from
-usage rather than defaulting to invariant. This could lead to some unexpected
-errors when combined with type inference. For example:
+usage rather than defaulting to invariant.
+
+The fact that mutable sequences are usually invariant can lead to some
+unexpected errors when combined with type inference. For example:
 
 .. code-block:: python
 


### PR DESCRIPTION
Closes #20366.

The "invariant by default" rule applies to the legacy `TypeVar` syntax. Under PEP 695 (`class MyClass[T]: ...`), mypy infers variance from usage instead. Updated the wording in `common_issues.rst` to make this distinction clear.