### PR TITLE
fix(modulefinder): use subpath instead of relative_path in fscache.isdir check in matches_gitignore

### DIFF
--- a/mypy/modulefinder.py
+++ b/mypy/modulefinder.py
@@ -711,7 +711,7 @@ def matches_gitignore(subpath: str, fscache: FileSystemCache, verbose: bool) -> 
     dir, _ = os.path.split(subpath)
     for gi_path, gi_spec in find_gitignores(dir):
         relative_path = os.path.relpath(subpath, gi_path)
-        if fscache.isdir(relative_path):
+        if fscache.isdir(subpath):
             relative_path = relative_path + "/"
         if gi_spec.match_file(relative_path):
             if verbose:


### PR DESCRIPTION
## Description
This PR resolves issue #21760 by passing `subpath` to `fscache.isdir()` in `matches_gitignore()` in `mypy/modulefinder.py`.

## Details
- Fixes directory-only pattern matching (e.g. `build/`, `sub/`) when using nested `.gitignore` files with `--exclude-gitignore`.