### PR TITLE
[mypyc] Fix inconsistent vtable method prefix

### DIFF
--- a/mypyc/codegen/emitclass.py
+++ b/mypyc/codegen/emitclass.py
@@ -608,9 +608,7 @@ def generate_vtable(
         method = entry.shadow_method if shadow and entry.shadow_method else entry.method
         emitter.emit_line(
             "(CPyVTableItem){}{}{},".format(
-                emitter.get_group_prefix(entry.method.decl),
-                NATIVE_PREFIX,
-                method.cname(emitter.names),
+                emitter.get_group_prefix(method.decl), NATIVE_PREFIX, method.cname(emitter.names)
             )
         )
 

--- a/mypyc/test-data/run-multimodule.test
+++ b/mypyc/test-data/run-multimodule.test
@@ -2019,3 +2019,32 @@ class Child(Parent):
 [file driver.py]
 from native import test
 test()
+
+[case testCompiledSubclassOfCompiledBaseThatAllowsInterpretedSubclasses]
+from mypy_extensions import mypyc_attr
+
+from other import CompiledBase
+
+class CompiledSubclass(CompiledBase):
+    def value(self) -> int:
+        return 1
+
+@mypyc_attr(allow_interpreted_subclasses=True)
+class CompiledSubclassThatAllowsInterpreted(CompiledBase):
+    def value(self) -> int:
+        return 2
+
+def test_compiled_subclasses_of_compiled_base_that_allows_interpreted_subclasses() -> None:
+    c1 = CompiledSubclass()
+    assert c1.value() == 1
+
+    c2 = CompiledSubclassThatAllowsInterpreted()
+    assert c2.value() == 2
+
+[file other.py]
+from mypy_extensions import mypyc_attr
+
+@mypyc_attr(allow_interpreted_subclasses=True)
+class CompiledBase:
+    def value(self) -> int:
+        raise NotImplementedError


### PR DESCRIPTION
When generating the vtable we emit the name of either `entry.method` or `entry.shadow_method`. However the group prefix is always based on `entry.method` so if the two methods are in different compilation groups, we generate invalid C.

Fix the inconsistency by using the same method for the prefix as for the name.