### PR TITLE
checker: say "parameter" instead of "argument" in missing-self diagnostic (#20939)

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1751,8 +1751,13 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
             return False
 
         if not func.arg_types:
+            # The diagnostic is emitted at method definition time, so "self"
+            # here is a parameter, not an argument supplied at a call site.
+            # Match the wording used by message_registry.py:227 for the
+            # parallel "self parameter missing" diagnostic. See #20939.
             self.fail(
-                'Method must have at least one argument. Did you forget the "self" argument?', defn
+                'Method must have at least one parameter. Did you forget the "self" parameter?',
+                defn,
             )
             return False
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3336,7 +3336,7 @@ from typing import Any
 class Test:
     def __setattr__() -> None: ... \
         # E: Invalid signature "Callable[[], None]" for "__setattr__" \
-        # E: Method must have at least one argument. Did you forget the "self" argument?
+        # E: Method must have at least one parameter. Did you forget the "self" parameter?
 
 t = Test()
 t.crash = 'test'  # E: Attribute function "__setattr__" with type "Callable[[], None]" does not accept self argument \
@@ -7829,7 +7829,7 @@ reveal_type(Foo().y)  # N: Revealed type is "builtins.list[Any]"
 # flags: --check-untyped-defs
 
 class Foo:
-    def bad():  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def bad():  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         self.x = 0  # E: Name "self" is not defined
 
 [case testMethodSelfArgumentChecks]
@@ -7848,7 +7848,7 @@ def to_same_callable(fn: Callable[P, T]) -> Callable[P, T]:
     return fn
 
 class A:
-    def undecorated() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def undecorated() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
 
     def undecorated_not_self(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
 
@@ -7875,7 +7875,7 @@ class A:
         return 0
 
     @to_same_callable
-    def g1() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def g1() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
 
     @to_same_callable
     def g2(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
@@ -7937,11 +7937,11 @@ reveal_type(A().fn3)  # N: Revealed type is "def (_x: builtins.int) -> builtins.
 
 class B:
     @remove_first  # E: Argument 1 to "remove_first" has incompatible type "Callable[[], int]"; expected "Callable[[T], int]"
-    def fn1() -> int:  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def fn1() -> int:  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         return 0
 
     @remove_first
-    def fn2(_x: int) -> int:  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def fn2(_x: int) -> int:  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         return 0
 
     @remove_first
@@ -8009,7 +8009,7 @@ def to_same_callable(fn: Callable[P, T]) -> Callable[P, T]:
 
 def unchecked():
     class Bad:
-        def fn() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def fn() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         def fn2(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
 
         # TODO: would be nice to make this error, but now we see the func
@@ -8030,29 +8030,29 @@ def unchecked():
 
 def checked() -> None:
     class Bad:
-        def fn() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def fn() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         def fn2(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
 
         @to_same_callable
-        def g() -> None: ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def g() -> None: ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         @to_same_callable
         def g2(x: int) -> None: ...  # E: "self" parameter missing for a non-static method (or an invalid type for self)
 
     class AlsoBad:
-        def fn(): ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def fn(): ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         def fn2(x): ...
 
         @to_same_callable
-        def g(): ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+        def g(): ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
         @to_same_callable
         def g2(x): ...
 
 class Ok:
-    def fn(): ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def fn(): ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
     def fn2(x): ...
 
     @to_same_callable
-    def g(): ...  # E: Method must have at least one argument. Did you forget the "self" argument?
+    def g(): ...  # E: Method must have at least one parameter. Did you forget the "self" parameter?
     @to_same_callable
     def g2(x): ...
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -2799,7 +2799,7 @@ class A:
     @dec
     def e(self) -> int: pass
     @property
-    def g() -> int: pass   # E: Method must have at least one argument. Did you forget the "self" argument?
+    def g() -> int: pass   # E: Method must have at least one parameter. Did you forget the "self" parameter?
     @property
     def h(self, *args, **kwargs) -> int: pass   # OK
 [builtins fixtures/property.pyi]

--- a/test-data/unit/check-super.test
+++ b/test-data/unit/check-super.test
@@ -375,7 +375,7 @@ class A:
         return 1
 
 class B(A):
-    def g() -> None: # E: Method must have at least one argument. Did you forget the "self" argument?
+    def g() -> None: # E: Method must have at least one parameter. Did you forget the "self" parameter?
         super().f() # E: "super()" requires one or two positional arguments in enclosing function
     def h(self) -> None:
         def a() -> None:

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -1572,11 +1572,11 @@ class A:
 [file b.py.3]
 2
 [out]
-a.py:3: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:3: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
-a.py:3: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:3: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
-a.py:3: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:3: error: Method must have at least one parameter. Did you forget the "self" parameter?
 
 [case testBaseClassDeleted]
 import m
@@ -1993,11 +1993,11 @@ class A:
 class A:
     def foo(self) -> int: pass
 [out]
-a.py:2: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:2: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
-a.py:2: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:2: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
-a.py:2: error: Method must have at least one argument. Did you forget the "self" argument?
+a.py:2: error: Method must have at least one parameter. Did you forget the "self" parameter?
 ==
 
 [case testPreviousErrorInMethodSemanal2]


### PR DESCRIPTION
<!-- Fixes #20939. -->

## Summary

The "missing self" diagnostic emitted at method-definition time currently
says *argument* twice, but in CPython terminology a value declared in a
function header is a **parameter** (an *argument* is what a caller
supplies). The wording change brings this single string into line with
the parallel diagnostic in `mypy/message_registry.py:227`, which already
uses "parameter":

```python
'"self" parameter missing for a non-static method (or an invalid type for self)'
```

Fixes python/mypy#20939.

## Context

The issue (filed by @kavik2002) flags the inconsistency:

> A method with no parameter gets the wrong error message saying
> `argument` instead of `parameter`.

The diagnostic is raised in `mypy/checker.py` (currently
`TypeChecker.check_method_or_accessor_override_for_base` → see
`mypy/checker.py:1755` on `master`) when a non-static method's signature
has zero declared parameters. At that point the type checker is
reasoning about the *definition*, not a call, so the noun "argument" is
wrong; "parameter" matches both the CPython glossary and mypy's own
sibling message.

## Changes

- `mypy/checker.py` — change the message string to use
  "parameter" twice. A short comment in the code records *why* the
  wording changed (so a future reader doesn't re-derive the
  parameter-vs-argument distinction from scratch).
- `test-data/unit/check-classes.test` — 13 fixture lines updated.
- `test-data/unit/check-functions.test` — 1 fixture line updated.
- `test-data/unit/check-super.test` — 1 fixture line updated.
- `test-data/unit/fine-grained.test` — 6 fixture lines updated.

The existing fixtures that assert this message become the regression
coverage: they fail on `master` against the new wording and pass on
this branch.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
python3 -m venv /tmp/repro-20939-env
source /tmp/repro-20939-env/bin/activate
pip install -q --upgrade pip

cat > /tmp/repro-20939.py <<'PY'
class Cls:
    def meth(): ...
PY

# --- BEFORE (origin/master) ---
pip install -q --force-reinstall --no-deps \
  "git+https://github.com/python/mypy.git@master"
mypy --no-incremental --cache-dir=/tmp/repro-20939-cache-before /tmp/repro-20939.py
# Expected: error contains 'Method must have at least one argument. Did you forget the "self" argument?'

# --- AFTER (this PR) ---
pip install -q --force-reinstall --no-deps \
  "git+https://github.com/jbbqqf/mypy.git@feat/20939-method-parameter-wording"
mypy --no-incremental --cache-dir=/tmp/repro-20939-cache-after /tmp/repro-20939.py
# Expected: error contains 'Method must have at least one parameter. Did you forget the "self" parameter?'
```

The only thing that changes between the two halves is the installed
mypy ref. The same `mypy /tmp/repro-20939.py` command runs both times.

## What I ran locally

- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-classes.test
  mypy/test/testcheck.py::TypeCheckSuite::check-functions.test
  mypy/test/testcheck.py::TypeCheckSuite::check-super.test`
  → **908 passed, 1 xfailed** (the xfail is preexisting and unrelated to
  this change).
- `pytest -n0 -k "testPreviousErrorInMethodSemanal or
  testReprocessMethodInNestedClassSemanal" mypy/test/`
  → **4 passed, 4 skipped** (the skips are the cache variants, also
  preexisting behaviour).
- `ruff check mypy/checker.py` → **All checks passed.**
- `black --check mypy/checker.py` → **clean.**
- BEFORE/AFTER reproducer (block above) — manually verified end-to-end.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Method with empty parameter list | `class C: def m(): ...` | new wording emitted | reproducer block + existing fixture `check-classes.test:7832` |
| 2 | `@property`-decorated method with no params | `@property\ndef g() -> int: pass` | new wording emitted | `check-functions.test:2802` |
| 3 | Nested-class method missing self (fine-grained reprocess) | `testReprocessMethodInNestedClassSemanal` | new wording emitted across reprocess passes | `fine-grained.test:1996–2000` |
| 4 | `@staticmethod` (suppresses diagnostic) | static method without self | no diagnostic | preserved by guard at `mypy/checker.py:1748` (unchanged) |
| 5 | Method with `*args` / `**kwargs` only | `def m(*args, **kwargs)` | no diagnostic (well-formed) | guard at `mypy/checker.py:1749` (unchanged) |

## Risk / blast radius

- Wording-only change. No type-checker behaviour or error code changes.
- Downstream consumers that grep mypy output for the **exact** old
  string `Method must have at least one argument. Did you forget the
  "self" argument?` will stop matching. This is the common cost of any
  message-wording fix; given that `message_registry.py:227` already
  uses "parameter" for the parallel diagnostic, the new wording is the
  more consistent target.
- All in-tree tests that assert the message have been updated in the
  same commit.

## Release note

```release-note
Diagnostic for a method with no parameters now says "parameter"
("Method must have at least one parameter. Did you forget the 'self'
parameter?") instead of "argument", matching the wording used by the
sibling 'self parameter missing' diagnostic.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against `python/mypy`'s `master` branch, the
`mypy/message_registry.py:227` parallel diagnostic, and the CPython
parameter/argument glossary. The reproducer block above was used during
development and is the same one a reviewer can paste verbatim.*
