### PR TITLE
fix(checker): avoid crash for constrained unpacked args

### DIFF
--- a/mypy/types_utils.py
+++ b/mypy/types_utils.py
@@ -154,6 +154,10 @@ def is_self_type_like(typ: Type, *, is_classmethod: bool) -> bool:
 def store_argument_type(
     defn: FuncItem, i: int, typ: CallableType, named_type: Callable[[str, list[Type]], Instance]
 ) -> None:
+    # Expanding an unpacked tuple can add synthetic positional arguments to
+    # the callable type without adding corresponding AST arguments.
+    if i >= len(defn.arguments):
+        return
     arg_type = typ.arg_types[i]
     if typ.arg_kinds[i] == ARG_STAR:
         if isinstance(arg_type, ParamSpecType):

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -3737,3 +3737,14 @@ def test(tp: type[T]) -> T: ...
 
 class C(Generic[T]): ...
 reveal_type(test(C))  # N: Revealed type is "__main__.C[Any]"
+
+[case testConstrainedTypeVarWithUnpackedArgs]
+from typing import Callable, Tuple, TypeVar
+from typing_extensions import Unpack
+
+T = TypeVar("T", str, bytes)
+
+def generic_fun(a: Callable[..., T], *args: Unpack[Tuple[int, float]]) -> None: ...
+
+generic_fun(lambda: "value", 1, 2.0)
+[builtins fixtures/tuple.pyi]


### PR DESCRIPTION
## Problem

A constrained generic function whose `*args` annotation contains an unpacked concrete tuple can crash mypy with `IndexError: list index out of range` during function checking.

## Root Cause

Expanding constrained type variables turns `Unpack[Tuple[int, float]]` into synthetic positional entries in the `CallableType`, but the copied `FuncItem` still contains only the original `*args` AST argument. `store_argument_type()` indexed the AST argument list using every expanded callable entry.

## Solution

Ignore expanded callable entries that have no corresponding AST argument. The original variadic argument is still stored normally before expansion, while synthetic entries no longer overwrite it or index past the AST list.

## Changes

- Add a bounds guard in `store_argument_type()` for synthetic expanded arguments.
- Add a generics regression case covering a constrained type variable followed by an unpacked tuple argument.

## Testing

- Baseline on current `master` (`b974556f`): the issue reproducer raised `IndexError` and reported `INTERNAL_ERROR`.
- `py -3.10 -m pytest 'mypy/test/testcheck.py::TypeCheckSuite::check-generics.test' -q`: 197 passed, 2 skipped.
- `py -3.10 -m black --check mypy/types_utils.py`: passed.
- `py -3.10 -m ruff check mypy/types_utils.py`: passed.
- `py -3.10 -m compileall -q mypy/types_utils.py`: passed.
- `py -3.10 -m mypy --config-file mypy_self_check.ini -p mypy`: 196 source files passed.
- `git diff --check`: passed.
- The full repository test suite was not run.

## Compatibility/Risk

The change affects only type storage during function checking and does not alter accepted type syntax or runtime behavior. Expanded synthetic arguments are skipped because they have no AST variable to receive a type; existing generic regression tests remain green.

## Notes for Reviewer

The regression is reproduced with the Python 3.10-compatible spelling `Unpack[Tuple[int, float]]`; it exercises the same expanded callable shape as the Python 3.13 syntax in the issue. I first tried matching expanded entries by argument name, but that caused two existing generic tests to regress, so the final patch uses the narrower bounds-only guard.

## Linked Issue

Fixes #21907