### PR TITLE
Fix spurious has-type error when unpacking a TypeVarTuple with a constrained TypeVar

### DIFF
--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -450,7 +450,9 @@ class TransformVisitor(NodeVisitor[Node]):
         )
 
     def visit_star_expr(self, node: StarExpr) -> StarExpr:
-        return StarExpr(node.expr)
+        new = StarExpr(self.expr(node.expr))
+        new.valid = node.valid
+        return new
 
     def visit_int_expr(self, node: IntExpr) -> IntExpr:
         return IntExpr(node.value)

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -2921,3 +2921,22 @@ def g(x: K) -> None:
     assert d is not None
     reveal_type(d)  # N: Revealed type is "tuple[K | list[int], ...] | tuple[*tuple[int | list[int], ...], int]"
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarTupleUnpackVarWithConstrainedTypeVarExpansion]
+# Regression test for https://github.com/python/mypy/issues/21693
+from typing import Generic, Tuple, TypeVar
+from typing_extensions import Literal, TypeVarTuple, Unpack
+
+T = TypeVar("T")
+P = TypeVar("P", Literal[True], Literal[False])
+Ts = TypeVarTuple("Ts")
+
+class Container(Generic[T, P]):
+    def foo(self) -> T: ...
+
+def f(container: Container[Tuple[Unpack[Ts]], P]) -> None:
+    result = container.foo()
+    reveal_type(result)  # N: Revealed type is "tuple[Unpack[Ts`-1]]"
+    y = (*result,)
+    reveal_type(y)  # N: Revealed type is "tuple[Unpack[Ts`-1]]"
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
Fixes #21693.

Unpacking a `TypeVarTuple` variable like `y = (*result,)` gave a bogus `Cannot determine type of "result"` error, but only when the enclosing function also had a value-constrained TypeVar. The result silently became `tuple[Any, ...]`.

The constrained TypeVar is what makes mypy re-check the body once per value, deep-copying the AST through `TransformVisitor`. Every visitor there recurses into its children and remaps `Var` references so they stay consistent within a copy, except `visit_star_expr`, which returned `StarExpr(node.expr)` without touching the inner expression. So in the copy the assignment target `result` got a fresh `Var` while `*result` still pointed at the original, which is never assigned, so its type never resolves.

The fix is a one-liner: recurse into the inner expression like everything else. I also carry over the `valid` flag, which the old code was dropping.

Added a regression test that fails on master and passes here. Full check, semanal, fine-grained, and transform suites pass.
