### PR TITLE
[mypyc] Use `other` arg instead of `self` for RHS type

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -867,7 +867,7 @@ def gen_glue_ne_method(builder: IRBuilder, cls: ClassIR, line: int) -> None:
     eq_sig = func_ir.decl.sig
     strict_typing = builder.options.strict_dunders_typing
     with builder.enter_method(cls, "__ne__", eq_sig.ret_type):
-        rhs_type = eq_sig.args[0].type if strict_typing else object_rprimitive
+        rhs_type = eq_sig.args[1].type if strict_typing else object_rprimitive
         rhs_arg = builder.add_argument("rhs", rhs_type)
         eqval = builder.add(MethodCall(builder.self(), "__eq__", [rhs_arg], line))
 

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -867,7 +867,7 @@ def gen_glue_ne_method(builder: IRBuilder, cls: ClassIR, line: int) -> None:
     eq_sig = func_ir.decl.sig
     strict_typing = builder.options.strict_dunders_typing
     with builder.enter_method(cls, "__ne__", eq_sig.ret_type):
-        rhs_type = eq_sig.args[1].type if strict_typing else object_rprimitive
+        rhs_type = eq_sig.args[1].type
         rhs_arg = builder.add_argument("rhs", rhs_type)
         eqval = builder.add(MethodCall(builder.self(), "__eq__", [rhs_arg], line))
 

--- a/mypyc/test-data/run-dunders.test
+++ b/mypyc/test-data/run-dunders.test
@@ -1009,3 +1009,15 @@ def test_equality_with_implicit_ne() -> None:
     assert not eq(Eq(1), Eq(2))
     assert ne(Eq(1), Eq(2))
     assert not ne(Eq(1), Eq(1))
+
+[case testDundersImplicitNeWithNarrowRhs]
+class Accepted:
+    pass
+
+class Eq:
+    def __eq__(self, other: Accepted) -> bool:  # type: ignore[override]
+        return True
+
+def test_implicit_ne_with_narrow_rhs() -> None:
+    assert Eq() == Accepted()
+    assert not (Eq() != Accepted())


### PR DESCRIPTION
Fixes #21568 

In `gen_glue_ne_method`, mypyc currently chooses the generated RHS argument type like this when strict dunder typing is enabled:

```python
rhs_type = eq_sig.args[0].type if strict_typing else object_rprimitive
```

However, the `__eq__` signature includes `self`, so `eq_sig.args[0]` is the type of `self`, not the type of `other`.