### PR TITLE
stubtest: don't crash when a classmethod's first parameter isn't named cls

### DIFF
--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1574,14 +1574,14 @@ def _resolve_funcitem_from_decorator(dec: nodes.OverloadPart) -> nodes.FuncItem 
         ):
             return func
         if decorator.fullname == "builtins.classmethod":
-            if func.arguments[0].variable.name not in ("_cls", "cls", "mcs", "metacls"):
-                raise StubtestFailure(
-                    f"unexpected class parameter name {func.arguments[0].variable.name!r} "
-                    f"in {dec.fullname}"
-                )
+            if not func.arguments or func.arguments[0].kind not in (nodes.ARG_POS, nodes.ARG_OPT):
+                # Nothing to drop, e.g. `def f(*args)`. inspect.signature of the runtime
+                # classmethod keeps the star argument too, so the two already line up.
+                return func
             # FuncItem is written so that copy.copy() actually works, even when compiled
             ret = copy.copy(func)
-            # Remove the cls argument, since it's not present in inspect.signature of classmethods
+            # Remove the cls argument, since it's not present in inspect.signature of classmethods.
+            # It can be given any name, so don't look at the name to decide.
             ret.arguments = ret.arguments[1:]
             return ret
         # Just give up on any other decorators. After excluding properties, we don't run into

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -682,6 +682,33 @@ class StubtestUnit(unittest.TestCase):
             """,
             error=None,
         )
+        # The first parameter of a classmethod can be called anything, see #16583
+        yield Case(
+            stub="""
+            class GoodOddClsName:
+                @classmethod
+                def f(GoodOddClsName, number: int) -> None: ...
+            """,
+            runtime="""
+            class GoodOddClsName:
+                @classmethod
+                def f(GoodOddClsName, number): pass
+            """,
+            error=None,
+        )
+        yield Case(
+            stub="""
+            class GoodStarArgsCls:
+                @classmethod
+                def f(*args: int) -> None: ...
+            """,
+            runtime="""
+            class GoodStarArgsCls:
+                @classmethod
+                def f(*args): pass
+            """,
+            error=None,
+        )
 
     @collect_cases
     def test_arg_mismatch(self) -> Iterator[Case]:


### PR DESCRIPTION
fixes #16583

the first parameter of a classmethod can be called anything . networkx really does write
`def construct(EdgeComponentAuxGraph, G)` . stubtest checked that name against a list of four
and raised `StubtestFailure` when it did not match :

```
StubtestFailure: unexpected class parameter name 'EdgeComponentAuxGraph' in pkg.EdgeComponentAuxGraph.construct
```

that is not a normal stubtest error , it stops the whole run , so one oddly named parameter
takes out stub checking for a whole distribution . that is what happens on
python/typeshed#13587 .

the name is never used for anything . the line right under it drops the argument by position ,
so the check was not guarding the code below it . it looks at the argument kind now instead .

while testing i found a second way onto the same line . a stub written `def f(*args)` under
`@classmethod` also crashed . there is nothing bound to drop in that case , and
`inspect.signature` of the runtime classmethod keeps the star argument too , so both sides
already match and it returns unchanged . dropping it would have made a false mismatch .

two cases added to `test_static_class_method` , one for the odd name and one for `*args` .
both fail on master with the crash above .

`teststubtest.py` and `teststubgen.py` give 440 passed , 1 skipped , 2 xfailed . self check
on the two files is clean , and so are black and ruff .

small heads up , #21863 adds its own cases to `test_static_class_method` starting on the same
line , so whichever goes in second will need a rebase . it is only the test file , that one
changes `verify_var` and this one changes `_resolve_funcitem_from_decorator` , so they do not
touch the same code .
