### PR TITLE
Fix error code of note about unbound type variable

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1825,6 +1825,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                         "Consider using the upper bound "
                         f"{format_type(typ.ret_type.upper_bound, self.options)} instead",
                         context=typ.ret_type,
+                        code=TYPE_VAR,
                     )
 
     def check_default_params(self, item: FuncItem, body_is_trivial: bool | None = None) -> None:

--- a/test-data/unit/check-typevar-unbound.test
+++ b/test-data/unit/check-typevar-unbound.test
@@ -13,6 +13,9 @@ def g() -> U: # E: A function returning TypeVar should receive at least one argu
               # N: Consider using the upper bound "int" instead
     ...
 
+def g2() -> U:  # type: ignore[type-var]
+    ...
+
 V = TypeVar('V', int, str)
 
 def h() -> V:  # E: A function returning TypeVar should receive at least one argument containing the same TypeVar


### PR DESCRIPTION
The note used the default `misc` error code, which was different from the error message.