### PR TITLE
Fix #21123: RecursionError on recursive type aliases with varying ParamSpec arguments

### DIFF
--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -85,12 +85,12 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
 
     def visit_type_alias_type(self, t: TypeAliasType) -> None:
         super().visit_type_alias_type(t)
+        assert t.alias is not None, f"Unfixed type alias {t.type_ref}"
         if t.is_recursive:
             if t.alias in self.seen_aliases:
                 # Avoid infinite recursion on recursive type aliases.
                 return
             self.seen_aliases.add(t.alias)
-        assert t.alias is not None, f"Unfixed type alias {t.type_ref}"
         is_error, is_invalid = self.validate_args(
             t.alias.name, tuple(t.args), t.alias.alias_tvars, t
         )

--- a/mypy/semanal_typeargs.py
+++ b/mypy/semanal_typeargs.py
@@ -15,7 +15,7 @@ from mypy.errors import Errors
 from mypy.message_registry import INVALID_PARAM_SPEC_LOCATION, INVALID_PARAM_SPEC_LOCATION_NOTE
 from mypy.messages import format_type
 from mypy.mixedtraverser import MixedTraverserVisitor
-from mypy.nodes import Block, ClassDef, Context, FakeInfo, FuncItem, MypyFile
+from mypy.nodes import Block, ClassDef, Context, FakeInfo, FuncItem, MypyFile, TypeAlias
 from mypy.options import Options
 from mypy.scope import Scope
 from mypy.subtypes import is_same_type, is_subtype
@@ -58,9 +58,11 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
         self.scope = Scope()
         # Should we also analyze function definitions, or only module top-levels?
         self.recurse_into_functions = True
-        # Keep track of the type aliases already visited. This is needed to avoid
-        # infinite recursion on types like A = Union[int, List[A]].
-        self.seen_aliases: set[TypeAliasType] = set()
+        # Keep track of the type alias definitions already visited. This is needed
+        # to avoid infinite recursion on recursive type aliases. We track by the
+        # underlying TypeAlias node (not TypeAliasType) so that recursive aliases
+        # with varying type arguments are still caught.
+        self.seen_aliases: set[TypeAlias] = set()
 
     def visit_mypy_file(self, o: MypyFile) -> None:
         self.errors.set_file(o.path, o.fullname, scope=self.scope, options=self.options)
@@ -84,10 +86,10 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
     def visit_type_alias_type(self, t: TypeAliasType) -> None:
         super().visit_type_alias_type(t)
         if t.is_recursive:
-            if t in self.seen_aliases:
+            if t.alias in self.seen_aliases:
                 # Avoid infinite recursion on recursive type aliases.
                 return
-            self.seen_aliases.add(t)
+            self.seen_aliases.add(t.alias)
         assert t.alias is not None, f"Unfixed type alias {t.type_ref}"
         is_error, is_invalid = self.validate_args(
             t.alias.name, tuple(t.args), t.alias.alias_tvars, t
@@ -105,7 +107,7 @@ class TypeArgumentAnalyzer(MixedTraverserVisitor):
                 # to verify the arguments satisfy the upper bounds of the expansion as well.
                 get_proper_type(t).accept(self)
         if t.is_recursive:
-            self.seen_aliases.discard(t)
+            self.seen_aliases.discard(t.alias)
 
     def visit_tuple_type(self, t: TupleType) -> None:
         t.items = flatten_nested_tuples(t.items)

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -957,9 +957,7 @@ def get_type_triggers(
 
 
 class TypeTriggersVisitor(TypeVisitor[list[str]]):
-    def __init__(
-        self, use_logical_deps: bool, seen_aliases: set[TypeAlias] | None = None
-    ) -> None:
+    def __init__(self, use_logical_deps: bool, seen_aliases: set[TypeAlias] | None = None) -> None:
         self.deps: list[str] = []
         self.seen_aliases: set[TypeAlias] = seen_aliases or set()
         self.use_logical_deps = use_logical_deps

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -122,6 +122,7 @@ from mypy.nodes import (
     StarExpr,
     SuperExpr,
     TupleExpr,
+    TypeAlias,
     TypeAliasExpr,
     TypeApplication,
     TypedDictExpr,
@@ -949,7 +950,7 @@ class DependencyVisitor(TraverserVisitor):
 
 
 def get_type_triggers(
-    typ: Type, use_logical_deps: bool, seen_aliases: set[TypeAliasType] | None = None
+    typ: Type, use_logical_deps: bool, seen_aliases: set[TypeAlias] | None = None
 ) -> list[str]:
     """Return all triggers that correspond to a type becoming stale."""
     return typ.accept(TypeTriggersVisitor(use_logical_deps, seen_aliases))
@@ -957,10 +958,10 @@ def get_type_triggers(
 
 class TypeTriggersVisitor(TypeVisitor[list[str]]):
     def __init__(
-        self, use_logical_deps: bool, seen_aliases: set[TypeAliasType] | None = None
+        self, use_logical_deps: bool, seen_aliases: set[TypeAlias] | None = None
     ) -> None:
         self.deps: list[str] = []
-        self.seen_aliases: set[TypeAliasType] = seen_aliases or set()
+        self.seen_aliases: set[TypeAlias] = seen_aliases or set()
         self.use_logical_deps = use_logical_deps
 
     def get_type_triggers(self, typ: Type) -> list[str]:
@@ -979,9 +980,9 @@ class TypeTriggersVisitor(TypeVisitor[list[str]]):
         return triggers
 
     def visit_type_alias_type(self, typ: TypeAliasType) -> list[str]:
-        if typ in self.seen_aliases:
+        if typ.alias in self.seen_aliases:
             return []
-        self.seen_aliases.add(typ)
+        self.seen_aliases.add(typ.alias)
         assert typ.alias is not None
         trigger = make_trigger(typ.alias.fullname)
         triggers = [trigger]

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -980,10 +980,10 @@ class TypeTriggersVisitor(TypeVisitor[list[str]]):
         return triggers
 
     def visit_type_alias_type(self, typ: TypeAliasType) -> list[str]:
+        assert typ.alias is not None
         if typ.alias in self.seen_aliases:
             return []
         self.seen_aliases.add(typ.alias)
-        assert typ.alias is not None
         trigger = make_trigger(typ.alias.fullname)
         triggers = [trigger]
         for arg in typ.args:

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -456,6 +456,7 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         # Skip type aliases already visited to avoid infinite recursion.
         # We track by the TypeAlias node so that recursive aliases with varying
         # type arguments are still caught.
+        assert t.alias is not None, f"Unfixed type alias {t.type_ref}"
         if self.seen_aliases is None:
             self.seen_aliases = set()
         elif t.alias in self.seen_aliases:
@@ -600,6 +601,7 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         # Skip type aliases already visited to avoid infinite recursion.
         # We track by the TypeAlias node so that recursive aliases with varying
         # type arguments are still caught.
+        assert t.alias is not None, f"Unfixed type alias {t.type_ref}"
         if self.seen_aliases is None:
             self.seen_aliases = set()
         elif t.alias in self.seen_aliases:

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -15,7 +15,10 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
-from typing import Any, Final, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar, cast
+
+if TYPE_CHECKING:
+    from mypy.nodes import TypeAlias
 
 from mypy_extensions import mypyc_attr, trait
 
@@ -356,9 +359,12 @@ class TypeQuery(SyntheticTypeVisitor[T]):
     """
 
     def __init__(self) -> None:
-        # Keep track of the type aliases already visited. This is needed to avoid
-        # infinite recursion on types like A = Union[int, List[A]].
-        self.seen_aliases: set[TypeAliasType] | None = None
+        # Keep track of the type alias definitions already visited. This is needed
+        # to avoid infinite recursion on recursive type aliases. We track by the
+        # underlying TypeAlias node (not TypeAliasType) so that recursive aliases
+        # with varying type arguments (e.g. A[P] -> A[Concatenate[int, P]]) are
+        # still caught.
+        self.seen_aliases: set[TypeAlias] | None = None
         # By default, we eagerly expand type aliases, and query also types in the
         # alias target. In most cases this is a desired behavior, but we may want
         # to skip targets in some cases (e.g. when collecting type variables).
@@ -447,13 +453,14 @@ class TypeQuery(SyntheticTypeVisitor[T]):
     def visit_type_alias_type(self, t: TypeAliasType, /) -> T:
         if self.skip_alias_target:
             return self.query_types(t.args)
-        # Skip type aliases already visited types to avoid infinite recursion
-        # (also use this as a simple-minded cache).
+        # Skip type aliases already visited to avoid infinite recursion.
+        # We track by the TypeAlias node so that recursive aliases with varying
+        # type arguments are still caught.
         if self.seen_aliases is None:
             self.seen_aliases = set()
-        elif t in self.seen_aliases:
-            return self.strategy([])
-        self.seen_aliases.add(t)
+        elif t.alias in self.seen_aliases:
+            return self.query_types(t.args)
+        self.seen_aliases.add(t.alias)
         return get_proper_type(t).accept(self)
 
     def query_types(self, types: Iterable[Type]) -> T:
@@ -487,10 +494,12 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         else:
             assert strategy == ALL_STRATEGY
             self.default = True
-        # Keep track of the type aliases already visited. This is needed to avoid
-        # infinite recursion on types like A = Union[int, List[A]]. An empty set is
-        # represented as None as a micro-optimization.
-        self.seen_aliases: set[TypeAliasType] | None = None
+        # Keep track of the type alias definitions already visited. This is needed
+        # to avoid infinite recursion on recursive type aliases. We track by the
+        # underlying TypeAlias node (not TypeAliasType) so that recursive aliases
+        # with varying type arguments (e.g. A[P] -> A[Concatenate[int, P]]) are
+        # still caught. An empty set is represented as None as a micro-optimization.
+        self.seen_aliases: set[TypeAlias] | None = None
         # By default, we eagerly expand type aliases, and query also types in the
         # alias target. In most cases this is a desired behavior, but we may want
         # to skip targets in some cases (e.g. when collecting type variables).
@@ -588,13 +597,14 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
     def visit_type_alias_type(self, t: TypeAliasType, /) -> bool:
         if self.skip_alias_target:
             return self.query_types(t.args)
-        # Skip type aliases already visited types to avoid infinite recursion
-        # (also use this as a simple-minded cache).
+        # Skip type aliases already visited to avoid infinite recursion.
+        # We track by the TypeAlias node so that recursive aliases with varying
+        # type arguments are still caught.
         if self.seen_aliases is None:
             self.seen_aliases = set()
-        elif t in self.seen_aliases:
-            return self.default
-        self.seen_aliases.add(t)
+        elif t.alias in self.seen_aliases:
+            return self.query_types(t.args)
+        self.seen_aliases.add(t.alias)
         return get_proper_type(t).accept(self)
 
     def query_types(self, types: list[Type] | tuple[Type, ...]) -> bool:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3705,7 +3705,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
     def __init__(self, id_mapper: IdMapper | None = None, *, options: Options) -> None:
         self.id_mapper = id_mapper
         self.options = options
-        self.dotted_aliases: set[TypeAliasType] | None = None
+        self.dotted_aliases: set[mypy.nodes.TypeAlias] | None = None
 
     def visit_unbound_type(self, t: UnboundType, /) -> str:
         s = t.name + "?"
@@ -3989,11 +3989,11 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             return get_proper_type(t).accept(self)
         if self.dotted_aliases is None:
             self.dotted_aliases = set()
-        elif t in self.dotted_aliases:
+        elif t.alias in self.dotted_aliases:
             return "..."
-        self.dotted_aliases.add(t)
+        self.dotted_aliases.add(t.alias)
         type_str = get_proper_type(t).accept(self)
-        self.dotted_aliases.discard(t)
+        self.dotted_aliases.discard(t.alias)
         return type_str
 
     def visit_unpack_type(self, t: UnpackType, /) -> str:

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2280,3 +2280,14 @@ class D[*Ts](Generic[Unpack[Us]]):  # E: Generic[...] base class is redundant \
                                     # E: Can only use one type var tuple in a class def
     pass
 [builtins fixtures/tuple.pyi]
+
+[case testPEP695RecursiveTypeAliasParamSpecConcatenate]
+from typing import Callable
+from typing_extensions import Concatenate
+
+type A[**P] = Callable[[Callable[P, None]], A[Concatenate[int, P]]]
+
+def foo[**P](x: A[P]) -> None:
+    reveal_type(x)  # N: Revealed type is "def (def (*P.args, **P.kwargs)) -> ..."
+[builtins fixtures/type.pyi]
+[typing fixtures/typing-full.pyi]

--- a/test-data/unit/reports.test
+++ b/test-data/unit/reports.test
@@ -155,9 +155,9 @@ z: NestedGen[Any]
 [outfile report/types-of-anys.txt]
  Name   Unannotated   Explicit   Unimported   Omitted Generics   Error   Special Form   Implementation Artifact
 -----------------------------------------------------------------------------------------------------------------
-    n             0          2            0                  8       0              0                         0
+    n             0          3            0                 14       0              0                         0
 -----------------------------------------------------------------------------------------------------------------
-Total             0          2            0                  8       0              0                         0
+Total             0          3            0                 14       0              0                         0
 
 [case testTypeVarTreatedAsEmptyLine]
 # cmd: mypy --html-report report n.py


### PR DESCRIPTION
### Summary
Fixes #21123.
Recursive type aliases that expand their ParamSpec arguments at each step (e.g. via Concatenate) caused mypy to crash with RecursionError. The fix makes cycle detection key on the underlying TypeAlias node instead of the TypeAliasType instance, so cycles are detected even when type arguments differ across expansions.

### Changes
File: mypy/type_visitor.py — TypeQuery, BoolTypeQuery Changed seen_aliases to set[TypeAlias], keying on t.alias instead of the TypeAliasType instance. On cycle hit, walk t.args instead of returning the strategy-neutral element so that fresh type variables are still surfaced to query consumers.
File: mypy/types.py — TypeStrVisitor Changed dotted_aliases to set[TypeAlias], keying on t.alias for in/add/discard. Added TYPE_CHECKING import for TypeAlias from mypy.nodes to avoid circular imports.
File: mypy/semanal_typeargs.py — TypeArgumentAnalyzer Changed seen_aliases to set[TypeAlias], keying on t.alias. Preserved existing early-return on cycle hit.
File: mypy/server/deps.py — TypeTriggersVisitor Updated __init__, get_type_triggers, and seen_aliases to use set[TypeAlias], keying on typ.alias.
File: test-data/unit/check-python312.test Added testPEP695RecursiveTypeAliasParamSpecConcatenate — the reproducer from the bug report verbatim. Crashes with RecursionError on master, passes on this branch.

### Testing
pytest -n0 -k testPEP695RecursiveTypeAliasParamSpecConcatenate
OR 
pytest -n0 mypy/test/[testcheck.py](http://testcheck.py/)::TypeCheckSuite::check-python312.test::testPEP695RecursiveTypeAliasParamSpecConcatenate

### Evidence of Passing Test:
<img width="1708" height="554" alt="unknown" src="https://github.com/user-attachments/assets/aae91758-9f01-49ec-aae9-c206a414dff3" />

