### PR TITLE
fix callable enum narrowing

### DIFF
--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -1657,6 +1657,18 @@ class ExpressionChecker(ExpressionVisitor[Type], ExpressionCheckerSharedApi):
                 object_type,
                 original_type=callee,
             )
+        elif isinstance(callee, LiteralType):
+            return self.check_call(
+                callee.fallback,
+                args,
+                arg_kinds,
+                context,
+                arg_names,
+                callable_node,
+                callable_name,
+                object_type,
+                original_type=original_type,
+            )
         elif isinstance(callee, UninhabitedType):
             ret = UninhabitedType()
             ret.ambiguous = callee.ambiguous

--- a/test-data/unit/check-enum.test
+++ b/test-data/unit/check-enum.test
@@ -2983,3 +2983,27 @@ def f(x: SE | None) -> None:
     else:
         reveal_type(x)  # N: Revealed type is "__main__.SE | None"
 [builtins fixtures/primitives.pyi]
+
+
+[case testCallableEnumNarrowing]
+# See: https://github.com/python/mypy/issues/17222
+
+import enum
+
+class Foo(enum.Enum):
+     FOO1 = enum.auto()
+     FOO2 = enum.auto()
+
+     def __call__(self) -> str:
+         return self.name
+
+foo = Foo.FOO1
+
+match foo:
+     case Foo.FOO1:
+        foo()
+        reveal_type(foo) # N: Revealed type is "Literal[__main__.Foo.FOO1]"
+     case _:
+        foo()
+        reveal_type(foo) # N: Revealed type is "Literal[__main__.Foo.FOO2]"
+[builtins fixtures/primitives.pyi]


### PR DESCRIPTION
Fixes #https://github.com/python/mypy/issues/17222

Narrowing an enum to a literal(with `==` or `match`) gives a `LiteralType`, which  was not being checked when type checking a call. This PR add a `LiteralType` branch to `check_call` that will delegate to its `fallback` instance.