### PR TITLE
Fix crash when unpacking a fixed-length tuple inside a tuple type

### DIFF
--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -119,6 +119,11 @@ def tuple_fallback(typ: TupleType) -> Instance:
                 and unpacked_type.type.fullname == "builtins.tuple"
             ):
                 items.append(unpacked_type.args[0])
+            elif isinstance(unpacked_type, TupleType):
+                # A fixed-length tuple being unpacked (e.g. *tuple[int, str], possibly
+                # via a type alias) isn't a TypeVarTupleType or a variable-length tuple
+                # Instance, but its own fallback already gives us the right element type.
+                items.append(tuple_fallback(unpacked_type).args[0])
             else:
                 raise NotImplementedError
         else:

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -2310,3 +2310,21 @@ type Alias[T] = list[T]
 def g[T = int](x: T) -> T: ...
 [out]
 _testNativeParserPEP695InStubNoVersionError.py:3: note: Revealed type is "def [T] (x: T) -> T"
+
+[case testNoCrashOnFixedTupleUnpackInGenericInferenceContext]
+# https://github.com/python/mypy/issues/21933
+# flags: --python-version=3.12
+from collections import deque
+
+type Inner = tuple[int, str]
+type Outer = tuple[bool, *Inner]
+
+
+class K(Base):
+    q: deque[Outer] = deque()
+    reveal_type(q)
+
+
+class Base: ...
+[out]
+_testNoCrashOnFixedTupleUnpackInGenericInferenceContext.py:11: note: Revealed type is "collections.deque[tuple[bool, *tuple[int, str]]]"


### PR DESCRIPTION
Fixes #21933.

The crash happens in `tuple_fallback()`. That function knows how to fold an unpacked item into the tuple's combined fallback type in two cases: a `TypeVarTuple` (using its upper bound) or a variable-length tuple `Instance`. It never learned about a third case PEP 646 also allows, unpacking a plain fixed-length tuple, so anything that hit this path raised `NotImplementedError` and mypy crashed outright.

This is easy to trigger with a type alias:

```python
type Inner = tuple[int, str]
type Outer = tuple[bool, *Inner]
```

`Outer` unpacks `Inner`, a fixed tuple, not a variable-length one or a TypeVarTuple, so `tuple_fallback` had nowhere to go. The reporter's repro needed `deque[Outer]` specifically because computing the fallback here only gets triggered along certain code paths (checking a generic type argument against its bound during overload resolution, in this case), but the underlying gap is in `tuple_fallback` itself, independent of `deque`.

The fix recurses into `tuple_fallback()` for the nested `TupleType` to get its own combined element type, then folds that into the union the same way the other two branches already do.

Added a regression test to `pythoneval.test` using the reporter's original repro (it needs the real `collections` stub, so it belongs there rather than in one of the in-process `check-*.test` files). Confirmed it reproduces the exact `INTERNAL ERROR` crash from the issue before the fix and passes cleanly after. Ran the full test suite locally, no regressions.