### PR TITLE
[mypyc] Use `method_sig` to get the method signature

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -862,9 +862,7 @@ def create_ne_from_eq(builder: IRBuilder, cdef: ClassDef) -> None:
 
 def gen_glue_ne_method(builder: IRBuilder, cls: ClassIR, line: int) -> None:
     """Generate a "__ne__" method from a "__eq__" method."""
-    func_ir = cls.get_method("__eq__")
-    assert func_ir
-    eq_sig = func_ir.decl.sig
+    eq_sig = cls.method_sig("__eq__")
     strict_typing = builder.options.strict_dunders_typing
     with builder.enter_method(cls, "__ne__", eq_sig.ret_type):
         rhs_type = eq_sig.args[0].type if strict_typing else object_rprimitive

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -1710,6 +1710,41 @@ assert sum_range(0) == 0
 assert sum_range(1) == 0
 assert sum_range(5) == 10
 
+[case testPackageCycleInheritedEq]
+-- Regression test for generating __ne__ from an inherited __eq__ when the
+-- inherited method's declaration is available before its FuncIR body has been
+-- generated. This can happen in package import cycles where __init__ imports a
+-- child module before the subpackage that defines the base class.
+from other.other_child import Child
+
+def make_child() -> Child:
+    return Child()
+
+[file other/__init__.py]
+from other.other_child import Child as Child
+from other.other_subpkg import Base as Base
+
+[file other/other_child.py]
+from other.other_subpkg import Base
+
+class Child(Base):
+    pass
+
+[file other/other_subpkg/__init__.py]
+from other.other_subpkg.other_base import Base as Base
+
+[file other/other_subpkg/other_base.py]
+class Base:
+    def __eq__(self, other: object) -> bool:
+        return True
+
+[file driver.py]
+from native import make_child
+left = make_child()
+right = make_child()
+assert left == right
+assert not (left != right)
+
 [case testSeparateCrossGroupInheritedInit]
 -- Under separate=True, a subclass whose __init__ is inherited from a
 -- different group must call the base's CPyPy_ wrapper through the exports


### PR DESCRIPTION
Fixes #21566

`create_ne_from_eq()` checks whether the class has an `__eq__` method using `cls.has_method("__eq__")`, but `gen_glue_ne_method()` then requires `cls.get_method("__eq__")` to return a concrete `FuncIR`.

In this package-cycle case, the inherited method declaration exists, but the concrete `FuncIR` body is not available yet. This makes `cls.has_method("__eq__")` true while `cls.get_method("__eq__")` returns None.
