### PR TITLE
Avoid warning about unreachable things multiple times with `--check-unreachable`

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -619,6 +619,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                                 and not self.is_noop_for_reachability(d)
                             ):
                                 self.msg.unreachable_statement(d)
+                                self.binder.suppress_unreachable_warnings()
                                 finish = True
                                 reported_unreachable = True
 
@@ -3331,6 +3332,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     and not self.is_noop_for_reachability(s)
                 ):
                     self.msg.unreachable_statement(s)
+                    self.binder.suppress_unreachable_warnings()
                     finish = True
                     reported_unreachable = True
 
@@ -5517,6 +5519,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                     self.accept(s.finally_body)
 
         if s.finally_body:
+            previously_suppressed = self.binder.is_unreachable_warning_suppressed()
             # Then we try again for the more restricted set of options
             # that can fall through. (Why do we need to check the
             # finally clause twice? Depending on whether the finally
@@ -5533,6 +5536,11 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 with IterationErrorWatcher(self.msg.errors, iter_errors):
                     self.accept(s.finally_body)
             self.msg.iteration_dependent_errors(iter_errors)
+
+            if not previously_suppressed:
+                # The finally body might have warned about unreachability,
+                # but we still want anything afterwards to warn too.
+                self.binder.frames[-1].suppress_unreachable_warnings = False
 
     def visit_try_without_finally(self, s: TryStmt, try_frame: bool) -> None:
         """Type check a try statement, ignoring the finally block.

--- a/test-data/unit/check-unreachable-code.test
+++ b/test-data/unit/check-unreachable-code.test
@@ -1751,3 +1751,30 @@ assert sys.platform == "win32"
 if False:
     reveal_type(5)  # E: Statement is unreachable \
                     # N: Revealed type is "Literal[5]?"
+
+[case testCheckUnreachableOnlyFlagsOnce]
+# flags: --check-unreachable --warn-unreachable
+if False:
+    if False:  # E: Statement is unreachable
+        "not flagged!"
+
+[case testCheckUnreachableHandlesFinallyRight]
+# flags: --check-unreachable --warn-unreachable
+def f1() -> None:
+    # it doesn't reset suppression
+    assert False
+    try:  # E: Statement is unreachable
+        pass
+    finally:
+        reveal_type(5)  # N: Revealed type is "Literal[5]?"
+    "something"
+
+def f2() -> None:
+    # but it does still mark things after as unreachable
+    try:
+        pass
+    finally:
+        assert False
+        reveal_type(5)  # E: Statement is unreachable \
+                        # N: Revealed type is "Literal[5]?"
+    "something"  # E: Statement is unreachable


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Refs https://github.com/python/mypy/issues/21835

On master, this is the case:
```py
if False:
    if False:  # E: Statement is unreachable
        "not flagged!"  # E: Statement is unreachable
```


<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
