### PR TITLE
Do not narrow Flag enums by member equality

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -246,6 +246,7 @@ from mypy.typeops import (
     false_only,
     fixup_partial_type,
     function_type,
+    is_flag_enum_type,
     is_literal_type_like,
     is_singleton_equality_type,
     is_singleton_identity_type,
@@ -7074,6 +7075,15 @@ class TypeChecker(NodeVisitor[None], TypeCheckerSharedApi, SplittingVisitor):
                 target_type = operand_types[j]
                 if should_coerce_literals:
                     target_type = coerce_to_literal(target_type)
+
+                # A Flag value can hold any combination of members, so the declared
+                # members are not an exhaustive set of values: ruling out e.g.
+                # `Programs.P2` does not rule out `Programs.P1 | Programs.P2`. Narrowing
+                # by member equality is therefore unsound for Flag enums.
+                if is_flag_enum_type(get_proper_type(expr_type)) or is_flag_enum_type(
+                    get_proper_type(target_type)
+                ):
+                    continue
 
                 # Morally what we want to do is narrow for each branch based on:
                 # `if_type, else_type = conditional_types(expr_type, target)`

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, TypeVar, cast
+from typing import Any, Final, TypeVar, cast
 
 from mypy.checker_state import checker_state
 from mypy.copytype import copy_type
@@ -1074,6 +1074,24 @@ def is_singleton_equality_type(typ: ProperType) -> bool:
     as judged by the `==` operator.
     """
     return isinstance(typ, LiteralType) or is_singleton_identity_type(typ)
+
+
+FLAG_ENUM_BASES: Final = ("enum.Flag", "enum.IntFlag")
+
+
+def is_flag_enum_type(typ: ProperType) -> bool:
+    """Is this type an instance of, or a member of, an enum.Flag subclass?
+
+    A Flag value can hold any combination of members, so the declared members
+    are not an exhaustive enumeration of the possible values.
+    """
+    if isinstance(typ, LiteralType) and typ.is_enum_literal():
+        typ = typ.fallback
+    return isinstance(typ, Instance) and typ.type.is_enum and is_flag_enum_class(typ.type)
+
+
+def is_flag_enum_class(info: TypeInfo) -> bool:
+    return any(base.fullname in FLAG_ENUM_BASES for base in info.mro)
 
 
 def try_expanding_sum_type_to_union(typ: Type, target_fullname: str | None) -> Type:

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -485,6 +485,63 @@ if int():
     x = x | C.b
 [builtins fixtures/enum.pyi]
 
+[case testFlagEnumEqualityNarrowing]
+from enum import Flag, auto
+
+class Programs(Flag):
+    NONE = 0
+    P1 = auto()
+    P2 = auto()
+    P3 = auto()
+    ALL = P1 | P2 | P3
+
+def f1(programs: Programs) -> None:
+    if programs == Programs.NONE:
+        return
+    if programs == Programs.P2:
+        return
+    # Flag values can hold any combination of members, so narrowing by member
+    # equality would be unsound here (e.g. `Programs.P1 | Programs.P2`).
+    reveal_type(programs)  # N: Revealed type is "__main__.Programs"
+
+def f2(programs: Programs) -> None:
+    if programs != Programs.P2:
+        reveal_type(programs)  # N: Revealed type is "__main__.Programs"
+[builtins fixtures/primitives.pyi]
+
+[case testFlagEnumIdentityNarrowing]
+from enum import Flag, auto
+
+class Programs(Flag):
+    NONE = 0
+    P1 = auto()
+    P2 = auto()
+    P3 = auto()
+    ALL = P1 | P2 | P3
+
+def f(programs: Programs) -> None:
+    if programs is not Programs.P2:
+        reveal_type(programs)  # N: Revealed type is "__main__.Programs"
+[builtins fixtures/primitives.pyi]
+
+[case testIntFlagEnumEqualityNarrowing]
+from enum import IntFlag, auto
+
+class Programs(IntFlag):
+    NONE = 0
+    P1 = auto()
+    P2 = auto()
+    P3 = auto()
+    ALL = P1 | P2 | P3
+
+def f(programs: Programs) -> None:
+    if programs == Programs.NONE:
+        return
+    if programs == Programs.P2:
+        return
+    reveal_type(programs)  # N: Revealed type is "__main__.Programs"
+[builtins fixtures/primitives.pyi]
+
 [case testAnonymousEnum]
 from enum import Enum
 class A:


### PR DESCRIPTION
Fixes #21937

## Description

`narrow_type_by_identity_equality` (used for `==`/`!=`/`is`/`is not` narrowing) expands an enum-typed expression into a union of member literals and, in the negative branch, rules out the compared-away member. For `enum.Flag` subclasses this is unsound: a Flag value can hold any combination of members, so the declared members are not an exhaustive value set.

The reported repro:

```python
class Programs(Flag):
    NONE = 0
    P1 = auto()
    P2 = auto()
    P3 = auto()
    ALL = P1 | P2 | P3

def f(programs: Programs) -> None:
    if programs == Programs.NONE:
        return
    if programs == Programs.P2:
        return
    if Programs.P2 in programs:  # error: Unsupported operand types for in
        ...
```

After the two `==` checks, mypy narrows `programs` to `Literal[Programs.P1, Programs.P3, Programs.ALL]` -- a type that a runtime value like `Programs.P1 | Programs.P2` cannot inhabit. The subsequent `Programs.P2 in programs` is then rejected: typeshed defines `Flag.__contains__(self, other: Self)`, and no member of the narrowed union accepts a `P2` value, even though `Programs.P2 in Programs.P1 | Programs.P2` is `True` at runtime.

This change skips equality/identity narrowing when either operand is a Flag value (an instance of, or a member of, an `enum.Flag`/`enum.IntFlag` subclass): the sound type for such a value is the enum class itself. Narrowing for regular enums is unchanged, since their members do form an exhaustive value set.

## Checklist

- [x] Added tests for all changed behaviour: 3 new cases in `check-enum.test`; they fail without the fix
- [x] Full `testcheck.py` suite passes locally (8207 passed, 15 skipped, 7 xfailed); `check-narrowing`, `check-expressions`, `check-literal`, `check-unreachable-code` also pass
- [x] `mypy --config-file mypy_self_check.ini` passes on the touched modules
- [x] `ruff check` / `ruff format --check` (pinned ruff 0.14.3) pass on the touched modules
