### PR TITLE
stubtest: don't flag __class_getitem__ as missing for PEP 695 generic stubs

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -700,6 +700,10 @@ def verify_typeinfo(
         to_check.discard("__init__")
     if is_runtime_typeddict:
         to_check.discard("__new__")
+    # PEP 695 generic syntax (class Foo[T]: ...) implicitly provides __class_getitem__
+    # at runtime, so don't require an explicit stub definition.
+    if stub.defn.type_args is not None:
+        to_check.discard("__class_getitem__")
 
     for entry in sorted(to_check):
         mangled_entry = entry

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -1825,6 +1825,19 @@ assert annotations
             runtime="class D:\n  def __class_getitem__(cls, type): ...",
             error=None,
         )
+        if sys.version_info >= (3, 12):
+            # PEP 695 generic syntax implicitly provides __class_getitem__ at runtime
+            yield Case(
+                stub="class D2[T]: ...",
+                runtime="class D2:\n    def __class_getitem__(cls, _): return cls",
+                error=None,
+            )
+            # Non-generic stub still reports missing __class_getitem__
+            yield Case(
+                stub="class D3: ...",
+                runtime="class D3:\n    def __class_getitem__(cls, _): return cls",
+                error="D3.__class_getitem__",
+            )
         yield Case(
             stub="class E:\n  def __getitem__(self, item: object) -> object: ...",
             runtime="class E:\n  def __getitem__(self, item: object, /) -> object: ...",


### PR DESCRIPTION
Fixes #21253

When a runtime class defines `__class_getitem__` explicitly and its stub uses PEP 695 generic syntax (`class Foo[T]: ...`), stubtest incorrectly reports that `__class_getitem__` is not present in the stub.

PEP 695 generic syntax implicitly provides `__class_getitem__` at runtime — Python adds it automatically when the class is defined with type parameter syntax. So a stub that uses `class Foo[T]: ...` is correct and should not require an explicit `__class_getitem__` definition.

The fix adds a discard of `__class_getitem__` from the to_check set when the stub class uses PEP 695 syntax (detected via `stub.defn.type_args is not None`), mirroring the existing pattern used for `__init__` in protocol classes and `__new__` in TypedDicts.

Traditional `Generic[T]` subclasses are unaffected since their `type_args` is `None`. Non-generic stubs with a runtime `__class_getitem__` still correctly report an error.