### PR TITLE
[mypyc] Add test for incremental builtin_base class construction across groups

### DIFF
--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -1739,8 +1739,8 @@ assert make_child(-1) == "child(-1)"
 # Regression: builtin_base classes (Exception subclasses) were unconditionally
 # added to func_to_decl in load_type_map, causing cross-group call sites to
 # emit CPyDef instead of CPyType for the constructor.
-from myerrors import MyError
-from myutil import process
+from other_errors import MyError
+from other_util import process
 
 def run(value: str) -> None:
     if not value:
@@ -1752,15 +1752,15 @@ def compute(x: str) -> str:
         raise MyError("no result")
     return result
 
-[file myerrors.py]
+[file other_errors.py]
 class MyError(Exception):
     pass
 
-[file myutil.py]
+[file other_util.py]
 def process(x: str) -> str:
     return x
 
-[file myutil.py.2]
+[file other_util.py.2]
 def process(x: str, flag: bool = False) -> str:
     return x.strip()
 

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -1734,3 +1734,47 @@ class Base:
 from native import make_child
 assert make_child(7) == "child(7)"
 assert make_child(-1) == "child(-1)"
+
+[case testIncrementalBuiltinBaseClassConstruction]
+# Regression: builtin_base classes (Exception subclasses) were unconditionally
+# added to func_to_decl in load_type_map, causing cross-group call sites to
+# emit CPyDef instead of CPyType for the constructor.
+from myerrors import MyError
+from myutil import process
+
+def run(value: str) -> None:
+    if not value:
+        raise MyError("empty")
+
+def compute(x: str) -> str:
+    result = process(x)
+    if not result:
+        raise MyError("no result")
+    return result
+
+[file myerrors.py]
+class MyError(Exception):
+    pass
+
+[file myutil.py]
+def process(x: str) -> str:
+    return x
+
+[file myutil.py.2]
+def process(x: str, flag: bool = False) -> str:
+    return x.strip()
+
+[file driver.py]
+from native import run, compute
+try:
+    run("")
+except Exception as e:
+    print(str(e))
+print(compute("hello"))
+
+[out]
+empty
+hello
+[out2]
+empty
+hello


### PR DESCRIPTION
The fix for this was included in #21369, but no dedicated test was added.

This adds `testIncrementalBuiltinBaseClassConstruction` to `run-multimodule.test`: three modules compiled with `separate=True`, where step 2 changes a helper module's signature to force the caller to be recompiled while the exception module is only loaded from cache.