### PR TITLE
fix(checker): associate code=codes.MISC with zero-member enum stub error and note

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2955,10 +2955,12 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     "enum membership. If so, use `member = value` to mark an enum member, "
                     "instead of `member: type`",
                     defn,
+                    code=codes.MISC,
                 )
                 self.note(
                     "See https://typing.readthedocs.io/en/latest/spec/enums.html#defining-members",
                     defn,
+                    code=codes.MISC,
                 )
 
         self.check_enum_bases(defn)


### PR DESCRIPTION
## Description
This PR resolves issue #21730 by associating `code=codes.MISC` with the zero-member enum stub error and note in `mypy/checker.py`.

## Details
- Allows zero-member enum errors in stubs to be cleanly suppressed using `# type: ignore[misc]` or `disable_error_code=misc` when intended by API authors.