### PR TITLE
Partially support old NumPy plugin in parallel type checking

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3358,6 +3358,8 @@ class State:
         self.priorities = {}  # id -> priority
         self.dep_line_map = {}  # id -> line
         self.dep_hashes = {}
+        # We copy imports as defs to (partially) support some legacy mypy plugins,
+        # most notably old NumPy plugin that does some imports patching, see #21323.
         copied_imports = False
         if not self.tree.defs and self.tree.raw_data is not None:
             self.tree.defs = list(self.tree.imports)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3358,9 +3358,15 @@ class State:
         self.priorities = {}  # id -> priority
         self.dep_line_map = {}  # id -> line
         self.dep_hashes = {}
+        copied_imports = False
+        if not self.tree.defs and self.tree.raw_data is not None:
+            self.tree.defs = list(self.tree.imports)
+            copied_imports = True
         dep_entries = manager.all_imported_modules_in_file(
             self.tree
         ) + self.manager.plugin.get_additional_deps(self.tree)
+        if copied_imports:
+            self.tree.defs = []
         for pri, id, line in dep_entries:
             self.priorities[id] = min(pri, self.priorities.get(id, PRI_ALL))
             if id == self.id:


### PR DESCRIPTION
Ref https://github.com/python/mypy/issues/21323

IIUC this will not fix the plugin completely unless we also call `get_additional_deps()` in the workers (which would be weird IMO). But most importantly the plugin will not crash unconditionally like now, but will infer less precise types.

cc @JukkaL 
