### PR TITLE
Allow instantiating type[None] / types.NoneType

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1940,6 +1940,11 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         """
         if isinstance(item, AnyType):
             return AnyType(TypeOfAny.from_another_any, source_any=item)
+        if isinstance(item, NoneType):
+            # `type(None)` / `type[None]` is instantiable at runtime and returns None.
+            return CallableType(
+                [], [], [], NoneType(), self.named_type("builtins.function"), from_type_type=True
+            )
         if isinstance(item, Instance):
             res = type_object_type(item.type)
             if isinstance(res, CallableType):

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3913,6 +3913,22 @@ def foo(arg: Type[Tuple[int]]):
     arg()  # E: Cannot instantiate type "type[tuple[int]]"
 [builtins fixtures/tuple.pyi]
 
+[case testTypeCanInstantiateNoneType]
+from types import NoneType
+
+type(None)()
+NoneType()
+
+def f(n: type[None]) -> None:
+    n()
+
+def g(n: type[NoneType]) -> None:  # E: NoneType should not be used as a type, please use None instead
+    n()
+
+f(NoneType)
+g(NoneType)
+[builtins fixtures/tuple.pyi]
+
 [case testTypeUsingTypeCOverloadedClass]
 from foo import *
 [file foo.pyi]


### PR DESCRIPTION
## Summary
`analyze_type_type_callee()` in `checkexpr.py` had no branch for mypy's internal `NoneType`. As a result, calling a callee of type `type[None]` incorrectly produced `Cannot instantiate type "type[None]"`, even though this is valid at runtime (`type(None)()` and `NoneType()` both return `None`).

Repro from the issue:
```python
from types import NoneType

type(None)()
NoneType()

def f(n: type[None]):
    n()

def g(n: type[NoneType]):
    n()

f(NoneType)
g(NoneType)
```

Before this change, mypy reported 4 spurious `Cannot instantiate type "type[None]"` errors (plus the expected `NoneType should not be used as a type` note). After this change, only the expected note remains.

Fix: add a case in `analyze_type_type_callee` that, for `NoneType` items, returns a nullary `CallableType` with return type `NoneType()`, mirroring how `type(None)` behaves at runtime.

## Test plan
- [x] Added `testTypeCanInstantiateNoneType` to `test-data/unit/check-classes.test`
- [x] `pytest mypy/test/testcheck.py -k "check-classes or check-python310"` -> 810 passed
- [x] `pytest mypy/test/testcheck.py` (full suite) -> 8175 passed
- [x] `mypy --config-file mypy_self_check.ini mypy/checkexpr.py` -> no issues
- [x] `pre-commit run` on changed files -> passed

Fixes #19660