### PR TITLE
Support .ff files with --cache-map

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1677,13 +1677,15 @@ def process_cache_map(
             parser.error(f"Duplicate --cache-map source {source})")
         if not source.endswith(".py") and not source.endswith(".pyi"):
             parser.error(f"Invalid --cache-map source {source} (triple[0] must be *.py[i])")
-        if not meta_file.endswith(".meta.json"):
+        if not meta_file.endswith((".meta.json", ".meta.ff")):
             parser.error(
-                "Invalid --cache-map meta_file %s (triple[1] must be *.meta.json)" % meta_file
+                "Invalid --cache-map meta_file %s (triple[1] must be *.meta.json or *.meta.ff)"
+                % meta_file
             )
-        if not data_file.endswith(".data.json"):
+        if not data_file.endswith((".data.json", ".data.ff")):
             parser.error(
-                "Invalid --cache-map data_file %s (triple[2] must be *.data.json)" % data_file
+                "Invalid --cache-map data_file %s (triple[2] must be *.data.json or *.data.ff)"
+                % data_file
             )
         options.cache_map[source] = (meta_file, data_file)
 


### PR DESCRIPTION
Previously only the .json extension was accepted, but we are now generating .ff cache files by default.