### PR TITLE
Report access to abstract static and class methods on the class

### DIFF
--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -423,6 +423,7 @@ def analyze_type_callable_member_access(name: str, typ: FunctionLike, mx: Member
             # the corresponding method in the current instance to avoid this edge case.
             # See https://github.com/python/mypy/pull/1787 for more info.
             # TODO: do not rely on same type variables being present in all constructor overloads.
+            check_abstract_class_attribute_access(name, instance_type, mx)
             result = analyze_class_attribute_access(
                 instance_type,
                 name,
@@ -436,6 +437,36 @@ def analyze_type_callable_member_access(name: str, typ: FunctionLike, mx: Member
         return _analyze_member_access(name, typ.fallback, mx)
     else:
         assert False, f"Unexpected type {instance_type!r}"
+
+
+def check_abstract_class_attribute_access(
+    name: str, instance_type: Instance, mx: MemberContext
+) -> None:
+    """Report accessing an abstract static or class method through its own class.
+
+    Only reached for a direct reference to the class. Through `type[T]`, or on an
+    instance, the runtime object may be a subclass which implements the method,
+    which is also why instance methods are excluded here.
+    """
+    if mx.suppress_errors or not instance_type.type.is_abstract:
+        return
+    if all(attr != name for attr, _ in instance_type.type.abstract_attributes):
+        return
+
+    node = instance_type.type.get(name)
+    if node is None:
+        return
+    func = node.node.func if isinstance(node.node, Decorator) else node.node
+    if not isinstance(func, SYMBOL_FUNCBASE_TYPES):
+        return
+
+    if func.is_static:
+        kind = "static method"
+    elif func.is_class:
+        kind = "class method"
+    else:
+        return
+    mx.msg.cannot_access_abstract_class_attribute(instance_type.type.name, name, kind, mx.context)
 
 
 def analyze_type_type_member_access(

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1580,6 +1580,15 @@ class MessageBuilder:
             self.note("Redefinition:", defn)
             self.pretty_callable_or_overload(new_type, defn, offset=4, parent_error=error)
 
+    def cannot_access_abstract_class_attribute(
+        self, class_name: str, attr_name: str, kind: str, context: Context
+    ) -> None:
+        self.fail(
+            f'Cannot access abstract {kind} "{attr_name}" of abstract class "{class_name}"',
+            context,
+            code=codes.ABSTRACT,
+        )
+
     def cannot_instantiate_abstract_class(
         self, class_name: str, abstract_attributes: dict[str, bool], context: Context
     ) -> None:

--- a/test-data/unit/check-abstract.test
+++ b/test-data/unit/check-abstract.test
@@ -1688,3 +1688,63 @@ from typing import TYPE_CHECKING
 class C:
     if TYPE_CHECKING:
         def dynamic(self) -> int: ...  # OK
+
+[case testAccessAbstractStaticAndClassMethodOnClass]
+from abc import abstractmethod, ABCMeta
+from typing import Type
+
+class A(metaclass=ABCMeta):
+    @staticmethod
+    @abstractmethod
+    def s() -> int: pass
+    @classmethod
+    @abstractmethod
+    def c(cls) -> int: pass
+    @abstractmethod
+    def m(self) -> int: pass
+
+A.s()  # E: Cannot access abstract static method "s" of abstract class "A"
+A.c()  # E: Cannot access abstract class method "c" of abstract class "A"
+f = A.s  # E: Cannot access abstract static method "s" of abstract class "A"
+
+# Unbound: whatever is passed as self may implement the method.
+g = A.m
+
+# An instance may be of a subclass which implements the method.
+def via_instance(a: A) -> None:
+    a.m()
+    a.s()
+    a.c()
+
+# So may the class object behind type[A].
+def via_type(t: Type[A]) -> None:
+    t.s()
+    t.c()
+[builtins fixtures/classmethod.pyi]
+
+[case testAccessAbstractStaticAndClassMethodOnSubclass]
+from abc import abstractmethod, ABCMeta
+
+class A(metaclass=ABCMeta):
+    @staticmethod
+    @abstractmethod
+    def s() -> int: pass
+    @classmethod
+    @abstractmethod
+    def c(cls) -> int: pass
+
+class Implemented(A):
+    @staticmethod
+    def s() -> int: return 0
+    @classmethod
+    def c(cls) -> int: return 0
+
+class StillAbstract(A):
+    @staticmethod
+    def s() -> int: return 0
+
+Implemented.s()
+Implemented.c()
+StillAbstract.s()
+StillAbstract.c()  # E: Cannot access abstract class method "c" of abstract class "StillAbstract"
+[builtins fixtures/classmethod.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #14939.

This follows the implementation @JukkaL outlined on the issue: report accessing
an abstract static method, and a class method too, on a direct reference to the
type object, but not through `type[T]`, since there the runtime class may be a
subclass which implements it. That is the same distinction the existing
instantiation check makes with `not callee.from_type_type`.

```python
from abc import ABC, abstractmethod

class Foo(ABC):
    @staticmethod
    @abstractmethod
    def s() -> int: ...

Foo.s()  # now: Cannot access abstract static method "s" of abstract class "Foo"
```

## What is and is not reported

| | Reported |
| --- | --- |
| `Foo.s()`, `Foo.c()` on the abstract class itself | yes |
| `Foo.s` without calling it | yes |
| Through `type[Foo]` | no |
| On an instance | no |
| Unbound instance method, `Foo.m` | no |
| On a subclass which implements it | no |
| On a subclass which is still abstract | yes, naming the subclass |

Instance methods are excluded for the reason `type[T]` is: whatever is passed as
`self` may implement the method. The check hangs off
`analyze_type_callable_member_access`, which is only reached for a direct class
reference — `analyze_type_type_member_access` handles `type[T]` and is left
alone. It reuses the existing `[abstract]` error code.

## Tests

Two cases in `check-abstract.test`, both of which fail on master:

- `testAccessAbstractStaticAndClassMethodOnClass` — the static and class method
  are reported on the class and on a bare reference, and not through `type[A]`,
  on an instance, or for an unbound instance method.
- `testAccessAbstractStaticAndClassMethodOnSubclass` — a subclass implementing
  both is silent, a subclass which implements only one is reported for the other
  and named in the message.

I checked what the tests actually catch by breaking each exclusion in turn:

| Exclusion removed | Caught by |
| --- | --- |
| Instance methods excluded | `OnClass` |
| `type[T]` path left alone | `OnClass` |
| `abstract_attributes` consulted | `OnSubclass` |

The first of those initially had no coverage: the test called the method on an
*instance*, which never reaches this code at all. Accessing the unbound method
through the class does, so `g = A.m` was added.

Full suites locally on Python 3.14 / Linux, uncompiled: `testcheck` 8202 passed,
`testfinegrained` / `testmerge` / `testtransform` / `testdeps` / `testpythoneval`
1453 passed. Self-check clean.

## Performance

The check runs on class attribute access, so it returns immediately unless the
class is abstract. Self-check with a cold cache, three runs each, uncompiled:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| this branch | 14.23s | 14.17s | 14.36s |
| master | 14.05s | 14.22s | 14.03s |

The ranges overlap, so I read this as noise, but the medians do put it 1% on the
slow side and I have not measured a compiled build.

## Notes for review

- This adds a new error, so mypy_primer is the real test of whether the rule is
  the right shape. A diff there is not automatically a bug in this PR — it may be
  exactly what the issue asks to catch — but I will work through anything it
  reports rather than assume.
- @erictraut recommended closing the issue as largely a duplicate of #14062.
  @JelleZijlstra distinguished the two: #14062 was about non-abstract
  static/classmethods on abstract classes, whereas this is about abstract ones.
  I have taken the issue staying open and labelled `good-second-issue` as the
  resolution of that, but say if you would rather revisit it.
- Independent of my other open PR, #21805; they touch different code.

## LLM disclosure

Per the contributing guidelines: this PR text was written with LLM assistance, and I am a
first-time contributor here, so I understand that may weigh against it — say so
and I will close it without any fuss. The design is @JukkaL's from the issue
rather than mine, and I can explain and defend every decision above.

One thing worth recording, since it came out of verification rather than the
first draft: the check first tested `isinstance(func, FuncBase)`, and self-check
correctly flagged everything after it as unreachable. `FuncBase` is not a
`SymbolNode` — `FuncDef` reaches it through `FuncItem` — so the narrowing gave
`Never`. `nodes.py` says as much right above the class and points at
`SYMBOL_FUNCBASE_TYPES`, which is what the code uses now.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
