### PR TITLE
Optimize SCC scheduler `not_ready_deps` tracking

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -230,10 +230,10 @@ class SCC:
         self.mod_ids = ids
         # Direct dependencies, should be populated by the caller.
         self.deps: set[int] = set(deps) if deps is not None else set()
-        # Direct dependencies that have not been processed yet.
-        # Should be populated by the caller. This set may change during graph
-        # processing, while the above stays constant.
-        self.not_ready_deps: set[int] = set()
+        # Count of direct dependencies that have not been processed yet.
+        # Populated by the caller (from len(deps)); decremented during graph
+        # processing as each dep completes. self.deps above stays constant.
+        self.not_ready_count: int = 0
         # SCCs that (directly) depend on this SCC. Note this is a list to
         # make processing order more predictable. Dependents will be notified
         # that they may be ready in the order in this list.
@@ -4630,10 +4630,11 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
         ready = []
         for done_scc in done:
             for dependent in done_scc.direct_dependents:
-                scc_by_id[dependent].not_ready_deps.discard(done_scc.id)
-                if not scc_by_id[dependent].not_ready_deps:
-                    not_ready.remove(scc_by_id[dependent])
-                    ready.append(scc_by_id[dependent])
+                dep_scc = scc_by_id[dependent]
+                dep_scc.not_ready_count -= 1
+                if dep_scc.not_ready_count == 0:
+                    not_ready.remove(dep_scc)
+                    ready.append(dep_scc)
     manager.trace(f"Transitive deps cache size: {sys.getsizeof(manager.transitive_deps_cache)}")
 
 
@@ -5014,9 +5015,10 @@ def prepare_sccs_full(
     for scc in sccs:
         # Remove trivial dependency on itself.
         scc_deps_map[scc].discard(scc)
-        for dep_scc in scc_deps_map[scc]:
+        dep_sccs = scc_deps_map[scc]
+        for dep_scc in dep_sccs:
             scc.deps.add(dep_scc.id)
-            scc.not_ready_deps.add(dep_scc.id)
+        scc.not_ready_count = len(dep_sccs)
     return scc_deps_map
 
 

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -231,7 +231,7 @@ class SCC:
         # Direct dependencies, should be populated by the caller.
         self.deps: set[int] = set(deps) if deps is not None else set()
         # Count of direct dependencies that have not been processed yet.
-        # Populated by the caller (from len(deps)); decremented during graph
+        # Populated by the caller from len(deps); decremented during graph
         # processing as each dep completes. self.deps above stays constant.
         self.not_ready_count: int = 0
         # SCCs that (directly) depend on this SCC. Note this is a list to
@@ -4632,7 +4632,7 @@ def process_graph(graph: Graph, manager: BuildManager) -> None:
             for dependent in done_scc.direct_dependents:
                 dep_scc = scc_by_id[dependent]
                 dep_scc.not_ready_count -= 1
-                if dep_scc.not_ready_count == 0:
+                if not dep_scc.not_ready_count:
                     not_ready.remove(dep_scc)
                     ready.append(dep_scc)
     manager.trace(f"Transitive deps cache size: {sys.getsizeof(manager.transitive_deps_cache)}")


### PR DESCRIPTION
The `not_ready_deps` was populated with each direct dependency ID to do the two operations below: 
- mark a dependency as completed by discarding it
- check if all dependences are done based on if it's empty

All of these could be done with a counter. The ids are never actually being used/inspected, just the size. So with a counter, we can just populate a counter with `len(dep_sccs)`, and rather than discarding an id we can just decrement the counter, and we can check if the counter is zero for when all dependencies have been completed.

This is roughly a ~2% speed up on a warm run. 