### PR TITLE
Apply signature hooks to decorator applications

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -5864,6 +5864,10 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 object_type = self.lookup_type(d.expr)
                 fullname = self.expr_checker.method_fullname(object_type, d.name)
             self.check_for_untyped_decorator(e.func, dec, d)
+            if fullname:
+                dec = self.expr_checker.transform_callee_type(
+                    fullname, dec, [temp], [nodes.ARG_POS], e, object_type=object_type
+                )
             sig, t2 = self.expr_checker.check_call(
                 dec, [temp], [nodes.ARG_POS], e, callable_name=fullname, object_type=object_type
             )

--- a/test-data/unit/check-custom-plugin.test
+++ b/test-data/unit/check-custom-plugin.test
@@ -908,6 +908,19 @@ reveal_type(dynamic_signature(b))  # N: Revealed type is "builtins.bytes"
 \[mypy]
 plugins=<ROOT>/test-data/unit/plugins/function_sig_hook.py
 
+[case testFunctionSigHookCalledOnDecorator]
+# flags: --config-file tmp/mypy.ini
+
+def dynamic_signature(arg1: str) -> str: ...
+
+@dynamic_signature
+def f() -> None: ...
+
+reveal_type(f)  # N: Revealed type is "def ()"
+[file mypy.ini]
+\[mypy]
+plugins=<ROOT>/test-data/unit/plugins/function_sig_hook.py
+
 [case testPluginCalledCorrectlyWhenMethodInDecorator]
 # flags: --config-file tmp/mypy.ini
 from typing import TypeVar, Callable


### PR DESCRIPTION
Fixes #21904

`visit_decorator_inner` calls `check_call` directly on the decorator's type, so a plugin's `get_function_signature_hook`/`get_method_signature_hook` never gets a chance to run for a decorator application. Those two hooks only ever fire from inside `transform_callee_type`, and every other call site that wants them calls that first before reaching `check_call`. `get_function_hook`/`get_method_hook` still work fine on a decorator, since `check_call` invokes those two on its own, which made the gap easy to miss: half the plugin hook family works on a decorator and half silently doesn't.

Calling `transform_callee_type` on the decorator's type before checking the call closes the gap the same way an ordinary call already gets it.

Added a test reusing the existing `function_sig_hook` fixture, applied as a decorator instead of a plain call, since nothing in the suite exercised a signature hook on a decorator before this.

Ran the full `testcheck.py` suite (8043 passed, 33 skipped, 7 xfailed) plus mypy's own self-check on the changed file, both clean.
