### PR TITLE
[mypyc] Fix `@property` getter memory leak

### DIFF
--- a/mypyc/irbuild/builder.py
+++ b/mypyc/irbuild/builder.py
@@ -1553,8 +1553,7 @@ class IRBuilder:
         return (
             isinstance(obj_rtype, RInstance)
             and obj_rtype.class_ir.is_ext_class
-            and obj_rtype.class_ir.has_attr(expr.name)
-            and not obj_rtype.class_ir.get_method(expr.name)
+            and any(expr.name in ir.attributes for ir in obj_rtype.class_ir.mro)
         )
 
     def mark_block_unreachable(self) -> None:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -5925,3 +5925,47 @@ assert NonExtDict.BASE == {"x": 1}
 assert NonExtDict.EXTENDED == {"x": 1, "y": 2}
 
 assert NonExtChained.Z == {10, 20, 30}
+
+[case testPropertyGetterLeak]
+class Bar:
+    pass
+
+class Foo:
+    def __init__(self) -> None:
+        self.obj: object = Bar()
+
+    @property
+    def val(self) -> object:
+        return self.obj
+
+[file other.py]
+import gc
+from native import Foo, Bar
+
+def check(foo: Foo) -> bool:
+    return isinstance(foo.val, Bar)
+
+def test_property_getter_no_leak() -> None:
+    foo = Foo()
+    gc.collect()
+    before = gc.get_objects()
+    for _ in range(100):
+        check(foo)
+    gc.collect()
+    after = gc.get_objects()
+    diff = len(after) - len(before)
+    assert diff <= 2, diff
+
+test_property_getter_no_leak()
+
+[file driver.py]
+import sys
+from other import check
+from native import Foo
+
+foo = Foo()
+init = sys.getrefcount(foo.obj)
+for _ in range(100):
+    check(foo)
+after = sys.getrefcount(foo.obj)
+assert after - init == 0, f"Leaked {after - init} refs"

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -5946,10 +5946,10 @@ def check(foo: Foo) -> bool:
     return isinstance(foo.val, Bar)
 
 def test_property_getter_no_leak() -> None:
-    foo = Foo()
     gc.collect()
     before = gc.get_objects()
     for _ in range(100):
+        foo = Foo()
         check(foo)
     gc.collect()
     after = gc.get_objects()


### PR DESCRIPTION
## Issue 

Mypyc can incorrectly borrow references from property getters (owned references).

The borrow mechanism is safe for struct field access since they return a pointer into the object's memory; Property getters on the other hand are method calls that return new owned references i.e the caller must `DECREF` them. If mypyc mistakes a property for a struct field, it skips the `DECREF`, leaking one reference per call.
                                                                                                                                                                                                                                               
I think this affects any expression context that enables borrowing (comparisons, `isinstance`, `is None` checks) when the borrowed expression is a property access on a cross-module class. We discovered this through OOM issues in SQLGlot, where `isinstance(self.this, Func)` (`this` is a `@property`) leaked on every call.
  

## Repro

```Python3                                                                  
  # base.py:
  class Bar:
      pass  
          
  class Foo:
      def __init__(self) -> None:
          self.obj: object = Bar()

      @property
      def val(self) -> object:
          return self.obj  
                                                                  
  # derived.py:
  from base import Foo, Bar
                           
  def check(foo: Foo) -> bool:
      return isinstance(foo.val, Bar)

  # test_leak.py: 
  import sys
  from base import Foo 
  from derived import check    
                           
  foo = Foo()
  init = sys.getrefcount(foo.obj)
  for _ in range(100):     
      check(foo) 
  print(f"Leaked refs: {sys.getrefcount(foo.obj) - init}")
```
                                                                                                                                                                                                                                               
Compile both with mypyc passing in `PYTHONHASHSEED=3` prints `Leaked refs: 100`.
                                                                                                                                                                                                                                           
## Root cause                                                                                                                                                                                                                                   

1. `is_native_attr_ref()` decides if an attribute access can safely borrow by checking `has_attr(name) and not get_method(name)` i.e "if there's an attribute but no method, it's a struct field".                                                       
2. Although `has_attr()` is always fully populated, `get_method()` depends on whether the class's module (`base` in this case) has been compiled yet. 
3. Modules within an SCC are compiled in nondeterministic order; If the module defining the property hasn't been compiled yet -> `get_method()` returns `None` -> `is_native_attr_ref` incorrectly treats the property as a borrowed struct field.

I think there's a broader issue here: Even when `derived.py` imports from `base.py` (no cycle), mypyc can place them in the same SCC and compile derived before base. Since `ir.methods` is only populated when a module's function bodies are compiled, any code that reads `ir.methods` (i.e `get_methods`) during compilation of a different module in the same SCC could have similar order-dependent bugs. 
                                                                                                                                                                                                                                
## The suggested fix                                                         

Check `ir.attributes` directly (struct fields only, always populated) instead of the unreliable `get_method`. I believe this is the getter-side counterpart to #21095 which fixed the same class of bug for property setters.                                                                                                                                        
   

                                                                                                     