### PR TITLE
fix: allow Final[T] instance fields in dataclasses to depend on type variables

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3398,9 +3398,21 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
             s.is_final_def
             and s.type
             and not has_no_typevars(s.type)
-            and self.scope.active_class() is not None
+            and (active_class := self.scope.active_class()) is not None
         ):
-            self.fail(message_registry.DEPENDENT_FINAL_IN_CLASS_BODY, s)
+            # Final[T] instance fields in dataclasses are not class attributes, so
+            # they are allowed to depend on type variables (PEP 591 / dataclass spec).
+            # Only suppress the error when the field is a dataclass instance field
+            # (not explicitly ClassVar).
+            lv = s.lvalues[0] if s.lvalues else None
+            is_dataclass_instance_field = (
+                "dataclass_tag" in active_class.metadata
+                and isinstance(lv, RefExpr)
+                and isinstance(lv.node, Var)
+                and not lv.node.is_classvar
+            )
+            if not is_dataclass_instance_field:
+                self.fail(message_registry.DEPENDENT_FINAL_IN_CLASS_BODY, s)
 
         if s.unanalyzed_type and not self.in_checked_function():
             self.msg.annotation_in_unchecked_function(context=s)

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1322,3 +1322,35 @@ class S9(S2, S4):  # E: Class "S9" has incompatible disjoint bases
     pass
 
 [builtins fixtures/tuple.pyi]
+
+[case testFinalDefiningTypevarsDataclassInstanceField]
+# Regression test for https://github.com/python/mypy/issues/21637
+# Final[T] instance fields in dataclasses must NOT trigger the
+# "cannot depend on type variables" error, because they are instance
+# attributes, not class attributes.
+from dataclasses import dataclass
+from typing import Final, Generic, TypeVar
+
+T = TypeVar("T")
+
+@dataclass(frozen=True)
+class A(Generic[T]):
+    value: Final[T]  # OK — instance field in a dataclass
+
+@dataclass(frozen=True)
+class B(Generic[T]):
+    value: T  # OK — control case without Final
+[builtins fixtures/dataclasses.pyi]
+[typing fixtures/typing-medium.pyi]
+
+[case testFinalDefiningTypevarsNonDataclassStillErrors]
+# Final[T] in a plain (non-dataclass) generic class body must still raise the error.
+from typing import Any, Final, Generic, TypeVar
+
+T = TypeVar("T")
+d: Any
+
+class C(Generic[T]):
+    x: Final[T] = d  # E: Final name declared in class body cannot depend on type variables
+[builtins fixtures/dataclasses.pyi]
+[typing fixtures/typing-medium.pyi]


### PR DESCRIPTION
## Summary

Fixes #21637.

`Final[T]` fields in a `@dataclass` body are **instance attributes**, not class attributes (PEP 591 / dataclass spec: *"A `Final` dataclass field initialized in the class body is not a class attribute unless explicitly annotated with `ClassVar`."*). The checker was unconditionally raising `Final name declared in class body cannot depend on type variables` for any `Final[T]` in a generic class body.

**Before:**
```python
from dataclasses import dataclass
from typing import Final, Generic, TypeVar

T = TypeVar("T")

@dataclass(frozen=True)
class A(Generic[T]):
    value: Final[T]  # error: Final name declared in class body cannot depend on type variables
```

**After:** no error (same behaviour as `value: T` without `Final`).

## Change

In `mypy/checker.py`, the condition that raises `DEPENDENT_FINAL_IN_CLASS_BODY` now skips the error when:
1. the active class has `dataclass_tag` in its metadata (i.e. it is a dataclass or dataclass-transform class), **and**
2. the lvalue is a `Var` that is not marked `is_classvar`.

Plain (non-dataclass) classes and explicit `ClassVar` fields are unaffected.

## Tests

Two new test cases in `test-data/unit/check-final.test`:

- `testFinalDefiningTypevarsDataclassInstanceField` — `Final[T]` instance field in a frozen generic dataclass must not produce an error.
- `testFinalDefiningTypevarsNonDataclassStillErrors` — `Final[T]` in a plain generic class must still produce the error.

All 83 existing check-final tests pass with no regressions.