### PR TITLE
Fix command mode with targets set in config

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1494,9 +1494,11 @@ def process_options(
     if special_opts.no_executable or options.no_site_packages:
         options.python_executable = None
 
-    # Paths listed in the config file will be ignored if any paths, modules or packages
-    # are passed on the command line.
-    if not (special_opts.files or special_opts.packages or special_opts.modules):
+    # File, package, and module targets from the config file are used only if no target
+    # is specified on the command line.
+    if not (
+        special_opts.files or special_opts.packages or special_opts.modules or special_opts.command
+    ):
         if options.files:
             special_opts.files = options.files
         if options.packages:

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -670,6 +670,14 @@ files = config.py
 mypy: error: Cannot read file 'override.py': No such file or directory
 == Return code: 2
 
+[case testCommandOverridesTargetsFromConfig]
+# cmd: mypy -c pass
+[file mypy.ini]
+\[mypy]
+files = should_be_ignored.py
+packages = should_be_ignored_package
+modules = should_be_ignored_module
+
 [case testErrorSummaryOnSuccess]
 # cmd: mypy --error-summary good.py
 [file good.py]


### PR DESCRIPTION
Fixes #15632.

When `-c` is provided, treat it as an explicitly specified command-line target. This prevents `files`, `packages`, or `modules` from the config file from being added alongside the command target and triggering the mutually exclusive target error.

Add a command-line regression test covering all three config target options.
