### PR TITLE
Suppress misleading Foo[...] suggestion for annotations with keyword args

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1957,7 +1957,9 @@ class TypeConverter:
 
         if not isinstance(self.parent(), ast3.List):
             note = None
-            if constructor:
+            if constructor and not e.keywords:
+                # Only suggest Foo[...] when there are no keyword arguments,
+                # since Foo[arg=val] is a SyntaxError (see #16506).
                 note = "Suggestion: use {0}[...] instead of {0}(...)".format(constructor)
             return self.invalid_type(e, note=note)
         if not constructor:

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -122,6 +122,11 @@ for v in x:  # type: int, int  # E: Syntax error in type annotation  [syntax] \
     # N: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
     pass
 
+[case testErrorCodeSyntaxError4_no_native_parse]
+# Keyword arguments in type annotation should not suggest Foo[...] (see #16506)
+def f(a: Foo(arg=int)) -> int:  # E: Invalid type comment or annotation  [valid-type]
+    pass
+
 [case testErrorCodeSyntaxErrorIgnoreNote]
 # This is a bit inconsistent -- syntax error would be more logical?
 x: 'a b'  # type: ignore[valid-type]

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -207,6 +207,18 @@ def f(a: Foo(int)) -> int:
 main:7: error: Invalid type comment or annotation
 main:7: note: Suggestion: use Foo[...] instead of Foo(...)
 
+[case testFasterParseTypeErrorCustomWithKeyword_no_native_parse]
+
+from typing import TypeVar, Generic
+T = TypeVar('T')
+class Foo(Generic[T]):
+  pass
+
+def f(a: Foo(arg=int)) -> int:
+    pass
+[out]
+main:7: error: Invalid type comment or annotation
+
 [case testFastParseMatMul]
 
 from typing import Any


### PR DESCRIPTION
## Summary

- Fixes #16506
- When a call expression with keyword arguments is used in a type annotation (e.g., `Foo(arg=val)`), mypy previously suggested `use Foo[...] instead of Foo(...)`. Since `Foo[arg=val]` is a `SyntaxError` in Python, this suggestion is misleading.
- This PR suppresses the bracket syntax suggestion when the call node contains keyword arguments. The "Invalid type comment or annotation" error is still emitted, just without the unhelpful note.

## Changes

- **`mypy/fastparse.py`**: Added a check for `e.keywords` in `visit_Call` so the `Suggestion: use Foo[...] instead of Foo(...)` note is only shown when there are no keyword arguments.
- **`test-data/unit/check-fastparse.test`**: Added test case `testFasterParseTypeErrorCustomWithKeyword` verifying no suggestion note is emitted for `Foo(arg=int)`.
- **`test-data/unit/check-errorcodes.test`**: Added test case `testErrorCodeSyntaxError4` verifying the error code behavior with keyword arguments.

## Test plan

- [x] `testFasterParseTypeErrorCustom_no_native_parse` still passes (existing behavior preserved for positional args)
- [x] `testFasterParseTypeErrorCustomWithKeyword_no_native_parse` passes (new test for keyword args)
- [x] `testErrorCodeSyntaxError4_no_native_parse` passes (new error code test)
- [x] All `testErrorCodeSyntaxError*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)