### PR TITLE
Fix crash in new-style type alias with variadic unpack

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -5771,7 +5771,10 @@ class SemanticAnalyzer(
                 res = make_any_non_unimported(res)
             eager = self.is_func_scope()
             if isinstance(res, ProperType) and isinstance(res, Instance):
-                fix_instance(res, self.fail, self.note, disallow_any=False, options=self.options)
+                if not validate_instance(res, self.fail, indexed):
+                    fix_instance(
+                        res, self.fail, self.note, disallow_any=False, options=self.options
+                    )
             alias_node = TypeAlias(
                 res,
                 self.qualified_name(s.name.name),

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2280,3 +2280,16 @@ class D[*Ts](Generic[Unpack[Us]]):  # E: Generic[...] base class is redundant \
                                     # E: Can only use one type var tuple in a class def
     pass
 [builtins fixtures/tuple.pyi]
+
+[case testPEP695VariadicAliasUnpack]
+class C[*Ts]:
+    pass
+
+type T[T, *Ts] = C[*Ts]
+
+x: T[bool, *tuple[()]]
+reveal_type(x)  # N: Revealed type is "__main__.C[()]"
+
+y: T[bool]
+reveal_type(y)  # N: Revealed type is "__main__.C[()]"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/20913
Closes https://github.com/python/mypy/pull/20931

Fix is trivial, don't fix what is already valid (since `fix_instance()` has some implicit assumptions) like we already do for old-style aliases.