### PR TITLE
Fix crash on partial type, --allow-redefinition, and global declaration

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8445,7 +8445,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     n.node = sym.node
                     n.kind = GDEF
                     n.fullname = sym.node.fullname
-                    self.binder.assign_type(n, sym.node.type, sym.node.type)
+                    typ = get_declaration(n)
+                    if typ is not None:
+                        self.binder.assign_type(n, typ, typ)
 
 
 class TypeCheckerAsSemanticAnalyzer(SemanticAnalyzerCoreInterface):

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -4369,3 +4369,22 @@ def g() -> None:
     reveal_type(x)  # N: Revealed type is "None | builtins.int"
     x = ""  # E: Incompatible types in assignment (expression has type "str", variable has type "int | None")
     reveal_type(x)  # N: Revealed type is "None | builtins.int"
+
+[case testLocalPartialTypesWithGlobalInitializedToEmptyListAndRedefine1]
+# flags: --allow-redefinition
+a = [] # E: Need type annotation for "a" (hint: "a: list[<type>] = ...")
+
+def f() -> None:
+    a.append(1)
+
+reveal_type(a) # N: Revealed type is "builtins.list[Any]"
+[builtins fixtures/list.pyi]
+
+[case testLocalPartialTypesWithGlobalInitializedToEmptyListAndRedefine2]
+# flags: --allow-redefinition
+x = []  # E: Need type annotation for "x" (hint: "x: list[<type>] = ...")
+
+# This used to crash.
+def f() -> None:
+    global x
+    x


### PR DESCRIPTION
Filter out partial types when updating binder.

Fixes #21423.