### PR TITLE
Fix TypedDict tuple context for Collection

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -163,6 +163,7 @@ TUPLE_LIKE_INSTANCE_NAMES: Final = (
     "builtins.tuple",
     "typing.Iterable",
     "typing.Container",
+    "typing.Collection",
     "typing.Sequence",
     "typing.Reversible",
 )

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -4601,6 +4601,23 @@ inputs: Sequence[Component] = [{
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictTupleExpressionWithCollectionContext]
+import collections.abc
+from typing import Collection, TypedDict
+
+class Item(TypedDict):
+    x: int
+
+def take(items: Collection[Item]) -> None: ...
+def take_abc(items: collections.abc.Collection[Item]) -> None: ...
+
+take(({"x": 1}, {"x": 2}))
+take_abc(({"x": 1}, {"x": 2}))
+items: Collection[Item] = ({"x": 1}, {"x": 2})
+abc_items: collections.abc.Collection[Item] = ({"x": 1}, {"x": 2})
+[builtins fixtures/dict.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testTypedDictAssignableToWiderContext]
 from typing import TypedDict, Union
 

--- a/test-data/unit/fixtures/typing-typeddict.pyi
+++ b/test-data/unit/fixtures/typing-typeddict.pyi
@@ -47,6 +47,8 @@ class Iterable(Protocol[T_co]):
 class Iterator(Iterable[T_co], Protocol):
     def __next__(self) -> T_co: pass
 
+class Collection(Iterable[T_co]): pass
+
 class Sequence(Iterable[T_co]):
     def __getitem__(self, n: Any) -> T_co: pass # type: ignore[explicit-any]
 


### PR DESCRIPTION
Fixes #8921.

Tuple expressions are contextually typed for `Sequence` and `Iterable`, but not for `Collection`. This meant a tuple literal containing a `TypedDict` literal could fail when the expected type was `Collection[Item]`, even though the same expression worked for related protocols.

This change adds `typing.Collection` to the tuple-like contextual typing set and adds regression coverage for both `typing.Collection` and `collections.abc.Collection`.

Validation:
- `python -m pytest -n0 -q mypy/test/testcheck.py::TypeCheckSuite::check-typeddict.test`