### PR TITLE
Speed up transitive_dep_hash for singleton SCCs

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -5086,18 +5086,33 @@ def deps_filtered(graph: Graph, vertices: AbstractSet[str], id: str, pri_max: in
 
 def transitive_dep_hash(scc: SCC, graph: Graph) -> bytes:
     """Compute stable snapshot of transitive import structure for given SCC."""
-    all_direct_deps = sorted(
-        {
-            dep
-            for id in scc.mod_ids
-            for dep in graph[id].dependencies
-            if graph[id].priorities.get(dep) != PRI_INDIRECT
-        }
-    )
+    mod_ids = scc.mod_ids
+    if len(mod_ids) == 1:
+        # Fast path: State.dependencies is already deduped and never contains
+        # self.id, so we can skip the dedupe set and the self-membership check.
+        (only_id,) = mod_ids
+        st = graph[only_id]
+        priorities = st.priorities
+        all_direct_deps = sorted(
+            dep for dep in st.dependencies if priorities.get(dep) != PRI_INDIRECT
+        )
+        buf = WriteBuffer()
+        for dep_id in all_direct_deps:
+            write_str_bare(buf, dep_id)
+            write_bytes_bare(buf, graph[dep_id].trans_dep_hash)
+        return hash_digest_bytes(buf.getvalue())
+    deps_set: set[str] = set()
+    for id in mod_ids:
+        state = graph[id]
+        priorities = state.priorities
+        for dep in state.dependencies:
+            if priorities.get(dep) != PRI_INDIRECT:
+                deps_set.add(dep)
+    all_direct_deps = sorted(deps_set)
     buf = WriteBuffer()
     for dep_id in all_direct_deps:
         write_str_bare(buf, dep_id)
-        if dep_id not in scc.mod_ids:
+        if dep_id not in mod_ids:
             write_bytes_bare(buf, graph[dep_id].trans_dep_hash)
     return hash_digest_bytes(buf.getvalue())
 


### PR DESCRIPTION
I noticed on a large codebase ~99.84% of SCCs are singletons.

So the two main changes are adding a singleton fast path and extracting `graph[id]` to be a local variable so that it does the lookup once per module rather than once per dependency, 

The time in the `transitive_dep_hash` function drops 22%, and improved the overall warm run by 1%