### PR TITLE
Fix error message for type application on non-generic expressions

### DIFF
--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -121,7 +121,7 @@ FUNCTION_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a type annotation", codes.NO_UNTYPED_DEF
 )
 ONLY_CLASS_APPLICATION: Final = ErrorMessage(
-    "Type application is only supported for generic classes"
+    "Type application is only supported for generic classes and type aliases"
 )
 RETURN_TYPE_EXPECTED: Final = ErrorMessage(
     "Function is missing a return type annotation", codes.NO_UNTYPED_DEF

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -426,7 +426,7 @@ from typing import TypeVar
 T = TypeVar('T')
 def f(x: T) -> T: pass
 
-y = f[int]  # E: Type application is only supported for generic classes
+y = f[int]  # E: Type application is only supported for generic classes and type aliases
 [out]
 
 
@@ -1004,7 +1004,7 @@ reveal_type(y)  # N: Revealed type is "builtins.int"
 
 U[int]  # E: Bad number of arguments for type alias, expected 0, given 1
 O[int]  # E: Bad number of arguments for type alias, expected 0, given 1 \
-        # E: Type application is only supported for generic classes
+        # E: Type application is only supported for generic classes and type aliases
 
 [case testAliasesInClassBodyNormalVsSubscripted]
 
@@ -1072,9 +1072,9 @@ reveal_type(ts) # N: Revealed type is "Any"
 us = UA.x # E: "<typing special form>" has no attribute "x"
 reveal_type(us) # N: Revealed type is "Any"
 
-xx = CA[str] + 1  # E: Type application is only supported for generic classes
-yy = TA[str]()  # E: Type application is only supported for generic classes
-zz = UA[str].x  # E: Type application is only supported for generic classes
+xx = CA[str] + 1  # E: Type application is only supported for generic classes and type aliases
+yy = TA[str]()  # E: Type application is only supported for generic classes and type aliases
+zz = UA[str].x  # E: Type application is only supported for generic classes and type aliases
 [builtins fixtures/tuple.pyi]
 [typing fixtures/typing-medium.pyi]
 [out]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -92,7 +92,7 @@ class B(Generic[P]): ...
 Other = B[P]
 
 T = TypeVar('T', bound=Alias[..., Any])
-Alias[..., Any]  # E: Type application is only supported for generic classes
+Alias[..., Any]  # E: Type application is only supported for generic classes and type aliases
 B[...]
 Other[...]
 [builtins fixtures/paramspec.pyi]

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2763,6 +2763,6 @@ T = TypeVar('T')
 
 def func(d: Callable[[Unpack[Ts]], T]) -> T: ...
 
-y = func[1, int] # E: Type application is only supported for generic classes \
+y = func[1, int] # E: Type application is only supported for generic classes and type aliases \
                  # E: Invalid type: try using Literal[1] instead?
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
## Summary

Update the error message "Type application is only supported for generic classes" to also mention type aliases, since type application is also valid for generic type aliases.

The original error message was misleading because it stated that type application is only supported for generic classes, but type aliases also support type application (e.g., `type TA[T] = list[T]; v: TA[int]` works correctly).

## Changes

- Updated `ONLY_CLASS_APPLICATION` error message in `mypy/message_registry.py` from "Type application is only supported for generic classes" to "Type application is only supported for generic classes and type aliases"
- Updated corresponding test expectations in:
  - `test-data/unit/check-generics.test`
  - `test-data/unit/check-parameter-specification.test`
  - `test-data/unit/check-typevar-tuple.test`

## Test plan

- [x] Ran `pytest mypy/test/testcheck.py::TypeCheckSuite::check-generics.test` - all 194 tests passed
- [x] Ran `pytest mypy/test/testcheck.py::TypeCheckSuite::check-parameter-specification.test` - tests passed
- [x] Ran `pytest mypy/test/testcheck.py::TypeCheckSuite::check-typevar-tuple.test` - tests passed
- [x] Manually verified the fix with a test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)