### PR TITLE
Don't suggest Foo[...] when Foo(arg=...) is used in annotation

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -1958,7 +1958,10 @@ class TypeConverter:
         if not isinstance(self.parent(), ast3.List):
             note = None
             if constructor:
-                note = "Suggestion: use {0}[...] instead of {0}(...)".format(constructor)
+                if e.keywords:
+                    note = "Cannot use a function call in a type annotation"
+                else:
+                    note = "Suggestion: use {0}[...] instead of {0}(...)".format(constructor)
             return self.invalid_type(e, note=note)
         if not constructor:
             self.fail(message_registry.ARG_CONSTRUCTOR_NAME_EXPECTED, e.lineno, e.col_offset)

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -207,6 +207,17 @@ def f(a: Foo(int)) -> int:
 main:7: error: Invalid type comment or annotation
 main:7: note: Suggestion: use Foo[...] instead of Foo(...)
 
+[case testFasterParseCallWithKeywordArgs_no_native_parse]
+
+def Foo(sort: bool) -> type:
+    return int
+
+def f(a: Foo(sort=True)) -> int:
+    pass
+[out]
+main:5: error: Invalid type comment or annotation
+main:5: note: Cannot use a function call in a type annotation
+
 [case testFastParseMatMul]
 
 from typing import Any


### PR DESCRIPTION
## Summary

Fixes #16506

When a function call with keyword arguments appears in a type annotation (e.g., `Foo(sort=True)`), mypy was suggesting `use Foo[...] instead of Foo(...)`. This suggestion is misleading because `Foo[sort=True]` is a syntax error -- the user likely intended a function call (e.g., returning `Annotated[...]`), not a type parameterization.

This PR changes the behavior so that:
- When keyword arguments are present (e.g., `Foo(sort=True)`), mypy shows `Cannot use a function call in a type annotation` instead of the misleading `Foo[...]` suggestion.
- When only positional arguments are used (e.g., `Foo(int)`), the existing `Suggestion: use Foo[...] instead of Foo(...)` message is preserved, since the user likely meant `Foo[int]`.

## Changes

- `mypy/fastparse.py`: In `visit_Call`, check `e.keywords` before choosing which note to attach. If the call has keyword arguments, use a generic "cannot call" message instead of suggesting bracket syntax.
- `test-data/unit/check-fastparse.test`: Added a test case for the keyword argument scenario.

## Test plan

- [x] Existing test `testFasterParseTypeErrorCustom_no_native_parse` still passes (positional args get `Foo[...]` suggestion)
- [x] New test `testFasterParseCallWithKeywordArgs_no_native_parse` passes (keyword args get "Cannot use a function call" message)
- [x] All 39 fastparse-related tests pass
- [x] Manual verification with reproduction script from the issue