### PR TITLE
Fix @overload decorator lines classified as Unanalyzed in lineprecision report

### DIFF
--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -46,11 +46,11 @@ from mypy.traverser import TraverserVisitor
 from mypy.type_visitor import ANY_STRATEGY, BoolTypeQuery
 from mypy.typeanal import collect_all_inner_types
 from mypy.types import (
+    OVERLOAD_NAMES,
     AnyType,
     CallableType,
     FunctionLike,
     Instance,
-    OVERLOAD_NAMES,
     TupleType,
     Type,
     TypeOfAny,

--- a/mypy/stats.py
+++ b/mypy/stats.py
@@ -50,6 +50,7 @@ from mypy.types import (
     CallableType,
     FunctionLike,
     Instance,
+    OVERLOAD_NAMES,
     TupleType,
     Type,
     TypeOfAny,
@@ -239,7 +240,10 @@ class StatisticsVisitor(TraverserVisitor):
         self.record_precise_if_checked_scope(o)
 
     def visit_name_expr(self, o: NameExpr) -> None:
-        if o.fullname in ("builtins.None", "builtins.True", "builtins.False", "builtins.Ellipsis"):
+        if (
+            o.fullname in ("builtins.None", "builtins.True", "builtins.False", "builtins.Ellipsis")
+            or o.fullname in OVERLOAD_NAMES
+        ):
             self.record_precise_if_checked_scope(o)
         else:
             self.process_node(o)
@@ -346,7 +350,12 @@ class StatisticsVisitor(TraverserVisitor):
                 self.type(self.typemap.get(node))
 
     def record_precise_if_checked_scope(self, node: Node) -> None:
-        if isinstance(node, Expression) and self.typemap and node not in self.typemap:
+        if (
+            isinstance(node, Expression)
+            and self.typemap
+            and node not in self.typemap
+            and not (isinstance(node, NameExpr) and node.fullname in OVERLOAD_NAMES)
+        ):
             kind = TYPE_UNANALYZED
         elif self.is_checked_scope():
             kind = TYPE_PRECISE

--- a/test-data/unit/check-reports.test
+++ b/test-data/unit/check-reports.test
@@ -343,3 +343,34 @@ Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
 -------------------------------------------------------------
 __main__      5        3          0    1      1           0
 m             4        3          0    1      0           0
+
+[case testLinePrecisionOverloadDecoratorCheckedScope]
+# flags: --lineprecision-report out
+from typing import overload
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+def f(x):
+    return x
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__      9        5          0    2      2           0
+
+[case testLinePrecisionOverloadDecoratorUncheckedScope]
+# flags: --lineprecision-report out
+from typing import overload
+
+def outer():
+    @overload
+    def f(x: int) -> int: ...
+    @overload
+    def f(x: str) -> str: ...
+    def f(x):
+        return x
+[outfile out/lineprecision.txt]
+Name      Lines  Precise  Imprecise  Any  Empty  Unanalyzed
+-------------------------------------------------------------
+__main__     10        1          0    7      2           0


### PR DESCRIPTION
Fixes #21638.

This is my first contribution PR to mypy.

As explained in the issue, `@overload` lines are classified as `unanalyzed`, which is fixed here with `StatisticsVisitor` now considering `OVERLOAD_NAMES` to be `precise` when in a typed scope.