### PR TITLE
Fix narrowing for AbstractSet and Mapping

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8925,7 +8925,6 @@ def reduce_and_conditional_type_maps(ms: list[TypeMap], *, use_meet: bool) -> Ty
 
 
 BUILTINS_CUSTOM_EQ_CHECKS: Final = {
-    "builtins.frozenset",
     "_collections_abc.dict_keys",
     "_collections_abc.dict_items",
 }

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8924,20 +8924,10 @@ def reduce_and_conditional_type_maps(ms: list[TypeMap], *, use_meet: bool) -> Ty
     return result
 
 
-BUILTINS_CUSTOM_EQ_CHECKS: Final = {"_collections_abc.dict_keys", "_collections_abc.dict_items"}
-
-
 def has_custom_eq_checks(t: Type) -> bool:
     return (
         custom_special_method(t, "__eq__", check_all=False)
         or custom_special_method(t, "__ne__", check_all=False)
-        # custom_special_method has special casing for builtins.* and typing.* that make the
-        # above always return False. Some builtin collections still have equality behavior that
-        # crosses nominal type boundaries and isn't captured by VALUE_EQUALITY_TYPE_DOMAINS.
-        or (
-            isinstance(pt := get_proper_type(t), Instance)
-            and pt.type.fullname in BUILTINS_CUSTOM_EQ_CHECKS
-        )
     )
 
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -9731,6 +9731,8 @@ CLOSED_VALUE_EQUALITY_DOMAINS: Final = {
     "builtins.bytes": "builtins.bytes",
     "builtins.bytearray": "builtins.bytes",
     "builtins.memoryview": "builtins.bytes",
+    "typing.Mapping": "typing.Mapping",
+    "typing.AbstractSet": "typing.AbstractSet",
 }
 
 VALUE_EQUALITY_DOMAINS: Final = {**OPEN_VALUE_EQUALITY_DOMAINS, **CLOSED_VALUE_EQUALITY_DOMAINS}

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8925,9 +8925,8 @@ def reduce_and_conditional_type_maps(ms: list[TypeMap], *, use_meet: bool) -> Ty
 
 
 def has_custom_eq_checks(t: Type) -> bool:
-    return (
-        custom_special_method(t, "__eq__", check_all=False)
-        or custom_special_method(t, "__ne__", check_all=False)
+    return custom_special_method(t, "__eq__", check_all=False) or custom_special_method(
+        t, "__ne__", check_all=False
     )
 
 

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8924,10 +8924,7 @@ def reduce_and_conditional_type_maps(ms: list[TypeMap], *, use_meet: bool) -> Ty
     return result
 
 
-BUILTINS_CUSTOM_EQ_CHECKS: Final = {
-    "_collections_abc.dict_keys",
-    "_collections_abc.dict_items",
-}
+BUILTINS_CUSTOM_EQ_CHECKS: Final = {"_collections_abc.dict_keys", "_collections_abc.dict_items"}
 
 
 def has_custom_eq_checks(t: Type) -> bool:

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2217,28 +2217,40 @@ _testDictOrUnionEdgeCases.py:10: note: Revealed type is "dict[str, dict[str, ...
 # flags: --strict-equality --warn-unreachable
 from typing import Mapping, AbstractSet
 
-def f1(x: Mapping[str, int]) -> None:
+def f1(x: Mapping[str, int], y: dict[str, int]) -> None:
     if isinstance(x, dict):
         reveal_type(x)
+
+    if x == y:
+        reveal_type(x)
+        reveal_type(y)
 
     if x == {}:
         reveal_type(x)
 
-def f2(x: AbstractSet[int]) -> None:
+def f2(x: AbstractSet[int], y: set[int]) -> None:
     if isinstance(x, set):
         reveal_type(x)
+
+    if x == y:
+        reveal_type(x)
+        reveal_type(y)
 
     if x == set():
         reveal_type(x)
 
-def f3(x: frozenset[str], y: set[str]):
+def f3(x: frozenset[int], y: set[int]):
     if x == y:
         reveal_type(x)
         reveal_type(y)
 [out]
 _testNarrowingMappingAndAbstractSet.py:6: note: Revealed type is "dict[Any, Any]"
 _testNarrowingMappingAndAbstractSet.py:9: note: Revealed type is "typing.Mapping[str, int]"
-_testNarrowingMappingAndAbstractSet.py:13: note: Revealed type is "set[Any]"
-_testNarrowingMappingAndAbstractSet.py:16: note: Revealed type is "typing.AbstractSet[int]"
-_testNarrowingMappingAndAbstractSet.py:20: note: Revealed type is "frozenset[str]"
-_testNarrowingMappingAndAbstractSet.py:21: note: Revealed type is "set[str]"
+_testNarrowingMappingAndAbstractSet.py:10: note: Revealed type is "dict[str, int]"
+_testNarrowingMappingAndAbstractSet.py:13: note: Revealed type is "typing.Mapping[str, int]"
+_testNarrowingMappingAndAbstractSet.py:17: note: Revealed type is "set[Any]"
+_testNarrowingMappingAndAbstractSet.py:20: note: Revealed type is "typing.AbstractSet[int]"
+_testNarrowingMappingAndAbstractSet.py:21: note: Revealed type is "set[int]"
+_testNarrowingMappingAndAbstractSet.py:24: note: Revealed type is "typing.AbstractSet[int]"
+_testNarrowingMappingAndAbstractSet.py:28: note: Revealed type is "frozenset[int]"
+_testNarrowingMappingAndAbstractSet.py:29: note: Revealed type is "set[int]"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2212,3 +2212,25 @@ d3: A = d1 | d2
 reveal_type(d1 | d2)
 [out]
 _testDictOrUnionEdgeCases.py:10: note: Revealed type is "dict[str, dict[str, ... | int] | int]"
+
+[case testNarrowingMappingAndAbstractSet]
+from typing import Mapping, AbstractSet
+
+def f1(x: Mapping[str, int]) -> None:
+    if isinstance(x, dict):
+        reveal_type(x)
+
+    if x == {}:
+        reveal_type(x)
+
+def f2(x: AbstractSet[int]) -> None:
+    if isinstance(x, set):
+        reveal_type(x)
+
+    if x == set():
+        reveal_type(x)
+[out]
+_testNarrowingMappingAndAbstractSet.py:5: note: Revealed type is "dict[Any, Any]"
+_testNarrowingMappingAndAbstractSet.py:8: note: Revealed type is "typing.Mapping[str, int]"
+_testNarrowingMappingAndAbstractSet.py:12: note: Revealed type is "set[Any]"
+_testNarrowingMappingAndAbstractSet.py:15: note: Revealed type is "typing.AbstractSet[int]"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2243,6 +2243,16 @@ def f3(x: frozenset[int], y: set[int]):
     if x == y:
         reveal_type(x)
         reveal_type(y)
+
+def f4(x: dict[str, int], y: set[str]):
+    if x.keys() == y:
+        reveal_type(x)
+        reveal_type(y)
+
+    z = x.keys()
+    if z == y:
+        reveal_type(z)
+        reveal_type(y)
 [out]
 _testNarrowingMappingAndAbstractSet.py:6: note: Revealed type is "dict[Any, Any]"
 _testNarrowingMappingAndAbstractSet.py:9: note: Revealed type is "typing.Mapping[str, int]"
@@ -2254,3 +2264,7 @@ _testNarrowingMappingAndAbstractSet.py:21: note: Revealed type is "set[int]"
 _testNarrowingMappingAndAbstractSet.py:24: note: Revealed type is "typing.AbstractSet[int]"
 _testNarrowingMappingAndAbstractSet.py:28: note: Revealed type is "frozenset[int]"
 _testNarrowingMappingAndAbstractSet.py:29: note: Revealed type is "set[int]"
+_testNarrowingMappingAndAbstractSet.py:33: note: Revealed type is "dict[str, int]"
+_testNarrowingMappingAndAbstractSet.py:34: note: Revealed type is "set[str]"
+_testNarrowingMappingAndAbstractSet.py:38: note: Revealed type is "_collections_abc.dict_keys[str, int]"
+_testNarrowingMappingAndAbstractSet.py:39: note: Revealed type is "set[str]"

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2214,6 +2214,7 @@ reveal_type(d1 | d2)
 _testDictOrUnionEdgeCases.py:10: note: Revealed type is "dict[str, dict[str, ... | int] | int]"
 
 [case testNarrowingMappingAndAbstractSet]
+# flags: --strict-equality --warn-unreachable
 from typing import Mapping, AbstractSet
 
 def f1(x: Mapping[str, int]) -> None:
@@ -2229,8 +2230,15 @@ def f2(x: AbstractSet[int]) -> None:
 
     if x == set():
         reveal_type(x)
+
+def f3(x: frozenset[str], y: set[str]):
+    if x == y:
+        reveal_type(x)
+        reveal_type(y)
 [out]
-_testNarrowingMappingAndAbstractSet.py:5: note: Revealed type is "dict[Any, Any]"
-_testNarrowingMappingAndAbstractSet.py:8: note: Revealed type is "typing.Mapping[str, int]"
-_testNarrowingMappingAndAbstractSet.py:12: note: Revealed type is "set[Any]"
-_testNarrowingMappingAndAbstractSet.py:15: note: Revealed type is "typing.AbstractSet[int]"
+_testNarrowingMappingAndAbstractSet.py:6: note: Revealed type is "dict[Any, Any]"
+_testNarrowingMappingAndAbstractSet.py:9: note: Revealed type is "typing.Mapping[str, int]"
+_testNarrowingMappingAndAbstractSet.py:13: note: Revealed type is "set[Any]"
+_testNarrowingMappingAndAbstractSet.py:16: note: Revealed type is "typing.AbstractSet[int]"
+_testNarrowingMappingAndAbstractSet.py:20: note: Revealed type is "frozenset[str]"
+_testNarrowingMappingAndAbstractSet.py:21: note: Revealed type is "set[str]"


### PR DESCRIPTION
This builds on the tech I added a few days ago in #21281. So we can also get rid of frozenset special case from #21151. I believe we account for all the dangerous_comparison logic now