### PR TITLE
Fix #20958: Support .git/info/exclude for --exclude-gitignore

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -728,6 +728,14 @@ def find_gitignores(dir: str) -> list[tuple[str, PathSpec]]:
     parent_dir = os.path.dirname(dir)
     if parent_dir == dir or os.path.exists(os.path.join(dir, ".git")):
         parent_gitignores = []
+        git_info_exclude = os.path.join(dir, ".git", "info", "exclude")
+        if os.path.isfile(git_info_exclude):
+            with open(git_info_exclude) as f:
+                exclude_lines = f.readlines()
+            try:
+                parent_gitignores = [(dir, PathSpec.from_lines("gitignore", exclude_lines))]
+            except GitIgnorePatternError:
+                print(f"error: could not parse {git_info_exclude}", file=sys.stderr)
     else:
         parent_gitignores = find_gitignores(parent_dir)
 

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -989,6 +989,17 @@ b
 [out]
 b/bpkg.py:1: error: "int" not callable
 
+[case testCmdlineExcludeGitignoreWithGitInfoExclude]
+# cmd: mypy --exclude-gitignore .
+[file .git/info/exclude]
+abc
+[file abc/apkg.py]
+1()
+[file c/cpkg.py]
+1()
+[out]
+c/cpkg.py:1: error: "int" not callable
+
 [case testCmdlineCfgExclude]
 # cmd: mypy .
 [file mypy.ini]


### PR DESCRIPTION
### Summary
Fixes #20958.
--exclude-gitignore now respects patterns in .git/info/exclude, not just .gitignore files. Previously, mypy ignored .git/info/exclude entirely, causing files matched by those patterns to still be checked.

### Changes
File: mypy/modulefinder.py — find_gitignores()
File: test-data/unit/cmdline.test

Added handling for .git/info/exclude inside the git root detection branch. When find_gitignores identifies a directory as a git root (i.e. it contains a .git folder), it now also checks for .git/info/exclude. If the file exists, it is parsed with PathSpec.from_lines("gitignore", ...) and included in the returned list of gitignore specs, alongside any .gitignore found in the same directory. Parse errors are printed to stderr and the file is skipped, matching the existing behavior for malformed .gitignore files.

### Testing
Added testCmdlineExcludeGitignoreWithGitInfoExclude to test-data/unit/cmdline.test to verify that patterns in .git/info/exclude are respected when using --exclude-gitignore.
To run the new test:

**Install dependencies:**
bashpip install -r test-requirements.txt
pip install -e .

### Run the test:
bashpytest -n0 -k testCmdlineExcludeGitignoreWithGitInfoExclude
Or with full node ID:
bashpytest -n0 mypy/test/testcmdline.py::PythonCmdlineSuite::cmdline.test::testCmdlineExcludeGitignoreWithGitInfoExclude

### Photo evidence of tests passing locally:
Specific test for this issue: 
<img width="849" height="187" alt="IMG_7911" src="https://github.com/user-attachments/assets/3584e457-16cb-40de-a0c7-3f60e5edd826" />

All cmdline.test passing: 
<img width="835" height="196" alt="IMG_3176" src="https://github.com/user-attachments/assets/2b111e4c-870f-4175-8f08-ecc1de5c66e8" />
