### PR TITLE
Fix false positive for NamedTuple subtype of TupleType

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -521,6 +521,10 @@ class SubtypeVisitor(TypeVisitor[bool]):
                             or mapped.type.has_type_var_tuple_type
                         ):
                             return True
+                    # A NamedTuple Instance is a subtype of its own TupleType
+                    # representation (they are two views of the same type).
+                    if mapped.type.is_named_tuple and mapped.type is right.partial_fallback.type:
+                        return True
             return False
         if isinstance(right, TypeVarTupleType):
             # tuple[Any, ...] is like Any in the world of tuples (see special case above).


### PR DESCRIPTION
When checking whether an Instance (specifically a NamedTuple instance) is a subtype of a TupleType, mypy incorrectly returned False even though the NamedTuple and its TupleType representation refer to the same underlying type. The fix is in mypy/subtypes.py in the SubtypeVisitor.visit_instance method: when the mapped type is a NamedTuple and shares its TypeInfo with the right-hand TupleType's partial fallback, we now return True. To verify, create a NamedTuple and assign it to a variable typed as the equivalent tuple; mypy should no longer report a false positive error.

Fixes #21528
