### PR TITLE
Rely on typeshed/stubs for slice typing

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -141,7 +141,6 @@ from mypy.typeanal import (
     fix_instance,
     has_any_from_unimported_type,
     instantiate_type_alias,
-    make_optional_type,
     set_any_tvars,
     validate_instance,
 )
@@ -5860,17 +5859,10 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         return type_type, instance_type
 
     def visit_slice_expr(self, e: SliceExpr) -> Type:
-        try:
-            supports_index = self.chk.named_type("typing_extensions.SupportsIndex")
-        except KeyError:
-            supports_index = self.chk.named_type("builtins.int")  # thanks, fixture life
-        expected = make_optional_type(supports_index)
         type_args = []
         for index in [e.begin_index, e.end_index, e.stride]:
             if index:
-                t = self.accept(index)
-                self.chk.check_subtype(t, expected, index, message_registry.INVALID_SLICE_INDEX)
-                type_args.append(t)
+                type_args.append(self.accept(index))
             else:
                 type_args.append(NoneType())
         return self.chk.named_generic_type("builtins.slice", type_args)

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -92,7 +92,6 @@ AMBIGUOUS_SLICE_OF_VARIADIC_TUPLE: Final = ErrorMessage("Ambiguous slice of a va
 TOO_MANY_TARGETS_FOR_VARIADIC_UNPACK: Final = ErrorMessage(
     "Too many assignment targets for variadic unpack"
 )
-INVALID_SLICE_INDEX: Final = ErrorMessage("Slice index must be an integer, SupportsIndex or None")
 CANNOT_INFER_LAMBDA_TYPE: Final = ErrorMessage("Cannot infer type of lambda")
 CANNOT_ACCESS_INIT: Final = (
     'Accessing "__init__" on an instance is unsound, since instance.__init__ could be from'

--- a/test-data/unit/check-class-namedtuple.test
+++ b/test-data/unit/check-class-namedtuple.test
@@ -538,7 +538,7 @@ class Base(NamedTuple):
                               # E: No overload variant of "__getitem__" of "tuple" matches argument type "TypeVar" \
                               # N: Possible overload variants: \
                               # N:     def __getitem__(self, int, /) -> int \
-                              # N:     def __getitem__(self, slice, /) -> tuple[int, ...]
+                              # N:     def __getitem__(self, slice[int | None], /) -> tuple[int, ...]
         return self.x
     def bad_override(self) -> int:
         return self.x

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -1226,10 +1226,10 @@ o[:]   # E: Value of type "object" is not indexable
 from typing import Any
 a: Any
 o: object
-a[o:1] # E: Slice index must be an integer, SupportsIndex or None
-a[1:o] # E: Slice index must be an integer, SupportsIndex or None
-a[o:]  # E: Slice index must be an integer, SupportsIndex or None
-a[:o]  # E: Slice index must be an integer, SupportsIndex or None
+a[o:1]
+a[1:o]
+a[o:]
+a[:o]
 [builtins fixtures/slice.pyi]
 
 [case testSliceSupportsIndex]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -438,7 +438,7 @@ weird_mixture: Union[KeyedTypedDict, KeyedNamedTuple]
 if weird_mixture["key"] is Key.B:       # E: No overload variant of "__getitem__" of "tuple" matches argument type "str" \
                                         # N: Possible overload variants: \
                                         # N:     def __getitem__(self, int, /) -> Literal[Key.C] \
-                                        # N:     def __getitem__(self, slice, /) -> tuple[Literal[Key.C], ...]
+                                        # N:     def __getitem__(self, slice[int | None], /) -> tuple[Literal[Key.C], ...]
     reveal_type(weird_mixture)          # N: Revealed type is "TypedDict('__main__.KeyedTypedDict', {'key': Literal[__main__.Key.B]}) | tuple[Literal[__main__.Key.C], fallback=__main__.KeyedNamedTuple]"
 else:
     reveal_type(weird_mixture)          # N: Revealed type is "TypedDict('__main__.KeyedTypedDict', {'key': Literal[__main__.Key.B]}) | tuple[Literal[__main__.Key.C], fallback=__main__.KeyedNamedTuple]"

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1435,7 +1435,7 @@ reveal_type(t[x])  # N: Revealed type is "builtins.int | builtins.str"
 t[y]  # E: No overload variant of "__getitem__" of "tuple" matches argument type "str" \
       # N: Possible overload variants: \
       # N:     def __getitem__(self, int, /) -> int | str \
-      # N:     def __getitem__(self, slice, /) -> tuple[int | str, ...]
+      # N:     def __getitem__(self, slice[int | None], /) -> tuple[int | str, ...]
 
 [builtins fixtures/tuple.pyi]
 
@@ -1444,7 +1444,7 @@ t = (0, "")
 x = 0
 y = ""
 reveal_type(t[x:])  # N: Revealed type is "builtins.tuple[builtins.int | builtins.str, ...]"
-t[y:]  # E: Slice index must be an integer, SupportsIndex or None
+t[y:]  # E: Invalid index type "slice[str, None, None]" for "tuple[int, str]"; expected type "slice[int | None]"
 [builtins fixtures/tuple.pyi]
 
 [case testTupleSliceStepZeroNoCrash]

--- a/test-data/unit/fixtures/slice.pyi
+++ b/test-data/unit/fixtures/slice.pyi
@@ -1,6 +1,10 @@
 # Builtins stub used in slicing test cases.
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, Protocol
 T = TypeVar('T')
+_Tco = TypeVar('_Tco', covariant=True)
+
+class SupportsIndex(Protocol):
+    def __index__(self) -> int: ...
 
 class object:
     def __init__(self): pass
@@ -12,8 +16,8 @@ class function: pass
 class int: pass
 class str: pass
 
-class slice: pass
+class slice(Generic[_Tco]): pass
 class ellipsis: pass
 class dict: pass
 class list(Generic[T]):
-    def __getitem__(self, x: slice) -> list[T]: pass
+    def __getitem__(self, x: slice[SupportsIndex | None]) -> list[T]: pass

--- a/test-data/unit/fixtures/tuple.pyi
+++ b/test-data/unit/fixtures/tuple.pyi
@@ -21,8 +21,9 @@ class tuple(Sequence[_Tco], Generic[_Tco]):
     def __contains__(self, item: object) -> bool: pass
     @overload
     def __getitem__(self, x: int) -> _Tco: pass
+    # Real stubs use SupportsIndex, but we use int to speed up tests, as this is a common fixture.
     @overload
-    def __getitem__(self, x: slice) -> Tuple[_Tco, ...]: ...
+    def __getitem__(self, x: slice[int | None]) -> Tuple[_Tco, ...]: ...
     def __mul__(self, n: int) -> Tuple[_Tco, ...]: pass
     def __rmul__(self, n: int) -> Tuple[_Tco, ...]: pass
     def __add__(self, x: Tuple[_Tco, ...]) -> Tuple[_Tco, ...]: pass
@@ -37,7 +38,7 @@ class int:
     def __neg__(self) -> 'int': pass
     def __pos__(self) -> 'int': pass
 class float: pass
-class slice: pass
+class slice(Generic[_Tco]): pass
 class bool(int): pass
 class str: pass # For convenience
 class bytes: pass
@@ -47,7 +48,7 @@ class list(Sequence[_T], Generic[_T]):
     @overload
     def __getitem__(self, i: int) -> _T: ...
     @overload
-    def __getitem__(self, s: slice) -> list[_T]: ...
+    def __getitem__(self, s: slice[int | None]) -> list[_T]: ...
     def __contains__(self, item: object) -> bool: ...
     def __iter__(self) -> Iterator[_T]: ...
 


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/2410

`slice` has been generic in typeshed for more than a year now. Also all builtin collections have precise `slice[SupportsIndex | None]` types for `__getitem__()`. So, I don't think we need to be "policing" `slice` anymore, it should be really responsibility of the stub maintainers now.

After some searching, I see there are still many plain `slice` annotations in the wild, so this will be a trade-off of false positives to false negatives, but I think this is a right trade-off, since status quo causes issues for pandas dataframes and similar APIs.

I also considered some "intermediate" solutions, where we would still enforce `SupportsIndex` in _some_ situations, but can't find anything that wouldn't be overly complicated.