### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+Python Security Response Team (PSRT) members balance security work against many
+other responsibilities. Please be thoughtful about the time and attention your
+report requires. Repeated failure to respect this will result in future reports
+being rejected, or the reporter being banned from the `python` GitHub organization,
+regardless of technical merit.
+
+## Reporting a Vulnerability
+
+Submit a vulnerability report using GitHub Security Advisories.
+
+Reports should be a few sentences describing the vulnerability. Ideally include
+a proof-of-concept script that reproduces the issue and provides a clear
+indication of whether the vulnerability is still present. Reports must be
+plain-text only, including attachments. No PDFs, binaries, notebooks, or other
+files that cannot be safely reviewed. If your proof-of-concept depends on a
+specially constructed binary file, please include a script to construct it
+rather than the file itself. Ideally, include a minimal patch with the mitigation
+for the report.
+
+Reports that do not contain a potential security vulnerability (such as spam or
+requesting compliance or due-diligence work) will be discarded without a reply.


### PR DESCRIPTION
The Python Security Response Team (PSRT), which currently handles security reporting for this project, prefers to receive vulnerability reports through [GitHub Security Advisories (GHSAs)](https://docs.github.com/en/code-security/concepts/vulnerability-reporting-and-management/repository-security-advisories), rather than by email at `security@python.org`. For more background, see python/psrt-ghsa-bot#60.

This PR adds a small `SECURITY.md` file with reporting instructions for the unlikely event that someone needs to report a vulnerability in this repository. It explains where to report vulnerabilities, how to submit a report, and includes a brief note about respectful communication. The content is largely based on CPython's [`SECURITY.md`](https://github.com/python/cpython/blob/main/.github/SECURITY.md) and [security policy](https://devguide.python.org/security/policy/).

Even if this repository has not previously received vulnerability reports, this PR provides a proactive reporting path so that, if a report is ever submitted, it reaches the right people through the PSRT's preferred process.

GHSAs are not currently enabled for this repository. Once enabled, they are only visible to people with admin privileges on the repository. To ensure the PSRT can access new reports, the PSRT maintains a bot, [`python/psrt-ghsa-bot`](https://github.com/python/psrt-ghsa-bot), which automatically adds the team as collaborators when a new report is submitted.

If there are no objections from the maintainers, the organisation administrators will enable GHSAs in this repository and configure the bot.

Closes #21763.