### PR TITLE
docs: fix duplicated word in overload docs

### DIFF
--- a/docs/source/more_types.rst
+++ b/docs/source/more_types.rst
@@ -573,7 +573,7 @@ implementation, then the body is not type checked. If you want to
 force mypy to check the body anyways, use the :option:`--check-untyped-defs <mypy --check-untyped-defs>`
 flag (:ref:`more details here <untyped-definitions-and-calls>`).
 
-The variants must also also be compatible with the implementation
+The variants must also be compatible with the implementation
 type hints. In the ``MyList`` example, mypy will check that the
 parameter type ``int`` and the return type ``T`` are compatible with
 ``int | slice`` and ``T | Sequence`` for the


### PR DESCRIPTION
Fixes a duplicated word in the overload implementation compatibility docs.

No code changes.