### PR TITLE
stubgen: don't recurse forever on a class that refers back to itself

### DIFF
--- a/mypy/stubgenc.py
+++ b/mypy/stubgenc.py
@@ -860,7 +860,11 @@ class InspectionStubGenerator(BaseStubGenerator):
                     ro_properties,
                     class_info,
                 )
-            elif inspect.isclass(value) and self.is_defined_in_module(value):
+            elif (
+                inspect.isclass(value)
+                and self.is_defined_in_module(value)
+                and not is_enclosing_class(value, class_info)
+            ):
                 self.generate_class_stub(attr, value, types, parent_class=class_info)
             else:
                 attrs.append((attr, value))
@@ -918,6 +922,19 @@ class InspectionStubGenerator(BaseStubGenerator):
         self.record_name(name)
         type_str = self.strip_or_import(self.get_type_annotation(obj))
         output.append(f"{name}: {type_str}")
+
+
+def is_enclosing_class(cls: type, class_info: ClassInfo | None) -> bool:
+    """Is 'cls' the class we are generating a stub for, or one that encloses it?
+
+    Such an attribute is a back reference (e.g. 'C.C = C', or two classes in the
+    same module exposing each other). Recursing into it would never terminate.
+    """
+    while class_info is not None:
+        if class_info.cls is cls:
+            return True
+        class_info = class_info.parent
+    return False
 
 
 def method_name_sort_key(name: str) -> tuple[int, str]:

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -953,6 +953,25 @@ class TestClass(TestBaseClass):
     pass
 
 
+class SelfReferential:
+    """A class that exposes itself as one of its own attributes."""
+
+
+SelfReferential.SelfReferential = SelfReferential  # type: ignore[attr-defined]
+
+
+class MutualParent:
+    """A class that exposes a sibling which points back at it."""
+
+
+class MutualChild:
+    """The sibling of MutualParent."""
+
+
+MutualParent.MutualChild = MutualChild  # type: ignore[attr-defined]
+MutualChild.MutualParent = MutualParent  # type: ignore[attr-defined]
+
+
 class StubgencSuite(unittest.TestCase):
     """Unit tests for stub generation from C modules using introspection.
 
@@ -1003,6 +1022,22 @@ class StubgencSuite(unittest.TestCase):
         gen.generate_class_stub("alias", object, output)
         assert_equal(gen.get_imports().splitlines(), [])
         assert_equal(output[0], "class alias:")
+
+    def test_generate_class_stub_no_crash_for_self_referential_class(self) -> None:
+        output: list[str] = []
+        mod = ModuleType(SelfReferential.__module__, "")
+        gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
+
+        gen.generate_class_stub("SelfReferential", SelfReferential, output)
+        assert_equal(output[0], "class SelfReferential:")
+
+    def test_generate_class_stub_no_crash_for_mutually_referential_classes(self) -> None:
+        output: list[str] = []
+        mod = ModuleType(MutualParent.__module__, "")
+        gen = InspectionStubGenerator(mod.__name__, known_modules=[mod.__name__], module=mod)
+
+        gen.generate_class_stub("MutualParent", MutualParent, output)
+        assert_equal(output[0], "class MutualParent:")
 
     def test_generate_class_stub_variable_type_annotation(self) -> None:
         # This class mimics the stubgen unit test 'testClassVariable'


### PR DESCRIPTION
Fixes #11989.

`InspectionStubGenerator.generate_class_stub()` walks the attributes of a class and recurses into every attribute whose value is a class defined in the same module. A class that exposes itself — `C.C = C`, which is what the issue's `_socket.CAPI`-style extension types do — therefore makes it recurse into itself until Python raises `RecursionError`.

The fix skips an attribute whose value is the class currently being generated or any class enclosing it. Such an attribute is a back reference, not a nested class, so nothing that was previously emitted is lost.

Note that comparing names (`attr != class_name`), as suggested in the issue, only covers half of the cases: when two classes in the same module expose each other (`P.C = C; C.P = P`) the names differ and the recursion is unchanged. The identity walk up `ClassInfo.parent` handles both; the branch already carried `parent_class=class_info`, so the chain was available.

Tests: two cases in `mypy/test/teststubgen.py` — a self-referential class and a mutually referential pair. Both raise `RecursionError` on master and pass with the change; the full `teststubgen.py` suite (367 tests) is green, and `self-check`, `ruff` and `black` are clean.