### PR TITLE
Improve call expressions in type annotations with native parser

### DIFF
--- a/mypy/nativeparse.py
+++ b/mypy/nativeparse.py
@@ -271,7 +271,7 @@ def parse_to_binary_ast(
         platform=options.platform,
         always_true=options.always_true,
         always_false=options.always_false,
-        cache_version=1,
+        cache_version=2,
     )
     return (
         ast_bytes,
@@ -939,6 +939,7 @@ def read_type(state: State, data: ReadBuffer) -> Type:
     elif tag == types.RAW_EXPRESSION_TYPE:
         type_name = read_str(data)
         value: types.LiteralValue | str | None
+        note: str | None = None
         if type_name == "builtins.bool":
             value = read_bool(data)
         elif type_name == "builtins.int":
@@ -953,9 +954,11 @@ def read_type(state: State, data: ReadBuffer) -> Type:
             tag = read_tag(data)
             assert tag == LITERAL_NONE, f"Expected LITERAL_NONE for invalid type, got {tag}"
             value = None
+            # Read optional note (cache_version >= 2)
+            note = read_str_opt(data)
         else:
             assert False, f"Unsupported RawExpressionType: {type_name}"
-        raw_type = RawExpressionType(value, type_name)
+        raw_type = RawExpressionType(value, type_name, note=note)
         read_loc(data, raw_type)
         expect_end_tag(data)
         return raw_type

--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -17,7 +17,7 @@ x: Annotated[int, THESE, ARE, IGNORED, FOR, NOW]
 reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
-[case testAnnotated3_no_native_parse]
+[case testAnnotated3]
 from typing_extensions import Annotated
 x: Annotated[int, -+~12.3, "som"[e], more(anno+a+ions, that=[are]), (b"ignored",), 4, N.O.W, ...]
 reveal_type(x)  # N: Revealed type is "builtins.int"

--- a/test-data/unit/check-fastparse.test
+++ b/test-data/unit/check-fastparse.test
@@ -194,7 +194,7 @@ def f(x, y):  # E: Type signature has too few parameters
 f(1, 2)
 f(1) # E: Missing positional argument "y" in call to "f"
 
-[case testFasterParseTypeErrorCustom_no_native_parse]
+[case testFasterParseTypeErrorCustom]
 
 from typing import TypeVar, Generic
 T = TypeVar('T')
@@ -207,7 +207,7 @@ def f(a: Foo(int)) -> int:
 main:7: error: Invalid type comment or annotation
 main:7: note: Suggestion: use Foo[...] instead of Foo(...)
 
-[case testFasterParseCallWithKeywordArgs_no_native_parse]
+[case testFasterParseCallWithKeywordArgs]
 
 def Foo(sort: bool) -> type:
     return int


### PR DESCRIPTION
In particular, `Annotated[foo, some_call(x=y)]` shouldn't generate an error.

This depends on mypyc/ast_serialize#52 (which is included in our minimum ast-serialize version dependency).