### PR TITLE
Fix dmypy traversal of missing graph dependencies

### DIFF
--- a/mypy/dmypy_server.py
+++ b/mypy/dmypy_server.py
@@ -769,7 +769,7 @@ class Server:
                 state = graph[nxt.module]
                 ancestors = state.ancestors or []
                 for dep in state.dependencies + ancestors:
-                    if dep not in seen:
+                    if dep not in seen and dep in graph:
                         seen.add(dep)
                         worklist.append(BuildSource(graph[dep].path, graph[dep].id, followed=True))
         return changed, new_files
@@ -779,7 +779,11 @@ class Server:
     ) -> list[BuildSource]:
         """Return the direct imports of module not included in seen."""
         state = graph[module[0]]
-        return [BuildSource(graph[dep].path, dep, followed=True) for dep in state.dependencies]
+        return [
+            BuildSource(graph[dep].path, dep, followed=True)
+            for dep in state.dependencies
+            if dep in graph
+        ]
 
     def find_added_suppressed(
         self, graph: mypy.build.Graph, seen: set[str], search_paths: SearchPaths

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -802,3 +802,37 @@ Found 1 error in 1 file (checked 1 source file)
 [file test.py]
 from xml.etree.ElementTree import Element
 1 + 'a'
+
+[case testDaemonRecheckMissingGraphDependency]
+$ dmypy start
+Daemon started
+$ dmypy check src/
+src/pkg/example.py:2: error: Name "x" already defined on line 1  [no-redef]
+Found 1 error in 1 file (checked 2 source files)
+== Return code: 1
+$ dmypy recheck
+src/pkg/example.py:2: error: Incompatible import of "x" (imported name has type "int", local name has type "str")  [assignment]
+Found 1 error in 1 file (checked 53 source files)
+== Return code: 1
+$ dmypy recheck
+src/pkg/example.py:2: error: Incompatible import of "x" (imported name has type "int", local name has type "str")  [assignment]
+Found 1 error in 1 file (checked 53 source files)
+== Return code: 1
+[file mypy.ini]
+\[mypy]
+follow_imports = normal
+mypy_path = src
+files = src/pkg/
+exclude = (?x)(
+    \./.*
+    | tests
+  )
+\[mypy-pkg.tests.*]
+follow_imports = skip
+[file src/pkg/__init__.py]
+[file src/pkg/example.py]
+x = "1"
+from pkg.tests.test_something import x
+[file src/pkg/tests/__init__.py]
+[file src/pkg/tests/test_something.py]
+x = 1

--- a/test-data/unit/daemon.test
+++ b/test-data/unit/daemon.test
@@ -804,19 +804,18 @@ from xml.etree.ElementTree import Element
 1 + 'a'
 
 [case testDaemonRecheckMissingGraphDependency]
-$ dmypy start
+-- Dropping pkg.tests from the graph leaves a stale ancestors edge behind, which
+-- a later recheck used to dereference unconditionally (KeyError: 'pkg.tests').
+$ dmypy start -- --no-error-summary
 Daemon started
 $ dmypy check src/
 src/pkg/example.py:2: error: Name "x" already defined on line 1  [no-redef]
-Found 1 error in 1 file (checked 2 source files)
 == Return code: 1
 $ dmypy recheck
 src/pkg/example.py:2: error: Incompatible import of "x" (imported name has type "int", local name has type "str")  [assignment]
-Found 1 error in 1 file (checked 53 source files)
 == Return code: 1
 $ dmypy recheck
 src/pkg/example.py:2: error: Incompatible import of "x" (imported name has type "int", local name has type "str")  [assignment]
-Found 1 error in 1 file (checked 53 source files)
 == Return code: 1
 [file mypy.ini]
 \[mypy]


### PR DESCRIPTION
Fixes #20279.

### Root cause

`fix_module_deps()` runs at the end of every follow-imports increment and
re-derives each state's edges so that `state.dependencies` only ever contains
IDs still present in the graph — anything dropped is moved to
`state.suppressed`. It does **not** rewrite `state.ancestors`.

`find_reachable_changed_modules()` traverses `state.dependencies + ancestors`
and dereferences `graph[dep]` unconditionally. Because ancestors are never
pruned, a stale ancestor ID survives into the next command and crashes the
daemon.

Concretely, with `pkg.tests` excluded from the build, the sequence is:

1. `dmypy recheck` (first) drops `pkg.tests` from the graph as unreached, but
   `pkg.tests.test_something` keeps `ancestors = ['pkg.tests']`.
   `fix_module_deps()` cleans `dependencies`/`suppressed` and leaves that
   dangling ancestor edge in place.
2. `dmypy recheck` (second) walks the edge and raises
   `KeyError: 'pkg.tests'`.

That two-step sequencing is why the issue reports the crash on *repeated*
rechecks rather than the first one.

### The change

Skip IDs that are no longer in the graph when traversing dependency and
ancestor edges. `direct_imports()` gets the same guard: it performs the
identical `graph[dep]` dereference, and it is called from inside the
follow-imports worklist loop *after* `fine_grained_manager.update()` calls that
can remove modules and *before* `fix_module_deps()` runs at the end of the
increment, so its input is not guaranteed clean either. I could not construct a
repro for that path, so that half is defensive symmetry rather than a
demonstrated crash — happy to drop it if you would prefer the minimal diff.

A deeper alternative would be to have `fix_module_deps()` prune `ancestors` the
way it prunes `dependencies`. I did not do that here because `ancestors` also
feeds `refresh_suppressed_submodules()`, so pruning it is a wider behavioural
change than this crash warrants. Glad to take that route instead if you think
the invariant belongs there.

### Test

`testDaemonRecheckMissingGraphDependency` reproduces the crash via a package
excluded with `follow_imports = skip`. Verified it fails without the fix with
exactly the reported `KeyError: 'pkg.tests'` (return code 2) and passes with
it. The daemon is started with `--no-error-summary` deliberately: the
`checked N source files` summary tracks the bundled typeshed and would make the
test fail spuriously after a typeshed sync.

Note that #20279 also has a report of the same `KeyError` reached through a
different route (mixing relative and absolute paths across projects). This
patch fixes the dangling-edge dereference itself, so it should cover that
route too, but the test here only exercises the excluded-package case.

### Checks run locally

- `pytest -n0 -q mypy/test/testdaemon.py` — 38 passed
- `pytest -n4 -q mypy/test/testfinegrained.py` — 755 passed, 27 skipped
- `python runtests.py self` — no issues in 341 source files
- `pre-commit run --files mypy/dmypy_server.py test-data/unit/daemon.test` — passed

LLM assistance was used while investigating and preparing this change.
