### PR TITLE
[mypyc] Optimize vec->list and vec->tuple conversions

### DIFF
--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -99,7 +99,7 @@ from mypyc.irbuild.format_str_tokenizer import (
     join_formatted_strings,
     tokenizer_format_call,
 )
-from mypyc.irbuild.vec import vec_append, vec_extend, vec_pop, vec_remove
+from mypyc.irbuild.vec import vec_append, vec_extend, vec_pop, vec_remove, vec_to_list
 from mypyc.primitives.bytearray_ops import isinstance_bytearray
 from mypyc.primitives.bytes_ops import (
     bytes_adjust_index_op,
@@ -327,6 +327,16 @@ def translate_len(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value 
                 return builder.builtin_len(obj, expr.line, use_pyssize_t=True)
             else:
                 return builder.builtin_len(obj, expr.line)
+    return None
+
+
+@specialize_function("builtins.list")
+def translate_vec_to_list(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
+    if len(expr.args) == 1 and expr.arg_kinds == [ARG_POS]:
+        arg_type = builder.node_type(expr.args[0])
+        if isinstance(arg_type, RVec):
+            vec = builder.accept(expr.args[0])
+            return vec_to_list(builder.builder, vec, expr.line)
     return None
 
 

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -100,6 +100,7 @@ from mypyc.irbuild.format_str_tokenizer import (
     tokenizer_format_call,
 )
 from mypyc.irbuild.vec import (
+    supports_vec_to_sequence,
     vec_append,
     vec_extend,
     vec_pop,
@@ -341,7 +342,7 @@ def translate_len(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value 
 def translate_vec_to_list(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
     if len(expr.args) == 1 and expr.arg_kinds == [ARG_POS]:
         arg_type = builder.node_type(expr.args[0])
-        if isinstance(arg_type, RVec):
+        if isinstance(arg_type, RVec) and supports_vec_to_sequence(arg_type):
             vec = builder.accept(expr.args[0])
             return vec_to_list(builder.builder, vec, expr.line)
     return None
@@ -411,7 +412,7 @@ def translate_list_from_generator_call(
 def translate_vec_to_tuple(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
     if len(expr.args) == 1 and expr.arg_kinds == [ARG_POS]:
         arg_type = builder.node_type(expr.args[0])
-        if isinstance(arg_type, RVec):
+        if isinstance(arg_type, RVec) and supports_vec_to_sequence(arg_type):
             vec = builder.accept(expr.args[0])
             return vec_to_tuple(builder.builder, vec, expr.line)
     return None

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -99,7 +99,14 @@ from mypyc.irbuild.format_str_tokenizer import (
     join_formatted_strings,
     tokenizer_format_call,
 )
-from mypyc.irbuild.vec import vec_append, vec_extend, vec_pop, vec_remove, vec_to_list, vec_to_tuple
+from mypyc.irbuild.vec import (
+    vec_append,
+    vec_extend,
+    vec_pop,
+    vec_remove,
+    vec_to_list,
+    vec_to_tuple,
+)
 from mypyc.primitives.bytearray_ops import isinstance_bytearray
 from mypyc.primitives.bytes_ops import (
     bytes_adjust_index_op,

--- a/mypyc/irbuild/specialize.py
+++ b/mypyc/irbuild/specialize.py
@@ -99,7 +99,7 @@ from mypyc.irbuild.format_str_tokenizer import (
     join_formatted_strings,
     tokenizer_format_call,
 )
-from mypyc.irbuild.vec import vec_append, vec_extend, vec_pop, vec_remove, vec_to_list
+from mypyc.irbuild.vec import vec_append, vec_extend, vec_pop, vec_remove, vec_to_list, vec_to_tuple
 from mypyc.primitives.bytearray_ops import isinstance_bytearray
 from mypyc.primitives.bytes_ops import (
     bytes_adjust_index_op,
@@ -397,6 +397,16 @@ def translate_list_from_generator_call(
             empty_op_llbuilder=builder.builder.new_list_op_with_length,
             set_item_op=set_item,
         )
+    return None
+
+
+@specialize_function("builtins.tuple")
+def translate_vec_to_tuple(builder: IRBuilder, expr: CallExpr, callee: RefExpr) -> Value | None:
+    if len(expr.args) == 1 and expr.arg_kinds == [ARG_POS]:
+        arg_type = builder.node_type(expr.args[0])
+        if isinstance(arg_type, RVec):
+            vec = builder.accept(expr.args[0])
+            return vec_to_tuple(builder.builder, vec, expr.line)
     return None
 
 

--- a/mypyc/irbuild/vec.py
+++ b/mypyc/irbuild/vec.py
@@ -48,6 +48,7 @@ from mypyc.ir.rtypes import (
     is_short_int_rprimitive,
     list_rprimitive,
     object_rprimitive,
+    tuple_rprimitive,
     optional_value_type,
     pointer_rprimitive,
     vec_api_by_item_type,
@@ -598,21 +599,35 @@ def vec_slice(
 
 
 def vec_to_list(builder: LowLevelIRBuilder, vec: Value, line: int) -> Value | None:
+    return _vec_to_sequence(builder, vec, line, "to_list", list_rprimitive)
+
+
+def vec_to_tuple(builder: LowLevelIRBuilder, vec: Value, line: int) -> Value | None:
+    return _vec_to_sequence(builder, vec, line, "to_tuple", tuple_rprimitive)
+
+
+def _vec_to_sequence(
+    builder: LowLevelIRBuilder,
+    vec: Value,
+    line: int,
+    method: str,
+    result_type: RType,
+) -> Value | None:
     vec_type = vec.type
     assert isinstance(vec_type, RVec)
     item_type = vec_type.item_type
     api_name = vec_api_by_item_type.get(item_type)
     if api_name is not None:
-        name = f"{api_name}.to_list"
+        name = f"{api_name}.{method}"
     elif vec_type.depth() == 0:
-        name = "VecTApi.to_list"
+        name = f"VecTApi.{method}"
     else:
         return None
     return builder.add(
         CallC(
             name,
             [vec],
-            list_rprimitive,
+            result_type,
             steals=[True],
             is_borrowed=False,
             error_kind=ERR_MAGIC,

--- a/mypyc/irbuild/vec.py
+++ b/mypyc/irbuild/vec.py
@@ -46,6 +46,7 @@ from mypyc.ir.rtypes import (
     is_int64_rprimitive,
     is_int_rprimitive,
     is_short_int_rprimitive,
+    list_rprimitive,
     object_rprimitive,
     optional_value_type,
     pointer_rprimitive,
@@ -594,3 +595,27 @@ def vec_slice(
         line=line,
     )
     return builder.add(call)
+
+
+def vec_to_list(builder: LowLevelIRBuilder, vec: Value, line: int) -> Value | None:
+    vec_type = vec.type
+    assert isinstance(vec_type, RVec)
+    item_type = vec_type.item_type
+    api_name = vec_api_by_item_type.get(item_type)
+    if api_name is not None:
+        name = f"{api_name}.to_list"
+    elif vec_type.depth() == 0:
+        name = "VecTApi.to_list"
+    else:
+        return None
+    return builder.add(
+        CallC(
+            name,
+            [vec],
+            list_rprimitive,
+            steals=[False],
+            is_borrowed=False,
+            error_kind=ERR_MAGIC,
+            line=line,
+        )
+    )

--- a/mypyc/irbuild/vec.py
+++ b/mypyc/irbuild/vec.py
@@ -606,6 +606,10 @@ def vec_to_tuple(builder: LowLevelIRBuilder, vec: Value, line: int) -> Value | N
     return _vec_to_sequence(builder, vec, line, "to_tuple", tuple_rprimitive)
 
 
+def supports_vec_to_sequence(vec_type: RVec) -> bool:
+    return vec_api_by_item_type.get(vec_type.item_type) is not None or vec_type.depth() == 0
+
+
 def _vec_to_sequence(
     builder: LowLevelIRBuilder, vec: Value, line: int, method: str, result_type: RType
 ) -> Value | None:
@@ -615,7 +619,7 @@ def _vec_to_sequence(
     api_name = vec_api_by_item_type.get(item_type)
     if api_name is not None:
         name = f"{api_name}.{method}"
-    elif vec_type.depth() == 0:
+    elif supports_vec_to_sequence(vec_type):
         name = f"VecTApi.{method}"
     else:
         return None

--- a/mypyc/irbuild/vec.py
+++ b/mypyc/irbuild/vec.py
@@ -48,9 +48,9 @@ from mypyc.ir.rtypes import (
     is_short_int_rprimitive,
     list_rprimitive,
     object_rprimitive,
-    tuple_rprimitive,
     optional_value_type,
     pointer_rprimitive,
+    tuple_rprimitive,
     vec_api_by_item_type,
     vec_item_type_tags,
 )
@@ -607,11 +607,7 @@ def vec_to_tuple(builder: LowLevelIRBuilder, vec: Value, line: int) -> Value | N
 
 
 def _vec_to_sequence(
-    builder: LowLevelIRBuilder,
-    vec: Value,
-    line: int,
-    method: str,
-    result_type: RType,
+    builder: LowLevelIRBuilder, vec: Value, line: int, method: str, result_type: RType
 ) -> Value | None:
     vec_type = vec.type
     assert isinstance(vec_type, RVec)

--- a/mypyc/irbuild/vec.py
+++ b/mypyc/irbuild/vec.py
@@ -613,7 +613,7 @@ def vec_to_list(builder: LowLevelIRBuilder, vec: Value, line: int) -> Value | No
             name,
             [vec],
             list_rprimitive,
-            steals=[False],
+            steals=[True],
             is_borrowed=False,
             error_kind=ERR_MAGIC,
             line=line,

--- a/mypyc/lib-rt/vecs/librt_vecs.h
+++ b/mypyc/lib-rt/vecs/librt_vecs.h
@@ -282,6 +282,7 @@ typedef struct _VecI64API {
     VecI64 (*from_iterable)(PyObject *, int64_t);
     VecI64 (*extend)(VecI64, PyObject *);
     VecI64 (*extend_vec)(VecI64, VecI64);
+    PyObject *(*to_list)(VecI64);
 } VecI64API;
 
 // vec[i32] operations + type objects (stored in a capsule)
@@ -300,6 +301,7 @@ typedef struct _VecI32API {
     VecI32 (*from_iterable)(PyObject *, int64_t);
     VecI32 (*extend)(VecI32, PyObject *);
     VecI32 (*extend_vec)(VecI32, VecI32);
+    PyObject *(*to_list)(VecI32);
 } VecI32API;
 
 // vec[i16] operations + type objects (stored in a capsule)
@@ -318,6 +320,7 @@ typedef struct _VecI16API {
     VecI16 (*from_iterable)(PyObject *, int64_t);
     VecI16 (*extend)(VecI16, PyObject *);
     VecI16 (*extend_vec)(VecI16, VecI16);
+    PyObject *(*to_list)(VecI16);
 } VecI16API;
 
 // vec[u8] operations + type objects (stored in a capsule)
@@ -336,6 +339,7 @@ typedef struct _VecU8API {
     VecU8 (*from_iterable)(PyObject *, int64_t);
     VecU8 (*extend)(VecU8, PyObject *);
     VecU8 (*extend_vec)(VecU8, VecU8);
+    PyObject *(*to_list)(VecU8);
 } VecU8API;
 
 // vec[float] operations + type objects (stored in a capsule)
@@ -354,6 +358,7 @@ typedef struct _VecFloatAPI {
     VecFloat (*from_iterable)(PyObject *, int64_t);
     VecFloat (*extend)(VecFloat, PyObject *);
     VecFloat (*extend_vec)(VecFloat, VecFloat);
+    PyObject *(*to_list)(VecFloat);
 } VecFloatAPI;
 
 // vec[bool] operations + type objects (stored in a capsule)
@@ -372,6 +377,7 @@ typedef struct _VecBoolAPI {
     VecBool (*from_iterable)(PyObject *, int64_t);
     VecBool (*extend)(VecBool, PyObject *);
     VecBool (*extend_vec)(VecBool, VecBool);
+    PyObject *(*to_list)(VecBool);
 } VecBoolAPI;
 
 #ifndef MYPYC_DECLARED_tuple_T2VOO
@@ -403,6 +409,7 @@ typedef struct _VecTAPI {
     VecT (*from_iterable)(size_t, PyObject *, int64_t);
     VecT (*extend)(VecT, PyObject *, size_t);
     VecT (*extend_vec)(VecT, VecT, size_t);
+    PyObject *(*to_list)(VecT);
 } VecTAPI;
 
 

--- a/mypyc/lib-rt/vecs/librt_vecs.h
+++ b/mypyc/lib-rt/vecs/librt_vecs.h
@@ -283,6 +283,7 @@ typedef struct _VecI64API {
     VecI64 (*extend)(VecI64, PyObject *);
     VecI64 (*extend_vec)(VecI64, VecI64);
     PyObject *(*to_list)(VecI64);
+    PyObject *(*to_tuple)(VecI64);
 } VecI64API;
 
 // vec[i32] operations + type objects (stored in a capsule)
@@ -302,6 +303,7 @@ typedef struct _VecI32API {
     VecI32 (*extend)(VecI32, PyObject *);
     VecI32 (*extend_vec)(VecI32, VecI32);
     PyObject *(*to_list)(VecI32);
+    PyObject *(*to_tuple)(VecI32);
 } VecI32API;
 
 // vec[i16] operations + type objects (stored in a capsule)
@@ -321,6 +323,7 @@ typedef struct _VecI16API {
     VecI16 (*extend)(VecI16, PyObject *);
     VecI16 (*extend_vec)(VecI16, VecI16);
     PyObject *(*to_list)(VecI16);
+    PyObject *(*to_tuple)(VecI16);
 } VecI16API;
 
 // vec[u8] operations + type objects (stored in a capsule)
@@ -340,6 +343,7 @@ typedef struct _VecU8API {
     VecU8 (*extend)(VecU8, PyObject *);
     VecU8 (*extend_vec)(VecU8, VecU8);
     PyObject *(*to_list)(VecU8);
+    PyObject *(*to_tuple)(VecU8);
 } VecU8API;
 
 // vec[float] operations + type objects (stored in a capsule)
@@ -359,6 +363,7 @@ typedef struct _VecFloatAPI {
     VecFloat (*extend)(VecFloat, PyObject *);
     VecFloat (*extend_vec)(VecFloat, VecFloat);
     PyObject *(*to_list)(VecFloat);
+    PyObject *(*to_tuple)(VecFloat);
 } VecFloatAPI;
 
 // vec[bool] operations + type objects (stored in a capsule)
@@ -378,6 +383,7 @@ typedef struct _VecBoolAPI {
     VecBool (*extend)(VecBool, PyObject *);
     VecBool (*extend_vec)(VecBool, VecBool);
     PyObject *(*to_list)(VecBool);
+    PyObject *(*to_tuple)(VecBool);
 } VecBoolAPI;
 
 #ifndef MYPYC_DECLARED_tuple_T2VOO
@@ -410,6 +416,7 @@ typedef struct _VecTAPI {
     VecT (*extend)(VecT, PyObject *, size_t);
     VecT (*extend_vec)(VecT, VecT, size_t);
     PyObject *(*to_list)(VecT);
+    PyObject *(*to_tuple)(VecT);
 } VecTAPI;
 
 

--- a/mypyc/lib-rt/vecs/vec_t.c
+++ b/mypyc/lib-rt/vecs/vec_t.c
@@ -447,6 +447,30 @@ PyObject *VecT_ToList(VecT v) {
     return list;
 }
 
+// Convert vec to tuple, stealing 'v'.
+PyObject *VecT_ToTuple(VecT v) {
+    Py_ssize_t n = v.len;
+    PyObject *tuple = PyTuple_New(n);
+    if (tuple == NULL) {
+        VEC_DECREF(v);
+        return NULL;
+    }
+    if (n > 0 && Py_REFCNT(v.buf) == 1) {
+        for (Py_ssize_t i = 0; i < n; i++) {
+            PyTuple_SET_ITEM(tuple, i, v.buf->items[i]);
+            v.buf->items[i] = NULL;
+        }
+    } else {
+        for (Py_ssize_t i = 0; i < n; i++) {
+            PyObject *item = v.buf->items[i];
+            Py_INCREF(item);
+            PyTuple_SET_ITEM(tuple, i, item);
+        }
+    }
+    VEC_DECREF(v);
+    return tuple;
+}
+
 // Remove item from 'vec', stealing 'vec'. Return 'vec' with item removed.
 VecT VecT_Remove(VecT v, PyObject *arg) {
     PyObject **items = v.buf->items;
@@ -795,6 +819,7 @@ VecTAPI Vec_TAPI = {
     VecT_Extend,
     VecT_ExtendVec,
     VecT_ToList,
+    VecT_ToTuple,
 };
 
 #endif  // MYPYC_EXPERIMENTAL

--- a/mypyc/lib-rt/vecs/vec_t.c
+++ b/mypyc/lib-rt/vecs/vec_t.c
@@ -423,16 +423,27 @@ VecT VecT_ExtendVec(VecT dst, VecT src, size_t item_type) {
     return new;
 }
 
+// Convert vec to list, stealing 'v'.
 PyObject *VecT_ToList(VecT v) {
     Py_ssize_t n = v.len;
     PyObject *list = PyList_New(n);
-    if (list == NULL)
+    if (list == NULL) {
+        VEC_DECREF(v);
         return NULL;
-    for (Py_ssize_t i = 0; i < n; i++) {
-        PyObject *item = v.buf->items[i];
-        Py_INCREF(item);
-        PyList_SET_ITEM(list, i, item);
     }
+    if (n > 0 && Py_REFCNT(v.buf) == 1) {
+        for (Py_ssize_t i = 0; i < n; i++) {
+            PyList_SET_ITEM(list, i, v.buf->items[i]);
+            v.buf->items[i] = NULL;
+        }
+    } else {
+        for (Py_ssize_t i = 0; i < n; i++) {
+            PyObject *item = v.buf->items[i];
+            Py_INCREF(item);
+            PyList_SET_ITEM(list, i, item);
+        }
+    }
+    VEC_DECREF(v);
     return list;
 }
 

--- a/mypyc/lib-rt/vecs/vec_t.c
+++ b/mypyc/lib-rt/vecs/vec_t.c
@@ -423,6 +423,19 @@ VecT VecT_ExtendVec(VecT dst, VecT src, size_t item_type) {
     return new;
 }
 
+PyObject *VecT_ToList(VecT v) {
+    Py_ssize_t n = v.len;
+    PyObject *list = PyList_New(n);
+    if (list == NULL)
+        return NULL;
+    for (Py_ssize_t i = 0; i < n; i++) {
+        PyObject *item = v.buf->items[i];
+        Py_INCREF(item);
+        PyList_SET_ITEM(list, i, item);
+    }
+    return list;
+}
+
 // Remove item from 'vec', stealing 'vec'. Return 'vec' with item removed.
 VecT VecT_Remove(VecT v, PyObject *arg) {
     PyObject **items = v.buf->items;
@@ -770,6 +783,7 @@ VecTAPI Vec_TAPI = {
     VecT_FromIterable,
     VecT_Extend,
     VecT_ExtendVec,
+    VecT_ToList,
 };
 
 #endif  // MYPYC_EXPERIMENTAL

--- a/mypyc/lib-rt/vecs/vec_template.c
+++ b/mypyc/lib-rt/vecs/vec_template.c
@@ -548,6 +548,22 @@ VEC FUNC(ExtendVec)(VEC dst, VEC src) {
     return vec_extend_items(dst, src.buf->items, src.len, dst.buf == src.buf);
 }
 
+PyObject *FUNC(ToList)(VEC v) {
+    Py_ssize_t n = v.len;
+    PyObject *list = PyList_New(n);
+    if (list == NULL)
+        return NULL;
+    for (Py_ssize_t i = 0; i < n; i++) {
+        PyObject *item = BOX_ITEM(v.buf->items[i]);
+        if (item == NULL) {
+            Py_DECREF(list);
+            return NULL;
+        }
+        PyList_SET_ITEM(list, i, item);
+    }
+    return list;
+}
+
 // Remove item from 'vec', stealing 'vec'. Return 'vec' with item removed.
 VEC FUNC(Remove)(VEC v, ITEM_C_TYPE x) {
     for (Py_ssize_t i = 0; i < v.len; i++) {
@@ -762,6 +778,7 @@ NAME(API) FEATURES = {
     FUNC(FromIterable),
     FUNC(Extend),
     FUNC(ExtendVec),
+    FUNC(ToList),
 };
 
 #endif  // MYPYC_EXPERIMENTAL

--- a/mypyc/lib-rt/vecs/vec_template.c
+++ b/mypyc/lib-rt/vecs/vec_template.c
@@ -548,19 +548,24 @@ VEC FUNC(ExtendVec)(VEC dst, VEC src) {
     return vec_extend_items(dst, src.buf->items, src.len, dst.buf == src.buf);
 }
 
+// Convert vec to list, stealing 'v'.
 PyObject *FUNC(ToList)(VEC v) {
     Py_ssize_t n = v.len;
     PyObject *list = PyList_New(n);
-    if (list == NULL)
+    if (list == NULL) {
+        VEC_DECREF(v);
         return NULL;
+    }
     for (Py_ssize_t i = 0; i < n; i++) {
         PyObject *item = BOX_ITEM(v.buf->items[i]);
         if (item == NULL) {
             Py_DECREF(list);
+            VEC_DECREF(v);
             return NULL;
         }
         PyList_SET_ITEM(list, i, item);
     }
+    VEC_DECREF(v);
     return list;
 }
 

--- a/mypyc/lib-rt/vecs/vec_template.c
+++ b/mypyc/lib-rt/vecs/vec_template.c
@@ -569,6 +569,27 @@ PyObject *FUNC(ToList)(VEC v) {
     return list;
 }
 
+// Convert vec to tuple, stealing 'v'.
+PyObject *FUNC(ToTuple)(VEC v) {
+    Py_ssize_t n = v.len;
+    PyObject *tuple = PyTuple_New(n);
+    if (tuple == NULL) {
+        VEC_DECREF(v);
+        return NULL;
+    }
+    for (Py_ssize_t i = 0; i < n; i++) {
+        PyObject *item = BOX_ITEM(v.buf->items[i]);
+        if (item == NULL) {
+            Py_DECREF(tuple);
+            VEC_DECREF(v);
+            return NULL;
+        }
+        PyTuple_SET_ITEM(tuple, i, item);
+    }
+    VEC_DECREF(v);
+    return tuple;
+}
+
 // Remove item from 'vec', stealing 'vec'. Return 'vec' with item removed.
 VEC FUNC(Remove)(VEC v, ITEM_C_TYPE x) {
     for (Py_ssize_t i = 0; i < v.len; i++) {
@@ -784,6 +805,7 @@ NAME(API) FEATURES = {
     FUNC(Extend),
     FUNC(ExtendVec),
     FUNC(ToList),
+    FUNC(ToTuple),
 };
 
 #endif  // MYPYC_EXPERIMENTAL

--- a/mypyc/test-data/irbuild-vec-i64.test
+++ b/mypyc/test-data/irbuild-vec-i64.test
@@ -985,3 +985,17 @@ def to_list(v):
 L0:
     r0 = VecI64Api.to_list(v)
     return r0
+
+[case testVecI64ConvertToTuple]
+from librt.vecs import vec
+from mypy_extensions import i64
+
+def to_tuple(v: vec[i64]) -> tuple[i64, ...]:
+    return tuple(v)
+[out]
+def to_tuple(v):
+    v :: vec[i64]
+    r0 :: tuple
+L0:
+    r0 = VecI64Api.to_tuple(v)
+    return r0

--- a/mypyc/test-data/irbuild-vec-i64.test
+++ b/mypyc/test-data/irbuild-vec-i64.test
@@ -971,3 +971,17 @@ def from_tuple(a):
 L0:
     r0 = VecI64Api.from_iterable(a, 0)
     return r0
+
+[case testVecI64ConvertToList]
+from librt.vecs import vec
+from mypy_extensions import i64
+
+def to_list(v: vec[i64]) -> list[i64]:
+    return list(v)
+[out]
+def to_list(v):
+    v :: vec[i64]
+    r0 :: list
+L0:
+    r0 = VecI64Api.to_list(v)
+    return r0

--- a/mypyc/test-data/irbuild-vec-nested.test
+++ b/mypyc/test-data/irbuild-vec-nested.test
@@ -16,6 +16,22 @@ L0:
     r1 = PySequence_List(r0)
     return r1
 
+[case testVecNestedConvertToTuple]
+from librt.vecs import vec
+from mypy_extensions import i64
+
+def to_tuple(v: vec[vec[i64]]) -> tuple[vec[i64], ...]:
+    return tuple(v)
+[out]
+def to_tuple(v):
+    v :: vec[vec[i64]]
+    r0 :: object
+    r1 :: tuple
+L0:
+    r0 = box(vec[vec[i64]], v)
+    r1 = PySequence_Tuple(r0)
+    return r1
+
 [case testVecNestedCreateEmpty]
 from librt.vecs import vec, append
 from mypy_extensions import i64

--- a/mypyc/test-data/irbuild-vec-nested.test
+++ b/mypyc/test-data/irbuild-vec-nested.test
@@ -1,5 +1,21 @@
 -- Test cases for nested vecs
 
+[case testVecNestedConvertToList]
+from librt.vecs import vec
+from mypy_extensions import i64
+
+def to_list(v: vec[vec[i64]]) -> list[vec[i64]]:
+    return list(v)
+[out]
+def to_list(v):
+    v :: vec[vec[i64]]
+    r0 :: object
+    r1 :: list
+L0:
+    r0 = box(vec[vec[i64]], v)
+    r1 = PySequence_List(r0)
+    return r1
+
 [case testVecNestedCreateEmpty]
 from librt.vecs import vec, append
 from mypy_extensions import i64

--- a/mypyc/test-data/irbuild-vec-nested.test
+++ b/mypyc/test-data/irbuild-vec-nested.test
@@ -32,6 +32,43 @@ L0:
     r1 = PySequence_Tuple(r0)
     return r1
 
+[case testVecNestedConvertToSequenceEvaluatesArgOnce]
+from librt.vecs import vec
+from mypy_extensions import i64
+
+def make() -> vec[vec[i64]]:
+    return vec[vec[i64]]()
+
+def to_list() -> list[vec[i64]]:
+    return list(make())
+
+def to_tuple() -> tuple[vec[i64], ...]:
+    return tuple(make())
+[out]
+def make():
+    r0 :: vec[vec[i64]]
+L0:
+    r0 = VecNestedApi.alloc(0, 0, 2, 1)
+    return r0
+def to_list():
+    r0 :: vec[vec[i64]]
+    r1 :: object
+    r2 :: list
+L0:
+    r0 = make()
+    r1 = box(vec[vec[i64]], r0)
+    r2 = PySequence_List(r1)
+    return r2
+def to_tuple():
+    r0 :: vec[vec[i64]]
+    r1 :: object
+    r2 :: tuple
+L0:
+    r0 = make()
+    r1 = box(vec[vec[i64]], r0)
+    r2 = PySequence_Tuple(r1)
+    return r2
+
 [case testVecNestedCreateEmpty]
 from librt.vecs import vec, append
 from mypy_extensions import i64

--- a/mypyc/test-data/irbuild-vec-t.test
+++ b/mypyc/test-data/irbuild-vec-t.test
@@ -14,6 +14,19 @@ L0:
     r0 = VecTApi.to_list(v)
     return r0
 
+[case testVecTConvertToTuple]
+from librt.vecs import vec
+
+def to_tuple(v: vec[str]) -> tuple[str, ...]:
+    return tuple(v)
+[out]
+def to_tuple(v):
+    v :: vec[str]
+    r0 :: tuple
+L0:
+    r0 = VecTApi.to_tuple(v)
+    return r0
+
 [case testVecTCreateEmpty]
 from librt.vecs import vec, append
 

--- a/mypyc/test-data/irbuild-vec-t.test
+++ b/mypyc/test-data/irbuild-vec-t.test
@@ -1,6 +1,19 @@
 -- Test cases for vec[t] where t is a boxed, non-vec type (PyObject *).
 -- Also tests for vec[t | None], which uses the same representation.
 
+[case testVecTConvertToList]
+from librt.vecs import vec
+
+def to_list(v: vec[str]) -> list[str]:
+    return list(v)
+[out]
+def to_list(v):
+    v :: vec[str]
+    r0 :: list
+L0:
+    r0 = VecTApi.to_list(v)
+    return r0
+
 [case testVecTCreateEmpty]
 from librt.vecs import vec, append
 

--- a/mypyc/test-data/run-vecs-i64.test
+++ b/mypyc/test-data/run-vecs-i64.test
@@ -655,3 +655,26 @@ def test_extend_from_bytes() -> None:
     v = vec[i64]([1])
     v = extend_iterable(v, b'\x02\x03')
     assert v == vec[i64]([1, 2, 3])
+
+def to_list(v: vec[i64]) -> list[i64]:
+    return list(v)
+
+def test_to_list_empty() -> None:
+    assert to_list(vec[i64]()) == []
+
+def test_to_list_single() -> None:
+    assert to_list(vec[i64]([5])) == [5]
+
+def test_to_list_multiple() -> None:
+    assert to_list(vec[i64]([1, 2, 3])) == [1, 2, 3]
+
+def test_to_list_large_values() -> None:
+    v = vec[i64]([-(2**63), 0, 2**63 - 1])
+    result = to_list(v)
+    assert result == [-(2**63), 0, 2**63 - 1]
+
+def test_to_list_does_not_consume() -> None:
+    v = vec[i64]([1, 2, 3])
+    l1 = to_list(v)
+    l2 = to_list(v)
+    assert l1 == l2 == [1, 2, 3]

--- a/mypyc/test-data/run-vecs-i64.test
+++ b/mypyc/test-data/run-vecs-i64.test
@@ -678,3 +678,26 @@ def test_to_list_does_not_consume() -> None:
     l1 = to_list(v)
     l2 = to_list(v)
     assert l1 == l2 == [1, 2, 3]
+
+def to_tuple(v: vec[i64]) -> Tuple[i64, ...]:
+    return tuple(v)
+
+def test_to_tuple_empty() -> None:
+    assert to_tuple(vec[i64]()) == ()
+
+def test_to_tuple_single() -> None:
+    assert to_tuple(vec[i64]([5])) == (5,)
+
+def test_to_tuple_multiple() -> None:
+    assert to_tuple(vec[i64]([1, 2, 3])) == (1, 2, 3)
+
+def test_to_tuple_large_values() -> None:
+    v = vec[i64]([-(2**63), 0, 2**63 - 1])
+    result = to_tuple(v)
+    assert result == (-(2**63), 0, 2**63 - 1)
+
+def test_to_tuple_does_not_consume() -> None:
+    v = vec[i64]([1, 2, 3])
+    t1 = to_tuple(v)
+    t2 = to_tuple(v)
+    assert t1 == t2 == (1, 2, 3)

--- a/mypyc/test-data/run-vecs-misc.test
+++ b/mypyc/test-data/run-vecs-misc.test
@@ -429,3 +429,17 @@ def test_vec_u8_to_bytes() -> None:
     assert bytes(vec[u8]([72, 101, 108, 108, 111])) == b"Hello"
     assert bytes(vec[u8]()) == b""
     assert bytes(vec[u8]([0, 255, 1])) == b"\x00\xff\x01"
+
+def u8_to_list(v: vec[u8]) -> list[u8]:
+    return list(v)
+
+def u8_to_tuple(v: vec[u8]) -> tuple[u8, ...]:
+    return tuple(v)
+
+def test_vec_u8_to_list() -> None:
+    assert u8_to_list(vec[u8]()) == []
+    assert u8_to_list(vec[u8]([0, 128, 255])) == [0, 128, 255]
+
+def test_vec_u8_to_tuple() -> None:
+    assert u8_to_tuple(vec[u8]()) == ()
+    assert u8_to_tuple(vec[u8]([0, 128, 255])) == (0, 128, 255)

--- a/mypyc/test-data/run-vecs-t.test
+++ b/mypyc/test-data/run-vecs-t.test
@@ -627,3 +627,37 @@ def test_to_list_shared_buffer() -> None:
     assert result == ['a', 'b']
     # v0 must still be valid
     assert v0 == vec[str](['a', 'b', 'c'])
+
+def to_tuple(v: vec[str]) -> Tuple[str, ...]:
+    return tuple(v)
+
+def to_tuple_optional(v: vec[Optional[str]]) -> Tuple[Optional[str], ...]:
+    return tuple(v)
+
+def test_to_tuple_empty() -> None:
+    assert to_tuple(vec[str]()) == ()
+
+def test_to_tuple_single() -> None:
+    assert to_tuple(vec[str](['hello'])) == ('hello',)
+
+def test_to_tuple_multiple() -> None:
+    assert to_tuple(vec[str](['a', 'b', 'c'])) == ('a', 'b', 'c')
+
+def test_to_tuple_optional() -> None:
+    assert to_tuple_optional(vec[Optional[str]](['x', None, 'y'])) == ('x', None, 'y')
+
+def test_to_tuple_does_not_consume() -> None:
+    v = vec[str](['a', 'b'])
+    t1 = to_tuple(v)
+    t2 = to_tuple(v)
+    assert t1 == t2 == ('a', 'b')
+
+def test_to_tuple_shared_buffer() -> None:
+    v0 = vec[str](['a', 'b', 'c'])
+    v1, item = pop(v0)
+    assert item == 'c'
+    # v0 and v1 share a buffer (v0.len=3, v1.len=2)
+    result = to_tuple(v1)
+    assert result == ('a', 'b')
+    # v0 must still be valid
+    assert v0 == vec[str](['a', 'b', 'c'])

--- a/mypyc/test-data/run-vecs-t.test
+++ b/mypyc/test-data/run-vecs-t.test
@@ -593,3 +593,27 @@ def test_extend_iterable_runtime_vec_shared_buffer_after_pop() -> None:
     v = extend_iterable(v1, it)
     assert v == vec[str](['a', 'b', 'a', 'b', 'c'])
     assert v0 == vec[str](['a', 'b', 'c'])
+
+def to_list(v: vec[str]) -> list[str]:
+    return list(v)
+
+def to_list_optional(v: vec[Optional[str]]) -> list[Optional[str]]:
+    return list(v)
+
+def test_to_list_empty() -> None:
+    assert to_list(vec[str]()) == []
+
+def test_to_list_single() -> None:
+    assert to_list(vec[str](['hello'])) == ['hello']
+
+def test_to_list_multiple() -> None:
+    assert to_list(vec[str](['a', 'b', 'c'])) == ['a', 'b', 'c']
+
+def test_to_list_optional() -> None:
+    assert to_list_optional(vec[Optional[str]](['x', None, 'y'])) == ['x', None, 'y']
+
+def test_to_list_does_not_consume() -> None:
+    v = vec[str](['a', 'b'])
+    l1 = to_list(v)
+    l2 = to_list(v)
+    assert l1 == l2 == ['a', 'b']

--- a/mypyc/test-data/run-vecs-t.test
+++ b/mypyc/test-data/run-vecs-t.test
@@ -617,3 +617,13 @@ def test_to_list_does_not_consume() -> None:
     l1 = to_list(v)
     l2 = to_list(v)
     assert l1 == l2 == ['a', 'b']
+
+def test_to_list_shared_buffer() -> None:
+    v0 = vec[str](['a', 'b', 'c'])
+    v1, item = pop(v0)
+    assert item == 'c'
+    # v0 and v1 share a buffer (v0.len=3, v1.len=2)
+    result = to_list(v1)
+    assert result == ['a', 'b']
+    # v0 must still be valid
+    assert v0 == vec[str](['a', 'b', 'c'])


### PR DESCRIPTION
Use specialized primitives to convert non-nested vecs to list/tuple objects.

As an optimization, move and clear references from the source vec if there is only one reference to the vec.

I used coding agent assist with small incremental changes.