### PR TITLE
Match new parser behavior w.r.t. posonly args

### DIFF
--- a/mypy/nativeparse.py
+++ b/mypy/nativeparse.py
@@ -672,7 +672,7 @@ def read_func_def(state: State, data: ReadBuffer) -> FuncDef:
     name = read_str(data)
     arguments, has_ann = read_parameters(state, data)
 
-    if special_function_elide_names(name):
+    if state.options.pos_only_special_methods and special_function_elide_names(name):
         for arg in arguments:
             arg.pos_only = True
 


### PR DESCRIPTION
This matches behavior of the new parser to the old one. Not adding tests, since some existing tests fail when switched to new parser, see https://github.com/python/mypy/pull/21823

cc @JukkaL 
