### PR TITLE
Include 2 more files in the sdist: CREDITS & typeshed/stdlib/_typeshed/README.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@
 prune mypy/typeshed
 include mypy/typeshed/LICENSE
 include mypy/typeshed/stdlib/VERSIONS
+include mypy/typeshed/stdlib/_typeshed/README.md
 recursive-include mypy/typeshed *.pyi
 
 # mypy and mypyc
@@ -46,8 +47,8 @@ include conftest.py
 include runtests.py
 include tox.ini
 
-include LICENSE mypyc/README.md CHANGELOG.md
-exclude .gitmodules CONTRIBUTING.md CREDITS ROADMAP.md action.yml .editorconfig
+include LICENSE mypyc/README.md CHANGELOG.md CREDITS
+exclude .gitmodules CONTRIBUTING.md ROADMAP.md action.yml .editorconfig
 exclude .git-blame-ignore-revs .pre-commit-config.yaml
 
 global-exclude *.py[cod]


### PR DESCRIPTION
Not required for anything, but it seems nice.

CREDITS was excluded back in 2020, but it seems polite to include it in the sdists https://github.com/python/mypy/pull/9592 / https://github.com/python/mypy/commit/f5f5485387c3ac9f4bbb56c036faee2a1abdaa70

With this PR, CREDITS won't be part of the wheel, but `typeshed/stdlib/_typeshed/README.md` will; let me know if I should exclude it from the wheel