### PR TITLE
Mark librt.time.time() non-experimental

### DIFF
--- a/mypyc/lib-rt/time/librt_time.c
+++ b/mypyc/lib-rt/time/librt_time.c
@@ -12,8 +12,6 @@
 #include <sys/time.h>
 #endif
 
-#ifdef MYPYC_EXPERIMENTAL
-
 // Internal function that returns a C double for mypyc primitives
 // Returns high-precision time in seconds (like time.time())
 static double
@@ -74,17 +72,11 @@ time_time(PyObject *self, PyObject *const *args, size_t nargs) {
     return PyFloat_FromDouble(result);
 }
 
-#endif
-
 static PyMethodDef librt_time_module_methods[] = {
-#ifdef MYPYC_EXPERIMENTAL
     {"time", (PyCFunction)time_time, METH_FASTCALL,
      PyDoc_STR("Return the current time in seconds since the Unix epoch as a floating point number.")},
-#endif
     {NULL, NULL, 0, NULL}
 };
-
-#ifdef MYPYC_EXPERIMENTAL
 
 static int
 time_abi_version(void) {
@@ -96,12 +88,9 @@ time_api_version(void) {
     return LIBRT_TIME_API_VERSION;
 }
 
-#endif
-
 static int
 librt_time_module_exec(PyObject *m)
 {
-#ifdef MYPYC_EXPERIMENTAL
     // Export mypyc internal C API via capsule
     static void *time_api[LIBRT_TIME_API_LEN] = {
         (void *)time_abi_version,
@@ -112,7 +101,6 @@ librt_time_module_exec(PyObject *m)
     if (PyModule_Add(m, "_C_API", c_api_object) < 0) {
         return -1;
     }
-#endif
     return 0;
 }
 

--- a/mypyc/lib-rt/time/librt_time.h
+++ b/mypyc/lib-rt/time/librt_time.h
@@ -1,14 +1,10 @@
 #ifndef LIBRT_TIME_H
 #define LIBRT_TIME_H
 
-#ifdef MYPYC_EXPERIMENTAL
-
 #include <Python.h>
 
 #define LIBRT_TIME_ABI_VERSION 1
 #define LIBRT_TIME_API_VERSION 1
 #define LIBRT_TIME_API_LEN 3
-
-#endif  // MYPYC_EXPERIMENTAL
 
 #endif  // LIBRT_TIME_H

--- a/mypyc/lib-rt/time/librt_time_api.c
+++ b/mypyc/lib-rt/time/librt_time_api.c
@@ -1,16 +1,5 @@
 #include "librt_time_api.h"
 
-#ifndef MYPYC_EXPERIMENTAL
-
-int
-import_librt_time(void)
-{
-    // All librt.time features are experimental for now, so don't set up the API here
-    return 0;
-}
-
-#else  // MYPYC_EXPERIMENTAL
-
 void *LibRTTime_API[LIBRT_TIME_API_LEN] = {0};
 
 int
@@ -45,5 +34,3 @@ import_librt_time(void)
     }
     return 0;
 }
-
-#endif // MYPYC_EXPERIMENTAL

--- a/mypyc/lib-rt/time/librt_time_api.h
+++ b/mypyc/lib-rt/time/librt_time_api.h
@@ -6,14 +6,10 @@
 int
 import_librt_time(void);
 
-#ifdef MYPYC_EXPERIMENTAL
-
 extern void *LibRTTime_API[LIBRT_TIME_API_LEN];
 
 #define LibRTTime_ABIVersion (*(int (*)(void)) LibRTTime_API[0])
 #define LibRTTime_APIVersion (*(int (*)(void)) LibRTTime_API[1])
 #define LibRTTime_time (*(double (*)(void)) LibRTTime_API[2])
-
-#endif  // MYPYC_EXPERIMENTAL
 
 #endif  // LIBRT_TIME_API_H

--- a/mypyc/test-data/run-librt-time.test
+++ b/mypyc/test-data/run-librt-time.test
@@ -1,4 +1,4 @@
-[case testTimeBasic_librt_experimental]
+[case testTimeBasic_librt]
 import time as stdlib_time
 from librt.time import time
 
@@ -28,14 +28,7 @@ def test_time_comparable_to_stdlib() -> None:
     # but keep it relatively high to avoid test flakiness in CI)
     assert abs(our_time - std_time) < 0.25
 
-[case testTimeNotAvailableInNonExperimentalBuild_librt_time]
-# This also ensures librt.time can be built without experimental features
-import librt.time
-
-def test_time_not_available() -> None:
-    assert not hasattr(librt.time, "time")
-
-[case testTimeUsedAtTopLevelOnly_librt_experimental]
+[case testTimeUsedAtTopLevelOnly_librt]
 from librt.time import time
 
 # The only reference to time() is at module top level


### PR DESCRIPTION
It is highly unlikely ABI for this module will change. We should start using this ourselves, as we do a lot of performance logging in mypy.

cc @JukkaL 