### PR TITLE
Ensure parallel workers are cleaned up after failures

### DIFF
--- a/mypy/build.py
+++ b/mypy/build.py
@@ -318,7 +318,14 @@ class WorkerClient:
         try:
             self.proc.wait(timeout=WORKER_SHUTDOWN_TIMEOUT)
         except subprocess.TimeoutExpired:
-            pass
+            # A worker may still be processing a request when an early build
+            # failure starts cleanup. Make sure it cannot outlive this build.
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=WORKER_SHUTDOWN_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
         if os.path.isfile(self.status_file):
             os.unlink(self.status_file)
 

--- a/mypy/test/testbuild.py
+++ b/mypy/test/testbuild.py
@@ -18,7 +18,7 @@ class _StuckProcess:
     def wait(self, timeout: float | None = None) -> int:
         self.wait_calls += 1
         if self.wait_calls == 1:
-            raise subprocess.TimeoutExpired(["mypy-worker"], timeout)
+            raise subprocess.TimeoutExpired(["mypy-worker"], timeout or 0.0)
         return 0
 
     def terminate(self) -> None:
@@ -31,7 +31,7 @@ class _StuckProcess:
 class WorkerTest(unittest.TestCase):
     def test_close_terminates_worker_after_shutdown_timeout(self) -> None:
         process = _StuckProcess()
-        with mock.patch.object(build.subprocess, "Popen", return_value=process):
+        with mock.patch.object(subprocess, "Popen", return_value=process):
             worker = build.WorkerClient("worker-status.json", "options", {})
             worker.close()
 

--- a/mypy/test/testbuild.py
+++ b/mypy/test/testbuild.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest import mock
+
+from mypy import build
+
+
+class _StuckProcess:
+    pid = 1
+
+    def __init__(self) -> None:
+        self.wait_calls = 0
+        self.terminated = False
+        self.killed = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_calls += 1
+        if self.wait_calls == 1:
+            raise subprocess.TimeoutExpired(["mypy-worker"], timeout)
+        return 0
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+class WorkerTest(unittest.TestCase):
+    def test_close_terminates_worker_after_shutdown_timeout(self) -> None:
+        process = _StuckProcess()
+        with mock.patch.object(build.subprocess, "Popen", return_value=process):
+            worker = build.WorkerClient("worker-status.json", "options", {})
+            worker.close()
+
+        self.assertTrue(process.terminated)
+        self.assertFalse(process.killed)
+        self.assertEqual(process.wait_calls, 2)


### PR DESCRIPTION
Fixes #21905.

Parallel output-json checks can raise a compile error while a build worker is still processing. Worker cleanup currently waits once and leaves a slow worker alive, which can surface as `ResourceWarning` and flaky failures on high-core systems. If the shutdown grace period expires, terminate the worker and fall back to killing it if needed.

Added a regression test for the timeout cleanup path.

Validation:
- `python -m pytest -o addopts='' -q mypy/test/testbuild.py mypy/test/testoutput.py`
- `python runtests.py testbuild.py`
- `python -m ruff check mypy/test/testbuild.py`
- `git diff --check`
