### PR TITLE
Add test for new walrus semantics allowed in Python 3.12

### DIFF
--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1818,6 +1818,44 @@ type YNested = (1 + (yield from [])) # E: Yield expression cannot be used within
 type ZNested = (1 + (a := 1))  # E: Named expression cannot be used within a type alias
 type KNested = (1 + (await 1))  # E: Await expression cannot be used within a type alias
 
+[case testWalrusRebindsNamesLoadedInComprehensionTargets]
+# Newly legal in https://github.com/python/cpython/pull/100581
+from typing import Any
+
+def f(c: Any, d: Any, e: Any, f: Any, g: Any, h: Any, j: Any) -> None:
+    ((c := 1) for a, (*b, c[d+e::f(g)], h.i) in j)
+    [(c := 1) for a, (*b, c[d+e::f(g)], h.i) in j]
+    {(c := 1) for a, (*b, c[d+e::f(g)], h.i) in j}
+
+    ((d := 1) for a, (*b, c[d+e::f(g)], h.i) in j)
+    [(d := 1) for a, (*b, c[d+e::f(g)], h.i) in j]
+    {(d := 1) for a, (*b, c[d+e::f(g)], h.i) in j}
+
+    ((e := 1) for a, (*b, c[d+e::f(g)], h.i) in j)
+    [(e := 1) for a, (*b, c[d+e::f(g)], h.i) in j]
+    {(e := 1) for a, (*b, c[d+e::f(g)], h.i) in j}
+
+    ((f := 1) for a, (*b, c[d+e::f(g)], h.i) in j)
+    [(f := 1) for a, (*b, c[d+e::f(g)], h.i) in j]
+    {(f := 1) for a, (*b, c[d+e::f(g)], h.i) in j}
+
+    ((g := 1) for a, (*b, c[d+e::f(g)], h.i) in j)
+    [(g := 1) for a, (*b, c[d+e::f(g)], h.i) in j]
+    {(g := 1) for a, (*b, c[d+e::f(g)], h.i) in j}
+
+    ((h := 1) for a, (*b, c[d+e::f(g)], h.i) in j)
+    [(h := 1) for a, (*b, c[d+e::f(g)], h.i) in j]
+    {(h := 1) for a, (*b, c[d+e::f(g)], h.i) in j}
+
+    ((i := 1) for a, (*b, c[d+e::f(g)], h.i) in j)
+    [(i := 1) for a, (*b, c[d+e::f(g)], h.i) in j]
+    {(i := 1) for a, (*b, c[d+e::f(g)], h.i) in j}
+
+    ((j := 1) for a, (*b, c[d+e::f(g)], h.i) in j)
+    [(j := 1) for a, (*b, c[d+e::f(g)], h.i) in j]
+    {(j := 1) for a, (*b, c[d+e::f(g)], h.i) in j}
+[builtins fixtures/primitives.pyi]
+
 [case testPEP695TypeAliasAndAnnotated]
 from typing_extensions import Annotated, Annotated as _Annotated
 import typing_extensions as t

--- a/test-data/unit/fixtures/primitives.pyi
+++ b/test-data/unit/fixtures/primitives.pyi
@@ -81,3 +81,5 @@ class range(Sequence[int]):
 def isinstance(x: object, t: Union[type, Tuple]) -> bool: pass
 
 class BaseException: pass
+
+class slice: pass


### PR DESCRIPTION
Don't think this actually happened in https://github.com/python/mypy/issues/15277

Technically we should error on Python 3.11 and lower and we don't