### PR TITLE
Refactor PEP 661 sentinel handling to use a synthetic nominal class

### DIFF
--- a/mypy/cache.py
+++ b/mypy/cache.py
@@ -48,10 +48,7 @@ bump CACHE_VERSION below.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Final, TypeAlias as _TypeAlias
-
-if TYPE_CHECKING:
-    from mypy.types import SentinelValue
+from typing import Any, Final, TypeAlias as _TypeAlias
 
 from librt.internal import (
     ReadBuffer as ReadBuffer,
@@ -72,7 +69,7 @@ from librt.internal import (
 from mypy_extensions import u8
 
 # High-level cache layout format
-CACHE_VERSION: Final = 11
+CACHE_VERSION: Final = 12
 
 # Type used internally to represent errors:
 #   (path, line, column, end_line, end_column, severity, message, code)
@@ -311,7 +308,6 @@ LITERAL_STR: Final[Tag] = 4
 LITERAL_BYTES: Final[Tag] = 5
 LITERAL_FLOAT: Final[Tag] = 6
 LITERAL_COMPLEX: Final[Tag] = 7
-LITERAL_SENTINEL: Final[Tag] = 8
 
 # Collections.
 LIST_GEN: Final[Tag] = 20
@@ -332,7 +328,7 @@ RESERVED: Final[Tag] = 254
 END_TAG: Final[Tag] = 255
 
 
-def read_literal(data: ReadBuffer, tag: Tag) -> int | str | bool | float | SentinelValue:
+def read_literal(data: ReadBuffer, tag: Tag) -> int | str | bool | float:
     if tag == LITERAL_INT:
         return read_int_bare(data)
     elif tag == LITERAL_STR:
@@ -343,18 +339,12 @@ def read_literal(data: ReadBuffer, tag: Tag) -> int | str | bool | float | Senti
         return True
     elif tag == LITERAL_FLOAT:
         return read_float_bare(data)
-    elif tag == LITERAL_SENTINEL:
-        from mypy.types import SentinelValue as _SentinelValue
-
-        return _SentinelValue(read_str_bare(data), read_str_bare(data))
     assert False, f"Unknown literal tag {tag}"
 
 
 # There is an intentional asymmetry between read and write for literals because
 # None and/or complex values are only allowed in some contexts but not in others.
-def write_literal(
-    data: WriteBuffer, value: int | str | bool | float | complex | SentinelValue | None
-) -> None:
+def write_literal(data: WriteBuffer, value: int | str | bool | float | complex | None) -> None:
     if isinstance(value, bool):
         write_bool(data, value)
     elif isinstance(value, int):
@@ -370,12 +360,8 @@ def write_literal(
         write_tag(data, LITERAL_COMPLEX)
         write_float_bare(data, value.real)
         write_float_bare(data, value.imag)
-    elif value is None:
-        write_tag(data, LITERAL_NONE)
     else:
-        write_tag(data, LITERAL_SENTINEL)
-        write_str_bare(data, value.fullname)
-        write_str_bare(data, value.name)
+        write_tag(data, LITERAL_NONE)
 
 
 def read_int(data: ReadBuffer) -> int:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -85,6 +85,7 @@ from mypy.nodes import (
     PromoteExpr,
     RefExpr,
     RevealExpr,
+    SentinelExpr,
     SetComprehension,
     SetExpr,
     SliceExpr,
@@ -6455,6 +6456,9 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
 
     def visit_newtype_expr(self, e: NewTypeExpr) -> Type:
         return AnyType(TypeOfAny.special_form)
+
+    def visit_sentinel_expr(self, e: SentinelExpr) -> Type:
+        return Instance(e.info, [], line=e.line, column=e.column)
 
     def visit_namedtuple_expr(self, e: NamedTupleExpr) -> Type:
         tuple_type = e.info.tuple_type

--- a/mypy/evalexpr.py
+++ b/mypy/evalexpr.py
@@ -186,6 +186,9 @@ class _NodeEvaluator(ExpressionVisitor[object]):
     def visit_newtype_expr(self, o: mypy.nodes.NewTypeExpr) -> object:
         return UNKNOWN
 
+    def visit_sentinel_expr(self, o: mypy.nodes.SentinelExpr) -> object:
+        return UNKNOWN
+
     def visit__promote_expr(self, o: mypy.nodes.PromoteExpr) -> object:
         return UNKNOWN
 

--- a/mypy/literals.py
+++ b/mypy/literals.py
@@ -36,6 +36,7 @@ from mypy.nodes import (
     ParamSpecExpr,
     PromoteExpr,
     RevealExpr,
+    SentinelExpr,
     SetComprehension,
     SetExpr,
     SliceExpr,
@@ -309,6 +310,9 @@ class _Hasher(ExpressionVisitor[Key | None]):
         return None
 
     def visit_newtype_expr(self, e: NewTypeExpr) -> None:
+        return None
+
+    def visit_sentinel_expr(self, e: SentinelExpr) -> None:
         return None
 
     def visit__promote_expr(self, e: PromoteExpr) -> None:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -103,6 +103,7 @@ from mypy.types import (
     flatten_nested_unions,
     get_proper_type,
     get_proper_types,
+    sentinel_display_name,
 )
 from mypy.typetraverser import TypeTraverserVisitor
 from mypy.util import plural_s, unmangle
@@ -2722,7 +2723,9 @@ def format_type_inner(
         if itype.type.fullname == "typing._SpecialForm":
             # This is not a real type but used for some typing-related constructs.
             return "<typing special form>"
-        if verbosity >= 2 or (fullnames and itype.type.fullname in fullnames):
+        if itype.type.is_sentinel:
+            base_str = sentinel_display_name(itype.type)
+        elif verbosity >= 2 or (fullnames and itype.type.fullname in fullnames):
             base_str = itype.type.fullname
         else:
             base_str = itype.type.name
@@ -2783,8 +2786,6 @@ def format_type_inner(
                 modifier += "="
             items.append(f"{item_name!r}{modifier}: {format(item_type)}")
         return f"TypedDict({{{', '.join(items)}}})"
-    elif isinstance(typ, LiteralType) and typ.is_sentinel_literal():
-        return format_literal_value(typ)
     elif isinstance(typ, LiteralType):
         return f"Literal[{format_literal_value(typ)}]"
     elif isinstance(typ, UnionType):
@@ -2792,9 +2793,6 @@ def format_type_inner(
         if not isinstance(typ, UnionType):
             return format(typ)
         literal_items, union_items = separate_union_literals(typ)
-        sentinel_items = [item for item in literal_items if item.is_sentinel_literal()]
-        literal_items = [item for item in literal_items if not item.is_sentinel_literal()]
-        union_items = [*sentinel_items, *union_items]
 
         # Coalesce multiple Literal[] members. This also changes output order.
         # If there's just one Literal item, retain the original ordering.

--- a/mypy/mixedtraverser.py
+++ b/mypy/mixedtraverser.py
@@ -10,6 +10,7 @@ from mypy.nodes import (
     NamedTupleExpr,
     NewTypeExpr,
     PromoteExpr,
+    SentinelExpr,
     TypeAlias,
     TypeAliasExpr,
     TypeAliasStmt,
@@ -94,6 +95,10 @@ class MixedTraverserVisitor(TraverserVisitor, TypeTraverserVisitor):
         if o.info:
             self.process_type_info(o.info)
         self.visit_optional_type(o.old_type)
+
+    def visit_sentinel_expr(self, o: SentinelExpr, /) -> None:
+        super().visit_sentinel_expr(o)
+        self.process_type_info(o.info)
 
     # Statements
 

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Sequence
@@ -78,6 +79,11 @@ from mypy.modules_state import modules_state
 from mypy.options import Options
 from mypy.util import is_sunder, is_typeshed_file, short_type
 from mypy.visitor import ExpressionVisitor, NodeVisitor, StatementVisitor
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 if TYPE_CHECKING:
     from mypy.patterns import Pattern
@@ -1646,9 +1652,7 @@ class Var(SymbolNode):
         if tag == LITERAL_COMPLEX:
             v.final_value = complex(read_float_bare(data), read_float_bare(data))
         elif tag != LITERAL_NONE:
-            val = read_literal(data, tag)
-            assert not isinstance(val, mypy.types.SentinelValue)
-            v.final_value = val
+            v.final_value = read_literal(data, tag)
         assert read_tag(data) == END_TAG
         return v
 
@@ -3544,6 +3548,30 @@ class NewTypeExpr(Expression):
         return visitor.visit_newtype_expr(self)
 
 
+class SentinelExpr(Expression):
+    """PEP 661 sentinel()/Sentinel() call expression.
+
+    Marks the rvalue of a sentinel declaration (`X = sentinel("X")`) so that its type
+    is the synthetic per-declaration class in `info`, rather than whatever ordinary
+    call-checking against sentinel's/Sentinel's __init__ signature would produce.
+    """
+
+    __slots__ = ("info",)
+
+    __match_args__ = ("info",)
+
+    # The synthesized class representing this specific sentinel.
+    info: TypeInfo
+
+    def __init__(self, info: TypeInfo, line: int, column: int) -> None:
+        super().__init__(line=line, column=column)
+        self.info = info
+
+    @override
+    def accept(self, visitor: ExpressionVisitor[T]) -> T:
+        return visitor.visit_sentinel_expr(self)
+
+
 class AwaitExpr(Expression):
     """Await expression (await ...)."""
 
@@ -3666,6 +3694,7 @@ class TypeInfo(SymbolNode):
         "is_named_tuple",
         "typeddict_type",
         "is_newtype",
+        "is_sentinel",
         "is_intersection",
         "metadata",
         "alt_promote",
@@ -3806,6 +3835,9 @@ class TypeInfo(SymbolNode):
     # Is this a newtype type?
     is_newtype: bool
 
+    # Is this a synthetic type generated for a PEP 661 sentinel()/Sentinel() declaration?
+    is_sentinel: bool
+
     # Is this a synthesized intersection type?
     is_intersection: bool
 
@@ -3860,6 +3892,7 @@ class TypeInfo(SymbolNode):
         "meta_fallback_to_any",
         "is_named_tuple",
         "is_newtype",
+        "is_sentinel",
         "is_protocol",
         "runtime_protocol",
         "is_final",
@@ -3907,6 +3940,7 @@ class TypeInfo(SymbolNode):
         self.is_named_tuple = False
         self.typeddict_type = None
         self.is_newtype = False
+        self.is_sentinel = False
         self.is_intersection = False
         self.metadata = {}
         self.self_type = None
@@ -4350,6 +4384,7 @@ class TypeInfo(SymbolNode):
                 self.meta_fallback_to_any,
                 self.is_named_tuple,
                 self.is_newtype,
+                self.is_sentinel,
                 self.is_protocol,
                 self.runtime_protocol,
                 self.is_final,
@@ -4423,12 +4458,13 @@ class TypeInfo(SymbolNode):
             ti.meta_fallback_to_any,
             ti.is_named_tuple,
             ti.is_newtype,
+            ti.is_sentinel,
             ti.is_protocol,
             ti.runtime_protocol,
             ti.is_final,
             ti.is_disjoint_base,
             ti.is_intersection,
-        ) = read_flags(data, num_flags=11)
+        ) = read_flags(data, num_flags=12)
         ti.metadata = read_json(data)
         tag = read_tag(data)
         if tag != LITERAL_NONE:

--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -63,7 +63,6 @@ from mypy.types import (
     LiteralType,
     NoneType,
     ProperType,
-    SentinelValue,
     TupleType,
     Type,
     TypeOfAny,
@@ -800,11 +799,11 @@ class DataclassTransformer:
         if node is None:
             return False
         node_type = get_proper_type(node)
-        if isinstance(node_type, LiteralType) and isinstance(node_type.value, SentinelValue):
-            # PEP 661 sentinel: `KW_ONLY = sentinel("KW_ONLY")` (Python 3.15+).
-            return node_type.value.fullname == "dataclasses.KW_ONLY"
         if not isinstance(node_type, Instance):
             return False
+        if node_type.type.is_sentinel:
+            # Clean up synthetic class's mangled fullname
+            return node_type.type.fullname.removesuffix("'") == "dataclasses.KW_ONLY"
         return node_type.type.fullname == "dataclasses.KW_ONLY"
 
     def _add_dataclass_fields_magic_attribute(self) -> None:

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -156,6 +156,7 @@ from mypy.nodes import (
     RefExpr,
     ReturnStmt,
     RevealExpr,
+    SentinelExpr,
     SetComprehension,
     SetExpr,
     SliceExpr,
@@ -290,7 +291,6 @@ from mypy.types import (
     ParamSpecType,
     PlaceholderType,
     ProperType,
-    SentinelValue,
     TrivialSyntheticTypeTranslator,
     TupleType,
     Type,
@@ -3435,15 +3435,31 @@ class SemanticAnalyzer(
         typ = self.named_type_or_none(callee.fullname)
         if typ is None:
             return None
-        name = f"{self.type.name}.{var.name}" if self.type is not None else var.name
-        return typ.copy_modified(
-            last_known_value=LiteralType(
-                SentinelValue(var.fullname, name),
-                fallback=typ,
-                line=rvalue.line,
-                column=rvalue.column,
-            )
+
+        # Give this sentinel its own synthetic nominal type (like NewType), rather than
+        # tagging the shared sentinel/Sentinel class with a Literal[...] value: a sentinel
+        # has no way to identify itself other than this type, unlike e.g. an enum member.
+        # The mangled name avoids colliding with the Var of the same name in this scope.
+        mangled_name = f"{var.name}'"
+        info = self.basic_new_typeinfo(mangled_name, typ, rvalue.line)
+        info.is_sentinel = True
+
+        # Insert directly rather than via add_symbol(): redefining the sentinel Var (e.g.
+        # reassigning MISSING = sentinel(...) again) is already reported once for the Var
+        # itself, and would otherwise also be (redundantly) reported for this mangled name.
+        symbol_table = self.type.names if self.type is not None else self.globals
+        symbol_table[mangled_name] = SymbolTableNode(
+            kind=MDEF if self.type is not None else GDEF,
+            node=info,
+            module_public=False,
+            module_hidden=True,
         )
+
+        # Redirect type-checking of this call expression to visit_sentinel_expr, so its
+        # type is this synthetic class rather than whatever ordinary call-checking
+        # against sentinel's/Sentinel's __init__ signature would otherwise produce.
+        rvalue.analyzed = SentinelExpr(info, line=rvalue.line, column=rvalue.column)
+        return Instance(info, [], line=rvalue.line, column=rvalue.column)
 
     def analyze_identity_global_assignment(self, s: AssignmentStmt) -> bool:
         """Special case 'X = X' in global scope.
@@ -4816,7 +4832,6 @@ class SemanticAnalyzer(
                     var.is_final
                     and isinstance(typ, Instance)
                     and typ.last_known_value
-                    and not isinstance(typ.last_known_value.value, SentinelValue)
                     and (not self.type or not self.type.is_enum)
                 ):
                     var.final_value = typ.last_known_value.value

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -158,7 +158,6 @@ from mypy.types import (
     ParamSpecType,
     PartialType,
     ProperType,
-    SentinelValue,
     TupleType,
     Type,
     TypeAliasType,
@@ -975,7 +974,13 @@ class TypeTriggersVisitor(TypeVisitor[list[str]]):
         return get_type_triggers(typ, self.use_logical_deps, self.seen_aliases)
 
     def visit_instance(self, typ: Instance) -> list[str]:
-        trigger = make_trigger(typ.type.fullname)
+        if typ.type.is_sentinel:
+            # The synthetic per-declaration class has a mangled fullname (see
+            # semanal.py's sentinel_type_for_var) that doesn't correspond to any
+            # externally visible symbol; trigger on the sentinel Var's fullname instead.
+            trigger = make_trigger(typ.type.fullname.removesuffix("'"))
+        else:
+            trigger = make_trigger(typ.type.fullname)
         triggers = [trigger]
         for arg in typ.args:
             triggers.extend(self.get_type_triggers(arg))
@@ -1097,10 +1102,7 @@ class TypeTriggersVisitor(TypeVisitor[list[str]]):
         return triggers
 
     def visit_literal_type(self, typ: LiteralType) -> list[str]:
-        triggers = self.get_type_triggers(typ.fallback)
-        if isinstance(typ.value, SentinelValue):
-            triggers.append(make_trigger(typ.value.fullname))
-        return triggers
+        return self.get_type_triggers(typ.fallback)
 
     def visit_unbound_type(self, typ: UnboundType) -> list[str]:
         return []

--- a/mypy/strconv.py
+++ b/mypy/strconv.py
@@ -594,6 +594,9 @@ class StrConv(NodeVisitor[str]):
     def visit_newtype_expr(self, o: mypy.nodes.NewTypeExpr) -> str:
         return f"NewTypeExpr:{o.line}({o.name}, {self.dump([o.old_type], o)})"
 
+    def visit_sentinel_expr(self, o: mypy.nodes.SentinelExpr) -> str:
+        return f"SentinelExpr:{o.line}({o.info.fullname})"
+
     def visit_lambda_expr(self, o: mypy.nodes.LambdaExpr) -> str:
         a = self.func_helper(o)
         return self.dump(a, o)

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import re
 from unittest import TestCase, skipUnless
 
-from librt.internal import ReadBuffer, WriteBuffer
-
-from mypy.cache import read_tag
 from mypy.erasetype import erase_type, remove_instance_last_known_values
 from mypy.indirection import TypeIndirectionVisitor
 from mypy.join import join_types
@@ -33,7 +30,6 @@ from mypy.test.helpers import Suite, assert_equal, assert_type, skip
 from mypy.test.typefixture import InterfaceTypeFixture, TypeFixture
 from mypy.typeops import false_only, make_simplified_union, true_only
 from mypy.types import (
-    LITERAL_TYPE,
     AnyType,
     CallableType,
     Instance,
@@ -41,7 +37,6 @@ from mypy.types import (
     NoneType,
     Overloaded,
     ProperType,
-    SentinelValue,
     TupleType,
     Type,
     TypedDictType,
@@ -70,25 +65,6 @@ class TypesSuite(Suite):
 
     def test_any(self) -> None:
         assert_equal(str(AnyType(TypeOfAny.special_form)), "Any")
-
-    def test_sentinel_literal_json_roundtrip(self) -> None:
-        literal = LiteralType(SentinelValue("__main__.MISSING", "MISSING"), self.fx.a)
-        assert_equal(str(literal), "MISSING")
-        data = literal.serialize()
-        assert isinstance(data, dict)
-        roundtrip = LiteralType.deserialize(data)
-        self.assertEqual(roundtrip.value, literal.value)
-        self.assertEqual(roundtrip.fallback.type_ref, self.fx.a.type.fullname)
-
-    def test_sentinel_literal_ff_roundtrip(self) -> None:
-        literal = LiteralType(SentinelValue("__main__.MISSING", "MISSING"), self.fx.a)
-        data = WriteBuffer()
-        literal.write(data)
-        buffer = ReadBuffer(data.getvalue())
-        assert read_tag(buffer) == LITERAL_TYPE
-        roundtrip = LiteralType.read(buffer)
-        self.assertEqual(roundtrip.value, literal.value)
-        self.assertEqual(roundtrip.fallback.type_ref, self.fx.a.type.fullname)
 
     def test_simple_unbound_type(self) -> None:
         u = UnboundType("Foo")

--- a/mypy/traverser.py
+++ b/mypy/traverser.py
@@ -62,6 +62,7 @@ from mypy.nodes import (
     RaiseStmt,
     ReturnStmt,
     RevealExpr,
+    SentinelExpr,
     SetComprehension,
     SetExpr,
     SliceExpr,
@@ -503,6 +504,9 @@ class TraverserVisitor(NodeVisitor[None]):
     def visit_newtype_expr(self, o: NewTypeExpr, /) -> None:
         return None
 
+    def visit_sentinel_expr(self, o: SentinelExpr, /) -> None:
+        return None
+
     def visit__promote_expr(self, o: PromoteExpr, /) -> None:
         return None
 
@@ -894,6 +898,11 @@ class ExtendedTraverserVisitor(TraverserVisitor):
         if not self.visit(o):
             return
         super().visit_newtype_expr(o)
+
+    def visit_sentinel_expr(self, o: SentinelExpr, /) -> None:
+        if not self.visit(o):
+            return
+        super().visit_sentinel_expr(o)
 
     def visit_await_expr(self, o: AwaitExpr, /) -> None:
         if not self.visit(o):

--- a/mypy/treetransform.py
+++ b/mypy/treetransform.py
@@ -69,6 +69,7 @@ from mypy.nodes import (
     RefExpr,
     ReturnStmt,
     RevealExpr,
+    SentinelExpr,
     SetComprehension,
     SetExpr,
     SliceExpr,
@@ -696,6 +697,9 @@ class TransformVisitor(NodeVisitor[Node]):
         res = NewTypeExpr(node.name, node.old_type, line=node.line, column=node.column)
         res.info = node.info
         return res
+
+    def visit_sentinel_expr(self, node: SentinelExpr) -> SentinelExpr:
+        return SentinelExpr(node.info, line=node.line, column=node.column)
 
     def visit_namedtuple_expr(self, node: NamedTupleExpr) -> NamedTupleExpr:
         return NamedTupleExpr(node.info)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -1060,13 +1060,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
         if isinstance(sym.node, Var) and sym.node.is_sentinel:
             typ = get_proper_type(sym.node.type)
-            if isinstance(typ, Instance) and typ.last_known_value is not None:
-                return LiteralType(
-                    value=typ.last_known_value.value,
-                    fallback=typ.last_known_value.fallback,
-                    line=t.line,
-                    column=t.column,
-                )
+            if isinstance(typ, Instance):
+                return Instance(typ.type, [], line=t.line, column=t.column)
 
         # None of the above options worked. We parse the args (if there are any)
         # to make sure there are no remaining semanal-only types, then give up.

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -37,7 +37,6 @@ from mypy.state import state
 from mypy.types import (
     ELLIPSIS_TYPE_NAMES,
     NOT_IMPLEMENTED_TYPE_NAMES,
-    SENTINEL_TYPE_NAMES,
     AnyType,
     CallableType,
     ExtraAttrs,
@@ -1057,10 +1056,10 @@ def is_singleton_identity_type(typ: ProperType) -> bool:
             (typ.type.is_enum and len(typ.type.enum_members) == 1)
             or (typ.type.fullname in ELLIPSIS_TYPE_NAMES)
             or (typ.type.fullname in NOT_IMPLEMENTED_TYPE_NAMES)
-            or (typ.type.fullname in SENTINEL_TYPE_NAMES)
+            or typ.type.is_sentinel
         )
     if isinstance(typ, LiteralType):
-        return typ.is_enum_literal() or typ.is_sentinel_literal() or isinstance(typ.value, bool)
+        return typ.is_enum_literal() or isinstance(typ.value, bool)
     if isinstance(typ, TypeType) and isinstance(typ.item, Instance) and typ.item.type.is_final:
         return True
     if isinstance(typ, FunctionLike) and typ.is_type_obj() and typ.type_object().is_final:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -98,12 +98,7 @@ JsonDict: _TypeAlias = dict[str, Any]
 #
 # Note: Float values are only used internally. They are not accepted within
 # Literal[...].
-class SentinelValue(NamedTuple):
-    fullname: str
-    name: str
-
-
-LiteralValue: _TypeAlias = int | str | bool | float | SentinelValue
+LiteralValue: _TypeAlias = int | str | bool | float
 
 
 TUPLE_NAMES: Final = ("builtins.tuple", "typing.Tuple")
@@ -123,6 +118,18 @@ SENTINEL_TYPE_NAMES: Final = (
     "typing_extensions.sentinel",
     "typing_extensions.Sentinel",
 )
+
+
+def sentinel_display_name(info: mypy.nodes.TypeInfo) -> str:
+    """User-facing name for a synthetic per-declaration sentinel class.
+
+    Its fullname is mangled (see semanal.py's sentinel_type_for_var) to avoid
+    colliding with the Var of the same name; this strips that mangling marker
+    and the module prefix, e.g. "mod.Cls.IN_CLASS'" -> "Cls.IN_CLASS".
+    """
+    name = info.fullname.removesuffix("'")
+    return name.removeprefix(f"{info.module_name}.")
+
 
 TYPED_NAMEDTUPLE_NAMES: Final = ("typing.NamedTuple", "typing_extensions.NamedTuple")
 
@@ -3354,15 +3361,11 @@ class LiteralType(ProperType):
     #       almost no test cases where we would redundantly compute
     #       `can_be_false`/`can_be_true`.
     def can_be_false_default(self) -> bool:
-        if isinstance(self.value, SentinelValue):
-            return False
         if self.fallback.type.is_enum:
             return self.fallback.can_be_false
         return not self.value
 
     def can_be_true_default(self) -> bool:
-        if isinstance(self.value, SentinelValue):
-            return True
         if self.fallback.type.is_enum:
             return self.fallback.can_be_true
         return bool(self.value)
@@ -3383,9 +3386,6 @@ class LiteralType(ProperType):
     def is_enum_literal(self) -> bool:
         return self.fallback.type.is_enum
 
-    def is_sentinel_literal(self) -> bool:
-        return isinstance(self.value, SentinelValue)
-
     def value_repr(self) -> str:
         """Returns the string representation of the underlying type.
 
@@ -3393,9 +3393,6 @@ class LiteralType(ProperType):
         except it includes some additional logic to correctly handle cases
         where the value is a string, byte string, a unicode string, or an enum.
         """
-        if isinstance(self.value, SentinelValue):
-            return self.value.name
-
         raw = repr(self.value)
         fallback_name = self.fallback.type.fullname
 
@@ -3414,19 +3411,16 @@ class LiteralType(ProperType):
             return raw
 
     def serialize(self) -> JsonDict | str:
-        value: LiteralValue | JsonDict = self.value
-        if isinstance(value, SentinelValue):
-            value = {".class": "SentinelValue", "fullname": value.fullname, "name": value.name}
-        return {".class": "LiteralType", "value": value, "fallback": self.fallback.serialize()}
+        return {
+            ".class": "LiteralType",
+            "value": self.value,
+            "fallback": self.fallback.serialize(),
+        }
 
     @classmethod
     def deserialize(cls, data: JsonDict) -> LiteralType:
         assert data[".class"] == "LiteralType"
-        value = data["value"]
-        if isinstance(value, dict):
-            assert value[".class"] == "SentinelValue"
-            value = SentinelValue(value["fullname"], value["name"])
-        return LiteralType(value=value, fallback=Instance.deserialize(data["fallback"]))
+        return LiteralType(value=data["value"], fallback=Instance.deserialize(data["fallback"]))
 
     def write(self, data: WriteBuffer) -> None:
         write_tag(data, LITERAL_TYPE)
@@ -3888,7 +3882,9 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         fullname = t.type.fullname
         if not self.options.reveal_verbose_types and fullname.startswith("builtins."):
             fullname = t.type.name
-        if t.last_known_value and not t.args:
+        if t.type.is_sentinel:
+            s = sentinel_display_name(t.type)
+        elif t.last_known_value and not t.args:
             # Instances with a literal fallback should never be generic. If they are,
             # something went wrong so we fall back to showing the full Instance repr.
             s = f"{t.last_known_value.accept(self)}?"
@@ -4044,7 +4040,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
                         )
                     else:
                         vs.append(
-                            f"{var.name}{f' = {var.default.accept(self)}' if var.has_default()  else ''}"
+                            f"{var.name}{f' = {var.default.accept(self)}' if var.has_default() else ''}"
                         )
                 else:
                     # For other TypeVarLikeTypes, use the name and default
@@ -4103,8 +4099,6 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         return repr(t.literal_value)
 
     def visit_literal_type(self, t: LiteralType, /) -> str:
-        if isinstance(t.value, SentinelValue):
-            return t.value_repr()
         return f"Literal[{t.value_repr()}]"
 
     def visit_union_type(self, t: UnionType, /) -> str:

--- a/mypy/visitor.py
+++ b/mypy/visitor.py
@@ -192,6 +192,10 @@ class ExpressionVisitor(Generic[T]):
         pass
 
     @abstractmethod
+    def visit_sentinel_expr(self, o: mypy.nodes.SentinelExpr, /) -> T:
+        pass
+
+    @abstractmethod
     def visit__promote_expr(self, o: mypy.nodes.PromoteExpr, /) -> T:
         pass
 
@@ -601,6 +605,9 @@ class NodeVisitor(Generic[T], ExpressionVisitor[T], StatementVisitor[T], Pattern
         raise NotImplementedError()
 
     def visit_newtype_expr(self, o: mypy.nodes.NewTypeExpr, /) -> T:
+        raise NotImplementedError()
+
+    def visit_sentinel_expr(self, o: mypy.nodes.SentinelExpr, /) -> T:
         raise NotImplementedError()
 
     def visit__promote_expr(self, o: mypy.nodes.PromoteExpr, /) -> T:

--- a/mypyc/irbuild/visitor.py
+++ b/mypyc/irbuild/visitor.py
@@ -60,6 +60,7 @@ from mypy.nodes import (
     RaiseStmt,
     ReturnStmt,
     RevealExpr,
+    SentinelExpr,
     SetComprehension,
     SetExpr,
     SliceExpr,
@@ -360,6 +361,9 @@ class IRBuilderVisitor(IRVisitor):
         assert False, "can't compile analysis-only expressions"
 
     def visit_newtype_expr(self, o: NewTypeExpr) -> Value:
+        assert False, "can't compile analysis-only expressions"
+
+    def visit_sentinel_expr(self, o: SentinelExpr) -> Value:
         assert False, "can't compile analysis-only expressions"
 
     def visit_temp_node(self, o: TempNode) -> Value:

--- a/mypyc/lib-rt/internal/librt_internal.c
+++ b/mypyc/lib-rt/internal/librt_internal.c
@@ -930,7 +930,6 @@ write_tag(PyObject *self, PyObject *const *args, size_t nargs) {
 #define LITERAL_BYTES 5
 #define LITERAL_FLOAT 6
 #define LITERAL_COMPLEX 7
-#define LITERAL_SENTINEL 8
 
 // Supported builtin collections.
 #define LIST_GEN 20
@@ -1162,11 +1161,6 @@ _skip_object(PyObject *data, uint8_t tag) {
         return _skip(data, 8);
     if (tag == LITERAL_COMPLEX)
         return _skip(data, 16);
-    if (tag == LITERAL_SENTINEL) {
-        if (unlikely(_skip_str_bytes(data) == CPY_NONE_ERROR))
-            return CPY_NONE_ERROR;
-        return _skip_str_bytes(data);
-    }
     PyErr_Format(PyExc_ValueError, "Unsupported tag: %d", tag);
     return CPY_NONE_ERROR;
 }

--- a/mypyc/test-data/run-classes.test
+++ b/mypyc/test-data/run-classes.test
@@ -2999,7 +2999,7 @@ from mypy_extensions import u8
 from librt.internal import (
     ReadBuffer, WriteBuffer, write_bool, read_bool, write_str, read_str, write_float, read_float,
     write_int, read_int, write_tag, read_tag, write_bytes, read_bytes,
-    cache_version, extract_symbol,
+    cache_version,
 )
 
 from testutil import assertRaises
@@ -3217,16 +3217,6 @@ def test_buffer_str_size() -> None:
         b = ReadBuffer(b.getvalue())
         assert read_str(b) == s
 
-def test_extract_symbol_sentinel_literal() -> None:
-    data = WriteBuffer()
-    write_tag(data, 8)  # LITERAL_SENTINEL
-    write_str(data, "__main__.MISSING")
-    write_str(data, "MISSING")
-    write_tag(data, 255)  # END_TAG
-
-    payload = data.getvalue()
-    assert extract_symbol(ReadBuffer(payload)) == payload
-
 [file driver.py]
 from native import *
 
@@ -3241,7 +3231,6 @@ test_buffer_str_size()
 test_buffer_int_powers()
 test_positive_long_int_serialized_bytes()
 test_negative_long_int_serialized_bytes()
-test_extract_symbol_sentinel_literal()
 
 def test_buffer_basic_interpreted() -> None:
     b = WriteBuffer()

--- a/test-data/unit/check-sentinels.test
+++ b/test-data/unit/check-sentinels.test
@@ -181,11 +181,38 @@ from typing_extensions import sentinel, assert_type
 MISSING = sentinel("MISSING")
 ALIAS = MISSING
 
-assert_type(ALIAS, sentinel)
+# The value still identifies as the same sentinel...
+assert_type(ALIAS, MISSING)
 
 def func(x: int | MISSING = MISSING) -> None:
     pass
 
 func(MISSING)
-func(ALIAS)  # E: Argument 1 to "func" has incompatible type "Sentinel"; expected "int | MISSING"
+func(ALIAS)
+
+# ...but the reassignment does not make ALIAS usable as a type alias.
+def uses_alias_as_type(x: ALIAS) -> None:  # E: Variable "__main__.ALIAS" is not valid as a type \
+        # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+    pass
 [builtins fixtures/tuple.pyi]
+
+[case testSentinelPreservedThroughGenericSubstitution]
+from typing import assert_type
+from typing_extensions import sentinel
+
+Unknown = sentinel("Unknown")
+
+def func(d: dict[str, str]) -> None:
+    var = d.get("key", Unknown)
+    assert_type(var, str | Unknown)
+[builtins fixtures/dict-full.pyi]
+
+[case testSentinelPreservedInErrorMessages]
+from typing_extensions import sentinel
+
+Unknown = sentinel("Unknown")
+
+def func(d: dict[str, str]) -> None:
+    var = d.get("key", Unknown)
+    x: int = var  # E: Incompatible types in assignment (expression has type "str | Unknown", variable has type "int")
+[builtins fixtures/dict-full.pyi]


### PR DESCRIPTION
<!-- If this pull request fixes an issue, add "Fixes #NNN" with the issue number. -->

Related

- Fixes https://github.com/python/mypy/issues/21866
- Hard left turn from initial implementation in https://github.com/python/mypy/pull/21647
- Motivation: https://github.com/python/mypy/pull/21888#discussion_r3849812444

<!--
Checklist:
- Read the [Contributing Guidelines](https://github.com/python/mypy/blob/master/CONTRIBUTING.md)
- Add tests for all changed behaviour.
- If you can't add a test, please explain why and how you verified your changes work.
- Make sure CI passes.
- Please do not force push to the PR once it has been reviewed.
-->
