### PR TITLE
Add opt-in flag for method hook defining-class fullnames

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -679,8 +679,11 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             self.strfrm_checker.check_str_format_call(e, format_value)
 
     def method_fullname(self, object_type: Type, method_name: str) -> str | None:
-        """Convert a method name to a fully qualified name, based on the class where the
-        method was defined. Return `None` if the name of `object_type` cannot be determined.
+        """Convert a method name to a fully qualified name.
+
+        By default this uses the class of the object where the method is called.
+        If the use_method_hook_defining_class option is enabled, this uses the class
+        where the method was defined.
         """
         object_type = get_proper_type(object_type)
 
@@ -694,15 +697,21 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
 
         type_name = None
         if isinstance(object_type, Instance):
-            info = object_type.type.get_containing_type_info(method_name)
-            type_name = info.fullname if info is not None else object_type.type.fullname
+            if self.chk.options.use_method_hook_defining_class:
+                info = object_type.type.get_containing_type_info(method_name)
+                type_name = info.fullname if info is not None else object_type.type.fullname
+            else:
+                type_name = object_type.type.fullname
         elif isinstance(object_type, (TypedDictType, LiteralType)):
             info = object_type.fallback.type.get_containing_type_info(method_name)
             type_name = info.fullname if info is not None else None
         elif isinstance(object_type, TupleType):
             fallback = tuple_fallback(object_type)
-            info = fallback.type.get_containing_type_info(method_name)
-            type_name = info.fullname if info is not None else fallback.type.fullname
+            if self.chk.options.use_method_hook_defining_class:
+                info = fallback.type.get_containing_type_info(method_name)
+                type_name = info.fullname if info is not None else fallback.type.fullname
+            else:
+                type_name = fallback.type.fullname
 
         if type_name:
             return f"{type_name}.{method_name}"

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -679,8 +679,8 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             self.strfrm_checker.check_str_format_call(e, format_value)
 
     def method_fullname(self, object_type: Type, method_name: str) -> str | None:
-        """Convert a method name to a fully qualified name, based on the type of the object that
-        it is invoked on. Return `None` if the name of `object_type` cannot be determined.
+        """Convert a method name to a fully qualified name, based on the class where the
+        method was defined. Return `None` if the name of `object_type` cannot be determined.
         """
         object_type = get_proper_type(object_type)
 
@@ -694,12 +694,15 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
 
         type_name = None
         if isinstance(object_type, Instance):
-            type_name = object_type.type.fullname
+            info = object_type.type.get_containing_type_info(method_name)
+            type_name = info.fullname if info is not None else object_type.type.fullname
         elif isinstance(object_type, (TypedDictType, LiteralType)):
             info = object_type.fallback.type.get_containing_type_info(method_name)
             type_name = info.fullname if info is not None else None
         elif isinstance(object_type, TupleType):
-            type_name = tuple_fallback(object_type).type.fullname
+            fallback = tuple_fallback(object_type)
+            info = fallback.type.get_containing_type_info(method_name)
+            type_name = info.fullname if info is not None else fallback.type.fullname
 
         if type_name:
             return f"{type_name}.{method_name}"

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1177,6 +1177,12 @@ def define_options(
     )
     # This undocumented feature exports limited line-level dependency information.
     internals_group.add_argument("--export-ref-info", action="store_true", help=argparse.SUPPRESS)
+    add_invertible_flag(
+        "--use-method-hook-defining-class",
+        default=False,
+        help=argparse.SUPPRESS,
+        group=internals_group,
+    )
 
     # Experimental parallel type-checking support.
     internals_group.add_argument(

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -78,6 +78,7 @@ OPTIONS_AFFECTING_CACHE: Final = (
         "strict_bytes",
         "fixed_format_cache",
         "untyped_calls_exclude",
+        "use_method_hook_defining_class",
         "enable_incomplete_feature",
         "install_types",
     }
@@ -340,6 +341,10 @@ class Options:
 
         # Paths of user plugins
         self.plugins: list[str] = []
+        # Temporary opt-in compatibility flag for plugin method hook fullnames.
+        # If True, inherited calls use the defining class (Base.method). If False,
+        # they use the call-site class (Derived.method).
+        self.use_method_hook_defining_class = False
 
         # Per-module options (raw)
         self.per_module_options: dict[str, dict[str, object]] = {}

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -647,7 +647,7 @@ class Plugin(CommonPluginApi):
         may infer a better type for the method. The hook is also called for special
         Python dunder methods except __init__ and __new__ (use get_function_hook to customize
         class instantiation). This function is called with the method full name using
-        the class of the object on which the method is called. For example, in this code:
+        the class where it was _defined_. For example, in this code:
 
             from lib import Special
 
@@ -663,7 +663,7 @@ class Plugin(CommonPluginApi):
             x: Special
             y = x[0]
 
-        this method is called with '__main__.Derived.method', and then with
+        this method is called with '__main__.Base.method', and then with
         'lib.Special.__getitem__'.
         """
         return None
@@ -672,7 +672,7 @@ class Plugin(CommonPluginApi):
         """Adjust return type of a method call.
 
         This is the same as get_function_hook(), but is called with the
-        method full name (using the class of the object on which the method is called).
+        method full name (again, using the class where the method is defined).
         """
         return None
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -647,7 +647,8 @@ class Plugin(CommonPluginApi):
         may infer a better type for the method. The hook is also called for special
         Python dunder methods except __init__ and __new__ (use get_function_hook to customize
         class instantiation). This function is called with the method full name using
-        the class where it was _defined_. For example, in this code:
+        the class of the object on which the method is called, unless
+        use_method_hook_defining_class is enabled. For example, in this code:
 
             from lib import Special
 
@@ -663,7 +664,8 @@ class Plugin(CommonPluginApi):
             x: Special
             y = x[0]
 
-        this method is called with '__main__.Base.method', and then with
+        this method is called with '__main__.Derived.method' (or '__main__.Base.method'
+        with use_method_hook_defining_class), and then with
         'lib.Special.__getitem__'.
         """
         return None
@@ -672,7 +674,8 @@ class Plugin(CommonPluginApi):
         """Adjust return type of a method call.
 
         This is the same as get_function_hook(), but is called with the
-        method full name (again, using the class where the method is defined).
+        method full name (with the same class selection behavior as
+        get_method_signature_hook()).
         """
         return None
 

--- a/mypy/plugin.py
+++ b/mypy/plugin.py
@@ -647,7 +647,7 @@ class Plugin(CommonPluginApi):
         may infer a better type for the method. The hook is also called for special
         Python dunder methods except __init__ and __new__ (use get_function_hook to customize
         class instantiation). This function is called with the method full name using
-        the class where it was _defined_. For example, in this code:
+        the class of the object on which the method is called. For example, in this code:
 
             from lib import Special
 
@@ -663,7 +663,7 @@ class Plugin(CommonPluginApi):
             x: Special
             y = x[0]
 
-        this method is called with '__main__.Base.method', and then with
+        this method is called with '__main__.Derived.method', and then with
         'lib.Special.__getitem__'.
         """
         return None
@@ -672,7 +672,7 @@ class Plugin(CommonPluginApi):
         """Adjust return type of a method call.
 
         This is the same as get_function_hook(), but is called with the
-        method full name (again, using the class where the method is defined).
+        method full name (using the class of the object on which the method is called).
         """
         return None
 

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -617,6 +617,7 @@ reveal_type(var.method(42))  # N: Revealed type is "builtins.int"
 [file mypy.ini]
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/method_hook_defining_class.py
+use_method_hook_defining_class = True
 
 [case testDynamicClassPlugin]
 # flags: --config-file tmp/mypy.ini

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -602,6 +602,22 @@ plugins=<ROOT>/test-data/unit/plugins/fully_qualified_test_hook.py
 [builtins fixtures/classmethod.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testMethodSignatureHookUsesDefiningClass]
+# flags: --config-file tmp/mypy.ini
+from typing import Any
+
+class Base:
+    def method(self, arg: Any) -> Any: ...
+
+class Derived(Base): ...
+
+var: Derived
+reveal_type(var.method(42))  # N: Revealed type is "builtins.int"
+
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/method_hook_defining_class.py
+
 [case testDynamicClassPlugin]
 # flags: --config-file tmp/mypy.ini
 from mod import declarative_base, Column, Instr

--- a/test-data/unit/plugins/arg_names.py
+++ b/test-data/unit/plugins/arg_names.py
@@ -26,8 +26,8 @@ class ArgNamesPlugin(Plugin):
             "mod.Class.mystaticmethod",
             "mod.ClassUnfilled.method",
             "mod.ClassStarExpr.method",
-            "mod.Base.method",
-            "mod.Base.myclassmethod",
+            "mod.ClassChild.method",
+            "mod.ClassChild.myclassmethod",
         }:
             return extract_classname_and_set_as_return_type_method
         return None

--- a/test-data/unit/plugins/arg_names.py
+++ b/test-data/unit/plugins/arg_names.py
@@ -26,8 +26,8 @@ class ArgNamesPlugin(Plugin):
             "mod.Class.mystaticmethod",
             "mod.ClassUnfilled.method",
             "mod.ClassStarExpr.method",
-            "mod.ClassChild.method",
-            "mod.ClassChild.myclassmethod",
+            "mod.Base.method",
+            "mod.Base.myclassmethod",
         }:
             return extract_classname_and_set_as_return_type_method
         return None

--- a/test-data/unit/plugins/method_hook_defining_class.py
+++ b/test-data/unit/plugins/method_hook_defining_class.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from mypy.plugin import MethodSigContext, Plugin
+from mypy.types import CallableType
+
+
+class DefiningClassPlugin(Plugin):
+    def get_method_signature_hook(
+        self, fullname: str
+    ) -> Callable[[MethodSigContext], CallableType] | None:
+        if fullname == "__main__.Base.method":
+            return defining_class_hook
+        return None
+
+
+def defining_class_hook(ctx: MethodSigContext) -> CallableType:
+    return ctx.default_signature.copy_modified(
+        ret_type=ctx.api.named_generic_type("builtins.int", [])
+    )
+
+
+def plugin(version: str) -> type[DefiningClassPlugin]:
+    return DefiningClassPlugin


### PR DESCRIPTION
﻿## Summary

This adds an opt-in flag for the defining-class behavior discussed in #19181.

By default, plugin method hooks still receive the call-site class name (e.g. Derived.method), so existing plugins keep working. If you set use_method_hook_defining_class = True in config (or pass --use-method-hook-defining-class), hooks get the class where the method was defined instead (Base.method).

Fixes #19181

## Test plan

- Ran the plugin hook tests locally, including the new defining-class regression test with the flag enabled
