### PR TITLE
[mypyc] Report an error if an acyclic class inherits from non-acyclic

### DIFF
--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -26,6 +26,7 @@ from mypy.nodes import (
     Decorator,
     Expression,
     FuncDef,
+    IndexExpr,
     MemberExpr,
     MypyFile,
     NameExpr,
@@ -117,6 +118,12 @@ def build_type_map(
                 prepare_non_ext_class_def(
                     module.path, module.fullname, cdef, errors, mapper, options
                 )
+
+    # Validate cross-class properties after all ClassIR flags are populated.
+    for module, cdef in classes:
+        with catch_errors(module.path, cdef.line):
+            if mapper.type_to_ir[cdef.info].is_ext_class:
+                validate_acyclic_class_bases(module.path, cdef, errors, mapper)
 
     # Prepare implicit attribute accessors as needed if an attribute overrides a property.
     for module, cdef in classes:
@@ -343,6 +350,51 @@ def can_subclass_builtin(builtin_base: str) -> bool:
             "builtins.object",
         )
     )
+
+
+def get_removed_base_fullname(expr: Expression) -> str | None:
+    if isinstance(expr, IndexExpr):
+        expr = expr.base
+    if isinstance(expr, RefExpr):
+        return expr.fullname
+    return None
+
+
+def find_non_acyclic_base(cdef: ClassDef, mapper: Mapper) -> str | None:
+    if cdef.type_args:
+        return "typing.Generic"
+
+    for expr in cdef.removed_base_type_exprs:
+        if fullname := get_removed_base_fullname(expr):
+            return fullname
+        return "a removed base class"
+
+    for base in cdef.info.mro[1:]:
+        if base.fullname == "builtins.object":
+            continue
+
+        base_ir = mapper.type_to_ir.get(base)
+        if base_ir is not None and base_ir.is_acyclic:
+            continue
+
+        return base.fullname
+
+    return None
+
+
+def validate_acyclic_class_bases(
+    path: str, cdef: ClassDef, errors: Errors, mapper: Mapper
+) -> None:
+    ir = mapper.type_to_ir[cdef.info]
+    if not ir.is_acyclic:
+        return
+
+    if fullname := find_non_acyclic_base(cdef, mapper):
+        errors.error(
+            f'"acyclic" can\'t be used in a class that inherits from non-acyclic type "{fullname}"',
+            path,
+            cdef.line,
+        )
 
 
 def prepare_class_def(

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -2140,11 +2140,19 @@ class InterpSub:
 
 [case testAcyclicClassRequiresAcyclicBases]
 from typing import Generic, TypeVar
-from mypy_extensions import mypyc_attr
+from mypy_extensions import mypyc_attr, trait
 
 T = TypeVar("T")
 
 class NonAcyclicBase:
+    pass
+
+@trait
+class TraitBase:
+    pass
+
+@mypyc_attr(native_class=False)
+class NonNativeBase:
     pass
 
 @mypyc_attr(acyclic=True)
@@ -2161,6 +2169,14 @@ class BadDerived(NonAcyclicBase):  # E: "acyclic" can't be used in a class that 
 
 @mypyc_attr(acyclic=True)
 class BadGeneric(Generic[T]):  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "typing.Generic"
+    pass
+
+@mypyc_attr(acyclic=True)
+class BadDerivedTrait(TraitBase):  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "__main__.TraitBase"
+    pass
+
+@mypyc_attr(acyclic=True)
+class BadDerivedNonNative(NonNativeBase):  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "__main__.NonNativeBase"
     pass
 
 [case testUnsupportedGetAttr]

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -2163,13 +2163,6 @@ class BadDerived(NonAcyclicBase):  # E: "acyclic" can't be used in a class that 
 class BadGeneric(Generic[T]):  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "typing.Generic"
     pass
 
-[case testAcyclicGenericIsRejected_python3_12]
-from mypy_extensions import mypyc_attr
-
-@mypyc_attr(acyclic=True)
-class BadGeneric[T]:  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "typing.Generic"
-    pass
-
 [case testUnsupportedGetAttr]
 from mypy_extensions import mypyc_attr
 

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -2138,6 +2138,38 @@ class NonNative:
 class InterpSub:
     pass
 
+[case testAcyclicClassRequiresAcyclicBases]
+from typing import Generic, TypeVar
+from mypy_extensions import mypyc_attr
+
+T = TypeVar("T")
+
+class NonAcyclicBase:
+    pass
+
+@mypyc_attr(acyclic=True)
+class AcyclicBase:
+    pass
+
+@mypyc_attr(acyclic=True)
+class GoodDerived(AcyclicBase):
+    pass
+
+@mypyc_attr(acyclic=True)
+class BadDerived(NonAcyclicBase):  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "__main__.NonAcyclicBase"
+    pass
+
+@mypyc_attr(acyclic=True)
+class BadGeneric(Generic[T]):  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "typing.Generic"
+    pass
+
+[case testAcyclicGenericIsRejected_python3_12]
+from mypy_extensions import mypyc_attr
+
+@mypyc_attr(acyclic=True)
+class BadGeneric[T]:  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "typing.Generic"
+    pass
+
 [case testUnsupportedGetAttr]
 from mypy_extensions import mypyc_attr
 

--- a/mypyc/test-data/irbuild-python312.test
+++ b/mypyc/test-data/irbuild-python312.test
@@ -1,0 +1,6 @@
+[case testAcyclicGenericIsRejected_python3_12]
+from mypy_extensions import mypyc_attr
+
+@mypyc_attr(acyclic=True)
+class BadGeneric[T]:  # E: "acyclic" can't be used in a class that inherits from non-acyclic type "typing.Generic"
+    pass

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -64,6 +64,9 @@ files = [
     "irbuild-match.test",
 ]
 
+if sys.version_info >= (3, 12):
+    files.append("irbuild-python312.test")
+
 if sys.version_info >= (3, 14):
     files.append("irbuild-python314.test")
 


### PR DESCRIPTION
Classes marked with `@mypyc_attr(acyclic=True)` are generated without the `Py_TPFLAGS_HAVE_GC` flag which opts them out of the cyclic GC. However, when they inherit from a class that does have this flag, cpython opts them back into the cyclic GC in `inherit_special` https://github.com/python/cpython/blob/main/Objects/typeobject.c#L8614.

The destructor generated by mypyc for acyclic classes does not untrack the instances before deallocating them which makes cpython issue a warning in debug builds https://github.com/python/cpython/blob/main/Python/gc.c#L2538. I wasn't able to confirm whether this can cause memory leaks but it's probably best to disallow this case.

This also affects generic classes that use the new type parameter syntax `class C[T]`. They implicitly inherit from `typing.Generic` which opts into GC https://github.com/python/cpython/blob/main/Objects/typevarobject.c#L2350.