### PR TITLE
Fail fast when user tries to generate reports with parallel workers

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -102,6 +102,8 @@ def main(
         options.native_parser = True
         if options.cache_dir == os.devnull:
             fail("error: cache must be enabled in parallel mode", stderr, options)
+        if options.report_dirs:
+            fail("error: reports are not supported in parallel mode yet", stderr, options)
 
     if options.allow_redefinition and not options.local_partial_types:
         fail(

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -101,9 +101,14 @@ def main(
         # Supporting both parsers would be really tricky, so just support the new one.
         options.native_parser = True
         if options.cache_dir == os.devnull:
-            fail("error: cache must be enabled in parallel mode", stderr, options)
+            fail("error: Cache must be enabled in parallel mode", stderr, options)
         if options.report_dirs:
-            fail("error: reports are not supported in parallel mode yet", stderr, options)
+            fail(
+                "error: Reports are not supported in parallel mode yet\n"
+                "note: Use -n0 to disable parallel checking",
+                stderr,
+                options,
+            )
 
     if options.allow_redefinition and not options.local_partial_types:
         fail(

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1282,7 +1282,7 @@ a.py:1: error: Simple statements must be separated by newlines or semicolons
 [file a.py]
 pass
 [out]
-error: cache must be enabled in parallel mode
+error: Cache must be enabled in parallel mode
 == Return code: 2
 
 [case testCheckingStubPackagesWorksInParallelMode]


### PR DESCRIPTION
This is not supported, and support is somewhat non-trivial, so fail fast instead of generating incomplete/empty reports.
cc @JukkaL 