### PR TITLE
Fix invalid contextual inference for generic call arguments

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1752,17 +1752,39 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             freeze_all_type_vars(fresh_ret_type)
             callee = callee.copy_modified(ret_type=fresh_ret_type)
 
+        formal_to_actual: list[list[int]] | None = None
         if callee.is_generic():
             callee = freshen_function_type_vars(callee)
+            callee_before_context = callee
             callee = self.infer_function_type_arguments_using_context(callee, context)
+            if callee != callee_before_context:
+                formal_to_actual = map_actuals_to_formals(
+                    arg_kinds,
+                    arg_names,
+                    callee.arg_kinds,
+                    callee.arg_names,
+                    lambda i: self.accept(args[i]),
+                )
+                if self.should_infer_args_without_context(
+                    callee_before_context,
+                    callee,
+                    args,
+                    arg_kinds,
+                    arg_names,
+                    formal_to_actual,
+                    context,
+                ):
+                    callee = callee_before_context
+                    formal_to_actual = None
 
-        formal_to_actual = map_actuals_to_formals(
-            arg_kinds,
-            arg_names,
-            callee.arg_kinds,
-            callee.arg_names,
-            lambda i: self.accept(args[i]),
-        )
+        if formal_to_actual is None:
+            formal_to_actual = map_actuals_to_formals(
+                arg_kinds,
+                arg_names,
+                callee.arg_kinds,
+                callee.arg_names,
+                lambda i: self.accept(args[i]),
+            )
 
         if callee.special_sig == "tuple" and len(args) == 1:
             with self.msg.filter_errors():
@@ -2060,6 +2082,115 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             else:
                 res.append(self.accept(arg))
         return res
+
+    def should_infer_args_without_context(
+        self,
+        callee: CallableType,
+        contextual_callee: CallableType,
+        args: list[Expression],
+        arg_kinds: list[ArgKind],
+        arg_names: Sequence[str | None] | None,
+        formal_to_actual: list[list[int]],
+        context: Context,
+    ) -> bool:
+        """Should we abandon contextual type argument inference for this call?
+
+        Context can infer a wider type argument than the actual argument supports when
+        the type variable also appears in an invariant or callback argument position.
+        In that case we can use regular argument inference instead, but only if it
+        produces a valid call whose return type still satisfies the outer context.
+        """
+        if contextual_callee.special_sig is not None or contextual_callee.is_type_obj():
+            # Keep the previous behavior for special synthetic signatures and type object
+            # calls, where context is often intentionally used to produce better errors.
+            return False
+
+        valid = True
+
+        def check_arg(
+            caller_type: Type,
+            original_caller_type: Type,
+            caller_kind: ArgKind,
+            callee_type: Type,
+            n: int,
+            m: int,
+            callee: CallableType,
+            object_type: Type | None,
+            context: Context,
+            outer_context: Context,
+        ) -> None:
+            nonlocal valid
+            if not is_subtype(
+                get_proper_type(caller_type),
+                get_proper_type(callee_type),
+                options=self.chk.options,
+            ):
+                valid = False
+
+        validation_callee = contextual_callee
+        validation_formal_to_actual = formal_to_actual
+        with self.msg.filter_errors(), self.chk.local_type_map:
+            if validation_callee.is_generic():
+                need_refresh = any(
+                    isinstance(v, (ParamSpecType, TypeVarTupleType))
+                    for v in validation_callee.variables
+                )
+                validation_callee = self.infer_function_type_arguments(
+                    validation_callee,
+                    args,
+                    arg_kinds,
+                    arg_names,
+                    validation_formal_to_actual,
+                    need_refresh,
+                    context,
+                )
+                if need_refresh:
+                    validation_formal_to_actual = map_actuals_to_formals(
+                        arg_kinds,
+                        arg_names,
+                        validation_callee.arg_kinds,
+                        validation_callee.arg_names,
+                        lambda i: self.accept(args[i]),
+                    )
+            arg_types = self.infer_arg_types_in_context(
+                validation_callee, args, arg_kinds, validation_formal_to_actual
+            )
+            self.check_argument_types(
+                arg_types,
+                arg_kinds,
+                args,
+                validation_callee,
+                validation_formal_to_actual,
+                context,
+                check_arg=check_arg,
+            )
+        if valid:
+            return False
+
+        ctx = self.type_context[-1]
+        if not ctx:
+            return False
+
+        with self.msg.filter_errors() as local_errors, self.chk.local_type_map:
+            formal_to_actual = map_actuals_to_formals(
+                arg_kinds,
+                arg_names,
+                callee.arg_kinds,
+                callee.arg_names,
+                lambda i: self.accept(args[i]),
+            )
+            need_refresh = any(
+                isinstance(v, (ParamSpecType, TypeVarTupleType)) for v in callee.variables
+            )
+            inferred_callee = self.infer_function_type_arguments(
+                callee, args, arg_kinds, arg_names, formal_to_actual, need_refresh, context
+            )
+        return (
+            not local_errors.has_new_errors()
+            and not has_ambiguous_uninhabited_component(inferred_callee.ret_type)
+            and not has_erased_component(inferred_callee.ret_type)
+            and is_subtype(inferred_callee.ret_type, ctx, options=self.chk.options)
+        )
 
     def infer_function_type_arguments_using_context(
         self, callable: CallableType, error_context: Context

--- a/test-data/unit/check-inference-context.test
+++ b/test-data/unit/check-inference-context.test
@@ -1542,6 +1542,70 @@ def check(paths: Iterable[str], key: Callable[[str], int]) -> Union[str, None]:
     return mymin(paths, key=key, default=None)
 [builtins fixtures/tuple.pyi]
 
+[case testContextInferenceDoesNotWidenInvariantArgument]
+from typing import Generic, Iterable, Iterator, TypeVar, Union
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+class Vec(Generic[T]):
+    def getitem(self, i: int) -> T: pass
+    def setitem(self, i: int, v: T) -> None: pass
+    def __init__(self, iterable: Iterable[T]) -> None: pass
+    def __iter__(self) -> Iterator[T]: pass
+    def __add__(self, value: "Vec[S]") -> "Vec[Union[S, T]]": pass
+
+def fmt(arg: Iterable[Union[int, str]]) -> None: pass
+
+l1: Vec[int] = Vec([1])
+l2: Vec[int] = Vec([1])
+fmt(l1 + l2)
+
+dummy = l1 + l2
+fmt(dummy)
+
+[case testContextInferenceDoesNotWidenKeyedMinItem]
+from typing import Callable, Iterable, List, Tuple, TypeVar
+
+T = TypeVar("T")
+
+def my_min(values: Iterable[T], *, key: Callable[[T], int]) -> T: pass
+def tuple_len(x: Tuple[str, ...]) -> int: pass
+def dot_join(parts: Iterable[str]) -> str: pass
+
+def smallest_prefix(x: List[Tuple[str, ...]]) -> str:
+    return dot_join(my_min(x, key=tuple_len))
+[builtins fixtures/tuple.pyi]
+
+[case testContextFallbackDoesNotUseAmbiguousNeverReturn]
+from typing import Generic, Protocol, TypeVar
+from typing_extensions import TypeVarTuple, Unpack
+
+PosArgT = TypeVarTuple("PosArgT")
+StatusT = TypeVar("StatusT")
+StatusT_co = TypeVar("StatusT_co", covariant=True)
+StatusT_contra = TypeVar("StatusT_contra", contravariant=True)
+
+class TaskStatus(Generic[StatusT_contra]):
+    def started(self, value: StatusT_contra) -> None: ...
+
+class NurseryStartFunc(Protocol[Unpack[PosArgT], StatusT_co]):
+    def __call__(
+        self, *args: Unpack[PosArgT], task_status: TaskStatus[StatusT_co]
+    ) -> object: ...
+
+def nursery_start(
+    async_fn: NurseryStartFunc[Unpack[PosArgT], StatusT], *args: Unpack[PosArgT]
+) -> StatusT: ...
+
+def task(a: int, b: str, *, task_status: TaskStatus[set[str]]) -> None: ...
+
+def test() -> None:
+    result: set[str] = nursery_start(task, 1, "b")
+    result = nursery_start(task, "a", 2)  # E: Argument 1 to "nursery_start" has incompatible type "def task(a: int, b: str, *, task_status: TaskStatus[set[str]]) -> None"; expected "NurseryStartFunc[str, int, set[str]]" \
+                                          # N: "NurseryStartFunc[str, int, set[str]].__call__" has type "def __call__(str, int, /, *, task_status: TaskStatus[set[str]]) -> object"
+[builtins fixtures/set.pyi]
+
 [case testBinaryOpInferenceContext]
 from typing import Literal, TypeVar
 
@@ -1615,6 +1679,34 @@ async def inner(c: Cls[T]) -> Optional[T]:
 async def outer(c: Cls[T]) -> Optional[T]:
     return await inner(c)
 [builtins fixtures/async_await.pyi]
+[typing fixtures/typing-async.pyi]
+
+[case testContextInferenceDoesNotWidenAwaitedInferredAttribute]
+from typing import Mapping, Optional, TypeVar
+
+K = TypeVar("K")
+
+async def select_one(options: Mapping[K, str]) -> Optional[K]:
+    return None
+
+class ViaInferredAttr:
+    async def m(self) -> None:
+        cases = {"a": "x"}
+        self._done = await select_one(cases)
+
+async def via_local() -> None:
+    cases = {"a": "x"}
+    done = await select_one(cases)
+    done = await select_one(cases)
+    done2: Optional[str] = await select_one(cases)
+
+class ViaAnnotatedAttr:
+    _done: Optional[str]
+
+    async def m(self) -> None:
+        cases = {"a": "x"}
+        self._done = await select_one(cases)
+[builtins fixtures/dict.pyi]
 [typing fixtures/typing-async.pyi]
 
 [case testContextFallbackNarrowingTernaryRValue]


### PR DESCRIPTION
Fixes: 
* #19304
* #21809
* #21104
* #20219
* #19259
* #18689
* #18267
* #18236 
* #17694
* #17025 
* #16953
* #16376
* #16310
* #15462
* #15087
* #12760
* #10281
* #10105
* #8478
* #5971
* #5874
* #5311
* #4150

Mypy can use the outer return context to specialize a generic callable before it has checked whether the actual arguments still fit the specialized signature.

This can produce false positives when the contextual type is wider than the actual argument supports. For example, in the issue repro the outer `Iterable[int | str]` context pushes `Vec.__add__` toward accepting `Vec[int | str]`, but the actual argument is `Vec[int]`, and `Vec` is invariant.

This PR keeps the existing contextual inference path, but adds a guard before committing to the context-specialized callable. If the specialized argument types are not compatible with the actual arguments, mypy falls back to ordinary argument inference, but only when that ordinary inferred return type still satisfies the original outer context.

The fallback is intentionally narrow. Constructors and special synthetic signatures keep the old behavior, since broader fallback caused regressions in existing tests, including `testAbstractTypeInADict` and constructor/type-alias cases that started reporting `Never`-based expected types.

Regression tests cover:
- invariant generic argument widening through `Vec.__add__`
- a `min(..., key=...)`-style callback case where return context widens the item type too far