### PR TITLE
Fix dmypy suggest crash after flushed diagnostics

### DIFF
--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -706,6 +706,7 @@ class SuggestionEngine:
     def reload(self, state: State) -> list[str]:
         """Recheck the module given by state."""
         assert state.path is not None
+        self.manager.errors.reset()
         self.fgmanager.flush_cache()
         return self.fgmanager.update([(state.id, state.path)], [])
 

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -392,6 +392,31 @@ def bar() -> None:
     x = foo('abc')  # type: str
     foo(arg='xyz')
 
+[case testDaemonSuggestStdlibAfterMessage]
+$ dmypy start -- --follow-imports=error --no-error-summary
+Daemon started
+$ dmypy check main.py
+main.py:1: note: Revealed type is "Literal[1]?"
+$ dmypy suggest os.path.islink --callsites
+No suggestions
+$ dmypy status
+Daemon is up and running
+$ dmypy suggest os.path.isdir --callsites
+No suggestions
+$ dmypy check main.py
+main.py:1: note: Revealed type is "Literal[1]?"
+== Return code: 1
+$ {python} -c "import shutil; shutil.copy('main2.py', 'main.py')"
+$ dmypy check main.py
+main.py:1: note: Revealed type is "Literal[2]?"
+== Return code: 1
+$ dmypy stop
+Daemon stopped
+[file main.py]
+reveal_type(1)
+[file main2.py]
+reveal_type(2)
+
 [case testDaemonInspectCheck]
 $ dmypy start
 Daemon started


### PR DESCRIPTION
Fixes #21765.

`dmypy suggest` could reload an automatically loaded module after a prior check had flushed diagnostics. If that reload reprocessed a user module, adding a new diagnostic violated the `flushed_files` invariant and crashed the daemon.

Reset the suggestion reload error accumulator before the fine-grained update, matching the existing fine-grained trigger behavior. Add a daemon regression test covering stdlib suggestions after a note, repeated suggestions, daemon status, and a subsequent incremental check.

Validation:
- `mypy/test/testdaemon.py`
- `mypy/test/testfinegrained.py -k Suggest`
- `mypy/test/testfinegrained.py`
- `python runtests.py self`
- `python runtests.py lint`
- `git diff --check`
