### PR TITLE
Fix crash on @types.coroutine with unannotated generator function

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5720,8 +5720,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
     ) -> None:
         # Fix the type if decorated with `@types.coroutine` or `@asyncio.coroutine`.
         defn = e.func
-        if defn.is_awaitable_coroutine:
-            assert isinstance(defn.type, CallableType)
+        if defn.is_awaitable_coroutine and isinstance(defn.type, CallableType):
             # Update the return type to AwaitableGenerator (unless we already did).
             # Note, this doesn't exist in typing.py, only in typing.pyi.
             if not is_named_instance(defn.type.ret_type, "typing.AwaitableGenerator"):
@@ -5744,6 +5743,22 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         if self.recurse_into_functions or e.func.def_or_infer_vars:
             with self.tscope.function_scope(e.func), self.set_recurse_into_functions():
                 self.check_func_item(e.func, name=e.func.name, allow_empty=allow_empty)
+
+        # For unannotated functions, defn.type is only available after check_func_item
+        # infers it. Apply the AwaitableGenerator wrapping now if it wasn't done above.
+        if defn.is_awaitable_coroutine and isinstance(defn.type, CallableType):
+            if not is_named_instance(defn.type.ret_type, "typing.AwaitableGenerator"):
+                t = defn.type.ret_type
+                c = defn.is_coroutine
+                ty = self.get_generator_yield_type(t, c)
+                tc = self.get_generator_receive_type(t, c)
+                if c:
+                    tr = self.get_coroutine_return_type(t)
+                else:
+                    tr = self.get_generator_return_type(t, c)
+                ret_type = self.named_generic_type("typing.AwaitableGenerator", [ty, tc, tr, t])
+                typ = defn.type.copy_modified(ret_type=ret_type)
+                defn.type = typ
 
         # Process decorators from the inside out to determine decorated signature, which
         # may be different from the declared signature.


### PR DESCRIPTION

- Combine type guard with isinstance check to avoid assertion on potentially None type
- Add deferred AwaitableGenerator wrapping for unannotated functions after type inference
- Apply generator type transformations (yield, receive, return) after check_func_item infers the function type
- Ensures coroutines decorated with @types.coroutine or @asyncio.coroutine are properly wrapped even when type annotations are missing

Fixes #21426.

**Problem**

mypy 2.0 crashes with `AssertionError` in `visit_decorator_inner` when
type-checking an unannotated generator function decorated with
`@types.coroutine` (or `@asyncio.coroutine`):

```python
import types

@types.coroutine
def f():
    yield
    return 1

AssertionError: assert isinstance(defn.type, CallableType)

This is a regression introduced in #21119 (split type-checking into interface and implementation phases). The AwaitableGenerator return-type wrapping was moved to the top of visit_decorator_inner, where it now runs before check_func_item. For unannotated functions, defn.type is still None at that point — it only gets inferred during check_func_item.

Fix

Replace the hard assert with an isinstance guard, and add a second (identical, idempotent) wrapping block after check_func_item to handle the case where the type was inferred rather than declared. The existing is_named_instance(..., "typing.AwaitableGenerator") check ensures the wrapping is never applied twice.