### PR TITLE
Reject non-string enum members as TypedDict keys

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4817,7 +4817,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                 if (
                     isinstance(key_type, LiteralType)
                     and isinstance(key_type.value, str)
-                    and key_type.fallback.type.fullname != "builtins.bytes"
+                    and is_subtype(key_type.fallback, self.named_type("builtins.str"))
                 ):
                     key_names.append(key_type.value)
                 else:

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -3004,6 +3004,32 @@ d[True] # E: TypedDict key must be a string literal; expected one of ("foo")
 [builtins fixtures/dict.pyi]
 [typing fixtures/typing-typeddict.pyi]
 
+[case testTypedDictEnumKey]
+# flags: --python-version 3.11
+from enum import Enum, StrEnum
+from typing import TypedDict
+
+class PlainEnum(Enum):
+    foo = "foo"
+
+class StringEnum(StrEnum):
+    foo = "foo"
+
+class StringMixinEnum(str, Enum):
+    foo = "foo"
+
+class TD(TypedDict):
+    foo: int
+
+d: TD
+d[PlainEnum.foo]  # E: TypedDict key must be a string literal; expected one of ("foo")
+d[PlainEnum.foo] = 1  # E: TypedDict key must be a string literal; expected one of ("foo") \
+    # E: Argument 1 to "__setitem__" has incompatible type "PlainEnum"; expected "str"
+reveal_type(d[StringEnum.foo])  # N: Revealed type is "builtins.int"
+reveal_type(d[StringMixinEnum.foo])  # N: Revealed type is "builtins.int"
+[builtins fixtures/enum.pyi]
+[typing fixtures/typing-typeddict.pyi]
+
 [case testTypedDictUppercaseKey]
 from typing import TypedDict
 


### PR DESCRIPTION
## Summary

TypedDict indexing currently accepts any `LiteralType` whose stored value is a string. Enum literals also store their member name as a string, so a plain Enum member such as `PlainEnum.foo` is mistaken for the key `"foo"` even though the member is not a `str` and the lookup raises `KeyError` at runtime.

Require the literal fallback to be a subtype of `str` before using its value as a TypedDict key. This rejects ordinary Enum members while preserving both `StrEnum` and `class E(str, Enum)` members, which are valid string keys at runtime.

The regression test covers reads and writes with a plain Enum and successful reads with both string-backed Enum forms.

Fixes #21722.

## Validation

- `python -m pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-typeddict.test` (362 passed)
- `python runtests.py self` (341 source files checked)
- `python runtests.py lint` (all hooks passed)

## AI assistance

OpenAI Codex was used for reproduction, code-path analysis, implementation, regression tests and the local validation above. I have personally reviewed the code in this PR and remain responsible for the submitted change and follow-up.