### PR TITLE
Document follow_imports_for_stubs usage

### DIFF
--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -382,6 +382,18 @@ section of the command line docs.
     to suppress the import of a module from ``typeshed``, replacing it
     with ``Any``.
 
+    For example, suppose your code monkey-patches ``email.message`` with extra
+    members that are not declared in its ``typeshed`` stub. You can treat
+    imports from that module as ``Any`` with a per-module section:
+
+    .. code-block:: ini
+
+        [mypy]
+
+        [mypy-email.message]
+        follow_imports = skip
+        follow_imports_for_stubs = True
+
     Used in conjunction with :confval:`follow_imports=error <follow_imports>`, this can be used
     to make any use of a particular ``typeshed`` module an error.
 


### PR DESCRIPTION
Fixes #4860

This adds a concrete `mypy.ini` example showing how to combine
`follow_imports = skip` with `follow_imports_for_stubs = True`. It also explains
the motivating case of a runtime monkey patch that is not represented in a
typeshed stub.

Tests:

- `pre-commit run --files docs/source/config_file.rst --show-diff-on-failure`
- `sphinx-build -n -d .tox/docs_doctree docs/source .tox/docs_out --color -W -bhtml`

No behavior test was added because this is a documentation-only change. I also
verified the sample configuration with mypy and confirmed the imported symbol
is revealed as `Any`.

Disclosure: This contribution was prepared with LLM assistance. I reviewed the
result and validated the example and documentation build locally.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
