### PR TITLE
Use sharding for sqlite cache (16 shards)

### DIFF
--- a/misc/apply-cache-diff.py
+++ b/misc/apply-cache-diff.py
@@ -19,19 +19,22 @@ from librt import base64
 from librt.internal import ReadBuffer
 
 from mypy.cache import CacheMeta
+from mypy.defaults import SQLITE_NUM_SHARDS
 from mypy.metastore import FilesystemMetadataStore, MetadataStore, SqliteMetadataStore
 from mypy.util import json_dumps, json_loads
 
 
-def make_cache(input_dir: str, sqlite: bool) -> MetadataStore:
+def make_cache(input_dir: str, sqlite: bool, num_shards: int = SQLITE_NUM_SHARDS) -> MetadataStore:
     if sqlite:
-        return SqliteMetadataStore(input_dir)
+        return SqliteMetadataStore(input_dir, num_shards=num_shards)
     else:
         return FilesystemMetadataStore(input_dir)
 
 
-def apply_diff(cache_dir: str, diff_file: str, sqlite: bool = False) -> None:
-    cache = make_cache(cache_dir, sqlite)
+def apply_diff(
+    cache_dir: str, diff_file: str, sqlite: bool = False, num_shards: int = SQLITE_NUM_SHARDS
+) -> None:
+    cache = make_cache(cache_dir, sqlite, num_shards=num_shards)
     with open(diff_file, "rb") as f:
         diff = json_loads(f.read())
 
@@ -63,11 +66,14 @@ def apply_diff(cache_dir: str, diff_file: str, sqlite: bool = False) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--sqlite", action="store_true", default=False, help="Use a sqlite cache")
+    parser.add_argument(
+        "--num-shards", type=int, default=SQLITE_NUM_SHARDS, help=argparse.SUPPRESS
+    )
     parser.add_argument("cache_dir", help="Directory for the cache")
     parser.add_argument("diff", help="Cache diff file")
     args = parser.parse_args()
 
-    apply_diff(args.cache_dir, args.diff, args.sqlite)
+    apply_diff(args.cache_dir, args.diff, args.sqlite, num_shards=args.num_shards)
 
 
 if __name__ == "__main__":

--- a/misc/convert-cache.py
+++ b/misc/convert-cache.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import argparse
 
+from mypy.defaults import SQLITE_NUM_SHARDS
 from mypy.metastore import FilesystemMetadataStore, MetadataStore, SqliteMetadataStore
 
 
@@ -27,6 +28,13 @@ def main() -> None:
         help="Convert to a sqlite cache (default: convert from)",
     )
     parser.add_argument(
+        "--num-shards",
+        type=int,
+        default=SQLITE_NUM_SHARDS,
+        dest="num_shards",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
         "--output_dir",
         action="store",
         default=None,
@@ -37,17 +45,23 @@ def main() -> None:
 
     input_dir = args.input_dir
     output_dir = args.output_dir or input_dir
+    num_shards = args.num_shards
     assert os.path.isdir(output_dir), f"{output_dir} is not a directory"
     if args.to_sqlite:
         input: MetadataStore = FilesystemMetadataStore(input_dir)
-        output: MetadataStore = SqliteMetadataStore(output_dir)
+        output: MetadataStore = SqliteMetadataStore(output_dir, num_shards=num_shards)
     else:
-        fnam = os.path.join(input_dir, "cache.db")
-        msg = f"{fnam} does not exist"
-        if not re.match(r"[0-9]+\.[0-9]+$", os.path.basename(input_dir)):
-            msg += f" (are you missing Python version at the end, e.g. {input_dir}/3.11)"
-        assert os.path.isfile(fnam), msg
-        input, output = SqliteMetadataStore(input_dir), FilesystemMetadataStore(output_dir)
+        if num_shards <= 1:
+            db_files = [os.path.join(input_dir, "cache.db")]
+        else:
+            db_files = [os.path.join(input_dir, f"cache.{i}.db") for i in range(num_shards)]
+        for fnam in db_files:
+            msg = f"{fnam} does not exist"
+            if not re.match(r"[0-9]+\.[0-9]+$", os.path.basename(input_dir)):
+                msg += f" (are you missing Python version at the end, e.g. {input_dir}/3.11)"
+            assert os.path.isfile(fnam), msg
+        input = SqliteMetadataStore(input_dir, num_shards=num_shards)
+        output = FilesystemMetadataStore(output_dir)
 
     for s in input.list_all():
         if s.endswith((".json", ".ff")):

--- a/misc/diff-cache.py
+++ b/misc/diff-cache.py
@@ -19,13 +19,14 @@ from librt import base64
 from librt.internal import ReadBuffer, WriteBuffer
 
 from mypy.cache import CacheMeta, CacheMetaEx
+from mypy.defaults import SQLITE_NUM_SHARDS
 from mypy.metastore import FilesystemMetadataStore, MetadataStore, SqliteMetadataStore
 from mypy.util import json_dumps, json_loads
 
 
-def make_cache(input_dir: str, sqlite: bool) -> MetadataStore:
+def make_cache(input_dir: str, sqlite: bool, num_shards: int = SQLITE_NUM_SHARDS) -> MetadataStore:
     if sqlite:
-        return SqliteMetadataStore(input_dir)
+        return SqliteMetadataStore(input_dir, num_shards=num_shards)
     else:
         return FilesystemMetadataStore(input_dir)
 
@@ -154,13 +155,16 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--verbose", action="store_true", default=False, help="Increase verbosity")
     parser.add_argument("--sqlite", action="store_true", default=False, help="Use a sqlite cache")
+    parser.add_argument(
+        "--num-shards", type=int, default=SQLITE_NUM_SHARDS, help=argparse.SUPPRESS
+    )
     parser.add_argument("input_dir1", help="Input directory for the original cache")
     parser.add_argument("input_dir2", help="Input directory for the target cache")
     parser.add_argument("output", help="Output file with the diff from original cache")
     args = parser.parse_args()
 
-    cache1 = make_cache(args.input_dir1, args.sqlite)
-    cache2 = make_cache(args.input_dir2, args.sqlite)
+    cache1 = make_cache(args.input_dir1, args.sqlite, num_shards=args.num_shards)
+    cache2 = make_cache(args.input_dir2, args.sqlite, num_shards=args.num_shards)
 
     type_misses: dict[str, int] = defaultdict(int)
     type_hits: dict[str, int] = defaultdict(int)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1273,6 +1273,10 @@ class BuildManager:
         self.metastore.commit()
         self.add_stats(cache_commit_time=time.time() - t0)
 
+    def commit_module(self, meta_file: str) -> None:
+        """Commit cache writes for a single module (identified by its meta file path)."""
+        self.metastore.commit_path(meta_file)
+
     def verbosity(self) -> int:
         return self.options.verbosity
 
@@ -4682,6 +4686,8 @@ def process_stale_scc(graph: Graph, ascc: SCC, manager: BuildManager) -> None:
 
     t4 = time.time()
     # Flush errors, and write cache in two phases: first data files, then meta files.
+    # The two-phase structure is needed because meta.dep_hashes references interface_hash
+    # values from other modules in the SCC, which are updated by write_cache().
     meta_tuples = {}
     errors_by_id = {}
     for id in stale:
@@ -4692,7 +4698,11 @@ def process_stale_scc(graph: Graph, ascc: SCC, manager: BuildManager) -> None:
             )
             manager.flush_errors(manager.errors.simplify_path(graph[id].xpath), formatted, False)
             errors_by_id[id] = errors
-        meta_tuples[id] = graph[id].write_cache()
+        meta_tuple = graph[id].write_cache()
+        meta_tuples[id] = meta_tuple
+        # Commit data file write immediately to avoid holding shard locks across modules.
+        if meta_tuple is not None:
+            manager.commit_module(meta_tuple[1])
     for id in stale:
         meta_tuple = meta_tuples[id]
         if meta_tuple is None:
@@ -4716,6 +4726,7 @@ def process_stale_scc(graph: Graph, ascc: SCC, manager: BuildManager) -> None:
             error_lines=errors_by_id.get(id, []),
         )
         write_cache_meta_ex(meta_file, meta_ex, manager)
+        manager.commit_module(meta_file)
     manager.done_sccs.add(ascc.id)
     manager.add_stats(
         load_missing_time=t1 - t0,
@@ -4768,6 +4779,9 @@ def process_stale_scc_interface(
     for id in stale:
         meta_tuple = graph[id].write_cache()
         meta_tuples[id] = meta_tuple
+        # Commit data file write immediately to avoid holding shard locks across modules.
+        if meta_tuple is not None:
+            manager.commit_module(meta_tuple[1])
     for id in stale:
         meta_tuple = meta_tuples[id]
         if meta_tuple is None:
@@ -4780,6 +4794,7 @@ def process_stale_scc_interface(
             if state.priorities.get(dep) != PRI_INDIRECT
         ]
         write_cache_meta(meta, manager, meta_file)
+        manager.commit_module(meta_file)
         scc_result.append((id, ModuleResult(graph[id].interface_hash.hex(), []), meta_file))
     manager.done_sccs.add(ascc.id)
     manager.add_stats(
@@ -4859,6 +4874,7 @@ def process_stale_scc_implementation(
             # If there are no errors, only write the cache, don't send anything back
             # to the caller (as a micro-optimization).
             write_cache_meta_ex(meta_file, meta_ex, manager)
+        manager.commit_module(meta_file)
 
     manager.add_stats(type_check_time_implementation=time.time() - t0)
     return scc_result

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1818,8 +1818,11 @@ def exclude_from_backups(target_dir: str) -> None:
 def create_metastore(options: Options, parallel_worker: bool) -> MetadataStore:
     """Create the appropriate metadata store."""
     if options.sqlite_cache:
+        num_shards = max(options.num_workers, 1)
         mds: MetadataStore = SqliteMetadataStore(
-            _cache_dir_prefix(options), set_journal_mode=not parallel_worker
+            _cache_dir_prefix(options),
+            set_journal_mode=not parallel_worker,
+            num_shards=num_shards,
         )
     else:
         mds = FilesystemMetadataStore(_cache_dir_prefix(options))

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1822,11 +1822,10 @@ def exclude_from_backups(target_dir: str) -> None:
 def create_metastore(options: Options, parallel_worker: bool) -> MetadataStore:
     """Create the appropriate metadata store."""
     if options.sqlite_cache:
-        num_shards = max(options.num_workers, 1)
         mds: MetadataStore = SqliteMetadataStore(
             _cache_dir_prefix(options),
             set_journal_mode=not parallel_worker,
-            num_shards=num_shards,
+            num_shards=options.sqlite_num_shards,
         )
     else:
         mds = FilesystemMetadataStore(_cache_dir_prefix(options))

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -4427,6 +4427,10 @@ def find_stale_sccs(
 
 def process_graph(graph: Graph, manager: BuildManager) -> None:
     """Process everything in dependency order."""
+    if manager.workers:
+        # Commit any cache writes from graph loading before workers try to read them.
+        manager.commit()
+
     # Broadcast graph to workers before computing SCCs to save a bit of time.
     # TODO: check if we can optimize by sending only part of the graph needed for given SCC.
     # For example only send modules in the SCC and their dependencies.

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -14,6 +14,7 @@ PYTHON3_VERSION: Final = (3, 10)
 PYTHON3_VERSION_MIN: Final = (3, 10)  # Keep in sync with supported target versions
 
 CACHE_DIR: Final = ".mypy_cache"
+SQLITE_NUM_SHARDS: Final = 16
 
 CONFIG_NAMES: Final = ["mypy.ini", ".mypy.ini"]
 SHARED_CONFIG_NAMES: Final = ["pyproject.toml", "setup.cfg"]

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1080,7 +1080,7 @@ def define_options(
     incremental_group.add_argument(
         "--sqlite-num-shards",
         type=int,
-        default=16,
+        default=defaults.SQLITE_NUM_SHARDS,
         dest="sqlite_num_shards",
         help=argparse.SUPPRESS,
     )

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1078,6 +1078,13 @@ def define_options(
         group=incremental_group,
     )
     incremental_group.add_argument(
+        "--sqlite-num-shards",
+        type=int,
+        default=16,
+        dest="sqlite_num_shards",
+        help=argparse.SUPPRESS,
+    )
+    incremental_group.add_argument(
         "--cache-fine-grained",
         action="store_true",
         help="Include fine-grained dependency information in the cache for the mypy daemon",

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -262,11 +262,10 @@ class SqliteMetadataStore(MetadataStore):
         self.dirty_shards.clear()
 
     def commit_path(self, name: str) -> None:
-        with record_time("sqlite.commit_path"):
-            i = self._shard_index(name)
-            if i in self.dirty_shards:
-                self.dbs[i].commit()
-                self.dirty_shards.discard(i)
+        i = self._shard_index(name)
+        if i in self.dirty_shards:
+            self.dbs[i].commit()
+            self.dirty_shards.discard(i)
 
     def list_all(self) -> Iterable[str]:
         for db in self.dbs:

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -200,17 +200,15 @@ class SqliteMetadataStore(MetadataStore):
                     connect_db(os_path_join(cache_dir_prefix, f"cache.{i}.db"), set_journal_mode)
                 )
 
-    def _db_for(self, name: str) -> sqlite3.Connection:
-        if not self.dbs:
-            raise FileNotFoundError()
-        if self.num_shards <= 1:
-            return self.dbs[0]
-        return self.dbs[hash_path_stem(name) % self.num_shards]
-
     def _shard_index(self, name: str) -> int:
         if self.num_shards <= 1:
             return 0
         return hash_path_stem(name) % self.num_shards
+
+    def _db_for(self, name: str) -> sqlite3.Connection:
+        if not self.dbs:
+            raise FileNotFoundError()
+        return self.dbs[self._shard_index(name)]
 
     def _query(self, name: str, field: str) -> Any:
         # Raises FileNotFound for consistency with the file system version

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -201,7 +201,14 @@ def hash_path_stem(s: str) -> int:
         c = i64(ord(s[i]))
         hv = (hv * 33) ^ c
         i -= 1
-    return (hv ^ (hv >> 16) ^ (hv >> 32) ^ (hv >> 48)) & 0xFFFFFF
+    # Murmur3 finalizer for better bit avalanche (improves shard uniformity)
+    hv = (hv ^ (hv >> 32)) & 0xFFFFFFFF
+    hv ^= hv >> 16
+    hv = (hv * 0x85EBCA6B) & 0xFFFFFFFF
+    hv ^= hv >> 13
+    hv = (hv * 0xC2B2AE35) & 0xFFFFFFFF
+    hv ^= hv >> 16
+    return int(hv)
 
 
 class SqliteMetadataStore(MetadataStore):

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -66,6 +66,14 @@ class MetadataStore:
         called.
         """
 
+    def commit_path(self, name: str) -> None:
+        """Commit changes related to a specific cache path.
+
+        For sharded stores, this commits only the shard containing the path.
+        Default implementation commits everything.
+        """
+        self.commit()
+
     @abstractmethod
     def list_all(self) -> Iterable[str]: ...
 
@@ -155,17 +163,10 @@ CREATE INDEX IF NOT EXISTS path_idx on files2(path);
 """
 
 
-def connect_db(db_file: str, set_journal_mode: bool, autocommit: bool = False) -> sqlite3.Connection:
+def connect_db(db_file: str, set_journal_mode: bool) -> sqlite3.Connection:
     import sqlite3.dbapi2
 
-    db = sqlite3.dbapi2.connect(
-        db_file,
-        check_same_thread=False,
-        # With autocommit, each statement is its own transaction, so the write lock
-        # is held only for microseconds per INSERT. This avoids long lock holds that
-        # block other workers writing to the same shard.
-        isolation_level=None if autocommit else "DEFERRED",
-    )
+    db = sqlite3.dbapi2.connect(db_file, check_same_thread=False)
     # This is a bit unfortunate (as we may get corrupt cache after e.g. Ctrl + C),
     # but without this flag, commits are *very* slow, especially when using HDDs,
     # see https://www.sqlite.org/faq.html#q19 for details.
@@ -213,9 +214,6 @@ class SqliteMetadataStore(MetadataStore):
             return
 
         os.makedirs(cache_dir_prefix, exist_ok=True)
-        # Use autocommit when sharded so each INSERT is its own transaction,
-        # minimizing lock hold time across workers.
-        autocommit = num_shards > 1
         if num_shards <= 1:
             self.dbs.append(
                 connect_db(os_path_join(cache_dir_prefix, "cache.db"), set_journal_mode)
@@ -226,7 +224,6 @@ class SqliteMetadataStore(MetadataStore):
                     connect_db(
                         os_path_join(cache_dir_prefix, f"cache.{i}.db"),
                         set_journal_mode,
-                        autocommit=autocommit,
                     )
                 )
         # Track which shards have been written to since last commit.
@@ -291,6 +288,13 @@ class SqliteMetadataStore(MetadataStore):
         for i in self.dirty_shards:
             self.dbs[i].commit()
         self.dirty_shards.clear()
+
+    def commit_path(self, name: str) -> None:
+        with record_time("sqlite.commit_path"):
+            i = self._shard_index(name)
+            if i in self.dirty_shards:
+                self.dbs[i].commit()
+                self.dirty_shards.discard(i)
 
     def list_all(self) -> Iterable[str]:
         for db in self.dbs:

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -11,12 +11,13 @@ We provide two implementations.
 from __future__ import annotations
 
 import binascii
-import hashlib
 import os
 import time
 from abc import abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
+
+from mypy_extensions import i64
 
 from mypy.util import os_path_join
 
@@ -177,28 +178,30 @@ def connect_db(db_file: str, set_journal_mode: bool) -> sqlite3.Connection:
     return db
 
 
-def _stable_hash(s: str) -> int:
-    """A deterministic hash, consistent across processes (unlike built-in hash())."""
-    return int.from_bytes(hashlib.md5(s.encode("utf-8")).digest()[:4], "little")
+def hash_path_stem(s: str) -> int:
+    """Hash the stem of a cache file path (everything before the first dot in the basename).
 
-
-def _cache_stem(name: str) -> str:
-    """Extract the canonical module stem from a cache file path.
-
-    All cache files for a module share a common prefix (the stem):
-      foo/bar/baz.meta.ff, foo/bar/baz.data.ff, foo/bar/baz.meta_ex.ff, etc.
-    For packages: foo/bar/__init__.meta.ff -> foo/bar/__init__
-
-    Global files like @deps.meta.json -> @deps
+    This is a combined stem-extraction + hash function optimized for mypyc compilation.
+    Uses only integer arithmetic, avoiding intermediate string allocations.
     """
-    # Split at first '.' in the basename to get the stem.
-    # E.g. "foo/bar/baz.meta.ff" -> "foo/bar/baz"
-    #      "foo/bar/__init__.data.ff" -> "foo/bar/__init__"
-    #      "@deps.meta.json" -> "@deps"
-    dot = name.find(".")
-    if dot == -1:
-        return name
-    return name[:dot]
+    # First find end of stem (scanning backwards, stop at first dot after last separator)
+    i = len(s) - 1
+    end: i64 = i
+    while i >= 0:
+        c: i64 = ord(s[i])
+        if c == ord("/") or c == ord("\\"):
+            break
+        if c == ord("."):
+            end = i
+        i -= 1
+    # Calculate hash
+    hv: i64 = 123
+    i = end
+    while i >= 0:
+        c = i64(ord(s[i]))
+        hv = (hv * 33) ^ c
+        i -= 1
+    return (hv ^ (hv >> 16) ^ (hv >> 32) ^ (hv >> 48)) & 0xFFFFFF
 
 
 class SqliteMetadataStore(MetadataStore):
@@ -234,12 +237,12 @@ class SqliteMetadataStore(MetadataStore):
             raise FileNotFoundError()
         if self.num_shards <= 1:
             return self.dbs[0]
-        return self.dbs[_stable_hash(_cache_stem(name)) % self.num_shards]
+        return self.dbs[hash_path_stem(name) % self.num_shards]
 
     def _shard_index(self, name: str) -> int:
         if self.num_shards <= 1:
             return 0
-        return _stable_hash(_cache_stem(name)) % self.num_shards
+        return hash_path_stem(name) % self.num_shards
 
     def _query(self, name: str, field: str) -> Any:
         # Raises FileNotFound for consistency with the file system version

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -11,6 +11,7 @@ We provide two implementations.
 from __future__ import annotations
 
 import binascii
+import hashlib
 import os
 import time
 from abc import abstractmethod
@@ -168,24 +169,54 @@ def connect_db(db_file: str, set_journal_mode: bool) -> sqlite3.Connection:
     return db
 
 
+def _stable_hash(s: str) -> int:
+    """A deterministic hash, consistent across processes (unlike built-in hash())."""
+    return int.from_bytes(hashlib.md5(s.encode("utf-8")).digest()[:4], "little")
+
+
 class SqliteMetadataStore(MetadataStore):
-    def __init__(self, cache_dir_prefix: str, set_journal_mode: bool = False) -> None:
+    def __init__(
+        self, cache_dir_prefix: str, set_journal_mode: bool = False, num_shards: int = 1
+    ) -> None:
         # We check startswith instead of equality because the version
         # will have already been appended by the time the cache dir is
         # passed here.
-        self.db = None
+        self.dbs: list[sqlite3.Connection] = []
+        self.num_shards = num_shards
         if cache_dir_prefix.startswith(os.devnull):
             return
 
         os.makedirs(cache_dir_prefix, exist_ok=True)
-        self.db = connect_db(os_path_join(cache_dir_prefix, "cache.db"), set_journal_mode)
+        if num_shards <= 1:
+            self.dbs.append(
+                connect_db(os_path_join(cache_dir_prefix, "cache.db"), set_journal_mode)
+            )
+        else:
+            for i in range(num_shards):
+                self.dbs.append(
+                    connect_db(
+                        os_path_join(cache_dir_prefix, f"cache.{i}.db"), set_journal_mode
+                    )
+                )
+        # Track which shards have been written to since last commit.
+        self.dirty_shards: set[int] = set()
+
+    def _db_for(self, name: str) -> sqlite3.Connection:
+        if not self.dbs:
+            raise FileNotFoundError()
+        if self.num_shards <= 1:
+            return self.dbs[0]
+        return self.dbs[_stable_hash(name) % self.num_shards]
+
+    def _shard_index(self, name: str) -> int:
+        if self.num_shards <= 1:
+            return 0
+        return _stable_hash(name) % self.num_shards
 
     def _query(self, name: str, field: str) -> Any:
         # Raises FileNotFound for consistency with the file system version
-        if not self.db:
-            raise FileNotFoundError()
-
-        cur = self.db.execute(f"SELECT {field} FROM files2 WHERE path = ?", (name,))
+        db = self._db_for(name)
+        cur = db.execute(f"SELECT {field} FROM files2 WHERE path = ?", (name,))
         results = cur.fetchall()
         if not results:
             raise FileNotFoundError()
@@ -205,39 +236,40 @@ class SqliteMetadataStore(MetadataStore):
     def write(self, name: str, data: bytes, mtime: float | None = None) -> bool:
         import sqlite3
 
-        if not self.db:
+        if not self.dbs:
             return False
         try:
             if mtime is None:
                 mtime = time.time()
-            self.db.execute(
+            db = self._db_for(name)
+            db.execute(
                 "INSERT OR REPLACE INTO files2(path, mtime, data) VALUES(?, ?, ?)",
                 (name, mtime, data),
             )
+            self.dirty_shards.add(self._shard_index(name))
         except sqlite3.OperationalError:
             return False
         return True
 
     def remove(self, name: str) -> None:
-        if not self.db:
-            raise FileNotFoundError()
-
-        self.db.execute("DELETE FROM files2 WHERE path = ?", (name,))
+        db = self._db_for(name)
+        db.execute("DELETE FROM files2 WHERE path = ?", (name,))
+        self.dirty_shards.add(self._shard_index(name))
 
     def commit(self) -> None:
-        if self.db:
-            self.db.commit()
+        for i in self.dirty_shards:
+            self.dbs[i].commit()
+        self.dirty_shards.clear()
 
     def list_all(self) -> Iterable[str]:
-        if self.db:
-            for row in self.db.execute("SELECT path FROM files2"):
+        for db in self.dbs:
+            for row in db.execute("SELECT path FROM files2"):
                 yield row[0]
 
     def close(self) -> None:
-        if self.db:
-            db = self.db
-            self.db = None
+        for db in self.dbs:
             db.close()
+        self.dbs.clear()
 
     def __del__(self) -> None:
         self.close()

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -155,10 +155,17 @@ CREATE INDEX IF NOT EXISTS path_idx on files2(path);
 """
 
 
-def connect_db(db_file: str, set_journal_mode: bool) -> sqlite3.Connection:
+def connect_db(db_file: str, set_journal_mode: bool, autocommit: bool = False) -> sqlite3.Connection:
     import sqlite3.dbapi2
 
-    db = sqlite3.dbapi2.connect(db_file, check_same_thread=False)
+    db = sqlite3.dbapi2.connect(
+        db_file,
+        check_same_thread=False,
+        # With autocommit, each statement is its own transaction, so the write lock
+        # is held only for microseconds per INSERT. This avoids long lock holds that
+        # block other workers writing to the same shard.
+        isolation_level=None if autocommit else "DEFERRED",
+    )
     # This is a bit unfortunate (as we may get corrupt cache after e.g. Ctrl + C),
     # but without this flag, commits are *very* slow, especially when using HDDs,
     # see https://www.sqlite.org/faq.html#q19 for details.
@@ -187,6 +194,9 @@ class SqliteMetadataStore(MetadataStore):
             return
 
         os.makedirs(cache_dir_prefix, exist_ok=True)
+        # Use autocommit when sharded so each INSERT is its own transaction,
+        # minimizing lock hold time across workers.
+        autocommit = num_shards > 1
         if num_shards <= 1:
             self.dbs.append(
                 connect_db(os_path_join(cache_dir_prefix, "cache.db"), set_journal_mode)
@@ -195,7 +205,9 @@ class SqliteMetadataStore(MetadataStore):
             for i in range(num_shards):
                 self.dbs.append(
                     connect_db(
-                        os_path_join(cache_dir_prefix, f"cache.{i}.db"), set_journal_mode
+                        os_path_join(cache_dir_prefix, f"cache.{i}.db"),
+                        set_journal_mode,
+                        autocommit=autocommit,
                     )
                 )
         # Track which shards have been written to since last commit.

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -185,6 +185,7 @@ class SqliteMetadataStore(MetadataStore):
         # passed here.
         self.dbs: list[sqlite3.Connection] = []
         self.num_shards = num_shards
+        self.dirty_shards: set[int] = set()
         if cache_dir_prefix.startswith(os.devnull):
             return
 
@@ -198,8 +199,6 @@ class SqliteMetadataStore(MetadataStore):
                 self.dbs.append(
                     connect_db(os_path_join(cache_dir_prefix, f"cache.{i}.db"), set_journal_mode)
                 )
-        # Track which shards have been written to since last commit.
-        self.dirty_shards: set[int] = set()
 
     def _db_for(self, name: str) -> sqlite3.Connection:
         if not self.dbs:

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -17,9 +17,7 @@ from abc import abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
-from mypy_extensions import i64
-
-from mypy.util import os_path_join
+from mypy.util import hash_path_stem, os_path_join
 
 if TYPE_CHECKING:
     # We avoid importing sqlite3 unless we are using it so we can mostly work
@@ -178,39 +176,6 @@ def connect_db(db_file: str, set_journal_mode: bool) -> sqlite3.Connection:
     return db
 
 
-def hash_path_stem(s: str) -> int:
-    """Hash the stem of a cache file path (everything before the first dot in the basename).
-
-    This is a combined stem-extraction + hash function optimized for mypyc compilation.
-    Uses only integer arithmetic, avoiding intermediate string allocations.
-    """
-    # First find end of stem (scanning backwards, stop at first dot after last separator)
-    i = len(s) - 1
-    end: i64 = i
-    while i >= 0:
-        c: i64 = ord(s[i])
-        if c == ord("/") or c == ord("\\"):
-            break
-        if c == ord("."):
-            end = i
-        i -= 1
-    # Calculate hash
-    hv: i64 = 123
-    i = end
-    while i >= 0:
-        c = i64(ord(s[i]))
-        hv = (hv * 33) ^ c
-        i -= 1
-    # Murmur3 finalizer for better bit avalanche (improves shard uniformity)
-    hv = (hv ^ (hv >> 32)) & 0xFFFFFFFF
-    hv ^= hv >> 16
-    hv = (hv * 0x85EBCA6B) & 0xFFFFFFFF
-    hv ^= hv >> 13
-    hv = (hv * 0xC2B2AE35) & 0xFFFFFFFF
-    hv ^= hv >> 16
-    return int(hv)
-
-
 class SqliteMetadataStore(MetadataStore):
     def __init__(
         self, cache_dir_prefix: str, set_journal_mode: bool = False, num_shards: int = 1
@@ -231,10 +196,7 @@ class SqliteMetadataStore(MetadataStore):
         else:
             for i in range(num_shards):
                 self.dbs.append(
-                    connect_db(
-                        os_path_join(cache_dir_prefix, f"cache.{i}.db"),
-                        set_journal_mode,
-                    )
+                    connect_db(os_path_join(cache_dir_prefix, f"cache.{i}.db"), set_journal_mode)
                 )
         # Track which shards have been written to since last commit.
         self.dirty_shards: set[int] = set()

--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -181,6 +181,25 @@ def _stable_hash(s: str) -> int:
     return int.from_bytes(hashlib.md5(s.encode("utf-8")).digest()[:4], "little")
 
 
+def _cache_stem(name: str) -> str:
+    """Extract the canonical module stem from a cache file path.
+
+    All cache files for a module share a common prefix (the stem):
+      foo/bar/baz.meta.ff, foo/bar/baz.data.ff, foo/bar/baz.meta_ex.ff, etc.
+    For packages: foo/bar/__init__.meta.ff -> foo/bar/__init__
+
+    Global files like @deps.meta.json -> @deps
+    """
+    # Split at first '.' in the basename to get the stem.
+    # E.g. "foo/bar/baz.meta.ff" -> "foo/bar/baz"
+    #      "foo/bar/__init__.data.ff" -> "foo/bar/__init__"
+    #      "@deps.meta.json" -> "@deps"
+    dot = name.find(".")
+    if dot == -1:
+        return name
+    return name[:dot]
+
+
 class SqliteMetadataStore(MetadataStore):
     def __init__(
         self, cache_dir_prefix: str, set_journal_mode: bool = False, num_shards: int = 1
@@ -218,12 +237,12 @@ class SqliteMetadataStore(MetadataStore):
             raise FileNotFoundError()
         if self.num_shards <= 1:
             return self.dbs[0]
-        return self.dbs[_stable_hash(name) % self.num_shards]
+        return self.dbs[_stable_hash(_cache_stem(name)) % self.num_shards]
 
     def _shard_index(self, name: str) -> int:
         if self.num_shards <= 1:
             return 0
-        return _stable_hash(name) % self.num_shards
+        return _stable_hash(_cache_stem(name)) % self.num_shards
 
     def _query(self, name: str, field: str) -> Any:
         # Raises FileNotFound for consistency with the file system version

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -302,6 +302,7 @@ class Options:
         self.incremental = True
         self.cache_dir = defaults.CACHE_DIR
         self.sqlite_cache = True
+        self.sqlite_num_shards = 16
         self.fixed_format_cache = True
         self.debug_cache = False
         self.skip_version_check = False

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -302,7 +302,7 @@ class Options:
         self.incremental = True
         self.cache_dir = defaults.CACHE_DIR
         self.sqlite_cache = True
-        self.sqlite_num_shards = 16
+        self.sqlite_num_shards = defaults.SQLITE_NUM_SHARDS
         self.fixed_format_cache = True
         self.debug_cache = False
         self.skip_version_check = False

--- a/mypy/test/test_diff_cache.py
+++ b/mypy/test/test_diff_cache.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 import unittest
 
+from mypy.defaults import SQLITE_NUM_SHARDS
 from mypy.test.config import PREFIX
 
 _MISC_DIR = os.path.join(PREFIX, "misc")
@@ -150,7 +151,7 @@ class DiffCacheIntegrationTests(unittest.TestCase):
             from mypy.metastore import SqliteMetadataStore
 
             def read_all(cache_dir: str) -> dict[str, bytes]:
-                store = SqliteMetadataStore(cache_dir)
+                store = SqliteMetadataStore(cache_dir, num_shards=SQLITE_NUM_SHARDS)
                 result = {name: store.read(name) for name in store.list_all()}
                 store.close()
                 return result

--- a/mypy/test/test_diff_cache.py
+++ b/mypy/test/test_diff_cache.py
@@ -152,8 +152,7 @@ class DiffCacheIntegrationTests(unittest.TestCase):
             def read_all(cache_dir: str) -> dict[str, bytes]:
                 store = SqliteMetadataStore(cache_dir)
                 result = {name: store.read(name) for name in store.list_all()}
-                for db in store.dbs:
-                    db.close()
+                store.close()
                 return result
 
             before = read_all(patched_ver)

--- a/mypy/test/test_diff_cache.py
+++ b/mypy/test/test_diff_cache.py
@@ -152,8 +152,8 @@ class DiffCacheIntegrationTests(unittest.TestCase):
             def read_all(cache_dir: str) -> dict[str, bytes]:
                 store = SqliteMetadataStore(cache_dir)
                 result = {name: store.read(name) for name in store.list_all()}
-                assert store.db is not None
-                store.db.close()
+                for db in store.dbs:
+                    db.close()
                 return result
 
             before = read_all(patched_ver)

--- a/mypy/util.py
+++ b/mypy/util.py
@@ -14,6 +14,8 @@ from collections.abc import Callable, Container, Iterable, Sequence, Sized
 from importlib import resources as importlib_resources
 from typing import IO, Any, Final, Literal, TypeVar
 
+from mypy_extensions import i64
+
 orjson: Any
 try:
     import orjson  # type: ignore[import-not-found, no-redef, unused-ignore]
@@ -1009,3 +1011,36 @@ def get_available_threads() -> int:
         available_threads = cpu_count
     _AVAILABLE_THREADS = available_threads
     return available_threads
+
+
+def hash_path_stem(s: str) -> int:
+    """Hash the stem of a cache file path (everything before the first dot in the basename).
+
+    This is a combined stem-extraction + hash function optimized for mypyc compilation.
+    Uses only integer arithmetic, avoiding intermediate string allocations.
+    """
+    # First find end of stem (scanning backwards, stop at first dot after last separator)
+    i = len(s) - 1
+    end: i64 = i
+    while i >= 0:
+        c: i64 = ord(s[i])
+        if c == ord("/") or c == ord("\\"):
+            break
+        if c == ord("."):
+            end = i
+        i -= 1
+    # Calculate hash
+    hv: i64 = 123
+    i = end
+    while i >= 0:
+        c = i64(ord(s[i]))
+        hv = (hv * 33) ^ c
+        i -= 1
+    # Murmur3 finalizer for better bit avalanche (improves shard uniformity)
+    hv = (hv ^ (hv >> 32)) & 0xFFFFFFFF
+    hv ^= hv >> 16
+    hv = (hv * 0x85EBCA6B) & 0xFFFFFFFF
+    hv ^= hv >> 13
+    hv = (hv * 0xC2B2AE35) & 0xFFFFFFFF
+    hv ^= hv >> 16
+    return int(hv)


### PR DESCRIPTION
SQLite writes can become a major bottleneck for parallel runs, since only one write can be active at any time. Sharding helps a lot and was pretty easy to implement and reason about. 

We need to be a bit careful to not have transactions that span multiple shards, as it might cause deadlocks. Sharding is based on path name without file name extension(s), so cache data for a single module goes to the same shard always.

Use a predictable string hash function that is tuned for mypyc. It's much faster than say SHA-1 (though hashing probably isn't a huge bottleneck).

A version of this with 8 shards was on the order of 20% faster in some cases when using 8 workers. The impact was bigger on macOS, but Linux was also better (at least on a cloud VM). Before merging, I'll run some benchmarks to validate that 16 shards don't regress anything.

Used coding agent assist here, but did things here in small reviewed increments.

Also updated the cache conversion and diff scripts (tested manually using coding agent).

Related to #21215.