### PR TITLE
Reduce TypeForm recognition slowdown: 2 identifier fast-reject filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ test_capi
 test_capi
 /mypyc/lib-rt/build/
 /mypyc/lib-rt/*.so
+
+# perf_compare.py --cache-binaries cache
+/misc/perf_compare/

--- a/misc/analyze_typeform_full_parse_profile.py
+++ b/misc/analyze_typeform_full_parse_profile.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Aggregate the full-parse profile log produced by mypy's
+SemanticAnalyzer.try_parse_as_type_expression() when run with
+MYPY_TYPEFORM_PROFILE_FULL_PARSE set.
+
+Usage:
+    # 1. Run mypy with the profile env var set; per-PID log files are
+    #    written as "<path>.<pid>":
+    MYPY_TYPEFORM_PROFILE_FULL_PARSE=/tmp/tf.log \\
+        python3 -m mypy --no-incremental -p your_package
+
+    # 2. Aggregate one or more per-PID files:
+    python3 misc/analyze_typeform_full_parse_profile.py /tmp/tf.log.*
+
+    # Optional: limit per-descriptor breakdown to top N rows per class.
+    python3 misc/analyze_typeform_full_parse_profile.py --top 20 /tmp/tf.log.*
+
+The script summarizes which (outcome, kind, subkind) classes account for
+the most full-parse time, and lists the top descriptors within each
+FAIL class -- the populations worth targeting with cheaper pre-filters
+upstream in try_parse_as_type_expression.
+
+See also:
+    - mypy/semanal.py: SemanticAnalyzer.try_parse_as_type_expression()
+    - mypy/semanal.py: _log_typeform_full_parse() (TSV schema docstring)
+    - misc/analyze_typeform_stats.py (aggregate counters via --dump-build-stats)
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+from collections import defaultdict
+from collections.abc import Iterable
+
+
+def read_rows(paths: Iterable[str]) -> list[tuple[str, str, str, str, int]]:
+    rows: list[tuple[str, str, str, str, int]] = []
+    for path in paths:
+        with open(path) as f:
+            for line in f:
+                # Skip header lines (each per-PID file starts with one).
+                if line.startswith("outcome\t"):
+                    continue
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) < 5:
+                    continue
+                outcome, kind, subkind, desc, dur_ns_str = parts[:5]
+                try:
+                    dur_ns = int(dur_ns_str)
+                except ValueError:
+                    continue
+                rows.append((outcome, kind, subkind, desc, dur_ns))
+    return rows
+
+
+def print_class_summary(rows: list[tuple[str, str, str, str, int]]) -> None:
+    buckets: dict[tuple[str, str, str], list[int]] = defaultdict(list)
+    total_ns = 0
+    for outcome, kind, subkind, _desc, dur_ns in rows:
+        buckets[(outcome, kind, subkind)].append(dur_ns)
+        total_ns += dur_ns
+
+    print("Class summary (by total time):")
+    print("=" * 80)
+    print(f"{'count':>7} {'total_ms':>10} {'mean_us':>9} {'med_us':>9} {'pct':>6}  class")
+    print("-" * 80)
+    ordered = sorted(
+        (
+            (sum(d), len(d), statistics.mean(d), statistics.median(d), key)
+            for key, d in buckets.items()
+        ),
+        reverse=True,
+    )
+    for total, n, mean, med, key in ordered:
+        pct = (100 * total / total_ns) if total_ns else 0
+        outcome, kind, subkind = key
+        print(
+            f"{n:>7} {total/1e6:>10.2f} {mean/1e3:>9.1f} {med/1e3:>9.1f} "
+            f"{pct:>5.1f}%  {outcome} {kind} {subkind}"
+        )
+    print("-" * 80)
+    print(f"TOTAL: {len(rows):,} events, {total_ns/1e6:.2f} ms")
+
+
+def print_fail_descriptors(rows: list[tuple[str, str, str, str, int]], top_n: int) -> None:
+    # Group FAIL rows by (kind, subkind) class, then by descriptor within each.
+    by_class: dict[tuple[str, str, str], dict[str, list[int]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for outcome, kind, subkind, desc, dur_ns in rows:
+        if outcome != "FAIL":
+            continue
+        by_class[(outcome, kind, subkind)][desc].append(dur_ns)
+
+    # Order classes by total FAIL time, descending.
+    class_totals = sorted(
+        ((sum(sum(d) for d in descs.values()), key, descs) for key, descs in by_class.items()),
+        reverse=True,
+    )
+    for total_ns, key, descs in class_totals:
+        outcome, kind, subkind = key
+        print()
+        print(
+            f"Top {top_n} descriptors in {outcome} {kind} {subkind} "
+            f"(class total {total_ns/1e6:.2f} ms):"
+        )
+        print("-" * 80)
+        print(f"{'count':>6} {'total_ms':>10} {'mean_us':>9}  descriptor")
+        rows_d = sorted(
+            ((sum(d), len(d), statistics.mean(d), desc) for desc, d in descs.items()), reverse=True
+        )
+        for tot, n, mean, desc in rows_d[:top_n]:
+            print(f"{n:>6} {tot/1e6:>10.3f} {mean/1e3:>9.1f}  {desc!r}")
+        if len(rows_d) > top_n:
+            print(f"... {len(rows_d) - top_n} more descriptors")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__
+    )
+    parser.add_argument(
+        "files", nargs="+", help="One or more per-PID profile files (e.g. /tmp/tf.log.*)"
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=20,
+        help="Max number of descriptors to list per FAIL class (default: 20)",
+    )
+    args = parser.parse_args()
+
+    rows = read_rows(args.files)
+    if not rows:
+        print("No data rows found in input files.", file=sys.stderr)
+        sys.exit(1)
+
+    print_class_summary(rows)
+    print_fail_descriptors(rows, args.top)
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/analyze_typeform_stats.py
+++ b/misc/analyze_typeform_stats.py
@@ -26,7 +26,6 @@ Example output:
 
 See also:
     - mypy/semanal.py: SemanticAnalyzer.try_parse_as_type_expression()
-    - mypy/semanal.py: DEBUG_TYPE_EXPRESSION_FULL_PARSE_FAILURES
 """
 
 import re
@@ -70,6 +69,7 @@ def analyze_stats(output: str) -> None:
         print(
             f"  - Expensive failed full parses: {failures:,} ({(failures / total * 100):.1f}% of all calls)"
         )
+        print("    - Analyze further with misc/analyze_typeform_full_parse_profile.py")
 
 
 if __name__ == "__main__":

--- a/misc/perf_compare.py
+++ b/misc/perf_compare.py
@@ -28,7 +28,43 @@ import statistics
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def winsorized_paired_stats(
+    diffs: list[float], *, trim_frac: float = 0.1, conf: float = 0.95
+) -> dict[str, float]:
+    """Robust summary of a list of per-round paired differences.
+
+    Point estimate: trimmed mean (drop ``trim_frac`` of values from each end), so a
+    single outlier round cannot drag the estimate.
+
+    Error bar: the Tukey-McLaughlin standard error of the trimmed mean, built from the
+    *Winsorized* variance. The tails are clamped to the boundary kept-value rather than
+    deleted -- deleting them and taking the ordinary variance of the survivors would
+    understate the error bar (it would measure only how calm the middle is, discarding
+    the fact that the tails were wild). The ``(1 - 2*trim_frac)`` divisor rescales for
+    the compression Winsorizing introduces.
+
+    Returns trimmed-mean estimate, median, the 95% CI half-width, and the kept count.
+    A normal-approx critical value is used (fine for the n>=~30 runs this is used with).
+    """
+    n = len(diffs)
+    s = sorted(diffs)
+    g = int(n * trim_frac)  # number trimmed from each end
+    median = statistics.median(s)
+    if n < 2 or n - 2 * g < 2:
+        est = statistics.mean(s)
+        return {"est": est, "median": median, "ci": 0.0, "kept": float(n)}
+    kept = s[g : n - g]
+    est = statistics.mean(kept)
+    # Winsorize: clamp the g smallest up to kept[0], the g largest down to kept[-1].
+    wins = [kept[0]] * g + kept + [kept[-1]] * g
+    wvar = statistics.variance(wins)  # sample Winsorized variance (df = n-1)
+    se = (wvar**0.5) / ((1 - 2 * trim_frac) * (n**0.5))
+    z = statistics.NormalDist().inv_cdf(0.5 + conf / 2)
+    return {"est": est, "median": median, "ci": z * se, "kept": float(len(kept))}
 
 
 def heading(s: str) -> None:
@@ -81,7 +117,14 @@ def edit_python_file(fnam: str) -> None:
 
 
 def run_benchmark(
-    compiled_dir: str, check_dir: str, *, incremental: bool, code: str | None, foreign: bool | None
+    compiled_dir: str,
+    check_dir: str,
+    *,
+    incremental: bool,
+    code: str | None,
+    foreign: bool | None,
+    metric: str = "wall",
+    workers1: bool = False,
 ) -> float:
     cache_dir = os.path.join(compiled_dir, ".mypy_cache")
     if os.path.isdir(cache_dir) and not incremental:
@@ -89,6 +132,8 @@ def run_benchmark(
     env = os.environ.copy()
     env["PYTHONPATH"] = os.path.abspath(compiled_dir)
     env["PYTHONHASHSEED"] = "1"
+    if workers1:
+        env["MYPY_NUM_WORKERS"] = "1"
     abschk = os.path.abspath(check_dir)
     cmd = [sys.executable, "-m", "mypy"]
     if code:
@@ -103,13 +148,42 @@ def run_benchmark(
             # Update a few files to force non-trivial incremental run
             edit_python_file(os.path.join(abschk, "mypy/__main__.py"))
             edit_python_file(os.path.join(abschk, "mypy/test/testcheck.py"))
-    t0 = time.time()
-    # Ignore errors, since some commits being measured may generate additional errors.
-    if foreign:
-        subprocess.run(cmd, cwd=check_dir, env=env)
+
+    def run() -> None:
+        # Ignore errors, since some commits being measured may generate additional errors.
+        if foreign:
+            subprocess.run(cmd, cwd=check_dir, env=env)
+        else:
+            subprocess.run(cmd, cwd=compiled_dir, env=env)
+
+    if metric == "wall":
+        stopwatch_func_w: Callable[[], float] = lambda: time.time()
+        delta_func_w: Callable[[float, float], float] = lambda t0, t1: t1 - t0
+
+        v0_w = stopwatch_func_w()  # capture
+        run()
+        v1_w = stopwatch_func_w()  # capture
+        return delta_func_w(v0_w, v1_w)
+    elif metric == "cpu":
+        if sys.platform == "win32":
+            raise NotImplementedError("--metric cpu is not implemented on Windows")
+        else:
+            import resource
+            from resource import struct_rusage as rusage
+
+            stopwatch_func_c: Callable[[], rusage] = lambda: resource.getrusage(
+                resource.RUSAGE_CHILDREN
+            )
+            delta_func_c: Callable[[rusage, rusage], float] = lambda r0, r1: (
+                r1.ru_utime - r0.ru_utime
+            ) + (r1.ru_stime - r0.ru_stime)
+
+            v0_c = stopwatch_func_c()  # capture
+            run()
+            v1_c = stopwatch_func_c()  # capture
+            return delta_func_c(v0_c, v1_c)
     else:
-        subprocess.run(cmd, cwd=compiled_dir, env=env)
-    return time.time() - t0
+        raise AssertionError(f"Unrecognized metric: {metric!r}")
 
 
 def main() -> None:
@@ -146,6 +220,41 @@ def main() -> None:
         help="set number of measurements to perform (default=15)",
     )
     parser.add_argument(
+        "--warmup-runs",
+        metavar="N",
+        default=1,
+        type=int,
+        help="set number of leading warmup runs to discard (default=1)",
+    )
+    parser.add_argument(
+        "--cache-binaries",
+        default=False,
+        action="store_true",
+        help="cache each commit's compiled clone under "
+        + "<script_dir>/perf_compare/binaries/<commit> and restore from there on later runs, "
+        + "skipping the ~5-min clone+compile. Off by default so it doesn't silently consume "
+        + "disk. Caveat: the cache is keyed by the commit string you pass, so reuse stable SHAs "
+        + "(a moving ref like a branch name or HEAD can serve a stale build -- delete the cache "
+        + "dir if in doubt).",
+    )
+    parser.add_argument(
+        "--metric",
+        choices=["wall", "cpu"],
+        default="wall",
+        help="quantity to measure per run: 'wall' (wall-clock, default) or 'cpu' (user+sys "
+        + "CPU time of the type-check process). 'cpu' is much less sensitive to background "
+        + "interference and scheduling, so it tightens the per-run distribution.",
+    )
+    parser.add_argument(
+        "--workers1",
+        default=False,
+        action="store_true",
+        help="run selfcheck with a single mypy worker (MYPY_NUM_WORKERS=1) to "
+        + "decrease variance in measurements. "
+        + "Strongly recommended when --metric=cpu. "
+        + "When omitted, uses mypy's default worker count.",
+    )
+    parser.add_argument(
         "-j",
         metavar="N",
         default=4,
@@ -178,20 +287,39 @@ def main() -> None:
     dont_setup: bool = args.dont_setup
     multi_file: bool = args.multi_file
     commits = args.commit
-    num_runs: int = args.num_runs + 1
+    baseline_commit: str = commits[0]
+    warmup_runs: int = args.warmup_runs
+    measurement_runs: int = args.num_runs
+    num_runs: int = measurement_runs + warmup_runs
     max_workers: int = args.j
     code: str | None = args.c
     foreign_repo: str | None = args.r
+    metric: str = args.metric
+    workers1: bool = args.workers1
+    cache_binaries: bool = args.cache_binaries
 
     if not (os.path.isdir(".git") and os.path.isdir("mypyc")):
         sys.exit("error: You must run this script from the mypy repo root")
 
+    archive_root = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "perf_compare", "binaries"
+    )
+
     target_dirs = []
+    dirs_to_compile = []
     for i, commit in enumerate(commits):
         target_dir = f"mypy.{i}.tmpdir"
         target_dirs.append(target_dir)
         if not dont_setup:
-            clone(target_dir, commit)
+            archive = os.path.join(archive_root, commit)
+            if cache_binaries and os.path.isdir(archive):
+                print(f"restore: copying {archive} -> {target_dir} (skipping clone+compile)")
+                if os.path.isdir(target_dir):
+                    shutil.rmtree(target_dir)
+                shutil.copytree(archive, target_dir, symlinks=True)
+            else:
+                clone(target_dir, commit)
+                dirs_to_compile.append(target_dir)
 
     if foreign_repo:
         check_dir = "mypy.foreign.tmpdir"
@@ -202,27 +330,32 @@ def main() -> None:
         if not dont_setup:
             clone(check_dir, commits[0])
 
-    if not dont_setup:
+    if not dont_setup and dirs_to_compile:
         heading("Compiling mypy")
         print("(This will take a while...)")
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [
-                executor.submit(build_mypy, target_dir, multi_file) for target_dir in target_dirs
+                executor.submit(build_mypy, target_dir, multi_file)
+                for target_dir in dirs_to_compile
             ]
             for future in as_completed(futures):
                 future.result()
 
-        print(f"Finished compiling mypy ({len(commits)} builds)")
+        print(f"Finished compiling mypy ({len(dirs_to_compile)} builds)")
+    elif not dont_setup:
+        print("All targets restored from archive; skipping compile step.")
 
-    heading("Performing measurements")
+    workers_desc = "workers: 1" if workers1 else "workers: default"
+    key_options_desc = f"(metric: {metric}-time, {workers_desc})"
+    heading(f"Performing measurements {key_options_desc}")
 
     results: dict[str, list[float]] = {}
     for n in range(num_runs):
-        if n == 0:
-            print("Warmup...")
+        if n < warmup_runs:
+            print(f"Warmup {n + 1}/{warmup_runs}...")
         else:
-            print(f"Run {n}/{num_runs - 1}...")
+            print(f"Run {n - warmup_runs + 1}/{num_runs - warmup_runs}...")
         items = list(enumerate(commits))
         random.shuffle(items)
         for i, commit in items:
@@ -232,26 +365,56 @@ def main() -> None:
                 incremental=incremental,
                 code=code,
                 foreign=bool(foreign_repo),
+                metric=metric,
+                workers1=workers1,
             )
-            # Don't record the first warm-up run
-            if n > 0:
+            # Don't record the leading warm-up runs
+            if n >= warmup_runs:
                 print(f"{commit}: t={tt:.3f}s")
                 results.setdefault(commit, []).append(tt)
 
     print()
-    heading("Results")
-    first = -1.0
+    heading(f"Results {key_options_desc}")
+    first_mean = -1.0
+    first_median = -1.0
     for commit in commits:
-        tt = statistics.mean(results[commit])
+        mean = statistics.mean(results[commit])
+        median = statistics.median(results[commit])
         # pstdev (instead of stdev) is used here primarily to accommodate the case where num_runs=1
         s = statistics.pstdev(results[commit]) if len(results[commit]) > 1 else 0
-        if first < 0:
-            delta = "0.0%"
-            first = tt
+        if first_mean < 0:
+            delta_mean = "0.0%"
+            first_mean = mean
+            delta_median = "0.0%"
+            first_median = median
         else:
-            d = (tt / first) - 1
-            delta = f"{d:+.1%}"
-        print(f"{commit:<25} {tt:.3f}s ({delta}) | stdev {s:.3f}s ")
+            d1 = (mean / first_mean) - 1
+            delta_mean = f"{d1:+.1%}"
+            d2 = (median / first_median) - 1
+            delta_median = f"{d2:+.1%}"
+        print(
+            f"{commit:<25} mean {mean:.3f}s ({delta_mean}) | stdev {s:.3f}s | "
+            f"median {median:.3f}s ({delta_median})"
+        )
+
+    # Paired per-round differences vs the baseline commit. Each round runs every commit
+    # once, so results[commit][k] is round k for every commit -- the differences are
+    # already matched. Differencing cancels round-level common-mode noise (a throttle or
+    # background-process spike that round slows every commit together), which is the bulk
+    # of the variance on a laptop. See winsorized_paired_stats for the robust estimator.
+    base_runs = results[baseline_commit]
+    base_center = statistics.median(base_runs)
+    heading(f"Paired deltas vs {baseline_commit} (per-round diffs; median +/- 95% CI)")
+    for commit in commits:
+        if commit == baseline_commit:
+            print(f"{commit:<25} baseline")
+            continue
+        diffs = [c - b for c, b in zip(results[commit], base_runs)]
+        st = winsorized_paired_stats(diffs)
+        ci_ms = st["ci"] * 1000
+        median_ms = st["median"] * 1000
+        pct = (st["median"] / base_center * 100) if base_center else 0.0
+        print(f"{commit:<25} median {median_ms:+7.1f}ms  +/-{ci_ms:4.1f}  ({pct:+.2f}%)")
 
     t = int(time.time() - whole_program_time_0)
     total_time_taken_formatted = ", ".join(
@@ -263,6 +426,18 @@ def main() -> None:
         "Total time taken by the whole benchmarking program (including any setup):",
         total_time_taken_formatted,
     )
+
+    # Archive compiled clones before cleanup, keyed by commit, so later runs can
+    # restore them instead of recompiling. Skip if destination already exists.
+    if cache_binaries:
+        os.makedirs(archive_root, exist_ok=True)
+        for target_dir, commit in zip(target_dirs, commits):
+            dest = os.path.join(archive_root, commit)
+            if os.path.isdir(dest):
+                print(f"archive: {dest} already exists, skipping")
+            else:
+                print(f"archive: copying {target_dir} -> {dest}")
+                shutil.copytree(target_dir, dest, symlinks=True)
 
     shutil.rmtree(check_dir)
     for target_dir in target_dirs:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8100,13 +8100,13 @@ class SemanticAnalyzer(
                     return
                 else:  # sym is not None
                     node = sym.node  # cache
-                    # The following early-reject checks are mutually exclusive
-                    # (a node is at most one of an unbound type variable, a value
-                    # Var, or a placeholder), so their order never affects which
-                    # expressions are rejected. They are ordered by descending
-                    # rejection frequency (measured on mypy's self-check) so the
-                    # commonest rejections exit first: unbound type variables
-                    # (~951) >> value Vars (~157) > placeholders (~23).
+                    # The following early-reject checks are mutually exclusive,
+                    # ordered by decreasing rejection frequency (measured on
+                    # mypy's self-check) so the commonest rejections exit first.
+                    # - TypeVarExpr, TypeVarTupleExpr, ParamSpecExpr (~951)
+                    # - Var (~157)
+                    # - FuncDef, OverloadedFuncDef, MypyFile (~48)
+                    # - PlaceholderNode (~23)
                     unbound_tvar_or_paramspec = (
                         isinstance(node, (TypeVarExpr, TypeVarTupleExpr, ParamSpecExpr))
                         and self.tvar_scope.get_binding(sym) is None
@@ -8125,6 +8125,10 @@ class SemanticAnalyzer(
                         # Var whose declared type is a concrete instance: it is
                         # a value (local, parameter, module-level constant),
                         # not a type expression.
+                        maybe_type_expr.as_type = None
+                        return
+                    if isinstance(node, (FuncDef, OverloadedFuncDef, MypyFile)):
+                        # Functions and modules are never type expressions.
                         maybe_type_expr.as_type = None
                         return
                     if isinstance(node, PlaceholderNode) and not node.becomes_typeinfo:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8100,12 +8100,13 @@ class SemanticAnalyzer(
                     return
                 else:  # sym is not None
                     node = sym.node  # cache
-                    if isinstance(node, PlaceholderNode) and not node.becomes_typeinfo:
-                        # Either:
-                        # 1. f'Cannot resolve name "{t.name}" (possible cyclic definition)'
-                        # 2. Reference to an unknown placeholder node.
-                        maybe_type_expr.as_type = None
-                        return
+                    # The following early-reject checks are mutually exclusive
+                    # (a node is at most one of an unbound type variable, a value
+                    # Var, or a placeholder), so their order never affects which
+                    # expressions are rejected. They are ordered by descending
+                    # rejection frequency (measured on mypy's self-check) so the
+                    # commonest rejections exit first: unbound type variables
+                    # (~951) >> value Vars (~157) > placeholders (~23).
                     unbound_tvar_or_paramspec = (
                         isinstance(node, (TypeVarExpr, TypeVarTupleExpr, ParamSpecExpr))
                         and self.tvar_scope.get_binding(sym) is None
@@ -8124,6 +8125,12 @@ class SemanticAnalyzer(
                         # Var whose declared type is a concrete instance: it is
                         # a value (local, parameter, module-level constant),
                         # not a type expression.
+                        maybe_type_expr.as_type = None
+                        return
+                    if isinstance(node, PlaceholderNode) and not node.becomes_typeinfo:
+                        # Either:
+                        # 1. f'Cannot resolve name "{t.name}" (possible cyclic definition)'
+                        # 2. Reference to an unknown placeholder node.
                         maybe_type_expr.as_type = None
                         return
             else:  # does not look like an identifier

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8116,6 +8116,16 @@ class SemanticAnalyzer(
                         # 2. unbound_paramspec: f'ParamSpec "{name}" is unbound' [codes.VALID_TYPE]
                         maybe_type_expr.as_type = None
                         return
+                    if (
+                        isinstance(node, Var)
+                        and isinstance(get_proper_type(node.type), Instance)
+                        and not self.var_is_typing_special_form(node)
+                    ):
+                        # Var whose declared type is a concrete instance: it is
+                        # a value (local, parameter, module-level constant),
+                        # not a type expression.
+                        maybe_type_expr.as_type = None
+                        return
             else:  # does not look like an identifier
                 if '"' in str_value or "'" in str_value:
                     # Only valid inside a Literal[...] or Annotated[..., ...] type
@@ -8208,6 +8218,8 @@ class SemanticAnalyzer(
             "typing.Literal",
             "typing_extensions.Literal",
             "typing.Optional",
+            "typing.Self",
+            "typing_extensions.Self",
             "typing.TypeGuard",
             "typing_extensions.TypeGuard",
             "typing.TypeIs",

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -50,10 +50,12 @@ Some important properties:
 
 from __future__ import annotations
 
+import os
 import re
+import time
 from collections.abc import Callable, Collection, Iterable, Iterator
 from contextlib import contextmanager
-from typing import Any, Final, TypeAlias as _TypeAlias, TypeGuard, TypeVar, cast
+from typing import Any, Final, TextIO, TypeAlias as _TypeAlias, TypeGuard, TypeVar, cast
 from typing_extensions import assert_never
 
 from mypy import errorcodes as codes, message_registry
@@ -320,11 +322,18 @@ from mypy.visitor import NodeVisitor
 T = TypeVar("T")
 
 
-# Whether to print diagnostic information for failed full parses
-# in SemanticAnalyzer.try_parse_as_type_expression().
+# Instrumentation: If non-None, every expression that reaches the expensive
+# full-parse block of SemanticAnalyzer.try_parse_as_type_expression()
+# is logged to a .tsv by log_typeform_full_parse().
 #
-# See also: misc/analyze_typeform_stats.py
-DEBUG_TYPE_EXPRESSION_FULL_PARSE_FAILURES: Final = False
+# See also:
+# - misc/analyze_typeform_full_parse_profile.py
+# - misc/analyze_typeform_stats.py
+_TYPEFORM_PROFILE_FULL_PARSE_PATH: Final = os.environ.get("MYPY_TYPEFORM_PROFILE_FULL_PARSE")
+_typeform_full_parse_log_file: TextIO | None = None
+
+# TSV column names for the full-parse profile log
+_TYPEFORM_PROFILE_FULL_PARSE_HEADER = "outcome\tkind\tsubkind\tdescriptor\tdur_ns\n"
 
 
 FUTURE_IMPORTS: Final = {
@@ -8164,6 +8173,9 @@ class SemanticAnalyzer(
         else:
             assert_never(maybe_type_expr)
 
+        full_parse_t0 = (
+            time.perf_counter_ns() if _TYPEFORM_PROFILE_FULL_PARSE_PATH is not None else 0
+        )
         with self.isolated_error_analysis():
             try:
                 t = self.expr_to_analyzed_type(maybe_type_expr)
@@ -8173,17 +8185,6 @@ class SemanticAnalyzer(
                 # Not a type expression
                 t = None
 
-            if DEBUG_TYPE_EXPRESSION_FULL_PARSE_FAILURES and t is None:
-                original_flushed_files = set(self.errors.flushed_files)  # save
-                try:
-                    errors = self.errors.new_messages()  # capture
-                finally:
-                    self.errors.flushed_files = original_flushed_files  # restore
-
-                print(
-                    f"SA.try_parse_as_type_expression: Full parse failure: {maybe_type_expr}, errors={errors!r}"
-                )
-
         # Count full parse attempts for profiling
         if t is not None:
             self.type_expression_full_parse_success_count += 1
@@ -8191,6 +8192,12 @@ class SemanticAnalyzer(
             self.type_expression_full_parse_failure_count += 1
 
         maybe_type_expr.as_type = t
+
+        if _TYPEFORM_PROFILE_FULL_PARSE_PATH is not None:
+            full_parse_t1 = time.perf_counter_ns()
+            self.log_typeform_full_parse(
+                maybe_type_expr, t is not None, full_parse_t1 - full_parse_t0
+            )
 
     @staticmethod
     def var_is_typing_special_form(var: Var) -> bool:
@@ -8207,6 +8214,91 @@ class SemanticAnalyzer(
             "typing_extensions.TypeIs",
             "typing.Union",
         ]
+
+    @staticmethod
+    def log_typeform_full_parse(expr: Expression, ok: bool, dur_ns: int) -> None:
+        """Log one entry into the full-parse block of try_parse_as_type_expression.
+
+        Active only when the MYPY_TYPEFORM_PROFILE_FULL_PARSE environment variable
+        is set to a file path. Each mypy process (worker) writes to its own file
+        named "<path>.<pid>" to avoid contention; concatenating those files yields
+        the complete profile. Aggregate with misc/analyze_typeform_full_parse_profile.py.
+
+        Output is tab-separated with one row per full-parse attempt:
+
+        outcome     "OK" if as_type was set, "FAIL" if the full parse rejected
+                    the expression (either by raising TypeTranslationError or by
+                    emitting errors during analysis).
+        kind        AST node kind: StrExpr | IndexExpr | OpExpr | (other).
+        subkind     For StrExpr: "ident" or "other" (based on whether the
+                    string is a Python identifier). For IndexExpr: "Name" or
+                    "Member" (base kind). For OpExpr: always "|" (no other op
+                    reaches here).
+        descriptor  Short, type-specific identifier for the expression:
+                        StrExpr   -> the string value, truncated to 80 chars
+                                    (with " (N)" suffix when truncated).
+                        IndexExpr -> the full stringified expression (str(expr),
+                                    with tabs/newlines escaped).
+                        OpExpr    -> the full stringified expression (str(expr),
+                                    with tabs/newlines escaped).
+        dur_ns      Wall-clock nanoseconds spent in the full-parse block for
+                    this expression (measured around expr_to_analyzed_type
+                    plus the surrounding isolated_error_analysis ctx).
+
+        The first line of each file is the column header (same as above).
+        """
+        global _typeform_full_parse_log_file
+        if _typeform_full_parse_log_file is None:
+            assert _TYPEFORM_PROFILE_FULL_PARSE_PATH is not None
+            _typeform_full_parse_log_file = open(
+                f"{_TYPEFORM_PROFILE_FULL_PARSE_PATH}.{os.getpid()}", "a", buffering=1
+            )
+            _typeform_full_parse_log_file.write(_TYPEFORM_PROFILE_FULL_PARSE_HEADER)
+        outcome = "OK" if ok else "FAIL"
+        if isinstance(expr, StrExpr):
+            raw = expr.value
+            val = (
+                raw[:80]
+                .replace("\\", "\\\\")
+                .replace("\t", "\\t")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+            )
+            if len(raw) > 80:
+                val += f" ({len(raw)})"
+            if raw.isidentifier():
+                subkind = "ident"
+            else:
+                subkind = "other"
+            line = f"{outcome}\tStrExpr\t{subkind}\t{val}\t{dur_ns}\n"
+        elif isinstance(expr, IndexExpr):
+            base = expr.base
+            if isinstance(base, NameExpr):
+                subkind = "Name"
+            elif isinstance(base, MemberExpr):
+                subkind = "Member"
+            else:
+                subkind = type(base).__name__
+            desc = (
+                str(expr)
+                .replace("\\", "\\\\")
+                .replace("\t", "\\t")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+            )
+            line = f"{outcome}\tIndexExpr\t{subkind}\t{desc}\t{dur_ns}\n"
+        elif isinstance(expr, OpExpr):
+            desc = (
+                str(expr)
+                .replace("\\", "\\\\")
+                .replace("\t", "\\t")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+            )
+            line = f"{outcome}\tOpExpr\t|\t{desc}\t{dur_ns}\n"
+        else:
+            line = f"{outcome}\t{type(expr).__name__}\t\t\t{dur_ns}\n"
+        _typeform_full_parse_log_file.write(line)
 
     @contextmanager
     def isolated_error_analysis(self) -> Iterator[None]:


### PR DESCRIPTION
References #21262.

Includes 2 filters from the original combined 7-filter PR:
* https://github.com/python/mypy/pull/21585

## Summary

Enabling `TypeForm` made `SemanticAnalyzer.try_parse_as_type_expression` run
eagerly on every expression in certain syntactic positions (~2.84M calls per
self-check). <5% of those reach an expensive full-parse block
(`expr_to_analyzed_type` + `isolated_error_analysis`), and ~91% of
*those* fail — pure wasted work.

This PR adds **2 cheap, early-reject filters** for the `StrExpr`-identifier
case, plus a **reordering** of the existing early-reject checks by decreasing 
rejection frequency. Together the two filters **eliminate 8%** of full 
parses (2,548 → 2,343) per self-check.

3 commits, all operating within the `str_value.isidentifier()`
branch of `try_parse_as_type_expression`:

1. **Filter A**: `isinstance(node, Var)` + more conditions
2. **Reorder** the 3 mutually-exclusive isinstance checks by decreasing rejection frequency.
3. **Filter B**: `isinstance(node, (FuncDef, OverloadedFuncDef, MypyFile))`

Looking at the `str_value.isidentifier()` branch alone,
84% (244 → 39) of failing full parses are eliminated per self-check.

## Performance

`misc/perf_compare.py`, single worker, paired per-round deltas.

### CPU time (canonical, lowest-variance) — master vs branch tip, n=100

```
python misc/perf_compare.py --warmup-runs 3 --num-runs 100 -j 3 \
    --metric cpu --workers1 <master> <tip>
```

- n=100: **−7.6 ms ±5.9 (−0.28%)**

Significant (CI excludes 0). This is the **net** effect of the branch.

### Wall-clock — master vs branch tip

```
python misc/perf_compare.py --warmup-runs 3 --num-runs 400 -j 3 <master> <tip>
```

- n=400: **−3.6 ms ±4.3 (−0.26%)**, CI [−7.9, +0.7].

Borderline significant: the CI just barely includes 0. Consistent with a real 
per-call win partly masked by multi-worker wall-clock.

## Correctness

All tests pass.

Note that the `var_is_typing_special_form` helper needed to be extended to
recognize stringified forms of `typing.Self` so that Filter A would not
incorrectly reject a stringified `'Self'` annotation, regressing the
`testSelfRecognizedInOtherSyntacticLocations` test.

## Open Questions

* ~~Should the 2 infrastructure commits be moved to a separate PR?~~ → Done <!-- Branch: f/perfcompare_more_sensitive -->
* ~~The full commit messages (after the subject line) on the 3 key commits
  are rather verbose. Let me know if you'd like me to trim them down,
  perhaps by removing everything after the subject.~~ → Done
