### PR TITLE
Fix is_overlapping_types for generic callables

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -541,12 +541,23 @@ def is_overlapping_types(
         return False
 
     if isinstance(left, CallableType) and isinstance(right, CallableType):
+        # We run is_callable_compatible in both directions, similar to the logic
+        # in is_unsafe_overlapping_overload_signatures
+        # See comments in https://github.com/python/mypy/pull/5476
         return is_callable_compatible(
             left,
             right,
             is_compat=_is_overlapping_types,
             is_proper_subtype=False,
             ignore_pos_arg_names=not overlap_for_overloads,
+            allow_partial_overlap=True,
+        ) or is_callable_compatible(
+            right,
+            left,
+            is_compat=_is_overlapping_types,
+            is_proper_subtype=False,
+            ignore_pos_arg_names=not overlap_for_overloads,
+            check_args_covariantly=True,
             allow_partial_overlap=True,
         )
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -8,7 +8,7 @@ from unittest import TestCase, skipUnless
 from mypy.erasetype import erase_type, remove_instance_last_known_values
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.join import join_types
-from mypy.meet import meet_types, narrow_declared_type
+from mypy.meet import is_overlapping_types, meet_types, narrow_declared_type
 from mypy.nodes import (
     ARG_NAMED,
     ARG_OPT,
@@ -644,6 +644,27 @@ class TypeOpsSuite(Suite):
     def assert_simplified_union(self, original: list[Type], union: Type) -> None:
         assert_equal(make_simplified_union(original), union)
         assert_equal(make_simplified_union(list(reversed(original))), union)
+
+    def test_generic_callable_overlap_is_symmetric(self) -> None:
+        any_type = AnyType(TypeOfAny.from_omitted_generics)
+        outer_t = TypeVarType("T", "T", TypeVarId(1), [], self.fx.o, any_type)
+        outer_s = TypeVarType("S", "S", TypeVarId(2), [], self.fx.o, any_type)
+        generic_t = TypeVarType("T", "T", TypeVarId(-1), [], self.fx.o, any_type)
+
+        callable_type = CallableType(
+            [outer_t], [ARG_POS], [None], outer_s, self.fx.function
+        )
+        generic_identity = CallableType(
+            [generic_t],
+            [ARG_POS],
+            [None],
+            generic_t,
+            self.fx.function,
+            variables=[generic_t],
+        )
+
+        assert is_overlapping_types(callable_type, generic_identity)
+        assert is_overlapping_types(generic_identity, callable_type)
 
     # Helpers
 

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -651,16 +651,9 @@ class TypeOpsSuite(Suite):
         outer_s = TypeVarType("S", "S", TypeVarId(2), [], self.fx.o, any_type)
         generic_t = TypeVarType("T", "T", TypeVarId(-1), [], self.fx.o, any_type)
 
-        callable_type = CallableType(
-            [outer_t], [ARG_POS], [None], outer_s, self.fx.function
-        )
+        callable_type = CallableType([outer_t], [ARG_POS], [None], outer_s, self.fx.function)
         generic_identity = CallableType(
-            [generic_t],
-            [ARG_POS],
-            [None],
-            generic_t,
-            self.fx.function,
-            variables=[generic_t],
+            [generic_t], [ARG_POS], [None], generic_t, self.fx.function, variables=[generic_t]
         )
 
         assert is_overlapping_types(callable_type, generic_identity)

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -4007,6 +4007,7 @@ def identity(x: T) -> T:
 
 def msg(cmp_property: Callable[[T], S]) -> None:
     if cmp_property == identity:
+        # TODO: the swapping of these reveal's is not ideal
         reveal_type(cmp_property)  # N: Revealed type is "def [T] (x: T`-1) -> T`-1"
         reveal_type(identity)  # N: Revealed type is "def (T`-1) -> S`-2"
         return

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -3993,3 +3993,21 @@ def f2(func: Callable[..., T], arg: str) -> T:
         return func(arg)
     return func(arg)
 [builtins fixtures/primitives.pyi]
+
+
+[case testNarrowGenericCallableEquality]
+# flags: --strict-equality --warn-unreachable
+from typing import Callable, TypeVar
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+def identity(x: T) -> T:
+    return x
+
+def msg(cmp_property: Callable[[T], S]) -> None:
+    if cmp_property == identity:
+        reveal_type(cmp_property)  # N: Revealed type is "def [T] (x: T`-1) -> T`-1"
+        reveal_type(identity)  # N: Revealed type is "def (T`-1) -> S`-2"
+        return
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Fixes #21182

This issue exposed this pre-existing deficiency in is_overlapping_types