### PR TITLE
Document that --local-partial-types are enabled by default

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -599,9 +599,9 @@ of the above sections.
 
     By default, mypy won't allow a variable to be redefined with an
     unrelated type. This flag enables the redefinition of *unannotated*
-    variables with an arbitrary type. You will also need to enable
-    :option:`--local-partial-types <mypy --local-partial-types>`.
-    Example:
+    variables with an arbitrary type. This also requires
+    :option:`--local-partial-types <mypy --no-local-partial-types>`, which is
+    enabled by default starting from mypy 2.0. Example:
 
     .. code-block:: python
 
@@ -644,7 +644,7 @@ of the above sections.
             reveal_type(values)  # Revealed type is list[float]
 
     Note: We are planning to turn this flag on by default in a future mypy
-    release, along with :option:`--local-partial-types <mypy --local-partial-types>`.
+    release.
 
 .. option:: --allow-redefinition
 
@@ -684,30 +684,26 @@ of the above sections.
            items = "100"  # valid, items now has type str
            items = int(items)  # valid, items now has type int
 
-.. option:: --local-partial-types
+.. option:: --no-local-partial-types
 
-    In mypy, the most common cases for partial types are variables initialized using ``None``,
-    but without explicit ``X | None`` annotations. By default, mypy won't check partial types
-    spanning module top level or class top level. This flag changes the behavior to only allow
-    partial types at local level, therefore it disallows inferring variable type for ``None``
-    from two assignments in different scopes. For example:
+    Disable local partial types to enable legacy type inference mode for
+    containers.
+
+    Local partial types prevent inferring a container type for a variable, when
+    the initial assignment happens at module top level or in a class body, and
+    the container item type is only set in a function. Example:
 
     .. code-block:: python
 
-        a = None  # Need type annotation here if using --local-partial-types
-        b: int | None = None
+        a = []  # Need type annotation unless using --no-local-partial-types
 
-        class Foo:
-            bar = None  # Need type annotation here if using --local-partial-types
-            baz: int | None = None
+        def func() -> None:
+            a.append(1)
 
-            def __init__(self) -> None:
-                self.bar = 1
+        reveal_type(a)  # "list[int]" if using --no-local-partial-types
 
-        reveal_type(Foo().bar)  # 'int | None' without --local-partial-types
-
-    Note: this option is always implicitly enabled in mypy daemon and will become
-    enabled by default in mypy v2.0 release.
+    Local partial types are enabled by default starting from mypy 2.0. The
+    mypy daemon requires local partial types.
 
 .. option:: --no-implicit-reexport
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -720,9 +720,9 @@ section of the command line docs.
 
     By default, mypy won't allow a variable to be redefined with an
     unrelated type. This flag enables the redefinition of unannotated
-    variables with an arbitrary type. You will also need to enable
-    :confval:`local_partial_types`.
-    Example:
+    variables with an arbitrary type. This also requires
+    :confval:`local_partial_types`, which is enabled by default starting
+    from mypy 2.0. Example:
 
     .. code-block:: python
 
@@ -761,7 +761,7 @@ section of the command line docs.
             reveal_type(values)  # Revealed type is list[float]
 
     Note: We are planning to turn this flag on by default in a future mypy
-    release, along with :confval:`local_partial_types`.
+    release.
 
 .. confval:: allow_redefinition_old
 
@@ -800,11 +800,11 @@ section of the command line docs.
 .. confval:: local_partial_types
 
     :type: boolean
-    :default: False
+    :default: True
 
-    Disallows inferring variable type for ``None`` from two assignments in different scopes.
-    This is always implicitly enabled when using the :ref:`mypy daemon <mypy_daemon>`.
-    This will be enabled by default in mypy v2.0 release.
+    This prevents inferring a variable type from an empty container (such as a list or
+    a dictionary) created at module top level or class body and updated in
+    a function. This must be enabled when using the :ref:`mypy daemon <mypy_daemon>`.
 
 .. confval:: disable_error_code
 

--- a/docs/source/mypy_daemon.rst
+++ b/docs/source/mypy_daemon.rst
@@ -61,7 +61,8 @@ you have a large codebase.)
 
 .. note::
 
-    The mypy daemon requires ``--local-partial-types`` and automatically enables it.
+    The mypy daemon requires ``--local-partial-types``, which is enabled
+    by default starting from mypy 2.0.
 
 
 Daemon client commands


### PR DESCRIPTION
The flag was enabled by default in #21163.

Also simplify the description of the feature (and make it up to date) since this feature is mostly a legacy thing now.