### PR TITLE
Fix variance inference issues caused by dataclass replace

### DIFF
--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -2278,7 +2278,7 @@ def infer_variance(info: TypeInfo, i: int) -> bool:
         self_type = fill_typevars(info)
         for member in all_non_object_members(info):
             # __mypy-replace is an implementation detail of the dataclass plugin
-            if member in ("__init__", "__new__", "__mypy-replace"):
+            if member in {"__init__", "__new__", "__replace__", "__mypy-replace"}:
                 continue
 
             if isinstance(self_type, TupleType):


### PR DESCRIPTION
Fixes #17623. We already special case `__init__` and `__new__`, so adding `__replace__` here feels alright

Along with #21675 should hopefully get rid of this surprising edge when moving to Python 3.13

I didn't add tests due to fixture issues