### PR TITLE
Fix stubtest false positive for an alias of a classmethod

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1313,6 +1313,34 @@ def verify_missing(
     yield Error(object_path, "is not present in stub", stub, runtime)
 
 
+def _unbind_classmethod_alias(
+    stub_type: mypy.types.Type | None, runtime: MaybeMissing[Any]
+) -> mypy.types.Type | None:
+    """Drop the implicit first argument of a stub alias that points at a classmethod.
+
+    An assignment such as ``d = c`` in a stub refers to the classmethod object, so its
+    type keeps the ``cls`` argument, whereas reading the same name off the class at
+    runtime gives a method already bound to it.
+    """
+    if stub_type is None:
+        return None
+    if not (inspect.ismethod(runtime) and isinstance(runtime.__self__, type)):
+        return stub_type
+    proper_type = mypy.types.get_proper_type(stub_type)
+    if not isinstance(proper_type, mypy.types.CallableType) or not proper_type.arg_types:
+        return stub_type
+    if not (
+        isinstance(mypy.types.get_proper_type(proper_type.arg_types[0]), mypy.types.TypeType)
+        or proper_type.arg_names[0] in ("cls", "mcls", "metacls")
+    ):
+        return stub_type
+    return proper_type.copy_modified(
+        arg_types=proper_type.arg_types[1:],
+        arg_kinds=proper_type.arg_kinds[1:],
+        arg_names=proper_type.arg_names[1:],
+    )
+
+
 @verify.register(nodes.Var)
 def verify_var(
     stub: nodes.Var, runtime: MaybeMissing[Any], object_path: list[str]
@@ -1331,23 +1359,24 @@ def verify_var(
         yield Error(object_path, "is read-only at runtime but not in the stub", stub, runtime)
 
     runtime_type = get_mypy_type_of_runtime_value(runtime, type_context=stub.type)
+    stub_type = _unbind_classmethod_alias(stub.type, runtime)
     note = ""
     if (
         runtime_type is not None
-        and stub.type is not None
-        and not is_subtype_helper(runtime_type, stub.type)
+        and stub_type is not None
+        and not is_subtype_helper(runtime_type, stub_type)
     ):
         should_error = True
         # Avoid errors when defining enums, since runtime_type is the enum itself, but we'd
         # annotate it with the type of runtime.value
         if isinstance(runtime, enum.Enum):
             runtime_type = get_mypy_type_of_runtime_value(runtime.value)
-            if runtime_type is not None and is_subtype_helper(runtime_type, stub.type):
+            if runtime_type is not None and is_subtype_helper(runtime_type, stub_type):
                 should_error = False
             # We always allow setting the stub value to Ellipsis (...), but use
             # _value_ type as a fallback if given. If a member is ... and _value_
             # type is given, all runtime types should be assignable to _value_.
-            proper_type = mypy.types.get_proper_type(stub.type)
+            proper_type = mypy.types.get_proper_type(stub_type)
             if (
                 isinstance(proper_type, mypy.types.Instance)
                 and proper_type.type.fullname in mypy.types.ELLIPSIS_TYPE_NAMES

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -682,6 +682,43 @@ class StubtestUnit(unittest.TestCase):
             """,
             error=None,
         )
+        # An alias in the stub refers to the classmethod object, which keeps its "cls"
+        # argument, while reading the same name off the class at runtime gives a bound
+        # method.
+        yield Case(
+            stub="""
+            class GoodAlias:
+                def m(self) -> None: ...
+                m_alias = m
+                @classmethod
+                def c(cls) -> None: ...
+                c_alias = c
+            """,
+            runtime="""
+            class GoodAlias:
+                def m(self): pass
+                m_alias = m
+                @classmethod
+                def c(cls): pass
+                c_alias = c
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class BadAlias:
+                @classmethod
+                def c(cls) -> None: ...
+                c_alias: int
+            """,
+            runtime="""
+            class BadAlias:
+                @classmethod
+                def c(cls): pass
+                c_alias = c
+            """,
+            error="BadAlias.c_alias",
+        )
 
     @collect_cases
     def test_arg_mismatch(self) -> Iterator[Case]:


### PR DESCRIPTION

Fixes #15717

Binding a classmethod to a second name makes stubtest reject a stub that matches the runtime exactly:

```python
# mod.py
class T:
    def a(self): pass
    b = a
    @classmethod
    def c(cls): pass
    d = c
```

```python
# mod.pyi
class T:
    def a(self) -> None: ...
    b = a
    @classmethod
    def c(cls) -> None: ...
    d = c
```

```
error: mod.T.d variable differs from runtime type def () -> Any
Stub: in file mod.pyi:6
def (cls: type[mod.T])
Runtime: in file mod.py:4
def ()
```

The plain-method alias `b` is fine; only the classmethod alias errors.

### Cause

Both sides are right, and the comparison is what is wrong. `d = c` in the stub names the classmethod *object*, whose type keeps the `cls` argument, whereas reading `T.d` at runtime goes through the descriptor and yields a method already bound to the class. `verify_var` then compares an unbound signature against a bound one and reports a difference that does not exist.

### Change

When the runtime value is a method bound to a class, `verify_var` now compares against the stub type with its leading `cls` removed.

The check is deliberately narrow. It applies only when:

- the runtime object is a bound method whose `__self__` is a class — an instance method bound to an instance is untouched,
- the stub type is a callable with at least one argument, and
- that first argument is a `type[...]`, or is named `cls` / `mcls` / `metacls`.

So a stub that already accounts for the binding, or one whose first parameter is a genuine value parameter, keeps being compared as before. A real mismatch still fails: annotating the alias as `c_alias: int` against a runtime method is still an error, and there is a test for it.

### Tests

Two cases added to `test_static_class_method`:

- a class with both a plain-method alias and a classmethod alias, matching at runtime: no error (fails before this change)
- a classmethod alias annotated as `int` in the stub: still an error

`mypy/test/teststubtest.py` passes (67 tests), self-check on `mypy/stubtest.py` is clean, and `ruff` / `black` are clean.

### Note

The enum branch of `verify_var` now reads the same local variable rather than `stub.type` directly. The value is identical there — an enum member is never a bound method — but self-check cannot narrow `stub.type` to non-`None` once the surrounding condition tests the local.
