### PR TITLE
Fall back when sqlite cache is unavailable

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -1912,14 +1912,21 @@ def exclude_from_backups(target_dir: str) -> None:
 
 def create_metastore(options: Options, parallel_worker: bool) -> MetadataStore:
     """Create the appropriate metadata store."""
+    cache_dir_prefix = _cache_dir_prefix(options)
     if options.sqlite_cache:
-        mds: MetadataStore = SqliteMetadataStore(
-            _cache_dir_prefix(options),
-            set_journal_mode=not parallel_worker,
-            num_shards=options.sqlite_num_shards,
-        )
+        try:
+            mds: MetadataStore = SqliteMetadataStore(
+                cache_dir_prefix,
+                set_journal_mode=not parallel_worker,
+                num_shards=options.sqlite_num_shards,
+            )
+        except ImportError:
+            # The sqlite3 Python module can be present even when the _sqlite3
+            # extension module is not available. Fall back to the filesystem
+            # cache instead of crashing when initializing the default cache.
+            mds = FilesystemMetadataStore(cache_dir_prefix)
     else:
-        mds = FilesystemMetadataStore(_cache_dir_prefix(options))
+        mds = FilesystemMetadataStore(cache_dir_prefix)
     return mds
 
 

--- a/mypy/test/testmetastore.py
+++ b/mypy/test/testmetastore.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import tempfile
 import unittest
-from typing import NoReturn
 from unittest.mock import patch
 
 from mypy import build
@@ -17,12 +16,12 @@ class TestMetadataStore(unittest.TestCase):
         options = Options()
         options.sqlite_cache = True
 
-        def missing_sqlite(db_file: str, set_journal_mode: bool) -> NoReturn:
-            raise ModuleNotFoundError("No module named '_sqlite3'")
-
         with tempfile.TemporaryDirectory() as tmpdir:
             options.cache_dir = tmpdir
-            with patch("mypy.metastore.connect_db", missing_sqlite):
+            with patch(
+                "mypy.build.SqliteMetadataStore",
+                side_effect=ModuleNotFoundError("No module named '_sqlite3'"),
+            ):
                 store = build.create_metastore(options, parallel_worker=False)
 
             try:

--- a/mypy/test/testmetastore.py
+++ b/mypy/test/testmetastore.py
@@ -1,0 +1,33 @@
+"""Unit tests for metadata stores."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from typing import NoReturn
+from unittest.mock import patch
+
+from mypy import build
+from mypy.metastore import FilesystemMetadataStore
+from mypy.options import Options
+
+
+class TestMetadataStore(unittest.TestCase):
+    def test_create_metastore_falls_back_to_filesystem_when_sqlite_missing(self) -> None:
+        options = Options()
+        options.sqlite_cache = True
+
+        def missing_sqlite(db_file: str, set_journal_mode: bool) -> NoReturn:
+            raise ModuleNotFoundError("No module named '_sqlite3'")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            options.cache_dir = tmpdir
+            with patch("mypy.metastore.connect_db", missing_sqlite):
+                store = build.create_metastore(options, parallel_worker=False)
+
+            try:
+                assert isinstance(store, FilesystemMetadataStore)
+                assert store.write("example.meta.json", b"{}")
+                assert store.read("example.meta.json") == b"{}"
+            finally:
+                store.close()

--- a/mypy/test/testmetastore.py
+++ b/mypy/test/testmetastore.py
@@ -12,6 +12,9 @@ from mypy.options import Options
 
 
 class TestMetadataStore(unittest.TestCase):
+    @unittest.skipUnless(
+        build.__file__.endswith(".py"), "mock patching is unreliable for compiled mypy"
+    )
     def test_create_metastore_falls_back_to_filesystem_when_sqlite_missing(self) -> None:
         options = Options()
         options.sqlite_cache = True


### PR DESCRIPTION
Fixes #21440

When the sqlite cache is enabled but the sqlite3 module cannot import (for example when CPython was built without _sqlite3), fall back to the filesystem metadata cache instead of crashing during metastore creation.

Tests:
- `python3 -m pytest -q mypy/test/testmetastore.py`
- `python3 -m mypy --config-file mypy_self_check.ini mypy/build.py mypy/test/testmetastore.py`
- `pre-commit run --files mypy/build.py mypy/test/testmetastore.py`
- `git diff --check`