### PR TITLE
Handle reachability consistently in two-phase checking

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -493,6 +493,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         self.binder = ConditionalTypeBinder(options)
         self.globals_binder = self.binder
         self.globals = tree.names
+        self.globals_unreachable: set[int] = set()
         self.return_types = []
         self.dynamic_funcs = []
         self.partial_types = []
@@ -577,6 +578,12 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         self.partial_types = []
         self.inferred_attribute_types = None
         self.scope = CheckerScope(self.tree)
+        self.globals_unreachable.clear()
+
+    def mark_unreachable(self, block: list[Statement], after: Statement) -> None:
+        """Marks all statements in block after a given one (inclusive) as unreachable."""
+        last_line = (last := block[-1]).end_line or last.line
+        self.globals_unreachable.update(range(after.line, last_line + 1))
 
     def check_first_pass(self, recurse_into_functions: bool = True) -> None:
         """Type check the entire file, but defer functions with unresolved references.
@@ -595,8 +602,12 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
             )
             with self.tscope.module_scope(self.tree.fullname):
                 with self.enter_partial_types(), self.binder.top_frame_context():
+                    marked_unreachable = False
                     for d in self.tree.defs:
                         if self.binder.is_unreachable():
+                            if not marked_unreachable:
+                                self.mark_unreachable(self.tree.defs, after=d)
+                                marked_unreachable = True
                             if not self.should_report_unreachable_issues():
                                 break
                             if not self.is_noop_for_reachability(d):
@@ -675,6 +686,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 # TODO: use impl_only in the daemon as well.
                 if not impl_only:
                     self.accept(node)
+                    return
+                if node.line in self.globals_unreachable:
                     return
                 if isinstance(node, (FuncDef, Decorator)):
                     self.check_partial_impl(node)
@@ -3244,8 +3257,12 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
             # as unreachable -- so we don't display an error.
             self.binder.unreachable()
             return
+        marked_unreachable = False
         for s in b.body:
             if self.binder.is_unreachable():
+                if self.scope.top_level_function() is None and not marked_unreachable:
+                    self.mark_unreachable(b.body, after=s)
+                    marked_unreachable = True
                 if not self.should_report_unreachable_issues():
                     break
                 if not self.is_noop_for_reachability(s):

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1701,3 +1701,37 @@ def main(contents: Any, commit: str | None) -> None:
 
 main({"commit": None}, None)
 [builtins fixtures/tuple.pyi]
+
+[case testUnreachableFunctionAfterTopLevelAssert]
+def foo() -> int:
+    ...
+
+raise Exception
+
+x = foo()
+
+def test() -> None:
+    # It is questionable to allow this, this test exists to check 1:1
+    # behavior match of parallel checking with sequential checking.
+    x + "hm..."
+
+class C:
+    def test(self) -> None:
+        x + "same here..."
+[builtins fixtures/exception.pyi]
+
+[case testUnreachableFunctionAfterClassLevelAssert]
+def foo() -> int:
+    ...
+
+class C:
+    x = foo()
+    raise Exception
+    def test(self) -> None:
+        # It is questionable to allow this, this test exists to check 1:1
+        # behavior match of parallel checking with sequential checking.
+        C.x + "hm..."
+
+def test_outer() -> None:
+    C.x + "no way"  # E: Unsupported left operand type for + ("int")
+[builtins fixtures/exception.pyi]


### PR DESCRIPTION
We have this (somewhat questionable) behaviour of not checking unreachable code. Surprisingly many repos rely on this. Thus we should preserve this behaviour in two-phase checking, which means skip top-level definitions that were found unreachable.

I tried few approaches, and using line numbers seems to be the simplest one.
cc @JukkaL 