### PR TITLE
Don't error unnecessarily about new syntax in dependencies where we ignore errors anyways

### DIFF
--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -206,12 +206,14 @@ def parse(
         options = Options()
     errors.set_file(fnam, module, options=options)
     is_stub_file = fnam.endswith(".pyi")
-    if is_stub_file:
+    if ignore_errors:
+        feature_version = sys.version_info[1]
+    elif is_stub_file:
         feature_version = defaults.PYTHON3_VERSION[1]
-        if options.python_version[0] == 3 and options.python_version[1] > feature_version:
-            feature_version = options.python_version[1]
     else:
         assert options.python_version[0] >= 3
+        feature_version = options.python_version[1]
+    if options.python_version[0] == 3 and options.python_version[1] > feature_version:
         feature_version = options.python_version[1]
     try:
         # Disable

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -158,8 +158,8 @@ def parse_test_case(case: DataDrivenTestCase) -> None:
             for arg in args:
                 if arg.startswith("version"):
                     compare_op = arg[7:9]
-                    if compare_op not in {">=", "=="}:
-                        _item_fail("Only >= and == version checks are currently supported")
+                    if compare_op not in {">=", "==", "< "}:
+                        _item_fail("Only `>=', `==', and `< ' version checks are currently supported")
                     version_str = arg[9:]
                     try:
                         version = tuple(int(x) for x in version_str.split("."))
@@ -181,6 +181,12 @@ def parse_test_case(case: DataDrivenTestCase) -> None:
                                 f'Only minor or patch version checks are currently supported with "==": {version_str!r}'
                             )
                         version_check = sys.version_info[: len(version)] == version
+                    elif compare_op == "< ":
+                        if version < defaults.PYTHON3_VERSION:
+                            _item_fail(
+                                f"{arg} always false since minimum runtime version is {defaults.PYTHON3_VERSION}"
+                            )
+                        version_check = sys.version_info < version
             if version_check:
                 tmp_output = [expand_variables(line) for line in item.data]
                 if os.path.sep == "\\" and case.normalize_output:

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -159,7 +159,9 @@ def parse_test_case(case: DataDrivenTestCase) -> None:
                 if arg.startswith("version"):
                     compare_op = arg[7:9]
                     if compare_op not in {">=", "==", "< "}:
-                        _item_fail("Only `>=', `==', and `< ' version checks are currently supported")
+                        _item_fail(
+                            "Only `>=', `==', and `< ' version checks are currently supported"
+                        )
                     version_str = arg[9:]
                     try:
                         version = tuple(int(x) for x in version_str.split("."))

--- a/test-data/unit/check-inline-config.test
+++ b/test-data/unit/check-inline-config.test
@@ -475,3 +475,10 @@ x = 1 # type: ignore # E: Unused "type: ignore" comment
 x = 1 # type: ignore # E: Unused "type: ignore" comment
 [out]
 main:2: error: Unrecognized option: amongus = True
+
+[case testNewSyntaxOldMypy]
+# flags: --python-version 3.10
+# mypy: ignore-errors=True
+x = t""
+[out version< 3.14]
+main:3: error: Invalid syntax


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

This fixes https://github.com/python/mypy/issues/21178 (at least my own root cause for it). This is actually a bit trickier than I thought (you can read that issue to see what I thought would work, which was naive!). However, even though we use the `ast` module and cannot make the errors nonblocking, we can work around the root cause of that issue i.e. that new features in dependencies can cause mypy to fail.

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
