### PR TITLE
Fix Windows IPC race condition when using parallel checking

### DIFF
--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -430,10 +430,8 @@ def ready_to_read(conns: Sequence[IPCBase], timeout: float | None = None) -> lis
         for _, ov in pending:
             ov.cancel()
         for i, ov in pending:
-            # Wait for the cancel (or completed read) to finalize.
-            _winapi.WaitForSingleObject(ov.event, 1000)
             try:
-                _, err = ov.GetOverlappedResult(False)
+                _, err = ov.GetOverlappedResult(True)
             except OSError as e:
                 err = e.winerror
                 # Cancellation is expected here; broken/disconnected pipes should be

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -433,13 +433,25 @@ def ready_to_read(conns: Sequence[IPCBase], timeout: float | None = None) -> lis
             # Wait for the cancel (or completed read) to finalize.
             _winapi.WaitForSingleObject(ov.event, 1000)
             try:
-                ov.GetOverlappedResult(False)
-            except OSError:
+                _, err = ov.GetOverlappedResult(False)
+            except OSError as e:
+                err = e.winerror
+                # Cancellation is expected here; broken/disconnected pipes should be
+                # surfaced as readable so the follow-up receive observes EOF/closure.
+                if err not in (
+                    _winapi.ERROR_OPERATION_ABORTED,
+                    _winapi.ERROR_BROKEN_PIPE,
+                    _winapi.ERROR_NETNAME_DELETED,
+                ):
+                    # Anything else is a real IPC failure, not part of the probe race.
+                    raise
+            if err == _winapi.ERROR_OPERATION_ABORTED:
                 # Operation was successfully cancelled -- no data consumed.
                 continue
-            data = ov.getbuffer()
-            if data:
-                conns[i].buffer.extend(data)
+            if err == 0:
+                data = ov.getbuffer()
+                if data:
+                    conns[i].buffer.extend(data)
             ready.append(i)
 
         return ready

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -421,28 +421,26 @@ def ready_to_read(conns: Sequence[IPCBase], timeout: float | None = None) -> lis
                     ov.cancel()
                 raise IPCException(f"Failed to wait for connections: {_winapi.GetLastError()}")
 
-        # Check which pending operations completed, cancel the rest
+        # Cancel all pending operations. CancelIoEx is asynchronous, so an
+        # operation may have completed before the cancel took effect. We then
+        # wait for all operations to finalize and check each result: completed
+        # reads get their data saved and are marked ready; cancelled ones are
+        # simply skipped. This avoids a race between checking if an operation
+        # is signaled and cancelling it.
+        for _, ov in pending:
+            ov.cancel()
         for i, ov in pending:
-            if _winapi.WaitForSingleObject(ov.event, 0) == _winapi.WAIT_OBJECT_0:
-                _, err = ov.GetOverlappedResult(True)
-                data = ov.getbuffer()
-                if data:
-                    conns[i].buffer.extend(data)
-                ready.append(i)
-            else:
-                ov.cancel()
-                # CancelIoEx is asynchronous -- wait for it to finalize so we
-                # can tell whether the read actually completed before the cancel
-                # took effect.  If it did, the byte has been consumed from the
-                # pipe and must be preserved in the connection buffer.
-                if _winapi.WaitForSingleObject(ov.event, 1000) == _winapi.WAIT_OBJECT_0:
-                    try:
-                        ov.GetOverlappedResult(False)
-                    except OSError:
-                        continue
-                    data = ov.getbuffer()
-                    if data:
-                        conns[i].buffer.extend(data)
+            # Wait for the cancel (or completed read) to finalize.
+            _winapi.WaitForSingleObject(ov.event, 1000)
+            try:
+                ov.GetOverlappedResult(False)
+            except OSError:
+                # Operation was successfully cancelled -- no data consumed.
+                continue
+            data = ov.getbuffer()
+            if data:
+                conns[i].buffer.extend(data)
+            ready.append(i)
 
         return ready
 

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -431,6 +431,18 @@ def ready_to_read(conns: Sequence[IPCBase], timeout: float | None = None) -> lis
                 ready.append(i)
             else:
                 ov.cancel()
+                # CancelIoEx is asynchronous -- wait for it to finalize so we
+                # can tell whether the read actually completed before the cancel
+                # took effect.  If it did, the byte has been consumed from the
+                # pipe and must be preserved in the connection buffer.
+                if _winapi.WaitForSingleObject(ov.event, 1000) == _winapi.WAIT_OBJECT_0:
+                    try:
+                        ov.GetOverlappedResult(False)
+                    except OSError:
+                        continue
+                    data = ov.getbuffer()
+                    if data:
+                        conns[i].buffer.extend(data)
 
         return ready
 

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -448,7 +448,7 @@ def ready_to_read(conns: Sequence[IPCBase], timeout: float | None = None) -> lis
             if err == _winapi.ERROR_OPERATION_ABORTED:
                 # Operation was successfully cancelled -- no data consumed.
                 continue
-            if err == 0:
+            if err in (0, _winapi.ERROR_MORE_DATA):
                 data = ov.getbuffer()
                 if data:
                     conns[i].buffer.extend(data)


### PR DESCRIPTION
Cancellation is asynchronous, so some data could be read after calling `cancel()`. Rework `ready_to_read` to first cancel all operations and then check for each if data is available.

See discussion in #21221 for more context.

I heavily relied on coding agent assist for this, but I did multiple review iterations and refinements.