### PR TITLE
Narrow context fallback limitation to walrus only

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -547,6 +547,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         self._unique_id = 0
         self._variance_dummy_type = None
 
+        # Assignment expression is the only *expression* that can have externally
+        # visible effects via binder. We bump this whenever this happens to handle
+        # situations when some expressions are accepted multiple times.
+        self.assignment_expression_effect = 0
+
     @property
     def expr_checker(self) -> mypy.checkexpr.ExpressionChecker:
         return self._expr_checker
@@ -4772,7 +4777,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # context that is ultimately used. This is however tricky with redefinitions.
         # For now we simply disable second accept in cases known to cause problems,
         # see e.g. testAssignToOptionalTupleWalrus.
-        binder_version = self.binder.version
+        assignment_expression_effect = self.assignment_expression_effect
 
         fallback_context_used = False
         with (
@@ -4802,7 +4807,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         union_fallback = (
             preferred_context is not None
             and isinstance(get_proper_type(lvalue_type), UnionType)
-            and binder_version == self.binder.version
+            and assignment_expression_effect == self.assignment_expression_effect
         )
 
         # Skip literal types, as they have special logic (for better errors).

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4461,7 +4461,10 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
 
     def visit_assignment_expr(self, e: AssignmentExpr) -> Type:
         value = self.accept(e.value)
+        binder_version = self.chk.binder.version
         self.chk.check_assignment(e.target, e.value)
+        if self.chk.binder.version != binder_version:
+            self.chk.assignment_expression_effect += 1
         self.chk.check_final(e)
         if not has_uninhabited_component(value):
             # TODO: can we get rid of this extra store_type()?

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1616,3 +1616,16 @@ async def outer(c: Cls[T]) -> Optional[T]:
     return await inner(c)
 [builtins fixtures/async_await.pyi]
 [typing fixtures/typing-async.pyi]
+
+[case testContextFallbackNarrowingTernaryRValue]
+from typing import Iterable, Union
+
+def foo(args: Union[Iterable[Union[str, int]], str, int]) -> Iterable[str]:
+    if isinstance(args, (str, int)):
+        args = (args,)
+    args = (
+        arg if isinstance(arg, str) else str()
+        for arg in args
+    )
+    return args
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/21273

This fixes regression caused by too cautious check in assignment context fallback. Ternary expression can change binder version, but only assignment expression can have an _externally visible_ effect. So I add a dedicated counter to track this.
