### PR TITLE
Analyse typeddict decorators

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2112,20 +2112,20 @@ class SemanticAnalyzer(
             and defn.info.typeddict_type
             and not has_placeholder(defn.info.typeddict_type)
         ):
-            # This is a valid TypedDict, and it is fully analyzed.
-            for decorator in defn.decorators:
-                decorator.accept(self)
-            return True
-        is_typeddict, info = self.typed_dict_analyzer.analyze_typeddict_classdef(defn)
+            # Don't reprocess everything
+            is_typeddict = True
+            info = defn.info
+        else:
+            is_typeddict, info = self.typed_dict_analyzer.analyze_typeddict_classdef(defn)
         if is_typeddict:
-            for decorator in defn.decorators:
-                decorator.accept(self)
-                if info is not None:
-                    self.analyze_class_decorator_common(defn, info, decorator)
             if info is None:
                 self.mark_incomplete(defn.name, defn)
             else:
                 self.prepare_class_def(defn, info, custom_names=True)
+            for decorator in defn.decorators:
+                decorator.accept(self)
+                if defn.info:
+                    self.analyze_class_decorator_common(defn, decorator)
             return True
         return False
 
@@ -2157,7 +2157,7 @@ class SemanticAnalyzer(
                 with self.scope.class_scope(defn.info):
                     for deco in defn.decorators:
                         deco.accept(self)
-                        self.analyze_class_decorator_common(defn, defn.info, deco)
+                        self.analyze_class_decorator_common(defn, deco)
                     with self.named_tuple_analyzer.save_namedtuple_body(info):
                         self.analyze_class_body_common(defn)
             return True
@@ -2239,7 +2239,7 @@ class SemanticAnalyzer(
 
     def analyze_class_decorator(self, defn: ClassDef, decorator: Expression) -> None:
         decorator.accept(self)
-        self.analyze_class_decorator_common(defn, defn.info, decorator)
+        self.analyze_class_decorator_common(defn, decorator)
         if isinstance(decorator, RefExpr):
             if decorator.fullname in RUNTIME_PROTOCOL_DECOS:
                 if defn.info.is_protocol:
@@ -2251,13 +2251,12 @@ class SemanticAnalyzer(
         ):
             defn.info.dataclass_transform_spec = self.parse_dataclass_transform_spec(decorator)
 
-    def analyze_class_decorator_common(
-        self, defn: ClassDef, info: TypeInfo, decorator: Expression
-    ) -> None:
+    def analyze_class_decorator_common(self, defn: ClassDef, decorator: Expression) -> None:
         """Common method for applying class decorators.
 
         Called on regular classes, typeddicts, and namedtuples.
         """
+        info = defn.info
         if refers_to_fullname(decorator, FINAL_DECORATOR_NAMES):
             info.is_final = True
         elif refers_to_fullname(decorator, DISJOINT_BASE_DECORATOR_NAMES):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2113,6 +2113,8 @@ class SemanticAnalyzer(
             and not has_placeholder(defn.info.typeddict_type)
         ):
             # This is a valid TypedDict, and it is fully analyzed.
+            for decorator in defn.decorators:
+                decorator.accept(self)
             return True
         is_typeddict, info = self.typed_dict_analyzer.analyze_typeddict_classdef(defn)
         if is_typeddict:

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -235,6 +235,20 @@ reveal_type(d)  # N: Revealed type is "TypedDict('__main__.D', {})"
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictDecoratorUndefinedNames]
+from typing import TypedDict
+
+@abc  # E: Name "abc" is not defined
+@efg.hij  # E: Name "efg" is not defined
+@klm[nop]  # E: Name "klm" is not defined \
+           # E: Name "nop" is not defined
+@qrs.tuv[wxy]  # E: Name "qrs" is not defined \
+               # E: Name "wxy" is not defined
+class A(TypedDict):
+    x: int
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testTypedDictWithClassmethodAlternativeConstructorDoesNotCrash]
 # https://github.com/python/mypy/issues/5653
 from typing import TypedDict


### PR DESCRIPTION
Previously, the semantic analyzer's special-case handling for TypedDict (analyze_typeddict_classdef) was returning early without visiting the decorators list in the ClassDef. This caused mypy to silently ignore invalid names, attributes, or subscripted expressions used as decorators on these classes.

Fixes #21030