### PR TITLE
Docs: clarify strict_optional description and link to more details

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -466,7 +466,8 @@ The following flags adjust how mypy handles values of type ``None``.
     .. warning::
 
         ``--no-strict-optional`` is evil. Avoid using it and definitely do
-        not use it without understanding what it does.
+        not use it without understanding what it does. See
+        :ref:`no-strict-optional` for more details.
 
 
 .. _configuring-warnings:

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -618,15 +618,16 @@ section of the command line docs.
     :type: boolean
     :default: True
 
-    Effectively disables checking of optional
+    If set to ``False``, effectively disables checking of optional
     types and ``None`` values. With this option, mypy doesn't
     generally check the use of ``None`` values -- it is treated
     as compatible with every type.
 
     .. warning::
 
-        ``strict_optional = false`` is evil. Avoid using it and definitely do
-        not use it without understanding what it does.
+        ``strict_optional = False`` is evil. Avoid using it and definitely do
+        not use it without understanding what it does. See
+        :ref:`no-strict-optional` for more details.
 
 
 Configuring warnings


### PR DESCRIPTION
Closes #21658

Updates the description of `strict_optional` / `--no-strict-optional` to explicitly clarify that setting it to `False` (or passing the flag) is what effectively disables checking, and adds a link to the strict optional documentation section for further reading on why it shouldn't be disabled.