### PR TITLE
Fix crash on invalid starred assignment target

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4516,10 +4516,9 @@ class SemanticAnalyzer(
         elif isinstance(lval, TupleExpr):
             self.analyze_tuple_or_list_lvalue(lval, explicit_type)
         elif isinstance(lval, StarExpr):
-            if nested:
-                self.analyze_lvalue(lval.expr, nested, explicit_type)
-            else:
+            if not nested:
                 self.fail("Starred assignment target must be in a list or tuple", lval)
+            self.analyze_lvalue(lval.expr, nested, explicit_type)
         else:
             self.fail("Invalid assignment target", lval)
 

--- a/test-data/unit/check-statements.test
+++ b/test-data/unit/check-statements.test
@@ -2104,6 +2104,12 @@ if int():
 -- ---------------
 
 
+[case testInvalidBareStarAssignmentTargetNoCrash]
+# https://github.com/python/mypy/issues/20796
+# flags: --debug-serialize
+*a = b  # E: Starred assignment target must be in a list or tuple \
+        # E: Name "b" is not defined
+
 [case testAssignListToStarExpr]
 from typing import List
 bs: List[A]


### PR DESCRIPTION
Fixes #20796

### Root cause

`*a = b` is invalid Python (a bare starred assignment target must be
wrapped in a list or tuple, e.g. `*a, = b`). Semantic analysis
already detects this and reports:

```
error: Starred assignment target must be in a list or tuple
```

However, in `analyze_lvalue()` (`mypy/semanal.py`), the branch
handling a non-nested `StarExpr` lvalue only called `self.fail(...)`
and returned, without analyzing the inner name expression
(`lval.expr`).

If the right-hand side of the assignment referenced an
as-yet-undefined name, semantic analysis has to defer the statement
for a later pass. As part of that deferral, `mark_incomplete()`
proactively registers the starred target's name (`a`) in the symbol
table as a `PlaceholderNode`, expecting it to later be replaced with
a real definition once the lvalue is fully analyzed.

Because the non-nested-`StarExpr` branch never analyzed `lval.expr`,
that placeholder was never resolved into a real `Var`. Later, when
mypy tried to write the incremental cache, serialization walked the
module's symbol table and hit the leftover `PlaceholderNode`,
crashing with:

```
NotImplementedError: Cannot serialize PlaceholderNode instance
```

### Fix

`mypy/semanal.py`: still analyze the inner lvalue (`lval.expr`) after
reporting the "Starred assignment target must be in a list or tuple"
error, matching what already happens for a valid nested star target.
This lets any pending placeholder for the name get resolved normally,
while the invalid-target error is still reported.

### Test

Added `testInvalidBareStarAssignmentTargetNoCrash` in
`test-data/unit/check-statements.test`, using `--debug-serialize` (the
existing mechanism used by a few other crash-regression tests, e.g.
`testNamedTupleDefaultValueDefer`) to exercise serialization even
without writing an on-disk cache. Verified this test crashes with the
reported `NotImplementedError` when the fix is reverted, and passes
with the fix.

### Verification

```
$ cat repro.py
*a = b
$ python -m mypy repro.py
repro.py:1: error: Starred assignment target must be in a list or tuple  [misc]
repro.py:1: error: Name "b" is not defined  [name-defined]
Found 2 errors in 1 file (checked 1 source file)
```

No more crash, and the two errors are reported as expected.

- `python -m pytest -q mypy/test/testcheck.py -k check-statements` — 172 passed
- `python -m pytest -q mypy/test/testsemanal.py` — 577 passed
- `python -m mypy --config-file mypy_self_check.ini mypy/semanal.py` — success