### PR TITLE
[mypyc] Fix librt API/ABI version checks

### DIFF
--- a/mypyc/lib-rt/base64/librt_base64_api.c
+++ b/mypyc/lib-rt/base64/librt_base64_api.c
@@ -9,28 +9,35 @@ import_librt_base64(void)
     if (mod == NULL)
         return -1;
     Py_DECREF(mod);  // we import just for the side effect of making the below work.
-    void *capsule = PyCapsule_Import("librt.base64._C_API", 0);
+    void **capsule = (void **)PyCapsule_Import("librt.base64._C_API", 0);
     if (capsule == NULL)
         return -1;
-    memcpy(LibRTBase64_API, capsule, sizeof(LibRTBase64_API));
-    if (LibRTBase64_ABIVersion() != LIBRT_BASE64_ABI_VERSION) {
+
+    // Only after version validation succeeds can we safely copy the full table.
+    int (*abi_version)(void) = (int (*)(void))capsule[0];
+    int (*api_version)(void) = (int (*)(void))capsule[1];
+    if (abi_version() != LIBRT_BASE64_ABI_VERSION) {
         char err[128];
         snprintf(err, sizeof(err), "ABI version conflict for librt.base64, expected %d, found %d",
             LIBRT_BASE64_ABI_VERSION,
-            LibRTBase64_ABIVersion()
+            abi_version()
         );
         PyErr_SetString(PyExc_ValueError, err);
         return -1;
     }
-    if (LibRTBase64_APIVersion() < LIBRT_BASE64_API_VERSION) {
+    if (api_version() < LIBRT_BASE64_API_VERSION) {
         char err[128];
         snprintf(err, sizeof(err),
                  "API version conflict for librt.base64, expected %d or newer, found %d (hint: upgrade librt)",
             LIBRT_BASE64_API_VERSION,
-            LibRTBase64_APIVersion()
+            api_version()
         );
         PyErr_SetString(PyExc_ValueError, err);
         return -1;
     }
+    // Provider API version is >= our expected version, which (by the API
+    // compatibility contract) means it has at least LIBRT_BASE64_API_LEN
+    // entries, so this copy is safe.
+    memcpy(LibRTBase64_API, capsule, sizeof(LibRTBase64_API));
     return 0;
 }

--- a/mypyc/lib-rt/internal/librt_internal_api.c
+++ b/mypyc/lib-rt/internal/librt_internal_api.c
@@ -9,28 +9,35 @@ import_librt_internal(void)
     if (mod == NULL)
         return -1;
     Py_DECREF(mod);  // we import just for the side effect of making the below work.
-    void *capsule = PyCapsule_Import("librt.internal._C_API", 0);
+    void **capsule = (void **)PyCapsule_Import("librt.internal._C_API", 0);
     if (capsule == NULL)
         return -1;
-    memcpy(NativeInternal_API, capsule, sizeof(NativeInternal_API));
-    if (NativeInternal_ABI_Version() != LIBRT_INTERNAL_ABI_VERSION) {
+
+    // Each librt capsule gives at least 20 entries. Validate version before copying the table.
+    int (*abi_version)(void) = (int (*)(void))capsule[13];
+    if (abi_version() != LIBRT_INTERNAL_ABI_VERSION) {
         char err[128];
         snprintf(err, sizeof(err), "ABI version conflict for librt.internal, expected %d, found %d",
             LIBRT_INTERNAL_ABI_VERSION,
-            NativeInternal_ABI_Version()
+            abi_version()
         );
         PyErr_SetString(PyExc_ValueError, err);
         return -1;
     }
-    if (NativeInternal_API_Version() < LIBRT_INTERNAL_API_VERSION) {
+    int (*api_version)(void) = (int (*)(void))capsule[19];
+    if (api_version() < LIBRT_INTERNAL_API_VERSION) {
         char err[128];
         snprintf(err, sizeof(err),
                  "API version conflict for librt.internal, expected %d or newer, found %d (hint: upgrade librt)",
             LIBRT_INTERNAL_API_VERSION,
-            NativeInternal_API_Version()
+            api_version()
         );
         PyErr_SetString(PyExc_ValueError, err);
         return -1;
     }
+    // Provider API version is >= our expected version, which (by the API
+    // compatibility contract) means it has at least LIBRT_INTERNAL_API_LEN
+    // entries, so this copy is safe.
+    memcpy(NativeInternal_API, capsule, sizeof(NativeInternal_API));
     return 0;
 }

--- a/mypyc/lib-rt/strings/librt_strings_api.c
+++ b/mypyc/lib-rt/strings/librt_strings_api.c
@@ -20,29 +20,36 @@ import_librt_strings(void)
     if (mod == NULL)
         return -1;
     Py_DECREF(mod);  // we import just for the side effect of making the below work.
-    void *capsule = PyCapsule_Import("librt.strings._C_API", 0);
+    void **capsule = (void **)PyCapsule_Import("librt.strings._C_API", 0);
     if (capsule == NULL)
         return -1;
-    memcpy(LibRTStrings_API, capsule, sizeof(LibRTStrings_API));
-    if (LibRTStrings_ABIVersion() != LIBRT_STRINGS_ABI_VERSION) {
+
+    // Only after version validation succeeds can we safely copy the full table.
+    int (*abi_version)(void) = (int (*)(void))capsule[0];
+    int (*api_version)(void) = (int (*)(void))capsule[1];
+    if (abi_version() != LIBRT_STRINGS_ABI_VERSION) {
         char err[128];
         snprintf(err, sizeof(err), "ABI version conflict for librt.strings, expected %d, found %d",
             LIBRT_STRINGS_ABI_VERSION,
-            LibRTStrings_ABIVersion()
+            abi_version()
         );
         PyErr_SetString(PyExc_ValueError, err);
         return -1;
     }
-    if (LibRTStrings_APIVersion() < LIBRT_STRINGS_API_VERSION) {
+    if (api_version() < LIBRT_STRINGS_API_VERSION) {
         char err[128];
         snprintf(err, sizeof(err),
                  "API version conflict for librt.strings, expected %d or newer, found %d (hint: upgrade librt)",
             LIBRT_STRINGS_API_VERSION,
-            LibRTStrings_APIVersion()
+            api_version()
         );
         PyErr_SetString(PyExc_ValueError, err);
         return -1;
     }
+    // Provider API version is >= our expected version, which (by the API
+    // compatibility contract) means it has at least LIBRT_STRINGS_API_LEN
+    // entries, so this copy is safe.
+    memcpy(LibRTStrings_API, capsule, sizeof(LibRTStrings_API));
     return 0;
 }
 

--- a/mypyc/lib-rt/time/librt_time_api.c
+++ b/mypyc/lib-rt/time/librt_time_api.c
@@ -9,28 +9,35 @@ import_librt_time(void)
     if (mod == NULL)
         return -1;
     Py_DECREF(mod);  // we import just for the side effect of making the below work.
-    void *capsule = PyCapsule_Import("librt.time._C_API", 0);
+    void **capsule = (void **)PyCapsule_Import("librt.time._C_API", 0);
     if (capsule == NULL)
         return -1;
-    memcpy(LibRTTime_API, capsule, sizeof(LibRTTime_API));
-    if (LibRTTime_ABIVersion() != LIBRT_TIME_ABI_VERSION) {
+
+    // Only after version validation succeeds can we safely copy the full table.
+    int (*abi_version)(void) = (int (*)(void))capsule[0];
+    int (*api_version)(void) = (int (*)(void))capsule[1];
+    if (abi_version() != LIBRT_TIME_ABI_VERSION) {
         char err[128];
         snprintf(err, sizeof(err), "ABI version conflict for librt.time, expected %d, found %d",
             LIBRT_TIME_ABI_VERSION,
-            LibRTTime_ABIVersion()
+            abi_version()
         );
         PyErr_SetString(PyExc_ValueError, err);
         return -1;
     }
-    if (LibRTTime_APIVersion() < LIBRT_TIME_API_VERSION) {
+    if (api_version() < LIBRT_TIME_API_VERSION) {
         char err[128];
         snprintf(err, sizeof(err),
                  "API version conflict for librt.time, expected %d or newer, found %d (hint: upgrade librt)",
             LIBRT_TIME_API_VERSION,
-            LibRTTime_APIVersion()
+            api_version()
         );
         PyErr_SetString(PyExc_ValueError, err);
         return -1;
     }
+    // Provider API version is >= our expected version, which (by the API
+    // compatibility contract) means it has at least LIBRT_TIME_API_LEN
+    // entries, so this copy is safe.
+    memcpy(LibRTTime_API, capsule, sizeof(LibRTTime_API));
     return 0;
 }


### PR DESCRIPTION
Check API and ABI versions first before memcpy, since an older installed version could have a smaller API table and we should not read past the end of the buffer.

`librt.vecs` uses a slightly different approach, this only modifies the submodules using the common approach.