### PR TITLE
Fix type narrowing for variable swaps after isinstance checks

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4182,9 +4182,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                         narrowed = self.binder.get(rv)
 
                         if narrowed is not None:
-                            captured_pairs.append(
-                                (lv, self.temp_node(narrowed, context=rv))
-                            )
+                            captured_pairs.append((lv, self.temp_node(narrowed, context=rv)))
                             continue
 
                     captured_pairs.append((lv, rv))

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4175,7 +4175,21 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     lr_pairs.append((star_lv.expr, rv_list))
                 lr_pairs.extend(zip(right_lvs, right_rvs))
 
+                captured_pairs: list[tuple[Lvalue, Expression]] = []
+
                 for lv, rv in lr_pairs:
+                    if isinstance(rv, NameExpr):
+                        narrowed = self.binder.get(rv)
+
+                        if narrowed is not None:
+                            captured_pairs.append(
+                                (lv, self.temp_node(narrowed, context=rv))
+                            )
+                            continue
+
+                    captured_pairs.append((lv, rv))
+
+                for lv, rv in captured_pairs:
                     self.check_assignment(lv, rv, infer_lvalue_type)
         else:
             self.check_multi_assignment(lvalues, rvalue, context, infer_lvalue_type)

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -3377,3 +3377,21 @@ def f2(x: A | None, t: type[A]):
     else:
         reveal_type(x)  # N: Revealed type is "None"
 [builtins fixtures/isinstancelist.pyi]
+
+[case testTupleSwapAfterIsinstance]
+class Base: pass
+class Sub1(Base): pass
+class Sub2(Base): pass
+
+def f(a: Base, b: Base) -> None:
+    if isinstance(b, Sub1) and isinstance(a, Sub2):
+        t = (b, a)
+
+        reveal_type(t)  # N: Revealed type is "tuple[__main__.Sub1, __main__.Sub2]"
+
+        a, b = t
+
+        reveal_type(a)  # N: Revealed type is "__main__.Sub1"
+        reveal_type(b)  # N: Revealed type is "__main__.Sub2"
+
+[builtins fixtures/isinstancelist.pyi]

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -4281,3 +4281,21 @@ def func(y: H) -> H:
     else:
         return y
 [builtins fixtures/primitives.pyi]
+
+[case testIsInstanceVariableSwapNarrowing]
+class Base:
+    pass
+
+class Sub1(Base):
+    pass
+
+class Sub2(Base):
+    pass
+
+def f(a: Base, b: Base) -> None:
+    if isinstance(b, Sub1) and isinstance(a, Sub2):
+        a, b = b, a
+        reveal_type(a)  # N: Revealed type is "__main__.Sub1"
+        reveal_type(b)  # N: Revealed type is "__main__.Sub2"
+
+[builtins fixtures/isinstancelist.pyi]


### PR DESCRIPTION
Fixes #21586

## Summary

This PR fixes incorrect type narrowing when variables are swapped after an `isinstance()` check.

Previously, in code such as:

```python
class Base: ...
class Sub1(Base): ...
class Sub2(Base): ...

def f(a: Base, b: Base) -> None:
    if isinstance(b, Sub1) and isinstance(a, Sub2):
        a, b = b, a

        reveal_type(a)  # Sub1
        reveal_type(b)  # Sub1
```

mypy incorrectly revealed `b` as `Sub1` instead of `Sub2`.

The issue occurred because narrowed binder information for RHS variables could be overwritten while processing a multi-assignment statement. This change captures narrowed RHS `NameExpr` types before assignments are applied, preserving simultaneous assignment semantics.

## Changes

* Capture narrowed RHS variable types before processing multi-assignment pairs.
* Use the captured types when checking assignments to avoid interference from earlier assignments in the same statement.
* Add regression tests covering:

  * Direct variable swaps after `isinstance()` narrowing.
  * Tuple-based swaps that preserve narrowed types.

## Testing

Verified with:

* `python -m pytest mypy/test/testcheck.py -k testIsInstanceVariableSwapNarrowing -n0`
* `python -m pytest mypy/test/testcheck.py -k testTupleSwapAfterIsinstance -n0`
* `python -m pytest mypy/test/testcheck.py -k narrowing -n0`
* `python -m pytest mypy/test/testcheck.py -k assignment -n0`
* `python -m pytest mypy/test/testcheck.py -k tuple -n0`
* `python -m pytest mypy/test/testcheck.py -k isinstance -n0`
* `python -m pytest mypy/test/testcheck.py -n0`
* `python -m pytest mypy/test/testcheck.py -n auto`

All tests pass.
