### PR TITLE
Only set journal mode in coordinator

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -901,7 +901,7 @@ class BuildManager:
                 ]
             )
 
-        self.metastore = create_metastore(options)
+        self.metastore = create_metastore(options, parallel_worker=parallel_worker)
 
         # a mapping from source files to their corresponding shadow files
         # for efficient lookup
@@ -1766,10 +1766,12 @@ def exclude_from_backups(target_dir: str) -> None:
         pass
 
 
-def create_metastore(options: Options) -> MetadataStore:
+def create_metastore(options: Options, parallel_worker: bool) -> MetadataStore:
     """Create the appropriate metadata store."""
     if options.sqlite_cache:
-        mds: MetadataStore = SqliteMetadataStore(_cache_dir_prefix(options))
+        mds: MetadataStore = SqliteMetadataStore(
+            _cache_dir_prefix(options), set_journal_mode=not parallel_worker
+        )
     else:
         mds = FilesystemMetadataStore(_cache_dir_prefix(options))
     return mds

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -154,7 +154,7 @@ CREATE INDEX IF NOT EXISTS path_idx on files2(path);
 """
 
 
-def connect_db(db_file: str) -> sqlite3.Connection:
+def connect_db(db_file: str, set_journal_mode: bool) -> sqlite3.Connection:
     import sqlite3.dbapi2
 
     db = sqlite3.dbapi2.connect(db_file, check_same_thread=False)
@@ -162,13 +162,14 @@ def connect_db(db_file: str) -> sqlite3.Connection:
     # but without this flag, commits are *very* slow, especially when using HDDs,
     # see https://www.sqlite.org/faq.html#q19 for details.
     db.execute("PRAGMA synchronous=OFF")
-    db.execute("PRAGMA journal_mode=WAL")
+    if set_journal_mode:
+        db.execute("PRAGMA journal_mode=WAL")
     db.executescript(SCHEMA)
     return db
 
 
 class SqliteMetadataStore(MetadataStore):
-    def __init__(self, cache_dir_prefix: str) -> None:
+    def __init__(self, cache_dir_prefix: str, set_journal_mode: bool = False) -> None:
         # We check startswith instead of equality because the version
         # will have already been appended by the time the cache dir is
         # passed here.
@@ -177,7 +178,7 @@ class SqliteMetadataStore(MetadataStore):
             return
 
         os.makedirs(cache_dir_prefix, exist_ok=True)
-        self.db = connect_db(os_path_join(cache_dir_prefix, "cache.db"))
+        self.db = connect_db(os_path_join(cache_dir_prefix, "cache.db"), set_journal_mode)
 
     def _query(self, name: str, field: str) -> Any:
         # Raises FileNotFound for consistency with the file system version

--- a/mypyc/codegen/emitmodule.py
+++ b/mypyc/codegen/emitmodule.py
@@ -133,7 +133,7 @@ class MypycPlugin(Plugin):
                 self.group_map[id] = (name, modules)
 
         self.compiler_options = compiler_options
-        self.metastore = create_metastore(options)
+        self.metastore = create_metastore(options, parallel_worker=False)
 
     def report_config_data(self, ctx: ReportConfigContext) -> tuple[str | None, list[str]] | None:
         # The config data we report is the group map entry for the module.


### PR DESCRIPTION
This should reduce test flakiness (esp. on Windows). @hauntsaninja IIUC this setting is per database, so setting it only in coordinator (main process) should be enough.