### PR TITLE
--warn-unused-config should not be a strict flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -599,7 +599,6 @@ def define_options(
     add_invertible_flag(
         "--warn-unused-configs",
         default=False,
-        strict_flag=True,
         help="Warn about unused '[mypy-<pattern>]' or '[[tool.mypy.overrides]]' config sections",
         group=config_group,
     )


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/21137

This flag has nothing to with type checking strictness, it is a convenience option for config maintenance.
