### PR TITLE
Fix crash when checking file in a read only directory

### DIFF
--- a/mypy/metastore.py
+++ b/mypy/metastore.py
@@ -189,7 +189,12 @@ class SqliteMetadataStore(MetadataStore):
         if cache_dir_prefix.startswith(os.devnull):
             return
 
-        os.makedirs(cache_dir_prefix, exist_ok=True)
+        try:
+            os.makedirs(cache_dir_prefix, exist_ok=True)
+        except OSError:
+            # Prevent failing on read-only filesystem and such.
+            return
+
         if num_shards <= 1:
             self.dbs.append(
                 connect_db(os_path_join(cache_dir_prefix, "cache.db"), set_journal_mode)

--- a/mypy/test/testmetastore.py
+++ b/mypy/test/testmetastore.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from mypy.metastore import SqliteMetadataStore
+
+
+@contextmanager
+def _read_only_dir(path: str) -> Iterator[str]:
+    original_mode = os.stat(path).st_mode
+    os.chmod(path, 0o555)
+    try:
+        yield path
+    finally:
+        os.chmod(path, original_mode)
+
+
+@unittest.skipIf(
+    sys.platform == "win32",
+    "POSIX chmod semantics: os.chmod(dir, 0o555) does not prevent writes on Windows",
+)
+class TestSqliteMetadataStore(unittest.TestCase):
+    def test_init_degrades_to_noop_when_cache_dir_not_creatable(self) -> None:
+        with tempfile.TemporaryDirectory() as parent, _read_only_dir(parent):
+            cache_dir = os.path.join(parent, "mypy_cache")
+
+            # Must not raise.
+            store = SqliteMetadataStore(cache_dir)
+
+            # Degraded to no-op state, matching the os.devnull short-circuit
+            # and FilesystemMetadataStore's behavior on read-only filesystems.
+            self.assertEqual(store.dbs, [])
+            self.assertFalse(store.write("foo.meta.json", b"{}"))
+            with self.assertRaises(FileNotFoundError):
+                store.read("foo.meta.json")
+            with self.assertRaises(FileNotFoundError):
+                store.getmtime("foo.meta.json")
+            self.assertEqual(list(store.list_all()), [])
+            # commit/close must be safe on an empty store
+            store.commit()
+            store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mypy/test/testmetastore.py
+++ b/mypy/test/testmetastore.py
@@ -4,20 +4,8 @@ import os
 import sys
 import tempfile
 import unittest
-from collections.abc import Iterator
-from contextlib import contextmanager
 
 from mypy.metastore import SqliteMetadataStore
-
-
-@contextmanager
-def _read_only_dir(path: str) -> Iterator[str]:
-    original_mode = os.stat(path).st_mode
-    os.chmod(path, 0o555)
-    try:
-        yield path
-    finally:
-        os.chmod(path, original_mode)
 
 
 @unittest.skipIf(
@@ -26,7 +14,9 @@ def _read_only_dir(path: str) -> Iterator[str]:
 )
 class TestSqliteMetadataStore(unittest.TestCase):
     def test_init_degrades_to_noop_when_cache_dir_not_creatable(self) -> None:
-        with tempfile.TemporaryDirectory() as parent, _read_only_dir(parent):
+        with tempfile.TemporaryDirectory() as parent:
+            os.chmod(parent, 0o555)
+
             cache_dir = os.path.join(parent, "mypy_cache")
 
             # Must not raise.


### PR DESCRIPTION
Only applies to new SqliteMetadataStore, which is the default since 1.20; old FilesystemMetadataStore doesn't crash.

Fixes https://github.com/python/mypy/issues/21495

-----

I added a test for `SqliteMetadataStore` -- a bit surprised there weren't any in the first place, perhaps the idea is that this is already covered by `cmdline` based integration tests? I had a stab at implementing one for consistency, but realized that there is no way to issue a `chmod -w` there, so figured a more specialized unit test is fine. Let me know if there is a better way to test this!

-----

>  Disclosing the use of LLMs in pull request description is recommended, but not required.

I used Claude to bisect when issue started happening and to suggest me best place to place code and make it consistent with existing testbase; but otherwise fully understand it!
