### PR TITLE
Fix false positive for super() call with constrained type variable

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -540,6 +540,14 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # example when type-checking class decorators.
         self.allow_abstract_call = False
 
+        # When checking one of the copies `expand_typevars` makes of a method for a
+        # class with a value-restricted type variable, this holds the self/cls type
+        # with that substitution already applied. `super()` (see `_super_arg_types`
+        # in checkexpr.py) consults this instead of recomputing an unsubstituted self
+        # type from the class's TypeInfo, so inherited members are checked against
+        # the same value substitution as the rest of the expanded copy.
+        self.expanding_self_type: ProperType | None = None
+
         # Child checker objects for specific AST node types
         self._expr_checker = mypy.checkexpr.ExpressionChecker(
             self, self.msg, self.plugin, per_line_checking_time_ns
@@ -1454,7 +1462,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         self.check_typevar_defaults(typ.variables)
         expanded = self.expand_typevars(defn, typ)
         original_typ = typ
-        for item, typ in expanded:
+        for item, typ, typevar_mapping in expanded:
             old_binder = self.binder
             self.binder = ConditionalTypeBinder(self.options)
             with self.binder.top_frame_context():
@@ -1541,29 +1549,33 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                             n.node = v
                             self.binder.assign_type(n, v.type, v.type)
 
-                with self.scope.push_function(defn):
-                    # We suppress reachability warnings for empty generator functions
-                    # (return; yield) which have a "yield" that's unreachable by definition
-                    # since it's only there to promote the function into a generator function.
-                    #
-                    # We also suppress reachability warnings when we use TypeVars with value
-                    # restrictions: we only want to report a warning if a certain statement is
-                    # marked as being suppressed in *all* of the expansions, but we currently
-                    # have no good way of doing this.
-                    #
-                    # TODO: Find a way of working around this limitation
-                    if _is_empty_generator_function(item) or len(expanded) >= 2:
-                        self.binder.suppress_unreachable_warnings()
-                    # When checking a third-party library, we can skip function body,
-                    # if during semantic analysis we found that there are no attributes
-                    # defined via self here.
-                    if (
-                        not self.can_skip_diagnostics
-                        or self.options.preserve_asts
-                        or not isinstance(defn, FuncDef)
-                        or defn.def_or_infer_vars
-                    ):
-                        self.accept(item.body)
+                self.expanding_self_type = self.self_type_for_expansion(defn, typevar_mapping)
+                try:
+                    with self.scope.push_function(defn):
+                        # We suppress reachability warnings for empty generator functions
+                        # (return; yield) which have a "yield" that's unreachable by definition
+                        # since it's only there to promote the function into a generator function.
+                        #
+                        # We also suppress reachability warnings when we use TypeVars with value
+                        # restrictions: we only want to report a warning if a certain statement is
+                        # marked as being suppressed in *all* of the expansions, but we currently
+                        # have no good way of doing this.
+                        #
+                        # TODO: Find a way of working around this limitation
+                        if _is_empty_generator_function(item) or len(expanded) >= 2:
+                            self.binder.suppress_unreachable_warnings()
+                        # When checking a third-party library, we can skip function body,
+                        # if during semantic analysis we found that there are no attributes
+                        # defined via self here.
+                        if (
+                            not self.can_skip_diagnostics
+                            or self.options.preserve_asts
+                            or not isinstance(defn, FuncDef)
+                            or defn.def_or_infer_vars
+                        ):
+                            self.accept(item.body)
+                finally:
+                    self.expanding_self_type = None
                 unreachable = self.binder.is_unreachable()
                 if new_frame is not None:
                     self.binder.pop_frame(True, 0)
@@ -2275,7 +2287,7 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
 
     def expand_typevars(
         self, defn: FuncItem, typ: CallableType
-    ) -> list[tuple[FuncItem, CallableType]]:
+    ) -> list[tuple[FuncItem, CallableType, dict[TypeVarId, Type]]]:
         # TODO use generator
         subst: list[list[tuple[TypeVarId, Type]]] = []
         tvars = list(typ.variables) or []
@@ -2289,13 +2301,37 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
         # value restricted type variables. (Except when running mypyc,
         # where we need one canonical version of the function.)
         if subst and not (self.options.mypyc or self.options.inspections):
-            result: list[tuple[FuncItem, CallableType]] = []
+            result: list[tuple[FuncItem, CallableType, dict[TypeVarId, Type]]] = []
             for substitutions in itertools.product(*subst):
                 mapping = dict(substitutions)
-                result.append((expand_func(defn, mapping), expand_type(typ, mapping)))
+                result.append((expand_func(defn, mapping), expand_type(typ, mapping), mapping))
             return result
         else:
-            return [(defn, typ)]
+            return [(defn, typ, {})]
+
+    def self_type_for_expansion(
+        self, defn: FuncItem, mapping: dict[TypeVarId, Type]
+    ) -> ProperType | None:
+        """Compute self/cls's type for one of `expand_typevars`'s substituted copies.
+
+        `expand_func` only rewrites types already present somewhere in `defn`'s
+        AST, so an implicit (unannotated) self/cls argument is left with no
+        type at all, and even an explicitly annotated one is read from `defn`
+        -- not the substituted copy -- by callers like `_super_arg_types` in
+        checkexpr.py, since `check_func_def` pushes `defn`, not the copy, onto
+        the checker scope. Returns `None` when there's no substitution to
+        apply (`mapping` empty) or no self/cls argument to compute a type for.
+        """
+        if not mapping or not defn.info or not defn.has_self_or_cls_argument:
+            return None
+        if not defn.arguments:
+            return None
+        self_type: ProperType | None = get_proper_type(defn.arguments[0].variable.type)
+        if self_type is None:
+            self_type = fill_typevars(defn.info)
+            if defn.is_class or defn.name == "__new__":
+                self_type = TypeType.make_normalized(self_type)
+        return expand_type(self_type, mapping)
 
     def check_explicit_override_decorator(
         self,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -5850,7 +5850,16 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
             method = self.chk.scope.current_function()
             assert method is not None
             if method.arguments:
-                instance_type: Type = method.arguments[0].variable.type or current_type
+                # If we're currently checking one of the copies `expand_typevars`
+                # makes for a class with a value-restricted type variable, use the
+                # already-substituted self type computed for this copy -- the
+                # scope always holds the original (unexpanded) function, so its
+                # own self argument's type (annotated or not) is never substituted.
+                instance_type: Type = (
+                    self.chk.expanding_self_type
+                    or method.arguments[0].variable.type
+                    or current_type
+                )
             else:
                 self.chk.fail(message_registry.SUPER_ENCLOSING_POSITIONAL_ARGS_REQUIRED, e)
                 return AnyType(TypeOfAny.from_error)

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -2631,8 +2631,56 @@ class Bar(Foo[AnyStr]):
     def method1(self, s: AnyStr, t: AnyStr) -> None:
         super().method1('x', b'y')  # Should be an error
 [out]
-main:10: error: Argument 1 to "method1" of "Foo" has incompatible type "str"; expected "AnyStr"
-main:10: error: Argument 2 to "method1" of "Foo" has incompatible type "bytes"; expected "AnyStr"
+main:10: error: Argument 1 to "method1" of "Foo" has incompatible type "str"; expected "bytes"
+main:10: error: Argument 2 to "method1" of "Foo" has incompatible type "bytes"; expected "str"
+
+[case testConstrainedGenericSuperNoFalsePositiveSameTypeVar]
+# https://github.com/python/mypy/issues/14774
+from typing import Generic, TypeVar
+
+T = TypeVar("T", float, int)
+
+class C(Generic[T]):
+    def __init__(self, i: T) -> None:
+        self.i: T = i
+
+class B(C[T]):
+    def __init__(self, i: T) -> None:
+        super().__init__(i)
+[out]
+
+[case testConstrainedGenericSuperNoFalsePositiveDistinctTypeVar]
+# https://github.com/python/mypy/issues/17757
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+N = TypeVar("N", int, float)
+
+class C(Generic[T]):
+    def __init__(self, c: T):
+        self.c = c
+
+class C2(C[N]):
+    def __init__(self, c: N):
+        super().__init__(c)
+[out]
+
+[case testConstrainedGenericSuperClassmethodNoFalsePositive]
+from typing import Generic, TypeVar
+
+N = TypeVar("N", int, float)
+
+class C(Generic[N]):
+    @classmethod
+    def make(cls, c: N) -> None:
+        pass
+
+class C2(C[N]):
+    @classmethod
+    def make(cls, c: N) -> None:
+        super().make(c)
+[builtins fixtures/classmethod.pyi]
+[out]
 
 [case testTypeVariableClashVar]
 from typing import Generic, TypeVar, Callable


### PR DESCRIPTION
Fixes #17757.
Fixes #14774.
Fixes #7362.

## Problem

`super().<method>(...)` inside a method of a class with a value-restricted (constrained) type variable raises a false-positive `arg-type` error, even when the argument's type matches the constrained type variable exactly:

```python
from typing import Generic, TypeVar

T = TypeVar("T", float, int)

class C(Generic[T]):
    def __init__(self, i: T) -> None:
        self.i: T = i

class B(C[T]):
    def __init__(self, i: T) -> None:
        super().__init__(i)  # false positive
```

```
error: Argument 1 to "__init__" of "C" has incompatible type "float"; expected "T"
error: Argument 1 to "__init__" of "C" has incompatible type "int"; expected "T"
```

Same root cause with a distinct subclass type variable bound through the base class (#17757's repro):

```python
class C2(C[N]):  # N = TypeVar("N", int, float)
    def __init__(self, c: N):
        super().__init__(c)  # same false positive
```

## Root cause

`checker.py`'s `expand_typevars` type-checks a method with a value-restricted type variable once per constraint value, producing a copy of the function via `expand_func` with that value substituted everywhere it appears in the function's own AST (parameter types, local variable types, etc.).

The self/cls argument is usually unannotated, so its `Var.type` is `None` -- there's nothing there for `expand_func`'s substitution to rewrite. When `checkexpr.py`'s `_super_arg_types` resolves a zero-argument `super()`, it falls back to `fill_typevars(e.info)`, which recomputes the self type fresh from the class's `TypeInfo` -- entirely unaware of which constraint value is currently being checked. `analyze_member_access` then substitutes the base class's generic parameter using this unsubstituted self type, so the *expected* argument type for the inherited method stays the literal, unsubstituted type variable (`T`/`N`), while the *actual* argument (correctly substituted by `expand_func`) is a concrete member type (`float`/`int`). Hence the mismatch, on every one of the type variable's constraint values.

(There's also a separate, subtler version of the same gap: even an *explicitly annotated* self argument's substituted type is inaccessible from `_super_arg_types`, because `check_func_def` pushes the original `defn` onto the checker scope for body-checking -- not the substituted copy `expand_typevars` produced -- so `self.chk.scope.current_function()` can never see the substitution either way.)

## Fix

- `expand_typevars` now also returns the type variable substitution mapping alongside each `(FuncItem, CallableType)` pair it produces.
- `check_func_def` uses that mapping to compute the correctly self/cls type for the copy currently being checked (`TypeChecker.self_type_for_expansion`), and stores it on a new `self.expanding_self_type` attribute for the duration of checking that copy's body.
- `_super_arg_types` consults `self.chk.expanding_self_type` first, before falling back to the existing (and, for this scenario, stale) checks.

This is scoped narrowly to the value-restricted-type-variable expansion path: `expanding_self_type` is `None` whenever there's no substitution mapping (i.e. for the overwhelming majority of methods, which don't have constrained type variables), so `_super_arg_types` falls through to its existing behavior unchanged in that case.

## Testing

Added three regression cases to `check-generics.test`:
- `testConstrainedGenericSuperNoFalsePositiveSameTypeVar` -- #14774's repro.
- `testConstrainedGenericSuperNoFalsePositiveDistinctTypeVar` -- #17757's repro (subclass type variable bound through the base).
- `testConstrainedGenericSuperClassmethodNoFalsePositive` -- same scenario through a classmethod, to cover the `cls`/`TypeType` branch of the self-type computation.

I also re-verified the existing `testConstrainedGenericSuper` test, which intentionally passes mismatched concrete `str`/`bytes` literals to a method expecting a single constrained type variable for both parameters (a genuine error, unrelated to this bug). That test's expected output needed updating: previously mypy reported both arguments as `expected "AnyStr"` (the literal, unsubstituted type variable name) for both of the two expansion passes; with this fix the error message correctly reports the concrete type expected in each pass (`expected "bytes"` in one pass, `expected "str"` in the other), which is strictly more informative and still correctly flags the call as an error.

- `python -m mypy --config-file mypy_self_check.ini -p mypy`: clean.
- `python runtests.py check-generics.test check-typevar-values.test check-generic-subtyping.test`: all pass (199/54/54 respectively, plus skips).
- `python runtests.py pytest-fast`: 12849 passed, 351 skipped, 8 xfailed -- no regressions.
- `python runtests.py pytest-slow`: 37 failed / 18 passed, but identical failure set on unmodified `main` (daemon/socket tests and a mypyc C-unit-test build step, both environment-dependent in this sandbox, unrelated to this change) -- confirmed via a side-by-side run.
- `black --check` / `ruff check` on the two changed `.py` files: clean.

## Also fixes a long-standing duplicate

While looking for other reports of this bug, I found #7362 (opened 2019, `str`/`int` constrained `TypeVar`, `class Child(Base[T])` reusing the same `T`) is the identical mechanism -- confirmed it's resolved by this fix too. It's covered by the existing `testConstrainedGenericSuperNoFalsePositiveSameTypeVar` regression case (same shape: a subclass reusing its base's constrained type variable directly through `super()`), so no additional test was needed for it specifically.

## Out of scope

There's a third, related-looking issue, #13566, with a similarly-worded false positive from an explicit `Base.__init__(self)` call (rather than `super()`) on a class with a *plain, unconstrained* type variable. I checked it against this fix and it's unaffected -- different mechanism, no value-restricted type variable involved. Left it alone rather than trying to fold it into this PR.

