### PR TITLE
Fix slicing with nonstrict optional

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -2108,7 +2108,7 @@ def fix_instance(
     t.args = tuple(args)
     fix_type_var_tuple_argument(t)
     if not t.type.has_type_var_tuple_type:
-        with state.strict_optional_set(options.strict_optional):
+        with state.strict_optional_set(True):
             fixed = expand_type(t, env)
         assert isinstance(fixed, Instance)
         t.args = fixed.args


### PR DESCRIPTION
Fixes #21261

I didn't add a regression test because you need custom fixtures and I just don't think any nonstrict optional change is worth the trouble