### PR TITLE
Do not call best_matches() unless we show the message

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3921,6 +3921,7 @@ def module_not_found(
         if (
             reason == ModuleNotFoundReason.NOT_FOUND
             and not errors.prefer_simple_messages()
+            and errors.is_error_code_enabled(code)
             and line not in errors.ignored_lines.get(caller_state.xpath, {})
         ):
             top_level_target = target.split(".")[0]

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7578,7 +7578,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         if isinstance(msg, str):
             msg = ErrorMessage(msg, code=code)
 
-        if self.msg.prefer_simple_messages():
+        if (
+            self.msg.prefer_simple_messages()
+            or code is not None
+            and not self.errors.is_error_code_enabled(code)
+        ):
             self.fail(msg, context)  # Fast path -- skip all fancy logic
             return False
 

--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -876,12 +876,8 @@ class Errors:
         return False
 
     def is_error_code_enabled(self, error_code: ErrorCode) -> bool:
-        if self.options:
-            current_mod_disabled = self.options.disabled_error_codes
-            current_mod_enabled = self.options.enabled_error_codes
-        else:
-            current_mod_disabled = set()
-            current_mod_enabled = set()
+        current_mod_disabled = self.options.disabled_error_codes
+        current_mod_enabled = self.options.enabled_error_codes
 
         if error_code in current_mod_disabled:
             return False

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1007,9 +1007,12 @@ class MessageBuilder:
                     matching_type_args.append(callee_arg_name)
                 else:
                     not_matching_type_args.append(callee_arg_name)
-        matches = best_matches(name, matching_type_args, n=3)
-        if not matches:
-            matches = best_matches(name, not_matching_type_args, n=3)
+        if not self.prefer_simple_messages():
+            matches = best_matches(name, matching_type_args, n=3)
+            if not matches:
+                matches = best_matches(name, not_matching_type_args, n=3)
+        else:
+            matches = []
         self.unexpected_keyword_argument_for_function(
             for_function(callee), name, context, matches=matches
         )
@@ -1128,9 +1131,12 @@ class MessageBuilder:
                     if item_has_type_match:
                         has_matching_variant = True
 
-                matches = best_matches(kwarg_name, matching_type_args, n=3)
-                if not matches:
-                    matches = best_matches(kwarg_name, not_matching_type_args, n=3)
+                if not self.prefer_simple_messages():
+                    matches = best_matches(kwarg_name, matching_type_args, n=3)
+                    if not matches:
+                        matches = best_matches(kwarg_name, not_matching_type_args, n=3)
+                else:
+                    matches = []
 
                 if matches:
                     kwargs_with_suggestions.append((kwarg_name, matches))

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3135,7 +3135,9 @@ class SemanticAnalyzer(
                     f'Module "{import_id}" does not explicitly export attribute "{source_id}"'
                 )
             elif not (
-                self.options.ignore_errors or self.cur_mod_node.path in self.errors.ignored_files
+                self.options.ignore_errors
+                or self.cur_mod_node.path in self.errors.ignored_files
+                or self.errors.prefer_simple_messages()
             ):
                 alternatives = set(module.names.keys()).difference({source_id})
                 matches = best_matches(source_id, alternatives, n=3)


### PR DESCRIPTION
This function is very slow. While playing with parallel checking for home-assistant/core I found that we spend ~30% in this function (compiled, 12 workers).