### PR TITLE
Add `--num-workers auto` option

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -1049,8 +1049,8 @@ enabled by default starting from mypy 2.0.
 
     Use ``NUMBER`` parallel worker processes (in addition to the coordinator
     process) to perform type-checking. Specifying ``--num-workers 0`` (default)
-    disables parallel checking. Automatic detection of the optimal number
-    of workers is not supported yet.
+    disables parallel checking. Automatic detection of the physical CPU core count
+    is possible through ``--num-workers auto```.
 
     This setting will override the ``MYPY_NUM_WORKERS`` environment
     variable if it is set.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import multiprocessing
 import os
 import platform
 import subprocess
@@ -1179,12 +1180,18 @@ def define_options(
     internals_group.add_argument("--export-ref-info", action="store_true", help=argparse.SUPPRESS)
 
     # Experimental parallel type-checking support.
+    def _num_workers_type(value: str) -> int:
+        if value == "auto":
+            return multiprocessing.cpu_count()
+
+        return int(value)
+
     internals_group.add_argument(
         "-n",
         "--num-workers",
-        type=int,
+        type=_num_workers_type,
         default=0,
-        help="Number of separate mypy worker processes (experimental)",
+        help="Number of separate mypy worker processes (experimental). With `auto` detects (and uses) physical CPU count.",
     )
 
     report_group = parser.add_argument_group(

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -1321,3 +1321,13 @@ error: Cache must be enabled in parallel mode
 from foo.api import bar as bar
 [file foo-stubs/api/bar.pyi]
 [out]
+
+[case testParallelAutoRunWithSyntaxError]
+# cmd: mypy a.py --num-workers=auto --pretty
+[file a.py]
+1 2
+[out]
+a.py:1: error: Simple statements must be separated by newlines or semicolons
+    1 2
+       ^
+== Return code: 2


### PR DESCRIPTION
Adds `--num-workers auto` behaviour, which automatically detects and uses the physical available CPU core count for parallel execution.

Behaviour is consistent with `pytest` interface.

Fixes https://github.com/python/mypy/issues/21477. 