### PR TITLE
Reduce TypeForm recognition slowdown (Take 3)

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8161,6 +8161,16 @@ class SemanticAnalyzer(
                         # 2. unbound_paramspec: f'ParamSpec "{name}" is unbound' [codes.VALID_TYPE]
                         maybe_type_expr.as_type = None
                         return
+                    if (
+                        isinstance(node, Var)
+                        and isinstance(get_proper_type(node.type), Instance)
+                        and not self.var_is_typing_special_form(node)
+                    ):
+                        # Var whose declared type is a concrete instance: it is
+                        # a value (local, parameter, module-level constant),
+                        # not a type expression.
+                        maybe_type_expr.as_type = None
+                        return
             else:  # does not look like an identifier
                 if '"' in str_value or "'" in str_value:
                     # Only valid inside a Literal[...] or Annotated[..., ...] type
@@ -8255,6 +8265,8 @@ class SemanticAnalyzer(
             "typing.Literal",
             "typing_extensions.Literal",
             "typing.Optional",
+            "typing.Self",
+            "typing_extensions.Self",
             "typing.TypeGuard",
             "typing_extensions.TypeGuard",
             "typing.TypeIs",

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8189,7 +8189,29 @@ class SemanticAnalyzer(
                         # 2. Reference to an unknown placeholder node.
                         maybe_type_expr.as_type = None
                         return
-            else:  # does not look like an identifier
+            elif (leftmost_name := dotted_identifier_leftmost(str_value)) is not None:
+                # Dotted-name string (e.g. "builtins.tuple", "typing.Mapping").
+                # Look up the leftmost component; if it cannot be a type prefix
+                # then the whole dotted name cannot spell a type. Mirrors the
+                # IndexExpr-with-MemberExpr-base filter logic below.
+                sym = self.lookup(leftmost_name, UnboundType(leftmost_name), suppress_errors=True)
+                if sym is None:
+                    # Leftmost component does not refer to anything in scope
+                    maybe_type_expr.as_type = None
+                    return
+                node = sym.node  # cache
+                if isinstance(node, PlaceholderNode) and not node.becomes_typeinfo:
+                    # Either:
+                    # 1. f'Cannot resolve name "{t.name}" (possible cyclic definition)'
+                    # 2. Reference to an unknown placeholder node.
+                    maybe_type_expr.as_type = None
+                    return
+                if isinstance(node, Var) and not self.var_is_typing_special_form(node):
+                    # Leftmost component is a Var: it is a value, so it cannot be
+                    # the module or class prefix of a dotted type name.
+                    maybe_type_expr.as_type = None
+                    return
+            else:  # does not look like an identifier or dotted identifier
                 if '"' in str_value or "'" in str_value:
                     # Only valid inside a Literal[...] or Annotated[..., ...] type
                     if "[" not in str_value:
@@ -8566,6 +8588,36 @@ def erase_func_annotations(func: FuncDef) -> None:
         arg.variable.type = None
     func.type = None
     func.unanalyzed_type = None
+
+
+def dotted_identifier_leftmost(s: str) -> str | None:
+    """The leftmost component of s, if s is a dotted identifier, else None.
+
+    A dotted identifier is two or more identifiers joined by ".", such as
+    "builtins.tuple" or "typing.Mapping". A bare identifier is not a dotted
+    identifier: callers are expected to handle that case separately.
+
+    Returns the leftmost component (which is never empty) so that callers
+    need not split s a second time to obtain it.
+    """
+    # NOTE: Scanning with find() rather than s.split(".") avoids allocating a
+    #       list, since only the leftmost component is ever needed.
+    dot = s.find(".")
+    if dot == -1:
+        return None
+    leftmost = s[:dot]
+    if not leftmost.isidentifier():
+        return None
+    start = dot + 1
+    while True:
+        dot = s.find(".", start)
+        if dot == -1:
+            if not s[start:].isidentifier():
+                return None
+            return leftmost
+        if not s[start:dot].isidentifier():
+            return None
+        start = dot + 1
 
 
 def has_nontype_char(s: str) -> bool:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8145,12 +8145,13 @@ class SemanticAnalyzer(
                     return
                 else:  # sym is not None
                     node = sym.node  # cache
-                    if isinstance(node, PlaceholderNode) and not node.becomes_typeinfo:
-                        # Either:
-                        # 1. f'Cannot resolve name "{t.name}" (possible cyclic definition)'
-                        # 2. Reference to an unknown placeholder node.
-                        maybe_type_expr.as_type = None
-                        return
+                    # The following early-reject checks are mutually exclusive
+                    # (a node is at most one of an unbound type variable, a value
+                    # Var, or a placeholder), so their order never affects which
+                    # expressions are rejected. They are ordered by descending
+                    # rejection frequency (measured on mypy's self-check) so the
+                    # commonest rejections exit first: unbound type variables
+                    # (~951) >> value Vars (~157) > placeholders (~23).
                     unbound_tvar_or_paramspec = (
                         isinstance(node, (TypeVarExpr, TypeVarTupleExpr, ParamSpecExpr))
                         and self.tvar_scope.get_binding(sym) is None
@@ -8169,6 +8170,12 @@ class SemanticAnalyzer(
                         # Var whose declared type is a concrete instance: it is
                         # a value (local, parameter, module-level constant),
                         # not a type expression.
+                        maybe_type_expr.as_type = None
+                        return
+                    if isinstance(node, PlaceholderNode) and not node.becomes_typeinfo:
+                        # Either:
+                        # 1. f'Cannot resolve name "{t.name}" (possible cyclic definition)'
+                        # 2. Reference to an unknown placeholder node.
                         maybe_type_expr.as_type = None
                         return
             else:  # does not look like an identifier

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -368,6 +368,13 @@ Tag: _TypeAlias = int
 # string literal as a type expression.
 _MULTIPLE_WORDS_NONTYPE_RE = re.compile(r'\s*[^\s.\'"|\[]+\s+[^\s.\'"|\[]')
 
+# Characters which never appear in a valid type expression.
+# NOTE: Allows '*' for (PEP 646 Unpack) and '+' for (Literal[+N])
+# NOTE: Stored as a tuple of single-character strings (rather than a str)
+#       so that iterating it does not allocate a new string per character
+#       when compiled with mypyc.
+_NONTYPE_CHARS: Final = tuple("!:/<>@%$^?;&~`\\")
+
 
 class SemanticAnalyzer(
     NodeVisitor[None], SemanticAnalyzerInterface, SemanticAnalyzerPluginInterface, SplittingVisitor
@@ -8201,6 +8208,24 @@ class SemanticAnalyzer(
                     # But cannot be a type expression.
                     maybe_type_expr.as_type = None
                     return
+                # Skip some checks when a non-zero even number of single or double quotes
+                # signals a possible Literal[...] component, whose quoted content
+                # could contain anything: symbols or identifiers that would be
+                # incorrectly processed by some checks.
+                sq = str_value.count("'")
+                dq = str_value.count('"')
+                if not ((sq > 0 and sq % 2 == 0) or (dq > 0 and dq % 2 == 0)):
+                    # Filter out string literals containing characters or boundary
+                    # patterns that never appear in valid type expressions:
+                    # - Leading '.' (incomplete dotted name, file extension, etc)
+                    # - Trailing '.' (incomplete dotted name, file extension, etc)
+                    # - Characters never valid in a type expression (e.g. '/', ':', '<', '>', '@')
+                    # - '-' not directly preceded by '[' (which can occur in Literal[-N])
+                    # NOTE: str_value is never empty here. Branches above return
+                    #       for every string shorter than 2 characters.
+                    if str_value[0] == "." or str_value[-1] == "." or has_nontype_char(str_value):
+                        maybe_type_expr.as_type = None
+                        return
         elif isinstance(maybe_type_expr, IndexExpr):
             if isinstance(maybe_type_expr.base, NameExpr):
                 if isinstance(
@@ -8541,3 +8566,37 @@ def erase_func_annotations(func: FuncDef) -> None:
         arg.variable.type = None
     func.type = None
     func.unanalyzed_type = None
+
+
+def has_nontype_char(s: str) -> bool:
+    """Whether s contains a character that cannot appear in a type expression.
+
+    Callers must exclude strings that may contain a quoted Literal[...]
+    component first, since quoted content can hold arbitrary characters.
+    """
+    # Look for _NONTYPE_CHARS
+    # NOTE: Iterating over s first (instead of _NONTYPE_CHARS) is NOT faster.
+    # NOTE: set.isdisjoint() is faster in interpreted-mypy (-22% runtime)
+    #       but slower in compiled-mypy (+16% runtime)
+    for ch in _NONTYPE_CHARS:
+        if ch in s:
+            return True
+
+    # Look for "-".
+    # It is valid only as a unary minus introducing a Literal[...] element,
+    # which is to say only where the preceding non-space character is a "["
+    # (as in Literal[-1]) or a "," (as in Literal[-1, -2]).
+    # A "-" anywhere else means s cannot be a type.
+    i = s.find("-")
+    while i != -1:
+        # Look for a preceding "[" or "," (skipping whitespace)
+        j = i - 1
+        while j >= 0 and s[j] == " ":
+            j -= 1
+        if j < 0 or (s[j] != "[" and s[j] != ","):
+            return True
+
+        # Continue to the next "-"
+        i = s.find("-", i + 1)
+
+    return False

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -8145,13 +8145,13 @@ class SemanticAnalyzer(
                     return
                 else:  # sym is not None
                     node = sym.node  # cache
-                    # The following early-reject checks are mutually exclusive
-                    # (a node is at most one of an unbound type variable, a value
-                    # Var, or a placeholder), so their order never affects which
-                    # expressions are rejected. They are ordered by descending
-                    # rejection frequency (measured on mypy's self-check) so the
-                    # commonest rejections exit first: unbound type variables
-                    # (~951) >> value Vars (~157) > placeholders (~23).
+                    # The following early-reject checks are mutually exclusive,
+                    # ordered by decreasing rejection frequency (measured on
+                    # mypy's self-check) so the commonest rejections exit first.
+                    # - TypeVarExpr, TypeVarTupleExpr, ParamSpecExpr (~951)
+                    # - Var (~157)
+                    # - FuncDef, OverloadedFuncDef, MypyFile (~48)
+                    # - PlaceholderNode (~23)
                     unbound_tvar_or_paramspec = (
                         isinstance(node, (TypeVarExpr, TypeVarTupleExpr, ParamSpecExpr))
                         and self.tvar_scope.get_binding(sym) is None
@@ -8170,6 +8170,10 @@ class SemanticAnalyzer(
                         # Var whose declared type is a concrete instance: it is
                         # a value (local, parameter, module-level constant),
                         # not a type expression.
+                        maybe_type_expr.as_type = None
+                        return
+                    if isinstance(node, (FuncDef, OverloadedFuncDef, MypyFile)):
+                        # Functions and modules are never type expressions.
                         maybe_type_expr.as_type = None
                         return
                     if isinstance(node, PlaceholderNode) and not node.becomes_typeinfo:


### PR DESCRIPTION
References #21262. Replaces #21585 and obsoletes #21596.

## Summary

Enabling `TypeForm` by default (referenced #21262) made
`SemanticAnalyzer.try_parse_as_type_expression` run eagerly on every expression
in certain syntactic positions. The cost is concentrated in the expensive
full-parse block (`expr_to_analyzed_type` + `isolated_error_analysis`), which
**fails ~87% of the time** - pure wasted work.

This branch adds early-reject filters that eliminate **74% of full parses
(2570 → 666)** on mypy's self-check, recovering **~46% of the regression**:
**+1.57% → +0.84%** CPU time.

**No new regexes** - per review feedback on replaced #21585. Every filter here
is plain string/`isinstance` work, and the two shape tests that were regexes
are now helper functions.

<details>
<summary>Why not do a type-context check?</summary>

Review of replaced #21585 suggested skipping the call to 
`SemanticAnalyzer.try_parse_as_type_expression` entirely when the type context
cannot be a `TypeForm`. That optimization already exists, but in the other
*type checker* pass at `ExpressionChecker.try_parse_as_type_expression`.
The same skip cannot be used in the *semantic analyzer* pass's function
because the type context is not yet known.

So cheaply filtering the inputs to `SA.try_parse_as_type_expression` is the
only remaining (obvious) lever to reduce its runtime contribution.

</details>

## Optimization Results

CPU time, single worker, paired per-round deltas, n=300:

```
python misc/perf_compare.py --warmup-runs 3 --num-runs 300 -j 3 \
    --metric cpu --workers1 \
    <TypeForm-disabled-commit> 5bb72b788 <tip-of-this-pr-branch>
```

| Commit | Mean | Median | Δ vs baseline (paired median ±95% CI) |
|---|---:|---:|---:|
| baseline, `<TypeForm-disabled-commit>` | 2.679 s | 2.676 s | - |
| master, `5bb72b788` | 2.720 s | 2.720 s | **+41.9 ms ±2.9 (+1.57%)** |
| all filters, `<tip-of-this-pr-branch>` | 2.703 s | 2.699 s | **+22.4 ms ±2.9 (+0.84%)** |

The feature branch recovers 
**19.5 ms of the 41.9 ms regression (~46% by paired median)** - 
leaving **+22.4 ms (~54%)**. Derivation:
- +41.9 ms - +22.4 ms == 19.5 ms recovered
-  19.5 ms / +41.9 ms == 46.5% (~46%) recovered
- +22.4 ms / +41.9 ms == 53.5% (~54%) left

A separate 2-way run of master vs `<tip-of-this-pr-branch>` measured
**−21.1 ms ±3.2**, consistent with the 19.5 ms recovered that was derived above.

<details>
<summary>Notes on the measurement</summary>

The baseline (`<TypeForm-disabled-commit>`) is current master (`5bb72b788`)
with referenced #21262 (SHA: `dd851f559`) reverted, so all three arms share
today's code and differ only in `TypeForm`. Measuring against the original
pre-#21262 master commit instead of today's master would have conflated
optimizations made during the following ~80 commits, including notably `c0cced35c`,
which optimised `SA.try_parse_as_type_expression` specifically.

Thus runtime regression measured here (+41.9 ms) is smaller than the
+50.2 ms reported in replaced #21585: part of the original regression has
already been absorbed upstream.

</details>

Full parses per self-check, identical corpus:

| | master | branch | |
|---|---:|---:|---|
| full parses | 2570 | 666 | **−74.1%** |
| - succeeded (produced a type) | 345 | 345 | **±0** ✅ |
| - failed (wasted work) | 2225 | 321 | **−85.6%** |

The successful-parse count is unchanged at every commit on the branch,
as expected: No expression that previously parsed as a type stopped doing so.

## Overview of changes

- Most changes are made to the `SemanticAnalyzer.try_parse_as_type_expression`
  function. All other changes occur within the same file.
- 5 commits, each individually profiled:
    - 4 commits add a filter
    - 1 commit reorders existing filters
- Any added filter can be dropped (if needed) without disturbing the other filters

### The filter commits

Bare-identifier strings (`"Foo"`):

1. Reject a `Var` whose declared type is a concrete `Instance` - a value, not a type.
2. Reject `FuncDef` / `OverloadedFuncDef` / `MypyFile` - functions and modules are never types.
3. Reorder the mutually-exclusive checks by measured rejection frequency.

Other strings:

4. Reject strings containing a character or boundary pattern that never appears
   in a type expression - leading/trailing `.`, or one of ``!:/<>@%$^?;&~`\``,
   or a `-` that is not a `Literal[...]` unary minus. Catches `"utf-8"`,
   `".pyi"`, `"error:"`, `"pkg/mod.py"`.
5. Dotted-name strings (`"builtins.tuple"`, `"typing.Mapping"`): look up the
   leftmost component and reject when it does not resolve, or resolves to a
   placeholder or a value `Var`.

Filters 4 and 5 replace `_NONTYPE_PATTERN_RE` and `_DOTTED_IDENTIFIER_RE` from
replaced #21585 with the helpers `has_nontype_char()` and `dotted_identifier_leftmost()`.
Each was verified to agree with the regex it replaces on all 1171 distinct
strings the full-parse profiler observes during a self-check.

<details>
<summary>Two specific hazards, and how they are handled</summary>

`var_is_typing_special_form` was extended to recognize `typing.Self` /
`typing_extensions.Self`, so filter 1 does not reject a stringified `'Self'`
annotation (otherwise `testSelfRecognizedInOtherSyntacticLocations` regresses).

In filter 4, `-` is treated as a unary minus wherever the preceding non-space
character is `[` or `,`, so `"Literal[-1, -2]"` and `"Literal[1, -2]"` are still
recognized. (`_NONTYPE_PATTERN_RE` in replaced #21585 used `(?<!\[)-`, which rejected
those.) On the strings observed during a self-check the two rules reject
identical sets, so the (improved) soundness costs nothing.

</details>

## Notes

- I don't think it's worth trying to recover the remaining +22.4 ms:
    - The 321 surviving failed parses are spread across four categories with
      no common cheap/obvious shape left
    - I experimented with adding some fancy `OpExpr` filters that actually
      gave a net *slowdown* of 1.9ms.

- The profiling instrumentation and the `misc/perf_compare.py` improvements used to produce these numbers are in a separate PR: #21832. Happy to fold them in here instead if that is easier to review.
