### PR TITLE
fix(checkexpr): use Any for omitted slice indices when strict_optional is False

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5908,6 +5908,8 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         for index in [e.begin_index, e.end_index, e.stride]:
             if index:
                 type_args.append(self.accept(index))
+            elif not self.chk.options.strict_optional:
+                type_args.append(AnyType(TypeOfAny.special_form))
             else:
                 type_args.append(NoneType())
         return self.chk.named_generic_type("builtins.slice", type_args)


### PR DESCRIPTION
## Description
This PR resolves issue #21777 by using `AnyType` for omitted slice indices when `strict_optional = False` in `visit_slice_expr()` in `mypy/checkexpr.py`.

## Details
- Prevents false-positive `Invalid index type "slice[int, None, None]" for "str"` errors when `strict_optional = False` is configured.