### PR TITLE
Allow reverse operator methods on protocols

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1962,6 +1962,9 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
 
         assert defn.info
 
+        if defn.info.is_protocol:
+            return
+
         # First check for a valid signature
         method_type = CallableType(
             [AnyType(TypeOfAny.special_form), AnyType(TypeOfAny.special_form)],

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1539,6 +1539,17 @@ f(C()) # E: No overload variant of "f" matches argument type "C" \
 [builtins fixtures/isinstance.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testProtocolReversePowWithModulo]
+from typing import overload, Protocol
+
+class PowableProto(Protocol):
+    @overload
+    def __rpow__(self, other: "PowableProto") -> "PowableProto": ...
+    @overload
+    def __rpow__(
+        self, other: "PowableProto", modulo: "PowableProto"
+    ) -> "PowableProto": ...
+
 -- Unions of protocol types
 -- ------------------------
 


### PR DESCRIPTION
Fixes #10786.

## Summary
- Skip reverse-operator signature and overlap checks for protocol definitions, matching their structural typing role rather than concrete runtime dispatch.
- Add regression coverage for a Protocol defining overloaded __rpow__ with a modulo argument.

## Tests
- .\.venv\Scripts\pytest.exe mypy/test/testcheck.py::TypeCheckSuite::check-protocols.test -q
- .\.venv\Scripts\pytest.exe mypy/test/testcheck.py::TypeCheckSuite::check-classes.test -q