### PR TITLE
Fix crash with duplicate TypeVarTuple base classes

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -2394,6 +2394,16 @@ class SemanticAnalyzer(
                 declared_tvars = remove_dups(declared_tvars + all_tvars)
         else:
             declared_tvars = all_tvars
+        seen_type_var_tuple = False
+        checked_tvars: TypeVarLikeList = []
+        for tvar in declared_tvars:
+            if isinstance(tvar[1], TypeVarTupleExpr):
+                if seen_type_var_tuple:
+                    self.fail("Can only use one type var tuple in a class def", context)
+                    continue
+                seen_type_var_tuple = True
+            checked_tvars.append(tvar)
+        declared_tvars = checked_tvars
         for i in reversed(removed):
             # We need to actually remove the base class expressions like Generic[T],
             # mostly because otherwise they will create spurious dependencies in fine

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -2295,6 +2295,14 @@ class D[*Ts](Generic[Unpack[Us]]):  # E: Generic[...] base class is redundant \
     pass
 [builtins fixtures/tuple.pyi]
 
+[case testPEP695MultipleTypeVarTuplesUsedAsBasesNoCrash]
+class C[*T, *U](T, U):  # E: Can only use one type var tuple in a class def \
+                        # E: All type parameters should be declared ("U" not declared) \
+                        # E: TypeVarTuple "T" is only valid with an unpack \
+                        # E: TypeVarTuple "U" is unbound
+    pass
+[builtins fixtures/tuple.pyi]
+
 [case testPEP695VariadicAliasUnpack]
 class C[*Ts]:
     pass

--- a/test-data/unit/check-typevar-tuple.test
+++ b/test-data/unit/check-typevar-tuple.test
@@ -957,6 +957,18 @@ def pipeline(*xs: Unpack[Tuple[int, Unpack[Tuple[str, ...]], bool]]) -> None:
     reduce(combine, xs)
 [builtins fixtures/tuple.pyi]
 
+[case testMultipleTypeVarTuplesInGenericBasesNoCrash]
+from typing import Generic
+from typing_extensions import TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+Us = TypeVarTuple("Us")
+
+class C(Generic[Unpack[Ts]], Generic[Unpack[Us]]):  # E: Only single Generic[...] or Protocol[...] can be in bases \
+                                                     # E: Can only use one type var tuple in a class def
+    pass
+[builtins fixtures/tuple.pyi]
+
 [case testVariadicStarArgsCallNoCrash]
 from typing import TypeVar, Callable, Tuple
 from typing_extensions import TypeVarTuple, Unpack


### PR DESCRIPTION
Fixes #20527

## Root cause

`clean_up_bases_and_infer_type_variables()` (in `mypy/semanal.py`) already had duplicate-TypeVarTuple guards in a couple of places, but they could still be bypassed, letting two `TypeVarTupleType`s end up in the final `declared_tvars`/`tvar_defs` list passed to `setup_type_vars()`. That later reaches `TypeInfo.add_type_vars()` in `mypy/nodes.py`, which asserts at most one `TypeVarTuple` is present:

```python
assert not self.has_type_var_tuple_type
```

Two ways to trigger this:

1. A TypeVarTuple used directly as a base class, e.g. the issue's repro:
   ```python
   class C[*T, *U](T, U):
       pass
   ```
   Here `[*T, *U]` is correctly flagged as invalid at declaration time ("Can only use one type var tuple in a class def"), and `U` is dropped from `declared_tvars`. But `T` and `U` are also used directly as base expressions, so `get_all_bases_tvars()` rediscovers `U` as a type variable "used but not declared" and merges it back into `declared_tvars`, resurrecting the second TypeVarTuple without any further check.

2. Multiple `Generic[Unpack[...]]`/`Protocol[Unpack[...]]` bases, e.g.:
   ```python
   class D(Generic[Unpack[Ts]], Generic[Unpack[Us]]):
       pass
   ```
   `analyze_class_typevar_declaration()` receives `has_type_var_tuple` as a plain parameter, so setting it internally for the first base doesn't propagate back to the loop in `clean_up_bases_and_infer_type_variables()`, and the second base's TypeVarTuple isn't recognized as a duplicate.

## Fix

Added a final pass over `declared_tvars`, right after all the existing merging logic, that keeps only the first `TypeVarTupleExpr` and reports the existing `"Can only use one type var tuple in a class def"` error for any subsequent ones (matching the message already used for this exact restriction elsewhere in the same function). This closes both leak paths at a single choke point instead of patching each one individually, and turns the crash into a normal user-facing error.

## Testing

- Added `testPEP695MultipleTypeVarTuplesUsedAsBasesNoCrash` to `test-data/unit/check-python312.test`, covering the exact issue repro.
- Added `testMultipleTypeVarTuplesInGenericBasesNoCrash` to `test-data/unit/check-typevar-tuple.test`, covering the old-style `Generic[Unpack[...]]` duplicate-base variant found while investigating.
- Ran `python -m pytest -q mypy/test/testcheck.py -k "typevartuple or TypeVarTuple or python312 or PEP695"` (226 passed), plus `check-generics`/`check-protocols`/`check-typevar-defaults`/`check-type-aliases`/`check-varargs`/`check-narrowing`/`check-parameter-specification`/`check-python310`/`check-python311`/`check-python313`/`check-functools`/`check-flags`/`native-parser-python312` (1371 passed, 4 skipped, 1 xfailed) and `mypy/test/testsemanal.py` (577 passed) for regressions.
- Confirmed the original repro no longer crashes and now reports clean errors instead.
- Ran `pre-commit run --files mypy/semanal.py test-data/unit/check-python312.test test-data/unit/check-typevar-tuple.test` (all hooks passed).