### PR TITLE
Fixes #21689 - stubgen --inspect-mode crash on PEP 604 unions

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -12,6 +12,7 @@ import importlib
 import inspect
 import keyword
 import os.path
+import types
 from collections.abc import Callable, Mapping
 from types import FunctionType, ModuleType
 from typing import Any
@@ -768,11 +769,26 @@ class InspectionStubGenerator(BaseStubGenerator):
 
                 rw_properties.append(f"{self._indent}{name}: {inferred_type}")
 
-    def get_type_fullname(self, typ: type) -> str:
+    def get_type_fullname(self, typ: object) -> str:
         """Given a type, return a string representation"""
         if typ is Any:
             return "Any"
-        typename = getattr(typ, "__qualname__", typ.__name__)
+        if typ is type(None):
+            return "None"
+        # PEP 604 unions (X | Y) are instances of types.UnionType at runtime.
+        # They have neither __qualname__ nor __name__, so format them explicitly.
+        if isinstance(typ, types.UnionType):
+            return " | ".join(self.get_type_fullname(arg) for arg in typ.__args__)
+        # Avoid evaluating typ.__name__ as a getattr default: that is evaluated
+        # eagerly and crashes for types.UnionType and similar constructs.
+        typename = getattr(typ, "__qualname__", None)
+        if typename is None:
+            typename = getattr(typ, "__name__", None)
+        if typename is None:
+            # This should not normally happen, but some types may resist our
+            # introspection attempts too hard. See
+            # https://github.com/python/mypy/issues/19031
+            return "_typeshed.Incomplete"
         module_name = self.get_obj_module(typ)
         if module_name is None:
             # This should not normally happen, but some types may resist our

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -1556,6 +1556,28 @@ class StubgencSuite(unittest.TestCase):
         )
         assert_equal(gen.get_imports().splitlines(), ["from typing import overload"])
 
+    def test_get_type_fullname_pep604_union(self) -> None:
+        # Regression test for https://github.com/python/mypy/issues/21689:
+        # types.UnionType (X | Y) must not crash under --inspect-mode.
+        mod = ModuleType("module", "")
+        gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
+        assert_equal(gen.get_type_fullname(int | str), "int | str")
+        assert_equal(gen.get_type_fullname(float | None), "float | None")
+        assert_equal(gen.get_type_fullname(int | str | bytes), "int | str | bytes")
+
+    def test_generate_function_stub_pep604_union_annotations(self) -> None:
+        def process(value: int | str) -> float | None:
+            if isinstance(value, int):
+                return float(value)
+            return None
+
+        output: list[str] = []
+        mod = ModuleType(process.__module__, "")
+        gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
+        gen.is_c_module = False
+        gen.generate_function_stub("process", process, output=output)
+        assert_equal(output, ["def process(value: int | str) -> float | None: ..."])
+
 
 class ArgSigSuite(unittest.TestCase):
     def test_repr(self) -> None:


### PR DESCRIPTION
Fixes #21689

`stubgen --inspect-mode` crashed with `AttributeError` on PEP 604 union annotations (`X | Y`), because runtime unions are `types.UnionType` objects with neither `__qualname__` nor `__name__`, and `getattr(typ, "__qualname__", typ.__name__)` evaluates the default eagerly.

This change formats `types.UnionType` as `X | Y`, maps `NoneType` to `None`, and looks up type names safely so inspect-mode stub generation succeeds for these annotations.

