### PR TITLE
Fix stubgen output for async context managers

### DIFF
--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -530,6 +530,7 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
     ) -> None:
         super().__init__(_all_, include_private, export_less, include_docstrings)
         self._decorators: list[str] = []
+        self._has_async_contextmanager = False
         # Stack of defined variables (per scope).
         self._vars: list[list[str]] = [[]]
         # What was generated previously in the stub file.
@@ -748,7 +749,10 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
         sigs = self.get_signatures(default_sig, self.sig_generators, ctx)
 
         for output in self.format_func_def(
-            sigs, is_coroutine=o.is_coroutine, decorators=self._decorators, docstring=ctx.docstring
+            sigs,
+            is_coroutine=o.is_coroutine and not self._has_async_contextmanager,
+            decorators=self._decorators,
+            docstring=ctx.docstring,
         ):
             self.add(output + "\n")
 
@@ -809,6 +813,10 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
                 o.func.is_overload = True
             elif qualname.endswith((".setter", ".deleter")):
                 self.add_decorator(qualname, require_name=False)
+            elif fullname == "contextlib.asynccontextmanager":
+                p = AliasPrinter(self)
+                self._decorators.append(f"@{decorator.accept(p)}")
+                self._has_async_contextmanager = True
             elif fullname in DATACLASS_TRANSFORM_NAMES:
                 p = AliasPrinter(self)
                 self._decorators.append(f"@{decorator.accept(p)}")
@@ -1365,6 +1373,7 @@ class ASTStubGenerator(BaseStubGenerator, mypy.traverser.TraverserVisitor):
 
     def clear_decorators(self) -> None:
         self._decorators.clear()
+        self._has_async_contextmanager = False
 
     def is_private_member(self, fullname: str) -> bool:
         parts = fullname.split(".")

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -355,6 +355,29 @@ def foo(x) -> None: ...
 def bar(x) -> None: ...
 def foo_bar(x) -> None: ...
 
+[case testAsyncContextManager]
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def ctx() -> AsyncIterator[int]:
+    yield 1
+
+class A:
+    @asynccontextmanager
+    async def ctx(self) -> AsyncGenerator[str, None]:
+        yield "value"
+[out]
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+def ctx() -> AsyncIterator[int]: ...
+
+class A:
+    @asynccontextmanager
+    def ctx(self) -> AsyncGenerator[str, None]: ...
+
 [case testMultipleAssignment]
 x, y = 1, 2
 [out]

--- a/test-data/unit/stubgen.test
+++ b/test-data/unit/stubgen.test
@@ -363,20 +363,28 @@ from contextlib import asynccontextmanager
 async def ctx() -> AsyncIterator[int]:
     yield 1
 
+async def coro() -> int:
+    return 1
+
 class A:
     @asynccontextmanager
     async def ctx(self) -> AsyncGenerator[str, None]:
         yield "value"
+
+    async def coro(self) -> int:
+        return 1
 [out]
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 
 @asynccontextmanager
 def ctx() -> AsyncIterator[int]: ...
+async def coro() -> int: ...
 
 class A:
     @asynccontextmanager
     def ctx(self) -> AsyncGenerator[str, None]: ...
+    async def coro(self) -> int: ...
 
 [case testMultipleAssignment]
 x, y = 1, 2


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #21869

Stubgen preserved both the asynccontextmanager decorator and the async keyword, producing a stub that mypy rejects because a stub body cannot establish an async generator.

This tracks when contextlib.asynccontextmanager is present and omits async only from the emitted stub signature. The decorator, return annotation, and source AST behavior remain otherwise unchanged. Regression coverage includes both a module function and a method.

Tests:
- .venv/bin/python -m pytest mypy/test/teststubgen.py -q (374 passed, 1 skipped, 2 xfailed)
- .venv/bin/pre-commit run --files mypy/stubgen.py test-data/unit/stubgen.test
- .venv/bin/python -m mypy --config-file mypy_self_check.ini mypy/stubgen.py

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you cannot add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->