### PR TITLE
Bump ast-serialize to 0.6.0

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -6,4 +6,4 @@ mypy_extensions>=1.0.0
 pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'
 librt>=0.12.0; platform_python_implementation != 'PyPy'
-ast-serialize>=0.5.0,<1.0.0
+ast-serialize>=0.6.0,<1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires = [
     "types-psutil",
     "types-setuptools",
     # required to work around a mypyc import bug
-    "ast-serialize>=0.5.0,<1.0.0",
+    "ast-serialize>=0.6.0,<1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -59,7 +59,7 @@ dependencies = [
   "pathspec>=1.0.0",
   "tomli>=1.1.0; python_version<'3.11'",
   "librt>=0.12.0; platform_python_implementation != 'PyPy'",
-  "ast-serialize>=0.5.0,<1.0.0",
+  "ast-serialize>=0.6.0,<1.0.0",
 ]
 dynamic = ["version"]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=test-requirements.txt --strip-extras test-requirements.in
 #
-ast-serialize==0.5.0
+ast-serialize==0.6.0
     # via -r mypy-requirements.txt
 attrs==26.1.0
     # via -r test-requirements.in


### PR DESCRIPTION
No semantic changes in this PR, just the new experimental Emscripten wheels.
