### PR TITLE
[mypyc] Resolve type aliases in function specialization 

### DIFF
--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -84,7 +84,7 @@ from mypyc.ir.rtypes import (
     string_writer_rprimitive,
     uint8_rprimitive,
 )
-from mypyc.irbuild.builder import IRBuilder
+from mypyc.irbuild.builder import IRBuilder, get_call_target_fullname
 from mypyc.irbuild.constant_fold import constant_fold_expr
 from mypyc.irbuild.for_helpers import (
     comprehension_helper,
@@ -198,7 +198,7 @@ def apply_function_specialization(
     builder: IRBuilder, expr: CallExpr, callee: RefExpr
 ) -> Value | None:
     """Invoke the Specializer callback for a function if one has been registered"""
-    return _apply_specialization(builder, expr, callee, callee.fullname)
+    return _apply_specialization(builder, expr, callee, get_call_target_fullname(callee))
 
 
 def apply_method_specialization(

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -1196,8 +1196,7 @@ def f():
     r4 :: i32
     r5 :: bit
     r6 :: short_int
-    r7 :: object
-    r8 :: tuple
+    r7 :: tuple
 L0:
     r0 = PyList_New(0)
     r1 = 0
@@ -1215,9 +1214,8 @@ L3:
     r1 = r6
     goto L1
 L4:
-    r7 = PyObject_GetIter(r0)
-    r8 = PySequence_Tuple(r7)
-    return r8
+    r7 = PyList_AsTuple(r0)
+    return r7
 def f2():
     r0 :: list
     r1 :: short_int

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -1177,3 +1177,74 @@ L2:
     r3 = 1
 L3:
     return r3
+
+[case testTupleTypeAliasFromGenerator]
+X = tuple[str, ...]
+
+def f() -> tuple[str, ...]:
+    return X(str(x) for x in range(5))
+
+def f2() -> tuple[str, ...]:
+    return tuple(str(x) for x in range(5))
+[out]
+def f():
+    r0 :: list
+    r1 :: short_int
+    x :: int
+    r2 :: bit
+    r3 :: str
+    r4 :: i32
+    r5 :: bit
+    r6 :: short_int
+    r7 :: object
+    r8 :: tuple
+L0:
+    r0 = PyList_New(0)
+    r1 = 0
+    x = r1
+L1:
+    r2 = int_lt r1, 10
+    if r2 goto L2 else goto L4 :: bool
+L2:
+    x = r1
+    r3 = CPyTagged_Str(x)
+    r4 = PyList_Append(r0, r3)
+    r5 = r4 >= 0 :: signed
+L3:
+    r6 = r1 + 2
+    r1 = r6
+    goto L1
+L4:
+    r7 = PyObject_GetIter(r0)
+    r8 = PySequence_Tuple(r7)
+    return r8
+def f2():
+    r0 :: list
+    r1 :: short_int
+    x :: int
+    r2 :: bit
+    r3 :: str
+    r4 :: i32
+    r5 :: bit
+    r6 :: short_int
+    r7 :: tuple
+L0:
+    r0 = PyList_New(0)
+    r1 = 0
+    x = r1
+L1:
+    r2 = int_lt r1, 10
+    if r2 goto L2 else goto L4 :: bool
+L2:
+    x = r1
+    r3 = CPyTagged_Str(x)
+    r4 = PyList_Append(r0, r3)
+    r5 = r4 >= 0 :: signed
+L3:
+    r6 = r1 + 2
+    r1 = r6
+    goto L1
+L4:
+    r7 = PyList_AsTuple(r0)
+    return r7
+

--- a/mypyc/test-data/irbuild-tuple.test
+++ b/mypyc/test-data/irbuild-tuple.test
@@ -1245,4 +1245,3 @@ L3:
 L4:
     r7 = PyList_AsTuple(r0)
     return r7
-


### PR DESCRIPTION
Attempt to resolve aliased types when applying function specializations, allowing for some optimizations that wouldn't be caught otherwise.

Still acclimating to the codebase, so if this makes sense to implement somewhere else let me know.