### PR TITLE
Fix stubtest false positive for a typevar default across overloads

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -833,6 +833,24 @@ def _verify_arg_name(
     )
 
 
+def _resolve_typevar_upper_bounds(stub_type: mypy.types.Type) -> mypy.types.Type:
+    """Replace type variables with their upper bounds, including inside a union.
+
+    Merging the items of an overload contributes one type variable per item, so an
+    argument annotated with the same ``TypeVar`` in several items ends up as a union of
+    distinct type variables. No runtime default value is a subtype of that.
+    """
+    proper_type = mypy.types.get_proper_type(stub_type)
+    if isinstance(proper_type, mypy.types.TypeVarType):
+        return proper_type.upper_bound
+    if isinstance(proper_type, mypy.types.UnionType):
+        with mypy.state.state.strict_optional_set(True):
+            return mypy.typeops.make_simplified_union(
+                [_resolve_typevar_upper_bounds(item) for item in proper_type.items]
+            )
+    return stub_type
+
+
 def _verify_arg_default_value(
     stub_arg: nodes.Argument, runtime_arg: inspect.Parameter
 ) -> Iterator[str]:
@@ -854,8 +872,8 @@ def _verify_arg_default_value(
             # UnboundTypes have ugly question marks following them, so default to var type.
             # Note we do this same fallback when constructing signatures in from_overloadedfuncdef
             stub_type = stub_arg.variable.type or stub_arg.type_annotation
-            if isinstance(stub_type, mypy.types.TypeVarType):
-                stub_type = stub_type.upper_bound
+            if stub_type is not None:
+                stub_type = _resolve_typevar_upper_bounds(stub_type)
             if (
                 runtime_type is not None
                 and stub_type is not None

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -939,6 +939,39 @@ class StubtestUnit(unittest.TestCase):
             """,
             error=None,
         )
+        # Merging the overload items contributes one type variable per item, so the
+        # default value is checked against a union of them rather than a single one.
+        yield Case(
+            stub="""
+            from typing import TypeVar
+
+            _T1 = TypeVar("_T1")
+
+            @overload
+            def f_typevar_default(x: int = 0) -> int: ...
+            @overload
+            def f_typevar_default(x: int, ret: _T1) -> _T1: ...
+            @overload
+            def f_typevar_default(x: int = 0, *, ret: _T1) -> _T1: ...
+            """,
+            runtime="def f_typevar_default(x=0, ret=1): return ret",
+            error=None,
+        )
+        # An upper bound still has to accept the runtime default.
+        yield Case(
+            stub="""
+            _T2 = TypeVar("_T2", bound=str)
+
+            @overload
+            def f_typevar_bound_default(x: int = 0) -> int: ...
+            @overload
+            def f_typevar_bound_default(x: int, ret: _T2) -> _T2: ...
+            @overload
+            def f_typevar_bound_default(x: int = 0, *, ret: _T2) -> _T2: ...
+            """,
+            runtime="def f_typevar_bound_default(x=0, ret=1): return ret",
+            error="f_typevar_bound_default",
+        )
 
     @collect_cases
     def test_decorated_overload(self) -> Iterator[Case]:


### PR DESCRIPTION

Fixes #21597

Adding a third overload that reuses `_T` makes stubtest reject a runtime default it accepted with two:

```python
# runtime
def foo(x=0, ret=1):
    return ret
```

```python
_T = TypeVar("_T")

@overload
def foo(x: int = 0) -> int: ...
@overload
def foo(x: int, ret: _T) -> _T: ...
@overload
def foo(x: int = 0, *, ret: _T) -> _T: ...  # adding this triggers the error
```

```
error: m.foo is inconsistent, runtime parameter "ret" has a default value of type
Literal[1], which is incompatible with stub parameter type _T | _T.
Inferred signature: def (x: int = ..., ret: _T | _T = ...)
```

### Cause

`_T | _T` is not a failure to deduplicate. `Signature.from_overloadedfuncdef` already merges argument types with `make_simplified_union`, but each overload item has its own type variable ids, so the `_T` from one item and the `_T` from another are distinct variables and the union is kept.

The problem is in `_verify_arg_default_value`, which unwrapped only a *bare* type variable:

```python
if isinstance(stub_type, mypy.types.TypeVarType):
    stub_type = stub_type.upper_bound
```

A union of type variables never took that branch, and nothing is a subtype of it, so any runtime default failed as soon as a second overload item mentioned the same `TypeVar`.

### Change

The unwrapping now applies inside a union too, so `_T | _T` is checked as `object` rather than as a union no value inhabits.

Upper bounds are preserved rather than erased: `erase_typevars()` would have replaced the variables with `Any` and quietly stopped catching real mismatches, so the helper maps each variable to its own upper bound. A bounded typevar still rejects an incompatible default — there is a test for exactly that, and the message it produces reads `stub parameter type str` instead of `str | str`.

### Tests

Two cases added to `test_overload`:

- three overloads sharing an unbounded `_T` with a runtime default: no error (fails before this change)
- the same shape with `TypeVar(bound=str)` and a runtime default of `1`: still an error

`mypy/test/teststubtest.py` passes (67 tests), self-check on `mypy/stubtest.py` is clean, and `ruff` / `black` are clean on both files.
