### PR TITLE
[codex] Allow ternary __rpow__ in protocols

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1696,6 +1696,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
             if (
                 defn.info
                 and self.is_reverse_op_method(name)
+                and not defn.info.is_protocol
                 and defn not in self.overload_impl_stack
             ):
                 # TODO: we should use decorated signature for this check.

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -4809,3 +4809,12 @@ bad_rep(t)  # E: Argument 1 to "bad_rep" has incompatible type "C"; expected "P[
             # N:     Got: \
             # N:         def rep(self) -> C
 [builtins fixtures/tuple.pyi]
+
+[case testProtocolTernaryRpow]
+from typing import Protocol
+
+class PowableProto(Protocol):
+    def __pow__(self, other: "PowableProto", modulo: "PowableProto") -> "PowableProto":
+        ...
+    def __rpow__(self, other: "PowableProto", modulo: "PowableProto") -> "PowableProto":
+        ...


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/10786.

## What changed

This skips the concrete reverse-operator signature validation for methods declared on protocol classes. Protocol declarations are structural requirements, so they should be able to describe a ternary `__rpow__` method without mypy rejecting the declaration as an invalid binary reverse-operator signature.

A regression test covers a protocol that declares both ternary `__pow__` and ternary `__rpow__`.

## Validation

- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-protocols.test -k testProtocolTernaryRpow`
- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-protocols.test`
- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-classes.test -k 'ReverseOperator or Operator'`
- Manual reproducer from the issue with `python -m mypy --config-file=/dev/null` now reports success.

## Limitations

I did not run the full mypy test suite locally; the targeted protocol and adjacent operator tests passed.
