### PR TITLE
Fix false positive "Expected TypedDict key to be string literal" for Union[TypedDict, dict[K, V]]

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -932,7 +932,8 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         kwargs: list[tuple[Expression | None, Expression]],
         context: Context,
     ) -> bool:
-        result = self.validate_typeddict_kwargs(kwargs=kwargs, callee=callee)
+        with self.msg.filter_errors():
+            result = self.validate_typeddict_kwargs(kwargs=kwargs, callee=callee)
         if result is not None:
             validated_kwargs, _ = result
             return callee.required_keys <= set(validated_kwargs.keys()) <= set(callee.items.keys())

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -941,6 +941,18 @@ c: Union[A, B] = {'@type': 'a-type', 'value': 'Test'}  # E: Type of TypedDict is
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictUnionWithNonTypedDictLiteralKey]
+from typing import Union, TypedDict
+
+class Foo(TypedDict):
+    some: str
+    name: str
+
+baz: Union[Foo, dict[int, float]] = {1: 5.2}
+baz2: Union[Foo, dict[int, float]] = {'some': 'x', 'name': 'y'}
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 -- Use dict literals
 
 [case testTypedDictDictLiterals]


### PR DESCRIPTION
When a variable is typed as `Union[TypedDict, dict[int, float]]`, mypy incorrectly
raised `Expected TypedDict key to be string literal` when assigning a dict literal
with non-string keys like `{1: 5.2}`. The plain `dict[int, float]` alternative makes
the assignment valid, so this was a false positive.

The root cause was that `match_typeddict_call_with_dict`, which is used as a probe to
check whether a dict literal could match a TypedDict, was emitting errors from
`validate_typeddict_kwargs` during the matching phase rather than silently returning
`False`. Wrapping the call in `filter_errors()` suppresses those spurious diagnostics.

Fixes #21510