### PR TITLE
Use `PYODIDE` environment variable for Emscripten cross-compilation detection

### DIFF
--- a/mypy/options.py
+++ b/mypy/options.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import os
 import pprint
 import re
 import sys
-import sysconfig
 from collections.abc import Callable
 from re import Pattern
 from typing import Any, Final
@@ -112,11 +112,11 @@ class Options:
         # then mypy does not search for PEP 561 packages.
         self.python_executable: str | None = sys.executable
 
-        # When cross compiling to emscripten, we need to rely on MACHDEP because
-        # sys.platform is the host build platform, not emscripten.
-        MACHDEP = sysconfig.get_config_var("MACHDEP")
-        if MACHDEP == "emscripten":
-            self.platform = MACHDEP
+        # When cross compiling to emscripten, sys.platform is the host build
+        # platform, not emscripten. Pyodide sets the PYODIDE environment variable
+        # at build time, so we use it to detect the emscripten target.
+        if "PYODIDE" in os.environ:
+            self.platform = "emscripten"
         else:
             self.platform = sys.platform
 


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Hi! I noticed that y'all were carrying this workaround ever since #14888. A better way to detect this is through [the `PYODIDE` environment variable, which we've documented over the years](https://pyodide-build.readthedocs.io/en/latest/how-to/migrate.html#detecting-pyodide-at-build-time), and is what most projects use now. The MACHDEP generality would mostly apply to non-Pyodide-specific WASM build targets, which are growing in relevance but are a bit less mature as Pyodide at this time.

Also, thank you for adopting PEP 783 and publishing pyemscripten wheels for mypy – we're pretty happy about it!

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
