### PR TITLE
Improve negative narrowing for literal expressions in containers

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -6925,7 +6925,16 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                                 narrowable_indices={0},
                             )
                             all_if_maps.append(if_map)
-                            if is_singleton_equality_type(get_proper_type(known_item)):
+                            # A literal expression in the container, e.g. `x in ('a', 'b')`,
+                            # gives the item an instance type with a last known value rather
+                            # than a literal type, but it still denotes a single value, so a
+                            # failed comparison against it is enough for negative narrowing.
+                            # Only this check coerces; the type we narrowed against above is
+                            # left alone, to keep `in` consistent with `==`.
+                            is_single_valued = is_singleton_equality_type(
+                                get_proper_type(coerce_to_literal(known_item))
+                            )
+                            if is_single_valued and not has_custom_eq_checks(p_known_item):
                                 all_else_maps.append(else_map)
                         if_map = reduce_or_conditional_type_maps(all_if_maps)
                         else_map = reduce_and_conditional_type_maps(all_else_maps, use_meet=True)

--- a/test-data/unit/check-narrowing.test
+++ b/test-data/unit/check-narrowing.test
@@ -3251,14 +3251,13 @@ def narrow_tuple_exact(x: Literal['a', 'b', 'c'], t: tuple[Literal['a'], Literal
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
 
 def narrow_tuple_expression(x: Literal['a', 'b', 'c']):
-    # TODO: this should match narrow_tuple_exact
     if x in ('a', 'b'):
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
     else:
-        reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
+        reveal_type(x)  # N: Revealed type is "Literal['c']"
 
     if x not in ('a', 'b'):
-        reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
+        reveal_type(x)  # N: Revealed type is "Literal['c']"
     else:
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
 
@@ -3294,7 +3293,7 @@ def narrow_list(x: Literal['a', 'b', 'c'], t: list[Literal['a', 'b']]):
     if x in ['a', 'b']:
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
     else:
-        reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
+        reveal_type(x)  # N: Revealed type is "Literal['c']"
 
     if x in ['a', 'b', *[]]:
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
@@ -3310,7 +3309,7 @@ def narrow_set(x: Literal['a', 'b', 'c'], t: set[Literal['a', 'b']]):
     if x in {'a', 'b'}:
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
     else:
-        reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
+        reveal_type(x)  # N: Revealed type is "Literal['c']"
 
     if x in {'a', 'b', *[]}:
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
@@ -3326,12 +3325,59 @@ def narrow_dict(x: Literal['a', 'b', 'c'], t: dict[Literal['a', 'b'], int]):
     if x in {'a': 0, 'b': 1}:
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
     else:
-        reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
+        reveal_type(x)  # N: Revealed type is "Literal['c']"
 
     if x in {'a': 0, 'b': 1, **{}}:
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
     else:
         reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b'] | Literal['c']"
+[builtins fixtures/primitives.pyi]
+
+
+[case testNarrowNotInLiteralContainer]
+# flags: --strict-equality --warn-unreachable
+from typing import Final, Literal
+
+VALID: Final = ('a', 'b')
+
+def narrow_int_literals(x: Literal[1, 2, 3]):
+    if x not in (1, 2):
+        reveal_type(x)  # N: Revealed type is "Literal[3]"
+    else:
+        reveal_type(x)  # N: Revealed type is "Literal[1] | Literal[2]"
+
+def narrow_final_tuple(x: Literal['a', 'b', 'c']):
+    if x not in VALID:
+        reveal_type(x)  # N: Revealed type is "Literal['c']"
+    else:
+        reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
+
+def narrow_mixed_container(x: Literal['a', 'b'] | None):
+    if x not in ('a', None):
+        reveal_type(x)  # N: Revealed type is "Literal['b']"
+    else:
+        reveal_type(x)  # N: Revealed type is "Literal['a'] | None"
+
+def exhaustive_check(x: Literal['a', 'b']) -> int:
+    if x in ('a',):
+        return 1
+    elif x in ('b',):
+        return 2
+    return 0  # E: Statement is unreachable
+
+def non_literal_item(x: Literal['a', 'b'], y: str):
+    # `y` denotes more than one value, so the negative branch stays wide
+    if x not in (y,):
+        reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
+    else:
+        reveal_type(x)  # N: Revealed type is "Literal['a'] | Literal['b']"
+
+def bool_int_overlap(x: Literal[0, 1, 2]):
+    # `False == 0` and `True == 1`, so this must stay as wide as `x != False`
+    if x not in (False,):
+        reveal_type(x)  # N: Revealed type is "Literal[0] | Literal[1] | Literal[2]"
+    else:
+        reveal_type(x)  # N: Revealed type is "Literal[0] | Literal[1] | Literal[2]"
 [builtins fixtures/primitives.pyi]
 
 


### PR DESCRIPTION
A membership test against a container written out as a literal expression does not
narrow the negative branch:

```python
from typing import Literal

def open_mode(mode: Literal["r", "w", "a"]) -> str:
    if mode in ("r", "w"):
        return "rw"
    reveal_type(mode)  # Literal['r'] | Literal['w'] | Literal['a']
    return "a"
```

With this change that reveal is `Literal['a']`.

The same container behind an annotation narrows fine, and so does the equivalent
`!=` chain, so today the result depends on how the container is spelled. Tuple,
list, set and dict literals all behave this way. The practical cost is that
`assert_never` over `Literal` alternatives is rejected when the branches are
written with `in` and accepted when they are written with `==`, and that the
common `VALID: Final = ("a", "b")` idiom followed by `if x not in VALID` leaves
`x` at its declared type. That last one is the tuple spelling. A `Final` list is
still not narrowed, since it infers as `list[str]` and the item type is gone by
the time the container is inspected.

This is a recorded gap rather than deliberate conservatism: `narrow_tuple_expression`
in check-narrowing.test carries a `# TODO: this should match narrow_tuple_exact`
marker on exactly this behaviour, added in #21456, and #21461 extended the same gap
to list, set and dict literals. I could not find an open issue for it.

## Cause

The gate that decides whether the else map can be kept asks
`is_singleton_equality_type`, which accepts a `LiteralType`. A literal written
inline never reaches that point as a `LiteralType`: it arrives as an `Instance` of
`builtins.str` carrying `last_known_value=Literal['r']`. The coercion just above
only fires for what `is_literal_type_like` recognises, which is `LiteralType`,
unions and type variables, plus a separate clause for enums. That is why enum
members and annotated containers already narrow while plain `str` and `int`
literals do not. The else map is computed correctly and then dropped on the floor.

## Fix

Coerce the container item before asking whether it denotes a single value.

Only the gate coerces. The type passed to `narrow_type_by_identity_equality` is
left as it was, so the positive branch is unchanged: `x in ["x"]` for
`x: str | int` still reveals `builtins.str`, matching `x == "x"`
(`testConsistentNarrowingEqAndIn`, #17864). Coercing the item itself is the
shorter patch, but I tried it and it turns that reveal into `Literal['x']` and
adds a spurious assignment error, so the coercion has to stay local to the gate.

The custom `__eq__` exemption is carried over from the block above, so
`testNarrowCustomEqEnumInLiteralContainer` (#21703) still declines to narrow.

## Soundness

`x not in (a, b)` should land in the same place as `x != a and x != b`. I checked
that by pairing every case against its `!=` control: `bool` against an `int`
literal, `int` against `float`, a class with a custom `__eq__` inside the narrowed
union, a custom `__eq__` enum, a `str` subclass in the container, `Any` in the
container, a plain variable, a container mixing a literal with a variable, and
`None` mixed with string literals. Every `not in` result matches its `!=` control
exactly. Only five of those twenty reveals move at all against master, and each one
moves from unnarrowed to whatever `!=` already produced.

## Tests

- Updated the five literal expression expectations in
  `testNarrowLiteralInLiteralContainer` and removed the now stale TODO.
- Added `testNarrowNotInLiteralContainer`, covering `int` literals, a `Final`
  tuple constant (which reaches the `TupleType` branch rather than the tuple
  expression one), a container mixing a literal with `None`, exhaustiveness, and
  two cases that must stay wide: a container holding a plain variable, and
  `False` against `Literal[0, 1, 2]`.
- Reverting only `mypy/checker.py` and keeping the test data makes both cases fail
  at nine sites. The two cases that must stay wide are identical either way.
- Ran the narrowing, enum, literal, unreachable, isinstance, expressions,
  optional, python310, typeddict, tuples, inference, flags, statements and
  classes test files locally; all pass. `black`, `ruff check` and `codespell` are
  clean on the changed file, and mypy's self check reports nothing new.

I expect mypy_primer to surface new `unreachable` diagnostics, since code after an
exhaustive `in` chain now genuinely is unreachable.
