### PR TITLE
Use a variadic tuple context to infer precise tuple types

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5348,8 +5348,20 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         if type_context_items is not None:
             unpack_in_context = find_unpack_in_list(type_context_items) is not None
         seen_unpack_in_items = False
+        # A variadic tuple context justifies inferring a precise tuple type even when
+        # tuple_context_matches() rejected the context because the structure doesn't
+        # line up exactly (e.g. (*a, "last") against tuple[str, *tuple[str, ...]]).
+        # Without this, such an expression collapses to tuple[str, ...], which is not
+        # assignable back to the variadic context. Note this deliberately does not feed
+        # unpack_in_context, whose index bookkeeping below relies on a full match.
+        variadic_context = (
+            isinstance(type_context, TupleType)
+            and find_unpack_in_list(type_context.items) is not None
+        )
         allow_precise_tuples = (
-            unpack_in_context or PRECISE_TUPLE_TYPES in self.chk.options.enable_incomplete_feature
+            unpack_in_context
+            or variadic_context
+            or PRECISE_TUPLE_TYPES in self.chk.options.enable_incomplete_feature
         )
 
         # Infer item types.  Give up if there's a star expression

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -1738,6 +1738,27 @@ vt = 1, *test(), 2  # OK, type context is used
 vt2 = 1, *test(), 2  # E: Need type annotation for "vt2"
 [builtins fixtures/tuple.pyi]
 
+[case testVariadicTupleContextStarPositionMismatch]
+from typing import Tuple
+from typing_extensions import Unpack
+
+a: Tuple[str, ...]
+b: Tuple[str, Unpack[Tuple[str, ...]]]
+
+# The star lines up with the context unpack.
+b = ("first", *a)
+# The star does not line up, but the context is still variadic, so the
+# precise tuple type is inferred rather than collapsing to tuple[str, ...].
+b = (*a, "last")
+
+# A variadic context must not paper over genuinely incompatible item types.
+c: Tuple[int, Unpack[Tuple[int, ...]]]
+c = (*a, "last")  # E: Incompatible types in assignment (expression has type "tuple[Unpack[tuple[str, ...]], str]", variable has type "tuple[int, Unpack[tuple[int, ...]]]")
+# A fixed-length context still requires enough items.
+d: Tuple[str, str, Unpack[Tuple[str, ...]]]
+d = ("only",)  # E: Incompatible types in assignment (expression has type "tuple[str]", variable has type "tuple[str, str, Unpack[tuple[str, ...]]]")
+[builtins fixtures/tuple.pyi]
+
 [case testVariadicTupleConcatenation]
 # flags: --enable-incomplete-feature=PreciseTupleTypes
 from typing import Tuple


### PR DESCRIPTION
Fixes #21476.

`(*a, "last")` where `a: tuple[str, ...]` is not accepted against the context `tuple[str, *tuple[str, ...]]`, while the mirrored `("first", *a)` is:

```python
a: tuple[str, ...]
b: tuple[str, *tuple[str, ...]]
b = ("first", *a)  # ok
b = (*a, "last")   # error: Incompatible types in assignment (expression has
                   # type "tuple[str, ...]", variable has type
                   # "tuple[str, *tuple[str, ...]]")
```

`tuple_context_matches()` only accepts a variadic context when the structure lines up exactly — the star item has to sit at the same index as the context unpack:

```python
return len(expr.items) == len(ctx.items) and ctx_unpack_index == expr_star_index
```

For `(*a, "last")` the unpack is at index 1 in the context but the star is at index 0, so the context is rejected. `type_context_items` is then never set, `unpack_in_context` stays `False`, and so `allow_precise_tuples` is `False` too. The star item therefore skips the precise-tuple branch and falls through to `check_lst_expr(e, "builtins.tuple", "<tuple>")`, giving `tuple[str, ...]` — which is not assignable back to a context requiring at least one item.

This decouples "is the context variadic" from "does the structure match exactly", and uses the former to enable precise tuple inference. `unpack_in_context` is deliberately left alone, because the `j` index bookkeeping further down is explicitly documented as depending on a full structure match.

With the change, the star item is inferred as `Unpack[tuple[str, ...]]`, so the expression types as `tuple[*tuple[str, ...], str]` and the assignment is accepted. This matches what `--enable-incomplete-feature=PreciseTupleTypes` already produced for this expression, and lines up with the existing `# TODO: try using tuple type context in more cases.` next to the structural check.

It is a narrowing of what is rejected, not a widening of what is accepted — incompatible item types and too-short tuples still error, and the diagnostics get slightly better because the reported expression type is now precise:

```
- expression has type "tuple[str, ...]",           variable has type "tuple[int, *tuple[int, ...]]"
+ expression has type "tuple[*tuple[str, ...], str]", variable has type "tuple[int, *tuple[int, ...]]"
```

### Tests

Added `testVariadicTupleContextStarPositionMismatch` to `check-typevar-tuple.test`, covering both star positions plus a wrong-item-type case and a too-short case so the change can't silently start accepting bad code. It fails on master and passes with this change.

Full `mypy/test/testcheck.py` suite: `8173 passed, 15 skipped, 7 xfailed`.

One case intentionally not addressed: `(*a, *a, "x")` still collapses to `tuple[str, ...]`, since a tuple type can only carry one unpack. That behaves the same before and after this change.
