### PR TITLE
stubtest: don't flag __class_getitem__ as missing on a generic stub

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -707,6 +707,16 @@ def verify_typeinfo(
             mangled_entry = f"_{stub.name.lstrip('_')}{entry}"
         stub_to_verify = next((t.names[entry].node for t in stub.mro if entry in t.names), MISSING)
         assert stub_to_verify is not None
+        # A generic class is subscriptable at the type level via its type
+        # parameters; a runtime `__class_getitem__` is just the implementation
+        # detail backing that. Don't report it as missing from a stub that
+        # already declares the class as generic. See #21253.
+        if (
+            entry == "__class_getitem__"
+            and isinstance(stub_to_verify, Missing)
+            and stub.is_generic()
+        ):
+            continue
         try:
             try:
                 runtime_attr = getattr(runtime, mangled_entry)

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -293,6 +293,33 @@ class StubtestUnit(unittest.TestCase):
         )
 
     @collect_cases
+    def test_class_getitem_on_generic(self) -> Iterator[Case]:
+        # A runtime `__class_getitem__` backs subscriptability that a stub
+        # expresses via generic type parameters, so it should not be reported
+        # as missing from a generic stub. See #21253.
+        yield Case(
+            stub="""
+            from typing import Generic, TypeVar
+            _T = TypeVar("_T")
+            class GenericClassGetItem(Generic[_T]): ...
+            """,
+            runtime="""
+            class GenericClassGetItem:
+                def __class_getitem__(cls, item, /): return cls
+            """,
+            error=None,
+        )
+        # But a non-generic stub should still flag the extra runtime method.
+        yield Case(
+            stub="class PlainClassGetItem: ...",
+            runtime="""
+            class PlainClassGetItem:
+                def __class_getitem__(cls, item, /): return cls
+            """,
+            error="PlainClassGetItem.__class_getitem__",
+        )
+
+    @collect_cases
     def test_types(self) -> Iterator[Case]:
         yield Case(
             stub="def mistyped_class() -> None: ...",


### PR DESCRIPTION
Fixes #21253

A class that implements `__class_getitem__` at runtime (to make itself subscriptable) is correctly modelled in a stub by declaring the class as **generic** — either with PEP 695 syntax (`class C[T]`) or `Generic[T]`. stubtest, however, reported a false positive in that case:

```
error: C.__class_getitem__ is not present in stub
```

`verify_typeinfo` iterates the runtime class members and, finding `__class_getitem__` on the runtime class with no counterpart in the (generic) stub, flagged it as missing.

### Change

In `verify_typeinfo`, skip the `__class_getitem__` runtime member when the stub class is generic (`TypeInfo.is_generic()`) and does not explicitly declare it — the generic type parameters already express that subscriptability at the type level. A non-generic stub that omits a runtime `__class_getitem__` is still reported as before, so the change only suppresses the false positive.

### Testing

- Added `test_class_getitem_on_generic` in `mypy/test/teststubtest.py` with two cases:
  - generic stub (`Generic[T]`) + runtime `__class_getitem__` → **no error**;
  - non-generic stub + runtime `__class_getitem__` → still reports `__class_getitem__ is not present in stub`.
- Verified the new test **fails without** the `stubtest.py` change and **passes with** it.
- Full `mypy/test/teststubtest.py` suite passes (68 tests), no regressions.
- `black`, `ruff`, and mypy self-check on `mypy/stubtest.py` are clean.

> (I used the `Generic[T]` form in the test rather than PEP 695 `class C[T]` so the stub parses on all supported Python versions; the fix covers both, since both make `TypeInfo.is_generic()` true.)

<sub>Disclosure: drafted with Claude Code; reviewed, understood, and tested locally.</sub>
