### PR TITLE
Depend on ast-serialize by default

### DIFF
--- a/docs/source/common_issues.rst
+++ b/docs/source/common_issues.rst
@@ -232,8 +232,7 @@ improved performance. You can ensure the presence of orjson using the ``faster-c
 
     python3 -m pip install -U mypy[faster-cache]
 
-Mypy may depend on orjson by default in the future. To use faster, native parser, use the
-``native-parse`` extra. Native parser will be default in near future.
+Mypy may depend on orjson by default in the future.
 
 Types of empty collections
 --------------------------

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -6,3 +6,4 @@ mypy_extensions>=1.0.0
 pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'
 librt>=0.9.0; platform_python_implementation != 'PyPy'
+ast-serialize>=0.2.0

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -6,4 +6,4 @@ mypy_extensions>=1.0.0
 pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'
 librt>=0.9.0; platform_python_implementation != 'PyPy'
-ast-serialize>=0.2.0
+ast-serialize>=0.2.0,<1.0.0

--- a/mypy/nativeparse.py
+++ b/mypy/nativeparse.py
@@ -26,8 +26,8 @@ from typing import Final, cast
 try:
     import ast_serialize  # type: ignore[import-not-found, unused-ignore]
 except ImportError:
-    print("error: native parser not installed")
-    print("note: to install run `pip install mypy[native-parser]`")
+    print("error: ast-serialize package not installed")
+    print("note: to install run `pip install ast-serialize`")
     sys.exit(2)
 
 from librt.internal import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
   "pathspec>=1.0.0",
   "tomli>=1.1.0; python_version<'3.11'",
   "librt>=0.9.0; platform_python_implementation != 'PyPy'",
+  "ast-serialize>=0.2.0",
 ]
 dynamic = ["version"]
 
@@ -65,7 +66,6 @@ mypyc = ["setuptools>=50"]
 reports = ["lxml"]
 install-types = ["pip"]
 faster-cache = ["orjson"]
-native-parser = ["ast-serialize>=0.2.0,<1.0.0"]
 
 [project.urls]
 Homepage = "https://www.mypy-lang.org/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "pathspec>=1.0.0",
   "tomli>=1.1.0; python_version<'3.11'",
   "librt>=0.9.0; platform_python_implementation != 'PyPy'",
-  "ast-serialize>=0.2.0",
+  "ast-serialize>=0.2.0,<1.0.0",
 ]
 dynamic = ["version"]
 
@@ -66,6 +66,7 @@ mypyc = ["setuptools>=50"]
 reports = ["lxml"]
 install-types = ["pip"]
 faster-cache = ["orjson"]
+native-parser = []
 
 [project.urls]
 Homepage = "https://www.mypy-lang.org/"

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -13,4 +13,3 @@ pytest-cov>=2.10.0
 setuptools>=77.0.3
 tomli>=1.1.0  # needed even on py311+ so the self check passes with --python-version 3.10
 pre_commit>=3.5.0
-ast-serialize>=0.2.0,<1.0.0


### PR DESCRIPTION
This way parallel checking is available in the default install (as an experimental feature in mypy 2.0).

We'll still support `pip install mypy[native-parser]` as a no-op for backward compat.