### PR TITLE
Fix crash when singledispatch is shadowed by a user function

### DIFF
--- a/mypy/plugins/singledispatch.py
+++ b/mypy/plugins/singledispatch.py
@@ -106,7 +106,8 @@ def create_singledispatch_function_callback(ctx: FunctionContext) -> Type:
         # singledispatch returns an instance of functools._SingleDispatchCallable according to
         # typeshed
         singledispatch_obj = get_proper_type(ctx.default_return_type)
-        assert isinstance(singledispatch_obj, Instance)
+        if not isinstance(singledispatch_obj, Instance):
+            return ctx.default_return_type
         singledispatch_obj.args += (func_type,)
 
     return ctx.default_return_type

--- a/test-data/unit/check-singledispatch.test
+++ b/test-data/unit/check-singledispatch.test
@@ -307,3 +307,15 @@ def default(val) -> int:
     return 3
 
 [builtins fixtures/args.pyi]
+
+[case testDontCrashWhenSingledispatchIsShadowedByUserFunction]
+# cmd: mypy -m functools
+[file functools.py]
+def singledispatch(func):
+    pass
+
+@singledispatch
+def f(fn):
+    pass
+[out]
+[builtins fixtures/args.pyi]


### PR DESCRIPTION
Fixes #20339

## Root cause

The plugin hook for `functools.singledispatch` (`create_singledispatch_function_callback` in `mypy/plugins/singledispatch.py`) is registered in `mypy/plugins/default.py` purely by matching the callee's fully qualified name against the string `"functools.singledispatch"`.

If a user's own code produces a function whose fullname happens to be exactly `"functools.singledispatch"` — e.g. a top-level module literally named `functools.py` that defines its own `def singledispatch(func): ...` — the plugin hook still fires for calls to that unrelated function, since the match is name-based rather than tied to the real typeshed definition.

In that case `ctx.default_return_type` is whatever mypy inferred for the user's own function (not an `Instance` of `functools._SingleDispatchCallable`, which is what the real typeshed stub for `singledispatch` returns), so:

```python
singledispatch_obj = get_proper_type(ctx.default_return_type)
assert isinstance(singledispatch_obj, Instance)
```

fails its assertion and crashes mypy with an `AssertionError` / `INTERNAL ERROR`.

## Fix

Following the reproduction and suggestion from @hauntsaninja in the issue thread, when `ctx.default_return_type` doesn't have the shape the plugin expects, back off and return `ctx.default_return_type` unchanged instead of asserting — the same pattern already used by the two earlier guard clauses in this function. This lets normal type checking continue rather than crashing.

## Testing

Added a regression test in `test-data/unit/check-singledispatch.test` (`testDontCrashWhenSingledispatchIsShadowedByUserFunction`) that defines a module named `functools.py` with its own `singledispatch` function, matching the issue's exact repro. Verified this test:
- crashes with the pre-fix code (reproduces the reported `AssertionError`)
- passes cleanly with the fix

Ran the targeted suite: `pytest mypy/test/testcheck.py -k singledispatch` → 16 passed, 2 xfailed (pre-existing, unrelated).

Also manually verified the original repro script from the issue no longer crashes and reports `Success: no issues found in 1 source file`.