### PR TITLE
[mypyc] Add memoization support for functools.cached_property

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -32,6 +32,7 @@ from mypyc.common import (
     MYPYC_DEFAULTS_SETUP,
     NATIVE_PREFIX,
     PREFIX,
+    PROPCACHE_PREFIX,
     REG_PREFIX,
     short_id_from_name,
 )
@@ -1268,6 +1269,34 @@ def generate_property_setter(
         )
     )
     emitter.emit_line("{")
+    # A NULL value means that the attribute is being deleted.
+    if cl.is_cached_property(attr):
+        # Deleting a functools.cached_property clears the cached value, so that
+        # it is recomputed on the next read. This matches CPython semantics,
+        # including raising AttributeError if there is no cached value.
+        slot_attr = PROPCACHE_PREFIX + attr
+        slot_expr = f"self->{emitter.attr(slot_attr)}"
+        slot_type = cl.attr_type(slot_attr)
+        emitter.emit_line("if (value == NULL) {")
+        emitter.emit_line(f"if ({slot_expr} == NULL) {{")
+        emitter.emit_line("PyErr_SetString(PyExc_AttributeError,")
+        emitter.emit_line(f'    "attribute {repr(attr)} of {repr(cl.name)} undefined");')
+        emitter.emit_line("return -1;")
+        emitter.emit_line("}")
+        emitter.emit_dec_ref(slot_expr, slot_type)
+        emitter.emit_line(f"{slot_expr} = NULL;")
+        emitter.emit_line("return 0;")
+        emitter.emit_line("}")
+    else:
+        # Properties otherwise have no deleter, so raise AttributeError
+        # (instead of calling the setter with a NULL value).
+        emitter.emit_line("if (value == NULL) {")
+        emitter.emit_line("PyErr_SetString(PyExc_AttributeError,")
+        emitter.emit_line(
+            f'    "{repr(cl.name)} object attribute {repr(attr)} cannot be deleted");'
+        )
+        emitter.emit_line("return -1;")
+        emitter.emit_line("}")
     if arg_type.is_unboxed:
         emitter.emit_unbox("value", "tmp", arg_type, error=ReturnHandler("-1"), declare_dest=True)
         emitter.emit_line(

--- a/mypyc/common.py
+++ b/mypyc/common.py
@@ -23,6 +23,8 @@ NEXT_LABEL_ATTR_NAME: Final = "__mypyc_next_label__"
 TEMP_ATTR_NAME: Final = "__mypyc_temp__"
 LAMBDA_NAME: Final = "__mypyc_lambda__"
 PROPSET_PREFIX: Final = "__mypyc_setter__"
+# Prefix of hidden attributes that store values of functools.cached_property properties
+PROPCACHE_PREFIX: Final = "__mypyc_cache__"
 SELF_NAME: Final = "__mypyc_self__"
 MYPYC_DEFAULTS_SETUP: Final = "__mypyc_defaults_setup"
 GENERATOR_ATTRIBUTE_PREFIX: Final = "__mypyc_generator_attribute__"

--- a/mypyc/ir/class_ir.py
+++ b/mypyc/ir/class_ir.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-from mypyc.common import PROPSET_PREFIX, JsonDict
+from mypyc.common import PROPCACHE_PREFIX, PROPSET_PREFIX, JsonDict
 from mypyc.ir.func_ir import FuncDecl, FuncIR, FuncSignature, RuntimeArg
 from mypyc.ir.ops import DeserMaps, Value
 from mypyc.ir.rtypes import RInstance, RType, deserialize_type, object_rprimitive
@@ -306,6 +306,10 @@ class ClassIR:
 
     def is_deletable(self, name: str) -> bool:
         return any(name in ir.deletable for ir in self.mro)
+
+    def is_cached_property(self, name: str) -> bool:
+        """Is the attribute a functools.cached_property backed by a hidden cache slot?"""
+        return any(PROPCACHE_PREFIX + name in ir.attributes for ir in self.mro)
 
     def is_always_defined(self, name: str) -> bool:
         if self.is_deletable(name):

--- a/mypyc/irbuild/function.py
+++ b/mypyc/irbuild/function.py
@@ -29,7 +29,7 @@ from mypy.nodes import (
     Var,
 )
 from mypy.types import CallableType, Type, UnboundType, get_proper_type
-from mypyc.common import FAST_PREFIX, LAMBDA_NAME, PROPSET_PREFIX, SELF_NAME
+from mypyc.common import FAST_PREFIX, LAMBDA_NAME, PROPCACHE_PREFIX, PROPSET_PREFIX, SELF_NAME
 from mypyc.ir.class_ir import ClassIR, NonExtClassInfo
 from mypyc.ir.func_ir import (
     FUNC_CLASSMETHOD,
@@ -42,10 +42,14 @@ from mypyc.ir.func_ir import (
 )
 from mypyc.ir.ops import (
     BasicBlock,
+    Box,
+    Branch,
+    Cast,
     ComparisonOp,
     GetAttr,
     Integer,
     LoadLiteral,
+    Op,
     Register,
     Return,
     SetAttr,
@@ -77,6 +81,7 @@ from mypyc.irbuild.env_class import (
 )
 from mypyc.irbuild.generator import gen_generator_func, gen_generator_func_body
 from mypyc.irbuild.targets import AssignmentTarget
+from mypyc.irbuild.util import is_cached_property
 from mypyc.primitives.dict_ops import (
     dict_get_method_with_none,
     dict_new_op,
@@ -500,7 +505,19 @@ def handle_ext_method(builder: IRBuilder, cdef: ClassDef, fdef: FuncDef) -> None
             py_setattr_op, [typ, builder.load_str(name), decorated_func], fdef.line
         )
 
+    cached_property = False
     if fdef.is_property:
+        if is_cached_property_class_member(cdef, fdef.name):
+            if class_ir.is_trait:
+                builder.error(
+                    '"functools.cached_property" is unsupported in traits and protocols', fdef.line
+                )
+            else:
+                # Add caching to the getter of a functools.cached_property
+                # (the setter is synthesized below).
+                cached_property = True
+                insert_cached_property_ops(func_ir, PROPCACHE_PREFIX + fdef.name, fdef.line)
+
         # If there is a property setter, it will be processed after the getter,
         # We populate the optional setter field with none for now.
         assert name not in class_ir.properties
@@ -513,6 +530,29 @@ def handle_ext_method(builder: IRBuilder, cdef: ClassDef, fdef: FuncDef) -> None
         class_ir.properties[name] = (getter_ir, func_ir)
 
     class_ir.methods[func_ir.decl.name] = func_ir
+
+    if cached_property:
+        # Synthesize the setter of a functools.cached_property. Note that this
+        # must be added to class_ir.methods immediately after the getter, since
+        # the vtable layout assumes that a property setter directly follows the
+        # getter.
+        setter_name = PROPSET_PREFIX + name
+        setter_ir = gen_cached_property_setter_ir(
+            builder, class_ir.method_decls[setter_name], fdef.line
+        )
+        builder.functions.append(setter_ir)
+        class_ir.methods[setter_name] = setter_ir
+        class_ir.properties[name] = (func_ir, setter_ir)
+
+        if class_ir.allow_interpreted_subclasses:
+            # Generate a shadow glue method for the setter so that attribute
+            # assignment dispatches properly for instances of interpreted
+            # subclasses.
+            f = gen_glue_property_setter(
+                builder, setter_ir.sig, setter_ir, class_ir, class_ir, fdef.line
+            )
+            class_ir.glue_methods[(class_ir, setter_name)] = f
+            builder.functions.append(f)
 
     # If this overrides a parent class method with a different type, we need
     # to generate a glue method to mediate between them.
@@ -576,7 +616,13 @@ def handle_non_ext_method(
 
     # TODO: Support property setters in non-extension classes
     if fdef.is_property:
-        prop = builder.load_module_attr_by_fullname("builtins.property", fdef.line)
+        if is_cached_property_class_member(cdef, fdef.name):
+            # Non-extension classes have an instance __dict__, so we can use
+            # functools.cached_property directly and get the full interpreted
+            # semantics, including caching.
+            prop = builder.get_module_attr("functools", "cached_property", fdef.line)
+        else:
+            prop = builder.load_module_attr_by_fullname("builtins.property", fdef.line)
         func_reg = builder.py_call(prop, [func_reg], fdef.line)
 
     elif builder.mapper.func_to_decl[fdef].kind == FUNC_CLASSMETHOD:
@@ -1217,6 +1263,90 @@ def gen_property_setter_ir(
     line = func_decl._line or -1
     if not is_trait:
         builder.add(SetAttr(self_reg, attr_name, value_reg, line))
+    builder.add(Return(builder.none(), line))
+    args, _, blocks, ret_type, fn_info = builder.leave()
+    return FuncIR(func_decl, args, blocks, line)
+
+
+def is_cached_property_class_member(cdef: ClassDef, name: str) -> bool:
+    """Is the class member with the given name a functools.cached_property?"""
+    sym = cdef.info.names.get(name)
+    return sym is not None and isinstance(sym.node, Decorator) and is_cached_property(sym.node)
+
+
+def insert_cached_property_ops(func_ir: FuncIR, slot: str, line: int) -> None:
+    """Add caching ops to the getter of a functools.cached_property.
+
+    The cached value is stored in a hidden attribute (the cache slot named
+    'slot', declared in the prepare phase). The transformed getter is
+    equivalent to this:
+
+        if is_defined(self.<slot>):
+            return self.<slot>
+        ... original body, with each "return r" replaced by ...
+        self.<slot> = r
+        return r
+
+    Boxed property types are stored in the slot as-is, with NULL marking an
+    undefined (not yet cached) value. Unboxed types (such as int) are stored
+    in a boxed form, since they may not have a dedicated error value.
+    """
+    self_reg = func_ir.arg_regs[0]
+    ret_type = func_ir.decl.sig.ret_type
+
+    # Store the computed value in the cache slot before each return.
+    for block in func_ir.blocks:
+        new_ops: list[Op] = []
+        for op in block.ops:
+            if isinstance(op, Return):
+                value = op.value
+                boxed: Value = value
+                if value.type.is_unboxed:
+                    box = Box(value, op.line)
+                    new_ops.append(box)
+                    boxed = box
+                new_ops.append(SetAttr(self_reg, slot, boxed, op.line))
+            new_ops.append(op)
+        block.ops = new_ops
+
+    # Create a new entry block that returns the value of the cache slot if it
+    # is defined, and otherwise runs the original getter body (which now also
+    # stores the computed value in the cache slot).
+    entry, cache_hit = BasicBlock(), BasicBlock()
+    compute = func_ir.blocks[0]
+    cached = GetAttr(self_reg, slot, line, allow_error_value=True)
+    entry.ops.append(cached)
+    entry.ops.append(Branch(cached, compute, cache_hit, Branch.IS_ERROR))
+    result: Value = cached
+    if ret_type.is_unboxed:
+        result = Unbox(cached, ret_type, line)
+        cache_hit.ops.append(result)
+    elif not is_same_type(ret_type, cached.type):
+        # The property in a subclass may have a narrower type than the
+        # cache slot defined in a base class.
+        result = Cast(cached, ret_type, line)
+        cache_hit.ops.append(result)
+    cache_hit.ops.append(Return(result, line))
+    func_ir.blocks = [entry, cache_hit, *func_ir.blocks]
+
+
+def gen_cached_property_setter_ir(builder: IRBuilder, func_decl: FuncDecl, line: int) -> FuncIR:
+    """Generate the setter of a functools.cached_property.
+
+    Assigning to a cached property stores the value in the cache slot,
+    similar to functools.cached_property in CPython (where an assignment
+    overrides the cached value through the instance __dict__).
+    """
+    name = func_decl.name
+    builder.enter(name)
+    self_type = func_decl.sig.args[0].type
+    self_reg = builder.add_argument("self", self_type)
+    value_reg = builder.add_argument("value", func_decl.sig.args[1].type)
+    assert name.startswith(PROPSET_PREFIX)
+    slot = PROPCACHE_PREFIX + name[len(PROPSET_PREFIX) :]
+    assert isinstance(self_type, RInstance), self_type
+    slot_type = self_type.class_ir.attr_type(slot)
+    builder.add(SetAttr(self_reg, slot, builder.coerce(value_reg, slot_type, line), line))
     builder.add(Return(builder.none(), line))
     args, _, blocks, ret_type, fn_info = builder.leave()
     return FuncIR(func_decl, args, blocks, line)

--- a/mypyc/irbuild/prepare.py
+++ b/mypyc/irbuild/prepare.py
@@ -43,6 +43,7 @@ from mypy.types import Instance, Type, get_proper_type
 from mypyc.common import (
     FAST_PREFIX,
     MYPYC_DEFAULTS_SETUP,
+    PROPCACHE_PREFIX,
     PROPSET_PREFIX,
     SELF_NAME,
     get_id_from_name,
@@ -75,6 +76,7 @@ from mypyc.irbuild.util import (
     default_attr_name,
     get_func_def,
     get_mypyc_attrs,
+    is_cached_property,
     is_dataclass,
     is_extension_class,
     is_trait,
@@ -326,6 +328,57 @@ def prepare_method_def(
             assert node.func.type, f"Expected return type annotation for property '{node.name}'"
             decl.is_prop_getter = True
             ir.property_types[node.name] = decl.sig.ret_type
+            if ir.is_ext_class and not ir.is_trait and is_cached_property(node):
+                prepare_cached_property(ir, module_name, cdef, mapper, node, decl)
+
+
+def prepare_cached_property(
+    ir: ClassIR,
+    module_name: str,
+    cdef: ClassDef,
+    mapper: Mapper,
+    node: Decorator,
+    getter_decl: FuncDecl,
+) -> None:
+    """Set up declarations for a functools.cached_property in a native class.
+
+    The cached value is stored in a hidden attribute (the "cache slot").
+    The property getter returns the value of the slot if it is defined, and
+    otherwise runs the decorated function and stores the result in the slot
+    (see handle_ext_method). Assigning to the property stores the assigned
+    value directly in the slot via a synthesized setter (the setter IR is
+    generated in transform_class_def).
+    """
+    name = node.name
+    ret_type = getter_decl.sig.ret_type
+    # If a base class already defines this cached property, reuse its cache
+    # slot. Both properties then share the cached value, similar to how
+    # functools.cached_property instances share an instance __dict__ entry.
+    if not is_inherited_cached_property(cdef, name, mapper):
+        # For unboxed property types use a boxed slot, so that an undefined
+        # cache slot is always represented by NULL.
+        slot_type = object_rprimitive if ret_type.is_unboxed else ret_type
+        ir.attributes[PROPCACHE_PREFIX + name] = slot_type
+    sig = FuncSignature(
+        (getter_decl.sig.args[0], RuntimeArg("value", ret_type, pos_only=True)), none_rprimitive
+    )
+    setter_decl = FuncDecl(PROPSET_PREFIX + name, cdef.name, module_name, sig, is_prop_setter=True)
+    ir.method_decls[PROPSET_PREFIX + name] = setter_decl
+
+
+def is_inherited_cached_property(cdef: ClassDef, name: str, mapper: Mapper) -> bool:
+    """Does a native base class already define a cached property with this name?"""
+    for base in cdef.info.mro[1:]:
+        base_ir = mapper.type_to_ir.get(base)
+        if base_ir is not None and base_ir.is_ext_class:
+            sym = base.names.get(name)
+            if (
+                sym is not None
+                and isinstance(sym.node, Decorator)
+                and is_cached_property(sym.node)
+            ):
+                return True
+    return False
 
 
 def prepare_fast_path(

--- a/mypyc/irbuild/statement.py
+++ b/mypyc/irbuild/statement.py
@@ -1227,7 +1227,15 @@ def transform_del_item(builder: IRBuilder, target: AssignmentTarget, line: int) 
     elif isinstance(target, AssignmentTargetAttr):
         if isinstance(target.obj_type, RInstance):
             cl = target.obj_type.class_ir
-            if not cl.is_deletable(target.attr):
+            # Deleting a functools.cached_property is supported: it clears the
+            # cached value (the property descriptor handles the deletion).
+            # Attributes of non-extension classes can always be deleted, since
+            # instances have an ordinary __dict__.
+            if (
+                cl.is_ext_class
+                and not cl.is_deletable(target.attr)
+                and not cl.is_cached_property(target.attr)
+            ):
                 builder.error(f'"{target.attr}" cannot be deleted', line)
                 builder.note(
                     'Using "__deletable__ = '

--- a/mypyc/irbuild/targets.py
+++ b/mypyc/irbuild/targets.py
@@ -45,7 +45,11 @@ class AssignmentTargetAttr(AssignmentTarget):
         self.obj = obj
         self.attr = attr
         self.can_borrow = can_borrow
-        if isinstance(obj.type, RInstance) and obj.type.class_ir.has_attr(attr):
+        if (
+            isinstance(obj.type, RInstance)
+            and obj.type.class_ir.is_ext_class
+            and obj.type.class_ir.has_attr(attr)
+        ):
             # Native attribute reference
             self.obj_type: RType = obj.type
             self.type = obj.type.attr_type(attr)

--- a/mypyc/irbuild/util.py
+++ b/mypyc/irbuild/util.py
@@ -65,6 +65,23 @@ def is_trait_decorator(d: Expression) -> bool:
     return isinstance(d, RefExpr) and d.fullname == "mypy_extensions.trait"
 
 
+def is_cached_property(node: Decorator) -> bool:
+    """Is the decorated function a functools.cached_property?
+
+    The semantic analyzer removes the cached_property decorator from
+    Decorator.decorators (it only marks the function as a settable
+    property), so we need to look at the original decorators. Ignore
+    properties that have additional decorators.
+    """
+    return (
+        node.func.is_property
+        and not node.decorators
+        and any(
+            refers_to_fullname(d, "functools.cached_property") for d in node.original_decorators
+        )
+    )
+
+
 def is_trait(cdef: ClassDef) -> bool:
     return any(is_trait_decorator(d) for d in cdef.decorators) or cdef.info.is_protocol
 

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -3244,3 +3244,80 @@ L5:
     r84 = r83 >= 0 :: signed
     r85 = __main__.NonExt :: type
     return 1
+
+[case testCachedProperty]
+from functools import cached_property
+
+class C:
+    @cached_property
+    def prop(self) -> int:
+        return 7
+
+def read(c: C) -> int:
+    return c.prop
+
+def write(c: C, x: int) -> None:
+    c.prop = x
+
+def delete(c: C) -> None:
+    del c.prop
+[out]
+def C.prop(self):
+    self :: __main__.C
+    r0 :: object
+    r1 :: int
+    r2 :: object
+    r3 :: bool
+L0:
+    r0 = self.__mypyc_cache__prop
+    if is_error(r0) goto L2 else goto L1
+L1:
+    r1 = unbox(int, r0)
+    return r1
+L2:
+    r2 = box(short_int, 14)
+    self.__mypyc_cache__prop = r2; r3 = is_error
+    return 14
+def C.__mypyc_setter__prop(self, value):
+    self :: __main__.C
+    value :: int
+    r0 :: object
+    r1 :: bool
+L0:
+    r0 = box(int, value)
+    self.__mypyc_cache__prop = r0; r1 = is_error
+    return 1
+def read(c):
+    c :: __main__.C
+    r0 :: int
+L0:
+    r0 = c.prop
+    return r0
+def write(c, x):
+    c :: __main__.C
+    x :: int
+    r0 :: bool
+L0:
+    c.prop = x; r0 = is_error
+    return 1
+def delete(c):
+    c :: __main__.C
+    r0 :: str
+    r1 :: i32
+    r2 :: bit
+L0:
+    r0 = 'prop'
+    r1 = PyObject_DelAttr(c, r0)
+    r2 = r1 >= 0 :: signed
+    return 1
+
+[case testCachedPropertyUnsupportedInTrait]
+from functools import cached_property
+from mypy_extensions import trait
+
+@trait
+class T:
+    @cached_property
+    def prop(self) -> int:  # E: "functools.cached_property" is unsupported in traits and protocols
+        return 7
+[out]

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -6006,3 +6006,311 @@ for _ in range(100):
     check(foo)
 after = sys.getrefcount(foo.obj)
 assert after - init == 0, f"Leaked {after - init} refs"
+
+[case testCachedProperty]
+from functools import cached_property
+from typing import List
+
+class C:
+    def __init__(self, x: int) -> None:
+        self.x = x
+        self.compute_count = 0
+
+    @cached_property
+    def boxed(self) -> List[int]:
+        self.compute_count += 1
+        return [self.x]
+
+    @cached_property
+    def unboxed(self) -> int:
+        self.compute_count += 1
+        return self.x * 2
+
+def test_body_runs_once() -> None:
+    c = C(5)
+    assert c.compute_count == 0
+    l = c.boxed
+    assert l == [5]
+    assert c.boxed is l
+    assert c.boxed is l
+    assert c.compute_count == 1
+    assert c.unboxed == 10
+    assert c.unboxed == 10
+    assert c.compute_count == 2
+
+def test_assignment_overrides_cached_value() -> None:
+    c = C(1)
+    c.unboxed = 42
+    assert c.unboxed == 42
+    c.boxed = [7]
+    assert c.boxed == [7]
+    assert c.compute_count == 0
+    # Assignment also overrides an already cached value
+    c2 = C(1)
+    assert c2.unboxed == 2
+    c2.unboxed = 3
+    assert c2.unboxed == 3
+    assert c2.compute_count == 1
+
+class PreSet(C):
+    def __init__(self) -> None:
+        super().__init__(1)
+        self.unboxed = 100
+
+def test_assignment_in_init() -> None:
+    d = PreSet()
+    assert d.unboxed == 100
+    assert d.compute_count == 0
+
+def test_del_invalidates_cached_value() -> None:
+    c = C(3)
+    assert c.unboxed == 6
+    assert c.compute_count == 1
+    del c.unboxed
+    assert c.unboxed == 6
+    assert c.compute_count == 2
+    del c.unboxed
+    try:
+        # There is no cached value to delete now
+        del c.unboxed
+    except AttributeError:
+        pass
+    else:
+        assert False
+    assert c.unboxed == 6
+    assert c.compute_count == 3
+
+class Base:
+    def __init__(self) -> None:
+        self.count = 0
+
+    @cached_property
+    def prop(self) -> int:
+        self.count += 1
+        return 1
+
+class Sub(Base):
+    @cached_property
+    def prop(self) -> int:
+        self.count += 1
+        return 2
+
+class SubNoOverride(Base):
+    pass
+
+def read_prop(b: Base) -> int:
+    return b.prop
+
+def test_subclass_override() -> None:
+    b = Base()
+    s = Sub()
+    n = SubNoOverride()
+    assert read_prop(b) == 1
+    assert read_prop(s) == 2
+    assert read_prop(n) == 1
+    assert read_prop(b) == 1
+    assert read_prop(s) == 2
+    assert read_prop(n) == 1
+    assert b.count == 1
+    assert s.count == 1
+    assert n.count == 1
+    b.prop = 5
+    assert read_prop(b) == 5 and read_prop(s) == 2
+
+def test_access_from_interpreted_code() -> None:
+    import interp
+    c = C(4)
+    assert interp.read_boxed(c) == [4]
+    assert interp.read_boxed(c) is c.boxed
+    assert c.compute_count == 1
+    interp.write_unboxed(c, 13)
+    assert c.unboxed == 13
+    assert c.compute_count == 1
+    interp.del_unboxed(c)
+    assert c.unboxed == 8
+    assert c.compute_count == 2
+
+[file interp.py]
+def read_boxed(c):
+    return c.boxed
+
+def write_unboxed(c, val):
+    c.unboxed = val
+
+def del_unboxed(c):
+    del c.unboxed
+
+[case testCachedPropertyMultiModule]
+import other
+
+def test_cached_property_in_other_module() -> None:
+    o = other.Other(3)
+    assert o.triple == 9
+    assert o.triple == 9
+    assert o.compute_count == 1
+    o.triple = 4
+    assert o.triple == 4
+    del o.triple
+    assert o.triple == 9
+    assert o.compute_count == 2
+
+[file other.py]
+from functools import cached_property
+
+class Other:
+    def __init__(self, x: int) -> None:
+        self.x = x
+        self.compute_count = 0
+
+    @cached_property
+    def triple(self) -> int:
+        self.compute_count += 1
+        return self.x * 3
+
+[case testCachedPropertyInterpretedSubclass]
+from functools import cached_property
+from mypy_extensions import mypyc_attr
+
+@mypyc_attr(allow_interpreted_subclasses=True)
+class Open:
+    def __init__(self) -> None:
+        self.count = 0
+
+    @cached_property
+    def val(self) -> int:
+        self.count += 1
+        return 10
+
+def read_val(o: Open) -> int:
+    return o.val
+
+def write_val(o: Open, val: int) -> None:
+    o.val = val
+
+[file driver.py]
+from functools import cached_property
+from native import Open, read_val, write_val
+
+# Reads of the inherited cached property see cached semantics
+class Sub(Open):
+    pass
+
+s = Sub()
+assert read_val(s) == 10
+assert read_val(s) == 10
+assert s.val == 10
+assert s.count == 1
+write_val(s, 11)
+assert s.val == 11 and read_val(s) == 11
+del s.val
+assert s.val == 10
+assert s.count == 2
+
+# An interpreted cached_property override is respected when reading
+# through the base class
+class SubOverride(Open):
+    @cached_property
+    def val(self) -> int:
+        self.count += 1
+        return 20
+
+o = SubOverride()
+assert read_val(o) == 20
+assert o.val == 20
+assert o.count == 1
+
+[case testCachedPropertyInstanceDict]
+# Where the cached value is stored depends on whether the instance has a
+# __dict__, which differs between a native class and its interpreted subclass.
+from functools import cached_property
+from mypy_extensions import mypyc_attr
+
+@mypyc_attr(allow_interpreted_subclasses=True)
+class Native:
+    def __init__(self) -> None:
+        self.runs = 0
+
+    @cached_property
+    def val(self) -> int:
+        self.runs += 1
+        return 10
+
+[file driver.py]
+from functools import cached_property
+from native import Native
+
+# A native (compiled) class has no instance __dict__. Its cached_property
+# memoizes into a hidden native slot, so caching works regardless.
+n = Native()
+assert not hasattr(n, "__dict__")
+assert n.val == 10 and n.val == 10
+assert n.runs == 1
+
+# CPython gives an *interpreted* subclass of a native class its own instance
+# __dict__ (a heap subclass of an extension type that lacks one gets a dict
+# added automatically). So a cached_property defined on the interpreted
+# subclass memoizes into that __dict__ with no extra setup, while the
+# inherited native cached_property keeps using the native slot.
+class Sub(Native):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sub_runs = 0
+
+    @cached_property
+    def sub_val(self) -> int:
+        self.sub_runs += 1
+        return 20
+
+s = Sub()
+assert hasattr(s, "__dict__")
+assert "sub_val" not in s.__dict__
+assert s.sub_val == 20 and s.sub_val == 20
+assert s.sub_runs == 1
+assert s.__dict__["sub_val"] == 20      # subclass cached_property -> instance __dict__
+assert s.val == 10 and s.val == 10
+assert s.runs == 1
+assert "val" not in s.__dict__          # inherited native cached_property -> native slot
+
+# A subclass that suppresses the instance __dict__ with __slots__ cannot use a
+# functools.cached_property defined on it: this raises at access time. This is
+# ordinary CPython behaviour and is unaffected by mypyc.
+class Slotted(Native):
+    __slots__ = ()
+
+    @cached_property
+    def slot_val(self) -> int:
+        return 30
+
+assert not hasattr(Slotted(), "__dict__")
+try:
+    Slotted().slot_val
+    assert False, "expected TypeError"
+except TypeError as e:
+    assert "__dict__" in str(e)
+
+[case testCachedPropertyNonNativeClass]
+from functools import cached_property
+from mypy_extensions import mypyc_attr
+
+@mypyc_attr(native_class=False)
+class NonNative:
+    def __init__(self) -> None:
+        self.count = 0
+
+    @cached_property
+    def val(self) -> int:
+        self.count += 1
+        return 5
+
+def test_non_native_cached_property() -> None:
+    # Non-native classes use functools.cached_property directly
+    assert isinstance(getattr(NonNative, "val"), cached_property)
+    o = NonNative()
+    assert o.val == 5
+    assert o.val == 5
+    assert o.count == 1
+    o.val = 6
+    assert o.val == 6
+    del o.val
+    assert o.val == 5
+    assert o.count == 2


### PR DESCRIPTION
Previously mypyc silently compiled `functools.cached_property` as a plain non-caching property which resulted in massive slowdowns on a real world project.  The semantic analyzer marks `cached_property` as `is_property` / `is_settable_property` like `builtins.property`, and mypyc had no handling of its own, so the decorated body re-ran on every access. 

<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Implementation:
- The prepare phase declares a hidden cache slot attribute (`__mypyc_cache__<name>`) on the ClassIR. Unboxed property types use a boxed slot so `NULL` uniformly represents 'not yet cached'. A subclass redefining an inherited cached property reuses the base slot (mirroring how functools shares the instance `__dict__` entry).
- The getter's generated IR is rewritten (insert_cached_property_ops): a new entry block returns the slot value when defined; the original body stores its result into the slot before each return.
- A setter is synthesized so assignment overrides the cached value, as with `functools.cached_property`; deletion clears the slot and raises `AttributeError` when nothing is cached, matching CPython semantics.
- Non-extension classes now use real functools.cached_property at class creation (previously they were silently degraded to `builtins.property` as well).
- cached_property in traits/protocols is rejected with a compile error rather than miscompiled.



<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
