### PR TITLE
Classify `__slots__` as class variables

### DIFF
--- a/mypy/plugins/attrs.py
+++ b/mypy/plugins/attrs.py
@@ -960,7 +960,9 @@ def _add_slots(ctx: mypy.plugin.ClassDefContext, attributes: list[Attribute]) ->
         [ctx.api.named_type("builtins.str") for _ in attributes],
         fallback=ctx.api.named_type("builtins.tuple"),
     )
-    add_attribute_to_class(api=ctx.api, cls=ctx.cls, name="__slots__", typ=slots_type)
+    add_attribute_to_class(
+        api=ctx.api, cls=ctx.cls, name="__slots__", typ=slots_type, is_classvar=True
+    )
 
 
 def _add_match_args(ctx: mypy.plugin.ClassDefContext, attributes: list[Attribute]) -> None:

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -475,6 +475,7 @@ class DataclassTransformer:
             self._cls,
             "__slots__",
             slots_type,
+            is_classvar=True,
             overwrite_existing=slots_defined_by_plugin,
         )
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -4648,6 +4648,7 @@ class SemanticAnalyzer(
             assert self.type is not None
             v.info = self.type
             v.is_initialized_in_class = True
+            v.is_classvar = name == "__slots__"
             v.allow_incompatible_override = name in ALLOW_INCOMPATIBLE_OVERRIDE
         if kind != LDEF:
             v._fullname = self.qualified_name(name)

--- a/mypyc/irbuild/classdef.py
+++ b/mypyc/irbuild/classdef.py
@@ -329,6 +329,9 @@ class ExtClassBuilder(ClassBuilder):
         # Variable declaration with no body
         if isinstance(stmt.rvalue, TempNode):
             return
+        # Native classes use mypyc's own layout, so don't emit __slots__ at runtime.
+        if lvalue.name == "__slots__":
+            return
         # Only treat marked class variables as class variables.
         if not (is_class_var(lvalue) or stmt.is_final_def):
             return

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -1175,6 +1175,23 @@ assert f() == 10
 A.x = 200
 assert f() == 200
 
+[case testSlotsNotEmittedAsClassVar]
+class Base:
+    __slots__ = ("value",)
+    value: int
+
+class Child(Base):
+    pass
+
+def make_child() -> Child:
+    child = Child()
+    child.value = 1
+    return child
+[file driver.py]
+from native import make_child
+
+assert make_child().value == 1
+
 [case testClassVarDoesNotShadowMethodGlobal]
 from typing import ClassVar
 from testutil import assertRaises

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1514,6 +1514,18 @@ class Some:
         self.y = 1  # E: Trying to assign name "y" that is not in "__slots__" of type "__main__.Some"
 [builtins fixtures/dataclasses.pyi]
 
+[case testDataclassGeneratedSlotsClassVariableOverride]
+from dataclasses import dataclass
+from typing import ClassVar
+
+@dataclass(slots=True)
+class Base:
+    value: int
+
+class Child(Base):
+    __slots__: ClassVar[tuple[str, ...]] = ()
+[builtins fixtures/tuple.pyi]
+
 [case testDataclassWithSlotsDef]
 from dataclasses import dataclass
 

--- a/test-data/unit/check-plugin-attrs.test
+++ b/test-data/unit/check-plugin-attrs.test
@@ -1745,6 +1745,19 @@ class C:
         self.c = 2  # E: Trying to assign name "c" that is not in "__slots__" of type "__main__.C"
 [builtins fixtures/plugin_attrs.pyi]
 
+[case testAttrsGeneratedSlotsClassVariableOverride]
+from typing import ClassVar
+
+import attrs
+
+@attrs.define(slots=True)
+class Base:
+    value: int
+
+class Child(Base):
+    __slots__: ClassVar[tuple[str, ...]] = ()
+[builtins fixtures/plugin_attrs.pyi]
+
 [case testAttrsClassWithSlotsDerivedFromNonSlots]
 import attrs
 

--- a/test-data/unit/check-slots.test
+++ b/test-data/unit/check-slots.test
@@ -85,6 +85,17 @@ A.b = 1
 [builtins fixtures/tuple.pyi]
 
 
+[case testSlotsClassVariableOverride]
+from typing import ClassVar
+
+class Base:
+    __slots__ = ()
+
+class Child(Base):
+    __slots__: ClassVar[tuple[str, ...]] = ()
+[builtins fixtures/tuple.pyi]
+
+
 [case testSlotsDefinitionMultipleVars1]
 class A:
     __slots__ = __fields__ = ("a", "b")


### PR DESCRIPTION
Python defines `__slots__` on the class, but mypy currently classifies generated slots as instance variables. This produces an inconsistent override error when a subclass declares an explicitly typed empty `__slots__`:

```python
from dataclasses import dataclass
from typing import ClassVar


@dataclass(slots=True)
class Base:
    x: float
    y: float


class Child(Base):
    __slots__: ClassVar[tuple[()]] = ()  # type: ignore[misc]
```

Before this change, the ignore is required to suppress:

```text
Cannot override instance variable (previously declared on base class "Base") with class variable  [misc]
```

The same inconsistency applies to ordinary `__slots__` and attrs-generated slots.

This PR classifies ordinary and plugin-generated `__slots__` symbols as class variables while preserving the existing special `__slots__` type and layout handling. It adds inheritance regression coverage for ordinary classes, dataclasses, and attrs classes.

Test plan:

- Focused `__slots__` regressions: 3 passed
- `check-slots.test`, `check-dataclasses.test`, `check-plugin-attrs.test`, and `check-classvar.test`: 364 passed
- `python3 -m pre_commit run --all-files`: all hooks passed

Fixes #21893