### PR TITLE
Add support for Final[...] in dataclasses

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -660,6 +660,14 @@ class DataclassTransformer:
                 else:
                     self._api.fail('"kw_only" argument must be a boolean literal', stmt.rvalue)
 
+            # Allow bare x: Final[int] in class body, since it will be set in the generated
+            # __init__() method (unless it is an InitVar), to match regular class semantics.
+            if node.is_final and not node.is_classvar and node.final_unset_in_class:
+                if is_init_var:
+                    self._api.fail("InitVar cannot be final", stmt.rvalue)
+                else:
+                    node.final_set_in_init = True
+
             if sym.type is None and node.is_final and node.is_inferred:
                 # This is a special case, assignment like x: Final = 42 is classified
                 # annotated above, but mypy strips the `Final` turning it into x = 42.

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -2698,3 +2698,30 @@ class ClassB(ClassA):
     def value(self) -> int:
         return 0
 [builtins fixtures/dict.pyi]
+
+[case testDataclassAllowsFinalField]
+# flags: --python-version=3.13
+from dataclasses import InitVar, dataclass
+from typing import Final, ClassVar
+
+@dataclass
+class C:
+    x: int
+    y: Final[int]
+    z: ClassVar[Final[int]] = 4
+
+c = C(1, 2)
+c.y = 3  # E: Cannot assign to final attribute "y"
+
+@dataclass
+class D(C):
+    x: Final[int]  # E: Cannot override writable attribute "x" with a final one
+
+@dataclass
+class Bad1:
+    x: Final[InitVar[int]]  # E: InitVar cannot be final
+
+@dataclass
+class Bad2:
+    x: InitVar[Final[int]]  # E: Final can be only used as an outermost qualifier in a variable annotation
+[builtins fixtures/dict.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/5608

This is a surprisingly popular feature (and btw part of the typing spec). The idea is simple, since we already allow:
```python
class C:
    x: Final[int]
    def __init__(self, x: int) -> None:
        self.x = x
```
we can manually set `final_set_in_init` for
```python
@dataclass
class C:
    x: Final[int]
```
because this is what the  generated `__init__()` will do.
