### PR TITLE
Fix nested .gitignore directory patterns not excluding under --exclude-gitignore

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -711,7 +711,7 @@ def matches_gitignore(subpath: str, fscache: FileSystemCache, verbose: bool) -> 
     dir, _ = os.path.split(subpath)
     for gi_path, gi_spec in find_gitignores(dir):
         relative_path = os.path.relpath(subpath, gi_path)
-        if fscache.isdir(relative_path):
+        if fscache.isdir(subpath):
             relative_path = relative_path + "/"
         if gi_spec.match_file(relative_path):
             if verbose:


### PR DESCRIPTION
## Problem

`matches_gitignore` (`mypy/modulefinder.py`) decides whether to append a trailing `/` (needed for directory-only gitignore patterns like `build/`) using the **wrong path**:

```python
def matches_gitignore(subpath: str, fscache: FileSystemCache, verbose: bool) -> bool:
    dir, _ = os.path.split(subpath)
    for gi_path, gi_spec in find_gitignores(dir):
        relative_path = os.path.relpath(subpath, gi_path)
        if fscache.isdir(relative_path):        # relative_path is relative to gi_path, not cwd
            relative_path = relative_path + "/"
        if gi_spec.match_file(relative_path):
            ...
```

`relative_path` is computed **relative to the `.gitignore`'s directory** (`gi_path`) so it can be matched by `gi_spec.match_file(...)` — that part is correct (gitignore patterns are relative to the gitignore's location). But that same gi_path-relative string is then passed to `fscache.isdir(...)`, which resolves paths relative to the process **cwd**. When the matched `.gitignore` lives in a scanned subdirectory (`gi_path != cwd`), the string doesn't resolve on disk, `isdir` returns `False`, the trailing `/` is never added, and **directory-only patterns in nested `.gitignore`s silently fail to exclude the directory**.

## Evidence (sibling proves intent)

The sibling `matches_exclude` in the same file does this correctly — it builds the match string via `os.path.relpath(subpath)` but calls `isdir` on the **original** path:

```python
subpath_str = os.path.relpath(subpath).replace(os.sep, "/")
if fscache.isdir(subpath):        # original subpath, not the relativized string
    subpath_str += "/"
```

## Fix

Stat the original `subpath` (keep `relative_path` only for the gitignore-spec match):

```python
if fscache.isdir(subpath):
    relative_path = relative_path + "/"
```

## Reproduction

`subpath = "mypkg/sub"` (a real directory), matched against a nested `.gitignore` in `mypkg/` containing `sub/`:

| | trailing `/` added? | directory excluded? |
|---|---|---|
| before (`isdir(relative_path)`) | no (`isdir("sub")` is False from cwd) | **no** ❌ |
| after (`isdir(subpath)`) | yes | yes ✅ |

Reachable from `find_sources.py` (and `modulefinder`) whenever `--exclude-gitignore` is enabled and a nested `.gitignore` uses a directory-only pattern.
