### PR TITLE
Fix TypedDict indexing with literal keys in comprehensions

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -6432,7 +6432,7 @@ class SemanticAnalyzer(
             if i > 0:
                 sequence.accept(self)
             # Bind index variables.
-            self.analyze_lvalue(index)
+            self.analyze_lvalue(index, is_index_var=True)
             for cond in conditions:
                 cond.accept(self)
 

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -779,6 +779,17 @@ def get_coordinate(p: TaggedPoint, key: str) -> Union[str, int]:
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testCanGetItemOfTypedDictWithStringLiteralKeyInComprehension]
+from typing import TypedDict
+Data = TypedDict('Data', {'field1': int, 'field2': str, 'field3': str})
+data: Data
+def is_str(value: object) -> bool: ...
+filtered_keys1 = [data[key] for key in ("field1", "field2", "field3")]
+filtered_keys2 = [key for key in ("field1", "field2", "field3") if is_str(data[key])]
+reveal_type(filtered_keys1)    # N: Revealed type is "builtins.list[builtins.int | builtins.str]"
+reveal_type(filtered_keys2)    # N: Revealed type is "builtins.list[builtins.str]"
+[builtins fixtures/for.pyi]
+[typing fixtures/typing-full.pyi]
 
 -- Special Method: __setitem__
 


### PR DESCRIPTION
Fixes #19317 

Uses exsiting index narrowing in for-loop. Previous PR: https://github.com/python/mypy/pull/18014