### PR TITLE
Update TypedDictType.__init__ signature to preserve backward compat

### DIFF
--- a/mypy/copytype.py
+++ b/mypy/copytype.py
@@ -107,7 +107,10 @@ class TypeShallowCopier(TypeVisitor[ProperType]):
 
     def visit_typeddict_type(self, t: TypedDictType) -> ProperType:
         return self.copy_common(
-            t, TypedDictType(t.items, t.required_keys, t.readonly_keys, t.is_closed, t.fallback)
+            t,
+            TypedDictType(
+                t.items, t.required_keys, t.readonly_keys, t.fallback, is_closed=t.is_closed
+            ),
         )
 
     def visit_literal_type(self, t: LiteralType) -> ProperType:

--- a/mypy/expandtype.py
+++ b/mypy/expandtype.py
@@ -350,7 +350,7 @@ class ExpandTypeVisitor(TrivialSyntheticTypeTranslator):
             return Instance(dict_type.type, [dict_type.args[0], extra_items])
         # TODO: when PEP 728 `extra_items` is implemented, pass extra_items below.
         is_closed = extra_items is None
-        return TypedDictType(kwargs, required_names, set(), is_closed, fallback=dict_type)
+        return TypedDictType(kwargs, required_names, set(), dict_type, is_closed=is_closed)
 
     def visit_type_var_tuple(self, t: TypeVarTupleType) -> Type:
         # Sometimes solver may need to expand a type variable with (a copy of) itself

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -277,7 +277,7 @@ def expr_to_unanalyzed_type(
                 value, options, allow_new_syntax, expr, lookup_qualified=lookup_qualified
             )
         result = TypedDictType(
-            items, set(), set(), False, Instance(MISSING_FALLBACK, ()), expr.line, expr.column
+            items, set(), set(), Instance(MISSING_FALLBACK, ()), expr.line, expr.column
         )
         result.extra_items_from = extra_items_from
         return result

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -2143,7 +2143,7 @@ class TypeConverter:
                     continue
                 return self.invalid_type(n)
             items[item_name.value] = self.visit(value)
-        result = TypedDictType(items, set(), set(), False, _dummy_fallback, n.lineno, n.col_offset)
+        result = TypedDictType(items, set(), set(), _dummy_fallback, n.lineno, n.col_offset)
         result.extra_items_from = extra_items_from
         return result
 

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -663,7 +663,9 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
 
             fallback = self.s.create_anonymous_fallback()
             is_closed = self.s.is_closed and t.is_closed
-            return TypedDictType(items, required_keys, readonly_keys, is_closed, fallback)
+            return TypedDictType(
+                items, required_keys, readonly_keys, fallback, is_closed=is_closed
+            )
         elif isinstance(self.s, Instance):
             return join_types(self.s, t.fallback)
         else:

--- a/mypy/meet.py
+++ b/mypy/meet.py
@@ -1186,7 +1186,9 @@ class TypeMeetVisitor(TypeVisitor[ProperType]):
 
             fallback = self.s.create_anonymous_fallback()
             required_keys = self.s.required_keys | t.required_keys
-            return TypedDictType(items, required_keys, readonly_keys, is_closed, fallback)
+            return TypedDictType(
+                items, required_keys, readonly_keys, fallback, is_closed=is_closed
+            )
         elif isinstance(self.s, Instance) and is_subtype(t, self.s):
             return t
         else:

--- a/mypy/nativeparse.py
+++ b/mypy/nativeparse.py
@@ -926,7 +926,7 @@ def read_type(state: State, data: ReadBuffer) -> Type:
                 extra_items_from.append(val)
             else:
                 td_items[key] = val
-        typeddict_type = TypedDictType(td_items, set(), set(), False, _dummy_fallback)
+        typeddict_type = TypedDictType(td_items, set(), set(), _dummy_fallback)
         typeddict_type.extra_items_from = extra_items_from
         read_loc(data, typeddict_type)
         expect_end_tag(data)

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -785,7 +785,7 @@ class TypedDictAnalyzer:
         assert fallback is not None
         info = existing_info or self.api.basic_new_typeinfo(name, fallback, line)
         typeddict_type = TypedDictType(
-            item_types, required_keys, readonly_keys, is_closed, fallback
+            item_types, required_keys, readonly_keys, fallback, is_closed=is_closed
         )
         any_placeholder = has_placeholder(typeddict_type)
         if typeddict_data:

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -39,6 +39,7 @@ from mypy.types import (
     ProperType,
     TupleType,
     Type,
+    TypedDictType,
     TypeOfAny,
     TypeType,
     TypeVarId,
@@ -222,6 +223,22 @@ class TypesSuite(Suite):
         A.accept(visitor)
         modules = visitor.modules
         assert modules == {"__main__", "builtins"}
+
+    def test_typeddict_type_constructor_signature(self) -> None:
+        typ = TypedDictType({"x": self.fx.o}, {"x"}, set(), self.fx.a, 10, 20)
+
+        assert typ.fallback is self.fx.a
+        assert_equal(typ.line, 10)
+        assert_equal(typ.column, 20)
+        assert not typ.is_closed
+
+        closed = TypedDictType({"x": self.fx.o}, {"x"}, set(), self.fx.a, is_closed=True)
+        assert closed.is_closed
+
+        with self.assertRaises(TypeError):
+            TypedDictType(  # type: ignore[call-arg]
+                {"x": self.fx.o}, {"x"}, set(), self.fx.a, 10, 20, True
+            )
 
 
 class TypeOpsSuite(Suite):

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -236,7 +236,7 @@ class TypesSuite(Suite):
         assert closed.is_closed
 
         with self.assertRaises(TypeError):
-            TypedDictType(  # type: ignore[call-arg]
+            TypedDictType(  # type: ignore[misc]
                 {"x": self.fx.o}, {"x"}, set(), self.fx.a, 10, 20, True
             )
 

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -284,11 +284,11 @@ class TypeTranslator(TypeVisitor[Type]):
             items,
             t.required_keys,
             t.readonly_keys,
-            t.is_closed,
             # TODO: This appears to be unsafe.
             cast(Any, t.fallback.accept(self)),
             t.line,
             t.column,
+            is_closed=t.is_closed,
         )
         self.set_cached(t, result)
         return result

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1416,7 +1416,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             fallback = t.fallback
             is_closed = t.is_closed
         return TypedDictType(
-            items, required_keys, readonly_keys, is_closed, fallback, t.line, t.column
+            items, required_keys, readonly_keys, fallback, t.line, t.column, is_closed=is_closed
         )
 
     def visit_raw_expression_type(self, t: RawExpressionType) -> Type:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3048,10 +3048,11 @@ class TypedDictType(ProperType):
         items: dict[str, Type],
         required_keys: set[str],
         readonly_keys: set[str],
-        is_closed: bool,
         fallback: Instance,
         line: int = -1,
         column: int = -1,
+        *,
+        is_closed: bool = False,
     ) -> None:
         super().__init__(line, column)
         self.items = items
@@ -3112,8 +3113,8 @@ class TypedDictType(ProperType):
             {n: deserialize_type(t) for (n, t) in data["items"]},
             set(data["required_keys"]),
             set(data["readonly_keys"]),
-            bool(data["is_closed"]),
             Instance.deserialize(data["fallback"]),
+            is_closed=bool(data["is_closed"]),
         )
 
     def write(self, data: WriteBuffer) -> None:
@@ -3133,8 +3134,8 @@ class TypedDictType(ProperType):
             read_type_map(data),
             set(read_str_list(data)),
             set(read_str_list(data)),
-            read_bool(data),
             fallback,
+            is_closed=read_bool(data),
         )
         assert read_tag(data) == END_TAG
         return ret
@@ -3178,7 +3179,13 @@ class TypedDictType(ProperType):
             items = {k: v for (k, v) in items.items() if k in item_names}
             required_keys &= set(item_names)
         return TypedDictType(
-            items, required_keys, readonly_keys, is_closed, fallback, self.line, self.column
+            items,
+            required_keys,
+            readonly_keys,
+            fallback,
+            self.line,
+            self.column,
+            is_closed=is_closed,
         )
 
     def zip(self, right: TypedDictType) -> Iterable[tuple[str, Type, Type]]:


### PR DESCRIPTION
The new signature added a new parameter in the middle of the signature,
which may break plugins. Add the new parameter to the end of the parameter 
list with a default value so that existing calls will continue to work. This looks 
a bit ugly, but backward compatibility is the priority here.