### PR TITLE
Run semantic analysis pass one if file doesn't exsit

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3314,7 +3314,9 @@ class State:
         #
         # TODO: This should not be considered as a semantic analysis
         #     pass -- it's an independent pass.
-        if not options.native_parser:
+        if not options.native_parser or not self.manager.fscache.exists(
+            self.xpath, real_only=True
+        ):
             analyzer = SemanticAnalyzerPreAnalysis()
             with self.wrap_context():
                 analyzer.visit_file(self.tree, self.xpath, self.id, options)


### PR DESCRIPTION
Noticed this while working on the other fixes from https://github.com/python/mypy/pull/21331. If file doesn't exist, it will be parsed with the old parser, even if the native parser is enabled, so we need to run semantic analysis pass one on it.

Not adding a test because this will not be needed soon (and I am lazy, sorry).

cc @JukkaL 
