### PR TITLE
Move trailing-comma config tests to check tests

### DIFF
--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1634,6 +1634,7 @@ if BLAH:
 [file mypy.ini]
 \[mypy]
 ignore_missing_imports = True
+# Keep `YOLO` last to verify it is parsed when the list has a trailing comma.
 always_true =
   YOLO1,
   YOLO,
@@ -1665,6 +1666,7 @@ def bar():
     pass
 [file mypy.ini]
 \[mypy]
+# Keep `no-untyped-def` last to verify it is parsed when the list has a trailing comma.
 disable_error_code =
   import,
   no-untyped-def,
@@ -2533,6 +2535,7 @@ if foo: ...  # E: Function "foo" could always be true in boolean context
 42 + "no"  # type: ignore
 [file mypy.ini]
 \[mypy]
+# Keep `truthy-bool` last to verify it is parsed when the list has a trailing comma.
 enable_error_code =
   used-before-def,
   ignore-without-code,

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1634,7 +1634,9 @@ if BLAH:
 [file mypy.ini]
 \[mypy]
 ignore_missing_imports = True
-always_true = YOLO1, YOLO
+always_true =
+  YOLO1,
+  YOLO,
 always_false = BLAH, BLAH1
 [builtins fixtures/bool.pyi]
 
@@ -1663,7 +1665,9 @@ def bar():
     pass
 [file mypy.ini]
 \[mypy]
-disable_error_code = import, no-untyped-def
+disable_error_code =
+  import,
+  no-untyped-def,
 
 
 [case testDisableErrorCodeConfigFilePyProjectTOML]
@@ -2529,7 +2533,10 @@ if foo: ...  # E: Function "foo" could always be true in boolean context
 42 + "no"  # type: ignore
 [file mypy.ini]
 \[mypy]
-enable_error_code = ignore-without-code, truthy-bool, used-before-def
+enable_error_code =
+  used-before-def,
+  ignore-without-code,
+  truthy-bool,
 
 \[mypy-tests.*]
 disable_error_code = ignore-without-code

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1210,32 +1210,6 @@ y: int = 'y'  # E: Incompatible types in assignment (expression has type "str", 
 z: int = 'z'
 [out]
 
-[case testCmdlineCfgEnableErrorCodeTrailingComma]
-# cmd: mypy .
-[file mypy.ini]
-\[mypy]
-enable_error_code =
-  truthy-bool,
-  redundant-expr,
-[out]
-
-[case testCmdlineCfgDisableErrorCodeTrailingComma]
-# cmd: mypy .
-[file mypy.ini]
-\[mypy]
-disable_error_code =
-  misc,
-  override,
-[out]
-
-[case testCmdlineCfgAlwaysTrueTrailingComma]
-# cmd: mypy .
-[file mypy.ini]
-\[mypy]
-always_true =
-  MY_VAR,
-[out]
-
 [case testCmdlineCfgModulesTrailingComma]
 # cmd: mypy
 [file mypy.ini]


### PR DESCRIPTION
Refs #5966.

This is a test-only change that moves multiline trailing-comma coverage from three subprocess-based `cmdline.test` cases into existing `check-flags.test` cases:

- `testCmdlineCfgEnableErrorCodeTrailingComma` -> `testPerModuleErrorCodesOverride`
- `testCmdlineCfgDisableErrorCodeTrailingComma` -> `testDisableErrorCodeConfigFile`
- `testCmdlineCfgAlwaysTrueTrailingComma` -> `testAlwaysTrueAlwaysFalseConfigFile`

The existing check cases exercise the configured behavior, so the command-line cases can be removed without losing coverage. In `testPerModuleErrorCodesOverride`, `truthy-bool` is placed last so the value immediately before the trailing comma is exercised by the test.

Tests:

- `python -m pytest -n0 -q mypy/test/testcheck.py::TypeCheckSuite::check-flags.test` (`219 passed`)
- `python -m pytest -n0 -q mypy/test/testcmdline.py -k "testCmdlineCfgFilesTrailingComma or testCmdlineCfgModulesTrailingComma or testCmdlineCfgPackagesTrailingComma"` (`3 passed`)

Local targeted timing on Windows with pytest parallelism disabled (`-n0`), averaged across three runs:

- Before, as three subprocess-based `cmdline.test` cases: 9.08s
- After, as three `check-flags.test` cases: 0.54s
