### PR TITLE
Fix crash on deferred generic class nested in function

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1156,7 +1156,8 @@ class SemanticAnalyzer(
                         leading_type = fill_typevars(info)
                     if func.is_class or func.name == "__new__":
                         leading_type = self.class_type(leading_type)
-                    func.type = replace_implicit_first_type(functype, leading_type)
+                    if not has_placeholder(leading_type):
+                        func.type = replace_implicit_first_type(functype, leading_type)
                 elif has_self_type and isinstance(func.unanalyzed_type, CallableType):
                     if not isinstance(get_proper_type(func.unanalyzed_type.arg_types[0]), AnyType):
                         if self.is_expected_self_type(

--- a/test-data/unit/check-newsemanal.test
+++ b/test-data/unit/check-newsemanal.test
@@ -3228,3 +3228,16 @@ def deco(fn: Callable[[], T]) -> Callable[[], T]: ...
 
 @deco
 def defer() -> int: ...
+
+[case testNestedClassSelfNoPlaceholder]
+from typing import Generic, TypeVar
+
+def test() -> None:
+    T = TypeVar("T", bound="Model")
+
+    class Query(Generic[T]):
+        def filter(self, value: T) -> None:
+            ...
+
+    class Model:
+        pass


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/21550

Fix is straightforward: do what we do in similar cases elsewhere -- do not store type until it has no placeholders. I am quite sure we don't need to defer in this case, as the only way this can happen is when the enclosing class will call `defer()` anyway.
