### PR TITLE
fix: use "constraints and a bound" in TypeVar error message

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4936,7 +4936,7 @@ class SemanticAnalyzer(
                     return None
             elif param_name == "bound":
                 if has_values:
-                    self.fail("TypeVar cannot have both values and an upper bound", context)
+                    self.fail("TypeVar cannot have both constraints and a bound", context)
                     return None
                 tv_arg = self.get_typevarlike_argument("TypeVar", param_name, param_value, context)
                 if tv_arg is None:

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -1062,7 +1062,7 @@ k = TypeVar('k', contravariant=1) # E: TypeVar "contravariant" may only be a lit
 
 [case testMoreInvalidTypevarArguments]
 from typing import TypeVar
-T = TypeVar('T', int, str, bound=bool) # E: TypeVar cannot have both values and an upper bound
+T = TypeVar('T', int, str, bound=bool) # E: TypeVar cannot have both constraints and a bound
 S = TypeVar('S', covariant=True, contravariant=True) \
     # E: TypeVar cannot be both covariant and contravariant
 [builtins fixtures/bool.pyi]


### PR DESCRIPTION
Fixes #20973.

PEP 484 uses **constraints** for the positional type arguments of `TypeVar`
(e.g. `TypeVar("T", int, str)`) and **bound** for the `bound=` keyword.
The existing error message used neither term correctly:

```
error: TypeVar cannot have both values and an upper bound
```

Updated to the standard PEP 484 terminology:

```
error: TypeVar cannot have both constraints and a bound
```

Changed `mypy/semanal.py` and the matching test fixture in
`test-data/unit/semanal-errors.test`.

Made with [Cursor](https://cursor.com)