### PR TITLE
Suppress redundant-expr for validation guards that always terminate

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5345,6 +5345,15 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # Fall-through to the original frame is handled explicitly in each block.
         with self.binder.frame_context(can_skip=False, conditional_frame=True, fall_through=0):
             for e, b in zip(s.expr, s.body):
+                # Suppress redundant-expr warnings for validation code
+                # that only terminates execution (raise,assert false, no return ,etc)
+                if (
+                    isinstance(e, OpExpr)
+                    and e.op == "and"
+                    and b.body
+                    and all(self.is_noop_for_reachability(stmt) for stmt in b.body) 
+                ):
+                    e.suppress_redundant_expr = True
                 t = get_proper_type(self.expr_checker.accept(e))
 
                 if isinstance(t, DeletedType):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5351,7 +5351,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     isinstance(e, OpExpr)
                     and e.op == "and"
                     and b.body
-                    and all(self.is_noop_for_reachability(stmt) for stmt in b.body) 
+                    and all(self.is_noop_for_reachability(stmt) for stmt in b.body)
                 ):
                     e.suppress_redundant_expr = True
                 t = get_proper_type(self.expr_checker.accept(e))

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4446,6 +4446,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             codes.REDUNDANT_EXPR in self.chk.options.enabled_error_codes
             and left_unreachable
             # don't report an error if it's intentional
+            and not e.suppress_redundant_expr
             and not e.right_always
         ):
             self.msg.redundant_left_operand(e.op, e.left)

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -2662,6 +2662,7 @@ class OpExpr(Expression):
         "right_unreachable",
         "analyzed",
         "as_type",
+        "suppress_redundant_expr",
     )
 
     __match_args__ = ("left", "op", "right")
@@ -2675,6 +2676,8 @@ class OpExpr(Expression):
     right_always: bool
     # Per static analysis only: Is the right side unreachable?
     right_unreachable: bool
+    # Suppress redundant-expr warnings for this expression.
+    suppress_redundant_expr: bool
     # Used for expressions that represent a type "X | Y" in some contexts
     analyzed: TypeAliasExpr | None
     # If this value expression can also be parsed as a valid type expression,
@@ -2693,6 +2696,7 @@ class OpExpr(Expression):
         self.right_always = False
         self.right_unreachable = False
         self.analyzed = analyzed
+        self.suppress_redundant_expr = False
         self.as_type = NotParsed.VALUE
 
     def accept(self, visitor: ExpressionVisitor[T]) -> T:

--- a/test-data/unit/check-errorcodes.test
+++ b/test-data/unit/check-errorcodes.test
@@ -964,6 +964,29 @@ for y in bad_list:
 [builtins fixtures/isinstancelist.pyi]
 [typing fixtures/typing-full.pyi]
 
+[case testNoRedundantExprForTypeIsAndRaise]
+# flags: --enable-error-code redundant-expr
+from typing import TypeVar, Sequence, Any
+from typing_extensions import TypeIs, Self
+
+class Cat:
+    def foo(self) -> Self:  # type: ignore[empty-body]
+        ...
+
+MyType = TypeVar('MyType', int, str, Cat)
+T = TypeVar('T')
+
+def _is_seq_of(seq: Sequence[Any], tp: type[T]) -> TypeIs[Sequence[T]]:  # type: ignore[empty-body]
+    ...
+
+def main(a: Sequence[MyType]) -> MyType:
+    if not _is_seq_of(a, Cat) and not _is_seq_of(a, int):
+        assert False
+    return a[0]
+
+[typing fixtures/typing-full.pyi]
+[builtins fixtures/tuple.pyi]
+
 
 [case testNamedTupleNameMismatch]
 from typing import NamedTuple


### PR DESCRIPTION
Fixes #21533.



## Summary



This PR suppresses `redundant-expr` warnings for `and` expressions used in validation guards whose bodies always terminate execution (for example, `raise`, `assert False`, or calls returning `NoReturn`).



The implementation reuses `is_noop_for_reachability()` to detect these cases, following a similar approach to unreachable-code diagnostics. This makes the behavior of constructs such as:



```python

if not x and not y:

    raise TypeError(...)

```



consistent with equivalent nested `if` statements when the body only performs validation and terminates execution.



A regression test has been added for the original reproducer from #21533.



## Verification



The following tests were run successfully:



* `python runtests.py check-expressions.test`

* `python runtests.py check-errorcodes.test`



## Notes



AI assistance was used to help understand and navigate the mypy codebase during investigation and implementation. The final code changes, testing, debugging, and validation were performed manually before submitting this PR.