### PR TITLE
[mypyc] Fix debug warnings/assertions from vecs

### DIFF
--- a/mypyc/lib-rt/vecs/librt_vecs.c
+++ b/mypyc/lib-rt/vecs/librt_vecs.c
@@ -139,6 +139,7 @@ VecGenericAlias_traverse(VecGenericAlias *self, visitproc visit, void *arg)
 static void
 VecGenericAlias_dealloc(VecGenericAlias *self)
 {
+    PyObject_GC_UnTrack(self);
     if (self->item_type && !Vec_IsMagicItemType(self->item_type)) {
         Py_DECREF((PyObject *)(self->item_type & ~1));
         self->item_type = 0;

--- a/mypyc/lib-rt/vecs/vec_nested.c
+++ b/mypyc/lib-rt/vecs/vec_nested.c
@@ -16,12 +16,17 @@ static inline VecNested vec_error() {
     return v;
 }
 
+static inline void vec_track_buffer(VecNested *vec) {
+    PyObject_GC_Track(vec->buf);
+}
+
 static inline PyObject *box_vec_item_by_index(VecNested v, Py_ssize_t index) {
     return VecNested_BoxItem(v, v.buf->items[index]);
 }
 
-// Alloc a partially initialized vec. Caller *must* initialize len and buf->items of the
-// return value.
+// Alloc a partially initialized vec. If size > 0, caller *must* immediately initialize len, 
+// and buf->items. Caller *must* also call vec_track_buffer on the returned vec but only
+// after initializing the items.
 static VecNested vec_alloc(Py_ssize_t size, size_t item_type, size_t depth) {
     VecNestedBufObject *buf = PyObject_GC_NewVar(VecNestedBufObject, &VecNestedBufType, size);
     if (buf == NULL)
@@ -31,7 +36,6 @@ static VecNested vec_alloc(Py_ssize_t size, size_t item_type, size_t depth) {
     if (!Vec_IsMagicItemType(item_type))
         Py_INCREF(VEC_BUF_ITEM_TYPE(buf));
     VecNested res = { .buf = buf };
-    PyObject_GC_Track(buf);
     return res;
 }
 
@@ -79,6 +83,7 @@ VecNested VecNested_New(Py_ssize_t size, Py_ssize_t cap, size_t item_type, size_
         vec.buf->items[i].buf = NULL;
     }
     vec.len = size;
+    vec_track_buffer(&vec);
     return vec;
 }
 
@@ -122,6 +127,7 @@ VecNested VecNested_Slice(VecNested vec, int64_t start, int64_t end) {
         Py_XINCREF(item.buf);
         res.buf->items[i] = item;
     }
+    vec_track_buffer(&res);
     return res;
 }
 
@@ -155,6 +161,7 @@ static PyObject *vec_subscript(PyObject *self, PyObject *item) {
             res.buf->items[i] = item;
             j += step;
         }
+        vec_track_buffer(&res);
         return VecNested_Box(res);
     } else {
         PyErr_Format(PyExc_TypeError, "vec indices must be integers or slices, not %.100s",
@@ -280,6 +287,7 @@ VecNested VecNested_Append(VecNested vec, VecNestedBufItem x) {
         }
         new.buf->items[vec.len] = x;
         new.len = vec.len + 1;
+        vec_track_buffer(&new);
         VEC_DECREF(vec);
         return new;
     }
@@ -381,6 +389,7 @@ VecNested VecNested_ExtendVec(VecNested dst, VecNested src) {
     }
     memset(new.buf->items + new_len, 0, sizeof(VecNestedBufItem) * (new_cap - new_len));
     new.len = new_len;
+    vec_track_buffer(&new);
     VEC_DECREF(dst);
     return new;
 }
@@ -679,6 +688,7 @@ PyObject *VecNested_FromIterable(size_t item_type, size_t depth, PyObject *itera
         }
     }
     v.len = 0;
+    vec_track_buffer(&v);
 
     PyObject *iter = PyObject_GetIter(iterable);
     if (iter == NULL) {

--- a/mypyc/lib-rt/vecs/vec_nested.c
+++ b/mypyc/lib-rt/vecs/vec_nested.c
@@ -24,7 +24,7 @@ static inline PyObject *box_vec_item_by_index(VecNested v, Py_ssize_t index) {
     return VecNested_BoxItem(v, v.buf->items[index]);
 }
 
-// Alloc a partially initialized vec. If size > 0, caller *must* immediately initialize len, 
+// Alloc a partially initialized vec. If size > 0, caller *must* immediately initialize len,
 // and buf->items. Caller *must* also call vec_track_buffer on the returned vec but only
 // after initializing the items.
 static VecNested vec_alloc(Py_ssize_t size, size_t item_type, size_t depth) {

--- a/mypyc/lib-rt/vecs/vec_t.c
+++ b/mypyc/lib-rt/vecs/vec_t.c
@@ -33,7 +33,7 @@ static inline void vec_track_buffer(VecT *vec) {
     }
 }
 
-// Alloc a partially initialized vec. If size > 0, caller *must* immediately initialize len, 
+// Alloc a partially initialized vec. If size > 0, caller *must* immediately initialize len,
 // and buf->items. Caller *must* also call vec_track_buffer on the returned vec but only
 // after initializing the items.
 static VecT vec_alloc(Py_ssize_t size, size_t item_type) {

--- a/mypyc/lib-rt/vecs/vec_t.c
+++ b/mypyc/lib-rt/vecs/vec_t.c
@@ -24,12 +24,18 @@ static inline VecTBufObject *alloc_buf(Py_ssize_t size, size_t item_type) {
         return NULL;
     buf->item_type = item_type;
     Py_INCREF(VEC_BUF_ITEM_TYPE(buf));
-    PyObject_GC_Track(buf);
     return buf;
 }
 
-// Alloc a partially initialized vec. Caller *must* immediately initialize len, and buf->items
-// if size > 0.
+static inline void vec_track_buffer(VecT *vec) {
+    if (vec->buf != NULL) {
+        PyObject_GC_Track(vec->buf);
+    }
+}
+
+// Alloc a partially initialized vec. If size > 0, caller *must* immediately initialize len, 
+// and buf->items. Caller *must* also call vec_track_buffer on the returned vec but only
+// after initializing the items.
 static VecT vec_alloc(Py_ssize_t size, size_t item_type) {
     VecTBufObject *buf;
 
@@ -51,6 +57,7 @@ PyObject *VecT_Box(VecT vec, size_t item_type) {
         vec.buf = alloc_buf(0, item_type);
         if (vec.buf == NULL)
             return NULL;
+        vec_track_buffer(&vec);
     }
     VecTObject *obj = PyObject_GC_New(VecTObject, &VecTType);
     if (obj == NULL) {
@@ -93,6 +100,7 @@ VecT VecT_New(Py_ssize_t size, Py_ssize_t cap, size_t item_type) {
     for (Py_ssize_t i = 0; i < cap; i++) {
         vec.buf->items[i] = NULL;
     }
+    vec_track_buffer(&vec);
     vec.len = size;
     return vec;
 }
@@ -143,6 +151,7 @@ VecT VecT_Slice(VecT vec, int64_t start, int64_t end) {
         Py_INCREF(item);
         res.buf->items[i] = item;
     }
+    vec_track_buffer(&res);
     return res;
 }
 
@@ -180,6 +189,7 @@ static PyObject *vec_subscript(PyObject *self, PyObject *item) {
             res.buf->items[i] = item;
             j += step;
         }
+        vec_track_buffer(&res);
         PyObject *result = VecT_Box(res, vec.buf->item_type);
         if (result == NULL) {
             VEC_DECREF(res);
@@ -260,6 +270,7 @@ VecT VecT_Append(VecT vec, PyObject *x, size_t item_type) {
         Py_INCREF(x);
         new.len = 1;
         new.buf->items[0] = x;
+        vec_track_buffer(&new);
         return new;
     }
     Py_ssize_t cap = VEC_CAP(vec);
@@ -294,6 +305,7 @@ VecT VecT_Append(VecT vec, PyObject *x, size_t item_type) {
         }
         new.buf->items[vec.len] = x;
         new.len = vec.len + 1;
+        vec_track_buffer(&new);
         VEC_DECREF(vec);
         return new;
     }
@@ -361,6 +373,7 @@ VecT VecT_ExtendVec(VecT dst, VecT src, size_t item_type) {
         }
         memset(new.buf->items + src.len, 0, sizeof(PyObject *) * (new_len - src.len));
         new.len = new_len;
+        vec_track_buffer(&new);
         return new;
     }
     Py_ssize_t cap = VEC_CAP(dst);
@@ -405,6 +418,7 @@ VecT VecT_ExtendVec(VecT dst, VecT src, size_t item_type) {
     }
     memset(new.buf->items + new_len, 0, sizeof(PyObject *) * (new_cap - new_len));
     new.len = new_len;
+    vec_track_buffer(&new);
     VEC_DECREF(dst);
     return new;
 }
@@ -680,6 +694,7 @@ PyObject *VecT_FromIterable(size_t item_type, PyObject *iterable, int64_t cap) {
             v.buf->items[i] = NULL;
     }
     v.len = 0;
+    vec_track_buffer(&v);
 
     PyObject *iter = PyObject_GetIter(iterable);
     if (iter == NULL) {


### PR DESCRIPTION
Two issues found by running the `vecs` tests with a debug build of python:

Fix assertion `PyObject_GC_Track() object is not valid` caused by calling the track function on vec buffers before their items are initialized. We have an optimization in place that doesn't immediately zero-initialize the buffers because they are set to their actual values right after calling the allocator. But that makes the GC track garbage memory so move the track function calls to after the items are initialized.

Fix resource warning about calling `PyObject_GC_Del` on `vec_generic_alias` objects. We were missing a `PyObject_GC_UnTrack` call in the deallocator.