### PR TITLE
Bump library dependencies again

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -5,5 +5,5 @@ typing_extensions>=4.14.0; python_version>='3.15'
 mypy_extensions>=1.0.0
 pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'
-librt>=0.14.0; platform_python_implementation != 'PyPy'
-ast-serialize>=0.7.0,<1.0.0
+librt>=0.15.0; platform_python_implementation != 'PyPy'
+ast-serialize>=0.8.0,<1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ requires = [
     "mypy_extensions>=1.0.0",
     "pathspec>=1.0.0",
     "tomli>=1.1.0; python_version<'3.11'",
-    "librt>=0.14.0; platform_python_implementation != 'PyPy'",
+    "librt>=0.15.0; platform_python_implementation != 'PyPy'",
     # the following is from build-requirements.txt
     "types-psutil",
     "types-setuptools",
     # required to work around a mypyc import bug
-    "ast-serialize>=0.7.0,<1.0.0",
+    "ast-serialize>=0.8.0,<1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -58,8 +58,8 @@ dependencies = [
   "mypy_extensions>=1.0.0",
   "pathspec>=1.0.0",
   "tomli>=1.1.0; python_version<'3.11'",
-  "librt>=0.14.0; platform_python_implementation != 'PyPy'",
-  "ast-serialize>=0.7.0,<1.0.0",
+  "librt>=0.15.0; platform_python_implementation != 'PyPy'",
+  "ast-serialize>=0.8.0,<1.0.0",
 ]
 dynamic = ["version"]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=test-requirements.txt --strip-extras test-requirements.in
 #
-ast-serialize==0.7.0
+ast-serialize==0.8.0
     # via -r mypy-requirements.txt
 attrs==26.1.0
     # via -r test-requirements.in
@@ -25,7 +25,7 @@ identify==2.6.19
     # via pre-commit
 iniconfig==2.3.0
     # via pytest
-librt==0.14.0 ; platform_python_implementation != "PyPy"
+librt==0.15.0 ; platform_python_implementation != "PyPy"
     # via -r mypy-requirements.txt
 lxml==6.1.0 ; python_version < "3.15"
     # via -r test-requirements.in


### PR DESCRIPTION
In this PR:
* `ast_serialize`: version-specific wheels for Emscripten
* `librt`: prepare for sentinel support
