### PR TITLE
Bump librt to 0.12.0

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -5,5 +5,5 @@ typing_extensions>=4.14.0; python_version>='3.15'
 mypy_extensions>=1.0.0
 pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'
-librt>=0.11.0; platform_python_implementation != 'PyPy'
+librt>=0.12.0; platform_python_implementation != 'PyPy'
 ast-serialize>=0.5.0,<1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
     "mypy_extensions>=1.0.0",
     "pathspec>=1.0.0",
     "tomli>=1.1.0; python_version<'3.11'",
-    "librt>=0.11.0; platform_python_implementation != 'PyPy'",
+    "librt>=0.12.0; platform_python_implementation != 'PyPy'",
     # the following is from build-requirements.txt
     "types-psutil",
     "types-setuptools",
@@ -58,7 +58,7 @@ dependencies = [
   "mypy_extensions>=1.0.0",
   "pathspec>=1.0.0",
   "tomli>=1.1.0; python_version<'3.11'",
-  "librt>=0.11.0; platform_python_implementation != 'PyPy'",
+  "librt>=0.12.0; platform_python_implementation != 'PyPy'",
   "ast-serialize>=0.5.0,<1.0.0",
 ]
 dynamic = ["version"]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,7 +25,7 @@ identify==2.6.19
     # via pre-commit
 iniconfig==2.3.0
     # via pytest
-librt==0.11.0 ; platform_python_implementation != "PyPy"
+librt==0.12.0 ; platform_python_implementation != "PyPy"
     # via -r mypy-requirements.txt
 lxml==6.1.0 ; python_version < "3.15"
     # via -r test-requirements.in


### PR DESCRIPTION
This bump includes:
* A mypy sync, including recent free-threading fixes.
* New experimental Emscripten wheels.