### PR TITLE
Add test coverage for walrus with allow-redefinition

### DIFF
--- a/test-data/unit/check-redefine2.test
+++ b/test-data/unit/check-redefine2.test
@@ -333,6 +333,18 @@ def f3() -> None:
         reveal_type(x) # N: Revealed type is "builtins.int | builtins.str"
     reveal_type(x) # N: Revealed type is "builtins.int | builtins.str"
 
+def f4(x: str | None) -> None:
+    if y := x:
+        reveal_type(y) # N: Revealed type is "builtins.str"
+    y = 1
+    reveal_type(y) # N: Revealed type is "builtins.int"
+
+def f5() -> None:
+    if z := 1:
+        reveal_type(z) # N: Revealed type is "builtins.int"
+    z = "s"
+    reveal_type(z) # N: Revealed type is "builtins.str"
+
 [case testNewRedefineOperatorAssignment]
 # flags: --allow-redefinition
 class D: pass


### PR DESCRIPTION
Summary
- Add regression coverage for assignment expressions used with `--allow-redefinition`.
- Cover variables introduced by walrus expressions and then redefined to a different type.

Reproduction
- Issue #7314 tracks the missing PEP 572 interaction coverage for `--allow-redefinition`.
- The added cases exercise `if y := x:` and `if z := 1:` followed by cross-type redefinition.

Root cause
- Existing tests covered assignment-expression branch merging, but did not cover subsequent redefinition of walrus-introduced variables under `--allow-redefinition`.

Changes
- Extended `testNewRedefineAssignmentExpression` in `test-data/unit/check-redefine2.test` with two focused cases.

Tests
- `.venv/bin/python -m pytest -n0 -q mypy/test/testcheck.py::TypeCheckSuite::check-redefine2.test -k NewRedefineAssignmentExpression`
- `.venv/bin/python -m pytest -n0 -q mypy/test/testcheck.py::TypeCheckSuite::check-redefine2.test`
- `.venv/bin/pre-commit run --files test-data/unit/check-redefine2.test`
- `git diff --check`

Screenshots/Logs
- Not applicable; test-only change.

Disclosure
- I used an LLM assistant while preparing this test-only change and reviewed the diff and test results before submission.