### PR TITLE
Document that --strict-bytes is enabled by default

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -764,11 +764,11 @@ of the above sections.
     Note that :option:`--strict-equality-for-none <mypy --strict-equality-for-none>`
     only works in combination with :option:`--strict-equality <mypy --strict-equality>`.
 
-.. option:: --strict-bytes
+.. option:: --no-strict-bytes
 
-    By default, mypy treats ``bytearray`` and ``memoryview`` as subtypes of ``bytes`` which
-    is not true at runtime. Use this flag to disable this behavior. ``--strict-bytes`` will
-    be enabled by default in *mypy 2.0*.
+    Treat ``bytearray`` and ``memoryview`` as subtypes of ``bytes``. This is not true
+    at runtime and can lead to unexpected behavior. This was the default behavior prior
+    to mypy 2.0.
 
     .. code-block:: python
 
@@ -777,10 +777,12 @@ of the above sections.
            with open("binary_file", "wb") as fp:
                fp.write(buf)
 
-       f(bytearray(b""))  # error: Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
-       f(memoryview(b""))  # error: Argument 1 to "f" has incompatible type "memoryview"; expected "bytes"
+       # Using --no-strict-bytes disables the following errors
+       f(bytearray(b""))  # Argument 1 to "f" has incompatible type "bytearray"; expected "bytes"
+       f(memoryview(b""))  # Argument 1 to "f" has incompatible type "memoryview"; expected "bytes"
 
-       # If `f` accepts any object that implements the buffer protocol, consider using:
+       # If `f` accepts any object that implements the buffer protocol,
+       # consider using Buffer instead:
        from collections.abc import Buffer  # "from typing_extensions" in Python 3.11 and earlier
 
        def f(buf: Buffer) -> None:

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -867,10 +867,10 @@ section of the command line docs.
 .. confval:: strict_bytes
 
    :type: boolean
-   :default: False
+   :default: True
 
-   Disable treating ``bytearray`` and ``memoryview`` as subtypes of ``bytes``.
-   This will be enabled by default in *mypy 2.0*.
+   If disabled, mypy treats ``bytearray`` and ``memoryview`` as subtypes of ``bytes``.
+   This has been enabled by default since mypy 2.0.
 
 .. confval:: strict
 

--- a/docs/source/duck_type_compatibility.rst
+++ b/docs/source/duck_type_compatibility.rst
@@ -8,9 +8,11 @@ supported for a small set of built-in types:
 
 * ``int`` is duck type compatible with ``float`` and ``complex``.
 * ``float`` is duck type compatible with ``complex``.
-* ``bytearray`` and ``memoryview`` are duck type compatible with ``bytes``.
-  (this will be disabled by default in **mypy 2.0**, and currently can be
-  disabled with :option:`--strict-bytes <mypy --strict-bytes>`.)
+
+.. note::
+   ``bytearray`` and ``memoryview`` were duck type compatible with ``bytes``
+   by default prior to mypy 2.0. This can still be enabled with
+   :option:`--no-strict-bytes <mypy --no-strict-bytes>`.
 
 For example, mypy considers an ``int`` object to be valid whenever a
 ``float`` object is expected.  Thus code like this is nice and clean

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -939,7 +939,7 @@ def define_options(
         "--no-strict-bytes",
         default=True,
         dest="strict_bytes",
-        help="Disable treating bytearray and memoryview as subtypes of bytes",
+        help="Treat bytearray and memoryview as subtypes of bytes",
         group=strictness_group,
     )
 

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -244,7 +244,8 @@ class Options:
         # Extend the logic of `strict_equality` to comparisons with `None`.
         self.strict_equality_for_none = False
 
-        # Disable treating bytearray and memoryview as subtypes of bytes
+        # If False, switch to pre-mypy-2.0 legacy behavior where bytearray and memoryview are
+        # treated as subtypes of bytes
         self.strict_bytes = True
 
         # Deprecated, use extra_checks instead.


### PR DESCRIPTION
`--strict-bytes` was enabled by default in #18371.