### PR TITLE
Cleanup some more tests after dropping 3.9 support

### DIFF
--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -986,9 +986,6 @@ elif sys.version_info[:2] == (3, 11):
 elif sys.version_info[:2] == (3, 10):
     def version() -> int:
         return 10
-elif sys.version_info[:2] == (3, 9):
-    def version() -> int:
-        return 9
 else:
     raise Exception("we don't support this version yet!")
 

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -378,7 +378,6 @@ class Application:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOrderingKwOnly]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 
 @dataclass(kw_only=True)
@@ -398,7 +397,6 @@ Application(rating='name', name=123) # E: Argument "rating" to "Application" has
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOrderingKwOnlyOnField]
-# flags: --python-version 3.10
 from dataclasses import dataclass, field
 
 @dataclass
@@ -417,7 +415,6 @@ Application(123, rating='name') # E: Argument 1 to "Application" has incompatibl
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOrderingKwOnlyOnFieldFalse]
-# flags: --python-version 3.10
 from dataclasses import dataclass, field
 
 @dataclass
@@ -434,7 +431,6 @@ Application('name')  # E: Too few arguments for "Application"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOrderingKwOnlyWithSentinel]
-# flags: --python-version 3.10
 from dataclasses import dataclass, KW_ONLY
 
 @dataclass
@@ -453,7 +449,6 @@ Application('name', rating=123)  # E: Too many positional arguments for "Applica
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOrderingKwOnlyWithSentinelAndFieldOverride]
-# flags: --python-version 3.10
 from dataclasses import dataclass, field, KW_ONLY
 
 @dataclass
@@ -473,7 +468,6 @@ Application(123, rating=123)  # E: "Application" gets multiple values for keywor
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOrderingKwOnlyWithSentinelAndSubclass]
-# flags: --python-version 3.10
 from dataclasses import dataclass, field, KW_ONLY
 
 @dataclass
@@ -500,7 +494,6 @@ D(123, False)  # E: Argument 1 to "D" has incompatible type "int"; expected "str
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesOrderingKwOnlyWithMultipleSentinel]
-# flags: --python-version 3.10
 from dataclasses import dataclass, field, KW_ONLY
 
 @dataclass
@@ -1427,7 +1420,6 @@ reveal_type(Foo(bar=1.5))  # N: Revealed type is "__main__.Foo"
 [typing fixtures/typing-typeddict.pyi]
 
 [case testDataclassWithSlotsArg]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 
 @dataclass(slots=True)
@@ -1443,7 +1435,6 @@ class Some:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassWithSlotsDef]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 
 @dataclass(slots=False)
@@ -1460,7 +1451,6 @@ class Some:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassWithSlotsDerivedFromNonSlot]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 
 class A:
@@ -1476,7 +1466,6 @@ class B(A):
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassWithSlotsConflict]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 
 @dataclass(slots=True)
@@ -1498,7 +1487,6 @@ class DynamicDef:  # E: "DynamicDef" both defines "__slots__" and is used with "
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassWithSlotsRuntimeAttr]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 
 @dataclass(slots=True)
@@ -1527,7 +1515,6 @@ NoSlots.__slots__  # E: "type[NoSlots]" has no attribute "__slots__"
 
 
 [case testSlotsDefinitionWithTwoPasses1]
-# flags: --python-version 3.10
 # https://github.com/python/mypy/issues/11821
 from typing import TypeVar, Protocol, Generic
 from dataclasses import dataclass
@@ -1545,7 +1532,6 @@ class Node(Generic[V]):  # Error was here
 [builtins fixtures/dataclasses.pyi]
 
 [case testSlotsDefinitionWithTwoPasses2]
-# flags: --python-version 3.10
 from typing import TypeVar, Protocol, Generic
 from dataclasses import dataclass
 
@@ -1563,7 +1549,6 @@ class Node(Generic[V]):  # E: "Node" both defines "__slots__" and is used with "
 [builtins fixtures/dataclasses.pyi]
 
 [case testSlotsDefinitionWithTwoPasses3]
-# flags: --python-version 3.10
 from typing import TypeVar, Protocol, Generic
 from dataclasses import dataclass
 
@@ -1581,7 +1566,6 @@ class Node(Generic[V]):  # E: "Node" both defines "__slots__" and is used with "
 [builtins fixtures/dataclasses.pyi]
 
 [case testSlotsDefinitionWithTwoPasses4]
-# flags: --python-version 3.10
 import dataclasses as dtc
 
 PublishedMessagesVar = dict[int, 'PublishedMessages']
@@ -1592,7 +1576,6 @@ class PublishedMessages:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassSlotsWithDeferredBase]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 
 @dataclass
@@ -1653,7 +1636,6 @@ def foo() -> None:
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassesMultipleInheritanceWithNonDataclass]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 
 @dataclass
@@ -1828,7 +1810,6 @@ class MyClass(MyGeneric[MyDataclass]): ...
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassWithMatchArgs]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 @dataclass
 class One:
@@ -1849,7 +1830,6 @@ reveal_type(e.__match_args__)  # N: Revealed type is "tuple[()]"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassWithMatchArgsAndKwOnly]
-# flags: --python-version 3.10
 from dataclasses import dataclass, field
 @dataclass(kw_only=True)
 class One:
@@ -1865,7 +1845,6 @@ reveal_type(Two.__match_args__)  # N: Revealed type is "tuple[Literal['a']]"
 [builtins fixtures/dataclasses.pyi]
 
 [case testDataclassWithoutMatchArgs]
-# flags: --python-version 3.10
 from dataclasses import dataclass
 @dataclass(match_args=False)
 class One:

--- a/test-data/unit/check-generic-alias.test
+++ b/test-data/unit/check-generic-alias.test
@@ -150,7 +150,7 @@ t23: collections.abc.ValuesView[str]
 [builtins fixtures/tuple.pyi]
 
 [case testGenericAliasIsinstanceUnreachable]
-# flags: --warn-unreachable --python-version 3.10
+# flags: --warn-unreachable
 from collections.abc import Iterable
 
 class A: ...
@@ -165,7 +165,7 @@ def test(dependencies: list[A] | None) -> None:
 [typing fixtures/typing-full.pyi]
 
 [case testGenericAliasRedundantExprCompoundIfExpr]
-# flags: --warn-unreachable --enable-error-code=redundant-expr --python-version 3.10
+# flags: --warn-unreachable --enable-error-code=redundant-expr
 
 from typing import Any, reveal_type
 from collections.abc import Iterable

--- a/test-data/unit/check-generic-subtyping.test
+++ b/test-data/unit/check-generic-subtyping.test
@@ -872,7 +872,6 @@ main:15: error: Item "V" of the upper bound "U | V | W" of type variable "T" has
 
 
 [case testTypeVarBoundToNewUnionAttributeAccess]
-# flags: --python-version 3.10
 from typing import TypeVar
 
 class U:
@@ -891,12 +890,12 @@ def f(x: T) -> None:
 
 [builtins fixtures/tuple.pyi]
 [out]
-main:14: error: Item "V" of the upper bound "U | V | W" of type variable "T" has no attribute "a"
-main:14: error: Item "W" of the upper bound "U | V | W" of type variable "T" has no attribute "a"
-main:15: error: Item "U" of the upper bound "U | V | W" of type variable "T" has no attribute "b"
-main:15: error: Item "W" of the upper bound "U | V | W" of type variable "T" has no attribute "b"
-main:16: error: Item "U" of the upper bound "U | V | W" of type variable "T" has no attribute "c"
-main:16: error: Item "V" of the upper bound "U | V | W" of type variable "T" has no attribute "c"
+main:13: error: Item "V" of the upper bound "U | V | W" of type variable "T" has no attribute "a"
+main:13: error: Item "W" of the upper bound "U | V | W" of type variable "T" has no attribute "a"
+main:14: error: Item "U" of the upper bound "U | V | W" of type variable "T" has no attribute "b"
+main:14: error: Item "W" of the upper bound "U | V | W" of type variable "T" has no attribute "b"
+main:15: error: Item "U" of the upper bound "U | V | W" of type variable "T" has no attribute "c"
+main:15: error: Item "V" of the upper bound "U | V | W" of type variable "T" has no attribute "c"
 
 
 [case testSubtypingIterableUnpacking1]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -7055,7 +7055,6 @@ def guard(x: object) -> TypeIs[int]:
 [builtins fixtures/tuple.pyi]
 
 [case testStartUsingPEP604Union]
-# flags: --python-version 3.10
 import a
 [file a.py]
 import lib

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -3623,7 +3623,7 @@ if x:
 [builtins fixtures/dict.pyi]
 
 [case testAllowPlainNoneForPartialAtModuleScope]
-# flags: --local-partial-types --python-version 3.10
+# flags: --local-partial-types
 x = None
 reveal_type(x)  # N: Revealed type is "None"
 

--- a/test-data/unit/check-namedtuple.test
+++ b/test-data/unit/check-namedtuple.test
@@ -1155,7 +1155,6 @@ def f(fields) -> None:
 [builtins fixtures/tuple.pyi]
 
 [case testNamedTupleHasMatchArgs]
-# flags: --python-version 3.10
 from typing import NamedTuple
 class One(NamedTuple):
     bar: int

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -1689,7 +1689,7 @@ else:
 
 
 [case testNarrowingWithTupleOfTypesPy310Plus]
-# flags: --python-version 3.10 --strict-equality --warn-unreachable
+# flags: --strict-equality --warn-unreachable
 class Base: ...
 
 class Impl1(Base): ...
@@ -2373,7 +2373,7 @@ def f(cls: Type[Union[None, int]]) -> None:
 [builtins fixtures/isinstance.pyi]
 
 [case testNarrowingIsSubclassNoneType4]
-# flags: --python-version 3.10 --strict-equality --warn-unreachable
+# flags: --strict-equality --warn-unreachable
 
 from types import NoneType
 from typing import Type, Union
@@ -2386,7 +2386,7 @@ def f(cls: Type[Union[None, int]]) -> None:
 [builtins fixtures/isinstance.pyi]
 
 [case testNarrowingIsInstanceNoIntersectionWithFinalTypeAndNoneType]
-# flags: --warn-unreachable --python-version 3.10 --strict-equality
+# flags: --warn-unreachable --strict-equality
 
 from types import NoneType
 from typing import final
@@ -2620,7 +2620,7 @@ def foo(location: ParameterLocation):
 [builtins fixtures/primitives.pyi]
 
 [case testConsistentNarrowingEqAndIn]
-# flags: --python-version 3.10 --strict-equality --warn-unreachable
+# flags: --strict-equality --warn-unreachable
 
 # https://github.com/python/mypy/issues/17864
 def f(x: str | int) -> None:
@@ -2636,7 +2636,7 @@ def f(x: str | int) -> None:
 [builtins fixtures/primitives.pyi]
 
 [case testConsistentNarrowingEqAndInWithCustomEq]
-# flags: --python-version 3.10 --strict-equality --warn-unreachable
+# flags: --strict-equality --warn-unreachable
 
 # https://github.com/python/mypy/issues/17864
 class C:
@@ -3063,7 +3063,7 @@ reveal_type(t.foo)  # N: Revealed type is "__main__.C"
 [builtins fixtures/property.pyi]
 
 [case testNarrowingNotImplemented]
-# flags: --python-version 3.10 --warn-unreachable
+# flags: --warn-unreachable
 from __future__ import annotations
 import types
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -142,7 +142,6 @@ reveal_type(whatever(217))  # N: Revealed type is "builtins.list[builtins.int]"
 [builtins fixtures/paramspec.pyi]
 
 [case testInvalidParamSpecType]
-# flags: --python-version 3.10
 from typing import ParamSpec
 
 P = ParamSpec("P")

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1788,7 +1788,6 @@ NoSlots.__slots__  # E: "type[NoSlots]" has no attribute "__slots__"
 [builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsWithMatchArgs]
-# flags: --python-version 3.10
 import attr
 
 @attr.s(match_args=True, auto_attribs=True)
@@ -1804,7 +1803,6 @@ reveal_type(ToMatch(1, 2, z=3).__match_args__)      # N: Revealed type is "tuple
 [builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsWithMatchArgsDefaultCase]
-# flags: --python-version 3.10
 import attr
 
 @attr.s(auto_attribs=True)
@@ -1825,7 +1823,6 @@ reveal_type(t2.__match_args__)  # N: Revealed type is "tuple[Literal['x']?, Lite
 [builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsWithMatchArgsOverrideExisting]
-# flags: --python-version 3.10
 import attr
 from typing import Final
 
@@ -1848,7 +1845,6 @@ reveal_type(WithoutMatch(x=1, y=2).__match_args__)  # N: Revealed type is "tuple
 [builtins fixtures/plugin_attrs.pyi]
 
 [case testAttrsMultipleInheritance]
-# flags: --python-version 3.10
 import attr
 
 @attr.s
@@ -2169,7 +2165,6 @@ reveal_type(a2)  # N: Revealed type is "__main__.A[builtins.int]"
 [builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveUnion]
-# flags: --python-version 3.10
 from typing import Generic, TypeVar
 import attrs
 
@@ -2199,7 +2194,6 @@ a2 = attrs.evolve(a_or_b, x=42, y=True, w={})  # E: Argument "w" to "evolve" of 
 [builtins fixtures/plugin_attrs.pyi]
 
 [case testEvolveUnionOfTypeVar]
-# flags: --python-version 3.10
 import attrs
 from typing import TypeVar
 

--- a/test-data/unit/check-type-aliases.test
+++ b/test-data/unit/check-type-aliases.test
@@ -956,7 +956,6 @@ c.SpecialExplicit = 4
 [typing fixtures/typing-medium.pyi]
 
 [case testNewStyleUnionInTypeAliasWithMalformedInstance]
-# flags: --python-version 3.10
 from typing import List
 
 A = List[int, str] | int  # E: "list" expects 1 type argument, but 2 given

--- a/test-data/unit/check-union-error-syntax.test
+++ b/test-data/unit/check-union-error-syntax.test
@@ -1,37 +1,32 @@
 [case testOrErrorSyntax]
-# flags: --python-version 3.10
 from typing import Union
 x : Union[bool, str]
 x = 3 # E: Incompatible types in assignment (expression has type "int", variable has type "bool | str")
 
 [case testOrNoneErrorSyntax]
-# flags: --python-version 3.10
 from typing import Union
 x : Union[bool, None]
 x = 3 # E: Incompatible types in assignment (expression has type "int", variable has type "bool | None")
 
 [case testNoneAsFinalItem]
-# flags: --python-version 3.10
 from typing import Union
 x : Union[bool, None, str]
 x = 3 # E: Incompatible types in assignment (expression has type "int", variable has type "bool | str | None")
 
 [case testLiteralOrErrorSyntax]
-# flags: --python-version 3.10
 from typing import Literal, Union
 x : Union[Literal[1], Literal[2], str]
 x = 3 # E: Incompatible types in assignment (expression has type "Literal[3]", variable has type "Literal[1, 2] | str")
 [builtins fixtures/tuple.pyi]
 
 [case testLiteralOrNoneErrorSyntax]
-# flags: --python-version 3.10
 from typing import Literal, Union
 x : Union[Literal[1], None]
 x = 3 # E: Incompatible types in assignment (expression has type "Literal[3]", variable has type "Literal[1] | None")
 [builtins fixtures/tuple.pyi]
 
 [case testOrSyntaxRecombined]
-# flags: --python-version 3.10 --allow-redefinition-new --local-partial-types
+# flags: --allow-redefinition-new --local-partial-types
 # The following revealed type is recombined because the finally body is visited twice.
 try:
     x = 1

--- a/test-data/unit/check-union-or-syntax.test
+++ b/test-data/unit/check-union-or-syntax.test
@@ -1,7 +1,6 @@
 -- Type checking of union types with '|' syntax
 
 [case testUnionOrSyntaxWithTwoBuiltinsTypes]
-# flags: --python-version 3.10
 from __future__ import annotations
 def f(x: int | str) -> int | str:
     reveal_type(x)  # N: Revealed type is "builtins.int | builtins.str"
@@ -12,7 +11,6 @@ reveal_type(f)  # N: Revealed type is "def (x: builtins.int | builtins.str) -> b
 [builtins fixtures/tuple.pyi]
 
 [case testUnionOrSyntaxWithThreeBuiltinsTypes]
-# flags: --python-version 3.10
 def f(x: int | str | float) -> int | str | float:
     reveal_type(x)  # N: Revealed type is "builtins.int | builtins.str | builtins.float"
     z: int | str | float = 0
@@ -21,7 +19,6 @@ def f(x: int | str | float) -> int | str | float:
 reveal_type(f)  # N: Revealed type is "def (x: builtins.int | builtins.str | builtins.float) -> builtins.int | builtins.str | builtins.float"
 
 [case testUnionOrSyntaxWithTwoTypes]
-# flags: --python-version 3.10
 class A: pass
 class B: pass
 def f(x: A | B) -> A | B:
@@ -32,7 +29,6 @@ def f(x: A | B) -> A | B:
 reveal_type(f)  # N: Revealed type is "def (x: __main__.A | __main__.B) -> __main__.A | __main__.B"
 
 [case testUnionOrSyntaxWithThreeTypes]
-# flags: --python-version 3.10
 class A: pass
 class B: pass
 class C: pass
@@ -44,24 +40,20 @@ def f(x: A | B | C) -> A | B | C:
 reveal_type(f)  # N: Revealed type is "def (x: __main__.A | __main__.B | __main__.C) -> __main__.A | __main__.B | __main__.C"
 
 [case testUnionOrSyntaxWithLiteral]
-# flags: --python-version 3.10
 from typing import Literal
 reveal_type(Literal[4] | str)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-full.pyi]
 
 [case testUnionOrSyntaxWithBadOperator]
-# flags: --python-version 3.10
 x: 1 + 2  # E: Invalid type comment or annotation
 
 [case testUnionOrSyntaxWithBadOperands]
-# flags: --python-version 3.10
 x: int | 42  # E: Invalid type: try using Literal[42] instead?
 y: 42 | int  # E: Invalid type: try using Literal[42] instead?
 z: str | 42 | int  # E: Invalid type: try using Literal[42] instead?
 
 [case testUnionOrSyntaxWithGenerics]
-# flags: --python-version 3.10
 from typing import List
 x: List[int | str]
 reveal_type(x)  # N: Revealed type is "builtins.list[builtins.int | builtins.str]"
@@ -84,7 +76,6 @@ y: "int | str" = 42
 reveal_type(y)  # N: Revealed type is "builtins.int | builtins.str"
 
 [case testUnionOrSyntaxWithTypeAliasWorking]
-# flags: --python-version 3.10
 T = int | str
 x: T
 reveal_type(x)  # N: Revealed type is "builtins.int | builtins.str"
@@ -116,7 +107,6 @@ from lib import x
 x: int | None
 
 [case testUnionOrSyntaxInMiscRuntimeContexts]
-# flags: --python-version 3.10
 from typing import cast
 
 class C(list[int | None]):
@@ -143,7 +133,6 @@ class C(list[int | None]):
 [builtins fixtures/type.pyi]
 
 [case testUnionOrSyntaxInIsinstance]
-# flags: --python-version 3.10
 class C: pass
 
 def f(x: int | str | C) -> None:
@@ -169,7 +158,6 @@ def f(x: Union[int, str, None]) -> None:
 [builtins fixtures/isinstance.pyi]
 
 [case testImplicit604TypeAliasWithCyclicImportInStub]
-# flags: --python-version 3.10
 from was_builtins import foo
 reveal_type(foo)  # N: Revealed type is "builtins.str | was_mmap.mmap"
 [file was_builtins.pyi]
@@ -183,7 +171,6 @@ class mmap: ...
 [builtins fixtures/type.pyi]
 
 [case testTypeAliasWithNewUnionIsInstance]
-# flags: --python-version 3.10
 SimpleAlias = int | str
 
 def foo(x: int | str | tuple):
@@ -200,7 +187,6 @@ isinstance(5, ParameterizedAlias)
 [builtins fixtures/type.pyi]
 
 [case testIsInstanceUnionNone]
-# flags: --python-version 3.10
 def foo(value: str | bool | None):
     assert not isinstance(value, str | None)
     reveal_type(value)  # N: Revealed type is "builtins.bool"
@@ -213,7 +199,6 @@ def bar(value: object):
 
 # TODO: Get this test to pass
 [case testImplicit604TypeAliasWithCyclicImportNotInStub-xfail]
-# flags: --python-version 3.10
 from was_builtins import foo
 reveal_type(foo)  # N: Revealed type is "Union[builtins.str, was_mmap.mmap]"
 [file was_builtins.py]

--- a/test-data/unit/check-unions.test
+++ b/test-data/unit/check-unions.test
@@ -1334,7 +1334,6 @@ x = y  # E: Incompatible types in assignment (expression has type "C1 | C2 | C3 
        # N: Item in the first union not in the second: "None"
 
 [case testTypeAliasWithOldUnionIsInstance]
-# flags: --python-version 3.10
 from typing import Union
 SimpleAlias = Union[int, str]
 

--- a/test-data/unit/check-vec.test
+++ b/test-data/unit/check-vec.test
@@ -1,5 +1,4 @@
 [case testVecBasics]
-# flags: --python-version 3.10
 from typing import Optional, Any, TypeVar
 
 from librt.vecs import vec

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -10341,7 +10341,6 @@ m.py:5: error: Invalid statement in TypedDict definition; expected "field_name: 
 m.py:5: error: Invalid statement in TypedDict definition; expected "field_name: field_type"
 
 [case testTypeAliasWithNewStyleUnionChangedToVariable]
-# flags: --python-version 3.10
 import a
 
 [file a.py]

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1614,7 +1614,6 @@ _testNarrowTypeForDictKeys.py:13: note: Revealed type is "str"
 _testNarrowTypeForDictKeys.py:15: note: Revealed type is "str | None"
 
 [case testTypeAliasWithNewStyleUnion]
-# flags: --python-version 3.10
 from typing import Literal, Type, TypeAlias, TypeVar
 
 Foo = Literal[1, 2]
@@ -1650,9 +1649,9 @@ def foo(x: T) -> T:
     a: A
     return x
 [out]
-_testTypeAliasWithNewStyleUnion.py:5: note: Revealed type is "typing._SpecialForm"
-_testTypeAliasWithNewStyleUnion.py:25: note: Revealed type is "type[int] | str"
-_testTypeAliasWithNewStyleUnion.py:28: note: Revealed type is "type[int] | str"
+_testTypeAliasWithNewStyleUnion.py:4: note: Revealed type is "typing._SpecialForm"
+_testTypeAliasWithNewStyleUnion.py:24: note: Revealed type is "type[int] | str"
+_testTypeAliasWithNewStyleUnion.py:27: note: Revealed type is "type[int] | str"
 
 [case testTypeAliasWithNewStyleUnionInStub]
 import m
@@ -1753,7 +1752,6 @@ _testTypedDictUnionGetFull.py:11: note: Revealed type is "TypedDict(_testTypedDi
 
 [case testTupleWithDifferentArgsPy310]
 # https://github.com/python/mypy/issues/11098
-# flags: --python-version 3.10
 Correct1 = str | tuple[float, float, str]
 Correct2 = tuple[float] | str
 Correct3 = tuple[float, ...] | str
@@ -1782,15 +1780,15 @@ WrongEllipsis = tuple[float, float, ...] | str  # Error
 
 reveal_type(tuple[int, str]((1, "x")))
 [out]
-_testTupleWithDifferentArgsPy310.py:15: note: Revealed type is "str | tuple[float, float, str]"
-_testTupleWithDifferentArgsPy310.py:16: note: Revealed type is "tuple[float] | str"
-_testTupleWithDifferentArgsPy310.py:17: note: Revealed type is "tuple[float, ...] | str"
-_testTupleWithDifferentArgsPy310.py:18: note: Revealed type is "tuple[float, str]"
-_testTupleWithDifferentArgsPy310.py:19: note: Revealed type is "tuple[float, ...]"
-_testTupleWithDifferentArgsPy310.py:20: note: Revealed type is "list[tuple[int, str]]"
-_testTupleWithDifferentArgsPy310.py:26: error: Invalid type: try using Literal[1] instead?
-_testTupleWithDifferentArgsPy310.py:27: error: Unexpected "..."
-_testTupleWithDifferentArgsPy310.py:29: note: Revealed type is "tuple[int, str]"
+_testTupleWithDifferentArgsPy310.py:14: note: Revealed type is "str | tuple[float, float, str]"
+_testTupleWithDifferentArgsPy310.py:15: note: Revealed type is "tuple[float] | str"
+_testTupleWithDifferentArgsPy310.py:16: note: Revealed type is "tuple[float, ...] | str"
+_testTupleWithDifferentArgsPy310.py:17: note: Revealed type is "tuple[float, str]"
+_testTupleWithDifferentArgsPy310.py:18: note: Revealed type is "tuple[float, ...]"
+_testTupleWithDifferentArgsPy310.py:19: note: Revealed type is "list[tuple[int, str]]"
+_testTupleWithDifferentArgsPy310.py:25: error: Invalid type: try using Literal[1] instead?
+_testTupleWithDifferentArgsPy310.py:26: error: Unexpected "..."
+_testTupleWithDifferentArgsPy310.py:28: note: Revealed type is "tuple[int, str]"
 
 [case testEnumIterMetaInference]
 import socket


### PR DESCRIPTION
Followup to #21243
Remove unnecessary `--python-version 3.10` flags now that 3.10 is the default.