### PR TITLE
Fix crash for empty Annotated type application

### DIFF
--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -122,11 +122,7 @@ def expr_to_unanalyzed_type(
                 else:
                     base_fullname = expr.base.fullname
 
-                if (
-                    base_fullname is not None
-                    and base_fullname in ANNOTATED_TYPE_NAMES
-                    and args
-                ):
+                if base_fullname is not None and base_fullname in ANNOTATED_TYPE_NAMES and args:
                     # TODO: this is not the optimal solution as we are basically getting rid
                     # of the Annotation definition and only returning the type information,
                     # losing all the annotations.

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -122,7 +122,11 @@ def expr_to_unanalyzed_type(
                 else:
                     base_fullname = expr.base.fullname
 
-                if base_fullname is not None and base_fullname in ANNOTATED_TYPE_NAMES:
+                if (
+                    base_fullname is not None
+                    and base_fullname in ANNOTATED_TYPE_NAMES
+                    and args
+                ):
                     # TODO: this is not the optimal solution as we are basically getting rid
                     # of the Annotation definition and only returning the type information,
                     # losing all the annotations.

--- a/test-data/unit/check-annotated.test
+++ b/test-data/unit/check-annotated.test
@@ -41,6 +41,11 @@ x: Annotated[int]  # E: Annotated[...] must have exactly one type argument and a
 reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/tuple.pyi]
 
+[case testAnnotatedBadEmptyTupleIndexInTypeApplication]
+from typing_extensions import Annotated
+list[Annotated[()]]  # E: Annotated[...] must have exactly one type argument and at least one annotation
+[builtins fixtures/list.pyi]
+
 [case testAnnotatedNested0]
 from typing_extensions import Annotated
 x: Annotated[Annotated[int, ...], ...]


### PR DESCRIPTION
Fixes #21471.

## Summary
- Avoid special-casing `Annotated[...]` as its inner type when the subscript has no arguments.
- Let the normal type analyzer report the existing `Annotated[...]` argument error instead of crashing.
- Add a regression test for `list[Annotated[()]]` in type application context.

## Tests
- `python3 -m pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-annotated.test`
- `python3 -m mypy --config-file mypy_self_check.ini -p mypy`
- `python3 -m mypy /tmp/mypy21471.py --show-traceback`
- `git diff --check`

Prepared with AI assistance; I reviewed and verified the changes.
