### PR TITLE
Fix crash on Unpack used without arguments in class bases

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2403,6 +2403,9 @@ class SemanticAnalyzer(
         if isinstance(t, UnboundType):
             sym = self.lookup_qualified(t.name, t)
             if sym and sym.fullname in UNPACK_TYPE_NAMES:
+                if not t.args:
+                    # Unpack used without arguments, e.g. `Protocol[Unpack]`
+                    return None
                 inner_t = t.args[0]
                 if isinstance(inner_t, UnboundType):
                     return self.analyze_unbound_tvar_impl(inner_t, is_unpacked=True)

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2765,3 +2765,11 @@ def func(d: Callable[[Unpack[Ts]], T]) -> T: ...
 y = func[1, int] # E: Type application is only supported for generic classes \
                  # E: Invalid type: try using Literal[1] instead?
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleUnpackWithoutArgsInProtocol]
+# https://github.com/python/mypy/issues/21467
+from typing import Protocol, Unpack
+
+class C(Protocol[Unpack]):  # E: Free type variable expected in Protocol[...]
+    pass
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #21467.

`analyze_unbound_tvar` accessed `t.args[0]` unconditionally when a class base was `Unpack` with no arguments (e.g. `class C(Protocol[Unpack]): ...`), raising `IndexError: tuple index out of range` during semantic analysis.

This adds a guard returning `None` in that case, so the existing "Free type variable expected in Protocol[...]" error is reported instead of crashing.

Added a regression test in `check-typevar-tuple.test`.