### PR TITLE
Fix formatting in `error_code_list2.rst`

### DIFF
--- a/docs/source/error_code_list2.rst
+++ b/docs/source/error_code_list2.rst
@@ -550,7 +550,7 @@ Example:
 Check that overrides of mutable attributes are safe [mutable-override]
 ----------------------------------------------------------------------
 
-`mutable-override` will enable the check for unsafe overrides of mutable attributes.
+``mutable-override`` will enable the check for unsafe overrides of mutable attributes.
 For historical reasons, and because this is a relatively common pattern in Python,
 this check is not enabled by default. The example below is unsafe, and will be
 flagged when this error code is enabled:


### PR DESCRIPTION
Before: 
<img width="730" height="167" alt="Снимок экрана 2026-05-10 в 13 27 42" src="https://github.com/user-attachments/assets/ac5711cd-40f8-47ec-b530-b3fc40d3c79f" />
