### PR TITLE
Fix cached_property access through classes

### DIFF
--- a/mypy/cache.py
+++ b/mypy/cache.py
@@ -72,7 +72,7 @@ from librt.internal import (
 from mypy_extensions import u8
 
 # High-level cache layout format
-CACHE_VERSION: Final = 11
+CACHE_VERSION: Final = 12
 
 # Type used internally to represent errors:
 #   (path, line, column, end_line, end_column, severity, message, code)

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -1301,6 +1301,20 @@ def analyze_class_attribute_access(
                 t, mx, cast(Decorator, node.node).var, itype, is_class=is_classmethod
             )
 
+        proper_t = get_proper_type(t)
+        if (
+            is_decorated
+            and cast(Decorator, node.node).is_cached_property
+            and isinstance(proper_t, CallableType)
+        ):
+            # ``cached_property.__get__(None, owner)`` returns the descriptor
+            # itself, unlike a regular property access. Preserve that type so
+            # class-level attributes such as ``A.value.attrname`` are valid.
+            cached_property = Instance(
+                mx.chk.lookup_typeinfo("functools.cached_property"), [proper_t.ret_type]
+            )
+            return apply_class_attr_hook(mx, hook, cached_property)
+
         result = t
         # __set__ is not called on class objects.
         if not mx.is_lvalue:

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -1314,7 +1314,14 @@ class Decorator(SymbolNode, Statement):
     A single Decorator object can include any number of function decorators.
     """
 
-    __slots__ = ("func", "decorators", "original_decorators", "var", "is_overload")
+    __slots__ = (
+        "func",
+        "decorators",
+        "original_decorators",
+        "var",
+        "is_overload",
+        "is_cached_property",
+    )
 
     __match_args__ = ("decorators", "var", "func")
 
@@ -1333,6 +1340,7 @@ class Decorator(SymbolNode, Statement):
         self.original_decorators = decorators.copy()
         self.var = var
         self.is_overload = False
+        self.is_cached_property = False
 
     @property
     def name(self) -> str:
@@ -1363,6 +1371,7 @@ class Decorator(SymbolNode, Statement):
             "func": self.func.serialize(),
             "var": self.var.serialize(),
             "is_overload": self.is_overload,
+            "is_cached_property": self.is_cached_property,
         }
 
     @classmethod
@@ -1370,6 +1379,7 @@ class Decorator(SymbolNode, Statement):
         assert data[".class"] == "Decorator"
         dec = Decorator(FuncDef.deserialize(data["func"]), [], Var.deserialize(data["var"]))
         dec.is_overload = data["is_overload"]
+        dec.is_cached_property = data.get("is_cached_property", False)
         return dec
 
     def write(self, data: WriteBuffer) -> None:
@@ -1377,6 +1387,7 @@ class Decorator(SymbolNode, Statement):
         self.func.write(data)
         self.var.write(data)
         write_bool(data, self.is_overload)
+        write_bool(data, self.is_cached_property)
         write_tag(data, END_TAG)
 
     @classmethod
@@ -1387,6 +1398,7 @@ class Decorator(SymbolNode, Statement):
         var = Var.read(data)
         dec = Decorator(func, [], var)
         dec.is_overload = read_bool(data)
+        dec.is_cached_property = read_bool(data)
         assert read_tag(data) == END_TAG
         return dec
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1779,6 +1779,7 @@ class SemanticAnalyzer(
                     dec.func.abstract_status = IS_ABSTRACT
                 elif refers_to_fullname(d, "functools.cached_property"):
                     dec.var.is_settable_property = True
+                    dec.is_cached_property = True
                 self.check_decorated_function_is_method("property", dec)
             elif refers_to_fullname(d, "typing.no_type_check"):
                 dec.var.type = AnyType(TypeOfAny.special_form)

--- a/test-data/unit/check-functools.test
+++ b/test-data/unit/check-functools.test
@@ -125,6 +125,30 @@ _T = TypeVar('_T')
 class cached_property(Generic[_T]): ...
 [builtins fixtures/property.pyi]
 
+[case testCachedPropertyClassAccess]
+from functools import cached_property
+
+class A:
+    @cached_property
+    def value(self) -> int: ...
+
+    @classmethod
+    def name(cls) -> str:
+        reveal_type(cls.value)  # N: Revealed type is "functools.cached_property[builtins.int]"
+        return cls.value.attrname or ""
+
+reveal_type(A.value)  # N: Revealed type is "functools.cached_property[builtins.int]"
+[file functools.pyi]
+from typing import Any, Generic, TypeVar, overload
+_T = TypeVar('_T')
+class cached_property(Generic[_T]):
+    attrname: str | None
+    @overload
+    def __get__(self, instance: None, owner: type[Any] | None = ...) -> cached_property[_T]: ...
+    @overload
+    def __get__(self, instance: object, owner: type[Any] | None = ...) -> _T: ...
+[builtins fixtures/property.pyi]
+
 [case testTotalOrderingWithForwardReference]
 from typing import Generic, Any, TypeVar
 import functools


### PR DESCRIPTION
## Summary

Fixes #21825.

`functools.cached_property.__get__` returns the descriptor when accessed through a class. Mypy now preserves that behavior for class-level access, while instance access continues to use the cached property's return type. The decorator marker is retained in serialized nodes and the cache format version is bumped so stale caches cannot misinterpret the new field.

## Evidence

- `test-data/unit/check-functools.test` covers class access from both `A.value` and a classmethod, including `.attrname`.
- `uv run --with mypy-extensions --with pytest --with pytest-xdist --with lxml python3 -m pytest -q mypy/test/testcheck.py -k 'check-functools'` (31 passed)
- `uv run --with mypy-extensions --with pytest --with filelock --with psutil --with types-psutil --with tomli --with lxml python3 -m mypy --config-file mypy_self_check.ini -p mypy` (clean)
- `uv run --with pre-commit pre-commit run --files mypy/checkmember.py mypy/nodes.py mypy/semanal.py mypy/cache.py test-data/unit/check-functools.test` (passed)
- `git diff --check`

No maintainer-only, legal, or contributor-account action is required.
