### PR TITLE
[mypyc] Fix non-deterministic class struct layout under `separate=True`

### DIFF
--- a/mypyc/analysis/attrdefined.py
+++ b/mypyc/analysis/attrdefined.py
@@ -424,14 +424,20 @@ def detect_undefined_bitmap(cl: ClassIR, seen: set[ClassIR]) -> None:
     for base in cl.base_mro[1:]:
         detect_undefined_bitmap(base, seen)
 
+    # Build fresh and assign once. This function is called per SCC and `seen`
+    # only dedupes within a single call, so appending in place to a shared base
+    # would accumulate duplicates across SCCs and produce non-deterministic
+    # struct layouts under separate=True.
+    new_attrs: list[str] = []
     if len(cl.base_mro) > 1:
-        cl.bitmap_attrs.extend(cl.base_mro[1].bitmap_attrs)
+        new_attrs.extend(cl.base_mro[1].bitmap_attrs)
     for n, t in cl.attributes.items():
         if t.error_overlap and not cl.is_always_defined(n):
-            cl.bitmap_attrs.append(n)
+            new_attrs.append(n)
 
     for base in cl.mro[1:]:
         if base.is_trait:
             for n, t in base.attributes.items():
-                if t.error_overlap and not cl.is_always_defined(n) and n not in cl.bitmap_attrs:
-                    cl.bitmap_attrs.append(n)
+                if t.error_overlap and not cl.is_always_defined(n) and n not in new_attrs:
+                    new_attrs.append(n)
+    cl.bitmap_attrs = new_attrs

--- a/mypyc/test/test_emitclass.py
+++ b/mypyc/test/test_emitclass.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import unittest
 
+from mypyc.analysis.attrdefined import detect_undefined_bitmap
 from mypyc.codegen.emitclass import getter_name, setter_name, slot_key
 from mypyc.ir.class_ir import ClassIR
+from mypyc.ir.rtypes import int32_rprimitive
 from mypyc.namegen import NameGenerator
 
 
@@ -33,3 +35,22 @@ class TestEmitClass(unittest.TestCase):
         generator = NameGenerator([["mod"]])
 
         assert getter_name(cls, "down", generator) == "testing___SomeClass_get_down"
+
+    def test_bitmap_attrs_stable_across_repeat_analysis(self) -> None:
+        # Regression: detect_undefined_bitmap used to mutate cl.bitmap_attrs
+        # in place, so under separate=True (one SCC per group) a shared base
+        # class would accumulate duplicate entries as each subclass's SCC
+        # walked into it, growing the emitted struct between builds.
+        base = ClassIR("Base", "mod")
+        base.attributes = {"i": int32_rprimitive}
+        sub = ClassIR("Sub", "mod")
+        sub.attributes = {"j": int32_rprimitive}
+        base.mro = base.base_mro = [base]
+        sub.mro = sub.base_mro = [sub, base]
+        base.children = [sub]
+
+        detect_undefined_bitmap(sub, seen=set())
+        for _ in range(10):
+            detect_undefined_bitmap(sub, seen=set())
+        assert base.bitmap_attrs == ["i"]
+        assert sub.bitmap_attrs == ["i", "j"]


### PR DESCRIPTION
The helper function `detect_undefined_bitmap` builds the list of attributes that need a per-instance "is set?" bit (`cl.bitmap_attrs`). It walks from a subclass up into its base and `.append()`s entries.

The walk dedupes within one call via `seen`, but the function is called once per SCC; Under `separate=True`, every subclass of a shared base lives in its own SCC, so the base is visited multiple times and gets the same entries re-appended on every pass.

After N visits, `base.bitmap_attrs` contains N duplicate copies of the same names, so attribute offsets shift between builds and not-rebuilt subclasses end up reading the wrong bytes. The added test case shows that on master branch `base.bitmap_attrs` has been populated with `["i"] * 11`

The fix: Build a fresh local list and assign once at the end. The function becomes idempotent and the struct layout remains identical after each incremental build. 


