### PR TITLE
Fix bug with dmypy not respecting @no_type_check after change in dependency

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1332,6 +1332,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         self.visit_func_def_impl(defn)
 
     def visit_func_def_impl(self, defn: FuncDef) -> None:
+        if defn.is_no_type_check:
+            # @typing.no_type_check: the body must be skipped. The decorator
+            # dispatch (visit_decorator) handles this at the top level, but a
+            # fine-grained reprocess can re-check the bare FuncDef target.
+            return
         with self.tscope.function_scope(defn), self.set_recurse_into_functions():
             self.check_func_item(defn, name=defn.name)
             if not self.can_skip_diagnostics:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1083,6 +1083,7 @@ FUNCDEF_FLAGS: Final = FUNCITEM_FLAGS + [
     "is_trivial_body",
     "is_trivial_self",
     "is_mypy_only",
+    "is_no_type_check",
 ]
 
 # Abstract status of a function
@@ -1109,6 +1110,7 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         "is_trivial_self",
         "is_invalid_redefinition",
         "is_mypy_only",
+        "is_no_type_check",
         # Present only when a function is decorated with @typing.dataclass_transform or similar
         "dataclass_transform_spec",
         "docstring",
@@ -1139,6 +1141,10 @@ class FuncDef(FuncItem, SymbolNode, Statement):
         self.original_def: None | FuncDef | Var | Decorator = None
         # Definitions that appear in if TYPE_CHECKING are marked with this flag.
         self.is_mypy_only = False
+        # Decorated with @typing.no_type_check: the body must never be type-checked.
+        # Stored as a durable flag so it survives fine-grained reprocessing of the
+        # FuncDef target (which bypasses the decorator dispatch in the checker).
+        self.is_no_type_check = False
         self.dataclass_transform_spec: DataclassTransformSpec | None = None
         self.docstring: str | None = None
         self.deprecated: str | None = None

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1810,6 +1810,7 @@ class SemanticAnalyzer(
         if (not dec.is_overload or dec.var.is_property) and self.type:
             dec.var.info = self.type
             dec.var.is_initialized_in_class = True
+        dec.func.is_no_type_check = no_type_check
         if no_type_check:
             erase_func_annotations(dec.func)
         if not no_type_check and (self.recurse_into_functions or dec.func.def_or_infer_vars):

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -11839,3 +11839,25 @@ def bar() -> str: return "a"
 main:2: note: Revealed type is "None | builtins.int"
 ==
 main:2: note: Revealed type is "None | builtins.str"
+
+[case testNoTypeCheckReprocessedViaDependency]
+# A @no_type_check function reprocessed via a dependency change (without editing
+# its own module) must still have its body skipped. Regression test: the daemon
+# used to re-check the bare FuncDef target, bypassing the @no_type_check guard.
+# flags: --check-untyped-defs
+import a
+[file a.py]
+from typing import no_type_check
+from b import SCALE
+
+@no_type_check
+def f() -> None:
+    factor: int = SCALE
+    bad: int = "not an int"
+[file b.py]
+SCALE: int = 3
+[file b.py.2]
+SCALE: str = ""
+[typing fixtures/typing-medium.pyi]
+[out]
+==


### PR DESCRIPTION
Currently, in daemon mode, the body of a `@no_type_check` function is type-checked anyway when the function is reprocessed because a type-check-dependency changed. This is even the case if the @no_type_check function isn't changed at all.

This leads to false positives, where mypy flags typing issues in a function that is not supposed to be type checked.

Other similar typing decorators are already correctly handled in the code. In this PR, I'm proposing to do the same for `typing.no_type_check`.

Moreover, this adds a fine-grained regression test.

## Reproduction

To reproduce the bug described above:
1. Create two local files:

```python
# a.py
from typing import no_type_check
from b import SCALE

  @no_type_check
  def func() -> None:
      factor: int = SCALE
      bad: int = "definitely not an int"
```

```python
# b.py
SCALE: int = 3
```
2. Run the daemon:
```
> dmypy run -- --check-untyped-defs a.py b.py
Success: no issues found in 2 source files
```
3. Edit only b.py, flipping the type of SCALE:
```python
# b.py
SCALE: str = "3"
```
4. Re-run the same daemon. The changed type of `b.SCALE` triggers a reprocess of `a.func`. Even though the function is still decorated with `@no_type_check`, it **gets type checked**:
```
> dmypy run -- --check-untyped-defs a.py b.py
a.py:8: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
a.py:9: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
Found 2 errors in 1 file (checked 2 source files)
```
5. This only happens in incremental mode. A cold daemon shows no errors:
```
> dmypy stop && dmypy run -- --check-untyped-defs a.py b.py
Success: no issues found in 2 source files
```

## Disclaimer

I've read the contributor guide. This was really hard to debug, so I've employed an LLM to come up with a reproduction, find the bug in the mypy codebase and implement a fix. I've reviewed the generated code and I'm happy with its quality. Happy to iterate over the code.