### PR TITLE
Fix false positive for constrained NamedTuple self types

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1768,7 +1768,37 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # This level of erasure matches the one in checkmember.check_self_arg(),
         # better keep these two checks consistent.
         erased = get_proper_type(erase_typevars(erase_to_bound(arg_type)))
-        if not is_subtype(ref_type, erased, ignore_type_params=True):
+
+        # Generic NamedTuple methods using constrained TypeVars can produce
+        # false positives here because constrained TypeVars are checked using
+        # union semantics during subtype comparison.
+        #
+        # Example:
+        #     S = TypeVar("S", str, bytes)
+        #
+        #     class Result(NamedTuple, Generic[S]):
+        #         ...
+        #
+        # In this case:
+        #     tuple[S] is compared against tuple[str]
+        #
+        # and incorrectly rejected.
+        #
+        # Skip this check for constrained generic NamedTuple tuple self types.
+        skip_namedtuple_constrained_check = (
+            isinstance(ref_type, TupleType)
+            and isinstance(arg_type, TupleType)
+            and ref_type.partial_fallback.type.tuple_type is not None
+            and any(
+                isinstance(item, TypeVarType) and item.values
+                for item in ref_type.items
+            )
+        )
+
+        if (
+            not skip_namedtuple_constrained_check
+            and not is_subtype(ref_type, erased, ignore_type_params=True)
+        ):
             if (
                 isinstance(erased, Instance)
                 and erased.type.is_protocol

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1785,14 +1785,25 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # and incorrectly rejected.
         #
         # Skip this check for constrained generic NamedTuple tuple self types.
+        has_constrained_typevar = False
+        namedtuple_ref_type: TupleType | None = None
+
+        proper_ref_type = get_proper_type(ref_type)
+        proper_arg_type = get_proper_type(arg_type)
+
+        if isinstance(proper_ref_type, TupleType):
+            namedtuple_ref_type = proper_ref_type
+
+            for item in proper_ref_type.items:
+                if isinstance(item, TypeVarType) and item.values:
+                    has_constrained_typevar = True
+                    break
+
         skip_namedtuple_constrained_check = (
-            isinstance(ref_type, TupleType)
-            and isinstance(arg_type, TupleType)
-            and ref_type.partial_fallback.type.tuple_type is not None
-            and any(
-                isinstance(item, TypeVarType) and item.values
-                for item in ref_type.items
-            )
+            namedtuple_ref_type is not None
+            and isinstance(proper_arg_type, TupleType)
+            and namedtuple_ref_type.partial_fallback.type.is_named_tuple
+            and has_constrained_typevar
         )
 
         if (

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1806,9 +1806,8 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
             and has_constrained_typevar
         )
 
-        if (
-            not skip_namedtuple_constrained_check
-            and not is_subtype(ref_type, erased, ignore_type_params=True)
+        if not skip_namedtuple_constrained_check and not is_subtype(
+            ref_type, erased, ignore_type_params=True
         ):
             if (
                 isinstance(erased, Instance)

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -2378,3 +2378,16 @@ class Bar(Enum):
     def bar(cls) -> Bar:
         ...
 [builtins fixtures/classmethod.pyi]
+
+[case testNamedTupleConstrainedTypeVarSelfType]
+from typing import Generic, NamedTuple, TypeVar
+
+S = TypeVar("S", str, bytes)
+
+class Result(NamedTuple, Generic[S]):
+    value: S
+
+    def get_value(self) -> S:
+        return self.value
+
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #21453

This PR fixes a false positive reported for methods on generic `NamedTuple` classes that use constrained type variables.

Example:

```python
from typing import Generic, NamedTuple, TypeVar

S = TypeVar("S", str, bytes)

class Result(NamedTuple, Generic[S]):
    value: S

    def get_value(self) -> S:
        return self.value
```

Previously mypy incorrectly reported:

```text
The erased type of self ... is not a supertype of its class ...
```

The issue occurred during self-type validation for tuple-backed `NamedTuple` types using constrained `TypeVar`s.

This change adds a narrow special-case in the self-type checker to avoid the false positive while preserving existing subtype semantics.

Changes included:

* Added a targeted fix in `mypy/checker.py`
* Added a regression test in `test-data/unit/check-selftype.test`

Verification:

* Reproduced the original issue locally
* Added regression coverage
* Ran `python -m pytest -q mypy/test/testcheck.py -n0`
* All tests passed
