### PR TITLE
fix: mention type aliases in "Type application" error message

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -121,7 +121,7 @@ FUNCTION_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a type annotation", codes.NO_UNTYPED_DEF
 )
 ONLY_CLASS_APPLICATION: Final = ErrorMessage(
-    "Type application is only supported for generic classes"
+    "Type application is only supported for generic classes and type aliases"
 )
 RETURN_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a return type annotation", codes.NO_UNTYPED_DEF

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -426,7 +426,7 @@ from typing import TypeVar
 T = TypeVar('T')
 def f(x: T) -> T: pass
 
-y = f[int]  # E: Type application is only supported for generic classes
+y = f[int]  # E: Type application is only supported for generic classes and type aliases
 [out]
 
 
@@ -1004,7 +1004,7 @@ reveal_type(y)  # N: Revealed type is "builtins.int"
 
 U[int]  # E: Bad number of arguments for type alias, expected 0, given 1
 O[int]  # E: Bad number of arguments for type alias, expected 0, given 1 \
-        # E: Type application is only supported for generic classes
+        # E: Type application is only supported for generic classes and type aliases
 
 [case testAliasesInClassBodyNormalVsSubscripted]
 
@@ -1072,9 +1072,9 @@ reveal_type(ts) # N: Revealed type is "Any"
 us = UA.x # E: "<typing special form>" has no attribute "x"
 reveal_type(us) # N: Revealed type is "Any"
 
-xx = CA[str] + 1  # E: Type application is only supported for generic classes
-yy = TA[str]()  # E: Type application is only supported for generic classes
-zz = UA[str].x  # E: Type application is only supported for generic classes
+xx = CA[str] + 1  # E: Type application is only supported for generic classes and type aliases
+yy = TA[str]()  # E: Type application is only supported for generic classes and type aliases
+zz = UA[str].x  # E: Type application is only supported for generic classes and type aliases
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-medium.pyi]
 [out]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -92,7 +92,7 @@ class B(Generic[P]): ...
 Other = B[P]
 
 T = TypeVar('T', bound=Alias[..., Any])
-Alias[..., Any]  # E: Type application is only supported for generic classes
+Alias[..., Any]  # E: Type application is only supported for generic classes and type aliases
 B[...]
 Other[...]
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2763,6 +2763,6 @@ T = TypeVar('T')
 
 def func(d: Callable[[Unpack[Ts]], T]) -> T: ...
 
-y = func[1, int] # E: Type application is only supported for generic classes \
+y = func[1, int] # E: Type application is only supported for generic classes and type aliases \
                  # E: Invalid type: try using Literal[1] instead?
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #20927.

The error message raised when type arguments are applied to a non-class expression (e.g. a generic function):

```
error: Type application is only supported for generic classes
```

is inaccurate because PEP 695 type aliases (`type TA[T] = list[T]`) also support type application (`TA[int]`). Updated to:

```
error: Type application is only supported for generic classes and type aliases
```

Updated `mypy/message_registry.py` (`ONLY_CLASS_APPLICATION`) and all matching test fixtures.

Made with [Cursor](https://cursor.com)