### PR TITLE
Fix loss of type inference in chained comparisons

### DIFF
--- a/mypy/binder.py
+++ b/mypy/binder.py
@@ -336,7 +336,12 @@ class ConditionalTypeBinder:
                 # See check-isinstance.test::testNoneCheckDoesNotMakeTypeVarOptional
                 # This is a safe assumption: the fact that we checked something with `is`
                 # or `isinstance` does not change the type of the value.
-                continue
+                if len(frames) == 1:
+                    # This is likely a sequential update, not a merge of
+                    # conditional branches. Let the update proceed to preserve narrowing.
+                    pass
+                else:
+                    continue
 
             # Remove exact duplicates to save pointless work later, this is
             # a micro-optimization for --allow-redefinition-new.


### PR DESCRIPTION
## Summary

A regression in mypy 1.20 caused loss of type narrowing for operands in chained comparisons. This was due to an overly aggressive check in the type binder that prevented unwanted type widening but also discarded valid narrowing from expressions like `is not`. The fix refines this check to distinguish between merging control-flow branches and sequential updates within an expression, ensuring that narrowing is preserved in chained comparisons.

## Changes

- **mypy/binder.py**: In mypy/binder.py, the `update_from_options` method has been modified to correctly handle type narrowing in chained comparisons. The original logic was too aggressive in preventing type widening and inadvertently discarded valid narrowing. The fix introduces a check on the number of frames being merged: if only one frame is involved, it's treated as a sequential update (like in a chained comparison) and the type narrowing is allowed to proceed. This restores correct type inference without re-introducing the bug the original code was intended to fix.

## Related Issue

Closes #21149

