### PR TITLE
Remove stale incremental-mode caveat from `warn_unused_configs` docs

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -127,7 +127,6 @@ Config file
 
     This flag makes mypy warn about unused ``[mypy-<pattern>]`` config
     file sections.
-    (This requires turning off incremental mode using :option:`--no-incremental`.)
 
 
 .. _import-discovery:

--- a/docs/source/config_file.rst
+++ b/docs/source/config_file.rst
@@ -1211,7 +1211,6 @@ These options may only be set in the global section (``[mypy]``).
 
     Warns about per-module sections in the config file that do not
     match any files processed when invoking mypy.
-    (This requires turning off incremental mode using :confval:`incremental = False <incremental>`.)
 
 .. confval:: verbosity
 


### PR DESCRIPTION
Since commit d3de4a4b4 (#20801), `warn_unused_configs` works in incremental mode, so the docs no longer need to say that `--no-incremental` / `incremental = False` is required.