### PR TITLE
Initial support for Python 3.15.0a8

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,6 +1,7 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
 # and the pins in setup.py
-typing_extensions>=4.6.0
+typing_extensions>=4.6.0; python_version<'3.15'
+typing_extensions>=4.14.0; python_version>='3.15'
 mypy_extensions>=1.0.0
 pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'

--- a/mypyc/lib-rt/misc_ops.c
+++ b/mypyc/lib-rt/misc_ops.c
@@ -1158,6 +1158,9 @@ void CPyTrace_LogEvent(const char *location, const char *line, const char *op, c
 typedef struct {
     PyObject_HEAD
     PyObject *name;
+#if CPY_3_15_FEATURES
+    PyObject *qualname;
+#endif
     PyObject *type_params;
     PyObject *compute_value;
     PyObject *value;

--- a/mypyc/lib-rt/mypyc_util.h
+++ b/mypyc/lib-rt/mypyc_util.h
@@ -160,6 +160,7 @@ static inline CPyTagged CPyTagged_ShortFromSsize_t(Py_ssize_t x) {
 #define CPY_3_11_FEATURES (PY_VERSION_HEX >= 0x030b0000)
 #define CPY_3_12_FEATURES (PY_VERSION_HEX >= 0x030c0000)
 #define CPY_3_14_FEATURES (PY_VERSION_HEX >= 0x030e0000)
+#define CPY_3_15_FEATURES (PY_VERSION_HEX >= 0x030f0000)
 
 #if CPY_3_12_FEATURES
 

--- a/mypyc/test-data/run-base64.test
+++ b/mypyc/test-data/run-base64.test
@@ -211,6 +211,11 @@ def test_urlsafe_b64decode_errors() -> None:
     for b in b"eA", b"eA=", b"eHk":
         with assertRaises(ValueError):
             b64decode(b)
+[out version>=3.15]
+driver.py:28: FutureWarning: invalid character '+' in URL-safe Base64 data will be discarded in future Python versions
+  test_func()
+driver.py:28: FutureWarning: invalid character '/' in URL-safe Base64 data will be discarded in future Python versions
+  test_func()
 
 [case testBase64UsedAtTopLevelOnly_librt]
 from librt.base64 import b64encode

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -971,7 +971,10 @@ print(z)
 [case testCheckVersion]
 import sys
 
-if sys.version_info[:2] == (3, 14):
+if sys.version_info[:2] == (3, 15):
+    def version() -> int:
+        return 15
+elif sys.version_info[:2] == (3, 14):
     def version() -> int:
         return 14
 elif sys.version_info[:2] == (3, 13):

--- a/mypyc/test-data/run-python312.test
+++ b/mypyc/test-data/run-python312.test
@@ -199,6 +199,7 @@ EnumLiteralAlias3 = Literal[SomeEnum.AVALUE] | None
 [typing fixtures/typing-full.pyi]
 
 [case testPEP695GenericTypeAlias]
+import sys
 from typing import Callable
 from types import GenericAlias
 
@@ -208,24 +209,36 @@ type A[T] = list[T]
 
 def test_generic_alias() -> None:
     assert type(A[str]) is GenericAlias
-    assert str(A[str]) == "A[str]"
+    if sys.version_info >= (3, 15):  # type: ignore[operator]
+        assert str(A[str]) == "_frozen_importlib.A[str]"
+    else:
+        assert str(A[str]) == "A[str]"
     assert str(getattr(A, "__value__")) == "list[T]"
 
 type B[T, S] = dict[S, T]
 
 def test_generic_alias_with_two_args() -> None:
-    assert str(B[str, int]) == "B[str, int]"
+    if sys.version_info >= (3, 15):   # type: ignore[operator]
+        assert str(B[str, int]) == "_frozen_importlib.B[str, int]"
+    else:
+        assert str(B[str, int]) == "B[str, int]"
     assert str(getattr(B, "__value__")) == "dict[S, T]"
 
 type C[*Ts] = tuple[*Ts]
 
 def test_type_var_tuple_type_alias() -> None:
-    assert str(C[int, str]) == "C[int, str]"
+    if sys.version_info >= (3, 15):   # type: ignore[operator]
+        assert str(C[int, str]) == "_frozen_importlib.C[int, str]"
+    else:
+        assert str(C[int, str]) == "C[int, str]"
     assert str(getattr(C, "__value__")) == "tuple[typing.Unpack[Ts]]"
 
 type D[**P] = Callable[P, int]
 
 def test_param_spec_type_alias() -> None:
-    assert str(D[[int, str]]) == "D[[int, str]]"
+    if sys.version_info >= (3, 15):   # type: ignore[operator]
+        assert str(D[[int, str]]) == "_frozen_importlib.D[[int, str]]"
+    else:
+        assert str(D[[int, str]]) == "D[[int, str]]"
     assert str(getattr(D, "__value__")) == "typing.Callable[P, int]"
 [typing fixtures/typing-full.pyi]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ requires = [
     # self-typechecking :/
     "setuptools >= 77.0.3",
     # the following is from mypy-requirements.txt/setup.py
-    "typing_extensions>=4.6.0",
+    "typing_extensions>=4.6.0; python_version<'3.15'",
+    "typing_extensions>=4.14.0; python_version>='3.15'",
     "mypy_extensions>=1.0.0",
     "pathspec>=1.0.0",
     "tomli>=1.1.0; python_version<'3.11'",
@@ -49,7 +50,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   # When changing this, also update build-system.requires and mypy-requirements.txt
-  "typing_extensions>=4.6.0",
+  "typing_extensions>=4.6.0; python_version<'3.15'",
+  "typing_extensions>=4.14.0; python_version>='3.15'",
   "mypy_extensions>=1.0.0",
   "pathspec>=1.0.0",
   "tomli>=1.1.0; python_version<'3.11'",


### PR DESCRIPTION
Some minor changes to be able to compile mypy with mypyc on Python 3.15.0a8.

- Update `typing-extensions` to `>=4.14.0` for Python `>=3.15` due to the removal of `typing.no_type_check_decorator`
https://github.com/python/cpython/issues/133601
https://docs.python.org/3/library/typing.html#typing.no_type_check_decorator
https://github.com/python/typing_extensions/blob/4.14.0/CHANGELOG.md
- `TypeAliasType.__qualname__` was added in https://github.com/python/cpython/issues/139817
- Some new FutureWarnings for b64_decode
https://github.com/python/cpython/issues/125346
https://github.com/python/cpython/pull/141128
