### PR TITLE
Fix overload inference with protocol __class__ overrides

### DIFF
--- a/mypy/constraints.py
+++ b/mypy/constraints.py
@@ -1050,6 +1050,11 @@ class ConstraintBuilderVisitor(TypeVisitor[list[Constraint]]):
         """
         res = []
         for member in protocol.type.protocol_members:
+            if member == "__class__":
+                # Every object exposes __class__, but it is not a useful
+                # structural constraint and can infer an unrelated protocol
+                # type variable from the concrete class object.
+                continue
             inst = mypy.subtypes.find_member(member, instance, subtype, class_obj=class_obj)
             temp = mypy.subtypes.find_member(member, template, subtype)
             if inst is None or temp is None:

--- a/mypy/test/testsubtypes.py
+++ b/mypy/test/testsubtypes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from mypy import api
 from mypy.nodes import CONTRAVARIANT, COVARIANT, INVARIANT
 from mypy.subtypes import is_subtype
 from mypy.test.helpers import Suite
@@ -8,6 +9,33 @@ from mypy.types import Instance, TupleType, Type, UninhabitedType, UnpackType
 
 
 class SubtypingSuite(Suite):
+    def test_protocol_overload_with_class_override(self) -> None:
+        source = """
+from collections.abc import Iterator, Sequence
+from typing import Any, Protocol, overload
+from typing_extensions import TypeVar, reveal_type
+
+T = TypeVar("T", covariant=True)
+
+class ReducedCovariantList(Protocol[T]):
+    @property  # type: ignore[misc]
+    def __class__(self) -> type[list[Any]]: ...  # type: ignore[override]
+    def __iter__(self) -> Iterator[T]: ...
+
+@overload
+def choose(value: ReducedCovariantList[str]) -> str: ...
+@overload
+def choose(value: Sequence[int]) -> int: ...
+def choose(value: Any) -> Any: ...
+
+reveal_type(choose([1]))
+"""
+        stdout, stderr, returncode = api.run(
+            ["--python-version", "3.14", "--no-incremental", "--show-error-codes", "-c", source]
+        )
+        assert returncode == 0, stderr
+        assert 'Revealed type is "int"' in stdout
+
     def setUp(self) -> None:
         self.fx = TypeFixture(INVARIANT)
         self.fx_contra = TypeFixture(CONTRAVARIANT)


### PR DESCRIPTION
## Problem

When a protocol overrides `__class__`, overload inference can select an incompatible overload. A concrete `list[int]` was incorrectly inferred as matching a protocol overload parameterized with `str`, so the call result was revealed as `str` instead of `int`.

## Root Cause

Protocol constraint inference treated the synthetic `__class__` member as a normal structural member. Because every object exposes `__class__`, its concrete class object could contribute an unrelated constraint for the protocol type variable and distort overload selection.

## Solution

Ignore `__class__` when inferring type-variable constraints from protocol members. It remains available for normal member lookup and structural compatibility checks; it is excluded only from constraint generation, where it cannot provide a useful protocol relationship.

## Changes

- Skip `__class__` in `infer_constraints_from_protocol_members`.
- Add a regression test covering protocol overload resolution with a `__class__` override.

## Testing

- `py -3.10 -m pytest -n0 -q mypy/test/testsubtypes.py -k protocol_overload_with_class_override` (passed: 1)
- `py -3.10 -m pytest -n0 -q mypy/test/testsubtypes.py` (passed: 27)
- `py -3.10 -m black --check mypy/constraints.py mypy/test/testsubtypes.py` (passed)
- `py -3.10 -m ruff check mypy/constraints.py mypy/test/testsubtypes.py` (passed)
- `py -3.10 -m compileall -q mypy/constraints.py mypy/test/testsubtypes.py` (passed)
- `git diff --check` (passed)
- `pre-commit` was attempted but could not complete because the first-time actionlint environment download returned `BadZipFile`; this remains unverified.

## Compatibility/Risk

The change is limited to protocol constraint inference and does not alter runtime behavior. The main risk is an unexpected effect on a protocol that intentionally relies on `__class__` for type-variable inference; the regression test and full subtype suite cover the affected path.

## Notes for Reviewer

Please review whether `__class__` should be excluded from protocol constraint inference globally or only for this overload-inference path, and consider adding any project-specific edge cases to the subtype test suite.

## Linked Issue

Closes #21795
