### PR TITLE
Handle PEP 604 unions in stubgen inspect mode

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -13,7 +13,7 @@ import inspect
 import keyword
 import os.path
 from collections.abc import Callable, Mapping
-from types import FunctionType, ModuleType
+from types import FunctionType, ModuleType, UnionType as RuntimeUnionType
 from typing import Any
 
 from mypy.fastparse import parse_type_comment
@@ -768,11 +768,19 @@ class InspectionStubGenerator(BaseStubGenerator):
 
                 rw_properties.append(f"{self._indent}{name}: {inferred_type}")
 
-    def get_type_fullname(self, typ: type) -> str:
+    def get_type_fullname(self, typ: object) -> str:
         """Given a type, return a string representation"""
         if typ is Any:
             return "Any"
-        typename = getattr(typ, "__qualname__", typ.__name__)
+        if typ is type(None):
+            return "None"
+        if isinstance(typ, RuntimeUnionType):
+            return " | ".join(self.get_type_fullname(item) for item in typ.__args__)
+        typename = getattr(typ, "__qualname__", None)
+        if typename is None:
+            typename = getattr(typ, "__name__", None)
+        if typename is None:
+            return "_typeshed.Incomplete"
         module_name = self.get_obj_module(typ)
         if module_name is None:
             # This should not normally happen, but some types may resist our

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -1069,6 +1069,17 @@ class StubgencSuite(unittest.TestCase):
             ],
         )
 
+    def test_non_c_generate_signature_with_pep604_union(self) -> None:
+        def test(arg0: int | str) -> float | None:
+            pass
+
+        output: list[str] = []
+        mod = ModuleType(test.__module__, "")
+        gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
+        gen.is_c_module = False
+        gen.generate_function_stub("test", test, output=output)
+        assert_equal(output, ["def test(arg0: int | str) -> float | None: ..."])
+
     def test_generate_c_type_inheritance(self) -> None:
         class TestClass(KeyError):
             pass


### PR DESCRIPTION
## Summary

Fixes `stubgen --inspect-mode` crashing when runtime annotations contain PEP 604 unions such as `int | str`.

Runtime inspection sees those annotations as `types.UnionType`, which does not define `__name__`. `InspectionStubGenerator.get_type_fullname()` now handles runtime union objects recursively and renders `type(None)` as `None`, so signatures like `float | None` stay valid in generated stubs.

Fixes #21689.

## Test Plan

- `python -m pytest mypy/test/teststubgen.py::StubgencSuite::test_non_c_generate_signature_with_pep604_union -q`
- `python -m pytest mypy/test/teststubgen.py::StubgencSuite -q`
- `python -m py_compile mypy/stubgenc.py mypy/test/teststubgen.py`
- `python -m black --fast --check mypy/stubgenc.py mypy/test/teststubgen.py`
- `python -m ruff check mypy/stubgenc.py mypy/test/teststubgen.py`
- `git diff --check`
