### PR TITLE
Fix exhaustive match after unreachable cases

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5944,6 +5944,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
             # The second pass narrows down the types and type checks bodies.
             unmatched_types: TypeMap = {s.subject: UninhabitedType()}
             for p, g, b in zip(s.patterns, s.guards, s.bodies):
+                case_is_unreachable = self.binder.is_unreachable()
                 current_subject_type = self.expr_checker.narrow_type_from_binder(
                     named_subject, subject_type
                 )
@@ -5996,8 +5997,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                             self.accept(b)
                     else:
                         self.accept(b)
-                self.push_type_map(else_map, from_assignment=False)
-                unmatched_types = else_map
+                if not case_is_unreachable:
+                    # Unreachable cases are still checked above, but they shouldn't revive
+                    # subject types that were already handled by earlier cases.
+                    self.push_type_map(else_map, from_assignment=False)
+                    unmatched_types = else_map
 
             if not is_unreachable_map(unmatched_types) and not self.current_node_deferred:
                 for typ in unmatched_types.values():

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -3625,6 +3625,21 @@ match b:
     case _:
         pass
 
+[case testExhaustiveMatchIgnoresUnreachableClassPattern]
+# flags: --enable-error-code exhaustive-match
+class A: pass
+class B: pass
+
+x: A | None
+
+match x:
+    case None:
+        pass
+    case A() as a:
+        pass
+    case B():
+        pass
+
 [case testNonExhaustiveMatchWithFlag]
 # flags: --enable-error-code exhaustive-match --strict-equality --warn-unreachable
 


### PR DESCRIPTION
Fixes #21517

## Summary
- keep match exhaustiveness from being updated by cases that are already unreachable
- still type-check unreachable cases so existing diagnostics are preserved
- add a regression for an exhaustive `A | None` match followed by an unreachable `B()` case

## Tests
- `.venv\Scripts\python -m pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-python310.test`
- `.venv\Scripts\python -m pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-unreachable-code.test`
- `.venv\Scripts\python -m mypy --enable-error-code exhaustive-match -c "class A: pass\nclass B: pass\nx: A | None\nmatch x:\n    case None:\n        pass\n    case A() as a:\n        pass\n    case B():\n        pass"`
- `.venv\Scripts\python -m pre_commit run --files mypy/checker.py test-data/unit/check-python310.test`
- `git diff --check`

LLM assistance was used while iterating on the patch and tests. I reviewed the change and can explain it.