### PR TITLE
Clarify implicit_reexport with strict mode

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -837,10 +837,6 @@ section of the command line docs.
     the item is imported using from-as or is included in ``__all__``. Note that mypy
     treats stub files as if this is always disabled. For example:
 
-    Although this option is enabled by default, :confval:`strict` enables
-    :option:`mypy --no-implicit-reexport`. Set ``implicit_reexport = true``
-    explicitly if you want to keep implicit reexports when using strict mode.
-
     .. code-block:: python
 
        # This won't re-export the value
@@ -850,6 +846,10 @@ section of the command line docs.
        # This will also re-export bar
        from foo import bar
        __all__ = ['bar']
+
+    Although this option is enabled by default, :confval:`strict` enables
+    :option:`mypy --no-implicit-reexport`. Set ``implicit_reexport = true``
+    explicitly if you want to keep implicit reexports when using strict mode.
 
 .. confval:: strict_equality
 

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -837,6 +837,10 @@ section of the command line docs.
     the item is imported using from-as or is included in ``__all__``. Note that mypy
     treats stub files as if this is always disabled. For example:
 
+    Although this option is enabled by default, :confval:`strict` enables
+    :option:`mypy --no-implicit-reexport`. Set ``implicit_reexport = true``
+    explicitly if you want to keep implicit reexports when using strict mode.
+
     .. code-block:: python
 
        # This won't re-export the value


### PR DESCRIPTION
Fixes #16971.

## Summary

Clarifies that `implicit_reexport` is enabled by default in normal configuration, but `strict` enables `--no-implicit-reexport` unless users explicitly set `implicit_reexport = true`.

## Why

The implementation default is still `implicit_reexport = true`, but users running with `strict = true` can observe behavior equivalent to `implicit_reexport = false`. This keeps the existing behavior and documents the strict-mode interaction near the config option.

## Validation

- Local two-file repro: default behavior allows implicit reexport.
- Local two-file repro: `--strict` reports `[attr-defined]` for the implicit reexport.
- Local config repro: `strict = true` reports `[attr-defined]`.
- Local config repro: `strict = true` plus `implicit_reexport = true` passes.
- `sphinx-build -b html ...` against a copied docs source tree succeeded; it emitted existing `changelog` toctree warnings.