### PR TITLE
Fix overload ambiguity returning Any when one overload returns Never

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3092,6 +3092,20 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                 self.chk.store_types(type_maps[0])
                 return erase_type(return_types[0]), erase_type(inferred_types[0])
             else:
+                # If exactly one match returns Never (uninhabited, non-ambiguous), it is the
+                # most specific result possible and there is no real ambiguity: Never is a
+                # subtype of every type, so the overload that returns Never is always the
+                # most precise answer regardless of which overload would otherwise be chosen.
+                never_indices = [
+                    i
+                    for i, t in enumerate(return_types)
+                    if isinstance(get_proper_type(t), UninhabitedType)
+                    and not get_proper_type(t).ambiguous  # type: ignore[union-attr]
+                ]
+                if len(never_indices) == 1:
+                    idx = never_indices[0]
+                    self.chk.store_types(type_maps[idx])
+                    return return_types[idx], inferred_types[idx]
                 return self.check_call(
                     callee=AnyType(TypeOfAny.special_form),
                     args=args,

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -1906,6 +1906,35 @@ a: Any
 reveal_type(f(a))     # N: Revealed type is "def (*Any, **Any) -> Any"
 reveal_type(f(a)(a))  # N: Revealed type is "Any"
 
+[case testOverloadWithOverlappingItemsAndAnyArgumentNeverReturn]
+# Regression test for https://github.com/python/mypy/issues/21027
+# When one overload returns Never, it is always the most specific result and
+# should be chosen even when an argument contains Any that would otherwise
+# cause overload ambiguity.
+from typing import Any, Generic, Never, TypeVar, overload
+
+T = TypeVar('T')
+
+@overload
+def f(x: int) -> Never: ...
+@overload
+def f(x: str) -> int: ...
+def f(x): ...
+
+def test_plain(a: Any) -> None:
+    reveal_type(f(a))  # N: Revealed type is "Never"
+
+T2 = TypeVar('T2')
+class A(Generic[T2]):
+    @overload
+    def g(self, x: int) -> Never: ...
+    @overload
+    def g(self, x: str) -> T2: ...
+    def g(self, x): ...
+
+def test_generic(obj: A[Any], a: Any) -> None:
+    reveal_type(obj.g(a))  # N: Revealed type is "Never"
+
 [case testOverloadOnOverloadWithType]
 from typing import Any, Type, TypeVar, overload
 from mod import MyInt


### PR DESCRIPTION
Fixes #21027.

When checking an overloaded call where the argument has type `Any`, mypy collects all matching overloads and checks whether the `Any` causes ambiguity. If it does and the return types differ, mypy falls back to `Any`. This is the right behavior in general, but it is wrong when one of the matching overloads returns `Never`.

`Never` is a subtype of every type. An overload returning `Never` is always the most specific result possible. If exactly one overload in the ambiguous set returns `Never`, there is no actual ambiguity to resolve: the `Never` overload is the right answer regardless of which overload would have been selected at runtime.

The bug was visible with `iter()` on generic classes that have both `__iter__` (returning `Never`) and `__getitem__`. The `iter()` builtin has two relevant overloads: one matching `SupportsIter` (uses `__iter__`) and one matching `_GetItemIterable` (uses `__getitem__`). When the class had an `Any` type argument, both overloads matched, ambiguity was detected, and `iter(x)` returned `Any` instead of `Never`.

Calling `x.__iter__()` directly returned `Never` correctly; only `iter(x)` was broken.

Before this fix:

```python
from typing import Any, Generic, Never, TypeVar, reveal_type

T1 = TypeVar("T1")
T2 = TypeVar("T2", bound=object)

class C(Generic[T1, T2]):
    def __getitem__(self, key: int) -> T2: ...
    def __iter__(self) -> Never: ...

def test(x: C[Any, str]) -> None:
    reveal_type(x.__iter__())  # Never
    reveal_type(iter(x))       # Any  <-- wrong
```

After this fix:

```python
    reveal_type(iter(x))       # Never  <-- correct
```

The fix is in `infer_overload_return_type` in `mypy/checkexpr.py`. After detecting Any-caused ambiguity, before falling back to `Any`, it checks whether exactly one of the matching overloads returns `Never`. If so, it returns that overload's result instead.