### PR TITLE
Update ast-serialize requirement to >=0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ mypyc = ["setuptools>=50"]
 reports = ["lxml"]
 install-types = ["pip"]
 faster-cache = ["orjson"]
-native-parser = ["ast-serialize>=0.1.2,<1.0.0"]
+native-parser = ["ast-serialize>=0.2.0,<1.0.0"]
 
 [project.urls]
 Homepage = "https://www.mypy-lang.org/"

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -13,4 +13,4 @@ pytest-cov>=2.10.0
 setuptools>=77.0.3
 tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.10
 pre_commit>=3.5.0
-ast-serialize>=0.1.2,<1.0.0
+ast-serialize>=0.2.0,<1.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=test-requirements.txt --strip-extras test-requirements.in
 #
-ast-serialize==0.1.2
+ast-serialize==0.2.0
     # via -r test-requirements.in
 attrs==25.4.0
     # via -r test-requirements.in


### PR DESCRIPTION
This includes parallel type checking improvements and a compatibility fix related to call expressions in annotations.