### PR TITLE
Narrow for frozendict membership check

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -8892,6 +8892,7 @@ def builtin_item_type(tp: Type) -> Type | None:
             "builtins.list",
             "builtins.tuple",
             "builtins.dict",
+            "builtins.frozendict",
             "builtins.set",
             "builtins.frozenset",
             "_collections_abc.dict_keys",


### PR DESCRIPTION
```
def narrow(key: int | None, mapping: frozendict[int, str]) -> None:
    if key in mapping:
        reveal_type(key)  # N: Revealed type is "builtins.int"
```

Linking #21447