### PR TITLE
Fix redundant cast detection for generic calls

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4861,13 +4861,18 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
         redundant_source_type = source_type
 
         if options.warn_redundant_casts:
+            cast_context = self.type_context[-1]
+
             with self.msg.filter_errors() as local_errors:
                 with (
                     self.chk.local_type_map,
                     self.chk.binder.frame_context(can_skip=False, discard=True),
                 ):
                     inferred_source_type = self.accept(
-                        expr.expr, type_context=None, allow_none_return=True, always_allow_any=True
+                        expr.expr,
+                        type_context=cast_context,
+                        allow_none_return=True,
+                        always_allow_any=True,
                     )
 
             if not local_errors.has_new_errors():

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4850,10 +4850,7 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
     def visit_cast_expr(self, expr: CastExpr) -> Type:
         """Type check a cast expression."""
         source_type = self.accept(
-            expr.expr,
-            type_context=AnyType(TypeOfAny.special_form),
-            allow_none_return=True,
-            always_allow_any=True,
+            expr.expr, type_context=None, allow_none_return=True, always_allow_any=True
         )
         target_type = expr.type
         options = self.chk.options

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4850,18 +4850,39 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
     def visit_cast_expr(self, expr: CastExpr) -> Type:
         """Type check a cast expression."""
         source_type = self.accept(
-            expr.expr, type_context=None, allow_none_return=True, always_allow_any=True
+            expr.expr,
+            type_context=AnyType(TypeOfAny.special_form),
+            allow_none_return=True,
+            always_allow_any=True,
         )
         target_type = expr.type
         options = self.chk.options
+
+        redundant_source_type = source_type
+
+        if options.warn_redundant_casts:
+            with self.msg.filter_errors() as local_errors:
+                with (
+                    self.chk.local_type_map,
+                    self.chk.binder.frame_context(can_skip=False, discard=True),
+                ):
+                    inferred_source_type = self.accept(
+                        expr.expr, type_context=None, allow_none_return=True, always_allow_any=True
+                    )
+
+            if not local_errors.has_new_errors():
+                redundant_source_type = inferred_source_type
+
         if (
             options.warn_redundant_casts
             and not is_same_type(target_type, AnyType(TypeOfAny.special_form))
-            and is_same_type(source_type, target_type)
+            and is_same_type(redundant_source_type, target_type)
         ):
             self.msg.redundant_cast(target_type, expr)
+
         if options.disallow_any_unimported and has_any_from_unimported_type(target_type):
             self.msg.unimported_type_becomes_any("Target type of cast", target_type, expr)
+
         check_for_explicit_any(
             target_type, self.chk.options, self.chk.is_typeshed_stub, self.msg, context=expr
         )

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -21,8 +21,8 @@ T = TypeVar("T")
 def identity(xs: list[T]) -> list[T]:
     return xs
 
-xs: list[int] = []
-cast(list[int], identity(xs))
+def f(xs: list[int]) -> list[int]:
+    return cast(list[int], identity(xs))
 [out]
 main:10: error: Redundant cast to "list[int]"
 

--- a/test-data/unit/check-warnings.test
+++ b/test-data/unit/check-warnings.test
@@ -12,6 +12,20 @@ c = cast(int, a)
 [out]
 main:5: error: Redundant cast to "int"
 
+[case testRedundantCastGenericReturn]
+# flags: --warn-redundant-casts
+from typing import TypeVar, cast
+
+T = TypeVar("T")
+
+def identity(xs: list[T]) -> list[T]:
+    return xs
+
+xs: list[int] = []
+cast(list[int], identity(xs))
+[out]
+main:10: error: Redundant cast to "list[int]"
+
 [case testRedundantCastWithIsinstance]
 # flags: --warn-redundant-casts
 from typing import cast, Union


### PR DESCRIPTION
Fixes #21796

`visit_cast_expr()` currently checks the source expression with an `Any` type context. For generic calls, that context participates in type argument inference, so a call such as `identity(xs)` is inferred as `list[Any]` inside `cast()` even though it is independently inferred as `list[int]`.

This prevents the redundant-cast check from recognizing that the source type and target type are the same.

Check the cast source expression without a type context so its type is inferred independently before comparing it with the cast target.

Also add a regression test covering redundant casts around generic return types.

Tests:
- `python runtests.py testRedundantCastGenericReturn`
- `python runtests.py check-warnings.test`
- `python runtests.py self`
- `python runtests.py lint`