### PR TITLE
Allow __rpow__ to accept an optional third modulo argument

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1979,14 +1979,19 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         assert defn.info
 
         # First check for a valid signature
-        method_type = CallableType(
-            [AnyType(TypeOfAny.special_form), AnyType(TypeOfAny.special_form)],
-            [nodes.ARG_POS, nodes.ARG_POS],
-            [None, None],
-            AnyType(TypeOfAny.special_form),
-            self.named_type("builtins.function"),
-        )
-        if not is_subtype(reverse_type, method_type):
+        method_types = [
+            CallableType(
+                [AnyType(TypeOfAny.special_form)] * num_args,
+                [nodes.ARG_POS] * num_args,
+                [None] * num_args,
+                AnyType(TypeOfAny.special_form),
+                self.named_type("builtins.function"),
+            )
+            # The data model allows __rpow__ to take an optional third "modulo"
+            # argument, mirroring the ternary form of __pow__.
+            for num_args in ([2, 3] if reverse_name == "__rpow__" else [2])
+        ]
+        if not any(is_subtype(reverse_type, method_type) for method_type in method_types):
             self.msg.invalid_signature(reverse_type, context)
             return
 

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -2509,6 +2509,25 @@ class C:
 tmp/foo.pyi:3: error: Invalid signature "Callable[[B], A]"
 tmp/foo.pyi:5: error: Invalid signature "Callable[[C, Any, Any], int]"
 
+[case testReverseOperatorMethodTernaryPow]
+from foo import *
+[file foo.pyi]
+from typing import overload
+class A:
+    def __rpow__(self, other: A, modulo: A) -> A: ...
+class B:
+    @overload
+    def __rpow__(self, other: B) -> B: ...
+    @overload
+    def __rpow__(self, other: B, modulo: B) -> B: ...
+class C:
+    def __rpow__(self, other: C, modulo: C, oops: C) -> C: ...
+class D:
+    def __radd__(self, other: D, modulo: D) -> D: ...
+[out]
+tmp/foo.pyi:10: error: Invalid signature "Callable[[C, C, C, C], C]"
+tmp/foo.pyi:12: error: Invalid signature "Callable[[D, D, D], D]"
+
 [case testReverseOperatorOrderingCase1]
 class A:
     def __radd__(self, other: 'A') -> int: ...


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #10786.

check_reverse_op_method validated every reverse operator method against a signature taking exactly two positional arguments, so mypy reported an Invalid signature error for any __rpow__ that declares a third modulo argument. The data model documents __rpow__ as taking an optional modulo argument, and typeshed itself declares the ternary form for int, float and complex, so valid code was being rejected.

The check also runs once per overload item, so an overloaded __rpow__ was flagged even when a two argument variant was declared alongside the ternary one. That is the case reported in the issue.

__rpow__ is now accepted with either two or three positional arguments. All other reverse operator methods are unchanged, and an __rpow__ with fewer than two or more than three arguments is still reported.

A test case in test-data/unit/check-classes.test covers the ternary form, the overloaded form from the issue, an __rpow__ with too many arguments, and a three argument __radd__ that must still be rejected. The full check suite, the self check, black and ruff all pass locally.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->