### PR TITLE
fix: clarify "Extra argument from **args" as "from **TypedDict"

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -957,7 +957,7 @@ class MessageBuilder:
         # Try to determine the name of the extra argument.
         for key in arg_type.items:
             if key not in callee.arg_names:
-                msg = f'Extra argument "{key}" from **args' + for_function(callee)
+                msg = f'Extra argument "{key}" from **TypedDict' + for_function(callee)
                 break
         else:
             self.too_many_arguments(callee, context)

--- a/test-data/unit/check-functools.test
+++ b/test-data/unit/check-functools.test
@@ -491,8 +491,8 @@ def main4(a2good: A2Good, a2bad: A2Bad, **d2: Unpack[D2]) -> None:
     partial(fn3, **d2)(**a2bad)  # E: Argument "a2" to "fn3" has incompatible type "int"; expected "str"
 
 def main5(**d2: Unpack[D2]) -> None:
-    partial(fn1, **d2)()  # E: Extra argument "a2" from **args for "fn1"
-    partial(fn2, **d2)()  # E: Extra argument "a2" from **args for "fn2"
+    partial(fn1, **d2)()  # E: Extra argument "a2" from **TypedDict for "fn1"
+    partial(fn2, **d2)()  # E: Extra argument "a2" from **TypedDict for "fn2"
 
 def main6(a2good: A2Good, a2bad: A2Bad, **d1: Unpack[D1]) -> None:
     partial(fn3, **d1)()  # E: Missing positional argument "a1" in call to "fn3"

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1835,9 +1835,9 @@ a: A
 f1(**a)
 f2(**a) # E: Argument "y" to "f2" has incompatible type "str"; expected "int"
 f3(**a) # E: Argument "x" to "f3" has incompatible type "int"; expected "B"
-f4(**a) # E: Extra argument "y" from **args for "f4"
+f4(**a) # E: Extra argument "y" from **TypedDict for "f4"
 f5(**a) # E: Missing positional arguments "y", "z" in call to "f5"
-f6(**a) # E: Extra argument "y" from **args for "f6"
+f6(**a) # E: Extra argument "y" from **TypedDict for "f6"
 f1(1, **a) # E: "f1" gets multiple values for keyword argument "x"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2251,7 +2251,7 @@ def test(
     **kwargs: Unpack[Keywords],
 ) -> T:
     if bool():
-        func(*args, **kwargs)  # E: Extra argument "a" from **args
+        func(*args, **kwargs)  # E: Extra argument "a" from **TypedDict
     return func(*args)
 def test2(
     x: int,


### PR DESCRIPTION
Fixes #20986.

When a `TypedDict` is unpacked with `**` and contains keys the callee
does not accept, the error message was:

```
error: Extra argument "y" from **args for "func"
```

`**args` looks like a `*args`/`**kwargs` variable name, which is
confusing.  Since this code path (`too_many_arguments_from_typed_dict`)
is only reached when the source is a `TypedDict`, the message is
updated to:

```
error: Extra argument "y" from **TypedDict for "func"
```

Changed `mypy/messages.py` and updated the four matching test fixtures
in `test-data/unit/`.

Made with [Cursor](https://cursor.com)