### PR TITLE
Fix nested Concatenate with ellipsis crash

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -580,6 +580,9 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             self.api.fail("Nested Concatenates are invalid", t, code=codes.VALID_TYPE)
 
         args = self.anal_array(t.args[:-1])
+        if any(isinstance(arg, (Parameters, ParamSpecType)) for arg in args):
+            self.api.fail("Nested Concatenates are invalid", t, code=codes.VALID_TYPE)
+            return AnyType(TypeOfAny.from_error)
         pre = ps.prefix if isinstance(ps, ParamSpecType) else ps
 
         # mypy can't infer this :(

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1927,28 +1927,27 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             self.allow_typed_dict_special_forms = old_allow_typed_dict_special_forms
             self.allow_ellipsis = old_allow_ellipsis
             self.allow_unpack = old_allow_unpack
-        if not allow_param_spec:
-            if isinstance(analyzed, Parameters):
+        if (
+            not allow_param_spec
+            and isinstance(analyzed, (ParamSpecType, Parameters))
+            and (isinstance(analyzed, Parameters) or analyzed.flavor == ParamSpecFlavor.BARE)
+        ):
+            is_concatenate = isinstance(analyzed, Parameters) or analyzed.prefix.arg_types
+            if is_concatenate:
                 self.fail("Invalid location for Concatenate", t, code=codes.VALID_TYPE)
                 self.note("You can use Concatenate as the first argument to Callable", t)
-                analyzed = AnyType(TypeOfAny.from_error)
-            elif isinstance(analyzed, ParamSpecType) and analyzed.flavor == ParamSpecFlavor.BARE:
-                if analyzed.prefix.arg_types:
-                    self.fail("Invalid location for Concatenate", t, code=codes.VALID_TYPE)
-                    self.note("You can use Concatenate as the first argument to Callable", t)
-                    analyzed = AnyType(TypeOfAny.from_error)
-                else:
-                    self.fail(
-                        INVALID_PARAM_SPEC_LOCATION.format(format_type(analyzed, self.options)),
-                        t,
-                        code=codes.VALID_TYPE,
-                    )
-                    self.note(
-                        INVALID_PARAM_SPEC_LOCATION_NOTE.format(analyzed.name),
-                        t,
-                        code=codes.VALID_TYPE,
-                    )
-                    analyzed = AnyType(TypeOfAny.from_error)
+            else:
+                self.fail(
+                    INVALID_PARAM_SPEC_LOCATION.format(format_type(analyzed, self.options)),
+                    t,
+                    code=codes.VALID_TYPE,
+                )
+                self.note(
+                    INVALID_PARAM_SPEC_LOCATION_NOTE.format(analyzed.name),
+                    t,
+                    code=codes.VALID_TYPE,
+                )
+            analyzed = AnyType(TypeOfAny.from_error)
         return analyzed
 
     def anal_var_def(self, var_def: TypeVarLikeType) -> TypeVarLikeType:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1937,6 +1937,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 self.fail("Invalid location for Concatenate", t, code=codes.VALID_TYPE)
                 self.note("You can use Concatenate as the first argument to Callable", t)
             else:
+                assert isinstance(analyzed, ParamSpecType)
                 self.fail(
                     INVALID_PARAM_SPEC_LOCATION.format(format_type(analyzed, self.options)),
                     t,

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -580,9 +580,6 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             self.api.fail("Nested Concatenates are invalid", t, code=codes.VALID_TYPE)
 
         args = self.anal_array(t.args[:-1])
-        if any(isinstance(arg, (Parameters, ParamSpecType)) for arg in args):
-            self.api.fail("Nested Concatenates are invalid", t, code=codes.VALID_TYPE)
-            return AnyType(TypeOfAny.from_error)
         pre = ps.prefix if isinstance(ps, ParamSpecType) else ps
 
         # mypy can't infer this :(
@@ -1930,27 +1927,28 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             self.allow_typed_dict_special_forms = old_allow_typed_dict_special_forms
             self.allow_ellipsis = old_allow_ellipsis
             self.allow_unpack = old_allow_unpack
-        if (
-            not allow_param_spec
-            and isinstance(analyzed, ParamSpecType)
-            and analyzed.flavor == ParamSpecFlavor.BARE
-        ):
-            if analyzed.prefix.arg_types:
+        if not allow_param_spec:
+            if isinstance(analyzed, Parameters):
                 self.fail("Invalid location for Concatenate", t, code=codes.VALID_TYPE)
                 self.note("You can use Concatenate as the first argument to Callable", t)
                 analyzed = AnyType(TypeOfAny.from_error)
-            else:
-                self.fail(
-                    INVALID_PARAM_SPEC_LOCATION.format(format_type(analyzed, self.options)),
-                    t,
-                    code=codes.VALID_TYPE,
-                )
-                self.note(
-                    INVALID_PARAM_SPEC_LOCATION_NOTE.format(analyzed.name),
-                    t,
-                    code=codes.VALID_TYPE,
-                )
-                analyzed = AnyType(TypeOfAny.from_error)
+            elif isinstance(analyzed, ParamSpecType) and analyzed.flavor == ParamSpecFlavor.BARE:
+                if analyzed.prefix.arg_types:
+                    self.fail("Invalid location for Concatenate", t, code=codes.VALID_TYPE)
+                    self.note("You can use Concatenate as the first argument to Callable", t)
+                    analyzed = AnyType(TypeOfAny.from_error)
+                else:
+                    self.fail(
+                        INVALID_PARAM_SPEC_LOCATION.format(format_type(analyzed, self.options)),
+                        t,
+                        code=codes.VALID_TYPE,
+                    )
+                    self.note(
+                        INVALID_PARAM_SPEC_LOCATION_NOTE.format(analyzed.name),
+                        t,
+                        code=codes.VALID_TYPE,
+                    )
+                    analyzed = AnyType(TypeOfAny.from_error)
         return analyzed
 
     def anal_var_def(self, var_def: TypeVarLikeType) -> TypeVarLikeType:

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1147,7 +1147,7 @@ from typing import Callable
 P = ParamSpec("P")
 
 def x(f: Callable[Concatenate[int, Concatenate[int, P]], None]) -> None: ...  # E: Nested Concatenates are invalid
-def y(f: Callable[Concatenate[Concatenate[...], ...], None]) -> None: ...  # E: Nested Concatenates are invalid
+def y(f: Callable[Concatenate[Concatenate[...], ...], None]) -> None: ...  # E: Invalid location for Concatenate  # N: You can use Concatenate as the first argument to Callable
 [builtins fixtures/paramspec.pyi]
 
 [case testPropagatedAnyConstraintsAreOK]

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -1147,6 +1147,7 @@ from typing import Callable
 P = ParamSpec("P")
 
 def x(f: Callable[Concatenate[int, Concatenate[int, P]], None]) -> None: ...  # E: Nested Concatenates are invalid
+def y(f: Callable[Concatenate[Concatenate[...], ...], None]) -> None: ...  # E: Nested Concatenates are invalid
 [builtins fixtures/paramspec.pyi]
 
 [case testPropagatedAnyConstraintsAreOK]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1831,10 +1831,3 @@ class tuple_aa_subclass(Tuple[A, A]): ...
 
 inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # E: Incompatible types in assignment (expression has type "tuple[A, A]", variable has type "tuple_aa_subclass")
 [builtins fixtures/tuple.pyi]
-
-[case testTuplePassedParameters]
-from typing_extensions import Concatenate
-
-def c(t: tuple[Concatenate[int, ...]]) -> None:  # E: Invalid location for Concatenate  # N: You can use Concatenate as the first argument to Callable
-    reveal_type(t)  # N: Revealed type is "tuple[Any]"
-[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1835,6 +1835,6 @@ inst_tuple_aa_subclass: tuple_aa_subclass = tuple_aa_subclass((A(), A()))[:]  # 
 [case testTuplePassedParameters]
 from typing_extensions import Concatenate
 
-def c(t: tuple[Concatenate[int, ...]]) -> None:  # E: Cannot use "[int, VarArg(Any), KwArg(Any)]" for tuple, only for ParamSpec
+def c(t: tuple[Concatenate[int, ...]]) -> None:  # E: Invalid location for Concatenate  # N: You can use Concatenate as the first argument to Callable
     reveal_type(t)  # N: Revealed type is "tuple[Any]"
 [builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #21404.

This rejects a nested `Concatenate[...]` when it appears in the prefix arguments of another `Concatenate`, including the `Concatenate[Concatenate[...], ...]` crash case from the issue. The existing nested-Concatenate error path only handled the `ParamSpec`-prefix form, so the ellipsis form could reach `Parameters(...)` with another `Parameters` object nested inside it.

Tests:
- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-parameter-specification.test -k testStackedConcatenateIsIllegal -q`
- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-parameter-specification.test -q`
- `python -m mypy --config-file mypy_self_check.ini mypy/typeanal.py`
- `python -m mypy --config-file mypy_self_check.ini -p mypy`
- `pre-commit run --files mypy/typeanal.py test-data/unit/check-parameter-specification.test`
- `git diff --check`
