### PR TITLE
Fix narrowing in comprehensions when the intersection is impossible

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -6040,7 +6040,15 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
 
                 # values are only part of the comprehension when all conditions are true
                 true_map, false_map = self.chk.find_isinstance_check(condition)
-                self.chk.push_type_map(true_map)
+                if mypy.checker.is_unreachable_map(true_map):
+                    # The condition can never be true. Unlike statements, the
+                    # left expression is still type checked, so apply the
+                    # impossible narrowing to the binder instead of marking
+                    # the frame unreachable, which would discard it (#21635).
+                    for expr, typ in true_map.items():
+                        self.chk.binder.put(expr, typ)
+                else:
+                    self.chk.push_type_map(true_map)
 
                 if codes.REDUNDANT_EXPR in self.chk.options.enabled_error_codes:
                     if mypy.checker.is_unreachable_map(true_map):

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1614,6 +1614,37 @@ reveal_type(g) # N: Revealed type is "typing.Generator[builtins.int, None, None]
 reveal_type(d) # N: Revealed type is "builtins.dict[builtins.int, builtins.int]"
 [builtins fixtures/isinstancelist.pyi]
 
+[case testComprehensionIsInstanceImpossibleIntersection]
+# https://github.com/python/mypy/issues/21635
+from typing import List
+
+class X:
+    def f(self) -> int:
+        return 0
+class Y:
+    def f(self) -> str:
+        return ''
+
+xs: List[X] = []
+l: List[Y] = [x for x in xs if isinstance(x, Y)]
+g = (reveal_type(x) for x in xs if isinstance(x, Y))  # N: Revealed type is "Never"
+d = {0: x for x in xs if isinstance(x, Y)}
+reveal_type(d)  # N: Revealed type is "builtins.dict[builtins.int, Never]"
+[builtins fixtures/isinstancelist.pyi]
+
+[case testComprehensionIsSubclassImpossibleIntersectionFinal]
+# https://github.com/python/mypy/issues/21635
+from typing import List, Type
+from typing_extensions import final
+
+@final
+class F: ...
+class Other: ...
+
+os: List[Other] = []
+fs: List[F] = [o for o in os if isinstance(o, F)]
+[builtins fixtures/isinstancelist.pyi]
+
 [case testIsinstanceInWrongOrderInBooleanOp]
 # flags: --warn-unreachable
 class A:


### PR DESCRIPTION
Fixes #21635

## Problem

When a comprehension condition narrows the index variable to an impossible type — e.g. `issubclass(cls, M)` where mypy determines a subclass of both classes cannot exist (the dataclass case from the issue, classes with incompatible method signatures, or `@final` classes) — the narrowing was silently discarded:

```python
alist: list[type[A]] = [B, C]
mlist: list[type[M]] = [cls for cls in alist if issubclass(cls, M)]
# error: List comprehension has incompatible type List[type[A]]; expected List[type[M]]
```

## Root cause

`check_for_comp()` pushes the condition's `true_map` via `push_type_map()`. For an impossible narrowing the map contains an `UninhabitedType`, so `push_type_map()` takes the `is_unreachable_map()` branch and only calls `binder.unreachable()` — **no narrowing is recorded**. That's fine for statements, where the checker skips unreachable blocks, but the comprehension's left expression is still type checked, so it was checked with the *unnarrowed* type (`type[A]`), producing the false positive.

(The equivalent `for`/`if` statement version "works" only because the `if` body is skipped as unreachable; with `--warn-unreachable` it reports the impossible subclass instead.)

## Fix

In `check_for_comp()`, when the condition's `true_map` is an unreachable map, apply the impossible narrowing to the binder instead of marking the frame unreachable. The left expression then checks against `Never` — matching the narrowing an equivalent `if` statement would produce — and the example above typechecks (the item type is `Never`, which is compatible with any expected item type).

This also covers generator expressions and dict comprehensions (all go through `check_for_comp()`), and mirrors what `analyze_cond_branch()` already does for conditional expressions (it types the unreachable branch as `UninhabitedType`).

## Verification

- New test cases in `check-isinstance.test` (`testComprehensionIsInstanceImpossibleIntersection`, `testComprehensionIsSubclassImpossibleIntersectionFinal`) — both fail on master and pass with this change.
- Full `testcheck` suite: 8189 passed, 33 skipped, 7 xfailed.
- Self check and `ruff check`/`ruff format` clean on the changed file.

## LLM disclosure

Per the CONTRIBUTING note on LLM-assisted contributions: this fix was developed with the assistance of an AI tool (Claude Code). I've reviewed the change and the investigation behind it, take full responsibility for it, and will respond to review feedback personally.
