### PR TITLE
Fix inferred type of a tuple indexed by a slice value

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4774,7 +4774,12 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         self.check_method_call_by_name("__getitem__", left_type, [index], [ARG_POS], context=index)
         # We could return the return type from above, but unions are often better than the join
         union = self.union_tuple_fallback_item(left_type)
-        if isinstance(index, SliceExpr):
+        # A slice always yields a tuple, whether written as slice syntax (a SliceExpr) or
+        # passed as a value of type slice (e.g. a variable), which isn't a SliceExpr.
+        index_type = get_proper_type(self.chk.lookup_type_or_none(index))
+        if isinstance(index, SliceExpr) or (
+            isinstance(index_type, Instance) and index_type.type.fullname == "builtins.slice"
+        ):
             return self.chk.named_generic_type("builtins.tuple", [union])
         return union
 

--- a/test-data/unit/check-tuples.test
+++ b/test-data/unit/check-tuples.test
@@ -1447,6 +1447,15 @@ reveal_type(t[x:])  # N: Revealed type is "builtins.tuple[builtins.int | builtin
 t[y:]  # E: Invalid index type "slice[str, None, None]" for "tuple[int, str]"; expected type "slice[int | None]"
 [builtins fixtures/tuple.pyi]
 
+[case testTupleIndexBySliceVariable]
+# https://github.com/python/mypy/issues/21708
+s: slice
+t = (0, "")
+reveal_type(t[s])  # N: Revealed type is "builtins.tuple[builtins.int | builtins.str, ...]"
+u = (0, 0)
+reveal_type(u[s])  # N: Revealed type is "builtins.tuple[builtins.int, ...]"
+[builtins fixtures/tuple.pyi]
+
 [case testTupleSliceStepZeroNoCrash]
 # This was crashing: https://github.com/python/mypy/issues/18062
 # TODO: emit better error when 0 is used for step


### PR DESCRIPTION
Fixes #21708

`(1, 2, 3)[s]` with `s: slice` came out as `int`, but it's a tuple at runtime and `a.__getitem__(s)` already gets `tuple[int, ...]` right. The subscript code only spotted a slice written as `t[1:2]` (a `SliceExpr`); a `slice` variable is a plain `NameExpr`, so it fell through to the int-index branch. Now it checks the index type too.

Test added next to `testNonliteralTupleSlice`, fails on the old code. Left the `int | slice` union case alone, it still gives the item type.
