### PR TITLE
Use 'native-parser' instead of 'native-parse' for optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ python2 = []
 reports = ["lxml"]
 install-types = ["pip"]
 faster-cache = ["orjson"]
-native-parse = ["ast-serialize>=0.1.1,<1.0.0"]
+native-parser = ["ast-serialize>=0.1.1,<1.0.0"]
 
 [project.urls]
 Homepage = "https://www.mypy-lang.org/"


### PR DESCRIPTION
This makes it consistent with the `--native-parser` flag. Now `pip install mypy[native-parser]` will install native parser support.