### PR TITLE
Use explicit Never for type inference

### DIFF
--- a/mypy/applytype.py
+++ b/mypy/applytype.py
@@ -39,7 +39,7 @@ def get_target_type(
     skip_unsatisfied: bool,
 ) -> Type | None:
     p_type = get_proper_type(type)
-    if isinstance(p_type, UninhabitedType) and tvar.has_default():
+    if isinstance(p_type, UninhabitedType) and p_type.ambiguous and tvar.has_default():
         return tvar.default
     if isinstance(tvar, ParamSpecType):
         return type

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4552,7 +4552,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 self.check_lvalue(sub_expr)[0] or
                 # This type will be used as a context for further inference of rvalue,
                 # we put Uninhabited if there is no information available from lvalue.
-                UninhabitedType()
+                UninhabitedType(ambiguous=True)
                 for sub_expr in lvalue.items
             ]
             lvalue_type = TupleType(types, self.named_type("builtins.tuple"))

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -2085,7 +2085,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         # Only substitute non-Uninhabited and non-erased types.
         new_args: list[Type | None] = []
         for arg in args:
-            if has_uninhabited_component(arg) or has_erased_component(arg):
+            if has_ambiguous_uninhabited_component(arg) or has_erased_component(arg):
                 new_args.append(None)
             else:
                 new_args.append(arg)
@@ -6719,8 +6719,8 @@ class HasUninhabitedComponentsQuery(types.BoolTypeQuery):
         return True
 
 
-def has_ambiguous_uninhabited_component(t: Type) -> bool:
-    return t.accept(HasAmbiguousUninhabitedComponentsQuery())
+def has_ambiguous_uninhabited_component(t: Type | None) -> bool:
+    return t is not None and t.accept(HasAmbiguousUninhabitedComponentsQuery())
 
 
 class HasAmbiguousUninhabitedComponentsQuery(types.BoolTypeQuery):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1389,9 +1389,9 @@ class UninhabitedType(ProperType):
 
     ambiguous: bool  # Is this a result of inference for a variable without constraints?
 
-    def __init__(self, line: int = -1, column: int = -1) -> None:
+    def __init__(self, line: int = -1, column: int = -1, *, ambiguous: bool = False) -> None:
         super().__init__(line, column)
-        self.ambiguous = False
+        self.ambiguous = ambiguous
 
     def can_be_true_default(self) -> bool:
         return False

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -150,6 +150,15 @@ def func_error_alias2(
     reveal_type(c)  # N: Revealed type is "builtins.dict[builtins.int, builtins.float]"
 [builtins fixtures/dict.pyi]
 
+[case testTypeVarDefaultsExplicitNever]
+from typing import Generic, Never, TypeVar
+
+D = TypeVar("D", default=int)
+class WithDefault(Generic[D]): pass
+
+never_with_default: WithDefault[Never] = WithDefault()
+explicit_with_default: WithDefault[Never] = WithDefault[Never]()
+
 [case testTypeVarDefaultsFunctions]
 from typing import TypeVar, ParamSpec, List, Union, Callable, Tuple
 from typing_extensions import TypeVarTuple, Unpack


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/20391

The problem became more prominent with type variables with defaults, so better be consistent.