### PR TITLE
Fix negative narrowing for containers

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6778,7 +6778,13 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                             expr_indices=[0, 1],
                             narrowable_indices={0},
                         )
-                        if else_map and not is_tuple_of_singletons(iterable_type):
+                        if else_map and not (
+                            isinstance(p_typ := get_proper_type(iterable_type), TupleType)
+                            and all(
+                                is_singleton_equality_type(get_proper_type(item))
+                                for item in p_typ.items
+                            )
+                        ):
                             # In general, we can't do negative narrowing, since e.g. the container
                             # could just be empty. However, we can do negative narrowing for some
                             # tuples e.g. `x not in (None,)`
@@ -8796,18 +8802,6 @@ def builtin_item_type(tp: Type) -> Type | None:
                 return map_instance_to_supertype(tp.fallback, base).args[0]
         assert False, "No Mapping base class found for TypedDict fallback"
     return None
-
-
-def is_tuple_of_singletons(tp: Type) -> bool:
-    tp = get_proper_type(tp)
-    if not isinstance(tp, TupleType):
-        return False
-    for item in tp.items:
-        if isinstance(item, UnpackType):
-            return False
-        if not is_singleton_equality_type(get_proper_type(item)):
-            return False
-    return True
 
 
 def is_unreachable_map(map: TypeMap) -> bool:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6778,6 +6778,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                             expr_indices=[0, 1],
                             narrowable_indices={0},
                         )
+                        if else_map and not is_tuple_of_singletons(iterable_type):
+                            # In general, we can't do negative narrowing, since e.g. the container
+                            # could just be empty. However, we can do negative narrowing for some
+                            # tuples e.g. `x not in (None,)`
+                            else_map = {}
 
                 if right_index in narrowable_operand_index_to_hash:
                     if_type, else_type = self.conditional_types_for_iterable(
@@ -8791,6 +8796,18 @@ def builtin_item_type(tp: Type) -> Type | None:
                 return map_instance_to_supertype(tp.fallback, base).args[0]
         assert False, "No Mapping base class found for TypedDict fallback"
     return None
+
+
+def is_tuple_of_singletons(tp: Type) -> bool:
+    tp = get_proper_type(tp)
+    if not isinstance(tp, TupleType):
+        return False
+    for item in tp.items:
+        if isinstance(item, UnpackType):
+            return False
+        if not is_singleton_equality_type(get_proper_type(item)):
+            return False
+    return True
 
 
 def is_unreachable_map(map: TypeMap) -> bool:

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -3268,6 +3268,21 @@ def f1(x: Union[str, float], t1: list[Literal['a', 'b']], t2: list[str]):
         reveal_type(x)  # N: Revealed type is "builtins.str | builtins.float"
 [builtins fixtures/primitives.pyi]
 
+[case testNegativeNarrowingInContainer]
+# flags: --warn-unreachable
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+
+def count(colors: list[Color]) -> None:
+    counts: dict[Color, int] = {}
+    for color in colors:
+        if color not in counts:
+            counts[color] = 0
+        counts[color] += 1
+[builtins fixtures/dict.pyi]
+
 [case testNarrowAnyWithEqualityOrContainment]
 # flags: --strict-equality --warn-unreachable
 # https://github.com/python/mypy/issues/17841


### PR DESCRIPTION
Fixes #21409

While we may be able to conclude `if color != Color.RED` is unreachable, we cannot do so for containment

Relevant tests for the special case are in testNarrowingOptionalEqualsNone

Co-authored-by Codex