### PR TITLE
Add support for TypeForm in incremental mode

### DIFF
--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3688,11 +3688,12 @@ class TypeType(ProperType):
     def write(self, data: WriteBuffer) -> None:
         write_tag(data, TYPE_TYPE)
         self.item.write(data)
+        write_bool(data, self.is_type_form)
         write_tag(data, END_TAG)
 
     @classmethod
     def read(cls, data: ReadBuffer) -> Type:
-        ret = TypeType.make_normalized(read_type(data))
+        ret = TypeType.make_normalized(read_type(data), is_type_form=read_bool(data))
         assert read_tag(data) == END_TAG
         return ret
 

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -8116,3 +8116,26 @@ tmp/m.py:5: note: Revealed type is "builtins.str"
 tmp/m.py:4: note: Revealed type is "def () -> builtins.int"
 tmp/m.py:5: error: Incompatible types in assignment (expression has type "type[A]", variable has type "int")
 tmp/m.py:6: note: Revealed type is "builtins.str"
+
+[case testTypeFormWorksInIncrementalMode]
+import b
+[file a.py]
+from typing import TypeVar
+from typing_extensions import TypeForm
+
+T = TypeVar("T")
+def test(arg: TypeForm[T]) -> T: ...
+
+[file b.py]
+from a import test
+test("int")
+
+[file b.py.2]
+from a import test
+reveal_type(test("int"))
+
+[builtins fixtures/primitives.pyi]
+[typing fixtures/typing-full.pyi]
+[out]
+[out2]
+tmp/b.py:2: note: Revealed type is "builtins.int"


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/21587

Fix is trivial. It looks like we didn't have any incremental tests for `TypeForm`.
