### PR TITLE
fix(type-analysis): preserve nested Final types in ClassVar

### DIFF
--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -646,6 +646,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                         t,
                         code=codes.VALID_TYPE,
                     )
+                elif t.args:
+                    return self.anal_type(t.args[0])
             return AnyType(TypeOfAny.from_error)
         elif fullname in TUPLE_NAMES:
             # Tuple is special because it is involved in builtin import cycle

--- a/test-data/unit/check-final.test
+++ b/test-data/unit/check-final.test
@@ -1134,6 +1134,16 @@ class A:
     b: ClassVar[Final[int]] = 1
     c: ClassVar[Final] = 1
 
+[case testNestedFinalClassVarPreservesType]
+# flags: --python-version 3.13
+from typing import ClassVar, Final, reveal_type
+
+class A:
+    value: ClassVar[Final[dict[str, int]]] = {}
+
+reveal_type(A.value)  # N: Revealed type is "builtins.dict[builtins.str, builtins.int]"
+[builtins fixtures/dict.pyi]
+
 [case testFinalClassWithAbstractMethod]
 from typing import final
 from abc import ABC, abstractmethod


### PR DESCRIPTION
## Problem

On Python 3.13 and newer, `ClassVar[Final[T]]` is accepted but the annotated class variable resolves to `Any` instead of preserving `T`.

## Root Cause

The type analyzer allows nested `Final` while analyzing `ClassVar`, but the `Final[...]` special-form branch still returns an error `AnyType` after accepting the nested form. This silently discards the inner type.

## Solution

When nested `Final[...]` is allowed and has a type argument, analyze and return that inner type. The existing diagnostic remains unchanged for contexts where nested `Final` is not permitted.

## Changes

- Preserve the inner type for accepted nested `Final[...]` annotations.
- Add a Python 3.13 regression case asserting that `ClassVar[Final[dict[str, int]]]` reveals the dictionary type.

## Testing

- Baseline on current `master` (`b974556f`): the issue reproducer revealed `Any` under `--python-version 3.13`.
- `py -3.10 -m pytest 'mypy/test/testcheck.py::TypeCheckSuite::check-final.test' -q`: 82 passed.
- `py -3.10 -m black --check mypy/typeanal.py`: passed.
- `py -3.10 -m ruff check mypy/typeanal.py`: passed.
- `py -3.10 -m compileall -q mypy/typeanal.py`: passed.
- `py -3.10 -m mypy --config-file mypy_self_check.ini -p mypy`: 196 source files.
- `git diff --check`: passed.
- The full repository test suite was not run.

## Compatibility/Risk

This changes only the result of an already-accepted nested `Final[...]` type form. Unsupported nested `Final` uses continue to report the existing validation error; no runtime behavior or public runtime API changes.

## Notes for Reviewer

The regression test uses `--python-version 3.13` while running the test harness on Python 3.10, so it exercises the version-gated type-analysis path without requiring a local Python 3.13 interpreter.

## Linked Issue

Fixes #21906