### PR TITLE
[mypyc] Fix librt.threading.Lock runtime type checks

### DIFF
--- a/mypyc/lib-rt/threading/librt_threading_api.h
+++ b/mypyc/lib-rt/threading/librt_threading_api.h
@@ -1,6 +1,8 @@
 #ifndef LIBRT_THREADING_API_H
 #define LIBRT_THREADING_API_H
 
+#include <stdbool.h>
+
 #include "librt_threading.h"
 
 int
@@ -16,5 +18,9 @@ extern void *LibRTThreading_API[LIBRT_THREADING_API_LEN];
 #define LibRTThreading_Lock_release_internal (*(char (*)(PyObject *self)) LibRTThreading_API[5])
 #define LibRTThreading_Lock_locked_internal (*(char (*)(PyObject *self)) LibRTThreading_API[6])
 #define LibRTThreading_Lock_acquire_blocking_internal (*(char (*)(PyObject *self, char blocking)) LibRTThreading_API[7])
+
+static inline bool CPyLock_Check(PyObject *obj) {
+    return Py_TYPE(obj) == LibRTThreading_Lock_type_internal();
+}
 
 #endif  // LIBRT_THREADING_API_H

--- a/mypyc/test-data/run-threading.test
+++ b/mypyc/test-data/run-threading.test
@@ -9,6 +9,10 @@ class BadBool:
     def __bool__(self) -> bool:
         raise RuntimeError("bad bool")
 
+class MutableLockHolder:
+    def __init__(self) -> None:
+        self.lock = Lock()
+
 def test_lock_basic() -> None:
     lock = Lock()
     assert not lock.locked()
@@ -23,6 +27,22 @@ def test_lock_context_manager() -> None:
         assert acquired is True
         assert lock.locked()
     assert not lock.locked()
+
+def test_mutable_lock_attribute() -> None:
+    mutable_holder = MutableLockHolder()
+    assert not mutable_holder.lock.locked()
+    with mutable_holder.lock:
+        assert mutable_holder.lock.locked()
+    assert not mutable_holder.lock.locked()
+
+    dynamic_holder: Any = mutable_holder
+    replacement = Lock()
+    dynamic_holder.lock = replacement
+    assert mutable_holder.lock is replacement
+    with mutable_holder.lock:
+        assert replacement.locked()
+    with assertRaises(TypeError):
+        dynamic_holder.lock = object()
 
 def test_lock_non_blocking() -> None:
     lock = Lock()


### PR DESCRIPTION
The definition of `CPyLock_Check` was missing.