### PR TITLE
Improve override error note for LSP violations

### DIFF
--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1293,6 +1293,9 @@ class MessageBuilder:
             )
         else:
             self.note(override_str, context, offset=ALIGN_OFFSET + 2 * OFFSET, parent_error=error)
+            self.note(
+                "This violates the Liskov substitution principle", context, parent_error=error
+            )
 
     def pretty_callable_or_overload(
         self,

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -9412,3 +9412,11 @@ from typ import NT
 def f() -> NT:
     return NT(x='')
 [builtins fixtures/tuple.pyi]
+
+[case testLSPOverrideNote]
+class A:
+    def f(self, x: object) -> object: ...
+class B(A):
+    def f(self, x: int) -> int: ...  # E: Argument 1 of "f" is incompatible with supertype "A"; supertype defines the argument type as "object" \
+                                     # N: This violates the Liskov substitution principle \
+                                     # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides


### PR DESCRIPTION
Fixes #7994.

Adds a note explaining that incompatible method overrides violate the Liskov substitution principle. The existing error is preserved; this change only adds an explanatory note.

Testing:
- Ran `python -m mypy /tmp/lsp_test.py` before/after
- `python runtests.py self`
- `python runtests.py lint`