### PR TITLE
Fix symlinked standard-library path detection

### DIFF
--- a/mypy/pyinfo.py
+++ b/mypy/pyinfo.py
@@ -47,7 +47,9 @@ def getsyspath() -> list[str]:
     )
     stdlib = sysconfig.get_path("stdlib")
     stdlib_ext = os.path.join(stdlib, "lib-dynload")
-    excludes = {stdlib_zip, stdlib, stdlib_ext}
+    # sysconfig may return a symlinked path while sys.path contains its resolved
+    # target (for example, with Homebrew Python installations).
+    excludes = {os.path.realpath(p) for p in (stdlib_zip, stdlib, stdlib_ext)}
 
     # Drop the first entry of sys.path
     # - If pyinfo.py is executed as a script (in a subprocess), this is the directory
@@ -63,7 +65,9 @@ def getsyspath() -> list[str]:
     offset = 0 if sys.version_info >= (3, 11) and sys.flags.safe_path else 1
 
     abs_sys_path = (os.path.abspath(p) for p in sys.path[offset:])
-    return [p for p in abs_sys_path if p not in excludes]
+    # Keep the original absolute spelling in the result; only resolve paths
+    # for the standard-library exclusion comparison.
+    return [p for p in abs_sys_path if os.path.realpath(p) not in excludes]
 
 
 def getsearchdirs() -> tuple[list[str], list[str]]:

--- a/mypy/test/testpyinfo.py
+++ b/mypy/test/testpyinfo.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from mypy import pyinfo
+
+
+class TestPyInfo(unittest.TestCase):
+    def test_getsyspath_excludes_symlinked_stdlib(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            real_stdlib = root / "real" / "lib" / "python3.13"
+            real_stdlib.mkdir(parents=True)
+            symlinked_stdlib = root / "link" / "lib" / "python3.13"
+            symlinked_stdlib.parent.parent.symlink_to(root / "real", target_is_directory=True)
+            site_packages = root / "site-packages"
+            site_packages.mkdir()
+
+            with (
+                patch.object(pyinfo.sys, "base_exec_prefix", str(root)),
+                patch.object(
+                    pyinfo.sysconfig, "get_path", autospec=True, return_value=str(symlinked_stdlib)
+                ),
+                patch.object(
+                    pyinfo.sys, "path", [str(root), str(real_stdlib), str(site_packages)]
+                ),
+            ):
+                search_path = pyinfo.getsyspath()
+
+        assert os.path.abspath(real_stdlib) not in search_path
+        assert os.path.abspath(site_packages) in search_path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #21474.

`sysconfig.get_path("stdlib")` can return a symlinked path while Python exposes the resolved target in `sys.path`, as with Homebrew installations. `getsyspath()` now compares real paths when excluding the host standard library, while preserving the absolute path spelling returned for non-standard-library entries. Added a regression test covering the symlinked layout.

Testing:
- `uv run --no-project --python 3.13 --with pytest --with mypy-extensions --with typing_extensions --with pathspec --with librt --with ast-serialize python -m pytest -q -o addopts="" mypy/test/testpyinfo.py`
- `uv run --no-project --python 3.13 --with pre-commit pre-commit run --files mypy/pyinfo.py mypy/test/testpyinfo.py`

Prepared with AI assistance; maintainer review is requested.