### PR TITLE
fix --install-types not tracking stubs when ignore_missing_imports is set

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3415,8 +3415,6 @@ def find_module_and_diagnose(
             if not (ignore_missing_imports or in_partial_package(id, manager)):
                 module_not_found(manager, caller_line, caller_state, id, result)
             elif result is ModuleNotFoundReason.APPROVED_STUBS_NOT_INSTALLED:
-                # Even when ignoring missing imports, track approved stub packages
-                # so that --install-types can still install them.
                 dist = stub_distribution_name(id)
                 if dist:
                     manager.missing_stub_packages.add(dist)


### PR DESCRIPTION
when `ignore_missing_imports` is enabled, `--install-types` silently skips recording approved stub packages since the error reporting path is bypassed entirely. this means running `mypy --install-types` won't install stubs like `types-Pygments` even though mypy knows about them.

this adds tracking of missing stub packages even when import errors are suppressed, so `--install-types` can still pick them up.

fixes #21068