### PR TITLE
Fix type variable inference for T | Wrapper[T] union patterns

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -424,7 +424,16 @@ def _infer_constraints(
         )
         if result:
             return result
-        elif has_recursive_types(template) and not has_recursive_types(actual):
+        elif (
+            has_recursive_types(template)
+            or (
+                any(isinstance(t, TypeVarType) for t in template.items)
+                and any(
+                    not isinstance(t, TypeVarType) and has_type_vars(t)
+                    for t in template.items
+                )
+            )
+        ) and not has_recursive_types(actual):
             return handle_recursive_union(template, actual, direction)
         return []
 
@@ -504,11 +513,13 @@ def merge_with_any(constraint: Constraint) -> Constraint:
 
 
 def handle_recursive_union(template: UnionType, actual: Type, direction: int) -> list[Constraint]:
-    # This is a hack to special-case things like Union[T, Inst[T]] in recursive types. Although
-    # it is quite arbitrary, it is a relatively common pattern, so we should handle it well.
-    # This function may be called when inferring against such union resulted in different
-    # constraints for each item. Normally we give up in such case, but here we instead split
-    # the union in two parts, and try inferring sequentially.
+    # Special-case unions of the form ``T | Wrapper[T]``, both in recursive type aliases and
+    # in plain generic function signatures (e.g. ``def f[T](x: T | list[T])``).
+    # When any_constraints() infers against each union branch independently it may yield
+    # conflicting results — e.g. ``T >= list[int]`` from the bare-T branch and ``T = int``
+    # from the ``list[T]`` branch — and gives up, leaving T unconstrained.  Instead, we
+    # split the union into non-TypeVar parts (tried first, since they give precise bounds
+    # like ``T = int``) and TypeVar parts (used as a fallback).
     non_type_var_items = [t for t in template.items if not isinstance(t, TypeVarType)]
     type_var_items = [t for t in template.items if isinstance(t, TypeVarType)]
     return infer_constraints(

--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -429,8 +429,7 @@ def _infer_constraints(
             or (
                 any(isinstance(t, TypeVarType) for t in template.items)
                 and any(
-                    not isinstance(t, TypeVarType) and has_type_vars(t)
-                    for t in template.items
+                    not isinstance(t, TypeVarType) and has_type_vars(t) for t in template.items
                 )
             )
         ) and not has_recursive_types(actual):

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -873,13 +873,7 @@ def g(x: Union[T, List[T]]) -> List[T]: pass
 def h(x: List[str]) -> None: pass
 g('a')() # E: "list[str]" not callable
 
-# The next line is a case where there are multiple ways to satisfy a constraint
-# involving a Union. Either T = list[str] or T = str would turn out to be valid,
-# but mypy doesn't know how to branch on these two options (and potentially have
-# to backtrack later) and defaults to T = Never. The result is an
-# awkward error message. Either a better error message, or simply accepting the
-# call, would be preferable here.
-g(['a']) # E: Argument 1 to "g" has incompatible type "list[str]"; expected "list[Never]"
+g(['a'])
 
 h(g(['a']))
 
@@ -890,6 +884,20 @@ i(a, a, b)
 i(b, a, b)
 i(a, b, b) # E: Argument 1 to "i" has incompatible type "list[int]"; expected "list[str]"
 [builtins fixtures/list.pyi]
+
+[case testUnionInferenceTypeVarWrapper]
+# Regression test for https://github.com/python/mypy/issues/21615
+# T | Wrapper[T] should infer T from the wrapped branch when the argument matches it.
+from typing import TypeVar, Union, List, Dict
+T = TypeVar('T')
+def f(x: Union[T, List[T]]) -> List[T]: pass
+def g(x: Union[T, Dict[str, T]]) -> T: pass
+
+reveal_type(f(1))      # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(f([1]))    # N: Revealed type is "builtins.list[builtins.int]"
+reveal_type(f(['a']))  # N: Revealed type is "builtins.list[builtins.str]"
+reveal_type(g({'k': 1}))  # N: Revealed type is "builtins.int"
+[builtins fixtures/dict.pyi]
 
 [case testCallableListJoinInference]
 from typing import Any, Callable


### PR DESCRIPTION
# Fix type variable inference for `T | Wrapper[T]` union patterns

## Summary

Fixes incorrect `Never` inference when calling a generic function whose parameter type
is a union of a bare TypeVar and a parameterized generic containing that same TypeVar,
such as `T | list[T]` or `T | dict[str, T]`.

Closes #21615

## Problem

Given this function:

```python
from typing import TypeVar, Union, List

T = TypeVar("T")

def f(x: Union[T, List[T]]) -> List[T]: ...

reveal_type(f([1, 2, 3]))  # was: list[Never]  (wrong — also raised a type error)
reveal_type(f([1, 2, 3]))  # now: list[int]     (correct)
```

Mypy was inferring `T = Never` for any call where the argument matched the
`Wrapper[T]` branch of the union instead of the bare `T` branch.

## Root Cause

In `_infer_constraints` (`mypy/constraints.py`), when the template is a `UnionType`
and the direction is `SUPERTYPE_OF`, mypy calls `any_constraints()` with one option
per union item:

| Branch | Constraint produced |
|--------|-------------------|
| `T` | `T ≥ list[int]` (overly broad) |
| `list[T]` | `T = int` (correct) |

Because these two options are structurally incompatible, `any_constraints()` gives up
and returns `[]`. With no constraints, the solver falls back to `T = Never`.

The existing helper `handle_recursive_union()` already resolves this correctly: it
tries the non-TypeVar items first (yielding the precise bound `T = int` from `list[T]`)
and falls back to the bare TypeVar items only when needed. However, it was only invoked
when `has_recursive_types(template)` was `True`, which is `False` for ordinary generic
function signatures.

## Fix

Extended the fallback condition in `_infer_constraints` to also call
`handle_recursive_union()` when `any_constraints()` returns empty **and** the union
template contains:

1. at least one bare `TypeVarType` item, **and**
2. at least one non-`TypeVarType` item that itself contains TypeVars (e.g. `list[T]`)

The second condition is the key guard. It ensures the fix applies only to genuine
`T | Wrapper[T]` patterns and not to unrelated unions such as `AnyStr | int`, where
`int` carries no TypeVars and the existing behavior is correct.

```python
# mypy/constraints.py  (simplified diff)

- elif has_recursive_types(template) and not has_recursive_types(actual):
+ elif (
+     has_recursive_types(template)
+     or (
+         any(isinstance(t, TypeVarType) for t in template.items)
+         and any(
+             not isinstance(t, TypeVarType) and has_type_vars(t)
+             for t in template.items
+         )
+     )
+ ) and not has_recursive_types(actual):
      return handle_recursive_union(template, actual, direction)
```

The docstring of `handle_recursive_union()` was also updated to document the broader
use case.

## Test Plan

- Updated `testUnionInference` in `test-data/unit/check-inference.test`: removed the
  stale expected-error annotation on `g(['a'])` that was documenting the bug (including
  the comment that called it an "awkward error message").
- Added `testUnionInferenceTypeVarWrapper` covering `T | list[T]` and `T | dict[str, T]`
  with both scalar and container arguments.
- Ran the full inference, union, generics, and recursive-types test suites — all pass.

```
1169 passed, 7 skipped, 1 xfailed   (inference / union / generics)
146  passed, 2 skipped               (recursive types)
```

## Behavior After Fix

```python
from typing import TypeVar, Union, List

T = TypeVar("T")

def f(x: Union[T, List[T]]) -> List[T]: ...

reveal_type(f(1))        # list[int]       ✓
reveal_type(f([]))       # list[Never]     (unchanged — empty list is a separate issue)
reveal_type(f([1, 2, 3]))  # list[int]    ✓  (was list[Never] + type error)
reveal_type(f(["a"]))   # list[str]       ✓  (was list[Never] + type error)
```

> **Note:** The `f([])` case still produces `list[Never]` because an empty list literal
> has type `list[Never]` before any context is applied. This is a pre-existing
> limitation shared with Pyright and is outside the scope of this fix.
