### PR TITLE
Do not freeze an unresolved type variable default into an instance

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -54,6 +54,7 @@ from mypy.plugin import AnalyzeTypeContext, Plugin, TypeAnalyzerPluginInterface
 from mypy.semanal_shared import (
     SemanticAnalyzerCoreInterface,
     SemanticAnalyzerInterface,
+    has_placeholder,
     paramspec_args,
     paramspec_kwargs,
 )
@@ -527,6 +528,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                         use_generic_error=True,
                         unexpanded_type=t,
                         analyzing_tvar_def=self.analyzing_tvar_def,
+                        api=self.api,
                     )
                     if self.analyzing_tvar_def and used_default:
                         self.api.record_fixed_type(res.type)
@@ -916,6 +918,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 disallow_any=self.options.disallow_any_generics and not self.is_typeshed_stub,
                 options=self.options,
                 analyzing_tvar_def=self.analyzing_tvar_def,
+                api=self.api,
             )
             if self.analyzing_tvar_def and used_default:
                 self.api.record_fixed_type(info)
@@ -2142,6 +2145,7 @@ def fix_instance(
     use_generic_error: bool = False,
     unexpanded_type: Type | None = None,
     analyzing_tvar_def: bool = False,
+    api: SemanticAnalyzerCoreInterface | None = None,
 ) -> bool:
     """Fix a malformed instance by replacing all type arguments with TypeVar default or Any.
 
@@ -2173,6 +2177,14 @@ def fix_instance(
             use_any = False
             if tv.has_default():
                 arg = tv.default
+                if api is not None and has_placeholder(arg):
+                    # The default is a forward reference that is not ready in this pass.
+                    # A placeholder nested inside a type does not stop that type from
+                    # being committed, so substituting one here freezes it in place.
+                    if api.final_iteration:
+                        use_any = True
+                    else:
+                        api.defer()
                 if analyzing_tvar_def:
                     # Record the use of default only when analyzing another default.
                     used_default = True

--- a/test-data/unit/check-typevar-defaults.test
+++ b/test-data/unit/check-typevar-defaults.test
@@ -1063,3 +1063,48 @@ A = list[T]
 a: A
 reveal_type(a)  # N: Revealed type is "builtins.list[builtins.list[Any]]"
 [builtins fixtures/tuple.pyi]
+
+[case testTypeVarDefaultPlaceholderInImportCycleTypedDict]
+import a
+from a import Base
+reveal_type(Base().inst())
+reveal_type(Base().group())
+[file a.py]
+from typing import Generic, TYPE_CHECKING
+from typing_extensions import TypeVar
+
+if TYPE_CHECKING:
+    from c import Inst
+    from d import Group
+
+T = TypeVar("T", default="Inst")
+
+class Base(Generic[T]):
+    def group(self) -> "Group": ...
+    def inst(self) -> T: ...
+
+[file b.py]
+from typing import Callable, Union
+from a import Base
+
+Alias = Union[Base, Callable[[], None]]
+
+[file c.py]
+from a import Base
+
+class Inst:
+    def make(self) -> Base: ...
+
+[file d.py]
+from typing import TYPE_CHECKING, Tuple
+from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    from b import Alias
+
+class Group(TypedDict):
+    params: "Tuple[Alias, ...]"
+[builtins fixtures/tuple.pyi]
+[out]
+main:3: note: Revealed type is "c.Inst"
+main:4: note: Revealed type is "TypedDict('d.Group', {'params': builtins.tuple[a.Base[c.Inst] | (def ()), ...]})"


### PR DESCRIPTION
Fixes #21741.

```
AssertionError: Must not defer during final iteration
  File "mypy/semanal.py", line 1036, in analyze_func_def
    self.defer(defn)
```

Bisected to 47ca4c247 (#21491). Before it, a class whose type variable default held a placeholder was marked incomplete and its body was not analysed; now it defers and carries on, so a leftover placeholder reaches the method signatures.

## Where the placeholder comes from

`fix_instance()` fills a missing type argument from `tv.default` without checking whether that default is ready:

```py
if tv.has_default():
    arg = tv.default
```

During a pass where the default is still a forward reference, `process_typevar_parameters()` has it as `PlaceholderType(None, ...)`, and that is what gets substituted. In the reproducer, `ParamMeasT = ParameterBase | Callable[[], None]` names the bare generic, so the alias target becomes `ParameterBase[<placeholder None>]`.

That freezes. A placeholder at the *top* of an alias target marks the alias incomplete, but a nested one deliberately does not, so that recursive aliases like `A = Sequence[str | A]` stay legal:

```py
incomplete_target = isinstance(res, ProperType) and isinstance(res, PlaceholderType)
```

So the alias is committed with the placeholder inside it, no further pass is asked for, and nothing ever resolves it: `visit_placeholder_type()` gives up on a placeholder with no fullname. From there it travels into the `TypedDict` item that names the alias, and then into the signature of the method that returns that TypedDict, where `analyze_func_def()` sees `has_placeholder(result)` on the final iteration and calls `defer()`.

The reported `Cannot resolve TypedDict item (possible cyclic definition)` is the same placeholder arriving one step earlier. It is not a real cycle in the user's code.

## The change

`fix_instance()` takes the analyzer API, and when the default it is about to substitute still has a placeholder it either asks for another pass or, on the final iteration, falls back to `Any`. The second half matters as much as the first: `defer()` documents that it must not be called once there is no pass left, and this is the one place that knows the default will never arrive.

Output for the reproducer now matches 2.1.0 exactly, both the crash and the spurious TypedDict error being gone:

```
m_param.py:24: error: Missing return statement  [empty-body]
m_param.py:28: error: Missing return statement  [empty-body]
m_instrument.py:12: error: Missing return statement  [empty-body]
Found 3 errors in 2 files (checked 4 source files)
```

The third caller of `fix_instance()`, the one in `semanal.py` that repairs an alias target, is left as it was: it has no test pulling on it here and I did not want to widen the change without one.

## Tests

`testTypeVarDefaultPlaceholderInImportCycleTypedDict` in `check-typevar-defaults.test`, a four-module cycle reduced from the reporter's repository. On master it is an `INTERNAL ERROR`. It also pins the answer rather than just the absence of a crash: the default resolves to `c.Inst` and the TypedDict item comes out as `tuple[a.Base[c.Inst] | (def ()), ...]`.

Ran locally on Windows: `testcheck` 8226 passed, plus `testsemanal`, `testtransform`, `testdeps`, `testmerge`, `testfinegrained` and `testtypegen`, 1944 passed. Self check clean.
