### PR TITLE
Allow re-declaring a TypeVar with an equivalent definition

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4775,6 +4775,27 @@ class SemanticAnalyzer(
             # Also give error for another type variable with the same name.
             (isinstance(existing.node, TypeVarExpr) and existing.node is call.analyzed)
         ):
+            # Allow re-declaring an existing TypeVar with an equivalent
+            # definition. This supports the try/except ImportError fallback
+            # pattern used for names like ``typing.AnyStr`` (deprecated in
+            # 3.13, removed in 3.18). Skip when any type still contains a
+            # placeholder, since placeholders compare equal regardless of
+            # the underlying name.
+            if (
+                isinstance(existing.node, TypeVarExpr)
+                and not any(has_placeholder(v) for v in values)
+                and not has_placeholder(upper_bound)
+                and not has_placeholder(default)
+                and not any(has_placeholder(v) for v in existing.node.values)
+                and not has_placeholder(existing.node.upper_bound)
+                and not has_placeholder(existing.node.default)
+                and existing.node.values == values
+                and existing.node.upper_bound == upper_bound
+                and existing.node.default == default
+                and existing.node.variance == variance
+            ):
+                call.analyzed = existing.node
+                return True
             self.fail(f'Cannot redefine "{name}" as a type variable', s)
             return False
 

--- a/test-data/unit/check-typevar-values.test
+++ b/test-data/unit/check-typevar-values.test
@@ -744,3 +744,32 @@ def fn(w: W) -> W:
         reveal_type(w)  # N: Revealed type is "builtins.int"
     return w
 [builtins fixtures/isinstance.pyi]
+
+[case testTypeVarRedeclarationEquivalent]
+# Redeclaring a TypeVar with the same definition is allowed (e.g. the
+# try/except ImportError fallback used for typing.AnyStr in 3.18+).
+from typing import TypeVar
+T = TypeVar('T', int, str)
+T = TypeVar('T', int, str)
+
+def f(x: T) -> T:
+    return x
+
+[case testTypeVarRedeclarationDifferentStillErrors]
+from typing import TypeVar
+T = TypeVar('T', int, str)
+T = TypeVar('T', int, float)  # E: Cannot redefine "T" as a type variable \
+                              # E: Invalid assignment target
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-full.pyi]
+
+[case testTypeVarRedeclarationFromImportEquivalent]
+from typing import TypeVar
+from a import T
+T = TypeVar('T', int, str)
+
+def f(x: T) -> T:
+    return x
+[file a.py]
+from typing import TypeVar
+T = TypeVar('T', int, str)


### PR DESCRIPTION
Currently mypy errors with `Cannot redefine "AnyStr" as a type variable` and
`Invalid assignment target` on the standard try/except ImportError fallback
pattern:

```python
from typing import TypeVar
try:
    from typing import AnyStr  # Removed in 3.18.
except ImportError:
    AnyStr = TypeVar('AnyStr', str, bytes)
```

This pattern will be needed once `typing.AnyStr` (deprecated in 3.13) is
actually removed in 3.18.

This PR relaxes the redefinition check in `process_typevar_declaration` so
that re-declaring an existing TypeVar with an equivalent definition is
treated as a no-op rather than an error. "Equivalent" means the same
values, upper bound, default, and variance.

To avoid masking real bugs, the relaxation is skipped whenever any of the
types involved still contains a placeholder, because placeholders compare
equal regardless of their forward-referenced name. This preserves the
existing behaviour exercised by `testNewAnalyzerDuplicateTypeVar` and
similar tests, where two declarations have different forward-ref bounds.

Genuinely different declarations (different constraints, bound, default,
or variance) still raise the original two errors.

Fixes #21332.