### PR TITLE
Resolve symlinks in getsyspath() stdlib exclusion

### DIFF
--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -47,7 +47,10 @@ def getsyspath() -> list[str]:
     )
     stdlib = sysconfig.get_path("stdlib")
     stdlib_ext = os.path.join(stdlib, "lib-dynload")
-    excludes = {stdlib_zip, stdlib, stdlib_ext}
+    # Resolve symlinks: base_exec_prefix / sysconfig paths retain the symlink
+    # form (e.g. Homebrew's /opt/homebrew/opt/python@3.13) while sys.path
+    # entries arrive pre-resolved by Python. See python/mypy#21474.
+    excludes = {os.path.realpath(p) for p in (stdlib_zip, stdlib, stdlib_ext)}
 
     # Drop the first entry of sys.path
     # - If pyinfo.py is executed as a script (in a subprocess), this is the directory
@@ -63,7 +66,7 @@ def getsyspath() -> list[str]:
     offset = 0 if sys.version_info >= (3, 11) and sys.flags.safe_path else 1
 
     abs_sys_path = (os.path.abspath(p) for p in sys.path[offset:])
-    return [p for p in abs_sys_path if p not in excludes]
+    return [p for p in abs_sys_path if os.path.realpath(p) not in excludes]
 
 
 def getsearchdirs() -> tuple[list[str], list[str]]:

--- a/mypy/test/test_pyinfo.py
+++ b/mypy/test/test_pyinfo.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import sys
+import sysconfig
+import tempfile
+import unittest
+
+from mypy import pyinfo
+
+
+class GetSysPathSuite(unittest.TestCase):
+    """Regression tests for mypy.pyinfo.getsyspath()."""
+
+    @unittest.skipIf(sys.platform == "win32", "os.symlink requires elevated privileges on Windows")
+    def test_excludes_stdlib_when_install_path_is_symlinked(self) -> None:
+        """Regression test for python/mypy#21474.
+
+        On Homebrew/pyenv/python-build-standalone, the Python install path is
+        reached via a symlink (e.g. ``/opt/homebrew/opt/python@3.13`` ->
+        ``/opt/homebrew/Cellar/python@3.13/3.13.7``). ``sys.base_exec_prefix``
+        and ``sysconfig.get_path("stdlib")`` retain the symlink form, while
+        entries of ``sys.path`` arrive pre-resolved by Python. ``getsyspath()``
+        normalised both sides with ``os.path.abspath`` (which does not resolve
+        symlinks), so the stdlib entry was never excluded and leaked into
+        ``SearchPaths.package_path``.
+        """
+        ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            real_prefix = os.path.join(tmp, "cellar")
+            real_stdlib = os.path.join(real_prefix, "lib", ver)
+            real_dynload = os.path.join(real_stdlib, "lib-dynload")
+            os.makedirs(real_dynload)
+
+            symlink_prefix = os.path.join(tmp, "opt")
+            os.symlink(real_prefix, symlink_prefix)
+            symlink_stdlib = os.path.join(symlink_prefix, "lib", ver)
+
+            # Sanity check that the two paths really do differ textually but
+            # resolve to the same directory — otherwise the bug isn't being
+            # exercised at all.
+            assert symlink_stdlib != real_stdlib
+            assert os.path.samefile(symlink_stdlib, real_stdlib)
+
+            original_base_exec_prefix = sys.base_exec_prefix
+            original_path = sys.path[:]
+            original_get_path = sysconfig.get_path
+
+            def fake_get_path(name: str) -> str:
+                assert name == "stdlib", f"unexpected get_path({name!r})"
+                return symlink_stdlib
+
+            try:
+                sys.base_exec_prefix = symlink_prefix
+                sysconfig.get_path = fake_get_path  # type: ignore[assignment]
+                # First entry is dropped by getsyspath() unless safe_path is
+                # on, so use a sentinel there.
+                sys.path = ["<sentinel>", real_stdlib, real_dynload]
+
+                result = pyinfo.getsyspath()
+            finally:
+                sys.base_exec_prefix = original_base_exec_prefix
+                sysconfig.get_path = original_get_path
+                sys.path = original_path
+
+            leaked = [
+                p
+                for p in result
+                if os.path.exists(p)
+                and (os.path.samefile(p, real_stdlib) or os.path.samefile(p, real_dynload))
+            ]
+            self.assertEqual(
+                leaked,
+                [],
+                f"stdlib leaked into getsyspath() result: {leaked!r} "
+                f"(full result: {result!r})",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #21474.

## Summary

`pyinfo.getsyspath()` normalised paths with `os.path.abspath`, which does
not resolve symlinks. When the install prefix is symlinked (Homebrew,
pyenv, python-build-standalone), `sys.base_exec_prefix` /
`sysconfig.get_path("stdlib")` retain the symlink form while `sys.path`
entries arrive pre-resolved, so the stdlib was never excluded from
`SearchPaths.package_path`. Stdlib modules unavailable at the configured
`--python-version` then surfaced as `[import-untyped]` instead of
`[import-not-found]`.

## Fix

Use `os.path.realpath` for the membership check. Returned paths still use
`os.path.abspath`.

## Tests

Added `mypy/test/test_pyinfo.py`, which builds a symlinked `opt -> cellar`
layout in a tmpdir and monkeypatches the relevant `sys`/`sysconfig`
attributes, so the bug reproduces on any OS supporting symlinks. Verified
failing on `python:3.13-slim` Docker and macOS before the fix, passing on
both after.