### PR TITLE
Reset errors before reloading dmypy suggestion targets

### DIFF
--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -707,6 +707,7 @@ class SuggestionEngine:
         """Recheck the module given by state."""
         assert state.path is not None
         self.fgmanager.flush_cache()
+        self.manager.errors.reset()
         return self.fgmanager.update([(state.id, state.path)], [])
 
     def ensure_loaded(self, state: State, force: bool = False) -> MypyFile:

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -370,6 +370,13 @@ bar.py:3: (str)
 bar.py:4: (arg=str)
 $ dmypy suggest foo.foo
 (str) -> int
+$ {python} -c "print('reveal_type(1)')" >note.py
+$ dmypy check foo.py bar.py note.py
+note.py:1: note: Revealed type is "Literal[1]?"
+== Return code: 1
+$ dmypy suggest --callsites foo.foo
+bar.py:3: (str)
+bar.py:4: (arg=str)
 $ {python} -c "import shutil; shutil.copy('foo2.py', 'foo.py')"
 $ dmypy check foo.py bar.py
 bar.py:3: error: Incompatible types in assignment (expression has type "int", variable has type "str")  [assignment]
@@ -391,6 +398,8 @@ from foo import foo
 def bar() -> None:
     x = foo('abc')  # type: str
     foo(arg='xyz')
+[file note.py]
+reveal_type(1)
 
 [case testDaemonInspectCheck]
 $ dmypy start


### PR DESCRIPTION
## Summary

- Reset the shared error state before reloading a module after a suggestion run.
- Add a daemon regression test covering a note emitted by a checked file followed by `dmypy suggest --callsites`.

The suggestion engine temporarily rechecks modules and flushes their messages. Reloading the module without resetting `Errors` left the flushed-file bookkeeping populated, so the next check could assert in `Errors._add_error_info`. This fixes #21765.

## Tests

- `py -3.10 -m pytest -q mypy/test/testdaemon.py`
- `py -3.10 -m ruff check mypy/suggestions.py`
- `git diff --check`

This change was prepared with Codex assistance and reviewed and verified by the submitting contributor.
