### PR TITLE
Fix overload resolution for type aliases to Any

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2994,7 +2994,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         matches: list[CallableType] = []
         return_types: list[Type] = []
         inferred_types: list[Type] = []
-        args_contain_any = any(map(has_any_type, arg_types))
+        args_contain_any = any(has_any_type_for_overload(arg_type) for arg_type in arg_types)
         type_maps: list[dict[Expression, Type]] = []
 
         for typ in plausible_targets:
@@ -6597,13 +6597,29 @@ def has_any_type(t: Type, ignore_in_type_obj: bool = False) -> bool:
     return t.accept(HasAnyType(ignore_in_type_obj))
 
 
+def has_any_type_for_overload(t: Type, ignore_in_type_obj: bool = False) -> bool:
+    """Like has_any_type, but also counts a top-level alias-to-Any.
+
+    has_any_type ignores TypeOfAny.from_alias_target so use sites don't trigger
+    --disallow-any-explicit, but for overload ambiguity we want an actual argument
+    that *is* an alias-to-Any to count (without making nested alias-to-Any count).
+    """
+    proper_t = get_proper_type(t)
+    if isinstance(proper_t, AnyType) and proper_t.type_of_any == TypeOfAny.from_alias_target:
+        return True
+    return has_any_type(t, ignore_in_type_obj=ignore_in_type_obj)
+
+
 class HasAnyType(types.BoolTypeQuery):
     def __init__(self, ignore_in_type_obj: bool) -> None:
         super().__init__(types.ANY_STRATEGY)
         self.ignore_in_type_obj = ignore_in_type_obj
 
     def visit_any(self, t: AnyType) -> bool:
-        return t.type_of_any != TypeOfAny.special_form  # special forms are not real Any types
+        return t.type_of_any not in (
+            TypeOfAny.special_form,
+            TypeOfAny.from_alias_target,
+        )
 
     def visit_callable_type(self, t: CallableType) -> bool:
         if self.ignore_in_type_obj and t.is_type_obj():
@@ -6842,7 +6858,7 @@ def any_causes_overload_ambiguity(
         # We ignore Anys in type object callables as ambiguity
         # creators, since that can lead to falsely claiming ambiguity
         # for overloads between Type and Callable.
-        if has_any_type(arg_type, ignore_in_type_obj=True):
+        if has_any_type_for_overload(arg_type, ignore_in_type_obj=True):
             matching_formals_unfiltered = [
                 (item_idx, lookup[arg_idx])
                 for item_idx, lookup in enumerate(actual_to_formal)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -6616,10 +6616,7 @@ class HasAnyType(types.BoolTypeQuery):
         self.ignore_in_type_obj = ignore_in_type_obj
 
     def visit_any(self, t: AnyType) -> bool:
-        return t.type_of_any not in (
-            TypeOfAny.special_form,
-            TypeOfAny.from_alias_target,
-        )
+        return t.type_of_any not in (TypeOfAny.special_form, TypeOfAny.from_alias_target)
 
     def visit_callable_type(self, t: CallableType) -> bool:
         if self.ignore_in_type_obj and t.is_type_obj():

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8269,7 +8269,7 @@ def make_any_non_explicit(t: Type) -> Type:
 class MakeAnyNonExplicit(TrivialSyntheticTypeTranslator):
     def visit_any(self, t: AnyType) -> Type:
         if t.type_of_any == TypeOfAny.explicit:
-            return t.copy_modified(TypeOfAny.special_form)
+            return t.copy_modified(TypeOfAny.from_alias_target)
         return t
 
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8263,13 +8263,19 @@ def remove_imported_names_from_symtable(names: SymbolTable, module: str) -> None
 
 def make_any_non_explicit(t: Type) -> Type:
     """Replace all Any types within in with Any that has attribute 'explicit' set to False"""
+    # An alias whose target is exactly Any should still behave like a real Any when used.
+    # Explicit Any nested inside a larger alias target is kept as the historical
+    # non-real Any flavor to avoid making large generic aliases overload-ambiguous.
+    proper_t = get_proper_type(t)
+    if isinstance(proper_t, AnyType) and proper_t.type_of_any == TypeOfAny.explicit:
+        return proper_t.copy_modified(TypeOfAny.from_alias_target)
     return t.accept(MakeAnyNonExplicit())
 
 
 class MakeAnyNonExplicit(TrivialSyntheticTypeTranslator):
     def visit_any(self, t: AnyType) -> Type:
         if t.type_of_any == TypeOfAny.explicit:
-            return t.copy_modified(TypeOfAny.from_alias_target)
+            return t.copy_modified(TypeOfAny.special_form)
         return t
 
     def visit_type_alias_type(self, t: TypeAliasType) -> Type:

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -483,7 +483,10 @@ def is_complex(t: Type) -> bool:
 
 
 def is_special_form_any(t: AnyType) -> bool:
-    return get_original_any(t).type_of_any == TypeOfAny.special_form
+    return get_original_any(t).type_of_any in (
+        TypeOfAny.special_form,
+        TypeOfAny.from_alias_target,
+    )
 
 
 def get_original_any(t: AnyType) -> AnyType:

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -483,10 +483,7 @@ def is_complex(t: Type) -> bool:
 
 
 def is_special_form_any(t: AnyType) -> bool:
-    return get_original_any(t).type_of_any in (
-        TypeOfAny.special_form,
-        TypeOfAny.from_alias_target,
-    )
+    return get_original_any(t).type_of_any in (TypeOfAny.special_form, TypeOfAny.from_alias_target)
 
 
 def get_original_any(t: AnyType) -> AnyType:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1760,7 +1760,11 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             #
             # TODO: Once we start adding support for enums, make sure we report a custom
             # error for case 2 as well.
-            if arg.type_of_any not in (TypeOfAny.from_error, TypeOfAny.special_form):
+            if arg.type_of_any not in (
+                TypeOfAny.from_error,
+                TypeOfAny.special_form,
+                TypeOfAny.from_alias_target,
+            ):
                 self.fail(
                     f'Parameter {idx} of Literal[...] cannot be of type "Any"',
                     ctx,

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -238,8 +238,9 @@ class TypeOfAny:
     # generating constraints.
     suggestion_engine: Final = 9
     # Does this Any come from a type alias whose target is Any (e.g.
-    # `Incomplete: TypeAlias = Any`)? It is a real Any (unlike special_form),
-    # but tagged separately so use sites don't trigger --disallow-any-explicit.
+    # `Incomplete: TypeAlias = Any`)? This is treated as a real Any for overload
+    # ambiguity when it appears as an actual argument, but is otherwise ignored like
+    # special_form to avoid triggering use-site explicit-Any errors.
     from_alias_target: Final = 10
 
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -237,6 +237,10 @@ class TypeOfAny:
     # used to ignore Anys inserted by the suggestion engine when
     # generating constraints.
     suggestion_engine: Final = 9
+    # Does this Any come from a type alias whose target is Any (e.g.
+    # `Incomplete: TypeAlias = Any`)? It is a real Any (unlike special_form),
+    # but tagged separately so use sites don't trigger --disallow-any-explicit.
+    from_alias_target: Final = 10
 
 
 def deserialize_type(data: JsonDict | str) -> Type:

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1381,6 +1381,22 @@ def h(i: int) -> None:  # E: Type of decorated function contains type "Any" ("Ca
     pass
 [builtins fixtures/list.pyi]
 
+[case testDisallowAnyDecoratedAliasToAny]
+# flags: --disallow-any-decorated
+from typing import Any, Callable, TypeVar
+from typing_extensions import TypeAlias
+
+F = TypeVar("F", bound=Callable[..., Any])
+AddressFormat: TypeAlias = Any
+
+def d(f: F) -> F:
+    return f
+
+@d
+def f(x: AddressFormat | None = None) -> int:
+    return 0
+[builtins fixtures/list.pyi]
+
 [case testDisallowAnyDecoratedReturnsCallableNoParams]
 # flags: --disallow-any-decorated
 from typing import Callable

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -562,6 +562,20 @@ reveal_type(b)                          # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 [out]
 
+[case testLiteralAliasToAnyAllowed]
+# Aliases to Any (e.g. typeshed's `Incomplete: TypeAlias = Any`) must not
+# trigger the Literal[...] cannot-be-Any error, matching the behavior of
+# unfollowed-import aliases.
+from typing import Any, Literal
+from typing_extensions import TypeAlias
+
+Incomplete: TypeAlias = Any
+
+a: Literal[Incomplete]
+reveal_type(a)                          # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]
+[out]
+
 [case testLiteralDisallowActualTypes]
 from typing import Literal
 

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -563,9 +563,6 @@ reveal_type(b)                          # N: Revealed type is "Any"
 [out]
 
 [case testLiteralAliasToAnyAllowed]
-# Aliases to Any (e.g. typeshed's `Incomplete: TypeAlias = Any`) must not
-# trigger the Literal[...] cannot-be-Any error, matching the behavior of
-# unfollowed-import aliases.
 from typing import Any, Literal
 from typing_extensions import TypeAlias
 

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6997,4 +6997,3 @@ def f(x: Incomplete) -> Incomplete:  # no error
 
 a: Incomplete = 1  # no error
 [builtins fixtures/tuple.pyi]
-

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6857,10 +6857,9 @@ if isinstance(headers, dict):
 reveal_type(headers)  # N: Revealed type is "__main__.Headers | typing.Iterable[tuple[builtins.bytes, builtins.bytes]]"
 [builtins fixtures/isinstancelist.pyi]
 
-[case testOverloadAliasToAnyArgWithNoneDefault]
-# An alias `Incomplete = Any` used as an overload arg must not silently match
-# the `default: None = None` overload. It should be treated as Any like a bare
-# Any value, triggering the overload-ambiguity fallback.
+[case testOverloadAliasToAnyArg]
+# An alias `Incomplete = Any` used as an overload arg should behave like bare
+# Any (engage the ambiguity fallback), not silently match a None-default overload.
 from typing import Any, TypeVar, overload
 from typing_extensions import TypeAlias
 
@@ -6880,112 +6879,18 @@ a: Incomplete
 b: Any
 reveal_type(M().get("k", a))  # N: Revealed type is "Any"
 reveal_type(M().get("k", b))  # N: Revealed type is "Any"
-[builtins fixtures/tuple.pyi]
 
-[case testOverloadAliasToAnyArgEquivalentToBareAny]
-# Alias-to-Any and bare Any should produce the same overload results.
-from typing import Any, overload
-from typing_extensions import TypeAlias
-
-Incomplete: TypeAlias = Any
-
+# Unambiguous overload: alias-Any picks the matching return type, no false ambiguity.
 @overload
-def f(x: int) -> int: ...
+def f(x: int, y: int) -> int: ...
 @overload
-def f(x: str) -> str: ...
-def f(x): ...
+def f(x: object, y: int) -> object: ...
+def f(x, y): ...
 
-a: Incomplete
-b: Any
-reveal_type(f(a))  # N: Revealed type is "Any"
-reveal_type(f(b))  # N: Revealed type is "Any"
-[builtins fixtures/tuple.pyi]
-
-[case testOverloadAliasToAnyArgChainedAlias]
-# A chained alias `Outer = Inner` where `Inner = Any` should still behave
-# like Any, both at the inner and outer level.
-from typing import Any, overload
-from typing_extensions import TypeAlias
-
-Inner: TypeAlias = Any
-Outer: TypeAlias = Inner
-
-@overload
-def f(x: int) -> int: ...
-@overload
-def f(x: str) -> str: ...
-def f(x): ...
-
-inner: Inner
-outer: Outer
-reveal_type(f(inner))  # N: Revealed type is "Any"
-reveal_type(f(outer))  # N: Revealed type is "Any"
-[builtins fixtures/tuple.pyi]
-
-[case testOverloadAliasToAnyArgImplicitAlias]
-# `MyAlias = Any` without an explicit TypeAlias annotation also gets the
-# alias-Any treatment and must engage the overload-ambiguity check.
-from typing import Any, overload
-
-MyAlias = Any
-
-@overload
-def f(x: int) -> int: ...
-@overload
-def f(x: str) -> str: ...
-def f(x): ...
-
-a: MyAlias
-reveal_type(f(a))  # N: Revealed type is "Any"
-[builtins fixtures/tuple.pyi]
-
-[case testOverloadAliasToAnyArgImported]
-# Alias-to-Any imported from another module must behave the same way.
-from typing import overload
-from other import Incomplete
-
-@overload
-def f(x: int) -> int: ...
-@overload
-def f(x: str) -> str: ...
-def f(x): ...
-
-a: Incomplete
-reveal_type(f(a))  # N: Revealed type is "Any"
-
-[file other.py]
-from typing import Any
-from typing_extensions import TypeAlias
-Incomplete: TypeAlias = Any
-[builtins fixtures/tuple.pyi]
-
-[case testOverloadAliasToAnyArgUnambiguous]
-# When overloads are unambiguous, alias-to-Any should pick that overload's
-# return type just like bare Any does (no false ambiguity).
-from typing import Any, overload
-from typing_extensions import TypeAlias
-
-Incomplete: TypeAlias = Any
-
-@overload
-def f(x: int, y: int, z: str) -> int: ...
-@overload
-def f(x: object, y: int, z: str) -> object: ...
-def f(x, y, z): ...
-
-a: Incomplete
-b: Any
-# Ambiguous on x: returns Any
-reveal_type(f(a, 1, ''))  # N: Revealed type is "Any"
-reveal_type(f(b, 1, ''))  # N: Revealed type is "Any"
-# Unambiguous: x is concrete, only y/z are Any
-reveal_type(f(1, a, ''))  # N: Revealed type is "builtins.int"
-reveal_type(f(1, b, ''))  # N: Revealed type is "builtins.int"
+reveal_type(f(1, a))  # N: Revealed type is "builtins.int"
 [builtins fixtures/tuple.pyi]
 
 [case testAliasToAnyDoesNotTriggerDisallowAnyExplicitAtUseSite]
-# --disallow-any-explicit must NOT fire at use sites of an `Alias = Any`
-# (the original purpose of make_any_non_explicit).
 # flags: --disallow-any-explicit --show-error-codes
 from typing import Any
 from typing_extensions import TypeAlias
@@ -6996,4 +6901,26 @@ def f(x: Incomplete) -> Incomplete:  # no error
     return x
 
 a: Incomplete = 1  # no error
+[builtins fixtures/tuple.pyi]
+
+[case testOverloadNestedAnyDoesNotTriggerAmbiguity]
+# Any (explicit or alias-to-Any) nested inside a generic argument should not
+# trigger the overload-ambiguity fallback — only a top-level Any actual arg counts.
+from typing import Any, Generic, TypeVar, overload
+from typing_extensions import TypeAlias
+
+T = TypeVar("T")
+Incomplete: TypeAlias = Any
+
+class Array(Generic[T]): pass
+
+class Series(Generic[T]):
+    @overload
+    def __add__(self: Series[bool], other: Array[Any]) -> Series[bool]: ...
+    @overload
+    def __add__(self: Series[T], other: Array[Any]) -> Series[T]: ...
+    def __add__(self, other): ...
+
+def f(x: Series[Any], y: Array[Incomplete]) -> None:
+    reveal_type(x + y)  # N: Revealed type is "__main__.Series[builtins.bool]"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6856,3 +6856,145 @@ if isinstance(headers, dict):
 
 reveal_type(headers)  # N: Revealed type is "__main__.Headers | typing.Iterable[tuple[builtins.bytes, builtins.bytes]]"
 [builtins fixtures/isinstancelist.pyi]
+
+[case testOverloadAliasToAnyArgWithNoneDefault]
+# An alias `Incomplete = Any` used as an overload arg must not silently match
+# the `default: None = None` overload. It should be treated as Any like a bare
+# Any value, triggering the overload-ambiguity fallback.
+from typing import Any, TypeVar, overload
+from typing_extensions import TypeAlias
+
+T = TypeVar("T")
+Incomplete: TypeAlias = Any
+
+class M:
+    @overload
+    def get(self, key: str, default: None = None) -> str | None: ...
+    @overload
+    def get(self, key: str, default: str) -> str: ...
+    @overload
+    def get(self, key: str, default: T) -> str | T: ...
+    def get(self, key, default=None): ...
+
+a: Incomplete
+b: Any
+reveal_type(M().get("k", a))  # N: Revealed type is "Any"
+reveal_type(M().get("k", b))  # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]
+
+[case testOverloadAliasToAnyArgEquivalentToBareAny]
+# Alias-to-Any and bare Any should produce the same overload results.
+from typing import Any, overload
+from typing_extensions import TypeAlias
+
+Incomplete: TypeAlias = Any
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+def f(x): ...
+
+a: Incomplete
+b: Any
+reveal_type(f(a))  # N: Revealed type is "Any"
+reveal_type(f(b))  # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]
+
+[case testOverloadAliasToAnyArgChainedAlias]
+# A chained alias `Outer = Inner` where `Inner = Any` should still behave
+# like Any, both at the inner and outer level.
+from typing import Any, overload
+from typing_extensions import TypeAlias
+
+Inner: TypeAlias = Any
+Outer: TypeAlias = Inner
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+def f(x): ...
+
+inner: Inner
+outer: Outer
+reveal_type(f(inner))  # N: Revealed type is "Any"
+reveal_type(f(outer))  # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]
+
+[case testOverloadAliasToAnyArgImplicitAlias]
+# `MyAlias = Any` without an explicit TypeAlias annotation also gets the
+# alias-Any treatment and must engage the overload-ambiguity check.
+from typing import Any, overload
+
+MyAlias = Any
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+def f(x): ...
+
+a: MyAlias
+reveal_type(f(a))  # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]
+
+[case testOverloadAliasToAnyArgImported]
+# Alias-to-Any imported from another module must behave the same way.
+from typing import overload
+from other import Incomplete
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+def f(x): ...
+
+a: Incomplete
+reveal_type(f(a))  # N: Revealed type is "Any"
+
+[file other.py]
+from typing import Any
+from typing_extensions import TypeAlias
+Incomplete: TypeAlias = Any
+[builtins fixtures/tuple.pyi]
+
+[case testOverloadAliasToAnyArgUnambiguous]
+# When overloads are unambiguous, alias-to-Any should pick that overload's
+# return type just like bare Any does (no false ambiguity).
+from typing import Any, overload
+from typing_extensions import TypeAlias
+
+Incomplete: TypeAlias = Any
+
+@overload
+def f(x: int, y: int, z: str) -> int: ...
+@overload
+def f(x: object, y: int, z: str) -> object: ...
+def f(x, y, z): ...
+
+a: Incomplete
+b: Any
+# Ambiguous on x: returns Any
+reveal_type(f(a, 1, ''))  # N: Revealed type is "Any"
+reveal_type(f(b, 1, ''))  # N: Revealed type is "Any"
+# Unambiguous: x is concrete, only y/z are Any
+reveal_type(f(1, a, ''))  # N: Revealed type is "builtins.int"
+reveal_type(f(1, b, ''))  # N: Revealed type is "builtins.int"
+[builtins fixtures/tuple.pyi]
+
+[case testAliasToAnyDoesNotTriggerDisallowAnyExplicitAtUseSite]
+# --disallow-any-explicit must NOT fire at use sites of an `Alias = Any`
+# (the original purpose of make_any_non_explicit).
+# flags: --disallow-any-explicit --show-error-codes
+from typing import Any
+from typing_extensions import TypeAlias
+
+Incomplete: TypeAlias = Any  # E: Explicit "Any" is not allowed  [explicit-any]
+
+def f(x: Incomplete) -> Incomplete:  # no error
+    return x
+
+a: Incomplete = 1  # no error
+[builtins fixtures/tuple.pyi]
+

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2242,3 +2242,20 @@ class D[*Ts](Generic[Unpack[Us]]):  # E: Generic[...] base class is redundant \
                                     # E: Can only use one type var tuple in a class def
     pass
 [builtins fixtures/tuple.pyi]
+
+[case testPEP695AliasToAnyOverloadAmbiguity]
+# A PEP 695 `type Incomplete = Any` alias used as an overload arg should
+# engage the overload-ambiguity fallback, just like a bare Any value.
+from typing import Any, overload
+
+type Incomplete = Any
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+def f(x): ...
+
+a: Incomplete
+reveal_type(f(a))  # N: Revealed type is "Any"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2242,20 +2242,3 @@ class D[*Ts](Generic[Unpack[Us]]):  # E: Generic[...] base class is redundant \
                                     # E: Can only use one type var tuple in a class def
     pass
 [builtins fixtures/tuple.pyi]
-
-[case testPEP695AliasToAnyOverloadAmbiguity]
-# A PEP 695 `type Incomplete = Any` alias used as an overload arg should
-# engage the overload-ambiguity fallback, just like a bare Any value.
-from typing import Any, overload
-
-type Incomplete = Any
-
-@overload
-def f(x: int) -> int: ...
-@overload
-def f(x: str) -> str: ...
-def f(x): ...
-
-a: Incomplete
-reveal_type(f(a))  # N: Revealed type is "Any"
-[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Aliases like `Incomplete: TypeAlias = Any` were being downgraded to `TypeOfAny.special_form`, the same flavor used for `NewType`-style higher-kinded types. `has_any_type` ignores `special_form` Anys when checking for overload ambiguity, which meant a 2-arg call to `os.environ.get` with an alias-`Any` default would silently match the `default: None = None` overload and return `str | None` instead of `Any`. No bueno
 
Add a dedicated` TypeOfAny.from_alias_target` flavor that suppresses `--disallow-any-explicit` at use sites (the original reason for the downgrade) but still counts as a real `Any` everywhere else. Stats reporting and the `Literal[...]` arg check are extended to keep their existing behavior for the new flavor.

Fixes #21344
