### PR TITLE
fix(dataclasses): skip non-Var ClassVars

### DIFF
--- a/mypy/plugins/dataclasses.py
+++ b/mypy/plugins/dataclasses.py
@@ -600,7 +600,11 @@ class DataclassTransformer:
                 # We will issue an error later.
                 continue
 
-            assert isinstance(node, Var), node
+            # A ClassVar assigned a class definition, such as a TypedDict,
+            # can be represented by a TypeInfo rather than a Var. Dataclasses
+            # ignore ClassVars, so there is no attribute to collect here.
+            if not isinstance(node, Var):
+                continue
 
             # x: ClassVar[int] is ignored by dataclasses.
             if node.is_classvar:

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -1,3 +1,17 @@
+[case testClassVarTypedDict]
+import dataclasses
+from typing import ClassVar, TypedDict
+
+@dataclasses.dataclass
+class X:
+    value: int
+    TD: ClassVar = TypedDict("TD", {"value": int})
+
+X.TD
+
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-medium.pyi]
+
 [case testDataclassesBasic]
 from dataclasses import dataclass
 


### PR DESCRIPTION
## Problem
Mypy reports an `INTERNAL ERROR` when a dataclass contains a `ClassVar` assigned to a functional `TypedDict` definition. The combination of `dataclass`, `ClassVar`, and `TypedDict` should be valid, but the dataclass plugin crashes during semantic analysis.

## Root Cause
The dataclass plugin assumes every annotated assignment symbol is a `Var`. A `ClassVar` assigned a class definition can instead be represented as a `TypeInfo`, causing `collect_attributes()` to hit an assertion before it can apply the normal ClassVar exclusion.

## Solution
Skip non-`Var` symbols during dataclass attribute collection. Dataclasses ignore ClassVars, so a class-definition symbol has no instance attribute to collect.

## Changes
- Replace the unconditional `Var` assertion with a narrow non-`Var` guard.
- Add a `check-dataclasses.test` regression covering `ClassVar = TypedDict(...)`.

## Testing
- Baseline on current master `deda499`: the supplied reproducer failed with `INTERNAL ERROR`.
- After the change, the reproducer completed with `Success: no issues found in 1 source file`.
- New regression: `testClassVarTypedDict` passed.
- Full `check-dataclasses.test`: 151 passed.
- Black check: passed.
- Ruff check on the changed source: passed.
- Compileall: passed.
- Mypy self-check: 196 source files passed.
- `git diff --check`: passed.

## Compatibility/Risk
This preserves existing handling for `Var`, `TypeAlias`, and `Decorator` symbols. It only avoids collecting a non-Var symbol that dataclasses would ignore, with no public API or runtime behavior change.

## Notes for Reviewer
The regression uses the same minimal shape reported in #21915 and exercises the plugin through mypy's standard semantic-analysis test harness. The guard is intentionally limited to the attribute-collection boundary.

## Linked Issue
Fixes #21915