### PR TITLE
Propagate walrus narrowing from nested expressions

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -148,11 +148,13 @@ from mypy.nodes import (
     CallExpr,
     ClassDef,
     ComparisonExpr,
+    ConditionalExpr,
     Context,
     ContinueStmt,
     Decorator,
     DelStmt,
     DictExpr,
+    DictionaryComprehension,
     EllipsisExpr,
     Expression,
     ExpressionStmt,
@@ -161,6 +163,7 @@ from mypy.nodes import (
     FuncBase,
     FuncDef,
     FuncItem,
+    GeneratorExpr,
     GlobalDecl,
     IfStmt,
     Import,
@@ -6625,9 +6628,41 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         if_map, else_map = self.find_isinstance_check_helper(
             node, in_boolean_context=in_boolean_context
         )
+        self.propagate_walrus_assignments(node, if_map, else_map)
         new_if_map = self.propagate_up_typemap_info(if_map)
         new_else_map = self.propagate_up_typemap_info(else_map)
         return new_if_map, new_else_map
+
+    def propagate_walrus_assignments(
+        self, node: Expression, if_map: TypeMap, else_map: TypeMap
+    ) -> None:
+        """Narrow the targets of walrus assignments nested within a condition.
+
+        Such an assignment has already happened by the time the condition has
+        been evaluated, so the assigned type applies to both branches, and both
+        maps are updated in place. Which branches are actually reached is decided
+        by the callers combining these maps: `and` carries the right operand's if
+        map into the if branch, and `or` carries its else map into the else
+        branch.
+        """
+        if isinstance(node, NameExpr):
+            # The most common condition, and it has no subexpressions.
+            return
+
+        collector = WalrusAssignmentCollector()
+        node.accept(collector)
+        if not collector.assignments:
+            return
+
+        for type_map in (if_map, else_map):
+            narrowed = {literal_hash(expr) for expr in type_map}
+            for assignment in collector.assignments:
+                if literal_hash(assignment.target) in narrowed:
+                    # The condition narrows this target more precisely.
+                    continue
+                assigned_type = self.lookup_type_or_none(assignment.value)
+                if assigned_type is not None:
+                    type_map[assignment.target] = assigned_type
 
     def find_isinstance_check_helper(
         self, node: Expression, *, in_boolean_context: bool = True
@@ -9815,6 +9850,46 @@ def collapse_walrus(e: Expression) -> Expression:
     if isinstance(e, AssignmentExpr):
         return e.target
     return e
+
+
+class WalrusAssignmentCollector(TraverserVisitor):
+    """Collect the walrus assignments which an expression always performs.
+
+    Traversal stops at any expression which may leave its operands unevaluated,
+    or which evaluates them in a separate scope. Every collected assignment has
+    therefore taken place once the visited expression has been evaluated,
+    whatever value it produced.
+    """
+
+    def __init__(self) -> None:
+        self.assignments: list[AssignmentExpr] = []
+
+    def visit_assignment_expr(self, o: AssignmentExpr, /) -> None:
+        self.assignments.append(o)
+        o.value.accept(self)
+
+    def visit_op_expr(self, o: OpExpr, /) -> None:
+        if o.op in ("and", "or"):
+            # Short-circuiting; find_isinstance_check recurses into these itself.
+            return
+        super().visit_op_expr(o)
+
+    def visit_comparison_expr(self, o: ComparisonExpr, /) -> None:
+        # `a < b < c` stops at the first false comparison.
+        for operand in o.operands[:2]:
+            operand.accept(self)
+
+    def visit_conditional_expr(self, o: ConditionalExpr, /) -> None:
+        o.cond.accept(self)
+
+    def visit_generator_expr(self, o: GeneratorExpr, /) -> None:
+        """Skip generator expressions, and the comprehensions built on them."""
+
+    def visit_dictionary_comprehension(self, o: DictionaryComprehension, /) -> None:
+        """Skip dictionary comprehensions."""
+
+    def visit_lambda_expr(self, o: LambdaExpr, /) -> None:
+        """Skip lambdas, whose body is not evaluated here."""
 
 
 def find_last_var_assignment_line(n: Node, v: Var) -> int:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6592,7 +6592,6 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         if_map, else_map = self.find_isinstance_check_helper(
             node, in_boolean_context=in_boolean_context
         )
-        self.propagate_walrus_assignments(node, if_map, else_map)
         new_if_map = self.propagate_up_typemap_info(if_map)
         new_else_map = self.propagate_up_typemap_info(else_map)
         return new_if_map, new_else_map
@@ -6600,19 +6599,20 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
     def propagate_walrus_assignments(
         self, node: Expression, if_map: TypeMap, else_map: TypeMap
     ) -> None:
-        """Narrow the targets of walrus assignments nested within a condition.
+        """Narrow the targets of walrus assignments nested within `node`.
 
-        Such an assignment has already happened by the time the condition has
-        been evaluated, so the assigned type applies to both branches, and both
-        maps are updated in place. Which branches are actually reached is decided
-        by the callers combining these maps: `and` carries the right operand's if
-        map into the if branch, and `or` carries its else map into the else
-        branch.
+        Only used for the right operand of `and` and `or`. Elsewhere the operand
+        is always evaluated, so the binder already carries the assignment and
+        adding it here would only widen the result: an entry makes the branches
+        join through the target's declaration, which may be wider than the type
+        assigned.
+
+        The assignment has happened once `node` has been evaluated, whatever
+        value it produced, so both maps are updated in place. Which branch that
+        reaches is decided by the caller combining them: `and` carries the right
+        operand's if map into the if branch, and `or` carries its else map into
+        the else branch.
         """
-        if isinstance(node, NameExpr):
-            # The most common condition, and it has no subexpressions.
-            return
-
         collector = WalrusAssignmentCollector()
         node.accept(collector)
         if not collector.assignments:
@@ -6744,6 +6744,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         elif isinstance(node, OpExpr) and node.op == "and":
             left_if_vars, left_else_vars = self.find_isinstance_check(node.left)
             right_if_vars, right_else_vars = self.find_isinstance_check(node.right)
+            self.propagate_walrus_assignments(node.right, right_if_vars, right_else_vars)
 
             # (e1 and e2) is true if both e1 and e2 are true,
             # and false if at least one of e1 and e2 is false.
@@ -6757,6 +6758,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         elif isinstance(node, OpExpr) and node.op == "or":
             left_if_vars, left_else_vars = self.find_isinstance_check(node.left)
             right_if_vars, right_else_vars = self.find_isinstance_check(node.right)
+            self.propagate_walrus_assignments(node.right, right_if_vars, right_else_vars)
 
             # (e1 or e2) is true if at least one of e1 or e2 is true,
             # and false if both e1 and e2 are false.

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -148,11 +148,13 @@ from mypy.nodes import (
     CallExpr,
     ClassDef,
     ComparisonExpr,
+    ConditionalExpr,
     Context,
     ContinueStmt,
     Decorator,
     DelStmt,
     DictExpr,
+    DictionaryComprehension,
     EllipsisExpr,
     Expression,
     ExpressionStmt,
@@ -161,6 +163,7 @@ from mypy.nodes import (
     FuncBase,
     FuncDef,
     FuncItem,
+    GeneratorExpr,
     GlobalDecl,
     IfStmt,
     Import,
@@ -6589,9 +6592,41 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         if_map, else_map = self.find_isinstance_check_helper(
             node, in_boolean_context=in_boolean_context
         )
+        self.propagate_walrus_assignments(node, if_map, else_map)
         new_if_map = self.propagate_up_typemap_info(if_map)
         new_else_map = self.propagate_up_typemap_info(else_map)
         return new_if_map, new_else_map
+
+    def propagate_walrus_assignments(
+        self, node: Expression, if_map: TypeMap, else_map: TypeMap
+    ) -> None:
+        """Narrow the targets of walrus assignments nested within a condition.
+
+        Such an assignment has already happened by the time the condition has
+        been evaluated, so the assigned type applies to both branches, and both
+        maps are updated in place. Which branches are actually reached is decided
+        by the callers combining these maps: `and` carries the right operand's if
+        map into the if branch, and `or` carries its else map into the else
+        branch.
+        """
+        if isinstance(node, NameExpr):
+            # The most common condition, and it has no subexpressions.
+            return
+
+        collector = WalrusAssignmentCollector()
+        node.accept(collector)
+        if not collector.assignments:
+            return
+
+        for type_map in (if_map, else_map):
+            narrowed = {literal_hash(expr) for expr in type_map}
+            for assignment in collector.assignments:
+                if literal_hash(assignment.target) in narrowed:
+                    # The condition narrows this target more precisely.
+                    continue
+                assigned_type = self.lookup_type_or_none(assignment.value)
+                if assigned_type is not None:
+                    type_map[assignment.target] = assigned_type
 
     def find_isinstance_check_helper(
         self, node: Expression, *, in_boolean_context: bool = True
@@ -9779,6 +9814,46 @@ def collapse_walrus(e: Expression) -> Expression:
     if isinstance(e, AssignmentExpr):
         return e.target
     return e
+
+
+class WalrusAssignmentCollector(TraverserVisitor):
+    """Collect the walrus assignments which an expression always performs.
+
+    Traversal stops at any expression which may leave its operands unevaluated,
+    or which evaluates them in a separate scope. Every collected assignment has
+    therefore taken place once the visited expression has been evaluated,
+    whatever value it produced.
+    """
+
+    def __init__(self) -> None:
+        self.assignments: list[AssignmentExpr] = []
+
+    def visit_assignment_expr(self, o: AssignmentExpr, /) -> None:
+        self.assignments.append(o)
+        o.value.accept(self)
+
+    def visit_op_expr(self, o: OpExpr, /) -> None:
+        if o.op in ("and", "or"):
+            # Short-circuiting; find_isinstance_check recurses into these itself.
+            return
+        super().visit_op_expr(o)
+
+    def visit_comparison_expr(self, o: ComparisonExpr, /) -> None:
+        # `a < b < c` stops at the first false comparison.
+        for operand in o.operands[:2]:
+            operand.accept(self)
+
+    def visit_conditional_expr(self, o: ConditionalExpr, /) -> None:
+        o.cond.accept(self)
+
+    def visit_generator_expr(self, o: GeneratorExpr, /) -> None:
+        """Skip generator expressions, and the comprehensions built on them."""
+
+    def visit_dictionary_comprehension(self, o: DictionaryComprehension, /) -> None:
+        """Skip dictionary comprehensions."""
+
+    def visit_lambda_expr(self, o: LambdaExpr, /) -> None:
+        """Skip lambdas, whose body is not evaluated here."""
 
 
 def find_last_var_assignment_line(n: Node, v: Var) -> int:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6628,7 +6628,6 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         if_map, else_map = self.find_isinstance_check_helper(
             node, in_boolean_context=in_boolean_context
         )
-        self.propagate_walrus_assignments(node, if_map, else_map)
         new_if_map = self.propagate_up_typemap_info(if_map)
         new_else_map = self.propagate_up_typemap_info(else_map)
         return new_if_map, new_else_map
@@ -6636,19 +6635,20 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
     def propagate_walrus_assignments(
         self, node: Expression, if_map: TypeMap, else_map: TypeMap
     ) -> None:
-        """Narrow the targets of walrus assignments nested within a condition.
+        """Narrow the targets of walrus assignments nested within `node`.
 
-        Such an assignment has already happened by the time the condition has
-        been evaluated, so the assigned type applies to both branches, and both
-        maps are updated in place. Which branches are actually reached is decided
-        by the callers combining these maps: `and` carries the right operand's if
-        map into the if branch, and `or` carries its else map into the else
-        branch.
+        Only used for the right operand of `and` and `or`. Elsewhere the operand
+        is always evaluated, so the binder already carries the assignment and
+        adding it here would only widen the result: an entry makes the branches
+        join through the target's declaration, which may be wider than the type
+        assigned.
+
+        The assignment has happened once `node` has been evaluated, whatever
+        value it produced, so both maps are updated in place. Which branch that
+        reaches is decided by the caller combining them: `and` carries the right
+        operand's if map into the if branch, and `or` carries its else map into
+        the else branch.
         """
-        if isinstance(node, NameExpr):
-            # The most common condition, and it has no subexpressions.
-            return
-
         collector = WalrusAssignmentCollector()
         node.accept(collector)
         if not collector.assignments:
@@ -6780,6 +6780,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         elif isinstance(node, OpExpr) and node.op == "and":
             left_if_vars, left_else_vars = self.find_isinstance_check(node.left)
             right_if_vars, right_else_vars = self.find_isinstance_check(node.right)
+            self.propagate_walrus_assignments(node.right, right_if_vars, right_else_vars)
 
             # (e1 and e2) is true if both e1 and e2 are true,
             # and false if at least one of e1 and e2 is false.
@@ -6793,6 +6794,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         elif isinstance(node, OpExpr) and node.op == "or":
             left_if_vars, left_else_vars = self.find_isinstance_check(node.left)
             right_if_vars, right_else_vars = self.find_isinstance_check(node.right)
+            self.propagate_walrus_assignments(node.right, right_if_vars, right_else_vars)
 
             # (e1 or e2) is true if at least one of e1 or e2 is true,
             # and false if both e1 and e2 are false.

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -4288,6 +4288,119 @@ def check_or_nested(maybe: bool) -> None:
         reveal_type(bar)  # N: Revealed type is "builtins.list[builtins.int]"
         reveal_type(baz)  # N: Revealed type is "builtins.list[builtins.int]"
 
+[case testInferWalrusAssignmentNestedInCondition]
+class Foo:
+    def __init__(self, value: bool) -> None:
+        self.value = value
+
+def truthy(x: object) -> bool: ...
+
+def check_binary_op(maybe: bool, n: int) -> None:
+    woo = None
+    if maybe and (woo := 5) + n:
+        reveal_type(woo)  # N: Revealed type is "builtins.int"
+    else:
+        reveal_type(woo)  # N: Revealed type is "builtins.int | None"
+
+def check_call(maybe: bool) -> None:
+    woo = None
+    if maybe and truthy(woo := Foo(True)):
+        reveal_type(woo)  # N: Revealed type is "__main__.Foo"
+    else:
+        reveal_type(woo)  # N: Revealed type is "__main__.Foo | None"
+
+def check_isinstance(maybe: bool) -> None:
+    woo = None
+    if maybe and isinstance(woo := Foo(True), Foo):
+        reveal_type(woo)  # N: Revealed type is "__main__.Foo"
+    else:
+        reveal_type(woo)  # N: Revealed type is "__main__.Foo | None"
+
+def check_comparison(maybe: bool, n: int) -> None:
+    woo = None
+    if maybe and (woo := 5) > n:
+        reveal_type(woo)  # N: Revealed type is "builtins.int"
+    else:
+        reveal_type(woo)  # N: Revealed type is "builtins.int | None"
+
+def check_unary_op(maybe: bool) -> None:
+    woo = None
+    if maybe and -(woo := 5):
+        reveal_type(woo)  # N: Revealed type is "builtins.int"
+    else:
+        reveal_type(woo)  # N: Revealed type is "builtins.int | None"
+
+def check_or(maybe: bool, n: int) -> None:
+    woo = None
+    if maybe or (woo := 5) + n:
+        reveal_type(woo)  # N: Revealed type is "builtins.int | None"
+    else:
+        reveal_type(woo)  # N: Revealed type is "builtins.int"
+
+def check_nested_walrus(maybe: bool, n: int) -> None:
+    foo = None
+    bar = None
+    if maybe and (foo := (bar := 5)) + n:
+        reveal_type(foo)  # N: Revealed type is "builtins.int"
+        reveal_type(bar)  # N: Revealed type is "builtins.int"
+    else:
+        reveal_type(foo)  # N: Revealed type is "builtins.int | None"
+        reveal_type(bar)  # N: Revealed type is "builtins.int | None"
+
+def check_nested_and(maybe: bool) -> None:
+    # Nested short-circuiting operators are not walked into, but they are still
+    # handled, because find_isinstance_check recurses into them itself.
+    woo = None
+    if maybe and (1 and (woo := 5)):
+        reveal_type(woo)  # N: Revealed type is "builtins.int"
+[builtins fixtures/len.pyi]
+
+[case testInferWalrusAssignmentNestedInConditionNotAlwaysEvaluated]
+from typing import List
+
+def check_ternary_branch(maybe: bool) -> None:
+    woo = None
+    if 1 if maybe else (woo := 5):
+        reveal_type(woo)  # N: Revealed type is "builtins.int | None"
+    else:
+        reveal_type(woo)  # N: Revealed type is "builtins.int | None"
+
+def check_ternary_condition(maybe: bool) -> None:
+    woo = None
+    if 1 if (woo := 5) else 0:
+        reveal_type(woo)  # N: Revealed type is "builtins.int"
+
+def check_comprehension(xs: List[int]) -> None:
+    woo = None
+    if [y for y in xs if (woo := y)]:
+        reveal_type(woo)  # N: Revealed type is "builtins.int | None"
+
+def check_chained_comparison(a: int, b: int) -> None:
+    # The else branch should stay optional, and does not. Pre-existing: the
+    # operand is narrowed through collapse_walrus in comparison_type_narrowing_helper.
+    woo = None
+    if a < b < (woo := 5):
+        reveal_type(woo)  # N: Revealed type is "builtins.int"
+    else:
+        reveal_type(woo)  # N: Revealed type is "builtins.int"
+[builtins fixtures/len.pyi]
+
+[case testInferWalrusAssignmentDoesNotWeakenNarrowing]
+from typing import Optional, Union
+
+def check_truthiness(val: Optional[int]) -> None:
+    if x := val:
+        reveal_type(x)  # N: Revealed type is "builtins.int"
+
+def check_isinstance(val: Union[int, str]) -> None:
+    if isinstance(x := val, int):
+        reveal_type(x)  # N: Revealed type is "builtins.int"
+
+def check_is_not_none(val: Optional[int]) -> None:
+    if (x := val) is not None:
+        reveal_type(x)  # N: Revealed type is "builtins.int"
+[builtins fixtures/isinstancelist.pyi]
+
 [case testInferOptionalAgainstAny]
 from typing import Any, Optional, TypeVar
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -4358,48 +4358,62 @@ def check_nested_and(maybe: bool) -> None:
 [case testInferWalrusAssignmentNestedInConditionNotAlwaysEvaluated]
 from typing import List
 
+# Each condition puts the walrus on the right of an `and`, which is where the
+# assignment is not carried by the binder and this narrowing applies.
+
 def check_ternary_branch(maybe: bool) -> None:
     woo = None
-    if 1 if maybe else (woo := 5):
+    if maybe and (1 if maybe else (woo := 5)):
         reveal_type(woo)  # N: Revealed type is "builtins.int | None"
     else:
         reveal_type(woo)  # N: Revealed type is "builtins.int | None"
 
 def check_ternary_condition(maybe: bool) -> None:
     woo = None
-    if 1 if (woo := 5) else 0:
+    if maybe and (1 if (woo := 5) else 0):
         reveal_type(woo)  # N: Revealed type is "builtins.int"
 
-def check_comprehension(xs: List[int]) -> None:
+def check_comprehension(maybe: bool, xs: List[int]) -> None:
     woo = None
-    if [y for y in xs if (woo := y)]:
+    if maybe and [y for y in xs if (woo := y)]:
         reveal_type(woo)  # N: Revealed type is "builtins.int | None"
 
-def check_chained_comparison(a: int, b: int) -> None:
-    # The else branch should stay optional, and does not. Pre-existing: chain
-    # operands are checked in one binder frame, so the assignment is recorded
-    # even when short-circuiting means it never ran.
+def check_chained_comparison(maybe: bool, a: int, b: int) -> None:
+    # Conservative: entering the branch does imply a < b was true and so the
+    # walrus ran, but operands after the second are not walked into.
     woo = None
-    if a < b < (woo := 5):
-        reveal_type(woo)  # N: Revealed type is "builtins.int"
-    else:
-        reveal_type(woo)  # N: Revealed type is "builtins.int"
+    if maybe and a < b < (woo := 5):
+        reveal_type(woo)  # N: Revealed type is "builtins.int | None"
 [builtins fixtures/len.pyi]
 
 [case testInferWalrusAssignmentDoesNotWeakenNarrowing]
 from typing import Optional, Union
 
-def check_truthiness(val: Optional[int]) -> None:
-    if x := val:
+# The walrus goes on the right of an `and` so that the narrowing added for the
+# assignment has to give way to the more precise narrowing from the condition.
+
+def check_truthiness(maybe: bool, val: Optional[int]) -> None:
+    if maybe and (x := val):
         reveal_type(x)  # N: Revealed type is "builtins.int"
 
-def check_isinstance(val: Union[int, str]) -> None:
-    if isinstance(x := val, int):
+def check_isinstance(maybe: bool, val: Union[int, str]) -> None:
+    if maybe and isinstance(x := val, int):
         reveal_type(x)  # N: Revealed type is "builtins.int"
 
-def check_is_not_none(val: Optional[int]) -> None:
-    if (x := val) is not None:
+def check_is_not_none(maybe: bool, val: Optional[int]) -> None:
+    if maybe and (x := val) is not None:
         reveal_type(x)  # N: Revealed type is "builtins.int"
+
+def truthy(x: object) -> bool: ...
+
+def check_declaration_wider_than_assignment(val: Optional[int], n: int) -> None:
+    # An operand that is always evaluated must not be given a map entry: the
+    # branches would then join through the declaration of x, which is wider than
+    # what the walrus assigned. Reported by mypy_primer against rotki.
+    x = val
+    if truthy(x := n):
+        pass
+    reveal_type(x)  # N: Revealed type is "builtins.int"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testInferOptionalAgainstAny]

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -4376,8 +4376,9 @@ def check_comprehension(xs: List[int]) -> None:
         reveal_type(woo)  # N: Revealed type is "builtins.int | None"
 
 def check_chained_comparison(a: int, b: int) -> None:
-    # The else branch should stay optional, and does not. Pre-existing: the
-    # operand is narrowed through collapse_walrus in comparison_type_narrowing_helper.
+    # The else branch should stay optional, and does not. Pre-existing: chain
+    # operands are checked in one binder frame, so the assignment is recorded
+    # even when short-circuiting means it never ran.
     woo = None
     if a < b < (woo := 5):
         reveal_type(woo)  # N: Revealed type is "builtins.int"


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #19430.

#19038 added narrowing for walrus assignments at the top level of a condition,
and for the `(foo := val).attr` / `(foo := val)[key]` forms reached through
`refine_parent_types`. Its helper `_propagate_walrus_assignments` notes that it
"only considers nested assignment exprs, does not recurse into other types" and
that a dedicated visitor could be added later. This is that visitor.

A walrus nested anywhere else in the condition was not propagated:

```python
def main(cond: bool, n: int) -> None:
    woo = None
    if cond and (woo := 5) + n:
        reveal_type(woo)  # was int | None, now int
```

## How it works

This applies only to the right operand of `and` and `or`. Everywhere else the
operand is always evaluated, so the binder already carries the assignment, and
adding a map entry there would only widen the result — see the mypy_primer note
below.

`WalrusAssignmentCollector` walks that operand and collects the walrus
assignments it is guaranteed to perform. Traversal stops wherever evaluation is
not guaranteed, or happens in another scope:

- `and` / `or`, which short-circuit
- the branches of a conditional expression (its condition is still walked)
- comprehensions and generator expressions
- lambda bodies
- the third and later operands of a chained comparison, since `a < b < c` stops
  at the first false comparison

Every collected assignment has therefore taken place once the condition has
been evaluated, whatever value it produced, so the assigned type is added to
**both** the if and the else map.

Deciding which branches the narrowing actually reaches is then left to the
existing map algebra, which already models exactly this. For
`cond and (woo := 5) + n`:

- `and_conditional_maps(left_if, right_if)` keeps the entry, because it is in
  the right operand's if map — narrowed in the if branch.
- `or_conditional_maps(left_else, right_else, coalesce_any=True)` drops it,
  because it is not in the left operand's else map — not narrowed in the else
  branch.

and symmetrically for `or`, which narrows in the else branch instead. This
matches the framing in the issue: the narrowing applies where the assignment is
reached on every path, i.e. for `and` but not for `or`.

Nested short-circuiting operators are not walked into, but they are still
handled, because `find_isinstance_check` recurses into them itself. There is a
test for that.

An existing entry for the same target is never overwritten, so narrowing from
the condition itself — truthiness, `isinstance`, `is not None` — is not weakened
to the bare assigned type. That is the main risk in this change, and it has its
own test case.

## Tests

Three cases in `check-inference.test`, next to the ones from #19038:

- `testInferWalrusAssignmentNestedInCondition` — binary operation, call,
  `isinstance`, comparison, unary operation, nested walrus, `or` narrowing the
  else branch, and a nested `and`.
- `testInferWalrusAssignmentNestedInConditionNotAlwaysEvaluated` — the branches
  of a conditional expression, a comprehension and a chained comparison operand
  are not narrowed, while a walrus in a conditional expression's condition is.
- `testInferWalrusAssignmentDoesNotWeakenNarrowing` — truthiness, `isinstance`
  and `is not None` narrowing survive.

Only the first of those fails on master. The other two are guards against this
change over-narrowing rather than regression tests for the issue, so I checked
what they actually catch by breaking each restriction in turn and seeing whether
a test noticed:

| Restriction removed | Caught by |
| --- | --- |
| Propagation limited to `and` / `or` right operands | `DoesNotWeakenNarrowing` |
| Existing narrowing not overwritten | `DoesNotWeakenNarrowing` |
| Conditional expression branches skipped | `NotAlwaysEvaluated` |
| Comprehensions skipped | `NotAlwaysEvaluated` |
| Chained comparison operands after the second skipped | `NotAlwaysEvaluated` |
| Lambda bodies skipped | nothing |

Every condition in those two cases puts the walrus on the right of an `and`, so
that the code path is actually reached.

The lambda restriction has no test because it is unobservable: a walrus in a
lambda body binds in the lambda's scope, so the outer variable is untouched
either way, and the whole suite passes with the restriction removed. I kept it
rather than dropping it, since walking into a body that is not evaluated would be
wrong on its own terms.

Full suites run locally on Python 3.14 / Linux, uncompiled: `testcheck` 8203
passed, and `testfinegrained` / `testmerge` / `testtransform` / `testdeps` /
`testpythoneval` 1453 passed. Self-check clean.

## A pre-existing soundness bug this turned up

While testing the chained-comparison restriction I found that outside an `and`,
a walrus in a lazily evaluated chain operand is narrowed as though it had always
run:

```python
class C:
    def __lt__(self, other: "C") -> bool: ...

def chain(a: C, b: C, v: C) -> None:
    woo = None
    if a < b < (woo := v):
        reveal_type(woo)  # C -- correct, a < b was true so the walrus ran
    else:
        reveal_type(woo)  # C -- unsound, a < b may have been false
```

If `a < b` is false the chain short-circuits, the walrus never runs, and `woo` is
still `None` in the else branch. Writing the same thing with `and` gives the
correct `C | None`, and putting the walrus in the first pair (`a < (woo := v) < c`)
correctly gives `C`.

The cause is not narrowing. `visit_comparison_expr` documents that `a < b > c` is
"check as `a < b and b > c`", but it accepts the operands in a plain loop with no
binder frame per pair, whereas `check_boolean_op` frames each side. So the
assignment is recorded unconditionally. Nothing narrows `C` here, which is how I
ruled out `comparison_type_narrowing_helper`.

I confirmed against master that this predates this PR and is not affected by it.
It is also why the restriction in the collector has to be tested through an
`and`, where the binder does not mask it. `check_chained_comparison` in
`testInferWalrusAssignmentNestedInConditionNotAlwaysEvaluated` pins the current
behaviour with a comment, so a fix will show up as a test change rather than
silently.

I have deliberately not fixed it here. It is the opposite defect — narrowing
applied where it should not be — it lives in expression checking rather than in
narrowing, and giving chained comparisons per-pair binder frames is a change with
real blast radius that deserves reviewing on its own. Happy to open an issue or a
PR for it, whichever you prefer.

## The mypy_primer diff

The first version of this hooked the propagation into `find_isinstance_check`
itself, and mypy_primer caught one diff for it, a new error in rotki. It was a
genuine regression rather than a true positive, and it is worth spelling out
because it shaped the design:

```python
def d(m: dict[str, tuple[str, int]], jgi: dict[str, str]) -> None:
    mgid = jgi.get("x")            # declared str | None
    if (mgid := m["y"][0]) == "z":
        pass
    reveal_type(mgid)              # master: str, first version: str | None
```

Inside both branches the type was `str` either way; the widening happened when
the branches were joined. With no map entry the binder simply keeps the type from
the assignment. With an entry, the join goes through `join_simple` bounded by the
target's declaration, which here is wider than what was assigned.

The operand in that condition is always evaluated, so the entry was not buying
anything: `if (woo := 5) + n:` already narrows correctly on master without this
PR. Restricting the propagation to the right operand of `and` and `or` removes
the regression and keeps every case the PR is for.
`check_declaration_wider_than_assignment` covers it.

## Performance

The collector only runs for the right operand of `and` and `or`, and returns
immediately when nothing was collected.

Self-check with a cold cache, three runs each, uncompiled:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| this branch | 14.50s | 14.31s | 14.35s |
| master | 14.42s | 14.51s | 14.18s |

No measurable difference on the median. I have not measured a compiled build, so
please treat these as indicative.

## Known limitations

- Nested short-circuiting operators reached through another expression, such as
  `truthy(a and (woo := 5))`, are not narrowed. Handling them would mean
  deciding which branch each side belongs to inside the collector, which is
  what `find_isinstance_check` already does; it seemed better not to duplicate
  that.
- The `in` narrowing from the original report in #19430 is #3229 and is
  unaffected by this.

## LLM disclosure

Per the contributing guidelines: this text was written with LLM assistance. I am a
first-time contributor here, so I understand that may weigh against the PR —
please say so if you would rather not take it on that basis and I will close it
without any fuss. I have read the surrounding code and can explain and defend
every decision above. Three of them came out of verification rather than from
the first draft, and are worth stating explicitly:

- An early version guarded the type maps with `if type_map is None`. Self-check
  flagged it as unreachable, correctly: `TypeMap` is `dict[Expression, Type]`
  with no `Optional`, and `conditional_types_to_typemaps` returns `{}` rather
  than `None`. The guard was dead code and is gone. Incidentally the docstring
  of `find_isinstance_check` still claims it "can return None, None", which
  looks stale — I left it alone as it is out of scope here.
- I expected `a < b < (woo := 5)` not to narrow in the if branch, and wrote a
  test asserting that. It was wrong: entering the if branch implies `a < b` was
  true, so the third operand was evaluated after all. Chasing that down is what
  surfaced the soundness bug above.
- I expected `cond and (1 and (woo := 5))` not to narrow, since the collector
  does not walk into nested `and`. It does narrow, because
  `find_isinstance_check` recurses into it. The test now records the real
  behaviour.
- The mypy_primer diff on the first push was a real regression in this PR, not a
  true positive. Finding that out is what led to restricting the propagation to
  short-circuiting operands, which is a better design than what I started with.
- My first diagnosis of the chained comparison bug blamed `collapse_walrus` in
  `comparison_type_narrowing_helper`. That was wrong, and the second commit here
  corrects the comment: reproducing it with a class whose `__lt__` returns plain
  `bool` shows nothing narrows the operand at all, which ruled that path out and
  pointed at the missing binder frame instead.
<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
