### PR TITLE
Fix inference when Any is passed as a type object

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1425,6 +1425,8 @@ class ConstraintBuilderVisitor(TypeVisitor[list[Constraint]]):
         if isinstance(self.actual, CallableType):
             if self.actual.is_type_obj():
                 instance_type = self.actual.get_instance_type()
+                if is_named_instance(instance_type, "typing.Any"):
+                    instance_type = AnyType(TypeOfAny.explicit)
                 if self.erase_types:
                     instance_type = erase_typevars(instance_type)
                 return infer_constraints(template.item, instance_type, self.direction)

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -3784,6 +3784,25 @@ foo(X)
 [builtins fixtures/tuple.pyi]
 [out]
 
+[case testInferGenericFromAnyTypeObject]
+from typing import Any, TypeVar, assert_type
+
+T = TypeVar("T")
+
+def instantiate(cls: type[T]) -> T:
+    return cls()
+
+assert_type(instantiate(Any), Any)
+reveal_type(instantiate(Any))  # N: Revealed type is "Any"
+[file typing.pyi]
+class Any: ...
+class Iterable: ...
+class Mapping: ...
+class TypeVar:
+    def __init__(self, name: str) -> None: ...
+def assert_type(value, typ): ...
+[out]
+
 [case testTypeUsingTypeCTypeAnyMember]
 from typing import Type, Any
 def foo(arg: Type[Any]):


### PR DESCRIPTION
Fixes #20859.

Recent typeshed versions represent `typing.Any` as a class at runtime. When that value was passed to a parameter of type `type[T]`, constraint inference extracted its internal `typing.Any` instance literally instead of treating it as the dynamic `Any` type. This produced a type that displayed as `Any` but was not semantically `Any`, so `assert_type(foo(Any), Any)` reported the confusing `Any` versus `Any` error.

This normalizes the `typing.Any` instance while inferring constraints from type objects. Other class objects keep their existing instance type. The regression test uses a class-based `typing.Any` fixture and checks both `assert_type` and the revealed inferred type.

Validation:
- Regression test: 1 passed
- `check-classes.test`: 610 passed, 1 xfailed
- mypy self-check: 196 source files clean
- pre-commit lint suite: passed
- Full pytest run: 13,907 passed, 653 skipped, 11 xfailed; 33 unrelated `mypyc` runtime tests failed because the Windows linker could not create the generated librt `.exp` file (`LNK1104`).
