### PR TITLE
Make type variable upper bound narrowing symmetric

### DIFF
--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -173,6 +173,15 @@ def narrow_declared_type(declared: Type, narrowed: Type) -> Type:
         return declared.copy_modified(
             upper_bound=narrow_declared_type(declared.upper_bound, original_narrowed)
         )
+    elif (
+        isinstance(narrowed, TypeVarType)
+        and not has_type_vars(original_declared)
+        and is_subtype(original_declared, narrowed.upper_bound)
+    ):
+        # This branch is a mirror image of the above one.
+        return narrowed.copy_modified(
+            upper_bound=narrow_declared_type(original_declared, narrowed.upper_bound)
+        )
     elif not is_overlapping_types(declared, narrowed):
         if state.strict_optional:
             return UninhabitedType()

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -4113,3 +4113,25 @@ def stringify(value: A | B | C) -> str:
         return value.name
     return ""
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVariableBoundNarrowingSymmetric]
+from typing import TypeVar
+
+class B: ...
+class C(B):
+    x: int
+
+H = TypeVar('H', bound=B)
+
+def func(y: H) -> H:
+    x: C
+    assert x == y
+    reveal_type(x)  # N: Revealed type is "H`-1"
+    reveal_type(y)  # N: Revealed type is "H`-1"
+    reveal_type(x.x)  # N: Revealed type is "builtins.int"
+    reveal_type(y.x)  # N: Revealed type is "builtins.int"
+    if bool():
+        return x
+    else:
+        return y
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/21199
Fixes https://github.com/python/mypy/issues/4952

This is kind of a simple-minded fix. The typeops around this are somewhat incomplete, but the opposite direction has been around for couple releases, and I don't think anyone complained, so I propose to go with this unless there are better ideas.