### PR TITLE
Update build and test requirements

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,7 +1,7 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
 # and the pins in setup.py
 typing_extensions>=4.6.0; python_version<'3.15'
-typing_extensions>=4.14.0; python_version>='3.15'
+typing_extensions>=4.16.0; python_version>='3.15'
 mypy_extensions>=1.0.0
 pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "setuptools >= 77.0.3",
     # the following is from mypy-requirements.txt/setup.py
     "typing_extensions>=4.6.0; python_version<'3.15'",
-    "typing_extensions>=4.14.0; python_version>='3.15'",
+    "typing_extensions>=4.16.0; python_version>='3.15'",
     "mypy_extensions>=1.0.0",
     "pathspec>=1.0.0",
     "tomli>=1.1.0; python_version<'3.11'",

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -5,7 +5,7 @@
 -r build-requirements.txt
 attrs>=18.0
 filelock>=3.3.0
-lxml>=5.3.0; python_version<'3.15'
+lxml>=6.1.2; python_version<'3.16'
 psutil>=4.0
 pytest>=8.1.0
 pytest-xdist>=1.34.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,13 +10,13 @@ attrs==26.1.0
     # via -r test-requirements.in
 cfgv==3.5.0
     # via pre-commit
-coverage==7.13.5
+coverage==7.15.4
     # via pytest-cov
-distlib==0.4.0
+distlib==0.4.3
     # via virtualenv
 execnet==2.1.2
     # via pytest-xdist
-filelock==3.29.0
+filelock==3.32.3
     # via
     #   -r test-requirements.in
     #   python-discovery
@@ -27,31 +27,29 @@ iniconfig==2.3.0
     # via pytest
 librt==0.15.0 ; platform_python_implementation != "PyPy"
     # via -r mypy-requirements.txt
-lxml==6.1.0 ; python_version < "3.15"
+lxml==6.1.2 ; python_version < "3.16"
     # via -r test-requirements.in
 mypy-extensions==1.1.0
     # via -r mypy-requirements.txt
 nodeenv==1.10.0
     # via pre-commit
-packaging==26.2
+packaging==26.3
     # via pytest
 pathspec==1.1.1
     # via -r mypy-requirements.txt
-platformdirs==4.9.6
-    # via
-    #   python-discovery
-    #   virtualenv
+platformdirs==4.11.3
+    # via virtualenv
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-pre-commit==4.6.0
+pre-commit==4.6.2
     # via -r test-requirements.in
 psutil==7.2.2
     # via -r test-requirements.in
-pygments==2.20.0
+pygments==2.21.0
     # via pytest
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   -r test-requirements.in
     #   pytest-cov
@@ -60,21 +58,21 @@ pytest-cov==7.1.0
     # via -r test-requirements.in
 pytest-xdist==3.8.0
     # via -r test-requirements.in
-python-discovery==1.3.0
+python-discovery==1.5.2
     # via virtualenv
 pyyaml==6.0.3
     # via pre-commit
 tomli==2.4.1
     # via -r test-requirements.in
-types-psutil==7.2.2.20260508
+types-psutil==7.2.2.20260518
     # via -r build-requirements.txt
-types-setuptools==82.0.0.20260508
+types-setuptools==84.0.0.20260812
     # via -r build-requirements.txt
-typing-extensions==4.15.0
+typing-extensions==4.16.0
     # via -r mypy-requirements.txt
-virtualenv==21.3.1
+virtualenv==21.7.4
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==82.0.1
+setuptools==84.0.0
     # via -r test-requirements.in


### PR DESCRIPTION
Update typing-extensions to 4.16.0, the first release with full support for Python 3.15.
Update lxml to 6.1.2, the first release with wheels for Python 3.15.