### PR TITLE
Fix TypeIs narrowing before isinstance

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6592,9 +6592,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     return {}, {}
                 if literal(expr) == LITERAL_TYPE:
                     original_type = self.lookup_type(expr)
-                    current_type = self.expr_checker.narrow_type_from_binder(
-                        expr, original_type
-                    )
+                    current_type = self.expr_checker.narrow_type_from_binder(expr, original_type)
                     yes_type, no_type = self.conditional_types_with_intersection(
                         current_type, self.get_isinstance_type(node.args[1]), expr
                     )
@@ -6604,11 +6602,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                         and is_subtype(current_type, yes_type, ignore_promotions=True)
                     ):
                         yes_type = current_type
-                    return conditional_types_to_typemaps(
-                        expr,
-                        yes_type,
-                        no_type,
-                    )
+                    return conditional_types_to_typemaps(expr, yes_type, no_type)
             elif refers_to_fullname(node.callee, "builtins.issubclass"):
                 if len(node.args) != 2:  # the error will be reported elsewhere
                     return {}, {}

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6594,12 +6594,12 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     original_type = self.lookup_type(expr)
                     current_type = self.expr_checker.narrow_type_from_binder(expr, original_type)
                     yes_type, no_type = self.conditional_types_with_intersection(
-                        current_type, self.get_isinstance_type(node.args[1]), expr
+                        original_type, self.get_isinstance_type(node.args[1]), expr
                     )
                     if (
                         self.binder.get(expr) is not None
                         and yes_type is not None
-                        and not isinstance(get_proper_type(current_type), AnyType)
+                        and not has_any_type(current_type)
                         and is_subtype(current_type, yes_type, ignore_promotions=True)
                     ):
                         yes_type = current_type
@@ -9352,6 +9352,46 @@ def is_valid_inferred_type(
     elif isinstance(proper_type, UninhabitedType):
         return False
     return not typ.accept(InvalidInferredTypes())
+
+
+def has_any_type(typ: Type) -> bool:
+    return _has_any_type(typ, set())
+
+
+def _has_any_type(typ: Type, seen: set[int]) -> bool:
+    if id(typ) in seen:
+        return False
+    seen.add(id(typ))
+    if isinstance(typ, TypeAliasType):
+        return any(_has_any_type(arg, seen) for arg in typ.args)
+    proper_type = get_proper_type(typ)
+    if isinstance(proper_type, AnyType):
+        return proper_type.type_of_any != TypeOfAny.special_form
+    if isinstance(proper_type, Instance):
+        return any(_has_any_type(arg, seen) for arg in proper_type.args)
+    if isinstance(proper_type, UnionType):
+        return any(_has_any_type(item, seen) for item in proper_type.items)
+    if isinstance(proper_type, TupleType):
+        return any(_has_any_type(item, seen) for item in proper_type.items)
+    if isinstance(proper_type, CallableType):
+        return any(_has_any_type(arg, seen) for arg in proper_type.arg_types) or _has_any_type(
+            proper_type.ret_type, seen
+        )
+    if isinstance(proper_type, TypeType):
+        return _has_any_type(proper_type.item, seen)
+    if isinstance(proper_type, TypeVarType):
+        return any(_has_any_type(value, seen) for value in proper_type.values) or _has_any_type(
+            proper_type.upper_bound, seen
+        )
+    if isinstance(proper_type, TypeVarTupleType):
+        return _has_any_type(proper_type.upper_bound, seen)
+    if isinstance(proper_type, TypedDictType):
+        return any(_has_any_type(item, seen) for item in proper_type.items.values())
+    if isinstance(proper_type, Overloaded):
+        return any(_has_any_type(item, seen) for item in proper_type.items)
+    if isinstance(proper_type, UnpackType):
+        return _has_any_type(proper_type.type, seen)
+    return False
 
 
 class InvalidInferredTypes(BoolTypeQuery):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6591,11 +6591,23 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 if len(node.args) != 2:  # the error will be reported elsewhere
                     return {}, {}
                 if literal(expr) == LITERAL_TYPE:
+                    original_type = self.lookup_type(expr)
+                    current_type = self.expr_checker.narrow_type_from_binder(
+                        expr, original_type
+                    )
+                    yes_type, no_type = self.conditional_types_with_intersection(
+                        current_type, self.get_isinstance_type(node.args[1]), expr
+                    )
+                    if (
+                        self.binder.get(expr) is not None
+                        and yes_type is not None
+                        and is_subtype(current_type, yes_type, ignore_promotions=True)
+                    ):
+                        yes_type = current_type
                     return conditional_types_to_typemaps(
                         expr,
-                        *self.conditional_types_with_intersection(
-                            self.lookup_type(expr), self.get_isinstance_type(node.args[1]), expr
-                        ),
+                        yes_type,
+                        no_type,
                     )
             elif refers_to_fullname(node.callee, "builtins.issubclass"):
                 if len(node.args) != 2:  # the error will be reported elsewhere

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6599,6 +6599,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     if (
                         self.binder.get(expr) is not None
                         and yes_type is not None
+                        and not isinstance(get_proper_type(current_type), AnyType)
                         and is_subtype(current_type, yes_type, ignore_promotions=True)
                     ):
                         yes_type = current_type

--- a/mypy/ipc.py
+++ b/mypy/ipc.py
@@ -340,7 +340,7 @@ class IPCServer(IPCBase):
             # for AF_UNIX sockets
             return os.path.join(self.sock_directory, self.name)
         else:
-            name = self.sock.getsockname()
+            name: object = self.sock.getsockname()
             assert isinstance(name, str)
             return name
 

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -3248,15 +3248,6 @@ def foo(x: object, t: type[Any]):
         reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/isinstance.pyi]
 
-[case testAssertIsinstanceAny]
-from typing import Any
-
-def f(x: Any) -> str:
-    assert isinstance(x, str)
-    reveal_type(x)  # N: Revealed type is "builtins.str"
-    return x
-[builtins fixtures/isinstance.pyi]
-
 [case testIsInstanceObject]
 # flags: --strict-equality --warn-unreachable
 from typing import Any

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -3248,6 +3248,15 @@ def foo(x: object, t: type[Any]):
         reveal_type(x)  # N: Revealed type is "Any"
 [builtins fixtures/isinstance.pyi]
 
+[case testAssertIsinstanceAny]
+from typing import Any
+
+def f(x: Any) -> str:
+    assert isinstance(x, str)
+    reveal_type(x)  # N: Revealed type is "builtins.str"
+    return x
+[builtins fixtures/isinstance.pyi]
+
 [case testIsInstanceObject]
 # flags: --strict-equality --warn-unreachable
 from typing import Any

--- a/test-data/unit/check-typeis.test
+++ b/test-data/unit/check-typeis.test
@@ -26,6 +26,25 @@ def main(a: Union[Point, Line, int]) -> None:
 
 [builtins fixtures/tuple.pyi]
 
+[case testTypeIsAndIsinstanceWithGenericAlias]
+from typing import Any, Generic, TypeVar
+from typing_extensions import TypeAlias, TypeIs
+
+T = TypeVar("T")
+class Slice(Generic[T]): pass
+
+SliceInt: TypeAlias = Slice[int | None]
+SliceStr: TypeAlias = Slice[str | None]
+
+def is_slice_int(obj: Any) -> TypeIs[SliceInt]: pass
+
+def main(obj: SliceInt | SliceStr) -> None:
+    if is_slice_int(obj):
+        pass
+    elif isinstance(obj, Slice):
+        reveal_type(obj)  # N: Revealed type is "__main__.Slice[builtins.str | None]"
+[builtins fixtures/isinstance.pyi]
+
 [case testTypeIsTypeArgsNone]
 from typing_extensions import TypeIs
 def foo(a: object) -> TypeIs:  # E: TypeIs must have exactly one type argument


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #21508.

This keeps `isinstance` narrowing based on the currently narrowed expression
type. When a previous `TypeIs` check has already removed one side of a union,
an `elif isinstance(...)` check against a runtime generic alias no longer
widens the expression back to its original type.

The change also adds regression coverage for a `TypeIs` false branch followed
by `isinstance(obj, Slice)`.

Tests:

- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-typeis.test -q`
- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-isinstance.test -q`
- `python -m mypy --config-file mypy_self_check.ini --no-incremental -p mypy`

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->