### PR TITLE
Preserve escaped test section markers in update-data

### DIFF
--- a/mypy/test/meta/test_update_data.py
+++ b/mypy/test/meta/test_update_data.py
@@ -72,6 +72,14 @@ class UpdateDataSuite(Suite):
             s1: str = 42  # E: bar
             [file b.py]
             s2: str = 43  # E: baz
+
+            [case testEscapedBracketInFile]
+            # flags: --config-file tmp/mypy.ini
+            s: str = 42  # E: foo
+            [file mypy.ini]
+            \\[mypy]
+            warn_unused_ignores = True
+
             [builtins fixtures/list.pyi]
             """)
 
@@ -126,6 +134,14 @@ class UpdateDataSuite(Suite):
         s1: str = 42  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
         [file b.py]
         s2: str = 43  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+
+        [case testEscapedBracketInFile]
+        # flags: --config-file tmp/mypy.ini
+        s: str = 42  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
+        [file mypy.ini]
+        \\[mypy]
+        warn_unused_ignores = True
+
         [builtins fixtures/list.pyi]
         """)
         assert result.input_updated == expected

--- a/mypy/test/update_data.py
+++ b/mypy/test/update_data.py
@@ -67,6 +67,7 @@ def _iter_fixes(
             comment_match = re.search(r"(?P<indent>\s+)(?P<comment># [EWN]: .+)$", source_line)
             if comment_match:
                 source_line = source_line[: comment_match.start("indent")]  # strip old comment
+            source_line = _escape_test_data_line(source_line)
             if reports:
                 indent = comment_match.group("indent") if comment_match else "  "
                 # multiline comments are on the first line and then on subsequent lines empty lines
@@ -85,3 +86,11 @@ def _iter_fixes(
             end_lineno=testcase.line + test_item.end_line - 1,
             lines=fix_lines + [""] * test_item.trimmed_newlines,
         )
+
+
+def _escape_test_data_line(line: str) -> str:
+    if line.startswith("["):
+        return "\\" + line
+    if line.startswith("--"):
+        return "--" + line
+    return line


### PR DESCRIPTION
## Summary

- Preserve escaped `.test` data lines when `--update-data` rewrites inline error comments.
- Add a regression test for an escaped `[mypy]` config section inside a `[file mypy.ini]` block.

## Reproduction

A `.test` case can include literal section-like lines by escaping the opening bracket, for example:

```text
[file mypy.ini]
\[mypy]
warn_unused_ignores = True
```

Before this change, running `pytest --update-data` on a case that touched that file section rewrote the line as `[mypy]`, dropping the escape.

## Root cause

`parse_test_data` unescapes special test-data lines before returning `TestItem.data`; `--update-data` then wrote those parsed source lines back directly. That is correct for executing the test case, but not for serializing it back to `.test` syntax.

## Changes

- Add a small serialization helper for update-data rewrites.
- Re-escape source lines that start with `[` so they stay literal data instead of becoming test section headers.
- Re-escape source lines that start with `--`, matching the existing parser escape convention for literal command-like lines.
- Cover the bracket case in `mypy/test/meta/test_update_data.py`.

## Tests

- `/tmp/mypy-update-data-venv/bin/python -m pytest -q mypy/test/meta/test_update_data.py`
- `git diff --check`
- `/tmp/mypy-update-data-venv/bin/python -m mypy --config-file mypy_self_check.ini mypy/test/update_data.py mypy/test/meta/test_update_data.py`

## Screenshots/Logs

Not applicable; test infrastructure change only.

Fixes #17465