### PR TITLE
Add --list-install-types flag

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -117,6 +117,13 @@ def main(
             options,
         )
 
+    if options.install_types and options.list_install_types:
+        fail(
+            "error: --install-types and --list-install-types cannot be used together",
+            stderr,
+            options,
+        )
+
     if options.install_types and (stdout is not sys.stdout or stderr is not sys.stderr):
         # Since --install-types performs user input, we want regular stdout and stderr.
         fail("error: --install-types not supported in this mode of running mypy", stderr, options)
@@ -136,11 +143,26 @@ def main(
             options,
         )
 
+    if options.list_install_types and not options.incremental:
+        fail(
+            "error: --list-install-types not supported with incremental mode disabled",
+            stderr,
+            options,
+        )
+
     if options.install_types and not sources:
         install_types(formatter, options, non_interactive=options.non_interactive)
         return
 
-    res, messages, blockers = run_build(sources, options, fscache, t0, stdout, stderr)
+    if options.list_install_types and not sources:
+        list_install_types(options, out=stdout)
+        return
+
+    # When --list-install-types is active, route all mypy diagnostic output to
+    # stderr so that only the package names end up on stdout (enabling pipe usage
+    # like: mypy --list-install-types src/ | xargs uv pip install).
+    build_stdout = stderr if options.list_install_types else stdout
+    res, messages, blockers = run_build(sources, options, fscache, t0, build_stdout, stderr)
 
     if options.non_interactive:
         missing_pkgs = read_types_packages_to_install(options.cache_dir, after_run=True)
@@ -166,11 +188,14 @@ def main(
             summary = formatter.format_error(
                 n_errors, n_files, len(sources), blockers=blockers, use_color=options.color_output
             )
-            stdout.write(summary + "\n")
+            build_stdout.write(summary + "\n")
         # Only notes should also output success
         elif not messages or n_notes == len(messages):
-            stdout.write(formatter.format_success(len(sources), options.color_output) + "\n")
-        stdout.flush()
+            build_stdout.write(formatter.format_success(len(sources), options.color_output) + "\n")
+        build_stdout.flush()
+
+    if options.list_install_types:
+        list_install_types(options, after_run=True, out=stdout)
 
     if options.install_types and not options.non_interactive:
         result = install_types(formatter, options, after_run=True, non_interactive=False)
@@ -1228,6 +1253,13 @@ def define_options(
         group=misc_group,
         inverse="--interactive",
     )
+    add_invertible_flag(
+        "--list-install-types",
+        default=False,
+        strict_flag=False,
+        help="Print detected missing library stub packages (one per line) without installing",
+        group=misc_group,
+    )
 
     if server_options:
         misc_group.add_argument(
@@ -1479,7 +1511,7 @@ def process_options(
                 special_opts.files,
             ]
         )
-        if code_methods == 0 and not options.install_types:
+        if code_methods == 0 and not options.install_types and not options.list_install_types:
             parser.error("Missing target module, package, files, or command.")
         elif code_methods > 1:
             parser.error("May only specify one of: module/package, files, or command.")
@@ -1703,6 +1735,19 @@ def read_types_packages_to_install(cache_dir: str, after_run: bool) -> list[str]
         return []
     with open(fnam) as f:
         return [line.strip() for line in f]
+
+
+def list_install_types(options: Options, *, after_run: bool = False, out: TextIO) -> None:
+    """Print missing stub packages one per line to *out*.
+
+    Callers should pass stdout here; mypy diagnostic output is routed to stderr
+    by the caller so that only package names reach stdout, making pipe usage
+    possible: mypy --list-install-types src/ | xargs uv pip install
+    """
+    packages = read_types_packages_to_install(options.cache_dir, after_run)
+    for pkg in packages:
+        out.write(pkg + "\n")
+    out.flush()
 
 
 def install_types(

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -409,6 +409,8 @@ class Options:
         # Install missing stub packages in non-interactive mode (don't prompt for
         # confirmation, and don't show any errors)
         self.non_interactive = False
+        # List missing stub packages to stdout (instead of installing them)
+        self.list_install_types = False
         # When we encounter errors that may cause many additional errors,
         # skip most errors after this many messages have been reported.
         # -1 means unlimited.

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -941,6 +941,38 @@ error: --install-types not supported without python executable or site packages
 [out]
 pkg.py:1: error: "int" not callable
 
+[case testCmdlineListInstallTypesConflictsWithInstallTypes]
+# cmd: mypy --list-install-types --install-types -m pkg
+[out]
+error: --install-types and --list-install-types cannot be used together
+== Return code: 2
+
+[case testCmdlineListInstallTypesRequiresIncremental]
+# cmd: mypy --list-install-types --no-incremental -m pkg
+[file pkg.py]
+1 + 2
+[out]
+error: --list-install-types not supported with incremental mode disabled
+== Return code: 2
+
+[case testCmdlineListInstallTypesNothingToDo]
+# cmd: mypy --list-install-types -m pkg
+[file pkg.py]
+1()
+[out]
+pkg.py:1: error: "int" not callable
+
+[case testCmdlineListInstallTypesMissingStubs]
+# cmd: mypy --list-install-types --no-site-packages -m pkg
+[file pkg.py]
+import requests
+[out]
+pkg.py:1: error: Library stubs not installed for "requests"
+pkg.py:1: note: Hint: "python3 -m pip install types-requests"
+pkg.py:1: note: (or run "mypy --install-types" to install all missing stub packages)
+pkg.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+types-requests
+
 [case testCmdlineExclude]
 # cmd: mypy --exclude abc .
 [file abc/apkg.py]


### PR DESCRIPTION
Closes #18156

## Summary

Adds `--list-install-types` flag that prints detected missing stub packages one per line to stdout, without installing them.

This enables pipe-based workflows with alternative package managers:

```bash
mypy --list-install-types src/ 2>/dev/null | xargs uv pip install
```

### Behavior

- When run with source files: runs the build, then prints missing stub packages to stdout; all mypy diagnostic output is routed to stderr so only package names reach stdout
- When run without source files: reads from the incremental cache (same as `--install-types` without files)
- Cannot be combined with `--install-types`
- Requires incremental mode (same constraint as `--install-types`)

### Example

```
$ mypy --list-install-types script.py 2>/dev/null
pandas-stubs
types-requests
```

## TODO

- [ ] Add tests

## Related Issues

- Fixes #18156
- Related: #10600