### PR TITLE
Start testing Python 3.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,12 @@ jobs:
           toxenv: py
           tox_extra_args: "-n 4"
           test_mypyc: true
+        - name: Test suite with py315-ubuntu, mypyc-compiled
+          python: '3.15'
+          os: ubuntu-24.04-arm
+          toxenv: py
+          tox_extra_args: "-n 4"
+          test_mypyc: true
         - name: Test suite with py314t-ubuntu, mypyc-compiled
           python: '3.14t'
           os: ubuntu-24.04-arm
@@ -196,6 +202,7 @@ jobs:
       if: ${{ !(matrix.debug_build || endsWith(matrix.python, '-dev')) }}
       with:
         python-version: ${{ matrix.python }}
+        allow-prereleases: true
 
     - name: Install tox
       run: |

--- a/mypyc/codegen/emit.py
+++ b/mypyc/codegen/emit.py
@@ -233,7 +233,7 @@ class Emitter:
 
         If it contains illegal characters, an empty string is returned."""
         line_width = self._indent + len(line)
-        formatted = pprint.pformat(obj, compact=True, width=max(90 - line_width, 20))
+        formatted = pprint.pformat(obj, compact=True, indent=1, width=max(90 - line_width, 20))
         if any(x in formatted for x in ("/*", "*/", "\0")):
             return ""
 

--- a/mypyc/lib-rt/byteswriter_extra_ops.h
+++ b/mypyc/lib-rt/byteswriter_extra_ops.h
@@ -1,9 +1,9 @@
 #ifndef BYTESWRITER_EXTRA_OPS_H
 #define BYTESWRITER_EXTRA_OPS_H
 
+#include <Python.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <Python.h>
 
 #include "mypyc_util.h"
 #include "strings/librt_strings_api.h"

--- a/mypyc/lib-rt/function_wrapper.c
+++ b/mypyc/lib-rt/function_wrapper.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
-#include <stdint.h>
 #include "CPy.h"
+#include <stdint.h>
 
 #define CPyFunction_weakreflist(f) (((PyCFunctionObject *)f)->m_weakreflist)
 #define CPyFunction_class(f) ((PyObject*) ((PyCMethodObject *) (f))->mm_class)

--- a/mypyc/lib-rt/stringwriter_extra_ops.h
+++ b/mypyc/lib-rt/stringwriter_extra_ops.h
@@ -1,9 +1,9 @@
 #ifndef STRINGWRITER_EXTRA_OPS_H
 #define STRINGWRITER_EXTRA_OPS_H
 
+#include <Python.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <Python.h>
 
 #include "mypyc_util.h"
 #include "strings/librt_strings_api.h"

--- a/mypyc/test-data/run-misc.test
+++ b/mypyc/test-data/run-misc.test
@@ -971,7 +971,10 @@ print(z)
 [case testCheckVersion]
 import sys
 
-if sys.version_info[:2] == (3, 15):
+if sys.version_info[:2] == (3, 16):
+    def version() -> int:
+        return 16
+elif sys.version_info[:2] == (3, 15):
     def version() -> int:
         return 15
 elif sys.version_info[:2] == (3, 14):

--- a/mypyc/test-data/run-python312.test
+++ b/mypyc/test-data/run-python312.test
@@ -229,9 +229,10 @@ type C[*Ts] = tuple[*Ts]
 def test_type_var_tuple_type_alias() -> None:
     if sys.version_info >= (3, 15):   # type: ignore[operator]
         assert str(C[int, str]) == "_frozen_importlib.C[int, str]"
+        assert str(getattr(C, "__value__")) == "tuple[typing.Unpack[~Ts]]"
     else:
         assert str(C[int, str]) == "C[int, str]"
-    assert str(getattr(C, "__value__")) == "tuple[typing.Unpack[Ts]]"
+        assert str(getattr(C, "__value__")) == "tuple[typing.Unpack[Ts]]"
 
 type D[**P] = Callable[P, int]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development",
   "Typing :: Typed",
 ]

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -363,11 +363,11 @@ mypy: error: Mypy no longer supports checking Python 2 code. Consider pinning to
 python_version = 3.10
 [out]
 
-[case testPythonVersionAccepted314]
+[case testPythonVersionAccepted315]
 # cmd: mypy -c pass
 [file mypy.ini]
 \[mypy]
-python_version = 3.14
+python_version = 3.15
 [out]
 
 [case testPythonVersionFallback]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -67,7 +67,7 @@ types-setuptools==80.9.0.20250822
     # via -r build-requirements.txt
 typing-extensions==4.15.0
     # via -r mypy-requirements.txt
-virtualenv==20.34.0
+virtualenv==20.35.4
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -46,7 +46,7 @@ pre-commit==4.3.0
     # via -r test-requirements.in
 psutil==7.1.0
     # via -r test-requirements.in
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pytest==8.4.2
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py312,
     py313,
     py314,
+    py315,
     docs,
     lint,
     type,


### PR DESCRIPTION
The first beta for Python 3.15 was released yesterday. Start running CI tests for it.