### PR TITLE
Preserve escaped test data section lines

### DIFF
--- a/mypy/test/test_update_data.py
+++ b/mypy/test/test_update_data.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+from unittest import TestCase
+
+from mypy.test.data import DataDrivenTestCase, DataFileFix
+from mypy.test.update_data import _iter_fixes
+
+
+class UpdateDataSuite(TestCase):
+    def test_preserves_escaped_section_header_like_file_line(self) -> None:
+        testcase = cast(
+            DataDrivenTestCase,
+            SimpleNamespace(
+                data="[file foo.ini]\n\\[mypy]\npython_version = 3.14\n", line=1, name="testCase"
+            ),
+        )
+
+        fixes = [fix for fix in _iter_fixes(testcase, [], incremental_step=1) if fix.lines]
+
+        assert fixes == [
+            DataFileFix(lineno=3, end_lineno=5, lines=["\\[mypy]", "python_version = 3.14"])
+        ]
+
+    def test_escapes_updated_source_line_that_looks_like_section_header(self) -> None:
+        testcase = cast(
+            DataDrivenTestCase, SimpleNamespace(data="\\[1] + 1\n", line=1, name="testCase")
+        )
+        actual = ["main:1: error: Something sus  [sus]"]
+
+        fixes = list(_iter_fixes(testcase, actual, incremental_step=1))
+
+        assert fixes == [
+            DataFileFix(lineno=2, end_lineno=3, lines=["\\[1] + 1  # E: Something sus  [sus]"])
+        ]

--- a/mypy/test/update_data.py
+++ b/mypy/test/update_data.py
@@ -76,12 +76,23 @@ def _iter_fixes(
                     is_last = j == len(reports) - 1
                     severity_char = severity[0].upper()
                     continuation = "" if is_last else " \\"
-                    fix_lines.append(f"{out_l}{indent}# {severity_char}: {msg}{continuation}")
+                    fix_lines.append(
+                        _escape_section_header_like_line(
+                            f"{out_l}{indent}# {severity_char}: {msg}{continuation}"
+                        )
+                    )
             else:
-                fix_lines.append(source_line)
+                fix_lines.append(_escape_section_header_like_line(source_line))
 
         yield DataFileFix(
             lineno=testcase.line + test_item.line - 1,
             end_lineno=testcase.line + test_item.end_line - 1,
             lines=fix_lines + [""] * test_item.trimmed_newlines,
         )
+
+
+def _escape_section_header_like_line(line: str) -> str:
+    """Escape source lines that would be parsed as .test section headers."""
+    if line.startswith("[") and line.strip().endswith("]"):
+        return f"\\{line}"
+    return line


### PR DESCRIPTION
Fixes #17465.

`parse_test_data()` unescapes lines that begin with `\[` so they can be treated as source text rather than `.test` section headers. When `--update-data` rewrites a test case, it was writing the parsed source line back directly, so an escaped line such as `\[mypy]` became `[mypy]` and could be parsed as a new section on the next run.

This keeps updated source lines escaped when they would otherwise look like section headers after being written back. It covers both unchanged lines in `[file ...]` sections and source lines that gain an inline `# E:` comment ending with an error code.

Validation:

- `/Users/bandi/Documents/Codex/2026-07-24/new-chat/work/mypy_venv/bin/python -m pytest mypy/test/test_update_data.py -q`
- `PYTHONPYCACHEPREFIX=/Users/bandi/Documents/Codex/2026-07-24/new-chat/work/.pycache /Users/bandi/Documents/Codex/2026-07-24/new-chat/work/mypy_venv/bin/python -m py_compile mypy/test/update_data.py mypy/test/test_update_data.py`
- `git diff --cached --check`
