### PR TITLE
Un-support narrowing final globals in functions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1659,10 +1659,6 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         Note that this doesn't do a full CFG analysis but uses a line number based
         heuristic that isn't correct in some (rare) cases.
         """
-        if v.is_final:
-            # Final vars are definitely never reassigned.
-            return False
-
         outers = self.tscope.outer_functions()
         if not outers:
             # Top-level function -- outer context is top level, and we can't reason about

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1238,9 +1238,7 @@ def check_final_init() -> None:
     new_instance.__init__()
 [builtins fixtures/tuple.pyi]
 
--- This is tricky and expensive to support in parallel mode.
--- We may want to stop supporting this niche use case
-[case testNarrowingOfFinalPersistsInFunctions_no_parallel]
+[case testNarrowingOfFinalInFunctionsNotSpecial]
 from typing import Final, Union
 
 def _init() -> Union[int, None]:
@@ -1249,18 +1247,17 @@ def _init() -> Union[int, None]:
 FOO: Final = _init()
 
 class Example:
-
     if FOO is not None:
         reveal_type(FOO)  # N: Revealed type is "builtins.int"
 
         def fn(self) -> int:
-            return FOO
+            return FOO  # E: Incompatible return value type (got "int | None", expected "int")
 
 if FOO is not None:
     reveal_type(FOO)  # N: Revealed type is "builtins.int"
 
     def func() -> int:
-        return FOO
+        return FOO  # E: Incompatible return value type (got "int | None", expected "int")
 
 [case testDisjointBase]
 from typing_extensions import disjoint_base


### PR DESCRIPTION
As discussed in https://github.com/python/mypy/pull/21119 this niche use case is tricky to support in parallel mode.

cc @JukkaL 