### PR TITLE
[mypyc]Fix reference leak in mypyc bytes concatenation

### DIFF
--- a/mypyc/primitives/bytes_ops.py
+++ b/mypyc/primitives/bytes_ops.py
@@ -64,7 +64,6 @@ binary_op(
     return_type=bytes_rprimitive,
     c_function_name="CPyBytes_Concat",
     error_kind=ERR_MAGIC,
-    steals=[True, False],
 )
 
 # bytes * int

--- a/mypyc/test-data/irbuild-bytes.test
+++ b/mypyc/test-data/irbuild-bytes.test
@@ -299,26 +299,3 @@ def foo(b: bytes, ba: bytearray) -> None:
 [out]
 main:7: error: Argument 1 to "bytes_func" has incompatible type "bytearray"; expected "bytes"
 main:8: error: Argument 1 to "bytearray_func" has incompatible type "bytes"; expected "bytearray"
-
-[case testBytesConcatRefcount]
-def f(a: bytes, b: bytes) -> bytes:
-    return b"1" + b
-[out]
-def f(a, b):
-    a, b, r0, r1 :: bytes
-L0:
-    r0 = b'1'
-    r1 = CPyBytes_Concat(r0, b)
-    return r1
-
-[case testChainedBytesConcatRefcount]
-def f(a: bytes, b: bytes, c: bytes) -> bytes:
-    return b"1" + b + c
-[out]
-def f(a, b, c):
-    a, b, c, r0, r1, r2 :: bytes
-L0:
-    r0 = b'1'
-    r1 = CPyBytes_Concat(r0, b)
-    r2 = CPyBytes_Concat(r1, c)
-    return r2

--- a/mypyc/test-data/irbuild-bytes.test
+++ b/mypyc/test-data/irbuild-bytes.test
@@ -299,3 +299,26 @@ def foo(b: bytes, ba: bytearray) -> None:
 [out]
 main:7: error: Argument 1 to "bytes_func" has incompatible type "bytearray"; expected "bytes"
 main:8: error: Argument 1 to "bytearray_func" has incompatible type "bytes"; expected "bytearray"
+
+[case testBytesConcatRefcount]
+def f(a: bytes, b: bytes) -> bytes:
+    return b"1" + b
+[out]
+def f(a, b):
+    a, b, r0, r1 :: bytes
+L0:
+    r0 = b'1'
+    r1 = CPyBytes_Concat(r0, b)
+    return r1
+
+[case testChainedBytesConcatRefcount]
+def f(a: bytes, b: bytes, c: bytes) -> bytes:
+    return b"1" + b + c
+[out]
+def f(a, b, c):
+    a, b, c, r0, r1, r2 :: bytes
+L0:
+    r0 = b'1'
+    r1 = CPyBytes_Concat(r0, b)
+    r2 = CPyBytes_Concat(r1, c)
+    return r2

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -2125,3 +2125,32 @@ L3:
     r8 = box(None, 1)
     inc_ref r8
     return r8
+
+[case testBytesConcatRefcount]
+def f(a: bytes, b: bytes) -> bytes:
+    return b"1" + a + b
+[out]
+def f(a, b):
+    a, b, r0, r1, r2 :: bytes
+L0:
+    r0 = b'1'
+    r1 = CPyBytes_Concat(r0, a)
+    r2 = CPyBytes_Concat(r1, b)
+    dec_ref r1
+    return r2
+
+[case testChainedBytesConcatRefcount]
+def f(a: bytes, b: bytes, c: bytes) -> bytes:
+    return b"1" + a + b + c
+[out]
+def f(a, b, c):
+    a, b, c, r0, r1, r2, r3 :: bytes
+L0:
+    r0 = b'1'
+    r1 = CPyBytes_Concat(r0, a)
+    r2 = CPyBytes_Concat(r1, b)
+    dec_ref r1
+    r3 = CPyBytes_Concat(r2, c)
+    dec_ref r2
+    return r3
+

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -2153,4 +2153,3 @@ L0:
     r3 = CPyBytes_Concat(r2, c)
     dec_ref r2
     return r3
-


### PR DESCRIPTION
Fixes [Mypyc #1192](https://github.com/mypyc/mypyc/issues/1192)

Fix a reference leak in mypyc-generated code for `bytes + bytes`.

The `bytes + bytes` primitive for `CPyBytes_Concat` was marked as stealing the
left operand with `steals=[True, False]`. However, `CPyBytes_Concat` does not
steal or decref either argument; it allocates and returns a new `bytes` object.

Because of this mismatch, the refcount pass skipped emitting a `dec_ref` for
owned left operands. For code such as:

```python
return (1).to_bytes(4, "big") + (2).to_bytes(4, "big")
````

the generated IR decrefed only the right operand after `CPyBytes_Concat`, leaving
the owned left operand alive. Chained concatenations amplified the leak because
intermediate concat results could also become leaked left operands.

This PR removes the incorrect `steals=[True, False]` annotation from the
`bytes + bytes` primitive, so both operands are treated as non-stolen and owned
operands are decrefed normally after the call.

The tests verify that the generated IR decrefs both owned operands after
`CPyBytes_Concat`.