### PR TITLE
Ignore num_workers in the daemon while it is not supported

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -192,13 +192,17 @@ class Server:
         options.show_traceback = True
         if options.use_fine_grained_cache:
             # Using fine_grained_cache implies generating and caring
-            # about the fine grained cache
+            # about the fine-grained cache.
             options.cache_fine_grained = True
         else:
             options.cache_dir = os.devnull
         # Fine-grained incremental doesn't support general partial types
         # (details in https://github.com/python/mypy/issues/4492)
         options.local_partial_types = True
+        # We don't support parallel checking in fine-grained mode yet.
+        # Ignore it for now, so that same config file can be used with
+        # mypy and with the daemon.
+        options.num_workers = 0
         self.status_file = status_file
 
         # Since the object is created in the parent process we can check


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/21475

Avoid the crash while we don't support this. The actual feature is tracked in https://github.com/python/mypy/issues/21346
