### PR TITLE
Fix protocol matching with __class__ override

### DIFF
--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3595,6 +3595,7 @@ EXCLUDED_PROTOCOL_ATTRIBUTES: Final = frozenset(
     {
         "__abstractmethods__",
         "__annotations__",
+        "__class__",
         "__dict__",
         "__doc__",
         "__init__",

--- a/test-data/unit/check-overloading.test
+++ b/test-data/unit/check-overloading.test
@@ -6856,3 +6856,42 @@ if isinstance(headers, dict):
 
 reveal_type(headers)  # N: Revealed type is "__main__.Headers | typing.Iterable[tuple[builtins.bytes, builtins.bytes]]"
 [builtins fixtures/isinstancelist.pyi]
+
+[case testOverloadProtocolClassPropertyDoesNotEraseListItemType]
+from collections.abc import Iterator, Sequence
+from typing import Any, Protocol, TypeVar, overload
+
+T_co = TypeVar("T_co", covariant=True)
+
+class ReducedCovariantList(Protocol[T_co]):
+    @property
+    def __class__(self) -> type[list[Any]]: ...
+    def __iter__(self) -> Iterator[T_co]: ...
+
+@overload
+def f(x: ReducedCovariantList[str]) -> str: ...
+@overload
+def f(x: Sequence[int]) -> int: ...
+def f(x: object) -> object: ...
+
+reveal_type(f([1]))  # N: Revealed type is "builtins.int"
+[file builtins.py]
+from typing import Generic, Self, TypeVar
+from collections.abc import Iterator, Sequence
+
+class object:
+    @property
+    def __class__(self) -> type[Self]: pass
+class type: pass
+class function: pass
+class property: pass
+class int: pass
+class str: pass
+class bool: pass
+class dict: pass
+class ellipsis: pass
+class tuple: pass
+
+T = TypeVar("T")
+class list(Sequence[T], Generic[T]):
+    def __iter__(self) -> Iterator[T]: pass


### PR DESCRIPTION
## Summary

Exclude `__class__` from protocol members, matching Python's special-attribute handling. This prevents a protocol-only `__class__` property from making `list[int]` satisfy an incompatible overload before the `Sequence[int]` overload is considered.

Adds a regression fixture derived from the reported example; `f([1])` now reveals `int`.

Fixes #21795.

## Verification

- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-overloading.test -k testOverloadProtocolClassPropertyDoesNotEraseListItemType`
- `pytest -n0 mypy/test/testcheck.py::TypeCheckSuite::check-overloading.test mypy/test/testcheck.py::TypeCheckSuite::check-protocols.test`
- `pytest -n0 mypy/test/testcheck.py` — 8194 passed, 26 skipped, 7 xfailed
- `python -m mypy --config-file mypy_self_check.ini -p mypy`
- `python runtests.py lint`
