### PR TITLE
[mypyc] Don't borrow list items on free-threaded builds

### DIFF
--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -773,7 +773,8 @@ def try_optimize_int_floor_divide(builder: IRBuilder, expr: OpExpr) -> OpExpr:
 def transform_index_expr(builder: IRBuilder, expr: IndexExpr) -> Value:
     index = expr.index
     base_type = builder.node_type(expr.base)
-    # We can borrow safely only if GIL is enabled
+    # We can borrow a list item safely only if GIL is enabled. The vec type is optimized for
+    # performance, so we'll do unsafe borrowing.
     can_borrow = (is_list_rprimitive(base_type) and not IS_FREE_THREADED) or isinstance(
         base_type, RVec
     )

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -801,7 +801,7 @@ def transform_index_expr(builder: IRBuilder, expr: IndexExpr) -> Value:
         if value:
             return value
 
-    index_reg = builder.accept(expr.index, can_borrow=can_borrow)
+    index_reg = builder.accept(expr.index, can_borrow=can_borrow or can_borrow_base)
     return builder.builder.get_item(
         base, index_reg, builder.node_type(expr), expr.line, can_borrow=builder.can_borrow
     )

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -777,7 +777,9 @@ def transform_index_expr(builder: IRBuilder, expr: IndexExpr) -> Value:
     can_borrow = (is_list_rprimitive(base_type) and not IS_FREE_THREADED) or isinstance(
         base_type, RVec
     )
-    can_borrow_base = can_borrow and is_borrow_friendly_expr(builder, index)
+    can_borrow_base = (
+        is_list_rprimitive(base_type) or isinstance(base_type, RVec)
+    ) and is_borrow_friendly_expr(builder, index)
 
     # Check for dunder specialization for non-slice indexing
     if not isinstance(index, SliceExpr):

--- a/mypyc/irbuild/expression.py
+++ b/mypyc/irbuild/expression.py
@@ -58,7 +58,7 @@ from mypy.types import (
     TypeType,
     get_proper_type,
 )
-from mypyc.common import MAX_SHORT_INT
+from mypyc.common import IS_FREE_THREADED, MAX_SHORT_INT
 from mypyc.ir.class_ir import ClassIR
 from mypyc.ir.func_ir import FUNC_CLASSMETHOD, FUNC_STATICMETHOD
 from mypyc.ir.ops import (
@@ -773,7 +773,10 @@ def try_optimize_int_floor_divide(builder: IRBuilder, expr: OpExpr) -> OpExpr:
 def transform_index_expr(builder: IRBuilder, expr: IndexExpr) -> Value:
     index = expr.index
     base_type = builder.node_type(expr.base)
-    can_borrow = is_list_rprimitive(base_type) or isinstance(base_type, RVec)
+    # We can borrow safely only if GIL is enabled
+    can_borrow = (is_list_rprimitive(base_type) and not IS_FREE_THREADED) or isinstance(
+        base_type, RVec
+    )
     can_borrow_base = can_borrow and is_borrow_friendly_expr(builder, index)
 
     # Check for dunder specialization for non-slice indexing

--- a/mypyc/primitives/list_ops.py
+++ b/mypyc/primitives/list_ops.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from mypyc.common import IS_FREE_THREADED
 from mypyc.ir.ops import ERR_FALSE, ERR_MAGIC, ERR_NEVER
 from mypyc.ir.rtypes import (
     bit_rprimitive,
@@ -108,28 +109,6 @@ method_op(
     priority=2,
 )
 
-# list[index] that produces a borrowed result
-method_op(
-    name="__getitem__",
-    arg_types=[list_rprimitive, int_rprimitive],
-    return_type=object_rprimitive,
-    c_function_name="CPyList_GetItemBorrow",
-    error_kind=ERR_MAGIC,
-    is_borrowed=True,
-    priority=3,
-)
-
-# list[index] that produces a borrowed result and index is known to be short
-method_op(
-    name="__getitem__",
-    arg_types=[list_rprimitive, short_int_rprimitive],
-    return_type=object_rprimitive,
-    c_function_name="CPyList_GetItemShortBorrow",
-    error_kind=ERR_MAGIC,
-    is_borrowed=True,
-    priority=4,
-)
-
 # Version with native int index
 method_op(
     name="__getitem__",
@@ -140,16 +119,39 @@ method_op(
     priority=5,
 )
 
-# Version with native int index
-method_op(
-    name="__getitem__",
-    arg_types=[list_rprimitive, int64_rprimitive],
-    return_type=object_rprimitive,
-    c_function_name="CPyList_GetItemInt64Borrow",
-    is_borrowed=True,
-    error_kind=ERR_MAGIC,
-    priority=6,
-)
+if not IS_FREE_THREADED:
+    # list[index] that produces a borrowed result
+    method_op(
+        name="__getitem__",
+        arg_types=[list_rprimitive, int_rprimitive],
+        return_type=object_rprimitive,
+        c_function_name="CPyList_GetItemBorrow",
+        error_kind=ERR_MAGIC,
+        is_borrowed=True,
+        priority=3,
+    )
+
+    # list[index] that produces a borrowed result and index is known to be short
+    method_op(
+        name="__getitem__",
+        arg_types=[list_rprimitive, short_int_rprimitive],
+        return_type=object_rprimitive,
+        c_function_name="CPyList_GetItemShortBorrow",
+        error_kind=ERR_MAGIC,
+        is_borrowed=True,
+        priority=4,
+    )
+
+    # Version with native int index
+    method_op(
+        name="__getitem__",
+        arg_types=[list_rprimitive, int64_rprimitive],
+        return_type=object_rprimitive,
+        c_function_name="CPyList_GetItemInt64Borrow",
+        is_borrowed=True,
+        error_kind=ERR_MAGIC,
+        priority=6,
+    )
 
 # This is unsafe because it assumes that the index is a non-negative integer
 # that is in-bounds for the list.

--- a/mypyc/test-data/exceptions.test
+++ b/mypyc/test-data/exceptions.test
@@ -98,7 +98,7 @@ L6:
     r5 = <error> :: int
     return r5
 
-[case testListSum]
+[case testListSum_withgil]
 from typing import List
 def sum(a: List[int], l: int) -> int:
     sum = 0

--- a/mypyc/test-data/irbuild-basic.test
+++ b/mypyc/test-data/irbuild-basic.test
@@ -2114,7 +2114,7 @@ L0:
     r1 = CPyTagged_Multiply(4, r0)
     return r1
 
-[case testNativeIndex]
+[case testNativeIndex_withgil]
 from typing import List
 class A:
     def __getitem__(self, index: int) -> int: pass

--- a/mypyc/test-data/irbuild-classes.test
+++ b/mypyc/test-data/irbuild-classes.test
@@ -1287,7 +1287,7 @@ L0:
     r2 = r1.x
     return r2
 
-[case testBorrowResultOfCustomGetItemInIfStatement]
+[case testBorrowResultOfCustomGetItemInIfStatement_withgil]
 from typing import List
 
 class C:

--- a/mypyc/test-data/irbuild-i64.test
+++ b/mypyc/test-data/irbuild-i64.test
@@ -1136,7 +1136,7 @@ L0:
     keep_alive d, d
     return r4
 
-[case testBorrowOverI64ListGetItem1]
+[case testBorrowOverI64ListGetItem1_withgil]
 from mypy_extensions import i64
 
 def f(n: i64) -> str:
@@ -1168,7 +1168,38 @@ L0:
     keep_alive a, n, r3
     return r5
 
-[case testBorrowOverI64ListGetItem2]
+[case testBorrowOverI64ListGetItem1_nogil]
+from mypy_extensions import i64
+
+def f(n: i64) -> str:
+    a = [C()]
+    return a[n].s
+
+class C:
+    s: str
+[out]
+def f(n):
+    n :: i64
+    r0 :: __main__.C
+    r1 :: list
+    r2 :: ptr
+    a :: list
+    r3 :: object
+    r4 :: __main__.C
+    r5 :: str
+L0:
+    r0 = C()
+    r1 = PyList_New(1)
+    r2 = list_items r1
+    buf_init_item r2, 0, r0
+    keep_alive r1
+    a = r1
+    r3 = CPyList_GetItemInt64(a, n)
+    r4 = cast(__main__.C, r3)
+    r5 = r4.s
+    return r5
+
+[case testBorrowOverI64ListGetItem2_withgil]
 from typing import List
 from mypy_extensions import i64
 
@@ -1188,6 +1219,31 @@ L0:
     r1 = unbox(i64, r0)
     r2 = r1 == 0
     keep_alive a, n
+    if r2 goto L1 else goto L2 :: bool
+L1:
+    return 1
+L2:
+    return 0
+
+[case testBorrowOverI64ListGetItem2_nogil]
+from typing import List
+from mypy_extensions import i64
+
+def f(a: List[i64], n: i64) -> bool:
+    if a[n] == 0:
+        return True
+    return False
+[out]
+def f(a, n):
+    a :: list
+    n :: i64
+    r0 :: object
+    r1 :: i64
+    r2 :: bit
+L0:
+    r0 = CPyList_GetItemInt64(a, n)
+    r1 = unbox(i64, r0)
+    r2 = r1 == 0
     if r2 goto L1 else goto L2 :: bool
 L1:
     return 1

--- a/mypyc/test-data/irbuild-lists.test
+++ b/mypyc/test-data/irbuild-lists.test
@@ -26,7 +26,7 @@ L0:
     r1 = cast(list, r0)
     return r1
 
-[case testListOfListGet2]
+[case testListOfListGet2_withgil]
 from typing import List
 def f(x: List[List[int]]) -> int:
     return x[0][1]
@@ -43,6 +43,24 @@ L0:
     r2 = CPyList_GetItemShort(r1, 2)
     r3 = unbox(int, r2)
     keep_alive x, r0
+    return r3
+
+[case testListOfListGet2_nogil]
+from typing import List
+def f(x: List[List[int]]) -> int:
+    return x[0][1]
+[out]
+def f(x):
+    x :: list
+    r0 :: object
+    r1 :: list
+    r2 :: object
+    r3 :: int
+L0:
+    r0 = CPyList_GetItemShort(x, 0)
+    r1 = cast(list, r0)
+    r2 = CPyList_GetItemShort(r1, 2)
+    r3 = unbox(int, r2)
     return r3
 
 [case testListSet]

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -1310,7 +1310,7 @@ def f():
 L0:
     return 0
 
-[case testBorrowListGetItemKeepAlive]
+[case testBorrowListGetItemKeepAlive_withgil]
 from typing import List
 
 def f() -> str:

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -1178,7 +1178,7 @@ L0:
     r2 = cast(str, r1)
     return r2
 
-[case testBorrowListGetItem2]
+[case testBorrowListGetItem2_withgil]
 from typing import List
 
 def attr_before_index(x: C) -> str:
@@ -1226,6 +1226,59 @@ L0:
     r0 = CPyList_GetItemShortBorrow(a, 0)
     r1 = borrow cast(__main__.C, r0)
     r2 = r1.n
+    return r2
+
+[case testBorrowListGetItem2_nogil]
+from typing import List
+
+def attr_before_index(x: C) -> str:
+    return x.a[x.n]
+
+def attr_after_index(a: List[C], i: int) -> int:
+    return a[i].n
+
+def attr_after_index_literal(a: List[C]) -> int:
+    return a[0].n
+
+class C:
+    a: List[str]
+    n: int
+[out]
+def attr_before_index(x):
+    x :: __main__.C
+    r0 :: list
+    r1 :: int
+    r2 :: object
+    r3 :: str
+L0:
+    r0 = borrow x.a
+    r1 = x.n
+    r2 = CPyList_GetItem(r0, r1)
+    dec_ref r1 :: int
+    r3 = cast(str, r2)
+    return r3
+def attr_after_index(a, i):
+    a :: list
+    i :: int
+    r0 :: object
+    r1 :: __main__.C
+    r2 :: int
+L0:
+    r0 = CPyList_GetItem(a, i)
+    r1 = cast(__main__.C, r0)
+    r2 = r1.n
+    dec_ref r1
+    return r2
+def attr_after_index_literal(a):
+    a :: list
+    r0 :: object
+    r1 :: __main__.C
+    r2 :: int
+L0:
+    r0 = CPyList_GetItemShort(a, 0)
+    r1 = cast(__main__.C, r0)
+    r2 = r1.n
+    dec_ref r1
     return r2
 
 [case testCannotBorrowListGetItem]

--- a/mypyc/test-data/refcount.test
+++ b/mypyc/test-data/refcount.test
@@ -592,6 +592,28 @@ L0:
     dec_ref d
     return 1
 
+[case testBorrowListObjectWithLiteralIndex_nogil]
+from typing import cast
+
+def f() -> str:
+    o = cast(object, [])
+    return cast(list[str], o)[0]
+[out]
+def f():
+    r0 :: list
+    o :: object
+    r1 :: list
+    r2 :: object
+    r3 :: str
+L0:
+    r0 = PyList_New(0)
+    o = r0
+    r1 = borrow cast(list, o)
+    r2 = CPyList_GetItemShort(r1, 0)
+    r3 = cast(str, r2)
+    dec_ref o
+    return r3
+
 [case testUnaryBranchSpecialCase]
 def f(x: bool) -> int:
     if x:
@@ -1252,9 +1274,8 @@ def attr_before_index(x):
     r3 :: str
 L0:
     r0 = borrow x.a
-    r1 = x.n
+    r1 = borrow x.n
     r2 = CPyList_GetItem(r0, r1)
-    dec_ref r1 :: int
     r3 = cast(str, r2)
     return r3
 def attr_after_index(a, i):

--- a/mypyc/test/test_exceptions.py
+++ b/mypyc/test/test_exceptions.py
@@ -11,7 +11,7 @@ from mypy.errors import CompileError
 from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase
 from mypyc.analysis.blockfreq import frequently_executed_blocks
-from mypyc.common import TOP_LEVEL_NAME
+from mypyc.common import IS_FREE_THREADED, TOP_LEVEL_NAME
 from mypyc.ir.pprint import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS,
@@ -34,6 +34,14 @@ class TestExceptionTransform(MypycDataSuite):
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         """Perform a runtime checking transformation test case."""
+
+        if "_withgil" in testcase.name and IS_FREE_THREADED:
+            # Test case should only run on a non-free-threaded build.
+            return
+        if "_nogil" in testcase.name and not IS_FREE_THREADED:
+            # Test case should only run on a free-threaded build.
+            return
+
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
             try:

--- a/mypyc/test/test_irbuild.py
+++ b/mypyc/test/test_irbuild.py
@@ -86,6 +86,9 @@ class TestGenOps(MypycDataSuite):
         if "_withgil" in testcase.name and IS_FREE_THREADED:
             # Test case should only run on a non-free-threaded build.
             return
+        if "_nogil" in testcase.name and not IS_FREE_THREADED:
+            # Test case should only run on a free-threaded build.
+            return
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)
             expected_output = replace_word_size(expected_output)

--- a/mypyc/test/test_refcount.py
+++ b/mypyc/test/test_refcount.py
@@ -11,7 +11,7 @@ import os.path
 from mypy.errors import CompileError
 from mypy.test.config import test_temp_dir
 from mypy.test.data import DataDrivenTestCase
-from mypyc.common import TOP_LEVEL_NAME
+from mypyc.common import IS_FREE_THREADED, TOP_LEVEL_NAME
 from mypyc.ir.pprint import format_func
 from mypyc.test.testutil import (
     ICODE_GEN_BUILTINS,
@@ -39,6 +39,12 @@ class TestRefCountTransform(MypycDataSuite):
         options = infer_ir_build_options_from_test_name(testcase.name)
         if options is None:
             # Skipped test case
+            return
+        if "_withgil" in testcase.name and IS_FREE_THREADED:
+            # Test case should only run on a non-free-threaded build.
+            return
+        if "_nogil" in testcase.name and not IS_FREE_THREADED:
+            # Test case should only run on a free-threaded build.
             return
         with use_custom_builtins(os.path.join(self.data_prefix, ICODE_GEN_BUILTINS), testcase):
             expected_output = remove_comment_lines(testcase.output)


### PR DESCRIPTION
Borrowing list items is unsafe on free-threaded builds, since another thread could be concurrently mutating the list. 

Also make it possible to have different expected test case outputs on free-threaded and GIL-enabled builds.

Work on mypyc/mypyc#1202.