### PR TITLE
Handle Self wrapped in Annotated when checking the expected self type

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -259,6 +259,7 @@ from mypy.typeanal import (
 )
 from mypy.typeops import function_type, get_type_vars, try_getting_str_literals_from_type
 from mypy.types import (
+    ANNOTATED_TYPE_NAMES,
     ASSERT_TYPE_NAMES,
     DATACLASS_TRANSFORM_NAMES,
     DEPRECATED_TYPE_NAMES,
@@ -1195,6 +1196,8 @@ class SemanticAnalyzer(
             return typ == self.type.self_type
         if isinstance(typ, UnboundType):
             sym = self.lookup_qualified(typ.name, typ, suppress_errors=True)
+            if sym is not None and sym.fullname in ANNOTATED_TYPE_NAMES and typ.args:
+                return self.is_expected_self_type(typ.args[0], is_classmethod=False)
             return sym is not None and sym.fullname in SELF_TYPE_NAMES
         return False
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1191,6 +1191,8 @@ class SemanticAnalyzer(
                 sym = self.lookup_qualified(typ.name, typ, suppress_errors=True)
                 if sym is not None and sym.fullname in TYPE_NAMES and typ.args:
                     return self.is_expected_self_type(typ.args[0], is_classmethod=False)
+                if sym is not None and sym.fullname in ANNOTATED_TYPE_NAMES and typ.args:
+                    return self.is_expected_self_type(typ.args[0], is_classmethod=True)
             return False
         if isinstance(typ, TypeVarType):
             return typ == self.type.self_type

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -1549,6 +1549,19 @@ reveal_type(D.meth())  # N: Revealed type is "__main__.D"
 reveal_type(D.bad())  # N: Revealed type is "Never"
 [builtins fixtures/classmethod.pyi]
 
+[case testTypingSelfAnnotatedType]
+# See: https://github.com/python/mypy/issues/21917
+
+from typing import Self
+from typing_extensions import Annotated
+
+class C:
+    def foo(self: Annotated[Self, "some_metadata"], x: int) -> None:
+        ...
+
+reveal_type(C.foo) # N: Revealed type is "def [Self <: __main__.C] (self: Self`2, x: builtins.int)"
+[builtins fixtures/tuple.pyi]
+
 [case testTypingSelfOverload]
 from typing import Self, overload, Union
 

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -1559,7 +1559,12 @@ class C:
     def foo(self: Annotated[Self, "some_metadata"], x: int) -> None:
         ...
 
+    @classmethod
+    def bar(cls: Annotated[type[Self], "some_metadata"], x: int) -> None:
+        ...
+
 reveal_type(C.foo) # N: Revealed type is "def [Self <: __main__.C] (self: Self`2, x: builtins.int)"
+reveal_type(C.bar) # N: Revealed type is "def (x: builtins.int)"
 [builtins fixtures/tuple.pyi]
 
 [case testTypingSelfOverload]


### PR DESCRIPTION
Fixes https://github.com/python/mypy/issues/21917

Self wrapped in Annotated was not being recognized as an expected self type. This PR updates `is_expected_self_type` to recurse through Annotated when checking unbound types.