### PR TITLE
Fix output config option in mypy.ini

### DIFF
--- a/mypy/config_parser.py
+++ b/mypy/config_parser.py
@@ -189,6 +189,7 @@ ini_config_types: Final[dict[str, _INI_PARSER_CALLABLE]] = {
     "quickstart_file": expand_path,
     "junit_xml": expand_path,
     "junit_format": check_junit_format,
+    "output": str,
     "follow_imports": check_follow_imports,
     "no_site_packages": bool,
     "plugins": lambda s: [p.strip() for p in split_commas(s)],

--- a/mypy/test/test_config_parser.py
+++ b/mypy/test/test_config_parser.py
@@ -5,10 +5,12 @@ import os
 import tempfile
 import unittest
 from collections.abc import Iterator
+from io import StringIO
 from pathlib import Path
 
-from mypy.config_parser import _find_config_file
+from mypy.config_parser import _find_config_file, parse_config_file
 from mypy.defaults import CONFIG_NAMES, SHARED_CONFIG_NAMES
+from mypy.options import Options
 
 
 @contextlib.contextmanager
@@ -128,3 +130,17 @@ class FindConfigFileSuite(unittest.TestCase):
                 result = _find_config_file()
                 assert result is not None
                 assert Path(result[2]).resolve() == parent_mypy.resolve()
+
+
+class ParseConfigFileSuite(unittest.TestCase):
+    def test_output_option_with_none_default(self) -> None:
+        with tempfile.TemporaryDirectory() as _tmpdir:
+            config = Path(_tmpdir) / "mypy.ini"
+            write_config(config, content="[mypy]\noutput = json\n")
+
+            options = Options()
+            stderr = StringIO()
+            parse_config_file(options, lambda: None, str(config), stderr=stderr)
+
+            assert options.output == "json"
+            assert stderr.getvalue() == ""


### PR DESCRIPTION
Fixes #21376

This makes `output = json` in `mypy.ini` take effect by registering `output` as a string-valued config option. `Options.output` defaults to `None`, so without an explicit config parser type entry it was treated as unrecognized and ignored.

This is intentionally the narrow version of the fix: it does not change the general handling of all `None`-default options.

I also added a config parser unit test that parses a temporary `mypy.ini` with `output = json` and verifies `Options.output` is set without stderr output.

Validation:
- `.venv/bin/python -m pytest mypy/test/test_config_parser.py`
- `.venv/bin/python -m black --check mypy/config_parser.py mypy/test/test_config_parser.py`
- `.venv/bin/python -m ruff check mypy/config_parser.py mypy/test/test_config_parser.py`
- `git diff --check`

Note: this replaces #21416, which I could not reopen after cleaning up the branch history.