### PR TITLE
fix(errors): avoid duplicate diagnostics for duplicate paths

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -681,7 +681,16 @@ class Errors:
         return info
 
     def _add_error_info(self, file: str, info: ErrorInfo) -> None:
-        assert file not in self.flushed_files
+        # A file can be revisited under a second module name after an earlier
+        # pass has flushed its diagnostics. Do not duplicate an error that has
+        # already been emitted for the same physical file, even if the two
+        # module states use different path spellings.
+        normalized_file = os.path.normcase(os.path.abspath(file))
+        if any(
+            os.path.normcase(os.path.abspath(flushed_file)) == normalized_file
+            for flushed_file in self.flushed_files
+        ):
+            return
         # process the stack of ErrorWatchers before modifying any internal state
         # in case we need to filter out the error entirely
         if self._filter_error(file, info):
@@ -1094,7 +1103,10 @@ class Errors:
 
         Use a form suitable for displaying to the user.
         """
-        self.flushed_files.add(path)
+        normalized_path = os.path.normcase(os.path.abspath(path))
+        if normalized_path in self.flushed_files:
+            return []
+        self.flushed_files.add(normalized_path)
         if formatter is not None:
             errors = create_errors(error_tuples)
             return [formatter.report_error(err) for err in errors]
@@ -1129,7 +1141,7 @@ class Errors:
         """
         msgs = []
         for path in self.error_info_map.keys():
-            if path not in self.flushed_files:
+            if os.path.normcase(os.path.abspath(path)) not in self.flushed_files:
                 error_tuples = self.file_messages(path)
                 msgs.extend(
                     self.format_messages(path, error_tuples, formatter=self.error_formatter)

--- a/test-data/unit/cmdline.test
+++ b/test-data/unit/cmdline.test
@@ -822,6 +822,26 @@ src/foo/bar.py: note:     a) adding `__init__.py` somewhere,
 src/foo/bar.py: note:     b) using `--explicit-package-bases` or adjusting `MYPYPATH`
 == Return code: 2
 
+[case testDuplicatePackageRootsReportsTypeError]
+# cmd: mypy --config-file pyproject.toml
+[file pyproject.toml]
+\[tool.mypy]
+python_version = "3.10"
+strict = true
+mypy_path = ["src", "src/outer/inner"]
+packages = ["outer", "example"]
+explicit_package_bases = true
+[file src/outer/__init__.py]
+[file src/outer/inner/example/__init__.py]
+[file src/outer/inner/example/module.py]
+def takes_int(value: int) -> None:
+    pass
+
+def broken() -> None:
+    takes_int("not an int")
+[out]
+src/outer/inner/example/module.py:5: error: Argument 1 to "takes_int" has incompatible type "str"; expected "int"
+
 [case testEnableInvalidErrorCode]
 # cmd: mypy --enable-error-code YOLO test.py
 [file test.py]


### PR DESCRIPTION
## Problem

When `packages` and `mypy_path` discover the same physical Python file under two module names, an ordinary type error in that file can trigger an internal `flushed_files` assertion instead of a diagnostic.

## Root Cause

The same physical file is processed and flushed more than once, while error flush bookkeeping compares path spellings literally. The duplicate module states can therefore report after the first flush, and the second flush can emit the same diagnostic again.

## Solution

Normalize flushed paths to absolute, case-insensitive paths and make error collection and message flushing idempotent for a physical file that has already been emitted.

## Changes

- Prevent duplicate error collection when a file is revisited under an equivalent path spelling.
- Prevent a second message flush for the same physical file.
- Add a command-line regression covering duplicate package roots plus an ordinary type error.

## Testing

- `PYTHONUTF8=1 python -m pytest -n0 mypy/test/testcmdline.py -k DuplicatePackageRoots` — passed (1 selected)
- `PYTHONUTF8=1 python -m pytest -n0 mypy/test/testcmdline.py` — passed (146/146)
- `python -m mypy --config-file mypy_self_check.ini -p mypy` — passed (196 source files)
- `python -m black --check mypy/errors.py` — passed
- `python -m ruff check mypy/errors.py` — passed
- `python -m compileall -q mypy/errors.py` — passed
- `git diff --check` — passed
- `pre-commit` — not verified: first-time actionlint environment setup returned `BadZipFile` before hooks completed

## Compatibility/Risk

This only affects diagnostics for a physical file that is revisited during one build. It preserves the first diagnostic and avoids an internal crash or duplicate output; normal files continue to use the existing error collection flow. No public API or dependency changed.

## Notes for Reviewer

The regression fails on the parent commit with `AssertionError` in `Errors._add_error_info`. The final test reports the expected `arg-type` diagnostic once. The test uses the same `packages` + overlapping `mypy_path` shape described in the issue and does not require external packages.

## Linked Issue

Fixes #21889
