### PR TITLE
Avoid eager file read in State.parse_file() when using native parser

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -3211,7 +3211,11 @@ class State:
             # The file was already parsed.
             return
 
-        if raw_data is None:
+        if raw_data is None and not (
+            self.options.native_parser
+            and self.source is None
+            and self.manager.fscache.exists(self.xpath, real_only=True)
+        ):
             source = self.get_source()
         else:
             source = ""


### PR DESCRIPTION
In `State.parse_file()` in `mypy/build.py`, `get_source()` was called unconditionally when `raw_data` was `None`, causing eager file reading in Python even when using the native parser with a single on-disk file in the batch. The fix makes `get_source()` conditional, skipping it when the native parser is enabled, no source override is present, and the file exists on disk — passing an empty string to `parse_file_inner()` instead, matching the parallel code path. Run `python -m pytest mypy/test/testparse.py mypy/test/testfinegrained.py -x -q` to verify.

Fixes #21514