### PR TITLE
[mypyc] Fix reference leak when setting unboxed refcounted attrs

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -1211,7 +1211,15 @@ def generate_setter(cl: ClassIR, attr: str, rtype: RType, emitter: Emitter) -> N
         emitter.emit_line("if (value != NULL) {")
 
     if rtype.is_unboxed:
-        emitter.emit_unbox("value", "tmp", rtype, error=ReturnHandler("-1"), declare_dest=True)
+        # Borrow the unboxed value: emit_inc_ref below takes the single owned
+        # reference, matching the borrowed-then-incref pattern of the other two
+        # branches. Without borrow=True, emit_unbox already creates a new
+        # reference for refcounted unboxed types (e.g. CPyTagged boxed ints,
+        # tuples with refcounted fields), so the emit_inc_ref would double the
+        # reference and leak the stored value on every set via this setter.
+        emitter.emit_unbox(
+            "value", "tmp", rtype, error=ReturnHandler("-1"), declare_dest=True, borrow=True
+        )
     elif is_same_type(rtype, object_rprimitive):
         emitter.emit_line("PyObject *tmp = value;")
     else:

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -6028,8 +6028,11 @@ import sys
 from native import IntField, TupleField
 
 # A heap-boxed int (>= 2**62) is stored as a refcounted PyObject*, unlike small
-# inline-tagged ints, so an over-incref strands a real reference.
-BIG = 1 << 70
+# inline-tagged ints, so an over-incref strands a real reference. Compute the
+# values at runtime (not as folded literals): on free-threaded builds code
+# constants are immortal, and getrefcount could not observe a leak on them.
+shift = 70
+BIG = 1 << shift
 
 def check_no_leak(make, value) -> None:
     base = sys.getrefcount(value)
@@ -6047,7 +6050,7 @@ check_no_leak(IntField, BIG)
 # Tuple[int, int] is stored as an unboxed RTuple; its boxed-int elements are
 # refcounted, so the setter must not over-incref them either. Use the same int
 # in both slots so each instance holds exactly two references to it.
-ELEM = 1 << 71
+ELEM = 1 << (shift + 1)
 base = sys.getrefcount(ELEM)
 objs = [TupleField((ELEM, ELEM)) for _ in range(100)]
 alive = sys.getrefcount(ELEM)

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -6006,3 +6006,58 @@ for _ in range(100):
     check(foo)
 after = sys.getrefcount(foo.obj)
 assert after - init == 0, f"Leaked {after - init} refs"
+
+[case testNativeAttrSetterRefcountLeak]
+# Setting a native attribute from interpreted code goes through the generated
+# getset descriptor setter. For refcounted unboxed types (heap-boxed ints,
+# tuples with refcounted items) the setter must take exactly one reference to
+# the stored value, not two.
+from dataclasses import dataclass
+from typing import Tuple
+
+@dataclass
+class IntField:
+    v: int
+
+@dataclass
+class TupleField:
+    v: Tuple[int, int]
+
+[file driver.py]
+import sys
+from native import IntField, TupleField
+
+# A heap-boxed int (>= 2**62) is stored as a refcounted PyObject*, unlike small
+# inline-tagged ints, so an over-incref strands a real reference.
+BIG = 1 << 70
+
+def check_no_leak(make, value) -> None:
+    base = sys.getrefcount(value)
+    objs = [make(value) for _ in range(100)]
+    alive = sys.getrefcount(value)
+    # Each live instance must hold exactly one reference to the field value.
+    assert alive - base == 100, f"expected 100 live refs, got {alive - base}"
+    del objs
+    after = sys.getrefcount(value)
+    assert after == base, f"leaked {after - base} refs"
+
+# The dataclass-generated __init__ stores self.v = v via the descriptor setter.
+check_no_leak(IntField, BIG)
+
+# Tuple[int, int] is stored as an unboxed RTuple; its boxed-int elements are
+# refcounted, so the setter must not over-incref them either. Use the same int
+# in both slots so each instance holds exactly two references to it.
+ELEM = 1 << 71
+base = sys.getrefcount(ELEM)
+objs = [TupleField((ELEM, ELEM)) for _ in range(100)]
+alive = sys.getrefcount(ELEM)
+assert alive - base == 200, f"expected 200 live refs, got {alive - base}"
+del objs
+assert sys.getrefcount(ELEM) == base, f"tuple field leaked {sys.getrefcount(ELEM) - base} refs"
+
+# Re-assigning through the setter must release the previous value too.
+o = IntField(BIG)
+base = sys.getrefcount(BIG)
+o.v = BIG
+o.v = BIG
+assert sys.getrefcount(BIG) == base, "reassignment leaked refs"


### PR DESCRIPTION
I ran into this memory leak which can reproduced with:
```python
from dataclasses import dataclass

@dataclass
class MyClass:
    v: int

c = MyClass(1 << 70)
```

This PR adds a fix and a test that fails without the fix. I am no expert on mypyc internals, so I asked Claude Code to fix this bug. It is a one-line change so I believe it will be easy to review.
From quick inspection it seems that the rest of the code has fewer comments than what Claude wrote, so if you prefer, I'll remove the verbose comment that this PR adds. Similarly for the test code, it can be shortened if wanted.

<details>

<summary>Long explanation from Claude code</summary>

### Description

A native attribute setter generated by mypyc over-increfs the stored value when
the attribute has a **refcounted unboxed type** — most importantly `int`
(`CPyTagged`), and also tuples with refcounted items.

For an unboxed type, `generate_setter` emitted:

```c
tmp = CPyTagged_FromObject(value);  // already creates a NEW (owned) reference
CPyTagged_INCREF(tmp);              // ...and then takes a second one
self->_v = tmp;
```

CPyTagged_FromObject already increfs in the heap-boxed case, so the setter
takes two references while the deallocator releases only one — leaking one
reference on every set through the setter. The other two branches of
generate_setter (object and the emit_cast path) are correct because they
produce a borrowed value and rely on the single emit_inc_ref to take
ownership; only the unboxed branch was inconsistent.

Why this shows up with dataclasses

This is reached whenever an attribute is set from interpreted code. The clearest
real-world case is the __init__ that the stdlib dataclasses module
synthesizes for a mypyc-compiled @dataclass: its self.v = v runs as
interpreted code and goes through the generated descriptor setter. So every
constructed instance of a compiled dataclass with a heap-boxed int field
(value ≥ 2**62) leaked one PyLong — silent, unbounded growth in long-lived
programs that build many such objects (e.g. 64-bit ids).

It does not depend on slots, frozen, eq, field count, or field
position; a hand-written native __init__ is unaffected because it stores via
SetAttr rather than the descriptor. Small (inline-tagged) ints, floats, and
object-typed fields are also unaffected since they aren't refcounted through
this path.

Reproducer

```python
from dataclasses import dataclass
import sys

@dataclass
class C:
    v: int

big = 1 << 70                  # heap-boxed int (>= 2**62), so it is refcounted
base = sys.getrefcount(big)
xs = [C(big) for _ in range(1000)]
del xs
print(sys.getrefcount(big) - base)   # before: 1000   after: 0
```

Fix

Unbox with borrow=True in the setter's unboxed branch, so all three branches
of generate_setter produce a borrowed value and the single emit_inc_ref
takes exactly one owned reference. borrow=True is a no-op for non-refcounted
unboxed types (float, fixed-width ints, bool) and is propagated correctly
through RTuple unboxing, which fixes the analogous leak for tuple-typed
attributes too.

Tests

Added testNativeAttrSetterRefcountLeak to mypyc/test-data/run-classes.test,
covering a boxed-int dataclass field, an unboxed Tuple[int, int] field, and
setter re-assignment. It fails before the fix (expected 100 live refs, got 200) and passes after.

</details>