### PR TITLE
Reject Self in PEP 695 type parameter bounds

### DIFF
--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -1888,7 +1888,11 @@ class SemanticAnalyzer(
     ) -> TypeVarLikeExpr | None:
         fullname = self.qualified_name(type_param.name)
         if type_param.upper_bound:
-            upper_bound = self.anal_type(type_param.upper_bound, allow_placeholder=True)
+            upper_bound = self.anal_type(
+                type_param.upper_bound,
+                allow_placeholder=True,
+                prohibit_self_type="a type parameter bound",
+            )
             # TODO: we should validate the upper bound is valid for a given kind.
             if upper_bound is None:
                 # This and below copies special-casing for old-style type variables, that
@@ -1929,7 +1933,11 @@ class SemanticAnalyzer(
             values: list[Type] = []
             if type_param.values:
                 for value in type_param.values:
-                    analyzed = self.anal_type(value, allow_placeholder=True)
+                    analyzed = self.anal_type(
+                        value,
+                        allow_placeholder=True,
+                        prohibit_self_type="a type parameter constraint",
+                    )
                     if analyzed is None:
                         analyzed = PlaceholderType(None, [], context.line)
                     if has_type_vars(analyzed):

--- a/test-data/unit/check-python312.test
+++ b/test-data/unit/check-python312.test
@@ -1446,6 +1446,14 @@ reveal_type(F[str]().m())  # N: Revealed type is "__main__.F[builtins.str]"
 reveal_type(F[str]().mm(b'x'))  # N: Revealed type is "tuple[__main__.F[builtins.str], builtins.bytes]"
 [builtins fixtures/tuple.pyi]
 
+[case testTypingSelfInvalidLocationsTypeParams]
+# flags: --python-version 3.12
+from typing import Self
+
+class C:
+    def bounded[T: Self](self: T) -> None: ...  # E: Self type cannot be used in a type parameter bound
+    def constrained[T: (C, Self)](self: T) -> None: ...  # E: Self type cannot be used in a type parameter constraint
+
 [case testPEP695CallAlias]
 class C:
     def __init__(self, x: str) -> None: ...


### PR DESCRIPTION
Closes #21960.

Mypy accepts ``Self`` as the bound of a PEP 695 type parameter, even though
``Self`` is only valid in the locations defined by PEP 673. The same path also
fails to apply the existing ``Self`` validation consistently to constraints.

The cause was that PEP 695 bounds and constraints were analyzed without the
existing ``prohibit_self_type`` context. The fix passes the appropriate
prohibition context through both paths and adds regression coverage to the
existing invalid-``Self`` test case.

### How this was tested

At the reported base commit ``ae39cdb2fba8908eeff6ec8d6b88879c62495fcc``, the
machine-checked reproduction accepted the invalid bound with
``mypy_exit=0`` and ``diagnostics=0``. After the change, the final independent
verification selected the focused test case and reported ``2 passed, 8225
deselected``.

The checks ran on Windows 11. Mailman recorded Python 3.14.3 for the host
command metadata; the target test environment used Python 3.12.14. Provider
integration testing was not part of this focused type-checker regression.

### An alternative not taken

The error could have been added as a special case at each PEP 695 analysis
call site. Reusing the existing ``prohibit_self_type`` context keeps bound,
constraint, nested, and ``typing_extensions.Self`` handling on one validation
path and avoids duplicate diagnostics logic.

### AI disclosure

This change was drafted with AI assistance: codex (``gpt-5.6-luna``) wrote the
patch and codex (``gpt-5.6-luna``) reviewed it under Mailman. The test results
above were executed by the Mailman harness. Human review and filing remain
pending.
