### PR TITLE
fix: use "parameter" instead of "argument" in missing-self error message

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1631,7 +1631,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
 
         if not func.arg_types:
             self.fail(
-                'Method must have at least one argument. Did you forget the "self" argument?', defn
+                'Method must have at least one parameter. Did you forget the "self" parameter?',
+                defn,
             )
             return False
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3336,7 +3336,7 @@ from typing import Any
 class Test:
     def __setattr__() -> None: ... \
         # E: Invalid signature "Callable[[], None]" for "__setattr__" \
-        # E: Method must have at least one argument. Did you forget the "self" argument?
+        # E: Method must have at least one parameter. Did you forget the "self" parameter?
 
 t = Test()
 t.crash = 'test'  # E: Attribute function "__setattr__" with type "Callable[[], None]" does not accept self argument \
@@ -7829,7 +7829,7 @@ reveal_type(Foo().y)  # N: Revealed type is "builtins.list[Any]"
 # flags: --check-untyped-defs
 
 class Foo:
-    def bad():  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def bad():  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         self.x = 0  # E: Name "self" is not defined
 
 [case testMethodSelfArgumentChecks]
@@ -7848,7 +7848,7 @@ def to_same_callable(fn: Callable[P, T]) -> Callable[P, T]:
     return fn
 
 class A:
-    def undecorated() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def undecorated() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
 
     def undecorated_not_self(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
 
@@ -7875,7 +7875,7 @@ class A:
         return 0
 
     @to_same_callable
-    def g1() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def g1() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
 
     @to_same_callable
     def g2(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
@@ -7937,11 +7937,11 @@ reveal_type(A().fn3)  # N: Revealed type is "def (_x: builtins.int) -> builtins.
 
 class B:
     @remove_first  # E: Argument 1 to "remove_first" has incompatible type "Callable[[], int]"; expected "Callable[[T], int]"
-    def fn1() -> int:  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def fn1() -> int:  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         return 0
 
     @remove_first
-    def fn2(_x: int) -> int:  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def fn2(_x: int) -> int:  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         return 0
 
     @remove_first
@@ -8009,7 +8009,7 @@ def to_same_callable(fn: Callable[P, T]) -> Callable[P, T]:
 
 def unchecked():
     class Bad:
-        def fn() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def fn() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         def fn2(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
 
         # TODO: would be nice to make this error, but now we see the func
@@ -8030,29 +8030,29 @@ def unchecked():
 
 def checked() -> None:
     class Bad:
-        def fn() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def fn() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         def fn2(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
 
         @to_same_callable
-        def g() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def g() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         @to_same_callable
         def g2(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
 
     class AlsoBad:
-        def fn(): ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def fn(): ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         def fn2(x): ...
 
         @to_same_callable
-        def g(): ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def g(): ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         @to_same_callable
         def g2(x): ...
 
 class Ok:
-    def fn(): ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def fn(): ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
     def fn2(x): ...
 
     @to_same_callable
-    def g(): ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def g(): ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
     @to_same_callable
     def g2(x): ...
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2771,7 +2771,7 @@ class A:
     @dec
     def e(self) -> int: pass
     @property
-    def g() -> int: pass   # E: Method must have at least one argument. Did you forget the "self" argument?
+    def g() -> int: pass   # E: Method must have at least one parameter. Did you forget the "self" parameter?
     @property
     def h(self, *args, **kwargs) -> int: pass   # OK
 [builtins fixtures/property.pyi]

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -375,7 +375,7 @@ class A:
         return 1
 
 class B(A):
-    def g() -> None: # E: Method must have at least one argument. Did you forget the "self" argument?
+    def g() -> None: # E: Method must have at least one parameter. Did you forget the "self" parameter?
         super().f() # E: "super()" requires one or two positional arguments in enclosing function
     def h(self) -> None:
         def a() -> None:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1572,11 +1572,11 @@ class A:
 [file b.py.3]
 2
 [out]
-a.py:3: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:3: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
-a.py:3: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:3: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
-a.py:3: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:3: error: Method must have at least one parameter. Did you forget the "self" parameter?
 
 [case testBaseClassDeleted]
 import m
@@ -1993,11 +1993,11 @@ class A:
 class A:
     def foo(self) -> int: pass
 [out]
-a.py:2: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:2: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
-a.py:2: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:2: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
-a.py:2: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:2: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
 
 [case testPreviousErrorInMethodSemanal2]


### PR DESCRIPTION
Fixes #20939.

The error message for methods defined without any parameters:

```
error: Method must have at least one argument. Did you forget the "self" argument?
```

uses the word *argument*, but in the context of a function definition the correct term is *parameter*. Updated the message to:

```
error: Method must have at least one parameter. Did you forget the "self" parameter?
```

Updated the source string in `mypy/checker.py` and all matching test fixtures.

Made with [Cursor](https://cursor.com)