### PR TITLE
Bump ast-serialize to 0.9.0

### DIFF
--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -6,4 +6,4 @@ mypy_extensions>=1.0.0
 pathspec>=1.0.0
 tomli>=1.1.0; python_version<'3.11'
 librt>=0.15.0; platform_python_implementation != 'PyPy'
-ast-serialize>=0.8.0,<1.0.0
+ast-serialize>=0.9.0,<1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires = [
     "types-psutil",
     "types-setuptools",
     # required to work around a mypyc import bug
-    "ast-serialize>=0.8.0,<1.0.0",
+    "ast-serialize>=0.9.0,<1.0.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -59,7 +59,7 @@ dependencies = [
   "pathspec>=1.0.0",
   "tomli>=1.1.0; python_version<'3.11'",
   "librt>=0.15.0; platform_python_implementation != 'PyPy'",
-  "ast-serialize>=0.8.0,<1.0.0",
+  "ast-serialize>=0.9.0,<1.0.0",
 ]
 dynamic = ["version"]
 

--- a/test-data/unit/native-parser.test
+++ b/test-data/unit/native-parser.test
@@ -1717,7 +1717,7 @@ MypyFile:1(
   ExpressionStmt:2(
     BytesExpr(foobar))
   ExpressionStmt:3(
-    BytesExpr(x\\n\\\')))
+    BytesExpr(x\\n\\')))
 
 [case testBytesLiteralWithEscapes]
 b'\r\n\t\x2f\xbe'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=test-requirements.txt --strip-extras test-requirements.in
 #
-ast-serialize==0.8.0
+ast-serialize==0.9.0
     # via -r mypy-requirements.txt
 attrs==26.1.0
     # via -r test-requirements.in


### PR DESCRIPTION
I intentionally not bumping cache version yet, to make sure backwards compatibility is OK.
