### PR TITLE
fix: do not narrow expression type to TypeVar on equality comparison

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6787,6 +6787,13 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 ):
                     continue
 
+                # Do not narrow based on a TypeVar target: we don't know its concrete type,
+                # so narrowing e.g. `x: int` to `T` when comparing `x == y: T` is wrong.
+                # The narrowed TypeVar type is typically a supertype of the original, causing
+                # false errors on subsequent operations. See: github.com/python/mypy/issues/21199
+                if isinstance(get_proper_type(target_type), TypeVarLikeType):
+                    continue
+
                 target = TypeRange(target_type, is_upper_bound=False)
 
                 if_map, else_map = conditional_types_to_typemaps(

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -3993,3 +3993,33 @@ def f2(func: Callable[..., T], arg: str) -> T:
         return func(arg)
     return func(arg)
 [builtins fixtures/primitives.pyi]
+
+[case testNarrowingEqualityTypeVarTarget]
+# Regression test for https://github.com/python/mypy/issues/21199
+# When the RHS of == is a TypeVar, the LHS should not be narrowed to the TypeVar type.
+# flags: --python-version 3.10
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def func_basic(x: int, y: T) -> None:
+    # x: int should remain int after comparing with TypeVar y; no error on x += 1
+    assert x == y
+    reveal_type(x)  # N: Revealed type is "builtins.int"
+    x += 1
+
+def func_union(x: int | str, y: T) -> None:
+    # x: int | str should not be narrowed to T when compared with TypeVar
+    assert x == y
+    reveal_type(x)  # N: Revealed type is "builtins.int | builtins.str"
+
+def func_not_equal(x: int | str, y: T) -> None:
+    # != should also not over-narrow based on TypeVar
+    if x != y:
+        reveal_type(x)  # N: Revealed type is "builtins.int | builtins.str"
+
+def func_concrete_target(x: int | str, y: int) -> None:
+    # When the target is a concrete type (not TypeVar), narrowing is still allowed
+    if x == y:
+        reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
When a variable is compared with `==` against a TypeVar operand, mypy was narrowing the left-hand variable to the TypeVar type. This caused false errors on subsequent operations — for example, `x: int` would be narrowed to `T` after `assert x == y` (where `y: T`), causing `x += 1` to be flagged as unsupported operands.

The regression was introduced in #20602, which routed `==` through `narrow_type_by_identity_equality` but did not guard against TypeVar targets. A TypeVar represents an unknown concrete type at the call site, so narrowing based on it can only lose information, not gain it.

This fix skips narrowing in `narrow_type_by_identity_equality` when the target type is a `TypeVarLikeType`. A more precise approach — intersecting the expression type with the TypeVar's upper bound — would require intersection type support and can be done as a follow-up.

Fixes #21199