### PR TITLE
Fix iterable membership with subclass item types

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3801,7 +3801,14 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
 
                 if not encountered_partial_type and not failed_out:
                     iterable_type = UnionType.make_union(iterable_types)
-                    if not is_subtype(left_type, iterable_type):
+                    matches_iterable_item = False
+                    if iterable_types:
+                        left_item_type = remove_instance_last_known_values(left_type)
+                        erased_iterable_type = remove_instance_last_known_values(iterable_type)
+                        matches_iterable_item = is_subtype(
+                            left_item_type, erased_iterable_type
+                        ) or is_subtype(erased_iterable_type, left_item_type)
+                    if not matches_iterable_item:
                         if not container_types:
                             self.msg.unsupported_operand_types("in", left_type, right_type, e)
                         else:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -3807,7 +3807,10 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                         erased_iterable_type = remove_instance_last_known_values(iterable_type)
                         matches_iterable_item = is_subtype(
                             left_item_type, erased_iterable_type
-                        ) or is_subtype(erased_iterable_type, left_item_type)
+                        ) or (
+                            not is_literal_type_like(left_type)
+                            and is_subtype(erased_iterable_type, left_item_type)
+                        )
                     if not matches_iterable_item:
                         if not container_types:
                             self.msg.unsupported_operand_types("in", left_type, right_type, e)

--- a/test-data/unit/check-expressions.test
+++ b/test-data/unit/check-expressions.test
@@ -412,6 +412,20 @@ class D(Iterable[A]):
     def __iter__(self) -> Iterator[A]: pass
 [builtins fixtures/bool.pyi]
 
+[case testInOperatorWithOverlappingIterableItemType]
+from typing import Iterator
+
+class Number(int): pass
+
+def numbers() -> Iterator[Number]:
+    yield Number()
+
+1 in numbers()
+Number() in numbers()
+'' in numbers()  # E: Unsupported operand types for in ("str" and "Iterator[Number]")
+[builtins fixtures/primitives.pyi]
+[typing fixtures/typing-medium.pyi]
+
 [case testNotInOperator]
 from typing import Iterator, Iterable, Any
 a: A


### PR DESCRIPTION
Fixes #21601.

This updates the fallback path for membership checks against iterables that do not implement `__contains__`. Previously, mypy required the left operand to be a subtype of the iterable item type. That is too strict for membership checks where the iterable item type is a subtype of the left operand, such as an `Iterator` of an `int` subclass.

The change accepts either subtype direction for the iterable item compatibility check, while preserving the existing strict-equality container diagnostics for actual containers.

Validation:
- `uv run pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-expressions.test -q`
- `uv run python -m mypy /tmp/mypy_21601.py --show-error-codes --hide-error-context --no-incremental`
