### PR TITLE
[mypyc] librt.strings no longer behind experimental compiler flag

### DIFF
--- a/mypyc/lib-rt/byteswriter_extra_ops.c
+++ b/mypyc/lib-rt/byteswriter_extra_ops.c
@@ -3,8 +3,6 @@
 
 #include "byteswriter_extra_ops.h"
 
-#ifdef MYPYC_EXPERIMENTAL
-
 char CPyBytesWriter_Write(PyObject *obj, PyObject *value) {
     BytesWriterObject *self = (BytesWriterObject *)obj;
     const char *data;
@@ -41,5 +39,3 @@ void CPyBytes_ReadError(int64_t index, Py_ssize_t size) {
                      (long long)index, size);
     }
 }
-
-#endif // MYPYC_EXPERIMENTAL

--- a/mypyc/lib-rt/byteswriter_extra_ops.h
+++ b/mypyc/lib-rt/byteswriter_extra_ops.h
@@ -1,8 +1,6 @@
 #ifndef BYTESWRITER_EXTRA_OPS_H
 #define BYTESWRITER_EXTRA_OPS_H
 
-#ifdef MYPYC_EXPERIMENTAL
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <Python.h>
@@ -285,7 +283,5 @@ CPyBytes_ReadF64BE(PyObject *bytes_obj, int64_t index) {
     const unsigned char *data = (const unsigned char *)PyBytes_AS_STRING(bytes_obj);
     return CPyBytes_ReadF64BEUnsafe(data + index);
 }
-
-#endif // MYPYC_EXPERIMENTAL
 
 #endif

--- a/mypyc/lib-rt/strings/librt_strings.c
+++ b/mypyc/lib-rt/strings/librt_strings.c
@@ -18,8 +18,6 @@
        ((BytesWriterObject *)data)->len += sizeof(type); \
     } while (0)
 
-#ifdef MYPYC_EXPERIMENTAL
-
 static PyTypeObject BytesWriterType;
 
 static bool
@@ -1110,10 +1108,7 @@ read_f64_be(PyObject *module, PyObject *const *args, size_t nargs) {
     return PyFloat_FromDouble(CPyBytes_ReadF64BEUnsafe(data + index));
 }
 
-#endif
-
 static PyMethodDef librt_strings_module_methods[] = {
-#ifdef MYPYC_EXPERIMENTAL
     {"write_i16_le", (PyCFunction) write_i16_le, METH_FASTCALL,
      PyDoc_STR("Write a 16-bit signed integer to BytesWriter in little-endian format")
     },
@@ -1174,11 +1169,8 @@ static PyMethodDef librt_strings_module_methods[] = {
     {"read_f64_be", (PyCFunction) read_f64_be, METH_FASTCALL,
      PyDoc_STR("Read a 64-bit float from bytes in big-endian format")
     },
-#endif
     {NULL, NULL, 0, NULL}
 };
-
-#ifdef MYPYC_EXPERIMENTAL
 
 static int
 strings_abi_version(void) {
@@ -1190,12 +1182,9 @@ strings_api_version(void) {
     return LIBRT_STRINGS_API_VERSION;
 }
 
-#endif
-
 static int
 librt_strings_module_exec(PyObject *m)
 {
-#ifdef MYPYC_EXPERIMENTAL
     if (PyType_Ready(&BytesWriterType) < 0) {
         return -1;
     }
@@ -1230,7 +1219,6 @@ librt_strings_module_exec(PyObject *m)
     if (PyModule_Add(m, "_C_API", c_api_object) < 0) {
         return -1;
     }
-#endif
     return 0;
 }
 

--- a/mypyc/lib-rt/strings/librt_strings.h
+++ b/mypyc/lib-rt/strings/librt_strings.h
@@ -1,8 +1,6 @@
 #ifndef LIBRT_STRINGS_H
 #define LIBRT_STRINGS_H
 
-#ifdef MYPYC_EXPERIMENTAL
-
 #include <stdbool.h>
 #include <Python.h>
 #include "librt_strings_common.h"
@@ -29,7 +27,5 @@ typedef struct {
     Py_ssize_t capacity;  // Total capacity of the buffer (number of code points)
     char data[WRITER_EMBEDDED_BUF_LEN];  // Default buffer
 } StringWriterObject;
-
-#endif  // MYPYC_EXPERIMENTAL
 
 #endif  // LIBRT_STRINGS_H

--- a/mypyc/lib-rt/strings/librt_strings_api.c
+++ b/mypyc/lib-rt/strings/librt_strings_api.c
@@ -1,16 +1,5 @@
 #include "librt_strings_api.h"
 
-#ifndef MYPYC_EXPERIMENTAL
-
-int
-import_librt_strings(void)
-{
-    // All librt.strings features are experimental for now, so don't set up the API here
-    return 0;
-}
-
-#else  // MYPYC_EXPERIMENTAL
-
 void *LibRTStrings_API[LIBRT_STRINGS_API_LEN] = {0};
 
 int
@@ -45,5 +34,3 @@ import_librt_strings(void)
     }
     return 0;
 }
-
-#endif // MYPYC_EXPERIMENTAL

--- a/mypyc/lib-rt/strings/librt_strings_api.h
+++ b/mypyc/lib-rt/strings/librt_strings_api.h
@@ -4,8 +4,6 @@
 int
 import_librt_strings(void);
 
-#ifdef MYPYC_EXPERIMENTAL
-
 #include <stdbool.h>
 #include <Python.h>
 #include "librt_strings.h"
@@ -35,7 +33,5 @@ static inline bool CPyBytesWriter_Check(PyObject *obj) {
 static inline bool CPyStringWriter_Check(PyObject *obj) {
     return Py_TYPE(obj) == LibRTStrings_StringWriter_type_internal();
 }
-
-#endif  // MYPYC_EXPERIMENTAL
 
 #endif  // LIBRT_STRINGS_API_H

--- a/mypyc/lib-rt/stringwriter_extra_ops.c
+++ b/mypyc/lib-rt/stringwriter_extra_ops.c
@@ -3,9 +3,5 @@
 
 #include "stringwriter_extra_ops.h"
 
-#ifdef MYPYC_EXPERIMENTAL
-
 // All StringWriter operations are currently implemented as inline functions
 // in stringwriter_extra_ops.h, or use the exported capsule API directly.
-
-#endif // MYPYC_EXPERIMENTAL

--- a/mypyc/lib-rt/stringwriter_extra_ops.h
+++ b/mypyc/lib-rt/stringwriter_extra_ops.h
@@ -1,8 +1,6 @@
 #ifndef STRINGWRITER_EXTRA_OPS_H
 #define STRINGWRITER_EXTRA_OPS_H
 
-#ifdef MYPYC_EXPERIMENTAL
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <Python.h>
@@ -73,7 +71,5 @@ static inline int32_t CPyStringWriter_GetItem(PyObject *obj, int64_t index) {
         return (int32_t)val;
     }
 }
-
-#endif // MYPYC_EXPERIMENTAL
 
 #endif

--- a/mypyc/primitives/librt_strings_ops.py
+++ b/mypyc/primitives/librt_strings_ops.py
@@ -24,7 +24,6 @@ function_op(
     return_type=bytes_writer_rprimitive,
     c_function_name="LibRTStrings_BytesWriter_internal",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS],
 )
 
@@ -34,7 +33,6 @@ method_op(
     return_type=bytes_rprimitive,
     c_function_name="LibRTStrings_BytesWriter_getvalue_internal",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS],
 )
 
@@ -44,7 +42,6 @@ method_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_Write",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -54,7 +51,6 @@ method_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_Write",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -64,7 +60,6 @@ method_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_Append",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -74,7 +69,6 @@ method_op(
     return_type=none_rprimitive,
     c_function_name="LibRTStrings_BytesWriter_truncate_internal",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS],
 )
 
@@ -84,7 +78,6 @@ function_op(
     return_type=short_int_rprimitive,
     c_function_name="CPyBytesWriter_Len",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -95,7 +88,6 @@ bytes_writer_adjust_index_op = custom_primitive_op(
     return_type=int64_rprimitive,
     c_function_name="CPyBytesWriter_AdjustIndex",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -106,7 +98,6 @@ bytes_writer_range_check_op = custom_primitive_op(
     return_type=bool_rprimitive,
     c_function_name="CPyBytesWriter_RangeCheck",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -117,7 +108,6 @@ bytes_writer_get_item_unsafe_op = custom_primitive_op(
     return_type=uint8_rprimitive,
     c_function_name="CPyBytesWriter_GetItem",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -128,7 +118,6 @@ bytes_writer_set_item_unsafe_op = custom_primitive_op(
     return_type=void_rtype,
     c_function_name="CPyBytesWriter_SetItem",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -140,7 +129,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteI16LE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -150,7 +138,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteI16BE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -160,7 +147,6 @@ function_op(
     return_type=int16_rprimitive,
     c_function_name="CPyBytes_ReadI16LE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -170,7 +156,6 @@ function_op(
     return_type=int16_rprimitive,
     c_function_name="CPyBytes_ReadI16BE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -182,7 +167,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteI32LE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -192,7 +176,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteI32BE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -202,7 +185,6 @@ function_op(
     return_type=int32_rprimitive,
     c_function_name="CPyBytes_ReadI32LE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -212,7 +194,6 @@ function_op(
     return_type=int32_rprimitive,
     c_function_name="CPyBytes_ReadI32BE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -224,7 +205,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteI64LE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -234,7 +214,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteI64BE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -244,7 +223,6 @@ function_op(
     return_type=int64_rprimitive,
     c_function_name="CPyBytes_ReadI64LE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -254,7 +232,6 @@ function_op(
     return_type=int64_rprimitive,
     c_function_name="CPyBytes_ReadI64BE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -266,7 +243,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteF32LE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -276,7 +252,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteF32BE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -286,7 +261,6 @@ function_op(
     return_type=float_rprimitive,
     c_function_name="CPyBytes_ReadF32LE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -296,7 +270,6 @@ function_op(
     return_type=float_rprimitive,
     c_function_name="CPyBytes_ReadF32BE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -308,7 +281,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteF64LE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -318,7 +290,6 @@ function_op(
     return_type=none_rprimitive,
     c_function_name="CPyBytesWriter_WriteF64BE",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -328,7 +299,6 @@ function_op(
     return_type=float_rprimitive,
     c_function_name="CPyBytes_ReadF64LE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -338,7 +308,6 @@ function_op(
     return_type=float_rprimitive,
     c_function_name="CPyBytes_ReadF64BE",
     error_kind=ERR_MAGIC_OVERLAPPING,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, BYTES_WRITER_EXTRA_OPS],
 )
 
@@ -350,7 +319,6 @@ function_op(
     return_type=string_writer_rprimitive,
     c_function_name="LibRTStrings_StringWriter_internal",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS],
 )
 
@@ -360,7 +328,6 @@ method_op(
     return_type=str_rprimitive,
     c_function_name="LibRTStrings_StringWriter_getvalue_internal",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS],
 )
 
@@ -370,7 +337,6 @@ method_op(
     return_type=none_rprimitive,
     c_function_name="LibRTStrings_StringWriter_write_internal",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS],
 )
 
@@ -380,7 +346,6 @@ method_op(
     return_type=none_rprimitive,
     c_function_name="CPyStringWriter_Append",
     error_kind=ERR_MAGIC,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, STRING_WRITER_EXTRA_OPS],
 )
 
@@ -390,7 +355,6 @@ function_op(
     return_type=short_int_rprimitive,
     c_function_name="CPyStringWriter_Len",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, STRING_WRITER_EXTRA_OPS],
 )
 
@@ -401,7 +365,6 @@ string_writer_adjust_index_op = custom_primitive_op(
     return_type=int64_rprimitive,
     c_function_name="CPyStringWriter_AdjustIndex",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, STRING_WRITER_EXTRA_OPS],
 )
 
@@ -412,7 +375,6 @@ string_writer_range_check_op = custom_primitive_op(
     return_type=bool_rprimitive,
     c_function_name="CPyStringWriter_RangeCheck",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, STRING_WRITER_EXTRA_OPS],
 )
 
@@ -423,6 +385,5 @@ string_writer_get_item_unsafe_op = custom_primitive_op(
     return_type=int32_rprimitive,
     c_function_name="CPyStringWriter_GetItem",
     error_kind=ERR_NEVER,
-    experimental=True,
     dependencies=[LIBRT_STRINGS, STRING_WRITER_EXTRA_OPS],
 )

--- a/mypyc/test-data/capsule-deps.test
+++ b/mypyc/test-data/capsule-deps.test
@@ -4,16 +4,7 @@ def f() -> None:
 [out]
 No deps
 
-[case testStringsNoCapsuleDepWithoutExperimental]
-# Test case missing _experimental suffix -> no deps
-from librt.strings import StringWriter
-
-def f() -> None:
-    StringWriter()
-[out]
-No deps
-
-[case testStringsCapsuleDep_experimental]
+[case testStringsCapsuleDep]
 from librt.strings import StringWriter
 
 def f() -> None:
@@ -21,7 +12,7 @@ def f() -> None:
 [out]
 Capsule(name='librt.strings')
 
-[case testStringsCapsuleDepFromParamType_experimental]
+[case testStringsCapsuleDepFromParamType]
 from librt.strings import StringWriter
 
 def f(s: StringWriter) -> None:
@@ -29,7 +20,7 @@ def f(s: StringWriter) -> None:
 [out]
 Capsule(name='librt.strings')
 
-[case testStringsCapsuleDepFromReturnType_experimental]
+[case testStringsCapsuleDepFromReturnType]
 from librt.strings import StringWriter
 
 def f() -> StringWriter:
@@ -37,7 +28,7 @@ def f() -> StringWriter:
 [out]
 Capsule(name='librt.strings')
 
-[case testStringsCapsuleDepFromUnion_experimental]
+[case testStringsCapsuleDepFromUnion]
 from typing import Union
 
 from librt.strings import StringWriter
@@ -47,7 +38,7 @@ def f(s: Union[StringWriter, str]) -> None:
 [out]
 Capsule(name='librt.strings')
 
-[case testStringsCapsuleDepFromTuple_experimental]
+[case testStringsCapsuleDepFromTuple]
 from librt.strings import StringWriter
 
 def f(s: tuple[int, StringWriter]) -> None:
@@ -55,7 +46,7 @@ def f(s: tuple[int, StringWriter]) -> None:
 [out]
 Capsule(name='librt.strings')
 
-[case testExtraFileDep_experimental]
+[case testExtraFileDep]
 from librt.strings import StringWriter
 
 def f(s: StringWriter) -> int:

--- a/mypyc/test-data/irbuild-librt-strings.test
+++ b/mypyc/test-data/irbuild-librt-strings.test
@@ -1,4 +1,4 @@
-[case testLibrtStrings_experimental_64bit]
+[case testLibrtStrings_64bit]
 from librt.strings import BytesWriter
 from mypy_extensions import u8, i64
 
@@ -94,7 +94,7 @@ L2:
     CPyBytesWriter_SetItem(b, r0, x)
     return 1
 
-[case testLibrtStrings_write_i16_le_experimental_64bit]
+[case testLibrtStrings_write_i16_le_64bit]
 from librt.strings import BytesWriter, write_i16_le
 from mypy_extensions import i16
 
@@ -117,7 +117,7 @@ L0:
     r0 = CPyBytesWriter_WriteI16LE(b, 1234)
     return 1
 
-[case testLibrtStrings_read_i16_le_experimental_64bit]
+[case testLibrtStrings_read_i16_le_64bit]
 from librt.strings import read_i16_le
 from mypy_extensions import i16, i64
 
@@ -140,7 +140,7 @@ L0:
     r0 = CPyBytes_ReadI16LE(b, 0)
     return r0
 
-[case testLibrtStrings_i32_le_experimental_64bit]
+[case testLibrtStrings_i32_le_64bit]
 from librt.strings import BytesWriter, write_i32_le, read_i32_le
 from mypy_extensions import i32, i64
 
@@ -180,7 +180,7 @@ L0:
     r0 = CPyBytes_ReadI32LE(b, 0)
     return r0
 
-[case testLibrtStrings_i64_le_experimental_64bit]
+[case testLibrtStrings_i64_le_64bit]
 from librt.strings import BytesWriter, write_i64_le, read_i64_le
 from mypy_extensions import i64
 
@@ -219,7 +219,7 @@ L0:
     r0 = CPyBytes_ReadI64LE(b, 0)
     return r0
 
-[case testLibrtStrings_StringWriter_experimental_64bit]
+[case testLibrtStrings_StringWriter_64bit]
 from librt.strings import StringWriter
 from mypy_extensions import i32, i64
 

--- a/mypyc/test-data/run-librt-strings.test
+++ b/mypyc/test-data/run-librt-strings.test
@@ -1,4 +1,4 @@
-[case testLibrtStrings_librt_experimental]
+[case testLibrtStrings_librt]
 from typing import Any
 import base64
 import binascii
@@ -1393,10 +1393,3 @@ def test_string_writer_wrapper_functions() -> None:
         s[6]
     with assertRaises(IndexError):
         s[-7]
-
-[case testStringsFeaturesNotAvailableInNonExperimentalBuild_librt]
-# This also ensures librt.strings can be built without experimental features
-import librt.strings
-
-def test_bytes_writer_not_available() -> None:
-    assert not hasattr(librt.strings, "BytesWriter")


### PR DESCRIPTION
It will be included in the default librt build, and the features can be used in compiled code without feature flags. It's still considered experimental from the functionality point of view, but not from the build system point of the view.

We are still missing documentation. I'll prepare it in another PR.