### PR TITLE
Fix 1.20 regression: type narrowing lost on reassignment with generator/ternary expressions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -379,6 +379,17 @@ class LocalTypeMap:
         return False
 
 
+class _AssignmentExprSeeker(TraverserVisitor):
+    """Check if an expression tree contains a walrus operator (:=)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.found = False
+
+    def visit_assignment_expr(self, o: AssignmentExpr) -> None:
+        self.found = True
+
+
 class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
     """Mypy type checker.
 
@@ -4757,7 +4768,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # context that is ultimately used. This is however tricky with redefinitions.
         # For now we simply disable second accept in cases known to cause problems,
         # see e.g. testAssignToOptionalTupleWalrus.
-        binder_version = self.binder.version
+        has_walrus = self._has_assignment_expr(rvalue)
 
         fallback_context_used = False
         with (
@@ -4787,7 +4798,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         union_fallback = (
             preferred_context is not None
             and isinstance(get_proper_type(lvalue_type), UnionType)
-            and binder_version == self.binder.version
+            and not has_walrus
         )
 
         # Skip literal types, as they have special logic (for better errors).
@@ -5090,6 +5101,13 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         """Type check a return statement."""
         self.check_return_stmt(s)
         self.binder.unreachable()
+
+    @staticmethod
+    def _has_assignment_expr(expr: Expression) -> bool:
+        """Check if an expression tree contains a walrus operator (:=)."""
+        seeker = _AssignmentExprSeeker()
+        expr.accept(seeker)
+        return seeker.found
 
     def infer_context_dependent(
         self, expr: Expression, type_ctx: Type, allow_none_func_call: bool

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4767,8 +4767,12 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # binder.accumulate_type_assignments() and assign the types inferred for type
         # context that is ultimately used. This is however tricky with redefinitions.
         # For now we simply disable second accept in cases known to cause problems,
-        # see e.g. testAssignToOptionalTupleWalrus.
-        has_walrus = self._has_assignment_expr(rvalue)
+        # see e.g. testAssignToOptionalTupleWalrus. We only need to scan for walrus
+        # when union fallback is otherwise applicable.
+        union_fallback_possible = (
+            preferred_context is not None and isinstance(get_proper_type(lvalue_type), UnionType)
+        )
+        has_walrus = union_fallback_possible and self._has_assignment_expr(rvalue)
 
         fallback_context_used = False
         with (
@@ -4795,11 +4799,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # Try re-inferring r.h.s. in empty context for union with explicit annotation,
         # and use it results in a narrower type. This helps with various practical
         # examples, see e.g. testOptionalTypeNarrowedByGenericCall.
-        union_fallback = (
-            preferred_context is not None
-            and isinstance(get_proper_type(lvalue_type), UnionType)
-            and not has_walrus
-        )
+        union_fallback = union_fallback_possible and not has_walrus
 
         # Skip literal types, as they have special logic (for better errors).
         try_fallback = redefinition_fallback or union_fallback or argument_redefinition_fallback

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4769,8 +4769,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # For now we simply disable second accept in cases known to cause problems,
         # see e.g. testAssignToOptionalTupleWalrus. We only need to scan for walrus
         # when union fallback is otherwise applicable.
-        union_fallback_possible = (
-            preferred_context is not None and isinstance(get_proper_type(lvalue_type), UnionType)
+        union_fallback_possible = preferred_context is not None and isinstance(
+            get_proper_type(lvalue_type), UnionType
         )
         has_walrus = union_fallback_possible and self._has_assignment_expr(rvalue)
 

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1514,6 +1514,19 @@ i = i if isinstance(i, int) else b
 reveal_type(i)  # N: Revealed type is "Any | builtins.int"
 [builtins fixtures/isinstance.pyi]
 
+[case testTypeNarrowingByReassignmentGeneratorTernary]
+from typing import Iterable, Union
+
+def foo(args: Union[Iterable[Union[str, int]], str, int]) -> Iterable[str]:
+    if isinstance(args, (str, int)):
+        args = (args,)
+    args = (
+        arg if isinstance(arg, str) else str(arg)
+        for arg in args
+    )
+    return args
+[builtins fixtures/isinstance.pyi]
+
 [case testLambdaInferenceUsesNarrowedTypes]
 from typing import Optional, Callable
 


### PR DESCRIPTION
## Summary

PR #20622 introduced a `binder_version` guard to prevent false negatives when walrus operators (`:=`) interact with type inference fallback logic. However, this guard was too broad: any expression that bumps the binder version (including generator expressions with ternary operators) would disable the union fallback path, causing type narrowing to be lost on reassignment.

## Problem

```python
from typing import Iterable

def foo(args: Iterable[str | int] | str | int) -> Iterable[str]:
    if isinstance(args, (str, int)):
        args = (args,)
    args = (
        arg if isinstance(arg, str) else str(arg)
        for arg in args
    )
    return args  # Error: Generator[str | int, ...] not compatible with Iterable[str]
```

This worked in mypy 1.19 but regressed in 1.20.

## Fix

Replace the `binder_version == self.binder.version` check with an explicit check for `AssignmentExpr` (walrus `:=`) in the expression tree, following the suggestion from @ilevkivskyi in the issue.

The walrus operator is the specific construct that causes problematic binder mutations during r.h.s. acceptance. Other constructs that bump the binder version (ternary in generators, etc.) are benign and should not disable the fallback.

## Changes

- Add `_AssignmentExprSeeker` (TraverserVisitor) to detect walrus in expression trees
- Add `TypeChecker._has_assignment_expr()` static method
- Replace `binder_version == self.binder.version` with `not has_walrus` in `union_fallback` guard

## Testing

- All 60 check-python38 tests pass, including `testAssignToOptionalTupleWalrus` and `testReturnTupleOptionalWalrus`
- Full testcheck suite running locally

Issue 21273