### PR TITLE
Fix implicit __loader__ module attribute

### DIFF
--- a/mypy/exportjson.py
+++ b/mypy/exportjson.py
@@ -104,6 +104,7 @@ def convert_symbol_table(self: SymbolTable, cfg: Config) -> Json:
         if key == "__builtins__" or value.no_serialize:
             continue
         if not cfg.implicit_names and key in {
+            "__loader__",
             "__spec__",
             "__package__",
             "__file__",

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -176,6 +176,7 @@ implicit_module_attrs: Final = {
     "__file__": "__builtins__.str",
     "__package__": "__builtins__.str",
     "__annotations__": None,  # dict[str, Any] bounded in add_implicit_module_attrs()
+    "__loader__": None,  # _typeshed.importlib.LoaderProtocol | None, see semanal.py
     "__spec__": None,  # importlib.machinery.ModuleSpec bounded in add_implicit_module_attrs()
 }
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -771,6 +771,23 @@ class SemanticAnalyzer(
                     self.defer()
                     return
                 typ = inst
+            elif name == "__loader__":
+                if self.options.use_builtins_fixtures:
+                    inst = self.named_type_or_none("builtins.object")
+                else:
+                    inst = self.named_type_or_none("_typeshed.importlib.LoaderProtocol")
+                if inst is None:
+                    if (
+                        self.final_iteration
+                        or self.options.clone_for_module("_typeshed.importlib").follow_imports
+                        == "skip"
+                    ):
+                        inst = self.named_type_or_none("builtins.object")
+                        assert inst is not None, "Cannot find builtins.object"
+                    else:
+                        self.defer()
+                        return
+                typ = UnionType.make_union([inst, NoneType()])
             elif name == "__spec__":
                 if self.options.use_builtins_fixtures:
                     inst = self.named_type_or_none("builtins.object")

--- a/test-data/unit/fine-grained-inspect.test
+++ b/test-data/unit/fine-grained-inspect.test
@@ -236,7 +236,7 @@ class C: ...
 [builtins fixtures/module.pyi]
 [out]
 ==
-{"<pack.bar>": ["C", "__annotations__", "__doc__", "__file__", "__name__", "__package__", "__spec__", "bar", "x"], "ModuleType": ["__file__", "__getattr__"]}
+{"<pack.bar>": ["C", "__annotations__", "__doc__", "__file__", "__loader__", "__name__", "__package__", "__spec__", "bar", "x"], "ModuleType": ["__file__", "__getattr__"]}
 
 [case testInspectModuleDef]
 # inspect2: --show=definition --include-kind tmp/foo.py:2:1


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Fixes #4182

Mypy now recognizes `__loader__` as an implicit module attribute. It uses `_typeshed.importlib.LoaderProtocol | None` with the standard typeshed and falls back to `object | None` when import following is unavailable or the test fixtures are active.

The existing implicit-module-attributes test now covers `__loader__`.

Tests:

- `.venv/bin/python -m pytest -n0 'mypy/test/testcheck.py::TypeCheckSuite::check-basic.test'` (46 passed)
- `.venv/bin/python -m pytest -n0 mypy/test/testexportjson.py` (8 passed)
- `.venv/bin/python -m pytest -n0 -k 'testInspectModuleAttrs'` (2 passed)
- `.venv/bin/python runtests.py self` (341 source files checked)
- `.venv/bin/python runtests.py lint` (all hooks passed)
- `.venv/bin/python -m mypy -c 'reveal_type(__loader__)'`

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
