### PR TITLE
[mypyc] Fix `default_factory` for inherited dataclass

### DIFF
--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -760,7 +760,6 @@ def find_attr_initializers(
     if cls.builtin_base:
         return set(), []
 
-    cls_type = dataclass_type(cdef)
     attrs_with_defaults: set[str] = set()
     default_assignments: list[tuple[AssignmentStmt, str]] = []
 
@@ -774,10 +773,11 @@ def find_attr_initializers(
         info_ir = builder.mapper.type_to_ir.get(info)
         if info_ir is None:
             continue
+        info_cls_type = dataclass_type(info.defn)
         for stmt in info.defn.defs.body:
             if not isinstance(stmt, AssignmentStmt):
                 continue
-            name = default_attr_name(stmt, info_ir, cls_type)
+            name = default_attr_name(stmt, info_ir, info_cls_type)
             if name is None:
                 continue
             attrs_with_defaults.add(name)

--- a/mypyc/test-data/run-python37.test
+++ b/mypyc/test-data/run-python37.test
@@ -74,8 +74,15 @@ class Person5:
     friends: Set[str] = field(default_factory=set)
     parents: FrozenSet[str] = frozenset()
 
+@dataclass
+class HasFactoryDefault:
+    x: dict[str, int] = field(default_factory=dict)
+
+class InheritsDataclassInit(HasFactoryDefault):
+    pass
+
 [file other.py]
-from native import Person1, Person1b, Person2, Person3, Person4, Person5, testBool
+from native import Person1, Person1b, Person2, Person3, Person4, Person5, testBool, InheritsDataclassInit
 i1 = Person1(age = 5, name = 'robot')
 assert i1.age == 5
 assert i1.name == 'robot'
@@ -125,6 +132,9 @@ assert Person1.__annotations__ == {'age': int, 'name': str}
 assert Person2.__annotations__ == {'age': int, 'name': str}
 assert Person5.__annotations__ == {'weight': float, 'friends': set,
                                        'parents': frozenset}
+v = InheritsDataclassInit()
+assert isinstance(v.x, dict)
+assert v.x == {}
 
 [file driver.py]
 import sys


### PR DESCRIPTION
Closes https://github.com/mypyc/mypyc/issues/1204, a `mypyc` issue.

The issue likely unblocks `isort` from being compiled with `mypyc`, which is why I took an interest it. Full disclosure is that I used AI to write this, it provided this test and code just from the linked issue but it looks sensible to me. I did not use additional prompting. Like I said, fix looks sensible: we now call `dataclass_type` for each entry in the MRO, instead of once.

I am aware the contributing guidelines say new contributors are not encourage to use LLMs but I hope the size of the PR and my track record as open source maintainer gives some flexibility here. I'm very aware that reviewing AI written PRs creates maintainer burden, but I'm committed to getting this over the finish line. To that end I:

Tested locally with `pytest mypyc/test/test_run.py ` and that looked okay.
Also tested that without the changes the added test would fail on `master`.
Also tried to run CI on my local fork (https://github.com/DanielNoord/mypy/pull/1), which succeeded.

Feel free to push changes to the branch or cherry pick this into another branch. I am not necessarily interested in getting credits for the fix/PR, I'd just like to continue with my attempt to get `isort` compiled and for that I need this in a `mypy` release :)