### PR TITLE
Behave consistently when type-checking stub package directly

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -921,12 +921,12 @@ class BuildManager:
             ):
                 continue
 
-            raise CompileError(
-                [
-                    f'mypy: error: "{os.path.relpath(path)}" shadows library module "{module}"',
-                    f'note: A user-defined top-level module with name "{module}" is not supported',
-                ]
+            self.errors.set_file(path, module, options)
+            self.error(None, f'This file shadows library module "{module}"', blocker=True)
+            self.note(
+                None, f'A user-defined top-level module with name "{module}" is not supported'
             )
+            self.errors.raise_error()
 
         if metastore is None:
             metastore = create_metastore(options, parallel_worker=parallel_worker)

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1257,6 +1257,14 @@ class BuildManager:
 
     def is_module(self, id: str) -> bool:
         """Is there a file in the file system corresponding to module id?"""
+        if id in self.modules:
+            # Micro-optimization, if already found it, it is definitely a module.
+            return True
+        if id in self.source_set.source_modules:
+            # Special case: if a module is passed on command line, we accept it even
+            # if we would not resolve it using regular mechanisms. This makes behavior
+            # consistent in cases like `mypy foo-stubs`, where stubs are not installed.
+            return True
         return find_module_simple(id, self) is not None
 
     def parse_file(

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -913,8 +913,8 @@ class BuildManager:
                 continue
             path = self.find_module_cache.find_module(module, fast_path=True)
             if not isinstance(path, str):
-                raise CompileError(
-                    [f"Failed to find builtin module {module}, perhaps typeshed is broken?"]
+                build_error(
+                    f'Failed to find builtin module "{module}", perhaps typeshed is broken?'
                 )
             if is_typeshed_file(options.abs_custom_typeshed_dir, path) or is_stub_package_file(
                 path
@@ -923,7 +923,7 @@ class BuildManager:
 
             raise CompileError(
                 [
-                    f'mypy: "{os.path.relpath(path)}" shadows library module "{module}"',
+                    f'mypy: error: "{os.path.relpath(path)}" shadows library module "{module}"',
                     f'note: A user-defined top-level module with name "{module}" is not supported',
                 ]
             )
@@ -1256,7 +1256,11 @@ class BuildManager:
         return res
 
     def is_module(self, id: str) -> bool:
-        """Is there a file in the file system corresponding to module id?"""
+        """Does the given fullname refer to a module?
+
+        Note: this does not always verify that the module exists and relies on
+        previously executed logic in find_module_and_diagnose().
+        """
         if id in self.modules:
             # Micro-optimization, if we already found it, it is definitely a module.
             return True
@@ -3158,7 +3162,7 @@ class State:
                     assert ioerr.errno is not None
                     raise CompileError(
                         [
-                            "mypy: error: cannot read file '{}': {}".format(
+                            "mypy: error: Cannot read file '{}': {}".format(
                                 self.path.replace(os.getcwd() + os.sep, ""),
                                 os.strerror(ioerr.errno),
                             )
@@ -3167,9 +3171,9 @@ class State:
                     ) from ioerr
                 except (UnicodeDecodeError, DecodeError) as decodeerr:
                     if self.path.endswith(".pyd"):
-                        err = f"{self.path}: error: stubgen does not support .pyd files"
+                        err = f"{self.path}: error: Stubgen does not support .pyd files"
                     else:
-                        err = f"{self.path}: error: cannot decode file: {str(decodeerr)}"
+                        err = f"{self.path}: error: Cannot decode file: {str(decodeerr)}"
                     raise CompileError([err], module_with_blocker=self.id) from decodeerr
             elif self.path and self.manager.fscache.isdir(self.path):
                 source = ""
@@ -3791,7 +3795,7 @@ def find_module_and_diagnose(
             # If we can't find a root source it's always fatal.
             # TODO: This might hide non-fatal errors from
             # root sources processed earlier.
-            raise CompileError([f"mypy: can't find module '{id}'"])
+            raise CompileError([f'mypy: error: Cannot find module "{id}"'])
         else:
             raise ModuleNotFound
 
@@ -3920,7 +3924,7 @@ def module_not_found(
     )
     if target == "builtins":
         manager.error(
-            line, "Cannot find 'builtins' module. Typeshed appears broken!", blocker=True
+            line, 'Cannot find "builtins" module. Typeshed appears broken!', blocker=True
         )
         errors.raise_error()
     else:

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1258,7 +1258,7 @@ class BuildManager:
     def is_module(self, id: str) -> bool:
         """Is there a file in the file system corresponding to module id?"""
         if id in self.modules:
-            # Micro-optimization, if already found it, it is definitely a module.
+            # Micro-optimization, if we already found it, it is definitely a module.
             return True
         if id in self.source_set.source_modules:
             # Special case: if a module is passed on command line, we accept it even

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1577,7 +1577,8 @@ def process_options(
                 reason = cache.find_module(p)
                 if reason is ModuleNotFoundReason.FOUND_WITHOUT_TYPE_HINTS:
                     fail(
-                        f"Package '{p}' cannot be type checked due to missing py.typed marker. See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
+                        f"Package '{p}' cannot be type checked due to missing py.typed marker.\n"
+                        "See https://mypy.readthedocs.io/en/stable/installed_packages.html for more details",
                         stderr,
                         options,
                     )
@@ -1698,7 +1699,7 @@ def read_types_packages_to_install(cache_dir: str, after_run: bool) -> list[str]
         if not after_run:
             sys.stderr.write(
                 "error: Can't determine which types to install with no files to check "
-                + "(and no cache from previous mypy run)\n"
+                "(and no cache from previous mypy run)\n"
             )
         else:
             sys.stderr.write(

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -2334,7 +2334,7 @@ tmp/c.py:1: error: Module "d" has no attribute "x"
 [delete nonexistent.py.2]
 [out]
 [out2]
-mypy: error: cannot read file 'tmp/nonexistent.py': No such file or directory
+mypy: error: Cannot read file 'tmp/nonexistent.py': No such file or directory
 
 [case testSerializeAbstractPropertyIncremental]
 from abc import abstractmethod

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1277,7 +1277,7 @@ pass
 error: cache must be enabled in parallel mode
 == Return code: 2
 
-[case testFooBar]
+[case testCheckingStubPackagesWorksInParallelMode]
 # cmd: mypy foo-stubs --num-workers=4
 [file foo-stubs/__init__.pyi]
 [file foo-stubs/api/__init__.pyi]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1276,3 +1276,11 @@ pass
 [out]
 error: cache must be enabled in parallel mode
 == Return code: 2
+
+[case testFooBar]
+# cmd: mypy foo-stubs --num-workers=4
+[file foo-stubs/__init__.pyi]
+[file foo-stubs/api/__init__.pyi]
+from foo.api import bar as bar
+[file foo-stubs/api/bar.pyi]
+[out]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -117,7 +117,7 @@ sub.pkg contains __init__.py but is not a valid Python package name
 [file a.py]
 # coding: uft-8
 [out]
-a.py: error: cannot decode file: unknown encoding: uft-8
+a.py: error: Cannot decode file: unknown encoding: uft-8
 == Return code: 2
 
 [case testCannotIgnoreDuplicateModule]
@@ -416,7 +416,7 @@ int_pow.py:11: note: Revealed type is "Any"
 [case testMissingFile]
 # cmd: mypy nope.py
 [out]
-mypy: error: cannot read file 'nope.py': No such file or directory
+mypy: error: Cannot read file 'nope.py': No such file or directory
 == Return code: 2
 
 [case testModulesAndPackages]
@@ -630,7 +630,7 @@ c.py:1: error: Name "fail" is not defined
 \[mypy]
 files = config.py
 [out]
-mypy: error: cannot read file 'override.py': No such file or directory
+mypy: error: Cannot read file 'override.py': No such file or directory
 == Return code: 2
 
 [case testErrorSummaryOnSuccess]
@@ -687,7 +687,7 @@ Found 2 errors in 2 files (checked 2 source files)
 [case testErrorSummaryOnBadUsage]
 # cmd: mypy --error-summary missing.py
 [out]
-mypy: error: cannot read file 'missing.py': No such file or directory
+mypy: error: Cannot read file 'missing.py': No such file or directory
 Found 1 error in 1 file (errors prevented further checking)
 == Return code: 2
 
@@ -763,7 +763,7 @@ imp.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#miss
 [file a.pyd]
 # coding: uft-8
 [out]
-a.pyd: error: stubgen does not support .pyd files
+a.pyd: error: Stubgen does not support .pyd files
 == Return code: 2
 
 [case testDuplicateModules]
@@ -1065,7 +1065,7 @@ except ValueError:
 from typing import *
 sys.path = path
 [out]
-mypy: "typing.py" shadows library module "typing"
+mypy: error: "typing.py" shadows library module "typing"
 note: A user-defined top-level module with name "typing" is not supported
 == Return code: 2
 
@@ -1083,7 +1083,7 @@ note: A user-defined top-level module with name "typing" is not supported
 [file dir/stdlib/collections/__init__.pyi]
 [file dir/stdlib/VERSIONS]
 [out]
-Failed to find builtin module mypy_extensions, perhaps typeshed is broken?
+mypy: error: Failed to find builtin module "mypy_extensions", perhaps typeshed is broken?
 == Return code: 2
 
 [case testCustomTypeshedDirFilePassedExplicitly]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1065,8 +1065,8 @@ except ValueError:
 from typing import *
 sys.path = path
 [out]
-mypy: error: "typing.py" shadows library module "typing"
-note: A user-defined top-level module with name "typing" is not supported
+typing.py: error: This file shadows library module "typing"
+typing.py: note: A user-defined top-level module with name "typing" is not supported
 == Return code: 2
 
 [case testCustomTypeshedDirWithRelativePathDoesNotCrash]

--- a/test-data/unit/fine-grained-blockers.test
+++ b/test-data/unit/fine-grained-blockers.test
@@ -502,7 +502,7 @@ def f(x: int) -> None: ...
 def f(x: str) -> None: ...
 [out]
 ==
-a.py: error: cannot decode file: 'ascii' codec can't decode byte 0xc3 in position 16: ordinal not in range(128)
+a.py: error: Cannot decode file: 'ascii' codec can't decode byte 0xc3 in position 16: ordinal not in range(128)
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
@@ -518,7 +518,7 @@ def f(x: int) -> None: ...
 def f(x: str) -> None: ...
 [out]
 ==
-a.py: error: cannot decode file: 'ascii' codec can't decode byte 0xc3 in position 17: ordinal not in range(128)
+a.py: error: Cannot decode file: 'ascii' codec can't decode byte 0xc3 in position 17: ordinal not in range(128)
 ==
 main:2: error: Argument 1 to "f" has incompatible type "int"; expected "str"
 
@@ -532,6 +532,6 @@ a.f(1)
 [file a.py.2]
 def f(x: str) -> None: ...
 [out]
-a.py: error: cannot decode file: 'ascii' codec can't decode byte 0xc3 in position 16: ordinal not in range(128)
+a.py: error: Cannot decode file: 'ascii' codec can't decode byte 0xc3 in position 16: ordinal not in range(128)
 ==
 main:3: error: Argument 1 to "f" has incompatible type "int"; expected "str"

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -6068,9 +6068,9 @@ a.py:1: error: "int" not callable
 [file a.py.2]
 1()
 [out]
-mypy: error: cannot read file 'tmp/nonexistent.py': No such file or directory
+mypy: error: Cannot read file 'tmp/nonexistent.py': No such file or directory
 ==
-mypy: error: cannot read file 'tmp/nonexistent.py': No such file or directory
+mypy: error: Cannot read file 'tmp/nonexistent.py': No such file or directory
 
 [case testNonExistentFileOnCommandLine2]
 # cmd: mypy a.py

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1518,7 +1518,7 @@ async def foo() -> None:
 x = 0
 1 + ''
 [out]
-mypy: "tmp/typing.py" shadows library module "typing"
+mypy: error: "tmp/typing.py" shadows library module "typing"
 note: A user-defined top-level module with name "typing" is not supported
 
 

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1518,8 +1518,8 @@ async def foo() -> None:
 x = 0
 1 + ''
 [out]
-mypy: error: "tmp/typing.py" shadows library module "typing"
-note: A user-defined top-level module with name "typing" is not supported
+typing.py: error: This file shadows library module "typing"
+typing.py: note: A user-defined top-level module with name "typing" is not supported
 
 
 [case testNoPython3StubAvailable]


### PR DESCRIPTION
Type-checking stub packages directly always worked, and people rely on this, e.g. people run `mypy scipy-stubs` in CI. However, there is a problem if the same exact stubs are not installed, then the incremental mode (and therefore parallel mode) is completely busted. This is because when computing dependencies `is_module()` returns False for these, and therefore most dependencies are missing.

There is a simple fix however: if a module is in source set, it should be definitely a module.
cc @JukkaL 

I also update some blocker error formatting in related code to be more consistent (e.g. use capitalized errors).