### PR TITLE
Fix Any identity narrowing of enum sentinels

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -7019,6 +7019,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 target_type = operand_types[j]
                 if should_coerce_literals:
                     target_type = coerce_to_literal(target_type)
+                if isinstance(get_proper_type(target_type), AnyType) and not isinstance(
+                    get_proper_type(expr_type), AnyType
+                ):
+                    continue
 
                 # Morally what we want to do is narrow for each branch based on:
                 # `if_type, else_type = conditional_types(expr_type, target)`

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2983,3 +2983,19 @@ def f(x: SE | None) -> None:
     else:
         reveal_type(x)  # N: Revealed type is "__main__.SE | None"
 [builtins fixtures/primitives.pyi]
+
+
+[case testEnumSentinelComparedToAny]
+import enum
+from typing import Any
+
+class SentinelType(enum.Enum):
+    SENTINEL = enum.auto()
+
+SENTINEL: SentinelType = SentinelType.SENTINEL
+
+x: Any = None
+if x is SENTINEL:
+    reveal_type(x)  # N: Revealed type is "Literal[__main__.SentinelType.SENTINEL]"
+    reveal_type(SENTINEL)  # N: Revealed type is "__main__.SentinelType"
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Fixes #21667.

This prevents identity/equality narrowing from using an `Any` comparison target to widen a non-`Any` expression. In the reported sentinel pattern, `x: Any` still narrows to the enum literal when `x is SENTINEL`, but the explicitly typed `SENTINEL: SentinelType` no longer becomes `Any` in the true branch.

Tests:
- `python runtests.py EnumSentinelComparedToAny`
- `python runtests.py check-enum.test`
- `python -m mypy --config-file mypy_self_check.ini mypy/checker.py`

Disclosure: I used an LLM-assisted coding tool to help inspect the narrowing path and prepare this patch; I reviewed the change and tests before submitting.
